### PR TITLE
[BugFix] Fix dependencies error for qwen3TTS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,19 +52,16 @@ dependencies = [
 cuda = [
     # For CUDA/CPU platform (default): pip install -e .[cuda]
     "onnxruntime>=1.23.2",  # Required for Qwen3TTS tokenizer
-    "sox>=1.4.0",  # Required for audio processing
 ]
 
 rocm = [
     # For AMD ROCm platform: pip install -e .[rocm]
-    "onnxruntime-rocm>=1.23.2",
-    "sox>=1.4.0",
+    "onnxruntime-rocm>=1.22.2",
 ]
 
 npu = [
     # For Ascend NPU platform: pip install -e .[npu]
     "onnxruntime-cann>=1.23.2",
-    "sox>=1.4.0",
 ]
 
 dev = [


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fix bug when using qwen3TTS

<img width="2278" height="1750" alt="image" src="https://github.com/user-attachments/assets/0125edc0-ec56-4b83-8472-36d826e45db0" />

## Test Plan

I have tested twice with uninstall and install, it works fine now

command: python examples/offline_inference/qwen3_tts/end2end.py 

## Test Result
<img width="1139" height="622" alt="image" src="https://github.com/user-attachments/assets/216ba3ad-6429-45e0-9d29-5be166bf1411" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
