### PR TITLE
[Misc] change example code default serve port

### DIFF
--- a/benchmarks/diffusion/diffusion_benchmark_serving.py
+++ b/benchmarks/diffusion/diffusion_benchmark_serving.py
@@ -1214,10 +1214,10 @@ if __name__ == "__main__":
         "--base-url",
         type=str,
         default=None,
-        help="Base URL of the server (e.g., http://localhost:8091). Overrides host/port.",
+        help="Base URL of the server (e.g., http://localhost:8000). Overrides host/port.",
     )
     parser.add_argument("--host", type=str, default="localhost", help="Server host.")
-    parser.add_argument("--port", type=int, default=8091, help="Server port.")
+    parser.add_argument("--port", type=int, default=8000, help="Server port.")
     parser.add_argument("--model", type=str, default="default", help="Model name.")
     parser.add_argument(
         "--endpoint",

--- a/benchmarks/diffusion/performance_dashboard/qwen_image_serving_performance.md
+++ b/benchmarks/diffusion/performance_dashboard/qwen_image_serving_performance.md
@@ -30,7 +30,7 @@ This document covers:
 
 ```bash
 vllm serve Qwen/Qwen-Image --omni \
-    --port 8091
+    --port 8000
 ```
 
 To replay step-wise continuous batching, compare

--- a/benchmarks/diffusion/performance_dashboard/wan_2_2_serving_performance.md
+++ b/benchmarks/diffusion/performance_dashboard/wan_2_2_serving_performance.md
@@ -30,7 +30,7 @@ This document covers:
 
 ```bash
 vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni \
-    --port 8091
+    --port 8000
 ```
 
 ## 3.2 Key Parameters

--- a/benchmarks/fish-speech/bench_speaker_cache.py
+++ b/benchmarks/fish-speech/bench_speaker_cache.py
@@ -11,7 +11,7 @@ Usage:
         --ref-audio /path/to/reference.wav \
         --ref-text "Transcript of the reference audio." \
         --num-prompts 20 \
-        --port 8091
+        --port 8000
 
 The script runs two rounds:
   A) Inline ref_audio: every request sends base64 audio (no cache)
@@ -176,7 +176,7 @@ async def main():
         description="Benchmark Fish Speech voice cache (inline vs uploaded)",
     )
     parser.add_argument("--host", default="127.0.0.1")
-    parser.add_argument("--port", type=int, default=8091)
+    parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--ref-audio", required=True, help="Path to reference audio file")
     parser.add_argument("--ref-text", required=True, help="Transcript of reference audio")
     parser.add_argument("--num-prompts", type=int, default=20)

--- a/benchmarks/glm_image/README.md
+++ b/benchmarks/glm_image/README.md
@@ -76,7 +76,7 @@ In offline mode all requests are submitted simultaneously and processed with con
 
 ```bash
 CUDA_VISIBLE_DEVICES=0,1 vllm serve /path/to/GLM-Image \
-    --omni --port 8091 --host 0.0.0.0 \
+    --omni --port 8000 --host 0.0.0.0 \
     --served-model-name glm-image
 ```
 
@@ -113,7 +113,7 @@ python benchmarks/glm_image/benchmark_glm_image.py \
 | `--seed` | - | Random seed |
 | `--model` | `default` | Model name (must match `--served-model-name`) |
 | `--host` | `localhost` | Server host |
-| `--port` | `8091` | Server port |
+| `--port` | `8000` | Server port |
 | `--output-file` | - | JSON output file for metrics |
 | `--num-input-images` | `1` | Number of input images for random I2I |
 

--- a/benchmarks/glm_image/benchmark_glm_image.py
+++ b/benchmarks/glm_image/benchmark_glm_image.py
@@ -452,7 +452,7 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=None)
     parser.add_argument("--model", type=str, default="default")
     parser.add_argument("--host", type=str, default="localhost")
-    parser.add_argument("--port", type=int, default=8091)
+    parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--output-file", type=str, default=None)
     parser.add_argument("--disable-tqdm", action="store_true")
     parser.add_argument("--num-input-images", type=int, default=1, help="For random I2I dataset.")

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -15,7 +15,7 @@ vllm serve Qwen/Qwen2.5-Omni-7B --omni
 Specify the port:
 
 ```bash
-vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8000
 ```
 
 If you have custom stage configs file, launch the server with command below

--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -17,7 +17,7 @@ worker stages use GPU 1 via `CUDA_VISIBLE_DEVICES`.
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
-    --port 8091 \
+    --port 8000 \
     --stage-id 0 \
     --omni-master-address 127.0.0.1 \
     --omni-master-port 26000
@@ -41,7 +41,7 @@ However, under the **stage-based CLI** paradigm, where each process strictly enc
 For example, as an alternative to the following composite configuration:
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --stage-overrides '{"1": {"gpu_memory_utilization": 0.5}}'
 ```
 

--- a/docs/configuration/pd_disaggregation.md
+++ b/docs/configuration/pd_disaggregation.md
@@ -157,7 +157,7 @@ runtime:
 ## 4. Launch with your custom config
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --stage-configs-path /path/to/qwen3_omni_pd.yaml
 ```
 

--- a/docs/configuration/stage_configs.md
+++ b/docs/configuration/stage_configs.md
@@ -107,7 +107,7 @@ the example below uses `CUDA_VISIBLE_DEVICES=0` for Stage 0 and
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
-    --port 8091 \
+    --port 8000 \
     --stage-id 0 \
     --omni-master-address 127.0.0.1 \
     --omni-master-port 26000
@@ -126,7 +126,7 @@ In the context of standard initialization architectures, utilizing the `--stage-
 for delineating stage-specific tuning from the CLI interface:
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --stage-overrides '{"1": {"gpu_memory_utilization": 0.5}}'
 ```
 
@@ -181,7 +181,7 @@ stages:
 Launched with both an explicit global flag and a per-stage override:
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --deploy-config my_overrides.yaml \
     --max-model-len 16384 \
     --stage-overrides '{"0": {"max_num_seqs": 8}}'
@@ -233,13 +233,13 @@ omni = Omni(model=model_name, stage_configs_path="/path/to/custom_stage_configs.
 
 For online serving:
 ```bash
-vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091 --deploy-config /path/to/deploy_config.yaml
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8000 --deploy-config /path/to/deploy_config.yaml
 ```
 
 Legacy online serving:
 
 ```bash
-vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8091 --stage-configs-path /path/to/stage_configs_file
+vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8000 --stage-configs-path /path/to/stage_configs_file
 ```
 !!! important
     We are actively iterating on the definition of stage configs, and we welcome all feedbacks from both community users and developers to help us shape the development!

--- a/docs/contributing/model/adding_diffusion_model.md
+++ b/docs/contributing/model/adding_diffusion_model.md
@@ -866,7 +866,7 @@ This tool automatically measures the execution time of selected pipeline modules
 
 Enable timing by setting:
 ```
-vllm serve Qwen/Qwen-Image --omni --port 8091 --enable-diffusion-pipeline-profiler
+vllm serve Qwen/Qwen-Image --omni --port 8000 --enable-diffusion-pipeline-profiler
 ```
 You can optionally specify which modules to profile:
 ```

--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -208,7 +208,7 @@ Single-stage diffusion serving with torch profiler:
 ```bash
 vllm serve Wan-AI/Wan2.2-I2V-A14B-Diffusers \
   --omni \
-  --port 8091 \
+  --port 8000 \
   --profiler-config '{
     "profiler": "torch",
     "torch_profiler_dir": "/tmp/vllm_profile_wan22_i2v",
@@ -237,7 +237,7 @@ nsys profile \
   -o serving_trace \
   vllm serve Wan-AI/Wan2.2-I2V-A14B-Diffusers \
     --omni \
-    --port 8091 \
+    --port 8000 \
     --profiler-config '{"profiler": "cuda"}'
 ```
 
@@ -247,10 +247,10 @@ Example profiling flow for an online Qwen-Image request:
 
 ```bash
 # Start profiling.
-curl -X POST http://localhost:8091/start_profile
+curl -X POST http://localhost:8000/start_profile
 
 # Send a Qwen-Image generation request while profiling is active.
-curl http://localhost:8091/v1/images/generations \
+curl http://localhost:8000/v1/images/generations \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen-Image",
@@ -258,7 +258,7 @@ curl http://localhost:8091/v1/images/generations \
   }'
 
 # Stop profiling and flush profiler artifacts.
-curl -X POST http://localhost:8091/stop_profile
+curl -X POST http://localhost:8000/stop_profile
 ```
 
 ## 5. Diffusion Pipeline Profiler

--- a/docs/design/architecture_overview.md
+++ b/docs/design/architecture_overview.md
@@ -147,7 +147,7 @@ outputs = omni.generate(om_inputs, sampling_params_list)
 Similar to vLLM, vLLM-Omni also provides a FastAPI-based server for online serving. Users can launch the server using the vllm serve command with the `--omni` flag:
 
 ```
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000
 ```
 
 Users can send requests to the server using curl:
@@ -174,7 +174,7 @@ user_content='[
     mm_processor_kwargs="{}"
 
 # send the request
-curl -sS -X POST http://localhost:8091/v1/chat/completions \
+curl -sS -X POST http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d @- <<EOF
 {

--- a/docs/design/feature/diffusion_continuous_batching.md
+++ b/docs/design/feature/diffusion_continuous_batching.md
@@ -48,7 +48,7 @@ above `1` if you want batching:
 
 ```bash
 vllm serve Qwen/Qwen-Image --omni \
-  --port 8091 \
+  --port 8000 \
   --step-execution \
   --max-num-seqs 8
 ```

--- a/docs/design/feature/hsdp.md
+++ b/docs/design/feature/hsdp.md
@@ -121,7 +121,7 @@ output = omni.generate(
 **Or via command line:**
 
 ```bash
-vllm serve Your-org/your-model --omni --port 8091 --use-hsdp
+vllm serve Your-org/your-model --omni --port 8000 --use-hsdp
 ```
 
 **Verify:**

--- a/docs/design/feature/ray_based_execution.md
+++ b/docs/design/feature/ray_based_execution.md
@@ -19,7 +19,7 @@ To use the Ray backend, specify `worker_backend="ray"` when initializing the eng
 ```bash
 vllm serve Qwen/Qwen2.5-Omni-7B \
   --omni \
-  --port 8091 \
+  --port 8000 \
   --worker-backend ray \
   --ray-address auto
 ```

--- a/docs/design/qwen3_omni_tts_performance_optimization.md
+++ b/docs/design/qwen3_omni_tts_performance_optimization.md
@@ -403,7 +403,7 @@ The WebSocket protocol uses `audio.start` / binary PCM chunks / `audio.done` fra
 ```bash
 vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct \
   --omni \
-  --port 8091
+  --port 8000
 ```
 
 Notes:
@@ -417,7 +417,7 @@ Notes:
 ```bash
 vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct \
   --omni \
-  --port 8091 \
+  --port 8000 \
   --stage-configs-path vllm_omni/model_executor/stage_configs/qwen3_omni_moe_async_chunk.yaml
 ```
 

--- a/docs/getting_started/installation/gpu/cuda.inc.md
+++ b/docs/getting_started/installation/gpu/cuda.inc.md
@@ -100,10 +100,10 @@ Here's an example deployment command that has been verified on 2 x H100's:
 docker run --runtime nvidia --gpus 2 \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     --env "HF_TOKEN=$HF_TOKEN" \
-    -p 8091:8091 \
+    -p 8000:8000 \
     --ipc=host \
     vllm/vllm-omni:v0.22.0 \
-    vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
+    vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000
 ```
 
 !!! tip

--- a/docs/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/getting_started/installation/gpu/rocm.inc.md
@@ -87,10 +87,10 @@ docker run --rm \
 --device /dev/dri \
 -v ~/.cache/huggingface:/root/.cache/huggingface \
 --env "HF_TOKEN=$HF_TOKEN" \
--p 8091:8091 \
+-p 8000:8000 \
 --ipc=host \
 vllm-omni-rocm \
---model Qwen/Qwen3-Omni-30B-A3B-Instruct --port 8091
+--model Qwen/Qwen3-Omni-30B-A3B-Instruct --port 8000
 ```
 
 ##### Launch with interactive session for development
@@ -131,7 +131,7 @@ docker run --rm \
   --env "HF_TOKEN=$HF_TOKEN" \
   -p 8091:8091 \
   vllm/vllm-omni-rocm:v0.22.0 \
-  --model Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
+  --model Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000
 ```
 
 #### Launch an interactive terminal with prebuilt docker image.

--- a/docs/getting_started/installation/gpu/xpu.inc.md
+++ b/docs/getting_started/installation/gpu/xpu.inc.md
@@ -38,7 +38,7 @@ docker run -it -d --shm-size 10g \
   -v ~/.cache/huggingface:/root/.cache/huggingface \
   --env "HF_TOKEN=$HF_TOKEN" \
   vllm-omni-xpu \
-  --model Qwen/Qwen2.5-Omni-3B --port 8091
+  --model Qwen/Qwen2.5-Omni-3B --port 8000
 ```
 
 # --8<-- [end:build-docker]

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -99,11 +99,11 @@ For more usages, please refer to [offline inference](../user_guide/examples/offl
 Text-to-image generation quickstart with vLLM-Omni:
 
 ```bash
-vllm serve Tongyi-MAI/Z-Image-Turbo --omni --port 8091
+vllm serve Tongyi-MAI/Z-Image-Turbo --omni --port 8000
 ```
 
 ```bash
-curl -s http://localhost:8091/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [

