### PR TITLE
[BugFix]Remove duplicate error handling for request results

### DIFF
--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -355,12 +355,6 @@ class AsyncOmni(OmniBase):
                             f"[{self._name}] Stage {stage_id} error on request {req_id}: {result['error']}",
                         )
                         raise RuntimeError(result)  # Request Finished due to error
-                    req_id = result.get("request_id")
-                    if "error" in result:
-                        logger.error(
-                            f"[{self._name}] Stage {stage_id} error on request {req_id}: {result['error']}",
-                        )
-                        raise RuntimeError(result)  # Request Finished due to error
 
                     engine_outputs = _load(result, obj_key="engine_outputs", shm_key="engine_outputs_shm")
                     if isinstance(engine_outputs, list):


### PR DESCRIPTION
<!-- markdownlint-disable -->
This pull request makes a minor change to the error handling logic in the `generate` method of `async_omni.py`. The code for logging and raising an error when an "error" is present in the result has been moved, but the overall functionality remains the same.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
