### PR TITLE
[Bugfix] fix kernel error for qwen3-omni

### DIFF
--- a/vllm_omni/model_executor/stage_configs/qwen3_omni_moe.yaml
+++ b/vllm_omni/model_executor/stage_configs/qwen3_omni_moe.yaml
@@ -72,7 +72,7 @@ stage_args:
     stage_type: llm  # Use llm stage type to launch OmniLLM
     runtime:
       devices: "1"
-      max_batch_size: 64
+      max_batch_size: 32
     engine_args:
       model_stage: code2wav
       model_arch: Qwen3OmniMoeForConditionalGeneration

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -416,6 +416,14 @@ class GPUARModelRunner(OmniGPUModelRunner):
         if grammar_output is not None:
             apply_grammar_bitmask(scheduler_output, grammar_output, self.input_batch, logits)
 
+        # Correct padding values of prompt_token_ids to match the logits vocabulary size
+        if logits is not None and not self.input_batch.sampling_metadata.no_penalties:
+            smd = self.input_batch.sampling_metadata
+            if smd.prompt_token_ids is not None:
+                logits_vocab = logits.shape[-1]
+                if self.input_batch.vocab_size > logits_vocab:
+                    smd.prompt_token_ids = smd.prompt_token_ids.clamp(max=logits_vocab)
+
         with record_function_or_nullcontext("gpu_model_runner: sample"):
             sampler_output = self._sample(logits, spec_decode_metadata)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
When vLLM groups requests into a batch, it builds sampling metadata where prompt_token_ids is a tensor with shape [num_reqs, max_prompt_len]. When request lengths are shorter than max_prompt_len, they are padded to the batch's maximum number of prompt tokens using the model's vocab_size. For multi-stage models, each stage has a different vocab_size. In Qwen3-Omni, the talker incorrectly uses the thinker's vocab_size during the sampling phase, causing an out-of-bounds computation error. I clamped the padding value of prompt_token_ids to match the correct vocab size for each stage.

This can help solve https://github.com/vllm-project/vllm-omni/issues/1520 & https://github.com/vllm-project/vllm-omni/issues/1532

## Test Plan
```
bash benchmarks/qwen3-omni/vllm_omni/eval_qwen3_moe_omni.sh
```

## Test Result
<img width="1338" height="1369" alt="image" src="https://github.com/user-attachments/assets/77ac5fdc-e86e-4570-a457-aa8b50bee832" />
<img width="2174" height="1349" alt="image" src="https://github.com/user-attachments/assets/a9ab4489-8e81-4b52-bc43-2b6d52cf4e3c" />
<img width="2169" height="1343" alt="image" src="https://github.com/user-attachments/assets/a0c2723e-5d5d-44c0-9d33-4dad3754ca68" />
<img width="2176" height="1332" alt="image" src="https://github.com/user-attachments/assets/90a7db18-839a-40d9-895e-3abf8cbc5435" />
<img width="2176" height="1349" alt="image" src="https://github.com/user-attachments/assets/50c66d3f-29f1-4d89-82a0-3bb44f317129" />
<img width="2185" height="1367" alt="image" src="https://github.com/user-attachments/assets/ce1512a1-07db-4e8f-bb0b-1ea812be37c7" />
<img width="2179" height="1252" alt="image" src="https://github.com/user-attachments/assets/57bba81d-d4c1-49d3-af14-ffea47456ea7" />
<img width="2227" height="1218" alt="image" src="https://github.com/user-attachments/assets/73fd0c48-f8c9-4c4d-8049-a5e0032e193d" />
<img width="2180" height="1153" alt="image" src="https://github.com/user-attachments/assets/7b65b0a9-a6be-4d42-b863-c054096482f6" />



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
