### PR TITLE
fix: use UUID for unique request IDs in /v1/images/edits endpoint

### DIFF
--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1396,7 +1396,7 @@ async def edit_images(
         _update_if_not_none(gen_params, "generator_device", generator_device)
 
         # 4. Generate images using AsyncOmni (multi-stage mode)
-        request_id = f"img_edit_{int(time.time())}"
+        request_id = f"img_edit_{uuid.uuid4().hex}"
         logger.info(f"Generating {n} image(s) {size_str}")
         result = await _generate_with_async_omni(
             engine_client=engine_client,


### PR DESCRIPTION
## Summary

Fixes #2048

## Problem

The `/v1/images/edits` endpoint uses `int(time.time())` to generate request IDs, which only has second-level precision. Multiple requests arriving within the same second receive identical IDs, causing:

1. Request 1 registers in request_states
2. Request 2 overwrites with a new ClientRequestState
3. Request 1 completes, but output routed to wrong queue
4. Request 2 hangs indefinitely

## Solution

Replace `int(time.time())` with `uuid.uuid4().hex`, matching the pattern used in `/v1/images/generations`.

```diff
-        request_id = f"img_edit_{int(time.time())}"
+        request_id = f"img_edit_{uuid.uuid4().hex}"
```

## Testing

Concurrent requests to `/v1/images/edits` will now receive unique IDs, preventing the race condition.