### PR TITLE
[Bugfix] Adjust Z-Image Tensor Parallelism Diff Threshold

### DIFF
--- a/tests/e2e/offline_inference/test_zimage_parallelism.py
+++ b/tests/e2e/offline_inference/test_zimage_parallelism.py
@@ -199,7 +199,7 @@ def test_zimage_tensor_parallel_tp2(tmp_path: Path):
 
     mean_abs_diff, p99_abs_diff = _diff_metrics(tp1_img, tp2_img)
     mean_threshold = 3e-2
-    p99_threshold = 5e-1
+    p99_threshold = 2.5e-1
     print(
         "Z-Image TP image diff stats (TP=1 vs TP=2): "
         f"mean_abs_diff={mean_abs_diff:.6e}, p99_abs_diff={p99_abs_diff:.6e}; "


### PR DESCRIPTION

## Purpose
As mentioned in multiple issues #1800 and #1734 , Z-Image Tensor Parallelism CI test can easily fail.

In this PR, I changed the max_abs_diff to a more robust p99 threshold, and changed it from 0.5 to 0.25.


## Test Plan

```bash
pytest -s -v tests/e2e/offline_inference/test_zimage_parallelism.py
```
## Test Result

The test results are obtained locally, not on CI machines:

```text
Z-Image TP image diff stats (TP=1 vs TP=2): mean_abs_diff=1.276649e-02, p99_abs_diff=1.254902e-01; thresholds: mean<=3.000000e-02, p99<=2.500000e-01; tp1_img=/tmp/pytest-of-root/pytest-11/test_zimage_tensor_parallel_tp0/zimage_tp1.png, tp2_img=/tmp/pytest-of-root/pytest-11/test_zimage_tensor_parallel_tp0/zimage_tp2.png   
Z-Image TP perf (lower is better): tp1_time_s=0.226686, tp2_time_s=0.098293    
Z-Image TP peak memory (MB): tp1_peak_mem=56013.69, tp2_peak_mem=30290.56

...

Z-Image VAE patch parallel image diff stats (TP=2, pp=1 vs pp=2): mean_abs_diff=0.000000e+00, p99_abs_diff=0.000000e+00; thresholds: mean<=5.000000e-03, p99<=1.000000e-01; pp1_img=/tmp/pytest-of-root/pytest-11/test_zimage_vae_patch_parallel0/zimage_tp2_vae_pp1.png, pp2_img=/tmp/pytest-of-root/pytest-11/test_zimage_vae_patch_parallel0/zimage_tp2_vae_pp2.png

============================== 2 passed, 4 warnings in 280.27s (0:04:40) ===============================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
