### PR TITLE
[Entrypoints] Minor optimization in the orchestrator's final stage determination logic

### DIFF
--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -313,12 +313,14 @@ class AsyncOmni(EngineClient):
         # Determine the final stage for E2E stats (highest stage_id with
         # final_output=True; fallback to last stage)
         final_stage_id_for_e2e = -1
+        last_stage_id = len(self.stage_list) - 1
         try:
-            for _sid, _st in enumerate(self.stage_list):
-                if getattr(_st, "final_output", False):
-                    final_stage_id_for_e2e = max(final_stage_id_for_e2e, _sid)
+            for _sid in range(last_stage_id, -1, -1):
+                if getattr(self.stage_list[_sid], "final_output", False):
+                    final_stage_id_for_e2e = _sid
+                    break
             if final_stage_id_for_e2e < 0:
-                final_stage_id_for_e2e = len(self.stage_list) - 1
+                final_stage_id_for_e2e = last_stage_id
         except Exception as e:
             logger.debug(
                 "[Orchestrator] Failed to determine final stage for E2E; \
@@ -326,7 +328,7 @@ class AsyncOmni(EngineClient):
                 e,
                 exc_info=True,
             )
-            final_stage_id_for_e2e = len(self.stage_list) - 1
+            final_stage_id_for_e2e = last_stage_id
         # Metrics/aggregation helper
         metrics = OrchestratorMetrics(
             num_stages,

--- a/vllm_omni/entrypoints/omni_llm.py
+++ b/vllm_omni/entrypoints/omni_llm.py
@@ -292,19 +292,21 @@ class OmniLLM:
 
         # Determine the final stage for E2E stats (highest stage_id with final_output=True; fallback to last stage)
         final_stage_id_for_e2e = -1
+        last_stage_id = len(self.stage_list) - 1
         try:
-            for _sid, _st in enumerate(self.stage_list):
-                if getattr(_st, "final_output", False):
-                    final_stage_id_for_e2e = max(final_stage_id_for_e2e, _sid)
+            for _sid in range(last_stage_id, -1, -1):
+                if getattr(self.stage_list[_sid], "final_output", False):
+                    final_stage_id_for_e2e = _sid
+                    break
             if final_stage_id_for_e2e < 0:
-                final_stage_id_for_e2e = len(self.stage_list) - 1
+                final_stage_id_for_e2e = last_stage_id
         except Exception as e:
             logger.debug(
                 "[Orchestrator] Failed to determine final stage for E2E; falling back to last: %s",
                 e,
                 exc_info=True,
             )
-            final_stage_id_for_e2e = len(self.stage_list) - 1
+            final_stage_id_for_e2e = last_stage_id
         # Metrics/aggregation helper
         metrics = OrchestratorMetrics(
             num_stages,


### PR DESCRIPTION

## Purpose
implements a minor optimization in the orchestrator's final stage determination logic across both omni_llm.py and async_omni.py.

- Store len(self.stage_list) - 1，reduce redundant len() calculations per execution
- Changed from forward iteration to backward iteration for final stage detection

## Test Result

