### PR TITLE
[Refactor][Diffusion] Make NPUWorker inherit GPUWorker

### DIFF
--- a/vllm_omni/diffusion/worker/gpu_worker.py
+++ b/vllm_omni/diffusion/worker/gpu_worker.py
@@ -168,14 +168,17 @@ class WorkerProc:
             logger.info(f"Worker {gpu_id} created result MessageQueue")
 
         assert od_config.master_port is not None
-        worker = GPUWorker(
+        self.worker = self._create_worker(gpu_id, od_config)
+        self.gpu_id = gpu_id
+        self._running = True
+
+    def _create_worker(self, gpu_id: int, od_config: OmniDiffusionConfig) -> GPUWorker:
+        """Create a worker instance. Override in subclasses for different worker types."""
+        return GPUWorker(
             local_rank=gpu_id,
             rank=gpu_id,
             od_config=od_config,
         )
-        self.worker = worker
-        self.gpu_id = gpu_id
-        self._running = True
 
     def return_result(self, output: DiffusionOutput):
         """

--- a/vllm_omni/diffusion/worker/npu/npu_worker.py
+++ b/vllm_omni/diffusion/worker/npu/npu_worker.py
@@ -5,48 +5,33 @@ import os
 import time
 
 import torch
-import zmq
-from transformers import PretrainedConfig
-from vllm.config import LoadConfig, ModelConfig, VllmConfig, set_current_vllm_config
-from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
-from vllm.distributed.parallel_state import (
-    init_distributed_environment,
-    initialize_model_parallel,
-)
+from vllm.config import LoadConfig, VllmConfig, set_current_vllm_config
 from vllm.logger import init_logger
 from vllm.utils.mem_utils import DeviceMemoryProfiler, GiB_bytes
 
+from vllm_omni.diffusion.cache.selector import get_cache_backend
 from vllm_omni.diffusion.data import (
-    SHUTDOWN_MESSAGE,
-    DiffusionOutput,
     OmniDiffusionConfig,
+    set_current_omni_diffusion_config,
+)
+from vllm_omni.diffusion.distributed.parallel_state import (
+    init_distributed_environment,
+    initialize_model_parallel,
 )
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.worker.gpu_worker import GPUWorker, WorkerProc
 
 logger = init_logger(__name__)
 
 
-class NPUWorker:
+class NPUWorker(GPUWorker):
     """
     A worker that executes the model on a single NPU.
+    Inherits from GPUWorker and overrides device-specific initialization.
     """
 
-    def __init__(
-        self,
-        local_rank: int,
-        rank: int,
-        od_config: OmniDiffusionConfig,
-    ):
-        self.local_rank = local_rank
-        self.rank = rank
-        self.od_config = od_config
-        self.pipeline = None
-
-        self.init_device_and_model()
-
     def init_device_and_model(self) -> None:
-        """Initialize the device and load the model."""
+        """Initialize the NPU device and load the model."""
         world_size = self.od_config.num_gpus
         rank = self.rank
         # Set environment variables for distributed initialization
@@ -60,26 +45,36 @@ class NPUWorker:
         torch.npu.set_device(device)
 
         # hack
-        # set hf_config to a fake one to avolid get attr error
-        class _FakePretrainedConfig(PretrainedConfig):
-            def __getattr__(self, name):
-                return "fake"
-
-        vllm_config = VllmConfig(model_config=ModelConfig(hf_config=_FakePretrainedConfig()), load_config=LoadConfig())
-        vllm_config.parallel_config.tensor_parallel_size = self.od_config.num_gpus
-        set_current_vllm_config(vllm_config)
-
-        init_distributed_environment(world_size=world_size, rank=rank)
-        initialize_model_parallel(tensor_model_parallel_size=world_size)
-
-        model_loader = DiffusersPipelineLoader(vllm_config.load_config)
-        time_before_load = time.perf_counter()
-        with DeviceMemoryProfiler() as m:
-            self.pipeline = model_loader.load_model(
-                od_config=self.od_config,
-                load_device=f"npu:{rank}",
+        vllm_config = VllmConfig()
+        vllm_config.parallel_config.tensor_parallel_size = self.od_config.parallel_config.tensor_parallel_size
+        vllm_config.parallel_config.data_parallel_size = self.od_config.parallel_config.data_parallel_size
+        self.vllm_config = vllm_config
+        with (
+            set_current_omni_diffusion_config(self.od_config),
+            set_current_vllm_config(vllm_config),
+        ):
+            init_distributed_environment(world_size=world_size, rank=rank)
+            logger.info(f"Worker {self.rank}: Initialized device and distributed environment.")
+            parallel_config = self.od_config.parallel_config
+            initialize_model_parallel(
+                data_parallel_size=parallel_config.data_parallel_size,
+                cfg_parallel_size=parallel_config.cfg_parallel_size,
+                sequence_parallel_size=parallel_config.sequence_parallel_size,
+                ulysses_degree=parallel_config.ulysses_degree,
+                ring_degree=parallel_config.ring_degree,
+                tensor_parallel_size=parallel_config.tensor_parallel_size,
+                pipeline_parallel_size=parallel_config.pipeline_parallel_size,
             )
-        time_after_load = time.perf_counter()
+
+            load_config = LoadConfig()
+            model_loader = DiffusersPipelineLoader(load_config)
+            time_before_load = time.perf_counter()
+            with DeviceMemoryProfiler() as m:
+                self.pipeline = model_loader.load_model(
+                    od_config=self.od_config,
+                    load_device=f"npu:{rank}",
+                )
+            time_after_load = time.perf_counter()
 
         logger.info(
             "Model loading took %.4f GiB and %.6f seconds",
@@ -88,129 +83,23 @@ class NPUWorker:
         )
         logger.info(f"Worker {self.rank}: Model loaded successfully.")
 
-    @torch.inference_mode()
-    def execute_model(self, reqs: list[OmniDiffusionRequest], od_config: OmniDiffusionConfig) -> DiffusionOutput:
-        """
-        Execute a forward pass.
-        """
-        assert self.pipeline is not None
-        # TODO: dealing with first req for now
-        req = reqs[0]
-        output = self.pipeline.forward(req)
-        return output
+        # Setup cache backend based on type (both backends use enable()/reset() interface)
+        self.cache_backend = get_cache_backend(self.od_config.cache_backend, self.od_config.cache_config)
 
-    def shutdown(self) -> None:
-        if torch.distributed.is_initialized():
-            try:
-                torch.distributed.destroy_process_group()
-                logger.info("Worker %s: Destroyed process group", self.rank)
-            except Exception as exc:  # pragma: no cover - best effort cleanup
-                logger.warning("Worker %s: Failed to destroy process group: %s", self.rank, exc)
+        if self.cache_backend is not None:
+            self.cache_backend.enable(self.pipeline)
 
 
-class NPUWorkerProc:
-    """Wrapper that runs one Worker in a separate process."""
+class NPUWorkerProc(WorkerProc):
+    """Wrapper that runs one NPUWorker in a separate process."""
 
-    def __init__(
-        self,
-        od_config: OmniDiffusionConfig,
-        gpu_id: int,
-        broadcast_handle,
-    ):
-        self.od_config = od_config
-
-        # Inter-process Communication
-        self.context = zmq.Context(io_threads=2)
-
-        # Initialize MessageQueue reader from handle
-        self.mq = MessageQueue.create_from_handle(broadcast_handle, gpu_id)
-
-        self.result_mq = None
-        self.result_mq_handle = None
-
-        # Setup result sender (only for rank 0 for now, or whoever needs to reply)
-        # Assuming only rank 0 replies to scheduler as per original logic
-        if gpu_id == 0:
-            # Create MessageQueue for results (1 writer -> 1 reader)
-            # We assume the reader (SyncScheduler) will act as rank 0
-            self.result_mq = MessageQueue(n_reader=1, n_local_reader=1, local_reader_ranks=[0])
-            self.result_mq_handle = self.result_mq.export_handle()
-            logger.info(f"Worker {gpu_id} created result MessageQueue")
-
-        assert od_config.master_port is not None
-        worker = NPUWorker(
+    def _create_worker(self, gpu_id: int, od_config: OmniDiffusionConfig) -> NPUWorker:
+        """Create an NPUWorker instead of GPUWorker."""
+        return NPUWorker(
             local_rank=gpu_id,
             rank=gpu_id,
             od_config=od_config,
         )
-        self.worker = worker
-        self.gpu_id = gpu_id
-        self._running = True
-
-    def return_result(self, output: DiffusionOutput):
-        """
-        replies to client, only on rank 0
-        """
-        if self.result_mq is not None:
-            self.result_mq.enqueue(output)
-
-    def recv_reqs(self):
-        """
-        Receive requests from broadcast queue
-        """
-        return self.mq.dequeue(indefinite=True)
-
-    # TODO: queueing, cancellation
-    def worker_busy_loop(self) -> None:
-        """Main busy loop for Multiprocessing Workers"""
-
-        logger.info(f"Worker {self.gpu_id} ready to receive requests via shared memory")
-
-        while self._running:
-            reqs = None
-            # 1: receive requests
-            try:
-                reqs = self.recv_reqs()
-            except Exception as e:
-                logger.error(
-                    f"Error receiving requests in scheduler event loop: {e}",
-                    exc_info=True,
-                )
-                continue
-
-            if reqs == SHUTDOWN_MESSAGE:
-                logger.info("Worker %s: Received shutdown message", self.gpu_id)
-                self._running = False
-                continue
-            if reqs is None:
-                logger.warning("Worker %s: Received empty payload, ignoring", self.gpu_id)
-                continue
-
-            # 2: execute, make sure a reply is always sent
-            try:
-                output = self.worker.execute_model(reqs, self.od_config)
-            except Exception as e:
-                logger.error(
-                    f"Error executing forward in event loop: {e}",
-                    exc_info=True,
-                )
-                output = DiffusionOutput(error=str(e))
-
-            try:
-                self.return_result(output)
-            except zmq.ZMQError as e:
-                # Reply failed; log and keep loop alive to accept future requests
-                logger.error(f"ZMQ error sending reply: {e}")
-                continue
-
-        logger.info("event loop terminated.")
-        try:
-            self.worker.shutdown()
-        except Exception as exc:  # pragma: no cover - best effort cleanup
-            logger.warning("Worker %s: Shutdown encountered an error: %s", self.gpu_id, exc)
-        # if self.result_sender is not None:
-        #     self.result_sender.close()
-        self.context.term()
 
     @staticmethod
     def worker_main(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fixes #482. Make NPUWorker inherit GPUWorker to reduce the duplicate code and maintaining cost. After this PR, cache-dit and USP are also supported on NPU.

## Test Plan

```bash
python text_to_image.py \
  --model Qwen/Qwen-Image \
  --prompt "a cup of coffee on the table" \
  --seed 42 \
  --cfg_scale 4.0 \
  --num_images_per_prompt 1 \
  --num_inference_steps 50 \
  --height 1024 \
  --width 1024 \
  --cache_backend  cache_dit \
  --ulysses_degree 4 \
  --output outputs/coffee.png
```

## Test Result

```bash
python text_to_image.py   --model Qwen/Qwen-Image   --prompt "a cup of coffee on the table"   --seed 42   --cfg_scale 4.0   --num_images_per_prompt 1   --num_inference_steps 50   --height 1024   --width 1024   --output outputs/coffee.png --cache_backend  cache_dit --ulysses_degree 4
INFO 12-26 04:40:10 [__init__.py:43] Available plugins for group vllm.platform_plugins:
INFO 12-26 04:40:10 [__init__.py:45] - ascend -> vllm_ascend:register
INFO 12-26 04:40:10 [__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 12-26 04:40:10 [__init__.py:217] Platform plugin ascend is activated
/usr/local/python3.11.13/lib/python3.11/site-packages/torch/amp/autocast_mode.py:266: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling
  warnings.warn(
Modular Diffusers is currently an experimental feature under active development. The API is subject to breaking changes in future releases.
INFO 12-26 04:40:15 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
WARNING 12-26 04:40:16 [mooncake_connector.py:18] Mooncake not available, MooncakeOmniConnector will not work
Downloading Model from https://www.modelscope.cn to directory: /root/.cache/modelscope/hub/models/Qwen/Qwen-Image
INFO 12-26 04:40:20 [group_coordinator.py:21] torch.npu synchronize
INFO 12-26 04:40:20 [diffusion_engine.py:138] Starting server...
INFO 12-26 04:40:23 [__init__.py:43] Available plugins for group vllm.platform_plugins:
INFO 12-26 04:40:23 [__init__.py:45] - ascend -> vllm_ascend:register
INFO 12-26 04:40:23 [__init__.py:43] Available plugins for group vllm.platform_plugins:
INFO 12-26 04:40:23 [__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 12-26 04:40:23 [__init__.py:45] - ascend -> vllm_ascend:register
INFO 12-26 04:40:23 [__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 12-26 04:40:23 [__init__.py:43] Available plugins for group vllm.platform_plugins:
INFO 12-26 04:40:23 [__init__.py:45] - ascend -> vllm_ascend:register
INFO 12-26 04:40:23 [__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 12-26 04:40:23 [__init__.py:43] Available plugins for group vllm.platform_plugins:
INFO 12-26 04:40:23 [__init__.py:45] - ascend -> vllm_ascend:register
INFO 12-26 04:40:23 [__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 12-26 04:40:23 [__init__.py:217] Platform plugin ascend is activated
INFO 12-26 04:40:23 [__init__.py:217] Platform plugin ascend is activated
INFO 12-26 04:40:23 [__init__.py:217] Platform plugin ascend is activated
INFO 12-26 04:40:23 [__init__.py:217] Platform plugin ascend is activated
/usr/local/python3.11.13/lib/python3.11/site-packages/torch/amp/autocast_mode.py:266: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling
  warnings.warn(
/usr/local/python3.11.13/lib/python3.11/site-packages/torch/amp/autocast_mode.py:266: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling
  warnings.warn(
/usr/local/python3.11.13/lib/python3.11/site-packages/torch/amp/autocast_mode.py:266: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling
  warnings.warn(
/usr/local/python3.11.13/lib/python3.11/site-packages/torch/amp/autocast_mode.py:266: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling
  warnings.warn(
Modular Diffusers is currently an experimental feature under active development. The API is subject to breaking changes in future releases.
Modular Diffusers is currently an experimental feature under active development. The API is subject to breaking changes in future releases.
Modular Diffusers is currently an experimental feature under active development. The API is subject to breaking changes in future releases.
Modular Diffusers is currently an experimental feature under active development. The API is subject to breaking changes in future releases.
INFO 12-26 04:40:28 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
INFO 12-26 04:40:28 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
INFO 12-26 04:40:28 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
INFO 12-26 04:40:28 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
WARNING 12-26 04:40:30 [mooncake_connector.py:18] Mooncake not available, MooncakeOmniConnector will not work
WARNING 12-26 04:40:30 [mooncake_connector.py:18] Mooncake not available, MooncakeOmniConnector will not work
WARNING 12-26 04:40:30 [mooncake_connector.py:18] Mooncake not available, MooncakeOmniConnector will not work
WARNING 12-26 04:40:30 [mooncake_connector.py:18] Mooncake not available, MooncakeOmniConnector will not work
INFO 12-26 04:40:30 [group_coordinator.py:21] torch.npu synchronize
INFO 12-26 04:40:30 [group_coordinator.py:21] torch.npu synchronize
INFO 12-26 04:40:30 [group_coordinator.py:21] torch.npu synchronize
INFO 12-26 04:40:30 [gpu_worker.py:168] Worker 0 created result MessageQueue
INFO 12-26 04:40:30 [group_coordinator.py:21] torch.npu synchronize
INFO 12-26 04:40:31 [scheduler.py:228] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 12-26 04:40:31 [utils.py:972] FLASHCOMM2 not enable.
WARNING 12-26 04:40:31 [platform.py:177] Model config is missing. This may indicate that we are running a test case
INFO 12-26 04:40:31 [platform.py:234] PIECEWISE compilation enabled on NPU. use_inductor not supported - using only ACL Graph mode
WARNING 12-26 04:40:31 [utils.py:463] Got empty model config. This typically occurs when an empty vllm_config is initialized (e.g., in unit tests), where config updates are intentionally skipped.
INFO 12-26 04:40:31 [scheduler.py:228] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 12-26 04:40:31 [utils.py:972] FLASHCOMM2 not enable.
WARNING 12-26 04:40:31 [platform.py:177] Model config is missing. This may indicate that we are running a test case
INFO 12-26 04:40:31 [platform.py:234] PIECEWISE compilation enabled on NPU. use_inductor not supported - using only ACL Graph mode
WARNING 12-26 04:40:31 [utils.py:463] Got empty model config. This typically occurs when an empty vllm_config is initialized (e.g., in unit tests), where config updates are intentionally skipped.
INFO 12-26 04:40:31 [scheduler.py:228] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 12-26 04:40:31 [utils.py:972] FLASHCOMM2 not enable.
WARNING 12-26 04:40:31 [platform.py:177] Model config is missing. This may indicate that we are running a test case
INFO 12-26 04:40:31 [platform.py:234] PIECEWISE compilation enabled on NPU. use_inductor not supported - using only ACL Graph mode
WARNING 12-26 04:40:31 [utils.py:463] Got empty model config. This typically occurs when an empty vllm_config is initialized (e.g., in unit tests), where config updates are intentionally skipped.
INFO 12-26 04:40:31 [scheduler.py:228] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 12-26 04:40:31 [utils.py:972] FLASHCOMM2 not enable.
WARNING 12-26 04:40:31 [platform.py:177] Model config is missing. This may indicate that we are running a test case
INFO 12-26 04:40:31 [platform.py:234] PIECEWISE compilation enabled on NPU. use_inductor not supported - using only ACL Graph mode
WARNING 12-26 04:40:31 [utils.py:463] Got empty model config. This typically occurs when an empty vllm_config is initialized (e.g., in unit tests), where config updates are intentionally skipped.
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
INFO 12-26 04:40:31 [npu_worker.py:57] Worker 0: Initialized device and distributed environment.
INFO 12-26 04:40:31 [npu_worker.py:57] Worker 2: Initialized device and distributed environment.
INFO 12-26 04:40:31 [npu_worker.py:57] Worker 3: Initialized device and distributed environment.
INFO 12-26 04:40:31 [npu_worker.py:57] Worker 1: Initialized device and distributed environment.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████| 4/4 [00:01<00:00,  2.18it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████| 4/4 [00:01<00:00,  2.19it/s]
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████| 4/4 [00:01<00:00,  2.11it/s]
/usr/local/python3.11.13/lib/python3.11/site-packages/torch/utils/_device.py:103: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:335.)
  return func(*args, **kwargs)
/usr/local/python3.11.13/lib/python3.11/site-packages/torch/utils/_device.py:103: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:335.)
  return func(*args, **kwargs)
/usr/local/python3.11.13/lib/python3.11/site-packages/torch/utils/_device.py:103: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:335.)
  return func(*args, **kwargs)
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████| 4/4 [00:02<00:00,  1.71it/s]
Loading safetensors checkpoint shards:   0% Completed | 0/9 [00:00<?, ?it/s]
/usr/local/python3.11.13/lib/python3.11/site-packages/torch/utils/_device.py:103: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:335.)
  return func(*args, **kwargs)
Loading safetensors checkpoint shards:  11% Completed | 1/9 [00:00<00:04,  1.64it/s]
Loading safetensors checkpoint shards:  22% Completed | 2/9 [00:00<00:03,  2.11it/s]
Loading safetensors checkpoint shards:  33% Completed | 3/9 [00:01<00:02,  2.15it/s]
Loading safetensors checkpoint shards:  44% Completed | 4/9 [00:01<00:02,  2.17it/s]
Loading safetensors checkpoint shards:  56% Completed | 5/9 [00:02<00:01,  2.18it/s]
Loading safetensors checkpoint shards:  67% Completed | 6/9 [00:02<00:01,  2.17it/s]
Loading safetensors checkpoint shards:  78% Completed | 7/9 [00:03<00:00,  2.25it/s]
Loading safetensors checkpoint shards:  89% Completed | 8/9 [00:03<00:00,  2.33it/s]
Loading safetensors checkpoint shards: 100% Completed | 9/9 [00:04<00:00,  2.35it/s]
Loading safetensors checkpoint shards: 100% Completed | 9/9 [00:04<00:00,  2.23it/s]

INFO 12-26 04:40:38 [diffusers_loader.py:214] Loading weights took 4.15 seconds
INFO 12-26 04:40:38 [diffusers_loader.py:214] Loading weights took 4.17 seconds
INFO 12-26 04:40:38 [diffusers_loader.py:214] Loading weights took 4.17 seconds
INFO 12-26 04:40:39 [npu_worker.py:79] Model loading took 53.7777 GiB and 7.750605 seconds
INFO 12-26 04:40:39 [npu_worker.py:84] Worker 0: Model loaded successfully.
INFO 12-26 04:40:39 [cache_dit_backend.py:296] Enabling cache-dit on transformer: Fn=1, Bn=0, W=4,
INFO 12-26 04:40:39 [cache_adapter.py:49] QwenImageTransformer2DModel is officially supported by cache-dit. Use it's pre-defined BlockAdapter directly!
WARNING 12-26 04:40:39 [__init__.py:47] Transformer class QwenImageTransformer2DModel is from vllm_omni not diffusers, skipping strict type check in BlockAdapter.
INFO 12-26 04:40:39 [block_adapters.py:220] Auto fill blocks_name: transformer_blocks.
INFO 12-26 04:40:39 [block_adapters.py:494] Match Block Forward Pattern: QwenImageTransformerBlock, ForwardPattern.Pattern_1
INFO 12-26 04:40:39 [block_adapters.py:494] IN:('hidden_states', 'encoder_hidden_states'), OUT:('encoder_hidden_states', 'hidden_states'))
INFO 12-26 04:40:39 [cache_adapter.py:134] Use custom 'enable_separate_cfg' from BlockAdapter: True. Pipeline: FakeDiffusionPipeline.
INFO 12-26 04:40:39 [cache_adapter.py:332] Collected Context Config: DBCache_F1B0_W4I1M0MC3_R0.24_CFG1, Calibrator Config: None
INFO 12-26 04:40:39 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for transformer_blocks, cache_context: transformer_blocks_281460688166672, context_manager: FakeDiffusionPipeline_281460688130320.
INFO 12-26 04:40:39 [cache_dit_backend.py:406] Cache-dit enabled successfully on QwenImagePipeline
INFO 12-26 04:40:39 [npu_worker.py:118] Worker 0: Scheduler loop started.
INFO 12-26 04:40:39 [gpu_worker.py:227] Worker 0 ready to receive requests via shared memory
INFO 12-26 04:40:39 [npu_worker.py:79] Model loading took 53.7777 GiB and 7.765640 seconds
INFO 12-26 04:40:39 [npu_worker.py:84] Worker 3: Model loaded successfully.
INFO 12-26 04:40:39 [cache_dit_backend.py:296] Enabling cache-dit on transformer: Fn=1, Bn=0, W=4,
INFO 12-26 04:40:39 [cache_adapter.py:49] QwenImageTransformer2DModel is officially supported by cache-dit. Use it's pre-defined BlockAdapter directly!
WARNING 12-26 04:40:39 [__init__.py:47] Transformer class QwenImageTransformer2DModel is from vllm_omni not diffusers, skipping strict type check in BlockAdapter.
INFO 12-26 04:40:39 [block_adapters.py:220] Auto fill blocks_name: transformer_blocks.
INFO 12-26 04:40:39 [block_adapters.py:494] Match Block Forward Pattern: QwenImageTransformerBlock, ForwardPattern.Pattern_1
INFO 12-26 04:40:39 [block_adapters.py:494] IN:('hidden_states', 'encoder_hidden_states'), OUT:('encoder_hidden_states', 'hidden_states'))
INFO 12-26 04:40:39 [cache_adapter.py:134] Use custom 'enable_separate_cfg' from BlockAdapter: True. Pipeline: FakeDiffusionPipeline.
INFO 12-26 04:40:39 [cache_adapter.py:332] Collected Context Config: DBCache_F1B0_W4I1M0MC3_R0.24_CFG1, Calibrator Config: None
INFO 12-26 04:40:39 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for transformer_blocks, cache_context: transformer_blocks_281460501286992, context_manager: FakeDiffusionPipeline_281460501204944.
INFO 12-26 04:40:39 [cache_dit_backend.py:406] Cache-dit enabled successfully on QwenImagePipeline
INFO 12-26 04:40:39 [npu_worker.py:118] Worker 3: Scheduler loop started.
INFO 12-26 04:40:39 [gpu_worker.py:227] Worker 3 ready to receive requests via shared memory
INFO 12-26 04:40:39 [npu_worker.py:79] Model loading took 53.7777 GiB and 7.826206 seconds
INFO 12-26 04:40:39 [npu_worker.py:84] Worker 2: Model loaded successfully.
INFO 12-26 04:40:39 [cache_dit_backend.py:296] Enabling cache-dit on transformer: Fn=1, Bn=0, W=4,
INFO 12-26 04:40:39 [cache_adapter.py:49] QwenImageTransformer2DModel is officially supported by cache-dit. Use it's pre-defined BlockAdapter directly!
WARNING 12-26 04:40:39 [__init__.py:47] Transformer class QwenImageTransformer2DModel is from vllm_omni not diffusers, skipping strict type check in BlockAdapter.
INFO 12-26 04:40:39 [block_adapters.py:220] Auto fill blocks_name: transformer_blocks.
INFO 12-26 04:40:39 [block_adapters.py:494] Match Block Forward Pattern: QwenImageTransformerBlock, ForwardPattern.Pattern_1
INFO 12-26 04:40:39 [block_adapters.py:494] IN:('hidden_states', 'encoder_hidden_states'), OUT:('encoder_hidden_states', 'hidden_states'))
INFO 12-26 04:40:39 [cache_adapter.py:134] Use custom 'enable_separate_cfg' from BlockAdapter: True. Pipeline: FakeDiffusionPipeline.
INFO 12-26 04:40:39 [cache_adapter.py:332] Collected Context Config: DBCache_F1B0_W4I1M0MC3_R0.24_CFG1, Calibrator Config: None
INFO 12-26 04:40:39 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for transformer_blocks, cache_context: transformer_blocks_281460679512208, context_manager: FakeDiffusionPipeline_281458838202384.
INFO 12-26 04:40:39 [cache_dit_backend.py:406] Cache-dit enabled successfully on QwenImagePipeline
INFO 12-26 04:40:39 [npu_worker.py:118] Worker 2: Scheduler loop started.
INFO 12-26 04:40:39 [gpu_worker.py:227] Worker 2 ready to receive requests via shared memory
INFO 12-26 04:40:40 [diffusers_loader.py:214] Loading weights took 5.20 seconds
INFO 12-26 04:40:40 [npu_worker.py:79] Model loading took 53.7777 GiB and 9.268813 seconds
INFO 12-26 04:40:40 [npu_worker.py:84] Worker 1: Model loaded successfully.
INFO 12-26 04:40:40 [cache_dit_backend.py:296] Enabling cache-dit on transformer: Fn=1, Bn=0, W=4,
INFO 12-26 04:40:40 [cache_adapter.py:49] QwenImageTransformer2DModel is officially supported by cache-dit. Use it's pre-defined BlockAdapter directly!
WARNING 12-26 04:40:40 [__init__.py:47] Transformer class QwenImageTransformer2DModel is from vllm_omni not diffusers, skipping strict type check in BlockAdapter.
INFO 12-26 04:40:40 [block_adapters.py:220] Auto fill blocks_name: transformer_blocks.
INFO 12-26 04:40:40 [block_adapters.py:494] Match Block Forward Pattern: QwenImageTransformerBlock, ForwardPattern.Pattern_1
INFO 12-26 04:40:40 [block_adapters.py:494] IN:('hidden_states', 'encoder_hidden_states'), OUT:('encoder_hidden_states', 'hidden_states'))
INFO 12-26 04:40:40 [cache_adapter.py:134] Use custom 'enable_separate_cfg' from BlockAdapter: True. Pipeline: FakeDiffusionPipeline.
INFO 12-26 04:40:40 [cache_adapter.py:332] Collected Context Config: DBCache_F1B0_W4I1M0MC3_R0.24_CFG1, Calibrator Config: None
INFO 12-26 04:40:40 [pattern_base.py:70] Match Blocks: CachedBlocks_Pattern_0_1_2, for transformer_blocks, cache_context: transformer_blocks_281461458673424, context_manager: FakeDiffusionPipeline_281461458821840.
INFO 12-26 04:40:40 [cache_dit_backend.py:406] Cache-dit enabled successfully on QwenImagePipeline
INFO 12-26 04:40:40 [npu_worker.py:118] Worker 1: Scheduler loop started.
INFO 12-26 04:40:40 [gpu_worker.py:227] Worker 1 ready to receive requests via shared memory
INFO 12-26 04:40:40 [scheduler.py:46] SyncScheduler initialized result MessageQueue

============================================================
Generation Configuration:
  Model: Qwen/Qwen-Image
  Inference steps: 50
  Cache backend: cache_dit
  Parallel configuration: ulysses_degree=4
  Image size: 1024x1024
============================================================

INFO 12-26 04:40:40 [omni_diffusion.py:86] Prepared 1 requests for generation.
('Warning: torch.save with "_use_new_zipfile_serialization = False" is not recommended for npu tensor, which may bring unexpected errors and hopefully set "_use_new_zipfile_serialization = True"', 'if it is necessary to use this, please convert the npu tensor to cpu tensor for saving')
INFO 12-26 04:40:40 [cache_dit_backend.py:427] Refreshing cache context for transformer with num_inference_steps: 50
INFO 12-26 04:40:40 [cache_dit_backend.py:427] Refreshing cache context for transformer with num_inference_steps: 50
INFO 12-26 04:40:40 [cache_adapter.py:723] ✅ Refreshed cache context: transformer_blocks_281460688166672, Collected Context Config: DBCache_F1B0_W4I1M0MC3_R0.24_N50_CFG1, Calibrator Config: None
INFO 12-26 04:40:40 [cache_dit_backend.py:427] Refreshing cache context for transformer with num_inference_steps: 50
INFO 12-26 04:40:40 [cache_adapter.py:723] ✅ Refreshed cache context: transformer_blocks_281460501286992, Collected Context Config: DBCache_F1B0_W4I1M0MC3_R0.24_N50_CFG1, Calibrator Config: None
INFO 12-26 04:40:40 [cache_dit_backend.py:427] Refreshing cache context for transformer with num_inference_steps: 50
INFO 12-26 04:40:40 [cache_adapter.py:723] ✅ Refreshed cache context: transformer_blocks_281461458673424, Collected Context Config: DBCache_F1B0_W4I1M0MC3_R0.24_N50_CFG1, Calibrator Config: None
INFO 12-26 04:40:40 [cache_adapter.py:723] ✅ Refreshed cache context: transformer_blocks_281460679512208, Collected Context Config: DBCache_F1B0_W4I1M0MC3_R0.24_N50_CFG1, Calibrator Config: None
('Warning: torch.save with "_use_new_zipfile_serialization = False" is not recommended for npu tensor, which may bring unexpected errors and hopefully set "_use_new_zipfile_serialization = True"', 'if it is necessary to use this, please convert the npu tensor to cpu tensor for saving')
Warning: The current version of the file storing weights is old, and it is relanded due to internal bug of torch and compatibility issue. We will deprecate the loading support for this type of file in the future, please use newer torch to re-store the weight file.
INFO 12-26 04:40:52 [diffusion_engine.py:85] Generation completed successfully.
INFO 12-26 04:40:52 [diffusion_engine.py:90] Post-processing completed in 0.1201 seconds
Total generation time: 11.7203 seconds (11720.33 ms)
Saved generated image to outputs/coffee.png
INFO 12-26 04:40:52 [gpu_worker.py:259] Worker 0: Received shutdown message
INFO 12-26 04:40:52 [gpu_worker.py:259] Worker 1: Received shutdown message
INFO 12-26 04:40:52 [gpu_worker.py:281] event loop terminated.
INFO 12-26 04:40:52 [gpu_worker.py:281] event loop terminated.
INFO 12-26 04:40:52 [gpu_worker.py:259] Worker 2: Received shutdown message
INFO 12-26 04:40:52 [gpu_worker.py:281] event loop terminated.
INFO 12-26 04:40:52 [gpu_worker.py:259] Worker 3: Received shutdown message
INFO 12-26 04:40:52 [gpu_worker.py:281] event loop terminated.
INFO 12-26 04:40:53 [npu_worker.py:126] Worker 0: Shutdown complete.
INFO 12-26 04:40:53 [npu_worker.py:126] Worker 3: Shutdown complete.
INFO 12-26 04:40:53 [npu_worker.py:126] Worker 1: Shutdown complete.
INFO 12-26 04:40:53 [npu_worker.py:126] Worker 2: Shutdown complete.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
