### PR TITLE
[BugFix] token2wav code out of range

### DIFF
--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
@@ -101,6 +101,12 @@ class Qwen2_5OmniForConditionalGeneration(
             self.talker.init_multi_modal(thinker_config)
             self.model = self.talker
             self.token2wav = None
+            # set suppress start id according to token2wav
+            t2w_token_end_id = getattr(
+                getattr(getattr(config, "token2wav_config", None), "dit_config", None), "num_embeds", None
+            )
+            if t2w_token_end_id:
+                self.model.set_suppress_start_id(t2w_token_end_id + 1)
 
         elif self.model_stage == "code2wav":
             self.thinker = None


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
As show in https://github.com/vllm-project/vllm-omni/issues/476

Talker with vocab_size 8448, while token2wav with 8193, and it will result out of range in token2wav.

Modify:
we suppress the token id [8194:8448] in talker stage.

## Test Plan
Run the benchmark again!

## Test Result
All Request Success
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Maximum request concurrency:             1         
Request rate configured (RPS):           1.00      
Benchmark duration (s):                  862.52    
Total input tokens:                      16721     
Total text input tokens:                 1000      
Total generated tokens:                  6714      
Request throughput (req/s):              0.12      
Audio throughput (num/s):                0.12      
Output token throughput (tok/s):         7.78      
Peak output token throughput (tok/s):    1.00      
Peak concurrent requests:                2.00      
Total Token throughput (tok/s):          27.17     
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
