### PR TITLE
[Hardware][AMD] Add gfx1151 (Strix Halo) support

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,9 +1,9 @@
-ARG BASE_IMAGE=rocm/vllm-dev:nightly_main_20251205
+ARG BASE_IMAGE=docker.io/rocm/vllm-dev:nightly_main_20251205
 FROM ${BASE_IMAGE}
 
 ARG COMMON_WORKDIR=/app
 ARG VLLM_VERSION=v0.12.0
-ARG PYTORCH_ROCM_ARCH="gfx942;gfx950"
+ARG PYTORCH_ROCM_ARCH="gfx942;gfx950;gfx1151"
 
 WORKDIR ${COMMON_WORKDIR}
 
@@ -35,8 +35,9 @@ RUN cd ${COMMON_WORKDIR}/vllm-omni && python3 -m pip install --no-cache-dir ".[d
 # This is needed to prevent the AITER automatic GPU arch detection from failing on MI325X.
 # The AITER version used in this dockerfile has issues with handling
 # the GPU archs of MI325X (CI machine) correctly. So we manually set the GPU archs here.
-# We reuse AITER_ROCM_ARCH from the base image to avoid duplication.
-ENV GPU_ARCHS=${AITER_ROCM_ARCH}
+# We add gfx1151 (Strix Halo) support in addition to datacenter GPUs.
+ARG GPU_ARCHS_ARG="gfx942;gfx950;gfx1151"
+ENV GPU_ARCHS=${GPU_ARCHS_ARG}
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 ENTRYPOINT []

--- a/docs/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/getting_started/installation/gpu/rocm.inc.md
@@ -1,6 +1,6 @@
 # --8<-- [start:requirements]
 
-- GPU: Validated on gfx942 (It should be supported on the AMD GPUs that are supported by vLLM.)
+- GPU: Validated on gfx942, gfx950, gfx1151 (Strix Halo). Should work on AMD GPUs supported by vLLM.
 
 # --8<-- [end:requirements]
 # --8<-- [start:set-up-using-python]
@@ -28,7 +28,7 @@ If you want to specify which GPU Arch to build for to cutdown build time:
 ```bash
 DOCKER_BUILDKIT=1 docker build \
   -f docker/Dockerfile.rocm \
-  --build-arg PYTORCH_ROCM_ARCH="gfx942;gfx950" \
+  --build-arg PYTORCH_ROCM_ARCH="gfx942;gfx950;gfx1151" \
   -t vllm-omni-rocm .
 ```
 


### PR DESCRIPTION
## Summary

Add support for AMD Ryzen AI Max+ (gfx1151/Strix Halo) APU in ROCm Dockerfile:

- Add `gfx1151` to `PYTORCH_ROCM_ARCH` build argument
- Add `gfx1151` to `GPU_ARCHS` environment variable
- Update documentation to include gfx1151 validation

## Test Plan

Tested on AMD Ryzen AI Max+ 395 with ROCm 7.1.1 / Ubuntu 25.10:

- [x] Docker image builds successfully with gfx1151 target
- [x] PyTorch ROCm detects GPU correctly
- [x] vLLM and vLLM-Omni import successfully
- [x] LLM inference works (~38 tok/s with Qwen2.5-1.5B-Instruct)

```bash
podman run --device=/dev/kfd --device=/dev/dri \
  vllm-omni-gfx1151:test python -c "import torch; print(torch.cuda.is_available())"
# True
```

## Known Limitations

| Issue | Description | Status |
|-------|-------------|--------|
| AITER | Diffusion models blocked - AITER library doesn't support gfx1151 | Upstream issue |
| HIP Memory | `hipMemGetInfo` reports incorrect values on APU | Upstream bug |

**Workaround for memory detection:** use `gpu_memory_utilization=0.22` for 32GB systems.

## Related Issues

- Upstream AITER needs gfx1151 support for diffusion models
- ROCm HIP memory detection bug on APU architecture