### PR TITLE
[CI] Remove overwhelming debug log

### DIFF
--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -192,15 +192,6 @@ class GPUARModelRunner(OmniGPUModelRunner):
                 num_encoder_reqs=len(scheduler_output.scheduled_encoder_inputs),
             )
 
-            logger.debug(
-                "Running batch with cudagraph_mode: %s, batch_descriptor: %s, "
-                "should_ubatch: %s, num_tokens_across_dp: %s",
-                cudagraph_mode,
-                batch_desc,
-                should_ubatch,
-                num_tokens_across_dp,
-            )
-
             num_tokens_padded = batch_desc.num_tokens
             num_reqs_padded = batch_desc.num_reqs if batch_desc.num_reqs is not None else num_reqs
             ubatch_slices, ubatch_slices_padded = maybe_create_ubatch_slices(
@@ -209,12 +200,6 @@ class GPUARModelRunner(OmniGPUModelRunner):
                 num_tokens_padded,
                 num_reqs_padded,
                 self.parallel_config.num_ubatches,
-            )
-
-            logger.debug(
-                "ubatch_slices: %s, ubatch_slices_padded: %s",
-                ubatch_slices,
-                ubatch_slices_padded,
             )
 
             pad_attn = cudagraph_mode == CUDAGraphMode.FULL
@@ -308,15 +293,6 @@ class GPUARModelRunner(OmniGPUModelRunner):
                 aux_hidden_states = None
 
             hidden_states, multimodal_outputs = self.extract_multimodal_outputs(model_output)
-            if multimodal_outputs is not None:
-                keys_or_type = (
-                    list(multimodal_outputs.keys())
-                    if isinstance(multimodal_outputs, dict)
-                    else type(multimodal_outputs)
-                )
-                logger.debug(f"[AR] execute_model: multimodal_outputs keys = {keys_or_type}")
-            else:
-                logger.debug("[AR] execute_model: multimodal_outputs is None")
 
             if not self.broadcast_pp_output:
                 # Common case.

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1151,12 +1151,6 @@ class OmniGPUModelRunner(GPUModelRunner):
         """Inject omni-specific kwargs into forward and cache model output"""
         model_kwargs_extra = self._build_model_kwargs_extra()
 
