### PR TITLE
[Doc] Update GPU installation commands

### DIFF
--- a/docs/getting_started/installation/gpu/cuda.inc.md
+++ b/docs/getting_started/installation/gpu/cuda.inc.md
@@ -22,6 +22,18 @@ vLLM-Omni is built based on vLLM. Please install it with command below.
 ```bash
 # vllm 0.16.0 is still under prerelease
 uv pip install --prerelease=allow vllm --extra-index-url https://wheels.vllm.ai/2d5be1dd5ce2e44dfea53ea03ff61143da5137eb
+
+# vllm 0.16.0 may have some bugs for cuda 12.9, here is how we solve them:
+export FLASHINFER_CUDA_TAG="$(python3 -c 'import torch; print((torch.version.cuda or "12.4").replace(".", ""))')"
+
+uv pip install --upgrade --force-reinstall \
+  "flashinfer-python==0.6.3" \
+  "flashinfer-cubin==0.6.3" \
+  "flashinfer-jit-cache==0.6.3" \
+  --extra-index-url "https://flashinfer.ai/whl/cu${FLASHINFER_CUDA_TAG}"
+
+uv pip install --upgrade --force-reinstall "nvidia-cublas-cu12==12.9.1.4"
+uv pip install --upgrade --force-reinstall "numpy==2.2.6"
 ```
 
 #### Installation of vLLM-Omni

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -21,6 +21,16 @@ source .venv/bin/activate
 # On CUDA
 # vllm 0.16.0 is still under prerelease
 uv pip install --prerelease=allow vllm --extra-index-url https://wheels.vllm.ai/2d5be1dd5ce2e44dfea53ea03ff61143da5137eb
+# vllm 0.16.0 may have some bugs for cuda 12.9, here is how we solve them:
+export FLASHINFER_CUDA_TAG="$(python3 -c 'import torch; print((torch.version.cuda or "12.4").replace(".", ""))')"
+uv pip install --upgrade --force-reinstall \
+  "flashinfer-python==0.6.3" \
+  "flashinfer-cubin==0.6.3" \
+  "flashinfer-jit-cache==0.6.3" \
+  --extra-index-url "https://flashinfer.ai/whl/cu${FLASHINFER_CUDA_TAG}"
+uv pip install --upgrade --force-reinstall "nvidia-cublas-cu12==12.9.1.4"
+uv pip install --upgrade --force-reinstall "numpy==2.2.6"
+
 
 # On ROCm
 uv pip install vllm==0.16.0 --extra-index-url https://wheels.vllm.ai/rocm/0.16.0/rocm700


### PR DESCRIPTION
## Purpose

