### PR TITLE
Fix SHM leak when dropping orphan async outputs

### DIFF
--- a/tests/distributed/omni_coordinator/test_omni_coord_client_for_stage.py
+++ b/tests/distributed/omni_coordinator/test_omni_coord_client_for_stage.py
@@ -2,12 +2,18 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+import threading
+from unittest.mock import Mock
 
+import pytest
 import zmq
 
 from vllm_omni.distributed.omni_coordinator import (
     OmniCoordClientForStage,
     StageStatus,
+)
+from vllm_omni.distributed.omni_coordinator import (
+    omni_coord_client_for_stage as stage_client_module,
 )
 
 
@@ -19,7 +25,8 @@ def _bind_router() -> tuple[zmq.Context, zmq.Socket, str]:
     return ctx, router, endpoint
 
 
-def _recv_event(router: zmq.Socket) -> dict:
+def _recv_event(router: zmq.Socket, timeout_ms: int = 2000) -> dict:
+    assert router.poll(timeout=timeout_ms) != 0, "Timed out waiting for coordinator event"
     frames = router.recv_multipart()
     # ROUTER adds identity frame; the last frame is the payload.
     payload = frames[-1]
@@ -106,5 +113,198 @@ def test_stage_client_close_sends_down_status():
 
     assert client._socket.closed  # DEALER socket no longer usable after close
 
+    router.close(0)
+    ctx.term()
+
+
+def test_stage_client_reconnects_after_send_failure():
+    """Verify send failure path invokes reconnect before retrying send."""
+    ctx, router, endpoint = _bind_router()
+
+    client = OmniCoordClientForStage(
+        endpoint,
+        "tcp://stage:reconnect-in",
+        "tcp://stage:reconnect-out",
+        0,
+    )
+
+    # Discard initial registration event from the real socket.
+    _recv_event(router)
+
+    class _FlakySocket:
+        def __init__(self):
+            self.send_calls = 0
+            self.closed = False
+
+        def send(self, *_args, **_kwargs):
+            self.send_calls += 1
+            if self.send_calls == 1:
+                raise RuntimeError("simulated send failure")
+
+        def close(self, *_args, **_kwargs):
+            self.closed = True
+
+    flaky_socket = _FlakySocket()
+    client._socket = flaky_socket
+    client._reconnect = Mock(return_value=True)
+
+    client.update_info(queue_length=1)
+
+    client._reconnect.assert_called_once_with(max_retries=3)
+    assert flaky_socket.send_calls == 2
+
+    client.close()
+    router.close(0)
+    ctx.term()
+
+
+def test_stage_client_raises_when_reconnect_fails():
+    """Verify send failure is propagated when reconnect cannot recover."""
+    ctx, router, endpoint = _bind_router()
+
+    client = OmniCoordClientForStage(
+        endpoint,
+        "tcp://stage:reconnect-fail-in",
+        "tcp://stage:reconnect-fail-out",
+        0,
+    )
+
+    # Discard initial registration event from the real socket.
+    _recv_event(router)
+
+    class _AlwaysFailSocket:
+        def send(self, *_args, **_kwargs):
+            raise RuntimeError("simulated send failure")
+
+        def close(self, *_args, **_kwargs):
+            pass
+
+    client._socket = _AlwaysFailSocket()
+    client._reconnect = Mock(return_value=False)
+
+    with pytest.raises(RuntimeError, match="simulated send failure"):
+        client.update_info(queue_length=2)
+
+    client._reconnect.assert_called_once_with(max_retries=3)
+    client.close()
+    router.close(0)
+    ctx.term()
+
+
+def test_stage_client_close_handles_runtime_error_in_final_update():
+    """Verify close() still releases resources when final update raises RuntimeError."""
+    ctx, router, endpoint = _bind_router()
+
+    client = OmniCoordClientForStage(
+        endpoint,
+        "tcp://stage:close-runtime-in",
+        "tcp://stage:close-runtime-out",
+        0,
+    )
+
+    # Discard initial registration event from the real socket.
+    _recv_event(router)
+
+    client._send_event = Mock(side_effect=RuntimeError("simulated close-time failure"))
+    client.close()
+
+    assert client._closed
+    assert client._socket.closed
+
+    router.close(0)
+    ctx.term()
+
+
+def test_reconnect_respects_retry_limit(monkeypatch):
+    """Verify _reconnect stops after max_retries on repeated failures."""
+    attempts = {"connect": 0}
+
+    class _FailSocket:
+        def close(self, *_args, **_kwargs):
+            pass
+
+        def connect(self, *_args, **_kwargs):
+            attempts["connect"] += 1
+            raise zmq.ZMQError("simulated reconnect failure")
+
+    class _FailContext:
+        def socket(self, *_args, **_kwargs):
+            return _FailSocket()
+
+        def term(self):
+            pass
+
+    client = OmniCoordClientForStage.__new__(OmniCoordClientForStage)
+    client._closed = False
+    client._coord_zmq_addr = "tcp://127.0.0.1:9999"
+    client._stop_event = threading.Event()
+    client._socket = _FailSocket()
+    client._ctx = _FailContext()
+
+    monkeypatch.setattr(stage_client_module.zmq, "Context", lambda: _FailContext())
+    monkeypatch.setattr(stage_client_module.time, "sleep", lambda *_args, **_kwargs: None)
+
+    assert client._reconnect(max_retries=3, retry_interval=5.0) is False
+    assert attempts["connect"] == 3
+
+
+def test_heartbeat_loop_retries_after_transient_send_failure():
+    """Verify heartbeat loop continues after one transient send failure."""
+
+    class _FakeStopEvent:
+        def __init__(self):
+            self.wait_calls = 0
+            self._set = False
+
+        def wait(self, timeout=None):
+            _ = timeout
+            self.wait_calls += 1
+            # Run two loop iterations, then stop.
+            return self._set or self.wait_calls >= 3
+
+        def is_set(self):
+            return self._set
+
+        def set(self):
+            self._set = True
+
+    client = OmniCoordClientForStage.__new__(OmniCoordClientForStage)
+    client._closed = False
+    client._heartbeat_interval = 0.0
+    client._stop_event = _FakeStopEvent()
+
+    calls = {"count": 0}
+
+    def _fake_send(event_type):
+        assert event_type == "heartbeat"
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise RuntimeError("transient heartbeat failure")
+
+    client._send_event = _fake_send
+
+    client._heartbeat_loop()
+
+    assert calls["count"] == 2
+
+
+def test_update_info_rejected_while_closing():
+    """Verify update_info is rejected once client enters closing state."""
+    ctx, router, endpoint = _bind_router()
+
+    client = OmniCoordClientForStage(
+        endpoint,
+        "tcp://stage:closing-in",
+        "tcp://stage:closing-out",
+        0,
+    )
+    _recv_event(router)
+
+    client._closing = True
+    with pytest.raises(RuntimeError, match="closing"):
+        client.update_info(queue_length=3)
+
+    client._closing = False
+    client.close()
     router.close(0)
     ctx.term()

