### PR TITLE
 [Docs] Fix GLM-Image docstring indentation to resolve CI failure

### DIFF
--- a/vllm_omni/diffusion/models/glm_image/glm_image_transformer.py
+++ b/vllm_omni/diffusion/models/glm_image/glm_image_transformer.py
@@ -546,9 +546,9 @@ class GlmImageTransformer2DModel(CachedTransformer):
     This is the vllm-omni optimized version of the GLM-Image DiT model.
 
     Args:
-        od_config: OmniDiffusionConfig containing model configuration. The
-            transformer hyper-parameters (e.g. patch size / channels / heads)
-            are read from `od_config.tf_model_config`.
+        od_config: OmniDiffusionConfig containing model configuration.
+            Transformer hyper-parameters (e.g. patch size / channels / heads) are read from
+            `od_config.tf_model_config`.
     """
 
     packed_modules_mapping = {


### PR DESCRIPTION

## Purpose
Fixes a documentation build failure in the CI pipeline.
The docstring for od_config in vllm_omni/diffusion/models/glm_image/glm_image_transformer.py had incorrect indentation, causing griffe to emit warnings. Since the documentation build runs in strict mode (mkdocs build --strict), these warnings were being treated as errors, causing the build to abort.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
