### PR TITLE
[Misc] Enable tensor_parallel_size argument with online serving cmd

### DIFF
--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -162,6 +162,7 @@ class AsyncOmni(OmniBase):
                     "cache_backend": cache_backend,
                     "cache_config": cache_config,
                     "enable_cpu_offload": kwargs.get("enable_cpu_offload", False),
+                    "enforce_eager": kwargs.get("enforce_eager", False),
                 },
                 "final_output": True,
                 "final_output_type": "image",


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Enable `tensor-parallel-size` argument for online serving when running Z-Image with TP=2

```
MODEL="${MODEL:-Tongyi-MAI/Z-Image-Turbo}"
PORT="${PORT:-8091}"
vllm serve "$MODEL" --omni \
    --port "$PORT" \
    --tensor-parallel-size 2
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
