### PR TITLE
[BugFix] Fixed the issue where ignore_eos was not working.

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -86,9 +86,13 @@ def mock_request():
     # OpenAI standard sampling fields
     request.temperature = None
     request.top_p = None
+    request.top_k = None
     request.max_tokens = None
+    request.min_tokens = None
     request.seed = None
+    request.ignore_eos = None
     request.stop = None
+    request.stop_token_ids = None
     request.frequency_penalty = None
     request.presence_penalty = None
     return request
@@ -106,9 +110,13 @@ def test_openai_sampling_fields_contains_expected_fields():
     expected_fields = {
         "temperature",
         "top_p",
+        "top_k",
         "max_tokens",
+        "min_tokens",
         "seed",
+        "ignore_eos",
         "stop",
+        "stop_token_ids",
         "frequency_penalty",
         "presence_penalty",
     }
@@ -234,20 +242,6 @@ def test_multiple_params_override_together(serving_chat, mock_request):
     # Preserved from YAML (not in _OPENAI_SAMPLING_FIELDS)
     assert comprehension_params.top_k == 1
     assert comprehension_params.repetition_penalty == 1.05
-
-
-def test_yaml_custom_params_not_overridden_by_request(serving_chat, mock_request):
-    """Test that YAML custom params (top_k, repetition_penalty) are not affected."""
-    # Even if request has these attributes, they should not override YAML
-    # because they're not in _OPENAI_SAMPLING_FIELDS
-    mock_request.top_k = 100  # Not in allowlist
-    mock_request.repetition_penalty = 2.0  # Not in allowlist
-
-    result = serving_chat._build_sampling_params_list_from_request(mock_request)
-
-    comprehension_params = result[0]
-    assert comprehension_params.top_k == 1  # YAML default preserved
-    assert comprehension_params.repetition_penalty == 1.05  # YAML default preserved
 
 
 # =============================================================================

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -489,9 +489,13 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
     _OPENAI_SAMPLING_FIELDS: set[str] = {
         "temperature",
         "top_p",
+        "top_k",
         "max_tokens",
+        "min_tokens",
         "seed",
+        "ignore_eos",
         "stop",
+        "stop_token_ids",
         "frequency_penalty",
         "presence_penalty",
     }


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix #1242 

## Test Plan

```
vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct 
     --omni 
     --port 8091 
     --stage-configs-path /vllm_omni/model_executor/stage_configs/qwen3_omni_moe_async_chunk.yaml
```
## Test Result

```
vllm bench serve     --omni   --dataset-name random   --port 28889   --max-concurrency 1
    --model Qwen/Qwen3-Omni-30B-A3B-Instruct   
    --endpoint /v1/chat/completions   --backend openai-chat-omni   
    --request-rate 1   --num-prompts 1   --random-input-len 100   
    --ignore-eos   --percentile-metrics ttft,tpot,itl,e2el,audio_ttfp,audio_rtf   
    --random-output-len 100   --extra_body '{"modalities": ["text", "audio"]}'
```

```
{'type': 'request_level_metrics',
'request_id': 'chatcmpl-bench-dff362ff-0',
'e2e_time_ms': 5127.692222595215,
'e2e_tpt': 10.817916081424503,
'e2e_total_tokens': 474,
 'transfers_total_time_ms': 0.0,
'transfers_total_bytes': 0,
 'stages': {0: {'stage_gen_time_ms': 26.72863006591797,
                'num_tokens_out': 100,
                 'num_tokens_in': 108},
             1: {'stage_gen_time_ms': 27.85658836364746, 'num_tokens_out': 266},
             2: {'stage_gen_time_ms': 268.20921897888184, 'num_tokens_out': 0}}}
```

```
============ Serving Benchmark Result ============
Successful requests:                     1
Failed requests:                         0
Maximum request concurrency:             1
Request rate configured (RPS):           1.00
Benchmark duration (s):                  6.26
Request throughput (req/s):              0.16
Peak concurrent requests:                1.00
----------------End-to-end Latency----------------
Mean E2EL (ms):                          5255.59
Median E2EL (ms):                        5255.59
P99 E2EL (ms):                           5255.59
================== Text Result ===================
Total input tokens:                      100
Total generated tokens:                  5050
Output token throughput (tok/s):         807.04
Peak output token throughput (tok/s):    61.00
Peak concurrent requests:                1.00
Total Token throughput (tok/s):          823.02
---------------Time to First Token----------------
Mean TTFT (ms):                          105.67
Median TTFT (ms):                        105.67
P99 TTFT (ms):                           105.67
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          1.02
Median TPOT (ms):                        1.02
P99 TPOT (ms):                           1.02
---------------Inter-token Latency----------------
Mean ITL (ms):                           14.12
Median ITL (ms):                         12.64
P99 ITL (ms):                            119.90
================== Audio Result ==================
Total audio duration generated(s):       20.95
Total audio frames generated:            502695
Audio throughput(audio duration/s):      3.35
---------------Time to First Packet---------------
Mean AUDIO_TTFP (ms):                    947.13
Median AUDIO_TTFP (ms):                  947.13
P99 AUDIO_TTFP (ms):                     947.13
-----------------Real Time Factor-----------------
Mean AUDIO_RTF:                          0.25
Median AUDIO_RTF:                        0.25
P99 AUDIO_RTF:                           0.25
==================================================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
