### PR TITLE
[Doc] Update installation instructions for vllm 0.16.0

### DIFF
--- a/docs/getting_started/installation/gpu/cuda.inc.md
+++ b/docs/getting_started/installation/gpu/cuda.inc.md
@@ -20,20 +20,7 @@ Therefore, it is recommended to install vLLM and vLLM-Omni with a **fresh new** 
 
 vLLM-Omni is built based on vLLM. Please install it with command below.
 ```bash
-# vllm 0.16.0 is still under prerelease
-uv pip install --prerelease=allow vllm --extra-index-url https://wheels.vllm.ai/2d5be1dd5ce2e44dfea53ea03ff61143da5137eb
-
-# vllm 0.16.0 may have some bugs for cuda 12.9, here is how we solve them:
-export FLASHINFER_CUDA_TAG="$(python3 -c 'import torch; print((torch.version.cuda or "12.4").replace(".", ""))')"
-
-uv pip install --upgrade --force-reinstall \
-  "flashinfer-python==0.6.3" \
-  "flashinfer-cubin==0.6.3" \
-  "flashinfer-jit-cache==0.6.3" \
-  --extra-index-url "https://flashinfer.ai/whl/cu${FLASHINFER_CUDA_TAG}"
-
-uv pip install --upgrade --force-reinstall "nvidia-cublas-cu12==12.9.1.4"
-uv pip install --upgrade --force-reinstall "numpy==2.2.6"
+uv pip install vllm --torch-backend=auto
 ```
 
 #### Installation of vLLM-Omni

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -19,18 +19,7 @@ uv venv --python 3.12 --seed
 source .venv/bin/activate
 
 # On CUDA
-# vllm 0.16.0 is still under prerelease
-uv pip install --prerelease=allow vllm --extra-index-url https://wheels.vllm.ai/2d5be1dd5ce2e44dfea53ea03ff61143da5137eb
-# vllm 0.16.0 may have some bugs for cuda 12.9, here is how we solve them:
-export FLASHINFER_CUDA_TAG="$(python3 -c 'import torch; print((torch.version.cuda or "12.4").replace(".", ""))')"
-uv pip install --upgrade --force-reinstall \
-  "flashinfer-python==0.6.3" \
-  "flashinfer-cubin==0.6.3" \
-  "flashinfer-jit-cache==0.6.3" \
-  --extra-index-url "https://flashinfer.ai/whl/cu${FLASHINFER_CUDA_TAG}"
-uv pip install --upgrade --force-reinstall "nvidia-cublas-cu12==12.9.1.4"
-uv pip install --upgrade --force-reinstall "numpy==2.2.6"
-
+uv pip install vllm==0.16.0 --torch-backend=auto
 
 # On ROCm
 uv pip install vllm==0.16.0 --extra-index-url https://wheels.vllm.ai/rocm/0.16.0/rocm700


