### PR TITLE
[Bugfix] Add missing dependencies (onnxruntime, sox) for Qwen3-TTS support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "openai-whisper>=20250625",
     "imageio[ffmpeg]>=2.37.2",
     "onnxruntime>=1.19.0",
-    "sox",
+    "sox>=1.5.0",
     # "vllm==0.14.0",  # TODO: fix the entrypoints overwrite problem
 ]
 


### PR DESCRIPTION
<!-- markdownlint-disable -->


## Purpose
This PR fixes the `ModuleNotFoundError` when serving Qwen3-TTS models.
As discussed in issue #945, the current container image is missing `onnxruntime` and `sox` dependencies, which are required for audio processing in Qwen3-TTS.
## Test Plan
- Validated that the model `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` loads successfully after installing these dependencies.
 ## Related Issue
Fixes #945
## Test Result
- Model loads and performs inference  correctly without crashing.
- Audio file generated successfully.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
