### PR TITLE
[Deps] Add `hf_transfer` to project dependencies

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,3 +12,4 @@ torchsde>=0.2.6
 openai-whisper>=20250625
 imageio[ffmpeg]>=2.37.2
 sox>=1.5.0
+hf_transfer>=0.1.9


### PR DESCRIPTION
### Summary

- Add `hf_transfer>=0.1.9` to `pyproject.toml` core dependencies to fix a runtime error when `HF_HUB_ENABLE_HF_TRANSFER=1` is set in the environment

### Motivation

On some machines, the environment variable `HF_HUB_ENABLE_HF_TRANSFER=1` is enabled by default (e.g. set in Docker images or user profiles) to speed up Hugging Face Hub downloads. However, after a standard `pip install vllm-omni`, the `hf_transfer` package is not installed automatically. This causes `huggingface_hub` to raise a `ValueError` at runtime when it attempts to download model files:

```
ValueError: Fast download using 'hf_transfer' is enabled (HF_HUB_ENABLE_HF_TRANSFER=1)
but 'hf_transfer' package is not available in your environment.
Try `pip install hf_transfer`.
```

This error surfaces during model initialization (e.g. in `resolve_model_config_path` -> `get_hf_file_to_dict` -> `hf_hub_download`), forcing users to manually run `pip install hf_transfer` before they can use the framework.

### Changes

- `pyproject.toml`: Added `"hf_transfer>=0.1.4"` to the `dependencies` list

### Test plan

- [x] `pip install -e .` completes successfully with `hf_transfer` included
- [x] Running inference with `HF_HUB_ENABLE_HF_TRANSFER=1` no longer raises `ModuleNotFoundError`
- [x] Running inference without `HF_HUB_ENABLE_HF_TRANSFER` still works as before (the package is installed but not activated unless the env var is set)
