### PR TITLE
[Doc]: Add bagel single/multi node usage with mooncake document

### DIFF
--- a/examples/offline_inference/bagel/README.md
+++ b/examples/offline_inference/bagel/README.md
@@ -197,7 +197,7 @@ pip install mooncake-transfer-engine-non-cuda
 
 ### Step 1: Start the Mooncake Master
 
-On the **primary node**, start the Mooncake master service:
+On the **primary node**, start the Mooncake master service (run in a separate terminal or background with `&`):
 
 ```bash
 # Optional: enable disk-backed storage by creating a directory and passing --root_fs_dir.
@@ -211,7 +211,7 @@ mooncake_master \
   --http_metadata_server_port=8080 \
   --metrics_port=9003 \
   --root_fs_dir=./mc_storage/ \
-  --cluster_id=mc-local-1
+  --cluster_id=mc-local-1 &
 ```
 
 ### Step 2: Run Offline Inference with Mooncake

--- a/examples/online_serving/bagel/README.md
+++ b/examples/online_serving/bagel/README.md
@@ -93,7 +93,7 @@ For more details on the Mooncake connector configuration, see the [Mooncake Stor
 
 You can deploy each stage on a **separate node** for better resource utilization. In this example, the orchestrator (Stage 0 / Thinker) and Stage 1 (DiT) run on different machines, connected via Mooncake.
 
-Assume the orchestrator node IP is `10.244.227.244`.
+Replace `<ORCHESTRATOR_IP>` below with the actual IP address of your orchestrator node (e.g., `10.244.227.244`).
 
 > [!WARNING]
 > **Before launching**, edit [`bagel_multiconnector.yaml`](../../../vllm_omni/model_executor/stage_configs/bagel_multiconnector.yaml) and replace the `metadata_server` and `master` addresses with your Mooncake master node's actual IP. Mismatched addresses will cause silent connection failures.
@@ -104,7 +104,7 @@ Assume the orchestrator node IP is `10.244.227.244`.
 mooncake_master \
   --rpc_port=50051 \
   --enable_http_metadata_server=true \
-  --http_metadata_server_host=10.244.227.244 \
+  --http_metadata_server_host=<ORCHESTRATOR_IP> \
   --http_metadata_server_port=8080 \
   --metrics_port=9003
 ```
@@ -113,10 +113,10 @@ mooncake_master \
 
 ```bash
 vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni \
-    --port 8000 \
+    --port 8000 \ # API server port for client requests
     --stage-configs-path vllm_omni/model_executor/stage_configs/bagel_multiconnector.yaml \
     --stage-id 0 \
-    -oma 10.244.227.244 \
+    -oma <ORCHESTRATOR_IP> \
     -omp 8091
 ```
 
@@ -127,7 +127,7 @@ vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni \
     --stage-configs-path vllm_omni/model_executor/stage_configs/bagel_multiconnector.yaml \
     --stage-id 1 \
     --headless \
-    -oma 10.244.227.244 \
+    -oma <ORCHESTRATOR_IP> \
     -omp 8091
 ```
 
@@ -150,7 +150,9 @@ vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni \
 | `-oma` | Orchestrator master address |
 | `-omp` | Orchestrator master port for Stage 1 to connect to Stage 0 for task coordination |
 
-> **Note**: Stage 0 (orchestrator) must be launched **before** Stage 1 (headless). Stage 0 will hang on startup until Stage 1 (worker) connects.
+> [!IMPORTANT]
+> **Startup Order**: Stage 0 (orchestrator) must be launched **before** Stage 1 (headless).
+> Stage 0 will appear to hang on startup until Stage 1 (worker) connects — this is expected behavior.
 
 **Network Requirements**
 


### PR DESCRIPTION
## Purpose
Add Mooncake connector usage documentation to BAGEL example READMEs, covering both single-node and multi-node deployment scenarios.
- Offline inference (examples/offline_inference/bagel/README.md): Add a "Using Mooncake Connector" section with prerequisites, Mooncake master startup instructions, and run commands for all modalities (text2img, img2text, text2text) using bagel_multiconnector.yaml.
- Online serving (examples/online_serving/bagel/README.md): Add a "Using Mooncake Connector" section for single-node Mooncake setup, and a separate "Multi-Node Deployment" section documenting cross-node stage-level deployment with --stage-id, --headless, -oma, and -omp arguments.
## Test Plan
Documentation-only change. No code changes.
- [x] Verified all referenced file paths (bagel_multiconnector.yaml, mooncake_store_connector.md) are valid
- [x] Verified markdown renders correctly via mkdocs serve
Test Result
N/A (documentation only)