### PR TITLE
[Bugfix] Detach tensors in lists in the GPU/NPU model runners when outputting to OmniOutput.

### DIFF
--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -303,6 +303,8 @@ class GPUARModelRunner(OmniGPUModelRunner):
                                 mm_payload[k] = sub_dict
                         elif isinstance(v, list):
                             element: torch.Tensor = v[0]
+                            if isinstance(element, torch.Tensor):
+                                element = element.detach().cpu().contiguous()
                             multimodal_outputs[k] = v[1:] if len(v) > 1 else v
                             mm_payload[k] = element
                     except Exception as e:

--- a/vllm_omni/worker/npu/npu_ar_model_runner.py
+++ b/vllm_omni/worker/npu/npu_ar_model_runner.py
@@ -862,6 +862,8 @@ class NPUARModelRunner(OmniNPUModelRunner):
                                 mm_payload[k] = sub_dict
                         elif isinstance(v, list):
                             element: torch.Tensor = v[0]
+                            if isinstance(element, torch.Tensor):
+                                element = element.detach().cpu().contiguous()
                             multimodal_outputs[k] = v[1:] if len(v) > 1 else v
                             mm_payload[k] = element
                     except Exception as e:


### PR DESCRIPTION
## Purpose
We need to detach the GPU tensors from lists, similar to what we do in the above tensor/dict options. Without this, the tensors remain on the GPU when being passed to the output, preventing them from being saved correctly and causing GPU memory leaks. 
## Test Plan

## Test Result

