### PR TITLE
[Bugfix] Expose base_model_paths property in _DiffusionServingModels

### DIFF
--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -177,7 +177,6 @@ class _DiffusionServingModels:
 
     def __init__(self, base_model_paths: list[BaseModelPath]) -> None:
         self._base_model_paths = base_model_paths
-        self.model_config = self._NullModelConfig()
 
     @property
     def base_model_paths(self) -> list[BaseModelPath]:


### PR DESCRIPTION
## Purpose

In pure diffusion mode, _DiffusionServingModels uses __getattr__ to intercept undefined attributes. Accessing base_model_paths returned a _Unsupported object instead of the actual list, causing NotImplementedError when
retrieving model names for video generation endpoints

`curl -s -D >(grep -i x-request-id >&2)    -o >(jq -r '.data[0].b64_json' | base64 --decode > output.png)    -X POST "http://localhost:8004/v1/images/edits"  -F "model=black-forest-labs/FLUX.2-klein-4B"  -F "image=@./test.jpg"    -F "prompt=change into orange."    -F "size=1024x1024"    -F "output_format=png"`

```
APIServer pid=494089)     model_name = serving_models.base_model_paths[0].name
(APIServer pid=494089)                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
(APIServer pid=494089) TypeError: '_Unsupported' object is not subscriptable
```

## Test Plan

## Test Result


(APIServer pid=111918) INFO 03-10 11:50:44 [diffusion_engine.py:86] Generation completed successfully.
(APIServer pid=111918) INFO 03-10 11:50:44 [diffusion_engine.py:108] Post-processing completed in 0.1113 seconds
(APIServer pid=111918) INFO 03-10 11:50:44 [diffusion_engine.py:111] DiffusionEngine.step breakdown: preprocess=0.00 ms, add_req_and_wait=25044.09 ms, postprocess=111.33 ms, total=25156.01 ms
(APIServer pid=111918) INFO 03-10 11:50:44 [omni_diffusion.py:128] OmniDiffusion.generate total: 25156.33 ms
(APIServer pid=111918) INFO 03-10 11:50:44 [api_server.py:1395] Successfully generated 1 image(s)
(APIServer pid=111918) INFO:     127.0.0.1:52072 - "POST /v1/images/edits HTTP/1.1" 200 OK
