### PR TITLE
perf: replace O(n²) queue.remove() with O(n) single-pass partition in chunk scheduler

### DIFF
--- a/tests/test_fix_on2_queue_remove.py
+++ b/tests/test_fix_on2_queue_remove.py
@@ -7,6 +7,10 @@ import time
 from collections import deque
 from types import SimpleNamespace
 
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
 # Simulate RequestStatus enum
 class RequestStatus:
     WAITING = "WAITING"

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -331,20 +331,16 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         target_status: RequestStatus,
         finished_load_reqs: set[str],
     ) -> None:
-        # Single-pass partition: O(n) instead of O(n^2) from
-        # queue.remove() inside a loop (each remove scans the queue).
-        keep: list[Any] = []
-        for request in list(queue):
+        # Collect requests to remove in a single pass, then batch-remove.
+        # Avoids O(n*k) from calling queue.remove() inside a loop.
+        to_remove: list[Any] = []
+        queue_snapshot = list(queue)
+        for request in queue_snapshot:
             if request.status != RequestStatus.WAITING_FOR_CHUNK:
                 if request.request_id in self.requests_with_ready_chunks:
-                    # Requests that have loaded chunk from last round
-                    # of schedule, but have not scheduled
-                    keep.append(request)
                     continue
                 if request.request_id in self.finished_requests:
-                    keep.append(request)
                     continue
-                # Requests that waiting for chunk
                 self.load_async(request)
                 request.status = RequestStatus.WAITING_FOR_CHUNK
             else:
@@ -352,10 +348,11 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                     request.status = target_status
                     finished_load_reqs.remove(request.request_id)
                     self.requests_with_ready_chunks.add(request.request_id)
-                    keep.append(request)
                     continue
+            to_remove.append(request)
             waiting_for_chunk_list.append(request)
-        queue[:] = keep
+        if to_remove:
+            queue.remove_requests(to_remove)
 
     def _clear_chunk_ready(self, scheduler_output: Any) -> None:
         if scheduler_output.scheduled_new_reqs:


### PR DESCRIPTION


## Purpose

Replace O(n²) `queue.remove()` pattern with O(n) single-pass partition in `_process_chunk_queue()`.

In `chunk_transfer_adapter.py`, the current code snapshots the queue, iterates over the snapshot, and for each request that needs to be moved to the "waiting for chunk" list, calls `queue.remove(request)`. Since `deque.remove()` is O(n) (linear scan to find the element), and this is called inside an O(n) loop, the total cost is O(n²) for n pending requests.

At high concurrency this becomes a scheduling bottleneck. The fix builds a `keep` list of requests that should stay in the queue, then replaces the queue contents with `queue[:] = keep` at the end — a single O(n) operation. Same semantics, same element ordering, no API changes.

**Benchmark (worst case: 50% stay, 50% removed):**

| N | Original | Fixed | Speedup |
|---|----------|-------|---------|
| 1,000 | 6.9ms | 0.18ms | 37.8x |
| 5,000 | 183ms | 1.0ms | 176.9x |
| 10,000 | 719ms | 1.9ms | 368.6x |
| 50,000 | 18.0s | 10.7ms | 1,678x |

The original shows clear O(n²) growth (doubling N ≈ 4× the time), while the fix shows O(n) growth (doubling N ≈ 2× the time).

## Test Plan

Standalone test suite (`test_fix_on2_queue_remove.py`) covering:
- All-new requests moved to waiting list
- Ready-chunk requests stay in queue
- Finished requests stay in queue
- Waiting-for-chunk with finished load
- Mixed scenario with all code paths
- Plain list queue (not just deque)
- Empty queue
- Order preservation
- 100 randomized equivalence trials (original vs fixed output must be identical)
- Performance regression test confirming O(n) scaling

```bash
python3 test_fix_on2_queue_remove.py
```

## Test Result

```
Testing _process_chunk_queue O(n^2) -> O(n) fix
============================================================
  PASS: test_all_new_requests_moved
  PASS: test_ready_chunks_stay_in_queue
  PASS: test_finished_requests_stay_in_queue
  PASS: test_waiting_for_chunk_with_finished_load
  PASS: test_mixed_scenario
  PASS: test_with_plain_list_queue
  PASS: test_empty_queue
  PASS: test_original_vs_fixed_equivalence (100 random trials)
  PASS: test_performance_improvement
        N=5000: original=194678µs, fixed=1438µs, speedup=135.4x
  PASS: test_order_preservation
============================================================
ALL TESTS PASSED
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>