### PR TITLE
[Bugfix] fix qwen image oom

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -311,7 +311,6 @@ class QwenEmbedRope(nn.Module):
             ],
             dim=1,
         )
-        self.rope_cache = {}
 
         # DO NOT USING REGISTER BUFFER HERE, IT WILL CAUSE COMPLEX NUMBERS LOSE ITS IMAGINARY PART
         self.scale_rope = scale_rope


### PR DESCRIPTION
## Purpose
Qwen image transformer will cache rope freqs for different height and width. It will cause oom when user send different resolution images

## Test Plan

```python
import base64
import random
import subprocess
from openai import OpenAI

client = OpenAI(
    api_key="None",
    base_url="http://localhost:8092/v1"
)

IMAGE_PATH = "./qwen-bear.png"
OUTPUT_PREFIX = "qwen_bear_reading"
MODEL_NAME = "Qwen/Qwen-Image-Edit-2511"

def get_gpu0_memory():
    try:
        result = subprocess.check_output(
            [
                "nvidia-smi",
                "--query-gpu=memory.used,memory.total",
                "--format=csv,noheader,nounits",
                "-i", "0"
            ],
            stderr=subprocess.DEVNULL
        )
        used, total = result.decode().strip().split(", ")
        return int(used), int(total)
    except Exception:
        return None, None


request_count = 0

while True:
    request_count += 1

    width = random.randint(512, 1024)
    height = random.randint(512, 1024)
    size = f"{width}x{height}"

    print(f"\n[Request {request_count}] size={size}")

    try:
        result = client.images.edit(
            model=MODEL_NAME,
            image=[
                open(IMAGE_PATH, "rb"),
            ],
            prompt=(
                "Change the bear in the input image to sitting and reading a book. "
                "Keep the bear recognizable from the original image. "
                "Make the scene cozy and natural, with soft lighting, warm colors, "
                "and a harmonious background."
            ),
            size=size,
            stream=False,
            output_format="jpeg",
            extra_body={
                "num_inference_steps": 1,
                "guidance_scale": 1.0,
            }
        )

        image_base64 = result.data[0].b64_json
        image_bytes = base64.b64decode(image_base64)

        # output_path = f"{OUTPUT_PREFIX}_{request_count}_{size}.jpeg"
        # with open(output_path, "wb") as f:
        #     f.write(image_bytes)

        # print(f"  ✔ Image saved: {output_path}")

    except Exception as e:
        print(f"  ✖ Request failed: {e}")

    used, total = get_gpu0_memory()
    if used is not None:
        print(f"GPU0 Memory: {used} MB / {total} MB ({used / total:.1%})")
    else:
        print("GPU0 Memory: unavailable")

```

## Test Result

```
[Request 32226] size=544x959
GPU0 Memory: 67151 MB / 143771 MB (46.7%)

[Request 32227] size=648x544
GPU0 Memory: 67151 MB / 143771 MB (46.7%)

[Request 32228] size=887x574
GPU0 Memory: 67151 MB / 143771 MB (46.7%)

[Request 32229] size=600x695
GPU0 Memory: 67151 MB / 143771 MB (46.7%)

[Request 32230] size=734x998
GPU0 Memory: 67151 MB / 143771 MB (46.7%)
```
same as the server started

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
