### PR TITLE
fix: use uuid.uuid4() for request IDs in /v1/images/edits to prevent collisions

### DIFF
--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -10,6 +10,7 @@ OpenAI-compatible async text-to-image generation API endpoints in api_server.py.
 import base64
 import io
 from argparse import Namespace
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
@@ -115,35 +116,44 @@ class FakeAsyncOmni:
     """Fake AsyncOmni that yields a single diffusion output."""
 
     def __init__(self):
-        self.stage_list = ["llm", "diffusion"]
+        self.stage_configs = [
+            SimpleNamespace(stage_type="llm"),
+            SimpleNamespace(stage_type="diffusion"),
+        ]
         self.default_sampling_params_list = [SamplingParams(temperature=0.1), OmniDiffusionSamplingParams()]
         self.captured_sampling_params_list = None
         self.captured_prompt = None
+        self.captured_request_ids = []
 
     async def generate(self, prompt, request_id, sampling_params_list):
         self.captured_sampling_params_list = sampling_params_list
         self.captured_prompt = prompt
+        self.captured_request_ids.append(request_id)
         images = [Image.new("RGB", (64, 64), color="green")]
         yield MockGenerationResult(images)
 
 
 @pytest.fixture
 def mock_async_diffusion(mocker: MockerFixture):
-    """Mock AsyncOmniDiffusion instance that returns fake images"""
-    mock = mocker.Mock()
-    mock.is_running = True  # For health endpoint
-    mock.check_health = mocker.AsyncMock()  # For LLM mode health check
+    """Mock diffusion engine that matches the current async-generator API."""
 
-    async def generate(**kwargs):
-        # Return n PIL images wrapped in result object
-        n = kwargs["sampling_params_list"][0].num_outputs_per_prompt
-        mock.captured_sampling_params_list = kwargs["sampling_params_list"]
-        mock.captured_prompt = kwargs["prompt"]
-        images = [Image.new("RGB", (64, 64), color="blue") for _ in range(n)]
-        return MockGenerationResult(images)
+    class MockAsyncDiffusion:
+        def __init__(self) -> None:
+            self.is_running = True
+            self.check_health = mocker.AsyncMock()
+            self.captured_sampling_params_list = None
+            self.captured_prompt = None
+            self.generate_calls = 0
 
-    mock.generate = mocker.AsyncMock(side_effect=generate)
-    return mock
+        async def generate(self, **kwargs):
+            self.generate_calls += 1
+            n = kwargs["sampling_params_list"][0].num_outputs_per_prompt
+            self.captured_sampling_params_list = kwargs["sampling_params_list"]
+            self.captured_prompt = kwargs["prompt"]
+            images = [Image.new("RGB", (64, 64), color="blue") for _ in range(n)]
+            yield MockGenerationResult(images)
+
+    return MockAsyncDiffusion()
 
 
 @pytest.fixture
@@ -159,8 +169,14 @@ def test_client(mock_async_diffusion):
     # Set up app state with diffusion engine
     app.state.engine_client = mock_async_diffusion
     app.state.diffusion_engine = mock_async_diffusion  # Also set for health endpoint