### PR DESCRIPTION
## Purpose
As the vllm v0.16.0 is officially released, we do not need to use the prerelease to install.
## Test Plan
Tested on a new Dockerfile:
```Dockerfile
FROM nvidia/cuda:12.9.0-devel-ubuntu22.04

ENV DEBIAN_FRONTEND=noninteractive \
    PYTHONUNBUFFERED=1 \
    PIP_NO_CACHE_DIR=1 \
    HF_HOME=/models/ \
    HF_HUB_CACHE=/models/hub \
    TRANSFORMERS_CACHE=/models/huggingface/transformers

RUN apt-get update && apt-get install -y --no-install-recommends \
    python3 python3-pip python3-dev ffmpeg sox libsox-fmt-all nvtop \
    git curl ca-certificates build-essential \
    && rm -rf /var/lib/apt/lists/*

# Install uv to /usr/local/bin (recommended)
RUN set -eux; \
    apt-get update; apt-get install -y --no-install-recommends curl ca-certificates; \
    rm -rf /var/lib/apt/lists/*; \
    curl -LsSf https://astral.sh/uv/install.sh | sh; \
    ln -sf /root/.local/bin/uv /usr/local/bin/uv; \
    uv --version

# Copy vllm-omni project for local installation
COPY vllm-omni /app/vllm-omni
WORKDIR /app/vllm-omni

# Create venv with Python 3.12
RUN cd /app/vllm-omni && uv venv --python 3.12 --seed

# Set environment to use the venv (persists across layers)
ENV VIRTUAL_ENV=/app/vllm-omni/.venv
ENV PATH="/app/vllm-omni/.venv/bin:$PATH"

# Install vllm and vllm-omni in the venv
RUN uv pip install vllm==0.16.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
    uv pip install -e .[dev] -i https://pypi.tuna.tsinghua.edu.cn/simple

ENTRYPOINT []
CMD ["python", "-c", "import torch, vllm; print('torch:', torch.__version__); print('vllm:', vllm.__version__); print('cuda:', torch.version.cuda); print('gpu:', torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'no')"]
```
## Test Result
Qwen 3 Omni offline passed:
```bash
dyvm6xrauser49@hk01dgx028:/scratch/dyvm6xra/dyvm6xrauser49/test$ docker run -it --rm --gpus all --name vllm-omni-test-cu129-omni   -v /scratch/dyvm6xra/dyvm6xrauser49/rebase/models:/models   cuda129-vllm-omni:latest bash
root@6c0bab862197:/app/vllm-omni# cd examples/offline_inference/qwen3_omni/
root@6c0bab862197:/app/vllm-omni/examples/offline_inference/qwen3_omni# python3 end2end.py 
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
WARNING 02-26 07:41:02 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
==================== 
 vllm version: 0.16.0 
 ====================
sample_demo_1.mp4: 100%|██████████████████████████████████████████████████████████████████████████████████████| 1.55M/1.55M [00:01<00:00, 1.02MB/s]
INFO 02-26 07:41:25 [weight_utils.py:50] Using model weights format ['*']
INFO 02-26 07:41:25 [omni.py:181] Initializing stages for model: Qwen/Qwen3-Omni-30B-A3B-Instruct
INFO 02-26 07:41:25 [omni.py:306] No omni_master_address provided, defaulting to localhost (127.0.0.1)
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'mrope_interleaved', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'mrope_interleaved', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
INFO 02-26 07:41:27 [initialization.py:251] Auto-configuring SharedMemoryConnector for edge ('0', '1')
INFO 02-26 07:41:27 [initialization.py:251] Auto-configuring SharedMemoryConnector for edge ('1', '2')
INFO 02-26 07:41:27 [initialization.py:270] Loaded OmniTransferConfig with 2 connector configurations
INFO 02-26 07:41:27 [factory.py:46] Created connector: SharedMemoryConnector
INFO 02-26 07:41:27 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
INFO 02-26 07:41:27 [factory.py:46] Created connector: SharedMemoryConnector
INFO 02-26 07:41:27 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
INFO 02-26 07:41:27 [omni_stage.py:254] [OmniStage] stage_config: {'stage_id': 0, 'stage_type': 'llm', 'runtime': {'devices': '0', 'max_batch_size': 64}, 'engine_args': {'stage_configs_path': None, 'log_stats': False, 'stage_init_timeout': 300, 'model': 'Qwen/Qwen3-Omni-30B-A3B-Instruct', 'model_stage': 'thinker', 'model_arch': 'Qwen3OmniMoeForConditionalGeneration', 'worker_type': 'ar', 'scheduler_cls': 'vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler', 'gpu_memory_utilization': 0.9, 'enforce_eager': False, 'trust_remote_code': True, 'engine_output_type': 'latent', 'distributed_executor_backend': 'mp', 'enable_prefix_caching': False, 'max_num_batched_tokens': 32768, 'hf_config_name': 'thinker_config', 'tensor_parallel_size': 1, 'max_num_seqs': 64, 'async_chunk': False}, 'final_output': True, 'final_output_type': 'text', 'is_comprehension': True, 'default_sampling_params': {'temperature': 0.4, 'top_p': 0.9, 'top_k': 1, 'max_tokens': 2048, 'seed': 42, 'detokenize': True, 'repetition_penalty': 1.05}}
INFO 02-26 07:41:27 [omni_stage.py:254] [OmniStage] stage_config: {'stage_id': 1, 'stage_type': 'llm', 'runtime': {'devices': '1', 'max_batch_size': 64}, 'engine_args': {'stage_configs_path': None, 'log_stats': False, 'stage_init_timeout': 300, 'model': 'Qwen/Qwen3-Omni-30B-A3B-Instruct', 'model_stage': 'talker', 'model_arch': 'Qwen3OmniMoeForConditionalGeneration', 'worker_type': 'ar', 'scheduler_cls': 'vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler', 'gpu_memory_utilization': 0.6, 'enforce_eager': False, 'trust_remote_code': True, 'engine_output_type': 'latent', 'enable_prefix_caching': False, 'max_num_batched_tokens': 32768, 'distributed_executor_backend': 'mp', 'hf_config_name': 'talker_config', 'max_num_seqs': 64, 'async_chunk': False}, 'engine_input_source': [0], 'custom_process_input_func': 'vllm_omni.model_executor.stage_input_processors.qwen3_omni.thinker2talker', 'default_sampling_params': {'temperature': 0.9, 'top_k': 50, 'max_tokens': 4096, 'seed': 42, 'detokenize': False, 'repetition_penalty': 1.05, 'stop_token_ids': [2150]}}
INFO 02-26 07:41:27 [omni_stage.py:254] [OmniStage] stage_config: {'stage_id': 2, 'stage_type': 'llm', 'runtime': {'devices': '1', 'max_batch_size': 64}, 'engine_args': {'stage_configs_path': None, 'log_stats': False, 'stage_init_timeout': 300, 'model': 'Qwen/Qwen3-Omni-30B-A3B-Instruct', 'model_stage': 'code2wav', 'model_arch': 'Qwen3OmniMoeForConditionalGeneration', 'worker_type': 'generation', 'scheduler_cls': 'vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler', 'enforce_eager': True, 'trust_remote_code': True, 'async_scheduling': False, 'enable_prefix_caching': False, 'engine_output_type': 'audio', 'gpu_memory_utilization': 0.1, 'distributed_executor_backend': 'mp', 'max_num_batched_tokens': 1000000, 'hf_config_name': 'thinker_config', 'max_num_seqs': 64, 'async_chunk': False}, 'engine_input_source': [1], 'custom_process_input_func': 'vllm_omni.model_executor.stage_input_processors.qwen3_omni.talker2code2wav', 'final_output': True, 'final_output_type': 'audio', 'default_sampling_params': {'temperature': 0.0, 'top_p': 1.0, 'top_k': -1, 'max_tokens': 65536, 'seed': 42, 'detokenize': True, 'repetition_penalty': 1.1}}
INFO 02-26 07:41:27 [omni.py:340] [Orchestrator] Loaded 3 stages
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
[Stage-1] WARNING 02-26 07:41:36 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
[Stage-1] INFO 02-26 07:41:36 [omni_stage.py:678] Starting stage worker with model: Qwen/Qwen3-Omni-30B-A3B-Instruct
[Stage-0] WARNING 02-26 07:41:36 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
[Stage-1] INFO 02-26 07:41:36 [omni_stage.py:693] [Stage] Set VLLM_WORKER_MULTIPROC_METHOD=spawn
[Stage-1] INFO 02-26 07:41:36 [omni_stage.py:721] [Stage-1] ZMQ transport detected; disabling SHM IPC (shm_threshold_bytes set to maxsize)
[Stage-1] INFO 02-26 07:41:36 [omni_stage.py:84] Using sequential init locks (nvml_available=True, pid_host=False)
[Stage-0] INFO 02-26 07:41:36 [omni_stage.py:678] Starting stage worker with model: Qwen/Qwen3-Omni-30B-A3B-Instruct
[Stage-0] INFO 02-26 07:41:36 [omni_stage.py:693] [Stage] Set VLLM_WORKER_MULTIPROC_METHOD=spawn
[Stage-0] INFO 02-26 07:41:36 [omni_stage.py:721] [Stage-0] ZMQ transport detected; disabling SHM IPC (shm_threshold_bytes set to maxsize)
[Stage-0] INFO 02-26 07:41:36 [omni_stage.py:84] Using sequential init locks (nvml_available=True, pid_host=False)
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_interleaved', 'interleaved', 'mrope_section'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_interleaved', 'mrope_section', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_interleaved', 'interleaved', 'mrope_section'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_interleaved', 'mrope_section', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
[Stage-1] INFO 02-26 07:41:38 [initialization.py:251] Auto-configuring SharedMemoryConnector for edge ('0', '1')
[Stage-1] INFO 02-26 07:41:38 [initialization.py:251] Auto-configuring SharedMemoryConnector for edge ('1', '2')
[Stage-1] INFO 02-26 07:41:38 [initialization.py:270] Loaded OmniTransferConfig with 2 connector configurations
[Stage-1] INFO 02-26 07:41:38 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-1] INFO 02-26 07:41:38 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
[Stage-1] INFO 02-26 07:41:38 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-1] INFO 02-26 07:41:38 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
[Stage-0] INFO 02-26 07:41:38 [initialization.py:251] Auto-configuring SharedMemoryConnector for edge ('0', '1')
[Stage-0] INFO 02-26 07:41:38 [initialization.py:251] Auto-configuring SharedMemoryConnector for edge ('1', '2')
[Stage-0] INFO 02-26 07:41:38 [initialization.py:270] Loaded OmniTransferConfig with 2 connector configurations
[Stage-0] INFO 02-26 07:41:38 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-0] INFO 02-26 07:41:38 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
[Stage-0] INFO 02-26 07:41:38 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-0] INFO 02-26 07:41:38 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_interleaved', 'interleaved', 'mrope_section'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_interleaved', 'mrope_section', 'interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section', 'interleaved'}
[Stage-2] WARNING 02-26 07:41:45 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
INFO 02-26 07:41:45 [omni.py:447] [Orchestrator] Waiting for 3 stages to initialize (timeout: 300s)
[Stage-2] INFO 02-26 07:41:45 [omni_stage.py:678] Starting stage worker with model: Qwen/Qwen3-Omni-30B-A3B-Instruct
[Stage-2] INFO 02-26 07:41:45 [omni_stage.py:693] [Stage] Set VLLM_WORKER_MULTIPROC_METHOD=spawn
[Stage-2] INFO 02-26 07:41:45 [omni_stage.py:721] [Stage-2] ZMQ transport detected; disabling SHM IPC (shm_threshold_bytes set to maxsize)
[Stage-2] INFO 02-26 07:41:45 [omni_stage.py:84] Using sequential init locks (nvml_available=True, pid_host=False)
[Stage-0] INFO 02-26 07:41:49 [model.py:529] Resolved architecture: Qwen3OmniMoeForConditionalGeneration
[Stage-0] INFO 02-26 07:41:49 [model.py:1549] Using max model len 65536
[Stage-0] INFO 02-26 07:41:49 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=32768.
[Stage-0] INFO 02-26 07:41:49 [vllm.py:689] Asynchronous scheduling is enabled.
[Stage-1] INFO 02-26 07:41:50 [model.py:529] Resolved architecture: Qwen3OmniMoeForConditionalGeneration
[Stage-1] INFO 02-26 07:41:50 [model.py:1549] Using max model len 65536
[Stage-1] INFO 02-26 07:41:50 [model.py:1549] Using max model len 65536
[Stage-1] INFO 02-26 07:41:50 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=32768.
[Stage-1] INFO 02-26 07:41:50 [vllm.py:689] Asynchronous scheduling is enabled.
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
[Stage-0] WARNING 02-26 07:42:14 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
(EngineCore_DP0 pid=2111) [Stage-0] INFO 02-26 07:42:14 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='Qwen/Qwen3-Omni-30B-A3B-Instruct', speculative_config=None, tokenizer='Qwen/Qwen3-Omni-30B-A3B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=65536, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen3-Omni-30B-A3B-Instruct, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [32768], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 128, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=2111) [Stage-0] WARNING 02-26 07:42:14 [multiproc_executor.py:921] Reducing Torch parallelism from 112 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
[Stage-1] WARNING 02-26 07:42:14 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
(EngineCore_DP0 pid=2177) [Stage-1] INFO 02-26 07:42:14 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='Qwen/Qwen3-Omni-30B-A3B-Instruct', speculative_config=None, tokenizer='Qwen/Qwen3-Omni-30B-A3B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=65536, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen3-Omni-30B-A3B-Instruct, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [32768], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 128, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=2177) [Stage-1] WARNING 02-26 07:42:14 [multiproc_executor.py:921] Reducing Torch parallelism from 112 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
[Stage-0] WARNING 02-26 07:42:22 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
[Stage-1] WARNING 02-26 07:42:23 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
[Stage-0] INFO 02-26 07:42:24 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:45575 backend=nccl
[Stage-0] INFO 02-26 07:42:24 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0
[Stage-1] INFO 02-26 07:42:25 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:50733 backend=nccl
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
[Stage-1] INFO 02-26 07:42:25 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
(Worker pid=2637) [Stage-0] INFO 02-26 07:42:37 [gpu_model_runner.py:4124] Starting to load model Qwen/Qwen3-Omni-30B-A3B-Instruct...
(Worker pid=2642) [Stage-1] INFO 02-26 07:42:38 [gpu_model_runner.py:4124] Starting to load model Qwen/Qwen3-Omni-30B-A3B-Instruct...
(Worker pid=2637) [Stage-0] INFO 02-26 07:42:38 [vllm.py:689] Asynchronous scheduling is enabled.
(Worker pid=2637) [Stage-0] INFO 02-26 07:42:38 [mm_encoder_attention.py:77] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
(Worker pid=2642) [Stage-1] INFO 02-26 07:42:38 [vllm.py:689] Asynchronous scheduling is enabled.
(Worker pid=2642) [Stage-1] INFO 02-26 07:42:54 [cuda.py:367] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(Worker pid=2637) [Stage-0] INFO 02-26 07:42:54 [cuda.py:367] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(Worker pid=2637) [Stage-0] INFO 02-26 07:42:54 [unquantized.py:131] Using TRITON backend for Unquantized MoE
(Worker pid=2642) [Stage-1] INFO 02-26 07:42:54 [unquantized.py:131] Using TRITON backend for Unquantized MoE
(Worker pid=2642) [Stage-1] WARNING 02-26 07:42:54 [qwen3_omni_moe_code_predictor_mtp.py:108] CUDAGraphMode.FULL_AND_PIECEWISE is currently not supported with flash attention for Qwen3-Omni talker MTP.removing flash attention from attention_backends
(Worker pid=2642) [Stage-1] WARNING 02-26 07:42:54 [qwen3_omni_moe_code_predictor_mtp.py:108] CUDAGraphMode.FULL_AND_PIECEWISE is currently not supported with flash attention for Qwen3-Omni talker MTP.removing flash attention from attention_backends
(Worker pid=2642) [Stage-1] WARNING 02-26 07:42:54 [qwen3_omni_moe_code_predictor_mtp.py:108] CUDAGraphMode.FULL_AND_PIECEWISE is currently not supported with flash attention for Qwen3-Omni talker MTP.removing flash attention from attention_backends
(Worker pid=2642) [Stage-1] WARNING 02-26 07:42:54 [qwen3_omni_moe_code_predictor_mtp.py:108] CUDAGraphMode.FULL_AND_PIECEWISE is currently not supported with flash attention for Qwen3-Omni talker MTP.removing flash attention from attention_backends
(Worker pid=2642) [Stage-1] WARNING 02-26 07:42:54 [qwen3_omni_moe_code_predictor_mtp.py:108] CUDAGraphMode.FULL_AND_PIECEWISE is currently not supported with flash attention for Qwen3-Omni talker MTP.removing flash attention from attention_backends
(Worker pid=2642) [Stage-1] INFO 02-26 07:42:55 [mm_encoder_attention.py:77] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
Loading safetensors checkpoint shards:   0% Completed | 0/15 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  40% Completed | 6/15 [00:00<00:00, 54.53it/s]
Loading safetensors checkpoint shards:  80% Completed | 12/15 [00:00<00:00, 53.00it/s]
Loading safetensors checkpoint shards:   0% Completed | 0/15 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 15/15 [00:00<00:00, 23.55it/s]
(Worker pid=2637) 
Loading safetensors checkpoint shards:  40% Completed | 6/15 [00:00<00:00, 55.90it/s]
Loading safetensors checkpoint shards:  80% Completed | 12/15 [00:00<00:00, 54.20it/s]
Loading safetensors checkpoint shards: 100% Completed | 15/15 [00:00<00:00, 22.63it/s]
(Worker pid=2642) 
(Worker pid=2642) [Stage-1] INFO 02-26 07:43:00 [qwen3_omni_moe_talker.py:465] [Model Loaded] name=Qwen3OmniMoeTalkerForConditionalGeneration, success=True, size=8604.35 MB, device=cuda:0
(Worker pid=2642) [Stage-1] INFO 02-26 07:43:00 [qwen3_omni.py:1162] Loaded 1200 weights for Qwen3OmniMoe (stage=talker)
(Worker pid=2642) [Stage-1] INFO 02-26 07:43:01 [default_loader.py:293] Loading weights took 4.12 seconds
(Worker pid=2642) [Stage-1] INFO 02-26 07:43:01 [gpu_model_runner.py:4221] Model loading took 8.5 GiB memory and 22.265327 seconds
(Worker pid=2642) [Stage-1] INFO 02-26 07:43:01 [gpu_model_runner.py:5140] Encoder cache will be initialized with a budget of 62720 tokens, and profiled with 1 video items of the maximum feature size.
(Worker pid=2642) [Stage-1] WARNING 02-26 07:43:03 [qwen3_omni_moe_talker.py:377] 
(Worker pid=2642) [Stage-1] WARNING 02-26 07:43:03 [qwen3_omni_moe_talker.py:377] 
(Worker pid=2642) [Stage-1] WARNING 02-26 07:43:03 [qwen3_omni_moe_talker.py:377] 
(Worker pid=2642) [Stage-1] WARNING 02-26 07:43:03 [qwen3_omni_moe_talker.py:377] THIS FUNCTION RETURNS DUMMY MULTIMODAL EMBEDDINGS FOR PROFILE RUN, SHOULD NOT BE CALLED IN INFERENCE.
(Worker pid=2642) [Stage-1] WARNING 02-26 07:43:03 [qwen3_omni_moe_talker.py:377] 
(Worker pid=2642) [Stage-1] WARNING 02-26 07:43:03 [qwen3_omni_moe_talker.py:377] 
(Worker pid=2642) [Stage-1] WARNING 02-26 07:43:03 [qwen3_omni_moe_talker.py:377] 
(Worker pid=2642) [Stage-1] WARNING 02-26 07:43:16 [backends.py:882] Failed to read file <frozen _collections_abc>
(Worker pid=2642) [Stage-1] INFO 02-26 07:43:16 [backends.py:916] Using cache directory: /root/.cache/vllm/torch_compile_cache/1c0dc3eaf5/rank_0_0/backbone for vLLM's torch.compile
(Worker pid=2642) [Stage-1] INFO 02-26 07:43:16 [backends.py:976] Dynamo bytecode transform time: 12.23 s
(Worker pid=2637) [Stage-0] INFO 02-26 07:43:22 [qwen3_omni.py:1162] Loaded 1183 weights for Qwen3OmniMoe (stage=thinker)
(Worker pid=2637) [Stage-0] INFO 02-26 07:43:25 [default_loader.py:293] Loading weights took 28.94 seconds
(Worker pid=2637) [Stage-0] INFO 02-26 07:43:25 [gpu_model_runner.py:4221] Model loading took 59.54 GiB memory and 47.181674 seconds
(Worker pid=2637) [Stage-0] INFO 02-26 07:43:26 [gpu_model_runner.py:5140] Encoder cache will be initialized with a budget of 62720 tokens, and profiled with 1 video items of the maximum feature size.
(Worker pid=2637) [Stage-0] INFO 02-26 07:43:34 [backends.py:916] Using cache directory: /root/.cache/vllm/torch_compile_cache/9e7a592cf5/rank_0_0/backbone for vLLM's torch.compile
(Worker pid=2637) [Stage-0] INFO 02-26 07:43:34 [backends.py:976] Dynamo bytecode transform time: 6.81 s
(Worker pid=2637) [Stage-0] INFO 02-26 07:43:45 [backends.py:351] Cache the graph of compile range (1, 32768) for later use
(Worker pid=2637) [Stage-0] WARNING 02-26 07:43:48 [fused_moe.py:1087] Using default MoE config. Performance might be sub-optimal! Config file not found at /app/vllm-omni/.venv/lib/python3.12/site-packages/vllm/model_executor/layers/fused_moe/configs/E=128,N=768,device_name=NVIDIA_H800.json
(Worker pid=2637) [Stage-0] INFO 02-26 07:43:53 [backends.py:368] Compiling a graph for compile range (1, 32768) takes 14.52 s
(Worker pid=2637) [Stage-0] INFO 02-26 07:43:53 [monitor.py:34] torch.compile takes 21.33 s in total
(Worker pid=2637) [Stage-0] INFO 02-26 07:43:54 [base.py:102] Available KV cache memory: 8.68 GiB (profiling fallback)
(EngineCore_DP0 pid=2111) [Stage-0] INFO 02-26 07:43:54 [kv_cache_utils.py:1307] GPU KV cache size: 94,768 tokens
(EngineCore_DP0 pid=2111) [Stage-0] INFO 02-26 07:43:54 [kv_cache_utils.py:1312] Maximum concurrency for 65,536 tokens per request: 1.45x
(Worker pid=2637) 2026-02-26 07:43:54,810 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
(Worker pid=2637) 2026-02-26 07:43:54,976 - INFO - autotuner.py:262 - flashinfer.jit: [Autotuner]: Autotuning process ends
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|█████████████████████████████████████████████████████| 19/19 [00:03<00:00,  6.28it/s]
Capturing CUDA graphs (decode, FULL): 100%|████████████████████████████████████████████████████████████████████████| 11/11 [00:00<00:00, 11.73it/s]
(Worker pid=2637) [Stage-0] INFO 02-26 07:43:59 [gpu_model_runner.py:5246] Graph capturing finished in 5 secs, took -1.64 GiB
(EngineCore_DP0 pid=2111) [Stage-0] INFO 02-26 07:43:59 [core.py:278] init engine (profile, create kv cache, warmup model) took 33.93 seconds
(EngineCore_DP0 pid=2177) [Stage-1] INFO 02-26 07:44:01 [shm_broadcast.py:542] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
(EngineCore_DP0 pid=2111) [Stage-0] WARNING 02-26 07:44:02 [scheduler.py:166] Using custom scheduler class vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore_DP0 pid=2111) The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
(EngineCore_DP0 pid=2111) [Stage-0] INFO 02-26 07:44:14 [vllm.py:689] Asynchronous scheduling is enabled.
[Stage-0] INFO 02-26 07:44:15 [omni_llm.py:173] Supported_tasks: ['generate']
[Stage-0] INFO 02-26 07:44:15 [initialization.py:324] [Stage-0] Initializing OmniConnectors with config keys: ['to_stage_1']
[Stage-0] INFO 02-26 07:44:15 [omni_stage.py:790] Max batch size: 64
INFO 02-26 07:44:15 [omni.py:437] [Orchestrator] Stage-0 reported ready
(EngineCore_DP0 pid=2177) [Stage-1] INFO 02-26 07:45:01 [shm_broadcast.py:542] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
(EngineCore_DP0 pid=2177) [Stage-1] INFO 02-26 07:46:01 [shm_broadcast.py:542] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
(Worker pid=2642) [Stage-1] INFO 02-26 07:46:33 [backends.py:351] Cache the graph of compile range (1, 32768) for later use
(Worker pid=2642) [Stage-1] INFO 02-26 07:46:33 [backends.py:368] Compiling a graph for compile range (1, 32768) takes 192.20 s
(Worker pid=2642) [Stage-1] INFO 02-26 07:46:33 [monitor.py:34] torch.compile takes 204.43 s in total
(Worker pid=2642) [Stage-1] INFO 02-26 07:46:37 [backends.py:916] Using cache directory: /root/.cache/vllm/torch_compile_cache/c14a76b28f/rank_0_0/backbone for vLLM's torch.compile
(Worker pid=2642) [Stage-1] INFO 02-26 07:46:37 [backends.py:976] Dynamo bytecode transform time: 2.84 s
WARNING 02-26 07:46:45 [omni.py:471] [Orchestrator] Initialization timeout: 1/3 stages ready. Missing stages: [1, 2]
WARNING 02-26 07:46:45 [omni.py:486] [Orchestrator] Stage initialization timeout. Troubleshooting Steps:
WARNING 02-26 07:46:45 [omni.py:486]   1) Ignore this warning if the model weight download / load from disk time is longer than 300s.
WARNING 02-26 07:46:45 [omni.py:486]   2) Verify GPU/device assignment in config (runtime.devices) is correct.
WARNING 02-26 07:46:45 [omni.py:486]   3) Check GPU/host memory availability; reduce model or batch size if needed.
WARNING 02-26 07:46:45 [omni.py:486]   4) Check model weights path and network reachability (if loading remotely).
WARNING 02-26 07:46:45 [omni.py:486]   5) Increase initialization wait time (stage_init_timeout or call-site timeout).
Adding requests:   0%|                                                                                                       | 0/1 [00:00<?, ?it/s[Stage-2] WARNING 02-26 07:46:45 [omni_stage.py:172] Timeout waiting for device 1 initialization lock, proceeding anywayunit/s, output: 0.00 unit/s]
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_interleaved', 'mrope_section'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section'}
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
(Worker pid=2642) [Stage-1] WARNING 02-26 07:46:46 [fused_moe.py:1087] Using default MoE config. Performance might be sub-optimal! Config file not found at /app/vllm-omni/.venv/lib/python3.12/site-packages/vllm/model_executor/layers/fused_moe/configs/E=128,N=384,device_name=NVIDIA_H800.json
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_interleaved', 'mrope_section'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section'}
[Stage-2] INFO 02-26 07:46:47 [initialization.py:251] Auto-configuring SharedMemoryConnector for edge ('0', '1')
[Stage-2] INFO 02-26 07:46:47 [initialization.py:251] Auto-configuring SharedMemoryConnector for edge ('1', '2')
[Stage-2] INFO 02-26 07:46:47 [initialization.py:270] Loaded OmniTransferConfig with 2 connector configurations
[Stage-2] INFO 02-26 07:46:47 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-2] INFO 02-26 07:46:47 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
[Stage-2] INFO 02-26 07:46:47 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-2] INFO 02-26 07:46:47 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_interleaved', 'mrope_section'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section'}
(Worker pid=2642) [Stage-1] INFO 02-26 07:46:48 [backends.py:368] Compiling a graph for compile range (1, 32768) takes 9.23 s
(Worker pid=2642) [Stage-1] INFO 02-26 07:46:48 [monitor.py:34] torch.compile takes 216.50 s in total
(Worker pid=2642) [Stage-1] INFO 02-26 07:46:51 [base.py:102] Available KV cache memory: 37.64 GiB (profiling fallback)
(EngineCore_DP0 pid=2177) [Stage-1] INFO 02-26 07:46:51 [kv_cache_utils.py:1307] GPU KV cache size: 1,973,216 tokens
(EngineCore_DP0 pid=2177) [Stage-1] INFO 02-26 07:46:51 [kv_cache_utils.py:1312] Maximum concurrency for 65,536 tokens per request: 30.11x
(Worker pid=2642) 2026-02-26 07:46:51,915 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
(Worker pid=2642) 2026-02-26 07:46:52,001 - INFO - autotuner.py:262 - flashinfer.jit: [Autotuner]: Autotuning process ends
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  68%|████████████████████████████████████▎                | 13/19 [00:03<00:01,  4.02it/s][Stage-2] INFO 02-26 07:46:56 [model.py:529] Resolved architecture: Qwen3OmniMoeForConditionalGeneration
[Stage-2] INFO 02-26 07:46:56 [model.py:1549] Using max model len 65536
[Stage-2] INFO 02-26 07:46:56 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=1000000.
[Stage-2] INFO 02-26 07:46:56 [vllm.py:689] Asynchronous scheduling is disabled.
[Stage-2] WARNING 02-26 07:46:56 [vllm.py:727] Enforce eager set, overriding optimization level to -O0
[Stage-2] INFO 02-26 07:46:56 [vllm.py:845] Cudagraph is disabled under eager mode
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|█████████████████████████████████████████████████████| 19/19 [00:04<00:00,  3.96it/s]
Capturing CUDA graphs (decode, FULL):  64%|██████████████████████████████████████████████▍                          | 7/11 [00:01<00:00,  7.03it/s]The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
Capturing CUDA graphs (decode, FULL): 100%|████████████████████████████████████████████████████████████████████████| 11/11 [00:01<00:00,  7.17it/s]
(Worker pid=2642) [Stage-1] INFO 02-26 07:46:59 [gpu_model_runner.py:5246] Graph capturing finished in 8 secs, took -0.10 GiB
(EngineCore_DP0 pid=2177) [Stage-1] INFO 02-26 07:46:59 [core.py:278] init engine (profile, create kv cache, warmup model) took 238.23 seconds
(EngineCore_DP0 pid=2177) [Stage-1] WARNING 02-26 07:47:02 [scheduler.py:166] Using custom scheduler class vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore_DP0 pid=2177) The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
(EngineCore_DP0 pid=2177) [Stage-1] INFO 02-26 07:47:16 [vllm.py:689] Asynchronous scheduling is enabled.
[Stage-1] INFO 02-26 07:47:18 [omni_llm.py:173] Supported_tasks: ['generate']
[Stage-1] INFO 02-26 07:47:18 [initialization.py:324] [Stage-1] Initializing OmniConnectors with config keys: ['from_stage_0']
[Stage-1] INFO 02-26 07:47:18 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-1] INFO 02-26 07:47:18 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
[Stage-1] INFO 02-26 07:47:18 [omni_stage.py:790] Max batch size: 64
[Stage-2] WARNING 02-26 07:47:19 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
(EngineCore_DP0 pid=10914) [Stage-2] INFO 02-26 07:47:19 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='Qwen/Qwen3-Omni-30B-A3B-Instruct', speculative_config=None, tokenizer='Qwen/Qwen3-Omni-30B-A3B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=65536, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen3-Omni-30B-A3B-Instruct, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [1000000], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=10914) [Stage-2] WARNING 02-26 07:47:19 [multiproc_executor.py:921] Reducing Torch parallelism from 112 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
[Stage-2] WARNING 02-26 07:47:26 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
(Worker pid=2642) [Stage-1] INFO 02-26 07:47:28 [mrope.py:345] Multimodal token idx changed!
[Stage-2] INFO 02-26 07:47:29 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:58329 backend=nccl
[Stage-2] INFO 02-26 07:47:29 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
(Worker pid=11189) [Stage-2] INFO 02-26 07:47:43 [gpu_model_runner.py:4124] Starting to load model Qwen/Qwen3-Omni-30B-A3B-Instruct...
(Worker pid=11189) [Stage-2] INFO 02-26 07:47:44 [vllm.py:689] Asynchronous scheduling is disabled.
(Worker pid=11189) [Stage-2] WARNING 02-26 07:47:44 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(Worker pid=11189) [Stage-2] INFO 02-26 07:47:44 [vllm.py:845] Cudagraph is disabled under eager mode
(Worker pid=11189) [Stage-2] WARNING 02-26 07:47:44 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(Worker pid=11189) [Stage-2] INFO 02-26 07:47:44 [vllm.py:845] Cudagraph is disabled under eager mode
Loading safetensors checkpoint shards:   0% Completed | 0/15 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  40% Completed | 6/15 [00:00<00:00, 54.22it/s]
Loading safetensors checkpoint shards:  80% Completed | 12/15 [00:00<00:00, 54.15it/s]
Loading safetensors checkpoint shards: 100% Completed | 15/15 [00:00<00:00, 46.34it/s]
(Worker pid=11189) 
(Worker pid=11189) [Stage-2] INFO 02-26 07:47:46 [qwen3_omni_code2wav.py:270] [Model Loaded] name=Qwen3OmniMoeCode2Wav, success=True, size=412.02 MB, device=cuda:0
(Worker pid=11189) [Stage-2] INFO 02-26 07:47:46 [qwen3_omni.py:1162] Loaded 230 weights for Qwen3OmniMoe (stage=code2wav)
(Worker pid=11189) [Stage-2] INFO 02-26 07:47:46 [default_loader.py:293] Loading weights took 0.55 seconds
(Worker pid=11189) [Stage-2] INFO 02-26 07:47:47 [gpu_model_runner.py:4221] Model loading took 0.41 GiB memory and 2.210475 seconds
(Worker pid=11189) [Stage-2] INFO 02-26 07:47:47 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.
(Worker pid=11189) [Stage-2] WARNING 02-26 07:47:47 [gpu_generation_model_runner.py:451] Dummy sampler run is not implemented for generation model
(EngineCore_DP0 pid=10914) [Stage-2] INFO 02-26 07:47:47 [core.py:278] init engine (profile, create kv cache, warmup model) took 0.59 seconds
(EngineCore_DP0 pid=10914) [Stage-2] WARNING 02-26 07:47:49 [scheduler.py:166] Using custom scheduler class vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore_DP0 pid=10914) [Stage-2] WARNING 02-26 07:47:49 [core.py:130] Disabling chunked prefill for model without KVCache
(EngineCore_DP0 pid=10914) The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
(EngineCore_DP0 pid=10914) [Stage-2] INFO 02-26 07:48:02 [vllm.py:689] Asynchronous scheduling is disabled.
(EngineCore_DP0 pid=10914) [Stage-2] WARNING 02-26 07:48:02 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=10914) [Stage-2] INFO 02-26 07:48:02 [vllm.py:845] Cudagraph is disabled under eager mode
[Stage-2] INFO 02-26 07:48:03 [omni_llm.py:173] Supported_tasks: ['generate']
[Stage-2] INFO 02-26 07:48:03 [initialization.py:324] [Stage-2] Initializing OmniConnectors with config keys: ['from_stage_1']
[Stage-2] INFO 02-26 07:48:03 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-2] INFO 02-26 07:48:03 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
[Stage-2] INFO 02-26 07:48:03 [omni_stage.py:790] Max batch size: 64
(Worker pid=11189) [Stage-2] INFO 02-26 07:48:13 [mrope.py:345] Multimodal token idx changed!
Processed prompts: 100%|███████████████████████████████████████| 1/1 [01:28<00:00, 88.21s/req, est. speed stage-2 tok/s: 61.58, avg e2e_lat: 0.0ms]
Adding requests:   0%|                                                                                                       | 0/1 [01:28<?, ?it/s]
query type: use_mixed_modalities
Request ID: 0_ccd9825b-98c9-47f9-8c15-c9d625c0b71e, Text saved to output_audio/0_ccd9825b-98c9-47f9-8c15-c9d625c0b71e.txt
Request ID: 0_ccd9825b-98c9-47f9-8c15-c9d625c0b71e, Saved audio to output_audio/output_0_ccd9825b-98c9-47f9-8c15-c9d625c0b71e.wav
[Stage-2] INFO 02-26 07:48:13 [omni_stage.py:838] Received shutdown signal
WARNING 02-26 07:48:13 [omni_stage.py:541] Failed to send shutdown to in_q: Socket operation on non-socket
[Stage-1] INFO 02-26 07:48:13 [omni_stage.py:838] Received shutdown signal
[Stage-0] INFO 02-26 07:48:13 [omni_stage.py:838] Received shutdown signal
(Worker pid=11189) [Stage-2] INFO 02-26 07:48:13 [multiproc_executor.py:732] Parent process exited, terminating worker
(Worker pid=11189) [Stage-2] INFO 02-26 07:48:13 [multiproc_executor.py:785] WorkerProc shutting down.
(Worker pid=2637) [Stage-0] INFO 02-26 07:48:13 [multiproc_executor.py:732] Parent process exited, terminating worker
(Worker pid=2637) [Stage-0] INFO 02-26 07:48:13 [multiproc_executor.py:785] WorkerProc shutting down.
(Worker pid=2642) [Stage-1] INFO 02-26 07:48:13 [multiproc_executor.py:732] Parent process exited, terminating worker
(Worker pid=2642) [Stage-1] INFO 02-26 07:48:13 [multiproc_executor.py:785] WorkerProc shutting down.
WARNING 02-26 07:48:18 [omni_stage.py:541] Failed to send shutdown to in_q: Socket operation on non-socket
WARNING 02-26 07:48:19 [omni_stage.py:541] Failed to send shutdown to in_q: Socket operation on non-socket
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please providing the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
