### PR TITLE
[Frontend] Add Prometheus request, abort, and stage metrics

### DIFF
--- a/docs/contributing/metrics.md
+++ b/docs/contributing/metrics.md
@@ -7,20 +7,24 @@ You can use these metrics in production to monitor the health and performance of
 
 - **Debugging and Troubleshooting**: Use detailed per-request metrics to diagnose issues, such as high transfer times or unexpected token counts.
 
-## How to Enable and View Metrics
+## Two Ways to Observe vLLM-Omni
 
-### Start the Service with Metrics Logging
+`--log-stats` and `--enable-metrics` serve different purposes:
+
+- `--log-stats` prints request-level summary tables to the server logs.
+- `--enable-metrics` exports vLLM-Omni Prometheus metrics under the shared `/metrics` endpoint.
+
+Use `--log-stats` when you want to inspect individual requests. Use `--enable-metrics` when you want long-running monitoring and dashboards. You can also enable both at the same time.
+
+### Example Commands
+
+Enable request-level log summaries only:
 
 ```bash
 vllm serve /workspace/models/Qwen3-Omni-30B-A3B-Instruct --omni --port 8014 --log-stats
 ```
 
-`--log-stats` and `--enable-metrics` serve different purposes:
-
-- `--log-stats` prints the request-level summary tables shown below to the server logs.
-- `--enable-metrics` exports vLLM-Omni Prometheus metrics under the shared `/metrics` endpoint.
-
-If you want both the log tables and the Prometheus endpoint, start the server with both flags:
+Enable both request-level log summaries and the Prometheus endpoint:
 
 ```bash
 vllm serve /workspace/models/Qwen3-Omni-30B-A3B-Instruct \
@@ -30,16 +34,19 @@ vllm serve /workspace/models/Qwen3-Omni-30B-A3B-Instruct \
   --enable-metrics
 ```
 
+If you only want the Prometheus endpoint, start the server with `--enable-metrics` and omit `--log-stats`.
+
+## Request-Level Log Stats (`--log-stats`)
+
 ### Send a Request
 
 ```bash
 python openai_chat_completion_client_for_multimodal_generation.py --query-type use_image
 ```
 
-### What You Will See
+### Example Output
 
 With `--log-stats` enabled, the server will output detailed metrics logs after each request. Example output:
-
 
 #### Overall Summary
 
@@ -84,21 +91,97 @@ With `--log-stats` enabled, the server will output detailed metrics logs after e
 | rx_decode_time_ms   | 111.865     | 31.706     |
 | in_flight_time_ms   | 2.015       | 2.819      |
 
+### How to Read the Tables
 
 These logs include:
 
 - **Overall summary**: total requests, wall time, average tokens/sec, etc.
-
 - **E2E table**: per-request latency and token counts.
-
 - **Stage table**: per-stage batch and timing details.
-
 - **Transfer table**: data transfer and timing for each edge.
 
 You can use these logs to monitor system health, debug performance, and analyze request-level metrics as described above.
 
+### Metrics Scope: Offline vs Online Inference
 
-## Prometheus Metrics
+For **offline inference** (batch mode), the summary includes both system-level metrics (aggregated across all requests) and per-request metrics. In this case, `e2e_requests` can be greater than 1, reflecting multiple completed requests in a batch.
+
+For **online inference** (serving mode), the summary is always per-request. `e2e_requests` is always 1, and only request-level metrics are reported for each completion.
+
+### Field Reference
+
+#### Overall Summary
+
+| Field                     | Meaning                                                                                       |
+|---------------------------|-----------------------------------------------------------------------------------------------|
+| `e2e_requests`            | Number of completed requests.                                                                 |
+| `e2e_wall_time_ms`        | Wall-clock time span from run start to last completion, in ms.                                |
+| `e2e_total_tokens`        | Total tokens counted across all completed requests (stage0 input + all stage outputs).        |
+| `e2e_avg_time_per_request_ms` | Average wall time per request: `e2e_wall_time_ms / e2e_requests`.                        |
+| `e2e_avg_tokens_per_s`    | Average token throughput over wall time: `e2e_total_tokens * 1000 / e2e_wall_time_ms`.       |
+| `e2e_stage_{i}_wall_time_ms` | Wall-clock time span for stage `i`, in ms. Each stage's wall time is reported as a separate field, such as `e2e_stage_0_wall_time_ms` or `e2e_stage_1_wall_time_ms`. |
+
+#### RequestE2EStats
+
+| Field                     | Meaning                                                          |
+|---------------------------|------------------------------------------------------------------|
+| `e2e_total_ms`            | End-to-end latency in ms.                                        |
+| `e2e_total_tokens`        | Total tokens for the request (stage0 input + all stage outputs). |
+| `transfers_total_time_ms` | Sum of transfer edge `total_time_ms` for this request.           |
+| `transfers_total_kbytes`  | Sum of transfer kbytes for this request.                         |
+
+#### StageRequestStats
+
+| Field                 | Meaning                                                                                                   |
+|-----------------------|-----------------------------------------------------------------------------------------------------------|
+| `batch_id`            | Batch index.                                                                                              |
+| `batch_size`          | Batch size.                                                                                               |
+| `num_tokens_in`       | Input tokens to the stage.                                                                                |
+| `num_tokens_out`      | Output tokens from the stage.                                                                             |
+| `stage_gen_time_ms`   | Stage compute time in ms, excluding post-processing time (reported separately as `postprocess_time_ms`). |
+| `image_num`           | Number of images generated (for diffusion/image stages).                                                  |
+| `resolution`          | Image resolution (for diffusion/image stages).                                                            |
+| `postprocess_time_ms` | Diffusion/image: post-processing time in ms.                                                              |
+
+#### TransferEdgeStats
+
+| Field                | Meaning                                                                   |
+|----------------------|---------------------------------------------------------------------------|
+| `size_kbytes`        | Total kbytes transferred.                                                 |
+| `tx_time_ms`         | Sender transfer time in ms.                                               |
+| `rx_decode_time_ms`  | Receiver decode time in ms.                                               |
+| `in_flight_time_ms`  | In-flight time in ms.                                                     |
+
+### Sanity Checks
+
+**Formulas:**
+
+- `e2e_total_tokens = Stage0's num_tokens_in + sum(all stages' num_tokens_out)`
+
+- `transfers_total_time_ms = sum(tx_time_ms + rx_decode_time_ms + in_flight_time_ms)` for every edge
+
+**Using the example above:**
+
+**e2e_total_tokens**
+
+- Stage0's `num_tokens_in`: **4,860**
+- Stage0's `num_tokens_out`: **67**
+- Stage1's `num_tokens_out`: **275**
+- Stage2's `num_tokens_out`: **0**
+
+so `e2e_total_tokens = 4,860 + 67 + 275 + 0 = 5,202`, which matches the table value `e2e_total_tokens`.
+
+**transfers_total_time_ms**
+
+For each edge:
+
+- 0->1: tx_time_ms (**78.701**) + rx_decode_time_ms (**111.865**) + in_flight_time_ms (**2.015**) = **192.581**
+
+- 1->2: tx_time_ms (**18.790**) + rx_decode_time_ms (**31.706**) + in_flight_time_ms (**2.819**) = **53.315**
+
+192.581 + 53.315 = **245.896** = transfers_total_time_ms, which matches the calculation (difference is due to rounding)
+
+## Prometheus Metrics (`--enable-metrics`)
 
 When `--enable-metrics` is set, vLLM-Omni registers its metrics into the shared Prometheus endpoint exposed by the serving process. If the server is started with `--port 8091`, you can inspect it with:
 
