### PR TITLE
feat(diffusion): log CUDA memory on scheduler allocation failures

### DIFF
--- a/tests/core/sched/test_omni_generation_scheduler_memory.py
+++ b/tests/core/sched/test_omni_generation_scheduler_memory.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import logging
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+# Find repo root by looking for pyproject.toml marker
+def _find_repo_root(start: Path) -> Path:
+    """Walk up from start to find repo root (contains pyproject.toml)."""
+    current = start.resolve()
+    while current != current.parent:
+        if (current / "pyproject.toml").exists():
+            return current
+        current = current.parent
+    raise FileNotFoundError(f"Could not find repo root from {start}")
+
+
+_REPO_ROOT = _find_repo_root(Path(__file__).resolve())
+
+
+def _ensure_module(name: str) -> ModuleType:
+    """Get or create a module stub without polluting existing modules."""
+    if name in sys.modules:
+        return sys.modules[name]
+    module = ModuleType(name)
+    sys.modules[name] = module
+    return module
+
+
+def _stub_scheduler_dependencies() -> None:
+    """Create minimal stubs for vllm/vllm_omni dependencies needed by the scheduler."""
+    _ensure_module("vllm")
+    _ensure_module("vllm.compilation")
+    cuda_graph = _ensure_module("vllm.compilation.cuda_graph")
+    if not hasattr(cuda_graph, "CUDAGraphStat"):
+        cuda_graph.CUDAGraphStat = type("CUDAGraphStat", (), {})
+
+    _ensure_module("vllm.distributed")
+    kv_events = _ensure_module("vllm.distributed.kv_events")
+    if not hasattr(kv_events, "KVEventBatch"):
+        kv_events.KVEventBatch = type("KVEventBatch", (), {})
+    _ensure_module("vllm.distributed.kv_transfer")
+    _ensure_module("vllm.distributed.kv_transfer.kv_connector")
+    _ensure_module("vllm.distributed.kv_transfer.kv_connector.v1")
+    kv_metrics = _ensure_module("vllm.distributed.kv_transfer.kv_connector.v1.metrics")
+    if not hasattr(kv_metrics, "KVConnectorStats"):
+        kv_metrics.KVConnectorStats = type("KVConnectorStats", (), {})
+
+    logger_mod = _ensure_module("vllm.logger")
+    if not hasattr(logger_mod, "init_logger"):
+        logger_mod.init_logger = logging.getLogger
+
+    _ensure_module("vllm.v1")
+    _ensure_module("vllm.v1.core")
+    kv_cache = _ensure_module("vllm.v1.core.kv_cache_manager")
+    if not hasattr(kv_cache, "KVCacheBlocks"):
+        kv_cache.KVCacheBlocks = type("KVCacheBlocks", (), {})
+
+    sched_interface = _ensure_module("vllm.v1.core.sched.interface")
+    if not hasattr(sched_interface, "PauseState"):
+        sched_interface.PauseState = type("PauseState", (), {"PAUSED_ALL": object(), "UNPAUSED": object()})
+
+    sched_output = _ensure_module("vllm.v1.core.sched.output")
+    if not hasattr(sched_output, "SchedulerOutput"):
+        sched_output.SchedulerOutput = type("SchedulerOutput", (), {})
+
+    request_queue = _ensure_module("vllm.v1.core.sched.request_queue")
+    if not hasattr(request_queue, "create_request_queue"):
+        request_queue.create_request_queue = lambda policy: []
+
+    scheduler_mod = _ensure_module("vllm.v1.core.sched.scheduler")
+    if not hasattr(scheduler_mod, "Scheduler"):
+        scheduler_mod.Scheduler = type("Scheduler", (), {})
+
+    sched_utils = _ensure_module("vllm.v1.core.sched.utils")
+    if not hasattr(sched_utils, "remove_all"):
+        sched_utils.remove_all = lambda seq, items: [x for x in seq if x not in items]
+
+    engine_mod = _ensure_module("vllm.v1.engine")
+    if not hasattr(engine_mod, "EngineCoreEventType"):
+        engine_mod.EngineCoreEventType = type("EngineCoreEventType", (), {"SCHEDULED": object()})
+    if not hasattr(engine_mod, "EngineCoreOutput"):
+        engine_mod.EngineCoreOutput = type("EngineCoreOutput", (), {})
+    if not hasattr(engine_mod, "EngineCoreOutputs"):
+        engine_mod.EngineCoreOutputs = type("EngineCoreOutputs", (), {})
+
+    perf_mod = _ensure_module("vllm.v1.metrics.perf")
+    if not hasattr(perf_mod, "PerfStats"):
+        perf_mod.PerfStats = type("PerfStats", (), {})
+
+    request_mod = _ensure_module("vllm.v1.request")
+    if not hasattr(request_mod, "Request"):
+        request_mod.Request = type("Request", (), {})
+    if not hasattr(request_mod, "RequestStatus"):
+        request_mod.RequestStatus = type("RequestStatus", (), {"FINISHED_STOPPED": object()})
+
+    spec_decode = _ensure_module("vllm.v1.spec_decode.metrics")
+    if not hasattr(spec_decode, "SpecDecodingStats"):
+        spec_decode.SpecDecodingStats = type("SpecDecodingStats", (), {})
+
+    _ensure_module("vllm_omni")
+    _ensure_module("vllm_omni.core")
+    _ensure_module("vllm_omni.core.sched")
+    omni_sched_output = _ensure_module("vllm_omni.core.sched.output")
+    if not hasattr(omni_sched_output, "OmniCachedRequestData"):
+        omni_sched_output.OmniCachedRequestData = type("OmniCachedRequestData", (), {})
+    if not hasattr(omni_sched_output, "OmniNewRequestData"):
+        omni_sched_output.OmniNewRequestData = type("OmniNewRequestData", (), {})
+
+    _ensure_module("vllm_omni.distributed")
+    _ensure_module("vllm_omni.distributed.omni_connectors")
+    _ensure_module("vllm_omni.distributed.omni_connectors.transfer_adapter")
+    chunk_adapter = _ensure_module("vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapter")
+    if not hasattr(chunk_adapter, "OmniChunkTransferAdapter"):
+        chunk_adapter.OmniChunkTransferAdapter = type("OmniChunkTransferAdapter", (), {})
+
+    outputs_mod = _ensure_module("vllm_omni.outputs")
+    if not hasattr(outputs_mod, "OmniModelRunnerOutput"):
+        outputs_mod.OmniModelRunnerOutput = type("OmniModelRunnerOutput", (), {})
+
+    _ensure_module("vllm_omni.diffusion")
+    # Load the actual memory_profiling module
+    mem_prof_path = _REPO_ROOT / "vllm_omni" / "diffusion" / "memory_profiling.py"
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("vllm_omni.diffusion.memory_profiling", mem_prof_path)
+    mem_prof = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mem_prof)
+    sys.modules["vllm_omni.diffusion.memory_profiling"] = mem_prof
+
+
+def _load_scheduler_module() -> ModuleType:
+    """Load the scheduler module with stubs, with cleanup."""
+    import importlib.util
+
+    _stub_scheduler_dependencies()
+
+    sched_path = _REPO_ROOT / "vllm_omni" / "core" / "sched" / "omni_generation_scheduler.py"
+    spec = importlib.util.spec_from_file_location("vllm_omni.core.sched.omni_generation_scheduler", sched_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def scheduler_module() -> Generator[ModuleType, None, None]:
+    """Load scheduler module for testing, with cleanup."""
+    # Save any existing module state
+    original_modules = {}
+    for name in list(sys.modules.keys()):
+        if name.startswith("vllm_omni.") or name.startswith("vllm."):
+            original_modules[name] = sys.modules.pop(name)
+
+    # Load and yield
+    module = _load_scheduler_module()
+    yield module
+
+    # Cleanup: restore original state
+    for name in list(sys.modules.keys()):
+        if name.startswith("vllm_omni.") or name.startswith("vllm."):
+            sys.modules.pop(name, None)
+    for name, mod in original_modules.items():
+        sys.modules[name] = mod
+
+
+class DummyRequest:
+    def __init__(self):
+        self.request_id = "req-1"
+        self.num_computed_tokens = 3
+        self.prompt_token_ids = [1, 2, 3, 4, 5]
+
+
+def test_log_allocation_failure_includes_memory_snapshot(monkeypatch, caplog, scheduler_module):
+    scheduler = object.__new__(scheduler_module.OmniGenerationScheduler)
+    scheduler._memory_profiling_enabled = True
+
+    monkeypatch.setattr(
+        scheduler_module,
+        "capture_cuda_memory_snapshot",
+        lambda: {
+            "device": 0,
+            "allocated_bytes": 1024,
+            "reserved_bytes": 2048,
+            "max_allocated_bytes": 4096,
+            "max_reserved_bytes": 8192,
+        },
+    )
+    monkeypatch.setattr(
+        scheduler_module,
+        "format_cuda_memory_snapshot",
+        lambda snapshot: "cuda:0 allocated=0.00GiB reserved=0.00GiB max_allocated=0.00GiB max_reserved=0.00GiB",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        scheduler._log_allocation_failure(DummyRequest(), required_tokens=2, token_budget=1)
+
+    assert "Diffusion scheduler allocation failed" in caplog.text
+    assert "request_id=req-1" in caplog.text
+    assert "token_budget=1" in caplog.text
+
+
+def test_log_allocation_failure_noop_when_disabled(caplog, scheduler_module):
+    scheduler = object.__new__(scheduler_module.OmniGenerationScheduler)
+    scheduler._memory_profiling_enabled = False
+
+    with caplog.at_level(logging.WARNING):
+        scheduler._log_allocation_failure(DummyRequest(), required_tokens=2, token_budget=1)
+
+    assert caplog.text == ""

--- a/tests/diffusion/test_memory_profiling.py
+++ b/tests/diffusion/test_memory_profiling.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+# Find repo root by looking for pyproject.toml marker
+def _find_repo_root(start: Path) -> Path:
+    """Walk up from start to find repo root (contains pyproject.toml)."""
+    current = start.resolve()
+    while current != current.parent:
+        if (current / "pyproject.toml").exists():
+            return current
+        current = current.parent
+    raise FileNotFoundError(f"Could not find repo root from {start}")
+
+
+_REPO_ROOT = _find_repo_root(Path(__file__).resolve())
+_MEMORY_PROFILING_PATH = _REPO_ROOT / "vllm_omni" / "diffusion" / "memory_profiling.py"
+
+
+def _load_memory_profiling() -> ModuleType:
+    """Load memory_profiling module without polluting sys.modules for other tests."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("vllm_omni.diffusion.memory_profiling", _MEMORY_PROFILING_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def memory_profiling_module() -> Generator[ModuleType, None, None]:
+    """Load memory_profiling module for testing, with cleanup."""
+    # Save any existing module state
+    original_modules = {}
+    test_module_name = "vllm_omni.diffusion.memory_profiling"
+    if test_module_name in sys.modules:
+        original_modules[test_module_name] = sys.modules.pop(test_module_name)
+
+    # Also clean up parent packages
+    for name in list(sys.modules.keys()):
+        if name.startswith("vllm_omni.") and name != test_module_name:
+            original_modules[name] = sys.modules.pop(name)
+
+    # Load and yield
+    module = _load_memory_profiling()
+    yield module
+
+    # Cleanup: restore original state
+    sys.modules.pop(test_module_name, None)
+    for name, mod in original_modules.items():
+        sys.modules[name] = mod
+
+
+def test_memory_log_env_var_name_is_stable(memory_profiling_module):
+    assert memory_profiling_module.get_memory_log_env_var() == "VLLM_OMNI_DIFFUSION_LOG_MEMORY"
+
+
+def test_memory_profiling_disabled_by_default(monkeypatch, memory_profiling_module):
+    monkeypatch.delenv("VLLM_OMNI_DIFFUSION_LOG_MEMORY", raising=False)
+    assert memory_profiling_module.is_memory_profiling_enabled() is False
+
+
+def test_memory_profiling_truthy_values(monkeypatch, memory_profiling_module):
+    monkeypatch.setenv("VLLM_OMNI_DIFFUSION_LOG_MEMORY", "true")
+    assert memory_profiling_module.is_memory_profiling_enabled() is True
+
+
+def test_format_cuda_memory_snapshot_none(memory_profiling_module):
+    assert memory_profiling_module.format_cuda_memory_snapshot(None) == "cuda=unavailable"

--- a/tests/diffusion/test_memory_profiling.py
+++ b/tests/diffusion/test_memory_profiling.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import logging
 import sys
 from collections.abc import Generator
 from pathlib import Path
@@ -65,12 +66,29 @@ def test_memory_log_env_var_name_is_stable(memory_profiling_module):
 
 def test_memory_profiling_disabled_by_default(monkeypatch, memory_profiling_module):
     monkeypatch.delenv("VLLM_OMNI_DIFFUSION_LOG_MEMORY", raising=False)
-    assert memory_profiling_module.is_memory_profiling_enabled() is False
+    logger = logging.getLogger("vllm_omni.core.sched.omni_generation_scheduler")
+    original_level = logger.level
+    logger.setLevel(logging.INFO)
+    try:
+        assert memory_profiling_module.is_memory_profiling_enabled() is False
+    finally:
+        logger.setLevel(original_level)
 
 
 def test_memory_profiling_truthy_values(monkeypatch, memory_profiling_module):
     monkeypatch.setenv("VLLM_OMNI_DIFFUSION_LOG_MEMORY", "true")
     assert memory_profiling_module.is_memory_profiling_enabled() is True
+
+
+def test_memory_profiling_enabled_by_debug_log_level(monkeypatch, memory_profiling_module):
+    monkeypatch.delenv("VLLM_OMNI_DIFFUSION_LOG_MEMORY", raising=False)
+    logger = logging.getLogger("vllm_omni.core.sched.omni_generation_scheduler")
+    original_level = logger.level
+    logger.setLevel(logging.DEBUG)
+    try:
+        assert memory_profiling_module.is_memory_profiling_enabled() is True
+    finally:
+        logger.setLevel(original_level)
 
 
 def test_format_cuda_memory_snapshot_none(memory_profiling_module):

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -17,6 +17,11 @@ from vllm.v1.request import Request, RequestStatus
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 
 from vllm_omni.core.sched.output import OmniCachedRequestData, OmniNewRequestData
+from vllm_omni.diffusion.memory_profiling import (
+    capture_cuda_memory_snapshot,
+    format_cuda_memory_snapshot,
+    is_memory_profiling_enabled,
+)
 from vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapter import (
     OmniChunkTransferAdapter,
 )
@@ -30,8 +35,24 @@ class OmniGenerationScheduler(VLLMScheduler):
         super().__init__(*args, **kwargs)
         model_config = self.vllm_config.model_config
         self.chunk_transfer_adapter = None
+        self._memory_profiling_enabled = is_memory_profiling_enabled()
         if getattr(model_config, "async_chunk", False):
             self.chunk_transfer_adapter = OmniChunkTransferAdapter(self.vllm_config)
+
+    def _log_allocation_failure(self, request: Request, required_tokens: int, token_budget: int) -> None:
+        if not self._memory_profiling_enabled:
+            return
+        snapshot = capture_cuda_memory_snapshot()
+        logger.warning(
+            "Diffusion scheduler allocation failed for request_id=%s required_tokens=%s token_budget=%s "
+            "computed_tokens=%s prompt_tokens=%s %s",
+            request.request_id,
+            required_tokens,
+            token_budget,
+            request.num_computed_tokens,
+            len(request.prompt_token_ids),
+            format_cuda_memory_snapshot(snapshot),
+        )
 
     def schedule(self) -> SchedulerOutput:
         """Diffusion fast path:
@@ -103,6 +124,11 @@ class OmniGenerationScheduler(VLLMScheduler):
                 num_lookahead_tokens=self.num_lookahead_tokens,
             )
             if new_blocks is None:
+                self._log_allocation_failure(
+                    request=request,
+                    required_tokens=required_tokens,
+                    token_budget=token_budget,
+                )
                 # Allocation failed (e.g., VRAM pressure); stop fast path and
                 # fall back to default scheduling
                 # Put the current request back to the head of the waiting queue
@@ -170,6 +196,11 @@ class OmniGenerationScheduler(VLLMScheduler):
                 num_lookahead_tokens=self.num_lookahead_tokens,
             )
             if new_blocks is None:
