### PR TITLE
Fix: Safe handling for multimodal_config to avoid 'NoneType' object h…

### DIFF
--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -52,7 +52,10 @@ class OmniEngineArgs(EngineArgs):
         # and adding the new omni-specific fields
         config_dict = base_config.__dict__.copy()
         # FIXME(Isotr0py): This is a temporary workaround for multimodal_config
-        config_dict = {**config_dict.pop("multimodal_config", {}).__dict__, **config_dict}
+        config_dict = {
+            **(getattr(mm := config_dict.pop("multimodal_config", None), "__dict__", mm or {})),
+            **config_dict,
+        }
 
         # Add the new omni-specific fields
         config_dict["stage_id"] = self.stage_id


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

This PR fixes an issue where multimodal_config may be None, causing:


`AttributeError: 'NoneType' object has no attribute '__dict__'`


The original implementation assumes that multimodal_config is always an object with a __dict__ attribute, but in real configurations it may be:

None

A dict

An object with attributes

This PR adds a safe, concise one-line implementation that supports all cases without changing existing behavior.

## Test Plan

Initialize Omni model with:

```
multimodal_config = None

multimodal_config = {}

multimodal_config = {"foo": "bar"}

custom multimodal config objects
```



## Test Result

All cases load successfully.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
