### PR TITLE
[Docs]Fix doc wrong link

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -4,7 +4,7 @@ vLLM-Omni supports unified multimodal comprehension and generation models across
 
 ## Model Implementation
 
-If vLLM-Omni natively supports a model, its implementation can be found in <gh-file:vllm-omni/model_executor/models> and <gh-file:vllm_omni/diffusion/models>.
+If vLLM-Omni natively supports a model, its implementation can be found in <gh-file:vllm_omni/model_executor/models> and <gh-file:vllm_omni/diffusion/models>.
 
 ## List of Supported Models for Nvidia GPU
 


### PR DESCRIPTION
## Purpose

Fix incorrect GitHub file link in documentation. The link `<gh-file:vllm-omni/model_executor/models>` in `docs/models/supported_models.md` was using a hyphen instead of an underscore, which would result in a broken link. This PR corrects it to `<gh-file:vllm_omni/model_executor/models>` to properly point to the actual package structure.

**Checklist:**
- [x] The purpose of the PR: Fix broken GitHub file link in supported models documentation
- [x] The test plan: Verify directory structure and documentation rendering
- [x] The test results: Links now correctly reference the actual package structure
- [x] Documentation update: Fixed `supported_models.md` to use correct package name with underscores
- [ ] Release notes update: Not required (minor documentation fix, not user-facing feature change)