### PR TITLE
[skip ci][Docs] doc fix for example snippets

### DIFF
--- a/docs/mkdocs/hooks/generate_examples.py
+++ b/docs/mkdocs/hooks/generate_examples.py
@@ -132,9 +132,19 @@ class Example:
             ".dat",
             ".db",
             ".sqlite",  # Data files
+            ".pyc",
+            ".pyo",
+            ".pyd",  # Python compiled
+            ".npy",
+            ".npz",
+            ".pkl",
+            ".pickle",  # Serialized data
         }
+        excluded_dirs = {"__pycache__", ".git", "node_modules", ".tox", ".mypy_cache"}
 
         def is_other_file(file: Path) -> bool:
+            if any(part in excluded_dirs for part in file.parts):
+                return False
             return file.is_file() and file != self.main_file and file.suffix.lower() not in binary_extensions
 
         return [file for file in self.path.rglob("*") if is_other_file(file)]


### PR DESCRIPTION
## Summary

- The `generate_examples` mkdocs hook was recursively scanning example directories and including `__pycache__/*.pyc` files as text snippets, causing a `UnicodeDecodeError` during the ReadTheDocs build (`fail_on_warning: true`).
- Added `.pyc`, `.pyo`, `.pyd`, `.npy`, `.npz`, `.pkl`, `.pickle` to the `binary_extensions` exclusion set, and added directory-level filtering to skip `__pycache__`, `.git`, `node_modules`, `.tox`, and `.mypy_cache` entirely.

## Test plan

- [x] Verified `mkdocs build --strict` passes locally after the fix (exit code 0, 175s build)
- [x] Confirmed no `.pyc` or `__pycache__` references remain in generated doc pages
