### PR TITLE
[BugFix] Fix assuming all stage model have talker

### DIFF
--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -563,7 +563,11 @@ class OmniGPUModelRunner(GPUModelRunner):
                     ubatch_slices=ubatch_slices,
                 ),
             ):
-                if getattr(self.model, "talker", None) is not None and hasattr(self.model, "talker_mtp") and num_tokens_padded == 1:
+                if (
+                    getattr(self.model, "talker", None) is not None
+                    and hasattr(self.model, "talker_mtp")
+                    and num_tokens_padded == 1
+                ):
                     outputs = self.talker_mtp(
                         self.talker_mtp_input_ids.gpu[:num_tokens_padded],
                         self.talker_mtp_inputs_embeds.gpu[:num_tokens_padded],


### PR DESCRIPTION
## Purpose

Related PR: https://github.com/vllm-project/vllm-omni/pull/726

The original code blindly accessed `self.model.talker`, assuming all stage models follow the Qwen2.5-Omni interface (where `talker` is explicitly set to `None` if unused). This PR changes the access to use `getattr(self.model, "talker", None)` to safely handle models lacking this attribute.