### PR TITLE
[Bugfix] fix issue251, qwen3 omni does not support chunked prefill now

### DIFF
--- a/vllm_omni/model_executor/stage_configs/qwen3_omni_moe.yaml
+++ b/vllm_omni/model_executor/stage_configs/qwen3_omni_moe.yaml
@@ -20,6 +20,7 @@ stage_args:
       engine_output_type: latent  # Output hidden states for talker
       distributed_executor_backend: "mp"
       enable_prefix_caching: false
+      max_num_batched_tokens: 32768
       hf_config_name: thinker_config
       tensor_parallel_size: 2
     final_output: true
@@ -49,6 +50,7 @@ stage_args:
        engine_output_type: latent  # Output codec codes for code2wav
       #  tensor_parallel_size: 2
        enable_prefix_caching: false
+       max_num_batched_tokens: 32768
        distributed_executor_backend: "mp"
        hf_config_name: talker_config
     engine_input_source: [0]


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
fix issue #251
refer to:

- https://github.com/vllm-project/vllm-omni/issues/139
- https://github.com/vllm-project/vllm-omni/pull/193
## Test Plan
python examples/online_serving/qwen3_omni/gradio_demo.py
prompt:explain this video
video:
https://github.com/user-attachments/assets/cb9fe21e-cd86-4a68-abd4-2b09eb42a4e9


## Test Result
<img width="1753" height="821" alt="image" src="https://github.com/user-attachments/assets/5f6e6da0-f2a4-488c-9f34-3c47ea66795b" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