-    app.state.stage_configs = [{"stage_type": "diffusion"}]
-    app.state.diffusion_model_name = "Qwen/Qwen-Image"  # For models endpoint
+    app.state.stage_configs = [SimpleNamespace(stage_type="diffusion")]
+    from vllm.entrypoints.openai.models.protocol import BaseModelPath
+
+    from vllm_omni.entrypoints.openai.api_server import _DiffusionServingModels
+
+    app.state.openai_serving_models = _DiffusionServingModels(
+        [BaseModelPath(name="Qwen/Qwen-Image", model_path="Qwen/Qwen-Image")]
+    )
     app.state.args = Namespace(
         default_sampling_params='{"0": {"num_inference_steps":4, "guidance_scale":7.5}}',
         max_generated_image_size=4096,  # 64*64
@@ -180,7 +196,32 @@ def async_omni_test_client():
     app.include_router(router)
 
     app.state.engine_client = FakeAsyncOmni()
-    app.state.stage_configs = [{"stage_type": "llm"}, {"stage_type": "diffusion"}]
+    app.state.stage_configs = [
+        SimpleNamespace(stage_type="llm"),
+        SimpleNamespace(stage_type="diffusion"),
+    ]
+    app.state.args = Namespace(
+        default_sampling_params='{"1": {"num_inference_steps":4, "guidance_scale":7.5}}',
+        max_generated_image_size=1048576,  # 1024*1024 to support resolution tests
+    )
+    return TestClient(app)
+
+
+@pytest.fixture
+def async_omni_stage_configs_only_client():
+    """Create test client with refactored AsyncOmni compatibility surface only."""
+    from fastapi import FastAPI
+
+    from vllm_omni.entrypoints.openai.api_server import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    engine = FakeAsyncOmni()
+    assert not hasattr(engine, "stage_list")
+    app.state.engine_client = engine
+    # Intentionally do not populate app.state.stage_configs. Refactored
+    # AsyncOmni exposes stage_configs on the engine instance.
     app.state.args = Namespace(
         default_sampling_params='{"1": {"num_inference_steps":4, "guidance_scale":7.5}}',
         max_generated_image_size=4096,  # 64*64
@@ -289,6 +330,45 @@ def test_generate_images_async_omni_sampling_params(async_omni_test_client):
     assert captured[1].height == 256
     assert captured[1].width == 256
     assert captured[1].seed == 7
+
+
+def test_generate_images_async_omni_stage_configs_only(async_omni_stage_configs_only_client):
+    """Regression: image generation accepts refactored AsyncOmni without stage_list."""
+    response = async_omni_stage_configs_only_client.post(
+        "/v1/images/generations",
+        json={
+            "prompt": "a castle",
+            "n": 1,
+            "size": "256x256",
+            "seed": 11,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data"]) == 1
+    engine = async_omni_stage_configs_only_client.app.state.engine_client
+    captured = engine.captured_sampling_params_list
+    assert captured is not None
+    assert len(captured) == 2
+    assert captured[1].seed == 11
+
+
+def test_image_edits_async_omni_stage_configs_only(async_omni_stage_configs_only_client):
+    """Regression: image edits accepts refactored AsyncOmni without stage_list."""
+    img_bytes = make_test_image_bytes((16, 16))
+    response = async_omni_stage_configs_only_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes)],
+        data={
+            "prompt": "edit me",
+            "size": "auto",
+        },
+    )
+    assert response.status_code == 200
+    engine = async_omni_stage_configs_only_client.app.state.engine_client
+    captured = engine.captured_sampling_params_list
+    assert captured is not None
+    assert len(captured) == 2
 
 
 def test_generate_multiple_images(test_client):
@@ -520,6 +600,13 @@ def test_parameter_validation():
     with pytest.raises(ValueError):
         ImageGenerationRequest(prompt="test", guidance_scale=21.0)
 
+    # Invalid layers for layered models (must stay within the backend-supported range)
+    with pytest.raises(ValueError):
+        ImageGenerationRequest(prompt="test", layers=2)
+
+    with pytest.raises(ValueError):
+        ImageGenerationRequest(prompt="test", layers=11)
+
 
 # Pass-Through Tests
 
@@ -538,13 +625,12 @@ def test_parameters_passed_through(test_client, mock_async_diffusion):
     )
     assert response.status_code == 200
 
-    # Ensure generate() was called exactly once
-    mock_async_diffusion.generate.assert_awaited_once()
-    call_kwargs = mock_async_diffusion.generate.call_args[1]["sampling_params_list"][0]
-    assert call_kwargs.num_inference_steps == 100
-    assert call_kwargs.guidance_scale == 7.5
-    assert call_kwargs.true_cfg_scale == 3.0
-    assert call_kwargs.seed == 42
+    assert mock_async_diffusion.generate_calls == 1
+    captured = mock_async_diffusion.captured_sampling_params_list[0]
+    assert captured.num_inference_steps == 100
+    assert captured.guidance_scale == 7.5
+    assert captured.true_cfg_scale == 3.0
+    assert captured.seed == 42
 
 
 def test_model_field_omitted_works(test_client):
