### PR TITLE
[Bugfix] Fix multi-audio input shape alignment for Qwen3-Omni Thinker

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -581,7 +581,7 @@ class Qwen3OmniMoeConditionalGenerationMixin(Qwen2_5OmniConditionalGenerationMix
             and input_audio_features.ndim == 3
         ):
             # (batch_size, feature_dim, chunk_size) -> (feature_dim, batch_size * chunk_size)
-            input_audio_features = input_audio_features.permute(1, 0, 2).reshape(input_audio_features.shape[1], -1)
+            input_audio_features = input_audio_features.permute(1, 0, 2).flatten(1)
         elif input_audio_features is not None and isinstance(input_audio_features, list):
             input_audio_features = torch.cat(input_audio_features, dim=-1)
         if (


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fix: https://github.com/vllm-project/vllm-omni/issues/640

This PR fixes the handling of multiple audio inputs in the Qwen3-Omni Thinker. Previously, when multiple audio segments were provided, the code incorrectly reshaped audio features and attention masks, resulting in mismatches between feature and mask dimensions and causing downstream runtime errors.

Key changes:

Properly concatenate audio features from shape [B, C, T] to [C, B*T], ensuring the model receives all audio segments as a continuous sequence along the time axis.

This resolves the shape mismatch error when multiple audio inputs are present.

## Test Plan
python -m pytest -sv tests/e2e/online_serving_full/test_qwen3_omni.py::test_text_audio_to_text_audio_001
## Test Result
The bug in issue #640 has been resolved, but another bug has appeared, which may be related to the recent cutdown bug.
```
_______________________________________________________________________________________________ test_text_audio_to_text_audio_001[test_config0] ________________________________________________________________________________________________

test_config = ('Qwen3-Omni-30B-A3B-Instruct', '/vllm-omni/vllm-omni-LJH/tests/e2e/stage_configs/qwen3_omni_ci.yaml')

    @pytest.mark.parametrize("test_config", test_params)
    def test_text_audio_to_text_audio_001(test_config: tuple[str, str]) -> None:
        """Test processing text, generating audio output via OpenAI API."""
    
        model, stage_config_path = test_config
        num_concurrent_requests = 5
        stage_config_path = modify_stage_config(stage_config_path, {
            0: {"runtime.devices": "4,3",
                "runtime.max_batch_size": num_concurrent_requests},
            1: {"runtime.max_batch_size": num_concurrent_requests, "runtime.devices": "4"},
            2: {"runtime.devices": "3"}
            })
        with OmniServer(model, ["--stage-configs-path", stage_config_path, "--stage-init-timeout", "90"]) as server:
            audio_data_url = []
            for _ in range(4):
                audio_data_url.append(f"data:audio/wav;base64,{generate_synthetic_audio(10, 5)}")
    
            messages = dummy_messages_from_mix_data(
                system_prompt=get_system_prompt(),
                audio_data_url=audio_data_url,
                content_text="What is recited in the audio? What is in this image? Describe the video briefly."
            )
    
            # Test single completion
            api_client = client(server)
            e2e_list = list()
            with concurrent.futures.ThreadPoolExecutor(max_workers=num_concurrent_requests) as executor:
                # Submit multiple completion requests concurrently
                futures = [
                    executor.submit(
                        api_client.chat.completions.create,
                        model=server.model,
                        messages=messages,
                        max_tokens=10,
                        stop=None,
                    )
                    for _ in range(num_concurrent_requests)
                ]
                start_time = time.perf_counter()
                # Wait for all requests to complete and collect results
                chat_completions = list()
                for future in concurrent.futures.as_completed(futures):
                    chat_completions.append(future.result())
                    # Verify E2E
                    current_e2e = time.perf_counter() - start_time
                    print(f"the request e2e is: {current_e2e}")
                    # TODO: Verify the E2E latency after confirmation baseline.
                    e2e_list.append(current_e2e)
    
            print(f"the avg e2e is: {sum(e2e_list)/len(e2e_list)}")
            # Verify all completions succeeded
            assert len(chat_completions) == num_concurrent_requests, "Not all requests succeeded."
            for chat_completion in chat_completions:
                # Verify audio output success
                audio_message = chat_completion.choices[1].message
                audio_data = audio_message.audio.data
                assert audio_data is not None, "No audio output is generated"
                assert audio_message.audio.expires_at > time.time(), "The generated audio has expired."
    
                # Verify text output success
                text_choice = chat_completion.choices[0]
                text_content = text_choice.message.content
                assert text_choice.message.content is not None, "No text output is generated"
                assert chat_completion.usage.completion_tokens == 10, "The output length differs from the requested max_tokens."
    
                # Verify text output same as audio output
                audio_content = convert_audio_to_text(audio_data)
                print(f"text content is: {text_content}")
                print(f"audio content is: {audio_content}")
>               assert cosine_similarity_text(audio_content,text_content) > 0.9, "The audio content is not same as the text"
E               AssertionError: The audio content is not same as the text
E               assert np.float64(0.5976143046671968) > 0.9
E                +  where np.float64(0.5976143046671968) = cosine_similarity_text('audi open drains the sound of waterfall', 'The audio contains the sound of a waterfall. There')

tests/e2e/online_serving_full/test_qwen3_omni.py:491: AssertionError

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
