### PR TITLE
Fix: Ensure stage_id is correctly passed to OmniEngineArgs

### DIFF
--- a/vllm_omni/entrypoints/async_omni_diffusion.py
+++ b/vllm_omni/entrypoints/async_omni_diffusion.py
@@ -53,12 +53,12 @@ class AsyncOmniDiffusion:
         self,
         model: str,
         od_config: OmniDiffusionConfig | None = None,
+        stage_id: int = 0,
         **kwargs: Any,
     ):
         self.model = model
 
         # Capture stage info from kwargs before they might be filtered out
-        stage_id = kwargs.get("stage_id")
         engine_input_source = kwargs.get("engine_input_source")
         cfg_kv_collect_func = kwargs.pop("cfg_kv_collect_func", None)
 

--- a/vllm_omni/entrypoints/omni_llm.py
+++ b/vllm_omni/entrypoints/omni_llm.py
@@ -53,6 +53,7 @@ class OmniLLM(LLM):
             for IPC. Objects larger than this threshold will use shared memory.
         batch_timeout: Timeout in seconds for batching requests within a stage
         init_timeout: Timeout in seconds for waiting for all stages to initialize
+        stage_id: Identifier for the stage in a multi-stage pipeline (default: 0)
         **kwargs: Additional keyword arguments passed to the base LLM class
             and engine
 
@@ -72,6 +73,7 @@ class OmniLLM(LLM):
         shm_threshold_bytes: int = 65536,
         batch_timeout: int = 10,
         init_timeout: int = 300,
+        stage_id: int = 0,
         **kwargs: Any,
     ):
         """LLM constructor with omni-specific configuration loading."""
@@ -145,6 +147,7 @@ class OmniLLM(LLM):
             structured_outputs_config=structured_outputs_instance,
             omni_kv_config=omni_kv_config,
             hf_overrides=hf_overrides or {},
+            stage_id=stage_id,
             **filter_dataclass_kwargs(OmniEngineArgs, kwargs),
         )
 

--- a/vllm_omni/entrypoints/omni_stage.py
+++ b/vllm_omni/entrypoints/omni_stage.py
@@ -897,7 +897,7 @@ def _stage_worker(
             engine_args = filter_dataclass_kwargs(OmniEngineArgs, engine_args)
             engine_args.pop("model", None)
             # Default to LLM engine
-            stage_engine = OmniLLM(model=model, **engine_args)
+            stage_engine = OmniLLM(model=model, stage_id=stage_id, **engine_args)
 
     logger.debug("Engine initialized")
     # Initialize OmniConnectors if configured
@@ -1338,7 +1338,6 @@ async def _stage_worker_async(
                 stage_connector_spec = dict(v.get("spec", {}))
                 break
             engine_args["stage_connector_spec"] = stage_connector_spec
-            engine_args["stage_id"] = stage_id
         if stage_type == "diffusion":
             # For diffusion, we need to extract diffusion-specific config
             engine_args = filter_dataclass_kwargs(OmniDiffusionConfig, engine_args)
@@ -1357,13 +1356,14 @@ async def _stage_worker_async(
             stage_engine = AsyncOmniDiffusion(
                 model=model,
                 od_config=od_config,
+                stage_id=stage_id,
                 **_diffusion_kwargs,
             )
             vllm_config = None  # Diffusion doesn't use vllm_config
         else:
             engine_args = filter_dataclass_kwargs(AsyncOmniEngineArgs, engine_args)
             engine_args.pop("model", None)
-            omni_engine_args = AsyncOmniEngineArgs(model=model, **engine_args)
+            omni_engine_args = AsyncOmniEngineArgs(model=model, stage_id=stage_id, **engine_args)
             usage_context = UsageContext.OPENAI_API_SERVER
             vllm_config = omni_engine_args.create_engine_config(usage_context=usage_context)
             stage_engine = AsyncOmniLLM.from_vllm_config(


### PR DESCRIPTION
## Purpose
In multi-stage pipeline processing, the `stage_id` parameter was not being correctly passed to `OmniEngineArgs` and `AsyncOmniEngineArgs`. The `stage_id` was extracted from `stage_payload` in worker processes but was never explicitly passed to `OmniLLM` constructor or `AsyncOmniEngineArgs` creation. As a result, `OmniEngineArgs` always used the default value of `0` for `stage_id`, regardless of the actual stage identifier.

This bug could cause issues in multi-stage pipelines where different stages need to be properly identified and configured.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
