### PR TITLE
[Bugfix] Fix removal of old logs when stats are enabled

### DIFF
--- a/vllm_omni/entrypoints/async_omni_llm.py
+++ b/vllm_omni/entrypoints/async_omni_llm.py
@@ -78,7 +78,7 @@ class AsyncOmniLLM(EngineClient):
         # Optional file handler for orchestrator
         self._log_file = log_file
         if self._log_file:
-            remove_old_logs(self._log_file, len(self.stage_list))
+            remove_old_logs(self._log_file, len(self.stage_configs))
             configure_orchestrator_logger(logger, self._log_file)
 
         self._stats_file, self._overall_stats_file = init_stats_paths(self._enable_stats, self._log_file)

--- a/vllm_omni/entrypoints/omni_llm.py
+++ b/vllm_omni/entrypoints/omni_llm.py
@@ -72,7 +72,7 @@ class OmniLLM:
         # Optional file handler for orchestrator
         self._log_file = log_file
         if self._log_file:
-            remove_old_logs(self._log_file, len(self.stage_list))
+            remove_old_logs(self._log_file, len(self.stage_configs))
             configure_orchestrator_logger(logger, self._log_file)
 
         self._stats_file, self._overall_stats_file = init_stats_paths(self._enable_stats, self._log_file)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
In `vllm_omni\entrypoints\omni_llm.py` and `vllm_omni\entrypoints\async_omni_llm.py`, since `self.stage_list` is initialized after calling the function to remove old logs, it is nonexistent/has zero length, leading to an erroneous approach when we enable stats logging (the `--enable-stats` arg). We simply replace `len(self.stage_list)` with `len(self.stage_configs)` since `self.stage_configs` is used to initialize `self.stage_list` itself.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
