### PR TITLE
[chore] Remove zmq context initialize

### DIFF
--- a/vllm_omni/diffusion/scheduler.py
+++ b/vllm_omni/diffusion/scheduler.py
@@ -13,14 +13,13 @@ logger = init_logger(__name__)
 
 class Scheduler:
     def initialize(self, od_config: OmniDiffusionConfig):
-        existing_context = getattr(self, "context", None)
-        if existing_context is not None and not existing_context.closed:
+        existing_mq = getattr(self, "mq", None)
+        if existing_mq is not None and not existing_mq.closed:
             logger.warning("SyncSchedulerClient is already initialized. Re-initializing.")
             self.close()
 
         self.num_workers = od_config.num_gpus
         self.od_config = od_config
-        self.context = zmq.Context()  # Standard synchronous context
 
         # Initialize single MessageQueue for all message types (generation & RPC)
         # Assuming all readers are local for now as per current launch_engine implementation
@@ -72,8 +71,5 @@ class Scheduler:
 
     def close(self):
         """Closes the socket and terminates the context."""
-        if hasattr(self, "context"):
-            self.context.term()
-        self.context = None
         self.mq = None
         self.result_mq = None


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
The Context has already been initialized in the __init__ method of MessageQueue, so it should not be necessary here.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
