### PR TITLE
[Perf] [Model] Fuse QK Norm and RoPE in QwenImageCrossAttention

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -15,7 +15,6 @@ from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.normalization import AdaLayerNormContinuous
 from vllm._custom_ops import fused_qk_norm_rope
-from vllm.platforms import current_platform
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -24,6 +23,7 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.platforms import current_platform
 
 from vllm_omni.diffusion.attention.backends.abstract import (
     AttentionMetadata,
@@ -480,9 +480,8 @@ class QwenImageCrossAttention(nn.Module):
             self.parallel_config = config.parallel_config
         except Exception:
             self.parallel_config = None
-        
-        self.use_fused_qk_rope = use_fused_qk_rope \
-            if use_fused_qk_rope is not None else False
+
+        self.use_fused_qk_rope = use_fused_qk_rope if use_fused_qk_rope is not None else False
 
     def forward(
         self,
@@ -591,10 +590,8 @@ class QwenImageCrossAttention(nn.Module):
             )
             img_qkv = img_qkv.view(img_qkv_shape_ori)
             txt_qkv = txt_qkv.view(txt_qkv_shape_ori)
-            img_query, img_key, img_value = img_qkv.split(
-                [q_size, kv_size, kv_size], dim=-1)
-            txt_query, txt_key, txt_value = txt_qkv.split(
-                [add_q_size, add_kv_size, add_kv_size], dim=-1)
+            img_query, img_key, img_value = img_qkv.split([q_size, kv_size, kv_size], dim=-1)
+            txt_query, txt_key, txt_value = txt_qkv.split([add_q_size, add_kv_size, add_kv_size], dim=-1)
 
             img_query = img_query.unflatten(-1, (self.query_num_heads, self.head_dim))
             img_key = img_key.unflatten(-1, (self.kv_num_heads, self.head_dim))

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -43,7 +43,7 @@ logger = init_logger(__name__)
 
 
 @functools.cache
-def has_fused_qk_rope():
+def has_fused_qknorm_rope():
     return current_platform.is_cuda_alike()
 
 
@@ -513,15 +513,15 @@ class QwenImageCrossAttention(nn.Module):
             txt_key = txt_key.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
             txt_value = txt_value.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
 
-            img_cos = vid_freqs.real.to(img_qkv.dtype)
-            img_sin = vid_freqs.imag.to(img_qkv.dtype)
-            txt_cos = txt_freqs.real.to(txt_qkv.dtype)
-            txt_sin = txt_freqs.imag.to(txt_qkv.dtype)
-
             img_query = self.norm_q(img_query)
             img_key = self.norm_k(img_key)
             txt_query = self.norm_added_q(txt_query)
             txt_key = self.norm_added_k(txt_key)
+
+            img_cos = vid_freqs.real.to(img_qkv.dtype)
+            img_sin = vid_freqs.imag.to(img_qkv.dtype)
+            txt_cos = txt_freqs.real.to(txt_qkv.dtype)
+            txt_sin = txt_freqs.imag.to(txt_qkv.dtype)
 
             img_query = self.rope(img_query, img_cos, img_sin)
             img_key = self.rope(img_key, img_cos, img_sin)
@@ -892,7 +892,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
         self.img_in = nn.Linear(in_channels, self.inner_dim)
         self.txt_in = nn.Linear(joint_attention_dim, self.inner_dim)
 
-        self.use_fused_qk_rope = has_fused_qk_rope()
+        self.use_fused_qk_rope = has_fused_qknorm_rope()
 
         self.transformer_blocks = nn.ModuleList(
             [

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -517,10 +517,10 @@ class QwenImageCrossAttention(nn.Module):
         add_q_size = self.add_query_num_heads * self.head_dim
         add_kv_size = self.add_kv_num_heads * self.head_dim
 
-        img_cos = vid_freqs.real.to(img_query.dtype)
-        img_sin = vid_freqs.imag.to(img_query.dtype)
-        txt_cos = txt_freqs.real.to(txt_query.dtype)
-        txt_sin = txt_freqs.imag.to(txt_query.dtype)
+        img_cos = vid_freqs.real.to(img_qkv.dtype)
+        img_sin = vid_freqs.imag.to(img_qkv.dtype)
+        txt_cos = txt_freqs.real.to(txt_qkv.dtype)
+        txt_sin = txt_freqs.imag.to(txt_qkv.dtype)
 
         if not self.use_fused_qk_rope:
             img_query, img_key, img_value = img_qkv.split([q_size, kv_size, kv_size], dim=-1)

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -44,7 +44,7 @@ logger = init_logger(__name__)
 
 @functools.cache
 def _has_fused_qknorm_rope():
-    return current_platform.is_rocm()
+    return current_platform.is_cuda_alike()
 
 
 class ImageRopePrepare(nn.Module):
@@ -533,11 +533,7 @@ class QwenImageCrossAttention(nn.Module):
             img_qkv = img_qkv.view(-1, img_qkv_shape_ori[-1])
             txt_qkv = txt_qkv.view(-1, txt_qkv_shape_ori[-1])
 
-            img_cos_sin = vid_freqs
-            txt_cos_sin = txt_freqs
-            img_position_ids = vid_position_ids
-            txt_position_ids = txt_position_ids
-
+            # fused_qk_norm_rope applies qk rmsnorm and rope to qkv in-place
             fused_qk_norm_rope(
                 qkv=img_qkv,
                 num_heads_q=self.query_num_heads,
@@ -545,11 +541,11 @@ class QwenImageCrossAttention(nn.Module):
                 num_heads_v=self.kv_num_heads,
                 head_dim=self.head_dim,
                 eps=self.eps,
-                q_weight=self.norm_q.weight.data,
-                k_weight=self.norm_k.weight.data,
-                cos_sin_cache=img_cos_sin,
+                q_weight=self.norm_q.weight,
+                k_weight=self.norm_k.weight,
+                cos_sin_cache=vid_freqs,
                 is_neox=False,
-                position_ids=img_position_ids,
+                position_ids=vid_position_ids,
             )
             fused_qk_norm_rope(
                 qkv=txt_qkv,
@@ -558,9 +554,9 @@ class QwenImageCrossAttention(nn.Module):
                 num_heads_v=self.add_kv_num_heads,
                 head_dim=self.head_dim,
                 eps=self.eps,
-                q_weight=self.norm_added_q.weight.data,
-                k_weight=self.norm_added_k.weight.data,
-                cos_sin_cache=txt_cos_sin,
+                q_weight=self.norm_added_q.weight,
+                k_weight=self.norm_added_k.weight,
+                cos_sin_cache=txt_freqs,
                 is_neox=False,
                 position_ids=txt_position_ids,
             )
@@ -892,6 +888,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
         self.img_in = nn.Linear(in_channels, self.inner_dim)
         self.txt_in = nn.Linear(joint_attention_dim, self.inner_dim)
 
+        # The fused qk norm rope is only supported when head_dim is divisible by 64
         self.use_fused_qk_rope = _has_fused_qknorm_rope() and attention_head_dim % 64 == 0
 
         self.transformer_blocks = nn.ModuleList(

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -43,8 +43,8 @@ logger = init_logger(__name__)
 
 
 @functools.cache
-def has_fused_qknorm_rope():
-    return current_platform.is_cuda_alike()
+def _use_fused_qknorm_rope():
+    return current_platform.is_rocm()
 
 
 class ImageRopePrepare(nn.Module):
@@ -892,7 +892,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
         self.img_in = nn.Linear(in_channels, self.inner_dim)
         self.txt_in = nn.Linear(joint_attention_dim, self.inner_dim)
 
-        self.use_fused_qk_rope = has_fused_qknorm_rope()
+        self.use_fused_qk_rope = _use_fused_qknorm_rope()
 
         self.transformer_blocks = nn.ModuleList(
             [

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -510,15 +510,20 @@ class QwenImageCrossAttention(nn.Module):
         if encoder_hidden_states_mask is not None and encoder_hidden_states_mask.all():
             encoder_hidden_states_mask = None
 
-        if not self.use_fused_qk_rope:
-            img_qkv, _ = self.to_qkv(hidden_states)
-            q_size = self.query_num_heads * self.head_dim
-            kv_size = self.kv_num_heads * self.head_dim
-            img_query, img_key, img_value = img_qkv.split([q_size, kv_size, kv_size], dim=-1)
+        img_qkv, _ = self.to_qkv(hidden_states)
+        q_size = self.query_num_heads * self.head_dim
+        kv_size = self.kv_num_heads * self.head_dim
+        txt_qkv, _ = self.add_kv_proj(encoder_hidden_states)
+        add_q_size = self.add_query_num_heads * self.head_dim
+        add_kv_size = self.add_kv_num_heads * self.head_dim
 
-            txt_qkv, _ = self.add_kv_proj(encoder_hidden_states)
-            add_q_size = self.add_query_num_heads * self.head_dim
-            add_kv_size = self.add_kv_num_heads * self.head_dim
+        img_cos = vid_freqs.real.to(img_query.dtype)
+        img_sin = vid_freqs.imag.to(img_query.dtype)
+        txt_cos = txt_freqs.real.to(txt_query.dtype)
+        txt_sin = txt_freqs.imag.to(txt_query.dtype)
+
+        if not self.use_fused_qk_rope:
+            img_query, img_key, img_value = img_qkv.split([q_size, kv_size, kv_size], dim=-1)
             txt_query, txt_key, txt_value = txt_qkv.split([add_q_size, add_kv_size, add_kv_size], dim=-1)
 
             img_query = img_query.unflatten(-1, (self.query_num_heads, self.head_dim))
@@ -534,32 +539,15 @@ class QwenImageCrossAttention(nn.Module):
             txt_query = self.norm_added_q(txt_query)
             txt_key = self.norm_added_k(txt_key)
 
-            img_cos = vid_freqs.real.to(img_query.dtype)
-            img_sin = vid_freqs.imag.to(img_query.dtype)
-            txt_cos = txt_freqs.real.to(txt_query.dtype)
-            txt_sin = txt_freqs.imag.to(txt_query.dtype)
-
             img_query = self.rope(img_query, img_cos, img_sin)
             img_key = self.rope(img_key, img_cos, img_sin)
             txt_query = self.rope(txt_query, txt_cos, txt_sin)
             txt_key = self.rope(txt_key, txt_cos, txt_sin)
-
-            seq_len_txt = encoder_hidden_states.shape[1]
-            joint_query = torch.cat([txt_query, img_query], dim=1)
-            joint_key = torch.cat([txt_key, img_key], dim=1)
-            joint_value = torch.cat([txt_value, img_value], dim=1)
         else:
-            img_qkv, _ = self.to_qkv(hidden_states)
-            txt_qkv, _ = self.add_kv_proj(encoder_hidden_states)
             img_qkv_shape_ori = img_qkv.shape
             txt_qkv_shape_ori = txt_qkv.shape
             img_qkv = img_qkv.view(-1, img_qkv_shape_ori[-1])
             txt_qkv = txt_qkv.view(-1, txt_qkv_shape_ori[-1])
-            
-            img_cos = vid_freqs.real.to(img_qkv.dtype)
-            img_sin = vid_freqs.imag.to(img_qkv.dtype)
-            txt_cos = txt_freqs.real.to(txt_qkv.dtype)
-            txt_sin = txt_freqs.imag.to(txt_qkv.dtype)
 
             img_cos_sin = torch.cat([img_cos, img_sin], dim=-1)
             img_position_ids = torch.arange(img_cos_sin.shape[0], device=img_cos_sin.device)
@@ -594,13 +582,8 @@ class QwenImageCrossAttention(nn.Module):
             )
             img_qkv = img_qkv.view(img_qkv_shape_ori)
             txt_qkv = txt_qkv.view(txt_qkv_shape_ori)
-            q_size = self.query_num_heads * self.head_dim
-            kv_size = self.kv_num_heads * self.head_dim
             img_query, img_key, img_value = img_qkv.split(
                 [q_size, kv_size, kv_size], dim=-1)
-
-            add_q_size = self.add_query_num_heads * self.head_dim
-            add_kv_size = self.add_kv_num_heads * self.head_dim
             txt_query, txt_key, txt_value = txt_qkv.split(
                 [add_q_size, add_kv_size, add_kv_size], dim=-1)
 
@@ -612,10 +595,10 @@ class QwenImageCrossAttention(nn.Module):
             txt_key = txt_key.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
             txt_value = txt_value.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
 
-            seq_len_txt = encoder_hidden_states.shape[1]
-            joint_query = torch.cat([txt_query, img_query], dim=1)
-            joint_key = torch.cat([txt_key, img_key], dim=1)
-            joint_value = torch.cat([txt_value, img_value], dim=1)
+        seq_len_txt = encoder_hidden_states.shape[1]
+        joint_query = torch.cat([txt_query, img_query], dim=1)
+        joint_key = torch.cat([txt_key, img_key], dim=1)
+        joint_value = torch.cat([txt_value, img_value], dim=1)
 
         if (
             self.parallel_config is not None

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -14,6 +14,8 @@ import torch.nn.functional as F
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.normalization import AdaLayerNormContinuous
+from vllm._custom_ops import fused_qk_norm_rope
+from vllm.platforms import current_platform
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
@@ -472,6 +474,8 @@ class QwenImageCrossAttention(nn.Module):
             self.parallel_config = config.parallel_config
         except Exception:
             self.parallel_config = None
+        
+        self.use_fused_qk_rope = current_platform.is_rocm()
 
     def forward(
         self,
@@ -506,43 +510,112 @@ class QwenImageCrossAttention(nn.Module):
         if encoder_hidden_states_mask is not None and encoder_hidden_states_mask.all():
             encoder_hidden_states_mask = None
 
-        img_qkv, _ = self.to_qkv(hidden_states)
-        q_size = self.query_num_heads * self.head_dim
-        kv_size = self.kv_num_heads * self.head_dim
-        img_query, img_key, img_value = img_qkv.split([q_size, kv_size, kv_size], dim=-1)
+        if not self.use_fused_qk_rope:
+            img_qkv, _ = self.to_qkv(hidden_states)
+            q_size = self.query_num_heads * self.head_dim
+            kv_size = self.kv_num_heads * self.head_dim
+            img_query, img_key, img_value = img_qkv.split([q_size, kv_size, kv_size], dim=-1)
 
-        txt_qkv, _ = self.add_kv_proj(encoder_hidden_states)
-        add_q_size = self.add_query_num_heads * self.head_dim
-        add_kv_size = self.add_kv_num_heads * self.head_dim
-        txt_query, txt_key, txt_value = txt_qkv.split([add_q_size, add_kv_size, add_kv_size], dim=-1)
+            txt_qkv, _ = self.add_kv_proj(encoder_hidden_states)
+            add_q_size = self.add_query_num_heads * self.head_dim
+            add_kv_size = self.add_kv_num_heads * self.head_dim
+            txt_query, txt_key, txt_value = txt_qkv.split([add_q_size, add_kv_size, add_kv_size], dim=-1)
 
-        img_query = img_query.unflatten(-1, (self.query_num_heads, self.head_dim))
-        img_key = img_key.unflatten(-1, (self.kv_num_heads, self.head_dim))
-        img_value = img_value.unflatten(-1, (self.kv_num_heads, self.head_dim))
+            img_query = img_query.unflatten(-1, (self.query_num_heads, self.head_dim))
+            img_key = img_key.unflatten(-1, (self.kv_num_heads, self.head_dim))
+            img_value = img_value.unflatten(-1, (self.kv_num_heads, self.head_dim))
 
-        txt_query = txt_query.unflatten(-1, (self.add_query_num_heads, self.head_dim))
-        txt_key = txt_key.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
-        txt_value = txt_value.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
+            txt_query = txt_query.unflatten(-1, (self.add_query_num_heads, self.head_dim))
+            txt_key = txt_key.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
+            txt_value = txt_value.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
 
-        img_query = self.norm_q(img_query)
-        img_key = self.norm_k(img_key)
-        txt_query = self.norm_added_q(txt_query)
-        txt_key = self.norm_added_k(txt_key)
+            img_query = self.norm_q(img_query)
+            img_key = self.norm_k(img_key)
+            txt_query = self.norm_added_q(txt_query)
+            txt_key = self.norm_added_k(txt_key)
 
-        img_cos = vid_freqs.real.to(img_query.dtype)
-        img_sin = vid_freqs.imag.to(img_query.dtype)
-        txt_cos = txt_freqs.real.to(txt_query.dtype)
-        txt_sin = txt_freqs.imag.to(txt_query.dtype)
+            img_cos = vid_freqs.real.to(img_query.dtype)
+            img_sin = vid_freqs.imag.to(img_query.dtype)
+            txt_cos = txt_freqs.real.to(txt_query.dtype)
+            txt_sin = txt_freqs.imag.to(txt_query.dtype)
 
-        img_query = self.rope(img_query, img_cos, img_sin)
-        img_key = self.rope(img_key, img_cos, img_sin)
-        txt_query = self.rope(txt_query, txt_cos, txt_sin)
-        txt_key = self.rope(txt_key, txt_cos, txt_sin)
+            img_query = self.rope(img_query, img_cos, img_sin)
+            img_key = self.rope(img_key, img_cos, img_sin)
+            txt_query = self.rope(txt_query, txt_cos, txt_sin)
+            txt_key = self.rope(txt_key, txt_cos, txt_sin)
 
-        seq_len_txt = encoder_hidden_states.shape[1]
-        joint_query = torch.cat([txt_query, img_query], dim=1)
-        joint_key = torch.cat([txt_key, img_key], dim=1)
-        joint_value = torch.cat([txt_value, img_value], dim=1)
+            seq_len_txt = encoder_hidden_states.shape[1]
+            joint_query = torch.cat([txt_query, img_query], dim=1)
+            joint_key = torch.cat([txt_key, img_key], dim=1)
+            joint_value = torch.cat([txt_value, img_value], dim=1)
+        else:
+            img_qkv, _ = self.to_qkv(hidden_states)
+            txt_qkv, _ = self.add_kv_proj(encoder_hidden_states)
+            img_qkv_shape_ori = img_qkv.shape
+            txt_qkv_shape_ori = txt_qkv.shape
+            img_qkv = img_qkv.view(-1, img_qkv_shape_ori[-1])
+            txt_qkv = txt_qkv.view(-1, txt_qkv_shape_ori[-1])
+            
+            img_cos = vid_freqs.real.to(img_qkv.dtype)
+            img_sin = vid_freqs.imag.to(img_qkv.dtype)
+            txt_cos = txt_freqs.real.to(txt_qkv.dtype)
+            txt_sin = txt_freqs.imag.to(txt_qkv.dtype)
+
+            img_cos_sin = torch.cat([img_cos, img_sin], dim=-1)
+            img_position_ids = torch.arange(img_cos_sin.shape[0], device=img_cos_sin.device)
+            txt_cos_sin = torch.cat([txt_cos, txt_sin], dim=-1)
+            txt_position_ids = torch.arange(txt_cos_sin.shape[0], device=txt_cos_sin.device)
+
+            fused_qk_norm_rope(
+                qkv=img_qkv,
+                num_heads_q=self.query_num_heads,
+                num_heads_k=self.kv_num_heads,
+                num_heads_v=self.kv_num_heads,
+                head_dim=self.head_dim,
+                eps=self.eps,
+                q_weight=self.norm_q.weight.data,
+                k_weight=self.norm_k.weight.data,
+                cos_sin_cache=img_cos_sin,
+                is_neox=False,
+                position_ids=img_position_ids,
+            )
+            fused_qk_norm_rope(
+                qkv=txt_qkv,
+                num_heads_q=self.add_query_num_heads,
+                num_heads_k=self.add_kv_num_heads,
+                num_heads_v=self.add_kv_num_heads,
+                head_dim=self.head_dim,
+                eps=self.eps,
+                q_weight=self.norm_added_q.weight.data,
+                k_weight=self.norm_added_k.weight.data,
+                cos_sin_cache=txt_cos_sin,
+                is_neox=False,
+                position_ids=txt_position_ids,
+            )
+            img_qkv = img_qkv.view(img_qkv_shape_ori)
+            txt_qkv = txt_qkv.view(txt_qkv_shape_ori)
+            q_size = self.query_num_heads * self.head_dim
+            kv_size = self.kv_num_heads * self.head_dim
+            img_query, img_key, img_value = img_qkv.split(
+                [q_size, kv_size, kv_size], dim=-1)
+
+            add_q_size = self.add_query_num_heads * self.head_dim
+            add_kv_size = self.add_kv_num_heads * self.head_dim
+            txt_query, txt_key, txt_value = txt_qkv.split(
+                [add_q_size, add_kv_size, add_kv_size], dim=-1)
+
+            img_query = img_query.unflatten(-1, (self.query_num_heads, self.head_dim))
+            img_key = img_key.unflatten(-1, (self.kv_num_heads, self.head_dim))
+            img_value = img_value.unflatten(-1, (self.kv_num_heads, self.head_dim))
+
+            txt_query = txt_query.unflatten(-1, (self.add_query_num_heads, self.head_dim))
+            txt_key = txt_key.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
+            txt_value = txt_value.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
+
+            seq_len_txt = encoder_hidden_states.shape[1]
+            joint_query = torch.cat([txt_query, img_query], dim=1)
+            joint_key = torch.cat([txt_key, img_key], dim=1)
+            joint_value = torch.cat([txt_value, img_value], dim=1)
 
         if (
             self.parallel_config is not None

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -42,6 +42,11 @@ from vllm_omni.diffusion.layers.rope import RotaryEmbedding
 logger = init_logger(__name__)
 
 
+@functools.cache
+def has_fused_qk_rope():
+    return current_platform.is_cuda_alike()
+
+
 class ImageRopePrepare(nn.Module):
     """Prepares image hidden_states and RoPE embeddings for sequence parallel.
 
@@ -406,6 +411,7 @@ class QwenImageCrossAttention(nn.Module):
         pre_only: bool = False,
         context_pre_only: bool = False,
         out_dim: int | None = None,
+        use_fused_qk_rope: bool | None = None,
     ) -> None:
         super().__init__()
         assert dim % num_heads == 0
@@ -475,7 +481,8 @@ class QwenImageCrossAttention(nn.Module):
         except Exception:
             self.parallel_config = None
         
-        self.use_fused_qk_rope = current_platform.is_rocm()
+        self.use_fused_qk_rope = use_fused_qk_rope \
+            if use_fused_qk_rope is not None else False
 
     def forward(
         self,
@@ -483,6 +490,8 @@ class QwenImageCrossAttention(nn.Module):
         encoder_hidden_states: torch.Tensor,
         vid_freqs: torch.Tensor,
         txt_freqs: torch.Tensor,
+        vid_position_ids: torch.Tensor | None = None,
+        txt_position_ids: torch.Tensor | None = None,
         hidden_states_mask: torch.Tensor | None = None,
         encoder_hidden_states_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -517,11 +526,6 @@ class QwenImageCrossAttention(nn.Module):
         add_q_size = self.add_query_num_heads * self.head_dim
         add_kv_size = self.add_kv_num_heads * self.head_dim
 
-        img_cos = vid_freqs.real.to(img_qkv.dtype)
-        img_sin = vid_freqs.imag.to(img_qkv.dtype)
-        txt_cos = txt_freqs.real.to(txt_qkv.dtype)
-        txt_sin = txt_freqs.imag.to(txt_qkv.dtype)
-
         if not self.use_fused_qk_rope:
             img_query, img_key, img_value = img_qkv.split([q_size, kv_size, kv_size], dim=-1)
             txt_query, txt_key, txt_value = txt_qkv.split([add_q_size, add_kv_size, add_kv_size], dim=-1)
@@ -533,6 +537,11 @@ class QwenImageCrossAttention(nn.Module):
             txt_query = txt_query.unflatten(-1, (self.add_query_num_heads, self.head_dim))
             txt_key = txt_key.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
             txt_value = txt_value.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
+
+            img_cos = vid_freqs.real.to(img_qkv.dtype)
+            img_sin = vid_freqs.imag.to(img_qkv.dtype)
+            txt_cos = txt_freqs.real.to(txt_qkv.dtype)
+            txt_sin = txt_freqs.imag.to(txt_qkv.dtype)
 
             img_query = self.norm_q(img_query)
             img_key = self.norm_k(img_key)
@@ -549,10 +558,10 @@ class QwenImageCrossAttention(nn.Module):
             img_qkv = img_qkv.view(-1, img_qkv_shape_ori[-1])
             txt_qkv = txt_qkv.view(-1, txt_qkv_shape_ori[-1])
 
-            img_cos_sin = torch.cat([img_cos, img_sin], dim=-1)
-            img_position_ids = torch.arange(img_cos_sin.shape[0], device=img_cos_sin.device)
-            txt_cos_sin = torch.cat([txt_cos, txt_sin], dim=-1)
-            txt_position_ids = torch.arange(txt_cos_sin.shape[0], device=txt_cos_sin.device)
+            img_cos_sin = vid_freqs
+            txt_cos_sin = txt_freqs
+            img_position_ids = vid_position_ids
+            txt_position_ids = txt_position_ids
 
             fused_qk_norm_rope(
                 qkv=img_qkv,
@@ -665,6 +674,7 @@ class QwenImageTransformerBlock(nn.Module):
         qk_norm: str = "rms_norm",
         eps: float = 1e-6,
         zero_cond_t: bool = False,
+        use_fused_qk_rope: bool | None = None,
     ):
         super().__init__()
 
@@ -684,6 +694,7 @@ class QwenImageTransformerBlock(nn.Module):
             added_kv_proj_dim=dim,
             context_pre_only=False,
             head_dim=attention_head_dim,
+            use_fused_qk_rope=use_fused_qk_rope,
         )
         self.img_norm2 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)
         self.img_mlp = FeedForward(dim=dim, dim_out=dim)
@@ -743,6 +754,7 @@ class QwenImageTransformerBlock(nn.Module):
         encoder_hidden_states_mask: torch.Tensor,
         temb: torch.Tensor,
         image_rotary_emb: tuple[torch.Tensor, torch.Tensor],
+        position_ids: tuple[torch.Tensor, torch.Tensor] | None = None,
         joint_attention_kwargs: dict[str, Any] | None = None,
         modulate_index: list[int] | None = None,
         hidden_states_mask: torch.Tensor | None = None,
@@ -776,6 +788,8 @@ class QwenImageTransformerBlock(nn.Module):
             encoder_hidden_states=txt_modulated,  # Text stream (will be processed as "context")
             vid_freqs=image_rotary_emb[0],
             txt_freqs=image_rotary_emb[1],
+            vid_position_ids=position_ids[0] if position_ids is not None else None,
+            txt_position_ids=position_ids[1] if position_ids is not None else None,
             hidden_states_mask=hidden_states_mask,
             encoder_hidden_states_mask=encoder_hidden_states_mask,
         )
@@ -901,6 +915,8 @@ class QwenImageTransformer2DModel(CachedTransformer):
         self.img_in = nn.Linear(in_channels, self.inner_dim)
         self.txt_in = nn.Linear(joint_attention_dim, self.inner_dim)
 
+        self.use_fused_qk_rope = has_fused_qk_rope()
+
         self.transformer_blocks = nn.ModuleList(
             [
                 QwenImageTransformerBlock(
@@ -908,6 +924,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
                     num_attention_heads=num_attention_heads,
                     attention_head_dim=attention_head_dim,
                     zero_cond_t=zero_cond_t,
+                    use_fused_qk_rope=self.use_fused_qk_rope,
                 )
                 for _ in range(num_layers)
             ]
@@ -976,6 +993,15 @@ class QwenImageTransformer2DModel(CachedTransformer):
         # _sp_plan will shard hidden_states and vid_freqs together via split_output=True
         # txt_freqs is kept replicated for dual-stream attention
         hidden_states, vid_freqs, txt_freqs = self.image_rope_prepare(hidden_states, img_shapes, txt_seq_lens)
+        if self.use_fused_qk_rope:
+            vid_freqs = torch.cat([vid_freqs.real, vid_freqs.imag], dim=-1)
+            txt_freqs = torch.cat([txt_freqs.real, txt_freqs.imag], dim=-1)
+            position_ids = [
+                torch.arange(vid_freqs.shape[0], device=vid_freqs.device).repeat(hidden_states.shape[0]),
+                torch.arange(txt_freqs.shape[0], device=txt_freqs.device).repeat(encoder_hidden_states.shape[0]),
+            ]
+        else:
+            position_ids = None
         image_rotary_emb = (vid_freqs, txt_freqs)
 
         # Ensure timestep tensor is on the same device and dtype as hidden_states
@@ -1010,6 +1036,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
                 encoder_hidden_states_mask=encoder_hidden_states_mask,
                 temb=temb,
                 image_rotary_emb=image_rotary_emb,
+                position_ids=position_ids,
                 joint_attention_kwargs=attention_kwargs,
                 modulate_index=modulate_index,
             )

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -43,7 +43,7 @@ logger = init_logger(__name__)
 
 
 @functools.cache
-def _use_fused_qknorm_rope():
+def _has_fused_qknorm_rope():
     return current_platform.is_rocm()
 
 
@@ -892,7 +892,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
         self.img_in = nn.Linear(in_channels, self.inner_dim)
         self.txt_in = nn.Linear(joint_attention_dim, self.inner_dim)
 
-        self.use_fused_qk_rope = _use_fused_qknorm_rope()
+        self.use_fused_qk_rope = _has_fused_qknorm_rope() and attention_head_dim % 64 == 0
 
         self.transformer_blocks = nn.ModuleList(
             [

--- a/vllm_omni/diffusion/worker/gpu_diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/gpu_diffusion_worker.py
@@ -279,7 +279,8 @@ class WorkerProc:
             return result, should_reply
         except Exception as e:
             logger.error(f"Error executing RPC: {e}", exc_info=True)
-            raise e
+            return {"status": "error", "error": str(e)}, should_reply
+            # raise e
 
     def worker_busy_loop(self) -> None:
         """Main busy loop for Multiprocessing Workers."""

--- a/vllm_omni/diffusion/worker/gpu_diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/gpu_diffusion_worker.py
@@ -279,8 +279,7 @@ class WorkerProc:
             return result, should_reply
         except Exception as e:
             logger.error(f"Error executing RPC: {e}", exc_info=True)
-            return {"status": "error", "error": str(e)}, should_reply
-            # raise e
+            raise e
 
     def worker_busy_loop(self) -> None:
         """Main busy loop for Multiprocessing Workers."""


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

For CUDA-like platforms, vLLM has a native fused kernel that combines QK RMSNorm and RoPE.

This PR integrates the fusion op into QwenImageCrossAttention, replacing the previous sequence of separate RMSNorm and RoPE calls.

Benchmarking on the Qwen-Image series, this reduces end-to-end latency by ~6.3% for Qwen/Qwen-Image-2512 and ~2.5% for Qwen/Qwen-Image-Edit-2511 on AMD MI300X.

Currently, the performance of this optimization has only been validated on ROCm, and it is not enabled on CUDA yet.

## Test Plan
Performance benchmark on MI300X

## Test Result
Qwen/Qwen-Image-2512 (vbench; t2i; max concurrency=1; 5 requests)
Metric | Before | This PR | Improvement
-- | -- | -- | --
Benchmark duration (s) | 51.36 | 48.33 | -
Request throughput (req/s) | 0.10 | 0.10 | -
Latency mean (s) | 10.2721 | 9.6664 | +6.27%
Latency median (s) | 10.2866 | 9.6736 | +6.34%
Latency p99 (s) | 10.2933 | 9.7184 | +5.92%

Qwen/Qwen-Image-Edit-2511 (vbench; i2i; max concurrency=1; 5 requests)
Metric | Before | This PR | Improvement
-- | -- | -- | --
Benchmark duration (s) | 123.60 | 120.66 | -
Request throughput (req/s) | 0.04 | 0.04 | -
Latency mean (s) | 24.7199 | 24.1308 | +2.44%
Latency median (s) | 24.7416 | 24.1340 | +2.52%
Latency p99 (s) | 24.7952 | 24.2080 | +2.43%

### Generation Test
Model: Qwen/Qwen-Image-2512
Prompt: "a cup of coffee on the table"

Before:
<img width="512" height="512" alt="rope_concat3_output_image_text2image_sanity" src="https://github.com/user-attachments/assets/35fc4a41-ad66-4c7d-bb05-17425e5fc9e0" />

This PR:
<img width="512" height="512" alt="rope_concat3_output_image_text2image_cache" src="https://github.com/user-attachments/assets/c9de306c-2404-42af-aca6-10dbe3efb15f" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
