### PR TITLE
[Chore] Import BaseRenderer From Package

### DIFF
--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -13,7 +13,7 @@ import torch
 from fastapi import Request
 from PIL import Image
 from pydantic import TypeAdapter
-from vllm.renderers.protocol import BaseRenderer
+from vllm.renderers import BaseRenderer
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.openai.protocol.chat_completion import OmniChatCompletionResponse


### PR DESCRIPTION
The `BaseRenderer` in vLLM has moved since `0.16.0`, which will break the import in chat serving if you're developing on the latest versions of vLLM and vLLM Omni together.

This changes the import to grab the `BaseRenderer` off the package, since it is compatible with `0.16.0` ([ref](https://github.com/vllm-project/vllm/blob/v0.16.0/vllm/renderers/__init__.py#L9)) and the current code ([ref](https://github.com/vllm-project/vllm/blob/main/vllm/renderers/__init__.py))