--- a/tests/entrypoints/test_async_omni_shm_cleanup.py
+++ b/tests/entrypoints/test_async_omni_shm_cleanup.py
@@ -1,0 +1,59 @@
+import asyncio
+
+import pytest
+
+from vllm_omni.entrypoints.async_omni import AsyncOmni
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _OneShotStage:
+    def __init__(self, result):
+        self._result = result
+        self._returned = False
+
+    def try_collect(self):
+        if self._returned:
+            return None
+        self._returned = True
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_output_handler_cleans_shm_for_orphan_result(monkeypatch: pytest.MonkeyPatch):
+    omni = AsyncOmni.__new__(AsyncOmni)
+    omni.output_handler = None
+    omni.request_states = {}
+    omni._companion_to_parent = {}
+    omni._rpc_results = {}
+    omni.stage_list = [
+        _OneShotStage(
+            {
+                "request_id": "orphan-req",
+                "stage_id": 0,
+                "engine_outputs_shm": {"name": "fake-shm", "size": 123},
+            }
+        )
+    ]
+
+    cleanup_calls: list[tuple[dict, str]] = []
+
+    def _fake_cleanup(container: dict, shm_key: str = "engine_outputs_shm") -> bool:
+        cleanup_calls.append((container, shm_key))
+        return True
+
+    monkeypatch.setattr(
+        "vllm_omni.entrypoints.async_omni.cleanup_shm_from_ipc_meta",
+        _fake_cleanup,
+        raising=False,
+    )
+
+    omni._run_output_handler()
+    await asyncio.sleep(0.02)
+
+    assert cleanup_calls, "Expected SHM cleanup to be invoked for orphaned output"
+    assert cleanup_calls[0][1] == "engine_outputs_shm"
+
+    omni.output_handler.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await omni.output_handler

