### PR TITLE
Fix TTS speaker typo and add supported languages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,4 +200,5 @@ extend-ignore-identifiers-re = [
     ".*nothink.*",
     ".*NOTHINK.*",
     ".*nin.*",
+    "Ono_Anna",
 ]

--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -308,7 +308,7 @@ class TestTTSMethods:
         assert speech_server._validate_tts_request(req) == "Input text cannot be empty"
 
         # Invalid language
-        req = OpenAICreateSpeechRequest(input="Hello", language="French")
+        req = OpenAICreateSpeechRequest(input="Hello", language="InvalidLang")
         assert "Invalid language" in speech_server._validate_tts_request(req)
 
         # Invalid speaker

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -27,10 +27,22 @@ _TTS_SPEAKERS: set[str] = {
     "Eric",
     "Ryan",
     "Aiden",
-    "One_Anna",
+    "Ono_Anna",
     "Sohee",
 }
-_TTS_LANGUAGES: set[str] = {"Auto", "Chinese", "English", "Japanese", "Korean"}
+_TTS_LANGUAGES: set[str] = {
+    "Auto",
+    "Chinese",
+    "English",
+    "Japanese",
+    "Korean",
+    "German",
+    "French",
+    "Russian",
+    "Portuguese",
+    "Spanish",
+    "Italian",
+}
 _TTS_MAX_INSTRUCTIONS_LENGTH = 500
 _TTS_MAX_NEW_TOKENS_MIN = 1
 _TTS_MAX_NEW_TOKENS_MAX = 4096


### PR DESCRIPTION
Fix speaker name typo: `One_Anna` → `Ono_Anna`

Reference: https://github.com/vllm-project/vllm-omni/pull/968#discussion_r2732050433

Also added more supported languages: German, French, Russian, Portuguese, Spanish, Italian.