+                self._log_allocation_failure(
+                    request=request,
+                    required_tokens=required_tokens,
+                    token_budget=token_budget,
+                )
                 # Allocation failed (e.g., VRAM pressure); stop fast path and
                 # fall back to default scheduling
                 # Put the current request back to the head of the waiting queue

--- a/vllm_omni/diffusion/memory_profiling.py
+++ b/vllm_omni/diffusion/memory_profiling.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+from typing import Any
+
+import torch
+
+_MEMORY_LOG_ENV = "VLLM_OMNI_DIFFUSION_LOG_MEMORY"
+
+
+def _is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on", "y"}
+
+
+def is_memory_profiling_enabled() -> bool:
+    return _is_truthy(os.environ.get(_MEMORY_LOG_ENV))
+
+
+def get_memory_log_env_var() -> str:
+    return _MEMORY_LOG_ENV
+
+
+def _bytes_to_gib(value: int) -> float:
+    return value / float(1024**3)
+
+
+def capture_cuda_memory_snapshot(device: int | str | torch.device | None = None) -> dict[str, Any] | None:
+    if not torch.cuda.is_available():
+        return None
+
+    if device is None:
+        device = torch.cuda.current_device()
+
+    # Normalize device to torch.device, then extract index
+    if isinstance(device, str):
+        torch_device = torch.device(device)
+    elif isinstance(device, torch.device):
+        torch_device = device
+    else:
+        # Integer index
+        torch_device = torch.device("cuda", device)
+
+    device_index = torch_device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+
+    return {
+        "device": device_index,
+        "allocated_bytes": torch.cuda.memory_allocated(device_index),
+        "reserved_bytes": torch.cuda.memory_reserved(device_index),
+        "max_allocated_bytes": torch.cuda.max_memory_allocated(device_index),
+        "max_reserved_bytes": torch.cuda.max_memory_reserved(device_index),
+    }
+
+
+def format_cuda_memory_snapshot(snapshot: dict[str, Any] | None) -> str:
+    if snapshot is None:
+        return "cuda=unavailable"
+
+    return (
+        f"cuda:{snapshot['device']} "
+        f"allocated={_bytes_to_gib(int(snapshot['allocated_bytes'])):.2f}GiB "
+        f"reserved={_bytes_to_gib(int(snapshot['reserved_bytes'])):.2f}GiB "
+        f"max_allocated={_bytes_to_gib(int(snapshot['max_allocated_bytes'])):.2f}GiB "
+        f"max_reserved={_bytes_to_gib(int(snapshot['max_reserved_bytes'])):.2f}GiB"
+    )
+
+
+def reset_cuda_peak_memory_stats(device: int | str | torch.device | None = None) -> None:
+    if not torch.cuda.is_available():
+        return
+
+    if device is None:
+        device = torch.cuda.current_device()
+
+    # Normalize device to torch.device, then extract index
+    if isinstance(device, str):
+        torch_device = torch.device(device)
+    elif isinstance(device, torch.device):
+        torch_device = device
+    else:
+        # Integer index
+        torch_device = torch.device("cuda", device)
+
+    device_index = torch_device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    torch.cuda.reset_peak_memory_stats(device_index)

