### PR TITLE
[Bugfix][Qwen-Image-Edit] Add a warning log for none negative_prompt

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -632,7 +632,7 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
             logger.warning(
                 "negative_prompt is not set. The official Qwen-Image-Edit model "
                 "may produce lower-quality results without a negative_prompt. "
-                "Qwen official repository recommends to use empty string as negative_prompt. "
+                "Qwen official repository recommends to use whitespace string as negative_prompt. "
                 "Note: some distilled variants may not be affected by this."
             )
 

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -567,7 +567,7 @@ class QwenImageEditPlusPipeline(nn.Module, SupportImageInput, QwenImageCFGParall
             logger.warning(
                 "negative_prompt is not set. The official Qwen-Image-Edit model "
                 "may produce lower-quality results without a negative_prompt. "
-                "Qwen official repository recommends to use empty string as negative_prompt. "
+                "Qwen official repository recommends to use whitespace string as negative_prompt. "
                 "Note: some distilled variants may not be affected by this."
             )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Add a warning log for none negative_prompt.

In https://huggingface.co/Qwen/Qwen-Image-Edit-2511, it recommends to the following configs:

```
inputs = {
    "image": [image1, image2],
    "prompt": prompt,
    "generator": torch.manual_seed(0),
    "true_cfg_scale": 4.0,
    "negative_prompt": " ",
    "num_inference_steps": 40,
    "guidance_scale": 1.0,
    "num_images_per_prompt": 1,
}
```

## Test Plan

Test it with examples that one includes negative_prompts, and one not include it.

```
python image_edit.py --model Qwen/Qwen-Image-Edit-2511 --image ../../cp-1.png ../../cp-2.png --prompt "根据这图1中女性和图2中的男性，生成一组结婚照，并遵循以下描述:新郎穿 着红色的中式马褂，新娘穿着精致的秀禾服，头戴金色凤冠。他们并肩站立在古老的朱红色宫墙前，背景是雕花的木窗。光线明亮柔和，构图对称，氛围喜庆而庄重。"  --num_inference_steps 40 --cfg_scale 4.0 --seed 15 --enforce_eager --vae_use_tiling --vae_use_slicing --output seed-15.png

python image_edit.py --model Qwen/Qwen-Image-Edit-2511 --image ../../cp-1.png ../../cp-2.png --prompt "根据这图1中女性和图2中的男性，生成一组结婚照，并遵循以下描述:新郎穿 着红色的中式马褂，新娘穿着精致的秀禾服，头戴金色凤冠。他们并肩站立在古老的朱红色宫墙前，背景是雕花的木窗。光线明亮柔和，构图对称，氛围喜庆而庄重。"  --num_inference_steps 40 --cfg_scale 4.0 --seed 15 --enforce_eager --vae_use_tiling --vae_use_slicing --output seed-15.png --negative_prompt " "
```

## Test Result

<img width="1423" height="654" alt="image" src="https://github.com/user-attachments/assets/9cc0ce7a-fbf8-4094-add5-dd8db096f9d0" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
