### PR TITLE
[Feature] Integrate Nunchaku SVDQuant W4A4 for diffusion models

### DIFF
--- a/examples/offline_inference/text_to_image/text_to_image_quant.py
+++ b/examples/offline_inference/text_to_image/text_to_image_quant.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Nunchaku SVDQuant W4A4 Quantized Inference Example.
+
+This script demonstrates how to run text-to-image generation using
+Nunchaku SVDQuant W4A4 quantization for faster inference.
+
+Requirements:
+    - Nunchaku library installed: pip install nunchaku
+    - Quantized checkpoint with SVDQuant weights
+
+Usage:
+    python text_to_image_quant.py \\
+        --model /path/to/nunchaku-checkpoint \\
+        --prompt "a cup of coffee on the table" \\
+        --output zimage_quant_output.png \\
+        --rank 128 \\
+        --precision nvfp4
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+import torch
+
+from vllm_omni.diffusion.data import DiffusionParallelConfig, logger
+from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.platforms import current_omni_platform
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate an image with Nunchaku SVDQuant quantization."
+    )
+    parser.add_argument(
+        "--model",
+        default="ultranationalism/nunchaku-z-image-turbo",
+        help="Diffusion model name or local path. Must be a quantized checkpoint with Nunchaku SVDQuant weights.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="a cup of coffee on the table",
+        help="Text prompt for image generation.",
+    )
+    parser.add_argument(
+        "--negative-prompt",
+        default=None,
+        help="Negative prompt for classifier-free conditional guidance.",
+    )
+    parser.add_argument("--seed", type=int, default=142, help="Random seed for deterministic results.")
+    parser.add_argument(
+        "--cfg-scale",
+        type=float,
+        default=4.0,
+        help="True classifier-free guidance scale.",
+    )
+    parser.add_argument(
+        "--guidance-scale",
+        type=float,
+        default=1.0,
+        help="Classifier-free guidance scale.",
+    )
+    parser.add_argument("--height", type=int, default=1024, help="Height of generated image.")
+    parser.add_argument("--width", type=int, default=1024, help="Width of generated image.")
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="zimage_quant_output.png",
+        help="Path to save the generated image (PNG).",
+    )
+    parser.add_argument(
+        "--num-images-per-prompt",
+        type=int,
+        default=1,
+        help="Number of images to generate for the given prompt.",
+    )
+    parser.add_argument(
+        "--num-inference-steps",
+        type=int,
+        default=50,
+        help="Number of denoising steps for the diffusion sampler.",
+    )
+
+    # Nunchaku quantization arguments
+    parser.add_argument(
+        "--rank",
+        type=int,
+        default=32,
+        help="Low-rank dimension for SVDQuant. Common values: 32, 64, 128.",
+    )
+    parser.add_argument(
+        "--precision",
+        type=str,
+        default="int4",
+        choices=["int4", "nvfp4"],
+        help=(
+            "Quantization precision. "
+            "'int4': Standard 4-bit integer quantization (group_size=64). "
+            "'nvfp4': NVIDIA FP4 format (group_size=16, requires Ampere+ GPU)."
+        ),
+    )
+    parser.add_argument(
+        "--act-unsigned",
+        action="store_true",
+        help="Use unsigned quantization for activations (may improve quality in some cases).",
+    )
+
+    # Parallelism arguments
+    parser.add_argument(
+        "--ulysses-degree",
+        type=int,
+        default=1,
+        help="Number of GPUs used for ulysses sequence parallelism.",
+    )
+    parser.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=1,
+        help="Number of GPUs used for tensor parallelism (TP) inside the DiT.",
+    )
+
+    # Offloading arguments
+    parser.add_argument(
+        "--enable-cpu-offload",
+        action="store_true",
+        help="Enable CPU offloading for diffusion models.",
+    )
+    parser.add_argument(
+        "--enable-layerwise-offload",
+        action="store_true",
+        help="Enable layerwise (blockwise) offloading on DiT modules.",
+    )
+
+    # Other arguments
+    parser.add_argument(
+        "--enforce-eager",
+        action="store_true",
+        help="Disable torch.compile and force eager execution.",
+    )
+    parser.add_argument(
+        "--vae-use-slicing",
+        action="store_true",
+        help="Enable VAE slicing for memory optimization.",
+    )
+    parser.add_argument(
+        "--vae-use-tiling",
+        action="store_true",
+        help="Enable VAE tiling for memory optimization.",
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    generator = torch.Generator(device=current_omni_platform.device_type).manual_seed(args.seed)
+
+    parallel_config = DiffusionParallelConfig(
+        ulysses_degree=args.ulysses_degree,
+        tensor_parallel_size=args.tensor_parallel_size,
+    )
+
+    omni = Omni(
+        model=args.model,
+        vae_use_slicing=args.vae_use_slicing,
+        vae_use_tiling=args.vae_use_tiling,
+        quantization="nunchaku",
+        quantization_config={
+            "rank": args.rank,
+            "precision": args.precision,
+            "act_unsigned": args.act_unsigned,
+        },
+        parallel_config=parallel_config,
+        enforce_eager=args.enforce_eager,
+        enable_cpu_offload=args.enable_cpu_offload,
+        enable_layerwise_offload=args.enable_layerwise_offload,
+    )
+
+    # Print configuration
+    print(f"\n{'=' * 60}")
+    print("Generation Configuration:")
+    print(f"  Model: {args.model}")
+    print(f"  Inference steps: {args.num_inference_steps}")
+    print(f"  Quantization: nunchaku (rank={args.rank}, precision={args.precision})")
+    print(
+        f"  Parallel: ulysses_degree={args.ulysses_degree}, "
+        f"tensor_parallel_size={args.tensor_parallel_size}"
+    )
+    print(f"  CPU offload: {args.enable_cpu_offload}")
+    print(f"  Layerwise offload: {args.enable_layerwise_offload}")
+    print(f"  Image size: {args.width}x{args.height}")
+    print(f"{'=' * 60}\n")
+
+    generation_start = time.perf_counter()
+    outputs = omni.generate(
+        {
+            "prompt": args.prompt,
+            "negative_prompt": args.negative_prompt,
+        },
+        OmniDiffusionSamplingParams(
+            height=args.height,
+            width=args.width,
+            generator=generator,
+            true_cfg_scale=args.cfg_scale,
+            guidance_scale=args.guidance_scale,
+            num_inference_steps=args.num_inference_steps,
+            num_outputs_per_prompt=args.num_images_per_prompt,
+        ),
+    )
+    generation_time = time.perf_counter() - generation_start
+
+    print(f"Total generation time: {generation_time:.4f} seconds ({generation_time * 1000:.2f} ms)")
+
+    # Extract images
+    if not outputs or len(outputs) == 0:
+        raise ValueError("No output generated from omni.generate()")
+
+    first_output = outputs[0]
+    if not hasattr(first_output, "request_output") or not first_output.request_output:
+        raise ValueError("No request_output found in OmniRequestOutput")
+
+    req_out = first_output.request_output[0]
+    if not isinstance(req_out, OmniRequestOutput) or not hasattr(req_out, "images"):
+        raise ValueError("Invalid request_output structure or missing 'images' key")
+
+    images = req_out.images
+    if not images:
+        raise ValueError("No images found in request_output")
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    suffix = output_path.suffix or ".png"
+    stem = output_path.stem or "zimage_quant_output"
+    if len(images) <= 1:
+        images[0].save(output_path)
+        print(f"Saved generated image to {output_path}")
+    else:
+        for idx, img in enumerate(images):
+            save_path = output_path.parent / f"{stem}_{idx}{suffix}"
+            img.save(save_path)
+            print(f"Saved generated image to {save_path}")
+
+    omni.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm_omni/diffusion/layers/quantization/__init__.py
+++ b/vllm_omni/diffusion/layers/quantization/__init__.py
@@ -1,0 +1,11 @@
+"""Quantization layers for vLLM-omni diffusion models."""
+
+from vllm_omni.diffusion.layers.quantization.svdq_nunchaku import (
+    NunchakuConfig,
+    NunchakuLinearMethod,
+)
+
+__all__ = [
+    "NunchakuConfig",
+    "NunchakuLinearMethod",
+]

--- a/vllm_omni/diffusion/layers/quantization/svdq_nunchaku.py
+++ b/vllm_omni/diffusion/layers/quantization/svdq_nunchaku.py
@@ -1,0 +1,661 @@
+"""Nunchaku SVDQuant quantization plugin for vLLM.
+
+This module implements a vLLM-compatible quantization plugin for Nunchaku's
+SVDQuant algorithm, supporting Tensor Parallel (TP) distribution.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import torch
+import torch.nn as nn
+from torch.nn.parameter import Parameter
+
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.layers.quantization import register_quantization_config
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+try:
+    from nunchaku.ops.gemm import svdq_gemm_w4a4_cuda
+    from nunchaku.ops.gemv import awq_gemv_w4a16_cuda
+    from nunchaku.ops.quantize import svdq_quantize_w4a4_act_fuse_lora_cuda
+    _NUNCHAKU_OPS_AVAILABLE = True
+except ImportError:
+    svdq_gemm_w4a4_cuda = None
+    awq_gemv_w4a16_cuda = None
+    svdq_quantize_w4a4_act_fuse_lora_cuda = None
+    _NUNCHAKU_OPS_AVAILABLE = False
+
+
+# ============================================================================
+# Weight Packing and Padding Utilities
+# ============================================================================
+
+
+def pad_to_multiple(tensor: torch.Tensor, dim: int, multiple: int) -> torch.Tensor:
+    """Pad a tensor along a specific dimension to be a multiple of a value.
+
+    Args:
+        tensor: Input tensor to pad
+        dim: Dimension to pad along
+        multiple: Target multiple for dimension size
+
+    Returns:
+        Padded tensor
+    """
+    current_size = tensor.shape[dim]
+    if current_size % multiple == 0:
+        return tensor
+
+    target_size = ((current_size + multiple - 1) // multiple) * multiple
+    pad_size = target_size - current_size
+
+    # Create padding specification (right pad on the specified dimension)
+    pad_spec = [0, 0] * tensor.ndim
+    pad_spec[-(2 * dim + 1)] = pad_size
+
+    return torch.nn.functional.pad(tensor, pad_spec, value=0)
+
+
+def pack_lowrank_weight(weight: torch.Tensor, down: bool = True) -> torch.Tensor:
+    """Pack low-rank projection weights for Nunchaku SVDQuant CUDA kernels.
+
+    Nunchaku's CUDA kernels require low-rank matrices to follow a specific
+    memory layout for optimal performance. This function packs FP16/BF16
+    weights according to these requirements.
+
+    Args:
+        weight: Low-rank weight tensor
+            - For down-projection: shape (in_features, rank)
+            - For up-projection: shape (out_features, rank)
+        down: True for down-projection, False for up-projection
+
+    Returns:
+        Packed weight tensor with optimized memory layout
+    """
+    if down:
+        # Down-projection: (in_features, rank)
+        # Nunchaku kernel expects shape (in_features, rank) with assertion: lora_down.shape[0] == N
+        M, K = weight.shape
+
+        # Ensure rank (K) is aligned to 16 for efficient memory access
+        if K % 16 != 0:
+            weight = pad_to_multiple(weight, dim=1, multiple=16)
+            K = weight.shape[1]
+
+        # Keep original shape (in_features, rank) - no transpose needed
+        packed = weight.contiguous()
+
+    else:
+        # Up-projection: (out_features, rank)
+        # Pack in row-major order but ensure proper alignment
+        N, K = weight.shape
+
+        # Ensure rank (K) is aligned to 16
+        if K % 16 != 0:
+            weight = pad_to_multiple(weight, dim=1, multiple=16)
+            K = weight.shape[1]
+
+        # Keep row-major but ensure contiguous memory
+        packed = weight.contiguous()
+
+    return packed
+
+
+@register_quantization_config("nunchaku")
+class NunchakuConfig(QuantizationConfig):
+    """Configuration for Nunchaku SVDQuant quantization.
+
+    Args:
+        rank: Low-rank approximation dimension for SVDQ
+        precision: Quantization precision ("int4" or "nvfp4")
+        group_size: Group size for quantization (auto-determined by precision)
+        act_unsigned: Whether to use unsigned quantization for activations
+    """
+
+    def __init__(
+        self,
+        rank: int = 32,
+        precision: str = "int4",
+        act_unsigned: bool = False,
+    ) -> None:
+        if not _NUNCHAKU_OPS_AVAILABLE:
+            raise ImportError(
+                "Nunchaku is not installed. Please install it to use "
+                "Nunchaku quantization."
+            )
+
+        self.rank = rank
+        self.precision = precision
+        self.act_unsigned = act_unsigned
+
+        # Determine group size based on precision
+        if precision == "nvfp4":
+            self.group_size = 16
+        elif precision == "int4":
+            self.group_size = 64
+        else:
+            raise ValueError(f"Invalid precision: {precision}")
+
+    def __repr__(self) -> str:
+        return (f"NunchakuConfig(rank={self.rank}, "
+                f"precision={self.precision}, "
+                f"act_unsigned={self.act_unsigned})")
+
+    @classmethod
+    def get_name(cls) -> str:
+        """Return the name of the quantization method."""
+        return "nunchaku"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> List[torch.dtype]:
+        """Return supported activation dtypes."""
+        return [torch.float16, torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        """Return the minimum CUDA compute capability required."""
+        return 80  # Requires Ampere or newer
+
+    @classmethod
+    def get_config_filenames(cls) -> List[str]:
+        """Return config filenames to search for quantization config."""
+        return ["quantization_config.json", "config.json"]
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "NunchakuConfig":
+        """Create config from a dictionary."""
+        rank = config.get("rank", 32)
+        precision = config.get("precision", "int4")
+        act_unsigned = config.get("act_unsigned", False)
+        return cls(
+            rank=rank,
+            precision=precision,
+            act_unsigned=act_unsigned,
+        )
+
+    # Layers that Nunchaku quantizes: attention (to_qkv, to_out) and
+    # feed_forward (net.0.proj / w13, net.2 / w2) in transformer blocks
+    # (layers, noise_refiner, context_refiner).
+    # Everything else (t_embedder, cap_embedder, all_x_embedder,
+    # all_final_layer, adaLN_modulation) stays unquantized.
+    _QUANTIZED_LAYER_PATTERNS = (
+        ".attention.to_qkv",
+        ".attention.to_out.",
+        ".feed_forward.w13",
+        ".feed_forward.w2",
+        ".feed_forward.net.0.proj",
+        ".feed_forward.net.2",
+    )
+
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+    ) -> Optional["NunchakuLinearMethod"]:
+        """Get the quantization method for a layer.
+
+        Only quantizes attention projections and FFN layers in transformer
+        blocks, matching Nunchaku's PTQ scope.
+        """
+        if isinstance(layer, LinearBase):
+            # Nunchaku quantizes attention (QKVParallelLinear, RowParallelLinear)
+            # and FFN (MergedColumnParallelLinear, RowParallelLinear) layers.
+            # ReplicatedLinear layers (adaLN, embedders, final_layer) stay
+            # unquantized — they use standard weight/bias from checkpoint.
+            if isinstance(layer, (QKVParallelLinear, MergedColumnParallelLinear, RowParallelLinear)):
+                return NunchakuLinearMethod(self)
+            return UnquantizedLinearMethod()
+        return None
+
+    def get_scaled_act_names(self) -> List[str]:
+        """Return names of activation scales (for smooth quantization)."""
+        return ["smooth_factor"]
+
+
+class NunchakuLinearMethod(LinearMethodBase):
+    """Linear method for Nunchaku SVDQuant quantization.
+
+    This implements the vLLM LinearMethodBase interface for SVDQ quantization,
+    handling weight creation with proper TP distribution and forward computation.
+    """
+
+    def __init__(self, quant_config: NunchakuConfig):
+        self.quant_config = quant_config
+
+    @staticmethod
+    def _swap_swiglu_halves(layer: nn.Module) -> None:
+        """Swap gate/up halves of quantized MergedColumnParallelLinear weights.
+
+        Diffusers FeedForward (GEGLU) convention:
+            output = gate * silu(up)
+            weight layout: [gate_rows ; up_rows]  (gate = first half)
+
+        vLLM SiluAndMul convention:
+            output = silu(first_half) * second_half
+            weight layout: [silu_rows ; linear_rows]
+
+        To match, we swap: put up (silu'd) first, gate (linear) second.
+        """
+        half = layer.qweight.shape[0] // 2
+        # qweight: (out, in//2) — swap output halves
+        layer.qweight.data = torch.cat(
+            [layer.qweight.data[half:], layer.qweight.data[:half]], dim=0
+        )
+
+        # wscales: (in//gs, out) — swap output halves (dim 1)
+        half_s = layer.wscales.shape[1] // 2
+        layer.wscales.data = torch.cat(
+            [layer.wscales.data[:, half_s:], layer.wscales.data[:, :half_s]],
+            dim=1,
+        )
+
+        # proj_up: (out, rank) — swap output halves
+        half_p = layer.proj_up.shape[0] // 2
+        layer.proj_up.data = torch.cat(
+            [layer.proj_up.data[half_p:], layer.proj_up.data[:half_p]], dim=0
+        )
+
+        # wcscales: (out,) — swap halves [nvfp4 only]
+        if hasattr(layer, "wcscales") and layer.wcscales is not None:
+            half_c = layer.wcscales.shape[0] // 2
+            layer.wcscales.data = torch.cat(
+                [layer.wcscales.data[half_c:], layer.wcscales.data[:half_c]]
+            )
+
+        logger.debug("Swapped SwiGLU gate/up halves for %s", type(layer).__name__)
+
+    def process_weights_after_loading(self, layer: nn.Module) -> None:
+        """Post-process quantized weights after checkpoint loading.
+
+        Two key steps:
+        1. SwiGLU shard swap for MergedColumnParallelLinear (w13):
+           Diffusers computes gate * silu(up) (gate=first half, up=second),
+           but vLLM's SiluAndMul computes silu(first) * second.
+           We swap the two output halves so the activation order matches.
+        2. Extract alpha from wtscale for the CUDA kernel.
+        """
+        # Materialize any meta-device parameters that weren't loaded from
+        # the checkpoint (e.g. wtscale, wcscales for nvfp4).  Find the
+        # device of an already-loaded parameter to use as the target.
+        target_device = None
+        for p in layer.parameters():
+            if not p.is_meta:
+                target_device = p.device
+                break
+        if target_device is not None:
+            for name, p in list(layer.named_parameters()):
+                if p.is_meta:
+                    new_p = Parameter(
+                        torch.ones_like(p, device=target_device),
+                        requires_grad=False,
+                    )
+                    setattr(layer, name, new_p)
+
+        alpha: Optional[float] = None
+
+        # Extract wtscale from checkpoint if available
+        if hasattr(layer, "wtscale") and layer.wtscale is not None:
+            wtscale = layer.wtscale
+            if isinstance(wtscale, Parameter):
+                wtscale_val = float(wtscale.data.detach().cpu().item())
+            elif isinstance(wtscale, torch.Tensor):
+                wtscale_val = float(wtscale.detach().cpu().item())
+            else:
+                wtscale_val = float(wtscale)
+
+            # Check if actually loaded from checkpoint (not default 1.0)
+            if abs(wtscale_val - 1.0) > 1e-6:
+                alpha = wtscale_val
+                wtscale_from_checkpoint = True
+                logger.debug(f"Using wtscale from checkpoint: {alpha}")
+            else:
+                logger.debug(f"wtscale is default value 1.0, not from checkpoint")
+
+        # 2. If wtscale not loaded, use alpha=1.0 and let wcscales handle scaling
+        # IMPORTANT: Do NOT calculate alpha from wcscales.mean() because:
+        # - Nunchaku kernel uses: Output = (Accumulator × alpha) × wcscales
+        # - If we set alpha=wcscales.mean(), we get: Output = Acc × mean(wcscales) × wcscales (WRONG!)
+        # - But Nunchaku expects: Output = Acc × 1.0 × wcscales = Acc × wcscales (CORRECT)
+        if alpha is None:
+            alpha = 1.0
+
+        layer._nunchaku_alpha = alpha
+
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        """Create quantized weights for the layer.
+
+        This method determines the TP direction (ColumnParallel or RowParallel)
+        and creates appropriately sharded parameters.
+
+        Args:
+            layer: The layer module to add parameters to
+            input_size_per_partition: Input dimension after TP partitioning
+            output_partition_sizes: List of output dimensions after TP partitioning
+            input_size: Original input dimension (before TP)
+            output_size: Original output dimension (before TP)
+            params_dtype: Data type for parameters
+        """
+        output_size_per_partition = sum(output_partition_sizes)
+
+        # Determine TP parallelization direction
+        is_row_parallel = (input_size_per_partition != input_size)
+        is_col_parallel = (output_size_per_partition != output_size)
+
+        config = self.quant_config
+        rank = config.rank
+        precision = config.precision
+        group_size = config.group_size
+
+        # For W4A4 quantization, LoRA projections and smooth factors must use bfloat16
+        # for correct activation quantization (matching Nunchaku's implementation)
+        lora_dtype = torch.bfloat16 if precision == "nvfp4" else params_dtype
+
+        # Helper function to set weight attributes
+        def set_weight_attrs(param: nn.Parameter, attrs: Dict[str, Any]):
+            """Set weight attributes for TP sharding."""
+            for key, value in attrs.items():
+                setattr(param, key, value)
+
+        # Create custom weight loaders for proj_down and proj_up
+        # These will handle name mapping (lora_down/lora_up -> proj_down/proj_up)
+        # and weight packing for CUDA kernel requirements
+        def proj_down_loader(param: nn.Parameter, loaded_weight: torch.Tensor):
+            """Custom loader for proj_down that packs weights."""
+            # Pack for down-projection (transpose + pad)
+            packed_weight = pack_lowrank_weight(loaded_weight, down=True)
+            logger.debug(
+                "Packed proj_down weight: %s -> %s",
+                loaded_weight.shape,
+                packed_weight.shape,
+            )
+            # Use default loader for the packed weight
+            default_weight_loader(param, packed_weight)
+
+        def proj_up_loader(param: nn.Parameter, loaded_weight: torch.Tensor):
+            """Custom loader for proj_up that packs weights."""
+            # Pack for up-projection (pad only)
+            packed_weight = pack_lowrank_weight(loaded_weight, down=False)
+            logger.debug(
+                "Packed proj_up weight: %s -> %s",
+                loaded_weight.shape,
+                packed_weight.shape,
+            )
+            # Use default loader for the packed weight
+            default_weight_loader(param, packed_weight)
+
+        # Quantized weight tensor (packed int4 -> int8)
+        # Shape: (out_features, in_features // 2)
+        qweight = nn.Parameter(
+            torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // 2,
+                dtype=torch.int8,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(qweight, {
+            "input_dim": 1,
+            "output_dim": 0,
+            "weight_loader": default_weight_loader,
+        })
+
+        # Weight scales
+        # Shape: (in_features // group_size, out_features)
+        wscales_dtype = (torch.float8_e4m3fn
+                        if precision == "nvfp4"
+                        else params_dtype)
+        wscales = nn.Parameter(
+            torch.empty(
+                input_size_per_partition // group_size,
+                output_size_per_partition,
+                dtype=wscales_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(wscales, {
+            "input_dim": 0,
+            "output_dim": 1,
+            "weight_loader": default_weight_loader,
+        })
+
+        # Low-rank projection matrices
+        # proj_down: (in_features, rank) - will be padded by weight loader if needed
+        proj_down = nn.Parameter(
+            torch.empty(
+                input_size_per_partition,
+                rank,
+                dtype=lora_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(proj_down, {
+            "input_dim": 0,  # Input dimension is first dimension
+            "output_dim": 1,
+            "weight_loader": proj_down_loader,  # Use custom loader
+        })
+
+        # proj_up: (out_features, rank) - will be padded by weight loader if needed
+        proj_up = nn.Parameter(
+            torch.empty(
+                output_size_per_partition,
+                rank,
+                dtype=lora_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(proj_up, {
+            "input_dim": 0,
+            "output_dim": 1,
+            "weight_loader": proj_up_loader,  # Use custom loader
+        })
+
+        # Smooth factors for activation quantization
+        # Shape: (in_features,)
+        smooth_factor = nn.Parameter(
+            torch.empty(
+                input_size_per_partition,
+                dtype=lora_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(smooth_factor, {
+            "input_dim": 0,
+            "weight_loader": default_weight_loader,
+        })
+
+        smooth_factor_orig = nn.Parameter(
+            torch.empty(
+                input_size_per_partition,
+                dtype=lora_dtype,
+            ),
+            requires_grad=False,
+        )
+        set_weight_attrs(smooth_factor_orig, {
+            "input_dim": 0,
+            "weight_loader": default_weight_loader,
+        })
+
+        # Override TP sharding attributes based on parallelization direction
+        if is_col_parallel:
+            # Column parallel: split output dimension (N)
+            # Mark which dimension should be sharded for TP
+            qweight.output_dim = 0
+            wscales.output_dim = 1
+            proj_up.output_dim = 0
+
+        if is_row_parallel:
+            # Row parallel: split input dimension (K)
+            # Mark which dimension should be sharded for TP
+            qweight.input_dim = 1
+            wscales.input_dim = 0
+            proj_down.input_dim = 0  # Input dimension is first dimension (in_features)
+            smooth_factor.input_dim = 0
+            smooth_factor_orig.input_dim = 0
+
+        # Register all parameters
+        layer.register_parameter("qweight", qweight)
+        layer.register_parameter("wscales", wscales)
+        layer.register_parameter("proj_down", proj_down)
+        layer.register_parameter("proj_up", proj_up)
+        layer.register_parameter("smooth_factor", smooth_factor)
+        layer.register_parameter("smooth_factor_orig", smooth_factor_orig)
+
+        # Optional parameters for nvfp4 precision
+        if precision == "nvfp4":
+            # wcscales: per-channel scales, must match output dtype (bfloat16)
+            # NOT float8_e4m3fn like wscales!
+            wcscales = nn.Parameter(
+                torch.ones(
+                    output_size_per_partition,
+                    dtype=lora_dtype,  # Use lora_dtype (bfloat16) for consistency with output
+                ),
+                requires_grad=False,
+            )
+            set_weight_attrs(wcscales, {
+                "output_dim": 0,
+                "weight_loader": default_weight_loader,
+            })
+            if is_col_parallel:
+                wcscales.output_dim = 0
+            layer.register_parameter("wcscales", wcscales)
+
+            # wtscale: Global scale parameter, must match output dtype (bfloat16)
+            # Create as Parameter so it can be loaded from checkpoint
+            wtscale = nn.Parameter(
+                torch.ones(1, dtype=lora_dtype),  # Shape (1,) to match checkpoint
+                requires_grad=False,
+            )
+            set_weight_attrs(wtscale, {
+                "weight_loader": default_weight_loader,
+            })
+            layer.register_parameter("wtscale", wtscale)
+        else:
+            layer.wcscales = None
+            layer.wtscale = None
+
+        # Store config attributes
+        layer.in_features = input_size
+        layer.out_features = output_size
+        layer.out_features_per_partition = output_size_per_partition  # For TP
+        layer.rank = rank
+        layer.precision = precision
+        layer.group_size = group_size
+        layer.act_unsigned = config.act_unsigned
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Apply SVDQ quantized linear transformation.
+
+        Args:
+            layer: The layer with quantized weights
+            x: Input tensor, shape (N, in_features) or (B, S, in_features)
+            bias: Optional bias tensor
+
+        Returns:
+            Output tensor, shape matches input except last dimension
+        """
+        # Reshape to 2D for kernel processing
+        orig_shape = x.shape
+        x_2d = x.reshape(-1, orig_shape[-1])
+
+        # Quantize activations and compute low-rank hidden states
+        quantized_x, ascales, lora_act_out = svdq_quantize_w4a4_act_fuse_lora_cuda(
+            x_2d,
+            lora_down=layer.proj_down,
+            smooth=layer.smooth_factor,
+            fp4=layer.precision == "nvfp4",
+            pad_size=256,
+        )
+
+        # Use per-partition output features (critical for TP correctness)
+        out_features = layer.out_features_per_partition
+
+        # IMPORTANT: Allocate output buffer using quantized_x.shape[0] (padded batch size)
+        # The quantization kernel may pad the batch dimension, so we must match that
+        out_2d = torch.empty(
+            quantized_x.shape[0],  # Use padded batch size from quantized_x
+            out_features,
+            dtype=layer.proj_up.dtype,
+            device=x_2d.device,
+        )
+
+        # Use cached alpha value (extracted in process_weights_after_loading)
+        alpha = getattr(layer, "_nunchaku_alpha", None)
+        wcscales = layer.wcscales if hasattr(layer, "wcscales") else None
+
+        # Perform quantized GEMM with low-rank correction
+        svdq_gemm_w4a4_cuda(
+            act=quantized_x,
+            wgt=layer.qweight,
+            out=out_2d,
+            ascales=ascales,
+            wscales=layer.wscales,
+            lora_act_in=lora_act_out,
+            lora_up=layer.proj_up,
+            bias=bias,
+            fp4=layer.precision == "nvfp4",
+            alpha=alpha,
+            wcscales=wcscales,
+            act_unsigned=layer.act_unsigned,
+        )
+
+        # Trim padding if batch was padded by quantization kernel
+        # out_2d might have shape (padded_batch, out_features)
+        # We need to trim it back to (actual_batch, out_features)
+        actual_batch = x_2d.shape[0]
+        if out_2d.shape[0] > actual_batch:
+            out_2d = out_2d[:actual_batch]
+
+        # Reshape back to original shape (except last dimension)
+        output = out_2d.reshape(*orig_shape[:-1], out_features)
+
+        # Gated-activation output swap for MergedColumnParallelLinear.
+        #
+        # Nunchaku checkpoints are quantized from diffusers models.
+        # diffusers' gated activations (GEGLU, SwiGLU) use the convention:
+        #   hidden, gate = proj(x).chunk(2)  =>  [linear ; activation]
+        # vLLM's gated activations (SiluAndMul, GeluAndMul) use:
+        #   act(x[:d]) * x[d:]              =>  [activation ; linear]
+        #
+        # Since the qweight is stored in a tiled/interleaved MMA layout
+        # (see nunchaku/lora/flux/packer.py:pack_weight), we cannot swap
+        # the weight rows directly. Instead we swap the output halves here.
+        #
+        # Assumption: MergedColumnParallelLinear is only used for gated FFN
+        # (SwiGLU / GeGLU) whose downstream activation follows the vLLM
+        # convention. This holds for all current diffusion models (Z-Image,
+        # Flux2, HunyuanImage3, etc.). If a future model uses
+        # MergedColumnParallelLinear with a diffusers-convention activation,
+        # this swap must be skipped for that model.
+        if isinstance(layer, MergedColumnParallelLinear):
+            d = output.shape[-1] // 2
+            output = torch.cat([output[..., d:], output[..., :d]], dim=-1)
+
+        return output

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -326,7 +326,11 @@ class DiffusersPipelineLoader:
         # all components' weights loading (AutoModel.from_pretrained etc).
         # We only enable strict check for non-quantized models
         # that have loaded weights tracking currently.
-        if loaded_weights is not None:
+        # Skip strict check for quantized models: quantization methods may
+        # create extra parameters (e.g. wtscale, wcscales) that don't have
+        # corresponding entries in the checkpoint.
+        has_quant = self.od_config and getattr(self.od_config, "quantization_config", None) is not None
+        if loaded_weights is not None and not has_quant:
             weights_not_loaded = weights_to_load - loaded_weights
             if weights_not_loaded:
                 raise ValueError(f"Following weights were not initialized from checkpoint: {weights_not_loaded}")

--- a/vllm_omni/diffusion/models/z_image/z_image_transformer.py
+++ b/vllm_omni/diffusion/models/z_image/z_image_transformer.py
@@ -968,6 +968,9 @@ class ZImageTransformer2DModel(CachedTransformer):
         return x, {}
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # Standard checkpoint stacked params mapping
+        # NOTE: use trailing dots to avoid substring collisions
+        # (e.g. ".w1." must NOT match ".w13.")
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             # self-attn
@@ -975,27 +978,53 @@ class ZImageTransformer2DModel(CachedTransformer):
             (".to_qkv.", ".to_k.", "k"),
             (".to_qkv.", ".to_v.", "v"),
             # ffn
-            (".w13", ".w1", 0),
-            (".w13", ".w3", 1),
+            (".w13.", ".w1.", 0),
+            (".w13.", ".w3.", 1),
         ]
         # Expose packed shard mappings for LoRA handling of fused projections.
         self.stacked_params_mapping = stacked_params_mapping
+
+        # Nunchaku (diffusers-style) checkpoint key remapping:
+        #   net.0.proj.* -> w13.*  (merged gate+up projection)
+        #   net.2.*      -> w2.*   (down projection)
+        nunchaku_path_rewrites = {
+            ".net.0.proj.": ".w13.",
+            ".net.2.": ".w2.",
+        }
 
         params_dict = dict(self.named_parameters())
 
         loaded_params = set[str]()
         for name, loaded_weight in weights:
+            # Apply Nunchaku key remapping if applicable
+            for old_path, new_path in nunchaku_path_rewrites.items():
+                if old_path in name:
+                    name = name.replace(old_path, new_path)
+                    break
+
+            # Try stacked params mapping (for standard checkpoints with
+            # separate to_q/to_k/to_v and w1/w3 weights).
+            # Quantized checkpoints (e.g. Nunchaku) may already have merged
+            # weights (to_qkv, w13) so these mappings won't match — the
+            # weight falls through to direct loading below.
+            matched = False
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
+                if name in params_dict:
+                    param = params_dict[name]
+                    weight_loader = param.weight_loader
+                    weight_loader(param, loaded_weight, shard_id)
+                    loaded_params.add(name)
+                matched = True
                 break
-            else:
-                param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight)
-            loaded_params.add(name)
+
+            if not matched:
+                if name in params_dict:
+                    param = params_dict[name]
+                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    weight_loader(param, loaded_weight)
+                    loaded_params.add(name)
+
         return loaded_params

