### PR TITLE
[XPU] Enable FLASH_ATTN on XPU

### DIFF
--- a/tests/diffusion/attention/test_flash_attn.py
+++ b/tests/diffusion/attention/test_flash_attn.py
@@ -269,7 +269,7 @@ if __name__ == "__main__":
     print("=" * 60)
 
     # Try to run tests
-    if torch.cuda.is_available() or torch.xpu.is_available():
+    if is_gpu:
         try:
             print("\n[Running Case 1: Padding Equivalence for FA]")
             test_padding_equivalence()

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -48,6 +48,47 @@ class FlashAttentionImpl(AttentionImpl):
         self.causal = causal
         self.softmax_scale = softmax_scale
 
+    @staticmethod
+    def _unwrap_flash_output(out: torch.Tensor | tuple[torch.Tensor, ...]) -> torch.Tensor:
+        # FA3 may return (out, lse), FA2 returns out
+        return out[0] if isinstance(out, tuple) else out
+
+    def _forward_varlen_masked(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        from vllm_omni.diffusion.attention.backends.utils.fa import (
+            _pad_input,
+            _unpad_input,
+            _upad_input,
+            flash_attn_varlen_func,
+        )
+
+        assert attention_mask.ndim == 2, "attention_mask must be 2D, (batch_size, seq_len)"
+        query_length = query.size(1)
+        q, k, v, indices_q, (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = _upad_input(
+            query, key, value, attention_mask, query_length, _unpad_input
+        )
+
+        out_unpad = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seq_lens_q,
+            cu_seqlens_k=cu_seq_lens_k,
+            max_seqlen_q=max_length_q,
+            max_seqlen_k=max_length_k,
+            **{
+                "causal": self.causal,
+                "softmax_scale": self.softmax_scale,
+            },
+        )
+        out_unpad = self._unwrap_flash_output(out_unpad)
+        return _pad_input(out_unpad, indices_q, query.size(0), query_length)
+
     def forward_cuda(
         self,
         query: torch.Tensor,
@@ -56,15 +97,9 @@ class FlashAttentionImpl(AttentionImpl):
         attn_metadata: AttentionMetadata = None,
     ) -> torch.Tensor:
         """CUDA/ROCm flash attention implementation."""
-        # Import flash attention functions with fallback chain from utils/fa.py
-        # FA3 (fa3_fwd_interface) -> FA3 (flash_attn_interface) -> FA2 (flash_attn)
         from vllm_omni.diffusion.attention.backends.utils.fa import (
             HAS_FLASH_ATTN,
-            _pad_input,
-            _unpad_input,
-            _upad_input,
             flash_attn_func,
-            flash_attn_varlen_func,
         )
 
         if not HAS_FLASH_ATTN:
@@ -74,45 +109,76 @@ class FlashAttentionImpl(AttentionImpl):
                 "Otherwise, use SDPA backend by setting DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA"
             )
 
-        query_length = query.size(1)
         attention_mask = attn_metadata.attn_mask if attn_metadata is not None else None
-        #  Contains at least one padding token in the sequence
+
         if attention_mask is not None and torch.any(~attention_mask):
