### PR TITLE
[BugFix] Fix Qwen3 TTS 0.6B profile run hang (#995)

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts.py
@@ -126,18 +126,12 @@ class Qwen3TTSModelForGeneration(nn.Module):
                 runtime_additional_information[key] = value[0]
 
         # During profile/warmup runs, text is empty and no real inputs exist.
-        # Short-circuit to avoid degenerate generation that hangs on small
-        # models (e.g. 0.6B) due to corrupted dummy inputs.
+        # Cap generation steps so the full pipeline executes (preserving
+        # KV-cache profiling behaviour) but exits quickly even if the model
+        # cannot converge from degenerate dummy inputs.
         if not text:
-            logger.info("Profile run detected (empty text). Returning dummy audio output.")
-            dummy_audio = torch.zeros(24000, dtype=torch.float32)  # 1s silence at 24kHz
-            return OmniOutput(
-                text_hidden_states=None,
-                multimodal_outputs={
-                    "model_outputs": dummy_audio,
-                    "sr": torch.tensor(24000, dtype=torch.int),
-                },
-            )
+            logger.info("Profile run detected (empty text). Capping max_new_tokens to 2.")
+            runtime_additional_information["max_new_tokens"] = 2
 
         # Call the appropriate generation method based on task_type
         if task_type == "CustomVoice":


### PR DESCRIPTION
## Purpose

Fix Qwen3-TTS-12Hz-0.6B-Base hanging during server startup (profile/warmup run).

Resolves #995

### Root Cause

During vLLM's profile/warmup run, `forward()` is called with dummy token IDs and empty `runtime_additional_information`. For the Base task type, this triggers `generate_voice_clone()` in ICL mode with degenerate inputs (1-second silent audio clip, placeholder ref_text). The 0.6B model cannot converge from this input and generates indefinitely, never producing an EOS token. The EngineCore times out waiting for the worker to finish, emitting:

```
No available shared memory broadcast block found in 60 seconds.
```

The 1.7B models are robust enough to produce EOS from the same degenerate input, which is why only 0.6B is affected.

### Fix

Cap `max_new_tokens` to 2 when `text` is empty (profile run detection), so the full generation pipeline executes — preserving KV-cache profiling behaviour — but exits quickly even when the model cannot converge from degenerate dummy inputs.

## Test Plan

```bash
# 1. Build Docker image
docker build -t vllm-omni-q3tts:latest -f docker/Dockerfile.ci .

# 2. Start server with 0.6B Base model
docker run -d \
  --name qwen3-tts-server \
  --gpus '"device=0"' \
  -p 8000:8000 \
  -v ~/.cache/huggingface:/root/.cache/huggingface \
  vllm-omni-q3tts:latest \
  vllm serve Qwen/Qwen3-TTS-12Hz-0.6B-Base \
    --omni --host 0.0.0.0 --port 8000 \
    --gpu-memory-utilization 0.9 --enforce-eager

# 3. Verify server starts (previously hung here)
curl http://localhost:8000/health

# 4. Send a TTS request
curl -X POST http://localhost:8000/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{
    "input": "Hello, this is a test.",
    "model": "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
    "task_type": "Base",
    "language": "English",
    "ref_audio": "data:audio/wav;base64,<base64_encoded_wav>",
    "ref_text": "Reference text for the audio.",
    "x_vector_only_mode": true,
    "max_new_tokens": 256
  }' -o output.wav
```

## Test Result

Tested on RTX 3090 (Ampere, sm_86), Docker, vllm-omni v0.14.0rc1:

- **Before fix**: Server hangs at `No available shared memory broadcast block found in 60 seconds` — never starts
- **After fix**: Profile run completes with capped generation (`max_new_tokens=2`), full pipeline executes, server starts successfully
- **0.6B Base inference**: HTTP 200, produces valid 3.34s non-silent 24kHz audio in 2.9s (x_vector_only voice cloning mode)
- **Approach**: Generation step cap preserves full pipeline execution during warmup (KV-cache profiling compatible) while bounding degenerate generation

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>**