### PR TITLE
fix: NextStep pipeline class in config fallback path

### DIFF
--- a/tests/e2e/offline_inference/test_nextstep_text2img.py
+++ b/tests/e2e/offline_inference/test_nextstep_text2img.py
@@ -1,0 +1,71 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+from tests.utils import hardware_test
+from vllm_omni.diffusion.data import DiffusionParallelConfig
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.platforms import current_omni_platform
+
+# ruff: noqa: E402
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from vllm_omni import Omni
+
+os.environ["VLLM_TEST_CLEAN_GPU_MEMORY"] = "1"
+
+
+@pytest.mark.core_model
+@pytest.mark.advanced_model
+@pytest.mark.diffusion
+@hardware_test(res={"cuda": "L4", "rocm": "MI325", "xpu": "B60"}, num_cards={"cuda": 1, "rocm": 2, "xpu": 2})
+def test_nextstep_text2img(run_level):
+    if run_level == "core_model":
+        pytest.skip()
+
+    m = None
+    try:
+        omni_kwargs = {
+            "model": "stepfun-ai/NextStep-1.1",
+            "model_class_name": "NextStep11Pipeline",
+        }
+        if current_omni_platform.is_xpu():
+            omni_kwargs["parallel_config"] = DiffusionParallelConfig(tensor_parallel_size=2)
+        m = Omni(**omni_kwargs)
+        # high resolution may cause OOM on L4
+        height = 256
+        width = 256
+        outputs = m.generate(
+            "a photo of a cat sitting on a laptop keyboard",
+            OmniDiffusionSamplingParams(
+                height=height,
+                width=width,
+                num_inference_steps=4,
+                guidance_scale=7.5,
+                guidance_scale_2=1.0,
+                generator=torch.Generator(current_omni_platform.device_type).manual_seed(42),
+                num_outputs_per_prompt=1,
+            ),
+        )
+        first_output = outputs[0]
+        assert first_output.final_output_type == "image"
+        assert getattr(first_output, "request_output", None), "no request_output on NextStep output"
+        req_out = first_output.request_output[0]
+        assert isinstance(req_out, OmniRequestOutput), "request_output[0] is not OmniRequestOutput"
+        assert getattr(req_out, "images", None), "no images in NextStep request_output"
+        images = req_out.images
+        assert len(images) == 1, f"expected 1 image, got {len(images)}"
+        assert images[0].width == width
+        assert images[0].height == height
+    except Exception as e:
+        print(f"Test failed with error: {e}")
+        raise
+    finally:
+        if m is not None and hasattr(m, "close"):
+            m.close()

--- a/vllm_omni/entrypoints/omni_diffusion.py
+++ b/vllm_omni/entrypoints/omni_diffusion.py
@@ -91,8 +91,7 @@ class OmniDiffusion:
             if model_type == "bagel" or "BagelForConditionalGeneration" in architectures:
                 pipeline_class = "BagelPipeline"
             elif model_type == "nextstep":
-                if od_config.model_class_name is None:
-                    pipeline_class = "NextStep11Pipeline"
+                pipeline_class = "NextStep11Pipeline"
             elif model_type == "glm-image" or "GlmImageForConditionalGeneration" in architectures:
                 pipeline_class = "GlmImagePipeline"
             elif architectures and len(architectures) == 1:


### PR DESCRIPTION
# Fix: NextStep pipeline class in fallback path (omni_diffusion.py)

## Summary

Fix NextStep-1.1 failing with `ValueError: Unknown model type: nextstep, architectures: ['LlamaForCausalLM']` when the fallback path is used (no `model_index.json`). The fix is to always set `pipeline_class = "NextStep11Pipeline"` when `model_type == "nextstep"`, and remove the incorrect `if od_config.model_class_name is None:` guard around it.

## Why the original line was added

In **PR #612** ([Model] Add new nextstep_1 (Diffusion) model (only T2I)), the NextStep branch was added with:

```python
elif model_type == "nextstep":
    if od_config.model_class_name is None:
        od_config.model_class_name = "NextStep11Pipeline"
```

The intent was to **respect caller override**: the CLI (`text_to_image.py`) explicitly sets `omni_kwargs["model_class_name"] = "NextStep11Pipeline"` for NextStep. The author wanted “only set the pipeline class when the caller hasn’t already set it,” so they guarded the assignment with `if od_config.model_class_name is None`.

## Why that line is wrong in the current code

The fallback path was later **refactored** to a single pattern:

1. Each branch (bagel, nextstep, glm-image, …) sets only a **local** variable `pipeline_class`.
2. **Once at the end**, we do: `if od_config.model_class_name is None: od_config.model_class_name = pipeline_class`.

So “don’t overwrite when the caller already set it” is already enforced in that one place. In the refactored flow, the nextstep branch must **always** set `pipeline_class = "NextStep11Pipeline"` so that (a) we don’t raise “Unknown model type” when `pipeline_class is None`, and (b) the end block can assign it to `od_config.model_class_name` when the caller did *not* set it.


```python
elif model_type == "nextstep":
    if od_config.model_class_name is None: 
        pipeline_class = "NextStep11Pipeline"
```

That is wrong here because:

- When the **caller does** set `model_class_name` (e.g. from the CLI), we **do not** set `pipeline_class`, so `pipeline_class` stays `None`, and we hit `if pipeline_class is None: raise ValueError(...)`.
- The “don’t overwrite” behavior is already handled at the end; the branch should not tie setting `pipeline_class` to whether the caller set `model_class_name`.

## Why we don’t need the guard anymore

- **Before the refactor:** The nextstep branch could correctly do “if None, then set”: `if od_config.model_class_name is None: od_config.model_class_name = "NextStep11Pipeline"`.
- **After the refactor:** The branch should only set the local variable: `pipeline_class = "NextStep11Pipeline"`. The shared block at the end (`if od_config.model_class_name is None: od_config.model_class_name = pipeline_class`) already implements “only set when the caller didn’t set it” for all model types, including NextStep. So we do **not** need the `if od_config.model_class_name is None:` guard in the nextstep branch; we only need to set `pipeline_class` unconditionally.

## Change

- **Before:** `if od_config.model_class_name is None: pipeline_class = "NextStep11Pipeline"`
- **After:** `pipeline_class = "NextStep11Pipeline"`

Behavior after the fix:

- Caller sets `model_class_name` → we don’t overwrite (end block skips assignment).
- Caller does not set it → we set it from `pipeline_class` (end block assigns).

