### PR TITLE
[Bugfix] Fix stable diffusion3 compatibility error

### DIFF
--- a/vllm_omni/diffusion/models/sd3/sd3_transformer.py
+++ b/vllm_omni/diffusion/models/sd3/sd3_transformer.py
@@ -102,8 +102,8 @@ class SD3CrossAttention(nn.Module):
         else:
             self.to_out = None
 
-        self.norm_added_q = RMSNorm(head_dim, eps=eps)
-        self.norm_added_k = RMSNorm(head_dim, eps=eps)
+        self.norm_added_q = RMSNorm(head_dim, eps=eps) if qk_norm else nn.Identity()
+        self.norm_added_k = RMSNorm(head_dim, eps=eps) if qk_norm else nn.Identity()
 
         self.attn = Attention(
             num_heads=num_heads,
@@ -341,8 +341,10 @@ class SD3Transformer2DModel(nn.Module):
         self.pooled_projection_dim = model_config.pooled_projection_dim
         self.joint_attention_dim = model_config.joint_attention_dim
         self.patch_size = model_config.patch_size
-        self.dual_attention_layers = model_config.dual_attention_layers
-        self.qk_norm = model_config.qk_norm
+        self.dual_attention_layers = (
+            model_config.dual_attention_layers if hasattr(model_config, "dual_attention_layers") else ()
+        )
+        self.qk_norm = model_config.qk_norm if hasattr(model_config, "qk_norm") else ""
         self.pos_embed_max_size = model_config.pos_embed_max_size
 
         self.pos_embed = PatchEmbed(


### PR DESCRIPTION

## Purpose
fix https://github.com/vllm-project/vllm-omni/issues/636

## Test Plan
```bash
import torch

from vllm_omni import Omni
generator = torch.Generator("cuda").manual_seed(42)
model_name = "/model/stable-diffusion-3-medium-diffusers/"
m = Omni(model=model_name, dtype=torch.half)
images = m.generate(
    "A cat holding a sign that says hello world",
    negative_prompt="",
    height=height,
    width=width,
    dtype=torch.half,
    num_inference_steps=28,
    guidance_scale=7,
    generator=generator,
    num_outputs_per_prompt=1,
)
```

## Test Result
<img width="600" height="643" alt="image" src="https://github.com/user-attachments/assets/9d5ecf46-a513-4fcc-bf9a-b8796d17c812" />