@@ -163,93 +246,3 @@ The current vLLM-Omni Prometheus metrics are:
 
 !!! note
     Some metric families may appear without samples until the corresponding event happens. For example, `vllm:omni_stage_postprocess_seconds` is only populated after a stage records post-processing time, and `vllm:omni_transfer_bytes_total` only increases after inter-stage transfer traffic is observed.
-
-
-## Metrics Scope: Offline vs Online Inference
-
-For **offline inference** (batch mode), the summary includes both system-level metrics (aggregated across all requests) and per-request metrics. In this case, `e2e_requests` can be greater than 1, reflecting multiple completed requests in a batch.
-
-For **online inference** (serving mode), the summary is always per-request. `e2e_requests` is always 1, and only request-level metrics are reported for each completion.
-
----
-
-## Parameter Details
-
-### Summary Metrics
-
-| Field                     | Meaning                                                                                       |
-|---------------------------|----------------------------------------------------------------------------------------------|
-| `e2e_requests`            | Number of completed requests.                                                                |
-| `e2e_wall_time_ms`        | Wall-clock time span from run start to last completion, in ms.                               |
-| `e2e_total_tokens`        | Total tokens counted across all completed requests (stage0 input + all stage outputs).       |
-| `e2e_avg_time_per_request_ms` | Average wall time per request: `e2e_wall_time_ms / e2e_requests`.                        |
-| `e2e_avg_tokens_per_s`    | Average token throughput over wall time: `e2e_total_tokens * 1000 / e2e_wall_time_ms`.      |
-| `e2e_stage_{i}_wall_time_ms` | Wall-clock time span for stage i, in ms. Each stage's wall time is reported as a separate field, e.g., `e2e_stage_0_wall_time_ms`, `e2e_stage_1_wall_time_ms`, etc. |
-
----
-
-### E2E Table (per request)
-
-| Field                     | Meaning                                                               |
-|---------------------------|-----------------------------------------------------------------------|
-| `e2e_total_ms`            | End-to-end latency in ms.                                             |
-| `e2e_total_tokens`        | Total tokens for the request (stage0 input + all stage outputs).      |
-| `transfers_total_time_ms` | Sum of transfer edge `total_time_ms` for this request.                |
-| `transfers_total_kbytes`  | Sum of transfer kbytes for this request.                              |
-
-
----
-
-### Stage Table (per stage event / request)
-
-| Field                     | Meaning                                                                                         |
-|---------------------------|-------------------------------------------------------------------------------------------------|
-| `batch_id`                | Batch index.                                                                                    |
-| `batch_size`              | Batch size.                                                                                     |
-| `num_tokens_in`           | Input tokens to the stage.                                                                      |
-| `num_tokens_out`          | Output tokens from the stage.                                                                   |
-| `stage_gen_time_ms`       | Stage compute time in ms, excluding postprocessing time (reported separately as `postprocess_time_ms`). |
-| `image_num`               | Number of images generated (for diffusion/image stages).                                        |
-| `resolution`              | Image resolution (for diffusion/image stages).                                                                  |
-| `postprocess_time_ms` | Diffusion/image: post-processing time in ms.                                                    |
-
----
-
-### Transfer Table (per edge / request)
-
-| Field                | Meaning                                                                   |
-|----------------------|---------------------------------------------------------------------------|
-| `size_kbytes`        | Total kbytes transferred.                                                 |
-| `tx_time_ms`         | Sender transfer time in ms.                                               |
-| `rx_decode_time_ms`  | Receiver decode time in ms.                                               |
-| `in_flight_time_ms`  | In-flight time in ms.                                                     |
-
-
-### Expectation of the Numbers (Verification)
-
-**Formulas:**
-
-- `e2e_total_tokens = Stage0's num_tokens_in + sum(all stages' num_tokens_out)`
-
-- `transfers_total_time_ms = sum(tx_time_ms + rx_decode_time_ms + in_flight_time_ms)` for every edge
-
-**Using the example above:**
-
-**e2e_total_tokens**
-
-- Stage0's `num_tokens_in`: **4,860**
-- Stage0's `num_tokens_out`: **67**
-- Stage1's `num_tokens_out`: **275**
-- Stage2's `num_tokens_out`: **0**
-
-so `e2e_total_tokens = 4,860 + 67 + 275 + 0 = 5,202`, which matches the table value `e2e_total_tokens`.
-
-**transfers_total_time_ms**
-
-For each edge:
-
-- 0->1: tx_time_ms (**78.701**) + rx_decode_time_ms (**111.865**) + in_flight_time_ms (**2.015**) = **192.581**
-
-- 1->2: tx_time_ms (**18.790**) + rx_decode_time_ms (**31.706**) + in_flight_time_ms (**2.819**) = **53.315**
-
-192.581 + 53.315 = **245.896** = transfers_total_time_ms, which matches the calculation (difference is due to rounding)

