### PR TITLE
[Bugfix] Add missing .gpu accessor for inputs_embeds CpuGpuBuffer in prefill overlay

### DIFF
--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1050,7 +1050,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                     dtype=self.dtype, device=self.device, non_blocking=True
                 )
                 start_offset = int(self.query_start_loc.cpu[req_index])
-                self.inputs_embeds[start_offset : start_offset + overlay_len].copy_(src)
+                self.inputs_embeds.gpu[start_offset : start_offset + overlay_len].copy_(src)
 
     def _update_additional_information(self, scheduler_output: "SchedulerOutput") -> None:
         for new_req in scheduler_output.scheduled_new_reqs:


### PR DESCRIPTION
## Purpose

Fix a `TypeError` crash in `_collect_additional_information_for_prefill()` when overlaying per-request `prompt_embeds` during prefill.

`self.inputs_embeds` is a `CpuGpuBuffer` (not a raw `torch.Tensor`), so direct indexing `self.inputs_embeds[start:end]` raises:
```
TypeError: 'CpuGpuBuffer' object is not subscriptable
```

The fix adds the `.gpu` accessor, consistent with all 6 other usages in the same file:

| Line | Code |
|------|------|
| 725 | `self.inputs_embeds.gpu[:num_tokens_padded]` |
| 731 | `self.inputs_embeds.gpu[:num_tokens_padded]` |
| 1130 | `self.inputs_embeds.gpu[:num_scheduled_tokens].copy_(...)` |
| 1155 | `self.inputs_embeds.gpu[token_ids_idx] = tokens_to_embeds` |
| 1157 | `self.inputs_embeds.gpu[:num_input_tokens]` |
| 1163 | `self.inputs_embeds.gpu[:num_input_tokens]` |
| **1053** | **`self.inputs_embeds[start:end].copy_(src)`** ← missing `.gpu` |

## Test Plan

This is a one-line accessor fix. The bug triggers when a request carries `prompt_embeds_cpu` (e.g., in multi-stage Omni pipelines where upstream stages pass embeddings to downstream), during prefill when `overlay_len > 0`.

Verified by code inspection: `self.inputs_embeds` is initialized via `self._make_buffer(self.max_num_tokens, self.hidden_size, dtype=self.dtype, numpy=False)` which returns a `CpuGpuBuffer` with `.cpu` and `.gpu` tensor attributes but no `__getitem__`.

## Test Result

Code inspection confirms:
- `CpuGpuBuffer` (defined in `vllm/v1/utils.py:105`) has only `.cpu`, `.gpu`, `.np` attributes and `copy_to_gpu()`/`copy_to_cpu()` methods — no `__getitem__`
- All other 6 usages of `self.inputs_embeds` in the same file correctly use `.gpu`
- Without fix: `TypeError: 'CpuGpuBuffer' object is not subscriptable`
- With fix: correctly writes prompt embeddings into the GPU buffer