### PR TITLE
[Refactor] Move text_to_image.py from offline_inference/qwen_image to offline_inference/text_to_image

### DIFF
--- a/examples/offline_inference/qwen_image/README.md
+++ b/examples/offline_inference/qwen_image/README.md
@@ -2,7 +2,6 @@
 
 This folder provides several entrypoints for experimenting with `Qwen/Qwen-Image` using vLLM-Omni:
 
-- `text_to_image.py`: command-line script for single image generation with advanced options.
 - `web_demo.py`: lightweight Gradio UI for interactive prompt/seed/CFG exploration.
 
 ## Basic Usage
@@ -19,27 +18,7 @@ if __name__ == "__main__":
 
 ## Local CLI Usage
 
-```bash
-python text_to_image.py \
-  --prompt "a cup of coffee on the table" \
-  --seed 42 \
-  --cfg_scale 4.0 \
-  --num_images_per_prompt 1 \
-  --num_inference_steps 50 \
-  --height 1024 \
-  --width 1024 \
-  --output outputs/coffee.png
-```
-
-Key arguments:
-
-- `--prompt`: text description (string).
-- `--seed`: integer seed for deterministic sampling.
-- `--cfg_scale`: true CFG scale (model-specific guidance strength).
-- `--num_images_per_prompt`: number of images to generate per prompt (saves as `output`, `output_1`, ...).
-- `--num_inference_steps`: diffusion sampling steps (more steps = higher quality, slower).
-- `--height/--width`: output resolution (defaults 1024x1024).
-- `--output`: path to save the generated PNG.
+Check `text_to_image.py` in `examples/offline_inference/text_to_image` for more details.
 
 > ℹ️ Qwen-Image currently publishes best-effort presets at `1328x1328`, `1664x928`, `928x1664`, `1472x1140`, `1140x1472`, `1584x1056`, and `1056x1584`. Adjust `--height/--width` accordingly for the most reliable outcomes.
 

--- a/examples/offline_inference/text_to_image/README.md
+++ b/examples/offline_inference/text_to_image/README.md
@@ -1,0 +1,41 @@
+# Text to Image Generation
+
+This example demonstrates how to generate images using `vllm-omni` with various diffusion models.
+
+## Local CLI Usage
+
+```bash
+python text_to_image.py \
+  --model Qwen/Qwen-Image \
+  --prompt "a cup of coffee on the table" \
+  --seed 42 \
+  --cfg_scale 4.0 \
+  --num_images_per_prompt 1 \
+  --num_inference_steps 50 \
+  --height 1024 \
+  --width 1024 \
+  --output outputs/coffee.png
+```
+
+### Arguments
+
+- `--model`: The model name or local path (default: `Qwen/Qwen-Image`).
+- `--prompt`: The text prompt for generation.
+- `--negative_prompt`: The negative text prompt (optional).
+- `--guidance_scale`: The classifier-free guidance scale (optional). Alias: `--cfg_scale`.
+- `--height`: Height of the generated image (default: 1024).
+- `--width`: Width of the generated image (default: 1024).
+- `--seed`: Random seed for reproducibility.
+- `--output`: Path to save the output image.
+
+### Examples
+
+**Qwen-Image:**
+```bash
+python text_to_image.py --model Qwen/Qwen-Image --prompt "a beautiful sunset" --guidance_scale 4.0
+```
+
+**Wan2.1:**
+```bash
+python text_to_image.py --model Wan-AI/Wan2.1-T2I-1.3B --prompt "a cat in a box" --guidance_scale 5.0
+```


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Refactor text_to_image.py to allow it to work with other diffusion models. 

## Test Plan
python examples/offline_inference/text_to_image/text_to_image.py  --model AIDC-AI/Ovis-Image-7B --prompt "A man skiing from a roller coaster in a desert" --height 128 --width 128 --num_inference_steps 10

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
