### PR TITLE
[Bugfix] Fix Hardcoded Datatypes in Z-image

### DIFF
--- a/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
+++ b/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
@@ -564,14 +564,14 @@ class ZImagePipeline(nn.Module):
 
             # Run CFG only if configured AND scale is non-zero
             apply_cfg = self.do_classifier_free_guidance and current_guidance_scale > 0
+            latents_typed = latents.to(self.od_config.dtype)
 
             if apply_cfg:
-                latents_typed = latents.to(self.transformer.dtype)
                 latent_model_input = latents_typed.repeat(2, 1, 1, 1)
                 prompt_embeds_model_input = prompt_embeds + negative_prompt_embeds
                 timestep_model_input = timestep.repeat(2)
             else:
-                latent_model_input = latents.to(self.transformer.dtype)
+                latent_model_input = latents_typed
                 prompt_embeds_model_input = prompt_embeds
                 timestep_model_input = timestep
 

--- a/vllm_omni/diffusion/models/z_image/z_image_transformer.py
+++ b/vllm_omni/diffusion/models/z_image/z_image_transformer.py
@@ -614,7 +614,6 @@ class ZImageTransformer2DModel(CachedTransformer):
         quant_config: "QuantizationConfig | None" = None,
     ) -> None:
         super().__init__()
-        self.dtype = torch.bfloat16
         self.in_channels = in_channels
         self.out_channels = in_channels
         self.all_patch_size = all_patch_size


### PR DESCRIPTION
## Purpose
Currently Z-image assumes that the latent inputs need to be cast to `bfloat16`; running it on another dtype will cause it to crash as shown below. 

```
from vllm_omni.entrypoints.omni import Omni

if __name__ == "__main__":
    omni = Omni(model="Tongyi-MAI/Z-Image-Turbo", dtype="float32")
```

(in the profiling dummy run)
```
[Stage-0] ERROR 02-17 18:48:36 [diffusion_worker.py:424]     return F.linear(input, self.weight, self.bias)
[Stage-0] ERROR 02-17 18:48:36 [diffusion_worker.py:424]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[Stage-0] ERROR 02-17 18:48:36 [diffusion_worker.py:424] RuntimeError: mat1 and mat2 must have the same dtype, but got BFloat16 and Float
```

This PR casts with the normalized dtype from the omni diffusion config instead to avoid crashing when running other dtypes.

## Test Plan
The above snippet should run without issues, as should the example below
```python
from vllm_omni.entrypoints.omni import Omni

if __name__ == "__main__":
    omni = Omni(model="Tongyi-MAI/Z-Image-Turbo", dtype="float32")
    prompt = "a cup of coffee on the table"
    outputs = omni.generate(prompt)
    images = outputs[0].request_output[0].images
    images[0].save("coffee.png")
```

## Test Result
The correct dtype is used to cast the latents in the example above, and it exits successfully.

I did also see that NaNs are produced with fp16 running with `DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA` as the backend, but that will likely need a separate fix.