--- a/docs/serving/audio_generate_api.md
+++ b/docs/serving/audio_generate_api.md
@@ -13,7 +13,7 @@ Each server instance runs a single model (specified at startup via `vllm-omni se
 ```bash
 vllm-omni serve stabilityai/stable-audio-open-1.0 \
     --host 0.0.0.0 \
-    --port 8091 \
+    --port 8000 \
     --gpu-memory-utilization 0.9 \
     --trust-remote-code \
     --enforce-eager \
@@ -25,7 +25,7 @@ vllm-omni serve stabilityai/stable-audio-open-1.0 \
 **Using curl:**
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "The sound of a cat purring",
@@ -39,7 +39,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 import httpx
 
 response = httpx.post(
-    "http://localhost:8091/v1/audio/generate",
+    "http://localhost:8000/v1/audio/generate",
     json={
         "input": "The sound of a cat purring",
         "audio_length": 10.0,
@@ -100,7 +100,7 @@ Returns binary audio data with the appropriate `Content-Type` header:
 Generate audio with only a text prompt (model defaults for all other parameters):
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "The sound of ocean waves crashing on a beach"
@@ -112,7 +112,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 Specify an explicit audio length in seconds:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "A dog barking",
@@ -125,7 +125,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 Use a negative prompt to steer generation away from undesired characteristics, and increase inference steps for higher quality:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "A piano playing a gentle melody",
@@ -141,7 +141,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 Set a `seed` to get deterministic results across runs:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Thunder and rain sounds",
@@ -155,7 +155,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 Combine all parameters for precise control over generation:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Thunder and rain sounds",
@@ -172,7 +172,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 For faster generation with slightly lower quality:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Birds chirping in a forest",
@@ -187,7 +187,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 import httpx
 
 response = httpx.post(
-    "http://localhost:8091/v1/audio/generate",
+    "http://localhost:8000/v1/audio/generate",
     json={
         "input": "Thunder and rain",
         "audio_length": 15.0,
@@ -302,7 +302,7 @@ The model finished but returned no audio data. Verify the server started success
 
 ```bash
 # Check if the server is healthy
-curl http://localhost:8091/health
+curl http://localhost:8000/health
 ```
 
 ### Audio Quality Issues
@@ -329,7 +329,7 @@ Enable debug logging:
 ```bash
 vllm-omni serve stabilityai/stable-audio-open-1.0 \
     --host 0.0.0.0 \
-    --port 8091 \
+    --port 8000 \
     --gpu-memory-utilization 0.9 \
     --trust-remote-code \
     --enforce-eager \

--- a/docs/serving/chat_completions_api.md
+++ b/docs/serving/chat_completions_api.md
@@ -21,7 +21,7 @@ or `height`. How you pass these extra fields depends on your client.
 Wrap generation parameters inside an `"extra_body"` key in the JSON body:
 
 ```bash
-curl -s http://localhost:8091/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [

--- a/docs/serving/speech_api.md
+++ b/docs/serving/speech_api.md
@@ -20,19 +20,19 @@ Each server instance runs a single model (specified at startup via `vllm serve <
 vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
     --deploy-config vllm_omni/deploy/qwen3_tts.yaml \
     --omni \
-    --port 8091 \
+    --port 8000 \
     --trust-remote-code \
     --enforce-eager
 
 # Fish Speech S2 Pro
-vllm serve fishaudio/s2-pro --omni --port 8091
+vllm serve fishaudio/s2-pro --omni --port 8000
 
 # Voxtral TTS
-vllm serve mistralai/Voxtral-4B-TTS-2603 --omni --port 8091
+vllm serve mistralai/Voxtral-4B-TTS-2603 --omni --port 8000
 
 # CosyVoice3 (voice cloning only — supply ref_audio + ref_text per request)
 vllm serve FunAudioLLM/Fun-CosyVoice3-0.5B-2512 \
-    --omni --port 8091 --trust-remote-code
+    --omni --port 8000 --trust-remote-code
 ```
 
 ### Generate Speech
@@ -40,7 +40,7 @@ vllm serve FunAudioLLM/Fun-CosyVoice3-0.5B-2512 \
 **Using curl:**
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, how are you?",
@@ -55,7 +55,7 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 import httpx
 
 response = httpx.post(
-    "http://localhost:8091/v1/audio/speech",
+    "http://localhost:8000/v1/audio/speech",
     json={
         "input": "Hello, how are you?",
         "voice": "vivian",
@@ -73,7 +73,7 @@ with open("output.wav", "wb") as f:
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="none")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="none")
 
 response = client.audio.speech.create(
     model="Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
@@ -196,7 +196,7 @@ Fields `ref_text` and `speaker_description` are omitted when not provided at upl
 **Usage Example:**
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/voices \
+curl -X POST http://localhost:8000/v1/audio/voices \
   -F "audio_sample=@/path/to/voice_sample.wav" \
   -F "consent=user_consent_id" \
   -F "name=custom_voice_1" \
@@ -274,7 +274,7 @@ Delete an uploaded voice sample.
 **Usage Example:**
 
 ```bash
-curl -X DELETE http://localhost:8091/v1/audio/voices/custom_voice_1
+curl -X DELETE http://localhost:8000/v1/audio/voices/custom_voice_1
 ```
 
 ## Examples
@@ -282,7 +282,7 @@ curl -X DELETE http://localhost:8091/v1/audio/voices/custom_voice_1
 ### CustomVoice with Style Instruction
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "I am so excited!",
@@ -298,13 +298,13 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign \
     --deploy-config vllm_omni/deploy/qwen3_tts.yaml \
     --omni \
-    --port 8091 \
+    --port 8000 \
     --trust-remote-code \
     --enforce-eager
 ```
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello world",
@@ -320,13 +320,13 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-Base \
     --deploy-config vllm_omni/deploy/qwen3_tts.yaml \
     --omni \
-    --port 8091 \
+    --port 8000 \
     --trust-remote-code \
     --enforce-eager
 ```
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, this is a cloned voice",
@@ -340,7 +340,7 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 
 Upload voice (speaker embedding only):
 ```bash
-curl -X POST http://localhost:8091/v1/audio/voices \
+curl -X POST http://localhost:8000/v1/audio/voices \
   -F "audio_sample=@/path/to/voice_sample.wav" \
   -F "consent=user_consent_id" \
   -F "name=custom_voice_1"
@@ -348,7 +348,7 @@ curl -X POST http://localhost:8091/v1/audio/voices \
 
 Upload voice with transcript (in-context cloning, higher quality):
 ```bash
-curl -X POST http://localhost:8091/v1/audio/voices \
+curl -X POST http://localhost:8000/v1/audio/voices \
   -F "audio_sample=@/path/to/voice_sample.wav" \
   -F "consent=user_consent_id" \
   -F "name=custom_voice_2" \
@@ -357,7 +357,7 @@ curl -X POST http://localhost:8091/v1/audio/voices \
 
 ### Use Uploaded Voice
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, this is a cloned voice",
@@ -499,7 +499,7 @@ Each item in the `items` array requires only `input` (the text). All other field
 **Basic batch with shared defaults:**
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech/batch \
+curl -X POST http://localhost:8000/v1/audio/speech/batch \
     -H "Content-Type: application/json" \
     -d '{
         "items": [
@@ -514,7 +514,7 @@ curl -X POST http://localhost:8091/v1/audio/speech/batch \
 **Per-item overrides (different voices and formats):**
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech/batch \
+curl -X POST http://localhost:8000/v1/audio/speech/batch \
     -H "Content-Type: application/json" \
     -d '{
         "items": [
@@ -528,7 +528,7 @@ curl -X POST http://localhost:8091/v1/audio/speech/batch \
 **Voice cloning with shared reference audio (Base task):**
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech/batch \
+curl -X POST http://localhost:8000/v1/audio/speech/batch \
     -H "Content-Type: application/json" \
     -d '{
         "items": [
@@ -550,7 +550,7 @@ import base64
 import httpx
 
 response = httpx.post(
-    "http://localhost:8091/v1/audio/speech/batch",
+    "http://localhost:8000/v1/audio/speech/batch",
     json={
         "items": [
             {"input": "First sentence."},
@@ -580,7 +580,7 @@ For best throughput, set both stages' `max_num_seqs` above 1 via `--stage-overri
 
 ```bash
 vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
-    --omni --port 8091 --trust-remote-code --enforce-eager \
+    --omni --port 8000 --trust-remote-code --enforce-eager \
     --stage-overrides '{"0":{"max_num_seqs":10,"gpu_memory_utilization":0.2},
                         "1":{"max_num_seqs":10,"gpu_memory_utilization":0.2}}'
 ```
@@ -684,7 +684,7 @@ Ensure you're using the correct model variant for your task type:
 
 ```bash
 # Check if server is responding
-curl http://localhost:8091/v1/audio/voices
+curl http://localhost:8000/v1/audio/voices
 ```
 
 ### Out of Memory
@@ -705,7 +705,7 @@ Enable debug logging:
 vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
     --deploy-config vllm_omni/deploy/qwen3_tts.yaml \
     --omni \
-    --port 8091 \
+    --port 8000 \
     --trust-remote-code \
     --enforce-eager \
     --uvicorn-log-level debug

--- a/docs/user_guide/diffusion/cache_acceleration/cache_dit.md
+++ b/docs/user_guide/diffusion/cache_acceleration/cache_dit.md
@@ -132,10 +132,10 @@ See the [image_edit.py](https://github.com/vllm-project/vllm-omni/blob/main/exam
 
 ```bash
 # Default configuration (recommended)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --cache-backend cache_dit
+vllm serve Qwen/Qwen-Image --omni --port 8000 --cache-backend cache_dit
 
 # Custom configuration
-vllm serve Qwen/Qwen-Image --omni --port 8091 \
+vllm serve Qwen/Qwen-Image --omni --port 8000 \
   --cache-backend cache_dit \
   --cache-config '{"Fn_compute_blocks": 1, "residual_diff_threshold": 0.12}'
 ```

--- a/docs/user_guide/diffusion/cache_acceleration/teacache.md
+++ b/docs/user_guide/diffusion/cache_acceleration/teacache.md
@@ -103,10 +103,10 @@ See the [text_to_image.py](https://github.com/vllm-project/vllm-omni/blob/main/e
 
 ```bash
 # Default configuration
-vllm serve Qwen/Qwen-Image --omni --port 8091 --cache-backend tea_cache
+vllm serve Qwen/Qwen-Image --omni --port 8000 --cache-backend tea_cache
 
 # Custom configuration
-vllm serve Qwen/Qwen-Image --omni --port 8091 \
+vllm serve Qwen/Qwen-Image --omni --port 8000 \
   --cache-backend tea_cache \
   --cache-config '{"rel_l1_thresh": 0.2}'
 ```

--- a/docs/user_guide/diffusion/frame_interpolation.md
+++ b/docs/user_guide/diffusion/frame_interpolation.md
@@ -59,13 +59,13 @@ introducing another heavyweight GPU context in the API server process.
 Start the server:
 
 ```bash
-vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8091
+vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8000
 ```
 
 Run a sync request with interpolation enabled:
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos/sync \
+curl -X POST http://localhost:8000/v1/videos/sync \
   -F "prompt=A dog running through a park" \
   -F "num_frames=81" \
   -F "width=832" \

--- a/docs/user_guide/diffusion/parallelism/cfg_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/cfg_parallel.md
@@ -78,7 +78,7 @@ Enable CFG-Parallel in online serving:
 
 ```bash
 # Default configuration
-vllm serve Qwen/Qwen-Image-Edit --omni --port 8091 --cfg-parallel-size 2
+vllm serve Qwen/Qwen-Image-Edit --omni --port 8000 --cfg-parallel-size 2
 
 ```
 

--- a/docs/user_guide/diffusion/parallelism/hsdp.md
+++ b/docs/user_guide/diffusion/parallelism/hsdp.md
@@ -91,14 +91,14 @@ python examples/offline_inference/image_to_video/image_to_video.py \
 **Standalone HSDP** (shard model across 4 GPUs):
 
 ```bash
-vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8091 \
+vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8000 \
     --use-hsdp --hsdp-shard-size 4
 ```
 
 **Combined with Sequence Parallel**:
 
 ```bash
-vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8091 \
+vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8000 \
     --use-hsdp --usp 4
 ```
 

--- a/docs/user_guide/diffusion/parallelism/sequence_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/sequence_parallel.md
@@ -130,27 +130,27 @@ python examples/offline_inference/text_to_image/text_to_image.py \
 
 ```bash
 # Text-to-image (requires >= 2 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --usp 2
+vllm serve Qwen/Qwen-Image --omni --port 8000 --usp 2
 ```
 
 **Ulysses-SP with UAA mode** (for models with non-divisible head counts):
 
 ```bash
-vllm serve Tongyi-MAI/Z-Image-Turbo --omni --port 8091 --usp 4 --ulysses-mode advanced_uaa
+vllm serve Tongyi-MAI/Z-Image-Turbo --omni --port 8000 --usp 4 --ulysses-mode advanced_uaa
 ```
 
 **Ring-Attention:**
 
 ```bash
 # Text-to-image (requires >= 2 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --ring 2
+vllm serve Qwen/Qwen-Image --omni --port 8000 --ring 2
 ```
 
 **Hybrid Ulysses + Ring:**
 
 ```bash
 # Text-to-image (requires >= 4 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --usp 2 --ring 2
+vllm serve Qwen/Qwen-Image --omni --port 8000 --usp 2 --ring 2
 ```
 
 ---

--- a/docs/user_guide/diffusion/parallelism/tensor_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/tensor_parallel.md
@@ -80,11 +80,11 @@ You can enable tensor parallelism in online serving via `--tensor-parallel-size`
 
 ```bash
 # Text-to-Image with Qwen-Image on 2 GPUs
-vllm serve Qwen/Qwen-Image --omni --port 8091 \
+vllm serve Qwen/Qwen-Image --omni --port 8000 \
     --tensor-parallel-size 2
 
 # Text-to-Image with Z-Image (TP=2 only)
-vllm serve Tongyi-MAI/Z-Image-Turbo --omni --port 8091 \
+vllm serve Tongyi-MAI/Z-Image-Turbo --omni --port 8000 \
     --tensor-parallel-size 2
 ```
 

--- a/docs/user_guide/diffusion/parallelism/vae_patch_parallel.md
+++ b/docs/user_guide/diffusion/parallelism/vae_patch_parallel.md
@@ -98,7 +98,7 @@ You can enable VAE patch parallelism in online serving via `--vae-patch-parallel
 
 ```bash
 # Text-to-Image with Z-Image, TP=2 + VAE patch parallel=2
-vllm serve Tongyi-MAI/Z-Image-Turbo --omni --port 8091 \
+vllm serve Tongyi-MAI/Z-Image-Turbo --omni --port 8000 \
     --tensor-parallel-size 2 \
     --vae-patch-parallel-size 2 \
     --vae-use-tiling

--- a/docs/user_guide/diffusion/step_execution.md
+++ b/docs/user_guide/diffusion/step_execution.md
@@ -31,7 +31,7 @@ outputs = omni.generate(
 
 ```bash
 vllm serve Qwen/Qwen-Image --omni \
-  --port 8091 \
+  --port 8000 \
   --step-execution \
   --max-num-seqs 8
 ```

--- a/docs/user_guide/diffusion_features.md
+++ b/docs/user_guide/diffusion_features.md
@@ -217,7 +217,7 @@ This optimization is **enabled by default** with 4 threads. No configuration is 
 
 ```bash
 # Default (multi-thread enabled, 4 threads)
-vllm serve Qwen/Qwen-Image --omni --port 8091
+vllm serve Qwen/Qwen-Image --omni --port 8000
 
 # Custom thread count
 vllm serve Wan-AI/Wan2.2-I2V-A14B-Diffusers --omni --num-weight-load-threads 8

--- a/docs/user_guide/examples/online_serving/bagel.md
+++ b/docs/user_guide/examples/online_serving/bagel.md
@@ -26,7 +26,7 @@ Both topologies support all four modalities: `text2img`, `img2img`, `img2text`, 
 The default pipeline is auto-detected from the model. No extra flags needed:
 
 ```bash
-vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8091
+vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8000
 ```
 
 Or use the convenience script:
@@ -43,7 +43,7 @@ bash run_server_stage_cli.sh --stage 1
 To use a custom deploy YAML (note: `--stage-configs-path` is deprecated in favor of `--deploy-config`):
 
 ```bash
-vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8091 \
+vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8000 \
     --deploy-config /path/to/deploy_config.yaml
 ```
 
@@ -54,7 +54,7 @@ See [`bagel.yaml`](https://github.com/vllm-project/vllm-omni/tree/main/vllm_omni
 The DiT stage contains a full LLM, ViT, VAE, and tokenizer, so it can handle all modalities (text2img, img2img, img2text, text2text, think) without a separate Thinker stage:
 
 ```bash
-vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8091 \
+vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8000 \
     --deploy-config vllm_omni/deploy/bagel_single_stage.yaml
 ```
 
@@ -65,7 +65,7 @@ See [`bagel_single_stage.yaml`](https://github.com/vllm-project/vllm-omni/tree/m
 For larger models or multi-GPU environments, enable TP via CLI:
 
 ```bash
-vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8091 --tensor-parallel-size 2
+vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8000 --tensor-parallel-size 2
 ```
 
 Or set `tensor_parallel_size` per stage in a custom deploy YAML.
@@ -82,7 +82,7 @@ vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni \
     --port 8000 \
     --stage-id 0 \
     --omni-master-address <ORCHESTRATOR_IP> \
-    --omni-master-port 8091
+    --omni-master-port 8000
 ```
 
 **2. Launch Stage 1 (DiT)** on the remote node in headless mode:
@@ -92,7 +92,7 @@ vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni \
     --stage-id 1 \
     --headless \
     --omni-master-address <ORCHESTRATOR_IP> \
-    --omni-master-port 8091
+    --omni-master-port 8000
 ```
 
 Or use the convenience script:
@@ -152,7 +152,7 @@ python openai_chat_client.py \
 **curl:**
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [{"role": "user", "content": [{"type": "text", "text": "<|im_start|>A beautiful sunset over mountains<|im_end|>"}]}],
@@ -198,7 +198,7 @@ cat <<EOF > payload.json
 }
 EOF
 
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d @payload.json
 ```
@@ -232,7 +232,7 @@ cat <<EOF > payload.json
 }
 EOF
 
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d @payload.json
 ```
@@ -250,7 +250,7 @@ python openai_chat_client.py \
 **curl:**
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [{"role": "user", "content": [{"type": "text", "text": "<|im_start|>user\nWhat is the capital of France?<|im_end|>\n<|im_start|>assistant\n"}]}],
@@ -264,7 +264,7 @@ curl http://localhost:8091/v1/chat/completions \
 | :------- | :------ | :---------- |
 | `--prompt` / `-p` | `A cute cat` | Text prompt |
 | `--output` / `-o` | `bagel_output.png` | Output file path |
-| `--server` / `-s` | `http://localhost:8091` | Server URL |
+| `--server` / `-s` | `http://localhost:8000` | Server URL |
 | `--image-url` / `-i` | `None` | Input image URL or local path (img2img/img2text) |
 | `--modality` / `-m` | `text2img` | `text2img`, `img2img`, `img2text`, `text2text` |
 | `--height` | `512` | Image height in pixels |

--- a/docs/user_guide/examples/online_serving/glm_image.md
+++ b/docs/user_guide/examples/online_serving/glm_image.md
@@ -8,7 +8,7 @@ memory, sampling params) live in `vllm_omni/deploy/glm_image.yaml`.
 ## Start Server
 
 ```bash
-vllm serve zai-org/GLM-Image --omni --port 8091
+vllm serve zai-org/GLM-Image --omni --port 8000
 ```
 
 The config system auto-detects the pipeline from the model's `model_index.json` — no
@@ -18,7 +18,7 @@ By default, stage 0 (AR) runs on GPU 0 and stage 1 (Diffusion) on GPU 1. To colo
 both stages on a single GPU, override per stage:
 
 ```bash
-vllm serve zai-org/GLM-Image --omni --port 8091 \
+vllm serve zai-org/GLM-Image --omni --port 8000 \
     --stage-0-devices 0 --stage-1-devices 0
 ```
 
@@ -27,7 +27,7 @@ vllm serve zai-org/GLM-Image --omni --port 8091 \
 ### Text-to-Image
 
 ```bash
-curl -s http://localhost:8091/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [
@@ -46,7 +46,7 @@ curl -s http://localhost:8091/v1/chat/completions \
 ### Image-to-Image (Image Editing)
 
 ```bash
-curl -s http://localhost:8091/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [
@@ -73,7 +73,7 @@ curl -s http://localhost:8091/v1/chat/completions \
 from openai import OpenAI
 import base64
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="none")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="none")
 
 response = client.chat.completions.create(
     model="zai-org/GLM-Image",

--- a/docs/user_guide/examples/online_serving/image_to_video.md
+++ b/docs/user_guide/examples/online_serving/image_to_video.md
@@ -10,7 +10,7 @@ This example demonstrates how to deploy the Wan2.2 image-to-video model for onli
 ### Basic Start
 
 ```bash
-vllm serve Wan-AI/Wan2.2-I2V-A14B-Diffusers --omni --port 8091
+vllm serve Wan-AI/Wan2.2-I2V-A14B-Diffusers --omni --port 8000
 ```
 
 ### Start with Parameters
@@ -23,7 +23,7 @@ bash run_server.sh
 
 The script allows overriding:
 - `MODEL` (default: `Wan-AI/Wan2.2-I2V-A14B-Diffusers`)
-- `PORT` (default: `8091`)
+- `PORT` (default: `8000`)
 - `BOUNDARY_RATIO` (default: `0.875`)
 - `FLOW_SHIFT` (default: `12.0`)
 - `CACHE_BACKEND` (default: `none`)
@@ -60,7 +60,7 @@ file. Metadata is returned via response headers:
 - `X-Inference-Time-S`: wall-clock inference time in seconds
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos/sync \
+curl -X POST http://localhost:8000/v1/videos/sync \
   -F "prompt=A bear playing with yarn, smooth motion" \
   -F "input_reference=@/path/to/input.png" \
   -F "size=832x480" \
@@ -103,7 +103,7 @@ export VLLM_OMNI_STORAGE_MAX_CONCURRENCY=8
 bash run_curl_image_to_video.sh
 
 # Or execute directly (OpenAI-style multipart)
-create_response=$(curl -s http://localhost:8091/v1/videos \
+create_response=$(curl -s http://localhost:8000/v1/videos \
   -H "Accept: application/json" \
   -F "prompt=A bear playing with yarn, smooth motion" \
   -F "negative_prompt=low quality, blurry, static" \
@@ -124,7 +124,7 @@ create_response=$(curl -s http://localhost:8091/v1/videos \
 
 video_id=$(echo "$create_response" | jq -r '.id')
 while true; do
-  status=$(curl -s "http://localhost:8091/v1/videos/${video_id}" | jq -r '.status')
+  status=$(curl -s "http://localhost:8000/v1/videos/${video_id}" | jq -r '.status')
   if [ "$status" = "completed" ]; then
     break
   fi
@@ -135,8 +135,8 @@ while true; do
   sleep 2
 done
 
-curl -s "http://localhost:8091/v1/videos/${video_id}" | jq .
-curl -L "http://localhost:8091/v1/videos/${video_id}/content" -o wan22_i2v_output.mp4
+curl -s "http://localhost:8000/v1/videos/${video_id}" | jq .
+curl -L "http://localhost:8000/v1/videos/${video_id}/content" -o wan22_i2v_output.mp4
 ```
 
 ## Request Format
@@ -144,7 +144,7 @@ curl -L "http://localhost:8091/v1/videos/${video_id}/content" -o wan22_i2v_outpu
 ### Required Fields
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos \
+curl -X POST http://localhost:8000/v1/videos \
   -F "prompt=A bear playing with yarn, smooth motion" \
   -F "negative_prompt=low quality, blurry, static" \
   -F "input_reference=@/path/to/qwen-bear.png"
@@ -157,7 +157,7 @@ instead of uploading a file. Do not send `input_reference` and
 `image_reference` together.
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos \
+curl -X POST http://localhost:8000/v1/videos \
   -F "prompt=A bear playing with yarn, smooth motion" \
   -F 'image_reference={"image_url":"https://example.com/qwen-bear.png"}'
 ```
@@ -165,7 +165,7 @@ curl -X POST http://localhost:8091/v1/videos \
 ### Generation with Parameters
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos \
+curl -X POST http://localhost:8000/v1/videos \
   -F "prompt=A bear playing with yarn, smooth motion" \
   -F "negative_prompt=low quality, blurry, static" \
   -F "input_reference=@/path/to/qwen-bear.png" \
@@ -191,7 +191,7 @@ execution details and feature constraints.
 ### Frame Interpolation Example
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos/sync \
+curl -X POST http://localhost:8000/v1/videos/sync \
   -F "prompt=A bear playing with yarn, smooth motion" \
   -F "input_reference=@/path/to/qwen-bear.png" \
   -F "width=832" \
@@ -227,32 +227,32 @@ curl -X POST http://localhost:8091/v1/videos/sync \
 ### Retrieve a job
 
 ```bash
-curl -s http://localhost:8091/v1/videos/${video_id} | jq .
+curl -s http://localhost:8000/v1/videos/${video_id} | jq .
 ```
 
 ### List jobs
 
 ```bash
-curl -s http://localhost:8091/v1/videos | jq .
+curl -s http://localhost:8000/v1/videos | jq .
 ```
 
 ### Download the completed video
 
 ```bash
-curl -L http://localhost:8091/v1/videos/${video_id}/content -o wan22_i2v_output.mp4
+curl -L http://localhost:8000/v1/videos/${video_id}/content -o wan22_i2v_output.mp4
 ```
 
 ### Delete a job and its stored file
 
 ```bash
-curl -X DELETE http://localhost:8091/v1/videos/${video_id} | jq .
+curl -X DELETE http://localhost:8000/v1/videos/${video_id} | jq .
 ```
 
 ## Poll Until Complete
 
 ```bash
 while true; do
-  status=$(curl -s http://localhost:8091/v1/videos/${video_id} | jq -r '.status')
+  status=$(curl -s http://localhost:8000/v1/videos/${video_id} | jq -r '.status')
   if [ "$status" = "completed" ]; then
     break
   fi

--- a/docs/user_guide/examples/online_serving/mimo_audio.md
+++ b/docs/user_guide/examples/online_serving/mimo_audio.md
@@ -15,7 +15,7 @@ export MIMO_AUDIO_TOKENIZER_PATH="XiaomiMiMo/MiMo-Audio-Tokenizer"
 
 vllm serve XiaomiMiMo/MiMo-Audio-7B-Instruct --omni \
     --served-model-name "MiMo-Audio-7B-Instruct" \
-    --port 18091 \
+    --port 8000 \
     --chat-template ./examples/online_serving/mimo_audio/chat_template.jinja
 ```
 > ⚠️ **Important**  

--- a/docs/user_guide/examples/online_serving/qwen2_5_omni.md
+++ b/docs/user_guide/examples/online_serving/qwen2_5_omni.md
@@ -12,12 +12,12 @@ Please refer to [README.md](https://github.com/vllm-project/vllm-omni/tree/main/
 ### Launch the Server
 
 ```bash
-vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8000
 ```
 
 If you have custom stage configs file, launch the server with command below
 ```bash
-vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091 --stage-configs-path /path/to/stage_configs_file
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8000 --stage-configs-path /path/to/stage_configs_file
 ```
 
 ### Send Multi-modal Request
@@ -30,7 +30,7 @@ cd examples/online_serving/qwen2_5_omni
 #### Send request via python
 
 ```bash
-python openai_chat_completion_client_for_multimodal_generation.py --query-type mixed_modalities --port 8091 --host "localhost"
+python openai_chat_completion_client_for_multimodal_generation.py --query-type mixed_modalities --port 8000 --host "localhost"
 ```
 
 The Python client supports the following command-line arguments:
@@ -76,7 +76,7 @@ You can control output modalities to specify which types of output the model sho
 #### Text only
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen2.5-Omni-7B",
@@ -88,7 +88,7 @@ curl http://localhost:8091/v1/chat/completions \
 #### Text + Audio
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen2.5-Omni-7B",
@@ -112,7 +112,7 @@ python openai_chat_completion_client_for_multimodal_generation.py \
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
 
 response = client.chat.completions.create(
     model="Qwen/Qwen2.5-Omni-7B",
@@ -127,7 +127,7 @@ print(response.choices[0].message.content)
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
 
 response = client.chat.completions.create(
     model="Qwen/Qwen2.5-Omni-7B",
@@ -169,7 +169,7 @@ The Gradio demo connects to a vLLM API server. You have two options:
 The convenience script launches both the vLLM server and Gradio demo together:
 
 ```bash
-./run_gradio_demo.sh --model Qwen/Qwen2.5-Omni-7B --server-port 8091 --gradio-port 7861
+./run_gradio_demo.sh --model Qwen/Qwen2.5-Omni-7B --server-port 8000 --gradio-port 7861
 ```
 
 This script will:
@@ -180,7 +180,7 @@ This script will:
 
 The script supports the following arguments:
 - `--model`: Model name/path (default: Qwen/Qwen2.5-Omni-7B)
-- `--server-port`: Port for vLLM server (default: 8091)
+- `--server-port`: Port for vLLM server (default: 8000)
 - `--gradio-port`: Port for Gradio demo (default: 7861)
 - `--stage-configs-path`: Path to custom stage configs YAML file (optional)
 - `--server-host`: Host for vLLM server (default: 0.0.0.0)
@@ -192,12 +192,12 @@ The script supports the following arguments:
 **Step 1: Launch the vLLM API server**
 
 ```bash
-vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8000
 ```
 
 If you have custom stage configs file:
 ```bash
-vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091 --stage-configs-path /path/to/stage_configs_file
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8000 --stage-configs-path /path/to/stage_configs_file
 ```
 
 **Step 2: Run the Gradio demo**
@@ -205,7 +205,7 @@ vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091 --stage-configs-path /path/to
 In a separate terminal:
 
 ```bash
-python gradio_demo.py --model Qwen/Qwen2.5-Omni-7B --api-base http://localhost:8091/v1 --port 7861
+python gradio_demo.py --model Qwen/Qwen2.5-Omni-7B --api-base http://localhost:8000/v1 --port 7861
 ```
 
 Then open `http://localhost:7861/` on your local browser to interact with the web UI.
@@ -213,7 +213,7 @@ Then open `http://localhost:7861/` on your local browser to interact with the we
 The gradio script supports the following arguments:
 
 - `--model`: Model name/path (should match the server model)
-- `--api-base`: Base URL for the vLLM API server (default: http://localhost:8091/v1)
+- `--api-base`: Base URL for the vLLM API server (default: http://localhost:8000/v1)
 - `--ip`: Host/IP for Gradio server (default: 127.0.0.1)
 - `--port`: Port for Gradio server (default: 7861)
 - `--share`: Share the Gradio demo publicly (creates a public link)

--- a/docs/user_guide/examples/online_serving/qwen3_omni.md
+++ b/docs/user_guide/examples/online_serving/qwen3_omni.md
@@ -12,7 +12,7 @@ Please refer to [README.md](https://github.com/vllm-project/vllm-omni/tree/main/
 ### Launch the Server
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000
 ```
 
 The default deployment configuration situated at `vllm_omni/deploy/qwen3_omni_moe.yaml` is resolved and loaded
@@ -21,7 +21,7 @@ Asynchronous chunk streaming is **enabled by default** within the bundled config
 
 To explicitly utilize a custom deployment YAML, specify the configuration path:
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --deploy-config /path/to/deploy_config_file
 ```
 
@@ -35,7 +35,7 @@ The example below pins Stage 0 to GPU 0 and Stage 1/2 to GPU 1 via
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
-    --port 8091 \
+    --port 8000 \
     --stage-id 0 \
     --omni-master-address 127.0.0.1 \
     --omni-master-port 26000
@@ -68,7 +68,7 @@ For the regular one-process launch, stage-specific CLI tuning is usually done
 with `--stage-overrides`, for example:
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --stage-overrides '{"1": {"gpu_memory_utilization": 0.5}}'
 ```
 
@@ -95,7 +95,7 @@ cd examples/online_serving/qwen3_omni
 ####  Send request via python
 
 ```bash
-python openai_chat_completion_client_for_multimodal_generation.py --query-type use_image --port 8091 --host "localhost"
+python openai_chat_completion_client_for_multimodal_generation.py --query-type use_image --port 8000 --host "localhost"
 ```
 
 The Python client supports the following command-line arguments:
@@ -140,7 +140,7 @@ You can control output modalities to specify which types of output the model sho
 #### Text only
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -152,7 +152,7 @@ curl http://localhost:8091/v1/chat/completions \
 #### Text + Audio
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -176,7 +176,7 @@ python openai_chat_completion_client_for_multimodal_generation.py \
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
 
 response = client.chat.completions.create(
     model="Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -191,7 +191,7 @@ print(response.choices[0].message.content)
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
 
 response = client.chat.completions.create(
     model="Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -233,7 +233,7 @@ The Gradio demo connects to a vLLM API server. You have two options:
 The convenience script launches both the vLLM server and Gradio demo together:
 
 ```bash
-./run_gradio_demo.sh --model Qwen/Qwen3-Omni-30B-A3B-Instruct --server-port 8091 --gradio-port 7861
+./run_gradio_demo.sh --model Qwen/Qwen3-Omni-30B-A3B-Instruct --server-port 8000 --gradio-port 7861
 ```
 
 This script will:
@@ -244,7 +244,7 @@ This script will:
 
 The script supports the following arguments:
 - `--model`: Model name/path (default: Qwen/Qwen3-Omni-30B-A3B-Instruct)
-- `--server-port`: Port for vLLM server (default: 8091)
+- `--server-port`: Port for vLLM server (default: 8000)
 - `--gradio-port`: Port for Gradio demo (default: 7861)
 - `--deploy-config`: Path to custom deploy config YAML file (optional)
 - `--server-host`: Host for vLLM server (default: 0.0.0.0)
@@ -256,12 +256,12 @@ The script supports the following arguments:
 **Step 1: Launch the vLLM API server**
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000
 ```
 
 If you have custom stage configs file:
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 --deploy-config /path/to/deploy_config_file
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 --deploy-config /path/to/deploy_config_file
 ```
 
 **Step 2: Run the Gradio demo**
@@ -269,7 +269,7 @@ vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 --deploy-config /
 In a separate terminal:
 
 ```bash
-python gradio_demo.py --model Qwen/Qwen3-Omni-30B-A3B-Instruct --api-base http://localhost:8091/v1 --port 7861
+python gradio_demo.py --model Qwen/Qwen3-Omni-30B-A3B-Instruct --api-base http://localhost:8000/v1 --port 7861
 ```
 
 Then open `http://localhost:7861/` on your local browser to interact with the web UI.
@@ -277,7 +277,7 @@ Then open `http://localhost:7861/` on your local browser to interact with the we
 The gradio script supports the following arguments:
 
 - `--model`: Model name/path (should match the server model)
-- `--api-base`: Base URL for the vLLM API server (default: http://localhost:8091/v1)
+- `--api-base`: Base URL for the vLLM API server (default: http://localhost:8000/v1)
 - `--ip`: Host/IP for Gradio server (default: 127.0.0.1)
 - `--port`: Port for Gradio server (default: 7861)
 - `--share`: Share the Gradio demo publicly (creates a public link)

--- a/docs/user_guide/examples/online_serving/text_to_audio.md
+++ b/docs/user_guide/examples/online_serving/text_to_audio.md
@@ -17,7 +17,7 @@ This example demonstrates how to deploy Stable Audio models for online text-to-a
 ```bash
 vllm-omni serve stabilityai/stable-audio-open-1.0 \
     --host 0.0.0.0 \
-    --port 8091 \
+    --port 8000 \
     --gpu-memory-utilization 0.9 \
     --trust-remote-code \
     --enforce-eager \
@@ -33,7 +33,7 @@ vllm-omni serve stabilityai/stable-audio-open-1.0 \
 bash curl_examples.sh
 
 # Or execute directly
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "The sound of a cat purring",
@@ -68,7 +68,7 @@ python stable_audio_client.py \
 
 The Python client supports the following command-line arguments:
 
-- `--api_url`: API endpoint URL (default: `http://localhost:8091/v1/audio/generate`)
+- `--api_url`: API endpoint URL (default: `http://localhost:8000/v1/audio/generate`)
 - `--text`: Text prompt for audio generation (default: `"The sound of a cat purring"`)
 - `--audio_length`: Audio length in seconds (default: `10.0`, max ~47s for `stable-audio-open-1.0`)
 - `--audio_start`: Audio start time in seconds (default: `0.0`)
@@ -85,7 +85,7 @@ The Python client supports the following command-line arguments:
 import httpx
 
 response = httpx.post(
-    "http://localhost:8091/v1/audio/generate",
+    "http://localhost:8000/v1/audio/generate",
     json={
         "input": "The sound of ocean waves crashing on a beach",
         "audio_length": 10.0,

--- a/docs/user_guide/examples/online_serving/text_to_image.md
+++ b/docs/user_guide/examples/online_serving/text_to_image.md
@@ -10,7 +10,7 @@ This example demonstrates how to deploy Qwen-Image model for online image genera
 ### Basic Start
 
 ```bash
-vllm serve Qwen/Qwen-Image --omni --port 8091
+vllm serve Qwen/Qwen-Image --omni --port 8000
 ```
 !!! note
     If you encounter Out-of-Memory (OOM) issues or have limited GPU memory, you can enable VAE slicing and tiling to reduce memory usage, --vae-use-slicing --vae-use-tiling
@@ -29,19 +29,19 @@ Enable Tensor Parallelism and VAE Patch Parallelism for faster inference:
 
 ```bash
 # With Tensor Parallelism (requires >= 2 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --tensor-parallel-size 2
+vllm serve Qwen/Qwen-Image --omni --port 8000 --tensor-parallel-size 2
 
 # With Tensor Parallelism and VAE Patch Parallelism (requires >= 2 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --tensor-parallel-size 2 --vae-patch-parallel-size 2 --vae-use-tiling
+vllm serve Qwen/Qwen-Image --omni --port 8000 --tensor-parallel-size 2 --vae-patch-parallel-size 2 --vae-use-tiling
 
 # With Sequence Parallelism (Ulysses-SP, requires >= 2 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --usp 2
+vllm serve Qwen/Qwen-Image --omni --port 8000 --usp 2
 
 # With Ring-Attention (requires >= 2 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --ring 2
+vllm serve Qwen/Qwen-Image --omni --port 8000 --ring 2
 
 # Combined: Ulysses + Ring (requires >= 4 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --usp 2 --ring 2
+vllm serve Qwen/Qwen-Image --omni --port 8000 --usp 2 --ring 2
 ```
 
 For more details on parallelism acceleration, see the [Parallelism Acceleration Guide](https://github.com/vllm-project/vllm-omni/tree/main/examples/diffusion/parallelism_acceleration.md).
@@ -55,7 +55,7 @@ For more details on parallelism acceleration, see the [Parallelism Acceleration 
 bash run_curl_text_to_image.sh
 
 # Or execute directly
-curl -s http://localhost:8091/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [
@@ -77,7 +77,7 @@ curl -s http://localhost:8091/v1/chat/completions \
 from openai import OpenAI
 import base64
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="none")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="none")
 
 response = client.chat.completions.create(
     model="Qwen/Qwen-Image",
@@ -139,7 +139,7 @@ python openai_chat_client.py \
 The `/v1/images/generations` endpoint supports a `lora` field in the request body:
 
 ```bash
-curl -X POST http://localhost:8091/v1/images/generations \
+curl -X POST http://localhost:8000/v1/images/generations \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "A piece of cheesecake",

--- a/docs/user_guide/examples/online_serving/text_to_speech.md
+++ b/docs/user_guide/examples/online_serving/text_to_speech.md
@@ -33,13 +33,13 @@ For offline inference of any of these models, see the [offline TTS hub](https://
 Launch the server (defaults shown — adjust `--port`, `--gpu-memory-utilization`, etc. as needed):
 
 ```bash
-vllm serve <hf-repo-or-local-path> --omni --port 8091
+vllm serve <hf-repo-or-local-path> --omni --port 8000
 ```
 
 Send a TTS request via curl:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, how are you?",
@@ -54,7 +54,7 @@ Or via Python httpx:
 import httpx
 
 response = httpx.post(
-    "http://localhost:8091/v1/audio/speech",
+    "http://localhost:8000/v1/audio/speech",
     json={
         "input": "Hello, how are you?",
         "voice": "default",
@@ -70,7 +70,7 @@ Or via the OpenAI SDK:
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="none")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="none")
 response = client.audio.speech.create(
     model="<hf-repo>",
     voice="default",
@@ -82,7 +82,7 @@ response.stream_to_file("output.wav")
 Streaming PCM output (where supported) — set `stream=true` with `response_format="pcm"`:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, how are you?",
@@ -111,7 +111,7 @@ If your downloaded checkpoint lacks `config.json`, add one with `{"model_type": 
 
 ### Launch
 ```bash
-vllm serve FunAudioLLM/Fun-CosyVoice3-0.5B-2512 --omni --port 8091 --trust-remote-code
+vllm serve FunAudioLLM/Fun-CosyVoice3-0.5B-2512 --omni --port 8000 --trust-remote-code
 # or:
 ./cosyvoice3/run_server.sh
 ```
@@ -157,7 +157,7 @@ pip install fish-speech
 
 ### Launch
 ```bash
-vllm serve fishaudio/s2-pro --omni --port 8091
+vllm serve fishaudio/s2-pro --omni --port 8000
 # or:
 ./fish_speech/run_server.sh
 ```
@@ -165,7 +165,7 @@ The deploy config auto-loads from `vllm_omni/deploy/fish_qwen3_omni.yaml` (the H
 
 ### Voice cloning
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, this is a cloned voice.",
@@ -185,7 +185,7 @@ python speech_client.py --text "Hello world" --stream --output output.pcm
 ### Gradio demo
 ```bash
 ./fish_speech/run_gradio_demo.sh             # launches server + Gradio
-python fish_speech/gradio_demo.py --api-base http://localhost:8091  # if server already running
+python fish_speech/gradio_demo.py --api-base http://localhost:8000  # if server already running
 ```
 
 ### Notes
@@ -239,7 +239,7 @@ python higgs_audio_v2/batch_speech_client.py \
 
 ### Launch
 ```bash
-vllm serve zai-org/GLM-TTS --omni --trust-remote-code --port 8091
+vllm serve zai-org/GLM-TTS --omni --trust-remote-code --port 8000
 # or:
 bash examples/online_serving/text_to_speech/glm_tts/run_server.sh /path/to/GLM-TTS
 ```
@@ -284,7 +284,7 @@ Voice cloning (offline) needs `transformers>=5.3.0`; auto voice works with `tran
 
 ### Launch
 ```bash
-vllm serve k2-fsa/OmniVoice --omni --port 8091 --trust-remote-code
+vllm serve k2-fsa/OmniVoice --omni --port 8000 --trust-remote-code
 # or:
 ./omnivoice/run_server.sh
 ```
@@ -317,7 +317,7 @@ Each variant ships smaller `0.6B` companions where available.
 
 ### Launch
 ```bash
-vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice --omni --port 8091
+vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice --omni --port 8000
 # or:
 ./qwen3_tts/run_server.sh                # default: CustomVoice
 ./qwen3_tts/run_server.sh VoiceDesign
@@ -368,10 +368,10 @@ python qwen3_tts/openai_speech_client.py \
 List available voices, or upload a custom one for Base cloning:
 ```bash
 # List
-curl http://localhost:8091/v1/audio/voices
+curl http://localhost:8000/v1/audio/voices
 
 # Upload
-curl -X POST http://localhost:8091/v1/audio/voices \
+curl -X POST http://localhost:8000/v1/audio/voices \
     -F "audio_sample=@/path/to/voice_sample.wav" \
     -F "consent=user_consent_id" \
     -F "name=custom_voice_1" \
@@ -399,7 +399,32 @@ Then start the server with that config and call the Speech API with only the voi
 ```bash
 vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-Base --omni --deploy-config /path/to/qwen3_tts_custom_voice.yaml
 
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{"input":"Hello from a precomputed voice.","voice":"alice","task_type":"Base"}' \
+    --output alice.wav
+```
+
+### Precomputed custom voices
+For reused Base voice-cloning speakers, precompute the reference artifacts once and load them at server startup:
+```bash
+python qwen3_tts/precompute_custom_voice.py \
+    --model Qwen/Qwen3-TTS-12Hz-1.7B-Base \
+    --voice-name alice \
+    --ref-audio /path/to/reference.wav \
+    --ref-text "Original transcript of the reference audio" \
+    --mode icl \
+    --output-dir /path/to/custom_voices
+```
+`--mode icl` stores both `speaker_embedding` and `ref_code`; `--mode xvec` stores only the speaker embedding. Add the output directory to a deploy config:
+```yaml
+custom_voice_dir: /path/to/custom_voices
+```
+Then start the server with that config and call the Speech API with only the voice name:
+```bash
+vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-Base --omni --deploy-config /path/to/qwen3_tts_custom_voice.yaml
+
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{"input":"Hello from a precomputed voice.","voice":"alice","task_type":"Base"}' \
     --output alice.wav
@@ -407,7 +432,7 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 
 ### Streaming PCM
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, how are you?",
@@ -449,6 +474,66 @@ python qwen3_tts/gradio_fastrtc_demo.py --api-base http://localhost:8000
 - `vllm_omni/deploy/qwen3_tts.yaml` is the default deploy config (loaded by HF `model_type`); per-stage runtime overrides are available via `--stage-N-<field> <value>`.
 
 ---
+
+## VoxCPM
+
+Split-stage TTS at 24 kHz.
+
+### Prerequisites
+```bash
+pip install voxcpm
+# or use a local source tree:
+export VLLM_OMNI_VOXCPM_CODE_PATH=/path/to/VoxCPM/src
+```
+
+If the native VoxCPM `config.json` lacks HF `model_type`, set up an HF-compatible config dir:
+```bash
+export VOXCPM_MODEL=/path/to/voxcpm-model
+export VLLM_OMNI_VOXCPM_HF_CONFIG_PATH=/tmp/voxcpm_hf_config
+mkdir -p "$VLLM_OMNI_VOXCPM_HF_CONFIG_PATH"
+cp "$VOXCPM_MODEL/config.json" "$VLLM_OMNI_VOXCPM_HF_CONFIG_PATH/config.json"
+cp "$VOXCPM_MODEL/generation_config.json" "$VLLM_OMNI_VOXCPM_HF_CONFIG_PATH/generation_config.json" 2>/dev/null || true
+python3 -c 'import json, os; p=os.path.join(os.environ["VLLM_OMNI_VOXCPM_HF_CONFIG_PATH"], "config.json"); cfg=json.load(open(p, "r", encoding="utf-8")); cfg["model_type"]="voxcpm"; cfg.setdefault("architectures", ["VoxCPMForConditionalGeneration"]); json.dump(cfg, open(p, "w", encoding="utf-8"), indent=2, ensure_ascii=False)'
+```
+
+### Launch
+```bash
+export VOXCPM_MODEL=/path/to/voxcpm-model
+./voxcpm/run_server.sh                # async-chunk streaming (default)
+./voxcpm/run_server.sh sync           # non-streaming
+```
+Or directly:
+```bash
+vllm serve "$VOXCPM_MODEL" \
+    --stage-configs-path vllm_omni/model_executor/stage_configs/voxcpm_async_chunk.yaml \
+    --trust-remote-code --enforce-eager --omni --port 8000
+```
+
+### Sending requests
+```bash
+# Basic TTS
+python voxcpm/openai_speech_client.py \
+    --model "$VOXCPM_MODEL" \
+    --text "This is a VoxCPM online text-to-speech example."
+
+# Voice cloning
+python voxcpm/openai_speech_client.py \
+    --model "$VOXCPM_MODEL" \
+    --text "This sentence is synthesized with a cloned voice." \
+    --ref-audio /path/to/reference.wav \
+    --ref-text "The exact transcript spoken in reference.wav."
+
+# Streaming PCM
+python voxcpm/openai_speech_client.py \
+    --model "$VOXCPM_MODEL" \
+    --text "This is a streaming VoxCPM request." \
+    --stream --output voxcpm_stream.pcm
+```
+
+### Notes
+- `voxcpm.yaml` for one-shot decode; `voxcpm_async_chunk.yaml` for single-request streaming. Do not use the async-chunk config for concurrent requests or `/v1/audio/speech/batch`.
+- Generic TTS fields not supported by VoxCPM: `voice`, `instructions`, `language`, `speaker_embedding`, `x_vector_only_mode`.
+- For benchmark measurement, see [`benchmarks/voxcpm`](https://github.com/vllm-project/vllm-omni/tree/main/benchmarks/voxcpm/README.md).
 
 ---
 
@@ -511,7 +596,7 @@ pip install -e /path/to/mistral-common  # or upgrade from PyPI when available
 
 ### Launch
 ```bash
-vllm serve mistralai/Voxtral-4B-TTS-2603 --omni --port 8091
+vllm serve mistralai/Voxtral-4B-TTS-2603 --omni --port 8000
 ```
 Deploy config auto-loads from `vllm_omni/deploy/voxtral_tts.yaml`.
 

--- a/docs/user_guide/examples/online_serving/text_to_video.md
+++ b/docs/user_guide/examples/online_serving/text_to_video.md
@@ -21,7 +21,7 @@ This example demonstrates how to deploy text-to-video models for online video ge
 #### Basic Start
 
 ```bash
-vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8091
+vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8000
 ```
 
 #### Start with Parameters
@@ -34,7 +34,7 @@ bash run_server.sh
 
 The script allows overriding:
 - `MODEL` (default: `Wan-AI/Wan2.2-T2V-A14B-Diffusers`)
-- `PORT` (default: `8091`)
+- `PORT` (default: `8000`)
 - `BOUNDARY_RATIO` (default: `0.875`)
 - `FLOW_SHIFT` (default: `5.0`)
 - `CACHE_BACKEND` (default: `none`)
@@ -71,7 +71,7 @@ file. Metadata is returned via response headers:
 - `X-Inference-Time-S`: wall-clock inference time in seconds
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos/sync \
+curl -X POST http://localhost:8000/v1/videos/sync \
   -F "prompt=Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage." \
   -F "size=832x480" \
   -F "num_frames=33" \
@@ -109,7 +109,7 @@ export VLLM_OMNI_STORAGE_MAX_CONCURRENCY=8
 bash run_curl_text_to_video.sh
 
 # Or execute directly (OpenAI-style multipart)
-create_response=$(curl -s http://localhost:8091/v1/videos \
+create_response=$(curl -s http://localhost:8000/v1/videos \
   -H "Accept: application/json" \
   -F "prompt=Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage." \
   -F "width=832" \
@@ -126,7 +126,7 @@ create_response=$(curl -s http://localhost:8091/v1/videos \
 
 video_id=$(echo "$create_response" | jq -r '.id')
 while true; do
-  status=$(curl -s "http://localhost:8091/v1/videos/${video_id}" | jq -r '.status')
+  status=$(curl -s "http://localhost:8000/v1/videos/${video_id}" | jq -r '.status')
   if [ "$status" = "completed" ]; then
     break
   fi
@@ -137,8 +137,8 @@ while true; do
   sleep 2
 done
 
-curl -s "http://localhost:8091/v1/videos/${video_id}" | jq .
-curl -L "http://localhost:8091/v1/videos/${video_id}/content" -o wan22_output.mp4
+curl -s "http://localhost:8000/v1/videos/${video_id}" | jq .
+curl -L "http://localhost:8000/v1/videos/${video_id}/content" -o wan22_output.mp4
 ```
 
 ## Request Format
@@ -146,14 +146,14 @@ curl -L "http://localhost:8091/v1/videos/${video_id}/content" -o wan22_output.mp
 ### Simple Text-to-Video Generation
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos \
+curl -X POST http://localhost:8000/v1/videos \
   -F "prompt=A cinematic view of a futuristic city at sunset"
 ```
 
 ### Generation with Parameters
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos \
+curl -X POST http://localhost:8000/v1/videos \
   -F "prompt=A cinematic view of a futuristic city at sunset" \
   -F "width=832" \
   -F "height=480" \
@@ -210,7 +210,7 @@ device without blocking the FastAPI event loop.
 Example: generate 5 frames and interpolate to 9 frames:
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos/sync \
+curl -X POST http://localhost:8000/v1/videos/sync \
   -F "prompt=A dog running through a park" \
   -F "num_frames=5" \
   -F "fps=8" \
@@ -240,32 +240,32 @@ curl -X POST http://localhost:8091/v1/videos/sync \
 ### Retrieve a job
 
 ```bash
-curl -s http://localhost:8091/v1/videos/${video_id} | jq .
+curl -s http://localhost:8000/v1/videos/${video_id} | jq .
 ```
 
 ### List jobs
 
 ```bash
-curl -s http://localhost:8091/v1/videos | jq .
+curl -s http://localhost:8000/v1/videos | jq .
 ```
 
 ### Download the completed video
 
 ```bash
-curl -L http://localhost:8091/v1/videos/${video_id}/content -o wan22_output.mp4
+curl -L http://localhost:8000/v1/videos/${video_id}/content -o wan22_output.mp4
 ```
 
 ### Delete a job and its stored file
 
 ```bash
-curl -X DELETE http://localhost:8091/v1/videos/${video_id} | jq .
+curl -X DELETE http://localhost:8000/v1/videos/${video_id} | jq .
 ```
 
 ## Poll Until Complete
 
 ```bash
 while true; do
-  status=$(curl -s http://localhost:8091/v1/videos/${video_id} | jq -r '.status')
+  status=$(curl -s http://localhost:8000/v1/videos/${video_id} | jq -r '.status')
   if [ "$status" = "completed" ]; then
     break
   fi

--- a/docs/user_guide/feature_compatibility.md
+++ b/docs/user_guide/feature_compatibility.md
@@ -118,13 +118,13 @@ python examples/offline_inference/text_to_image/text_to_image.py \
 
 ```bash
 # TeaCache + Ulysses-SP
-vllm serve Qwen/Qwen-Image --omni --port 8091 \
+vllm serve Qwen/Qwen-Image --omni --port 8000 \
   --cache-backend tea_cache \
   --cache-config '{"rel_l1_thresh": 0.2}' \
   --usp 2
 
 # Cache-DiT + Ring-Attention
-vllm serve Qwen/Qwen-Image --omni --port 8091 \
+vllm serve Qwen/Qwen-Image --omni --port 8000 \
   --cache-backend cache_dit \
   --cache-config '{"Fn_compute_blocks": 1, "max_warmup_steps": 8}' \
   --ring 2
@@ -133,7 +133,7 @@ vllm serve Qwen/Qwen-Image --omni --port 8091 \
 ### Cache + CFG-Parallel
 
 ```bash
-vllm serve Qwen/Qwen-Image-Edit --omni --port 8091 \
+vllm serve Qwen/Qwen-Image-Edit --omni --port 8000 \
   --cache-backend cache_dit \
   --cfg-parallel-size 2
 ```
@@ -142,13 +142,13 @@ vllm serve Qwen/Qwen-Image-Edit --omni --port 8091 \
 
 ```bash
 # CFG-Parallel + Ulysses-SP (4 GPUs total)
-vllm serve Qwen/Qwen-Image-Edit --omni --port 8091 \
+vllm serve Qwen/Qwen-Image-Edit --omni --port 8000 \
   --cache-backend cache_dit \
   --cfg-parallel-size 2 \
   --usp 2
 
 # Hybrid Ulysses + Ring (4 GPUs total)
-vllm serve Qwen/Qwen-Image --omni --port 8091 \
+vllm serve Qwen/Qwen-Image --omni --port 8000 \
   --cache-backend cache_dit \
   --usp 2 \
   --ring 2

--- a/examples/online_serving/bagel/README.md
+++ b/examples/online_serving/bagel/README.md
@@ -24,7 +24,7 @@ Both topologies support all four modalities: `text2img`, `img2img`, `img2text`, 
 The default pipeline is auto-detected from the model. No extra flags needed:
 
 ```bash
-vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8091
+vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8000
 ```
 
 Or use the convenience script:
@@ -41,7 +41,7 @@ bash run_server_stage_cli.sh --stage 1
 To use a custom deploy YAML, pass it via `--deploy-config`:
 
 ```bash
-vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8091 \
+vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8000 \
     --deploy-config /path/to/deploy_config.yaml
 ```
 
@@ -52,7 +52,7 @@ See [`bagel.yaml`](../../../vllm_omni/deploy/bagel.yaml) for the default two-sta
 The DiT stage contains a full LLM, ViT, VAE, and tokenizer, so it can handle all modalities (text2img, img2img, img2text, text2text, think) without a separate Thinker stage:
 
 ```bash
-vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8091 \
+vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8000 \
     --deploy-config vllm_omni/deploy/bagel_single_stage.yaml
 ```
 
@@ -63,7 +63,7 @@ See [`bagel_single_stage.yaml`](../../../vllm_omni/deploy/bagel_single_stage.yam
 For larger models or multi-GPU environments, enable TP via CLI:
 
 ```bash
-vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8091 --tensor-parallel-size 2
+vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni --port 8000 --tensor-parallel-size 2
 ```
 
 Or set `tensor_parallel_size` per stage in a custom deploy YAML.
@@ -99,7 +99,7 @@ vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni \
     --port 8000 \
     --stage-id 0 \
     --omni-master-address <ORCHESTRATOR_IP> \
-    --omni-master-port 8091
+    --omni-master-port 8000
 ```
 
 **2. Launch Stage 1 (DiT)** on the remote node in headless mode:
@@ -109,7 +109,7 @@ vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni \
     --stage-id 1 \
     --headless \
     --omni-master-address <ORCHESTRATOR_IP> \
-    --omni-master-port 8091
+    --omni-master-port 8000
 ```
 
 Or use the convenience script:
@@ -169,7 +169,7 @@ python openai_chat_client.py \
 **curl:**
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [{"role": "user", "content": [{"type": "text", "text": "<|im_start|>A beautiful sunset over mountains<|im_end|>"}]}],
@@ -215,7 +215,7 @@ cat <<EOF > payload.json
 }
 EOF
 
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d @payload.json
 ```
@@ -249,7 +249,7 @@ cat <<EOF > payload.json
 }
 EOF
 
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d @payload.json
 ```
@@ -267,7 +267,7 @@ python openai_chat_client.py \
 **curl:**
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [{"role": "user", "content": [{"type": "text", "text": "<|im_start|>user\nWhat is the capital of France?<|im_end|>\n<|im_start|>assistant\n"}]}],
@@ -281,7 +281,7 @@ curl http://localhost:8091/v1/chat/completions \
 | :------- | :------ | :---------- |
 | `--prompt` / `-p` | `A cute cat` | Text prompt |
 | `--output` / `-o` | `bagel_output.png` | Output file path |
-| `--server` / `-s` | `http://localhost:8091` | Server URL |
+| `--server` / `-s` | `http://localhost:8000` | Server URL |
 | `--image-url` / `-i` | `None` | Input image URL or local path (img2img/img2text) |
 | `--modality` / `-m` | `text2img` | `text2img`, `img2img`, `img2text`, `text2text` |
 | `--height` | `512` | Image height in pixels |

--- a/examples/online_serving/bagel/openai_chat_client.py
+++ b/examples/online_serving/bagel/openai_chat_client.py
@@ -16,7 +16,7 @@ import requests
 
 def generate_image(
     prompt: str,
-    server_url: str = "http://localhost:8091",
+    server_url: str = "http://localhost:8000",
     image_url: str | None = None,
     height: int | None = None,
     width: int | None = None,
@@ -127,7 +127,7 @@ def main():
     parser = argparse.ArgumentParser(description="Bagel multimodal chat client")
     parser.add_argument("--prompt", "-p", default="A cute cat", help="Text prompt")
     parser.add_argument("--output", "-o", default="bagel_output.png", help="Output file (for image results)")
-    parser.add_argument("--server", "-s", default="http://localhost:8091", help="Server URL")
+    parser.add_argument("--server", "-s", default="http://localhost:8000", help="Server URL")
 
     # Modality Control
     parser.add_argument("--image-url", "-i", type=str, help="Input image URL or local path")

--- a/examples/online_serving/bagel/run_server.sh
+++ b/examples/online_serving/bagel/run_server.sh
@@ -2,7 +2,7 @@
 # Bagel online serving startup script
 
 MODEL="${MODEL:-ByteDance-Seed/BAGEL-7B-MoT}"
-PORT="${PORT:-8091}"
+PORT="${PORT:-8000}"
 
 echo "Starting Bagel server..."
 echo "Model: $MODEL"

--- a/examples/online_serving/bagel/run_server_stage_cli.sh
+++ b/examples/online_serving/bagel/run_server_stage_cli.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 MODEL="${MODEL:-ByteDance-Seed/BAGEL-7B-MoT}"
-PORT="${PORT:-8091}"
+PORT="${PORT:-8000}"
 MASTER_ADDRESS="${MASTER_ADDRESS:-127.0.0.1}"
 MASTER_PORT="${MASTER_PORT:-8092}"
 STAGE="all"

--- a/examples/online_serving/dynin_omni/README.md
+++ b/examples/online_serving/dynin_omni/README.md
@@ -27,7 +27,7 @@ Run from repository root:
 ```bash
 vllm-omni serve snu-aidas/Dynin-Omni \
   --omni \
-  --port 8091 \
+  --port 8000 \
   --stage-configs-path "$(pwd)/vllm_omni/model_executor/stage_configs/dynin_omni.yaml"
 ```
 
@@ -36,7 +36,7 @@ If `vllm-omni` is not in PATH, run:
 ```bash
 PYTHONPATH="$(pwd)" python -m vllm_omni.entrypoints.cli.main serve snu-aidas/Dynin-Omni \
   --omni \
-  --port 8091 \
+  --port 8000 \
   --stage-configs-path "$(pwd)/vllm_omni/model_executor/stage_configs/dynin_omni.yaml"
 ```
 

--- a/examples/online_serving/dynin_omni/openai_chat_completion_client_for_multimodal_generation.py
+++ b/examples/online_serving/dynin_omni/openai_chat_completion_client_for_multimodal_generation.py
@@ -299,7 +299,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--port",
         type=int,
-        default=8091,
+        default=8000,
         help="Port of the vLLM Omni API server",
     )
     parser.add_argument(

--- a/examples/online_serving/image_to_video/README.md
+++ b/examples/online_serving/image_to_video/README.md
@@ -7,7 +7,7 @@ This example demonstrates how to deploy the Wan2.2 image-to-video model for onli
 ### Basic Start
 
 ```bash
-vllm serve Wan-AI/Wan2.2-I2V-A14B-Diffusers --omni --port 8091
+vllm serve Wan-AI/Wan2.2-I2V-A14B-Diffusers --omni --port 8000
 ```
 
 ### Start with Parameters
@@ -20,7 +20,7 @@ bash run_server.sh
 
 The script allows overriding:
 - `MODEL` (default: `Wan-AI/Wan2.2-I2V-A14B-Diffusers`)
-- `PORT` (default: `8091`)
+- `PORT` (default: `8000`)
 - `BOUNDARY_RATIO` (default: `0.875`)
 - `FLOW_SHIFT` (default: `12.0`)
 - `CACHE_BACKEND` (default: `none`)
@@ -33,7 +33,7 @@ For a local Wan2.2-LightX2V Diffusers directory on Ascend/NPU, you can start the
 ```bash
 vllm serve /path/to/Wan2.2-I2V-A14B-LightX2V-Diffusers-Lightning \
   --omni \
-  --port 8091 \
+  --port 8000 \
   --flow-shift 12 \
   --cfg-parallel-size 1 \
   --ulysses-degree 4 \
@@ -74,7 +74,7 @@ file. Metadata is returned via response headers:
 - `X-Inference-Time-S`: wall-clock inference time in seconds
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos/sync \
+curl -X POST http://localhost:8000/v1/videos/sync \
   -F "prompt=A bear playing with yarn, smooth motion" \
   -F "input_reference=@/path/to/input.png" \
   -F "size=832x480" \
@@ -96,7 +96,7 @@ For Wan Lightning/Distill checkpoints, pass `{"sample_solver":"euler"}` via `ext
 Example matching the local LightX2V deployment above:
 
 ```bash
-curl -sS -X POST http://localhost:8091/v1/videos/sync \
+curl -sS -X POST http://localhost:8000/v1/videos/sync \
   -H "Accept: video/mp4" \
   -F "prompt=A cat playing with yarn" \
   -F "input_reference=@/path/to/input.jpg" \
@@ -142,7 +142,7 @@ bash run_curl_image_to_video.sh
 SAMPLE_SOLVER=euler bash run_curl_image_to_video.sh
 
 # Or execute directly (OpenAI-style multipart)
-create_response=$(curl -s http://localhost:8091/v1/videos \
+create_response=$(curl -s http://localhost:8000/v1/videos \
   -H "Accept: application/json" \
   -F "prompt=A bear playing with yarn, smooth motion" \
   -F "negative_prompt=low quality, blurry, static" \
@@ -161,7 +161,7 @@ create_response=$(curl -s http://localhost:8091/v1/videos \
 
 video_id=$(echo "$create_response" | jq -r '.id')
 while true; do
-  status=$(curl -s "http://localhost:8091/v1/videos/${video_id}" | jq -r '.status')
+  status=$(curl -s "http://localhost:8000/v1/videos/${video_id}" | jq -r '.status')
   if [ "$status" = "completed" ]; then
     break
   fi
@@ -172,8 +172,8 @@ while true; do
   sleep 2
 done
 
-curl -s "http://localhost:8091/v1/videos/${video_id}" | jq .
-curl -L "http://localhost:8091/v1/videos/${video_id}/content" -o wan22_i2v_output.mp4
+curl -s "http://localhost:8000/v1/videos/${video_id}" | jq .
+curl -L "http://localhost:8000/v1/videos/${video_id}/content" -o wan22_i2v_output.mp4
 ```
 
 ## Request Format
@@ -181,7 +181,7 @@ curl -L "http://localhost:8091/v1/videos/${video_id}/content" -o wan22_i2v_outpu
 ### Required Fields
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos \
+curl -X POST http://localhost:8000/v1/videos \
   -F "prompt=A bear playing with yarn, smooth motion" \
   -F "negative_prompt=low quality, blurry, static" \
   -F "input_reference=@/path/to/qwen-bear.png"
@@ -194,7 +194,7 @@ instead of uploading a file. Do not send `input_reference` and
 `image_reference` together.
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos \
+curl -X POST http://localhost:8000/v1/videos \
   -F "prompt=A bear playing with yarn, smooth motion" \
   -F 'image_reference={"image_url":"https://example.com/qwen-bear.png"}'
 ```
@@ -202,7 +202,7 @@ curl -X POST http://localhost:8091/v1/videos \
 ### Generation with Parameters
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos \
+curl -X POST http://localhost:8000/v1/videos \
   -F "prompt=A bear playing with yarn, smooth motion" \
   -F "negative_prompt=low quality, blurry, static" \
   -F "input_reference=@/path/to/qwen-bear.png" \
@@ -241,32 +241,32 @@ curl -X POST http://localhost:8091/v1/videos \
 ### Retrieve a job
 
 ```bash
-curl -s http://localhost:8091/v1/videos/${video_id} | jq .
+curl -s http://localhost:8000/v1/videos/${video_id} | jq .
 ```
 
 ### List jobs
 
 ```bash
-curl -s http://localhost:8091/v1/videos | jq .
+curl -s http://localhost:8000/v1/videos | jq .
 ```
 
 ### Download the completed video
 
 ```bash
-curl -L http://localhost:8091/v1/videos/${video_id}/content -o wan22_i2v_output.mp4
+curl -L http://localhost:8000/v1/videos/${video_id}/content -o wan22_i2v_output.mp4
 ```
 
 ### Delete a job and its stored file
 
 ```bash
-curl -X DELETE http://localhost:8091/v1/videos/${video_id} | jq .
+curl -X DELETE http://localhost:8000/v1/videos/${video_id} | jq .
 ```
 
 ## Poll Until Complete
 
 ```bash
 while true; do
-  status=$(curl -s http://localhost:8091/v1/videos/${video_id} | jq -r '.status')
+  status=$(curl -s http://localhost:8000/v1/videos/${video_id} | jq -r '.status')
   if [ "$status" = "completed" ]; then
     break
   fi

--- a/examples/online_serving/mimo_audio/README.md
+++ b/examples/online_serving/mimo_audio/README.md
@@ -15,7 +15,7 @@ export MIMO_AUDIO_TOKENIZER_PATH="XiaomiMiMo/MiMo-Audio-Tokenizer"
 
 vllm serve XiaomiMiMo/MiMo-Audio-7B-Instruct --omni \
     --served-model-name "MiMo-Audio-7B-Instruct" \
-    --port 18091 \
+    --port 8000 \
     --chat-template ./examples/online_serving/mimo_audio/chat_template.jinja
 ```
 > ⚠️ **Important**  

--- a/examples/online_serving/mimo_audio/openai_chat_completion_client_for_multimodal_generation.py
+++ b/examples/online_serving/mimo_audio/openai_chat_completion_client_for_multimodal_generation.py
@@ -16,7 +16,7 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 # Modify OpenAI's API key and API base to use vLLM's API server.
 openai_api_key = "EMPTY"
-openai_api_base = "http://localhost:18091/v1"
+openai_api_base = "http://localhost:8000/v1"
 
 
 # Modify OpenAI's API key and API base to use vLLM's API server.

--- a/examples/online_serving/ming_flash_omni/README.md
+++ b/examples/online_serving/ming_flash_omni/README.md
@@ -20,14 +20,14 @@ For standalone TTS (talker only), see the [Ming-flash-omni-TTS section in the Te
 
 **Thinker + Talker (omni-speech, text + audio output):**
 ```bash
-vllm serve Jonathan1909/Ming-flash-omni-2.0 --omni --port 8091
+vllm serve Jonathan1909/Ming-flash-omni-2.0 --omni --port 8000
 ```
 
 The model registry auto-loads corresponding deploy yaml.
 
 **Thinker-only (text output):**
 ```bash
-vllm serve Jonathan1909/Ming-flash-omni-2.0 --omni --port 8091 \
+vllm serve Jonathan1909/Ming-flash-omni-2.0 --omni --port 8000 \
     --deploy-config vllm_omni/deploy/ming_flash_omni_thinker_only.yaml
 ```
 
@@ -45,7 +45,7 @@ full flag list):
 python examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py \
     --model Jonathan1909/Ming-flash-omni-2.0 \
     --query-type use_mixed_modalities \
-    --port 8091 --host localhost \
+    --port 8000 --host localhost \
     --modalities text
 ```
 
@@ -160,7 +160,7 @@ streaming, reasoning mode), see the recipe at
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
 
 response = client.chat.completions.create(
     model="Jonathan1909/Ming-flash-omni-2.0",

--- a/examples/online_serving/ming_flash_omni/run_curl_multimodal_generation.sh
+++ b/examples/online_serving/ming_flash_omni/run_curl_multimodal_generation.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Server port
-PORT="${PORT:-8091}"
+PORT="${PORT:-8000}"
 # Default query type
 QUERY_TYPE="${1:-text}"
 

--- a/examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py
+++ b/examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py
@@ -542,7 +542,7 @@ def parse_args():
     parser.add_argument(
         "--port",
         type=int,
-        default=8091,
+        default=8000,
         help="Port of the vLLM Omni API server.",
     )
     parser.add_argument(

--- a/examples/online_serving/qwen2_5_omni/README.md
+++ b/examples/online_serving/qwen2_5_omni/README.md
@@ -9,12 +9,12 @@ Please refer to [README.md](../../../README.md)
 ### Launch the Server
 
 ```bash
-vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8000
 ```
 
 If you have custom stage configs file, launch the server with command below
 ```bash
-vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091 --stage-configs-path /path/to/stage_configs_file
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8000 --stage-configs-path /path/to/stage_configs_file
 ```
 
 ### Send Multi-modal Request
@@ -27,7 +27,7 @@ cd examples/online_serving/qwen2_5_omni
 #### Send request via python
 
 ```bash
-python examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py --model Qwen/Qwen2.5-Omni-7B --query-type use_mixed_modalities --port 8091 --host "localhost"
+python examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py --model Qwen/Qwen2.5-Omni-7B --query-type use_mixed_modalities --port 8000 --host "localhost"
 ```
 
 The Python client supports the following command-line arguments:
@@ -74,7 +74,7 @@ You can control output modalities to specify which types of output the model sho
 #### Text only
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen2.5-Omni-7B",
@@ -86,7 +86,7 @@ curl http://localhost:8091/v1/chat/completions \
 #### Text + Audio
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen2.5-Omni-7B",
@@ -111,7 +111,7 @@ python examples/online_serving/openai_chat_completion_client_for_multimodal_gene
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
 
 response = client.chat.completions.create(
     model="Qwen/Qwen2.5-Omni-7B",
@@ -126,7 +126,7 @@ print(response.choices[0].message.content)
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
 
 response = client.chat.completions.create(
     model="Qwen/Qwen2.5-Omni-7B",
@@ -160,7 +160,7 @@ The Gradio demo connects to a vLLM API server. You have two options:
 The convenience script launches both the vLLM server and Gradio demo together:
 
 ```bash
-./run_gradio_demo.sh --model Qwen/Qwen2.5-Omni-7B --server-port 8091 --gradio-port 7861
+./run_gradio_demo.sh --model Qwen/Qwen2.5-Omni-7B --server-port 8000 --gradio-port 7861
 ```
 
 This script will:
@@ -171,7 +171,7 @@ This script will:
 
 The script supports the following arguments:
 - `--model`: Model name/path (default: Qwen/Qwen2.5-Omni-7B)
-- `--server-port`: Port for vLLM server (default: 8091)
+- `--server-port`: Port for vLLM server (default: 8000)
 - `--gradio-port`: Port for Gradio demo (default: 7861)
 - `--stage-configs-path`: Path to custom stage configs YAML file (optional)
 - `--server-host`: Host for vLLM server (default: 0.0.0.0)
@@ -183,12 +183,12 @@ The script supports the following arguments:
 **Step 1: Launch the vLLM API server**
 
 ```bash
-vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8000
 ```
 
 If you have custom stage configs file:
 ```bash
-vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091 --stage-configs-path /path/to/stage_configs_file
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8000 --stage-configs-path /path/to/stage_configs_file
 ```
 
 **Step 2: Run the Gradio demo**
@@ -196,7 +196,7 @@ vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091 --stage-configs-path /path/to
 In a separate terminal:
 
 ```bash
-python gradio_demo.py --model Qwen/Qwen2.5-Omni-7B --api-base http://localhost:8091/v1 --port 7861
+python gradio_demo.py --model Qwen/Qwen2.5-Omni-7B --api-base http://localhost:8000/v1 --port 7861
 ```
 
 Then open `http://localhost:7861/` on your local browser to interact with the web UI.
@@ -204,7 +204,7 @@ Then open `http://localhost:7861/` on your local browser to interact with the we
 The gradio script supports the following arguments:
 
 - `--model`: Model name/path (should match the server model)
-- `--api-base`: Base URL for the vLLM API server (default: http://localhost:8091/v1)
+- `--api-base`: Base URL for the vLLM API server (default: http://localhost:8000/v1)
 - `--ip`: Host/IP for Gradio server (default: 127.0.0.1)
 - `--port`: Port for Gradio server (default: 7861)
 - `--share`: Share the Gradio demo publicly (creates a public link)

--- a/examples/online_serving/qwen2_5_omni/gradio_demo.py
+++ b/examples/online_serving/qwen2_5_omni/gradio_demo.py
@@ -78,7 +78,7 @@ def parse_args():
     )
     parser.add_argument(
         "--api-base",
-        default="http://localhost:8091/v1",
+        default="http://localhost:8000/v1",
         help="Base URL for the vLLM API server.",
     )
     parser.add_argument(

--- a/examples/online_serving/qwen2_5_omni/run_curl_multimodal_generation.sh
+++ b/examples/online_serving/qwen2_5_omni/run_curl_multimodal_generation.sh
@@ -186,7 +186,7 @@ EOF
 )
 
 output=$(curl -sS --retry 3 --retry-delay 3 --retry-connrefused \
-    -X POST http://localhost:8091/v1/chat/completions \
+    -X POST http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d "$request_body")
 

--- a/examples/online_serving/qwen2_5_omni/run_gradio_demo.sh
+++ b/examples/online_serving/qwen2_5_omni/run_gradio_demo.sh
@@ -5,13 +5,13 @@
 #   ./run_gradio_demo.sh [OPTIONS]
 #
 # Example:
-#   ./run_gradio_demo.sh --model Qwen/Qwen2.5-Omni-7B --server-port 8091 --gradio-port 7861
+#   ./run_gradio_demo.sh --model Qwen/Qwen2.5-Omni-7B --server-port 8000 --gradio-port 7861
 
 set -e
 
 # Default values
 MODEL="Qwen/Qwen2.5-Omni-7B"
-SERVER_PORT=8091
+SERVER_PORT=8000
 GRADIO_PORT=7861
 STAGE_CONFIGS_PATH=""
 SERVER_HOST="0.0.0.0"
@@ -54,7 +54,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --model MODEL                 Model name/path (default: Qwen/Qwen2.5-Omni-7B)"
-            echo "  --server-port PORT            Port for vLLM server (default: 8091)"
+            echo "  --server-port PORT            Port for vLLM server (default: 8000)"
             echo "  --gradio-port PORT            Port for Gradio demo (default: 7861)"
             echo "  --stage-configs-path PATH     Path to custom stage configs YAML file (optional)"
             echo "  --server-host HOST            Host for vLLM server (default: 0.0.0.0)"

--- a/examples/online_serving/qwen3_omni/README.md
+++ b/examples/online_serving/qwen3_omni/README.md
@@ -28,7 +28,7 @@ For the bundled 3x-GPU multi-replica layout (talker/code2wav scale-out),
 use:
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --deploy-config vllm_omni/deploy/qwen3_omni_moe_multi_replicas.yaml
 ```
 

--- a/examples/online_serving/qwen3_omni/README.md
+++ b/examples/online_serving/qwen3_omni/README.md
@@ -9,7 +9,7 @@ Please refer to [README.md](../../../README.md)
 ### Launch the Server
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000
 ```
 
 The default deployment configuration, situated at `vllm_omni/deploy/qwen3_omni_moe.yaml`, is resolved and loaded
@@ -20,7 +20,7 @@ Additionally, NPU, ROCm, and XPU per-platform configuration deltas are determini
 
 To explicitly utilize a custom deployment YAML, mandate the configuration path accordingly:
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --deploy-config /path/to/your_deploy_config.yaml
 ```
 
@@ -42,7 +42,7 @@ The example below pins Stage 0 to GPU 0 and Stage 1/2 to GPU 1 via
 
 ```bash
 CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
-    --port 8091 \
+    --port 8000 \
     --stage-id 0 \
     --omni-master-address 127.0.0.1 \
     --omni-master-port 26000
@@ -75,7 +75,7 @@ For standard **unified-process** launcher, stage-specific CLI configuration tuni
 via the `--stage-overrides` directive, as demonstrated below:
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --stage-overrides '{"1": {"gpu_memory_utilization": 0.5}}'
 ```
 
@@ -102,27 +102,27 @@ editing the YAML. There are three layers, in increasing specificity:
 
 ```bash
 # Tighter memory budget on a smaller GPU
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --gpu-memory-utilization 0.85
 
 # Disable cudagraphs (e.g. for debugging)
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --enforce-eager
 
 # Reduce context length
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --max-model-len 32768
 
 # Toggle prefix caching on every stage (yaml default: off)
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --enable-prefix-caching
 # ...or force it off if the yaml turned it on
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --no-enable-prefix-caching
 
 # Toggle pipeline-wide async chunked streaming between stages
 # (yaml default for qwen3_omni_moe: on)
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --no-async-chunk
 ```
 
@@ -149,7 +149,7 @@ parser defaults). If you don't pass a flag, the YAML value wins.
 
 ```bash
 # Lower stage 1's memory budget; leave others at the YAML default
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
     --stage-overrides '{
         "1": {"gpu_memory_utilization": 0.5},
         "2": {"max_num_batched_tokens": 65536}
@@ -244,7 +244,7 @@ cd examples/online_serving/qwen3_omni
 ####  Send request via python
 
 ```bash
-python examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py --model Qwen/Qwen3-Omni-30B-A3B-Instruct --query-type use_image --port 8091 --host "localhost"
+python examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py --model Qwen/Qwen3-Omni-30B-A3B-Instruct --query-type use_image --port 8000 --host "localhost"
 ```
 
 #### Realtime WebSocket client (`openai_realtime_client.py`)
@@ -263,7 +263,7 @@ pip install websockets
 
 ```bash
 python openai_realtime_client.py \
-  --url ws://localhost:8091/v1/realtime \
+  --url ws://localhost:8000/v1/realtime \
   --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
   --input-wav /path/to/input_16k_mono.wav \
   --output-wav realtime_output.wav \
@@ -274,7 +274,7 @@ python openai_realtime_client.py \
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--url` | `ws://localhost:8091/v1/realtime` | Full WebSocket URL including path |
+| `--url` | `ws://localhost:8000/v1/realtime` | Full WebSocket URL including path |
 | `--model` | `Qwen/Qwen3-Omni-30B-A3B-Instruct` | Must match the served model (sent in `session.update`) |
 | `--input-wav` | *(required)* | Input WAV: mono, 16-bit PCM, **16 kHz** |
 | `--output-wav` | `realtime_output.wav` | Output path for concatenated reply audio |
@@ -288,7 +288,7 @@ python openai_realtime_client.py \
 Ensure the server is running, for example:
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000
 ```
 
 The Python client supports the following command-line arguments:
@@ -338,7 +338,7 @@ You can control output modalities to specify which types of output the model sho
 #### Text only
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -350,7 +350,7 @@ curl http://localhost:8091/v1/chat/completions \
 #### Text + Audio
 
 ```bash
-curl -s http://localhost:8091/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -375,7 +375,7 @@ python examples/online_serving/openai_chat_completion_client_for_multimodal_gene
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
 
 response = client.chat.completions.create(
     model="Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -391,7 +391,7 @@ print(response.choices[0].message.content)
 import base64
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
 
 response = client.chat.completions.create(
     model="Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -416,7 +416,7 @@ When requesting audio output, you can choose the TTS speaker (voice) used for sy
 Pass a `speaker` field in the request body:
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -445,7 +445,7 @@ Pass `speaker` in `extra_body`:
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="EMPTY")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
 
 response = client.chat.completions.create(
     model="Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -481,7 +481,7 @@ The Gradio demo connects to a vLLM API server. You have two options:
 The convenience script launches both the vLLM server and Gradio demo together:
 
 ```bash
-./run_gradio_demo.sh --model Qwen/Qwen3-Omni-30B-A3B-Instruct --server-port 8091 --gradio-port 7861
+./run_gradio_demo.sh --model Qwen/Qwen3-Omni-30B-A3B-Instruct --server-port 8000 --gradio-port 7861
 ```
 
 This script will:
@@ -492,7 +492,7 @@ This script will:
 
 The script supports the following arguments:
 - `--model`: Model name/path (default: Qwen/Qwen3-Omni-30B-A3B-Instruct)
-- `--server-port`: Port for vLLM server (default: 8091)
+- `--server-port`: Port for vLLM server (default: 8000)
 - `--gradio-port`: Port for Gradio demo (default: 7861)
 - `--deploy-config`: Path to custom deploy config YAML file (optional)
 - `--server-host`: Host for vLLM server (default: 0.0.0.0)
@@ -504,12 +504,12 @@ The script supports the following arguments:
 **Step 1: Launch the vLLM API server**
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000
 ```
 
 If you have custom stage configs file:
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 --deploy-config /path/to/deploy_config_file
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 --deploy-config /path/to/deploy_config_file
 ```
 
 **Step 2: Run the Gradio demo**
@@ -517,7 +517,7 @@ vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 --deploy-config /
 In a separate terminal:
 
 ```bash
-python gradio_demo.py --model Qwen/Qwen3-Omni-30B-A3B-Instruct --api-base http://localhost:8091/v1 --port 7861
+python gradio_demo.py --model Qwen/Qwen3-Omni-30B-A3B-Instruct --api-base http://localhost:8000/v1 --port 7861
 ```
 
 Then open `http://localhost:7861/` on your local browser to interact with the web UI.
@@ -525,7 +525,7 @@ Then open `http://localhost:7861/` on your local browser to interact with the we
 The gradio script supports the following arguments:
 
 - `--model`: Model name/path (should match the server model)
-- `--api-base`: Base URL for the vLLM API server (default: http://localhost:8091/v1)
+- `--api-base`: Base URL for the vLLM API server (default: http://localhost:8000/v1)
 - `--ip`: Host/IP for Gradio server (default: 127.0.0.1)
 - `--port`: Port for Gradio server (default: 7861)
 - `--share`: Share the Gradio demo publicly (creates a public link)

--- a/examples/online_serving/qwen3_omni/gradio_demo.py
+++ b/examples/online_serving/qwen3_omni/gradio_demo.py
@@ -73,7 +73,7 @@ def parse_args():
     )
     parser.add_argument(
         "--api-base",
-        default="http://localhost:8091/v1",
+        default="http://localhost:8000/v1",
         help="Base URL for the vLLM API server.",
     )
     parser.add_argument(

--- a/examples/online_serving/qwen3_omni/openai_realtime_client.py
+++ b/examples/online_serving/qwen3_omni/openai_realtime_client.py
@@ -14,7 +14,7 @@ Optional debugging: pass ``--delta-dump-dir DIR`` to write every
 
 Usage:
   python openai_realtime_client.py \
-      --url ws://localhost:8091/v1/realtime \
+      --url ws://localhost:8000/v1/realtime \
       --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
       --input-wav input_16k_mono.wav \
       --output-wav realtime_output.wav \
@@ -256,7 +256,7 @@ async def run_clients_concurrent(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Realtime audio/text client for vLLM-Omni")
-    parser.add_argument("--url", default="ws://localhost:8091/v1/realtime", help="WebSocket URL")
+    parser.add_argument("--url", default="ws://localhost:8000/v1/realtime", help="WebSocket URL")
     parser.add_argument(
         "--model",
         default="Qwen/Qwen3-Omni-30B-A3B-Instruct",

--- a/examples/online_serving/qwen3_omni/run_curl_multimodal_generation.sh
+++ b/examples/online_serving/qwen3_omni/run_curl_multimodal_generation.sh
@@ -164,7 +164,7 @@ EOF
 )
 
 output=$(curl -sS --retry 3 --retry-delay 3 --retry-connrefused \
-    -X POST http://localhost:8091/v1/chat/completions \
+    -X POST http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d "$request_body")
 

--- a/examples/online_serving/qwen3_omni/run_gradio_demo.sh
+++ b/examples/online_serving/qwen3_omni/run_gradio_demo.sh
@@ -5,13 +5,13 @@
 #   ./run_gradio_demo.sh [OPTIONS]
 #
 # Example:
-#   ./run_gradio_demo.sh --model Qwen/Qwen3-Omni-30B-A3B-Instruct --server-port 8091 --gradio-port 7861
+#   ./run_gradio_demo.sh --model Qwen/Qwen3-Omni-30B-A3B-Instruct --server-port 8000 --gradio-port 7861
 
 set -e
 
 # Default values
 MODEL="Qwen/Qwen3-Omni-30B-A3B-Instruct"
-SERVER_PORT=8091
+SERVER_PORT=8000
 GRADIO_PORT=7861
 STAGE_CONFIGS_PATH=""
 SERVER_HOST="0.0.0.0"
@@ -54,7 +54,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --model MODEL                 Model name/path (default: Qwen/Qwen3-Omni-30B-A3B-Instruct)"
-            echo "  --server-port PORT            Port for vLLM server (default: 8091)"
+            echo "  --server-port PORT            Port for vLLM server (default: 8000)"
             echo "  --gradio-port PORT            Port for Gradio demo (default: 7861)"
             echo "  --stage-configs-path PATH     Path to custom stage configs YAML file (optional)"
             echo "  --server-host HOST            Host for vLLM server (default: 0.0.0.0)"

--- a/examples/online_serving/stable_audio/README.md
+++ b/examples/online_serving/stable_audio/README.md
@@ -16,7 +16,7 @@ Generate audio from text prompts using Stable Audio models via an OpenAI-compati
 ```bash
 vllm-omni serve stabilityai/stable-audio-open-1.0 \
     --host 0.0.0.0 \
-    --port 8091 \
+    --port 8000 \
     --gpu-memory-utilization 0.9 \
     --trust-remote-code \
     --enforce-eager \
@@ -28,7 +28,7 @@ vllm-omni serve stabilityai/stable-audio-open-1.0 \
 #### Using curl
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "The sound of a cat purring",
@@ -96,7 +96,7 @@ Returns audio data in the requested format (default: WAV).
 ### Basic Generation
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "The sound of ocean waves"
@@ -106,7 +106,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 ### Custom Duration
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "A dog barking",
@@ -117,7 +117,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 ### High Quality with Negative Prompt
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "A piano playing a gentle melody",
@@ -131,7 +131,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 ### Reproducible Generation
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Thunder and rain sounds",
@@ -145,7 +145,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 For faster generation with slightly lower quality:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Birds chirping in a forest",
@@ -210,7 +210,7 @@ python stable_audio_client.py \
 ## Troubleshooting
 
 ### Server not responding
-- Check if server is running: `curl http://localhost:8091/health`
+- Check if server is running: `curl http://localhost:8000/health`
 - Check server logs for errors
 
 ### Audio quality issues

--- a/examples/online_serving/stable_audio/curl_examples.sh
+++ b/examples/online_serving/stable_audio/curl_examples.sh
@@ -3,7 +3,7 @@
 
 # Example 1: Simple request with default parameters
 echo "Example 1: Simple request with default parameters"
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "The sound audience clapping and cheering in a stadium"
@@ -11,7 +11,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 
 # Example 2: Request with custom audio_length
 echo "Example 2: Custom audio length (5 seconds)"
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "The sound of a dog barking",
@@ -20,7 +20,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 
 # Example 3: Request with negative prompt for quality control
 echo "Example 3: With negative prompt"
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "A piano playing a gentle melody",
@@ -30,7 +30,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 
 # Example 4: Full control with all parameters
 echo "Example 4: Full control (custom length, guidance, steps, seed)"
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Thunder and rain sounds",
@@ -43,7 +43,7 @@ curl -X POST http://localhost:8091/v1/audio/generate \
 
 # Example 5: Quick generation with fewer steps (faster but lower quality)
 echo "Example 5: Quick generation (fewer steps)"
-curl -X POST http://localhost:8091/v1/audio/generate \
+curl -X POST http://localhost:8000/v1/audio/generate \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Ocean waves crashing on a beach",

--- a/examples/online_serving/stable_audio/stable_audio_client.py
+++ b/examples/online_serving/stable_audio/stable_audio_client.py
@@ -32,7 +32,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Generate audio with Stable Audio via OpenAI-compatible API")
     parser.add_argument(
         "--api_url",
-        default="http://localhost:8091/v1/audio/generate",
+        default="http://localhost:8000/v1/audio/generate",
         help="API endpoint URL",
     )
     parser.add_argument(

--- a/examples/online_serving/text_to_image/README.md
+++ b/examples/online_serving/text_to_image/README.md
@@ -7,7 +7,7 @@ This example demonstrates how to deploy Qwen-Image model for online image genera
 ### Basic Start
 
 ```bash
-vllm serve Qwen/Qwen-Image --omni --port 8091
+vllm serve Qwen/Qwen-Image --omni --port 8000
 ```
 !!! note
     If you encounter Out-of-Memory (OOM) issues or have limited GPU memory, you can enable VAE slicing and tiling to reduce memory usage, --vae-use-slicing --vae-use-tiling
@@ -26,19 +26,19 @@ Enable Tensor Parallelism and VAE Patch Parallelism for faster inference:
 
 ```bash
 # With Tensor Parallelism (requires >= 2 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --tensor-parallel-size 2
+vllm serve Qwen/Qwen-Image --omni --port 8000 --tensor-parallel-size 2
 
 # With Tensor Parallelism and VAE Patch Parallelism (requires >= 2 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --tensor-parallel-size 2 --vae-patch-parallel-size 2 --vae-use-tiling
+vllm serve Qwen/Qwen-Image --omni --port 8000 --tensor-parallel-size 2 --vae-patch-parallel-size 2 --vae-use-tiling
 
 # With Sequence Parallelism (Ulysses-SP, requires >= 2 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --usp 2
+vllm serve Qwen/Qwen-Image --omni --port 8000 --usp 2
 
 # With Ring-Attention (requires >= 2 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --ring 2
+vllm serve Qwen/Qwen-Image --omni --port 8000 --ring 2
 
 # Combined: Ulysses + Ring (requires >= 4 GPUs)
-vllm serve Qwen/Qwen-Image --omni --port 8091 --usp 2 --ring 2
+vllm serve Qwen/Qwen-Image --omni --port 8000 --usp 2 --ring 2
 ```
 
 For more details on parallelism acceleration, see the [Parallelism Acceleration Guide](../../diffusion/parallelism_acceleration.md).
@@ -52,7 +52,7 @@ For more details on parallelism acceleration, see the [Parallelism Acceleration 
 bash run_curl_text_to_image.sh
 
 # Or execute directly
-curl -s http://localhost:8091/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [
@@ -74,7 +74,7 @@ curl -s http://localhost:8091/v1/chat/completions \
 from openai import OpenAI
 import base64
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="none")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="none")
 
 response = client.chat.completions.create(
     model="Qwen/Qwen-Image",
@@ -133,7 +133,7 @@ python openai_chat_client.py \
 The `/v1/images/generations` endpoint supports a `lora` field in the request body:
 
 ```bash
-curl -X POST http://localhost:8091/v1/images/generations \
+curl -X POST http://localhost:8000/v1/images/generations \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "A piece of cheesecake",

--- a/examples/online_serving/text_to_image/gradio_demo.py
+++ b/examples/online_serving/text_to_image/gradio_demo.py
@@ -3,7 +3,7 @@
 Qwen-Image Gradio Demo for online serving.
 
 Usage:
-    python gradio_demo.py [--server http://localhost:8091] [--port 7860]
+    python gradio_demo.py [--server http://localhost:8000] [--port 7860]
 """
 
 import argparse
@@ -174,7 +174,7 @@ def create_demo(server_url: str):
 
 def main():
     parser = argparse.ArgumentParser(description="Qwen-Image Gradio Demo")
-    parser.add_argument("--server", default="http://localhost:8091", help="Server URL")
+    parser.add_argument("--server", default="http://localhost:8000", help="Server URL")
     parser.add_argument("--port", type=int, default=7860, help="Gradio port")
     parser.add_argument("--share", action="store_true", help="Create public link")
 

--- a/examples/online_serving/text_to_image/openai_chat_client.py
+++ b/examples/online_serving/text_to_image/openai_chat_client.py
@@ -16,7 +16,7 @@ import requests
 
 def generate_image(
     prompt: str,
-    server_url: str = "http://localhost:8091",
+    server_url: str = "http://localhost:8000",
     height: int | None = None,
     width: int | None = None,
     steps: int | None = None,
@@ -118,7 +118,7 @@ def main():
     parser = argparse.ArgumentParser(description="Qwen-Image chat client")
     parser.add_argument("--prompt", "-p", default="a cup of coffee on the table", help="Text prompt")
     parser.add_argument("--output", "-o", default="qwen_image_output.png", help="Output file")
-    parser.add_argument("--server", "-s", default="http://localhost:8091", help="Server URL")
+    parser.add_argument("--server", "-s", default="http://localhost:8000", help="Server URL")
     parser.add_argument("--height", type=int, default=1024, help="Image height")
     parser.add_argument("--width", type=int, default=1024, help="Image width")
     parser.add_argument("--steps", type=int, default=50, help="Inference steps")

--- a/examples/online_serving/text_to_image/run_curl_text_to_image.sh
+++ b/examples/online_serving/text_to_image/run_curl_text_to_image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Qwen-Image text-to-image curl example
 
-curl -X POST http://localhost:8091/v1/images/generations \
+curl -X POST http://localhost:8000/v1/images/generations \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "a dragon laying over the spine of the Green Mountains of Vermont",

--- a/examples/online_serving/text_to_image/run_server.sh
+++ b/examples/online_serving/text_to_image/run_server.sh
@@ -2,7 +2,7 @@
 # Qwen-Image online serving startup script
 
 MODEL="${MODEL:-Qwen/Qwen-Image}"
-PORT="${PORT:-8091}"
+PORT="${PORT:-8000}"
 
 echo "Starting Qwen-Image server..."
 echo "Model: $MODEL"

--- a/examples/online_serving/text_to_speech/README.md
+++ b/examples/online_serving/text_to_speech/README.md
@@ -30,13 +30,13 @@ CosyVoice3 is intentionally absent: no online example exists for it yet. See its
 Launch the server (defaults shown — adjust `--port`, `--gpu-memory-utilization`, etc. as needed):
 
 ```bash
-vllm serve <hf-repo-or-local-path> --omni --port 8091
+vllm serve <hf-repo-or-local-path> --omni --port 8000
 ```
 
 Send a TTS request via curl:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, how are you?",
@@ -51,7 +51,7 @@ Or via Python httpx:
 import httpx
 
 response = httpx.post(
-    "http://localhost:8091/v1/audio/speech",
+    "http://localhost:8000/v1/audio/speech",
     json={
         "input": "Hello, how are you?",
         "voice": "default",
@@ -67,7 +67,7 @@ Or via the OpenAI SDK:
 ```python
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8091/v1", api_key="none")
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="none")
 response = client.audio.speech.create(
     model="<hf-repo>",
     voice="default",
@@ -79,7 +79,7 @@ response.stream_to_file("output.wav")
 Streaming PCM output (where supported) — set `stream=true` with `response_format="pcm"`:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, how are you?",
@@ -101,7 +101,7 @@ For full request-shape documentation (all parameters, response formats, error co
 
 ### Launch
 ```bash
-vllm serve zai-org/GLM-TTS --omni --trust-remote-code --port 8091
+vllm serve zai-org/GLM-TTS --omni --trust-remote-code --port 8000
 # or:
 bash examples/online_serving/text_to_speech/glm_tts/run_server.sh /path/to/GLM-TTS
 ```
@@ -165,7 +165,7 @@ export VLLM_OMNI_FISH_KVCACHE_ATTN=0
 
 ### Launch
 ```bash
-vllm serve fishaudio/s2-pro --omni --port 8091
+vllm serve fishaudio/s2-pro --omni --port 8000
 # or:
 ./fish_speech/run_server.sh
 ```
@@ -173,7 +173,7 @@ The deploy config auto-loads from `vllm_omni/deploy/fish_qwen3_omni.yaml` (the H
 
 ### Voice cloning
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, this is a cloned voice.",
@@ -193,7 +193,7 @@ python speech_client.py --text "Hello world" --stream --output output.pcm
 ### Gradio demo
 ```bash
 ./fish_speech/run_gradio_demo.sh             # launches server + Gradio
-python fish_speech/gradio_demo.py --api-base http://localhost:8091  # if server already running
+python fish_speech/gradio_demo.py --api-base http://localhost:8000  # if server already running
 ```
 
 ### Notes
@@ -215,7 +215,7 @@ Equivalent manual command:
 ```bash
 vllm serve Jonathan1909/Ming-flash-omni-2.0 \
     --deploy-config vllm_omni/deploy/ming_flash_omni_tts.yaml \
-    --host 0.0.0.0 --port 8091 \
+    --host 0.0.0.0 --port 8000 \
     --trust-remote-code --omni
 ```
 
@@ -249,7 +249,7 @@ Single-stage 0.1B AR LM + MOSS-Audio-Tokenizer-Nano codec at 48 kHz mono. Every 
 
 ### Launch
 ```bash
-vllm serve OpenMOSS-Team/MOSS-TTS-Nano --omni --port 8091
+vllm serve OpenMOSS-Team/MOSS-TTS-Nano --omni --port 8000
 # or:
 ./moss_tts_nano/run_server.sh
 ```
@@ -264,7 +264,7 @@ REF_WAV="$REF_DIR/zh_1.wav"
 [ -s "$REF_WAV" ] || curl -L -o "$REF_WAV" https://raw.githubusercontent.com/OpenMOSS/MOSS-TTS-Nano/main/assets/audio/zh_1.wav
 REF_AUDIO=$(base64 -w 0 "$REF_WAV")
 
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d "{
         \"input\": \"你好，这是语音合成测试。\",
@@ -275,7 +275,7 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 
 ### Streaming PCM
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d "{
         \"input\": \"Hello, streaming output from MOSS-TTS-Nano.\",
@@ -291,7 +291,7 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 ./moss_tts_nano/run_gradio_demo.sh
 
 # Option 2: server already running
-python moss_tts_nano/gradio_demo.py --api-base http://localhost:8091
+python moss_tts_nano/gradio_demo.py --api-base http://localhost:8000
 ```
 Then open http://localhost:7860 in your browser.
 
@@ -313,7 +313,7 @@ Voice cloning (offline) needs `transformers>=5.3.0`; auto voice works with `tran
 
 ### Launch
 ```bash
-vllm serve k2-fsa/OmniVoice --omni --port 8091 --trust-remote-code
+vllm serve k2-fsa/OmniVoice --omni --port 8000 --trust-remote-code
 # or:
 ./omnivoice/run_server.sh
 ```
@@ -359,7 +359,7 @@ Each variant ships smaller `0.6B` companions where available.
 
 ### Launch
 ```bash
-vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice --omni --port 8091
+vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice --omni --port 8000
 # or:
 ./qwen3_tts/run_server.sh                # default: CustomVoice
 ./qwen3_tts/run_server.sh VoiceDesign
@@ -400,10 +400,10 @@ python qwen3_tts/openai_speech_client.py \
 List available voices, or upload a custom one for Base cloning:
 ```bash
 # List
-curl http://localhost:8091/v1/audio/voices
+curl http://localhost:8000/v1/audio/voices
 
 # Upload
-curl -X POST http://localhost:8091/v1/audio/voices \
+curl -X POST http://localhost:8000/v1/audio/voices \
     -F "audio_sample=@/path/to/voice_sample.wav" \
     -F "consent=user_consent_id" \
     -F "name=custom_voice_1" \
@@ -431,15 +431,30 @@ Then start the server with that config and call the Speech API with only the voi
 ```bash
 vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-Base --omni --deploy-config /path/to/qwen3_tts_custom_voice.yaml
 
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{"input":"Hello from a precomputed voice.","voice":"alice","task_type":"Base"}' \
     --output alice.wav
 ```
 
-### Streaming PCM
+### Precomputed custom voices
+For reused Base voice-cloning speakers, precompute the reference artifacts once and load them at server startup:
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+python qwen3_tts/precompute_custom_voice.py \
+    --model Qwen/Qwen3-TTS-12Hz-1.7B-Base \
+    --voice-name alice \
+    --ref-audio /path/to/reference.wav \
+    --ref-text "Original transcript of the reference audio" \
+    --mode icl \
+    --output-dir /path/to/custom_voices
+```
+`--mode icl` stores both `speaker_embedding` and `ref_code`; `--mode xvec` stores only the speaker embedding. Add the output directory to a deploy config:
+```yaml
+custom_voice_dir: /path/to/custom_voices
+```
+Then start the server with that config and call the Speech API with only the voice name:
+```bash
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, how are you?",
@@ -537,7 +552,7 @@ pip install -e /path/to/mistral-common  # or upgrade from PyPI when available
 
 ### Launch
 ```bash
-vllm serve mistralai/Voxtral-4B-TTS-2603 --omni --port 8091
+vllm serve mistralai/Voxtral-4B-TTS-2603 --omni --port 8000
 ```
 Deploy config auto-loads from `vllm_omni/deploy/voxtral_tts.yaml`.
 

--- a/examples/online_serving/text_to_speech/fish_speech/gradio_demo.py
+++ b/examples/online_serving/text_to_speech/fish_speech/gradio_demo.py
@@ -7,7 +7,7 @@ Supports:
 
 Usage:
     # Start the server first (see run_server.sh), then:
-    python gradio_demo.py --api-base http://localhost:8091
+    python gradio_demo.py --api-base http://localhost:8000
 
     # Or use run_gradio_demo.sh to start both server and demo together.
 """
@@ -25,7 +25,7 @@ import numpy as np
 import soundfile as sf
 
 PCM_SAMPLE_RATE = 44100
-DEFAULT_API_BASE = "http://localhost:8091"
+DEFAULT_API_BASE = "http://localhost:8000"
 
 
 def encode_audio_to_base64(audio_data: tuple) -> str:

--- a/examples/online_serving/text_to_speech/fish_speech/run_gradio_demo.sh
+++ b/examples/online_serving/text_to_speech/fish_speech/run_gradio_demo.sh
@@ -3,12 +3,12 @@
 #
 # Usage:
 #   ./run_gradio_demo.sh
-#   CUDA_VISIBLE_DEVICES=0 PORT=8091 GRADIO_PORT=7860 ./run_gradio_demo.sh
+#   CUDA_VISIBLE_DEVICES=0 PORT=8000 GRADIO_PORT=7860 ./run_gradio_demo.sh
 
 set -e
 
 MODEL="${MODEL:-fishaudio/s2-pro}"
-PORT="${PORT:-8091}"
+PORT="${PORT:-8000}"
 GRADIO_PORT="${GRADIO_PORT:-7860}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/examples/online_serving/text_to_speech/fish_speech/run_server.sh
+++ b/examples/online_serving/text_to_speech/fish_speech/run_server.sh
@@ -8,7 +8,7 @@
 set -e
 
 MODEL="${MODEL:-fishaudio/s2-pro}"
-PORT="${PORT:-8091}"
+PORT="${PORT:-8000}"
 
 echo "Starting Fish Speech S2 Pro server with model: $MODEL"
 

--- a/examples/online_serving/text_to_speech/fish_speech/speech_client.py
+++ b/examples/online_serving/text_to_speech/fish_speech/speech_client.py
@@ -18,7 +18,7 @@ import os
 
 import httpx
 
-DEFAULT_API_BASE = "http://localhost:8091"
+DEFAULT_API_BASE = "http://localhost:8000"
 DEFAULT_API_KEY = "EMPTY"
 
 

--- a/examples/online_serving/text_to_speech/ming_flash_omni_tts/run_server.sh
+++ b/examples/online_serving/text_to_speech/ming_flash_omni_tts/run_server.sh
@@ -4,14 +4,14 @@
 # Usage:
 #   ./run_server.sh
 #   MODEL=/path/to/local/model ./run_server.sh
-#   PORT=8091 ./run_server.sh
+#   PORT=8000 ./run_server.sh
 #   HOST=127.0.0.1 ./run_server.sh   # bind only to loopback
 
 set -e
 
 MODEL="${MODEL:-Jonathan1909/Ming-flash-omni-2.0}"
 HOST="${HOST:-0.0.0.0}"
-PORT="${PORT:-8091}"
+PORT="${PORT:-8000}"
 DEPLOY_CONFIG="${DEPLOY_CONFIG:-vllm_omni/deploy/ming_flash_omni_tts.yaml}"
 
 echo "Starting Ming standalone TTS server with model: $MODEL"

--- a/examples/online_serving/text_to_speech/ming_flash_omni_tts/speech_client.py
+++ b/examples/online_serving/text_to_speech/ming_flash_omni_tts/speech_client.py
@@ -6,7 +6,7 @@ import sys
 
 import httpx
 
-DEFAULT_API_BASE = "http://localhost:8091"
+DEFAULT_API_BASE = "http://localhost:8000"
 DEFAULT_API_KEY = "EMPTY"
 DEFAULT_MODEL = "Jonathan1909/Ming-flash-omni-2.0"
 

--- a/examples/online_serving/text_to_speech/moss_tts_nano/gradio_demo.py
+++ b/examples/online_serving/text_to_speech/moss_tts_nano/gradio_demo.py
@@ -11,7 +11,7 @@ Also supports non-streaming mode (full audio download) via gr.Audio.
 
 Usage:
     # Start the server first (see run_server.sh), then:
-    python gradio_demo.py --api-base http://localhost:8091
+    python gradio_demo.py --api-base http://localhost:8000
 
     # Or use run_gradio_demo.sh to start both server and demo together.
 """
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 # MOSS-TTS-Nano outputs 48 kHz stereo (2-channel interleaved).
 PCM_SAMPLE_RATE = 48000
 PCM_CHANNELS = 2
-DEFAULT_API_BASE = "http://localhost:8091"
+DEFAULT_API_BASE = "http://localhost:8000"
 
 # MOSS-TTS-Nano is voice-cloning-only — no built-in presets. Users must
 # upload a reference audio clip + transcript in the UI.

--- a/examples/online_serving/text_to_speech/moss_tts_nano/run_gradio_demo.sh
+++ b/examples/online_serving/text_to_speech/moss_tts_nano/run_gradio_demo.sh
@@ -3,12 +3,12 @@
 #
 # Usage:
 #   ./run_gradio_demo.sh
-#   CUDA_VISIBLE_DEVICES=0 PORT=8091 GRADIO_PORT=7860 ./run_gradio_demo.sh
+#   CUDA_VISIBLE_DEVICES=0 PORT=8000 GRADIO_PORT=7860 ./run_gradio_demo.sh
 
 set -e
 
 MODEL="${MODEL:-OpenMOSS-Team/MOSS-TTS-Nano}"
-PORT="${PORT:-8091}"
+PORT="${PORT:-8000}"
 GRADIO_PORT="${GRADIO_PORT:-7860}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/examples/online_serving/text_to_speech/moss_tts_nano/run_server.sh
+++ b/examples/online_serving/text_to_speech/moss_tts_nano/run_server.sh
@@ -3,12 +3,12 @@
 #
 # Usage:
 #   ./run_server.sh
-#   CUDA_VISIBLE_DEVICES=0 PORT=8091 ./run_server.sh
+#   CUDA_VISIBLE_DEVICES=0 PORT=8000 ./run_server.sh
 
 set -e
 
 MODEL="${MODEL:-OpenMOSS-Team/MOSS-TTS-Nano}"
-PORT="${PORT:-8091}"
+PORT="${PORT:-8000}"
 
 echo "Starting MOSS-TTS-Nano server with model: $MODEL"
 

--- a/examples/online_serving/text_to_speech/omnivoice/run_server.sh
+++ b/examples/online_serving/text_to_speech/omnivoice/run_server.sh
@@ -8,7 +8,7 @@
 set -e
 
 MODEL="${MODEL:-k2-fsa/OmniVoice}"
-PORT="${PORT:-8091}"
+PORT="${PORT:-8000}"
 
 echo "Starting OmniVoice server with model: $MODEL"
 

--- a/examples/online_serving/text_to_speech/omnivoice/speech_client.py
+++ b/examples/online_serving/text_to_speech/omnivoice/speech_client.py
@@ -17,7 +17,7 @@ import os
 
 import httpx
 
-DEFAULT_API_BASE = "http://localhost:8091"
+DEFAULT_API_BASE = "http://localhost:8000"
 DEFAULT_API_KEY = "EMPTY"
 
 

--- a/examples/online_serving/text_to_speech/qwen3_tts/batch_speech_client.py
+++ b/examples/online_serving/text_to_speech/qwen3_tts/batch_speech_client.py
@@ -33,7 +33,7 @@ import os
 
 import httpx
 
-DEFAULT_API_BASE = "http://localhost:8091"
+DEFAULT_API_BASE = "http://localhost:8000"
 DEFAULT_API_KEY = "EMPTY"
 
 

--- a/examples/online_serving/text_to_speech/qwen3_tts/openai_speech_client.py
+++ b/examples/online_serving/text_to_speech/qwen3_tts/openai_speech_client.py
@@ -36,7 +36,7 @@ import os
 import httpx
 
 # Default server configuration
-DEFAULT_API_BASE = "http://localhost:8091"
+DEFAULT_API_BASE = "http://localhost:8000"
 DEFAULT_API_KEY = "EMPTY"
 
 

--- a/examples/online_serving/text_to_speech/qwen3_tts/run_server.sh
+++ b/examples/online_serving/text_to_speech/qwen3_tts/run_server.sh
@@ -33,7 +33,7 @@ echo "Starting Qwen3-TTS server with model: $MODEL"
 vllm-omni serve "$MODEL" \
     --deploy-config vllm_omni/deploy/qwen3_tts.yaml \
     --host 0.0.0.0 \
-    --port 8091 \
+    --port 8000 \
     --gpu-memory-utilization 0.9 \
     --trust-remote-code \
     --omni

--- a/examples/online_serving/text_to_speech/voxcpm/openai_speech_client.py
+++ b/examples/online_serving/text_to_speech/voxcpm/openai_speech_client.py
@@ -1,0 +1,155 @@
+"""OpenAI-compatible client for VoxCPM via /v1/audio/speech.
+
+Examples:
+    # Basic text-to-speech
+    python openai_speech_client.py --text "Hello from VoxCPM"
+
+    # Voice cloning
+    python openai_speech_client.py \
+        --text "This sentence uses the cloned voice." \
+        --ref-audio /path/to/reference.wav \
+        --ref-text "The exact transcript spoken in the reference audio."
+
+    # Streaming PCM output
+    python openai_speech_client.py \
+        --text "This is a streaming VoxCPM request." \
+        --stream \
+        --output output.pcm
+"""
+
+import argparse
+import base64
+import os
+
+import httpx
+
+DEFAULT_API_BASE = "http://localhost:8000"
+DEFAULT_API_KEY = "EMPTY"
+DEFAULT_MODEL = "OpenBMB/VoxCPM1.5"
+
+
+def encode_audio_to_base64(audio_path: str) -> str:
+    """Encode a local audio file to base64 data URL."""
+    if not os.path.exists(audio_path):
+        raise FileNotFoundError(f"Audio file not found: {audio_path}")
+
+    ext = audio_path.lower().rsplit(".", 1)[-1]
+    mime_map = {
+        "wav": "audio/wav",
+        "mp3": "audio/mpeg",
+        "flac": "audio/flac",
+        "ogg": "audio/ogg",
+    }
+    mime_type = mime_map.get(ext, "audio/wav")
+
+    with open(audio_path, "rb") as f:
+        audio_b64 = base64.b64encode(f.read()).decode("utf-8")
+    return f"data:{mime_type};base64,{audio_b64}"
+
+
+def build_payload(args) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "model": args.model,
+        "input": args.text,
+        "response_format": "pcm" if args.stream else args.response_format,
+    }
+
+    if args.ref_audio:
+        if args.ref_audio.startswith(("http://", "https://", "data:")):
+            payload["ref_audio"] = args.ref_audio
+        else:
+            payload["ref_audio"] = encode_audio_to_base64(args.ref_audio)
+    if args.ref_text:
+        payload["ref_text"] = args.ref_text
+    if args.max_new_tokens is not None:
+        payload["max_new_tokens"] = args.max_new_tokens
+    if args.stream:
+        payload["stream"] = True
+
+    return payload
+
+
+def run_tts(args) -> None:
+    payload = build_payload(args)
+    api_url = f"{args.api_base}/v1/audio/speech"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {args.api_key}",
+    }
+
+    print(f"Model: {args.model}")
+    print(f"Text: {args.text}")
+    if args.ref_audio:
+        print("Mode: voice cloning")
+        print(f"Reference audio: {args.ref_audio}")
+    else:
+        print("Mode: text-to-speech")
+
+    if args.stream:
+        output_path = args.output or "voxcpm_output.pcm"
+        with httpx.Client(timeout=300.0) as client:
+            with client.stream("POST", api_url, json=payload, headers=headers) as response:
+                if response.status_code != 200:
+                    print(f"Error: {response.status_code}")
+                    print(response.read().decode("utf-8", errors="ignore"))
+                    return
+
+                total_bytes = 0
+                with open(output_path, "wb") as f:
+                    for chunk in response.iter_bytes():
+                        if not chunk:
+                            continue
+                        f.write(chunk)
+                        total_bytes += len(chunk)
+        print(f"Streamed {total_bytes} bytes to: {output_path}")
+        return
+
+    with httpx.Client(timeout=300.0) as client:
+        response = client.post(api_url, json=payload, headers=headers)
+
+    if response.status_code != 200:
+        print(f"Error: {response.status_code}")
+        print(response.text)
+        return
+
+    try:
+        text = response.content.decode("utf-8")
+        if text.startswith('{"error"'):
+            print(f"Error: {text}")
+            return
+    except UnicodeDecodeError:
+        pass
+
+    output_path = args.output or "voxcpm_output.wav"
+    with open(output_path, "wb") as f:
+        f.write(response.content)
+    print(f"Audio saved to: {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="VoxCPM OpenAI-compatible speech client")
+    parser.add_argument("--api-base", default=DEFAULT_API_BASE, help="API base URL")
+    parser.add_argument("--api-key", default=DEFAULT_API_KEY, help="API key")
+    parser.add_argument("--model", "-m", default=DEFAULT_MODEL, help="Model name or path")
+    parser.add_argument("--text", required=True, help="Text to synthesize")
+    parser.add_argument("--ref-audio", default=None, help="Reference audio path, URL, or data URL")
+    parser.add_argument(
+        "--ref-text",
+        default=None,
+        help="The exact transcript spoken in the reference audio",
+    )
+    parser.add_argument("--stream", action="store_true", help="Enable streaming PCM output")
+    parser.add_argument(
+        "--response-format",
+        default="wav",
+        choices=["wav", "pcm", "flac", "mp3", "aac", "opus"],
+        help="Audio format for non-streaming mode (default: wav)",
+    )
+    parser.add_argument("--max-new-tokens", type=int, default=None, help="Maximum tokens to generate")
+    parser.add_argument("--output", "-o", default=None, help="Output file path")
+    args = parser.parse_args()
+    run_tts(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/online_serving/text_to_speech/voxcpm/run_server.sh
+++ b/examples/online_serving/text_to_speech/voxcpm/run_server.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Launch vLLM-Omni server for VoxCPM online speech serving.
+#
+# Usage:
+#   ./run_server.sh                 # default: async_chunk stage config
+#   ./run_server.sh async           # async_chunk stage config
+#   ./run_server.sh sync            # no-async-chunk stage config
+#   VOXCPM_MODEL=/path/to/model ./run_server.sh
+
+set -e
+
+MODE="${1:-async}"
+MODEL="${VOXCPM_MODEL:-OpenBMB/VoxCPM1.5}"
+
+case "$MODE" in
+    async)
+        STAGE_CONFIG="vllm_omni/model_executor/stage_configs/voxcpm_async_chunk.yaml"
+        ;;
+    sync)
+        STAGE_CONFIG="vllm_omni/deploy/voxcpm.yaml"
+        ;;
+    *)
+        echo "Unknown mode: $MODE"
+        echo "Supported: async, sync"
+        exit 1
+        ;;
+esac
+
+echo "Starting VoxCPM server with model: $MODEL"
+echo "Stage config: $STAGE_CONFIG"
+
+vllm serve "$MODEL" \
+    --stage-configs-path "$STAGE_CONFIG" \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --trust-remote-code \
+    --enforce-eager \
+    --omni

--- a/examples/online_serving/text_to_speech/voxtral_tts/gradio_demo.py
+++ b/examples/online_serving/text_to_speech/voxtral_tts/gradio_demo.py
@@ -130,7 +130,7 @@ def wait_for_server(base_url: str, timeout: float = _SERVER_CHECK_TIMEOUT) -> bo
     """Block until the server is available or timeout is reached.
 
     Args:
-        base_url: Base URL of the server (e.g., "http://localhost:8091/v1")
+        base_url: Base URL of the server (e.g., "http://localhost:8000/v1")
         timeout: Maximum time to wait in seconds
 
     Returns:
@@ -166,7 +166,7 @@ def fetch_voices_and_languages(base_url: str, model: str) -> tuple[list[str], di
     of available voices from the /v1/audio/voices endpoint and organizes them.
 
     Args:
-        base_url: Base URL of the server API (e.g., "http://localhost:8091/v1")
+        base_url: Base URL of the server API (e.g., "http://localhost:8000/v1")
         model: Model name (used for logging)
 
     Returns:
@@ -503,7 +503,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Voxtral TTS Gradio Demo")
     parser.add_argument("--model", type=str, default="mistralai/Voxtral-4B-TTS-2603", help="Name of model repo on HF")
     parser.add_argument("--host", type=str, default="localhost", help="Name of host")
-    parser.add_argument("--port", type=str, default="8091", help="port number")
+    parser.add_argument("--port", type=str, default="8000", help="port number")
     parser.add_argument(
         "--output-dir",
         type=str,

--- a/examples/online_serving/text_to_video/README.md
+++ b/examples/online_serving/text_to_video/README.md
@@ -18,7 +18,7 @@ This example demonstrates how to deploy text-to-video models for online video ge
 #### Basic Start
 
 ```bash
-vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8091
+vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8000
 ```
 
 #### Start with Parameters
@@ -31,7 +31,7 @@ bash run_server.sh
 
 The script allows overriding:
 - `MODEL` (default: `Wan-AI/Wan2.2-T2V-A14B-Diffusers`)
-- `PORT` (default: `8091`)
+- `PORT` (default: `8000`)
 - `BOUNDARY_RATIO` (default: `0.875`)
 - `FLOW_SHIFT` (default: `5.0`)
 - `CACHE_BACKEND` (default: `none`)
@@ -68,7 +68,7 @@ file. Metadata is returned via response headers:
 - `X-Inference-Time-S`: wall-clock inference time in seconds
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos/sync \
+curl -X POST http://localhost:8000/v1/videos/sync \
   -F "prompt=Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage." \
   -F "size=832x480" \
   -F "num_frames=33" \
@@ -106,7 +106,7 @@ export VLLM_OMNI_STORAGE_MAX_CONCURRENCY=8
 bash run_curl_text_to_video.sh
 
 # Or execute directly (OpenAI-style multipart)
-create_response=$(curl -s http://localhost:8091/v1/videos \
+create_response=$(curl -s http://localhost:8000/v1/videos \
   -H "Accept: application/json" \
   -F "prompt=Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage." \
   -F "width=832" \
@@ -123,7 +123,7 @@ create_response=$(curl -s http://localhost:8091/v1/videos \
 
 video_id=$(echo "$create_response" | jq -r '.id')
 while true; do
-  status=$(curl -s "http://localhost:8091/v1/videos/${video_id}" | jq -r '.status')
+  status=$(curl -s "http://localhost:8000/v1/videos/${video_id}" | jq -r '.status')
   if [ "$status" = "completed" ]; then
     break
   fi
@@ -134,8 +134,8 @@ while true; do
   sleep 2
 done
 
-curl -s "http://localhost:8091/v1/videos/${video_id}" | jq .
-curl -L "http://localhost:8091/v1/videos/${video_id}/content" -o wan22_output.mp4
+curl -s "http://localhost:8000/v1/videos/${video_id}" | jq .
+curl -L "http://localhost:8000/v1/videos/${video_id}/content" -o wan22_output.mp4
 ```
 
 ## Request Format
@@ -143,14 +143,14 @@ curl -L "http://localhost:8091/v1/videos/${video_id}/content" -o wan22_output.mp
 ### Simple Text-to-Video Generation
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos \
+curl -X POST http://localhost:8000/v1/videos \
   -F "prompt=A cinematic view of a futuristic city at sunset"
 ```
 
 ### Generation with Parameters
 
 ```bash
-curl -X POST http://localhost:8091/v1/videos \
+curl -X POST http://localhost:8000/v1/videos \
   -F "prompt=A cinematic view of a futuristic city at sunset" \
   -F "width=832" \
   -F "height=480" \
@@ -205,32 +205,32 @@ curl -X POST http://localhost:8091/v1/videos \
 ### Retrieve a job
 
 ```bash
-curl -s http://localhost:8091/v1/videos/${video_id} | jq .
+curl -s http://localhost:8000/v1/videos/${video_id} | jq .
 ```
 
 ### List jobs
 
 ```bash
-curl -s http://localhost:8091/v1/videos | jq .
+curl -s http://localhost:8000/v1/videos | jq .
 ```
 
 ### Download the completed video
 
 ```bash
-curl -L http://localhost:8091/v1/videos/${video_id}/content -o wan22_output.mp4
+curl -L http://localhost:8000/v1/videos/${video_id}/content -o wan22_output.mp4
 ```
 
 ### Delete a job and its stored file
 
 ```bash
-curl -X DELETE http://localhost:8091/v1/videos/${video_id} | jq .
+curl -X DELETE http://localhost:8000/v1/videos/${video_id} | jq .
 ```
 
 ## Poll Until Complete
 
 ```bash
 while true; do
-  status=$(curl -s http://localhost:8091/v1/videos/${video_id} | jq -r '.status')
+  status=$(curl -s http://localhost:8000/v1/videos/${video_id} | jq -r '.status')
   if [ "$status" = "completed" ]; then
     break
   fi

--- a/recipes/Baidu/ERNIE-Image.md
+++ b/recipes/Baidu/ERNIE-Image.md
@@ -60,7 +60,7 @@ Add more sections for other hardware as community validation lands.
 ```bash
 vllm serve baidu/ERNIE-Image --omni \
   --enable-layerwise-offload \
-  --port 8091
+  --port 8000
 ```
 
 **ERNIE-Image-Turbo (distilled, faster):**
@@ -68,7 +68,7 @@ vllm serve baidu/ERNIE-Image --omni \
 ```bash
 vllm serve baidu/ERNIE-Image-Turbo --omni \
   --enable-layerwise-offload \
-  --port 8091
+  --port 8000
 ```
 
 ### 2 x RTX 4090 (Multi-GPU, 24GB VRAM)
@@ -81,7 +81,7 @@ vllm serve baidu/ERNIE-Image-Turbo --omni \
 vllm serve baidu/ERNIE-Image --omni \
   --tensor-parallel-size 2 \
   --enable-cpu-offload \
-  --port 8091
+  --port 8000
 ```
 
 **ERNIE-Image-Turbo (distilled, faster):**
@@ -90,7 +90,7 @@ vllm serve baidu/ERNIE-Image --omni \
 vllm serve baidu/ERNIE-Image-Turbo --omni \
   --tensor-parallel-size 2 \
   --enable-cpu-offload \
-  --port 8091
+  --port 8000
 ```
 
 #### Verification
@@ -98,7 +98,7 @@ vllm serve baidu/ERNIE-Image-Turbo --omni \
 After the server is ready, test with a simple request:
 
 ```bash
-curl -X POST http://localhost:8091/v1/images/generations \
+curl -X POST http://localhost:8000/v1/images/generations \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "A photo of a cat sitting on a laptop keyboard, digital art style.",
@@ -112,7 +112,7 @@ curl -X POST http://localhost:8091/v1/images/generations \
 For ERNIE-Image-Turbo, reduce the inference steps:
 
 ```bash
-curl -X POST http://localhost:8091/v1/images/generations \
+curl -X POST http://localhost:8000/v1/images/generations \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "A photo of a cat sitting on a laptop keyboard, digital art style.",

--- a/recipes/Qwen/Qwen-Image.md
+++ b/recipes/Qwen/Qwen-Image.md
@@ -48,14 +48,14 @@ with more hardware sections as community validation lands.
 Start the baseline server:
 
 ```bash
-vllm serve Qwen/Qwen-Image --omni --port 8091
+vllm serve Qwen/Qwen-Image --omni --port 8000
 ```
 
 To enable the step-wise runtime without batching:
 
 ```bash
 vllm serve Qwen/Qwen-Image --omni \
-  --port 8091 \
+  --port 8000 \
   --step-execution \
   --max-num-seqs 1
 ```
@@ -64,7 +64,7 @@ To enable experimental compatible-request batching:
 
 ```bash
 vllm serve Qwen/Qwen-Image --omni \
-  --port 8091 \
+  --port 8000 \
   --step-execution \
   --max-num-seqs 8
 ```
@@ -81,7 +81,7 @@ Run the existing client example after the server is ready:
 
 ```bash
 python examples/online_serving/text_to_image/openai_chat_client.py \
-  --server http://localhost:8091 \
+  --server http://localhost:8000 \
   --prompt "A ceramic teapot on a wooden table" \
   --output /tmp/qwen_image_recipe.png
 ```
@@ -89,7 +89,7 @@ python examples/online_serving/text_to_image/openai_chat_client.py \
 For a direct API smoke test:
 
 ```bash
-curl http://localhost:8091/v1/images/generations \
+curl http://localhost:8000/v1/images/generations \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen-Image",

--- a/recipes/Qwen/Qwen3-Omni.md
+++ b/recipes/Qwen/Qwen3-Omni.md
@@ -34,7 +34,7 @@ exercised by repository examples and tests.
 From repository root:
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000
 ```
 
 Notes:
@@ -49,7 +49,7 @@ Notes:
 For advanced customization, pass an overlay YAML:
 
 ```bash
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
   --deploy-config /path/to/your_qwen3_omni_overrides.yaml
 ```
 
@@ -59,15 +59,15 @@ Prefer CLI overrides for day-to-day tuning:
 
 ```bash
 # Disable async chunking when using /v1/realtime
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
   --no-async-chunk
 
 # Example per-stage tuning in unified launch
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
   --stage-overrides '{"1": {"gpu_memory_utilization": 0.5}}'
 
 # Tune max_num_seqs per stage (single process launch)
-vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 \
+vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8000 \
   --stage-overrides '{
     "0": {"max_num_seqs": 8},
     "1": {"max_num_seqs": 4},
@@ -85,7 +85,7 @@ Default stage-based commands:
 ```bash
 # Stage 0: Thinker + API server
 CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
-  --port 8091 \
+  --port 8000 \
   --stage-id 0 \
   --omni-master-address 127.0.0.1 \
   --omni-master-port 26000 &
@@ -110,7 +110,7 @@ Optional: explicit per-stage `max_num_seqs` tuning:
 ```bash
 # Stage 0
 CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni \
-  --port 8091 \
+  --port 8000 \
   --stage-id 0 \
   --max-num-seqs 8 \
   --omni-master-address 127.0.0.1 \
@@ -143,14 +143,14 @@ After server startup, run a multimodal example client:
 python examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py \
   --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
   --query-type use_image \
-  --port 8091 \
+  --port 8000 \
   --host localhost
 ```
 
 Quick API smoke test (text-only output):
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -166,7 +166,7 @@ together.
 Quick API smoke test (text + audio output):
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
@@ -179,7 +179,7 @@ Realtime WebSocket check (`/v1/realtime`) requires async chunk disabled:
 
 ```bash
 python examples/online_serving/qwen3_omni/openai_realtime_client.py \
-  --url ws://localhost:8091/v1/realtime \
+  --url ws://localhost:8000/v1/realtime \
   --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
   --input-wav /path/to/input_16k_mono.wav \
   --output-wav realtime_output.wav
@@ -196,7 +196,7 @@ Text-focused random workload:
 vllm bench serve \
   --omni \
   --host localhost \
-  --port 8091 \
+  --port 8000 \
   --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
   --endpoint /v1/chat/completions \
   --backend openai-chat-omni \
@@ -223,7 +223,7 @@ Synthetic multimodal workload (`random-mm`):
 vllm bench serve \
   --omni \
   --host localhost \
-  --port 8091 \
+  --port 8000 \
   --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
   --endpoint /v1/chat/completions \
   --backend openai-chat-omni \

--- a/recipes/Tencent/HunyuanImage-3.0-Instruct.md
+++ b/recipes/Tencent/HunyuanImage-3.0-Instruct.md
@@ -75,7 +75,7 @@ These commands use explicit CLI flags for all parallelism and runtime settings.
 ```bash
 vllm serve tencent/HunyuanImage-3.0-Instruct \
   --omni \
-  --port 8091 \
+  --port 8000 \
   --tensor-parallel-size 4 \
   --quantization fp8 \
   --distributed-executor-backend mp \
@@ -88,7 +88,7 @@ vllm serve tencent/HunyuanImage-3.0-Instruct \
 ```bash
 vllm serve tencent/HunyuanImage-3.0-Instruct \
   --omni \
-  --port 8091 \
+  --port 8000 \
   --tensor-parallel-size 2 \
   --usp 2 \
   --quantization fp8 \
@@ -102,7 +102,7 @@ vllm serve tencent/HunyuanImage-3.0-Instruct \
 ```bash
 vllm serve tencent/HunyuanImage-3.0-Instruct \
   --omni \
-  --port 8091 \
+  --port 8000 \
   --tensor-parallel-size 2 \
   --cfg-parallel-size 2 \
   --quantization fp8 \
@@ -114,7 +114,7 @@ vllm serve tencent/HunyuanImage-3.0-Instruct \
 Generate one 1024x1024 image:
 
 ```bash
-curl -s http://localhost:8091/v1/chat/completions \
+curl -s http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "messages": [
@@ -149,7 +149,7 @@ generate 1024x1024 images with 50 denoising steps.
 
 Check that:
 
-- The server responds on `http://localhost:8091/health`.
+- The server responds on `http://localhost:8000/health`.
 - The generation request writes a valid PNG file.
 - Logs include `Selected CutlassFP8ScaledMMLinearKernel` for dense FP8
   linear layers and `Using TRITON Fp8 MoE` for MoE layers.

--- a/recipes/fishaudio/Fish-Speech-S2-Pro.md
+++ b/recipes/fishaudio/Fish-Speech-S2-Pro.md
@@ -73,7 +73,7 @@ export VLLM_OMNI_FISH_KVCACHE_ATTN=0
 #### Command
 
 ```bash
-vllm serve fishaudio/s2-pro --omni --port 8091
+vllm serve fishaudio/s2-pro --omni --port 8000
 ```
 
 Notes:
@@ -88,7 +88,7 @@ Notes:
 Basic TTS:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, how are you?",
@@ -101,7 +101,7 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 Voice cloning:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
         "input": "Hello, this is a cloned voice.",

--- a/recipes/inclusionAI/Ming-flash-omni-2.0.md
+++ b/recipes/inclusionAI/Ming-flash-omni-2.0.md
@@ -60,7 +60,7 @@ Adjust `devices` in the YAML to match your hardware.
 Thinker only (text output):
 
 ```bash
-vllm serve Jonathan1909/Ming-flash-omni-2.0 --omni --port 8091
+vllm serve Jonathan1909/Ming-flash-omni-2.0 --omni --port 8000
 ```
 
 Thinker + talker (text and/or audio output):
@@ -68,7 +68,7 @@ Thinker + talker (text and/or audio output):
 ```bash
 vllm serve Jonathan1909/Ming-flash-omni-2.0 \
     --omni \
-    --port 8091 \
+    --port 8000 \
     --log-stats
 ```
 
@@ -79,7 +79,7 @@ vllm serve Jonathan1909/Ming-flash-omni-2.0 \
 Text output from a multimodal (image) input:
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
       "model": "Jonathan1909/Ming-flash-omni-2.0",
@@ -97,7 +97,7 @@ curl http://localhost:8091/v1/chat/completions \
 Spoken response from a text query (save the WAV bytes):
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
       "model": "Jonathan1909/Ming-flash-omni-2.0",
@@ -113,7 +113,7 @@ Text + audio output from an audio input (swap `audio_url` for `video_url`
 or `image_url` to exercise the other multimodal input paths):
 
 ```bash
-curl http://localhost:8091/v1/chat/completions \
+curl http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
       "model": "Jonathan1909/Ming-flash-omni-2.0",
@@ -131,7 +131,7 @@ curl http://localhost:8091/v1/chat/completions \
 Streaming text output via SSE (set `"stream": true`):
 
 ```bash
-curl -N http://localhost:8091/v1/chat/completions \
+curl -N http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{
       "model": "Jonathan1909/Ming-flash-omni-2.0",
@@ -176,7 +176,7 @@ The bundled `ming_flash_omni_tts.yaml` runs the talker on a single GPU and expos
 vllm serve Jonathan1909/Ming-flash-omni-2.0 \
     --omni \
     --deploy-config vllm_omni/deploy/ming_flash_omni_tts.yaml \
-    --port 8091 \
+    --port 8000 \
     --log-stats
 ```
 
@@ -187,7 +187,7 @@ vllm serve Jonathan1909/Ming-flash-omni-2.0 \
 Basic curl:
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
       "model": "Jonathan1909/Ming-flash-omni-2.0",
@@ -199,7 +199,7 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 Speaker selection (e.g. `lingguang`):
 
 ```bash
-curl -X POST http://localhost:8091/v1/audio/speech \
+curl -X POST http://localhost:8000/v1/audio/speech \
     -H "Content-Type: application/json" \
     -d '{
       "model": "Jonathan1909/Ming-flash-omni-2.0",

--- a/tests/e2e/online_serving/test_bagel.py
+++ b/tests/e2e/online_serving/test_bagel.py
@@ -8,7 +8,7 @@ This test validates that the Bagel model can serve image generation requests
 via the OpenAI-compatible chat completions API.
 
 Equivalent to running:
-    vllm-omni serve "ByteDance-Seed/BAGEL-7B-MoT" --omni --port 8091
+    vllm-omni serve "ByteDance-Seed/BAGEL-7B-MoT" --omni --port 8000
 
     # text2img
     python3 examples/online_serving/bagel/openai_chat_client.py \\

--- a/tests/examples/online_serving/test_qwen2_5_omni.py
+++ b/tests/examples/online_serving/test_qwen2_5_omni.py
@@ -34,7 +34,7 @@ stage_configs = [get_deploy_config_path("ci/qwen2_5_omni.yaml")]
 example_dir = str(Path(__file__).parent.parent.parent.parent / "examples" / "online_serving")
 # Create parameter combinations for model and stage config
 test_params = [
-    OmniServerParams(model=model, port=8091, stage_config_path=stage_config)
+    OmniServerParams(model=model, port=8000, stage_config_path=stage_config)
     for model in models
     for stage_config in stage_configs
 ]

--- a/tests/examples/online_serving/test_qwen3_omni.py
+++ b/tests/examples/online_serving/test_qwen3_omni.py
@@ -34,7 +34,7 @@ stage_configs = [get_deploy_config_path("ci/qwen3_omni_moe.yaml")]
 example_dir = str(Path(__file__).parent.parent.parent.parent / "examples" / "online_serving")
 # Create parameter combinations for model and stage config
 test_params = [
-    OmniServerParams(model=model, port=8091, stage_config_path=stage_config)
+    OmniServerParams(model=model, port=8000, stage_config_path=stage_config)
     for model in models
     for stage_config in stage_configs
 ]

--- a/tests/test_arg_utils.py
+++ b/tests/test_arg_utils.py
@@ -112,7 +112,7 @@ def test_split_drops_unclassified():
     raw = {
         "max_num_seqs": 64,  # engine
         "host": "0.0.0.0",  # unclassified (server)
-        "port": 8091,  # unclassified (server)
+        "port": 8000,  # unclassified (server)
         "ssl_keyfile": "key.pem",  # unclassified (server)
     }
     orch, engine = split_kwargs(raw, engine_cls=_FakeEngineArgs)
@@ -138,7 +138,7 @@ def test_split_mixed_real_world():
         "log_stats": False,
         # server / unclassified
         "host": "0.0.0.0",
-        "port": 8091,
+        "port": 8000,
         "api_key": "secret",
         # None values
         "ray_address": None,
@@ -207,7 +207,7 @@ def test_unclassified_without_user_typed_silent():
     handler.setLevel(logging.WARNING)
     vllm_logger.addHandler(handler)
     try:
-        raw = {"host": "0.0.0.0", "port": 8091, "max_num_seqs": 64}
+        raw = {"host": "0.0.0.0", "port": 8000, "max_num_seqs": 64}
         split_kwargs(raw, engine_cls=_FakeEngineArgs, user_typed=None)
         assert "host" not in buf.getvalue()
     finally:

--- a/tools/wan22/assemble_wan22_i2v_diffusers.py
+++ b/tools/wan22/assemble_wan22_i2v_diffusers.py
@@ -377,7 +377,7 @@ def main() -> int:
     print(f"  transformer weight: {_weight_summary(transformer_copied)}")
     print(f"  transformer_2 weight: {_weight_summary(transformer_2_copied)}")
     print("\nUse it with vLLM-Omni, for example:")
-    print(f"  vllm serve {output_dir} --omni --port 8091")
+    print(f"  vllm serve {output_dir} --omni --port 8000")
     return 0
 
 

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -36,10 +36,10 @@ The server automatically detects the model type:
 
 Examples:
   # Start an Omni LLM server
-  vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091
+  vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8000
 
   # Start a diffusion model server
-  vllm serve Qwen/Qwen-Image --omni --port 8091
+  vllm serve Qwen/Qwen-Image --omni --port 8000
 
 Search by using: `--help=<ConfigGroup>` to explore options by section (e.g.,
 --help=OmniConfig)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Currently, the Omni service is started using `vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni`, which uses port 8000 by default. However, some examples use port 8091 as the default.

Therefore, it would be helpful to change the default port from 8091 to 8000 in the examples.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
