### PR TITLE
Fix no embed text spk tokens

### DIFF
--- a/docs/getting_started/installation/gpu/cuda.inc.md
+++ b/docs/getting_started/installation/gpu/cuda.inc.md
@@ -20,20 +20,7 @@ Therefore, it is recommended to install vLLM and vLLM-Omni with a **fresh new** 
 
 vLLM-Omni is built based on vLLM. Please install it with command below.
 ```bash
-# vllm 0.16.0 is still under prerelease
-uv pip install --prerelease=allow vllm --extra-index-url https://wheels.vllm.ai/2d5be1dd5ce2e44dfea53ea03ff61143da5137eb
-
-# vllm 0.16.0 may have some bugs for cuda 12.9, here is how we solve them:
-export FLASHINFER_CUDA_TAG="$(python3 -c 'import torch; print((torch.version.cuda or "12.4").replace(".", ""))')"
-
-uv pip install --upgrade --force-reinstall \
-  "flashinfer-python==0.6.3" \
-  "flashinfer-cubin==0.6.3" \
-  "flashinfer-jit-cache==0.6.3" \
-  --extra-index-url "https://flashinfer.ai/whl/cu${FLASHINFER_CUDA_TAG}"
-
-uv pip install --upgrade --force-reinstall "nvidia-cublas-cu12==12.9.1.4"
-uv pip install --upgrade --force-reinstall "numpy==2.2.6"
+uv pip install vllm --torch-backend=auto
 ```
 
 #### Installation of vLLM-Omni

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -19,18 +19,7 @@ uv venv --python 3.12 --seed
 source .venv/bin/activate
 
 # On CUDA
