### PR TITLE
[Misc] fix ring att log

### DIFF
--- a/vllm_omni/diffusion/attention/parallel/ring.py
+++ b/vllm_omni/diffusion/attention/parallel/ring.py
@@ -120,7 +120,7 @@ class RingParallelAttention:
         if query.dtype == torch.float32 or not HAS_FLASH_ATTN:
             if not HAS_FLASH_ATTN and backend_pref != "sdpa":
                 logger = init_logger(__name__)
-                logger.warning("Flash Attention is not available! Force enabling SDPA.")
+                logger.warning_once("Flash Attention is not available! Force enabling SDPA.")
             backend_pref = "sdpa"
 
         # Extract joint tensors

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -500,7 +500,7 @@ def get_cached_compilation_config():
 
 def get_current_omni_diffusion_config() -> OmniDiffusionConfig:
     if _current_omni_diffusion_config is None:
-        logger.warning("Current OmniDiffusionConfig is not set.")
+        logger.warning_once("Current OmniDiffusionConfig is not set.")
         return OmniDiffusionConfig()
     return _current_omni_diffusion_config
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
 fix ring att log, the relevant pr #582  will fix the context issues.
```
[Stage-0] WARNING 01-04 08:41:56 [data.py:503] Current OmniDiffusionConfig is not set.

[Stage-0] WARNING 01-04 08:41:56 [ring.py:123] Flash Attention is not available! Force enabling SDPA.

[Stage-0] WARNING 01-04 08:41:56 [data.py:503] Current OmniDiffusionConfig is not set.

[Stage-0] WARNING 01-04 08:41:56 [ring.py:123] Flash Attention is not available! Force enabling SDPA.

[Stage-0] WARNING 01-04 08:41:56 [data.py:503] Current OmniDiffusionConfig is not set.

[Stage-0] WARNING 01-04 08:41:56 [ring.py:123] Flash Attention is not available! Force enabling SDPA.

[Stage-0] WARNING 01-04 08:41:56 [data.py:503] Current OmniDiffusionConfig is not set.

[Stage-0] WARNING 01-04 08:41:56 [ring.py:123] Flash Attention is not available! Force enabling SDPA.

[Stage-0] WARNING 01-04 08:41:56 [data.py:503] Current OmniDiffusionConfig is not set.

[Stage-0] WARNING 01-04 08:41:56 [ring.py:123] Flash Attention is not available! Force enabling SDPA.

[Stage-0] WARNING 01-04 08:41:56 [data.py:503] Current OmniDiffusionConfig is not set.

[Stage-0] WARNING 01-04 08:41:56 [ring.py:123] Flash Attention is not available! Force enabling SDPA.

[Stage-0] WARNING 01-04 08:41:56 [data.py:503] Current OmniDiffusionConfig is not set.

[Stage-0] WARNING 01-04 08:41:56 [data.py:503] Current OmniDiffusionConfig is not set.

[Stage-0] WARNING 01-04 08:41:56 [ring.py:123] Flash Attention is not available! Force enabling SDPA.

[Stage-0] WARNING 01-04 08:41:56 [ring.py:123] Flash Attention is not available! Force enabling SDPA.

[Stage-0] WARNING 01-04 08:41:56 [data.py:503] Current OmniDiffusionConfig is not set.

[Stage-0] WARNING 01-04 08:41:56 [ring.py:123] Flash Attention is not available! Force enabling SDPA.

[Stage-0] WARNING 01-04 08:41:56 [data.py:503] Current OmniDiffusionConfig is not set.

[Stage-0] WARNING 01-04 08:41:56 [ring.py:123] Flash Attention is not available! Force enabling SDPA.

[Stage-0] WARNING 01-04 08:41:56 [data.py:503] Current OmniDiffusionConfig is not set.

[Stage-0] WARNING 01-04 08:41:56 [ring.py:123] Flash Attention is not available! Force enabling SDPA.
```

## Test Plan
```
cd examples/offline_inference/text_to_image
python text_to_image.py   --model /workspace/models/Qwen/Qwen-Image   --prompt "a cup of coffee on the table"   --seed 42   --cfg_scale 4.0   --num_images_per_prompt 1   --num_inference_steps 50   --height 1024   --width 1024   --output outputs/coffee.png --cache_backend cache_dit --ring_degree 2
```
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
