### PR TITLE
[Model] Add SpargeAttentionBackend for Wan 2.2

### DIFF
--- a/docs/design/module/dit_module.md
+++ b/docs/design/module/dit_module.md
@@ -441,6 +441,8 @@ class Attention(nn.Module):
 
 - **SageAttention**: Sparse attention implementation from SageAttention library
 
+- **SpargeAttention**: Sparse attention implementation from SpargeAttention library
+
 - **AscendAttention**: NPU-optimized attention for Ascend hardware
 
 These backends provide the **kernel implementations** for attention computation. For attention-level sequence parallelism strategies (Ring Attention, Ulysses), see [Parallel Attention](#52-parallel-attention).
@@ -463,7 +465,7 @@ def get_attn_backend(head_size: int) -> type[AttentionBackend]:
 
 1. **Environment Variable**: `DIFFUSION_ATTENTION_BACKEND` for manual override
 
-    - Valid values: `FLASH_ATTN`, `TORCH_SDPA`, `SAGE_ATTN`, `ASCEND`
+    - Valid values: `FLASH_ATTN`, `TORCH_SDPA`, `SAGE_ATTN`, `SPARGE_ATTN`, `ASCEND`
 
     - Example: `export DIFFUSION_ATTENTION_BACKEND=SAGE_ATTN`
 
@@ -478,6 +480,8 @@ def get_attn_backend(head_size: int) -> type[AttentionBackend]:
 - **FlashAttention**: Requires `flash-attn` package installed
 
 - **SageAttention**: Requires `sage-attention` package (from THU-ML GitHub)
+
+- **SpargeAttention**: Requires `spas_sage_attn` package (from THU-ML GitHub)
 
 - **AscendAttention**: Only available on Ascend NPU hardware
 
@@ -504,6 +508,10 @@ _BACKEND_CONFIG = {
     "SAGE_ATTN": {
         "module": "vllm_omni.diffusion.attention.backends.sage_attn",
         "class": "SageAttentionBackend",
+    },
+    "SPARGE_ATTN": {
+        "module": "vllm_omni.diffusion.attention.backends.sparge_attn",
+        "class": "SpargeAttentionBackend",
     },
     "ASCEND": {
         "module": "vllm_omni.diffusion.attention.backends.ascend_attn",

--- a/docs/design/module/dit_module.md
+++ b/docs/design/module/dit_module.md
@@ -483,6 +483,8 @@ def get_attn_backend(head_size: int) -> type[AttentionBackend]:
 
 - **SpargeAttention**: Requires `spas_sage_attn` package (from THU-ML GitHub)
 
+  - Environment variable `SPARGE_ATTN_TOPK` to set topk (default: 0.5)
+
 - **AscendAttention**: Only available on Ascend NPU hardware
 
 #### Attention Backend Registry

--- a/vllm_omni/diffusion/attention/backends/sparge_attn.py
+++ b/vllm_omni/diffusion/attention/backends/sparge_attn.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+
 import torch
 from vllm.logger import init_logger
-import os
 
 from vllm_omni.diffusion.attention.backends.abstract import (
     AttentionBackend,
@@ -21,6 +22,7 @@ except ImportError:
         " by pip install git+https://github.com/thu-ml/SpargeAttn.git@bfd980b781784c04ad6a53e7ee657c0645d99171"
     )
     raise ImportError
+
 
 class SpargeAttentionBackend(AttentionBackend):
     accept_output_buffer: bool = True

--- a/vllm_omni/diffusion/attention/backends/sparge_attn.py
+++ b/vllm_omni/diffusion/attention/backends/sparge_attn.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from vllm.logger import init_logger
+import os
+
+from vllm_omni.diffusion.attention.backends.abstract import (
+    AttentionBackend,
+    AttentionImpl,
+    AttentionMetadata,
+)
+
+logger = init_logger(__name__)
+
+try:
+    from spas_sage_attn import spas_sage2_attn_meansim_topk_cuda
+except ImportError:
+    logger.warning(
+        "SpargeAttentionBackend is not available. You may install spas_sage_attn"
+        " by pip install git+https://github.com/thu-ml/SpargeAttn.git@bfd980b781784c04ad6a53e7ee657c0645d99171"
+    )
+    raise ImportError
+
+class SpargeAttentionBackend(AttentionBackend):
+    accept_output_buffer: bool = True
+
+    @staticmethod
+    def get_supported_head_sizes() -> list[int]:
+        return [64, 128]
+
+    @staticmethod
+    def get_name() -> str:
+        return "SPARGE_ATTN"
+
+    @staticmethod
+    def get_impl_cls() -> type["SpargeAttentionImpl"]:
+        return SpargeAttentionImpl
+
+
+class SpargeAttentionImpl(AttentionImpl):
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        softmax_scale: float,
+        causal: bool = False,
+        num_kv_heads: int | None = None,
+        prefix: str = "",
+        **extra_impl_args,
+    ) -> None:
+        self.causal = causal
+        self.softmax_scale = softmax_scale
+
+        # TODO Add this to attention configuration when available
+        sparge_attn_topk = os.environ.get("SPARGE_ATTN_TOPK")
+        self.topk = float(sparge_attn_topk) if sparge_attn_topk is not None else 0.5
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AttentionMetadata = None,
+    ) -> torch.Tensor:
+        output = spas_sage2_attn_meansim_topk_cuda(
+            query,
+            key,
+            value,
+            topk=self.topk,
+            tensor_layout="NHD",
+            is_causal=self.causal,
+            scale=self.softmax_scale,
+        )
+        return output

--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 from vllm.logger import init_logger
 
-from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata, AttentionBackend
+from vllm_omni.diffusion.attention.backends.abstract import AttentionBackend, AttentionMetadata
 from vllm_omni.diffusion.attention.parallel import build_parallel_attention_strategy
 from vllm_omni.diffusion.attention.parallel.ring import RingParallelAttention
 from vllm_omni.diffusion.attention.selector import get_attn_backend
@@ -35,7 +35,7 @@ class Attention(nn.Module):
         gather_idx: int = 1,
         use_sync: bool = False,
         # To support different attn backends in cross- and self-attention
-        attn_backend : AttentionBackend = None
+        attn_backend: AttentionBackend = None,
     ):
         super().__init__()
         self.attn_backend = get_attn_backend(-1) if attn_backend is None else attn_backend

