### PR TITLE
[Bugfix] Fix 'NoneType' AttributeError in stable-diffusion model detect

### DIFF
--- a/vllm_omni/diffusion/utils/hf_utils.py
+++ b/vllm_omni/diffusion/utils/hf_utils.py
@@ -18,13 +18,13 @@ def _looks_like_bagel(model_name: str) -> bool:
     """Best-effort detection for Bagel (non-diffusers) diffusion models."""
     try:
         cfg = get_hf_file_to_dict("config.json", model_name)
+        model_type = cfg.get("model_type")
+        if model_type == "bagel":
+            return True
+        architectures = cfg.get("architectures") or []
+        return "BagelForConditionalGeneration" in architectures
     except Exception:
         return False
-    model_type = cfg.get("model_type")
-    if model_type == "bagel":
-        return True
-    architectures = cfg.get("architectures") or []
-    return "BagelForConditionalGeneration" in architectures
 
 
 @lru_cache


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
This PR is to fix `NoneType` attribute error which happens in diffusion model config parsing. **Note that it happens only in case that no valid HF_TOKEN provided in first time launch of model.**
```
Traceback (most recent call last):
  File "/usr/local/bin/vllm", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "/mnt/disk4/fanlilin/tmp2/vllm-omni/vllm_omni/entrypoints/cli/main.py", line 48, in main
    cmds[args.subparser].validate(args)
  File "/mnt/disk4/fanlilin/tmp2/vllm-omni/vllm_omni/entrypoints/cli/serve.py", line 59, in validate
    if model and is_diffusion_model(model):
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/disk4/fanlilin/tmp2/vllm-omni/vllm_omni/diffusion/utils/hf_utils.py", line 79, in is_diffusion_model
    return _looks_like_bagel(model_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/disk4/fanlilin/tmp2/vllm-omni/vllm_omni/diffusion/utils/hf_utils.py", line 23, in _looks_like_bagel
    model_type = cfg.get("model_type")
                 ^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
