### PR TITLE
[Bugfix] Fix NameError in OmniDiffusion init for Bagel/NextStep after GLM-Image merge

### DIFF
--- a/vllm_omni/entrypoints/omni_diffusion.py
+++ b/vllm_omni/entrypoints/omni_diffusion.py
@@ -86,16 +86,15 @@ class OmniDiffusion:
                 od_config.tf_model_config = TransformerConfig()
                 od_config.update_multimodal_support()
             elif model_type == "glm-image" or "GlmImageForConditionalGeneration" in architectures:
-                pipeline_class = "GlmImagePipeline"
+                od_config.model_class_name = "GlmImagePipeline"
+                od_config.tf_model_config = TransformerConfig()
+                od_config.update_multimodal_support()
             elif architectures and len(architectures) == 1:
-                pipeline_class = architectures[0]
-
-            if pipeline_class is None:
+                od_config.model_class_name = architectures[0]
+                od_config.tf_model_config = TransformerConfig()
+                od_config.update_multimodal_support()
+            else:
                 raise ValueError(f"Unknown model type: {model_type}, architectures: {architectures}")
-
-            od_config.model_class_name = pipeline_class
-            od_config.tf_model_config = TransformerConfig()
-            od_config.update_multimodal_support()
 
         self.engine: DiffusionEngine = DiffusionEngine.make_engine(od_config)
 


### PR DESCRIPTION
## Summary
- PR #920 (GLM-Image support) refactored the model-type dispatch in `OmniDiffusion.__init__` but introduced a bug: the GLM-Image and single-architecture branches assign to a local `pipeline_class` variable, while lines 93-98 unconditionally read it. When Bagel or NextStep models hit their branches (which set `od_config` directly), `pipeline_class` is never defined, causing a `NameError`.
- Fix: make each branch self-contained — every branch sets `od_config.model_class_name`, `tf_model_config`, and calls `update_multimodal_support()` directly. No shared `pipeline_class` variable needed.

## Test plan
- [x] Verify Bagel model loads without crash: `OmniDiffusion(model="ByteDance-Seed/BAGEL-7B-MoT")`
- [x] Verify GLM-Image still works: `OmniDiffusion(model="THUDM/GLM-Image-1.0")`
- [x] Verify single-architecture fallback path still works