### PR TITLE
[CI/Build] Add L5 stability and reliability test framework

### DIFF
--- a/docs/contributing/ci/tests_style.md
+++ b/docs/contributing/ci/tests_style.md
@@ -143,26 +143,32 @@ vllm_omni/                                    tests/
                                                │   ├── test_image_gen_edit.py
                                                │   ├── test_images_generations_lora.py
                                                │   └── stage_configs/
-                                               └── offline_inference/                  ✅
-                                                   ├── test_qwen2_5_omni.py
-                                                   ├── test_qwen3_omni.py
-                                                   ├── test_bagel_text2img.py
-                                                   ├── test_t2i_model.py
-                                                   ├── test_t2v_model.py
-                                                   ├── test_ovis_image.py
-                                                   ├── test_zimage_tensor_parallel.py
-                                                   ├── test_cache_dit.py
-                                                   ├── test_teacache.py
-                                                   ├── test_stable_audio_model.py
-                                                   ├── test_diffusion_cpu_offload.py
-                                                   ├── test_diffusion_layerwise_offload.py
-                                                   ├── test_diffusion_lora.py
-                                                   ├── test_sequence_parallel.py
-                                                   └── stage_configs/
-                                                       ├── qwen2_5_omni_ci.yaml
-                                                       ├── qwen3_omni_ci.yaml
-                                                       ├── bagel_*.yaml
-                                                       └── npu/, rocm/, etc.
+                                               ├── offline_inference/                  ✅
+                                               │   ├── test_qwen2_5_omni.py
+                                               │   ├── test_qwen3_omni.py
+                                               │   ├── test_bagel_text2img.py
+                                               │   ├── test_t2i_model.py
+                                               │   ├── test_t2v_model.py
+                                               │   ├── test_ovis_image.py
+                                               │   ├── test_zimage_tensor_parallel.py
+                                               │   ├── test_cache_dit.py
+                                               │   ├── test_teacache.py
+                                               │   ├── test_stable_audio_model.py
+                                               │   ├── test_diffusion_cpu_offload.py
+                                               │   ├── test_diffusion_layerwise_offload.py
+                                               │   ├── test_diffusion_lora.py
+                                               │   ├── test_sequence_parallel.py
+                                               │   └── stage_configs/
+                                               │       ├── qwen2_5_omni_ci.yaml
+                                               │       ├── qwen3_omni_ci.yaml
+                                               │       ├── bagel_*.yaml
+                                               │       └── npu/, rocm/, etc.
+                                               ├── stability/                          ✅ L5(a)
+                                               │   ├── conftest.py
+                                               │   └── weekly.json
+                                               └── reliability/                        ✅ L5(b)
+                                                   ├── conftest.py
+                                                   └── test_omni_recovery.py
 ```
 
 

--- a/tests/e2e/reliability/__init__.py
+++ b/tests/e2e/reliability/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/e2e/reliability/conftest.py
+++ b/tests/e2e/reliability/conftest.py
@@ -90,16 +90,10 @@ def assert_graceful_recovery(
         result: The recovery outcome to validate.
         max_recovery_seconds: Upper bound for acceptable recovery time.
     """
-    assert result.recovered, (
-        f"System did not recover from {result.fault_type.value}: "
-        f"{result.error_message}"
-    )
+    assert result.recovered, f"System did not recover from {result.fault_type.value}: {result.error_message}"
     duration = result.recovery_duration_seconds
     assert duration is not None
-    assert duration <= max_recovery_seconds, (
-        f"Recovery from {result.fault_type.value} took {duration:.1f}s "
-        f"(budget: {max_recovery_seconds}s)"
-    )
+    assert duration <= max_recovery_seconds, f"Recovery from {result.fault_type.value} took {duration:.1f}s (budget: {max_recovery_seconds}s)"
 
 
 @pytest.fixture

--- a/tests/e2e/reliability/conftest.py
+++ b/tests/e2e/reliability/conftest.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Reliability / chaos-test helpers for L5 recovery testing.
+
+This module provides fixtures and utilities for simulating fault scenarios
+(process kill, OOM simulation, abnormal inputs, network disruption) and
+verifying that the serving system recovers gracefully.
+"""
+
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import pytest
+
+
+class FaultType(Enum):
+    """Catalogue of injectable fault scenarios."""
+
+    PROCESS_KILL = "process_kill"
+    OOM_SIMULATION = "oom_simulation"
+    ABNORMAL_INPUT = "abnormal_input"
+    NETWORK_DISRUPTION = "network_disruption"
+    WORKER_RESTART = "worker_restart"
+
+
+@dataclass
+class RecoveryResult:
+    """Outcome of a single fault-injection + recovery cycle."""
+
+    fault_type: FaultType
+    injection_time: float
+    recovery_time: float | None
+    recovered: bool
+    error_message: str | None = None
+
+    @property
+    def recovery_duration_seconds(self) -> float | None:
+        """Wall-clock seconds between fault injection and full recovery."""
+        if self.recovery_time is None:
+            return None
+        return self.recovery_time - self.injection_time
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for JSON reporting."""
+        return {
+            "fault_type": self.fault_type.value,
+            "recovered": self.recovered,
+            "recovery_duration_s": self.recovery_duration_seconds,
+            "error_message": self.error_message,
+        }
+
+
+def wait_for_healthy(
+    health_check_fn: Any,
+    timeout_seconds: float = 120.0,
+    poll_interval: float = 2.0,
+) -> bool:
+    """Poll a health-check callable until it returns ``True`` or timeout.
+
+    Args:
+        health_check_fn: Zero-arg callable returning ``True`` when service
+                         is healthy.
+        timeout_seconds: Maximum wait time.
+        poll_interval: Seconds between polls.
+
+    Returns:
+        ``True`` if the service became healthy within the timeout.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            if health_check_fn():
+                return True
+        except Exception:
+            pass
+        time.sleep(poll_interval)
+    return False
+
+
+def assert_graceful_recovery(
+    result: RecoveryResult,
+    max_recovery_seconds: float = 120.0,
+) -> None:
+    """Assert that the system recovered within the allowed time budget.
+
+    Args:
+        result: The recovery outcome to validate.
+        max_recovery_seconds: Upper bound for acceptable recovery time.
+    """
+    assert result.recovered, (
+        f"System did not recover from {result.fault_type.value}: "
+        f"{result.error_message}"
+    )
+    duration = result.recovery_duration_seconds
+    assert duration is not None
+    assert duration <= max_recovery_seconds, (
+        f"Recovery from {result.fault_type.value} took {duration:.1f}s "
+        f"(budget: {max_recovery_seconds}s)"
+    )
+
+
+@pytest.fixture
+def fault_types() -> list[FaultType]:
+    """Fixture exposing the available fault types for parametrized tests."""
+    return list(FaultType)

--- a/tests/e2e/reliability/test_omni_recovery.py
+++ b/tests/e2e/reliability/test_omni_recovery.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+L5 Reliability tests -- recovery / chaos scenarios for omni models.
+
+These tests inject faults into a running vLLM-Omni serving instance and
+verify that the system recovers within an acceptable time budget.
+
+Fault categories:
+  (a) Process kill & restart  -- validates auto-recovery / graceful restart
+  (b) Abnormal input          -- validates error handling without crash
+  (c) Resource pressure (OOM) -- validates graceful degradation
+
+Run:
+    pytest -s -v tests/e2e/reliability/test_omni_recovery.py
+"""
+
+import os
+import time
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+import pytest
+
+from tests.e2e.reliability.conftest import (
+    FaultType,
+    RecoveryResult,
+    assert_graceful_recovery,
+    wait_for_healthy,
+)
+
+pytestmark = [pytest.mark.slow]
+
+
+# ---------------------------------------------------------------------------
+# Abnormal-input recovery
+# ---------------------------------------------------------------------------
+@pytest.mark.core_model
+@pytest.mark.omni
+class TestAbnormalInputRecovery:
+    """Verify the server stays healthy after receiving malformed requests."""
+
+    @staticmethod
+    def _send_malformed_request(client: object, model: str) -> None:
+        """Send a deliberately malformed chat-completion request."""
+        import openai
+
+        assert isinstance(client, openai.OpenAI)
+        try:
+            client.chat.completions.create(
+                model=model,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "unknown_modality", "data": "garbage"},
+                        ],
+                    }
+                ],
+                stream=False,
+            )
+        except Exception:
+            pass
+
+    @staticmethod
+    def _server_is_healthy(client: object, model: str) -> bool:
+        """Return True if a simple text request succeeds."""
+        import openai
+
+        assert isinstance(client, openai.OpenAI)
+        try:
+            resp = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": "Say hello."}],
+                max_tokens=8,
+                stream=False,
+            )
+            return resp.choices[0].message.content is not None
+        except Exception:
+            return False
+
+    def test_abnormal_input_recovery(self, client: object, omni_server: object) -> None:
+        """Inject malformed input and assert the server remains healthy.
+
+        Deploy Setting: default yaml
+        Fault: unknown_modality payload
+        Expectation: server returns error but stays alive for subsequent
+                     valid requests.
+        """
+        model = omni_server.model  # type: ignore[attr-defined]
+        injection_time = time.monotonic()
+
+        self._send_malformed_request(client, model)
+
+        healthy = wait_for_healthy(
+            lambda: self._server_is_healthy(client, model),
+            timeout_seconds=30.0,
+        )
+        recovery_time = time.monotonic() if healthy else None
+
+        result = RecoveryResult(
+            fault_type=FaultType.ABNORMAL_INPUT,
+            injection_time=injection_time,
+            recovery_time=recovery_time,
+            recovered=healthy,
+            error_message=None if healthy else "Server unresponsive after malformed input",
+        )
+        assert_graceful_recovery(result, max_recovery_seconds=30.0)

--- a/tests/e2e/stability/__init__.py
+++ b/tests/e2e/stability/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/e2e/stability/conftest.py
+++ b/tests/e2e/stability/conftest.py
@@ -9,7 +9,6 @@ detecting drift that indicates leaks or degradation.
 """
 
 import json
-import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -130,15 +129,9 @@ def assert_stability_thresholds(
         actual_drift = report.compute_drift(metric_name)
 
         if metric_name == "throughput_rps":
-            assert actual_drift >= -max_drift, (
-                f"Throughput dropped {abs(actual_drift):.1f}% "
-                f"(threshold: {max_drift}%)"
-            )
+            assert actual_drift >= -max_drift, f"Throughput dropped {abs(actual_drift):.1f}% (threshold: {max_drift}%)"
         else:
-            assert actual_drift <= max_drift, (
-                f"{metric_name} drifted +{actual_drift:.1f}% "
-                f"(threshold: {max_drift}%)"
-            )
+            assert actual_drift <= max_drift, f"{metric_name} drifted +{actual_drift:.1f}% (threshold: {max_drift}%)"
 
 
 def collect_process_memory_mb() -> float:

--- a/tests/e2e/stability/conftest.py
+++ b/tests/e2e/stability/conftest.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Stability test helpers for L5 long-run testing.
+
+This module provides fixtures and utilities for monitoring resource usage
+(memory, VRAM, latency, throughput) over extended serving periods and
+detecting drift that indicates leaks or degradation.
+"""
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+@dataclass
+class MetricsSample:
+    """A single point-in-time snapshot of monitored metrics."""
+
+    timestamp: float
+    rss_memory_mb: float = 0.0
+    vram_used_mb: float = 0.0
+    p99_latency_ms: float = 0.0
+    throughput_rps: float = 0.0
+    error_count: int = 0
+
+
+@dataclass
+class StabilityReport:
+    """Aggregated report for a stability test run."""
+
+    test_name: str
+    duration_seconds: float
+    samples: list[MetricsSample] = field(default_factory=list)
+
+    @property
+    def baseline_window(self) -> list[MetricsSample]:
+        """Return the first 10% of samples as the baseline window."""
+        count = max(1, len(self.samples) // 10)
+        return self.samples[:count]
+
+    @property
+    def tail_window(self) -> list[MetricsSample]:
+        """Return the last 10% of samples as the tail window."""
+        count = max(1, len(self.samples) // 10)
+        return self.samples[-count:]
+
+    def compute_drift(self, metric_name: str) -> float:
+        """Compute percentage drift between baseline and tail windows.
+
+        Returns:
+            Percentage change from baseline mean to tail mean.
+            Positive means the metric increased; negative means it decreased.
+        """
+        if len(self.samples) < 2:
+            return 0.0
+
+        baseline_vals = [getattr(s, metric_name) for s in self.baseline_window]
+        tail_vals = [getattr(s, metric_name) for s in self.tail_window]
+
+        baseline_mean = sum(baseline_vals) / len(baseline_vals)
+        tail_mean = sum(tail_vals) / len(tail_vals)
+
+        if baseline_mean == 0:
+            return 0.0
+        return ((tail_mean - baseline_mean) / baseline_mean) * 100.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize report to a dictionary for JSON export."""
+        return {
+            "test_name": self.test_name,
+            "duration_seconds": self.duration_seconds,
+            "num_samples": len(self.samples),
+            "drifts": {
+                "rss_memory_mb": self.compute_drift("rss_memory_mb"),
+                "vram_used_mb": self.compute_drift("vram_used_mb"),
+                "p99_latency_ms": self.compute_drift("p99_latency_ms"),
+                "throughput_rps": self.compute_drift("throughput_rps"),
+                "error_count": self.compute_drift("error_count"),
+            },
+        }
+
+
+def load_stability_configs(config_path: str | None = None) -> list[dict[str, Any]]:
+    """Load stability test configurations from a JSON file.
+
+    Args:
+        config_path: Path to the JSON config. Defaults to weekly.json
+                     in the same directory as this module.
+
+    Returns:
+        List of stability test configuration dicts.
+    """
+    if config_path is None:
+        config_path = str(Path(__file__).parent / "weekly.json")
+
+    abs_path = Path(config_path).resolve()
+    with open(abs_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def assert_stability_thresholds(
+    report: StabilityReport,
+    thresholds: dict[str, float],
+) -> None:
+    """Assert that no metric drifted beyond the configured thresholds.
+
+    Args:
+        report: The completed stability report.
+        thresholds: Mapping of threshold keys to maximum allowed drift %.
+                    Keys follow the pattern ``max_{metric}_drift_pct``.
+    """
+    drift_map = {
+        "max_memory_drift_pct": "rss_memory_mb",
+        "max_vram_drift_pct": "vram_used_mb",
+        "max_p99_latency_drift_pct": "p99_latency_ms",
+        "max_throughput_drop_pct": "throughput_rps",
+        "max_error_rate_pct": "error_count",
+    }
+
+    for threshold_key, metric_name in drift_map.items():
+        max_drift = thresholds.get(threshold_key)
+        if max_drift is None:
+            continue
+
+        actual_drift = report.compute_drift(metric_name)
+
+        if metric_name == "throughput_rps":
+            assert actual_drift >= -max_drift, (
+                f"Throughput dropped {abs(actual_drift):.1f}% "
+                f"(threshold: {max_drift}%)"
+            )
+        else:
+            assert actual_drift <= max_drift, (
+                f"{metric_name} drifted +{actual_drift:.1f}% "
+                f"(threshold: {max_drift}%)"
+            )
+
+
+def collect_process_memory_mb() -> float:
+    """Return the RSS memory of the current process in MiB."""
+    try:
+        import psutil
+
+        process = psutil.Process()
+        return process.memory_info().rss / (1024 * 1024)
+    except ImportError:
+        return 0.0
+
+
+def collect_vram_used_mb(device_index: int = 0) -> float:
+    """Return VRAM usage for the given device in MiB."""
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            free_bytes, total_bytes = torch.cuda.mem_get_info(device_index)
+            return (total_bytes - free_bytes) / (1024 * 1024)
+    except Exception:
+        pass
+    return 0.0
+
+
+@pytest.fixture(scope="module")
+def stability_configs() -> list[dict[str, Any]]:
+    """Fixture that loads stability test configurations."""
+    return load_stability_configs()


### PR DESCRIPTION
## Purpose
Scaffold the L5 tier of the CI/CD plan (issue #400) by adding the missing stability and reliability test frameworks.

- Split L5 into **(a) long-run stability** and **(b) recovery/chaos** tests
- Add tests/e2e/stability/ with weekly.json config and monitoring helpers
- Add tests/e2e/reliability/ with fault-injection helpers and recovery test template
- Update CI_5levels.md with concrete examples (replacing WIP placeholder)
- Document diffusion/audio quality regression signals approach (CLIP/wav2vec embeddings)

## Test Plan

- [ ] Verify pytest --collect-only tests/e2e/stability/ collects without errors
- [ ] Verify pytest --collect-only tests/e2e/reliability/ collects without errors
- [ ] Review docs/contributing/ci/CI_5levels.md renders correctly with mkdocs serve

## Test Result

Framework scaffolding only - no GPU-dependent tests executed yet. Full L5 tests require weekly CI infrastructure.

Made with [Cursor](https://cursor.com)