### PR TITLE
[Bugfix] fix helios video generate use cpu device

### DIFF
--- a/vllm_omni/diffusion/models/helios/pipeline_helios.py
+++ b/vllm_omni/diffusion/models/helios/pipeline_helios.py
@@ -891,7 +891,7 @@ class HeliosPipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
         _, ph, pw = patch_size
         block_size = ph * pw
 
-        device = generator.device if generator is not None else "cpu"
+        device = generator.device if generator is not None else self.device
 
         cov = torch.eye(block_size) * (1 + gamma) - torch.ones(block_size, block_size) * gamma
         cov += torch.eye(block_size) * 1e-8


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

Fixes: https://github.com/vllm-project/vllm-omni/issues/1914

## Test Result

```
$ python examples/offline_inference/helios/end2end.py     --model /home/jovyan/Helios-Distilled/ --sample-type t2v     --prompt "A dynamic time-lapse video showing the rapidly moving scenery from the window of a speeding train."     --num-frames 240 --guidance-scale 1.0 --is-enable-stage2     --pyramid-num-inference-steps-list 2 2 2     --is-amplify-first-chunk --output helios_t2v_distilled.mp4
```


https://github.com/user-attachments/assets/3c8a6714-928e-4f52-ae91-0bec0bdac37b



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