--- a/docs/contributing/metrics.md
+++ b/docs/contributing/metrics.md
@@ -15,6 +15,21 @@ You can use these metrics in production to monitor the health and performance of
 vllm serve /workspace/models/Qwen3-Omni-30B-A3B-Instruct --omni --port 8014 --log-stats
 ```
 
+`--log-stats` and `--enable-metrics` serve different purposes:
+
+- `--log-stats` prints the request-level summary tables shown below to the server logs.
+- `--enable-metrics` exports vLLM-Omni Prometheus metrics under the shared `/metrics` endpoint.
+
+If you want both the log tables and the Prometheus endpoint, start the server with both flags:
+
+```bash
+vllm serve /workspace/models/Qwen3-Omni-30B-A3B-Instruct \
+  --omni \
+  --port 8091 \
+  --log-stats \
+  --enable-metrics
+```
+
 ### Send a Request
 
 ```bash
@@ -81,6 +96,73 @@ These logs include:
 - **Transfer table**: data transfer and timing for each edge.
 
 You can use these logs to monitor system health, debug performance, and analyze request-level metrics as described above.
+
+
+## Prometheus Metrics
+
+When `--enable-metrics` is set, vLLM-Omni registers its metrics into the shared Prometheus endpoint exposed by the serving process. If the server is started with `--port 8091`, you can inspect it with:
+
+```bash
+curl http://0.0.0.0:8091/metrics
+```
+
+The response contains:
+
+- Default Python/runtime metrics such as `python_gc_*` and `process_*`.
+- HTTP server metrics such as `http_requests_total` and `http_request_duration_seconds`.
+- vLLM-Omni metrics prefixed with `vllm:omni_`.
+
+### Example `/metrics` Output
+
+The full endpoint can be long. A typical response looks like this:
+
+```text
+# HELP http_requests_total Total number of requests by method, status and handler.
+# TYPE http_requests_total counter
+http_requests_total{handler="/v1/chat/completions",method="POST",status="2xx"} 6.0
+http_requests_total{handler="/v1/chat/completions",method="POST",status="4xx"} 1.0
+http_requests_total{handler="/v1/images/generations",method="POST",status="5xx"} 1.0
+
+# HELP vllm:omni_stage_generation_seconds Generation time for completed vLLM-Omni stage events.
+# TYPE vllm:omni_stage_generation_seconds histogram
+vllm:omni_stage_generation_seconds_bucket{final_output_type="text",le="0.5",model_name="Qwen3-Omni-30B-A3B-Instruct",stage_id="0"} 3.0
+vllm:omni_stage_generation_seconds_bucket{final_output_type="text",le="1.0",model_name="Qwen3-Omni-30B-A3B-Instruct",stage_id="0"} 4.0
+vllm:omni_stage_generation_seconds_count{final_output_type="text",model_name="Qwen3-Omni-30B-A3B-Instruct",stage_id="0"} 6.0
+vllm:omni_stage_generation_seconds_sum{final_output_type="text",model_name="Qwen3-Omni-30B-A3B-Instruct",stage_id="0"} 11.19272518157959
+
+# HELP vllm:omni_requests_total Total number of vLLM-Omni orchestrator requests.
+# TYPE vllm:omni_requests_total counter
+vllm:omni_requests_total{final_output_type="text",model_name="Qwen3-Omni-30B-A3B-Instruct"} 1.0
+vllm:omni_requests_total{final_output_type="audio",model_name="Qwen3-Omni-30B-A3B-Instruct"} 3.0
+vllm:omni_requests_total{final_output_type="image",model_name="Qwen3-Omni-30B-A3B-Instruct"} 2.0
+
+# HELP vllm:omni_requests_aborted_total Total number of aborted vLLM-Omni orchestrator requests.
+# TYPE vllm:omni_requests_aborted_total counter
+vllm:omni_requests_aborted_total{final_output_type="text",model_name="Qwen3-Omni-30B-A3B-Instruct"} 2.0
+
+# HELP vllm:omni_e2e_request_latency_seconds End-to-end latency of successful vLLM-Omni requests.
+# TYPE vllm:omni_e2e_request_latency_seconds histogram
+vllm:omni_e2e_request_latency_seconds_bucket{final_output_type="audio",le="10.0",model_name="Qwen3-Omni-30B-A3B-Instruct"} 1.0
+vllm:omni_e2e_request_latency_seconds_bucket{final_output_type="audio",le="20.0",model_name="Qwen3-Omni-30B-A3B-Instruct"} 2.0
+vllm:omni_e2e_request_latency_seconds_count{final_output_type="audio",model_name="Qwen3-Omni-30B-A3B-Instruct"} 3.0
+vllm:omni_e2e_request_latency_seconds_sum{final_output_type="audio",model_name="Qwen3-Omni-30B-A3B-Instruct"} 72.84698152542114
+```
+
+### vLLM-Omni Metrics Exposed
+
+The current vLLM-Omni Prometheus metrics are:
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `vllm:omni_stage_generation_seconds` | Histogram | `model_name`, `stage_id`, `final_output_type` | Generation latency for completed stage events. |
+| `vllm:omni_stage_postprocess_seconds` | Histogram | `model_name`, `stage_id`, `final_output_type` | Post-processing latency for completed stage events. |
+| `vllm:omni_transfer_bytes_total` | Counter | `model_name`, `from_stage`, `to_stage`, `used_shm` | Total bytes transferred between stages. |
+| `vllm:omni_requests_total` | Counter | `model_name`, `final_output_type` | Total number of orchestrator requests started. |
+| `vllm:omni_requests_aborted_total` | Counter | `model_name`, `final_output_type` | Total number of aborted orchestrator requests. |
+| `vllm:omni_e2e_request_latency_seconds` | Histogram | `model_name`, `final_output_type` | End-to-end latency for successful requests. |
+
+!!! note
+    Some metric families may appear without samples until the corresponding event happens. For example, `vllm:omni_stage_postprocess_seconds` is only populated after a stage records post-processing time, and `vllm:omni_transfer_bytes_total` only increases after inter-stage transfer traffic is observed.
 
 
 ## Metrics Scope: Offline vs Online Inference

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -354,8 +354,6 @@ class AsyncOmni(EngineClient, OmniBase):
         except (asyncio.CancelledError, GeneratorExit):
             if input_stream_task is not None and not input_stream_task.done():
                 input_stream_task.cancel()