--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 from vllm.logger import init_logger
 
-from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata, AttentionBackend
 from vllm_omni.diffusion.attention.parallel import build_parallel_attention_strategy
 from vllm_omni.diffusion.attention.parallel.ring import RingParallelAttention
 from vllm_omni.diffusion.attention.selector import get_attn_backend
@@ -34,9 +34,11 @@ class Attention(nn.Module):
         scatter_idx: int = 2,
         gather_idx: int = 1,
         use_sync: bool = False,
+        # To support different attn backends in cross- and self-attention
+        attn_backend : AttentionBackend = None
     ):
         super().__init__()
-        self.attn_backend = get_attn_backend(-1)
+        self.attn_backend = get_attn_backend(-1) if attn_backend is None else attn_backend
         self.attn_impl_cls = self.attn_backend.get_impl_cls()
         self.attention = self.attn_impl_cls(
             num_heads=num_heads,

--- a/vllm_omni/diffusion/attention/selector.py
+++ b/vllm_omni/diffusion/attention/selector.py
@@ -28,6 +28,10 @@ _BACKEND_CONFIG = {
         "module": "vllm_omni.diffusion.attention.backends.sage_attn",
         "class": "SageAttentionBackend",
     },
+    "SPARGE_ATTN": {
+        "module": "vllm_omni.diffusion.attention.backends.sparge_attn",
+        "class": "SpargeAttentionBackend",
+    },
     "ASCEND": {"module": "vllm_omni.diffusion.attention.backends.ascend_attn", "class": "AscendAttentionBackend"},
 }
 

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -17,16 +17,17 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import QKVParallelLinear, ReplicatedLinear
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
-from vllm_omni.diffusion import envs
-from vllm_omni.diffusion.attention.backends.flash_attn import FlashAttentionBackend
+try:
+    from vllm_omni.diffusion.attention.backends.flash_attn import FlashAttentionBackend
+
+    HAS_FLASH_ATTN = True
+except ImportError:
+    HAS_FLASH_ATTN = False
+
 from vllm_omni.diffusion.attention.backends.sdpa import SDPABackend
 from vllm_omni.diffusion.attention.layer import Attention
 
 logger = init_logger(__name__)
