### PR TITLE
[Bugfix] Fix SD3.5-medium attn2 uninitialized weights

### DIFF
--- a/vllm_omni/diffusion/models/sd3/sd3_transformer.py
+++ b/vllm_omni/diffusion/models/sd3/sd3_transformer.py
@@ -156,8 +156,12 @@ class SD3CrossAttention(nn.Module):
         else:
             self.to_out = None
 
-        self.norm_added_q = RMSNorm(head_dim, eps=eps) if qk_norm else nn.Identity()
-        self.norm_added_k = RMSNorm(head_dim, eps=eps) if qk_norm else nn.Identity()
+        if added_kv_proj_dim is not None and qk_norm:
+            self.norm_added_q = RMSNorm(head_dim, eps=eps)
+            self.norm_added_k = RMSNorm(head_dim, eps=eps)
+        else:
+            self.norm_added_q = nn.Identity()
+            self.norm_added_k = nn.Identity()
 
         self.attn = Attention(
             num_heads=self.to_qkv.num_heads,


### PR DESCRIPTION
Fixes #1633.

`SD3TransformerBlock` constructs `attn2` without passing `added_kv_proj_dim=None`, so `SD3CrossAttention` creates `add_kv_proj`/`to_add_out`/`norm_added_{q,k}` layers that don't exist in the SD3.5-medium checkpoint. The strict weight loader then raises `ValueError: Following weights were not initialized`.

Fix: pass `added_kv_proj_dim=None` and `context_pre_only=True` when constructing `attn2`.