### PR TITLE
[Bugfix][Model] Fix LongCat Image Config Handling / Layer Creation

### DIFF
--- a/vllm_omni/diffusion/models/longcat_image/longcat_image_transformer.py
+++ b/vllm_omni/diffusion/models/longcat_image/longcat_image_transformer.py
@@ -528,7 +528,6 @@ class LongCatImageTransformer2DModel(nn.Module):
         num_attention_heads = model_config.num_attention_heads
         joint_attention_dim = model_config.joint_attention_dim
         pooled_projection_dim = model_config.pooled_projection_dim
-        axes_dims_rope = model_config.axes_dims_rope if hasattr(model_config, "axes_dims_rope") else [16, 56, 56]
         axes_dims_rope = getattr(model_config, "axes_dims_rope", [16, 56, 56])
         self.out_channels = in_channels
         self.inner_dim = num_attention_heads * attention_head_dim


### PR DESCRIPTION
## Purpose
Fixes the LongCat bug mentioned in https://github.com/vllm-project/vllm-omni/issues/1456; currently the LongCat pipeline is relying on default param values at init time instead of parsing them from the config; the default values are incorrect for the number of transformer layers in models like `LongCat-Image`, see the [config](https://huggingface.co/meituan-longcat/LongCat-Image/blob/main/transformer/config.json)

- `num_layers` should be 10, but currently we make 19
- `num_single_layers` should be 20, but currently we make 38

This PR pulls the values from the config to avoid creating the extra transformers layers that don't have weights.

## Test Plan
You can check this by running a generation and timing / measuring resources.
```python
from time import time
from vllm_omni.entrypoints.omni import Omni
from vllm_omni.inputs.data import OmniDiffusionSamplingParams


sampling_params = OmniDiffusionSamplingParams(
    height=768,
    width=1344,
    guidance_scale=4.0,
    num_inference_steps=50,
    seed=42,
)
if __name__ == "__main__":
    omni = Omni(model="meituan-longcat/LongCat-Image")
    prompt = "a cup of coffee on the table"
    start = time()
    outputs = omni.generate(prompt, sampling_params)
    end = time()
    print(f"Generation time -> {end - start}")
    images = outputs[0].request_output[0].images
    images[0].save("coffee.png")
```

## Test Result
Resource consumption is lower and generation is much faster; example numbers for running on an A100:

Prior to the fix:
- GPU usage from nvidia-smi is around `43912MiB` and the generation time is about 46 seconds

After the fix:
- GPU usage from nvidia-smi is around `33218MiB` and the generation time is about 25 seconds

Output is visually identical before/after the fix:
<img width="1344" height="768" alt="coffee_fixed" src="https://github.com/user-attachments/assets/5cd35095-7a99-4c1f-a0ea-598217f291d6" />
