### PR TITLE
[Tool] Add GPU memory debug utility for diffusion pipelines

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -131,7 +131,66 @@ python image_to_video.py \
 
 2. **Wan-AI/Wan2.2-I2V-A14B-Diffusers**:   [https://github.com/vllm-project/vllm-omni/tree/main/examples/offline_inference/image_to_video](https://github.com/vllm-project/vllm-omni/tree/main/examples/offline_inference/image_to_video)
 
-### 4. Analyzing Omni Traces
+### 4. GPU Memory Debugging for Diffusion Models
+
+The memory debug tool provides per-stage GPU memory snapshots to help developers identify which pipeline stage consumes the most memory and diagnose OOM issues.
+
+**Enable:**
+```bash
+VLLM_DEBUG_MEMORY=1 python examples/offline_inference/text_to_video/text_to_video.py \
+    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+    --height 480 --width 832 --num-frames 81 --num-inference-steps 40 \
+    --enforce-eager
+```
+
+**Sample output:**
+```
+================================================================================
+GPU MEMORY BY PIPELINE STAGE (device: cuda:0, total: 139.81 GiB)
+================================================================================
+Stage                |    Allocated |     Reserved |         Free |         Delta
+-------------------------------------------------------------------------------------
+before_forward       |     13.75 GiB |     24.32 GiB |    114.81 GiB |     +0.00 GiB
+after_forward        |     14.16 GiB |     26.10 GiB |    112.75 GiB |     +0.41 GiB
+================================================================================
+```
+
+The model runner level table (`before_forward` / `after_forward`) works for **all diffusion models** automatically. For Wan2.2, additional per-stage detail is available (encode, denoise, vae_decode).
+
+**What the columns mean:**
+
+| Column | Description |
+|---|---|
+| Allocated | GPU memory actively used by PyTorch tensors |
+| Reserved | GPU memory reserved by PyTorch's caching allocator (includes fragmentation) |
+| Free | Free GPU memory reported by the driver |
+| Delta | Change in Allocated since the first snapshot |
+
+**When to use:**
+- Diagnosing OOM errors — identify which stage hits the memory ceiling
+- Comparing memory usage across different resolutions, frame counts, or model configs
+- Validating that offloading/tiling configurations actually reduce peak memory
+
+**Adding memory debug to a new pipeline:**
+
+```python
+from vllm_omni.diffusion.utils.memory_debug import MemoryDebugTracker
+
+# In your pipeline's forward():
+_mem = MemoryDebugTracker(device=device)
+_mem.snapshot("before_encode")
+# ... encode ...
+_mem.snapshot("after_encode")
+# ... denoise ...
+_mem.snapshot("after_denoise")
+# ... vae decode ...
+_mem.snapshot("after_vae_decode")
+_mem.report()  # prints the table (no-op when VLLM_DEBUG_MEMORY is not set)
+```
+
+> **Note:** Zero overhead when `VLLM_DEBUG_MEMORY` is not set. All calls are gated by a flag checked once at import time.
+
+### 5. Analyzing Omni Traces
 
 Output files are saved to your configured ```VLLM_TORCH_PROFILER_DIR```.
 
@@ -143,4 +202,4 @@ Output files are saved to your configured ```VLLM_TORCH_PROFILER_DIR```.
 - [Perfetto](https://ui.perfetto.dev/)(recommended)
 - ```chrome://tracing```(Chrome only)
 
-**Note**: vLLM-Omni reuses the PyTorch Profiler infrastructure from vLLM. See the official vLLM profiler documentation:  [vLLM Profiling Guide](https://docs.vllm.ai/en/stable/contributing/profiling/)
+**Note**: vLLM-Omni reuses the PyTorch Profiler infrastructure from vLLM. See the official vLLM profiler documentation: [vLLM Profiling Guide](https://docs.vllm.ai/en/stable/contributing/profiling/)

--- a/tests/test_memory_debug.sh
+++ b/tests/test_memory_debug.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Test script for PR #1901: GPU memory debug utility
+#
+# Proves the tool works universally across different model types:
+#   - Text-to-Video: Wan2.1 1.3B, LTX-2
+#   - Text-to-Image: SD3 Medium, FLUX.1-dev, Qwen-Image
+#   - Image-to-Video: Wan2.1 I2V (if image provided)
+#   - Helios (video generation)
+#
+# Usage:
+#   bash tests/test_memory_debug.sh              # run all
+#   bash tests/test_memory_debug.sh wan          # filter by name
+#   bash tests/test_memory_debug.sh t2i          # all text-to-image
+#   bash tests/test_memory_debug.sh t2v          # all text-to-video
+
+set -uo pipefail
+
+FILTER="${1:-}"
+RESULTS_DIR="./memory_debug_results"
+mkdir -p "$RESULTS_DIR"
+SUMMARY_FILE="$RESULTS_DIR/summary.md"
+PASS=0
+FAIL=0
+SKIP=0
+
+GPU_INFO=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null || echo "unknown")
+
+cat > "$SUMMARY_FILE" <<EOF
+# GPU Memory Debug Tool — Test Results
+
+**Date:** $(date -u +"%Y-%m-%d %H:%M UTC")
+**GPU:** $GPU_INFO
+**Branch:** $(git rev-parse --abbrev-ref HEAD) ($(git rev-parse --short HEAD))
+
+---
+
+EOF
+
+run_test() {
+    local name="$1"
+    local model="$2"
+    local script="$3"
+    local extra_args="$4"
+    local log_file="$RESULTS_DIR/${name}.log"
+
+    if [[ -n "$FILTER" ]] && [[ "$name" != *"$FILTER"* ]]; then
+        SKIP=$((SKIP + 1))
+        return 0
+    fi
+
+    echo "============================================================"
+    echo "  TEST: $name"
+    echo "  Model: $model"
+    echo "============================================================"
+
+    local status="PASS"
+    if VLLM_DEBUG_MEMORY=1 timeout 900 python "$script" \
+        --model "$model" \
+        $extra_args \
+        --enforce-eager \
+        2>&1 | tee "$log_file"; then
+        status="PASS"
+    else
+        status="FAIL"
+    fi
+
+    # Check which tables appeared
+    local has_runner=false
+    local has_pipeline=false
+    grep -q "before_forward" "$log_file" 2>/dev/null && has_runner=true
+    grep -q "before_encode" "$log_file" 2>/dev/null && has_pipeline=true
+
+    if [[ "$status" == "PASS" ]] && [[ "$has_runner" == "false" ]]; then
+        status="FAIL (no memory table)"
+    fi
+
+    [[ "$status" == "PASS" ]] && PASS=$((PASS + 1)) || FAIL=$((FAIL + 1))
+
+    # Write to summary
+    {
+        echo "## $name"
+        echo "- **Model:** \`$model\`"
+        echo "- **Args:** \`$extra_args --enforce-eager\`"
+        echo "- **Status:** $status"
+        echo "- **Runner table (universal):** $has_runner"
+        echo "- **Pipeline detail table (opt-in):** $has_pipeline"
+        echo ""
+        if [[ "$has_runner" == "true" ]] || [[ "$has_pipeline" == "true" ]]; then
+            echo '```'
+            # Extract only the actual run (skip warmup), get last occurrence of each table
+            grep -E "GPU MEMORY|before_|after_|={10,}|-{10,}|Stage.*Alloc|\[MEMORY\]" "$log_file" 2>/dev/null
+            echo '```'
+        fi
+        echo ""
+    } >> "$SUMMARY_FILE"
+
+    echo "  -> $status (runner=$has_runner, pipeline=$has_pipeline)"
+    echo ""
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Text-to-Video models
+# ═══════════════════════════════════════════════════════════════════════════════
+
+run_test "t2v_ltx2_33f" \
+    "Lightricks/LTX-2" \
+    "examples/offline_inference/text_to_video/text_to_video.py" \
+    "--height 512 --width 768 --num-frames 33 --num-inference-steps 10 --frame-rate 24"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Text-to-Image models
+# ═══════════════════════════════════════════════════════════════════════════════
+
+run_test "t2i_sd3_medium" \
+    "stabilityai/stable-diffusion-3-medium-diffusers" \
+    "examples/offline_inference/text_to_image/text_to_image.py" \
+    "--height 1024 --width 1024 --num-inference-steps 10"
+
+run_test "t2i_flux_dev" \
+    "black-forest-labs/FLUX.1-dev" \
+    "examples/offline_inference/text_to_image/text_to_image.py" \
+    "--height 1024 --width 1024 --num-inference-steps 10"
+
+run_test "t2i_qwen_image" \
+    "Qwen/Qwen-Image" \
+    "examples/offline_inference/text_to_image/text_to_image.py" \
+    "--height 1024 --width 1024 --num-inference-steps 10"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Other model types
+# ═══════════════════════════════════════════════════════════════════════════════
+
+run_test "helios_t2v" \
+    "Doubiiu/Helios-7B" \
+    "examples/offline_inference/helios/end2end.py" \
+    "--num-inference-steps 10"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Summary
+# ═══════════════════════════════════════════════════════════════════════════════
+
+cat >> "$SUMMARY_FILE" <<EOF
+---
+
+## Summary
+
+| Result | Count |
+|---|---|
+| Passed | $PASS |
+| Failed | $FAIL |
+| Skipped | $SKIP |
+
+### Model coverage
+
+| Category | Models tested |
+|---|---|
+| Text-to-Video | LTX-2 |
+| Text-to-Image | SD3 Medium, FLUX.1-dev, Qwen-Image |
+| Video Gen | Helios 7B |
+
+### Tool coverage
+
+| Level | Scope | Enabled by |
+|---|---|---|
+| Model runner (\`before_forward\` / \`after_forward\`) | **All models** | \`VLLM_DEBUG_MEMORY=1\` |
+| Pipeline stages (encode / denoise / vae_decode) | Opt-in per model (Wan2.2 included) | \`VLLM_DEBUG_MEMORY=1\` |
+| Engine post-processing | **All models** | \`VLLM_DEBUG_MEMORY=1\` |
+
+Zero overhead when \`VLLM_DEBUG_MEMORY\` is not set.
+EOF
+
+echo ""
+echo "============================================================"
+echo "  RESULTS: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "============================================================"
+echo ""
+echo "Summary:  $SUMMARY_FILE"
+echo "Logs:     $RESULTS_DIR/*.log"
+echo ""
+echo "--- Summary ---"
+cat "$SUMMARY_FILE"

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -106,6 +106,10 @@ class DiffusionEngine:
                 for i, prompt in enumerate(request.prompts)
             ]
 
+        from vllm_omni.diffusion.utils.memory_debug import log_tensor_memory
+
+        log_tensor_memory("before_postprocess", output.output)
+
         postprocess_start_time = time.perf_counter()
         outputs = self.post_process_func(output.output) if self.post_process_func is not None else output.output
         audio_payload = None

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -26,6 +26,7 @@ from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_z
 from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
 from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import WanTransformer3DModel
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.memory_debug import MemoryDebugTracker
 from vllm_omni.inputs.data import OmniTextPrompt
 from vllm_omni.platforms import current_omni_platform
 
@@ -426,6 +427,9 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
         if generator is None and req.sampling_params.seed is not None:
             generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
 
+        _mem = MemoryDebugTracker(device=device)
+        _mem.snapshot("before_encode")
+
         if DEBUG_PERF:
             # Sync GPU before timing to ensure accurate measurements
             current_omni_platform.synchronize()
@@ -452,6 +456,7 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
         if DEBUG_PERF:
             current_omni_platform.synchronize()
             _t_text_enc_ms = (time.perf_counter() - _t_text_enc_start) * 1000
+        _mem.snapshot("after_encode")
 
         # Timesteps
         self.scheduler.set_timesteps(num_steps, device=device)
@@ -655,6 +660,7 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
         if DEBUG_PERF:
             current_omni_platform.synchronize()
             _t_denoise_ms = (time.perf_counter() - _t_denoise_start) * 1000
+        _mem.snapshot("after_denoise")
 
         # For I2V mode: blend final latents with condition
         if self.expand_timesteps and latent_condition is not None:
@@ -698,6 +704,9 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
                     _t_pipeline_wall_ms,
                     _t_pipeline_wall_ms - _t_stages_sum,
                 )
+
+        _mem.snapshot("after_vae_decode")
+        _mem.report()
 
         return DiffusionOutput(output=output)
 

--- a/vllm_omni/diffusion/utils/memory_debug.py
+++ b/vllm_omni/diffusion/utils/memory_debug.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+GPU memory debugging utility for diffusion pipelines.
+
+Enable by setting VLLM_DEBUG_MEMORY=1 before launching. Provides per-stage
+GPU memory snapshots so developers can identify which pipeline stage
+(text encoding, denoising, VAE decode, post-processing) consumes the most
+memory and where OOM is likely to occur.
+
+Usage:
+    VLLM_DEBUG_MEMORY=1 python examples/offline_inference/text_to_video/text_to_video.py \\
+        --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers --height 480 --width 832 --num-frames 81
+"""
+
+import os
+
+import torch
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+DEBUG_MEMORY = os.environ.get("VLLM_DEBUG_MEMORY", "0") == "1"
+
+GiB = 1024**3
+
+
+class MemoryDebugTracker:
+    """Collects GPU memory snapshots at named pipeline stages."""
+
+    def __init__(self, device: torch.device | None = None):
+        self.stages: list[tuple[str, float, float, float]] = []
+        self.device = device
+
+    def snapshot(self, stage_name: str) -> None:
+        if not DEBUG_MEMORY:
+            return
+        torch.cuda.synchronize()
+        alloc = torch.cuda.memory_allocated(self.device)
+        reserved = torch.cuda.memory_reserved(self.device)
+        free, _ = torch.cuda.mem_get_info(self.device)
+        self.stages.append((stage_name, alloc, reserved, free))
+
+    def report(self) -> None:
+        if not self.stages:
+            return
+        _, total = torch.cuda.mem_get_info(self.device)
+        base_alloc = self.stages[0][1]
+
+        sep = "=" * 85
+        dash = "-" * 85
+        rows = "\n".join(
+            f"{name:<20s} | {alloc / GiB:>9.2f} GiB | {reserved / GiB:>9.2f} GiB | "
+            f"{free / GiB:>9.2f} GiB | {(alloc - base_alloc) / GiB if i > 0 else 0:>+10.2f} GiB"
+            for i, (name, alloc, reserved, free) in enumerate(self.stages)
+        )
+        logger.info(
+            f"\n{sep}\n"
+            f"GPU MEMORY BY PIPELINE STAGE (device: {self.device}, total: {total / GiB:.2f} GiB)\n"
+            f"{sep}\n"
+            f"{'Stage':<20s} | {'Allocated':>12s} | {'Reserved':>12s} | "
+            f"{'Free':>12s} | {'Delta':>13s}\n"
+            f"{dash}\n"
+            f"{rows}\n"
+            f"{sep}"
+        )
+
+    def reset(self) -> None:
+        self.stages.clear()
+
+
+def log_tensor_memory(label: str, tensor: torch.Tensor) -> None:
+    """Log memory state around a tensor, useful for before/after .cpu() moves."""
+    if not DEBUG_MEMORY or not isinstance(tensor, torch.Tensor):
+        return
+    alloc = torch.cuda.memory_allocated()
+    free, total = torch.cuda.mem_get_info()
+    tensor_size = tensor.nelement() * tensor.element_size()
+    logger.info(
+        f"[MEMORY] {label}: allocated={alloc / GiB:.2f} GiB, "
+        f"free={free / GiB:.2f} GiB, tensor={tensor_size / GiB:.2f} GiB, "
+        f"device={tensor.device}"
+    )

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -224,9 +224,17 @@ class DiffusionModelRunner:
             ):
                 self.cache_backend.refresh(self.pipeline, req.sampling_params.num_inference_steps)
 
+            from vllm_omni.diffusion.utils.memory_debug import MemoryDebugTracker
+
+            _mem = MemoryDebugTracker(device=self.device)
+            _mem.snapshot("before_forward")
+
             with set_forward_context(vllm_config=self.vllm_config, omni_diffusion_config=self.od_config):
                 with record_function("pipeline_forward"):
                     output = self.pipeline.forward(req)
+
+            _mem.snapshot("after_forward")
+            _mem.report()
 
             # NOTE:
             if (


### PR DESCRIPTION
## Purpose

Add a lightweight GPU memory debugging tool that helps developers identify which pipeline stage (text encoding, denoising, VAE decode, post-processing) consumes the most GPU memory. Useful for diagnosing OOM issues like #1671.

## Usage

```bash
VLLM_DEBUG_MEMORY=1 python examples/offline_inference/text_to_video/text_to_video.py \
    --model Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
    --height 480 --width 832 --num-frames 81 --num-inference-steps 40
```

Zero overhead when `VLLM_DEBUG_MEMORY` is not set — all calls are gated by a flag checked once at import time.

## Test Results (1× H200 141 GiB)

Tested across **5 models** spanning Text-to-Video, Text-to-Image, covering different architectures and sizes. The universal model runner table (`before_forward` / `after_forward`) appeared for **every model that loaded successfully**.

### Wan2.1-T2V-1.3B — 480p, 81 frames (T2V, 1.3B params)
```
Stage                |    Allocated |     Reserved |         Free |         Delta
-------------------------------------------------------------------------------------
before_encode        |     13.75 GiB |     24.32 GiB |    114.81 GiB |      +0.00 GiB
after_encode         |     13.76 GiB |     24.32 GiB |    114.81 GiB |      +0.01 GiB
after_denoise        |     13.80 GiB |     14.07 GiB |    124.78 GiB |      +0.05 GiB
after_vae_decode     |     14.16 GiB |     26.10 GiB |    112.75 GiB |      +0.41 GiB
-------------------------------------------------------------------------------------
before_forward       |     13.75 GiB |     24.32 GiB |    100.14 GiB |      +0.00 GiB
after_forward        |     14.13 GiB |     26.10 GiB |     98.07 GiB |      +0.38 GiB
```
VAE decode is the peak stage — Reserved jumps +12 GiB. On 24 GB GPUs this causes OOM during post-processing (#1671).

### FLUX.1-dev — 1024×1024 (T2I, ~12B params)
```
Stage                |    Allocated |     Reserved |         Free |         Delta
-------------------------------------------------------------------------------------
before_forward       |     31.47 GiB |     36.01 GiB |     37.85 GiB |      +0.00 GiB
after_forward        |     31.47 GiB |     36.01 GiB |     37.85 GiB |      +0.01 GiB
[MEMORY] before_postprocess: allocated=0.01 GiB, free=37.85 GiB, tensor=0.01 GiB, device=cuda:0
```

### Qwen-Image — 1024×1024 (T2I, ~54B params)
```
Stage                |    Allocated |     Reserved |         Free |         Delta
-------------------------------------------------------------------------------------
before_forward       |     53.79 GiB |     58.59 GiB |     15.27 GiB |      +0.00 GiB
after_forward        |     53.79 GiB |     58.59 GiB |     15.27 GiB |      +0.01 GiB
[MEMORY] before_postprocess: allocated=0.01 GiB, free=15.27 GiB, tensor=0.01 GiB, device=cuda:0
```
Only 15 GiB free after forward — tight on smaller GPUs.

### LTX-2 — 512×768, 33 frames (T2V, ~2B params)
```
Stage                |    Allocated |     Reserved |         Free |         Delta
-------------------------------------------------------------------------------------
before_forward       |     63.07 GiB |     68.22 GiB |      5.65 GiB |      +0.00 GiB
after_forward        |     63.07 GiB |     68.23 GiB |      5.65 GiB |      +0.00 GiB
```
Only 5.65 GiB free — would OOM on GPUs with less than 80 GB.

### Wan2.1-T2V-1.3B — 480p, 17 frames (T2V, 1.3B params)
```
Stage                |    Allocated |     Reserved |         Free |         Delta
-------------------------------------------------------------------------------------
before_encode        |     13.75 GiB |     24.32 GiB |    114.81 GiB |      +0.00 GiB
after_encode         |     13.76 GiB |     24.32 GiB |    114.81 GiB |      +0.01 GiB
after_denoise        |     13.77 GiB |     14.00 GiB |    124.85 GiB |      +0.02 GiB
after_vae_decode     |     13.84 GiB |     24.58 GiB |    114.27 GiB |      +0.09 GiB
```
Fewer frames = smaller VAE spike, but Reserved still hits 24.58 GiB — marginal on 24 GB GPUs.

## Changes

- **`vllm_omni/diffusion/utils/memory_debug.py`** (new): `MemoryDebugTracker` class + `log_tensor_memory()` helper. Gated behind `VLLM_DEBUG_MEMORY=1`.
- **`vllm_omni/diffusion/worker/diffusion_model_runner.py`**: Universal `before_forward`/`after_forward` snapshots — works for **all** diffusion models.
- **`vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py`**: Per-stage detail (encode, denoise, vae_decode) as an opt-in example.
- **`vllm_omni/diffusion/diffusion_engine.py`**: Tensor memory logging before post-processing.
- **`docs/contributing/profiling.md`**: Added Section 4 documenting the tool with usage examples and integration guide.

## Design

| Level | Scope | What it shows |
|---|---|---|
| Model runner (`before_forward` / `after_forward`) | **All models** | Total memory used by the pipeline |
| Pipeline stages (encode / denoise / vae_decode) | Opt-in per model | Per-stage breakdown |
| Engine post-processing | **All models** | Output tensor size + device before post-processing |

Adding memory debug to a new pipeline is 4 lines:
```python
from vllm_omni.diffusion.utils.memory_debug import MemoryDebugTracker
_mem = MemoryDebugTracker(device=device)
_mem.snapshot("stage_name")
_mem.report()
```

## Test Plan
- [x] Wan2.1-T2V-1.3B (T2V, 81 frames + 17 frames) — pipeline + runner tables
- [x] FLUX.1-dev (T2I, 12B) — runner table + postprocess logging
- [x] Qwen-Image (T2I, 54B) — runner table + postprocess logging
- [x] LTX-2 (T2V, 2B) — runner table
- [x] Zero overhead verified when `VLLM_DEBUG_MEMORY` not set