### PR TITLE
[Bugfix] Fix f-string formatting in image generation pipelines

### DIFF
--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image_edit.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image_edit.py
@@ -466,7 +466,7 @@ class LongCatImageEditPipeline(nn.Module):
         if height % (self.vae_scale_factor * 2) != 0 or width % (self.vae_scale_factor * 2) != 0:
             logger.warning(
                 "`height` and `width` have to be divisible by "
-                "{self.vae_scale_factor * 2} but are {height} and {width}. "
+                f"{self.vae_scale_factor * 2} but are {height} and {width}. "
                 "Dimensions will be resized accordingly"
             )
 

--- a/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
+++ b/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
@@ -328,7 +328,7 @@ class OvisImagePipeline(
                 "Provide either `prompt` or `prompt_embeds`. Cannot leave both `prompt` and `prompt_embeds` undefined."
             )
         elif prompt is not None and (not isinstance(prompt, str) and not isinstance(prompt, list)):
-            raise ValueError("`prompt` has to be of type `str` or `list[str]` but is {type(prompt)}")
+            raise ValueError(f"`prompt` has to be of type `str` or `list[str]` but is {type(prompt)}")
 
         if negative_prompt is not None and negative_prompt_embeds is not None:
             raise ValueError(

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -308,7 +308,7 @@ class QwenImagePipeline(
         if height % (self.vae_scale_factor * 2) != 0 or width % (self.vae_scale_factor * 2) != 0:
             logger.warning(
                 f"`height` and `width` have to be divisible by {self.vae_scale_factor * 2} "
-                "but are {height} and {width}. Dimensions will be resized accordingly"
+                f"but are {height} and {width}. Dimensions will be resized accordingly"
             )
 
         # if callback_on_step_end_tensor_inputs is not None and not all(


### PR DESCRIPTION
## Purpose

Fix f-string formatting errors in image generation pipelines. This PR resolves missing f-string prefixes in three pipeline files that would cause string formatting to fail at runtime:

  - Fixed f-string in LongCatImageEditPipeline warning message
  - Fixed f-string in OvisImagePipeline ValueError message
  - Fixed f-string in QwenImagePipeline warning message
## Test Plan

## Test Result
