### PR TITLE
[Doc] change `vllm_omni`  to `vllm-omni`

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -23,7 +23,7 @@ Install vLLM-Omni from source with development dependencies:
 
 ```bash
 git clone https://github.com/vllm-project/vllm-omni.git
-cd vllm_omni
+cd vllm-omni
 uv pip install -e ".[dev]"
 ```
 

--- a/docs/getting_started/installation/gpu/cuda.inc.md
+++ b/docs/getting_started/installation/gpu/cuda.inc.md
@@ -44,7 +44,7 @@ uv pip install vllm==0.11.0 --torch-backend=auto
 Install additional requirements for vLLM-Omni
 ```bash
 git clone https://github.com/vllm-project/vllm-omni.git
-cd vllm_omni
+cd vllm-omni
 uv pip install -e .
 ```
 


### PR DESCRIPTION
## Purpose

Update documentation to correct the directory name in installation instructions. Previously, the `cd` command used `vllm_omni`, which is incorrect. This PR changes it to `vllm-omni` to match the actual repository name and ensure consistency across all setup guides.

## Test Plan

*   Verify that cloning the repository and running `cd vllm-omni` works as expected.
*   Confirm that `uv pip install -e .` and `uv pip install -e ".[dev]"` execute successfully after navigating to the correct directory.

## Test Result

*   Successfully cloned the repository and navigated to `vllm-omni`.
*   Installation commands ran without errors.
*   Documentation reflects the correct directory name in both `getting_started` and `installation/gpu` sections.
