### PR TITLE
[bugfix] remove vllm speech route

### DIFF
--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -735,6 +735,9 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     return StreamingResponse(content=generator, media_type="text/event-stream")
 
 
+_remove_route_from_router(router, "/v1/audio/speech", {"POST"})
+
+
 @router.post(
     "/v1/audio/speech",
     dependencies=[Depends(validate_json_request)],


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fix 400 Bad Request when calling `/v1/audio/speech` with Qwen3-TTS voices (e.g., `Vivian`, `Ryan`).

vllm's built-in `/v1/audio/speech` route validates the `voice` parameter against OpenAI's voice list (`alloy`, `echo`, `shimmer`, etc.), rejecting any Qwen3-TTS voice names. Because vllm-omni never removed this upstream route, vllm's handler took precedence over omni's, which has proper Qwen3-TTS validation.                                              

The fix adds `_remove_route_from_router(router, "/v1/audio/speech", {"POST"})` before registering omni's speech endpoint, consistent with how `/v1/chat/completions`, `/health`, and `/v1/models` are already handled.                            

Fixes https://github.com/vllm-project/vllm-omni/issues/1041 and addresses [this comment](https://github.com/vllm-project/vllm-omni/issues/1008#issuecomment-3815390247).    

## Test Plan
```bash                                                                                                                  
# Start server                                                                                                           
vllm-omni serve /path/to/Qwen3-TTS-12Hz-1.7B-CustomVoice \                                                               
    --stage-configs-path vllm_omni/model_executor/stage_configs/qwen3_tts.yaml \                                         
    --host 0.0.0.0 --port 8800 \                                                                                         
    --trust-remote-code --enforce-eager --omni                                                                           
                                                                                                                         
# Test with Qwen3-TTS voice (previously returned 400)                                                                    
curl -X POST http://localhost:8800/v1/audio/speech -H "Content-Type: application/json" -d '{"input": "今天天气真好", "voice": "Ryan", "instructions": "用开心的语气说"}' --output test_ryan.wav -w "\nHTTP Status: %{http_code}\n"
```

## Test Result
[test_ryan.wav](https://github.com/user-attachments/files/24928200/test_ryan.wav)


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
