### PR TITLE
[Refactor][Perf] Replace _LocalPredictorKVCache with SDPA

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code_predictor_vllm.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code_predictor_vllm.py
@@ -65,6 +65,7 @@ class CodePredictorAttention(nn.Module):
             bias=qkv_bias,
             quant_config=quant_config,
             prefix=f"{prefix}.qkv_proj",
+            disable_tp=True,
         )
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
@@ -72,6 +73,7 @@ class CodePredictorAttention(nn.Module):
             bias=False,
             quant_config=quant_config,
             prefix=f"{prefix}.o_proj",
+            disable_tp=True,
         )
 
         self.rotary_emb = get_rope(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

To solve some problems:
- The code predictor (a small 5-layer sub-model for residual codebook prediction) was borrowing model runner v2's attn_utils (vllm.v1.worker.gpu.attn_utils) to manage its own KV cache, but vllm-omni uses model runner v1. The current implementation is so hacky.
- We have to add the NPU-specifc code branch because v2 backends needed different metadata formats.


The code predictor doesn't need paged attention because paged attention solves three problems it doesn't have:

- Variable-length sequences — Paged attention manages memory efficiently when sequences have unpredictable lengths (hundreds to thousands of tokens). The code predictor always runs exactly num_code_groups tokens (~32), known at init time.
- Memory fragmentation across concurrent sequences — Paged attention avoids fragmentation when the engine juggles thousands of sequences with different lifetimes. The code predictor runs a small batch, allocates at startup, and reuses the same buffer every frame.
- Shared KV cache pool managed by the scheduler — The main LLM's KV cache is allocated/freed by vLLM's scheduler across requests. The code predictor's KV cache is private — it's allocated once, used for ~30 decode steps, then zeroed. No scheduler involvement.

## Test Plan

```
CUDA_VISIBLE_DEVICES=0 python -m vllm_omni.entrypoints.cli.main serve     "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"     --omni --host 127.0.0.1 --port 8000     --stage-configs-path benchmarks/qwen3-tts/vllm_omni/configs/qwen3_tts_bs1.yaml     --trust-remote-code
```

```
python benchmarks/qwen3-tts/vllm_omni/bench_tts_serve.py     --port 8000     --num-prompts 50     --max-concurrency 1 4 10     --save-audio     --result-dir benchmarks/qwen3-tts/results/
```

## Test Result

It looks like RTF values have some problem...

Before:

```
======================================================================
 Summary: async_chunk
======================================================================
  Conc   TTFP(ms)     E2E(ms)      RTF      Audio(s/s)   Req/s
  ------ ------------ ------------ -------- ------------ --------
  1      2502.4       7012.5       2.477    0.40         0.1
  4      23747.9      27808.0      9.832    0.41         0.1
  10     70739.9      75256.3      23.191   0.41         0.1
======================================================================
```

After:

```
======================================================================
 Summary: async_chunk
======================================================================
  Conc   TTFP(ms)     E2E(ms)      RTF      Audio(s/s)   Req/s
  ------ ------------ ------------ -------- ------------ --------
  1      2042.6       5650.0       1.996    0.50         0.2
  4      19093.7      23453.3      8.049    0.51         0.2
  10     51751.7      55537.6      17.790   0.51         0.2
======================================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
