### PR TITLE
[Enhancement] Upgrade cache-dit from 1.2.0 to 1.3.0

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,7 +6,7 @@ diffusers>=0.36.0
 accelerate==1.12.0
 gradio==5.50
 soundfile>=0.13.1
-cache-dit==1.2.0
+cache-dit==1.3.0
 tqdm>=4.66.0
 torchsde>=0.2.6
 openai-whisper>=20250625


### PR DESCRIPTION
## Purpose

Upgrade the `cache-dit` dependency from 1.2.0 to 1.3.0 (latest release). This is a version bump with full API backward compatibility — all existing imports, `enable_cache()`, `refresh_context()`, `BlockAdapter`, `DBCacheConfig`, etc., remain unchanged.

## Test Plan

- Verified all `cache_dit` imports used in `vllm_omni/diffusion/cache/cache_dit_backend.py` pass with 1.3.0
- Ran offline inference benchmark on **Qwen/Qwen-Image** (text-to-image, 1024x1024, 50 steps) comparing with and without cache-dit acceleration
- Pre-commit passes on the changed file

```bash
# Without cache-dit (baseline)
CUDA_VISIBLE_DEVICES=1 python examples/offline_inference/text_to_image/text_to_image.py \
  --model Qwen/Qwen-Image --prompt "a cup of coffee on the table" \
  --seed 142 --num-inference-steps 50 --height 1024 --width 1024

# With cache-dit 1.3.0
CUDA_VISIBLE_DEVICES=1 python examples/offline_inference/text_to_image/text_to_image.py \
  --model Qwen/Qwen-Image --prompt "a cup of coffee on the table" \
  --seed 142 --num-inference-steps 50 --height 1024 --width 1024 \
  --cache-backend cache_dit --enable-cache-dit-summary
```

## Test Result

Benchmark on single NVIDIA H800 GPU:

| Metric | Without Cache-DiT | With Cache-DiT 1.3.0 | Speedup |
|---|---|---|---|
| Total generation time | 7.551s | 3.761s | **2.01x** |
| Diffusion engine exec time | 7,436ms | 3,644ms | **2.04x** |

Cache-dit 1.3.0 delivers ~2x acceleration on Qwen-Image with default DBCache config (`Fn=1, Bn=0, W=4, threshold=0.24`), consistent with 1.2.0 behavior.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands.
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update — N/A, no doc changes needed.
- [ ] (Optional) Release notes update — N/A, minor dependency bump.
</details>