### PR TITLE
[Bugfix] Use uds for zmq address if not set --stage-id

### DIFF
--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -371,9 +371,13 @@ class OmniBase:
             # Allocate endpoints for each stage
             total_stages = len(self.stage_configs)
             self._handshake_endpoints = {}
+
+            # If --stage-id is not set, use local_only mode
+            local_only = self._single_stage_id is None
+
             for sid in range(total_stages):
-                in_endpoint = get_engine_client_zmq_addr(local_only=False, host=self._zmq_master_address)
-                out_endpoint = get_engine_client_zmq_addr(local_only=False, host=self._zmq_master_address)
+                in_endpoint = get_engine_client_zmq_addr(local_only=local_only, host=self._zmq_master_address)
+                out_endpoint = get_engine_client_zmq_addr(local_only=local_only, host=self._zmq_master_address)
                 self._handshake_endpoints[sid] = (in_endpoint, out_endpoint)
                 logger.debug(
                     f"[{self._name}] Allocated endpoints for stage-{sid}: in={in_endpoint}, out={out_endpoint}"


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Quik fix test failure: 
https://buildkite.com/vllm/vllm-omni/builds/3417/steps/waterfall?sid=019c99b1-9a45-48c5-9bfe-1776c5704c1c&tab=output

Because ports are pre-allocated whose number are equal to stage number to used by zmq communication between api server and  engines. So there is a chance that they allocate same port for different stage, and port conflict happens then.

## Test Plan

Not tested locally.

## Test Result

Not tested locally.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please providing the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
