### PR TITLE
[BUGFIX] Delete the CUDA context in the stage process.

### DIFF
--- a/tests/entrypoints/test_stage_utils.py
+++ b/tests/entrypoints/test_stage_utils.py
@@ -55,4 +55,3 @@ def test_set_stage_devices_respects_logical_ids(monkeypatch):
     set_stage_devices(stage_id=0, devices="0,1")
 
     assert os.environ["CUDA_VISIBLE_DEVICES"] == "6,7"
-    

--- a/vllm_omni/entrypoints/stage_utils.py
+++ b/vllm_omni/entrypoints/stage_utils.py
@@ -64,15 +64,6 @@ def set_stage_devices(
 
     env_var = get_device_control_env_var()
 
-    # Select device-specific torch functions
-    if device_type == "npu":
-        device_type_label = "NPU"
-    elif device_type == "cuda":
-        device_type_label = "CUDA"
-    else:
-        logger.debug("[Stage-%s] Unsupported device type: %s", stage_id, device_type)
-        return
-
     try:
         selected_physical: int | None = None
         logical_idx: int | None = None
@@ -110,7 +101,7 @@ def set_stage_devices(
                         selected_physical,
                     )
                 except Exception as e:
-                    logger.debug("[Stage-%s] Failed to parse first %s device: %s", stage_id, device_type_label, e)
+                    logger.debug("[Stage-%s] Failed to parse first %s device: %s", stage_id, device_type, e)
                     selected_physical = None
         elif isinstance(devices, (int, str)) and (isinstance(devices, int) or str(devices).isdigit()):
             logical_idx = max(0, int(devices))


### PR DESCRIPTION
## Purpose

We have observed that there are often many processes present on the GPU, even though some of them use only about 500 MB of CUDA memory. This issue was also mentioned in #104 
<img width="1916" height="233" alt="image" src="https://github.com/user-attachments/assets/9f432457-54bd-4f0d-9bca-724b76b6f046" />

<img width="805" height="421" alt="image" src="https://github.com/user-attachments/assets/4de9b42a-5c45-401a-9c1b-845efe96c347" />

After further analysis, we found that each stage process checks whether its assigned device is available by calling `torch.set_device` after setting the device information. However, this approach initializes a CUDA context on each GPU, leaving a nontrivial amount of residual CUDA memory allocated. 

<img width="1544" height="963" alt="image" src="https://github.com/user-attachments/assets/2a7360c5-e11c-468b-afb9-e9c731b9a004" />

Since this availability check can be safely performed on the underlying worker side, we have removed it here to avoid unnecessary CUDA context creation and reduce GPU memory overhead.

## Test Result
<img width="750" height="260" alt="image" src="https://github.com/user-attachments/assets/ca174dfb-dcd1-4ef4-ab41-7671b2338f96" />

