### PR TITLE
[BugFix] ignore mm data from stages to async omni

### DIFF
--- a/vllm_omni/entrypoints/omni_stage.py
+++ b/vllm_omni/entrypoints/omni_stage.py
@@ -21,6 +21,7 @@ from typing import Any
 from vllm.inputs import TextPrompt
 from vllm.inputs.preprocess import InputPreprocessor
 from vllm.logger import init_logger
+from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams
 from vllm.tokenizers import TokenizerLike
 from vllm.usage.usage_lib import UsageContext
@@ -1468,7 +1469,7 @@ async def _stage_worker_async(
             batch_request_ids, batch_request_outputs, _gen_ms_list, batch_metrics
         ):
             try:
-                r_outputs = [output]
+                r_outputs = [output_strip(output, omni_stage)]
                 use_shm, payload = maybe_dump_to_shm(r_outputs, shm_threshold_bytes)
                 if use_shm:
                     out_q.put(
@@ -1554,3 +1555,23 @@ def make_stage_stats(_agg_total_tokens: int, _agg_total_gen_time_ms: float):
     from vllm_omni.entrypoints.log_utils import StageStats
 
     return StageStats(total_token=_agg_total_tokens, total_gen_time=_agg_total_gen_time_ms)
+
+
+def output_strip(r_output: RequestOutput, omni_stage: OmniStage):
+    if omni_stage.final_output and omni_stage.final_output_type != "text":
+        return r_output
+
+    if getattr(r_output, "finished", False):
+        return r_output
+
+    mm_output = getattr(r_output, "multimodal_output", None)
+    if mm_output is not None:
+        r_output.multimodal_output = {}
+
+    outputs = getattr(r_output, "outputs", None)
+    if outputs is not None:
+        for out in outputs:
+            if getattr(out, "multimodal_output", None):
+                out.multimodal_output = {}
+
+    return r_output


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
As describe in https://github.com/JiusiServe/vllm-omni/issues/76#issuecomment-3797601881
the stage 0, stage1， return the accumulate mm data to async omni，when mm data is large, the transfer from stage to async omni can become the bottleneck.

<img width="1529" height="620" alt="image" src="https://github.com/user-attachments/assets/0e11ce98-4c9f-4026-b4f9-460cfb10380d" />

Changed:
    When request in stage 0/1 unfinished, we don't need to return mm data. So we add an adapter between stage0/1 and async omni.

we can see that:
rps from 0.12 to 0.16
ttft from 1681ms to 330ms


## Test Plan
1. Run benchmark  without chunk , and check /dev/shm consumption
```
vllm bench serve --omni --dataset-name random \
            --port 8294 \
            --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
            --endpoint /v1/chat/completions \
            --backend openai-chat-omni \
            --request-rate 0.2 \
            --num-prompts 50 \
            --random-input-len 2500 \
            --ignore-eos \
            --percentile-metrics ttft,tpot,itl,e2el,audio_ttfp,audio_rtf \
            --random-output-len 300
```



## Test Result
### Before
/dev/shm reach 63GB
```
============ Serving Benchmark Result ============
Successful requests:                     50        
Failed requests:                         0         
Request rate configured (RPS):           0.20      
Benchmark duration (s):                  420.28    
Request throughput (req/s):              0.12      
Peak concurrent requests:                32.00     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          149493.26 
Median E2EL (ms):                        153361.19 
P99 E2EL (ms):                           209778.09 
================== Text Result ===================
Total input tokens:                      125000    
Total generated tokens:                  249876    
Output token throughput (tok/s):         594.54    
Peak output token throughput (tok/s):    20.00     
Peak concurrent requests:                32.00     
Total Token throughput (tok/s):          891.96    
---------------Time to First Token----------------
Mean TTFT (ms):                          1681.63   
Median TTFT (ms):                        1462.17   
P99 TTFT (ms):                           4145.96   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          69.25     
Median TPOT (ms):                        30.73     
P99 TPOT (ms):                           417.20    
---------------Inter-token Latency----------------
Mean ITL (ms):                           132.24    
Median ITL (ms):                         93.77     
P99 ITL (ms):                            640.25    
================== Audio Result ==================
Total audio duration generated(s):       3264.56   
Total audio frames generated:            78349215  
Audio throughput(audio duration/s):      7.77      
---------------Time to First Packet---------------
Mean AUDIO_TTFP (ms):                    149488.64 
Median AUDIO_TTFP (ms):                  153358.91 
P99 AUDIO_TTFP (ms):                     209770.72 
-----------------Real Time Factor-----------------
Mean AUDIO_RTF:                          0.00      
Median AUDIO_RTF:                        0.00      
P99 AUDIO_RTF:                           0.00      
==================================================

```
### After
/dev/shm less than GB

```
============ Serving Benchmark Result ============
Successful requests:                     50        
Failed requests:                         0         
Request rate configured (RPS):           0.20      
Benchmark duration (s):                  299.64    
Request throughput (req/s):              0.17      
Peak concurrent requests:                16.00     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          44516.15  
Median E2EL (ms):                        47601.85  
P99 E2EL (ms):                           77715.31  
================== Text Result ===================
Total input tokens:                      125000    
Total generated tokens:                  1317864   
Output token throughput (tok/s):         4398.09   
Peak output token throughput (tok/s):    148.00    
Peak concurrent requests:                16.00     
Total Token throughput (tok/s):          4815.25   
---------------Time to First Token----------------
Mean TTFT (ms):                          331.42    
Median TTFT (ms):                        302.06    
P99 TTFT (ms):                           736.66    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          2.73      
Median TPOT (ms):                        1.74      
P99 TPOT (ms):                           9.58      
---------------Inter-token Latency----------------
Mean ITL (ms):                           23.00     
Median ITL (ms):                         18.62     
P99 ITL (ms):                            225.70    
================== Audio Result ==================
Total audio duration generated(s):       3172.30   
Total audio frames generated:            76134945  
Audio throughput(audio duration/s):      10.59     
---------------Time to First Packet---------------
Mean AUDIO_TTFP (ms):                    44511.70  
Median AUDIO_TTFP (ms):                  47596.32  
P99 AUDIO_TTFP (ms):                     77709.33  
-----------------Real Time Factor-----------------
Mean AUDIO_RTF:                          0.00      
Median AUDIO_RTF:                        0.00      
P99 AUDIO_RTF:                           0.00  
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
