### PR TITLE
[Debug] Enable curl retry aligned with openai

### DIFF
--- a/examples/online_serving/qwen2_5_omni/run_curl_multimodal_generation.sh
+++ b/examples/online_serving/qwen2_5_omni/run_curl_multimodal_generation.sh
@@ -160,9 +160,6 @@ esac
 echo "Running query type: $QUERY_TYPE"
 echo ""
 
-MAX_RETRIES=3
-RETRY_DELAY=3
-
 request_body=$(cat <<EOF
 {
   "model": "Qwen/Qwen2.5-Omni-7B",
@@ -188,26 +185,10 @@ request_body=$(cat <<EOF
 EOF
 )
 
-output=""
-for attempt in $(seq 1 "$MAX_RETRIES"); do
-  http_response=$(curl -sS -w "\n%{http_code}" -X POST http://localhost:8091/v1/chat/completions \
-      -H "Content-Type: application/json" \
-      -d "$request_body")
-
-  http_code=$(echo "$http_response" | tail -1)
-  output=$(echo "$http_response" | sed '$d')
-
-  if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
-    break
-  fi
-
-  if [[ "$attempt" -lt "$MAX_RETRIES" ]]; then
-    echo "Request failed with HTTP $http_code, retrying ($attempt/$MAX_RETRIES) in ${RETRY_DELAY}s..." >&2
-    sleep "$RETRY_DELAY"
-  else
-    echo "Request failed with HTTP $http_code after $MAX_RETRIES attempts" >&2
-  fi
-done
+output=$(curl -sS --retry 3 --retry-delay 3 --retry-connrefused \
+    -X POST http://localhost:8091/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d "$request_body")
 
 # Here it only shows the text content of the first choice. Audio content has many binaries, so it's not displayed here.
 echo "Output of request: $(echo "$output" | jq '.choices[0].message.content')"

--- a/examples/online_serving/qwen3_omni/run_curl_multimodal_generation.sh
+++ b/examples/online_serving/qwen3_omni/run_curl_multimodal_generation.sh
@@ -138,9 +138,6 @@ esac
 echo "Running query type: $QUERY_TYPE"
 echo ""
 
-MAX_RETRIES=3
-RETRY_DELAY=3
-
 request_body=$(cat <<EOF
 {
   "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -166,26 +163,10 @@ request_body=$(cat <<EOF
 EOF
 )
 
-output=""
-for attempt in $(seq 1 "$MAX_RETRIES"); do
-  http_response=$(curl -sS -w "\n%{http_code}" -X POST http://localhost:8091/v1/chat/completions \
-      -H "Content-Type: application/json" \
-      -d "$request_body")
-
-  http_code=$(echo "$http_response" | tail -1)
-  output=$(echo "$http_response" | sed '$d')
-
-  if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
-    break
-  fi
-
-  if [[ "$attempt" -lt "$MAX_RETRIES" ]]; then
-    echo "Request failed with HTTP $http_code, retrying ($attempt/$MAX_RETRIES) in ${RETRY_DELAY}s..." >&2
-    sleep "$RETRY_DELAY"
-  else
-    echo "Request failed with HTTP $http_code after $MAX_RETRIES attempts" >&2
-  fi
-done
+output=$(curl -sS --retry 3 --retry-delay 3 --retry-connrefused \
+    -X POST http://localhost:8091/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d "$request_body")
 
 # Here it only shows the text content of the first choice. Audio content has many binaries, so it's not displayed here.
 echo "Output of request: $(echo "$output" | jq '.choices[0].message.content')"


### PR DESCRIPTION
## Purpose
Add HTTP retry logic (max 3 attempts, 3s delay) to run_curl_multimodal_generation.sh for both Qwen2.5-Omni and Qwen3-Omni, fixing intermittent test failures caused by server-side TimeoutError when fetching remote media URLs.
```text
tests/examples/online_serving/test_qwen2_5_omni.py::test_send_multimodal_request_003[omni_server0] 
=== PRE-TEST GPU CLEANUP ===
GPU cleanup disabled
INFO 02-27 07:56:48 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=2048.
--- Running test: test_send_multimodal_request_003[omni_server0]
(APIServer pid=268402) WARNING 02-27 07:56:48 [protocol.py:51] The following fields were present in the request but ignored: {'sampling_params_list', 'modalities'}
[Stage-1] INFO 02-27 07:56:49 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, MM cache hit rate: 0.0%
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785] Chat completion failed: 
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785] Traceback (most recent call last):
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/aiohttp/streams.py", line 371, in _wait
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     await waiter
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785] asyncio.exceptions.CancelledError
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785] 
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785] The above exception was the direct cause of the following exception:
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785] 
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785] Traceback (most recent call last):
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/vllm_omni/entrypoints/openai/api_server.py", line 783, in create_chat_completion
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     generator = await handler.create_chat_completion(request, raw_request)
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/vllm_omni/entrypoints/openai/serving_chat.py", line 243, in create_chat_completion
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     conversation, engine_prompts = await self._preprocess_chat(
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/vllm_omni/entrypoints/openai/serving_chat.py", line 457, in _preprocess_chat
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     (conversation,), (engine_prompt,) = await renderer.render_chat_async(
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/vllm/renderers/protocol.py", line 377, in render_chat_async
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     for conv, prompt in await asyncio.gather(*rendered):
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/vllm/renderers/hf.py", line 694, in render_messages_async
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     conversation, mm_data, mm_uuids = await parse_chat_messages_async(
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 1582, in parse_chat_messages_async
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     mm_data, mm_uuids = await mm_tracker.resolve_items()
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 693, in resolve_items
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     modality: await asyncio.gather(*coros)
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 898, in _image_with_uuid_async
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     await self._connector.fetch_image_async(image_url) if image_url else None
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/vllm/multimodal/media/connector.py", line 272, in fetch_image_async
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     return await self.load_from_url_async(
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/vllm/multimodal/media/connector.py", line 179, in load_from_url_async
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     data = await connection.async_get_bytes(
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/vllm/connections.py", line 114, in async_get_bytes
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     return await r.read()
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]            ^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 693, in read
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     self._body = await self.content.read()
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]                  ^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/aiohttp/streams.py", line 442, in read
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     block = await self.readany()
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]             ^^^^^^^^^^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/aiohttp/streams.py", line 464, in readany
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     await self._wait("readany")
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/aiohttp/streams.py", line 370, in _wait
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     with self._timer:
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]          ^^^^^^^^^^^
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]   File "/app/vllm-omni/.venv/lib/python3.12/site-packages/aiohttp/helpers.py", line 713, in __exit__
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785]     raise asyncio.TimeoutError from exc_val
(APIServer pid=268402) ERROR 02-27 07:56:55 [api_server.py:785] TimeoutError
(APIServer pid=268402) INFO:     127.0.0.1:53300 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
All output:
```
## Test Plan
```bash
export CUDA_VISIBLE_DEVICES=3,6,7 && python3 -m pytest -s -vv tests/examples/online_serving/test_qwen2_5_omni.py::test_send_multimodal_request_003 -m "advanced_model" --run-level "advanced_model"
```
## Test Result
```bash
root@6d162d61c010:/app/vllm-omni# export CUDA_VISIBLE_DEVICES=3,6,7 && python3 -m pytest -s -vv tests/examples/online_serving/test_qwen2_5_omni.py::test_send_multimodal_request_003 -m "advanced_model" --run-level "advanced_model"
WARNING 02-27 08:52:38 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
============================================================ test session starts =============================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /app/vllm-omni/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /app/vllm-omni
configfile: pyproject.toml
plugins: cov-7.0.0, asyncio-1.3.0, anyio-4.12.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                             

tests/examples/online_serving/test_qwen2_5_omni.py::test_send_multimodal_request_003[omni_server0] Path engine_args.load_format does not exist
Path engine_args.load_format does not exist
Path engine_args.load_format does not exist
Pre-test GPU status:
[GPU Memory Monitor] Waiting for GPU 3, 6, 7 to free memory, Condition: Memory usage ratio ≤ 5.0%
[GPU Memory Status] Current usage:
  GPU 3: 0.5GiB/79.6GiB (0.7%)
  GPU 6: 0.5GiB/79.6GiB (0.7%)
  GPU 7: 0.5GiB/79.6GiB (0.7%)
[GPU Memory Freed] Devices 3, 6, 7 meet memory condition
   Condition: Memory usage ratio ≤ 5.0%
   Wait time: 0.0 seconds (0.0 minutes)
   Final status:
     GPU 3: 0.5GiB/79.6GiB (0.7%)
     GPU 6: 0.5GiB/79.6GiB (0.7%)
     GPU 7: 0.5GiB/79.6GiB (0.7%)
Post-test GPU status:

================================================================================
NVIDIA GPU Information (nvidia-smi)
================================================================================
Fri Feb 27 08:52:39 2026       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.161.08             Driver Version: 535.161.08   CUDA Version: 12.9     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA H800                    On  | 00000000:1B:00.0 Off |                    0 |
| N/A   24C    P0              69W / 700W |      3MiB / 81559MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA H800                    On  | 00000000:43:00.0 Off |                    0 |
| N/A   26C    P0              66W / 700W |      3MiB / 81559MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   2  NVIDIA H800                    On  | 00000000:52:00.0 Off |                    0 |
| N/A   26C    P0              68W / 700W |      3MiB / 81559MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
... (showing first 20 of 48 lines)

================================================================================
Detailed GPU Processes (nvidia-smi pmon)
================================================================================
# gpu         pid  type    sm    mem    enc    dec    command
# Idx           #   C/G     %      %      %      %    name
    0          -     -      -      -      -      -    -              
    1          -     -      -      -      -      -    -              
    2          -     -      -      -      -      -    -              
    3          -     -      -      -      -      -    -              
    4          -     -      -      -      -      -    -              
    5          -     -      -      -      -      -    -              
    6          -     -      -      -      -      -    -              
    7          -     -      -      -      -      -    -              


================================================================================
System Processes with GPU keywords
================================================================================
Launching OmniServer with: /app/vllm-omni/.venv/bin/python3 -m vllm_omni.entrypoints.cli.main serve Qwen/Qwen2.5-Omni-7B --omni --host 127.0.0.1 --port 8091 --stage-configs-path /app/vllm-omni/tests/e2e/stage_configs/qwen2_5_omni_ci_1772182358.yaml --stage-init-timeout 120
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
WARNING 02-27 08:52:50 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
/app/vllm-omni/vllm_omni/__init__.py:30: RuntimeWarning: Failed to import version from _version.py: No module named 'vllm_omni._version'
This typically happens in development mode before building.
Using fallback version 'dev'.
  from .version import __version__, __version_tuple__  # isort:skip
INFO 02-27 08:52:52 [logo.py:45]        █     █     █▄   ▄█       ▄▀▀▀▀▄ █▄   ▄█ █▄    █ ▀█▀ 
INFO 02-27 08:52:52 [logo.py:45]  ▄▄ ▄█ █     █     █ ▀▄▀ █  ▄▄▄  █    █ █ ▀▄▀ █ █ ▀▄  █  █  
INFO 02-27 08:52:52 [logo.py:45]   █▄█▀ █     █     █     █       █    █ █     █ █   ▀▄█  █  
INFO 02-27 08:52:52 [logo.py:45]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀        ▀▀▀▀  ▀     ▀ ▀     ▀ ▀▀▀ 
INFO 02-27 08:52:52 [logo.py:45] 
(APIServer pid=327235) INFO 02-27 08:52:52 [utils.py:287] vLLM server version 0.16.0, serving model Qwen/Qwen2.5-Omni-7B
(APIServer pid=327235) INFO 02-27 08:52:52 [utils.py:223] non-default args: {'model_tag': 'Qwen/Qwen2.5-Omni-7B', 'host': '127.0.0.1', 'port': 8091, 'model': 'Qwen/Qwen2.5-Omni-7B'}
(APIServer pid=327235) INFO 02-27 08:52:52 [weight_utils.py:50] Using model weights format ['*']
(APIServer pid=327235) INFO 02-27 08:52:52 [omni.py:181] Initializing stages for model: Qwen/Qwen2.5-Omni-7B
(APIServer pid=327235) INFO 02-27 08:52:52 [omni.py:313] No omni_master_address provided, defaulting to localhost (127.0.0.1)
(APIServer pid=327235) WARNING 02-27 08:52:52 [utils.py:111] Filtered out 1 callable object(s) from base_engine_args that are not compatible with OmegaConf: ['dispatch_function']. 
(APIServer pid=327235) INFO 02-27 08:52:52 [initialization.py:233] Auto-configuring SharedMemoryConnector for edge ('0', '1')
(APIServer pid=327235) INFO 02-27 08:52:52 [initialization.py:233] Auto-configuring SharedMemoryConnector for edge ('1', '2')
(APIServer pid=327235) INFO 02-27 08:52:52 [initialization.py:270] Loaded OmniTransferConfig with 2 connector configurations
(APIServer pid=327235) INFO 02-27 08:52:52 [factory.py:46] Created connector: SharedMemoryConnector
(APIServer pid=327235) INFO 02-27 08:52:52 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
(APIServer pid=327235) INFO 02-27 08:52:52 [factory.py:46] Created connector: SharedMemoryConnector
(APIServer pid=327235) INFO 02-27 08:52:52 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
(APIServer pid=327235) INFO 02-27 08:52:52 [omni.py:347] [AsyncOrchestrator] Loaded 3 stages
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
[Stage-1] WARNING 02-27 08:53:03 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
/app/vllm-omni/vllm_omni/__init__.py:30: RuntimeWarning: Failed to import version from _version.py: No module named 'vllm_omni._version'
This typically happens in development mode before building.
Using fallback version 'dev'.
  from .version import __version__, __version_tuple__  # isort:skip
[Stage-1] INFO 02-27 08:53:03 [omni_stage.py:1132] [Stage-1] ZMQ transport detected; disabling SHM IPC (shm_threshold_bytes set to maxsize)
[Stage-1] INFO 02-27 08:53:03 [initialization.py:324] [Stage-1] Initializing OmniConnectors with config keys: ['from_stage_0']
[Stage-1] INFO 02-27 08:53:03 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-1] INFO 02-27 08:53:03 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
[Stage-1] INFO 02-27 08:53:03 [omni_stage.py:85] Using sequential init locks (nvml_available=True, pid_host=False)
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
[Stage-0] WARNING 02-27 08:53:04 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
/app/vllm-omni/vllm_omni/__init__.py:30: RuntimeWarning: Failed to import version from _version.py: No module named 'vllm_omni._version'
This typically happens in development mode before building.
Using fallback version 'dev'.
  from .version import __version__, __version_tuple__  # isort:skip
[Stage-0] INFO 02-27 08:53:04 [omni_stage.py:1132] [Stage-0] ZMQ transport detected; disabling SHM IPC (shm_threshold_bytes set to maxsize)
[Stage-0] INFO 02-27 08:53:04 [initialization.py:324] [Stage-0] Initializing OmniConnectors with config keys: ['to_stage_1']
[Stage-0] INFO 02-27 08:53:04 [omni_stage.py:85] Using sequential init locks (nvml_available=True, pid_host=False)
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section'}
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
[Stage-2] WARNING 02-27 08:53:14 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
/app/vllm-omni/vllm_omni/__init__.py:30: RuntimeWarning: Failed to import version from _version.py: No module named 'vllm_omni._version'
This typically happens in development mode before building.
Using fallback version 'dev'.
  from .version import __version__, __version_tuple__  # isort:skip
(APIServer pid=327235) INFO 02-27 08:53:14 [omni.py:458] [AsyncOrchestrator] Waiting for 3 stages to initialize (timeout: 600s)
[Stage-2] INFO 02-27 08:53:14 [omni_stage.py:1132] [Stage-2] ZMQ transport detected; disabling SHM IPC (shm_threshold_bytes set to maxsize)
[Stage-2] INFO 02-27 08:53:14 [initialization.py:324] [Stage-2] Initializing OmniConnectors with config keys: ['from_stage_1']
[Stage-2] INFO 02-27 08:53:14 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-2] INFO 02-27 08:53:14 [initialization.py:60] Created connector for 1 -> 2: SharedMemoryConnector
[Stage-2] INFO 02-27 08:53:14 [omni_stage.py:85] Using sequential init locks (nvml_available=True, pid_host=False)
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'mrope_section'}
[Stage-1] INFO 02-27 08:53:17 [model.py:529] Resolved architecture: Qwen2_5OmniForConditionalGeneration
[Stage-1] INFO 02-27 08:53:17 [model.py:1549] Using max model len 16384
[Stage-1] INFO 02-27 08:53:17 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=16384.
[Stage-1] INFO 02-27 08:53:17 [vllm.py:689] Asynchronous scheduling is enabled.
[Stage-1] WARNING 02-27 08:53:17 [vllm.py:727] Enforce eager set, overriding optimization level to -O0
[Stage-1] INFO 02-27 08:53:17 [vllm.py:845] Cudagraph is disabled under eager mode
[Stage-0] INFO 02-27 08:53:18 [model.py:529] Resolved architecture: Qwen2_5OmniForConditionalGeneration
[Stage-0] INFO 02-27 08:53:18 [model.py:1549] Using max model len 16384
[Stage-0] INFO 02-27 08:53:18 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=16384.
[Stage-0] INFO 02-27 08:53:18 [vllm.py:689] Asynchronous scheduling is enabled.
[Stage-0] WARNING 02-27 08:53:18 [vllm.py:727] Enforce eager set, overriding optimization level to -O0
[Stage-0] INFO 02-27 08:53:18 [vllm.py:845] Cudagraph is disabled under eager mode
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
[Stage-2] INFO 02-27 08:53:26 [model.py:529] Resolved architecture: Qwen2_5OmniForConditionalGeneration
[Stage-2] INFO 02-27 08:53:26 [model.py:1549] Using max model len 32768
[Stage-2] INFO 02-27 08:53:26 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=100000.
[Stage-2] WARNING 02-27 08:53:26 [scheduler.py:266] max_num_batched_tokens (100000) exceeds max_num_seqs * max_model_len (32768). This may lead to unexpected behavior.
[Stage-2] INFO 02-27 08:53:26 [vllm.py:689] Asynchronous scheduling is enabled.
[Stage-2] WARNING 02-27 08:53:26 [vllm.py:727] Enforce eager set, overriding optimization level to -O0
[Stage-2] INFO 02-27 08:53:26 [vllm.py:845] Cudagraph is disabled under eager mode
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
[Stage-0] WARNING 02-27 08:53:42 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
/app/vllm-omni/vllm_omni/__init__.py:30: RuntimeWarning: Failed to import version from _version.py: No module named 'vllm_omni._version'
This typically happens in development mode before building.
Using fallback version 'dev'.
  from .version import __version__, __version_tuple__  # isort:skip
/app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
  warnings.warn(
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:53:43 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='Qwen/Qwen2.5-Omni-7B', speculative_config=None, tokenizer='Qwen/Qwen2.5-Omni-7B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=16384, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen2.5-Omni-7B, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [16384], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
[Stage-1] WARNING 02-27 08:53:43 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
/app/vllm-omni/vllm_omni/__init__.py:30: RuntimeWarning: Failed to import version from _version.py: No module named 'vllm_omni._version'
This typically happens in development mode before building.
Using fallback version 'dev'.
  from .version import __version__, __version_tuple__  # isort:skip
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:53:43 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='Qwen/Qwen2.5-Omni-7B', speculative_config=None, tokenizer='Qwen/Qwen2.5-Omni-7B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=16384, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen2.5-Omni-7B, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [16384], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:53:46 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.5:39341 backend=nccl
[W227 08:53:46.914357401 socket.cpp:209] [c10d] The hostname of the client socket cannot be retrieved. err=-3
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:53:46 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:53:47 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.5:57551 backend=nccl
[W227 08:53:47.430058483 socket.cpp:209] [c10d] The hostname of the client socket cannot be retrieved. err=-3
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:53:47 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A
(EngineCore_DP0 pid=329811) The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
(EngineCore_DP0 pid=329814) The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
[Stage-2] WARNING 02-27 08:53:49 [envs.py:94] No Flash Attention backend found, using pytorch SDPA implementation
/app/vllm-omni/vllm_omni/__init__.py:30: RuntimeWarning: Failed to import version from _version.py: No module named 'vllm_omni._version'
This typically happens in development mode before building.
Using fallback version 'dev'.
  from .version import __version__, __version_tuple__  # isort:skip
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:53:49 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='Qwen/Qwen2.5-Omni-7B', speculative_config=None, tokenizer='Qwen/Qwen2.5-Omni-7B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen2.5-Omni-7B, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [100000], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:53:53 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.5:54533 backend=nccl
[W227 08:53:53.477703548 socket.cpp:209] [c10d] The hostname of the client socket cannot be retrieved. err=-3
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:53:53 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A
(EngineCore_DP0 pid=330463) The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:53:58 [gpu_model_runner.py:4124] Starting to load model Qwen/Qwen2.5-Omni-7B...
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:53:58 [vllm.py:689] Asynchronous scheduling is enabled.
(EngineCore_DP0 pid=329811) [Stage-0] WARNING 02-27 08:53:58 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:53:58 [vllm.py:845] Cudagraph is disabled under eager mode
(EngineCore_DP0 pid=329811) [Stage-0] WARNING 02-27 08:53:58 [qwen2_5_omni_thinker.py:346] flash_attn is not available, the model may not yield the exactly same result as the transformers implementation in the audio tower part.
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:53:58 [mm_encoder_attention.py:77] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:53:59 [gpu_model_runner.py:4124] Starting to load model Qwen/Qwen2.5-Omni-7B...
(EngineCore_DP0 pid=329811) [Stage-0] WARNING 02-27 08:53:59 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:53:59 [vllm.py:845] Cudagraph is disabled under eager mode
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:53:59 [cuda.py:367] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:53:59 [vllm.py:689] Asynchronous scheduling is enabled.
(EngineCore_DP0 pid=329814) [Stage-1] WARNING 02-27 08:53:59 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:53:59 [vllm.py:845] Cudagraph is disabled under eager mode
(EngineCore_DP0 pid=329814) [Stage-1] WARNING 02-27 08:53:59 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:53:59 [vllm.py:845] Cudagraph is disabled under eager mode
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:53:59 [cuda.py:367] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:53:59 [mm_encoder_attention.py:77] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
Loading safetensors checkpoint shards:   0% Completed | 0/5 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  20% Completed | 1/5 [00:00<00:00,  4.37it/s]
Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:00<00:00, 15.22it/s]
(EngineCore_DP0 pid=329811) 
Loading safetensors checkpoint shards:   0% Completed | 0/5 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:00<00:00, 148.96it/s]
(EngineCore_DP0 pid=329814) 
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:04 [gpu_model_runner.py:4124] Starting to load model Qwen/Qwen2.5-Omni-7B...
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:05 [vllm.py:689] Asynchronous scheduling is enabled.
(EngineCore_DP0 pid=330463) [Stage-2] WARNING 02-27 08:54:05 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:05 [vllm.py:845] Cudagraph is disabled under eager mode
(EngineCore_DP0 pid=330463) [Stage-2] WARNING 02-27 08:54:05 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:05 [vllm.py:845] Cudagraph is disabled under eager mode
(EngineCore_DP0 pid=330463) [Stage-2] WARNING 02-27 08:54:05 [utils.py:67] Trying to guess the arguments for old-style model class <class 'vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_token2wav.Qwen2_5OmniToken2WavModel'>
Loading safetensors checkpoint shards:   0% Completed | 0/5 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 5/5 [00:00<00:00, 149.19it/s]
(EngineCore_DP0 pid=330463) 
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:06 [weight_utils.py:50] Using model weights format ['*.pt']
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:08 [qwen2_5_omni_token2wav.py:1759] [Model Loaded] name=Qwen2_5OmniToken2WavForConditionalGenerationVLLM, success=True, size=1492.80 MB, device=cuda:0
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:08 [default_loader.py:293] Loading weights took 1.51 seconds
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:08 [gpu_model_runner.py:4221] Model loading took 1.46 GiB memory and 3.060778 seconds
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:08 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:08 [qwen2_5_omni.py:945] Currently, we do not use the chunked process, we only use the token2wav.process_chunk for the whole sequence. The stream mode will be implemented in the future.
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:54:09 [default_loader.py:293] Loading weights took 8.72 seconds
(EngineCore_DP0 pid=330463) [Stage-2] WARNING 02-27 08:54:09 [gpu_generation_model_runner.py:451] Dummy sampler run is not implemented for generation model
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:09 [core.py:278] init engine (profile, create kv cache, warmup model) took 0.94 seconds
(EngineCore_DP0 pid=330463) [Stage-2] WARNING 02-27 08:54:09 [scheduler.py:166] Using custom scheduler class vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore_DP0 pid=330463) [Stage-2] WARNING 02-27 08:54:09 [core.py:130] Disabling chunked prefill for model without KVCache
(EngineCore_DP0 pid=330463) [Stage-2] WARNING 02-27 08:54:09 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:54:09 [vllm.py:845] Cudagraph is disabled under eager mode
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:54:10 [gpu_model_runner.py:4221] Model loading took 16.74 GiB memory and 11.088087 seconds
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:54:10 [gpu_model_runner.py:5113] Skipping memory profiling for multimodal encoder and encoder cache.
(APIServer pid=327235) INFO 02-27 08:54:10 [omni.py:448] [AsyncOrchestrator] Stage-2 reported ready
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:54:11 [base.py:102] Available KV cache memory: 52.23 GiB (profiling fallback)
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:54:11 [kv_cache_utils.py:1307] GPU KV cache size: 978,000 tokens
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:54:11 [kv_cache_utils.py:1312] Maximum concurrency for 16,384 tokens per request: 59.69x
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:54:11 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:54:11 [core.py:278] init engine (profile, create kv cache, warmup model) took 1.79 seconds
(EngineCore_DP0 pid=329811) [Stage-0] WARNING 02-27 08:54:11 [scheduler.py:166] Using custom scheduler class vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore_DP0 pid=329811) [Stage-0] WARNING 02-27 08:54:12 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=329811) [Stage-0] INFO 02-27 08:54:12 [vllm.py:845] Cudagraph is disabled under eager mode
(APIServer pid=327235) INFO 02-27 08:54:12 [omni.py:448] [AsyncOrchestrator] Stage-0 reported ready
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:54:13 [qwen2_5_omni_talker.py:198] [Model Loaded] name=Qwen2_5OmniTalkerForConditionalGeneration, success=True, size=5087.96 MB, device=cuda:0
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:54:13 [default_loader.py:293] Loading weights took 11.91 seconds
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:54:13 [gpu_model_runner.py:4221] Model loading took 6.03 GiB memory and 14.079092 seconds
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:54:14 [gpu_model_runner.py:5113] Skipping memory profiling for multimodal encoder and encoder cache.
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:54:15 [base.py:102] Available KV cache memory: 63.16 GiB (profiling fallback)
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:54:15 [kv_cache_utils.py:1307] GPU KV cache size: 1,379,632 tokens
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:54:15 [kv_cache_utils.py:1312] Maximum concurrency for 16,384 tokens per request: 84.21x
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:54:15 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:54:15 [core.py:278] init engine (profile, create kv cache, warmup model) took 1.33 seconds
(EngineCore_DP0 pid=329814) [Stage-1] WARNING 02-27 08:54:15 [scheduler.py:166] Using custom scheduler class vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore_DP0 pid=329814) [Stage-1] WARNING 02-27 08:54:15 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=329814) [Stage-1] INFO 02-27 08:54:15 [vllm.py:845] Cudagraph is disabled under eager mode
(APIServer pid=327235) INFO 02-27 08:54:16 [omni.py:448] [AsyncOrchestrator] Stage-1 reported ready
(APIServer pid=327235) INFO 02-27 08:54:16 [omni.py:477] [AsyncOrchestrator] All stages initialized successfully
(APIServer pid=327235) The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
(APIServer pid=327235) INFO 02-27 08:54:31 [async_omni.py:232] [AsyncOrchestrator] Initialized input_processor, io_processor, and model_config from stage-0
(APIServer pid=327235) INFO 02-27 08:54:31 [api_server.py:477] Supported tasks: {'generate'}
(APIServer pid=327235) INFO 02-27 08:54:31 [api_server.py:539] Initialized io_processor for AsyncOmni
(APIServer pid=327235) INFO 02-27 08:54:31 [serving.py:188] Warming up chat template processing...
(APIServer pid=327235) INFO 02-27 08:54:38 [hf.py:318] Detected the chat template content format to be 'openai'. You can set `--chat-template-content-format` to override this.
(APIServer pid=327235) INFO 02-27 08:54:38 [serving.py:213] Chat template warmup completed in 6632.4ms
(APIServer pid=327235) WARNING 02-27 08:54:39 [serving_speech.py:117] No speakers found in talker_config (checked spk_id and speaker_id)
(APIServer pid=327235) INFO 02-27 08:54:39 [serving_speech.py:73] Loaded 0 supported speakers: []
(APIServer pid=327235) INFO 02-27 08:54:39 [api_server.py:270] Starting vLLM API server 0 on http://127.0.0.1:8091
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:38] Available routes are:
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /openapi.json, Methods: HEAD, GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /docs, Methods: HEAD, GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /docs/oauth2-redirect, Methods: HEAD, GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /redoc, Methods: HEAD, GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /load, Methods: GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /version, Methods: GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /tokenize, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /detokenize, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /inference/v1/generate, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /metrics, Methods: GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /health, Methods: GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /ping, Methods: GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /ping, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /invocations, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/responses, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/completions, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/completions/render, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/messages, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/chat/completions, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/audio/speech, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/audio/voices, Methods: GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /health, Methods: GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/models, Methods: GET
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/images/generations, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/images/edits, Methods: POST
(APIServer pid=327235) INFO 02-27 08:54:39 [launcher.py:47] Route: /v1/videos, Methods: POST
(APIServer pid=327235) INFO:     Started server process [327235]
(APIServer pid=327235) INFO:     Waiting for application startup.
(APIServer pid=327235) INFO:     Application startup complete.
Server ready on 127.0.0.1:8091
OmniServer started successfully

=== PRE-TEST GPU CLEANUP ===
GPU cleanup disabled
INFO 02-27 08:54:40 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 02-27 08:54:40 [vllm.py:689] Asynchronous scheduling is enabled.
--- Running test: test_send_multimodal_request_003[omni_server0]
(APIServer pid=327235) WARNING 02-27 08:54:40 [protocol.py:51] The following fields were present in the request but ignored: {'modalities', 'sampling_params_list'}
(APIServer pid=327235) INFO 02-27 08:54:44 [async_omni.py:341] [AsyncOrchestrator] Entering scheduling loop: stages=3, final_stage=2
[Stage-0] INFO 02-27 08:54:52 [loggers.py:259] Engine 000: Avg prompt throughput: 790.4 tokens/s, Avg generation throughput: 4.0 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.8%, Prefix cache hit rate: 0.0%, MM cache hit rate: 0.0%
[Stage-1] INFO 02-27 08:54:55 [loggers.py:259] Engine 000: Avg prompt throughput: 790.7 tokens/s, Avg generation throughput: 17.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.6%, Prefix cache hit rate: 0.0%, MM cache hit rate: 0.0%
[Stage-0] INFO 02-27 08:55:02 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 3.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, MM cache hit rate: 0.0%
(EngineCore_DP0 pid=330463) [Stage-2] INFO 02-27 08:55:05 [qwen2_5_omni.py:945] Currently, we do not use the chunked process, we only use the token2wav.process_chunk for the whole sequence. The stream mode will be implemented in the future.
[Stage-1] INFO 02-27 08:55:05 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 82.8 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%, MM cache hit rate: 0.0%
(APIServer pid=327235) WARNING 02-27 08:55:09 [protocol.py:51] The following fields were present in the request but ignored: {'reasoning_content'}
(APIServer pid=327235) INFO:     127.0.0.1:51034 - "POST /v1/chat/completions HTTP/1.1" 200 OK
All output:
Running query type: mixed_modalities

Output of request: "The audio recites \"Mary had a little lamb\". The image shows a baby with glasses reading a book. It's funny because it's so unexpected to see a baby wearing glasses and actually reading a book. Babies usually don't read books like that. So, what do you think about this? Do you have any other thoughts on it?"

text content is: "The audio recites \"Mary had a little lamb\". The image shows a baby with glasses reading a book. It's funny because it's so unexpected to see a baby wearing glasses and actually reading a book. Babies usually don't read books like that. So, what do you think about this? Do you have any other thoughts on it?"

PASSEDGPU cleanup disabled
OmniServer stopping...
[rank0]:[W227 08:55:09.000227639 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
[rank0]:[W227 08:55:09.005069419 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
[rank0]:[W227 08:55:09.052896788 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
(APIServer pid=327235) INFO 02-27 08:55:19 [launcher.py:122] Shutting down FastAPI HTTP server.
(APIServer pid=327235) WARNING 02-27 08:55:19 [async_omni.py:48] Failed to send shutdown signal to stage input queue: 
(APIServer pid=327235) WARNING 02-27 08:55:19 [async_omni.py:48] Failed to send shutdown signal to stage input queue: 
(APIServer pid=327235) WARNING 02-27 08:55:19 [async_omni.py:48] Failed to send shutdown signal to stage input queue: 
(APIServer pid=327235) WARNING 02-27 08:55:19 [omni_stage.py:542] Failed to send shutdown to in_q: Socket operation on non-socket
(APIServer pid=327235) WARNING 02-27 08:55:19 [omni_stage.py:542] Failed to send shutdown to in_q: Socket operation on non-socket
(APIServer pid=327235) WARNING 02-27 08:55:19 [omni_stage.py:542] Failed to send shutdown to in_q: Socket operation on non-socket
(APIServer pid=327235) INFO:     Shutting down
(APIServer pid=327235) INFO:     Waiting for application shutdown.
(APIServer pid=327235) INFO:     Application shutdown complete.
(APIServer pid=327235) Pre-test GPU status:
[GPU Memory Monitor] Waiting for GPU 3, 6, 7 to free memory, Condition: Memory usage ratio ≤ 5.0%
[GPU Memory Status] Current usage:
  GPU 3: 0.5GiB/79.6GiB (0.7%)
  GPU 6: 0.5GiB/79.6GiB (0.7%)
  GPU 7: 0.5GiB/79.6GiB (0.7%)
[GPU Memory Freed] Devices 3, 6, 7 meet memory condition
   Condition: Memory usage ratio ≤ 5.0%
   Wait time: 0.0 seconds (0.0 minutes)
   Final status:
     GPU 3: 0.5GiB/79.6GiB (0.7%)
     GPU 6: 0.5GiB/79.6GiB (0.7%)
     GPU 7: 0.5GiB/79.6GiB (0.7%)
Post-test GPU status:

================================================================================
NVIDIA GPU Information (nvidia-smi)
================================================================================
Fri Feb 27 08:55:22 2026       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.161.08             Driver Version: 535.161.08   CUDA Version: 12.9     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA H800                    On  | 00000000:1B:00.0 Off |                    0 |
| N/A   24C    P0              69W / 700W |      3MiB / 81559MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   1  NVIDIA H800                    On  | 00000000:43:00.0 Off |                    0 |
| N/A   26C    P0              66W / 700W |      3MiB / 81559MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
|   2  NVIDIA H800                    On  | 00000000:52:00.0 Off |                    0 |
| N/A   26C    P0              68W / 700W |      3MiB / 81559MiB |      0%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
... (showing first 20 of 48 lines)

================================================================================
Detailed GPU Processes (nvidia-smi pmon)
================================================================================
# gpu         pid  type    sm    mem    enc    dec    command
# Idx           #   C/G     %      %      %      %    name
    0          -     -      -      -      -      -    -              
    1          -     -      -      -      -      -    -              
    2          -     -      -      -      -      -    -              
    3          -     -      -      -      -      -    -              
    4          -     -      -      -      -      -    -              
    5          -     -      -      -      -      -    -              
    6          -     -      -      -      -      -    -              
    7          -     -      -      -      -      -    -              


================================================================================
System Processes with GPU keywords
================================================================================
OmniServer stopped


============================================================== warnings summary ==============================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110
  /app/vllm-omni/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:110: FutureWarning: Using `TRANSFORMERS_CACHE` is deprecated and will be removed in v5 of Transformers. Use `HF_HOME` instead.
    warnings.warn(

vllm_omni/__init__.py:30
  /app/vllm-omni/vllm_omni/__init__.py:30: RuntimeWarning: Failed to import version from _version.py: No module named 'vllm_omni._version'
  This typically happens in development mode before building.
  Using fallback version 'dev'.
    from .version import __version__, __version_tuple__  # isort:skip

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 1 passed, 4 warnings in 166.81s (0:02:46) ==================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
root@6d162d61c010:/app/vllm-omni# 
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please providing the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
