### PR TITLE
[Feat] Enable loading local Qwen-Image model

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -240,19 +240,32 @@ class QwenImagePipeline(
         prefix: str = "",
     ):
         super().__init__()
+        self.od_config = od_config
         self.device = get_local_device()
         model = od_config.model
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(model, subfolder="scheduler")
+
+        # Check if model is a local path
+        local_files_only = os.path.exists(model)
+
+        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+            model, subfolder="scheduler", local_files_only=local_files_only
+        )
         logger.info("Loaded Qwen-Image scheduler successfully")
 
         with set_default_torch_dtype(torch.bfloat16):
-            self.text_encoder = Qwen2_5_VLForConditionalGeneration.from_pretrained(model, subfolder="text_encoder")
+            self.text_encoder = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+                model, subfolder="text_encoder", local_files_only=local_files_only
+            )
             logger.info("Loaded Qwen-Image text encoder successfully")
-            self.vae = AutoencoderKLQwenImage.from_pretrained(model, subfolder="vae").to(self.device)
+            self.vae = AutoencoderKLQwenImage.from_pretrained(
+                model, subfolder="vae", local_files_only=local_files_only
+            ).to(self.device)
             logger.info("Loaded Qwen-Image VAE successfully")
             self.transformer = QwenImageTransformer2DModel()
             logger.info("Initialized Qwen-Image transformer successfully.")
-            self.tokenizer = Qwen2Tokenizer.from_pretrained(model, subfolder="tokenizer")
+            self.tokenizer = Qwen2Tokenizer.from_pretrained(
+                model, subfolder="tokenizer", local_files_only=local_files_only
+            )
             logger.info("Loaded Qwen-Image tokenizer successfully.")
 
         self.stage = None
@@ -763,10 +776,14 @@ class QwenImagePipeline(
                     for name, tensor in state_dict.items():
                         yield name, tensor
 
-        model_name = "Qwen/Qwen-Image"
         try:
-            # Use the arguments as verified by the user
-            model_path = download_weights_from_hf_specific(model_name, None, ["*"])
+            # Get model path from config or download from HF
+            model_name = self.od_config.model if hasattr(self, "od_config") else "Qwen/Qwen-Image"
+            if os.path.exists(model_name):
+                model_path = model_name
+            else:
+                model_path = download_weights_from_hf_specific(model_name, None, ["*"])
+
             transformer_path = os.path.join(model_path, "transformer")
             self.transformer.load_weights(weight_iterator(transformer_path))
 


### PR DESCRIPTION
## Purpose

Enable loading local Qwen-Image model. 

## Test Plan

```
python text_to_image.py \
  --model /local/path/Qwen/Qwen-Image \
  --prompt "a cup of coffee on the table" \
  --seed 42 \
  --cfg_scale 4.0 \
  --num_images_per_prompt 1 \
  --num_inference_steps 50 \
  --height 1024 \
  --width 1024 \
  --output outputs/coffee.png
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