-            if req_state is not None and req_state.metrics is not None:
-                req_state.metrics.on_request_aborted(request_id)
             await self.abort(request_id)
             logger.info(f"[AsyncOmni] Request {request_id} aborted.")
             raise

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -33,8 +33,8 @@ from vllm_omni.entrypoints.omni_base import (
 )
 from vllm_omni.metrics.stats import OrchestratorAggregator as OrchestratorMetrics
 from vllm_omni.metrics import (
+    get_omni_prometheus_metrics,
     infer_request_output_type,
-    omni_prometheus_metrics,
 )
 from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.platforms import current_omni_platform
@@ -296,7 +296,7 @@ class AsyncOmni(EngineClient, OmniBase):
                 log_stats=self.log_stats,
                 wall_start_ts=wall_start_ts,
                 final_stage_id_for_e2e=final_stage_id_for_e2e,
-                prometheus_metrics=omni_prometheus_metrics if self.enable_metrics else None,
+                prometheus_metrics=get_omni_prometheus_metrics() if self.enable_metrics else None,
                 model_name=self.model_name if self.enable_metrics else None,
             )
             req_state = ClientRequestState(request_id)

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -32,6 +32,10 @@ from vllm_omni.entrypoints.omni_base import (
     OmniEngineDeadError,
 )
 from vllm_omni.metrics.stats import OrchestratorAggregator as OrchestratorMetrics
+from vllm_omni.metrics import (
+    infer_request_output_type,
+    omni_prometheus_metrics,
+)
 from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.platforms import current_omni_platform
 
@@ -267,6 +271,7 @@ class AsyncOmni(EngineClient, OmniBase):
         logger.debug(f"[AsyncOmni] generate() called for request {request_id}")
 
         input_stream_task: asyncio.Task | None = None
+        req_state: ClientRequestState | None = None
         try:
             # Start final output dispatcher on the first call to generate()
             self._final_output_handler()
@@ -283,15 +288,16 @@ class AsyncOmni(EngineClient, OmniBase):
             # Track per-request metrics
             wall_start_ts = time.time()
             req_start_ts: dict[str, float] = {}
-
             # Determine the final stage for E2E stats
             final_stage_id_for_e2e = self._compute_final_stage_id(output_modalities)
 
             metrics = OrchestratorMetrics(
-                self.num_stages,
-                self.log_stats,
-                wall_start_ts,
-                final_stage_id_for_e2e,
+                num_stages=self.num_stages,
+                log_stats=self.log_stats,
+                wall_start_ts=wall_start_ts,
+                final_stage_id_for_e2e=final_stage_id_for_e2e,
+                prometheus_metrics=omni_prometheus_metrics if self.enable_metrics else None,
+                model_name=self.model_name if self.enable_metrics else None,
             )
             req_state = ClientRequestState(request_id)
             req_state.metrics = metrics
@@ -321,6 +327,11 @@ class AsyncOmni(EngineClient, OmniBase):
                     final_stage_id=final_stage_id_for_e2e,
                 )
             submit_ts = time.time()
+            metrics.on_request_started(
+                req_id=request_id,
+                req_start_ts=submit_ts,
+                final_output_type=infer_request_output_type(output_modalities),
+            )
             req_state.metrics.stage_first_ts[0] = submit_ts
             req_start_ts[request_id] = submit_ts
 
@@ -338,12 +349,13 @@ class AsyncOmni(EngineClient, OmniBase):
                 yield output
 
             logger.debug(f"[AsyncOmni] Request {request_id} completed")
-
             self._log_summary_and_cleanup(request_id)
 
         except (asyncio.CancelledError, GeneratorExit):
             if input_stream_task is not None and not input_stream_task.done():
                 input_stream_task.cancel()
+            if req_state is not None and req_state.metrics is not None:
+                req_state.metrics.on_request_aborted(request_id)
             await self.abort(request_id)
             logger.info(f"[AsyncOmni] Request {request_id} aborted.")
             raise
@@ -580,7 +592,6 @@ class AsyncOmni(EngineClient, OmniBase):
                         continue
 
                     req_state.stage_id = stage_id
-
                     # Route to the per-request queue
                     await req_state.queue.put(msg)
 
@@ -673,6 +684,9 @@ class AsyncOmni(EngineClient, OmniBase):
         request_ids = [request_id] if isinstance(request_id, str) else list(request_id)
         await self.engine.abort_async(request_ids)
         for req_id in request_ids:
+            req_state = self.request_states.get(req_id)
+            if req_state is not None and req_state.metrics is not None:
+                req_state.metrics.on_request_aborted(req_id)
             self.request_states.pop(req_id, None)
         if self.log_stats:
             logger.info("[AsyncOmni] Aborted request(s) %s", ",".join(request_ids))

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -99,6 +99,11 @@ class OmniServeCommand(CLISubcommand):
         # stage-config factory can give YAML precedence over argparse defaults.
         args._cli_explicit_keys = detect_explicit_cli_keys(sys.argv[1:], OmniServeCommand._parser)
 
+        if args.enable_metrics:
+            logger.info("vLLM-Omni Prometheus metrics enabled")
+        else:
+            logger.info("vLLM-Omni Prometheus metrics disabled")
+
         if args.headless:
             run_headless(args)
         else:
@@ -214,6 +219,11 @@ class OmniServeCommand(CLISubcommand):
             "--log-stats",
             action="store_true",
             help="Enable logging the stats.",