-
-env_info = envs.PACKAGES_CHECKER.get_packages_info()
-
-HAS_FLASH_ATTN = env_info["has_flash_attn"]
 
 
 def apply_rotary_emb_wan(

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -348,7 +348,7 @@ class WanCrossAttention(nn.Module):
         # TODO Add this to attention configuration when available
         attn_backend = None
         if os.environ.get("DIFFUSION_ATTENTION_BACKEND") == "SPARGE_ATTN":
-            attn_backend = FlashAttentionBackend if HAS_FLASH_ATTN else SDPABackend 
+            attn_backend = FlashAttentionBackend if HAS_FLASH_ATTN else SDPABackend
 
         # Unified attention layer
         self.attn = Attention(

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -2,10 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import math
+import os
 from collections.abc import Iterable
 from typing import Any
-
-import os
 
 import torch
 import torch.nn as nn
@@ -19,15 +18,16 @@ from vllm.model_executor.layers.linear import QKVParallelLinear, ReplicatedLinea
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from vllm_omni.diffusion import envs
-from vllm_omni.diffusion.attention.layer import Attention
-from vllm_omni.diffusion.attention.backends.sdpa import SDPABackend
 from vllm_omni.diffusion.attention.backends.flash_attn import FlashAttentionBackend
+from vllm_omni.diffusion.attention.backends.sdpa import SDPABackend
+from vllm_omni.diffusion.attention.layer import Attention
 
 logger = init_logger(__name__)
 
 env_info = envs.PACKAGES_CHECKER.get_packages_info()
 
 HAS_FLASH_ATTN = env_info["has_flash_attn"]
+
 
 def apply_rotary_emb_wan(
     hidden_states: torch.Tensor,
@@ -356,7 +356,7 @@ class WanCrossAttention(nn.Module):
             head_size=head_dim,
             softmax_scale=1.0 / (head_dim**0.5),
             causal=False,
-            attn_backend=attn_backend
+            attn_backend=attn_backend,
         )
 
     def forward(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Add `SpargeAttentionBackend` for Wan 2.2, see RFC #765 

Configuration of top-k parameter through environnement variable `SPARGE_ATTN_TOPK` (default 0.5)

## Test Plan

Test on one A100 (80GB VRAM, Cuda 12.8) on text to video with the following parameters:
- Model Wan-AI/Wan2.2-T2V-A14B-Diffusers
- 32 Frames AND 64 Frames 
- 480*640 (height * width)
- 16 FPS
- guidance_scale 4.0 
- guidance_scale_high 3.0
- num_inference_steps 40

## Test Result

**32 Frames** 
| Method | Time (ms) |
|---|--|
|SDPA  | 272605
| FA | 271913
| SAGE  | 277183
| SPARGE (topk = 0.8) | 271983
| SPARGE (topk = 0.5) | 258489
| SPARGE (topk = 0.3) | 249406
| SPARGE (topk = 0.2) | 242661

**64 Frames** 
| Method | Time (ms) |
|---|--|
|SDPA  |  506538
| FA | 493371
| SAGE  | 510049
| SPARGE (topk = 0.8) | 504307
| SPARGE (topk = 0.5) | 467071
| SPARGE (topk = 0.3) | 417368
| SPARGE (topk = 0.2) | 401132

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
