### PR TITLE
[Fix] Increase max wait time for server readiness to accommodate model loading

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -920,7 +920,7 @@ class OmniServer:
         )
 
         # Wait for server to be ready
-        max_wait = 600  # 10 minutes
+        max_wait = 1200  # 20 minutes
         start_time = time.time()
         while time.time() - start_time < max_wait:
             try:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fix #1029 example 10 and follow-up to #1075 . This is introduced by switching to the common `OmniServer` from `test.confest` with default `max_time=600s` (In the CI use case, we increase the time to `1200s` to accommodate that in the previous PRs, but it was overwritten - we revert the changes here)

`Loading safetensors checkpoint shards:  67% 2/3 [07:35<03:42, 222.93s/it]ERROR/usr/local/lib/python3.12/dist-packages/coverage/control.py:958: CoverageWarning: No data was collected. (no-data-collected); see https://coverage.readthedocs.io/en/7.13.2/messages.html#warning-no-data-collected`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
