### PR TITLE
[BugFix] Fix unexpected crash when init OmniDiffusion

### DIFF
--- a/vllm_omni/entrypoints/omni_diffusion.py
+++ b/vllm_omni/entrypoints/omni_diffusion.py
@@ -75,16 +75,13 @@ class OmniDiffusion:
             # Map model_type or architecture to pipeline class
             model_type = cfg.get("model_type")
             architectures = cfg.get("architectures") or []
+            pipeline_class = None
             # Bagel/NextStep models don't have a model_index.json, so we set the pipeline class name manually
             if model_type == "bagel" or "BagelForConditionalGeneration" in architectures:
-                od_config.model_class_name = "BagelPipeline"
-                od_config.tf_model_config = TransformerConfig()
-                od_config.update_multimodal_support()
+                pipeline_class = "BagelPipeline"
             elif model_type == "nextstep":
                 if od_config.model_class_name is None:
-                    od_config.model_class_name = "NextStep11Pipeline"
-                od_config.tf_model_config = TransformerConfig()
-                od_config.update_multimodal_support()
+                    pipeline_class = "NextStep11Pipeline"
             elif model_type == "glm-image" or "GlmImageForConditionalGeneration" in architectures:
                 pipeline_class = "GlmImagePipeline"
             elif architectures and len(architectures) == 1:


### PR DESCRIPTION
When init class of OmniDiffusion, it may cause unexpected crash since var "pipeline_class" may not be initialied.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix unexpected crash when init OmniDiffusion.

