### PR TITLE
[Docs] Add API usage examples for modality control in online serving

### DIFF
--- a/docs/user_guide/examples/online_serving/qwen2_5_omni.md
+++ b/docs/user_guide/examples/online_serving/qwen2_5_omni.md
@@ -79,14 +79,16 @@ You can control output modalities to specify which types of output the model sho
 
 ### Supported modalities
 
-| Modality | Output |
-|----------|--------|
-| `text`   | Text only |
-| `audio`  | Text + Audio (audio generation requires text) |
-
-If not specified, the model uses its default output modalities.
+| Modalities | Output |
+|------------|--------|
+| `["text"]` | Text only |
+| `["audio"]` | Text + Audio |
+| `["text", "audio"]` | Text + Audio |
+| Not specified | Text + Audio (default) |
 
 ### Using curl
+
+#### Text only
 
 ```bash
 curl http://localhost:8091/v1/chat/completions \
@@ -95,6 +97,18 @@ curl http://localhost:8091/v1/chat/completions \
     "model": "Qwen/Qwen2.5-Omni-7B",
     "messages": [{"role": "user", "content": "Describe vLLM in brief."}],
     "modalities": ["text"]
+  }'
+```
+
+#### Text + Audio
+
+```bash
+curl http://localhost:8091/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-Omni-7B",
+    "messages": [{"role": "user", "content": "Describe vLLM in brief."}],
+    "modalities": ["audio"]
   }'
 ```
 
@@ -108,6 +122,8 @@ python openai_chat_completion_client_for_multimodal_generation.py \
 
 ### Using OpenAI Python SDK
 
+#### Text only
+
 ```python
 from openai import OpenAI
 
@@ -119,6 +135,23 @@ response = client.chat.completions.create(
     modalities=["text"]
 )
 print(response.choices[0].message.content)
+```
+
+#### Text + Audio
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+
+response = client.chat.completions.create(
+    model="Qwen/Qwen2.5-Omni-7B",
+    messages=[{"role": "user", "content": "Describe vLLM in brief."}],
+    modalities=["audio"]
+)
+# Response contains two choices: one with text, one with audio
+print(response.choices[0].message.content)  # Text response
+print(response.choices[1].message.audio)    # Audio response
 ```
 
 ## Run Local Web UI Demo

--- a/docs/user_guide/examples/online_serving/qwen3_omni.md
+++ b/docs/user_guide/examples/online_serving/qwen3_omni.md
@@ -87,14 +87,16 @@ You can control output modalities to specify which types of output the model sho
 
 ### Supported modalities
 
-| Modality | Output |
-|----------|--------|
-| `text`   | Text only |
-| `audio`  | Text + Audio (audio generation requires text) |
-
-If not specified, the model uses its default output modalities.
+| Modalities | Output |
+|------------|--------|
+| `["text"]` | Text only |
+| `["audio"]` | Text + Audio |
+| `["text", "audio"]` | Text + Audio |
+| Not specified | Text + Audio (default) |
 
 ### Using curl
+
+#### Text only
 
 ```bash
 curl http://localhost:8091/v1/chat/completions \
@@ -103,6 +105,18 @@ curl http://localhost:8091/v1/chat/completions \
     "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
     "messages": [{"role": "user", "content": "Describe vLLM in brief."}],
     "modalities": ["text"]
+  }'
+```
+
+#### Text + Audio
+
+```bash
+curl http://localhost:8091/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+    "messages": [{"role": "user", "content": "Describe vLLM in brief."}],
+    "modalities": ["audio"]
   }'
 ```
 
@@ -116,6 +130,8 @@ python openai_chat_completion_client_for_multimodal_generation.py \
 
 ### Using OpenAI Python SDK
 
+#### Text only
+
 ```python
 from openai import OpenAI
 
@@ -124,10 +140,26 @@ client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
 response = client.chat.completions.create(
     model="Qwen/Qwen3-Omni-30B-A3B-Instruct",
     messages=[{"role": "user", "content": "Describe vLLM in brief."}],
-    modalities=["text"],
-    max_tokens=100,
+    modalities=["text"]
 )
 print(response.choices[0].message.content)
+```
+
+#### Text + Audio
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+
+response = client.chat.completions.create(
+    model="Qwen/Qwen3-Omni-30B-A3B-Instruct",
+    messages=[{"role": "user", "content": "Describe vLLM in brief."}],
+    modalities=["audio"]
+)
+# Response contains two choices: one with text, one with audio
+print(response.choices[0].message.content)  # Text response
+print(response.choices[1].message.audio)    # Audio response
 ```
 
 ## Run Local Web UI Demo


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

  ## Purpose

  Improve documentation for output modality control in online serving.

  The current documentation only shows Python client script usage (`--modalities` flag) but lacks API-level usage examples. This PR adds:
  - curl examples showing how to use `modalities` parameter in API requests
  - OpenAI Python SDK examples
  - Clear documentation of supported modality values and their behavior

  Related to PR #298 which implemented the modality control feature.

  ## Test Plan

  Documentation changes only. Verified markdown syntax is correct.

  ## Test Result

  N/A (documentation only)

  ---
  <details>
  <summary> Essential Elements of an Effective PR Description Checklist </summary>

  - [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
  - [x] The test plan, such as providing test command.
  - [x] The test results, such as pasting the results comparison before and after, or e2e results
  - [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
  - [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
  </details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