+        )
+        omni_config_group.add_argument(
+            "--enable-metrics",
+            action="store_true",
+            help="Enable vLLM-Omni Prometheus request metrics in the shared /metrics endpoint.",
         )
         omni_config_group.add_argument(
             "--log-file",

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -16,8 +16,8 @@ from vllm_omni.metrics import (
     OrchestratorAggregator as OrchestratorMetrics,
 )
 from vllm_omni.metrics import (
+    get_omni_prometheus_metrics,
     infer_request_output_type,
-    omni_prometheus_metrics,
 )
 from vllm_omni.outputs import OmniRequestOutput
 
@@ -133,7 +133,7 @@ class Omni(OmniBase):
                     log_stats=self.log_stats,
                     wall_start_ts=wall_start_ts,
                     final_stage_id_for_e2e=final_stage_id,
-                    prometheus_metrics=omni_prometheus_metrics if self.enable_metrics else None,
+                    prometheus_metrics=get_omni_prometheus_metrics() if self.enable_metrics else None,
                     model_name=self.model_name if self.enable_metrics else None,
                 )
                 req_state = ClientRequestState(req_id)

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -12,7 +12,13 @@ from vllm.sampling_params import RequestOutputKind
 
 from vllm_omni.entrypoints.client_request_state import ClientRequestState
 from vllm_omni.entrypoints.omni_base import OmniBase
-from vllm_omni.metrics.stats import OrchestratorAggregator as OrchestratorMetrics
+from vllm_omni.metrics import (
+    OrchestratorAggregator as OrchestratorMetrics,
+)
+from vllm_omni.metrics import (
+    infer_request_output_type,
+    omni_prometheus_metrics,
+)
 from vllm_omni.outputs import OmniRequestOutput
 
 if TYPE_CHECKING:
@@ -123,10 +129,12 @@ class Omni(OmniBase):
                 req_final_stage_ids[req_id] = final_stage_id
 
                 metrics = OrchestratorMetrics(
-                    self.num_stages,
-                    self.log_stats,
-                    wall_start_ts,
-                    final_stage_id,
+                    num_stages=self.num_stages,
+                    log_stats=self.log_stats,
+                    wall_start_ts=wall_start_ts,
+                    final_stage_id_for_e2e=final_stage_id,
+                    prometheus_metrics=omni_prometheus_metrics if self.enable_metrics else None,
+                    model_name=self.model_name if self.enable_metrics else None,
                 )
                 req_state = ClientRequestState(req_id)
                 req_state.metrics = metrics
@@ -146,6 +154,11 @@ class Omni(OmniBase):
                     final_stage_id=final_stage_id,
                 )
                 submit_ts = time.time()
+                metrics.on_request_started(
+                    req_id=req_id,
+                    req_start_ts=submit_ts,
+                    final_output_type=infer_request_output_type(prompt_modalities),
+                )
                 req_state.metrics.stage_first_ts[0] = submit_ts
                 req_start_ts[req_id] = submit_ts
 
@@ -198,6 +211,9 @@ class Omni(OmniBase):
         request_ids = [request_id] if isinstance(request_id, str) else list(request_id)
         self.engine.abort(request_ids)
         for req_id in request_ids:
+            req_state = self.request_states.get(req_id)
+            if req_state is not None and req_state.metrics is not None:
+                req_state.metrics.on_request_aborted(req_id)
             self.request_states.pop(req_id, None)
         if self.log_stats:
             logger.info("[Omni] Aborted request(s) %s", ",".join(request_ids))

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -152,6 +152,8 @@ class OmniBase(PDDisaggregationMixin):
         model = omni_snapshot_download(model)
         self.__dict__["_name"] = self.__class__.__name__
         self.model = model
+        self.model_name = model
+        self.enable_metrics = bool(kwargs.get("enable_metrics", False))
         self.log_stats = log_stats
         # Provisional value (mirrors the CLI/caller kwarg); the engine resolves
         # pipeline + deploy YAML + CLI precedence below and the final value is
@@ -400,16 +402,16 @@ class OmniBase(PDDisaggregationMixin):
             metrics.stage_first_ts[stage_id] = submit_ts if submit_ts is not None else now
         metrics.stage_last_ts[stage_id] = max(metrics.stage_last_ts[stage_id] or 0.0, now)
 
+        stage_meta = self.engine.get_stage_metadata(stage_id)
         _m = result.get("metrics")
         if finished and _m is not None:
-            metrics.on_stage_metrics(stage_id, req_id, _m)
-
-        stage_meta = self.engine.get_stage_metadata(stage_id)
+            metrics.on_stage_metrics(stage_id, req_id, _m, stage_meta["final_output_type"])
         if not stage_meta["final_output"]:
             return None
 
         try:
             rid_key = str(req_id)
+            metrics.set_request_output_type(req_id, stage_meta["final_output_type"])
             if stage_id == final_stage_id_for_e2e and rid_key not in metrics.e2e_done and finished:
                 metrics.on_finalize_request(
                     stage_id,

--- a/vllm_omni/metrics/__init__.py
+++ b/vllm_omni/metrics/__init__.py
@@ -1,9 +1,19 @@
+from .prometheus import (
+    OmniPrometheusMetrics,
+    infer_request_output_type,
+    normalize_output_type,
+    omni_prometheus_metrics,
+)
 from .stats import OrchestratorAggregator, StageRequestStats, StageStats
 from .utils import count_tokens_from_outputs
 
 __all__ = [
+    "OmniPrometheusMetrics",
     "OrchestratorAggregator",
     "StageStats",
     "StageRequestStats",
     "count_tokens_from_outputs",
+    "infer_request_output_type",
+    "normalize_output_type",
+    "omni_prometheus_metrics",
 ]

--- a/vllm_omni/metrics/__init__.py
+++ b/vllm_omni/metrics/__init__.py
@@ -1,8 +1,8 @@
 from .prometheus import (
     OmniPrometheusMetrics,
+    get_omni_prometheus_metrics,
     infer_request_output_type,
     normalize_output_type,
-    omni_prometheus_metrics,
 )
 from .stats import OrchestratorAggregator, StageRequestStats, StageStats
 from .utils import count_tokens_from_outputs
@@ -13,7 +13,7 @@ __all__ = [
     "StageStats",
     "StageRequestStats",
     "count_tokens_from_outputs",
+    "get_omni_prometheus_metrics",
     "infer_request_output_type",
     "normalize_output_type",
-    "omni_prometheus_metrics",
 ]

--- a/vllm_omni/metrics/prometheus.py
+++ b/vllm_omni/metrics/prometheus.py
@@ -23,6 +23,8 @@ E2E_LATENCY_BUCKETS = (
     300.0,
 )
 
+_omni_prometheus_metrics: OmniPrometheusMetrics | None = None
+
 
 def normalize_output_type(output_type: str | None) -> str:
     if not output_type:
@@ -145,4 +147,9 @@ class OmniPrometheusMetrics:
         ).inc()
 
 
