### PR TITLE
[BugFix]Remove duplicate code

### DIFF
--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -275,8 +275,7 @@ class OmniGenerationScheduler(VLLMScheduler):
 
         # Remove the stopped requests from the running and waiting queues.
         if stopped_running_reqs:
-            if stopped_running_reqs:
-                self.running = remove_all(self.running, stopped_running_reqs)
+            self.running = remove_all(self.running, stopped_running_reqs)
         if stopped_preempted_reqs:
             # This is a rare case and unlikely to impact performance.
             self.waiting.remove_requests(stopped_preempted_reqs)


### PR DESCRIPTION
## Purpose
Remove redundant nested `if` checks in `vllm_omni/core/sched/omni_generation_scheduler.py`.
The condition `if stopped_running_reqs:` was checked twice consecutively, which is unnecessary. This PR simplifies the logic by removing the inner duplicate check.