### PR TITLE
[Bugfix] Fix Qwen-Image SP and TeaCache incompatibility

### DIFF
--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -219,10 +219,7 @@ def extract_qwen_context(
     # EXTRACT MODULATED INPUT (for cache decision)
     # ============================================================================
     block = module.transformer_blocks[0]
-    # For zero_cond_t=True, temb has 2x batch size (doubled timestep).
-    # Use only the first half for the modulated input extraction.
-    temb_for_mod = temb[: temb.shape[0] // 2] if module.zero_cond_t else temb
-    img_mod_params = block.img_mod(temb_for_mod)
+    img_mod_params = block.img_mod(temb)
     img_mod1, _ = img_mod_params.chunk(2, dim=-1)
     img_modulated, _ = block.img_norm1(hidden_states, img_mod1)
 
@@ -275,9 +272,7 @@ def extract_qwen_context(
 
     def postprocess(h):
         """Apply Qwen-specific output postprocessing."""
-        # For zero_cond_t=True, temb has 2x batch size; use only the first half.
-        pp_temb = temb.chunk(2, dim=0)[0] if module.zero_cond_t else temb
-        h = module.norm_out(h, pp_temb)
+        h = module.norm_out(h, temb)
         output = module.proj_out(h)
         if not return_dict:
             return (output,)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
 Solving #2092 

**Root Cause**: 

In the `extract_qwen_context function`, the TeaCache extractor directly invokes `module.img_in` and `module.pos_embed`, bypassing the `image_rope_prepare` module. This prevents the Sequence Parallel (SP) `SequenceParallelSplitHook` from being triggered, resulting in `hidden_states` not being properly sharded.

**When SP is enabled**:

The `_sp_plan` registers a `SequenceParallelSplitHook` on `image_rope_prepare` to shard `hidden_states` after the forward pass

**Solution**
- Modify the extract_qwen_context function in vllm_omni/diffusion/cache/teacache/extractors.py:
- Invoke image_rope_prepare: Replace direct calls to img_in and pos_embed to ensure the SP split hook is triggered
- Invoke modulate_index_prepare: Replace direct timestep processing to ensure modulate_index is correctly sharded when zero_cond_t=True
- Pass modulate_index: Pass modulate_index to the transformer blocks in run_transformer_blocks

This ensures TeaCache is properly compatible with Sequence Parallelism (both Ulysses-SP and Ring Attention).

## Test Plan

```bash
# ulysses-sp
 python examples/offline_inference/text_to_image/text_to_image.py --model Qwen/Qwen-Image --ulysses-degree 2 --cache-backend tea_cache
# ring attention
python examples/offline_inference/text_to_image/text_to_image.py --model Qwen/Qwen-Image --ring-degree 2 --cache-backend tea_cache
```

## Test Result


| SP | TeaCache |  e2e latency | Image |
| ---| ---| ---| ---|
| usp=2 | ON | 2.37s|  <img width="256" height="256" alt="qwen_image_output" src="https://github.com/user-attachments/assets/159e0078-42dc-499e-8960-c1938693eca0" />| 
| ring=2| ON|  2.78s | <img width="256" height="256" alt="qwen_image_output" src="https://github.com/user-attachments/assets/12cae73d-8932-4e6d-84ec-d3cff307e8e6" />




---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
