### PR TITLE
[BugFix] Explicitly release file locks during stage worker init

### DIFF
--- a/vllm_omni/entrypoints/omni_stage.py
+++ b/vllm_omni/entrypoints/omni_stage.py
@@ -601,6 +601,7 @@ def _stage_worker(
         # or when process dies
         for lock_fd in lock_files:
             try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
                 _os.close(lock_fd)
                 logger.debug("Released initialization lock (fd=%s)", lock_fd)
             except (OSError, ValueError):
@@ -1104,6 +1105,7 @@ async def _stage_worker_async(
         # or when process dies
         for lock_fd in lock_files:
             try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
                 _os.close(lock_fd)
                 logger.debug("Released initialization lock (fd=%s)", lock_fd)
             except (OSError, ValueError):


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix Issue #643 

During initialization of stage workers, there exist implicit release of locks and potential contention scenarios. This PR explicitly unlock with `LOCK_U` before closing file descriptors to ensure immediate lock release and prevents potential contention. 

cc @Gaohan123 , @gcanlin 

## Test Plan

Offline inference end2end test (`examples/offline_inference/qwen3_omni/end2end.py`).

## Test Result

Before (without explicitly releasing, stage-0 wait to acquire the locks and timeout, and proceed anyway):
`e2e_total_time_ms`: 146190.48142433167, stage-0 `total_time_ms`: 133930.07564544678,

After (stages acquire locks in a staggered way):
`e2e_total_time_ms`: 14761.743545532227, stage-0 `total_time_ms`: 2176.140785217285,

### Ordering of acquiring/releasing the locks
Note that for `Qwen/Qwen3-Omni-30B-A3B-Instruct` in the offline end2end test, the stages configs are (from `vllm_omni/model_executor/stage_configs/qwen3_omni_moe.yaml`):
```yaml
  - stage_id: 0
    stage_type: llm  # Use llm stage type to launch OmniLLM
    runtime:
      devices: "0,1"
...
  - stage_id: 1
    stage_type: llm  # Use llm stage type to launch OmniLLM
    runtime:
      devices: "1"
...
  - stage_id: 2
    stage_type: llm  # Use llm stage type to launch OmniLLM
    runtime:
      devices: "0"
```

And the logs indicating the acquirement and release ordering for now are:
```bash
[Stage-0] DEBUG 01-08 09:21:22 [omni_stage.py:558] Acquired exclusive lock for device 0
[Stage-1] DEBUG 01-08 09:21:22 [omni_stage.py:558] Acquired exclusive lock for device 1
...
INFO 01-08 09:22:22 [omni.py:295] [Orchestrator] Stage-1 reported ready
[Stage-0] DEBUG 01-08 09:22:22 [omni_stage.py:558] Acquired exclusive lock for device 1
...
INFO 01-08 09:24:10 [omni.py:295] [Orchestrator] Stage-0 reported ready
[Stage-2] DEBUG 01-08 09:24:10 [omni_stage.py:558] Acquired exclusive lock for device 0
...
INFO 01-08 09:25:18 [omni.py:295] [Orchestrator] Stage-2 reported ready
```

<details>
<summary>End2end script result summary before this fix</summary>

```text
INFO 01-08 03:24:35 [omni.py:777] [Summary] {'e2e_requests': 1,
INFO 01-08 03:24:35 [omni.py:777]  'e2e_total_time_ms': 146190.48142433167,
INFO 01-08 03:24:35 [omni.py:777]  'e2e_sum_time_ms': 146188.65752220154,
INFO 01-08 03:24:35 [omni.py:777]  'e2e_total_tokens': 232,
INFO 01-08 03:24:35 [omni.py:777]  'e2e_avg_time_per_request_ms': 146188.65752220154,
INFO 01-08 03:24:35 [omni.py:777]  'e2e_avg_tokens_per_s': 1.5869904268377755,
INFO 01-08 03:24:35 [omni.py:777]  'wall_time_ms': 146190.48142433167,
INFO 01-08 03:24:35 [omni.py:777]  'final_stage_id': {'0_a789ecc1-65af-47e0-8ef2-698913be0777': 2},
INFO 01-08 03:24:35 [omni.py:777]  'stages': [{'stage_id': 0,
INFO 01-08 03:24:35 [omni.py:777]              'requests': 1,
INFO 01-08 03:24:35 [omni.py:777]              'tokens': 30,
INFO 01-08 03:24:35 [omni.py:777]              'total_time_ms': 133930.07564544678,
INFO 01-08 03:24:35 [omni.py:777]              'avg_time_per_request_ms': 133930.07564544678,
INFO 01-08 03:24:35 [omni.py:777]              'avg_tokens_per_s': 0.22399748417539186},
INFO 01-08 03:24:35 [omni.py:777]             {'stage_id': 1,
INFO 01-08 03:24:35 [omni.py:777]              'requests': 1,
INFO 01-08 03:24:35 [omni.py:777]              'tokens': 135,
INFO 01-08 03:24:35 [omni.py:777]              'total_time_ms': 11599.428653717041,
INFO 01-08 03:24:35 [omni.py:777]              'avg_time_per_request_ms': 11599.428653717041,
INFO 01-08 03:24:35 [omni.py:777]              'avg_tokens_per_s': 11.638504277255},
INFO 01-08 03:24:35 [omni.py:777]             {'stage_id': 2,
INFO 01-08 03:24:35 [omni.py:777]              'requests': 1,
INFO 01-08 03:24:35 [omni.py:777]              'tokens': 0,
INFO 01-08 03:24:35 [omni.py:777]              'total_time_ms': 152.42505073547363,
INFO 01-08 03:24:35 [omni.py:777]              'avg_time_per_request_ms': 152.42505073547363,
INFO 01-08 03:24:35 [omni.py:777]              'avg_tokens_per_s': 0.0}],
INFO 01-08 03:24:35 [omni.py:777]  'transfers': [{'from_stage': 0,
INFO 01-08 03:24:35 [omni.py:777]                 'to_stage': 1,
INFO 01-08 03:24:35 [omni.py:777]                 'samples': 1,
INFO 01-08 03:24:35 [omni.py:777]                 'total_bytes': 2311717,
INFO 01-08 03:24:35 [omni.py:777]                 'total_time_ms': 5.521059036254883,
INFO 01-08 03:24:35 [omni.py:777]                 'tx_mbps': 3349.6718434919894,
INFO 01-08 03:24:35 [omni.py:777]                 'rx_samples': 1,
INFO 01-08 03:24:35 [omni.py:777]                 'rx_total_bytes': 2311717,
INFO 01-08 03:24:35 [omni.py:777]                 'rx_total_time_ms': 8.063793182373047,
INFO 01-08 03:24:35 [omni.py:777]                 'rx_mbps': 2293.4288593147658,
INFO 01-08 03:24:35 [omni.py:777]                 'total_samples': 1,
INFO 01-08 03:24:35 [omni.py:777]                 'total_transfer_time_ms': 15.37013053894043,
INFO 01-08 03:24:35 [omni.py:777]                 'total_mbps': 1203.2256950027765},
INFO 01-08 03:24:35 [omni.py:777]                {'from_stage': 1,
INFO 01-08 03:24:35 [omni.py:777]                 'to_stage': 2,
INFO 01-08 03:24:35 [omni.py:777]                 'samples': 1,
INFO 01-08 03:24:35 [omni.py:777]                 'total_bytes': 6590,
INFO 01-08 03:24:35 [omni.py:777]                 'total_time_ms': 0.2970695495605469,
INFO 01-08 03:24:35 [omni.py:777]                 'tx_mbps': 177.4668594542536,
INFO 01-08 03:24:35 [omni.py:777]                 'rx_samples': 1,
INFO 01-08 03:24:35 [omni.py:777]                 'rx_total_bytes': 6590,
INFO 01-08 03:24:35 [omni.py:777]                 'rx_total_time_ms': 2.7642250061035156,
INFO 01-08 03:24:35 [omni.py:777]                 'rx_mbps': 19.07225348283595,
INFO 01-08 03:24:35 [omni.py:777]                 'total_samples': 1,
INFO 01-08 03:24:35 [omni.py:777]                 'total_transfer_time_ms': 3.9055347442626953,
INFO 01-08 03:24:35 [omni.py:777]                 'total_mbps': 13.49879170258226}]}
```

</details>


<details>
<summary>Result summary after this fix</summary>

```text
INFO 01-08 09:25:33 [omni.py:782] [Summary] {'e2e_requests': 1,
INFO 01-08 09:25:33 [omni.py:782]  'e2e_total_time_ms': 14761.743545532227,
INFO 01-08 09:25:33 [omni.py:782]  'e2e_sum_time_ms': 14760.218620300293,
INFO 01-08 09:25:33 [omni.py:782]  'e2e_total_tokens': 232,
INFO 01-08 09:25:33 [omni.py:782]  'e2e_avg_time_per_request_ms': 14760.218620300293,
INFO 01-08 09:25:33 [omni.py:782]  'e2e_avg_tokens_per_s': 15.717924372808511,
INFO 01-08 09:25:33 [omni.py:782]  'wall_time_ms': 14761.743545532227,
INFO 01-08 09:25:33 [omni.py:782]  'final_stage_id': {'0_4c21d539-8692-493e-b7a1-7b8373ca1efe': 2},
INFO 01-08 09:25:33 [omni.py:782]  'stages': [{'stage_id': 0,
INFO 01-08 09:25:33 [omni.py:782]              'requests': 1,
INFO 01-08 09:25:33 [omni.py:782]              'tokens': 30,
INFO 01-08 09:25:33 [omni.py:782]              'total_time_ms': 2176.140785217285,
INFO 01-08 09:25:33 [omni.py:782]              'avg_time_per_request_ms': 2176.140785217285,
INFO 01-08 09:25:33 [omni.py:782]              'avg_tokens_per_s': 13.785872772475305},
INFO 01-08 09:25:33 [omni.py:782]             {'stage_id': 1,
INFO 01-08 09:25:33 [omni.py:782]              'requests': 1,
INFO 01-08 09:25:33 [omni.py:782]              'tokens': 135,
INFO 01-08 09:25:33 [omni.py:782]              'total_time_ms': 11920.458555221558,
INFO 01-08 09:25:33 [omni.py:782]              'avg_time_per_request_ms': 11920.458555221558,
INFO 01-08 09:25:33 [omni.py:782]              'avg_tokens_per_s': 11.325067687170936},
INFO 01-08 09:25:33 [omni.py:782]             {'stage_id': 2,
INFO 01-08 09:25:33 [omni.py:782]              'requests': 1,
INFO 01-08 09:25:33 [omni.py:782]              'tokens': 0,
INFO 01-08 09:25:33 [omni.py:782]              'total_time_ms': 157.1950912475586,
INFO 01-08 09:25:33 [omni.py:782]              'avg_time_per_request_ms': 157.1950912475586,
INFO 01-08 09:25:33 [omni.py:782]              'avg_tokens_per_s': 0.0}],
INFO 01-08 09:25:33 [omni.py:782]  'transfers': [{'from_stage': 0,
INFO 01-08 09:25:33 [omni.py:782]                 'to_stage': 1,
INFO 01-08 09:25:33 [omni.py:782]                 'samples': 1,
INFO 01-08 09:25:33 [omni.py:782]                 'total_bytes': 2311717,
INFO 01-08 09:25:33 [omni.py:782]                 'total_time_ms': 5.454540252685547,
INFO 01-08 09:25:33 [omni.py:782]                 'tx_mbps': 3390.5215001199404,
INFO 01-08 09:25:33 [omni.py:782]                 'rx_samples': 1,
INFO 01-08 09:25:33 [omni.py:782]                 'rx_total_bytes': 2311717,
INFO 01-08 09:25:33 [omni.py:782]                 'rx_total_time_ms': 6.970882415771484,
INFO 01-08 09:25:33 [omni.py:782]                 'rx_mbps': 2652.997841156851,
INFO 01-08 09:25:33 [omni.py:782]                 'total_samples': 1,
INFO 01-08 09:25:33 [omni.py:782]                 'total_transfer_time_ms': 13.344287872314453,
INFO 01-08 09:25:33 [omni.py:782]                 'total_mbps': 1385.8915647622655},
INFO 01-08 09:25:33 [omni.py:782]                {'from_stage': 1,
INFO 01-08 09:25:33 [omni.py:782]                 'to_stage': 2,
INFO 01-08 09:25:33 [omni.py:782]                 'samples': 1,
INFO 01-08 09:25:33 [omni.py:782]                 'total_bytes': 6590,
INFO 01-08 09:25:33 [omni.py:782]                 'total_time_ms': 0.2970695495605469,
INFO 01-08 09:25:33 [omni.py:782]                 'tx_mbps': 177.4668594542536,
INFO 01-08 09:25:33 [omni.py:782]                 'rx_samples': 1,
INFO 01-08 09:25:33 [omni.py:782]                 'rx_total_bytes': 6590,
INFO 01-08 09:25:33 [omni.py:782]                 'rx_total_time_ms': 2.471923828125,
INFO 01-08 09:25:33 [omni.py:782]                 'rx_mbps': 21.327518024691358,
INFO 01-08 09:25:33 [omni.py:782]                 'total_samples': 1,
INFO 01-08 09:25:33 [omni.py:782]                 'total_transfer_time_ms': 3.528118133544922,
INFO 01-08 09:25:33 [omni.py:782]                 'total_mbps': 14.942810304095149}]}
```

</details>


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
