### PR TITLE
[Doc] fix i2i online serving doc

### DIFF
--- a/docs/user_guide/examples/online_serving/image_to_image.md
+++ b/docs/user_guide/examples/online_serving/image_to_image.md
@@ -46,24 +46,27 @@ bash run_curl_image_edit.sh input.png "Convert this image to watercolor style"
 
 # Or execute directly
 IMG_B64=$(base64 -w0 input.png)
-curl -s http://localhost:8092/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"messages\": [{
-      \"role\": \"user\",
-      \"content\": [
-        {\"type\": \"text\", \"text\": \"Convert this image to watercolor style\"},
-        {\"type\": \"image_url\", \"image_url\": {\"url\": \"data:image/png;base64,\$IMG_B64\"}}
-      ]
-    }],
-    \"extra_body\": {
-      \"height\": 1024,
-      \"width\": 1024,
-      \"num_inference_steps\": 50,
-      \"guidance_scale\": 7.5,
-      \"seed\": 42
-    }
-  }" | jq -r '.choices[0].message.content[0].image_url.url' | cut -d',' -f2 | base64 -d > output.png
+
+cat <<EOF > request.json
+{
+  "messages": [{
+    "role": "user",
+    "content": [
+      {"type": "text", "text": "Convert this image to watercolor style"},
+      {"type": "image_url", "image_url": {"url": "data:image/png;base64,$IMG_B64"}}
+    ]
+  }],
+  "extra_body": {
+    "height": 1024,
+    "width": 1024,
+    "num_inference_steps": 50,
+    "guidance_scale": 1,
+    "seed": 42
+  }
+}
+EOF
+
+curl -s http://localhost:8092/v1/chat/completions   -H "Content-Type: application/json"   -d @request.json | jq -r '.choices[0].message.content[0].image_url.url' | cut -d',' -f2 | base64 -d > output.png
 ```
 
 ### Method 2: Using Python Client

--- a/examples/online_serving/image_to_image/README.md
+++ b/examples/online_serving/image_to_image/README.md
@@ -43,24 +43,27 @@ bash run_curl_image_edit.sh input.png "Convert this image to watercolor style"
 
 # Or execute directly
 IMG_B64=$(base64 -w0 input.png)
-curl -s http://localhost:8092/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"messages\": [{
-      \"role\": \"user\",
-      \"content\": [
-        {\"type\": \"text\", \"text\": \"Convert this image to watercolor style\"},
-        {\"type\": \"image_url\", \"image_url\": {\"url\": \"data:image/png;base64,\$IMG_B64\"}}
-      ]
-    }],
-    \"extra_body\": {
-      \"height\": 1024,
-      \"width\": 1024,
-      \"num_inference_steps\": 50,
-      \"guidance_scale\": 7.5,
-      \"seed\": 42
-    }
-  }" | jq -r '.choices[0].message.content[0].image_url.url' | cut -d',' -f2 | base64 -d > output.png
+
+cat <<EOF > request.json
+{
+  "messages": [{
+    "role": "user",
+    "content": [
+      {"type": "text", "text": "Convert this image to watercolor style"},
+      {"type": "image_url", "image_url": {"url": "data:image/png;base64,$IMG_B64"}}
+    ]
+  }],
+  "extra_body": {
+    "height": 1024,
+    "width": 1024,
+    "num_inference_steps": 50,
+    "guidance_scale": 1,
+    "seed": 42
+  }
+}
+EOF
+
+curl -s http://localhost:8092/v1/chat/completions   -H "Content-Type: application/json"   -d @request.json | jq -r '.choices[0].message.content[0].image_url.url' | cut -d',' -f2 | base64 -d > output.png
 ```
 
 ### Method 2: Using Python Client


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
fix i2i online serving doc
## Test Plan

```
vllm serve Qwen/Qwen-Image-Edit-2511 --omni --port 8092
```

```
IMG_B64=$(base64 -w0 input.png)

cat <<EOF > request.json
{
  "messages": [{
    "role": "user",
    "content": [
      {"type": "text", "text": "Convert this image to watercolor style"},
      {"type": "image_url", "image_url": {"url": "data:image/png;base64,$IMG_B64"}}
    ]
  }],
  "extra_body": {
    "height": 1024,
    "width": 1024,
    "num_inference_steps": 50,
    "guidance_scale": 1,
    "seed": 42
  }
}
EOF

curl -s http://localhost:8092/v1/chat/completions   -H "Content-Type: application/json"   -d @request.json | jq -r '.choices[0].message.content[0].image_url.url' | cut -d',' -f2 | base64 -d > output.png
```
## Test Result

