### PR TITLE
fix: use uuid4 for request_id in /v1/images/edits to prevent collisions

### DIFF
--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1396,7 +1396,7 @@ async def edit_images(
         _update_if_not_none(gen_params, "generator_device", generator_device)
 
         # 4. Generate images using AsyncOmni (multi-stage mode)
-        request_id = f"img_edit_{int(time.time())}"
+        request_id = f"img_edit_{uuid.uuid4().hex}"
         logger.info(f"Generating {n} image(s) {size_str}")
         result = await _generate_with_async_omni(
             engine_client=engine_client,


### PR DESCRIPTION
## Summary

Fix for issue #2048: the /v1/images/edits endpoint generates non-unique request IDs causing requests to hang.

## Problem

The endpoint used int(time.time()) for request IDs with only second-level precision. Multiple concurrent requests within the same second received identical IDs, causing request state collisions and hangs.

## Solution

Changed to uuid.uuid4().hex, matching what /v1/images/generations already uses.

## Changes

- 1 file changed, 1 line modified
- uuid module already imported in api_server.py