### PR TITLE
[Feature] Abort diffusion request

### DIFF
--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+import signal
 import time
-from collections.abc import Iterable
 from typing import Any
 
 import PIL.Image
@@ -371,7 +371,13 @@ class DiffusionEngine:
         if hasattr(self, "executor"):
             self.executor.shutdown()
 
-    def abort(self, request_id: str | Iterable[str]) -> None:
-        # TODO implement it
-        logger.warning("DiffusionEngine abort is not implemented yet")
-        pass
+    def abort(self) -> None:
+        """
+        Abort diffusion generation requests.
+        """
+        try:
+            for worker_pid in self.executor.get_worker_pids():
+                os.kill(worker_pid, signal.SIGUSR1)
+                logger.info("Interrupt signal sent to worker.")
+        except Exception as e:
+            logger.error(f"Failed to interrupt current diffusion forward: {e}")

--- a/vllm_omni/diffusion/executor/abstract.py
+++ b/vllm_omni/diffusion/executor/abstract.py
@@ -84,3 +84,8 @@ class DiffusionExecutor(ABC):
     def shutdown(self) -> None:
         """Shutdown the executor and release resources."""
         pass
+
+    @abstractmethod
+    def get_worker_pids(self) -> None:
+        """Get worker pid."""
+        pass

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -130,6 +130,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
     def add_req(self, request: OmniDiffusionRequest) -> DiffusionOutput:
         return self.scheduler.add_req(request)
 
+    def get_worker_pids(self):
+        return [process.pid for process in self._processes]
+
     def collective_rpc(
         self,
         method: str,

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -991,6 +991,7 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
         HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
     },
 )
+@with_cancellation
 async def edit_images(
     raw_request: Request,
     image: list[UploadFile] | None = File(None),
@@ -1014,7 +1015,7 @@ async def edit_images(
     seed: int | None = Form(None),
     # vllm-omni extension for per-request LoRA.
     lora: str | None = Form(None),  # Json string
-) -> ImageGenerationResponse:
+) -> ImageGenerationResponse | None:
     """
     OpenAI-compatible image edit endpoint.
     """


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Support to abort diffusion request, event for dit is Running
Aborting logic is :
(1) cancel stage async def generate
(2) if engine step is waiting is self._executor, cancel to avoid to execute
(3) if engine step is Running, we send interupter signal to worker wo set self.model.pipeline._interupter = True
(4) self.model.pipeline._interupter will reset to False when new forward begin.





## Test Plan
(1) set inference step to 50, run complete request, total time is 60s
![fa8c0270f517c01e43db8f0fafd337f6](https://github.com/user-attachments/assets/03f4314d-c5e8-4e0a-85ee-9a1b7d3105fd)

(2) abort request, and time between recive abort and finish request is 2s
<img width="1079" height="189" alt="309decf17b4f02030d83e3bc318d8a96" src="https://github.com/user-attachments/assets/e24b14cc-2356-4aad-b134-0336bdf65e08" />

(3) send request 1 => and then send request 2 => kill request 2
request 2 not waiting for execute step forward, but also can abort.

![26dab359ce3fec0003203a8246c6aa1d](https://github.com/user-attachments/assets/25b8031a-363c-4dc5-97e5-91cdf45f6d56)

(4) continue test with kill and full curl.
```
#!/usr/bin/env bash

set -e

CURL_SCRIPT="./curl.sh"
REPEAT=5
INTERRUPT_DELAY=1        # 每次中断前等待时间
LOG_DIR="./curl_logs"

mkdir -p "$LOG_DIR"

script_start_ts=$(date +%s.%N)

echo "=============================="
echo "Step 1: Run full curl.sh (baseline)"
echo "=============================="
start_ts=$(date +%s.%N)
setsid bash "$CURL_SCRIPT" > "$LOG_DIR/baseline.log" 2>&1
end_ts=$(date +%s.%N)
echo "Baseline runtime: $(echo "$end_ts - $start_ts" | bc) seconds"
echo

echo "=============================="
echo "Step 2: Run + interrupt (${REPEAT} times)"
echo "=============================="

for i in $(seq 1 $REPEAT); do
    echo "---- Interrupt run #$i ----"

    # 启动 curl.sh 在独立会话，确保可以 kill 整个脚本及子进程
    setsid bash "$CURL_SCRIPT" > "$LOG_DIR/interrupt_${i}.log" 2>&1 &
    pid=$!

    # 给进程启动一点时间再中断
    sleep $INTERRUPT_DELAY

    echo "Sending SIGINT to PID $pid (entire process group)"
    # 使用负号 kill 整个会话进程组
    kill -TERM -$pid

    # 等待进程退出，避免残留
    kill -KILL -$pid 2>/dev/null || true

    echo "Interrupt run #$i completed (should have been aborted)"
    echo
done

echo "=============================="
echo "Step 3: Run full curl.sh again"
echo "=============================="
start_ts=$(date +%s.%N)
setsid bash "$CURL_SCRIPT" > "$LOG_DIR/post_abort.log" 2>&1
end_ts=$(date +%s.%N)
echo "Post-abort runtime: $(echo "$end_ts - $start_ts" | bc) seconds"
echo

script_end_ts=$(date +%s.%N)

echo "=============================="
echo "Total script runtime: $(echo "$script_end_ts - $script_start_ts" | bc) seconds"
echo "All logs saved under: $LOG_DIR/"
echo "=============================="
echo "Done"
```
After 5 kill request , last full curl request take 2s more time to complete.
<img width="560" height="670" alt="792723787e689d4307f124aea5f5dc3f" src="https://github.com/user-attachments/assets/93d42996-f3be-401f-a42b-ce127b2f6637" />



## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