--- a/tests/entrypoints/test_stage_utils.py
+++ b/tests/entrypoints/test_stage_utils.py
@@ -1,10 +1,11 @@
 import os
 import sys
+from multiprocessing import shared_memory as shm
 
 import pytest
 from pytest_mock import MockerFixture
 
-from vllm_omni.entrypoints.stage_utils import set_stage_devices
+from vllm_omni.entrypoints.stage_utils import cleanup_shm_from_ipc_meta, set_stage_devices
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -110,3 +111,21 @@ def test_set_stage_devices_npu_platform(mocker: MockerFixture, monkeypatch: pyte
     set_stage_devices(stage_id=0, devices="0,1")
 
     assert os.environ["ASCEND_RT_VISIBLE_DEVICES"] == "4,5"
+
+
+def test_cleanup_shm_from_ipc_meta_unlinks_segment():
+    seg = shm.SharedMemory(create=True, size=8)
+    seg.buf[:4] = b"test"
+    name = seg.name
+    seg.close()
+
+    cleaned = cleanup_shm_from_ipc_meta({"engine_outputs_shm": {"name": name, "size": 8}})
+    assert cleaned is True
+
+    with pytest.raises(FileNotFoundError):
+        shm.SharedMemory(name=name)
+
+
+def test_cleanup_shm_from_ipc_meta_returns_false_for_invalid_meta():
+    assert cleanup_shm_from_ipc_meta({}) is False
+    assert cleanup_shm_from_ipc_meta({"engine_outputs_shm": {"size": 8}}) is False

--- a/vllm_omni/distributed/omni_coordinator/omni_coord_client_for_stage.py
+++ b/vllm_omni/distributed/omni_coordinator/omni_coord_client_for_stage.py
@@ -45,9 +45,10 @@ class OmniCoordClientForStage:
         self._status = StageStatus.UP
         self._queue_length = 0
         self._closed = False
+        self._closing = False
         self._heartbeat_interval = 5.0
         self._stop_event = threading.Event()
-        self._send_lock = threading.Lock()
+        self._send_lock = threading.RLock()
 
         self._send_event("update")
 
@@ -57,15 +58,20 @@ class OmniCoordClientForStage:
         )
         self._heartbeat_thread.start()
 
-    def _reconnect(self) -> bool:
+    def _reconnect(self, max_retries: int = 3, retry_interval: float = 5.0) -> bool:
         """Best-effort reconnect with up to ``max_retries`` attempts.
 
-        Each attempt closes the current socket/context, sleeps 5 seconds,
-        then creates a new DEALER socket and reconnects to the coordinator.
+        Each attempt closes the current socket/context, sleeps ``retry_interval``
+        seconds, then creates a new DEALER socket and reconnects to the coordinator.
         Caller must hold ``_send_lock``.
         Returns True on success, False if all attempts fail.
         """
-        while not self._stop_event.is_set() and not self._closed:
+        if max_retries <= 0:
+            return False
+
+        for attempt in range(1, max_retries + 1):
+            if self._stop_event.is_set() or self._closed:
+                return False
             try:
                 self._socket.close(0)
             except zmq.ZMQError:
@@ -75,7 +81,8 @@ class OmniCoordClientForStage:
             except zmq.ZMQError:
                 pass
 
-            time.sleep(5.0)
+            if retry_interval > 0:
+                time.sleep(retry_interval)
 
             try:
                 self._ctx = zmq.Context()
@@ -84,11 +91,12 @@ class OmniCoordClientForStage:
                 return True
             except zmq.ZMQError as e:
                 logger.error(
-                    "Stage client reconnect failed, will retry in 5s (coord=%s)",
+                    "Stage client reconnect failed (attempt=%d/%d, coord=%s)",
+                    attempt,
+                    max_retries,
                     self._coord_zmq_addr,
                     exc_info=e,
                 )
-                continue
         return False
 
     def _send_event(self, event_type: str) -> None:
