### PR TITLE
[CI] Qwen2.5 omni online test

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import base64
 import os
+import tempfile
 import time
 from contextlib import contextmanager
+from typing import Optional
 
+import requests
+from vllm.assets.audio import AudioAsset
+from vllm.assets.image import ImageAsset
+from vllm.multimodal.image import convert_image_mode
 from vllm.platforms import current_platform
 
 if current_platform.is_rocm():
@@ -105,3 +112,124 @@ def wait_for_gpu_memory_to_clear(
             raise ValueError(f"Memory of devices {devices=} not free after {dur_s=:.02f} ({threshold=})")
 
         time.sleep(5)
+
+
+def _check_model_available(model_name: str) -> bool:
+    """Check if model weights are available locally or allowed to download."""
+    try:
+        from huggingface_hub import snapshot_download
+        from huggingface_hub.utils import LocalEntryNotFoundError
+
+        try:
+            snapshot_download(model_name, local_files_only=True)
+            return True
+        except LocalEntryNotFoundError:
+            return os.environ.get("VLLM_OMNI_DOWNLOAD_MODEL", "0") == "1"
+    except ImportError:
+        return False
+
+
+def _create_local_128_image_path() -> str:
+    """Create a temporary 128x128 PNG from built-in asset and return its path."""
+    image = convert_image_mode(ImageAsset("cherry_blossom").pil_image.resize((128, 128)), "RGB")
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as f:
+        image.save(f, format="PNG")
+        return f.name
+
+
+def encode_base64_content_from_url(content_url: str) -> str:
+    """Encode remote content to base64."""
+    with requests.get(content_url) as response:
+        response.raise_for_status()
+        return base64.b64encode(response.content).decode("utf-8")
+
+
+def encode_base64_content_from_file(file_path: str) -> str:
+    """Encode a local file to base64."""
+    with open(file_path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+
+def get_video_url_from_path(video_path: Optional[str]) -> str:
+    """Convert a video path (local or remote) to a URL or data URL."""
+    if not video_path:
+        return "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/sample_demo_1.mp4"
+
+    if video_path.startswith(("http://", "https://")):
+        return video_path
+
+    if not os.path.exists(video_path):
+        raise FileNotFoundError(f"Video file not found: {video_path}")
+
+    video_path_lower = video_path.lower()
+    if video_path_lower.endswith(".mp4"):
+        mime_type = "video/mp4"
+    elif video_path_lower.endswith(".webm"):
+        mime_type = "video/webm"
+    elif video_path_lower.endswith(".mov"):
+        mime_type = "video/quicktime"
+    elif video_path_lower.endswith(".avi"):
+        mime_type = "video/x-msvideo"
+    elif video_path_lower.endswith(".mkv"):
+        mime_type = "video/x-matroska"
+    else:
+        mime_type = "video/mp4"
+
+    video_base64 = encode_base64_content_from_file(video_path)
+    return f"data:{mime_type};base64,{video_base64}"
+
+
+def get_image_url_from_path(image_path: Optional[str]) -> str:
+    """Convert an image path (local or remote) to a URL or data URL."""
+    if not image_path:
+        return "https://vllm-public-assets.s3.us-west-2.amazonaws.com/vision_model_images/cherry_blossom.jpg"
+
+    if image_path.startswith(("http://", "https://")):
+        return image_path
+
+    if not os.path.exists(image_path):
+        raise FileNotFoundError(f"Image file not found: {image_path}")
+
+    image_path_lower = image_path.lower()
+    if image_path_lower.endswith((".jpg", ".jpeg")):
+        mime_type = "image/jpeg"
+    elif image_path_lower.endswith(".png"):
+        mime_type = "image/png"
+    elif image_path_lower.endswith(".gif"):
+        mime_type = "image/gif"
+    elif image_path_lower.endswith(".webp"):
+        mime_type = "image/webp"
+    else:
+        mime_type = "image/jpeg"
+
+    image_base64 = encode_base64_content_from_file(image_path)
+    return f"data:{mime_type};base64,{image_base64}"
+
+
+def get_audio_url_from_path(audio_path: Optional[str]) -> str:
+    """Convert an audio path (local or remote) to a URL or data URL."""
+    if not audio_path:
+        return AudioAsset("mary_had_lamb").url
+
+    if audio_path.startswith(("http://", "https://")):
+        return audio_path
+
+    if not os.path.exists(audio_path):
+        raise FileNotFoundError(f"Audio file not found: {audio_path}")
+
+    audio_path_lower = audio_path.lower()
+    if audio_path_lower.endswith((".mp3", ".mpeg")):
+        mime_type = "audio/mpeg"
+    elif audio_path_lower.endswith(".wav"):
+        mime_type = "audio/wav"
+    elif audio_path_lower.endswith(".ogg"):
+        mime_type = "audio/ogg"
+    elif audio_path_lower.endswith(".flac"):
+        mime_type = "audio/flac"
+    elif audio_path_lower.endswith(".m4a"):
+        mime_type = "audio/mp4"
+    else:
+        mime_type = "audio/wav"
+
+    audio_base64 = encode_base64_content_from_file(audio_path)
+    return f"data:{mime_type};base64,{audio_base64}"


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Add test for Qwen 2.5 Omni in the online mode.
## Test Plan
pytest -s -v tests/multi_stages/test_qwen2_5_omni_online_server.py 
## Test Result
```bash
[SERVER] (APIServer pid=3313426) WARNING 12-08 16:01:10 [protocol.py:93] The following fields were present in the request but ignored: {'sampling_params_list'}
[SERVER] (APIServer pid=3313426) The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
[SERVER] (APIServer pid=3313426) INFO 12-08 16:01:15 [chat_utils.py:560] Detected the chat template content format to be 'openai'. You can set `--chat-template-content-format` to override this.
[SERVER] --------------------------------
[SERVER] [Stage-0] Received batch size=1, request_ids=chatcmpl-162f2828d55342d5a7d8e0404979f6e6
[SERVER] --------------------------------
[SERVER] --------------------------------
[SERVER] [Stage-1] Received batch size=1, request_ids=chatcmpl-162f2828d55342d5a7d8e0404979f6e6
[SERVER] --------------------------------
[SERVER] (EngineCore_DP0 pid=3315853) /mnt/ztc_vllm/vllm-omni/vllm_omni/worker/gpu_model_runner.py:207: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)
[SERVER] (EngineCore_DP0 pid=3315853)   info_dict[k] = torch.from_numpy(arr)
[SERVER] --------------------------------
[SERVER] [Stage-2] Received batch size=1, request_ids=chatcmpl-162f2828d55342d5a7d8e0404979f6e6
[SERVER] --------------------------------
[SERVER] (EngineCore_DP0 pid=3317141) INFO:vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni:Currently, we do not use the chunked process, we only use the token2wav.process_chunk for the whole sequence. The stream mode will be implemented in the future.
[SERVER] [Stage-2] Enqueued req=chatcmpl-162f2828d55342d5a7d8e0404979f6e6, use_shm=False, tokens_out=0
[SERVER] (APIServer pid=3313426) INFO:vllm_omni.entrypoints.async_omni:[Summary] {'e2e_requests': 1, 'e2e_total_time_ms': 1006.9944858551025, 'e2e_sum_time_ms': 1006.6421031951904, 'e2e_total_tokens': 0, 'e2e_avg_time_per_request_ms': 1006.6421031951904, 'e2e_avg_tokens_per_s': 0.0, 'wall_time_ms': 1006.9944858551025, 'final_stage_id': 2, 'stages': [{'stage_id': 0, 'requests': 1, 'tokens': 10, 'total_time_ms': 240.6463623046875, 'avg_time_per_request_ms': 240.6463623046875, 'avg_tokens_per_s': 41.55475239363388}, {'stage_id': 1, 'requests': 1, 'tokens': 10, 'total_time_ms': 209.23089981079102, 'avg_time_per_request_ms': 209.23089981079102, 'avg_tokens_per_s': 47.794087818974496}, {'stage_id': 2, 'requests': 1, 'tokens': 0, 'total_time_ms': 512.6142501831055, 'avg_time_per_request_ms': 512.6142501831055, 'avg_tokens_per_s': 0.0}], 'transfers': [{'from_stage': 0, 'to_stage': 1, 'samples': 1, 'total_bytes': 933153, 'total_time_ms': 2.802133560180664, 'tx_mbps': 2664.121405947077, 'rx_samples': 1, 'rx_total_bytes': 933153, 'rx_total_time_ms': 7.469892501831055, 'rx_mbps': 999.3750242282723, 'total_samples': 1, 'total_transfer_time_ms': 11.152029037475586, 'total_mbps': 669.4050001944629}, {'from_stage': 1, 'to_stage': 2, 'samples': 1, 'total_bytes': 92, 'total_time_ms': 27.720928192138672, 'tx_mbps': 0.02655033752472693, 'rx_samples': 1, 'rx_total_bytes': 92, 'rx_total_time_ms': 0.02765655517578125, 'rx_mbps': 26.612135724137932, 'total_samples': 1, 'total_transfer_time_ms': 55.82094192504883, 'total_mbps': 0.013185015777559475}]}
[SERVER] (APIServer pid=3313426) INFO:     127.0.0.1:59850 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:httpx:HTTP Request: POST http://127.0.0.1:41295/v1/chat/completions "HTTP/1.1 200 OK"
PASSED
../../../tests/multi_stages/test_qwen2_5_omni_online_server.py::TestQwen25OmniOnlineServingWithOpenAIClient::test_openai_client_image [SERVER] (APIServer pid=3313426) WARNING 12-08 16:01:17 [protocol.py:93] The following fields were present in the request but ignored: {'sampling_params_list'}
[SERVER] --------------------------------
[SERVER] [Stage-0] Received batch size=1, request_ids=chatcmpl-a64d9c083a484e68a8bcd77c2d67e867
[SERVER] --------------------------------
[SERVER] --------------------------------
[SERVER] [Stage-1] Received batch size=1, request_ids=chatcmpl-a64d9c083a484e68a8bcd77c2d67e867
[SERVER] --------------------------------
[SERVER] --------------------------------
[SERVER] [Stage-2] Received batch size=1, request_ids=chatcmpl-a64d9c083a484e68a8bcd77c2d67e867
[SERVER] --------------------------------
[SERVER] (EngineCore_DP0 pid=3317141) INFO:vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni:Currently, we do not use the chunked process, we only use the token2wav.process_chunk for the whole sequence. The stream mode will be implemented in the future.
[SERVER] [Stage-2] Enqueued req=chatcmpl-a64d9c083a484e68a8bcd77c2d67e867, use_shm=False, tokens_out=0
[SERVER] (APIServer pid=3313426) INFO:vllm_omni.entrypoints.async_omni:[Summary] {'e2e_requests': 1, 'e2e_total_time_ms': 7108.616352081299, 'e2e_sum_time_ms': 7108.5779666900635, 'e2e_total_tokens': 0, 'e2e_avg_time_per_request_ms': 7108.5779666900635, 'e2e_avg_tokens_per_s': 0.0, 'wall_time_ms': 7108.616352081299, 'final_stage_id': 2, 'stages': [{'stage_id': 0, 'requests': 1, 'tokens': 10, 'total_time_ms': 6400.304317474365, 'avg_time_per_request_ms': 6400.304317474365, 'avg_tokens_per_s': 1.5624257072741998}, {'stage_id': 1, 'requests': 1, 'tokens': 10, 'total_time_ms': 211.2293243408203, 'avg_time_per_request_ms': 211.2293243408203, 'avg_tokens_per_s': 47.34191159871777}, {'stage_id': 2, 'requests': 1, 'tokens': 0, 'total_time_ms': 493.88623237609863, 'avg_time_per_request_ms': 493.88623237609863, 'avg_tokens_per_s': 0.0}], 'transfers': [{'from_stage': 0, 'to_stage': 1, 'samples': 1, 'total_bytes': 1263077, 'total_time_ms': 1.374959945678711, 'tx_mbps': 7349.025716536154, 'rx_samples': 1, 'rx_total_bytes': 1263077, 'rx_total_time_ms': 1.1720657348632812, 'rx_mbps': 8621.202462828316, 'total_samples': 1, 'total_transfer_time_ms': 5.581378936767578, 'total_mbps': 1810.415690186416}, {'from_stage': 1, 'to_stage': 2, 'samples': 1, 'total_bytes': 92, 'total_time_ms': 0.02765655517578125, 'tx_mbps': 26.612135724137932, 'rx_samples': 1, 'rx_total_bytes': 92, 'rx_total_time_ms': 0.024318695068359375, 'rx_mbps': 30.26478180392157, 'total_samples': 1, 'total_transfer_time_ms': 0.30493736267089844, 'total_mbps': 2.413610433150899}]}
[SERVER] (APIServer pid=3313426) INFO:     127.0.0.1:59866 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:httpx:HTTP Request: POST http://127.0.0.1:41295/v1/chat/completions "HTTP/1.1 200 OK"
Image response:         buf_widget'orderほう蓮  obj💨third💨third
PASSED
../../../tests/multi_stages/test_qwen2_5_omni_online_server.py::TestQwen25OmniOnlineServingWithOpenAIClient::test_openai_client_list_models [SERVER] (APIServer pid=3313426) INFO:     127.0.0.1:44584 - "GET /v1/models HTTP/1.1" 200 OK
INFO:httpx:HTTP Request: GET http://127.0.0.1:41295/v1/models "HTTP/1.1 200 OK"
Models via OpenAI client: ['Qwen/Qwen2.5-Omni-7B']
PASSED
Shutting down server...
Server shut down successfully


======================================================================= warnings summary ========================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== tests coverage =========================================================================
________________________________________________________ coverage: platform linux, python 3.12.3-final-0 ________________________________________________________

Name                                                                                                      Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------------------------------------------------------------
/mnt/ztc_vllm/vllm-omni/vllm_omni/__init__.py                                                                 7      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/config/__init__.py                                                          2      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/config/model.py                                                           190    157    17%   73, 77, 83-85, 102-387
/mnt/ztc_vllm/vllm-omni/vllm_omni/core/__init__.py                                                            0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/core/dit_cache_manager.py                                                   3      3     0%   9-13
/mnt/ztc_vllm/vllm-omni/vllm_omni/core/sched/__init__.py                                                      4      4     0%   5-9
/mnt/ztc_vllm/vllm-omni/vllm_omni/core/sched/omni_ar_scheduler.py                                            99     99     0%   1-233
/mnt/ztc_vllm/vllm-omni/vllm_omni/core/sched/omni_generation_scheduler.py                                   136    136     0%   1-312
/mnt/ztc_vllm/vllm-omni/vllm_omni/core/sched/output.py                                                       12     12     0%   1-43
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/__init__.py                                                       0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/attention/__init__.py                                             0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/attention/backends/__init__.py                                    0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/attention/backends/abstract.py                                   41     41     0%   4-78
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/attention/backends/flash_attn.py                                 28     28     0%   4-74
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/attention/backends/sdpa.py                                       25     25     0%   4-66
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/attention/layer.py                                               13     13     0%   4-43
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/attention/selector.py                                            19     19     0%   4-53
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/data.py                                                         117     26    78%   25-27, 30, 33, 36-40, 184-200, 206-207, 211, 244
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/diffusion_engine.py                                              92     75    18%   26-32, 35-43, 55, 59-73, 76-134, 137, 140-163
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/distributed/__init__.py                                           0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/distributed/utils.py                                              7      7     0%   4-15
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/layers/__init__.py                                                0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/model_loader/__init__.py                                          0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/model_loader/diffusers_loader.py                                101    101     0%   3-223
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/models/__init__.py                                                0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/models/qwen_image/__init__.py                                     3      3     0%   5-13
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py                        281    281     0%   4-748
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py                     265    265     0%   4-645
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/models/z_image/__init__.py                                        0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/models/z_image/pipeline_z_image.py                              233    233     0%   18-615
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/models/z_image/z_image_transformer.py                           310    310     0%   18-655
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/omni_diffusion.py                                                44     29    34%   21-29, 44-62, 69-86, 89, 92
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/registry.py                                                      25     17    32%   39-49, 62-70
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/request.py                                                       97     14    86%   157-166, 171-176, 179
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/scheduler.py                                                     43     25    42%   23-39, 44-45, 48, 52-63, 67-71
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/utils/__init__.py                                                 0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/utils/hf_utils.py                                                14      8    43%   9-12, 17-21
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/utils/network_utils.py                                           14     10    29%   10-19
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/worker/__init__.py                                                2      2     0%   5-7
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/worker/gpu_worker.py                                            114    114     0%   3-233
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/worker/npu/__init__.py                                            2      2     0%   5-7
/mnt/ztc_vllm/vllm-omni/vllm_omni/diffusion/worker/npu/npu_worker.py                                        116    116     0%   3-237
/mnt/ztc_vllm/vllm-omni/vllm_omni/distributed/__init__.py                                                     0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/engine/__init__.py                                                         47      3    94%   107, 137-138
/mnt/ztc_vllm/vllm-omni/vllm_omni/engine/arg_utils.py                                                        53     27    49%   40, 49-72, 101, 105-124
/mnt/ztc_vllm/vllm-omni/vllm_omni/engine/output_processor.py                                                266    230    14%   35-37, 50-76, 97-163, 192-208, 217-231, 262-266, 279, 304-320, 343-434, 441-466, 471-474, 480-494, 498-501, 505-510, 514, 518-525, 528-539
/mnt/ztc_vllm/vllm-omni/vllm_omni/engine/processor.py                                                        97     71    27%   55-73, 81-82, 132-269
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/__init__.py                                                     0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/async_omni.py                                                 342    262    23%   96-115, 124-149, 152-170, 179-192, 195-196, 208-211, 250-460, 463-525, 533, 537, 541, 545, 548, 551-556, 559-564, 567, 570-573, 576-579, 582, 585, 588, 591, 594, 597, 601, 605, 613, 616, 619, 684-776, 797-806
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/chat_utils.py                                                 109    109     0%   1-242
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/cli/__init__.py                                                 2      2     0%   3-5
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/cli/main.py                                                    29     29     0%   5-57
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/cli/serve.py                                                   34     34     0%   5-102
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/log_utils.py                                                  289    256    11%   12-48, 52-63, 67-76, 80-85, 97, 121, 149, 176, 190, 194, 198, 213, 237, 256, 279-286, 312-323, 336-380, 392-420, 424-434, 442-459, 465-495, 507-526, 529-572, 594-606, 617-648, 652-693
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/omni.py                                                        33     22    33%   11, 17-22, 29-39, 43, 47-49, 52-54
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/omni_llm.py                                                   273    234    14%   87-102, 111-135, 138-155, 164-176, 179-182, 210-216, 223-461, 464-511, 542-620
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/omni_stage.py                                                 432    395     9%   55-88, 96, 104, 112, 120, 128, 136, 144, 154-155, 183-218, 226-248, 257-258, 267-271, 292-319, 333-646, 661, 671-910
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/openai/__init__.py                                              0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/openai/api_server.py                                          130    130     0%   1-347
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/openai/serving_chat.py                                        304    304     0%   1-779
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/stage_utils.py                                                178    157    12%   43-154, 159, 167-176, 181-193, 198-203, 213-220, 228-231, 240-242, 254-273, 285-291, 296-304
/mnt/ztc_vllm/vllm-omni/vllm_omni/entrypoints/utils.py                                                       59     47    20%   28-62, 81-101, 113-124
/mnt/ztc_vllm/vllm-omni/vllm_omni/inputs/__init__.py                                                          0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/inputs/data.py                                                             28     12    57%   5-7, 97-108
/mnt/ztc_vllm/vllm-omni/vllm_omni/inputs/parse.py                                                            13     10    23%   29-42
/mnt/ztc_vllm/vllm-omni/vllm_omni/inputs/preprocess.py                                                       31     19    39%   30-53, 75-97
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/__init__.py                                                  0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/layers/__init__.py                                           0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/layers/mrope.py                                            341    309     9%   27-39, 66-78, 99-134, 151-167, 182-206, 228-315, 330-413, 447-585, 596-607, 611-615, 623, 633-638, 657-685
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/model_loader/__init__.py                                     0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/model_loader/weight_utils.py                                26     26     0%   1-73
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/__init__.py                                           3      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/output_templates.py                                   8      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen2_5_omni/__init__.py                              0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py                        508    508     0%   1-1050
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_talker.py                 118    118     0%   1-239
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py                473    473     0%   1-1059
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_token2wav.py              751    751     0%   5-1831
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_old.py                           224    224     0%   1-520
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen3_omni/__init__.py                                2      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen3_omni/qwen3_moe.py                              96     76    21%   36-64, 71-102, 106-111, 117-127, 135-173
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py                            443    387    13%   85-178, 187-193, 213-218, 223-225, 233-236, 240, 244, 280-682, 703-727, 733, 751-796, 800-802, 822-906, 909-925, 930-982, 995-1019, 1030-1077, 1085, 1091-1132
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_code2wav.py                    68     68     0%   6-224
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_code_predictor_mtp.py     187    187     0%   9-523
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py                 286    286     0%   1-704
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py                826    712    14%   111-112, 124-125, 137-144, 152-155, 166-172, 180-182, 195-212, 215-216, 230-242, 259-268, 282-293, 314-323, 335-408, 412, 416, 419-445, 448-504, 510-515, 522-568, 571-598, 612-616, 632-646, 659-698, 703-713, 718, 721-732, 735-738, 741, 757-815, 828-869, 878-910, 918-1004, 1031-1064, 1071-1106, 1116-1129, 1155-1162, 1165-1227, 1231, 1240-1252, 1256-1258, 1261-1272, 1275, 1278-1299, 1309-1319, 1330-1401, 1414-1436, 1443, 1446-1469, 1483-1668
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/registry.py                                           4      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/utils.py                                             18     13    28%   9, 13-30, 37-39
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/models/vision.py                                            12     12     0%   1-23
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/stage_configs/__init__.py                                    0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/stage_input_processors/__init__.py                           0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/stage_input_processors/qwen2_5_omni.py                      30     30     0%   1-63
/mnt/ztc_vllm/vllm-omni/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py                        58     58     0%   6-173
/mnt/ztc_vllm/vllm-omni/vllm_omni/outputs.py                                                                 12      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/patch.py                                                                   26      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/request.py                                                                 12      4    67%   33-37, 55
/mnt/ztc_vllm/vllm-omni/vllm_omni/sample/__init__.py                                                          0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/utils/__init__.py                                                           2      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/utils/platform_utils.py                                                    30     23    23%   8-15, 19, 24-32, 44-54
/mnt/ztc_vllm/vllm-omni/vllm_omni/version.py                                                                  2      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/__init__.py                                                          0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/gpu_ar_model_runner.py                                             153    153     0%   7-364
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/gpu_ar_worker.py                                                    31     31     0%   1-85
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/gpu_generation_model_runner.py                                     192    192     0%   7-582
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/gpu_generation_worker.py                                            32     32     0%   1-84
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/gpu_model_runner.py                                                445    445     0%   1-897
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/npu/__init__.py                                                      0      0   100%
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/npu/npu_ar_model_runner.py                                         455    455     0%   4-963
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/npu/npu_ar_worker.py                                                 6      6     0%   4-15
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/npu/npu_generation_model_runner.py                                 278    278     0%   4-748
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/npu/npu_generation_worker.py                                         6      6     0%   4-15
/mnt/ztc_vllm/vllm-omni/vllm_omni/worker/npu/npu_model_runner.py                                            282    282     0%   4-552
---------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                     11654  10673     8%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
