### PR TITLE
[Feature] Enable use_audio_in_video for Qwen 3 Omni Online

### DIFF
--- a/examples/online_serving/qwen3_omni/openai_chat_completion_client_for_multimodal_generation.py
+++ b/examples/online_serving/qwen3_omni/openai_chat_completion_client_for_multimodal_generation.py
@@ -308,19 +308,24 @@ def get_multi_audios_query(custom_prompt: str | None = None):
 
 def get_use_audio_in_video_query(
     video_path: str | None = None,
-    audio_path: str | None = None,
     custom_prompt: str | None = None,
 ):
+    """Query for use_audio_in_video mode.
+
+    When use_audio_in_video=True, audio is automatically extracted from the video
+    by the server. Do NOT send a separate audio_url - this would cause a mismatch
+    between the number of audio and video items.
+    """
     question = custom_prompt or (
         "Describe the content of the video in details, then convert what the baby say into text."
     )
     video_url = get_video_url_from_path(video_path)
-    audio_url = get_audio_url_from_path(audio_path)
+    # Note: audio is extracted from video automatically when use_audio_in_video=True
+    # Do not include a separate audio_url here
     return {
         "role": "user",
         "content": [
             {"type": "video_url", "video_url": {"url": video_url}},
-            {"type": "audio_url", "audio_url": {"url": audio_url}},
             {"type": "text", "text": question},
         ],
     }
@@ -397,7 +402,6 @@ def run_multimodal_generation(args) -> None:
     elif args.query_type == "use_audio_in_video":
         prompt = query_func(
             video_path=video_path,
-            audio_path=audio_path,
             custom_prompt=custom_prompt,
         )
     else:
@@ -484,7 +488,7 @@ def parse_args():
         "--query-type",
         "-q",
         type=str,
-        default="use_mixed_modalities",
+        default="use_audio_in_video",
         choices=query_map.keys(),
         help="Query type.",
     )

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -336,14 +336,19 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
                 mm_item_counts,
             )
         else:
-            if use_audio_in_video and "audio" in mm_prompt_updates:
+            if use_audio_in_video:
+                # When use_audio_in_video=True, audio is extracted from video and embedded
+                # in the video placeholder tokens. We should:
+                # 1. Filter out audio from prompt updates (audio has no separate placeholder)
+                # 2. Apply remaining updates (video, image, etc.)
+                # 3. Derive audio placeholders from video placeholders
                 filtered_updates = {k: v for k, v in mm_prompt_updates.items() if k != "audio"}
                 prompt_ids, mm_placeholders = self._apply_prompt_updates(
                     prompt_ids,
                     filtered_updates,
                 )
                 # Derive audio placeholders from video placeholders
-                mm_placeholders = self._derive_audio_from_video_placeholders(mm_placeholders, mm_prompt_updates)
+                mm_placeholders = self._derive_audio_from_video_placeholders(mm_placeholders, mm_item_counts)
             else:
                 prompt_ids, mm_placeholders = self._apply_prompt_updates(
                     prompt_ids,
@@ -508,18 +513,27 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
     def _derive_audio_from_video_placeholders(
         self,
         placeholders: Mapping[str, list[PlaceholderFeaturesInfo]],
-        mm_prompt_updates: MultiModalPromptUpdates,
+        mm_item_counts: Mapping[str, int],
     ) -> Mapping[str, list[PlaceholderFeaturesInfo]]:
         """
         Helper to derive audio placeholders from video placeholders when
         use_audio_in_video=True.
+
+        In use_audio_in_video mode, audio is extracted from video and embedded
+        within the video placeholder tokens. This function creates audio placeholder
+        info by extracting the audio token positions from video placeholders.
+
+        Args:
+            placeholders: Current placeholders (should contain "video")
+            mm_item_counts: Counts of multimodal items from mm_items.get_all_counts()
         """
         if "video" not in placeholders:
             return placeholders
 
         # Validate audio and video counts match
+        # In use_audio_in_video mode, audio count comes from mm_items (extracted from video)
         num_videos = len(placeholders["video"])
-        num_audios = len(mm_prompt_updates.get("audio", []))
+        num_audios = mm_item_counts.get("audio", 0)
         if num_audios != num_videos:
             raise ValueError(
                 f"use_audio_in_video requires equal number of audio and video items, got {num_audios=}, {num_videos=}"


### PR DESCRIPTION
## Purpose
As in #879 , this PR is to support use_audio_in_video for Qwen 3 Omni Online
## Test Plan

Start server:
```bash
vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
```

Tested 2 Prompts:
1. Defult video as baby reading:

```bash
python openai_chat_completion_client_for_multimodal_generation.py --query-type use_audio_in_video
```
3. An [example video](https://www.youtube.com/shorts/EoUV_XKtRGM?feature=share) with view and clear talk:
```bash
python openai_chat_completion_client_for_multimodal_generation.py --query-type use_audio_in_video --video-path  example.mp4
```

## Test Result
1. Baby Reading video:
[audio_0.wav](https://github.com/user-attachments/files/25067395/audio_0.wav)

```bash
python openai_chat_completion_client_for_multimodal_generation.py --query-type use_audio_in_video
Chat completion output from text: In the video, a young child is sitting on a bed, engrossed in reading a book. The child appears to be wearing glasses and is dressed in light-colored clothing. The setting seems to be a cozy bedroom with various items scattered around, including clothes and possibly some toys. The child's attention is focused on the book, flipping through the pages with curiosity and interest. The environment suggests a comfortable and familiar space, likely at home.

The child says, "I'm going to read this book."
Audio saved to audio_0.wav
```
2. Example video:
[audio_0.wav](https://github.com/user-attachments/files/25067218/audio_0.wav)

```bash
Chat completion output from text: The video is a short-form motivational clip, likely from YouTube Shorts, featuring serene nature scenery with overlaid inspirational text.

**Content Description:**

*   **Visuals:** The scene is filmed from a first-person perspective, looking forward from the bow of a kayak or canoe on a calm, turquoise-colored lake. The water is still, creating a mirror-like reflection of the surrounding landscape. In the distance, majestic mountains with snow-capped peaks rise against a clear, bright blue sky. The shoreline on the left is covered in dense evergreen forests.
*   **Text Overlay:** White text appears sequentially over the scenic background, delivering a message:
    *   "Before one can leave the situation they are in, they"
    *   "there is another path worth taking."
    *   "It's not always seeing but trusting"
*   **Interface Elements:** The top of the screen displays the title "Powerful Motivational Speech | Short - 30 Second..." and the creator's name, "Eddie Pinero Cli...". A "订阅" (Subscribe) button is visible. At the bottom, a standard video player interface shows a progress bar, a pause button, and the "Shorts" logo.

**Audio Transcription:**

A male voice narrates the text that appears on screen. The audio is clear and delivered in a calm, motivational tone.

*   **Transcription:** "Before one can leave the situation they are in, there is another path worth taking. It's not always seeing but trusting."
Audio saved to audio_0.wav
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