-# vllm 0.16.0 is still under prerelease
-uv pip install --prerelease=allow vllm --extra-index-url https://wheels.vllm.ai/2d5be1dd5ce2e44dfea53ea03ff61143da5137eb
-# vllm 0.16.0 may have some bugs for cuda 12.9, here is how we solve them:
-export FLASHINFER_CUDA_TAG="$(python3 -c 'import torch; print((torch.version.cuda or "12.4").replace(".", ""))')"
-uv pip install --upgrade --force-reinstall \
-  "flashinfer-python==0.6.3" \
-  "flashinfer-cubin==0.6.3" \
-  "flashinfer-jit-cache==0.6.3" \
-  --extra-index-url "https://flashinfer.ai/whl/cu${FLASHINFER_CUDA_TAG}"
-uv pip install --upgrade --force-reinstall "nvidia-cublas-cu12==12.9.1.4"
-uv pip install --upgrade --force-reinstall "numpy==2.2.6"
-
+uv pip install vllm==0.16.0 --torch-backend=auto
 
 # On ROCm
 uv pip install vllm==0.16.0 --extra-index-url https://wheels.vllm.ai/rocm/0.16.0/rocm700


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fix: https://github.com/vllm-project/vllm-omni/issues/1453
## Test Plan
pytest -s -v tests/e2e/offline_inference/test_qwen2_5_omni.py
## Test Result
```
=== PRE-TEST GPU CLEANUP ===
GPU cleanup disabled
INFO 02-27 17:13:03 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 02-27 17:13:03 [vllm.py:689] Asynchronous scheduling is enabled.
--- Running test: test_mix_to_audio[omni_runner0]
Multiple -pix_fmt options specified for stream 0, only the last option '-pix_fmt yuv420p' will be used.
Adding requests:   0%|                                                                                                                                                                                                    | 0/1 [00:00<?, ?it/s(EngineCore_DP0 pid=354357) [Stage-2] INFO 02-27 17:13:38 [qwen2_5_omni.py:947] Currently, we do not use the chunked process, we only use the token2wav.process_chunk for the whole sequence. The stream mode will be implemented in the future.]
Processed prompts: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:45<00:00, 45.24s/req, est. speed stage-2 tok/s: 77.85, avg e2e_lat: 0.0ms]
Adding requests:   0%|                                                                                                                                                                                                    | 0/1 [00:45<?, ?it/s]
audio content is: tensor([ 5.7220e-05,  1.2112e-04,  9.3460e-05,  ..., -7.4863e-05,
         7.6294e-06, -1.1587e-04])
PASSEDGPU cleanup disabled

tests/e2e/offline_inference/test_qwen2_5_omni.py::test_text_to_text[omni_runner0] 
=== PRE-TEST GPU CLEANUP ===
GPU cleanup disabled
INFO 02-27 17:13:49 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=2048.
--- Running test: test_text_to_text[omni_runner0]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.35req/s, est. speed stage-0 tok/s: 122.83, avg e2e_lat: 0.0ms]
Adding requests:   0%|                                                                                                                                                                                                    | 0/1 [00:00<?, ?it/s]
text content is: The capital of China is Beijing. Well, that's a basic fact you should know. If you have any other questions about China or anything else, feel free to ask.
PASSEDGPU cleanup disabled
OmniRunner stopping...
[Stage-0] INFO 02-27 17:13:50 [omni_stage.py:842] Received shutdown signal
[Stage-2] INFO 02-27 17:13:50 [omni_stage.py:842] Received shutdown signal
[Stage-1] INFO 02-27 17:13:50 [omni_stage.py:842] Received shutdown signal
WARNING 02-27 17:13:50 [omni_stage.py:542] Failed to send shutdown to in_q: Socket operation on non-socket
[rank0]:[W227 17:13:50.395243278 ProcessGroupNCCL.cpp:1553] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
[rank0]:[W227 17:13:50.404585832 ProcessGroupNCCL.cpp:1553] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
[rank0]:[W227 17:13:50.439491977 ProcessGroupNCCL.cpp:1553] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
WARNING 02-27 17:13:55 [omni_stage.py:542] Failed to send shutdown to in_q: Socket operation on non-socket
WARNING 02-27 17:13:56 [omni_stage.py:542] Failed to send shutdown to in_q: Socket operation on non-socket
Pre-test GPU status:
[GPU Memory Monitor] Waiting for GPU 0, 1, 2, 3, 4, 5, 6, 7 to free memory, Condition: Memory usage ratio ≤ 5.0%
[GPU Memory Status] Current usage:
  GPU 0: 0.8GiB/80.0GiB (0.9%)
  GPU 1: 0.8GiB/80.0GiB (0.9%)
  GPU 2: 0.8GiB/80.0GiB (0.9%)
  GPU 3: 0.8GiB/80.0GiB (0.9%)
  GPU 4: 0.8GiB/80.0GiB (0.9%)
  GPU 5: 0.8GiB/80.0GiB (0.9%)
  GPU 6: 64.9GiB/80.0GiB (81.1%)
  GPU 7: 64.9GiB/80.0GiB (81.1%)
[GPU Memory Status] Current usage:
  GPU 0: 0.8GiB/80.0GiB (0.9%)
  GPU 1: 0.8GiB/80.0GiB (0.9%)
  GPU 2: 0.8GiB/80.0GiB (0.9%)
  GPU 3: 0.8GiB/80.0GiB (1.0%)
  GPU 4: 0.8GiB/80.0GiB (0.9%)
  GPU 5: 0.8GiB/80.0GiB (0.9%)
  GPU 6: 64.9GiB/80.0GiB (81.1%)
  GPU 7: 64.9GiB/80.0GiB (81.1%)
Pre-test cleanup note: [GPU Memory Timeout] Devices 0, 1, 2, 3, 4, 5, 6, 7 still don't meet memory condition after 6.8 seconds
Condition: Memory usage ratio ≤ 5.0%
Current status:
  GPU 0: 0.8GiB/80.0GiB (0.9%)
  GPU 1: 0.8GiB/80.0GiB (0.9%)
  GPU 2: 0.8GiB/80.0GiB (0.9%)
  GPU 3: 0.8GiB/80.0GiB (1.0%)
  GPU 4: 0.8GiB/80.0GiB (0.9%)
  GPU 5: 0.8GiB/80.0GiB (0.9%)
  GPU 6: 64.9GiB/80.0GiB (81.1%)
  GPU 7: 64.9GiB/80.0GiB (81.1%)
Post-test GPU status:

================================================================================
NVIDIA GPU Information (nvidia-smi)
================================================================================
nvidia-smi not available or timed out

================================================================================
Detailed GPU Processes (nvidia-smi pmon)
================================================================================
nvidia-smi pmon not available

================================================================================
System Processes with GPU keywords
================================================================================
OmniRunner stopped

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please providing the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
