### PR TITLE
[Bugfix] Validate temperature in talker stage for issue#494

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -1047,6 +1047,10 @@ class Qwen3OmniMoeForConditionalGeneration(
         if getattr(self, "model_stage", None) == "talker" and isinstance(logits, torch.Tensor):
             # suppress tokens by setting their probability to ~1e-9 (finite very small)
             suppressed_tokens = self._get_talker_suppressed_tokens()
+            # validate the temperature to ensure all positive for talker stage
+            temperature = sampling_metadata.temperature
+            if temperature is not None and torch.any(temperature <= 0):
+                raise ValueError("Temperature must be positive for talker stage.")
             try:
                 logits_cpu = logits.cpu()
                 logits_cpu[:, suppressed_tokens] = -1e9


### PR DESCRIPTION
# Problem Description
Successfully reproduced the issue reported in #494: When the temperature parameter in the talker stage is set to 0.0, the generated prompt_token_ids contain excessive repeated segments, which leads to significant blank/empty segments in the audio generated by the Code2wav stage.

# Changes
This pull request adds an important validation step to the `dummy_tensors` method in `qwen3_omni.py` to ensure the temperature parameter is always positive during the "talker" stage. This helps prevent invalid sampling behavior and potential runtime errors.