-omni_prometheus_metrics = OmniPrometheusMetrics()
+def get_omni_prometheus_metrics(registry: CollectorRegistry | None = None) -> OmniPrometheusMetrics:
+    global _omni_prometheus_metrics
+
+    if _omni_prometheus_metrics is None:
+        _omni_prometheus_metrics = OmniPrometheusMetrics(registry=registry)
+    return _omni_prometheus_metrics

--- a/vllm_omni/metrics/prometheus.py
+++ b/vllm_omni/metrics/prometheus.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from collections.abc import Sequence
 
 from prometheus_client import CollectorRegistry, Counter, Histogram
@@ -24,6 +25,7 @@ E2E_LATENCY_BUCKETS = (
 )
 
 _omni_prometheus_metrics: OmniPrometheusMetrics | None = None
+_omni_prometheus_metrics_lock = threading.Lock()
 
 
 def normalize_output_type(output_type: str | None) -> str:
@@ -151,5 +153,7 @@ def get_omni_prometheus_metrics(registry: CollectorRegistry | None = None) -> Om
     global _omni_prometheus_metrics
 
     if _omni_prometheus_metrics is None:
-        _omni_prometheus_metrics = OmniPrometheusMetrics(registry=registry)
+        with _omni_prometheus_metrics_lock:
+            if _omni_prometheus_metrics is None:
+                _omni_prometheus_metrics = OmniPrometheusMetrics(registry=registry)
     return _omni_prometheus_metrics

--- a/vllm_omni/metrics/prometheus.py
+++ b/vllm_omni/metrics/prometheus.py
@@ -131,7 +131,7 @@ class OmniPrometheusMetrics:
             model_name=model_name,
             from_stage=str(from_stage),
             to_stage=str(to_stage),
-            used_shm=str(bool(used_shm)),
+            used_shm=str(bool(used_shm)).lower(),
         ).inc(size_bytes)
 
     def on_request_succeeded(self, model_name: str, final_output_type: str | None, latency_seconds: float) -> None:

--- a/vllm_omni/metrics/prometheus.py
+++ b/vllm_omni/metrics/prometheus.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from prometheus_client import CollectorRegistry, Counter, Histogram
+from vllm.v1.metrics.prometheus import get_prometheus_registry
+
+DEFAULT_OUTPUT_TYPE = "unknown"
+E2E_LATENCY_BUCKETS = (
+    0.1,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    20.0,
+    30.0,
+    45.0,
+    60.0,
+    90.0,
+    120.0,
+    180.0,
+    300.0,
+)
+
+
+def normalize_output_type(output_type: str | None) -> str:
+    if not output_type:
+        return DEFAULT_OUTPUT_TYPE
+    return str(output_type)
+
+
+def infer_request_output_type(output_modalities: Sequence[str] | None) -> str:
+    if not output_modalities:
+        return DEFAULT_OUTPUT_TYPE
+    if isinstance(output_modalities, str):
+        return normalize_output_type(output_modalities)
+
+    unique_modalities = {normalize_output_type(modality) for modality in output_modalities if modality}
+    if len(unique_modalities) != 1:
+        return DEFAULT_OUTPUT_TYPE
+    return unique_modalities.pop()
+
+
+class OmniPrometheusMetrics:
+    def __init__(self, registry: CollectorRegistry | None = None) -> None:
+        self.registry = registry or get_prometheus_registry()
+        self.stage_generation_seconds = Histogram(
+            name="vllm:omni_stage_generation_seconds",
+            documentation="Generation time for completed vLLM-Omni stage events.",
+            labelnames=("model_name", "stage_id", "final_output_type"),
+            buckets=E2E_LATENCY_BUCKETS,
+            registry=self.registry,
+        )
+        self.stage_postprocess_seconds = Histogram(
+            name="vllm:omni_stage_postprocess_seconds",
+            documentation="Postprocess time for completed vLLM-Omni stage events.",
+            labelnames=("model_name", "stage_id", "final_output_type"),
+            buckets=E2E_LATENCY_BUCKETS,
+            registry=self.registry,
+        )
+        self.transfer_bytes_total = Counter(
+            name="vllm:omni_transfer_bytes_total",
+            documentation="Total bytes transferred between vLLM-Omni stages.",
+            labelnames=("model_name", "from_stage", "to_stage", "used_shm"),
+            registry=self.registry,
+        )
+        self.requests_total = Counter(
+            name="vllm:omni_requests_total",
+            documentation="Total number of vLLM-Omni orchestrator requests.",
+            labelnames=("model_name", "final_output_type"),
+            registry=self.registry,
+        )
+        self.requests_aborted_total = Counter(
+            name="vllm:omni_requests_aborted_total",
+            documentation="Total number of aborted vLLM-Omni orchestrator requests.",
+            labelnames=("model_name", "final_output_type"),
+            registry=self.registry,
+        )
+        self.e2e_request_latency_seconds = Histogram(
+            name="vllm:omni_e2e_request_latency_seconds",
+            documentation="End-to-end latency of successful vLLM-Omni requests.",
+            labelnames=("model_name", "final_output_type"),
+            buckets=E2E_LATENCY_BUCKETS,
+            registry=self.registry,
+        )
+
+    def on_request_started(self, model_name: str, final_output_type: str | None = None) -> None:
+        self.requests_total.labels(
+            model_name=model_name,
+            final_output_type=normalize_output_type(final_output_type),
+        ).inc()
+
+    def on_stage_completed(
+        self,
+        model_name: str,
+        stage_id: int,
+        final_output_type: str | None,
+        generation_seconds: float,
+    ) -> None:
+        self.stage_generation_seconds.labels(
+            model_name=model_name,
+            stage_id=str(stage_id),
+            final_output_type=normalize_output_type(final_output_type),
+        ).observe(generation_seconds)
+
+    def on_stage_postprocessed(
+        self,
+        model_name: str,
+        stage_id: int,
+        final_output_type: str | None,
+        postprocess_seconds: float,
+    ) -> None:
+        self.stage_postprocess_seconds.labels(
+            model_name=model_name,
+            stage_id=str(stage_id),
+            final_output_type=normalize_output_type(final_output_type),
+        ).observe(postprocess_seconds)
+
+    def on_transfer_recorded(
+        self,
+        model_name: str,
+        from_stage: int,
+        to_stage: int,
+        used_shm: bool,
+        size_bytes: int,
+    ) -> None:
+        self.transfer_bytes_total.labels(
+            model_name=model_name,
+            from_stage=str(from_stage),
+            to_stage=str(to_stage),
+            used_shm=str(bool(used_shm)),
+        ).inc(size_bytes)
+
+    def on_request_succeeded(self, model_name: str, final_output_type: str | None, latency_seconds: float) -> None:
+        self.e2e_request_latency_seconds.labels(
+            model_name=model_name,
+            final_output_type=normalize_output_type(final_output_type),
+        ).observe(latency_seconds)
+
+    def on_request_aborted(self, model_name: str, final_output_type: str | None = None) -> None:
+        self.requests_aborted_total.labels(
+            model_name=model_name,
+            final_output_type=normalize_output_type(final_output_type),
+        ).inc()
+
+
+omni_prometheus_metrics = OmniPrometheusMetrics()

