### PR TITLE
[bugfix] Fix Wan2.2 I2V warmup failure by adding support_image_input attribute

### DIFF
--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable
-from typing import ClassVar
 
 import numpy as np
 import PIL.Image
@@ -121,8 +120,6 @@ class Wan22I2VPipeline(nn.Module, SupportImageInput):
     Supports both Wan2.1-style I2V (with CLIP image embeddings) and
     Wan2.2-style I2V (with expand_timesteps for TI2V-5B).
     """
-
-    support_image_input: ClassVar[bool] = True
 
     def __init__(
         self,

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_ti2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_ti2v.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import os
 from collections.abc import Iterable
-from typing import ClassVar
 
 import numpy as np
 import PIL.Image
@@ -115,8 +114,6 @@ class Wan22TI2VPipeline(nn.Module, SupportImageInput):
     Uses expand_timesteps mode for I2V conditioning where the first frame
     is conditioned on the input image latent.
     """
-
-    support_image_input: ClassVar[bool] = True
 
     def __init__(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

fix issue https://github.com/vllm-project/vllm-omni/issues/786

The `Wan22I2VPipeline` and `Wan22TI2VPipeline` classes were missing the `support_image_input = True` attribute, causing the warmup to skip providing a dummy image, which then failed the I2V pipeline's mandatory image requirement. The fix adds this attribute to both classes.

## Test code

```
python examples/offline_inference/image_to_video/image_to_video.py \
  --model Wan-AI/Wan2.2-I2V-A14B-Diffusers \
  --image input.jpg \
  --prompt "A cat playing with yarn" \
  --num_frames 17 \
  --num_inference_steps 1 \
  --guidance_scale 5.0 \
  --fps 16 \
  --output test_i2v_fix.mp4
```

## Results

https://github.com/user-attachments/assets/2b18b6f4-4561-4527-a095-366eeea1a252




---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