From #1427 , the vllm for v0.16.0 is still under prerelease and cannot be installed by current command.
## Test Plan
Tested on Qwen 3 Omni offline with cuda 12.8.
## Test Result
```bash
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
==================== 
 vllm version: 0.16.0 
 ====================
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/vllm/assets/video.py:149: UserWarning: PySoundFile failed. Trying audioread instead.
  return librosa.load(self.video_path, sr=sampling_rate)[0]
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/librosa/core/audio.py:184: FutureWarning: librosa.core.audio.__audioread_load
        Deprecated as of librosa version 0.10.0.
        It will be removed in librosa version 1.0.
  y, sr_native = __audioread_load(path, offset, duration, dtype)
INFO 02-23 03:37:49 [weight_utils.py:50] Using model weights format ['*']
INFO 02-23 03:37:50 [omni.py:138] Initializing stages for model: Qwen/Qwen3-Omni-30B-A3B-Instruct
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section', 'mrope_interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section'}
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section', 'mrope_interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section'}
INFO 02-23 03:37:51 [initialization.py:215] Auto-configuring SharedMemoryConnector for edge ('0', '1')
INFO 02-23 03:37:51 [initialization.py:215] Auto-configuring SharedMemoryConnector for edge ('1', '2')
INFO 02-23 03:37:51 [initialization.py:234] Loaded OmniTransferConfig with 2 connector configurations
INFO 02-23 03:37:51 [factory.py:46] Created connector: SharedMemoryConnector
INFO 02-23 03:37:51 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
INFO 02-23 03:37:51 [factory.py:46] Created connector: SharedMemoryConnector
INFO 02-23 03:37:51 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
INFO 02-23 03:37:51 [omni_stage.py:249] [OmniStage] stage_config: {'stage_id': 0, 'stage_type': 'llm', 'runtime': {'devices': '0', 'max_batch_size': 64}, 'engine_args': {'model_stage': 'thinker', 'model_arch': 'Qwen3OmniMoeForConditionalGeneration', 'worker_type': 'ar', 'scheduler_cls': 'vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler', 'gpu_memory_utilization': 0.9, 'enforce_eager': False, 'trust_remote_code': True, 'engine_output_type': 'latent', 'distributed_executor_backend': 'mp', 'enable_prefix_caching': False, 'max_num_batched_tokens': 32768, 'hf_config_name': 'thinker_config', 'tensor_parallel_size': 1, 'max_num_seqs': 64, 'async_chunk': False}, 'final_output': True, 'final_output_type': 'text', 'is_comprehension': True, 'default_sampling_params': {'temperature': 0.4, 'top_p': 0.9, 'top_k': 1, 'max_tokens': 2048, 'seed': 42, 'detokenize': True, 'repetition_penalty': 1.05}}
INFO 02-23 03:37:51 [omni_stage.py:249] [OmniStage] stage_config: {'stage_id': 1, 'stage_type': 'llm', 'runtime': {'devices': '1', 'max_batch_size': 64}, 'engine_args': {'model_stage': 'talker', 'model_arch': 'Qwen3OmniMoeForConditionalGeneration', 'worker_type': 'ar', 'scheduler_cls': 'vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler', 'gpu_memory_utilization': 0.6, 'enforce_eager': False, 'trust_remote_code': True, 'engine_output_type': 'latent', 'enable_prefix_caching': False, 'max_num_batched_tokens': 32768, 'distributed_executor_backend': 'mp', 'hf_config_name': 'talker_config', 'max_num_seqs': 64, 'async_chunk': False}, 'engine_input_source': [0], 'custom_process_input_func': 'vllm_omni.model_executor.stage_input_processors.qwen3_omni.thinker2talker', 'default_sampling_params': {'temperature': 0.9, 'top_k': 50, 'max_tokens': 4096, 'seed': 42, 'detokenize': False, 'repetition_penalty': 1.05, 'stop_token_ids': [2150]}}
INFO 02-23 03:37:51 [omni_stage.py:249] [OmniStage] stage_config: {'stage_id': 2, 'stage_type': 'llm', 'runtime': {'devices': '1', 'max_batch_size': 64}, 'engine_args': {'model_stage': 'code2wav', 'model_arch': 'Qwen3OmniMoeForConditionalGeneration', 'worker_type': 'generation', 'scheduler_cls': 'vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler', 'enforce_eager': True, 'trust_remote_code': True, 'async_scheduling': False, 'enable_prefix_caching': False, 'engine_output_type': 'audio', 'gpu_memory_utilization': 0.1, 'distributed_executor_backend': 'mp', 'max_num_batched_tokens': 1000000, 'hf_config_name': 'thinker_config', 'max_num_seqs': 64, 'async_chunk': False}, 'engine_input_source': [1], 'custom_process_input_func': 'vllm_omni.model_executor.stage_input_processors.qwen3_omni.talker2code2wav', 'final_output': True, 'final_output_type': 'audio', 'default_sampling_params': {'temperature': 0.0, 'top_p': 1.0, 'top_k': -1, 'max_tokens': 65536, 'seed': 42, 'detokenize': True, 'repetition_penalty': 1.1}}
INFO 02-23 03:37:51 [omni.py:357] [Orchestrator] Waiting for 3 stages to initialize (timeout: 300s)
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
[Stage-1] INFO 02-23 03:38:09 [omni_stage.py:646] Starting stage worker with model: Qwen/Qwen3-Omni-30B-A3B-Instruct
[Stage-1] INFO 02-23 03:38:09 [omni_stage.py:659] [Stage] Set VLLM_WORKER_MULTIPROC_METHOD=spawn
[Stage-1] INFO 02-23 03:38:09 [omni_stage.py:74] NVML process-scoped memory available and PID host is available — concurrent init is safe, skipping locks
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'mrope_interleaved', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'mrope_interleaved', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
[Stage-1] INFO 02-23 03:38:11 [initialization.py:215] Auto-configuring SharedMemoryConnector for edge ('0', '1')
[Stage-1] INFO 02-23 03:38:11 [initialization.py:215] Auto-configuring SharedMemoryConnector for edge ('1', '2')
[Stage-1] INFO 02-23 03:38:11 [initialization.py:234] Loaded OmniTransferConfig with 2 connector configurations
[Stage-1] INFO 02-23 03:38:11 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-1] INFO 02-23 03:38:11 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
[Stage-1] INFO 02-23 03:38:11 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-1] INFO 02-23 03:38:11 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
[Stage-2] INFO 02-23 03:38:11 [omni_stage.py:646] Starting stage worker with model: Qwen/Qwen3-Omni-30B-A3B-Instruct
[Stage-2] INFO 02-23 03:38:11 [omni_stage.py:659] [Stage] Set VLLM_WORKER_MULTIPROC_METHOD=spawn
[Stage-2] INFO 02-23 03:38:11 [omni_stage.py:74] NVML process-scoped memory available and PID host is available — concurrent init is safe, skipping locks
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
[Stage-0] INFO 02-23 03:38:11 [omni_stage.py:646] Starting stage worker with model: Qwen/Qwen3-Omni-30B-A3B-Instruct
[Stage-0] INFO 02-23 03:38:11 [omni_stage.py:659] [Stage] Set VLLM_WORKER_MULTIPROC_METHOD=spawn
[Stage-0] INFO 02-23 03:38:11 [omni_stage.py:74] NVML process-scoped memory available and PID host is available — concurrent init is safe, skipping locks
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'mrope_interleaved', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'mrope_interleaved', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved', 'mrope_interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'mrope_interleaved', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
[Stage-2] INFO 02-23 03:38:13 [initialization.py:215] Auto-configuring SharedMemoryConnector for edge ('0', '1')
[Stage-2] INFO 02-23 03:38:13 [initialization.py:215] Auto-configuring SharedMemoryConnector for edge ('1', '2')
[Stage-2] INFO 02-23 03:38:13 [initialization.py:234] Loaded OmniTransferConfig with 2 connector configurations
[Stage-2] INFO 02-23 03:38:13 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-2] INFO 02-23 03:38:13 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
[Stage-2] INFO 02-23 03:38:13 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-2] INFO 02-23 03:38:13 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved', 'mrope_interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
[Stage-0] INFO 02-23 03:38:13 [initialization.py:215] Auto-configuring SharedMemoryConnector for edge ('0', '1')
[Stage-0] INFO 02-23 03:38:13 [initialization.py:215] Auto-configuring SharedMemoryConnector for edge ('1', '2')
[Stage-0] INFO 02-23 03:38:13 [initialization.py:234] Loaded OmniTransferConfig with 2 connector configurations
[Stage-0] INFO 02-23 03:38:13 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-0] INFO 02-23 03:38:13 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
[Stage-0] INFO 02-23 03:38:13 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-0] INFO 02-23 03:38:13 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'mrope_interleaved', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved', 'mrope_interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
[Stage-1] INFO 02-23 03:38:31 [model.py:529] Resolved architecture: Qwen3OmniMoeForConditionalGeneration
[Stage-1] INFO 02-23 03:38:31 [model.py:1549] Using max model len 65536
[Stage-1] INFO 02-23 03:38:31 [model.py:1549] Using max model len 65536
[Stage-1] INFO 02-23 03:38:31 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=32768.
[Stage-1] INFO 02-23 03:38:31 [vllm.py:689] Asynchronous scheduling is enabled.
[Stage-2] INFO 02-23 03:38:32 [model.py:529] Resolved architecture: Qwen3OmniMoeForConditionalGeneration
[Stage-2] INFO 02-23 03:38:32 [model.py:1549] Using max model len 65536
[Stage-2] INFO 02-23 03:38:32 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=1000000.
[Stage-2] INFO 02-23 03:38:32 [vllm.py:689] Asynchronous scheduling is disabled.
[Stage-2] WARNING 02-23 03:38:32 [vllm.py:727] Enforce eager set, overriding optimization level to -O0
[Stage-2] INFO 02-23 03:38:32 [vllm.py:845] Cudagraph is disabled under eager mode
[Stage-0] INFO 02-23 03:38:32 [model.py:529] Resolved architecture: Qwen3OmniMoeForConditionalGeneration
[Stage-0] INFO 02-23 03:38:32 [model.py:1549] Using max model len 65536
[Stage-0] INFO 02-23 03:38:32 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=32768.
[Stage-0] INFO 02-23 03:38:32 [vllm.py:689] Asynchronous scheduling is enabled.
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
(EngineCore_DP0 pid=53575) [Stage-1] INFO 02-23 03:39:02 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='Qwen/Qwen3-Omni-30B-A3B-Instruct', speculative_config=None, tokenizer='Qwen/Qwen3-Omni-30B-A3B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=65536, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen3-Omni-30B-A3B-Instruct, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [32768], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 128, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=53575) [Stage-1] WARNING 02-23 03:39:02 [multiproc_executor.py:921] Reducing Torch parallelism from 112 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
(EngineCore_DP0 pid=53643) [Stage-2] INFO 02-23 03:39:02 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='Qwen/Qwen3-Omni-30B-A3B-Instruct', speculative_config=None, tokenizer='Qwen/Qwen3-Omni-30B-A3B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=65536, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen3-Omni-30B-A3B-Instruct, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [1000000], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=53643) [Stage-2] WARNING 02-23 03:39:02 [multiproc_executor.py:921] Reducing Torch parallelism from 112 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
(EngineCore_DP0 pid=53809) [Stage-0] INFO 02-23 03:39:04 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='Qwen/Qwen3-Omni-30B-A3B-Instruct', speculative_config=None, tokenizer='Qwen/Qwen3-Omni-30B-A3B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=65536, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen3-Omni-30B-A3B-Instruct, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [32768], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 128, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=53809) [Stage-0] WARNING 02-23 03:39:04 [multiproc_executor.py:921] Reducing Torch parallelism from 112 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
[Stage-1] INFO 02-23 03:39:22 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:44721 backend=nccl
[Stage-1] INFO 02-23 03:39:22 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0
[Stage-2] INFO 02-23 03:39:22 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:50239 backend=nccl
[Stage-2] INFO 02-23 03:39:22 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0
[Stage-0] INFO 02-23 03:39:23 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:55231 backend=nccl
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
[Stage-0] INFO 02-23 03:39:23 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
(Worker pid=55635) [Stage-1] INFO 02-23 03:39:33 [gpu_model_runner.py:4124] Starting to load model Qwen/Qwen3-Omni-30B-A3B-Instruct...
(Worker pid=55635) [Stage-1] INFO 02-23 03:39:33 [vllm.py:689] Asynchronous scheduling is enabled.
(Worker pid=55863) [Stage-0] INFO 02-23 03:39:34 [gpu_model_runner.py:4124] Starting to load model Qwen/Qwen3-Omni-30B-A3B-Instruct...
(Worker pid=55863) [Stage-0] INFO 02-23 03:39:35 [vllm.py:689] Asynchronous scheduling is enabled.
(Worker pid=55658) [Stage-2] INFO 02-23 03:39:35 [gpu_model_runner.py:4124] Starting to load model Qwen/Qwen3-Omni-30B-A3B-Instruct...
(Worker pid=55863) [Stage-0] INFO 02-23 03:39:35 [mm_encoder_attention.py:77] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
(Worker pid=55658) [Stage-2] INFO 02-23 03:39:35 [vllm.py:689] Asynchronous scheduling is disabled.
(Worker pid=55658) [Stage-2] WARNING 02-23 03:39:35 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(Worker pid=55658) [Stage-2] INFO 02-23 03:39:35 [vllm.py:845] Cudagraph is disabled under eager mode
(Worker pid=55658) [Stage-2] WARNING 02-23 03:39:35 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(Worker pid=55658) [Stage-2] INFO 02-23 03:39:35 [vllm.py:845] Cudagraph is disabled under eager mode
Loading safetensors checkpoint shards:   0% Completed | 0/15 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:   7% Completed | 1/15 [00:00<00:07,  1.80it/s]
Loading safetensors checkpoint shards:  20% Completed | 3/15 [00:00<00:02,  4.90it/s]
Loading safetensors checkpoint shards:  33% Completed | 5/15 [00:00<00:01,  7.38it/s]
Loading safetensors checkpoint shards:  47% Completed | 7/15 [00:01<00:00,  8.77it/s]
Loading safetensors checkpoint shards:  60% Completed | 9/15 [00:01<00:01,  5.29it/s]
Loading safetensors checkpoint shards:  73% Completed | 11/15 [00:01<00:00,  6.64it/s]
Loading safetensors checkpoint shards:  87% Completed | 13/15 [00:02<00:00,  6.46it/s]
(Worker pid=55863) [Stage-0] INFO 02-23 03:39:39 [cuda.py:367] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(Worker pid=55635) [Stage-1] INFO 02-23 03:39:39 [cuda.py:367] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(Worker pid=55863) [Stage-0] INFO 02-23 03:39:39 [unquantized.py:131] Using TRITON backend for Unquantized MoE
(Worker pid=55635) [Stage-1] INFO 02-23 03:39:39 [unquantized.py:131] Using TRITON backend for Unquantized MoE
(Worker pid=55635) <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(Worker pid=55635) <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
(Worker pid=55863) <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(Worker pid=55863) <frozen importlib._bootstrap_external>:1297: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:40 [qwen3_omni_moe_code_predictor_mtp.py:108] CUDAGraphMode.FULL_AND_PIECEWISE is currently not supported with flash attention for Qwen3-Omni talker MTP.removing flash attention from attention_backends
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:40 [qwen3_omni_moe_code_predictor_mtp.py:108] CUDAGraphMode.FULL_AND_PIECEWISE is currently not supported with flash attention for Qwen3-Omni talker MTP.removing flash attention from attention_backends
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:40 [qwen3_omni_moe_code_predictor_mtp.py:108] CUDAGraphMode.FULL_AND_PIECEWISE is currently not supported with flash attention for Qwen3-Omni talker MTP.removing flash attention from attention_backends
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:40 [qwen3_omni_moe_code_predictor_mtp.py:108] CUDAGraphMode.FULL_AND_PIECEWISE is currently not supported with flash attention for Qwen3-Omni talker MTP.removing flash attention from attention_backends
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:40 [qwen3_omni_moe_code_predictor_mtp.py:108] CUDAGraphMode.FULL_AND_PIECEWISE is currently not supported with flash attention for Qwen3-Omni talker MTP.removing flash attention from attention_backends
(Worker pid=55635) [Stage-1] INFO 02-23 03:39:40 [mm_encoder_attention.py:77] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
Loading safetensors checkpoint shards:  93% Completed | 14/15 [00:04<00:00,  1.95it/s]
Loading safetensors checkpoint shards: 100% Completed | 15/15 [00:04<00:00,  2.30it/s]
Loading safetensors checkpoint shards: 100% Completed | 15/15 [00:04<00:00,  3.48it/s]
(Worker pid=55658) 
Loading safetensors checkpoint shards:   0% Completed | 0/15 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  40% Completed | 6/15 [00:00<00:00, 54.69it/s]
Loading safetensors checkpoint shards:  80% Completed | 12/15 [00:00<00:00, 53.40it/s]
(Worker pid=55658) [Stage-2] INFO 02-23 03:39:42 [qwen3_omni_code2wav.py:272] [Model Loaded] name=Qwen3OmniMoeCode2Wav, success=True, size=412.02 MB, device=cuda:0
(Worker pid=55658) [Stage-2] INFO 02-23 03:39:42 [qwen3_omni.py:1152] Loaded 230 weights for Qwen3OmniMoe (stage=code2wav)
(Worker pid=55658) [Stage-2] INFO 02-23 03:39:42 [default_loader.py:293] Loading weights took 4.91 seconds
Loading safetensors checkpoint shards:   0% Completed | 0/15 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  40% Completed | 6/15 [00:00<00:00, 54.86it/s]
Loading safetensors checkpoint shards: 100% Completed | 15/15 [00:00<00:00, 21.90it/s]
(Worker pid=55635) 
Loading safetensors checkpoint shards:  80% Completed | 12/15 [00:00<00:00, 53.55it/s]
(Worker pid=55658) [Stage-2] INFO 02-23 03:39:42 [gpu_model_runner.py:4221] Model loading took 0.41 GiB memory and 6.365857 seconds
(Worker pid=55658) [Stage-2] INFO 02-23 03:39:42 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.
Loading safetensors checkpoint shards: 100% Completed | 15/15 [00:00<00:00, 22.36it/s]
(Worker pid=55863) 
(Worker pid=55658) [Stage-2] WARNING 02-23 03:39:46 [gpu_generation_model_runner.py:452] Dummy sampler run is not implemented for generation model
(EngineCore_DP0 pid=53643) [Stage-2] INFO 02-23 03:39:46 [core.py:278] init engine (profile, create kv cache, warmup model) took 3.35 seconds
(EngineCore_DP0 pid=53643) [Stage-2] WARNING 02-23 03:39:48 [scheduler.py:166] Using custom scheduler class vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore_DP0 pid=53643) [Stage-2] WARNING 02-23 03:39:48 [core.py:130] Disabling chunked prefill for model without KVCache
(EngineCore_DP0 pid=53643) The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
(Worker pid=55635) [Stage-1] INFO 02-23 03:39:53 [qwen3_omni_moe_talker.py:465] [Model Loaded] name=Qwen3OmniMoeTalkerForConditionalGeneration, success=True, size=8604.35 MB, device=cuda:0
(Worker pid=55635) [Stage-1] INFO 02-23 03:39:53 [qwen3_omni.py:1152] Loaded 1200 weights for Qwen3OmniMoe (stage=talker)
(Worker pid=55635) [Stage-1] INFO 02-23 03:39:53 [default_loader.py:293] Loading weights took 11.16 seconds
(Worker pid=55635) [Stage-1] INFO 02-23 03:39:53 [gpu_model_runner.py:4221] Model loading took 8.5 GiB memory and 19.581176 seconds
(Worker pid=55635) [Stage-1] INFO 02-23 03:39:54 [gpu_model_runner.py:5140] Encoder cache will be initialized with a budget of 62720 tokens, and profiled with 1 video items of the maximum feature size.
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:55 [qwen3_omni_moe_talker.py:377] 
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:55 [qwen3_omni_moe_talker.py:377] 
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:55 [qwen3_omni_moe_talker.py:377] 
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:55 [qwen3_omni_moe_talker.py:377] THIS FUNCTION RETURNS DUMMY MULTIMODAL EMBEDDINGS FOR PROFILE RUN, SHOULD NOT BE CALLED IN INFERENCE.
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:55 [qwen3_omni_moe_talker.py:377] 
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:55 [qwen3_omni_moe_talker.py:377] 
(Worker pid=55635) [Stage-1] WARNING 02-23 03:39:55 [qwen3_omni_moe_talker.py:377] 
(EngineCore_DP0 pid=53643) [Stage-2] INFO 02-23 03:39:58 [vllm.py:689] Asynchronous scheduling is disabled.
(EngineCore_DP0 pid=53643) [Stage-2] WARNING 02-23 03:39:58 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=53643) [Stage-2] INFO 02-23 03:39:58 [vllm.py:845] Cudagraph is disabled under eager mode
[Stage-2] INFO 02-23 03:39:59 [omni_llm.py:172] Supported_tasks: ['generate']
[Stage-2] INFO 02-23 03:39:59 [initialization.py:288] [Stage-2] Initializing OmniConnectors with config keys: ['from_stage_1']
[Stage-2] INFO 02-23 03:39:59 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-2] INFO 02-23 03:39:59 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
[Stage-2] INFO 02-23 03:39:59 [omni_stage.py:738] Max batch size: 64
INFO 02-23 03:39:59 [omni.py:350] [Orchestrator] Stage-2 reported ready
(Worker pid=55635) [Stage-1] INFO 02-23 03:40:17 [backends.py:916] Using cache directory: /scratch/dyvm6xra/dyvm6xrauser49/omni-features/models/xdg-cache/vllm/torch_compile_cache/dbf932212e/rank_0_0/backbone for vLLM's torch.compile
(Worker pid=55635) [Stage-1] INFO 02-23 03:40:17 [backends.py:976] Dynamo bytecode transform time: 20.53 s
(Worker pid=55635) [Stage-1] INFO 02-23 03:40:26 [backends.py:351] Cache the graph of compile range (1, 32768) for later use
(Worker pid=55635) [Stage-1] INFO 02-23 03:40:26 [backends.py:368] Compiling a graph for compile range (1, 32768) takes 4.57 s
(Worker pid=55635) [Stage-1] INFO 02-23 03:40:26 [monitor.py:34] torch.compile takes 25.11 s in total
(Worker pid=55635) [Stage-1] INFO 02-23 03:40:33 [backends.py:916] Using cache directory: /scratch/dyvm6xra/dyvm6xrauser49/omni-features/models/xdg-cache/vllm/torch_compile_cache/adc180dc9a/rank_0_0/backbone for vLLM's torch.compile
(Worker pid=55635) [Stage-1] INFO 02-23 03:40:33 [backends.py:976] Dynamo bytecode transform time: 5.13 s
(Worker pid=55635) [Stage-1] WARNING 02-23 03:40:36 [fused_moe.py:1087] Using default MoE config. Performance might be sub-optimal! Config file not found at /scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/vllm/model_executor/layers/fused_moe/configs/E=128,N=384,device_name=NVIDIA_H800.json
(Worker pid=55635) [Stage-1] INFO 02-23 03:40:37 [backends.py:368] Compiling a graph for compile range (1, 32768) takes 2.25 s
(Worker pid=55635) [Stage-1] INFO 02-23 03:40:37 [monitor.py:34] torch.compile takes 32.49 s in total
(Worker pid=55635) [Stage-1] INFO 02-23 03:40:38 [base.py:81] Available KV cache memory: 37.18 GiB (process-scoped)
(EngineCore_DP0 pid=53575) [Stage-1] INFO 02-23 03:40:38 [kv_cache_utils.py:1307] GPU KV cache size: 1,949,520 tokens
(EngineCore_DP0 pid=53575) [Stage-1] INFO 02-23 03:40:38 [kv_cache_utils.py:1312] Maximum concurrency for 65,536 tokens per request: 29.75x
(Worker pid=55635) 2026-02-23 03:40:38,551 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
(Worker pid=55635) 2026-02-23 03:40:38,811 - INFO - autotuner.py:262 - flashinfer.jit: [Autotuner]: Autotuning process ends
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|████████████████████████████████████████████████| 19/19 [00:03<00:00,  5.92it/s]
Capturing CUDA graphs (decode, FULL): 100%|███████████████████████████████████████████████████████████████████| 11/11 [00:01<00:00,  8.35it/s]
(Worker pid=55635) [Stage-1] INFO 02-23 03:40:44 [gpu_model_runner.py:5246] Graph capturing finished in 5 secs, took -0.44 GiB
(EngineCore_DP0 pid=53575) [Stage-1] INFO 02-23 03:40:44 [core.py:278] init engine (profile, create kv cache, warmup model) took 50.42 seconds
(EngineCore_DP0 pid=53575) [Stage-1] WARNING 02-23 03:40:46 [scheduler.py:166] Using custom scheduler class vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore_DP0 pid=53575) The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
(EngineCore_DP0 pid=53575) [Stage-1] INFO 02-23 03:40:56 [vllm.py:689] Asynchronous scheduling is enabled.
[Stage-1] INFO 02-23 03:40:57 [omni_llm.py:172] Supported_tasks: ['generate']
[Stage-1] INFO 02-23 03:40:57 [initialization.py:288] [Stage-1] Initializing OmniConnectors with config keys: ['from_stage_0']
[Stage-1] INFO 02-23 03:40:57 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-1] INFO 02-23 03:40:57 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
[Stage-1] INFO 02-23 03:40:57 [omni_stage.py:738] Max batch size: 64
INFO 02-23 03:40:57 [omni.py:350] [Orchestrator] Stage-1 reported ready
(Worker pid=55863) [Stage-0] INFO 02-23 03:41:25 [qwen3_omni.py:1152] Loaded 1183 weights for Qwen3OmniMoe (stage=thinker)
(Worker pid=55863) [Stage-0] INFO 02-23 03:41:25 [default_loader.py:293] Loading weights took 102.97 seconds
(Worker pid=55863) [Stage-0] INFO 02-23 03:41:29 [gpu_model_runner.py:4221] Model loading took 59.54 GiB memory and 113.120604 seconds
(Worker pid=55863) [Stage-0] INFO 02-23 03:41:29 [gpu_model_runner.py:5140] Encoder cache will be initialized with a budget of 62720 tokens, and profiled with 1 video items of the maximum feature size.
(Worker pid=55863) [Stage-0] INFO 02-23 03:41:42 [backends.py:916] Using cache directory: /scratch/dyvm6xra/dyvm6xrauser49/omni-features/models/xdg-cache/vllm/torch_compile_cache/6ffafd0eed/rank_0_0/backbone for vLLM's torch.compile
(Worker pid=55863) [Stage-0] INFO 02-23 03:41:42 [backends.py:976] Dynamo bytecode transform time: 11.66 s
(Worker pid=55863) [Stage-0] INFO 02-23 03:41:46 [backends.py:351] Cache the graph of compile range (1, 32768) for later use
(Worker pid=55863) [Stage-0] WARNING 02-23 03:41:46 [fused_moe.py:1087] Using default MoE config. Performance might be sub-optimal! Config file not found at /scratch/dyvm6xra/dyvm6xrauser49/omni-features/.venv/lib/python3.12/site-packages/vllm/model_executor/layers/fused_moe/configs/E=128,N=768,device_name=NVIDIA_H800.json
(Worker pid=55863) [Stage-0] INFO 02-23 03:41:50 [backends.py:368] Compiling a graph for compile range (1, 32768) takes 3.98 s
(Worker pid=55863) [Stage-0] INFO 02-23 03:41:50 [monitor.py:34] torch.compile takes 15.63 s in total
(Worker pid=55863) [Stage-0] INFO 02-23 03:41:51 [base.py:81] Available KV cache memory: 8.25 GiB (process-scoped)
(EngineCore_DP0 pid=53809) [Stage-0] INFO 02-23 03:41:51 [kv_cache_utils.py:1307] GPU KV cache size: 90,080 tokens
(EngineCore_DP0 pid=53809) [Stage-0] INFO 02-23 03:41:51 [kv_cache_utils.py:1312] Maximum concurrency for 65,536 tokens per request: 1.37x
(Worker pid=55863) 2026-02-23 03:41:51,425 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
(Worker pid=55863) 2026-02-23 03:41:52,152 - INFO - autotuner.py:262 - flashinfer.jit: [Autotuner]: Autotuning process ends
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|████████████████████████████████████████████████| 19/19 [00:01<00:00, 10.19it/s]
Capturing CUDA graphs (decode, FULL): 100%|███████████████████████████████████████████████████████████████████| 11/11 [00:01<00:00,  9.90it/s]
(Worker pid=55863) [Stage-0] INFO 02-23 03:41:55 [gpu_model_runner.py:5246] Graph capturing finished in 4 secs, took -2.03 GiB
(EngineCore_DP0 pid=53809) [Stage-0] INFO 02-23 03:41:55 [core.py:278] init engine (profile, create kv cache, warmup model) took 26.81 seconds
(EngineCore_DP0 pid=53809) [Stage-0] WARNING 02-23 03:41:57 [scheduler.py:166] Using custom scheduler class vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore_DP0 pid=53809) The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
(EngineCore_DP0 pid=53809) [Stage-0] INFO 02-23 03:42:08 [vllm.py:689] Asynchronous scheduling is enabled.
[Stage-0] INFO 02-23 03:42:08 [omni_llm.py:172] Supported_tasks: ['generate']
[Stage-0] INFO 02-23 03:42:08 [initialization.py:288] [Stage-0] Initializing OmniConnectors with config keys: ['to_stage_1']
[Stage-0] INFO 02-23 03:42:08 [omni_stage.py:738] Max batch size: 64
INFO 02-23 03:42:08 [omni.py:350] [Orchestrator] Stage-0 reported ready
INFO 02-23 03:42:08 [omni.py:376] [Orchestrator] All stages initialized successfully
Adding requests:   0%|                                                                                                  | 0/1 [00:00<?, ?it/s(Worker pid=55635) [Stage-1] INFO 02-23 03:42:44 [mrope.py:345] Multimodal token idx changed!st. speed input: 0.00 unit/s, output: 0.00 unit/s]
(Worker pid=55658) [Stage-2] INFO 02-23 03:42:59 [mrope.py:345] Multimodal token idx changed!
Processed prompts: 100%|██████████████████████████████████| 1/1 [00:51<00:00, 51.32s/req, est. speed stage-2 tok/s: 45.38, avg e2e_lat: 0.0ms]
query type: use_audio_in_video████████████████████████████| 1/1 [00:51<00:00, 51.32s/req, est. speed stage-2 tok/s: 45.38, avg e2e_lat: 0.0ms]
Request ID: 0_a0a6bc36-4fb7-491a-883b-bc2b871d738d, Text saved to output_audio/0_a0a6bc36-4fb7-491a-883b-bc2b871d738d.txt
Request ID: 0_a0a6bc36-4fb7-491a-883b-bc2b871d738d, Saved audio to output_audio/output_0_a0a6bc36-4fb7-491a-883b-bc2b871d738d.wav
[Stage-2] INFO 02-23 03:43:00 [omni_stage.py:786] Received shutdown signal
[Stage-1] INFO 02-23 03:43:00 [omni_stage.py:786] Received shutdown signal
[Stage-0] INFO 02-23 03:43:00 [omni_stage.py:786] Received shutdown signal
(Worker pid=55658) (Worker pid=55863) (Worker pid=55635) [Stage-0] INFO 02-23 03:43:17 [multiproc_executor.py:732] Parent process exited, terminating worker
[Stage-2] INFO 02-23 03:43:17 [multiproc_executor.py:732] Parent process exited, terminating worker
[Stage-1] WARNING 02-23 03:43:17 [multiproc_executor.py:797] WorkerProc was terminated
(Worker pid=55635) (Worker pid=55658) [Stage-2] WARNING 02-23 03:43:17 [multiproc_executor.py:797] WorkerProc was terminated
[Stage-1] INFO 02-23 03:43:17 [multiproc_executor.py:732] Parent process exited, terminating worker
(Worker pid=55863) [Stage-0] WARNING 02-23 03:43:17 [multiproc_executor.py:797] WorkerProc was terminated
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please providing the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
