### PR TITLE
[Perf] [Model] Fuse RoPE invocations in QwenImageCrossAttention

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -534,10 +534,12 @@ class QwenImageCrossAttention(nn.Module):
         txt_cos = txt_freqs.real.to(txt_query.dtype)
         txt_sin = txt_freqs.imag.to(txt_query.dtype)
 
-        img_query = self.rope(img_query, img_cos, img_sin)
-        img_key = self.rope(img_key, img_cos, img_sin)
-        txt_query = self.rope(txt_query, txt_cos, txt_sin)
-        txt_key = self.rope(txt_key, txt_cos, txt_sin)
+        img_qk = torch.cat([img_query, img_key], dim=0)
+        img_qk = self.rope(img_qk, img_cos, img_sin)
+        img_query, img_key = torch.chunk(img_qk, 2, dim=0)
+        txt_qk = torch.cat([txt_query, txt_key], dim=0)
+        txt_qk = self.rope(txt_qk, txt_cos, txt_sin)
+        txt_query, txt_key = torch.chunk(txt_qk, 2, dim=0)
 
         seq_len_txt = encoder_hidden_states.shape[1]
         joint_query = torch.cat([txt_query, img_query], dim=1)

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -552,6 +552,10 @@ class QwenImageCrossAttention(nn.Module):
             and self.parallel_config.sequence_parallel_size > 1
             and not get_forward_context().split_text_embed_in_sp
         ):
+            txt_query = joint_query[:, :seq_len_txt, :, :]
+            img_query = joint_query[:, seq_len_txt:, :, :]
+            txt_key = joint_key[:, :seq_len_txt, :, :]
+            img_key = joint_key[:, seq_len_txt:, :, :]
             attn_metadata = AttentionMetadata(
                 joint_query=txt_query,
                 joint_key=txt_key,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

This PR reduces rotary embedding overhead in QwenImageCrossAttention by fusing previously separate RoPE calls into one.

Instead of applying RoPE independently for query and key tensors of image and text segments, this PR concatenates the q/k tensors, leveraging the fact that txt and img are combined along the sequence dimension, before feeding the combined tensor into RoPE, so that it only needs to be executed once.

Benchmarking on Qwen-Image series, it shows improvement to end-to-end latency of ~11% for Qwen-Image-Edit-2511 and ~29% for Qwen-Image-2512 on AMD MI300X.

## Test Plan

Performance benchmark on MI300X

## Test Result

Qwen/Qwen-Image-2512 (vbench; t2i; max concurrency=1; 5 requests)
Metric | Before | This PR
-- | -- | --
Benchmark duration (s) | 78.12 | 55.13
Request throughput (req/s) | 0.06 | 0.09
Latency mean (s) | 15.6236 | 11.0263
Latency median (s) | 15.6525 | 11.0563
Latency p99 (s) | 15.6837 | 11.0821

Qwen/Qwen-Image-Edit-2511 (vbench; i2i; max concurrency=1; 5 requests)
Metric | Before | This PR
-- | -- | --
Benchmark duration (s) | 139.95 | 123.91
Request throughput (req/s) | 0.04 | 0.04
Latency mean (s) | 27.9895 | 24.7815
Latency median (s) | 28.0357 | 24.8072
Latency p99 (s) | 28.0508 | 24.8454


### Generation test
Model: Qwen/Qwen-Image-2512
Prompt: "a cup of coffee on the table"

Before:
<img width="256" height="256" alt="base2_output_image_text2image" src="https://github.com/user-attachments/assets/8d0d1758-b5f0-4976-97c2-3ff8d7391c38" />
This PR:
<img width="256" height="256" alt="rope_concat2_output_image_text2image" src="https://github.com/user-attachments/assets/47184555-483b-4de8-a92a-e012599f67e0" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
