### PR TITLE
[BugFix] Failed to print DEBUG level log

### DIFF
--- a/vllm_omni/entrypoints/omni_stage.py
+++ b/vllm_omni/entrypoints/omni_stage.py
@@ -893,7 +893,7 @@ async def _stage_worker_async(
         _rx_bytes_by_rid[rid] = int(_rx_metrics.get("rx_transfer_bytes", 0))
 
         sampling_params = task["sampling_params"]
-        _logging.getLogger(__name__).debug("[Stage-%s] Received batch size=1, request_ids=%d", stage_id, rid)
+        _logging.getLogger(__name__).debug("[Stage-%s] Received batch size=1, request_ids=%s", stage_id, rid)
         print("--------------------------------", flush=True)
         print(f"[Stage-{stage_id}] Received batch size=1, request_ids={rid}", flush=True)
         print("--------------------------------", flush=True)

--- a/vllm_omni/logger.py
+++ b/vllm_omni/logger.py
@@ -1,0 +1,22 @@
+import logging
+
+from vllm.logger import init_logger
+
+
+def _configure_vllm_omni_root_logger():
+    """
+    Configure the root logger for vllm_omni to propagate to vllm's root logger.
+    """
+    vllm_root = logging.getLogger("vllm")
+    vllm_omni_root = logging.getLogger("vllm_omni")
+    vllm_omni_root.handlers = []
+
+    vllm_omni_root.parent = vllm_root
+
+    vllm_omni_root.propagate = True
+
+    vllm_omni_root.setLevel(logging.NOTSET)
+
+
+_configure_vllm_omni_root_logger()
+init_logger(__name__)

--- a/vllm_omni/patch.py
+++ b/vllm_omni/patch.py
@@ -9,6 +9,7 @@ from vllm.v1.engine import EngineCoreOutputs as _OriginalEngineCoreOutputs
 from vllm.v1.engine import EngineCoreRequest as _OriginalEngineCoreRequest
 from vllm.v1.request import Request as _OriginalRequest
 
+import vllm_omni.logger  # noqa: F401
 from vllm_omni.engine import OmniEngineCoreOutput, OmniEngineCoreOutputs, OmniEngineCoreRequest
 from vllm_omni.inputs.data import OmniTokensPrompt
 from vllm_omni.model_executor.layers.mrope import MRotaryEmbedding


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
As describe in https://github.com/vllm-project/vllm-omni/issues/306 , VLLM config it log for root module 'vllm', and the sub model automatically inherit the parent logger. But the vllm_omni module failed to automatically inherit  vllm.

So we need to init vllm_omni root logger, witch inherit the parent logger.

## Test Plan
Set Env:
```
export VLLM_LOGGING_LEVEL=DEBUG
```

We can see the debug log:
```
(APIServer pid=229190) DEBUG 12-14 11:05:57 [async_omni.py:297] [Orchestrator] generate() called
(APIServer pid=229190) DEBUG 12-14 11:05:57 [async_omni.py:341] [Orchestrator] Seeding request into stage-0
(APIServer pid=229190) DEBUG 12-14 11:05:57 [async_omni.py:353] [Orchestrator] Enqueued request chatcmpl-3daace1c1d424c6f9315b1175d7ae7dc to stage-0
(APIServer pid=229190) DEBUG 12-14 11:05:57 [async_omni.py:355] [Orchestrator] Entering scheduling loop: stages=3
DEBUG 12-14 11:05:57 [omni_stage.py:896] [Stage-0] Received batch size=1, request_ids=chatcmpl-3daace1c1d424c6f9315b1175d7ae7dc
--------------------------------
[Stage-0] Received batch size=1, request_ids=chatcmpl-3daace1c1d424c6f9315b1175d7ae7dc
--------------------------------

```


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
