### PR TITLE
[bugfix] Fix QwenImageEditPipeline transformer init

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -224,7 +224,7 @@ class QwenImageEditPipeline(
         self.vae = AutoencoderKLQwenImage.from_pretrained(model, subfolder="vae", local_files_only=local_files_only).to(
             self.device
         )
-        self.transformer = QwenImageTransformer2DModel()
+        self.transformer = QwenImageTransformer2DModel(od_config=od_config)
         self.tokenizer = Qwen2Tokenizer.from_pretrained(model, subfolder="tokenizer", local_files_only=local_files_only)
         self.processor = Qwen2VLProcessor.from_pretrained(
             model, subfolder="processor", local_files_only=local_files_only


### PR DESCRIPTION
Basic gist is that when I went to use the `QwenImageEditPipeline`, I was getting an error like:

```
TypeError: QwenImageTransformer2DModel.__init__() missing 1 required positional argument: 'od_config'
[rank0]:[W1208 11:42:45.848416931 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```

So I put together this patch. Thanks!

---

The QwenImageTransformer2DModel requires od_config as a positional argument, but the QwenImageEditPipeline was initializing it without passing this parameter, causing a TypeError at runtime.

This commit updates the initialization to match the pattern used in QwenImagePipeline (line 270 of pipeline_qwen_image.py):

    self.transformer = QwenImageTransformer2DModel(od_config=od_config)

Error before fix:
    TypeError: QwenImageTransformer2DModel.__init__() missing 1 required
    positional argument: 'od_config'

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.
