### PR TITLE
[Bugfix] Fix SDPA attention mask dtype and shape (Fix #857)

### DIFF
--- a/vllm_omni/diffusion/attention/backends/sdpa.py
+++ b/vllm_omni/diffusion/attention/backends/sdpa.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Literal
+
 import torch
 from vllm.logger import init_logger
 
@@ -13,17 +15,27 @@ from vllm_omni.diffusion.attention.backends.abstract import (
 logger = init_logger(__name__)
 
 
-def _maybe_reshape_attn_mask(query: torch.Tensor, key: torch.Tensor, attn_mask: torch.Tensor | None = None):
+SDPAMaskMode = Literal["broadcast_k", "full_qk"]
+
+
+def _maybe_reshape_attn_mask(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    attn_mask: torch.Tensor | None = None,
+    mask_mode: SDPAMaskMode = "broadcast_k",
+):
     """
     Reshape Attention Mask
-    [batch_size, seq_len_k] -> [batch_size, 1, seq_len_q, seq_len_k]
+    2D [batch_size, seq_len_k] ->
+      - broadcast_k: [batch_size, 1, 1, seq_len_k]
+      - full_qk: [batch_size, 1, seq_len_q, seq_len_k]
     """
     # Skip Attention Mask if all values are 1, `None` mask can speedup the computation
     if attn_mask is not None and torch.all(attn_mask != 0):
         attn_mask = None
 
     # Reshape Attention Mask
-    # [batch_size, seq_len_k] -> [batch_size, 1, seq_len_q, seq_len_k]
+    # 2D [batch_size, seq_len_k] mask only.
     if (
         attn_mask is not None
         and attn_mask.ndim == 2
@@ -32,7 +44,14 @@ def _maybe_reshape_attn_mask(query: torch.Tensor, key: torch.Tensor, attn_mask: 
     ):
         B, Sq, Skv = attn_mask.shape[0], query.shape[1], key.shape[1]
         attn_mask = attn_mask.to(torch.bool)
-        attn_mask = attn_mask.unsqueeze(1).expand(B, Sq, Skv).unsqueeze(1).contiguous()
+        if mask_mode == "full_qk":
+            # NPU path requires explicit [B, 1, Q, K] mask layout.
+            attn_mask = attn_mask.unsqueeze(1).expand(B, Sq, Skv).unsqueeze(1).contiguous()
+        elif mask_mode == "broadcast_k":
+            # CUDA-like backends prefer [B, 1, 1, K] and rely on SDPA broadcast.
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(2)
+        else:
+            raise ValueError(f"Unsupported SDPA mask mode: {mask_mode}")
     return attn_mask
 
 
@@ -70,18 +89,19 @@ class SDPAImpl(AttentionImpl):
         self.causal = causal
         self.softmax_scale = softmax_scale
 
-    def forward_cuda(
+    def _forward_impl(
         self,
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
         attn_metadata: AttentionMetadata | None = None,
+        mask_mode: SDPAMaskMode = "broadcast_k",
     ) -> torch.Tensor:
         # Normalize mask before permuting q/k/v.
         # _maybe_reshape_attn_mask expects sequence length on dim=1.
         attention_mask = None
         if attn_metadata:
-            attention_mask = _maybe_reshape_attn_mask(query, key, attn_metadata.attn_mask)
+            attention_mask = _maybe_reshape_attn_mask(query, key, attn_metadata.attn_mask, mask_mode=mask_mode)
 
         query, key, value = (x.permute(0, 2, 1, 3) for x in (query, key, value))
         output = torch.nn.functional.scaled_dot_product_attention(
@@ -96,6 +116,15 @@ class SDPAImpl(AttentionImpl):
         out = output.permute(0, 2, 1, 3)
         return out
 
+    def forward_cuda(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AttentionMetadata | None = None,
+    ) -> torch.Tensor:
+        return self._forward_impl(query, key, value, attn_metadata, mask_mode="broadcast_k")
+
     def forward_xpu(
         self,
         query: torch.Tensor,
@@ -103,7 +132,7 @@ class SDPAImpl(AttentionImpl):
         value: torch.Tensor,
         attn_metadata: AttentionMetadata | None = None,
     ) -> torch.Tensor:
-        return self.forward_cuda(query, key, value, attn_metadata)
+        return self._forward_impl(query, key, value, attn_metadata, mask_mode="broadcast_k")
 
     def forward_hip(
         self,
@@ -112,7 +141,7 @@ class SDPAImpl(AttentionImpl):
         value: torch.Tensor,
         attn_metadata: AttentionMetadata | None = None,
     ) -> torch.Tensor:
-        return self.forward_cuda(query, key, value, attn_metadata)
+        return self._forward_impl(query, key, value, attn_metadata, mask_mode="broadcast_k")
 
     def forward_npu(
         self,
@@ -121,4 +150,4 @@ class SDPAImpl(AttentionImpl):
         value: torch.Tensor,
         attn_metadata: AttentionMetadata | None = None,
     ) -> torch.Tensor:
-        return self.forward_cuda(query, key, value, attn_metadata)
+        return self._forward_impl(query, key, value, attn_metadata, mask_mode="full_qk")


### PR DESCRIPTION
<!-- markdownlint-disable -->


## Purpose

Fix vllm-project/vllm-omni#857.

On latest upstream `main` (**830d261f**), the Qwen-Image pipeline still fails when `Omni.generate()` receives a list of prompts. The failure is caused by `attn_mask` not satisfying SDPA requirements (dtype and/or shape mismatch, e.g. 2D `[B, Skv]` mask reaching `scaled_dot_product_attention`).

This PR normalizes `attn_mask` (dtype + shape) before SDPA so that batched prompts no longer trigger dtype/shape errors.

Related:

- #1031 addressed NPU mask constraints.
- #1090 attempts a dtype fix, but shape mismatch still occurs in my testing (see details below).

Fixes: #857

Change: normalize attn_metadata.attn_mask before the SDPA call in vllm_omni/diffusion/attention/backends/sdpa.py (SDPA backend), converting 2D [B, Skv] masks into a SDPA-compatible broadcastable shape and ensuring dtype is bool.

## Test Plan

Reproduce on upstream `main`:

- Checkout: **830d261f**
- Run reproduction from #857 (batched prompts, `max_batch_size: 3`)
- Expect: SDPA dtype/shape mismatch error.

<details>
<summary> <b>Stage config</b> </summary>

```yaml
# test-qwen-image-stage-config.yaml
stage_args:
  - 'stage_id': 0,
    'stage_type': 'diffusion'
    'runtime':
      'process': True
      'devices': '1'
      'max_batch_size': 3 # This is important
    'engine_args': 
      'model': 'Qwen/Qwen-Image'
      'cache_backend': 'none'
      'cache_config': None,
      'model_stage': 'diffusion'
    'final_output': True,
    'final_output_type': 'image'
```

</details>

<details>
<summary><b> Complete test script </b></summary>

```python
import os
from pprint import pprint

from vllm_omni.entrypoints.omni import Omni
from vllm_omni.outputs import OmniRequestOutput

current_dir = os.path.dirname(os.path.abspath(__file__))

if __name__ == "__main__":
    omni = Omni(
        model="Qwen/Qwen-Image",
        stage_configs_path=os.path.join(current_dir, "test-qwen-image-stage-config.yaml"),
    )
    prompts = [
        "a cup of coffee on a table",
        "a toy dinosaur on a sandy beach",
        "a fox waking up in bed and yawning",
    ]
    sp = {"num_outputs_per_prompt": 1}
    try:
        from vllm_omni.inputs.data import OmniDiffusionSamplingParams

        sp = OmniDiffusionSamplingParams(**sp)
        omni_outputs = omni.generate(prompts, sp)
    except ImportError:
        omni_outputs = omni.generate(prompts, **sp)
    print("===================")
    print("Got output")
    pprint(omni_outputs)
    print("===================")
    for i_batch, output_batch in enumerate(omni_outputs):
        if not output_batch.request_output:  # potentially empty list
            print(f"Batch {i_batch} has empty request_output")
            continue
        batch_request_output = output_batch.request_output[0]
        if not isinstance(batch_request_output, OmniRequestOutput):
            print(f"Batch {i_batch} is an empty namespace")
            continue
        images_in_this_batch = batch_request_output.images
        for i_image, image in enumerate(images_in_this_batch):
            image.save(f"batch{i_batch}-item{i_image}.jpg")
            print("saved to", f"batch{i_batch}-item{i_image}.jpg")

```

</details>

Validate on this branch:

- Checkout: **7e1517d9** (This PR)
- Run the same command.
- Expect: no SDPA dtype/shape exception; generation proceeds.

## Test Result

### Test

### Before (upstream `main`: [830d261f])

Key Error:
```log
[Stage-0,] ERROR 02-11 22:23:00 [diffusion_worker.py:320] Error executing RPC: Dynamo failed to run FX node with fake tensors: call_function <built-in function scaled_dot_product_attention>(*(FakeTensor(..., device='cuda:0', size=(s47, 24, s31 + s87, 128),
[Stage-0,] ERROR 02-11 22:23:00 [diffusion_worker.py:320]            dtype=torch.bfloat16), FakeTensor(..., device='cuda:0', size=(s47, 24, s31 + s87, 128),
[Stage-0,] ERROR 02-11 22:23:00 [diffusion_worker.py:320]            dtype=torch.bfloat16), FakeTensor(..., device='cuda:0', size=(s47, 24, s31 + s87, 128),
[Stage-0,] ERROR 02-11 22:23:00 [diffusion_worker.py:320]            dtype=torch.bfloat16)), **{'attn_mask': FakeTensor(..., device='cuda:0', size=(s47, s70 + s87), dtype=torch.int64), 'dropout_p': 0.0, 'is_causal': False, 'scale': 0.0883883476483184}): got RuntimeError('Expected attn_mask dtype to be bool or float or to match query dtype, but got attn_mask.dtype: long int and  query.dtype: c10::BFloat16 instead.')
```


### After (this PR: [7e1517d9])

After fix: generation completes and produces non-empty images for all 3 prompts (see outputs below).

![batch0-item0](https://github.com/user-attachments/assets/f4287193-b904-41da-9247-f7b9b20cda23)
![batch1-item0](https://github.com/user-attachments/assets/19163aee-241c-4097-b9e8-36721e22fd45)
![batch2-item0](https://github.com/user-attachments/assets/6a80de85-930d-4d19-a259-4b6867d722c0)


### Note on #1090

Even with the dtype adjustment proposed in #1090, shape mismatch still occurs in my testing:

Key Error:
```log
[Stage-0,] ERROR 02-11 23:58:00 [diffusion_worker.py:315] Error executing RPC: Dynamo failed to run FX node with fake tensors: call_function <built-in function scaled_dot_product_attention>(*(FakeTensor(..., device='cuda:0', size=(s47, s31 + s87, 24, 128),
[Stage-0,] ERROR 02-11 23:58:00 [diffusion_worker.py:315]            dtype=torch.bfloat16), FakeTensor(..., device='cuda:0', size=(s47, s31 + s87, 24, 128),
[Stage-0,] ERROR 02-11 23:58:00 [diffusion_worker.py:315]            dtype=torch.bfloat16), FakeTensor(..., device='cuda:0', size=(s47, s31 + s87, 24, 128),
[Stage-0,] ERROR 02-11 23:58:00 [diffusion_worker.py:315]            dtype=torch.bfloat16)), **{'attn_mask': FakeTensor(..., device='cuda:0', size=(s47, s70 + s87), dtype=torch.bool), 'dropout_p': 0.0, 'is_causal': False, 'scale': 0.0883883476483184}): got RuntimeError('expand: attempting to expand a dimension of length s47 -> 24!')
```

This indicates the 2D mask [B, Skv] is still being expanded against a mismatched dimension. So shape normalization is still required.

---
<details> <summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR (Fix #857).

- [x] The test plan (reproduction + validation command).

- [x] The test results (before/after logs attached).

- [ ] (Optional) Documentation update (not needed).

- [ ] (Optional) Release notes update (not needed).

</details>
