### PR TITLE
[Doc] Clarify POST /v1/videos accepts multipart/form-data, not JSON

### DIFF
--- a/docs/user_guide/examples/online_serving/image_to_video.md
+++ b/docs/user_guide/examples/online_serving/image_to_video.md
@@ -102,6 +102,11 @@ curl -L "http://localhost:8091/v1/videos/${video_id}/content" -o wan22_i2v_outpu
 
 ## Request Format
 
+!!! note
+    The `POST /v1/videos` endpoint accepts **multipart/form-data** (`-F` flags
+    in curl), not a JSON request body. See the [Response Format](#response-format)
+    section below for the JSON returned after a job is created.
+
 ### Required Fields
 
 ```bash
@@ -142,9 +147,9 @@ curl -X POST http://localhost:8091/v1/videos \
   -F "seed=42"
 ```
 
-## Create Response Format
+## Response Format
 
-`POST /v1/videos` returns a job record.
+`POST /v1/videos` returns a JSON job record (not a video file).
 
 ```json
 {

--- a/docs/user_guide/examples/online_serving/text_to_video.md
+++ b/docs/user_guide/examples/online_serving/text_to_video.md
@@ -100,6 +100,11 @@ curl -L "http://localhost:8091/v1/videos/${video_id}/content" -o wan22_output.mp
 
 ## Request Format
 
+!!! note
+    The `POST /v1/videos` endpoint accepts **multipart/form-data** (`-F` flags
+    in curl), not a JSON request body. See the [Response Format](#response-format)
+    section below for the JSON returned after a job is created.
+
 ### Simple Text-to-Video Generation
 
 ```bash
@@ -145,9 +150,9 @@ curl -X POST http://localhost:8091/v1/videos \
 | `seed`                | int    | None    | Random seed (reproducible)                       |
 | `lora`                | object | None    | LoRA configuration                               |
 
-## Create Response Format
+## Response Format
 
-`POST /v1/videos` returns a job record.
+`POST /v1/videos` returns a JSON job record (not a video file).
 
 ```json
 {


### PR DESCRIPTION
## Purpose

The `POST /v1/videos` endpoint only accepts `multipart/form-data`, but the documentation section titled "Create Response Format" was ambiguous — users mistook the JSON response example for the request format and got 400 errors when POSTing JSON.

Fixes #2039

## Changes

Applied to both `text_to_video.md` and `image_to_video.md` (both describe the same `/v1/videos` endpoint):

- Renamed "Create Response Format" → "Response Format" (consistent with `text_to_image.md`)
- Added a `note` admonition in "Request Format" sections clarifying the endpoint accepts `multipart/form-data` only

**Note:** The corresponding `examples/online_serving/*/README.md` files have a similar "Create Response Format" heading; this can be addressed in a follow-up.

## Test Plan

- Documentation-only change, no code modified
- Verified markdown syntax is valid on inspection; `!!! note` admonition and `#response-format` anchor usage matches existing docs patterns (e.g. `text_to_image.md`)