### PR TITLE
Disable mm processor cache in CI stage configs

### DIFF
--- a/tests/e2e/offline_inference/stage_configs/npu/qwen2_5_omni_ci.yaml
+++ b/tests/e2e/offline_inference/stage_configs/npu/qwen2_5_omni_ci.yaml
@@ -21,6 +21,7 @@ stage_args:
       trust_remote_code: true
       engine_output_type: latent
       enable_prefix_caching: false
+      mm_processor_cache_gb: 0
     is_comprehension: true
     final_output: true
     final_output_type: text

--- a/tests/e2e/stage_configs/qwen2_5_omni_thinker_ci.yaml
+++ b/tests/e2e/stage_configs/qwen2_5_omni_thinker_ci.yaml
@@ -18,6 +18,7 @@ stage_args:
       trust_remote_code: true
       engine_output_type: latent
       enable_prefix_caching: false
+      mm_processor_cache_gb: 0
     is_comprehension: true
     final_output: true
     final_output_type: text

--- a/tests/e2e/stage_configs/qwen3_omni_ci.yaml
+++ b/tests/e2e/stage_configs/qwen3_omni_ci.yaml
@@ -22,6 +22,7 @@ stage_args:
     max_num_batched_tokens: 32768
     max_model_len: 32768
     enable_prefix_caching: false
+    mm_processor_cache_gb: 0
     hf_config_name: thinker_config
     tensor_parallel_size: 1
     load_format: dummy

--- a/tests/e2e/stage_configs/rocm/qwen2_5_omni_ci.yaml
+++ b/tests/e2e/stage_configs/rocm/qwen2_5_omni_ci.yaml
@@ -22,6 +22,7 @@ stage_args:
       trust_remote_code: true
       engine_output_type: latent
       enable_prefix_caching: false
+      mm_processor_cache_gb: 0
     is_comprehension: true
     final_output: true
     final_output_type: text

--- a/tests/e2e/stage_configs/rocm/qwen3_omni_ci.yaml
+++ b/tests/e2e/stage_configs/rocm/qwen3_omni_ci.yaml
@@ -20,6 +20,7 @@ stage_args:
       engine_output_type: latent  # Output hidden states for talker
       distributed_executor_backend: "mp"
       enable_prefix_caching: false
+      mm_processor_cache_gb: 0
       hf_config_name: thinker_config
       tensor_parallel_size: 1
       load_format: dummy


### PR DESCRIPTION
## Summary
- Set `mm_processor_cache_gb: 0` for the thinker stage in all CI configs that were missing it
- Affected configs: Qwen3-Omni (H100, ROCm), Qwen2.5-Omni (ROCm, NPU, thinker-only)
- The main `qwen2_5_omni_ci.yaml` already had this set; this PR makes the rest consistent

## Test plan
- [ ] Verify CI tests still pass with the updated configs