### PR TITLE
[Bugfix]: initialize num_cached_tokens in generation scheduler to prevent metrics crash

### DIFF
--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -103,6 +103,8 @@ class OmniGenerationScheduler(VLLMScheduler):
                 break
             if self.log_stats:
                 request.record_event(EngineCoreEventType.SCHEDULED, scheduled_timestamp)
+            if request.num_cached_tokens < 0:
+                request.num_cached_tokens = num_computed_tokens
             req_to_new_blocks[request.request_id] = new_blocks
             num_scheduled_tokens[request.request_id] = num_new_tokens
             cached_prompt_token_ids[request.request_id] = request.prompt_token_ids
@@ -164,6 +166,8 @@ class OmniGenerationScheduler(VLLMScheduler):
             self.running.append(request)
             if self.log_stats:
                 request.record_event(EngineCoreEventType.SCHEDULED, scheduled_timestamp)
+            if request.num_cached_tokens < 0:
+                request.num_cached_tokens = request.num_computed_tokens
 
             req_to_new_blocks[request.request_id] = new_blocks
             num_scheduled_tokens[request.request_id] = num_new_tokens


### PR DESCRIPTION
## Summary
- Initialize `request.num_cached_tokens` in `OmniGenerationScheduler.schedule()` to prevent Prometheus counter crash
- The base vLLM scheduler does this initialization, but the generation scheduler's fast path skipped it
- Without this fix, `num_cached_tokens` stays at `-1` (sentinel), producing a negative `local_cache_hit` value that crashes the Prometheus counter

## Root Cause
`num_cached_tokens` is initialized to `-1` in `vllm/v1/request.py`. The base `Scheduler.schedule()` sets it to `num_computed_tokens` on first scheduling. `OmniGenerationScheduler` overrides `schedule()` with a fast path that skips this initialization. When metrics are recorded, `PromptTokenStats.local_cache_hit` becomes negative (`-1 + 0 - 0 = -1`), and `prometheus_client.Counter.inc(-1)` raises `ValueError`.

This kills the Stage-1 engine after the first request, making all subsequent requests fail with `EngineDeadError`.

## Fix
Add the same `num_cached_tokens` initialization (matching the base scheduler) in both scheduling loops:
- Running requests loop (line 106)
- Waiting requests loop (line 169)

## Test plan
- [ ] Verify Stage-1 engine survives multiple consecutive TTS requests
- [ ] Verify metrics are recorded correctly with non-negative values

Fixes #1477