### PR TITLE
[WIP] Vectorize talker code predictor to avoid per-position recomputation

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py
@@ -212,9 +212,13 @@ class Qwen3OmniMoeTalkerForConditionalGeneration(
         summed_embeddings = current_input_flat[:, 1:, :].sum(
             dim=1
         )  # Sum over code groups, keep batch and hidden dims -> [B*T, hidden_size]
-        summed_embeddings = summed_embeddings.view(
-            batch_size, seq_len, -1
-        )  # Reshape back to [batch, seq_len, hidden_size]
+        if seq_len == 1:
+            # Reshape back to [batch, hidden_size]
+            summed_embeddings = summed_embeddings.view(batch_size, -1)
+        else:
+            summed_embeddings = summed_embeddings.view(
+                batch_size, seq_len, -1
+            )  # Reshape back to [batch, seq_len, hidden_size]
 
         return result_codes, summed_embeddings
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Resolves: https://github.com/vllm-project/vllm-omni/issues/1610
## Test Plan
```
vllm serve /workspace/models/Qwen3-Omni-30B-A3B-Instruct --omni --port 50146
```
## Test Result
Opt

```
============ Serving Benchmark Result ============							
Successful requests:                     100       							
Failed requests:                         0         							
Maximum request concurrency:             10        							
Benchmark duration (s):                  155.35    							
Request throughput (req/s):              0.64      							
Peak concurrent requests:                16.00     							
----------------End-to-end Latency----------------							
Mean E2EL (ms):                          14701.95  							
Median E2EL (ms):                        14058.64  							
P99 E2EL (ms):                           30286.59  							
================== Text Result ===================							
Total input tokens:                      10000     							
Total generated tokens:                  10000     							
Output token throughput (tok/s):         64.37     							
Peak output token throughput (tok/s):    257.00    							
Peak concurrent requests:                16.00     							
Total Token throughput (tok/s):          128.74    							
---------------Time to First Token----------------							
Mean TTFT (ms):                          131.56    							
Median TTFT (ms):                        91.68     							
P99 TTFT (ms):                           438.81    							
-----Time per Output Token (excl. 1st token)------							
Mean TPOT (ms):                          23.56     							
Median TPOT (ms):                        22.04     							
P99 TPOT (ms):                           42.70     							
---------------Inter-token Latency----------------							
Mean ITL (ms):                           23.38     							
Median ITL (ms):                         20.20     							
P99 ITL (ms):                            86.82     							
================== Audio Result ==================							
Total audio duration generated(s):       2630.11   							
Total audio frames generated:            63122175  							
Audio throughput(audio duration/s):      16.93     							
---------------Time to First Packet---------------							
Mean AUDIO_TTFP (ms):                    14654.62  							
Median AUDIO_TTFP (ms):                  14012.12  							
P99 AUDIO_TTFP (ms):                     30226.56  							
-----------------Real Time Factor-----------------							
Mean AUDIO_RTF:                          0.60      							
Median AUDIO_RTF:                        0.53      							
P99 AUDIO_RTF:                           1.18      							
==================================================							

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
