### PR TITLE
[Bugfix] Remove debug code in AsyncOmni.del to fix resource leak

### DIFF
--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -192,8 +192,6 @@ class AsyncOmni(EngineClient):
                 logger.warning("[Orchestrator] Failed to stop stage worker: %s", e)
 
     def __del__(self) -> None:  # best-effort
-        print("[AsyncOmni] __del__ close()", flush=True)
-        raise Exception("test")
         try:
             self.close()
         except Exception as e:


### PR DESCRIPTION
## Purpose

Remove leftover debug code (`print` and `raise Exception("test")`) from the `AsyncOmni.__del__` method.

These lines were causing two critical issues:
1.  **Resource Leak**: The intentional exception prevented `self.close()` from executing, causing background processes and IPC resources to remain unreleased.
2.  **Polluted Output**: The `print` statement outputted direct debug logs instead of using the configured logger.

## Test Plan

1.  **Verify Cleanup**:
    - Run an inference script that utilizes [AsyncOmni](cci:2://file:///proj-tango-pvc/users/zhipeng.wang/workspace/vllm-omni/vllm_omni/entrypoints/async_omni.py:54:0-616:84).
    - Interrupt the script (Ctrl+C) or let it finish.
    - Check system processes (e.g., `ps aux | grep vllm`) to ensure all stage worker processes are correctly terminated.
2.  **Verify Logging**:
    - Confirm that `[AsyncOmni] __del__ close()` is no longer printed to stdout.

## Test Result

- **Before**: `Exception: test` was raised (and ignored/logged by the finalizer), and background processes were left running.
- **After**: Object destruction proceeds silently, and `self.close()` is successfully called to clean up resources.