### PR TITLE
[Bugfix] Set PREEMPTED status when moving requests from running to waiting queue

### DIFF
--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -295,6 +295,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         )
         while len(running_queue) > self.scheduler_max_num_seqs:
             request = running_queue.pop()
+            request.status = RequestStatus.PREEMPTED
             waiting_queue.prepend_requests([request])
 
     def restore_queues(self, waiting_queue: Any, running_queue: list[Request]) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

When the running queue exceeds `scheduler_max_num_seqs` in async chunk mode, requests are moved to the waiting queue. The base scheduler expects waiting queue requests to have `WAITING` or `PREEMPTED` status, but the requests retained their `RUNNING` status, causing `Invalid request status: RUNNING` error.

## Test Plan

Qwen3-Omni:

```
vllm bench serve --omni --dataset-name random --port 8091 --max-concurrency 10 --model Qwen/Qwen3-Omni-30B-A3B-Instruct --endpoint /v1/chat/completions --backend openai-chat-omni --num-prompts 100 --random-input-len 100 --ignore-eos --percentile-metrics ttft,tpot,itl,e2el,audio_ttfp,audio_rtf --random-output-len 100 --extra_body '{"modalities": ["text", "audio"]}'
```

```
vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091 --stage-configs-path /root/vllm-workspace/vllm-omni/vllm_omni/platforms/npu/stage_configs/qwen3_omni_moe_async_chunk.yaml
```

## Test Result

I tested on NPU:

```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Maximum request concurrency:             10
Benchmark duration (s):                  868.59
Request throughput (req/s):              0.12
Peak concurrent requests:                14.00
----------------End-to-end Latency----------------
Mean E2EL (ms):                          81511.37
Median E2EL (ms):                        84425.49
P99 E2EL (ms):                           134560.01
================== Text Result ===================
Total input tokens:                      10000
Total generated tokens:                  10000
Output token throughput (tok/s):         11.51
Peak output token throughput (tok/s):    100.00
Peak concurrent requests:                14.00
Total Token throughput (tok/s):          23.03
---------------Time to First Token----------------
Mean TTFT (ms):                          530.21
Median TTFT (ms):                        425.05
P99 TTFT (ms):                           1576.20
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          69.72
Median TPOT (ms):                        63.12
P99 TPOT (ms):                           105.19
---------------Inter-token Latency----------------
Mean ITL (ms):                           69.02
Median ITL (ms):                         60.75
P99 ITL (ms):                            505.09
================== Audio Result ==================
Total audio duration generated(s):       2517.04
Total audio frames generated:            60409080
Audio throughput(audio duration/s):      2.90
---------------Time to First Packet---------------
Mean AUDIO_TTFP (ms):                    10181.04
Median AUDIO_TTFP (ms):                  7630.57
P99 AUDIO_TTFP (ms):                     33740.78
-----------------Real Time Factor-----------------
Mean AUDIO_RTF:                          3.24
Median AUDIO_RTF:                        3.23
P99 AUDIO_RTF:                           3.36
==================================================
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
