### PR TITLE
[Bugfix] Fix redundant shm broadcast warnings in diffusion workers

### DIFF
--- a/vllm_omni/diffusion/worker/gpu_worker.py
+++ b/vllm_omni/diffusion/worker/gpu_worker.py
@@ -129,7 +129,7 @@ class WorkerProc:
         """
         Receive requests from broadcast queue
         """
-        return self.mq.dequeue()
+        return self.mq.dequeue(indefinite=True)
 
     # TODO: queueing, cancellation
     def worker_busy_loop(self) -> None:

--- a/vllm_omni/diffusion/worker/npu/npu_worker.py
+++ b/vllm_omni/diffusion/worker/npu/npu_worker.py
@@ -129,7 +129,7 @@ class NPUWorkerProc:
         """
         Receive requests from broadcast queue
         """
-        return self.mq.dequeue()
+        return self.mq.dequeue(indefinite=True)
 
     # TODO: queueing, cancellation
     def worker_busy_loop(self) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

When running qwen-image gradio demo (or any diffusion model), the worker processes generate redundant log messages every 60 seconds:

```
INFO 12-01 05:28:41 [shm_broadcast.py:466] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-cons
```

## Test Plan

```
cd examples/offline_inference/qwen_image
python gradio_demo.py
```

## Test Result

Before:

```text
* Running on local URL:  http://127.0.0.1:7862
INFO:httpx:HTTP Request: GET http://127.0.0.1:7862/gradio_api/startup-events "HTTP/1.1 200 OK"
INFO:httpx:HTTP Request: HEAD http://127.0.0.1:7862/ "HTTP/1.1 200 OK"
* To create a public link, set `share=True` in `launch()`.
INFO:httpx:HTTP Request: GET https://api.gradio.app/pkg-version "HTTP/1.1 200 OK"
INFO:vllm_omni.diffusion.omni_diffusion:Prepared 1 requests for generation.
INFO:vllm_omni.diffusion.diffusion_engine:Generation completed successfully.
INFO:vllm_omni.diffusion.omni_diffusion:Prepared 1 requests for generation.
INFO:vllm_omni.diffusion.diffusion_engine:Generation completed successfully.
INFO 12-01 05:28:41 [shm_broadcast.py:466] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-cons
uming work (e.g. compilation).
INFO 12-01 05:29:41 [shm_broadcast.py:466] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-cons
uming work (e.g. compilation).
INFO 12-01 05:30:41 [shm_broadcast.py:466] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-cons
uming work (e.g. compilation).
...
```

After fix:

```text
* Running on local URL:  http://127.0.0.1:7862
INFO:httpx:HTTP Request: GET http://127.0.0.1:7862/gradio_api/startup-events "HTTP/1.1 200 OK"
INFO:httpx:HTTP Request: HEAD http://127.0.0.1:7862/ "HTTP/1.1 200 OK"
* To create a public link, set `share=True` in `launch()`.
INFO:httpx:HTTP Request: GET https://api.gradio.app/pkg-version "HTTP/1.1 200 OK"
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
