### PR TITLE
[bugfix] qwen3-tts check_model_inputs

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
@@ -495,7 +495,7 @@ class Qwen3TTSTokenizerV2DecoderTransformerModel(Qwen3TTSTokenizerV2DecoderPreTr
         # Initialize weights and apply final processing
         self.post_init()
 
-    @check_model_inputs()
+    @check_model_inputs
     @auto_docstring
     def forward(
         self,


### PR DESCRIPTION
ref: https://github.com/vllm-project/vllm-omni/issues/923
```
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]     return _bootstrap._gcd_import(name[level:], package, level)
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "<frozen importlib._bootstrap_external>", line 999, in exec_module
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "/mnt/user/qibaoyuan/vllm-omni-qby/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts.py", line 36, in <module>
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]     from .modeling_qwen3_tts import Qwen3TTSForConditionalGeneration
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "/mnt/user/qibaoyuan/vllm-omni-qby/vllm_omni/model_executor/models/qwen3_tts/modeling_qwen3_tts.py", line 54, in <module>
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]     from .qwen3_tts_tokenizer import Qwen3TTSTokenizer
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "/mnt/user/qibaoyuan/vllm-omni-qby/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_tokenizer.py", line 28, in <module>
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]     from .tokenizer_12hz.modeling_qwen3_tts_tokenizer_v2 import (
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "/mnt/user/qibaoyuan/vllm-omni-qby/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py", line 472, in <module>
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]     class Qwen3TTSTokenizerV2DecoderTransformerModel(Qwen3TTSTokenizerV2DecoderPreTrainedModel):
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]   File "/mnt/user/qibaoyuan/vllm-omni-qby/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py", line 498, in Qwen3TTSTokenizerV2DecoderTransformerModel
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]     @check_model_inputs()
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768]      ^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 01-23 15:36:40 [registry.py:768] TypeError: check_model_inputs() missing 1 required positional argument: 'func'
```

## Purpose

Fix a bug in the `check_model_inputs` annotation caused by an extra pair of parentheses.

## Test Plan
`python3 -u  end2end.py --query-type Base --use-batch-sample`
## Test Result
```
Adding requests:   0%|                                                                                                                                                                                               | 0/2 [00:19<?, ?it/s]
Request ID: 0_5af8f90c-156e-418c-974f-7c77c77bbf45, Saved audio to output_audio/output_0_5af8f90c-156e-418c-974f-7c77c77bbf45.wav
Request ID: 1_20ec4969-a40b-4c03-b328-f0fc385f3a0e, Saved audio to output_audio/output_1_20ec4969-a40b-4c03-b328-f0fc385f3a0e.wav
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
