### PR TITLE
[Bugfix] Handle numpy array outputs when generate image

### DIFF
--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -1110,27 +1110,6 @@ def test_normalize_image():
     assert result.size == (64, 64)
 
 
-def test_normalize_image_out_of_range_warning(caplog):
-    """Test _normalize_image logs warning for out-of-range float values"""
-    import numpy as np
-
-    from vllm_omni.entrypoints.openai.api_server import _normalize_image
-
-    # Test values outside [-1, 1] range
-    arr = np.array([[[[-1.5, 0.5, 1.5]]]], dtype=np.float32)
-    result = _normalize_image(arr)
-    assert isinstance(result, Image.Image)
-    assert "outside expected [-1, 1]" in caplog.text
-
-    caplog.clear()
-
-    # Test values outside [0, 1] range (large positive)
-    arr = np.array([[[[2.0, 3.0, 5.0]]]], dtype=np.float32)
-    result = _normalize_image(arr)
-    assert isinstance(result, Image.Image)
-    assert "outside expected [0, 1]" in caplog.text
-
-
 def test_extract_images_from_result():
     """Test _extract_images_from_result with various result formats"""
     import numpy as np
@@ -1146,7 +1125,7 @@ def test_extract_images_from_result():
     assert images == []
 
     # Test nested batch: [np.array(shape=(3, 64, 64, 3))]
-    batch = np.random.randint(0, 255, (3, 64, 64, 3), dtype=np.uint8)
+    batch = np.random.randint(0, 255, (3, 1, 64, 64, 3), dtype=np.uint8)
 
     class BatchResult:
         def __init__(self):

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -1071,3 +1071,112 @@ def test_image_edit_with_seed_zero_single_stage(test_client):
         f"Expected seed=0, but got seed={captured_sampling_params.seed}. "
         "This indicates the bug where seed=0 is treated as falsy."
     )
