### PR TITLE
[Feat] Omni progress metrics

### DIFF
--- a/examples/offline_inference/qwen2_5_omni/end2end.py
+++ b/examples/offline_inference/qwen2_5_omni/end2end.py
@@ -5,12 +5,12 @@ Offline E2E example for vLLM-Omni (Qwen2.5-Omni).
 """
 
 import os
+import time
 from typing import NamedTuple
 
 import librosa
 import numpy as np
 import soundfile as sf
-import time
 from PIL import Image
 from vllm.assets.audio import AudioAsset
 from vllm.assets.image import ImageAsset
@@ -379,7 +379,9 @@ def main(args):
                     sampling_rate=args.sampling_rate,
                 )
             elif args.query_type == "use_audio_in_video":
-                qr = query_func(video_path=args.video_path, num_frames=args.num_frames, sampling_rate=args.sampling_rate)
+                qr = query_func(
+                    video_path=args.video_path, num_frames=args.num_frames, sampling_rate=args.sampling_rate
+                )
             elif args.query_type == "multi_audios":
                 qr = query_func(audio_path=args.audio_path, sampling_rate=args.sampling_rate)
             elif args.query_type == "use_image":
@@ -468,7 +470,9 @@ def main(args):
         else:  # thinker, or unknown
             sp = thinker
         auto_sampling_params.append(sp)
-        print(f"[Info] Stage-{stage_id} (model_stage={model_stage}) → sampling_params: max_tokens={sp.max_tokens}, temp={sp.temperature}")
+        print(
+            f"[Info] Stage-{stage_id} (model_stage={model_stage}) → sampling_params: max_tokens={sp.max_tokens}, temp={sp.temperature}"
+        )
 
     # --- STEP 4: Run generation -----------------------------------------------------
     _print_run_header(model_name, args, len(request_inputs))
@@ -479,6 +483,7 @@ def main(args):
     except Exception as e:
         print(f"[CRITICAL] Generation failed: {e}")
         import traceback
+
         traceback.print_exc()
         raise
     t1 = time.time()
@@ -493,7 +498,7 @@ def main(args):
     for stage_output in omni_outputs:
         final_type = getattr(stage_output, "final_output_type", None)
         if not final_type:
-            print(f"[Skip] Stage output has no final_output_type — skipping")
+            print("[Skip] Stage output has no final_output_type — skipping")
             continue
 
         outputs = list(stage_output.request_output)
@@ -531,6 +536,7 @@ def main(args):
             except Exception as e:
                 print(f"[Error] Failed to save {rid} ({final_type}): {e}")
                 import traceback
+
                 traceback.print_exc()
 
     print(f"[Summary] Saved {saved} artifacts into: {output_dir}")

--- a/vllm_omni/entrypoints/log_utils.py
+++ b/vllm_omni/entrypoints/log_utils.py
@@ -7,10 +7,10 @@ from typing import Any
 
 from vllm_omni.entrypoints.stage_utils import append_jsonl as _append_jsonl
 
-
 # =========================
 # File/log helpers
 # =========================
+
 
 def remove_old_logs(log_file: str | None, num_stages: int) -> None:
     try:
@@ -92,6 +92,7 @@ def _safe_append_jsonl(path: str | None, record: dict[str, Any]) -> None:
 # =========================
 # Transfer logging
 # =========================
+
 
 def log_transfer_tx(
     stats_file: str | None,
@@ -177,6 +178,7 @@ def log_transfer_total(
 # Orchestrator logging
 # =========================
 
+
 def log_orchestrator_e2e(
     stats_file: str | None,
     request_id: Any,
@@ -213,6 +215,7 @@ def log_overall_record(overall_stats_file: str | None, record: dict[str, Any]) -
 # =========================
 # Stage logging
 # =========================
+
 
 def log_stage_request_stats(
     stats_file: str | None,
@@ -316,6 +319,7 @@ def compute_and_log_stage_request_stats(
 # =========================
 # Aggregation helpers
 # =========================
+
 
 def record_stage_metrics(
     per_request: dict[str, dict[str, Any]],
@@ -497,6 +501,7 @@ def build_transfer_summary(
 # Orchestrator metrics class
 # =========================
 
+
 class OrchestratorMetrics:
     """
     Collects per-stage, per-request, transfer, and end-to-end metrics.
@@ -530,7 +535,7 @@ class OrchestratorMetrics:
         self.transfer_edge_req: dict[tuple[int, int, str], dict[str, float]] = {}
 
         # E2E
