### PR TITLE
[Fix] stabilize diffusion images LoRA E2E across CI drift

### DIFF
--- a/tests/e2e/online_serving/test_images_generations_lora.py
+++ b/tests/e2e/online_serving/test_images_generations_lora.py
@@ -12,10 +12,6 @@ This validates:
 import base64
 import json
 import os
-import signal
-import subprocess
-import sys
-import time
 from io import BytesIO
 from pathlib import Path
 
@@ -25,7 +21,8 @@ import requests
 import torch
 from PIL import Image
 from safetensors.torch import save_file
-from vllm.utils.network_utils import get_open_port
+
+from tests.conftest import OmniServer
 
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
@@ -35,87 +32,6 @@ MODEL = "Tongyi-MAI/Z-Image-Turbo"
 PROMPT = "a photo of a cat sitting on a laptop keyboard"
 SIZE = "256x256"
 SEED = 42
-
-
-class OmniServer:
-    """Omniserver for vLLM-Omni tests."""
-
-    def __init__(
-        self,
-        model: str,
-        serve_args: list[str],
-        *,
-        env_dict: dict[str, str] | None = None,
-    ) -> None:
-        self.model = model
-        self.serve_args = serve_args
-        self.env_dict = env_dict
-        self.proc: subprocess.Popen | None = None
-        self.host = "127.0.0.1"
-        self.port = get_open_port()
-
-    def _start_server(self) -> None:
-        env = os.environ.copy()
-        env["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
-        if self.env_dict is not None:
-            env.update(self.env_dict)
-
-        cmd = [
-            sys.executable,
-            "-m",
-            "vllm_omni.entrypoints.cli.main",
-            "serve",
-            self.model,
-            "--omni",
-            "--host",
-            self.host,
-            "--port",
-            str(self.port),
-        ] + self.serve_args
-
-        print(f"Launching OmniServer with: {' '.join(cmd)}")
-        self.proc = subprocess.Popen(
-            cmd,
-            env=env,
-            cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),  # vllm-omni root
-            start_new_session=True,
-        )
-
-        # Wait for server to be ready.
-        max_wait = 1200
-        url = f"http://{self.host}:{self.port}/v1/models"
-        start_time = time.time()
-        while time.time() - start_time < max_wait:
-            try:
-                resp = requests.get(url, headers={"Authorization": "Bearer EMPTY"}, timeout=10)
-                if resp.status_code == 200:
-                    print(f"Server ready on {self.host}:{self.port}")
-                    return
-            except Exception:
-                pass
-            time.sleep(2)
-
-        raise RuntimeError(f"Server failed to become ready within {max_wait} seconds")
-
-    def __enter__(self):
-        self._start_server()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.proc is None:
-            return
-        try:
-            os.killpg(self.proc.pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        try:
-            self.proc.wait(timeout=30)
-        except subprocess.TimeoutExpired:
-            try:
-                os.killpg(self.proc.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
-            self.proc.wait()
 
 
 @pytest.fixture(scope="module")
@@ -205,7 +121,8 @@ def _assert_slice_close(
     max_thresh = max(10.0, base_max + 4.0)
     mean_thresh = max(6.0, base_mean + 4.0)
     assert max_diff <= max_thresh and mean_diff <= mean_thresh, (
-        f"{label} slice mismatch (max={max_diff:.1f}, mean={mean_diff:.1f}): {actual.tolist()}"
+        f"{label} slice mismatch (max={max_diff:.1f} > {max_thresh:.1f} or "
+        f"mean={mean_diff:.1f} > {mean_thresh:.1f}): {actual.tolist()}"
     )
 
 
@@ -260,6 +177,7 @@ def test_images_generations_per_request_lora_switching(omni_server: OmniServer, 
     # Ensure switching back to no-LoRA restores the base output.
     base_img_2 = _post_images(omni_server, _basic_payload())
     base_slice_2 = _image_blue_tail_slice(base_img_2)
+    _, base_reset_mean = _slice_diff_stats(base_slice_2, base_slice)
     _assert_slice_close(
         base_slice_2,
         base_slice,
@@ -269,7 +187,7 @@ def test_images_generations_per_request_lora_switching(omni_server: OmniServer, 
     )
 
     # Ensure LoRA effects are clearly above the baseline drift.
-    min_delta = max(base_ref_mean + 1.0, 1.5)
+    min_delta = max(base_reset_mean + 1.0, 1.5)
     assert a_vs_base > min_delta, f"lora_a_vs_base drift too small: {a_vs_base} <= {min_delta}"
     assert b_vs_base > min_delta, f"lora_b_vs_base drift too small: {b_vs_base} <= {min_delta}"
     assert b_vs_a > min_delta, f"lora_b_vs_lora_a drift too small: {b_vs_a} <= {min_delta}"


### PR DESCRIPTION
## Purpose
fix https://github.com/vllm-project/vllm-omni/issues/1066

Local runs were stable but CI on different machines showed small numeric drift, causing the fixed base_after_reset thresholds to fail intermittently. This change measures a baseline “no‑LoRA” drift and derives dynamic, looser tolerances from that baseline, while still requiring LoRA deltas to be clearly above the baseline. The test  becomes robust across hardware/backends.

## Test Plan
-  pytest -s -v tests/e2e/online_serving/test_images_generations_lora.py
## Test Result
- Passed
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
