### PR TITLE
[Bugfix] Support passing vllm cli args to online serving in vLLM-Omni

### DIFF
--- a/examples/online_serving/qwen3_omni/openai_chat_completion_client_for_multimodal_generation.py
+++ b/examples/online_serving/qwen3_omni/openai_chat_completion_client_for_multimodal_generation.py
@@ -205,11 +205,7 @@ def get_video_query(video_path: Optional[str] = None, custom_prompt: Optional[st
         "content": [
             {
                 "type": "video_url",
-                "video_url": {
-                    # "url": "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/sample_demo_1.mp4"
-                    # Use absolute path with file:// (note: three slashes for absolute paths)
-                    "url": "file:///mnt/vllm_open_release/sora_gen_high_res.mp4"
-                },
+                "video_url": {"url": video_url},
             },
             {
                 "type": "text",

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -3,10 +3,10 @@ import multiprocessing as mp
 import os
 import socket
 import time
+from argparse import Namespace
 from collections.abc import AsyncGenerator, Iterable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Optional, Union
-from argparse import Namespace
 
 import torch
 
@@ -62,21 +62,23 @@ class AsyncOmni(EngineClient):
 
     Args:
         model: Model name or path to load
-        stage_configs_path: Optional path to YAML file containing stage
-            configurations. If None, configurations are loaded from the model.
-        log_stats: Whether to enable statistics logging
-        log_file: Optional path prefix for log files. If provided, logs will
-            be written to files with stage-specific suffixes.
-        init_sleep_seconds: Number of seconds to sleep between starting
-            each stage process during initialization
-        shm_threshold_bytes: Threshold in bytes for using shared memory
-            for IPC. Objects larger than this threshold will use shared memory.
-        batch_timeout: Timeout in seconds for batching requests within a stage
-        init_timeout: Timeout in seconds for waiting for all stages to initialize
+        cli_args: Namespace object containing command-line arguments.
+            Expected attributes include:
+            - stage_configs_path: Optional path to YAML file containing stage
+              configurations. If None, configurations are loaded from the model.
+            - log_stats: Whether to enable statistics logging
+            - log_file: Optional path prefix for log files. If provided, logs will
+              be written to files with stage-specific suffixes.
+            - init_sleep_seconds: Number of seconds to sleep between starting
+              each stage process during initialization
+            - shm_threshold_bytes: Threshold in bytes for using shared memory
+              for IPC. Objects larger than this threshold will use shared memory.
+            - batch_timeout: Timeout in seconds for batching requests within a stage
+            - init_timeout: Timeout in seconds for waiting for all stages to initialize
         **kwargs: Additional keyword arguments passed to stage engines
 
     Example:
-        >>> async_llm = AsyncOmni(model="Qwen/Qwen2.5-Omni-7B")
+        >>> async_llm = AsyncOmni(model="Qwen/Qwen2.5-Omni-7B", cli_args=args)
         >>> async for output in async_llm.generate(
         ...     prompt="Hello",
         ...     request_id="req-1",

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -185,11 +185,6 @@ async def build_async_omni_from_stage_config(
     async_omni: Optional[EngineClient] = None
 
     try:
-        # if getattr(args, "stage_configs_path", None):
-        #     async_omni = AsyncOmni(model=args.model, stage_configs_path=args.stage_configs_path)
-        # else:
-        #     async_omni = AsyncOmni(model=args.model)
-        
         async_omni = AsyncOmni(model=args.model, cli_args=args)
 
         # # Don't keep the dummy data in memory

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -1,6 +1,6 @@
 import os
 from collections import Counter
-from dataclasses import is_dataclass, asdict
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any
 
@@ -15,7 +15,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent
 
 def _convert_dataclasses_to_dict(obj: Any) -> Any:
     """Recursively convert non-serializable objects to OmegaConf-compatible types.
-    
+
     This is needed because OmegaConf cannot handle:
     - Dataclass objects with Literal type annotations (e.g., StructuredOutputsConfig)
     - Counter objects (from collections or vllm.utils)
@@ -25,7 +25,7 @@ def _convert_dataclasses_to_dict(obj: Any) -> Any:
     # IMPORTANT: Check Counter BEFORE dict, since Counter is a subclass of dict
     # Handle Counter objects (convert to dict)
     # Check by class name first to catch both collections.Counter and vllm.utils.Counter
-    if hasattr(obj, '__class__') and obj.__class__.__name__ == 'Counter':
+    if hasattr(obj, "__class__") and obj.__class__.__name__ == "Counter":
         try:
             return dict(obj)
         except (TypeError, ValueError):
@@ -52,7 +52,7 @@ def _convert_dataclasses_to_dict(obj: Any) -> Any:
     if isinstance(obj, (list, tuple)):
         return type(obj)(_convert_dataclasses_to_dict(item) for item in obj)
     # Try to convert any dict-like object (has keys/values methods) to dict
-    if hasattr(obj, 'keys') and hasattr(obj, 'values') and not isinstance(obj, (str, bytes)):
+    if hasattr(obj, "keys") and hasattr(obj, "values") and not isinstance(obj, (str, bytes)):
         try:
             return {k: _convert_dataclasses_to_dict(v) for k, v in obj.items()}
         except (TypeError, ValueError, AttributeError):
@@ -62,7 +62,7 @@ def _convert_dataclasses_to_dict(obj: Any) -> Any:
     return obj
 
 
-def load_stage_configs_from_model(model: str, base_engine_args: dict={}) -> list:
+def load_stage_configs_from_model(model: str, base_engine_args: dict = {}) -> list:
     """Load stage configurations from model's default config file.
 
     Loads stage configurations based on the model type and device type.
@@ -87,7 +87,9 @@ def load_stage_configs_from_model(model: str, base_engine_args: dict={}) -> list
         device_config_file = f"vllm_omni/model_executor/stage_configs/{device_type}/{model_type}.yaml"
         device_config_path = PROJECT_ROOT / device_config_file
         if os.path.exists(device_config_path):
-            stage_configs = load_stage_configs_from_yaml(config_path=str(device_config_path), base_engine_args=base_engine_args)
+            stage_configs = load_stage_configs_from_yaml(
+                config_path=str(device_config_path), base_engine_args=base_engine_args
+            )
             return stage_configs
 
     # Fall back to default config
@@ -99,7 +101,7 @@ def load_stage_configs_from_model(model: str, base_engine_args: dict={}) -> list
     return stage_configs
 
 
-def load_stage_configs_from_yaml(config_path: str, base_engine_args: dict={}) -> list:
+def load_stage_configs_from_yaml(config_path: str, base_engine_args: dict = {}) -> list:
     """Load stage configurations from a YAML file.
 
     Args:
@@ -116,7 +118,7 @@ def load_stage_configs_from_yaml(config_path: str, base_engine_args: dict={}) ->
     for stage_arg in stage_args:
         base_engine_args_tmp = base_engine_args.copy()
         # Update base_engine_args with stage-specific engine_args if they exist
-        if hasattr(stage_arg, 'engine_args') and stage_arg.engine_args is not None:
+        if hasattr(stage_arg, "engine_args") and stage_arg.engine_args is not None:
             base_engine_args_tmp = OmegaConf.merge(base_engine_args_tmp, stage_arg.engine_args)
         stage_arg.engine_args = base_engine_args_tmp
     return stage_args

--- a/vllm_omni/model_executor/stage_configs/qwen3_omni_moe.yaml
+++ b/vllm_omni/model_executor/stage_configs/qwen3_omni_moe.yaml
@@ -7,21 +7,21 @@
 stage_args:
   - stage_id: 0
     runtime:
-      devices: "0"
+      devices: "0,1"
       max_batch_size: 1
     engine_args:
       model_stage: thinker
       model_arch: Qwen3OmniMoeForConditionalGeneration
       worker_cls: vllm_omni.worker.gpu_ar_worker.GPUARWorker
       scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
-      gpu_memory_utilization: 0.8
+      gpu_memory_utilization: 0.6
       enforce_eager: true
       trust_remote_code: true
       engine_output_type: latent  # Output hidden states for talker
       distributed_executor_backend: "mp"
       enable_prefix_caching: false
       hf_config_name: thinker_config
-      # tensor_parallel_size: 2
+      tensor_parallel_size: 2
     final_output: true
     final_output_type: text
     is_comprehension: true
@@ -43,7 +43,7 @@ stage_args:
        model_arch: Qwen3OmniMoeForConditionalGeneration
        worker_cls: vllm_omni.worker.gpu_ar_worker.GPUARWorker
        scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
-       gpu_memory_utilization: 0.8
+       gpu_memory_utilization: 0.5
        enforce_eager: true
        trust_remote_code: true
        engine_output_type: latent  # Output codec codes for code2wav


### PR DESCRIPTION
## Purpose
This PR supports pass vllm cli args to online serving in vLLM-Omni. Extra cli args and default args will be passed to each engine. And args in stage_configs will override default setting.
## Test Plan
Following README.md in examples/online_serving
## Test Result
Testing results of Qwen2.5-omni with online serving
```bash
python openai_chat_completion_client_for_multimodal_generation.py --query-type mixed_modalities
Chat completion output from text: The audio recites "Mary had a little lamb". The first image shows cherry blossoms with a tower in the background. It's not clear why it would be considered funny without more context. Maybe there's something about the way the baby looks or the situation that makes it seem funny to you? If you can tell me more, I could try to figure out what might make it funny. So, what do you think?
Audio saved to audio_0.wav
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
