### PR TITLE
[Bugfix] Fix redundant finished req status updating on OmniGenerationScheduler

### DIFF
--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -77,7 +77,6 @@ class OmniGenerationScheduler(VLLMScheduler):
                     self.chunk_transfer_adapter is not None
                     and request.request_id in self.chunk_transfer_adapter.finished_requests
                 ):
-                    request.status = RequestStatus.FINISHED_STOPPED
                     # Upstream may finish with no terminal tokens; append one pad token so we can emit FINISHED.
                     if len(request.prompt_token_ids) <= num_computed_tokens:
                         request.prompt_token_ids.append(0)
@@ -132,7 +131,6 @@ class OmniGenerationScheduler(VLLMScheduler):
             # async_chunk: wait for the first upstream chunk (don't start with placeholders).
             if self.chunk_transfer_adapter is not None and len(request.prompt_token_ids) == 0:
                 if request.request_id in self.chunk_transfer_adapter.finished_requests:
-                    request.status = RequestStatus.FINISHED_STOPPED
                     request.prompt_token_ids.append(0)
                     try:
                         request._all_token_ids.append(0)  # type: ignore[attr-defined]


### PR DESCRIPTION
Hi, this PR refers to Issue #1507.

Do NOT set FINISHED_STOPPED here. Setting it in schedule() causes update_from_output() to skip the request (is_finished() returns True), preventing proper cleanup. The status will be set correctly in update_from_output() after model execution.

```python
class OmniGenerationScheduler(VLLMScheduler):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        model_config = self.vllm_config.model_config
        self.chunk_transfer_adapter = None
        if getattr(model_config, "async_chunk", False):
            self.chunk_transfer_adapter = OmniChunkTransferAdapter(self.vllm_config)

    def schedule(self) -> SchedulerOutput:
        ................
        already_finished_reqs: set[Request] = set()
        while req_index < len(self.running) and token_budget > 0:
            request = self.running[req_index]
            # OMNI: Skip requests that are not in self.requests
            if request.request_id not in self.requests or (
                self.chunk_transfer_adapter is None and request.status == RequestStatus.FINISHED_STOPPED
            ):
                already_finished_reqs.add(request)
                req_index += 1
                continue

            num_computed_tokens = request.num_computed_tokens
            required_tokens = len(request.prompt_token_ids) - num_computed_tokens
            # async_chunk: don't schedule placeholder tokens when no new chunk is available.
            if required_tokens <= 0:
                if (
                    self.chunk_transfer_adapter is not None
                    and request.request_id in self.chunk_transfer_adapter.finished_requests
                ):
                    # Remove >>>>>>>>>>>>>>>>request.status = RequestStatus.FINISHED_STOPPED<<<<<<<<<<<<<<<<<<<<
                    # Upstream may finish with no terminal tokens; append one pad token so we can emit FINISHED.
                    if len(request.prompt_token_ids) <= num_computed_tokens:
                        request.prompt_token_ids.append(0)
                        try:
                            request._all_token_ids.append(0)  # type: ignore[attr-defined]
                        except Exception:
                            pass
                    required_tokens = len(request.prompt_token_ids) - num_computed_tokens
                else:
                    req_index += 1
                    continue

         # OMNI: Remove already finished requests from running queue
        if already_finished_reqs:
            self.running = remove_all(self.running, already_finished_reqs)

        # Fast path selection and scheduling (treat all as diffusion requests,
        # independent of pooling_params)
        while self.waiting and token_budget > 0 and len(self.running) < self.max_num_running_reqs:
            request = self.waiting.peek_request()
            # OMNI: Skip requests that are not in self.requests
            if request.request_id not in self.requests or (
                self.chunk_transfer_adapter is None and request.status == RequestStatus.FINISHED_STOPPED
            ):
                # Pop the finished request from waiting queue and don't schedule it
                self.waiting.pop_request()
                continue

            # async_chunk: wait for the first upstream chunk (don't start with placeholders).
            if self.chunk_transfer_adapter is not None and len(request.prompt_token_ids) == 0:
                if request.request_id in self.chunk_transfer_adapter.finished_requests:
                    # Remove >>>>>>>>>>>>>request.status = RequestStatus.FINISHED_STOPPED<<<<<<<<<<<<<<<
                    request.prompt_token_ids.append(0)
                    try:
                        request._all_token_ids.append(0)  # type: ignore[attr-defined]
                    except Exception:
                        pass
                else:
                    self.waiting.pop_request()
                    skipped_waiting_requests.prepend_request(request)
                    continue
```

@qibaoyuan We encountered the error while integrating the incoming MIMO-Audio support:

```text
(EngineCore_DP0 pid=3268384) [Stage-1] ERROR 02-26 15:33:00 [core.py:1008]   File "/mnt/user/qibaoyuan/vllm-omni-qby/vllm_omni/worker/gpu_generation_model_runner.py", line 74, in _update_request_states
(EngineCore_DP0 pid=3268384) [Stage-1] ERROR 02-26 15:33:00 [core.py:1008]     self.input_batch.add_request(req_state)
(EngineCore_DP0 pid=3268384) [Stage-1] ERROR 02-26 15:33:00 [core.py:1008]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_input_batch.py", line 331, in add_request
(EngineCore_DP0 pid=3268384) [Stage-1] ERROR 02-26 15:33:00 [core.py:1008]     self.token_ids_cpu[req_index, :num_prompt_tokens] = request.prompt_token_ids
(EngineCore_DP0 pid=3268384) [Stage-1] ERROR 02-26 15:33:00 [core.py:1008]     ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3268384) [Stage-1] ERROR 02-26 15:33:00 [core.py:1008] ValueError: could not broadcast input array from shape (18193,) into shape (18192,)

```