### PR TITLE
[Bugfix]: Fix merging updated additional information to ensure dict type

### DIFF
--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -879,7 +879,8 @@ class OmniGPUModelRunner(GPUModelRunner):
     def _update_additional_information(self, scheduler_output: "SchedulerOutput") -> None:
         for new_req in scheduler_output.scheduled_new_reqs:
             payload_info = getattr(new_req, "additional_information", None)
-            self._merge_additional_information_update(new_req.req_id, payload_info)
+            if isinstance(payload_info, dict):
+                self._merge_additional_information_update(new_req.req_id, payload_info)
 
         if hasattr(scheduler_output.scheduled_cached_reqs, "additional_information"):
             cached_infos = getattr(scheduler_output.scheduled_cached_reqs, "additional_information", {})


### PR DESCRIPTION
## Quote from [Issues 1290](https://github.com/vllm-project/vllm-omni/issues/1290#issue-3916270073)


### 🐛 Describe the bug

When improving new model (MiMo-Audio) to support Async_chunk, and find the issue in `gpu_model_runner.py`. For Qwen3, the first stage(thinker) do not have `preprocess` func, so will not execute the `self._update_additional_information(scheduler_output)` logic. In general, the `"additional_information"` is an `AdditionalInformationPayload` Obj in scheduler_output.scheduled_new_reqs from `vllm_omni/engine/input_processor.py` when passing to first stage.

And for now, due to fused two stages in MiMo-Audio, we have `has_preprocess` func in first stage, so it is an `AdditionalInformationPayload` Obj when passing here, and raise error to execute `upd.items()` in `self._merge_additional_information_update(new_req.req_id, payload_info)`. Obj DO NOT has items().

Issues codes:
```python
if hasattr(self.model, "has_preprocess") and self.model.has_preprocess:
            # Overlay custom prompt_embeds per request for the prompt portion;
            # collect additional_information (tensor/list) for prefill portion only
            decode_req_ids = []
            if self.vllm_config.model_config.async_chunk:
                self._update_additional_information(scheduler_output)
            for req_index, req_id in enumerate(self.input_batch.req_ids):
```


Add the `dict` type check, to fix it, like below.

```python
def _update_additional_information(self, scheduler_output: "SchedulerOutput") -> None:
        for new_req in scheduler_output.scheduled_new_reqs:
            payload_info = getattr(new_req, "additional_information", None)
            if isinstance(payload_info, dict):
                self._merge_additional_information_update(new_req.req_id, payload_info)

        if hasattr(scheduler_output.scheduled_cached_reqs, "additional_information"):
            cached_infos = getattr(scheduler_output.scheduled_cached_reqs, "additional_information", {})
            if isinstance(cached_infos, dict):
                for req_id, req_infos in cached_infos.items():
                    self._merge_additional_information_update(req_id, req_infos)
```