### PR TITLE
[Bugfix] Fix Ovis Image crash when guidance_scale is set without negative_prompt

### DIFF
--- a/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
+++ b/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
@@ -681,6 +681,7 @@ class OvisImagePipeline(nn.Module, CFGParallelMixin):
 
         negative_text_ids = None
         if do_classifier_free_guidance:
+            negative_prompt = negative_prompt if negative_prompt is not None else ""
             negative_prompt_embeds, negative_text_ids = self.encode_prompt(
                 prompt=negative_prompt,
                 prompt_embeds=negative_prompt_embeds,


### PR DESCRIPTION
## Purpose

Fix #1950

When `guidance_scale > 1.0` is set without providing a `negative_prompt`, the Ovis Image pipeline crashes with `TypeError: 'NoneType' object is not iterable` in `_get_messages()`.

This is because `negative_prompt` defaults to `None`, which is passed directly to `encode_prompt()` → `_get_ovis_prompt_embeds()` → `_get_messages()`, where it tries to iterate over `None`.

The fix defaults `negative_prompt` to an empty string `""` when it is `None`, consistent with other pipelines (longcat_image, nextstep_1_1, flux2_klein, etc.).

## Test Plan
Run offline inference with `guidance_scale=5.0` and **without** `negative_prompt` (the crash scenario from #1950):

```bash
python examples/offline_inference/text_to_image/text_to_image.py \
  --model /data/models/AIDC-AI/Ovis-Image-7B \
  --output outputs/ovis-image-no-neg-prompt.png \
  --prompt "a lovely bunny holding a sign that says 'vllm-omni'" \
  --seed 42 \
  --tensor-parallel-size 1 \
  --num-images-per-prompt 1 \
  --num-inference-steps 50 \
  --height 1024 \
  --width 1024 \
  --guidance-scale 5.0
```

## Test Result
- Before fix: `TypeError: 'NoneType' object is not iterable` in `_get_messages()`
- After fix: Image generated successfully (38.5s, 1024x1024)

<img width="1024" height="1024" alt="ovis-image-no-neg-prompt" src="https://github.com/user-attachments/assets/0889f13a-6d51-4054-9f2b-a31b146f3c4a" />
