### PR TITLE
[Bugfix] Fix padding bug in 12Hz tokenizer ConvTranspose1d decode

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
@@ -197,12 +197,13 @@ class Qwen3TTSTokenizerV2CausalTransConvNet(nn.Module):
         self.conv = nn.ConvTranspose1d(in_channels, out_channels, kernel_size, stride=stride)
 
         pad = kernel_size - stride
-        self.left_pad = math.ceil(pad)
-        self.right_pad = pad = self.left_pad
+        self.left_pad = 0
+        self.right_pad = int(pad)
 
     def forward(self, hidden_state):
         hidden_state = self.conv(hidden_state)
-        hidden_state = hidden_state[..., self.left_pad : hidden_state.shape[-1] - self.right_pad]
+        if self.right_pad > 0:
+            hidden_state = hidden_state[..., : hidden_state.shape[-1] - self.right_pad]
         return hidden_state.contiguous()
 
 


### PR DESCRIPTION
## Purpose

Fix padding bugs in the 12Hz speech tokenizer decoder (`Qwen3TTSTokenizerV2CausalTransConvNet`), syncing with the upstream fix from [QwenLM/Qwen3-TTS@5f8581d](https://github.com/QwenLM/Qwen3-TTS/commit/5f8581d05e70d2a11c6f0787284eede65f044d98).

Two bugs in `__init__` and `forward`:

1. **Chained assignment bug**: `self.right_pad = pad = self.left_pad` is a chained assignment that sets both `pad` and `self.right_pad` to `self.left_pad`, making them always equal. The intended behavior is `left_pad = 0` and `right_pad = kernel_size - stride`.
2. **Slicing bug**: The old `forward` trimmed from both left and right unconditionally. Additionally, if `right_pad` is 0, `hidden_state[..., :-0]` returns an empty tensor (Python gotcha: `x[:-0]` == `x[:0]`). The fix only trims from the right and guards against `right_pad == 0`.

## Test Plan

```bash
python examples/offline_inference/qwen3_tts/end2end.py --query-type CustomVoice
```

## Test Result

Offline inference with `Qwen3-TTS-12Hz-1.7B-CustomVoice` completed successfully, producing valid audio output (shape=(247680,), sr=24000, ~10.3s).
[output_0_94945aa2-880b-4966-8a44-a52f3147e11d.wav](https://github.com/user-attachments/files/25117644/output_0_94945aa2-880b-4966-8a44-a52f3147e11d.wav)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>