### PR TITLE
fix: add diffusion offload args to OmniConfig group instead of serve_parser

### DIFF
--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -194,17 +194,17 @@ class OmniServeCommand(CLISubcommand):
         )
 
         # diffusion model offload parameters
-        serve_parser.add_argument(
+        omni_config_group.add_argument(
             "--enable-cpu-offload",
             action="store_true",
             help="Enable CPU offloading for diffusion models.",
         )
-        serve_parser.add_argument(
+        omni_config_group.add_argument(
             "--enable-layerwise-offload",
             action="store_true",
             help="Enable layerwise (blockwise) offloading on DiT modules.",
         )
-        serve_parser.add_argument(
+        omni_config_group.add_argument(
             "--layerwise-num-gpu-layers",
             type=int,
             default=1,


### PR DESCRIPTION
## Purpose
```
options:
  --aggregate-engine-logging
                        Log aggregate rather than per-engine statistics when
                        using data parallelism. (default: False)
  --api-server-count API_SERVER_COUNT, -asc API_SERVER_COUNT
                        How many API server processes to run. Defaults to
                        data_parallel_size if not specified. (default: None)
  --config CONFIG       Read CLI options from a config file. Must be a YAML
                        with the following options: https://docs.vllm.ai/en/la
                        test/configuration/serve_args.html (default: None)
  --disable-log-requests, --no-disable-log-requests
                        [DEPRECATED] Disable logging requests. (default: True)
  --disable-log-stats   Disable logging statistics. (default: False)
  --enable-cpu-offload  Enable CPU offloading for diffusion models. (default:
                        False)
  --enable-layerwise-offload
                        Enable layerwise (blockwise) offloading on DiT
                        modules. (default: False)
  --enable-log-requests, --no-enable-log-requests
                        Enable logging requests. (default: False)
  --headless            Run in headless mode. See multi-node data parallel
                        documentation for more details. (default: False)
  --layerwise-num-gpu-layers LAYERWISE_NUM_GPU_LAYERS
                        Number of layers (blocks) to keep on GPU during
                        generation. (default: 1)
  -h, --help            show this help message and exit
```

Looking at the code context:
Lines 76-78 create an `omni_config_group` (argument group), and from line 80 to line 194, all arguments are correctly added to `omni_config_group`. However, at lines 197-212, three diffusion offload arguments (`--enable-cpu-offload`, `--enable-layerwise-offload`, `--layerwise-num-gpu-layers`) suddenly switch to using serve_parser. Then from line 215 onward, it reverts to omni_config_group.

Functionally, both work the same — `omni_config_group` is just an argument group of `serve_parser`, so all arguments end up in the same Namespace. There is no difference in runtime behavior.
However, it does affect the --help output organization:
* Arguments added to `omni_config_group` are grouped under the "`OmniConfig`" section heading.
* Arguments added to `serve_parser` directly fall into the default "options" section, mixed in with other general arguments.

This is most likely an oversight during development — the author forgot to use omni_config_group when adding these three arguments. They should be changed to `omni_config_group.add_argument()` for consistency.