### PR TITLE
[Bugfix] Qwen2.5-omni Qwen3-omni online gradio.py example fix

### DIFF
--- a/examples/online_serving/qwen2_5_omni/gradio_demo.py
+++ b/examples/online_serving/qwen2_5_omni/gradio_demo.py
@@ -91,6 +91,41 @@ def parse_args():
         default=None,
         help="Path to custom stage configs YAML file (optional).",
     )
+    parser.add_argument(
+        "--log-stats",
+        action="store_true",
+        help="Enable statistics logging for AsyncOmni.",
+    )
+    parser.add_argument(
+        "--log-file",
+        type=str,
+        default=None,
+        help="Path prefix for AsyncOmni log files.",
+    )
+    parser.add_argument(
+        "--init-sleep-seconds",
+        type=int,
+        default=30,
+        help="Seconds to sleep between starting stage processes.",
+    )
+    parser.add_argument(
+        "--shm-threshold-bytes",
+        type=int,
+        default=65536,
+        help="Threshold in bytes for using shared memory IPC.",
+    )
+    parser.add_argument(
+        "--batch-timeout",
+        type=int,
+        default=10,
+        help="Batching timeout (seconds) inside each stage.",
+    )
+    parser.add_argument(
+        "--init-timeout",
+        type=int,
+        default=ASYNC_INIT_TIMEOUT,
+        help="Timeout (seconds) for initializing all stages.",
+    )
     return parser.parse_args()
 
 
@@ -99,12 +134,12 @@ def build_async_omni_cli_args(base_args: argparse.Namespace) -> argparse.Namespa
     return argparse.Namespace(
         model=base_args.model,
         stage_configs_path=getattr(base_args, "stage_configs_path", None),
-        log_stats=False,
-        log_file=None,
-        init_sleep_seconds=0,
-        shm_threshold_bytes=65536,
-        batch_timeout=10,
-        init_timeout=ASYNC_INIT_TIMEOUT,
+        log_stats=bool(getattr(base_args, "log_stats", False)),
+        log_file=getattr(base_args, "log_file", None),
+        init_sleep_seconds=int(getattr(base_args, "init_sleep_seconds", 30)),
+        shm_threshold_bytes=int(getattr(base_args, "shm_threshold_bytes", 65536)),
+        batch_timeout=int(getattr(base_args, "batch_timeout", 10)),
+        init_timeout=int(getattr(base_args, "init_timeout", ASYNC_INIT_TIMEOUT)),
     )
 
 

--- a/examples/online_serving/qwen3_omni/gradio_demo.py
+++ b/examples/online_serving/qwen3_omni/gradio_demo.py
@@ -94,6 +94,41 @@ def parse_args():
         default=None,
         help="Path to custom stage configs YAML file (optional).",
     )
+    parser.add_argument(
+        "--log-stats",
+        action="store_true",
+        help="Enable statistics logging for AsyncOmni.",
+    )
+    parser.add_argument(
+        "--log-file",
+        type=str,
+        default=None,
+        help="Path prefix for AsyncOmni log files.",
+    )
+    parser.add_argument(
+        "--init-sleep-seconds",
+        type=int,
+        default=30,
+        help="Seconds to sleep between starting stage processes.",
+    )
+    parser.add_argument(
+        "--shm-threshold-bytes",
+        type=int,
+        default=65536,
+        help="Threshold in bytes for using shared memory IPC.",
+    )
+    parser.add_argument(
+        "--batch-timeout",
+        type=int,
+        default=10,
+        help="Batching timeout (seconds) inside each stage.",
+    )
+    parser.add_argument(
+        "--init-timeout",
+        type=int,
+        default=ASYNC_INIT_TIMEOUT,
+        help="Timeout (seconds) for initializing all stages.",
+    )
     return parser.parse_args()
 
 