@@ -640,6 +726,29 @@ def test_image_edit_images_processing(async_omni_test_client):
     assert processed_images[1].size == (24, 24)
 
 
+def test_image_edit_rejects_multiple_images_when_model_does_not_support_them(async_omni_test_client):
+    img_bytes_1 = make_test_image_bytes((16, 16))
+    img_bytes_2 = make_test_image_bytes((32, 32))
+
+    engine = async_omni_test_client.app.state.engine_client
+    engine.get_diffusion_od_config = lambda: SimpleNamespace(supports_multimodal_inputs=False)
+
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[
+            ("image", img_bytes_1),
+            ("image", img_bytes_2),
+        ],
+        data={"prompt": "hello world."},
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"] == "Received multiple input images. Only a single image is supported by this model."
+    )
+    assert engine.captured_prompt is None
+
+
 def test_image_edit_parameter_pass(async_omni_test_client):
     img_bytes_1 = make_test_image_bytes((16, 16))
 
@@ -683,6 +792,120 @@ def test_image_edit_parameter_pass(async_omni_test_client):
         assert data["size"] == "16x24"
 
 
+def test_image_edit_layers_and_resolution(async_omni_test_client):
+    """Test layers and resolution parameters for layered models."""
+    img_bytes = make_test_image_bytes((16, 16))
+
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes)],
+        data={
+            "prompt": "decompose into layers",
+            "layers": 4,
+            "resolution": 1024,
+        },
+    )
+    assert response.status_code == 200
+    engine = async_omni_test_client.app.state.engine_client
+    captured_sampling_params = engine.captured_sampling_params_list[-1]
+    assert captured_sampling_params.layers == 4
+    assert captured_sampling_params.resolution == 1024
+
+
+def test_image_edit_resolution_auto_size(async_omni_test_client):
+    """Test that size='auto' with resolution lets pipeline calculate dimensions."""
+    img_bytes = make_test_image_bytes((16, 16))
+
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes)],
+        data={
+            "prompt": "test",
+            "size": "auto",
+            "resolution": 640,
+        },
+    )
+    assert response.status_code == 200
+    engine = async_omni_test_client.app.state.engine_client
+    captured_sampling_params = engine.captured_sampling_params_list[-1]
+    # When resolution is set with size=auto, width/height should be None
+    # to let pipeline calculate based on resolution
+    assert captured_sampling_params.width is None
+    assert captured_sampling_params.height is None
+    assert captured_sampling_params.resolution == 640
+
+
+def test_image_edit_invalid_resolution(async_omni_test_client):
+    """Test that invalid resolution values are rejected with 400."""
+    img_bytes = make_test_image_bytes((16, 16))
+
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes)],
+        data={
+            "prompt": "test",
+            "resolution": 512,  # Invalid, only 640 or 1024 are supported
+        },
+    )
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "Invalid resolution" in detail
+    assert "512" in detail
+
+
+def test_image_edit_invalid_layers(async_omni_test_client):
+    """Test that layered image edits reject out-of-range layers with 400."""
+    img_bytes = make_test_image_bytes((16, 16))
+
+    # Test layers below the supported range
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes)],
+        data={
+            "prompt": "test",
+            "layers": 2,
+        },
+    )
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "Invalid layers" in detail
+    assert "layers must be between 3 and 10 inclusive" in detail
+
+    # Test layers above the supported range
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes)],
+        data={
+            "prompt": "test",
+            "layers": 11,
+        },
+    )
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "Invalid layers" in detail
+    assert "layers must be between 3 and 10 inclusive" in detail
+
+
+def test_image_edit_resolution_and_size_conflict(async_omni_test_client):
+    """Test that providing both resolution and explicit size raises 400."""
+    img_bytes = make_test_image_bytes((16, 16))
+
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes)],
+        data={
+            "prompt": "test",
+            "resolution": 1024,
+            "size": "512x512",  # Conflict: both resolution and explicit size
+        },
+    )
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "Cannot specify both" in detail
+    assert "resolution" in detail
+    assert "size" in detail
+
+
 def test_image_edit_parameter_default(async_omni_test_client):
     img_bytes_1 = make_test_image_bytes((24, 16))
 
