### PR TITLE
[Cleanup] Move cosyvoice3 tests to model subdirectory

### DIFF
--- a/vllm_omni/diffusion/layers/adalayernorm.py
+++ b/vllm_omni/diffusion/layers/adalayernorm.py
@@ -1,3 +1,5 @@
+from importlib.util import find_spec
+
 import torch
 import torch.nn as nn
 from vllm.logger import init_logger
@@ -5,6 +7,8 @@ from vllm.logger import init_logger
 from vllm_omni.diffusion.layers.custom_op import CustomOp
 
 logger = init_logger(__name__)
+
+_HAS_MINDIESD = find_spec("mindiesd") is not None
 
 
 class AdaLayerNorm(CustomOp):
@@ -83,10 +87,21 @@ class AdaLayerNorm(CustomOp):
     ) -> torch.Tensor:
         shift_result, scale_result, gate_result = self.preprocess(mod_params, index)
 
+        if _HAS_MINDIESD:
+            try:
+                from mindiesd import layernorm_scale_shift
+
+                output = layernorm_scale_shift(self.layernorm, x, scale_result, shift_result, fused=True)
+
+                return output, gate_result
+            except ImportError as e:
+                logger.warning_once(f"mindiesd import failed, falling back to torch_npu: {e}")
+
         import torch_npu
 
-        output = torch_npu.npu_layer_norm_eval(
-            x, normalized_shape=[self.hidden_size], weight=(1 + scale_result), bias=shift_result, eps=self.eps
+        output = (
+            torch_npu.npu_layer_norm_eval(x, normalized_shape=[self.hidden_size], eps=self.eps) * (1 + scale_result)
+            + shift_result
         )
 
         return output, gate_result

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -68,6 +68,21 @@ class DiffusionModelRunner:
         # Initialize KV cache manager for connector management
         self.kv_transfer_manager = OmniKVTransferManager.from_od_config(od_config)
 
+    def _compile_transformer(self, attr_name: str) -> None:
+        """Compile a transformer attribute on the pipeline with torch.compile."""
+        model = getattr(self.pipeline, attr_name, None)
+        if model is None:
+            return
+        try:
+            setattr(self.pipeline, attr_name, regionally_compile(model, dynamic=True))
+            logger.info("Model runner: %s compiled with torch.compile.", attr_name)
+        except Exception as e:
+            logger.warning(
+                "Model runner: torch.compile for %s failed: %s. Using eager mode.",
+                attr_name,
+                e,
+            )
+
     def load_model(
         self,
         memory_pool_context_fn: callable | None = None,
@@ -131,14 +146,8 @@ class DiffusionModelRunner:
         # Apply torch.compile if not in eager mode
         if not self.od_config.enforce_eager:
             if current_omni_platform.supports_torch_inductor():
-                try:
-                    self.pipeline.transformer = regionally_compile(
-                        self.pipeline.transformer,
-                        dynamic=True,
-                    )
-                    logger.info("Model runner: Model compiled with torch.compile.")
-                except Exception as e:
-                    logger.warning(f"Model runner: torch.compile failed with error: {e}. Using eager mode.")
+                self._compile_transformer("transformer")
+                self._compile_transformer("transformer_2")
             else:
                 logger.warning(
                     "Model runner: Platform %s does not support torch inductor, skipping torch.compile.",


### PR DESCRIPTION
## Summary
- Move cosyvoice3 test files to `tests/model_executor/models/cosyvoice3/` to match the project convention used by qwen3_tts and qwen2_5_omni
- Follow-up to #498