### PR TITLE
[Bugfix] Enable torch.compile for low noise model (transformer_2)

### DIFF
--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -68,6 +68,21 @@ class DiffusionModelRunner:
         # Initialize KV cache manager for connector management
         self.kv_transfer_manager = OmniKVTransferManager.from_od_config(od_config)
 
+    def _compile_transformer(self, attr_name: str) -> None:
+        """Compile a transformer attribute on the pipeline with torch.compile."""
+        model = getattr(self.pipeline, attr_name, None)
+        if model is None:
+            return
+        try:
+            setattr(self.pipeline, attr_name, regionally_compile(model, dynamic=True))
+            logger.info("Model runner: %s compiled with torch.compile.", attr_name)
+        except Exception as e:
+            logger.warning(
+                "Model runner: torch.compile for %s failed: %s. Using eager mode.",
+                attr_name,
+                e,
+            )
+
     def load_model(
         self,
         memory_pool_context_fn: callable | None = None,
@@ -131,25 +146,8 @@ class DiffusionModelRunner:
         # Apply torch.compile if not in eager mode
         if not self.od_config.enforce_eager:
             if current_omni_platform.supports_torch_inductor():
-                try:
-                    self.pipeline.transformer = regionally_compile(
-                        self.pipeline.transformer,
-                        dynamic=True,
-                    )
-                    logger.info("Model runner: Model compiled with torch.compile.")
-                except Exception as e:
-                    logger.warning(f"Model runner: torch.compile failed with error: {e}. Using eager mode.")
-                # Also compile transformer_2 (low noise model) if it exists
-                transformer_2 = getattr(self.pipeline, "transformer_2", None)
-                if transformer_2 is not None:
-                    try:
-                        self.pipeline.transformer_2 = regionally_compile(
-                            transformer_2,
-                            dynamic=True,
-                        )
-                        logger.info("Model runner: transformer_2 compiled with torch.compile.")
-                    except Exception as e:
-                        logger.warning(f"Model runner: torch.compile for transformer_2 failed: {e}. Using eager mode.")
+                self._compile_transformer("transformer")
+                self._compile_transformer("transformer_2")
             else:
                 logger.warning(
                     "Model runner: Platform %s does not support torch inductor, skipping torch.compile.",


### PR DESCRIPTION
## Summary
- `torch.compile` via `regionally_compile` was only applied to the primary transformer (high noise model), missing `transformer_2` (low noise model) used in pipelines like Wan2.2.
- This adds compilation for `transformer_2` when it exists on the pipeline, using the same `regionally_compile` pattern with independent error handling.

Fixes #1535

## Test plan
- Verified on models with `transformer_2` (e.g., Wan2.2 MoE) that the low noise model is now compiled.
- Models without `transformer_2` are unaffected (`getattr` returns `None`, block is skipped).