--- a/vllm_omni/diffusion/quantization/__init__.py
+++ b/vllm_omni/diffusion/quantization/__init__.py
@@ -29,6 +29,7 @@ from vllm.logger import init_logger
 from .base import DiffusionQuantizationConfig
 from .fp8 import DiffusionFp8Config
 from .gguf import DiffusionGgufConfig
+from .nunchaku import DiffusionNunchakuConfig
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.base_config import (
@@ -42,6 +43,7 @@ logger = init_logger(__name__)
 _QUANT_CONFIG_REGISTRY: dict[str, type[DiffusionQuantizationConfig]] = {
     "fp8": DiffusionFp8Config,
     "gguf": DiffusionGgufConfig,
+    "nunchaku": DiffusionNunchakuConfig,
 }
 
 SUPPORTED_QUANTIZATION_METHODS = list(_QUANT_CONFIG_REGISTRY.keys())
@@ -111,6 +113,7 @@ __all__ = [
     "DiffusionQuantizationConfig",
     "DiffusionFp8Config",
     "DiffusionGgufConfig",
+    "DiffusionNunchakuConfig",
     "get_diffusion_quant_config",
     "get_vllm_quant_config_for_layers",
     "SUPPORTED_QUANTIZATION_METHODS",

--- a/vllm_omni/diffusion/quantization/base.py
+++ b/vllm_omni/diffusion/quantization/base.py
@@ -49,6 +49,29 @@ class DiffusionQuantizationConfig(ABC):
         """Return supported activation dtypes."""
         return [torch.bfloat16, torch.float16]
 
+    def transform_weight(
+        self, name: str, loaded_weight: "torch.Tensor", model_class_name: str = ""
+    ) -> list[tuple[str, "torch.Tensor"]]:
+        """Transform a checkpoint weight entry before it reaches load_weights.
+
+        Override this in subclasses to remap checkpoint key names and/or
+        manipulate tensors (e.g. split, swap shards) so the model's
+        load_weights sees the canonical naming convention.
+
+        Args:
+            name: Original weight name from checkpoint.
+            loaded_weight: The weight tensor.
+            model_class_name: The model class name (e.g. "ZImageTransformer2DModel"),
+                used by quantization methods that need per-model key mapping.
+
+        Returns:
+            A list of (new_name, tensor) pairs.  Most implementations return
+            a single pair; returning multiple pairs is useful when a single
+            checkpoint tensor must be split into several model parameters.
+            Returning an empty list drops the weight silently.
+        """
+        return [(name, loaded_weight)]
+
     @classmethod
     def get_min_capability(cls) -> int:
         """Minimum GPU compute capability required.

--- a/vllm_omni/diffusion/quantization/nunchaku.py
+++ b/vllm_omni/diffusion/quantization/nunchaku.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Nunchaku SVDQuant quantization config for diffusion transformers.
+
+Nunchaku checkpoints use diffusers-style FeedForward naming (net.0.proj / net.2)
+while vLLM-Omni models may use different conventions (e.g. w13 / w2 for Z-Image).
+Additionally, the SwiGLU activation order differs between diffusers and vLLM:
+diffusers computes ``x[:d] * silu(x[d:])`` while vLLM's SiluAndMul computes
+``silu(x[:d]) * x[d:]``, requiring a shard swap during weight loading.
+
+This config maintains per-model key mapping tables so that model code stays clean.
+"""
+
+import torch
+
+from .base import DiffusionQuantizationConfig
+
+# Per-model weight key mapping tables.
+# Each entry: "source_key_fragment": ("target_key_fragment", swap_swiglu)
+#   - swap_swiglu=True: swap the two halves of the merged gate+up weight
+#     to account for SwiGLU activation order difference.
+_MODEL_KEY_MAPPING: dict[str, dict[str, tuple[str, bool]]] = {
+    "ZImageTransformer2DModel": {
+        ".net.0.proj.": (".w13.", True),
+        ".net.2.": (".w2.", False),
+    },
+    # Pipeline wrapper delegates to the transformer above, but the loader
+    # sees the pipeline class name. Use the same mapping.
+    "ZImagePipeline": {
+        ".net.0.proj.": (".w13.", True),
+        ".net.2.": (".w2.", False),
+    },
+    # Models whose internal naming already matches Nunchaku/diffusers style
+    # (e.g. Flux uses net[0]/net[2]) need no mapping — just omit them here.
+    #
+    # To add a new model, add an entry mapping Nunchaku's diffusers-style keys
+    # to the model's internal parameter names.
+}
+
+
+class DiffusionNunchakuConfig(DiffusionQuantizationConfig):
+    """Nunchaku SVDQuant W4A4 quantization config.
+
+    Uses Nunchaku's custom CUDA kernels for W4A4 GEMM with low-rank
+    correction.  The underlying ``NunchakuConfig`` (a vLLM
+    ``QuantizationConfig``) is passed to linear layers so they create
+    the required quantized parameters (qweight, wscales, proj_down,
+    proj_up, smooth_factor, etc.).
+
+    Args:
+        rank: Low-rank approximation dimension for SVDQuant.
+        precision: Quantization precision ("int4" or "nvfp4").
+        act_unsigned: Whether to use unsigned activation quantization.
+    """
+
+    def __init__(
+        self,
+        rank: int = 32,
+        precision: str = "int4",
+        act_unsigned: bool = False,
+    ):
+        from vllm_omni.diffusion.layers.quantization.svdq_nunchaku import (
+            NunchakuConfig,
+        )
+
+        self.rank = rank
+        self.precision = precision
+        self.act_unsigned = act_unsigned
+
+        # NunchakuConfig implements vLLM's QuantizationConfig interface,
+        # providing NunchakuLinearMethod that creates quantized parameters
+        # (qweight, wscales, proj_down, proj_up, smooth_factor, etc.)
+        # and runs the SVDQuant CUDA kernels in forward().
+        self._vllm_config = NunchakuConfig(
+            rank=rank,
+            precision=precision,
+            act_unsigned=act_unsigned,
+        )
+
+    def get_name(self) -> str:
+        return "nunchaku"
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 80  # Ampere or newer
+
+    def transform_weight(
+        self, name: str, loaded_weight: torch.Tensor, model_class_name: str = ""
+    ) -> list[tuple[str, torch.Tensor]]:
+        """Remap Nunchaku (diffusers-style) checkpoint keys to model conventions.
+
+        Uses the per-model mapping table in ``_MODEL_KEY_MAPPING``.  Models not
+        listed in the table are assumed to already use diffusers-compatible
+        naming and are passed through unchanged.
+        """
+        mapping = _MODEL_KEY_MAPPING.get(model_class_name, {})
+        for src, (dst, swap) in mapping.items():
+            if src in name:
+                new_name = name.replace(src, dst)
+                if swap:
+                    # Swap halves to fix SwiGLU activation order.
+                    # Diffusers: [gate, up], vLLM SiluAndMul expects: [up, gate]
+                    mid = loaded_weight.shape[0] // 2
+                    loaded_weight = torch.cat([loaded_weight[mid:], loaded_weight[:mid]], dim=0)
+                return [(new_name, loaded_weight)]
+        return [(name, loaded_weight)]


### PR DESCRIPTION
## Summary
- Integrate [Nunchaku](https://github.com/nunchaku-ai/nunchaku) as a quantization backend for diffusion transformers, enabling W4A4 inference with SVD low-rank correction.
- Verified on Z-Image-Turbo: **~2.2x speedup** over BF16 on RTX 5090 with comparable image quality.

## Motivation
SVDQuant (W4A4) provides significant inference speedup and reduced memory footprint for DiT models. Nunchaku's PTX-optimized kernels are community-proven (FLUX, Qwen-Image) and lightweight enough to integrate as an optional backend.

The main blocker during integration was **weight key mapping**: Nunchaku checkpoints use diffusers-style naming while vLLM models use different conventions, and the naming is not standardized across models (Z-Image: `w13`/`w2`, Flux: `linear_in`/`linear_out`, QwenImage: no remap needed). This mapping must currently be hardcoded per-model in `load_weights`, which is the primary effort when adding new model support.

Additionally, Nunchaku's weight format is highly optimized (tiled/interleaved MMA layout via PTX assembly), so the glue code (weight packing, activation swap, shape calculations) is tightly coupled to Nunchaku's internal layout. This means weight-level manipulation (e.g. row-swapping for SwiGLU convention) is not possible — we handle this via runtime output swap instead.

## Changes
- **NunchakuConfig / NunchakuLinearMethod** (`svdq_nunchaku.py`): vLLM quantization plugin with W4A4 GEMM + SVD low-rank correction. Quantizes QKV, MergedColumnParallel, and RowParallel layers; leaves ReplicatedLinear (adaLN, embedders) unquantized.
- **Gated-activation output swap**: Nunchaku checkpoints (from diffusers) store merged gate+up weights in diffusers order `[linear ; activation]`, while vLLM's SiluAndMul expects `[activation ; linear]`. Applied automatically at runtime in `NunchakuLinearMethod.apply()` for all `MergedColumnParallelLinear` layers.
- **DiffusionNunchakuConfig** (`nunchaku.py`): Per-model weight key mapping table for translating diffusers-style naming to vLLM conventions.
- **Z-Image support**: key remapping (`net.0.proj` → `w13`, `net.2` → `w2`) in `load_weights`, fixed `stacked_params_mapping` substring collision (`.w1` falsely matching `.w13`).
- **Example script** `text_to_image_quant.py`.

## Quantized Model
- HuggingFace: https://huggingface.co/ultranationalism/nunchaku-z-image-turbo
- ModelScope: https://www.modelscope.cn/models/ultranationalism/nunchaku-z-image-turbo

## Quality Comparison (RTX 5090, seed=42, Z-Image-Turbo 1024x1024)

| BF16 (13.4s) | Nunchaku W4A4 nvfp4 (6.0s, 2.2x faster) |
|---|---|
| <img width="400" alt="bf16" src="https://github.com/user-attachments/assets/3a04d63e-3a6d-42d8-a5d0-b8328a904501" /> | <img width="400" alt="quant" src="https://github.com/user-attachments/assets/1778d30a-e46b-461c-bdd4-95acd7516e5a" /> |

## Follow-up Plans
- **Auto-infer rank/precision** from safetensors file metadata (currently must be specified manually via `--rank` / `--precision`). Nunchaku checkpoints embed `quantization_config` (including `rank`, `group_size`, `method`) and `model_class` in safetensors metadata — the same mechanism Nunchaku's own `from_pretrained` uses. This would eliminate the need for users to specify these parameters manually.
- **Auto key mapping**: derive weight name mapping from Nunchaku model metadata on meta device, eliminating per-model hardcoding
- **CI/CD tests**: unit tests for weight loading, key remapping, and E2E inference

## Test Plan
- [x] E2E quantized Z-Image-Turbo inference (RTX 5090, RTX 5060 Ti)
- [x] BF16 vs quantized visual quality comparison (same seed, same GPU)
- [x] CPU offload compatibility verified

Closes #507
