### PR TITLE
[Bugfix] fix offline text_to_image error from #1009

### DIFF
--- a/examples/offline_inference/text_to_image/text_to_image.py
+++ b/examples/offline_inference/text_to_image/text_to_image.py
@@ -175,16 +175,6 @@ def parse_args() -> argparse.Namespace:
         help="Scale factor for LoRA weights (default: 1.0).",
     )
     parser.add_argument(
-        "--vae_use_slicing",
-        action="store_true",
-        help="Enable VAE slicing for memory optimization.",
-    )
-    parser.add_argument(
-        "--vae_use_tiling",
-        action="store_true",
-        help="Enable VAE tiling for memory optimization.",
-    )
-    parser.add_argument(
         "--vae-patch-parallel-size",
         type=int,
         default=1,
@@ -286,7 +276,6 @@ def main():
     omni_kwargs = {
         "model": args.model,
         "enable_layerwise_offload": args.enable_layerwise_offload,
-        "layerwise_num_gpu_layers": args.layerwise_num_gpu_layers,
         "vae_use_slicing": args.vae_use_slicing,
         "vae_use_tiling": args.vae_use_tiling,
         "cache_backend": args.cache_backend,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

fix #1512
## Test Plan

```
python examples/offline_inference/text_to_image/text_to_image.py   --model /workspace/models/black-forest-labs/FLUX.2-klein-4B     --prompt "a photo of a forest with mist swirling around the tree trunks. The word 'FLUX.2' is painted over it in big, red brush strokes with visible texture"   --height 768   --width 1360   --seed 42   --cfg-scale 4.0   --num-images-per-prompt 1   --num-inference-steps 40   --output outputs/flux2_klein_4b.png 
INFO 02-26 09:30:34 [omni.py:181] Initializing stages for model: /workspace/models/black-forest-labs/FLUX.2-klein-4B
INFO 02-26 09:30:34 [omni.py:306] No omni_master_address provided, defaulting to localhost (127.0.0.1)
INFO 02-26 09:30:34 [initialization.py:35] No OmniTransferConfig provided
INFO 02-26 09:30:34 [omni_stage.py:254] [OmniStage] stage_config: {'stage_id': 0, 'stage_type': 'diffusion', 'runtime': {'process': True, 'devices': '0', 'max_batch_size': 1}, 'engine_args': {'enable_layerwise_offload': False, 'vae_use_slicing': False, 'vae_use_tiling': False, 'cache_backend': None, 'cache_config': None, 'enable_cache_dit_summary': False, 'parallel_config': {'pipeline_parallel_size': 1, 'data_parallel_size': 1, 'tensor_parallel_size': 1, 'sequence_parallel_size': 1, 'ulysses_degree': 1, 'ring_degree': 1, 'cfg_parallel_size': 1, 'vae_patch_parallel_size': 1}, 'enforce_eager': False, 'enable_cpu_offload': False, 'model': '/workspace/models/black-forest-labs/FLUX.2-klein-4B', 'model_stage': 'diffusion'}, 'final_output': True, 'final_output_type': 'image'}
INFO 02-26 09:30:34 [omni.py:340] [Orchestrator] Loaded 1 stages
INFO 02-26 09:30:34 [omni.py:447] [Orchestrator] Waiting for 1 stages to initialize (timeout: 300s)
[Stage-0] INFO 02-26 09:30:49 [omni_stage.py:678] Starting stage worker with model: /workspace/models/black-forest-labs/FLUX.2-klein-4B
[Stage-0] INFO 02-26 09:30:49 [omni_stage.py:693] [Stage] Set VLLM_WORKER_MULTIPROC_METHOD=spawn
[Stage-0] INFO 02-26 09:30:49 [omni_stage.py:721] [Stage-0] ZMQ transport detected; disabling SHM IPC (shm_threshold_bytes set to maxsize)
[Stage-0] INFO 02-26 09:30:49 [omni_stage.py:84] Using sequential init locks (nvml_available=True, pid_host=False)
[Stage-0] INFO 02-26 09:30:50 [multiproc_executor.py:74] Starting server...
[Stage-0] INFO 02-26 09:31:05 [diffusion_worker.py:343] Worker 0 created result MessageQueue
[Stage-0] INFO 02-26 09:31:07 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=2048.
[Stage-0] INFO 02-26 09:31:07 [vllm.py:689] Asynchronous scheduling is enabled.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Stage-0] INFO 02-26 09:31:07 [diffusion_worker.py:114] Worker 0: Initialized device and distributed environment.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Stage-0] INFO 02-26 09:31:07 [parallel_state.py:536] Building SP subgroups from explicit sp_group_ranks (sp_size=1, ulysses=1, ring=1, use_ulysses_low=True).
[Stage-0] INFO 02-26 09:31:07 [parallel_state.py:578] SP group details for rank 0: sp_group=[0], ulysses_group=[0], ring_group=[0]
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
Loading checkpoint shards: 100%|█████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.63it/s]
[Stage-0] INFO 02-26 09:31:12 [platform.py:77] Defaulting to diffusion attention backend FLASH_ATTN
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.42it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.42it/s]

[Stage-0] INFO 02-26 09:31:15 [diffusers_loader.py:266] Loading weights took 0.78 seconds
[Stage-0] INFO 02-26 09:31:15 [diffusion_model_runner.py:118] Model loading took 14.8745 GiB and 7.847052 seconds
[Stage-0] INFO 02-26 09:31:15 [diffusion_model_runner.py:123] Model runner: Model loaded successfully.
[Stage-0] INFO 02-26 09:31:15 [diffusion_model_runner.py:139] Model runner: Model compiled with torch.compile.
[Stage-0] INFO 02-26 09:31:15 [diffusion_model_runner.py:163] Model runner: Initialization complete.
[Stage-0] INFO 02-26 09:31:15 [diffusion_worker.py:141] Worker 0: Process-scoped GPU memory after model loading: 0.00 GiB.
[Stage-0] INFO 02-26 09:31:15 [manager.py:90] Initializing DiffusionLoRAManager: device=cuda:0, dtype=torch.bfloat16, max_cached_adapters=1, static_lora_path=None
[Stage-0] INFO 02-26 09:31:15 [diffusion_worker.py:84] Worker 0: Initialization complete.
[Stage-0] INFO 02-26 09:31:15 [diffusion_worker.py:477] Worker 0: Scheduler loop started.
[Stage-0] INFO 02-26 09:31:15 [diffusion_worker.py:400] Worker 0 ready to receive requests via shared memory
[Stage-0] INFO 02-26 09:31:15 [scheduler.py:38] SyncScheduler initialized result MessageQueue
[Stage-0] INFO 02-26 09:31:15 [diffusion_engine.py:341] dummy run to warm up the model
[Stage-0] INFO 02-26 09:31:15 [manager.py:538] Deactivating all adapters: 0 layers
[Stage-0] WARNING 02-26 09:31:15 [kv_transfer_manager.py:517] Request has no ID, cannot receive KV cache
[Stage-0] INFO 02-26 09:31:30 [omni_stage.py:790] Max batch size: 1
INFO 02-26 09:31:30 [omni.py:437] [Orchestrator] Stage-0 reported ready
INFO 02-26 09:31:30 [omni.py:466] [Orchestrator] All stages initialized successfully

============================================================
Generation Configuration:
  Model: /workspace/models/black-forest-labs/FLUX.2-klein-4B
  Inference steps: 40
  Cache backend: None (no acceleration)
  Quantization: None (BF16)
  Parallel configuration: tensor_parallel_size=1, ulysses_degree=1, ring_degree=1, cfg_parallel_size=1, vae_patch_parallel_size=1
  CPU offload: False
  Image size: 1360x768
============================================================

Adding requests:   0%|                                                                                       | 0/1 [00:00<?, ?it/s[Stage-0] INFO 02-26 09:31:30 [manager.py:538] Deactivating all adapters: 0 layersst. speed input: 0.00 unit/s, output: 0.00 unit/s]
[Stage-0] WARNING 02-26 09:31:30 [kv_transfer_manager.py:421] No connector available for receiving KV cache
[Stage-0] INFO 02-26 09:31:37 [diffusion_engine.py:80] Generation completed successfully.
[Stage-0] INFO 02-26 09:31:37 [diffusion_engine.py:98] Post-processing completed in 0.2083 seconds
Processed prompts: 100%|████████████████████████| 1/1 [00:06<00:00,  6.81s/img, est. speed stage-0 img/s: 0.00, avg e2e_lat: 0.0ms]
Adding requests:   0%|                                                                                       | 0/1 [00:06<?, ?it/s]
Total generation time: 6.8120 seconds (6812.00 ms)
INFO 02-26 09:31:37 [text_to_image.py:386] Outputs: [OmniRequestOutput(request_id='', finished=True, stage_id=0, final_output_type='image', request_output=[OmniRequestOutput(request_id='0_b19e3772-9331-4428-8705-fb1e7e9ef772', finished=True, stage_id=None, final_output_type='image', request_output=None, images=[1 PIL Images], prompt={'prompt': "a photo of a forest with mist swirling around the tree trunks. The word 'FLUX.2' is painted over it in big, red brush strokes with visible texture", 'negative_prompt': None, 'additional_information': {'global_request_id': ['0_b19e3772-9331-4428-8705-fb1e7e9ef772']}}, latents=None, metrics={'image_num': 1, 'resolution': 640, 'postprocess_time_ms': 208.32514762878418}, multimodal_output={})], images=[], prompt=None, latents=None, metrics={}, multimodal_output={})]
Saved generated image to outputs/flux2_klein_4b.png
[Stage-0] INFO 02-26 09:31:37 [omni_stage.py:838] Received shutdown signal
WARNING 02-26 09:31:37 [omni_stage.py:541] Failed to send shutdown to in_q: Socket operation on non-socket
[Stage-0] INFO 02-26 09:31:37 [diffusion_worker.py:429] Worker 0: Received shutdown message
[Stage-0] INFO 02-26 09:31:37 [diffusion_worker.py:450] event loop terminated.
[Stage-0] INFO 02-26 09:31:37 [diffusion_worker.py:485] Worker 0: Shutdown complete.
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please providing the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
