### PR TITLE
[fix] Add support for loading model from a local path

### DIFF
--- a/vllm_omni/model_executor/models/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni.py
@@ -819,11 +819,16 @@ class Qwen2_5OmniForConditionalGeneration(
         # Load token2wav weights (if any)
         if token2wav_weights and self.token2wav is not None:
             # download weights from huggingface for spk_dict.pt
-            hf_model_folder = download_weights_from_hf_specific(
-                self.vllm_config.model_config.model,
-                self.vllm_config.load_config.download_dir,
-                allow_patterns=["*.pt"],
-            )
+            model_path = self.vllm_config.model_config.model
+            download_dir = self.vllm_config.load_config.download_dir
+            if os.path.exists(model_path):
+                hf_model_folder = model_path
+            else:
+                hf_model_folder = download_weights_from_hf_specific(
+                    model_path,
+                    download_dir,
+                    allow_patterns=["*.pt"],
+                )
             self._init_token2wav_model(hf_model_folder)
             t2w_loaded = self.token2wav.load_weights(
                 token2wav_weights, os.path.join(hf_model_folder, "spk_dict.pt")


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Add support for loading token2wav_weights from a local absolute file path.

## Test Plan

python3 end2end.py --model **/to/path/llm/Qwen2.5-Omni-3B** --prompts "who are you?" --voice-type "m02" --dit-ckpt none --bigvgan-ckpt none --output-wav output_audio --prompt_type text

## Test Result

If not fixed, the result will be a model loading error:

```
(EngineCore_DP0 pid=7550)                 ^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=7550)   File "/Users/bob/.envs/vllm-omni-official/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 106, in _inner_fn
(EngineCore_DP0 pid=7550)     validate_repo_id(arg_value)
(EngineCore_DP0 pid=7550)   File "/Users/bob/.envs/vllm-omni-official/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 154, in validate_repo_id
(EngineCore_DP0 pid=7550)     raise HFValidationError(
(EngineCore_DP0 pid=7550) huggingface_hub.errors.HFValidationError: Repo id must be in the form 'repo_name' or 'namespace/repo_name': '/to/path//Qwen2.5-Omni-3B'. Use `repo_type` argument if needed.

```
After applying this patch, it works well.
```
(EngineCore_DP0 pid=9068) WARNING 11-09 04:21:12 [utils.py:72] Trying to guess the arguments for old-style model class <class 'vllm_omni.model_executor.models.qwen2_5_omni_token2wav.Qwen2_5OmniToken2WavModel'>
Loading safetensors checkpoint shards:   0% Completed | 0/3 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:00<00:00, 35.76it/s]
(EngineCore_DP0 pid=9068) 

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/hsliuustc0106/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