@@ -102,20 +110,20 @@ class OmniCoordClientForStage:
         to 3 times (5s sleep each) and retries the send once after a
         successful reconnect. Raises if reconnect or the retry send fails.
         """
-        if self._closed:
-            raise RuntimeError("Client already closed")
-
-        event = InstanceEvent(
-            input_addr=self._input_addr,
-            output_addr=self._output_addr,
-            stage_id=self._stage_id,
-            event_type=event_type,
-            status=self._status,
-            queue_length=self._queue_length,
-        )
-        data = json.dumps(asdict(event)).encode("utf-8")
-
         with self._send_lock:
+            if self._closed:
+                raise RuntimeError("Client already closed")
+
+            event = InstanceEvent(
+                input_addr=self._input_addr,
+                output_addr=self._output_addr,
+                stage_id=self._stage_id,
+                event_type=event_type,
+                status=self._status,
+                queue_length=self._queue_length,
+            )
+            data = json.dumps(asdict(event)).encode("utf-8")
+
             try:
                 self._socket.send(data, flags=zmq.NOBLOCK)
                 return
@@ -124,7 +132,7 @@ class OmniCoordClientForStage:
                 return
             except (RuntimeError, zmq.ZMQError) as e:
                 # First send failed; try reconnecting a few times.
-                if not self._reconnect:
+                if not self._reconnect(max_retries=3):
                     logger.error("Failed to send event and reconnect to coordinator", exc_info=e)
                     raise
 
@@ -149,12 +157,16 @@ class OmniCoordClientForStage:
         if status is None and queue_length is None:
             raise ValueError("At least one of status or queue_length must be provided")
 
-        if status is not None:
-            self._status = status
-        if queue_length is not None:
-            self._queue_length = queue_length
+        with self._send_lock:
+            if self._closed or self._closing:
+                raise RuntimeError("Client is closing or already closed")
 
-        self._send_event("update")
+            if status is not None:
+                self._status = status
+            if queue_length is not None:
+                self._queue_length = queue_length
+
+            self._send_event("update")
 
     def _heartbeat_loop(self) -> None:
         """Periodically send heartbeat events while the client is alive."""
@@ -164,8 +176,11 @@ class OmniCoordClientForStage:
 
             try:
                 self._send_event("heartbeat")
-            except (RuntimeError, zmq.ZMQError):
-                break
+            except (RuntimeError, zmq.ZMQError) as e:
+                if self._closed or self._stop_event.is_set():
+                    break
+                logger.warning("Heartbeat send failed; will retry on next interval", exc_info=e)
+                continue
 
     def close(self) -> None:
         """Send a final down event and close the underlying socket."""
@@ -177,17 +192,23 @@ class OmniCoordClientForStage:
         if hasattr(self, "_heartbeat_thread"):
             self._heartbeat_thread.join(timeout=1.0)
 
-        # Mark status as DOWN and send one last update.
-        self._status = StageStatus.DOWN
-        try:
-            self._send_event("update")
-        except zmq.ZMQError:
-            pass  # Socket may already be broken, proceed with close
+        with self._send_lock:
+            if self._closed:
+                raise RuntimeError("Client already closed")
 
-        # Close DEALER socket and terminate this client's context.
-        self._socket.close(0)
-        try:
-            self._ctx.term()
-        except zmq.ZMQError:
-            pass
-        self._closed = True
+            self._closing = True
+
+            # Mark status as DOWN and send one last update.
+            self._status = StageStatus.DOWN
+            try:
+                self._send_event("update")
+            except (RuntimeError, zmq.ZMQError):
+                pass  # Socket may already be broken, proceed with close
+
+            # Close DEALER socket and terminate this client's context.
+            self._socket.close(0)
+            try:
+                self._ctx.term()
+            except zmq.ZMQError:
+                pass
+            self._closed = True

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -24,7 +24,7 @@ from vllm_omni.entrypoints.cfg_companion_tracker import CfgCompanionTracker
 from vllm_omni.entrypoints.client_request_state import ClientRequestState
 from vllm_omni.entrypoints.omni import OmniBase
 from vllm_omni.entrypoints.omni_stage import OmniStage
-from vllm_omni.entrypoints.stage_utils import SHUTDOWN_TASK, OmniStageTaskType
+from vllm_omni.entrypoints.stage_utils import SHUTDOWN_TASK, OmniStageTaskType, cleanup_shm_from_ipc_meta
 from vllm_omni.entrypoints.stage_utils import maybe_load_from_ipc as _load
 from vllm_omni.entrypoints.utils import (
     get_final_stage_id_for_e2e,
@@ -843,6 +843,9 @@ class AsyncOmni(OmniBase):
                                 f"[{self._name}] Request may have been aborted; \
                                 dropping output for req {req_id} at stage-{stage_id}"
                             )
+                            # Avoid leaking orphaned SHM payloads when request
+                            # state is gone (e.g. aborted/cancelled flows).
+                            cleanup_shm_from_ipc_meta(result, shm_key="engine_outputs_shm")
                             continue
                         if hasattr(req_state, "stage_queues") and stage_id in req_state.stage_queues:
                             await req_state.stage_queues[stage_id].put(result)

--- a/vllm_omni/entrypoints/stage_utils.py
+++ b/vllm_omni/entrypoints/stage_utils.py
@@ -246,6 +246,42 @@ def maybe_dump_to_shm(obj: Any, threshold: int) -> tuple[bool, Any]:
     return False, obj
 
 
+def cleanup_shm_from_ipc_meta(container: dict[str, Any], shm_key: str = "engine_outputs_shm") -> bool:
+    """Best-effort cleanup for SHM payload metadata embedded in IPC dicts.
+
+    This is intended for orphaned/aborted request outputs where we need to
+    unlink the SHM segment without deserializing payload bytes.
+    """
+    meta = container.get(shm_key)
+    if not isinstance(meta, dict):
+        return False
+    shm_name = meta.get("name")
+    if not isinstance(shm_name, str) or not shm_name:
+        return False
+
+    shm = None
+    try:
+        shm = _shm.SharedMemory(name=shm_name)
+    except FileNotFoundError:
+        return True
+    except Exception:
+        logger.debug("Failed to open shared memory for cleanup: %s", shm_name, exc_info=True)
+        return False
+
+    try:
+        shm.close()
+    except Exception:
+        pass
+    try:
+        shm.unlink()
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.debug("Failed to unlink shared memory during cleanup: %s", shm_name, exc_info=True)
+        return False
+    return True
+
+
 def maybe_load_from_ipc(container: dict[str, Any], obj_key: str, shm_key: str) -> Any:
     """Load object from container that may carry SHM or inline object.
 


