### PR TITLE
[Bugfix] Fix on_finalize_request method arguments number mismatch

### DIFF
--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -392,7 +392,6 @@ class AsyncOmni(OmniBase):
                                 metrics.on_finalize_request(
                                     stage_id,
                                     req_id,
-                                    [engine_outputs],
                                     _req_start_ts.get(req_id, _wall_start_ts),
                                 )
                         except Exception as e:


### PR DESCRIPTION
## Purpose
delete `engine_outputs` argument
<img width="1704" height="175" alt="image" src="https://github.com/user-attachments/assets/e569b37a-2d7f-4556-a277-5cb1188599aa" />

