### PR TITLE
[BugFix] Qwen3-Omni / Qwen2.5-Omni thinker batching with audio input

### DIFF
--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
@@ -92,7 +92,6 @@ class Qwen2_5OmniConditionalGenerationMixin(Qwen2_5OmniConditionalGenerationMixi
         elif feature_attention_mask is not None and isinstance(feature_attention_mask, list):
             for i in range(len(feature_attention_mask)):
                 feature_attention_mask[i] = feature_attention_mask[i].reshape(-1)
-            # feature_attention_mask = torch.cat(feature_attention_mask, dim=-1)
         return Qwen2_5OmniAudioFeatureInputs(
             type="audio_features",
             input_features=input_audio_features,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

The bug is described in #449.

The reason is, in embed_multimodal, it will create a `Qwen2_5OmniAudioFeatureInputs`, which defined as:
```
    input_features: Annotated[
        torch.Tensor | list[torch.Tensor],
        TensorShape("nmb", "tsl", dynamic_dims={"tsl"}),
    ]

    audio_feature_lengths: Annotated[torch.Tensor, TensorShape("na")]

    feature_attention_mask: Annotated[
        torch.Tensor | list[torch.Tensor],
        TensorShape("na", "msl", dynamic_dims={"msl"}),
    ]
```

However, in `_parse_and_validate_audio_input`, it will:
```python
        elif feature_attention_mask is not None and isinstance(feature_attention_mask, list):
            feature_attention_mask = torch.cat(feature_attention_mask, dim=-1)
```
The feature attention mask will cat to a 1-D tensor.

Here i change it to reshape the list.

## Test Plan

The same script in #449.


## Test Result

Logs:

```
(Worker pid=1475513) INFO 12-24 12:07:35 [mrope.py:452] Multimodal token idx changed!
[Stage-2] Generate done: batch=1, req_ids=['3_b135320c-e108-47d7-90be-939a16e25d4b'], gen_ms=193.4
--------------------------------
[Stage-1] Received batch size=1, request_ids=['4_66e1598e-a999-4c4a-b557-81854df02a6d']
--------------------------------
(Worker pid=1478066) INFO 12-24 12:07:45 [mrope.py:452] Multimodal token idx changed!
[Stage-1] Generate done: batch=1, req_ids=['4_66e1598e-a999-4c4a-b557-81854df02a6d'], gen_ms=9413.2
[Stage-2] Max batch size: 1
--------------------------------
[Stage-2] Received batch size=1, request_ids=['4_66e1598e-a999-4c4a-b557-81854df02a6d']
--------------------------------
(Worker pid=1475513) INFO 12-24 12:07:55 [mrope.py:452] Multimodal token idx changed!
[Stage-2] Generate done: batch=1, req_ids=['4_66e1598e-a999-4c4a-b557-81854df02a6d'], gen_ms=109.6
INFO 12-24 12:07:55 [omni_llm.py:483] [Summary] {'e2e_requests': 5, 'e2e_total_time_ms': 105387.35771179199, 'e2e_sum_time_ms': 449833.83655548096, 'e2e_total_tokens': 0, 'e2e_avg_time_per_request_ms': 89966.76731109619, 'e2e_avg_tokens_per_s': 0.0, 'wall_time_ms': 105387.35771179199, 'final_stage_id': {'0_20ecc631-a7ae-4c7b-a7ec-bc2e7b8db17a': 2, '1_250dada6-326c-415f-862b-7ad3d1595db5': 2, '2_dd2258b0-7508-4420-89d6-f48868be1302': 2, '3_b135320c-e108-47d7-90be-939a16e25d4b': 2, '4_66e1598e-a999-4c4a-b557-81854df02a6d': 2}, 'stages': [{'stage_id': 0, 'requests': 5, 'tokens': 178, 'total_time_ms': 29806.282997131348, 'avg_time_per_request_ms': 5961.2565994262695, 'avg_tokens_per_s': 5.9718952550081905}, {'stage_id': 1, 'requests': 5, 'tokens': 1039, 'total_time_ms': 87276.67260169983, 'avg_time_per_request_ms': 17455.334520339966, 'avg_tokens_per_s': 11.904670160165617}, {'stage_id': 2, 'requests': 5, 'tokens': 0, 'total_time_ms': 19645.23410797119, 'avg_time_per_request_ms': 3929.0468215942383, 'avg_tokens_per_s': 0.0}], 'transfers': [{'from_stage': 0, 'to_stage': 1, 'samples': 5, 'total_bytes': 27576940, 'total_time_ms': 97.13101387023926, 'tx_mbps': 2271.319027872272, 'rx_samples': 5, 'rx_total_bytes': 27576940, 'rx_total_time_ms': 28.836488723754883, 'rx_mbps': 7650.56807413108, 'total_samples': 5, 'total_transfer_time_ms': 55793.09797286987, 'total_mbps': 3.954172254555164}, {'from_stage': 1, 'to_stage': 2, 'samples': 5, 'total_bytes': 3706138, 'total_time_ms': 4.370450973510742, 'tx_mbps': 6783.991899166221, 'rx_samples': 5, 'rx_total_bytes': 3706138, 'rx_total_time_ms': 9.023189544677734, 'rx_mbps': 3285.8784416745757, 'total_samples': 5, 'total_transfer_time_ms': 799.7004985809326, 'total_mbps': 37.075260116271394}]}
(Worker pid=1475513) INFO 12-24 12:07:55 [multiproc_executor.py:709] Parent process exited, terminating worker
(Worker pid=1478066) INFO 12-24 12:07:55 [multiproc_executor.py:709] Parent process exited, terminating worker
(Worker pid=1472610) INFO 12-24 12:07:55 [multiproc_executor.py:709] Parent process exited, terminating worker
Generation completed in 110.56s
Processing outputs...
Results saved to /workspace/pqbuild/omni_test/audio_test/results/Qwen3-Omni_vllm_audio.json

All requested tests completed!
```

Results:

[outputs_vllm.zip](https://github.com/user-attachments/files/24321871/outputs_vllm.zip)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