-            assert attention_mask.ndim == 2, "attention_mask must be 2D, (batch_size, seq_len)"
-            q, k, v, indices_q, (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = _upad_input(
-                query, key, value, attention_mask, query_length, _unpad_input
-            )
-
-            out_unpad = flash_attn_varlen_func(
-                q,
-                k,
-                v,
-                cu_seqlens_q=cu_seq_lens_q,
-                cu_seqlens_k=cu_seq_lens_k,
-                max_seqlen_q=max_length_q,
-                max_seqlen_k=max_length_k,
-                **{
-                    "causal": self.causal,
-                    "softmax_scale": self.softmax_scale,
-                },
-            )
-            if isinstance(out_unpad, tuple):
-                out_unpad = out_unpad[0]
-
-            out = _pad_input(out_unpad, indices_q, query.size(0), query_length)
-
-        else:
-            out = flash_attn_func(
+            return self._forward_varlen_masked(
                 query,
                 key,
                 value,
-                causal=self.causal,
-                softmax_scale=self.softmax_scale,
+                attention_mask,
             )
-            # FA3 may return (out, lse) tuple, FA2 returns just out
-            if isinstance(out, tuple):
-                out = out[0]
-        return out
+
+        out = flash_attn_func(
+            query,
+            key,
+            value,
+            causal=self.causal,
+            softmax_scale=self.softmax_scale,
+        )
+        return self._unwrap_flash_output(out)
+
+    def forward_xpu(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AttentionMetadata = None,
+    ) -> torch.Tensor:
+        """XPU flash attention implementation."""
+        from vllm_omni.diffusion.attention.backends.utils.fa import (
+            HAS_FLASH_ATTN,
+            flash_attn_varlen_func,
+        )
+
+        if not HAS_FLASH_ATTN:
+            raise ImportError(
+                "FlashAttentionBackend requires Flash Attention. "
+                "Please assure vllm-xpu-kernels properly installed. "
+                "Otherwise, use SDPA backend by setting DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA"
+            )
+
+        attention_mask = attn_metadata.attn_mask if attn_metadata is not None else None
+
+        if attention_mask is not None and torch.any(~attention_mask):
+            return self._forward_varlen_masked(
+                query,
+                key,
+                value,
+                attention_mask,
+            )
+
+        batch_size, q_len = query.size()[:2]
+        cu_seqlens = torch.arange(0, (batch_size + 1) * q_len, step=q_len, dtype=torch.int32, device=query.device)
+        # b s ... -> (b s) ...
+        query = query.flatten(0, 1)
+        key = key.flatten(0, 1)
+        value = value.flatten(0, 1)
+
+        out = flash_attn_varlen_func(
+            query,
+            key,
+            value,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=q_len,
+            max_seqlen_k=q_len,
+            causal=self.causal,
+            softmax_scale=self.softmax_scale,
+        )
+        out = self._unwrap_flash_output(out)
+        # (b s) h d -> b s h d
+        return out.reshape(batch_size, q_len, *out.shape[1:])
 
     def forward_npu(
         self,
@@ -143,75 +209,3 @@ class FlashAttentionImpl(AttentionImpl):
             layout="BNSD",
         )
         return output
-
-    def forward_xpu(
-        self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-        attn_metadata: AttentionMetadata = None,
-    ) -> torch.Tensor:
-        """XPU flash attention implementation."""
-        from vllm_omni.diffusion.attention.backends.utils.fa import (
-            HAS_FLASH_ATTN,
-            _pad_input,
-            _unpad_input,
-            _upad_input,
-            flash_attn_varlen_func,
-        )
-
-        if not HAS_FLASH_ATTN:
-            raise ImportError(
-                "FlashAttentionBackend requires Flash Attention. "
-                "Otherwise, use SDPA backend by setting DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA"
-            )
-
-        query_length = query.size(1)
-        attention_mask = attn_metadata.attn_mask if attn_metadata is not None else None
-        #  Contains at least one padding token in the sequence
-        if attention_mask is not None and torch.any(~attention_mask):
-            assert attention_mask.ndim == 2, "attention_mask must be 2D, (batch_size, seq_len)"
-            q, k, v, indices_q, (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = _upad_input(
-                query, key, value, attention_mask, query_length, _unpad_input
-            )
-
-            out_unpad = flash_attn_varlen_func(
-                q,
-                k,
-                v,
-                cu_seqlens_q=cu_seq_lens_q,
-                cu_seqlens_k=cu_seq_lens_k,
-                max_seqlen_q=max_length_q,
-                max_seqlen_k=max_length_k,
-                **{
-                    "causal": self.causal,
-                    "softmax_scale": self.softmax_scale,
-                },
-            )
-            if isinstance(out_unpad, tuple):
-                out_unpad = out_unpad[0]
-
-            out = _pad_input(out_unpad, indices_q, query.size(0), query_length)
-
-        else:
-            from einops import rearrange
-
-            batch_size, q_len = query.size()[:2]
-            cu_seqlens = torch.arange(0, (batch_size + 1) * q_len, step=q_len, dtype=torch.int32, device=query.device)
-            max_seqlen = q_len
-
-            query, key, value = (rearrange(x, "b s ... -> (b s) ...") for x in [query, key, value])
-
-            out = flash_attn_varlen_func(
-                query,
-                key,
-                value,
-                cu_seqlens_q=cu_seqlens,
-                cu_seqlens_k=cu_seqlens,
-                max_seqlen_q=max_seqlen,
-                max_seqlen_k=max_seqlen,
-                causal=self.causal,
-                softmax_scale=self.softmax_scale,
-            )
-            out = rearrange(out, "(b s) h d -> b s h d", b=batch_size)
-        return out

--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -33,9 +33,6 @@ if current_omni_platform.is_rocm():
 elif current_omni_platform.is_xpu():
     try:
         from vllm.v1.attention.backends.fa_utils import flash_attn_varlen_func  # noqa: F401
-
-        # XPU uses unified flash_attn API, below assignment to ensure HAS_FLASH_ATTN true
-        flash_attn_func = flash_attn_varlen_func
     except (ImportError, ModuleNotFoundError):
         pass
 else:
@@ -71,7 +68,7 @@ else:
 
 # If no FA backend available, SDPA backend will be selected at the platform level
 # flash_attn_func and flash_attn_varlen_func will be None
-HAS_FLASH_ATTN = flash_attn_func is not None
+HAS_FLASH_ATTN = flash_attn_func is not None or flash_attn_varlen_func is not None
 
 
 def _index_first_axis(tensor, indices):


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
This PR is to add XPU path in `FLASH_ATTN` backend.

## Test Plan
```
 DIFFUSION_ATTENTION_BACKEND=FLASH_ATTN  python ./examples/offline_inference/text_to_image/text_to_image.py
 pytest -s -v tests/diffusion/attention/test_flash_attn.py
```
## Test Result
<img width="329" height="326" alt="image" src="https://github.com/user-attachments/assets/9427a69a-8b5f-45b0-97a5-61e938ad55f2" />
```
=== Case 1: Padding Equivalence Test ===
Output A shape: torch.Size([1, 64, 8, 64])
Output B shape: torch.Size([1, 84, 8, 64])
Output B unpadded shape: torch.Size([1, 64, 8, 64])
Max absolute difference: 0.000000
Mean absolute difference: 0.000000
✓ Case 1 PASSED: Padded and unpadded outputs are very close!
PASSEDGPU cleanup disabled

tests/diffusion/attention/test_flash_attn.py::test_fa_vs_sdpa
=== PRE-TEST GPU CLEANUP ===
GPU cleanup disabled
INFO 02-11 08:51:58 [scheduler.py:226] Chunked prefill is enabled with max_num_batched_tokens=2048.
--- Running test: test_fa_vs_sdpa

=== Case 2: FA vs SDPA Comparison ===
Batch size: 2
FA output shape: torch.Size([2, 84, 8, 64])
SDPA output shape: torch.Size([2, 84, 8, 64])
Max absolute difference (valid region): 0.007812
Mean absolute difference (valid region): 0.000000
✓ Case 2 PASSED: FA and SDPA outputs are very close!
PASSEDGPU cleanup disabled

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