## Test Plan
python examples/offline_inference/bagel/end2end.py --model /data/BAGEL-7B-MoT --modality text2img --prompts 'A cute cat'
## Test Result
```
INFO 02-27 20:41:24 [omni.py:181] Initializing stages for model: /data/BAGEL-7B-MoT
INFO 02-27 20:41:24 [omni.py:313] No omni_master_address provided, defaulting to localhost (127.0.0.1)
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
INFO 02-27 20:41:25 [initialization.py:233] Auto-configuring SharedMemoryConnector for edge ('0', '1')
INFO 02-27 20:41:25 [initialization.py:270] Loaded OmniTransferConfig with 1 connector configurations
INFO 02-27 20:41:25 [factory.py:46] Created connector: SharedMemoryConnector
INFO 02-27 20:41:25 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
INFO 02-27 20:41:25 [omni.py:347] [Orchestrator] Loaded 2 stages
INFO 02-27 20:41:25 [omni.py:458] [Orchestrator] Waiting for 2 stages to initialize (timeout: 300s)
[Stage-1] INFO 02-27 20:41:47 [omni_stage.py:679] Starting stage worker with model: /data/BAGEL-7B-MoT
[Stage-0] INFO 02-27 20:41:47 [omni_stage.py:679] Starting stage worker with model: /data/BAGEL-7B-MoT
[Stage-1] INFO 02-27 20:41:47 [omni_stage.py:694] [Stage] Set VLLM_WORKER_MULTIPROC_METHOD=spawn
[Stage-1] INFO 02-27 20:41:47 [omni_stage.py:725] [Stage-1] ZMQ transport detected; disabling SHM IPC (shm_threshold_bytes set to maxsize)
[Stage-1] INFO 02-27 20:41:47 [omni_stage.py:85] Using sequential init locks (nvml_available=True, pid_host=False)
[Stage-0] INFO 02-27 20:41:47 [omni_stage.py:694] [Stage] Set VLLM_WORKER_MULTIPROC_METHOD=spawn
[Stage-0] INFO 02-27 20:41:47 [omni_stage.py:725] [Stage-0] ZMQ transport detected; disabling SHM IPC (shm_threshold_bytes set to maxsize)
[Stage-0] INFO 02-27 20:41:47 [omni_stage.py:85] Using sequential init locks (nvml_available=True, pid_host=False)
[Stage-1] WARNING 02-27 20:41:47 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:41:47 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:41:57 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:41:58 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:41:58 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:41:59 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:41:59 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:41:59 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:00 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
/usr/local/lib/python3.12/dist-packages/fa3_fwd/_C.abi3.so: undefined symbol: torch_list_push_back
[Stage-1] WARNING 02-27 20:42:00 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:00 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:01 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:01 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:02 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:02 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:02 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:02 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:03 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:03 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:04 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:04 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:04 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:04 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:05 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:05 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:06 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:06 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-0] WARNING 02-27 20:42:07 [omni_stage.py:173] Timeout waiting for device 4 initialization lock, proceeding anyway
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
[Stage-0] INFO 02-27 20:42:07 [initialization.py:233] Auto-configuring SharedMemoryConnector for edge ('0', '1')
[Stage-0] INFO 02-27 20:42:07 [initialization.py:270] Loaded OmniTransferConfig with 1 connector configurations
[Stage-0] INFO 02-27 20:42:07 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-0] INFO 02-27 20:42:07 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
[Stage-0] INFO 02-27 20:42:07 [model.py:529] Resolved architecture: BagelForConditionalGeneration
[Stage-0] INFO 02-27 20:42:07 [model.py:1549] Using max model len 32768
[Stage-0] INFO 02-27 20:42:07 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=32768.
[Stage-0] INFO 02-27 20:42:07 [vllm.py:689] Asynchronous scheduling is enabled.
[Stage-0] WARNING 02-27 20:42:07 [vllm.py:727] Enforce eager set, overriding optimization level to -O0
[Stage-0] INFO 02-27 20:42:07 [vllm.py:845] Cudagraph is disabled under eager mode
/usr/local/lib/python3.12/dist-packages/transformers/models/auto/image_processing_auto.py:647: FutureWarning: The image_processor_class argument is deprecated and will be removed in v4.42. Please use `slow_image_processor_class`, or `fast_image_processor_class` instead
  warnings.warn(
[Stage-1] WARNING 02-27 20:42:08 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:08 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] INFO 02-27 20:42:12 [multiproc_executor.py:74] Starting server...
(EngineCore_DP0 pid=2809228) [Stage-0] INFO 02-27 20:42:30 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='/data/BAGEL-7B-MoT', speculative_config=None, tokenizer='/data/BAGEL-7B-MoT', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=/data/BAGEL-7B-MoT, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [32768], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=2809228) [Stage-0] WARNING 02-27 20:42:30 [multiproc_executor.py:921] Reducing Torch parallelism from 88 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
[Stage-1] INFO 02-27 20:42:36 [diffusion_worker.py:349] Worker 0 created result MessageQueue
[Stage-1] INFO 02-27 20:42:36 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=2048.
[Stage-1] INFO 02-27 20:42:36 [vllm.py:689] Asynchronous scheduling is enabled.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Stage-1] INFO 02-27 20:42:36 [diffusion_worker.py:114] Worker 0: Initialized device and distributed environment.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Stage-1] INFO 02-27 20:42:36 [parallel_state.py:575] Building SP subgroups from explicit sp_group_ranks (sp_size=1, ulysses=1, ring=1, use_ulysses_low=True).
[Stage-1] INFO 02-27 20:42:36 [parallel_state.py:617] SP group details for rank 0: sp_group=[0], ulysses_group=[0], ring_group=[0]
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Stage-1] WARNING 02-27 20:42:38 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
[Stage-1] WARNING 02-27 20:42:38 [interface.py:584] Current platform cuda does not have '__iter__' attribute.
/usr/local/lib/python3.12/dist-packages/fa3_fwd/_C.abi3.so: undefined symbol: torch_list_push_back
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:03<00:00,  1.95s/it]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:03<00:00,  1.95s/it]

[Stage-1] INFO 02-27 20:42:49 [pipeline_bagel.py:716] BagelPipeline weight filter kept 1466/1467 tensors (shape mismatches seen: 0)
[Stage-1] INFO 02-27 20:42:49 [diffusers_loader.py:301] Loading weights took 4.28 seconds
[Stage-1] INFO 02-27 20:42:50 [diffusion_model_runner.py:118] Model loading took 26.5314 GiB and 13.652462 seconds
[Stage-1] INFO 02-27 20:42:50 [diffusion_model_runner.py:123] Model runner: Model loaded successfully.
[Stage-1] INFO 02-27 20:42:50 [diffusion_model_runner.py:163] Model runner: Initialization complete.
[Stage-1] INFO 02-27 20:42:51 [diffusion_worker.py:142] Worker 0: Process-scoped GPU memory after model loading: 0.00 GiB.
[Stage-1] INFO 02-27 20:42:51 [manager.py:91] Initializing DiffusionLoRAManager: device=cuda:0, dtype=torch.bfloat16, max_cached_adapters=1, static_lora_path=None
[Stage-1] INFO 02-27 20:42:51 [diffusion_worker.py:84] Worker 0: Initialization complete.
[Stage-1] INFO 02-27 20:42:51 [diffusion_worker.py:483] Worker 0: Scheduler loop started.
[Stage-1] INFO 02-27 20:42:51 [diffusion_worker.py:406] Worker 0 ready to receive requests via shared memory
[Stage-1] INFO 02-27 20:42:51 [scheduler.py:41] SyncScheduler initialized result MessageQueue
[Stage-1] INFO 02-27 20:42:51 [diffusion_engine.py:341] dummy run to warm up the model
[Stage-1] INFO 02-27 20:42:51 [manager.py:566] Deactivating all adapters: 0 layers
[Stage-1] WARNING 02-27 20:42:51 [kv_transfer_manager.py:517] Request has no ID, cannot receive KV cache
/usr/local/lib/python3.12/dist-packages/transformers/models/auto/image_processing_auto.py:647: FutureWarning: The image_processor_class argument is deprecated and will be removed in v4.42. Please use `slow_image_processor_class`, or `fast_image_processor_class` instead
  warnings.warn(
[Stage-0] INFO 02-27 20:42:53 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:58879 backend=nccl
[Stage-0] INFO 02-27 20:42:53 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A
[Stage-1] INFO 02-27 20:42:54 [initialization.py:324] [Stage-1] Initializing OmniConnectors with config keys: ['from_stage_0']
[Stage-1] INFO 02-27 20:42:54 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-1] INFO 02-27 20:42:54 [initialization.py:60] Created connector for 0 -> 1: SharedMemoryConnector
[Stage-1] INFO 02-27 20:42:54 [omni_stage.py:794] Max batch size: 1
INFO 02-27 20:42:54 [omni.py:448] [Orchestrator] Stage-1 reported ready
(Worker pid=2809959) [Stage-0] INFO 02-27 20:42:57 [gpu_model_runner.py:4124] Starting to load model /data/BAGEL-7B-MoT...
(Worker pid=2809959) [Stage-0] INFO 02-27 20:42:57 [vllm.py:689] Asynchronous scheduling is enabled.
(Worker pid=2809959) [Stage-0] WARNING 02-27 20:42:57 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(Worker pid=2809959) [Stage-0] INFO 02-27 20:42:57 [vllm.py:845] Cudagraph is disabled under eager mode
(Worker pid=2809959) [Stage-0] INFO 02-27 20:42:58 [cuda.py:367] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(Worker pid=2809959) [Stage-0] WARNING 02-27 20:42:58 [bagel.py:391] Overriding vit_config.num_hidden_layers from 27 to 26 to match the Bagel model checkpoint.
(Worker pid=2809959) [Stage-0] WARNING 02-27 20:42:58 [bagel.py:397] Setting vit_config.vision_use_head to False as it is not present in the Bagel model checkpoint.
(Worker pid=2809959) [Stage-0] INFO 02-27 20:42:58 [mm_encoder_attention.py:77] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00, 61.68it/s]
(Worker pid=2809959) 
(Worker pid=2809959) [Stage-0] INFO 02-27 20:43:00 [default_loader.py:293] Loading weights took 2.08 seconds
(Worker pid=2809959) [Stage-0] INFO 02-27 20:43:01 [gpu_model_runner.py:4221] Model loading took 15.04 GiB memory and 2.953527 seconds
(Worker pid=2809959) [Stage-0] INFO 02-27 20:43:01 [gpu_model_runner.py:5140] Encoder cache will be initialized with a budget of 32768 tokens, and profiled with 6 image items of the maximum feature size.
(Worker pid=2809959) Using a slow image processor as `use_fast` is unset and a slow processor was saved with this model. `use_fast=True` will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with `use_fast=False`.
(Worker pid=2809959) [Stage-0] INFO 02-27 20:43:15 [base.py:102] Available KV cache memory: 7.31 GiB (profiling fallback)
(EngineCore_DP0 pid=2809228) [Stage-0] INFO 02-27 20:43:15 [kv_cache_utils.py:1307] GPU KV cache size: 136,800 tokens
(EngineCore_DP0 pid=2809228) [Stage-0] INFO 02-27 20:43:15 [kv_cache_utils.py:1312] Maximum concurrency for 32,768 tokens per request: 4.17x
(Worker pid=2809959) [Stage-0] INFO 02-27 20:43:15 [kernel_warmup.py:44] Skipping FlashInfer autotune because it is disabled.
(EngineCore_DP0 pid=2809228) [Stage-0] INFO 02-27 20:43:15 [core.py:278] init engine (profile, create kv cache, warmup model) took 14.12 seconds
(EngineCore_DP0 pid=2809228) [Stage-0] WARNING 02-27 20:43:15 [scheduler.py:166] Using custom scheduler class vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore_DP0 pid=2809228) /usr/local/lib/python3.12/dist-packages/transformers/models/auto/image_processing_auto.py:647: FutureWarning: The image_processor_class argument is deprecated and will be removed in v4.42. Please use `slow_image_processor_class`, or `fast_image_processor_class` instead
(EngineCore_DP0 pid=2809228)   warnings.warn(
(EngineCore_DP0 pid=2809228) [Stage-0] INFO 02-27 20:43:16 [vllm.py:689] Asynchronous scheduling is enabled.
(EngineCore_DP0 pid=2809228) [Stage-0] WARNING 02-27 20:43:16 [vllm.py:734] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=2809228) [Stage-0] INFO 02-27 20:43:16 [vllm.py:845] Cudagraph is disabled under eager mode
[Stage-0] INFO 02-27 20:43:16 [omni_llm.py:173] Supported_tasks: ['generate']
[Stage-0] INFO 02-27 20:43:16 [initialization.py:324] [Stage-0] Initializing OmniConnectors with config keys: ['to_stage_1']
[Stage-0] INFO 02-27 20:43:16 [omni_stage.py:794] Max batch size: 1
INFO 02-27 20:43:16 [omni.py:448] [Orchestrator] Stage-0 reported ready
INFO 02-27 20:43:16 [omni.py:477] [Orchestrator] All stages initialized successfully
Adding requests:   0%|                                                                                                                                                                                                          | 0/1 [00:00<?, ?it/s(Worker pid=2809959) [Stage-0] INFO 02-27 20:43:16 [kv_transfer_manager.py:142] Initializing OmniConnector with config: {'type': 'SharedMemoryConnector', 'shm_threshold_bytes': 65536, 'role': 'sender'}speed input: 0.00 unit/s, output: 0.00 unit/s]
(Worker pid=2809959) [Stage-0] INFO 02-27 20:43:16 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-1] INFO 02-27 20:43:16 [manager.py:566] Deactivating all adapters: 0 layers
[Stage-1] INFO 02-27 20:43:16 [kv_transfer_manager.py:142] Initializing OmniConnector with config: {'type': 'SharedMemoryConnector', 'shm_threshold_bytes': 65536, 'role': 'receiver'}
[Stage-1] INFO 02-27 20:43:16 [factory.py:46] Created connector: SharedMemoryConnector
[Stage-1] INFO 02-27 20:43:16 [kv_transfer_manager.py:437] Wait for KV cache for request 0_74ac9579-6dc5-4656-97cd-564b761ce381 from stage 0 to 1...
[Stage-1] INFO 02-27 20:43:16 [kv_transfer_manager.py:450] Successfully received KV cache for 0_74ac9579-6dc5-4656-97cd-564b761ce381, 0 bytes
(Worker pid=2809959) [Stage-0] INFO 02-27 20:43:16 [kv_transfer_manager.py:361] KV transfer OK: 0_74ac9579-6dc5-4656-97cd-564b761ce381, 346856 bytes
[Stage-1] INFO 02-27 20:44:16 [shm_broadcast.py:542] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
[Stage-1] INFO 02-27 20:45:16 [shm_broadcast.py:542] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
[Stage-1] INFO 02-27 20:46:00 [diffusion_engine.py:80] Generation completed successfully.
[Stage-1] INFO 02-27 20:46:00 [diffusion_engine.py:98] Post-processing completed in 0.0002 seconds
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [02:44<00:00, 164.16s/img, est. speed stage-1 img/s: 0.04, avg e2e_lat: 0.0ms]
Adding requests:   0%|                                                                                                                                                                                                          | 0/1 [02:44<?, ?it/s]
[Info] Saved stage output image to output_1_stage_None_0.png
[OmniRequestOutput(request_id='', finished=True, stage_id=0, final_output_type='text', request_output=[RequestOutput(request_id=0_74ac9579-6dc5-4656-97cd-564b761ce381, prompt="<|im_start|>'A cute cat'<|im_end|>", prompt_token_ids=[151644, 51274, 18838, 8251, 6, 151645], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text='', token_ids=[151645], routed_experts=None, cumulative_logprob=None, logprobs=None, finish_reason=stop, stop_reason=None)], finished=True, metrics=None, lora_request=None, num_cached_tokens=0, multi_modal_placeholders={})], images=[], prompt=None, latents=None, metrics={}, multimodal_output={}), OmniRequestOutput(request_id='', finished=True, stage_id=1, final_output_type='image', request_output=[OmniRequestOutput(request_id='0_74ac9579-6dc5-4656-97cd-564b761ce381', finished=True, stage_id=None, final_output_type='image', request_output=None, images=[1 PIL Images], prompt={'prompt_token_ids': [151645], 'multi_modal_data': None}, latents=None, metrics={'image_num': 1, 'resolution': 640, 'postprocess_time_ms': 0.17786026000976562}, multimodal_output={})], images=[], prompt=None, latents=None, metrics={}, multimodal_output={})]
[Stage-0] INFO 02-27 20:46:01 [omni_stage.py:842] Received shutdown signal
[Stage-1] INFO 02-27 20:46:01 [omni_stage.py:842] Received shutdown signal
WARNING 02-27 20:46:01 [omni_stage.py:542] Failed to send shutdown to in_q: Socket operation on non-socket
WARNING 02-27 20:46:06 [omni_stage.py:542] Failed to send shutdown to in_q: Socket operation on non-socket
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