@@ -102,12 +137,12 @@ def build_async_omni_cli_args(base_args: argparse.Namespace) -> argparse.Namespa
     return argparse.Namespace(
         model=base_args.model,
         stage_configs_path=getattr(base_args, "stage_configs_path", None),
-        log_stats=False,
-        log_file=None,
-        init_sleep_seconds=0,
-        shm_threshold_bytes=65536,
-        batch_timeout=10,
-        init_timeout=ASYNC_INIT_TIMEOUT,
+        log_stats=bool(getattr(base_args, "log_stats", False)),
+        log_file=getattr(base_args, "log_file", None),
+        init_sleep_seconds=int(getattr(base_args, "init_sleep_seconds", 30)),
+        shm_threshold_bytes=int(getattr(base_args, "shm_threshold_bytes", 65536)),
+        batch_timeout=int(getattr(base_args, "batch_timeout", 10)),
+        init_timeout=int(getattr(base_args, "init_timeout", ASYNC_INIT_TIMEOUT)),
     )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
fix issue

- #247

## Test Plan
python examples/online_serving/qwen2_5_omni/gradio_demo.py --model /workspace/models/Qwen/Qwen2.5-Omni-7B
## Test Result
```
INFO:httpx:HTTP Request: GET http://localhost:7861/gradio_api/startup-events "HTTP/1.1 200 OK"

INFO:httpx:HTTP Request: HEAD http://localhost:7861/ "HTTP/1.1 200 OK"

* To create a public link, set `share=True` in `launch()`.

--------------------------------

[Stage-0] Received batch size=1, request_ids=0

--------------------------------

--------------------------------

[Stage-1] Received batch size=1, request_ids=0

--------------------------------

(EngineCore_DP0 pid=5102) /workspace/c00580271/cwq_branch/vllm-omni/vllm_omni/worker/gpu_model_runner.py:207: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:203.)

(EngineCore_DP0 pid=5102)   info_dict[k] = torch.from_numpy(arr)

--------------------------------

[Stage-2] Received batch size=1, request_ids=0

--------------------------------

(EngineCore_DP0 pid=5099) INFO:vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni:Currently, we do not use the chunked process, we only use the token2wav.process_chunk for the whole sequence. The stream mode will be implemented in the future.

INFO:vllm_omni.entrypoints.async_omni:[Summary] {'e2e_requests': 1, 'e2e_total_time_ms': 25743.138313293457, 'e2e_sum_time_ms': 25742.77091026306, 'e2e_total_tokens': 0, 'e2e_avg_time_per_request_ms': 25742.77091026306, 'e2e_avg_tokens_per_s': 0.0, 'wall_time_ms': 25743.138313293457, 'final_stage_id': 2, 'stages': [{'stage_id': 0, 'requests': 1, 'tokens': 49, 'total_time_ms': 1740.2911186218262, 'avg_time_per_request_ms': 1740.2911186218262, 'avg_tokens_per_s': 28.156208737538204}, {'stage_id': 1, 'requests': 1, 'tokens': 823, 'total_time_ms': 20198.933124542236, 'avg_time_per_request_ms': 20198.933124542236, 'avg_tokens_per_s': 40.744726215268926}, {'stage_id': 2, 'requests': 1, 'tokens': 0, 'total_time_ms': 3762.7434730529785, 'avg_time_per_request_ms': 3762.7434730529785, 'avg_tokens_per_s': 0.0}], 'transfers': [{'from_stage': 0, 'to_stage': 1, 'samples': 1, 'total_bytes': 1650152, 'total_time_ms': 1.3203620910644531, 'tx_mbps': 9998.178597628024, 'rx_samples': 1, 'rx_total_bytes': 1650152, 'rx_total_time_ms': 2.2895336151123047, 'rx_mbps': 5765.897435558055, 'total_samples': 1, 'total_transfer_time_ms': 4.13203239440918, 'total_mbps': 3194.8481376529917}, {'from_stage': 1, 'to_stage': 2, 'samples': 1, 'total_bytes': 2503, 'total_time_ms': 0.3561973571777344, 'tx_mbps': 56.216026302543504, 'rx_samples': 1, 'rx_total_bytes': 2503, 'rx_total_time_ms': 0.03147125244140625, 'rx_mbps': 636.2632067878787, 'total_samples': 1, 'total_transfer_time_ms': 1.3468265533447266, 'total_mbps': 14.867541741193131}]}

/workspace/c00580271/.venv/lib/python3.12/site-packages/gradio/processing_utils.py:688: UserWarning: Trying to convert audio automatically from float32 to 16-bit int format.

  warnings.warn(warning.format(data.dtype))
```
<img width="1759" height="847" alt="image" src="https://github.com/user-attachments/assets/c62033d9-f58b-4580-aae5-77053e8722c0" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
