### PR TITLE
[Bugfix] Fix left_context_size type mismatch in non-async Base Code2Wav path

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
@@ -219,7 +219,14 @@ class Qwen3TTSCode2Wav(nn.Module):
                 if i >= len(left_context_size):
                     break
                 if "left_context_size" in info:
-                    left_context_size[i] = info["left_context_size"]
+                    val = info["left_context_size"]
+                    # Non-async path sends a list (required by
+                    # serialize_additional_information which drops
+                    # plain ints); async chunk path sends a plain int.
+                    # Handle both.
+                    if isinstance(val, list):
+                        val = val[0] if val else 0
+                    left_context_size[i] = int(val)
         for i, req_ids in enumerate(request_ids_list):
             if req_ids.numel() < 1:
                 parsed.append((0, 0))

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_tts.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_tts.py
@@ -45,6 +45,9 @@ def talker2code2wav(
             ref_code_len = 0
         # Code2Wav expects codebook-major flat: [Q*num_frames]
         codec_codes = audio_codes.transpose(0, 1).cpu().reshape(-1).tolist()
+        # Wrap ref_code_len in a list: serialize_additional_information()
+        # only preserves tensor and list values; plain ints are dropped.
+        # The consumer (Qwen3TTSCode2Wav.forward) unwraps the list.
         additional_information = {"left_context_size": [ref_code_len]} if ref_code_len > 0 else None
         code2wav_inputs.append(
             OmniTokensPrompt(


### PR DESCRIPTION
## Purpose

Disclaimer: this PR contains AI-generated code

Qwen3TTSCode2Wav.forward() compares ctx_frames against 0 (line 287: "if ctx_frames > 0"), but the non-async Base path passes left_context_size as a single-element list [ref_code_len] to survive serialize_additional_information(), which only supports tensor and list values (plain ints are dropped). The async chunk path bypasses serialization and passes a plain int directly. 

The list wrapper in talker2code2wav() is intentional — without it the serializer drops the key and ctx_frames silently falls back to 0, causing ref_code context to never be trimmed from the output audio.

Fix the consumer (Qwen3TTSCode2Wav.forward) to unwrap the list when present, handling both the serialized list form (non-async) and the plain int form (async chunk path). 

The bug was introduced in PR #1731 (761eff93) which added ref_code support to the non-async path but did not account for the type mismatch between serialized list and the int comparison downstream. It was masked by the token overflow crash (max_model_len=32768 < prompt tokens) which prevented the code from reaching the comparison.

Fixes: https://github.com/vllm-project/vllm-omni/issues/203


## Test Plan

After modifying `qwen3_tts_no_async_chunk.yaml` to increase the `max_model_len`, run

```bash
/workspace/.venv/bin/python -m pytest -sv tests/e2e/online_serving/test_qwen3_tts_base_expansion.py --run-level "advanced_model"
```

## Test Result

TBD

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
