### PR TITLE
feat(diffusion): log CUDA memory on scheduler allocation failures

### DIFF
--- a/tests/core/sched/test_omni_generation_scheduler_memory.py
+++ b/tests/core/sched/test_omni_generation_scheduler_memory.py
@@ -1,0 +1,48 @@
+import logging
+
+from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
+
+
+class DummyRequest:
+    def __init__(self):
+        self.request_id = "req-1"
+        self.num_computed_tokens = 3
+        self.prompt_token_ids = [1, 2, 3, 4, 5]
+
+
+def test_log_allocation_failure_includes_memory_snapshot(monkeypatch, caplog):
+    scheduler = object.__new__(OmniGenerationScheduler)
+    scheduler._memory_profiling_enabled = True
+
+    monkeypatch.setattr(
+        "vllm_omni.core.sched.omni_generation_scheduler.capture_cuda_memory_snapshot",
+        lambda: {
+            "device": 0,
+            "allocated_bytes": 1024,
+            "reserved_bytes": 2048,
+            "max_allocated_bytes": 4096,
+            "max_reserved_bytes": 8192,
+        },
+    )
+    monkeypatch.setattr(
+        "vllm_omni.core.sched.omni_generation_scheduler.format_cuda_memory_snapshot",
+        lambda snapshot: "cuda:0 allocated=0.00GiB reserved=0.00GiB max_allocated=0.00GiB max_reserved=0.00GiB",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        scheduler._log_allocation_failure(DummyRequest(), required_tokens=2, token_budget=1)
+
+    assert "Diffusion scheduler allocation failed" in caplog.text
+    assert "request_id=req-1" in caplog.text
+    assert "token_budget=1" in caplog.text
+
+
+def test_log_allocation_failure_noop_when_disabled(caplog):
+    scheduler = object.__new__(OmniGenerationScheduler)
+    scheduler._memory_profiling_enabled = False
+
+    with caplog.at_level(logging.WARNING):
+        scheduler._log_allocation_failure(DummyRequest(), required_tokens=2, token_budget=1)
+
+    assert caplog.text == ""
+

--- a/tests/diffusion/test_memory_profiling.py
+++ b/tests/diffusion/test_memory_profiling.py
@@ -1,0 +1,23 @@
+from vllm_omni.diffusion.memory_profiling import (
+    format_cuda_memory_snapshot,
+    get_memory_log_env_var,
+    is_memory_profiling_enabled,
+)
+
+
+def test_memory_log_env_var_name_is_stable():
+    assert get_memory_log_env_var() == "VLLM_OMNI_DIFFUSION_LOG_MEMORY"
+
+
+def test_memory_profiling_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("VLLM_OMNI_DIFFUSION_LOG_MEMORY", raising=False)
+    assert is_memory_profiling_enabled() is False
+
+
+def test_memory_profiling_truthy_values(monkeypatch):
+    monkeypatch.setenv("VLLM_OMNI_DIFFUSION_LOG_MEMORY", "true")
+    assert is_memory_profiling_enabled() is True
+
+
+def test_format_cuda_memory_snapshot_none():
+    assert format_cuda_memory_snapshot(None) == "cuda=unavailable"

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -17,6 +17,11 @@ from vllm.v1.request import Request, RequestStatus
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 
 from vllm_omni.core.sched.output import OmniCachedRequestData, OmniNewRequestData
+from vllm_omni.diffusion.memory_profiling import (
+    capture_cuda_memory_snapshot,
+    format_cuda_memory_snapshot,
+    is_memory_profiling_enabled,
+)
 from vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapter import (
     OmniChunkTransferAdapter,
 )
@@ -30,8 +35,24 @@ class OmniGenerationScheduler(VLLMScheduler):
         super().__init__(*args, **kwargs)
         model_config = self.vllm_config.model_config
         self.chunk_transfer_adapter = None
+        self._memory_profiling_enabled = is_memory_profiling_enabled()
         if getattr(model_config, "async_chunk", False):
             self.chunk_transfer_adapter = OmniChunkTransferAdapter(self.vllm_config)
+
+    def _log_allocation_failure(self, request: Request, required_tokens: int, token_budget: int) -> None:
+        if not self._memory_profiling_enabled:
+            return
+        snapshot = capture_cuda_memory_snapshot()
+        logger.warning(
+            "Diffusion scheduler allocation failed for request_id=%s required_tokens=%s token_budget=%s "
+            "computed_tokens=%s prompt_tokens=%s %s",
+            request.request_id,
+            required_tokens,
+            token_budget,
+            request.num_computed_tokens,
+            len(request.prompt_token_ids),
+            format_cuda_memory_snapshot(snapshot),
+        )
 
     def schedule(self) -> SchedulerOutput:
         """Diffusion fast path:
@@ -103,6 +124,11 @@ class OmniGenerationScheduler(VLLMScheduler):
                 num_lookahead_tokens=self.num_lookahead_tokens,
             )
             if new_blocks is None:
+                self._log_allocation_failure(
+                    request=request,
+                    required_tokens=required_tokens,
+                    token_budget=token_budget,
+                )
                 # Allocation failed (e.g., VRAM pressure); stop fast path and
                 # fall back to default scheduling
                 # Put the current request back to the head of the waiting queue
@@ -170,6 +196,11 @@ class OmniGenerationScheduler(VLLMScheduler):
                 num_lookahead_tokens=self.num_lookahead_tokens,
             )
             if new_blocks is None:
+                self._log_allocation_failure(
+                    request=request,
+                    required_tokens=required_tokens,
+                    token_budget=token_budget,
+                )
                 # Allocation failed (e.g., VRAM pressure); stop fast path and
                 # fall back to default scheduling
                 # Put the current request back to the head of the waiting queue
@@ -566,3 +597,4 @@ class OmniGenerationScheduler(VLLMScheduler):
             eco.scheduler_stats = stats
 
         return engine_core_outputs
+

--- a/vllm_omni/diffusion/memory_profiling.py
+++ b/vllm_omni/diffusion/memory_profiling.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+from typing import Any
+
+import torch
+
+_MEMORY_LOG_ENV = "VLLM_OMNI_DIFFUSION_LOG_MEMORY"
+
+
+def _is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on", "y"}
+
+
+def is_memory_profiling_enabled() -> bool:
+    return _is_truthy(os.environ.get(_MEMORY_LOG_ENV))
+
+
+def get_memory_log_env_var() -> str:
+    return _MEMORY_LOG_ENV
+
+
+def _bytes_to_gib(value: int) -> float:
+    return value / float(1024**3)
+
+
+def capture_cuda_memory_snapshot(device: int | str | torch.device | None = None) -> dict[str, Any] | None:
+    if not torch.cuda.is_available():
+        return None
+
+    if device is None:
+        device = torch.cuda.current_device()
+    torch_device = torch.device("cuda", device) if not isinstance(device, torch.device) else device
+    device_index = torch_device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+
+    return {
+        "device": device_index,
+        "allocated_bytes": torch.cuda.memory_allocated(device_index),
+        "reserved_bytes": torch.cuda.memory_reserved(device_index),
+        "max_allocated_bytes": torch.cuda.max_memory_allocated(device_index),
+        "max_reserved_bytes": torch.cuda.max_memory_reserved(device_index),
+    }
+
+
+def format_cuda_memory_snapshot(snapshot: dict[str, Any] | None) -> str:
+    if snapshot is None:
+        return "cuda=unavailable"
+
+    return (
+        f"cuda:{snapshot['device']} "
+        f"allocated={_bytes_to_gib(int(snapshot['allocated_bytes'])):.2f}GiB "
+        f"reserved={_bytes_to_gib(int(snapshot['reserved_bytes'])):.2f}GiB "
+        f"max_allocated={_bytes_to_gib(int(snapshot['max_allocated_bytes'])):.2f}GiB "
+        f"max_reserved={_bytes_to_gib(int(snapshot['max_reserved_bytes'])):.2f}GiB"
+    )
+
+
+def reset_cuda_peak_memory_stats(device: int | str | torch.device | None = None) -> None:
+    if not torch.cuda.is_available():
+        return
+
+    if device is None:
+        device = torch.cuda.current_device()
+    torch_device = torch.device("cuda", device) if not isinstance(device, torch.device) else device
+    device_index = torch_device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    torch.cuda.reset_peak_memory_stats(device_index)


### PR DESCRIPTION
Issue #1818 reports high VRAM overhead in the diffusion stage and specifically asks for a way to inspect memory usage in more detail.

This PR adds a minimal diagnostic hook for that case:
- introduces a small `memory_profiling` helper for CUDA memory snapshots
- logs allocated/reserved/max CUDA memory when the diffusion scheduler fails to allocate slots
- keeps the feature opt-in behind `VLLM_OMNI_DIFFUSION_LOG_MEMORY`
- adds focused unit tests for the helper and scheduler log path

Why this scope:
- it does not claim to fully solve the underlying VRAM overhead yet
- it gives maintainers and users actionable visibility at the exact failure point
- it avoids changing the diffusion execution path or adding broader profiling/config surface area

Validation:
- `D:\anaconda\python.exe -m compileall ...` on modified files
- direct helper smoke checks for env flag + snapshot formatting
- attempted pytest on focused tests, but repo-level `tests/conftest.py` currently requires `soundfile` in this environment and blocks test collection before these tests run

If this direction looks good, the next step can build on these diagnostics to correlate scheduler allocation failures with actual device memory pressure in reproductions from #1818.
