### PR TITLE
[Bugfix][Qwen3-TTS] Fix task type

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts.py
@@ -81,7 +81,7 @@ class Qwen3TTSModelForGeneration(nn.Module):
             torch_dtype=torch.bfloat16,
             **attn_kwargs,
         )
-        self.task_type = model_path.split("-")[-1].strip("/")
+        self.task_type = model_path.split("-")[-1].split("/")[0]
         # Mark that this model produces multimodal outputs
         self.have_multimodal_outputs = True
 


### PR DESCRIPTION
I was unable to run Qwen3 TTS on latest main branch. The model path gets evaluated to `/root/.cache/huggingface/hub/models--Qwen--Qwen3-TTS-12Hz-1.7BCustomVoice/snapshots/0c0e3051f131929182e2c023b9537f8b1c68adfe` which makes `self.task_type: CustomVoice/snapshots/0c0e3051f131929182e2c023b9537f8b1c68adfe` and hence it gives wrong task type issue. 

printing values on latest main gives
```
self.task_type: CustomVoice/snapshots/0c0e3051f131929182e2c023b9537f8b1c68adfe
(Worker pid=87650) model_path: /root/.cache/huggingface/hub/models--Qwen--Qwen3-TTS-12Hz-1.7B-CustomVoice/snapshots/0c0e3051f131929182e2c023b9537f8b1c68adfe
```

I reverted to `linyueqian/fix/multimodal-output-property` from [here](https://github.com/vllm-project/vllm-omni/pull/1203) which works for me. 

printing values on `linyueqian/fix/multimodal-output-property` branch gives
```
self.task_type: CustomVoice
(Worker pid=90803) model_path: Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice
```

This makes the task type matching more robust such that it works on both kinds of model path.

I deleted my `/root/.cache/huggingface/hub/models--Qwen--Qwen3-TTS-12Hz-1.7B-CustomVoice/` and reran latest main but it didnt fix. I suspect some change has corrupted the model path is being passed. This PR works for both cases but I am still curious what led to this change in model path and if its right.