### PR TITLE
[Bugfix] Fix Qwen-omni Online Inference Bug caused by check_stop and long sequence

### DIFF
--- a/vllm_omni/core/sched/scheduler.py
+++ b/vllm_omni/core/sched/scheduler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Optional
 
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -81,7 +80,7 @@ class OmniScheduler(VLLMScheduler):
         kv_connector_output = model_runner_output.kv_connector_output
 
         outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
-        spec_decoding_stats: Optional[SpecDecodingStats] = None
+        spec_decoding_stats: SpecDecodingStats | None = None
         kv_connector_stats = kv_connector_output.kv_connector_stats if kv_connector_output else None
 
         # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix #101 



### Current Problem

#### `check_stop` in vllm
The `check_stop` function in vllm is invoked by 

```python
# vllm/vllm/v1/core/sched/scheduler.py
# Check for stop and update request status.
if new_token_ids:
    new_token_ids, stopped = self._update_request_with_output(
        request, new_token_ids
    )

# Stop checking for pooler models.
pooler_output = None
if pooler_outputs:
    pooler_output = pooler_outputs[req_index]
    stopped = check_stop(request, self.max_model_len, pooler_output)  # ← Call site 1
```

`check_stop` is only called when `pooler_outputs` is not empty. 

For standard vLLM text generative models ( engine_output_type="text"), in prefill phase, new_token_ids is empty, pooler_outputs is None. 

Therefore `check_stop` is NEVER called when `output_token_ids` is empty during prefill

#### `check_stop` in vllm-omni
vLLM-Omni 's OmniScheduler inherits vllm's Scheduler class, and reuse the`check_stop` function in vllm. 

vLLM-Omni supports multi-stage pipelines where some stages have engine_output_type="latent" . in prefill phase, new_token_ids is empty but `pooler_outputs`can be set during prefill in asynchronous scheduling.

Therefore `check_stop` CAN BE called when `output_token_ids` is empty  during prefill phase.

### Solution

Add a monkey patch in `vllm_omni/patch.py` that wraps `check_stop` with a safe version that checks if `output_token_ids` is empty before accessing `[-1]`. The patch is applied at module import time (via `vllm_omni/__init__.py`) to ensure it takes effect before any scheduler classes import and bind `check_stop` to a local variable.


## Test Plan

Tested  with main branch commit: `a5800cd2`
After rebase to the latest main branch, Qwen2.5Omni has another online inference bug: "Inference failed: 'str' object has no attribute 'get'". It's probably caused the code changes incurred by Qwen3Omni.

```shell
cd vllm-omni/examples/online_serving
python gradio_demo.py
```

Upload a high resolution video (1280 × 704) in the web client and run generation.

Note that Qwen2.5Omni uses Qwen2VL vision encoder preprocessing, which will uniformly sample a fixed number of frames (default 32) from the orignal video by np.linspace, and resize the video according to the grid size, so higher resolution video can easily increase the vision sequence length. And a longer sequence leads to longer prefill time so as to trigger this check_stop IndexError bug.


## Test Result

Before:

