### PR TITLE
[Bugfix] Fix ring attention for npu device

### DIFF
--- a/vllm_omni/diffusion/attention/backends/ring/ring_kernels.py
+++ b/vllm_omni/diffusion/attention/backends/ring/ring_kernels.py
@@ -266,7 +266,7 @@ def flashinfer_attn_forward(
     return out, lse
 
 
-def npu_attn_forward(    
+def npu_attn_forward(
     q,
     k,
     v,
@@ -276,17 +276,14 @@ def npu_attn_forward(
     window_size=(-1, -1),
     softcap=None,
     alibi_slopes=None,
-    return_softmax=False
+    return_softmax=False,
 ):
     assert HAS_NPU, "torch_npu is not available"
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** (-0.5)
     causal_mask = None
     if causal:
-        causal_mask = torch.triu(
-            torch.ones(q.shape[1], k.shape[1], dtype=torch.uint8, device=q.device),
-            diagonal=1
-        )
+        causal_mask = torch.triu(torch.ones(q.shape[1], k.shape[1], dtype=torch.uint8, device=q.device), diagonal=1)
     block_out, block_lse = torch_npu.npu_fused_infer_attention_score(
         q,
         k,

--- a/vllm_omni/diffusion/attention/backends/ring/ring_selector.py
+++ b/vllm_omni/diffusion/attention/backends/ring/ring_selector.py
@@ -20,6 +20,7 @@ from .ring_kernels import (
     flash_attn_forward_aiter,
     flashinfer_attn_forward,
     pytorch_attn_forward,
+    npu_attn_forward
 )
 
 if HAS_SAGE_ATTENTION:
@@ -160,7 +161,7 @@ def select_flash_attn_impl(
     elif impl_type == AttnType.NPU:
         if not HAS_NPU:
             raise ImportError("torch_npu is not available!")
-        return npu_fused_infer_attention_score
+        return npu_attn_forward
 
     elif attn_processor is not None:
         return attn_processor

--- a/vllm_omni/diffusion/attention/backends/ring/ring_selector.py
+++ b/vllm_omni/diffusion/attention/backends/ring/ring_selector.py
@@ -19,8 +19,8 @@ from .ring_kernels import (
     flash_attn_forward,
     flash_attn_forward_aiter,
     flashinfer_attn_forward,
+    npu_attn_forward,
     pytorch_attn_forward,
-    npu_attn_forward
 )
 
 if HAS_SAGE_ATTENTION:
@@ -28,9 +28,6 @@ if HAS_SAGE_ATTENTION:
 
 if HAS_SPARSE_SAGE_ATTENTION:
     from spas_sage_attn.autotune import SparseAttentionMeansim
-
-if HAS_NPU:
-    from torch_npu import npu_fused_infer_attention_score
 
 
 class AttnType(Enum):


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fix the ring-attention for diffusion when running on NPU. 

There is a bug when enabling  ring-attention on NPU:
```
rank0]:[W107 21:14:04.201960667 VariableFallbackKernel.cpp:250] Warning: CAUTION: The operator 'aten::_scaled_dot_product_efficient_attention' is not currently supported on the NPU backend and will fall back to run on the CPU. This may have performance implications. (function npu_cpu_fallback)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] Error executing RPC: Could not run 'aten::_scaled_dot_product_efficient_attention' with arguments from the 'CPU' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). If you are a Facebook employee using PyTorch on mobile, please visit https://fburl.com/ptmfixes for possible resolutions. 'aten::_scaled_dot_product_efficient_attention' is only available for these backends: [PrivateUse1, Meta, SparsePrivateUse1, BackendSelect, Python, FuncTorchDynamicLayerBackMode, Functionalize, Named, Conjugate, Negative, ZeroTensor, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradHIP, AutogradXLA, AutogradMPS, AutogradIPU, AutogradXPU, AutogradHPU, AutogradVE, AutogradLazy, AutogradMTIA, AutogradMAIA, AutogradPrivateUse1, AutogradPrivateUse2, AutogradPrivateUse3, AutogradMeta, AutogradNestedTensor, Tracer, AutocastCPU, AutocastMTIA, AutocastMAIA, AutocastXPU, AutocastMPS, AutocastCUDA, AutocastPrivateUse1, FuncTorchBatched, BatchedNestedTensor, FuncTorchVmapMode, Batched, VmapMode, FuncTorchGradWrapper, PythonTLSSnapshot, FuncTorchDynamicLayerFrontMode, PreDispatch, PythonDispatcher].
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] 
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] PrivateUse1: registered at torch_npu/csrc/aten/VariableFallbackKernel.cpp:259 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] Meta: registered at /dev/null:241 [kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] SparsePrivateUse1: registered at torch_npu/csrc/aten/VariableFallbackKernel.cpp:270 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] BackendSelect: fallthrough registered at /pytorch/aten/src/ATen/core/BackendSelectFallbackKernel.cpp:3 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] Python: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:194 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] FuncTorchDynamicLayerBackMode: registered at /pytorch/aten/src/ATen/functorch/DynamicLayer.cpp:479 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] Functionalize: registered at /pytorch/aten/src/ATen/FunctionalizeFallbackKernel.cpp:375 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] Named: registered at /pytorch/aten/src/ATen/core/NamedRegistrations.cpp:7 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] Conjugate: registered at /pytorch/aten/src/ATen/ConjugateFallback.cpp:17 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] Negative: registered at /pytorch/aten/src/ATen/native/NegateFallback.cpp:18 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] ZeroTensor: registered at /pytorch/aten/src/ATen/ZeroTensorFallback.cpp:86 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] ADInplaceOrView: fallthrough registered at /pytorch/aten/src/ATen/core/VariableFallbackKernel.cpp:104 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradOther: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradCPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradCUDA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradHIP: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradXLA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradMPS: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradIPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradXPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradHPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradVE: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradLazy: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradMTIA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradMAIA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradPrivateUse1: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradPrivateUse2: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradPrivateUse3: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:22RROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradPrivateUse2: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradPrivateUse3: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradMeta: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutogradNestedTensor: registered at /pytorch/torch/csrc/autograd/generated/VariableType_3.cpp:19687 [autograd kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] Tracer: registered at /pytorch/torch/csrc/autograd/generated/TraceType_3.cpp:15107 [kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutocastCPU: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:322 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutocastMTIA: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:466 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutocastMAIA: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:504 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutocastXPU: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:542 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutocastMPS: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:209 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutocastCUDA: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:165 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] AutocastPrivateUse1: fallthrough registered at torch_npu/csrc/aten/AutoCastOps.cpp:20 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] FuncTorchBatched: registered at /pytorch/aten/src/ATen/functorch/BatchRulesLinearAlgebra.cpp:749 [kernel]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] BatchedNestedTensor: registered at /pytorch/aten/src/ATen/functorch/LegacyBatchingRegistrations.cpp:758 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] FuncTorchVmapMode: fallthrough registered at /pytorch/aten/src/ATen/functorch/VmapModeRegistrations.cpp:27 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] Batched: registered at /pytorch/aten/src/ATen/LegacyBatchingRegistrations.cpp:1075 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] VmapMode: fallthrough registered at /pytorch/aten/src/ATen/VmapModeRegistrations.cpp:33 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] FuncTorchGradWrapper: registered at /pytorch/aten/src/ATen/functorch/TensorWrapper.cpp:210 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] PythonTLSSnapshot: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:202 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] FuncTorchDynamicLayerFrontMode: registered at /pytorch/aten/src/ATen/functorch/DynamicLayer.cpp:475 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] PreDispatch: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:206 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] PythonDispatcher: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:198 [backend fallback]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] Traceback (most recent call last):
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/worker/gpu_worker.py", line 221, in execute_rpc
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     result = func(*args, **kwargs)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]              ^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/worker/gpu_worker.py", line 120, in generate
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return self.execute_model(requests, self.od_config)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/usr/local/lib64/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return func(*args, **kwargs)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/worker/gpu_worker.py", line 140, in execute_model
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     output = self.pipeline.forward(req)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]              ^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py", line 717, in forward
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     latents = self.diffuse(ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]               ^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py", line 556, in diffuse
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     noise_pred = self.transformer(
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]                  ^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return self._call_impl(*args, **kwargs)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return forward_call(*args, **kwargs)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py", line 784, in forward
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     encoder_hidden_states, hidden_states = block(
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]                                            ^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return self._call_impl(*args, **kwargs)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return forward_call(*args, **kwargs)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py", line 575, in forward
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     attn_output = self.attn(
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]                   ^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return self._call_impl(*args, **kwargs)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return forward_call(*args, **kwargs)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py", line 427, in forward
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     joint_hidden_states = self.attn(
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]                           ^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return self._call_impl(*args, **kwargs)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/usr/local/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return forward_call(*args, **kwargs)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/attention/layer.py", line 96, in forward
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     out = self._run_ring_attention(query, key, value, attn_metadata)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/attention/layer.py", line 120, in _run_ring_attention
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return self.ring_runner.run_attention(
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/attention/parallel/ring.py", line 138, in run_attention
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return ring_pytorch_attn_func(
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/attention/backends/ring_pytorch_attn.py", line 34, in ring_pytorch_attn_func
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return RingAttentionFunc.apply(
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/usr/local/lib64/python3.11/site-packages/torch/autograd/function.py", line 576, in apply
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return super().apply(*args, **kwargs)  # type: ignore[misc]
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/attention/backends/ring_pytorch_attn.py", line 94, in forward
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     block_out, block_lse = pytorch_attn_forward(
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]                            ^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/mnt/deepseek/cloudide/tpcode/omni/omni/vllm-omni/vllm_omni/diffusion/attention/backends/ring/ring_kernels.py", line 85, in pytorch_attn_forward
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     out, lse = _scaled_dot_product_efficient_attention(
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]   File "/usr/local/lib64/python3.11/site-packages/torch/_ops.py", line 1243, in __call__
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]     return self._op(*args, **kwargs)
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226]            ^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 2026-01-07 21:14:05.207 [gpu_worker.py:226] NotImplementedError: Could not run 'aten::_scaled_dot_product_efficient_attention' with arguments from the 'CPU' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). If you are a Facebook employee using PyTorch on mobile, please visit https://fburl.com/ptmfixes for possible resolutions. 'aten::_scaled_dot_product_efficient_attention' is only available for these backends: [PrivateUse1, Meta, SparsePrivateUse1, BackendSelect, Python, FuncTorchDynamicLayerBackMode, Functionalize, Named, Conjugate, Negative, ZeroTensor, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradHIP, AutogradXLA, AutogradMPS, AutogradIPU, AutogradXPU, AutogradHPU, AutogradVE, AutogradLazy, AutogradMTIA, AutogradMAIA, AutogradPrivateUse1, AutogradPrivateUse2, AutogradPrivateUse3, AutogradMeta, AutogradNestedTensor, Tracer, AutocastCPU, AutocastMTIA, AutocastMAIA, AutocastXPU, AutocastMPS, AutocastCUDA, AutocastPrivateUse1, FuncTorchBatched, BatchedNestedTensor, FuncTorchVmapMode, Batched, VmapMode, FuncTorchGradWrapper, PythonTLSSnapshot, FuncTorchDynamicLayerFrontMode, PreDispatch, PythonDispatcher].
```


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
