### PR TITLE
[Bugfix]Fix bug of online server can not return mutli images

### DIFF
--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -1906,6 +1906,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         choices: list[ChatCompletionResponseChoice] = []
         final_res = omni_outputs.request_output
 
+        # Handle profiling data
+        stage_durations = omni_outputs.stage_durations
+
         # Handle different image output formats
         images = []
 
@@ -1959,6 +1962,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     "image_url": {
                         "url": f"data:image/png;base64,{img_base64}",
                     },
+                    "stage_durations": stage_durations,
                 }
             )
 
@@ -2168,7 +2172,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             # Extract images from result
             # Handle nested OmniRequestOutput structure where images might be in request_output
             images = getattr(result.request_output, "images", [])
-            stage_durations = result.stage_durations
             stage_durations = result.stage_durations
 
             # Convert images to base64 content


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
When i use vllm-omni to infer Qwen-Image-Layered, i found this model return mutli pictures but vllm-omni report an error.
## Test Plan
Start a Qwen-Image-Layered online service to conduct reasoning tests.
### Our start command
vllm serve ./Qwen-Image-Layered \
  --omni \
  --port 8091 \
  --log-stats \
  --vae-use-slicing \
  --vae-use-tiling 
### curl command
#!/bin/bash

INPUT_IMG="./rabbit.png"
CURRENT_TIME=$(date +%Y%m%d%H%M%S)
OUTPUT="${3:-image_edit_${CURRENT_TIME}.png}"
#OUTPUT="./output.png"
REQUEST_JSON_FILE="./test.json"
IMAGE_BASE64=$(base64 -w0 "$INPUT_IMG")

base64 -w0 "$INPUT_IMG" \
  | jq -Rs '{
    messages: [{
      role: "user",
      content: [
        {"type": "image_url", "image_url": {"url": ("data:image/png;base64," + .)}}
      ]
    }],
    extra_body: {
        num_inference_steps: 50,
        cfg_scale: 4.0,
        output: "layered",
        layers: 4,
        color_format: "RGBA"
    }
  }' > "$REQUEST_JSON_FILE"


curl -s "http://localhost:8091/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -d @"$REQUEST_JSON_FILE" | \
jq -r '.choices[0].message.content[] | .image_url.url | split(",")[1]' | \
while IFS= read -r base64_data; do
    ((i++))
    echo "$base64_data" | base64 -d > "${OUTPUT_PREFIX}_${i}.png"
    echo "Saved ${OUTPUT_PREFIX}_${i}.png"
done

## Test result
output 4 pics
<img width="107" height="62" alt="image" src="https://github.com/user-attachments/assets/246fbf7b-8e4e-44b0-a324-018383dae92e" />

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