+
+
+def test_normalize_image():
+    """Test _normalize_image with various input types"""
+    import numpy as np
+
+    from vllm_omni.entrypoints.openai.api_server import _normalize_image
+
+    # Test PIL Image input
+    img = Image.new("RGB", (64, 64), color="red")
+    result = _normalize_image(img)
+    assert isinstance(result, Image.Image)
+    assert result.size == (64, 64)
+
+    # Test uint8 numpy array
+    arr = np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)
+    result = _normalize_image(arr)
+    assert isinstance(result, Image.Image)
+    assert result.size == (64, 64)
+
+    # Test float [0, 1] numpy array
+    arr = np.random.rand(64, 64, 3).astype(np.float32)
+    result = _normalize_image(arr)
+    assert isinstance(result, Image.Image)
+    assert result.size == (64, 64)
+
+    # Test float [-1, 1] numpy array
+    arr = np.random.rand(64, 64, 3).astype(np.float32) * 2 - 1
+    result = _normalize_image(arr)
+    assert isinstance(result, Image.Image)
+    assert result.size == (64, 64)
+
+    # Test batch dimensions (1, 1, H, W, C)
+    arr = np.random.randint(0, 255, (1, 1, 64, 64, 3), dtype=np.uint8)
+    result = _normalize_image(arr)
+    assert isinstance(result, Image.Image)
+    assert result.size == (64, 64)
+
+
+def test_normalize_image_out_of_range_warning(caplog):
+    """Test _normalize_image logs warning for out-of-range float values"""
+    import numpy as np
+
+    from vllm_omni.entrypoints.openai.api_server import _normalize_image
+
+    # Test values outside [-1, 1] range
+    arr = np.array([[[[-1.5, 0.5, 1.5]]]], dtype=np.float32)
+    result = _normalize_image(arr)
+    assert isinstance(result, Image.Image)
+    assert "outside expected [-1, 1]" in caplog.text
+
+    caplog.clear()
+
+    # Test values outside [0, 1] range (large positive)
+    arr = np.array([[[[2.0, 3.0, 5.0]]]], dtype=np.float32)
+    result = _normalize_image(arr)
+    assert isinstance(result, Image.Image)
+    assert "outside expected [0, 1]" in caplog.text
+
+
+def test_extract_images_from_result():
+    """Test _extract_images_from_result with various result formats"""
+    import numpy as np
+
+    from vllm_omni.entrypoints.openai.api_server import _extract_images_from_result
+
+    # Test empty result
+    class EmptyResult:
+        pass
+
+    result = EmptyResult()
+    images = _extract_images_from_result(result)
+    assert images == []
+
+    # Test nested batch: [np.array(shape=(3, 64, 64, 3))]
+    batch = np.random.randint(0, 255, (3, 64, 64, 3), dtype=np.uint8)
+
+    class BatchResult:
+        def __init__(self):
+            self.images = [batch]
+
+    result = BatchResult()
+    images = _extract_images_from_result(result)
+    assert len(images) == 3
+    assert all(isinstance(img, Image.Image) for img in images)
+    assert all(img.size == (64, 64) for img in images)
+
+    # Test dict path: result.request_output["images"]
+    class DictRequestOutput:
+        def __init__(self):
+            self.request_output = {"images": [np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)]}
+
+    result = DictRequestOutput()
+    images = _extract_images_from_result(result)
+    assert len(images) == 1
+    assert isinstance(images[0], Image.Image)
+
+    # Test attribute path: result.request_output.images
+    class AttrRequestOutput:
+        def __init__(self):
+            self.request_output = type(
+                "obj", (), {"images": [np.random.randint(0, 255, (32, 32, 3), dtype=np.uint8)]}
+            )()
+
+    result = AttrRequestOutput()
+    images = _extract_images_from_result(result)
+    assert len(images) == 1
+    assert isinstance(images[0], Image.Image)
+    assert images[0].size == (32, 32)

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1674,13 +1674,24 @@ def _update_if_not_none(object: Any, key: str, val: Any) -> None:
 
 def _normalize_image(image: Any) -> Any:
     """Normalize a single image output to a PIL-compatible format."""
+    if not np.issubdtype(image.dtype, np.integer) and not np.issubdtype(image.dtype, np.floating):
+        raise ValueError(f"Unsupported dtype: {image.dtype}")
     if isinstance(image, np.ndarray):
         while image.ndim > 3:
             image = image[0]
-        if np.issubdtype(image.dtype, np.floating):
-            if image.min() < 0:
-                image = np.clip(image, -1.0, 1.0) * 0.5 + 0.5
-            image = (np.clip(image, 0.0, 1.0) * 255).astype(np.uint8)
+        if image.min() < 0:
+            if image.min() < -1.01 or image.max() > 1.01:
+                logger.warning(
+                    f"Image float range [{image.min():.2f}, {image.max():.2f}] outside expected [-1, 1]. "
+                    f"Clipping to [-1, 1] before normalization."
+                )
+            image = np.clip(image, -1.0, 1.0) * 0.5 + 0.5
+        elif image.max() > 1.01:
+            logger.warning(
+                f"Image float range [{image.min():.2f}, {image.max():.2f}] outside expected [0, 1]. "
+                f"Clipping to [0, 1] before normalization."
+            )
+        image = (np.clip(image, 0.0, 1.0) * 255).astype(np.uint8)
         image = Image.fromarray(image)
     return image
 

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1710,6 +1710,10 @@ def _extract_images_from_result(result: Any) -> list[Any]:
             images = request_output["images"]
         elif hasattr(request_output, "images") and request_output.images:
             images = request_output.images
