### PR TITLE
[bugfix] Fix Qwen Image pipeline when inputting batch request

### DIFF
--- a/vllm_omni/diffusion/attention/backends/sdpa.py
+++ b/vllm_omni/diffusion/attention/backends/sdpa.py
@@ -54,7 +54,6 @@ class SDPAImpl(AttentionImpl):
         value: torch.Tensor,
         attn_metadata: AttentionMetadata = None,
     ) -> torch.Tensor:
-        query, key, value = (x.permute(0, 2, 1, 3) for x in (query, key, value))
         attention_mask = attn_metadata.attn_mask if attn_metadata else None
 
         output = torch.nn.functional.scaled_dot_product_attention(
@@ -66,5 +65,4 @@ class SDPAImpl(AttentionImpl):
             is_causal=self.causal,
             scale=self.softmax_scale,
         )
-        out = output.permute(0, 2, 1, 3)
-        return out
+        return output

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -401,6 +401,7 @@ class QwenImagePipeline(
         )
 
         prompt_embeds = prompt_embeds.to(dtype=dtype)
+        encoder_attention_mask = encoder_attention_mask.to(dtype=torch.bool)
 
         return prompt_embeds, encoder_attention_mask
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix #857 

**But the current draft PR only ensurses that the code _can run_. When it accepts a batch input, the output images are all black.** I am not very familiar with this part.

Can someone else help me debug it?

## Test Plan

It may require an e2e test case with batch inputs. But let's discuss whether the current CI machine can handle it, and whether it is currently necessary (because not all models support batch input, and the current documentation explicitly discourage users to do so).

I see there are other draft PR adding complete diffusion model test. Maybe they are related.

For any ad-hoc test currently, refer to #857 for the test script that triggers this issue.

## Test Result

NA

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
