### PR TITLE
Fix OmniGen2 transformer config loading for HF models

### DIFF
--- a/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
+++ b/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
@@ -36,6 +36,7 @@ from vllm_omni.diffusion.models.omnigen2.omnigen2_transformer import (
     OmniGen2Transformer2DModel,
 )
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.inputs.data import OmniTextPrompt
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
@@ -673,37 +674,7 @@ class OmniGen2Pipeline(nn.Module):
             self.device
         )
 
-        # Transformer config is loaded at entrypoint into od_config.tf_model_config.params.
-        transformer_config = od_config.tf_model_config.params
-        transformer_kwargs = {}
-        if isinstance(transformer_config, dict):
-            param_mapping = {
-                "patch_size": "patch_size",
-                "in_channels": "in_channels",
-                "out_channels": "out_channels",
-                "hidden_size": "hidden_size",
-                "num_layers": "num_layers",
-                "num_refiner_layers": "num_refiner_layers",
-                "num_attention_heads": "num_attention_heads",
-                "num_kv_heads": "num_kv_heads",
-                "multiple_of": "multiple_of",
-                "ffn_dim_multiplier": "ffn_dim_multiplier",
-                "norm_eps": "norm_eps",
-                "axes_dim_rope": "axes_dim_rope",
-                "axes_lens": "axes_lens",
-                "text_feat_dim": "text_feat_dim",
-                "timestep_scale": "timestep_scale",
-            }
-            for config_key, param_name in param_mapping.items():
-                if config_key in transformer_config:
-                    value = transformer_config[config_key]
-                    # Handle tuple parameters (axes_dim_rope, axes_lens)
-                    if isinstance(value, list) and param_name in (
-                        "axes_dim_rope",
-                        "axes_lens",
-                    ):
-                        value = tuple(value)
-                    transformer_kwargs[param_name] = value
+        transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, OmniGen2Transformer2DModel)
         self.transformer = OmniGen2Transformer2DModel(**transformer_kwargs)
         self.mllm = Qwen2_5_VLForConditionalGeneration.from_pretrained(
             model, subfolder="mllm", local_files_only=local_files_only


### PR DESCRIPTION


## Purpose
When OmniGen2 is loaded using a HuggingFace repo ID (for example `OmniGen2/OmniGen2`), the previous implementation constructed the transformer config path as:
```python
transformer_config_path = os.path.join(model, "transformer", "config.json")
```
This assumes that `model` is a **local directory**. However, when a HuggingFace repo ID is provided, the model files are actually stored inside the HuggingFace cache snapshot directory rather than the repo name itself.
Because of this, the pipeline attempted to locate the config file at: _OmniGen2/OmniGen2/transformer/config.json_
which does not exist locally.
This caused OmniGen2 initialization to fail.

## Error Logs
Below is the error observed during model loading:

```
RuntimeError: [DEBUG] model=OmniGen2/OmniGen2,
path=OmniGen2/OmniGen2/transformer/config.json,
exists=False

[Stage-0] ERROR [multiproc_executor.py:118]
Rank 0 scheduler is dead. Please check if there are relevant logs

[Stage-0] ERROR [multiproc_executor.py:120]
Exit code: 1
```

The logs confirmed that the pipeline attempted to locate `transformer/config.json` using the HuggingFace repo ID directly instead of resolving the HuggingFace cache snapshot path.

---

## Root Cause

For HuggingFace models, files are downloaded into the HF cache under a snapshot directory such as:

```
~/.cache/huggingface/hub/models--OmniGen2--OmniGen2/snapshots/<hash>/
```

The previous implementation did not resolve this snapshot path before constructing the transformer config path.

---

## Fix

This PR resolves the transformer config path using the HuggingFace utility:

```
get_hf_file_to_dict
```
This ensures that the config file can be correctly located regardless of whether the model is provided as:

- a **local model directory**
- a **HuggingFace repo ID**

The transformer config is now retrieved through HF utilities that resolve the cached snapshot path automatically.

---

## Test Plan

Tested OmniGen2 loading using a HuggingFace repo ID.

Example command used for validation:

```
python examples/offline_inference/image_to_image/image_edit.py \
  --image qwen-bear.png \
  --model "OmniGen2/OmniGen2" \
  --prompt "Change the background to classroom."
```

---

## Test Result

Before fix:

```
RuntimeError: [DEBUG] model=OmniGen2/OmniGen2
path=OmniGen2/OmniGen2/transformer/config.json
exists=False

Rank 0 scheduler is dead
```

After fix:

```
Loading checkpoint shards: 100% | 4/4
OmniDiffusion generation completed successfully
Saved edited image to outputs/hf_image_edit.png
```

Model initialization and inference now complete successfully when loading OmniGen2 using a HuggingFace repo ID.