@@ -705,12 +928,13 @@ def test_image_edit_parameter_default(async_omni_test_client):
     assert captured_sampling_params.num_inference_steps == 4
     assert captured_sampling_params.guidance_scale == 7.5
 
+    # Test that a size exceeding max_generated_image_size returns 400
     response = async_omni_test_client.post(
         "/v1/images/edits",
         files=[("image", img_bytes_1)],
         data={
             "prompt": "hello world.",
-            "size": "96x96",
+            "size": "2048x2048",  # 4,194,304 pixels > max_generated_image_size (1,048,576)
         },
     )
     assert response.status_code == 400
@@ -886,3 +1110,52 @@ def test_image_edit_with_seed_zero_single_stage(test_client):
         f"Expected seed=0, but got seed={captured_sampling_params.seed}. "
         "This indicates the bug where seed=0 is treated as falsy."
     )
+
+
+def test_image_edits_request_id_unique(async_omni_test_client):
+    """Regression test for request_id collision in /v1/images/edits.
+
+    Previously, request_id was generated using int(time.time()), which only has
+    second-level precision. Two requests in the same second would get identical
+    request_ids like 'img_edit_1234567890', causing request state collisions
+    where one request's result would overwrite the other's.
+
+    The fix uses random_uuid() to generate globally unique request IDs.
+    This test verifies that two requests in the same second receive distinct
+    request_ids (not relying on timing/concurrency to create uniqueness).
+    """
+    img_bytes_1 = make_test_image_bytes((16, 16))
+
+    # Issue two requests in rapid succession
+    response1 = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes_1)],
+        data={"prompt": "edit this image"},
+    )
+    assert response1.status_code == 200
+
+    response2 = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes_1)],
+        data={"prompt": "edit this image"},
+    )
+    assert response2.status_code == 200
+
+    # Verify both requests received distinct request_ids
+    engine = async_omni_test_client.app.state.engine_client
+    captured_request_ids = engine.captured_request_ids
+    assert len(captured_request_ids) == 2
+    assert captured_request_ids[0] != captured_request_ids[1], (
+        f"Expected two distinct request_ids, but got: {captured_request_ids}. "
+        "This indicates a request_id collision where two requests in the same "
+        "second share the same ID, which can cause state corruption."
+    )
+
+    # Verify request_ids have the expected prefix and format
+    for request_id in captured_request_ids:
+        assert request_id.startswith("img_edit_"), f"Expected request_id to start with 'img_edit-', got: {request_id}"
+        # uuid4().hex is always 32 hex chars
+        suffix = request_id[len("img_edit-") :]
+        assert len(suffix) == 32 and all(c in "0123456789abcdef" for c in suffix), (
+            f"Expected 32-char hex suffix, got: {suffix}"
+        )


### PR DESCRIPTION
## Summary

Fixes issue where multiple `/v1/images/edits` requests within the same second get identical request IDs like `img_edit_1774005805`, causing request state collisions.

### Bug
The endpoint used `int(time.time())` for request IDs, which only has second-level precision. Multiple concurrent requests would overwrite each other's state, causing:
1. Request 1 registers with its ClientRequestState (queue A)
2. Request 2 overwrites it with a new state (queue B)
3. Request 1 completes, output goes to queue B and cleans up the shared ID
4. Request 2 completes but finds no entry - result is silently dropped
5. Request 2's `generate()` coroutine hangs indefinitely

### Fix
Apply the same pattern already used in `/v1/images/generations`: use `uuid.uuid4().hex` for globally unique request IDs.

### Files changed
- `vllm_omni/entrypoints/openai/api_server.py`: Changed `request_id = f"img_edit_{int(time.time())}"` to `request_id = f"img_edit_{uuid.uuid4().hex}"`

Closes #2048
