### PR TITLE
[Misc] Add Qwen2.5-Omni-3B model support to Gradio demo

### DIFF
--- a/examples/online_serving/qwen2_5_omni/gradio_demo.py
+++ b/examples/online_serving/qwen2_5_omni/gradio_demo.py
@@ -15,38 +15,43 @@ from PIL import Image
 
 SEED = 42
 
+DEFAULT_SAMPLING_PARAMS = {
+    "thinker": {
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "top_k": -1,
+        "max_tokens": 2048,
+        "seed": SEED,
+        "detokenize": True,
+        "repetition_penalty": 1.1,
+    },
+    "talker": {
+        "temperature": 0.9,
+        "top_p": 0.8,
+        "top_k": 40,
+        "max_tokens": 2048,
+        "seed": SEED,
+        "detokenize": True,
+        "repetition_penalty": 1.05,
+        "stop_token_ids": [8294],
+    },
+    "code2wav": {
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "top_k": -1,
+        "max_tokens": 2048,
+        "seed": SEED,
+        "detokenize": True,
+        "repetition_penalty": 1.1,
+    },
+}
+
 SUPPORTED_MODELS: dict[str, dict[str, Any]] = {
+    "Qwen/Qwen2.5-Omni-3B": {
+        "sampling_params": DEFAULT_SAMPLING_PARAMS,
+    },
     "Qwen/Qwen2.5-Omni-7B": {
-        "sampling_params": {
-            "thinker": {
-                "temperature": 0.0,
-                "top_p": 1.0,
-                "top_k": -1,
-                "max_tokens": 2048,
-                "seed": SEED,
-                "detokenize": True,
-                "repetition_penalty": 1.1,
-            },
-            "talker": {
-                "temperature": 0.9,
-                "top_p": 0.8,
-                "top_k": 40,
-                "max_tokens": 2048,
-                "seed": SEED,
-                "detokenize": True,
-                "repetition_penalty": 1.05,
-                "stop_token_ids": [8294],
-            },
-            "code2wav": {
-                "temperature": 0.0,
-                "top_p": 1.0,
-                "top_k": -1,
-                "max_tokens": 2048,
-                "seed": SEED,
-                "detokenize": True,
-                "repetition_penalty": 1.1,
-            },
-        },
+        "sampling_params": DEFAULT_SAMPLING_PARAMS,
     },
 }
 # Ensure deterministic behavior across runs.


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Adds support for the Qwen2.5-Omni-3B model to the Gradio demo interface.

Previously, the Gradio demo only supported the 7B model, causing an `AssertionError` when attempting to use the 3B model. This PR:
- Adds `Qwen/Qwen2.5-Omni-3B` to `SUPPORTED_MODELS` dictionary
- Refactors configuration to use shared `DEFAULT_SAMPLING_PARAMS` constant to eliminate code duplication
- Both 3B and 7B models now reference identical sampling parameters

## Test Plan
No new test files required as this is a configuration-only change that:
- Adds an existing model variant (3B) with identical sampling parameters to the 7B model
- Does not introduce new functionality or code paths
- Existing Gradio demo tests already cover this code path

Manual testing performed:
```bash
python examples/online_serving/qwen2_5_omni/gradio_demo.py --model Qwen/Qwen2.5-Omni-3B
```

## Test Result

**Before:**
```
Traceback (most recent call last):
  File "examples/online_serving/qwen2_5_omni/gradio_demo.py", line 584, in <module>
    main()
  File "examples/online_serving/qwen2_5_omni/gradio_demo.py", line 553, in main
    assert model_name in SUPPORTED_MODELS, (
AssertionError: Unsupported model 'Qwen/Qwen2.5-Omni-3B'. Supported models: dict_keys(['Qwen/Qwen2.5-Omni-7B'])
```

**After:**
```
Connecting to API server at: http://localhost:8091/v1
✓ Connected to API server
* Running on local URL:  http://127.0.0.1:7861
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please providing the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
