### PR TITLE
[Bug]: fix CUDA OOM during diffusion post-processing

### DIFF
--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -107,9 +107,15 @@ class DiffusionEngine:
                 for i, prompt in enumerate(request.prompts)
             ]
 
-        # Move output to CPU before post-processing to avoid device OOM.
+        # When CPU offload is enabled, move output to CPU before
+        # post-processing to avoid device OOM — model weights may still
+        # reside on the device and leave no headroom for intermediates.
         output_data = output.output
-        if isinstance(output_data, torch.Tensor) and output_data.device.type != "cpu":
+        if (
+            self.od_config.enable_cpu_offload
+            and isinstance(output_data, torch.Tensor)
+            and output_data.device.type != "cpu"
+        ):
             output_data = output_data.cpu()
 
         postprocess_start_time = time.perf_counter()


### PR DESCRIPTION
## Purpose

Fix #1671, CUDA out-of-memory errors that occur during diffusion post-processing (denormalization / numpy conversion), even when the generation itself succeeds.

After the diffusion forward pass, the model weights (including VAE) may still reside on the GPU — especially under CPU-offload configurations where the VAE is the last module to run. The post-processing step (postprocess_video / postprocess) performs in-place arithmetic (e.g., `(images * 0.5 + 0.5).clamp(0, 1)`) that allocates intermediate tensors on the same device. On memory-constrained GPUs (e.g., 24 GB), this small additional allocation is enough to trigger OOM.

The fix moves the output tensor to CPU before post-processing. This is safe because post-processing only produces numpy arrays or PIL images — no GPU computation is needed.

## Memory Analysis

Profiled with `VLLM_DEBUG_MEMORY=1` (see #1901) on 1× H200 (141 GB) to understand per-stage GPU memory usage:

### Wan2.1-T2V-1.3B, 480p, 81 frames, 20 steps
```
Stage                |    Allocated |     Reserved |         Free | Used by Stage
--------------------------------------------------------------------------------
before_encode        |     13.75 GiB |     24.32 GiB |    114.81 GiB |      0.00 GiB
after_encode         |     13.76 GiB |     24.32 GiB |    114.81 GiB |      0.01 GiB
after_denoise        |     13.80 GiB |     14.07 GiB |    124.78 GiB |      0.05 GiB
after_vae_decode     |     14.16 GiB |     26.10 GiB |    112.75 GiB |      0.41 GiB
```

**Key findings:**
- **VAE decode is the peak memory stage** — PyTorch reserved memory jumps from 14 GiB to 26 GiB (+12 GiB)
- On a **24 GB GPU** (e.g., RTX 4090): model weights (~14 GiB) + VAE reserved (~26 GiB) exceeds GPU capacity
- Post-processing (`denormalize`) runs **after** VAE decode when GPU memory is at peak — allocating even small intermediates triggers OOM
- The `.cpu()` move frees the output tensor from GPU before post-processing, providing the headroom needed on memory-constrained setups

### Wan2.1-T2V-1.3B, 480p, 17 frames, 20 steps
```
Stage                |    Allocated |     Reserved |         Free | Used by Stage
--------------------------------------------------------------------------------
before_encode        |     13.75 GiB |     24.32 GiB |    114.81 GiB |      0.00 GiB
after_encode         |     13.76 GiB |     24.32 GiB |    114.81 GiB |      0.01 GiB
after_denoise        |     13.77 GiB |     14.00 GiB |    124.85 GiB |      0.02 GiB
after_vae_decode     |     13.84 GiB |     24.58 GiB |    114.27 GiB |      0.09 GiB
```
- Fewer frames = smaller VAE spike, but Reserved still hits 24.58 GiB — marginal on 24 GB GPUs

## Reproduction

Observed with Wan2.2-TI2V-5B-Diffusers on 4× RTX 4090 (24 GB each), `--tensor-parallel-size 2 --enable-cpu-offload`:

```
[Stage-0] INFO  Generation completed successfully.
[Stage-0] ERROR CUDA out of memory. Tried to allocate 152.00 MiB.
  ...
  File ".../diffusers/image_processor.py", line 240, in denormalize
    return (images * 0.5 + 0.5).clamp(0, 1)
```

Generation succeeds, but post-processing OOMs because the VAE weights + decoded video tensor leave no headroom on the GPU.

## Test Plan

- Verified the traceback originates from `DiffusionEngine.step()` → `post_process_func(output.output)`, confirming the tensor is still on CUDA at that point.
- The change is a one-line guard (`output.cpu()`) with no behavioral change to the post-processing output — downstream consumers already expect CPU tensors / numpy arrays.
- Existing models that don't hit OOM are unaffected (`.cpu()` on an already-CPU tensor is a no-op).
- Uses device-agnostic check (`output_data.device.type != "cpu"`) per reviewer feedback — works on ROCm/NPU/XPU too.

## Essential Elements of an Effective PR Description Checklist