### PR TITLE
[CI/Build] Fix Doc 404s

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,10 +125,7 @@ plugins:
           - https://numpy.org/doc/stable/objects.inv
           # Temporarily disabled due to decompression errors
           # - https://pytorch.org/docs/stable/objects.inv
-          # Temporary disabled due to HTTP 404 error
-          # - https://psutil.readthedocs.io/en/stable/objects.inv
-          - https://psutil.readthedocs.io/objects.inv
-
+          - https://psutil.readthedocs.io/stable/objects.inv
 
 markdown_extensions:
   - attr_list


### PR DESCRIPTION
## Purpose
Doc builds seem to be broken with `https://psutil.readthedocs.io/en/stable/objects.inv` resolving to 404 - it looks like psutil is using the single version of readthedocs, but it isn't redirecting correctly for the above link.