--- a/vllm_omni/metrics/stats.py
+++ b/vllm_omni/metrics/stats.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from vllm.logger import init_logger
 
+from vllm_omni.metrics.prometheus import OmniPrometheusMetrics, normalize_output_type
 from vllm_omni.metrics.utils import _build_field_defs, _build_row, _format_table
 
 logger = init_logger(__name__)
@@ -119,10 +120,14 @@ class OrchestratorAggregator:
         log_stats: bool,
         wall_start_ts: float,
         final_stage_id_for_e2e: dict[str, int] | int,
+        prometheus_metrics: OmniPrometheusMetrics | None = None,
+        model_name: str | None = None,
     ) -> None:
         self.num_stages = int(num_stages)
         self.log_stats = bool(log_stats)
         self.final_stage_id_for_e2e = final_stage_id_for_e2e
+        self.prometheus_metrics = prometheus_metrics
+        self.model_name = model_name
         self.init_run_state(wall_start_ts)
         self.stage_events: dict[str, list[StageRequestStats]] = {}
         self.transfer_events: dict[
@@ -147,6 +152,58 @@ class OrchestratorAggregator:
         self.diffusion_metrics: defaultdict[str, defaultdict[str, float]] = defaultdict(
             lambda: defaultdict(float)
         )  # {request_id: {diffusion_metrics_key: accumulated_metrics_data}}
+        self.request_start_ts: dict[str, float] = {}
+        self.request_output_types: dict[str, str] = {}
+        self.request_finalized: set[str] = set()
+
+    def _prometheus_enabled(self) -> bool:
+        return self.prometheus_metrics is not None and self.model_name is not None
+
+    def _resolve_output_type(self, req_id: str, final_output_type: str | None = None) -> str:
+        if final_output_type:
+            return normalize_output_type(final_output_type)
+        if req_id in self.request_output_types:
+            return self.request_output_types[req_id]
+        if req_id in self.stage_events:
+            for evt in reversed(self.stage_events[req_id]):
+                if evt.final_output_type:
+                    return normalize_output_type(evt.final_output_type)
+        return normalize_output_type(None)
+
+    def on_request_started(
+        self,
+        req_id: Any,
+        req_start_ts: float,
+        final_output_type: str | None = None,
+    ) -> bool:
+        rid_key = str(req_id)
+        if rid_key in self.request_start_ts:
+            return False
+        self.request_start_ts[rid_key] = float(req_start_ts)
+        self.request_output_types[rid_key] = self._resolve_output_type(rid_key, final_output_type)
+        if self._prometheus_enabled():
+            self.prometheus_metrics.on_request_started(
+                model_name=self.model_name,
+                final_output_type=self.request_output_types[rid_key],
+            )
+        return True
+
+    def set_request_output_type(self, req_id: Any, final_output_type: str | None) -> None:
+        if final_output_type:
+            self.request_output_types[str(req_id)] = normalize_output_type(final_output_type)
+
+    def on_request_aborted(self, req_id: Any, final_output_type: str | None = None) -> bool:
+        rid_key = str(req_id)
+        if rid_key in self.request_finalized:
+            return False
+        self.request_finalized.add(rid_key)
+        self.request_output_types[rid_key] = self._resolve_output_type(rid_key, final_output_type)
+        if self._prometheus_enabled():
+            self.prometheus_metrics.on_request_aborted(
+                model_name=self.model_name,
+                final_output_type=self.request_output_types[rid_key],
+            )
+        return True
 
     def _get_or_create_transfer_event(
         self,
@@ -189,6 +246,14 @@ class OrchestratorAggregator:
             evt.size_bytes += int(size_bytes)
             evt.tx_time_ms += float(tx_time_ms)
             evt.used_shm = evt.used_shm or bool(used_shm)
+            if self._prometheus_enabled() and size_bytes > 0:
+                self.prometheus_metrics.on_transfer_recorded(
+                    model_name=self.model_name,
+                    from_stage=int(from_stage),
+                    to_stage=int(to_stage),
+                    used_shm=bool(used_shm),
+                    size_bytes=int(size_bytes),
+                )
             return evt
         except Exception:
             return None
@@ -347,6 +412,13 @@ class OrchestratorAggregator:
         if stats.stage_id == 0:
             self.stage_total_tokens[stats.stage_id] += int(stats.num_tokens_in)
         self.stage_events.setdefault(str(stats.request_id), []).append(stats)
+        if self._prometheus_enabled():
+            self.prometheus_metrics.on_stage_completed(
+                model_name=self.model_name,
+                stage_id=stage_id,
+                final_output_type=stats.final_output_type,
+                generation_seconds=max(0.0, float(stats.stage_gen_time_ms) / 1000.0),
+            )
 
         self.record_transfer_rx(stats)
 
@@ -355,6 +427,13 @@ class OrchestratorAggregator:
             for stats in self.stage_events[req_id]:
                 if stats.stage_id == stage_id:
                     stats.postprocess_time_ms = float(postproc_time_ms)
+                    if self._prometheus_enabled():
+                        self.prometheus_metrics.on_stage_postprocessed(
+                            model_name=self.model_name,
+                            stage_id=stage_id,
+                            final_output_type=stats.final_output_type,
+                            postprocess_seconds=max(0.0, float(postproc_time_ms) / 1000.0),
+                        )
                     break
         else:
             logger.warning(
@@ -423,12 +502,14 @@ class OrchestratorAggregator:
         stage_id: int,
         req_id: Any,
         req_start_ts: float,
-    ) -> None:
+        finished_at: float | None = None,
+    ) -> bool:
         rid_key = str(req_id)
-        if rid_key in self.e2e_done:
-            return  # Already finalized
-        _t0 = float(req_start_ts)
-        _t1 = time.time()
+        if rid_key in self.request_finalized:
+            return False
+        self.request_finalized.add(rid_key)
+        _t0 = float(self.request_start_ts.get(rid_key, req_start_ts))
+        _t1 = time.time() if finished_at is None else float(finished_at)
         # Update last output time for this stage
         prev_last = self.stage_last_ts[stage_id]
         self.stage_last_ts[stage_id] = _t1 if prev_last is None else max(prev_last, _t1)
@@ -460,6 +541,14 @@ class OrchestratorAggregator:
             ),
         )
         self.e2e_events.append(per_req_record)