-        self.e2e_total_ms: float = 0.0          # sum of per-request e2e
+        self.e2e_total_ms: float = 0.0  # sum of per-request e2e
         self.e2e_total_tokens: int = 0
         self.e2e_count: int = 0
         self.e2e_done: set[str] = set()
@@ -762,14 +767,12 @@ class OrchestratorMetrics:
 
         # New: throughput definitions
         wall_toks_per_s = (self.e2e_total_tokens * 1000.0 / wall_time_ms) if wall_time_ms > 0 else 0.0
-        service_toks_per_s = (
-            (self.e2e_total_tokens * 1000.0 / self.sum_service_ms) if self.sum_service_ms > 0 else 0.0
-        )
+        service_toks_per_s = (self.e2e_total_tokens * 1000.0 / self.sum_service_ms) if self.sum_service_ms > 0 else 0.0
 
         summary: dict[str, Any] = {
             "e2e_requests": int(self.e2e_count),
-            "e2e_total_time_ms": float(wall_time_ms),    # total wall time (what you waited)
-            "e2e_sum_time_ms": float(self.e2e_total_ms), # sum of per-request e2e (includes queueing)
+            "e2e_total_time_ms": float(wall_time_ms),  # total wall time (what you waited)
+            "e2e_sum_time_ms": float(self.e2e_total_ms),  # sum of per-request e2e (includes queueing)
             "e2e_total_tokens": int(self.e2e_total_tokens),
             "e2e_avg_time_per_request_ms": float(e2e_avg_req),
             "e2e_avg_tokens_per_s": float(e2e_avg_tok),

--- a/vllm_omni/entrypoints/omni_llm.py
+++ b/vllm_omni/entrypoints/omni_llm.py
@@ -5,10 +5,10 @@ import uuid
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
-from tqdm import tqdm
 
 import cloudpickle
 from pydantic import ValidationError
+from tqdm import tqdm
 
 # External library imports (vLLM)
 from vllm.config import CompilationConfig, StructuredOutputsConfig, is_init_field
@@ -492,7 +492,7 @@ class OmniLLM:
 
             if not made_progress:
                 time.sleep(0.005)
-        
+
         pbar.close()
         logger.debug("[Orchestrator] All requests completed")
 

--- a/vllm_omni/entrypoints/omni_stage.py
+++ b/vllm_omni/entrypoints/omni_stage.py
@@ -1312,4 +1312,3 @@ async def _stage_worker_async(
     print("--------------------------------", flush=True)
     print(f"[Stage-{stage_id}] Stage worker exiting", flush=True)
     print("--------------------------------", flush=True)
-    


### PR DESCRIPTION
## Link to Issue:
#370 This Pr is to partly address the issue for poor UX design. 

## Purpose
This PR enhances the vLLM-Omni offline inference system with progress tracking and improved performance metrics to provide better observability and user experience during multi-stage multimodal inference.

## Test Plan
1. Progress Visualization: Adds tqdm progress bar showing real-time request completion and throughput metrics during generation
2. Enhanced Metrics System: Introduces comprehensive time breakdown distinguishing between:
   - **Service time**: Actual model computation time per stage
   - **Transfer time**: Data movement between pipeline stages
   - **Queue time**: Waiting time in inter-stage queues
 3. **Better Throughput Metrics**: Provides both wall_tokens_per_s (total time) and service_tokens_per_s (pure compute time)
 4. **Improved Stage Logging**: Enhanced debug output with clearer batch processing information

**Files Modified**:

    - examples/omni_e2e.py: Enhanced main inference script with progress bar and better error handling

    - vllm_omni/entrypoints/omni_llm.py: Integrated progress tracking into orchestrator core

    - vllm_omni/entrypoints/omni_stage.py: Improved stage worker logging and batch processing visibility

    - vllm_omni/entrypoints/log_utils.py: Complete metrics system overhaul with detailed time breakdown

## Test Plan
example->qwen omni 2.5-> multiple requests

## Test Result
<img width="1288" height="425" alt="Screenshot from 2025-12-25 23-37-18" src="https://github.com/user-attachments/assets/a667ad1e-cf9c-458b-b063-4d7d9522aba2" />

## Before vs After Comparison
- Before: No progress indication, basic timing metrics only
- After:
    - Real-time progress visualization with throughput
    - Detailed time breakdown for performance analysis
    - Better debugging visibility with enhanced stage logging

## Verfication Results
1. Progress bar appears and updates correctly for all query types
2. New metrics collected without breaking existing stats


