### PR TITLE
[Log] [Bugfix] Fix flash attention log

### DIFF
--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-from fa3_fwd_interface import flash_attn_func, flash_attn_varlen_func
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.attention.backends.abstract import (
@@ -10,7 +9,13 @@ from vllm_omni.diffusion.attention.backends.abstract import (
     AttentionImpl,
     AttentionMetadata,
 )
-from vllm_omni.diffusion.attention.backends.utils.fa import _pad_input, _unpad_input, _upad_input
+from vllm_omni.diffusion.attention.backends.utils.fa import (
+    _pad_input,
+    _unpad_input,
+    _upad_input,
+    flash_attn_func,
+    flash_attn_varlen_func,
+)
 
 logger = init_logger(__name__)
 

--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -15,6 +15,13 @@
 import torch
 import torch.nn.functional as F
 
+compute_capability = torch.cuda.get_device_capability()
+major, minor = compute_capability
+if 80 <= major * 10 + minor < 100:
+    from fa3_fwd_interface import flash_attn_func, flash_attn_varlen_func  # noqa: F401
+else:
+    from flash_attn import flash_attn_func, flash_attn_varlen_func  # noqa: F401
+
 
 def _index_first_axis(tensor, indices):
     """

--- a/vllm_omni/diffusion/envs.py
+++ b/vllm_omni/diffusion/envs.py
@@ -184,10 +184,18 @@ class PackagesEnvChecker:
             if "Turing" in gpu_name or "Tesla" in gpu_name or "T4" in gpu_name:
                 return False
             else:
-                from flash_attn import __version__
+                compute_capability = torch.cuda.get_device_capability()
+                major, minor = compute_capability
+                if 80 <= major * 10 + minor < 100:
+                    from fa3_fwd import __version__
 
-                if __version__ < "2.6.0":
-                    raise ImportError("install flash_attn >= 2.6.0")
+                    if __version__ < "2.6.0":
+                        raise ImportError("install fa3_fwd >= 2.6.0")
+                else:
+                    from flash_attn import __version__
+
+                    if __version__ < "2.6.0":
+                        raise ImportError("install flash_attn >= 2.6.0")
                 return True
         except ImportError:
             if not packages_info.get("has_aiter", False):


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

It fixes the issue https://github.com/vllm-project/vllm-omni/issues/950 . However, we still need to consolidate the use of 

```
if 80 <= major * 10 + minor < 100:
    from fa3_fwd_interface import flash_attn_func, flash_attn_varlen_func  # noqa: F401
else:
    from flash_attn import flash_attn_func, flash_attn_varlen_func  # noqa: F401
```

in `vllm_omni/diffusion/attention/backends/ring/ring_globals.py` and `vllm_omni/diffusion/attention/backends/ring/ring_kernels.py`  in future PR.


## Test Plan

Ensure that it does not print the warning message on H100 when flash attention is not installed but flash-attention is installed.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