```
(APIServer pid=94900) INFO:     Started server process [94900]
(APIServer pid=94900) INFO:     Waiting for application startup.
(APIServer pid=94900) INFO:     Application startup complete.
(APIServer pid=94900) WARNING 01-04 08:05:32 [protocol.py:112] The following fields were present in the request but ignored: {'extra_body'}
(APIServer pid=94900) INFO 01-04 08:05:32 [serving_chat.py:1838] Diffusion chat request chatcmpl-217c5f8db925402b: prompt='Convert this image to watercolor style', ref_images=1, params={'height': 1024, 'width': 1024, 'num_inference_steps': 50, 'guidance_scale': 1, 'seed': 42}
[Stage-0] INFO 01-04 08:05:32 [diffusion_engine.py:81] Pre-processing completed in 0.0857 seconds
[Stage-0] INFO 01-04 08:06:32 [shm_broadcast.py:501] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
[Stage-0] INFO 01-04 08:07:08 [diffusion_engine.py:86] Generation completed successfully.
[Stage-0] INFO 01-04 08:07:09 [diffusion_engine.py:109] Post-processing completed in 0.0864 seconds
(APIServer pid=94900) INFO 01-04 08:07:09 [log_utils.py:549] {'type': 'request_level_metrics',
(APIServer pid=94900) INFO 01-04 08:07:09 [log_utils.py:549]  'request_id': 'chatcmpl-217c5f8db925402b',
(APIServer pid=94900) INFO 01-04 08:07:09 [log_utils.py:549]  'e2e_time_ms': 96398.33092689514,
(APIServer pid=94900) INFO 01-04 08:07:09 [log_utils.py:549]  'e2e_tpt': 0.0,
(APIServer pid=94900) INFO 01-04 08:07:09 [log_utils.py:549]  'e2e_total_tokens': 0,
(APIServer pid=94900) INFO 01-04 08:07:09 [log_utils.py:549]  'transfers_total_time_ms': 0.0,
(APIServer pid=94900) INFO 01-04 08:07:09 [log_utils.py:549]  'transfers_total_bytes': 0,
(APIServer pid=94900) INFO 01-04 08:07:09 [log_utils.py:549]  'stages': {0: {'stage_gen_time_ms': 96365.00000953674,
(APIServer pid=94900) INFO 01-04 08:07:09 [log_utils.py:549]                 'num_tokens_out': 0,
(APIServer pid=94900) INFO 01-04 08:07:09 [log_utils.py:549]                 'num_tokens_in': 0}}}
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468] [Summary] {'e2e_requests': 1,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]  'e2e_total_time_ms': 96398.65016937256,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]  'e2e_sum_time_ms': 96398.33092689514,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]  'e2e_total_tokens': 0,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]  'e2e_avg_time_per_request_ms': 96398.33092689514,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]  'e2e_avg_tokens_per_s': 0.0,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]  'wall_time_ms': 96398.65016937256,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]  'final_stage_id': 0,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]  'stages': [{'stage_id': 0,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]              'requests': 1,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]              'tokens': 0,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]              'total_time_ms': 96398.62394332886,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]              'avg_time_per_request_ms': 96398.62394332886,
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]              'avg_tokens_per_s': 0.0}],
(APIServer pid=94900) INFO 01-04 08:07:09 [async_omni.py:468]  'transfers': []}
(APIServer pid=94900) INFO 01-04 08:07:09 [serving_chat.py:1974] Diffusion chat completed for request chatcmpl-217c5f8db925402b: 1 images
(APIServer pid=94900) /workspace/c00580271/.venv/lib/python3.12/site-packages/pydantic/main.py:464: UserWarning: Pydantic serializer warnings:
(APIServer pid=94900)   PydanticSerializationUnexpectedValue(Expected `str` - serialized value may not be as expected [field_name='content', input_value=[{'type': 'image_url', 'i...t+A1AAAAAElFTkSuQmCC'}}], input_type=list])
(APIServer pid=94900)   return self.__pydantic_serializer__.to_python(
(APIServer pid=94900) INFO:     127.0.0.1:45044 - "POST /v1/chat/completions HTTP/1.1" 200 OK

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
