### PR TITLE
[Bugfix] Remove unsupported enable_force_include_usage param from stream generator

### DIFF
--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -271,7 +271,6 @@ class OmniOpenAIServingChat(OpenAIServingChat):
                 conversation,
                 tokenizer,
                 request_metadata,
-                enable_force_include_usage=self.enable_force_include_usage,
             )
 
         try:


### PR DESCRIPTION
## Purpose

Fix streaming chat completion error when using `stream: true`.

The parent class `OpenAIServingChat.chat_completion_stream_generator()` does not accept `enable_force_include_usage` as a parameter in vLLM 0.12.0. The method accesses this value via `self.enable_force_include_usage` internally.

Reference: [vLLM v0.12.0 serving_chat.py](https://github.com/vllm-project/vllm/blob/v0.12.0/vllm/entrypoints/openai/serving_chat.py#L527)

Fixes error:
OpenAIServingChat.chat_completion_stream_generator() got an unexpected keyword argument 'enable_force_include_usage'

## Test Plan

```bash
  curl http://localhost:8000/v1/chat/completions \
      -H "Content-Type: application/json" \
      -d '{"model": "Qwen3-Omni-30B-A3B-Instruct", "messages": [{"role": "user", "content": "Hello"}], "modalities": ["text"], "stream": true}'
```

## Test Result
**Before**: 500 Internal Server Error (unexpected keyword argument)
```
{"error":{"message":"OpenAIServingChat.chat_completion_stream_generator() got an unexpected keyword argument 'enable_force_include_usage'","type":"Internal Server Error","param":null,"code":500}}
```

**After**: Another error...
```
 {"error": {"message": "'OmniRequestOutput' object has no attribute 'prompt_token_ids'", "type": "BadRequestError", "param": null, "code": 400}}
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
