### PR TITLE
[BugFix] Fix noisy output without setting a seed in Qwen Image

### DIFF
--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -5,6 +5,7 @@ import multiprocessing.forkserver as forkserver
 import os
 
 # Image generation API imports
+import random
 import time
 from argparse import Namespace
 from collections.abc import AsyncIterator
@@ -984,6 +985,13 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
             gen_params.true_cfg_scale = request.true_cfg_scale
         if request.seed is not None:
             gen_params.seed = request.seed
+        else:
+            # If seed is not provided, generate a random one to ensure
+            # a proper generator is initialized in the backend.
+            # This fixes issues where using the default global generator
+            # might produce blurry images in some environments.
+            gen_params.seed = random.randint(0, 2**32 - 1)
+
         request_id = f"img_gen_{int(time.time())}"
 
         logger.info(f"Generating {request.n} image(s) {size_str}")


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fix #959 
Reason: Without specifying a random seed, the random noise in multiprocessing/distributed environments may not be correctly synchronized. 
Methods: add default random seed to api server
## Test Plan

## Test Result
```bash
from openai import OpenAI

import base64
import os
from datetime import datetime
client = OpenAI(base_url="http://localhost:40021/v1", api_key="none")

response = client.images.generate(
    model="/home/natureofnature/models/Qwen-Image-2512/",
    prompt="a horse jumping over a fence nearby a babbling brook",
    n=1,
    size="1024x1024",
    response_format="b64_json",
)

for idx, image in enumerate(response.data):
    image_data = base64.b64decode(image.b64_json)
    
    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
    filename = f"generated_image_{timestamp}_{idx}.png"
    
    with open(filename, "wb") as f:
        f.write(image_data)
    
    print(f"Image saved to: {filename}")
```
<img width="775" height="775" alt="image" src="https://github.com/user-attachments/assets/2351e796-e317-48f9-845c-e22308962f1a" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
