### PR TITLE
[BugFix] Fix chat template warmup error for TTS models without chat templates

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_chat_warmup.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_warmup.py
@@ -1,30 +1,30 @@
 """Tests for OmniOpenAIServingChat.warmup() chat template handling."""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
+
+from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
 
 
 def _make_mock_serving_chat():
-    """Build a minimal OmniOpenAIServingChat without a real engine."""
-    from vllm_omni.entrypoints.openai.serving_chat import OmniOpenAIServingChat
-
-    instance = object.__new__(OmniOpenAIServingChat)
-    instance.chat_template = None
-    instance.chat_template_content_format = "auto"
-    instance.default_chat_template_kwargs = {}
+    """Build a mock OmniOpenAIServingChat using create_autospec."""
+    instance = create_autospec(OmniOpenAIServingChat, instance=True)
 
     mock_tokenizer = MagicMock()
     mock_tokenizer.name_or_path = "test-model"
 
     mock_renderer = MagicMock()
     mock_renderer.get_tokenizer.return_value = mock_tokenizer
-
     instance.renderer = mock_renderer
+
+    instance.chat_template = None
 
     mock_model_config = MagicMock()
     mock_model_config.trust_remote_code = False
     mock_model_config.hf_config.model_type = "test"
     instance.model_config = mock_model_config
+
+    instance.warmup = OmniOpenAIServingChat.warmup.__get__(instance)
 
     return instance
 

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -119,19 +119,21 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         """
         from vllm.renderers.hf import resolve_chat_template
 
+        # resolve_chat_template
+        # We must call it before super().warmup() because the parent catches
+        # Exceptions internally and logs an ERROR traceback which we want to
+        # avoid for models that legitimately have no chat template (e.g. TTS).
         tokenizer = self.renderer.get_tokenizer()
         resolved = resolve_chat_template(
             tokenizer,
-            chat_template=getattr(self, "chat_template", None),
+            chat_template=self.chat_template,
             tools=None,
             model_config=self.model_config,
         )
 
         if resolved is None:
             logger.info(
-                "Skipping chat template warmup: no chat template found "
-                "for tokenizer '%s'. This is expected for models that "
-                "do not use the chat completions API (e.g. TTS models).",
+                "No chat template found for '%s', skipping warmup.",
                 tokenizer.name_or_path,
             )
             return


### PR DESCRIPTION
## Purpose

Fixes #1997

- TTS models (e.g. Qwen3-TTS) report `"generate"` in supported tasks because their LLM talker stage does autoregressive generation, which causes `OmniOpenAIServingChat` to be created and warmed up. However, TTS tokenizers don't define a chat template, so the warmup raises a confusing `ChatTemplateResolutionError` during server startup.
- Overrides `warmup()` in `OmniOpenAIServingChat` to check if a chat template is resolvable before proceeding. If no template exists, warmup is skipped with an informative log. Models with chat templates are unaffected — they follow the same code path as before.

## Test Plan

- [x] Start vllm-omni server with Qwen3-TTS model
- [x] Confirm TTS requests via `/v1/audio/speech` still work normally after startup
- [x] Run newly added unit tests.

## Test Result

Above tests all fine.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