--- a/vllm_omni/diffusion/memory_profiling.py
+++ b/vllm_omni/diffusion/memory_profiling.py
@@ -33,25 +33,22 @@ def _bytes_to_gib(value: int) -> float:
     return value / float(1024**3)
 
 
+def _device_index(device: int | str | torch.device | None) -> int:
+    """Normalize *device* to a torch.device and return its integer index."""
+    if device is None:
+        device = torch.cuda.current_device()
+    # Build a torch.device and extract its index (avoids pyright narrowing issues
+    # with torch.device("cuda", int) → int | torch.device)
+    d = torch.device("cuda", device) if isinstance(device, int) else torch.device(device)
+    idx = d.index
+    return idx if idx is not None else torch.cuda.current_device()
+
+
 def capture_cuda_memory_snapshot(device: int | str | torch.device | None = None) -> dict[str, Any] | None:
     if not torch.cuda.is_available():
         return None
 
-    if device is None:
-        device = torch.cuda.current_device()
-
-    # Normalize device to torch.device, then extract index
-    if isinstance(device, str):
-        torch_device = torch.device(device)
-    elif isinstance(device, torch.device):
-        torch_device = device
-    else:
-        # Integer index
-        torch_device = torch.device("cuda", device)
-
-    device_index = torch_device.index
-    if device_index is None:
-        device_index = torch.cuda.current_device()
+    device_index = _device_index(device)
 
     return {
         "device": device_index,
@@ -78,20 +75,4 @@ def format_cuda_memory_snapshot(snapshot: dict[str, Any] | None) -> str:
 def reset_cuda_peak_memory_stats(device: int | str | torch.device | None = None) -> None:
     if not torch.cuda.is_available():
         return
-
-    if device is None:
-        device = torch.cuda.current_device()
-
-    # Normalize device to torch.device, then extract index
-    if isinstance(device, str):
-        torch_device = torch.device(device)
-    elif isinstance(device, torch.device):
-        torch_device = device
-    else:
-        # Integer index
-        torch_device = torch.device("cuda", device)
-
-    device_index = torch_device.index
-    if device_index is None:
-        device_index = torch.cuda.current_device()
-    torch.cuda.reset_peak_memory_stats(device_index)
+    torch.cuda.reset_peak_memory_stats(_device_index(device))

--- a/vllm_omni/diffusion/memory_profiling.py
+++ b/vllm_omni/diffusion/memory_profiling.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import logging
 import os
 from typing import Any
 
@@ -15,8 +16,13 @@ def _is_truthy(value: str | None) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on", "y"}
 
 
+def _is_diffusion_debug_logging_enabled() -> bool:
+    logger = logging.getLogger("vllm_omni.core.sched.omni_generation_scheduler")
+    return logger.isEnabledFor(logging.DEBUG)
+
+
 def is_memory_profiling_enabled() -> bool:
-    return _is_truthy(os.environ.get(_MEMORY_LOG_ENV))
+    return _is_truthy(os.environ.get(_MEMORY_LOG_ENV)) or _is_diffusion_debug_logging_enabled()
 
 
 def get_memory_log_env_var() -> str:


### PR DESCRIPTION
Issue #1818 asks for better visibility into diffusion-stage VRAM usage, especially when `gpu_memory_utilization` does not explain the observed memory pressure.

This PR keeps scope intentionally small and focused on diagnosis:
- adds a tiny `memory_profiling` helper for CUDA memory snapshots
- logs allocated/reserved/max CUDA memory at the exact point where the diffusion scheduler fails to allocate slots
- supports two lightweight ways to turn it on:
  - set `VLLM_OMNI_DIFFUSION_LOG_MEMORY=1`
  - or run the scheduler logger at `DEBUG`
- adds focused tests for the helper and the scheduler logging path

## E2E use case

This is meant for reproductions like #1818 where a diffusion request hits scheduler allocation failure under real GPU pressure.

Example setup:
- model: an omni diffusion pipeline (for example GLM-4.1V / Qwen-Image style diffusion stage)
- workload: prompt/image generation request that enters diffusion scheduling
- symptom: allocation fails even though `gpu_memory_utilization` alone does not make the failure obvious

How to use this PR in that situation:
1. enable one of the diagnostics:
   - `VLLM_OMNI_DIFFUSION_LOG_MEMORY=1`, or
   - set `vllm_omni.core.sched.omni_generation_scheduler` to `DEBUG`
2. rerun the same failing request
3. inspect the warning log emitted exactly at the allocation failure point

Expected log shape:
```text
Diffusion scheduler allocation failed for request_id=<id> required_tokens=<n> token_budget=<n> computed_tokens=<n> prompt_tokens=<n> cuda:0 allocated=<x>GiB reserved=<y>GiB max_allocated=<z>GiB max_reserved=<w>GiB
```

## E2E result

With this change, the failure point now exposes concrete CUDA memory numbers instead of only returning an allocation failure with no device-memory context. That makes it much easier to compare:
- current allocated vs reserved memory
- peak memory reached before failure
- token budget / required tokens at the exact failing scheduler step

This does not claim to fix the underlying VRAM overhead yet. It is intended to make the next round of root-cause analysis reproducible and data-driven.

## Changes since last update
- addressed string device handling (`cuda:0`)
- cleaned up test module loading to avoid cross-test pollution
- added a second activation path via scheduler `DEBUG` logging so diagnosis is not env-var only

## Local validation
- `python -m pytest --noconftest tests/diffusion/test_memory_profiling.py tests/core/sched/test_omni_generation_scheduler_memory.py -q`
- result: `7 passed`