### PR TITLE
[Voxtral] Fix Voxtral TTS end2end.py

### DIFF
--- a/examples/offline_inference/voxtral_tts/end2end.py
+++ b/examples/offline_inference/voxtral_tts/end2end.py
@@ -69,7 +69,9 @@ async def run_streaming(inputs, sampling_params_list, model_name, args, output_d
         ttfa = None
         accumulated_sample = 0
 
-        async for stage_output in async_omni.generate(single_input, request_id, sampling_params_list):
+        async for stage_output in async_omni.generate(
+            single_input, request_id=request_id, sampling_params_list=sampling_params_list
+        ):
             mm_output = stage_output.multimodal_output
             finished = stage_output.finished
             if not mm_output or "audio" not in mm_output:


### PR DESCRIPTION
### Purpose
Aligned Voxtral TTS offline inference example `end2end.py` to align with `AsyncOmni.generate()` signature change in https://github.com/vllm-project/vllm-omni/pull/2037.

### Testing Plan
Command pass on local. CI test will be added after model checkpoint is released.
```
python3 examples/offline_inference/voxtral_tts/end2end.py \
--output-dir /mnt/vast/chenyo.sun/vllm-omni/out_32_1  \
--stage-configs-path vllm_omni/model_executor/stage_configs/voxtral_tts.yaml \
--model /mnt/vast/shared/chenyo.sun/260213_voxtral-mini-tts-260213/consolidated \
--text "Hi good morning. Welcome to the Smith & Nephew Q4 and Full Year '25 Results Presentation. I'm Deepak Nath, I'm the Chief Executive Officer, and joining me is John Rogers, our CFO. I'm pleased to report a strong finish to 2025, delivering results at the high end of our guidance on revenue growth, margin and free cash flow. For the full year, underlying revenue growth of 5.3% and all three of our business units grew by over 5%. Sports Medicine and Joint Repair within that had another strong year." \
--audio-path "/root/workspace/221025_Mistral AI_VO_Sarah_Category 1_Line 20_3 Stern.wav" \
--num_prompts 32 \
--concurrency 32 \
--stream
```