-        runtime_info = model_kwargs_extra.get("runtime_additional_information", [])
-        if runtime_info:
-            for i, info in enumerate(runtime_info):
-                if info:
-                    logger.debug(f"[OMNI] req[{i}] runtime_additional_information keys: {list(info.keys())}")
-
         model_output = super()._model_forward(
             input_ids=input_ids,
             positions=positions,


### PR DESCRIPTION
## Purpose
Currently, there are duplicate debug log in CI making it unreadable. This PR is going to remove these logs.
```text
[2026-02-24T18:51:14Z] [0;36m(EngineCore_DP0 pid=1120)[0;0m [Stage-1] [37mDEBUG[0m [90m02-24 10:51:14[0m [90m[gpu_ar_model_runner.py:319][0m [AR] execute_model: multimodal_outputs is None
[2026-02-24T18:51:14Z] [0;36m(EngineCore_DP0 pid=1120)[0;0m [Stage-1] [37mDEBUG[0m [90m02-24 10:51:14[0m [90m[gpu_ar_model_runner.py:195][0m Running batch with cudagraph_mode: NONE, batch_descriptor: BatchDescriptor(num_tokens=1, num_reqs=None, uniform=False, has_lora=False, num_active_loras=0), should_ubatch: False, num_tokens_across_dp: None
[2026-02-24T18:51:14Z] [0;36m(EngineCore_DP0 pid=1120)[0;0m [Stage-1] [37mDEBUG[0m [90m02-24 10:51:14[0m [90m[gpu_ar_model_runner.py:214][0m ubatch_slices: None, ubatch_slices_padded: None
[2026-02-24T18:51:14Z] [0;36m(EngineCore_DP0 pid=1120)[0;0m [Stage-1] [37mDEBUG[0m [90m02-24 10:51:14[0m [90m[gpu_model_runner.py:1158][0m [OMNI] req[0] runtime_additional_information keys: ['thinker_result', 'prompt_embeds', 'prompt_token_ids', 'thinker_output_token_ids', 'thinker_result_shape', 'prompt_embeds_shape', 'thinker_reply_part']
[2026-02-24T18:51:14Z] [0;36m(EngineCore_DP0 pid=1120)[0;0m [Stage-1] [37mDEBUG[0m [90m02-24 10:51:14[0m [90m[gpu_ar_model_runner.py:319][0m [AR] execute_model: multimodal_outputs is None
[2026-02-24T18:51:14Z] [0;36m(EngineCore_DP0 pid=1120)[0;0m [Stage-1] [37mDEBUG[0m [90m02-24 10:51:14[0m [90m[gpu_ar_model_runner.py:195][0m Running batch with cudagraph_mode: NONE, batch_descriptor: BatchDescriptor(num_tokens=1, num_reqs=None, uniform=False, has_lora=False, num_active_loras=0), should_ubatch: False, num_tokens_across_dp: None
[2026-02-24T18:51:14Z] [0;36m(EngineCore_DP0 pid=1120)[0;0m [Stage-1] [37mDEBUG[0m [90m02-24 10:51:14[0m [90m[gpu_ar_model_runner.py:214][0m ubatch_slices: None, ubatch_slices_padded: None
[2026-02-24T18:51:14Z] [0;36m(EngineCore_DP0 pid=1120)[0;0m [Stage-1] [37mDEBUG[0m [90m02-24 10:51:14[0m [90m[gpu_model_runner.py:1158][0m [OMNI] req[0] runtime_additional_information keys: ['thinker_result', 'prompt_embeds', 'prompt_token_ids', 'thinker_output_token_ids', 'thinker_result_shape', 'prompt_embeds_shape', 'thinker_reply_part']
[2026-02-24T18:51:14Z] [0;36m(EngineCore_DP0 pid=1120)[0;0m [Stage-1] [37mDEBUG[0m [90m02-24 10:51:14[0m [90m[gpu_ar_model_runner.py:319][0m [AR] execute_model: multimodal_outputs is None
[2026-02-24T18:51:14Z] [0;36m(EngineCore_DP0 pid=1120)[0;0m [Stage-1] [37mDEBUG[0m [90m02-24 10:51:14[0m [90m[gpu_ar_model_runner.py:195][0m Running batch with cudagraph_mode: NONE, batch_descriptor: BatchDescriptor(num_tokens=1, num_reqs=None, uniform=False, has_lora=False, num_active_loras=0), should_ubatch: False, num_tokens_across_dp: None
```

## Test Plan
Tested on Qwen3 Omni offline with this command:
```bash
CUDA_VISIBLE_DEVICES=0,1 VLLM_LOGGING_LEVEL=DEBUG python3 end2end.py > test.log
```
## Test Result
All these four logs are removed
```bash
INFO 02-25 02:59:56 [omni.py:463] [Orchestrator] All stages initialized successfully
DEBUG 02-25 02:59:56 [omni.py:862] [Orchestrator] generate() called
DEBUG 02-25 02:59:56 [omni.py:920] [Orchestrator] Seeding 1 requests into stage-0
DEBUG 02-25 02:59:56 [omni.py:933] [Orchestrator] Enqueued request 0_5837994d-e129-4f91-bec9-fe65d96c1394 to stage-0
DEBUG 02-25 02:59:56 [omni.py:950] [Orchestrator] Entering scheduling loop: total_requests=1, stages=3
[Stage-0] DEBUG 02-25 03:00:07 [omni_stage.py:943] Received batch size=1, request_ids=['0_5837994d-e129-4f91-bec9-fe65d96c1394']
(EngineCore_DP0 pid=3075745) [Stage-0] DEBUG 02-25 03:00:14 [v1/engine/core.py:1049] EngineCore loop active.
(Worker pid=3077180) [Stage-0] DEBUG 02-25 03:00:14 [v1/worker/gpu_model_runner.py:2444] Finish execute for mm hash 38ed273d7d4a95538718ccd81e4181a463bac1d5fc59120acc810159f9579c4b
(Worker pid=3077180) [Stage-0] DEBUG 02-25 03:00:14 [v1/worker/ec_connector_model_runner_mixin.py:32] Not have ec transfer please check
(Worker pid=3077180) [Stage-0] DEBUG 02-25 03:00:14 [v1/worker/gpu_model_runner.py:2444] Finish execute for mm hash eff008d21a75ac7954469f7ed0e7b64c9cc31a2de5bad7a0f088ca23bf274365
(Worker pid=3077180) [Stage-0] DEBUG 02-25 03:00:14 [v1/worker/ec_connector_model_runner_mixin.py:32] Not have ec transfer please check
(Worker pid=3077180) [Stage-0] DEBUG 02-25 03:00:14 [v1/worker/gpu_model_runner.py:2444] Finish execute for mm hash 1c3146402655efa520bfb9ff995a09142319428b876bf7196cc5e14fbbf45d2e
(Worker pid=3077180) [Stage-0] DEBUG 02-25 03:00:14 [v1/worker/ec_connector_model_runner_mixin.py:32] Not have ec transfer please check
(EngineCore_DP0 pid=3075745) [Stage-0] DEBUG 02-25 03:00:18 [v1/engine/core.py:1043] EngineCore waiting for work.
[Stage-0] DEBUG 02-25 03:00:18 [omni_stage.py:976] Generate done: batch=1, req_ids=['0_5837994d-e129-4f91-bec9-fe65d96c1394'], gen_ms=11286.2
[Stage-0] DEBUG 02-25 03:00:18 [omni_stage.py:1043] Enqueued result for request 0_5837994d-e129-4f91-bec9-fe65d96c1394 to downstream
DEBUG 02-25 03:00:18 [omni.py:1010] [Orchestrator] Stage-0 completed request 0_5837994d-e129-4f91-bec9-fe65d96c1394; forwarding or finalizing
DEBUG 02-25 03:00:18 [omni.py:1016] [Orchestrator] Request 0_5837994d-e129-4f91-bec9-fe65d96c1394 finalized at stage-0
DEBUG 02-25 03:00:19 [omni.py:1100] [Orchestrator] Forwarded request 0_5837994d-e129-4f91-bec9-fe65d96c1394 to stage-1
[Stage-1] DEBUG 02-25 03:00:29 [omni_stage.py:943] Received batch size=1, request_ids=['0_5837994d-e129-4f91-bec9-fe65d96c1394']
(EngineCore_DP0 pid=3075487) [Stage-1] DEBUG 02-25 03:00:29 [v1/engine/core.py:1049] EngineCore loop active.
(Worker pid=3077106) [Stage-1] INFO 02-25 03:00:29 [mrope.py:345] Multimodal token idx changed!
(EngineCore_DP0 pid=3075487) [Stage-1] DEBUG 02-25 03:00:49 [v1/engine/core.py:1043] EngineCore waiting for work.
[Stage-1] DEBUG 02-25 03:00:49 [omni_stage.py:976] Generate done: batch=1, req_ids=['0_5837994d-e129-4f91-bec9-fe65d96c1394'], gen_ms=20362.9
[Stage-1] DEBUG 02-25 03:00:49 [omni_stage.py:1043] Enqueued result for request 0_5837994d-e129-4f91-bec9-fe65d96c1394 to downstream
DEBUG 02-25 03:00:49 [omni.py:1010] [Orchestrator] Stage-1 completed request 0_5837994d-e129-4f91-bec9-fe65d96c1394; forwarding or finalizing
DEBUG 02-25 03:00:49 [omni.py:1100] [Orchestrator] Forwarded request 0_5837994d-e129-4f91-bec9-fe65d96c1394 to stage-2
[Stage-2] DEBUG 02-25 03:00:59 [omni_stage.py:943] Received batch size=1, request_ids=['0_5837994d-e129-4f91-bec9-fe65d96c1394']
(EngineCore_DP0 pid=3075563) [Stage-2] DEBUG 02-25 03:00:59 [v1/engine/core.py:1049] EngineCore loop active.
(Worker pid=3077165) [Stage-2] INFO 02-25 03:00:59 [mrope.py:345] Multimodal token idx changed!
(Worker pid=3077165) [Stage-2] DEBUG 02-25 03:01:00 [gpu_generation_model_runner.py:178] Running batch with cudagraph_mode: NONE, batch_descriptor: BatchDescriptor(num_tokens=18608, num_reqs=None, uniform=False, has_lora=False, num_active_loras=0), should_ubatch: False, num_tokens_across_dp: None
(Worker pid=3077165) [Stage-2] DEBUG 02-25 03:01:00 [gpu_generation_model_runner.py:197] ubatch_slices: None, ubatch_slices_padded: None
(EngineCore_DP0 pid=3075563) [Stage-2] DEBUG 02-25 03:01:00 [v1/engine/core.py:1043] EngineCore waiting for work.
[Stage-2] DEBUG 02-25 03:01:00 [omni_stage.py:976] Generate done: batch=1, req_ids=['0_5837994d-e129-4f91-bec9-fe65d96c1394'], gen_ms=479.0
[Stage-2] DEBUG 02-25 03:01:00 [omni_stage.py:1043] Enqueued result for request 0_5837994d-e129-4f91-bec9-fe65d96c1394 to downstream
DEBUG 02-25 03:01:00 [omni.py:1010] [Orchestrator] Stage-2 completed request 0_5837994d-e129-4f91-bec9-fe65d96c1394; forwarding or finalizing
DEBUG 02-25 03:01:00 [omni.py:1016] [Orchestrator] Request 0_5837994d-e129-4f91-bec9-fe65d96c1394 finalized at stage-2
DEBUG 02-25 03:01:00 [omni.py:1110] [Orchestrator] Request 0_5837994d-e129-4f91-bec9-fe65d96c1394 fully completed (1/1)
DEBUG 02-25 03:01:00 [omni.py:1116] [Orchestrator] All requests completed
[Stage-2] INFO 02-25 03:01:00 [omni_stage.py:837] Received shutdown signal
[Stage-1] INFO 02-25 03:01:00 [omni_stage.py:837] Received shutdown signal
[Stage-0] INFO 02-25 03:01:00 [omni_stage.py:837] Received shutdown signal
query type: use_mixed_modalities
Request ID: 0_5837994d-e129-4f91-bec9-fe65d96c1394, Text saved to output_audio/0_5837994d-e129-4f91-bec9-fe65d96c1394.txt
Request ID: 0_5837994d-e129-4f91-bec9-fe65d96c1394, Saved audio to output_audio/output_0_5837994d-e129-4f91-bec9-fe65d96c1394.wav
WARNING 02-25 03:01:00 [omni_stage.py:540] Failed to send shutdown to in_q: Socket operation on non-socket
(EngineCore_DP0 pid=3075745) [Stage-0] DEBUG 02-25 03:01:00 [v1/engine/core.py:1002] EngineCore exiting.
(EngineCore_DP0 pid=3075563) [Stage-2] DEBUG 02-25 03:01:00 [v1/engine/core.py:1002] EngineCore exiting.
(Worker pid=3077165) [Stage-2] INFO 02-25 03:01:00 [v1/executor/multiproc_executor.py:732] Parent process exited, terminating worker
(Worker pid=3077165) [Stage-2] INFO 02-25 03:01:00 [v1/executor/multiproc_executor.py:785] WorkerProc shutting down.
(Worker pid=3077180) [Stage-0] INFO 02-25 03:01:00 [v1/executor/multiproc_executor.py:732] Parent process exited, terminating worker
(EngineCore_DP0 pid=3075487) [Stage-1] DEBUG 02-25 03:01:00 [v1/engine/core.py:1002] EngineCore exiting.
(Worker pid=3077180) [Stage-0] INFO 02-25 03:01:00 [v1/executor/multiproc_executor.py:785] WorkerProc shutting down.
(Worker pid=3077106) [Stage-1] INFO 02-25 03:01:00 [v1/executor/multiproc_executor.py:732] Parent process exited, terminating worker
(Worker pid=3077106) [Stage-1] INFO 02-25 03:01:00 [v1/executor/multiproc_executor.py:785] WorkerProc shutting down.
WARNING 02-25 03:01:04 [omni_stage.py:540] Failed to send shutdown to in_q: Socket operation on non-socket
WARNING 02-25 03:01:05 [omni_stage.py:540] Failed to send shutdown to in_q: Socket operation on non-socket
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please providing the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