```
--------------------------------
[Stage-0] Received batch size=1, request_ids=0
--------------------------------
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710] EngineCore encountered a fatal error.
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710] Traceback (most recent call last):
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 701, in run_engine_core
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]     engine_core.run_busy_loop()
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 728, in run_busy_loop
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]     self._process_engine_step()
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 754, in _process_engine_step
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]     outputs, model_executed = self.step_fn()
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]                               ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 287, in step
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]     engine_core_outputs = self.scheduler.update_from_output(
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py", line 929, in update_from_output
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]     stopped = check_stop(request, self.max_model_len,
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/core/sched/utils.py", line 59, in check_stop
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]     last_token_id = request.output_token_ids[-1]
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]                     ~~~~~~~~~~~~~~~~~~~~~~~~^^^^
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/utils.py", line 76, in __getitem__
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]     return self._x[item]
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710]            ~~~~~~~^^^^^^
(EngineCore_DP0 pid=23530) ERROR 11-29 03:29:52 [core.py:710] IndexError: list index out of range
(EngineCore_DP0 pid=23530) Process EngineCore_DP0:
(EngineCore_DP0 pid=23530) Traceback (most recent call last):
(EngineCore_DP0 pid=23530)   File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore_DP0 pid=23530)     self.run()
(EngineCore_DP0 pid=23530)   File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore_DP0 pid=23530)     self._target(*self._args, **self._kwargs)
(EngineCore_DP0 pid=23530)   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 712, in run_engine_core
(EngineCore_DP0 pid=23530)     raise e
(EngineCore_DP0 pid=23530)   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 701, in run_engine_core
(EngineCore_DP0 pid=23530)     engine_core.run_busy_loop()
(EngineCore_DP0 pid=23530)   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 728, in run_busy_loop
(EngineCore_DP0 pid=23530)     self._process_engine_step()
(EngineCore_DP0 pid=23530)   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 754, in _process_engine_step
(EngineCore_DP0 pid=23530)     outputs, model_executed = self.step_fn()
(EngineCore_DP0 pid=23530)                               ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=23530)   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 287, in step
(EngineCore_DP0 pid=23530)     engine_core_outputs = self.scheduler.update_from_output(
(EngineCore_DP0 pid=23530)                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=23530)   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/core/sched/scheduler.py", line 929, in update_from_output
(EngineCore_DP0 pid=23530)     stopped = check_stop(request, self.max_model_len,
(EngineCore_DP0 pid=23530)               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=23530)   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/core/sched/utils.py", line 59, in check_stop
(EngineCore_DP0 pid=23530)     last_token_id = request.output_token_ids[-1]
(EngineCore_DP0 pid=23530)                     ~~~~~~~~~~~~~~~~~~~~~~~~^^^^
(EngineCore_DP0 pid=23530)   File "/workspace/c00580271/.venv/lib/python3.12/site-packages/vllm/v1/utils.py", line 76, in __getitem__
(EngineCore_DP0 pid=23530)     return self._x[item]
(EngineCore_DP0 pid=23530)            ~~~~~~~^^^^^^
(EngineCore_DP0 pid=23530) IndexError: list index out of range
```


After:
```
--------------------------------
[Stage-0] Received batch size=1, request_ids=0
--------------------------------
--------------------------------
[Stage-1] Received batch size=1, request_ids=0
--------------------------------
(EngineCore_DP0 pid=3796958) /home/public/yx/vllm-omni/vllm_omni/worker/gpu_model_runner.py:200: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)
(EngineCore_DP0 pid=3796958)   info_dict[k] = torch.from_numpy(arr)
--------------------------------
[Stage-2] Received batch size=1, request_ids=0
--------------------------------
(EngineCore_DP0 pid=3797901) INFO:vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni:Currently, we do not use the chunked process, we only use the token2wav.process_chunk for the whole sequence. The stream mode will be implemented in the future.
INFO:vllm_omni.entrypoints.async_omni_llm:[Summary] {'e2e_requests': 1, 'e2e_total_time_ms': 42916.38112068176, 'e2e_sum_time_ms': 42916.06593132019, 'e2e_total_tokens': 0, 'e2e_avg_time_per_request_ms': 42916.06593132019, 'e2e_avg_tokens_per_s': 0.0, 'wall_time_ms': 42916.38112068176, 'final_stage_id': 2, 'stages': [{'stage_id': 0, 'requests': 1, 'tokens': 95, 'total_time_ms': 9671.6787815094, 'avg_time_per_request_ms': 9671.6787815094, 'avg_tokens_per_s': 9.822493296781506}, {'stage_id': 1, 'requests': 1, 'tokens': 1639, 'total_time_ms': 23347.6824760437, 'avg_time_per_request_ms': 23347.6824760437, 'avg_tokens_per_s': 70.19968691461025}, {'stage_id': 2, 'requests': 1, 'tokens': 0, 'total_time_ms': 9389.553546905518, 'avg_time_per_request_ms': 9389.553546905518, 'avg_tokens_per_s': 0.0}], 'transfers': [{'from_stage': 0, 'to_stage': 1, 'samples': 1, 'total_bytes': 171941969, 'total_time_ms': 291.2886142730713, 'tx_mbps': 4722.243454083278, 'rx_samples': 1, 'rx_total_bytes': 171941969, 'rx_total_time_ms': 292.6826477050781, 'rx_mbps': 4699.751634699094, 'total_samples': 1, 'total_transfer_time_ms': 584.8522186279297, 'total_mbps': 2351.9373068756126}, {'from_stage': 1, 'to_stage': 2, 'samples': 1, 'total_bytes': 4939, 'total_time_ms': 0.400543212890625, 'tx_mbps': 98.64603550476191, 'rx_samples': 1, 'rx_total_bytes': 4939, 'rx_total_time_ms': 0.040531158447265625, 'rx_mbps': 974.8549391058824, 'total_samples': 1, 'total_transfer_time_ms': 1.180887222290039, 'total_mbps': 33.45958805733898}]}
```



## CC List

cc @tzhouam @Gaohan123 

cc @ywang96  Shoud we implement this `safe_check_stop` directly in vllm later on?

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