+        self.request_output_types[rid_key] = self._resolve_output_type(rid_key)
+        if self._prometheus_enabled():
+            self.prometheus_metrics.on_request_succeeded(
+                model_name=self.model_name,
+                final_output_type=self.request_output_types[rid_key],
+                latency_seconds=max(0.0, e2e_ms / 1000.0),
+            )
+        return True
 
     def build_and_log_summary(self) -> dict[str, Any]:
         if not self.log_stats:


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
This PR adds Prometheus metrics for the `vllm-omni` orchestrator and wires them into the existing shared `/metrics` endpoint via the upstream vLLM Prometheus registry.

Main changes:
- Add omni request-level Prometheus metrics:
  - `vllm:omni_requests_total`
  - `vllm:omni_requests_aborted_total`
  - `vllm:omni_e2e_request_latency_seconds`
- Add omni stage/transfer metrics derived from the existing aggregator data:
  - `vllm:omni_stage_generation_seconds`
  - `vllm:omni_stage_postprocess_seconds`
  - `vllm:omni_transfer_bytes_total`
- Move Prometheus lifecycle bookkeeping into `OrchestratorAggregator` so the sync/async orchestrator paths keep thin metric hooks.
- Add `--enable-metrics` to `omni serve` to control whether omni-specific metrics are emitted.
- Narrow the termination metric semantics from generic failures to explicit aborted/cancelled requests only, and rename the metric accordingly.

This keeps `--log-stats` for detailed per-request debugging while exposing stable low-cardinality metrics for monitoring and dashboards.

## Test Plan
Manual runtime verification:

```bash
vllm serve Qwen/Qwen-Image-Edit --omni --port 8091 --enable-metrics
curl http://0.0.0.0:8091/metrics
```

Local validation:

```bash
python -m py_compile \
  vllm_omni/metrics/prometheus.py \
  vllm_omni/metrics/stats.py \
  vllm_omni/entrypoints/async_omni.py \
  vllm_omni/entrypoints/omni.py \
  vllm_omni/entrypoints/cli/serve.py
```

I also ran focused local validation scripts to verify:
- `requests_total` / `requests_aborted_total` semantics
- successful request latency histogram recording
- stage and transfer metric emission from the existing aggregator hooks
- updated long-tail latency buckets for diffusion/image requests

## Test Result
Observed the following omni-specific metrics after sending test requests:

```text
vllm:omni_requests_total{final_output_type="image",model_name="/.aistudio/aistudio-modelhub/zeta/f29400004_100100039"} 2.0
vllm:omni_requests_aborted_total{final_output_type="image",model_name="/.aistudio/aistudio-modelhub/zeta/f29400004_100100039"} 1.0

vllm:omni_e2e_request_latency_seconds_count{final_output_type="image",model_name="/.aistudio/aistudio-modelhub/zeta/f29400004_100100039"} 1.0
vllm:omni_e2e_request_latency_seconds_sum{final_output_type="image",model_name="/.aistudio/aistudio-modelhub/zeta/f29400004_100100039"} 64.80759859085083

vllm:omni_e2e_request_latency_seconds_bucket{final_output_type="image",le="60.0",model_name="/.aistudio/aistudio-modelhub/zeta/f29400004_100100039"} 0.0
vllm:omni_e2e_request_latency_seconds_bucket{final_output_type="image",le="90.0",model_name="/.aistudio/aistudio-modelhub/zeta/f29400004_100100039"} 1.0
```

This confirms:
- 2 omni requests were observed
- 1 request was aborted
- 1 successful request was recorded in the E2E latency histogram
- the updated histogram buckets captured a ~64.8s image request in the `le="90.0"` bucket

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)