### PR TITLE
[Bugfix] fix qwen_image_edit error when input parameters size is not 1024*1024

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -674,7 +674,7 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
             width = width or calculated_width
             vae_width = calculated_width
             vae_height = calculated_height
-            
+
             multiple_of = self.vae_scale_factor * 2
             width = width // multiple_of * multiple_of
             height = height // multiple_of * multiple_of


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fixed the runtime error of the qwen_image_edit module during inference when the input parameters size is not 1024×1024. The root cause was that the input image was not properly preprocessed; we have now added reasonable image scaling logic to address this.
This PR modifies the corresponding processing logic and supplements image preprocessing code by referencing the implementation of qwen_image_edit_2509, ensuring the output results meet expectations.

## Test Plan

## Test Result
Before fix:
An error about mismatched size would occur when the input parameters  was not 1024×1024.
After fix:
Users can now input parameters of other sizes. The feature has been tested and runs normally.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
