### PR TITLE
[Bugfix] [Example] Add fallback to `worker_backend` and `ray_address` in `AsyncOmni` to fix gradio demos

### DIFF
--- a/examples/online_serving/qwen2_5_omni/gradio_demo.py
+++ b/examples/online_serving/qwen2_5_omni/gradio_demo.py
@@ -126,19 +126,6 @@ def parse_args():
         default=ASYNC_INIT_TIMEOUT,
         help="Timeout (seconds) for initializing all stages.",
     )
-    parser.add_argument(
-        "--worker-backend",
-        type=int,
-        default="multi_process",
-        choices=["multi_process", "ray"],
-        help="The backend to use for stage workers.",
-    )
-    parser.add_argument(
-        "--ray-address",
-        type=str,
-        default="",
-        help="(Optional) Specify if you use Ray backend.",
-    )
     return parser.parse_args()
 
 
@@ -153,8 +140,6 @@ def build_async_omni_cli_args(base_args: argparse.Namespace) -> argparse.Namespa
         shm_threshold_bytes=int(getattr(base_args, "shm_threshold_bytes", 65536)),
         batch_timeout=int(getattr(base_args, "batch_timeout", 10)),
         init_timeout=int(getattr(base_args, "init_timeout", ASYNC_INIT_TIMEOUT)),
-        worker_backend=getattr(base_args, "worker_backend", "multi_process"),
-        ray_address=getattr(base_args, "ray_address", ""),
     )
 
 

--- a/examples/online_serving/qwen3_omni/gradio_demo.py
+++ b/examples/online_serving/qwen3_omni/gradio_demo.py
@@ -129,19 +129,6 @@ def parse_args():
         default=ASYNC_INIT_TIMEOUT,
         help="Timeout (seconds) for initializing all stages.",
     )
-    parser.add_argument(
-        "--worker-backend",
-        type=int,
-        default="multi_process",
-        choices=["multi_process", "ray"],
-        help="The backend to use for stage workers.",
-    )
-    parser.add_argument(
-        "--ray-address",
-        type=str,
-        default="",
-        help="(Optional) Specify if you use Ray backend.",
-    )
     return parser.parse_args()
 
 
@@ -156,8 +143,6 @@ def build_async_omni_cli_args(base_args: argparse.Namespace) -> argparse.Namespa
         shm_threshold_bytes=int(getattr(base_args, "shm_threshold_bytes", 65536)),
         batch_timeout=int(getattr(base_args, "batch_timeout", 10)),
         init_timeout=int(getattr(base_args, "init_timeout", ASYNC_INIT_TIMEOUT)),
-        worker_backend=getattr(base_args, "worker_backend", "multi_process"),
-        ray_address=getattr(base_args, "ray_address", ""),
     )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

https://github.com/vllm-project/vllm-omni/pull/215 introduced `worker_backend` and `ray_address` arguments. They do not have default values. 
```
        self.worker_backend = cli_args.worker_backend
        self.ray_address = cli_args.ray_address
```

Gradio demos like qwen2_5 omni gradio demo, and qwen3 omni gradio demo missing `worker_backend` and `ray_address` from cli. We should fix it from `AsyncOmni` to retain initial behaviour (which is the single node behaviour). Thus we should default the `worker_backend` to `multi_process`. 

Moreover, we don't modify the gradio demos because those are single node examples.

## Test Plan

## Test Result

Able to run the examples locally.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