+    # Handle when generate more than one image
+    if images and isinstance(images[0], np.ndarray) and images[0].shape[0] > 1 and images[0].ndim == 5:
+        # Unwrap batch: (N, T, H, W, C) -> [img1, img2, ...]
+        images = list(images[0])
     # Flatten nested lists (e.g., from layered models like Qwen-Image-Layered).
     # Note: This only flattens one level deep. Deeper nesting is not supported.
     flattened = []

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -18,6 +18,7 @@ from http import HTTPStatus
 from typing import Annotated, Any, Literal, cast
 
 import httpx
+import numpy as np
 import vllm.envs as envs
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, WebSocket
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
@@ -1671,6 +1672,19 @@ def _update_if_not_none(object: Any, key: str, val: Any) -> None:
         setattr(object, key, val)
 
 
+def _normalize_image(image: Any) -> Any:
+    """Normalize a single image output to a PIL-compatible format."""
+    if isinstance(image, np.ndarray):
+        while image.ndim > 3:
+            image = image[0]
+        if np.issubdtype(image.dtype, np.floating):
+            if image.min() < 0:
+                image = np.clip(image, -1.0, 1.0) * 0.5 + 0.5
+            image = (np.clip(image, 0.0, 1.0) * 255).astype(np.uint8)
+        image = Image.fromarray(image)
+    return image
+
+
 def _extract_images_from_result(result: Any) -> list[Any]:
     images = []
     if hasattr(result, "images") and result.images:
@@ -1689,7 +1703,7 @@ def _extract_images_from_result(result: Any) -> list[Any]:
             flattened.extend(img)
         else:
             flattened.append(img)
-    return flattened
+    return [_normalize_image(img) for img in flattened]
 
 
 async def _load_input_images(

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1674,6 +1674,10 @@ def _update_if_not_none(object: Any, key: str, val: Any) -> None:
 
 def _normalize_image(image: Any) -> Any:
     """Normalize a single image output to a PIL-compatible format."""
+    if isinstance(image, Image.Image):
+        return image
+    if not isinstance(image, np.ndarray):
+        raise ValueError(f"Unsupported image type: {type(image)}")
     if not np.issubdtype(image.dtype, np.integer) and not np.issubdtype(image.dtype, np.floating):
         raise ValueError(f"Unsupported dtype: {image.dtype}")
     if isinstance(image, np.ndarray):


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fixes: https://github.com/vllm-project/vllm-omni/pull/1660

Wan2.2 video pipelines return numpy arrays (output_type="np"), but image_api_utils.py assumes PIL Images and calls img.save(). 

We `_extract_images_from_result` this method to add a numpy-to-PIL conversion.

Serve:
```
vllm serve /home/jovyan/Wan2.2-T2V-A14B-Diffusers/ --omni --port 8091
```

Test:
```
curl  -X POST "http://localhost:8091/v1/images/generations"   -H "Content-Type: application/json"   --data '{
            "model": "/home/jovyan/Wan2.2-T2V-A14B-Diffusers/",
            "prompt": "a cat",
            "n": 1,
            "size": "256x256",
            "seed": 7
}' | jq -r '.data[0].b64_json' | base64 -d > cat.png
```

<img width="256" height="256" alt="cat" src="https://github.com/user-attachments/assets/5390f027-0ef2-4288-8930-0f4f791d7a80" />


```
curl -X POST "http://localhost:8000/v1/images/generations" \
  -H "Content-Type: application/json" \
  --data '{
    "model": "/home/jovyan/Wan2.2-T2V-A14B-Diffusers/",
    "prompt": "a cat",
    "n": 2,
    "size": "256x256",
    "seed": 7
  }' \
| jq -r '.data[].b64_json' \
| nl -v 0 \
| while read i img; do
    echo "$img" | base64 -d > "cat${i}.png"
  done
```

<img width="256" height="256" alt="cat0" src="https://github.com/user-attachments/assets/0d96bfd8-f403-4037-8816-9578956febbd" />
<img width="256" height="256" alt="cat1" src="https://github.com/user-attachments/assets/f072871c-2314-4284-8c65-ea0fed1955e4" />



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