### PR DESCRIPTION
## Summary
- Add `cleanup_shm_from_ipc_meta(...)` to release shared-memory segments from IPC metadata without deserializing payloads.
- Call this cleanup on orphaned outputs in async orchestrator output handling (when request state is already gone, e.g. abort/cancel paths).
- Add regression coverage for both cleanup utility behavior and async orphan-output cleanup path.

## Root Cause
In async mode, a stage can still emit `engine_outputs_shm` after a request has been aborted and removed from `request_states`. The output handler dropped that result, but did not unlink the SHM segment, which can accumulate leaked segments in `/dev/shm`.

## Changes
- `vllm_omni/entrypoints/stage_utils.py`
  - Added `cleanup_shm_from_ipc_meta(container, shm_key="engine_outputs_shm") -> bool`.
- `vllm_omni/entrypoints/async_omni.py`
  - On orphaned output drop path, call `cleanup_shm_from_ipc_meta(...)` before `continue`.
- `tests/entrypoints/test_stage_utils.py`
  - Added unit tests for successful SHM unlink and invalid metadata behavior.
- `tests/entrypoints/test_async_omni_shm_cleanup.py`
  - Added regression test that verifies cleanup is invoked for orphaned async outputs.

## Verification
- `pre-commit run --files vllm_omni/entrypoints/async_omni.py vllm_omni/entrypoints/stage_utils.py tests/entrypoints/test_stage_utils.py tests/entrypoints/test_async_omni_shm_cleanup.py`
- `python3 -m py_compile vllm_omni/entrypoints/async_omni.py vllm_omni/entrypoints/stage_utils.py tests/entrypoints/test_stage_utils.py tests/entrypoints/test_async_omni_shm_cleanup.py`

## Notes
- Full local `pytest` suite was not executed in this environment.
