### PR TITLE
[NPU] Support Helios-Mid / Distilled

### DIFF
--- a/vllm_omni/diffusion/models/helios/scheduling_helios.py
+++ b/vllm_omni/diffusion/models/helios/scheduling_helios.py
@@ -78,7 +78,7 @@ class HeliosScheduler(SchedulerMixin, ConfigMixin):
         num_train_timesteps = self.config.num_train_timesteps
         shift = self.config.shift
 
-        alphas = np.linspace(1, 1 / num_train_timesteps, num_train_timesteps + 1)
+        alphas = np.linspace(1, 1 / num_train_timesteps, num_train_timesteps + 1, dtype=np.float32)
         sigmas = 1.0 - alphas
         sigmas = np.flip(shift * sigmas / (1 + (shift - 1) * sigmas))[:-1].copy()
         sigmas = torch.from_numpy(sigmas)
@@ -133,11 +133,11 @@ class HeliosScheduler(SchedulerMixin, ConfigMixin):
             timestep_ratio = self.timestep_ratios[i_s]
             timestep_max = min(self.timesteps[int(timestep_ratio[0] * training_steps)], 999)
             timestep_min = self.timesteps[min(int(timestep_ratio[1] * training_steps), training_steps - 1)]
-            timesteps = np.linspace(timestep_max, timestep_min, training_steps + 1)
+            timesteps = np.linspace(timestep_max, timestep_min, training_steps + 1, dtype=np.float32)
             self.timesteps_per_stage[i_s] = (
                 timesteps[:-1] if isinstance(timesteps, torch.Tensor) else torch.from_numpy(timesteps[:-1])
             )
-            stage_sigmas = np.linspace(0.999, 0, training_steps + 1)
+            stage_sigmas = np.linspace(0.999, 0, training_steps + 1, dtype=np.float32)
             self.sigmas_per_stage[i_s] = torch.from_numpy(stage_sigmas[:-1])
 
     @property
@@ -188,10 +188,11 @@ class HeliosScheduler(SchedulerMixin, ConfigMixin):
                 stage_timesteps[0].item(),
                 stage_timesteps[-1].item(),
                 num_inference_steps,
+                dtype=np.float32,
             )
 
             stage_sigmas = self.sigmas_per_stage[stage_index]
-            ratios = np.linspace(stage_sigmas[0].item(), stage_sigmas[-1].item(), num_inference_steps)
+            ratios = np.linspace(stage_sigmas[0].item(), stage_sigmas[-1].item(), num_inference_steps, dtype=np.float32)
             sigmas = torch.from_numpy(ratios)
 
         self.timesteps = torch.from_numpy(timesteps).to(device=device)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Support Helios-Mid / Helios-Distilled on NPU.

## Test Plan

```
python examples/offline_inference/helios/end2end.py \
    --model /root/.cache/modelscope/hub/models/BestWishYSH/Helios-Mid --sample-type t2v \
    --prompt "A dynamic time-lapse video showing the rapidly moving scenery from the window of a speeding train." \
    --guidance-scale 5.0 --is-enable-stage2 \
    --pyramid-num-inference-steps-list 20 20 20 \
    --use-cfg-zero-star --use-zero-init --zero-steps 1 \
    --output helios_t2v_mid.mp4 \
    --num-inference-steps 4 \
    --num-frames 4 \
    --tensor-parallel-size 2
```

```
python examples/offline_inference/helios/end2end.py     --model /root/.cache/modelscope/hub/models/BestWishYSH/Helios-Distilled --sample-type t2v     --prompt "A dynamic time-lapse video showing the rapidly moving scenery from the window of a speeding train."     --num-frames 4 --num-inference-steps 4 --guidance-scale 1.0 --is-enable-stage2     --pyramid-num-inference-steps-list 2 2 2     --is-amplify-first-chunk --output helios_t2v_distilled.mp4
```

## Test Result

```
[Stage-0] INFO 03-04 06:26:00 [shm_broadcast.py:542] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
[Stage-0] INFO 03-04 06:27:00 [shm_broadcast.py:542] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
[Stage-0] INFO 03-04 06:27:34 [diffusion_engine.py:80] Generation completed successfully.
[Stage-0] INFO 03-04 06:27:34 [diffusion_engine.py:98] Post-processing completed in 0.1079 seconds
Processed prompts: 100%|██████████████████████████████████| 1/1 [02:35<00:00, 155.04s/img, est. speed stage-0 img/s: 0.00, avg e2e_lat: 0.0ms]
Adding requests:   0%|                                                                                                  | 0/1 [02:35<?, ?it/s]
Total generation time: 155.0494 seconds (155049.43 ms)
Saved generated video to helios_t2v_mid.mp4
[Stage-0] INFO 03-04 06:27:35 [omni_stage.py:870] Received shutdown signal
WARNING 03-04 06:27:35 [omni_stage.py:545] Failed to send shutdown to in_q: Socket operation on non-socket
[Stage-0] INFO 03-04 06:27:35 [diffusion_worker.py:435] Worker 0: Received shutdown message
[Stage-0] INFO 03-04 06:27:35 [diffusion_worker.py:456] event loop terminated.
[Stage-0] INFO 03-04 06:27:35 [diffusion_worker.py:435] Worker 1: Received shutdown message
[Stage-0] INFO 03-04 06:27:35 [diffusion_worker.py:456] event loop terminated.
[Stage-0] INFO 03-04 06:27:35 [diffusion_worker.py:491] Worker 0: Shutdown complete.
[Stage-0] INFO 03-04 06:27:35 [diffusion_worker.py:491] Worker 1: Shutdown complete.
```

```
[Stage-0] INFO 03-04 06:50:55 [diffusion_engine.py:80] Generation completed successfully.
[Stage-0] INFO 03-04 06:50:55 [diffusion_engine.py:98] Post-processing completed in 0.1585 seconds
Processed prompts: 100%|███████████████████████████████████| 1/1 [00:29<00:00, 29.07s/img, est. speed stage-0 img/s: 0.00, avg e2e_lat: 0.0ms]
Adding requests:   0%|                                                                                                  | 0/1 [00:29<?, ?it/s]
Total generation time: 29.0758 seconds (29075.75 ms)
Saved generated video to helios_t2v_distilled.mp4
[Stage-0] INFO 03-04 06:50:56 [omni_stage.py:870] Received shutdown signal
WARNING 03-04 06:50:56 [omni_stage.py:545] Failed to send shutdown to in_q: Socket operation on non-socket
[Stage-0] INFO 03-04 06:50:56 [diffusion_worker.py:435] Worker 0: Received shutdown message
[Stage-0] INFO 03-04 06:50:56 [diffusion_worker.py:456] event loop terminated.
[Stage-0] INFO 03-04 06:50:56 [diffusion_worker.py:491] Worker 0: Shutdown complete.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
