### PR TITLE
[Voxtral TTS] Use 8 step flow matching instead of 16

### DIFF
--- a/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
@@ -48,7 +48,7 @@ class CUDAGraphAcousticTransformerWrapper:
         self.acoustic_embeddings_levels = self.acoustic_transformer.acoustic_embeddings_levels
 
         self.cfg_alpha = 1.2
-        self.n_steps = 16
+        self.n_steps = 8
 
         # Graph storage
         self.graphs: dict[int, CUDAGraph] = {}

--- a/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
@@ -437,7 +437,7 @@ class FlowMatchingAudioTransformer(nn.Module):
 
         # Flow matching constants
         # TODO(chenyo): hardcoded, need to fix
-        self._acoustic_decode_iters = 16
+        self._acoustic_decode_iters = 8
         # TODO(chenyo): hardcoded, need to fix
         self._cfg_alpha = 1.2
         self._noise_scale = 1.0


### PR DESCRIPTION
## Purpose
Use 8 step flow matching instead of 16. Eval shows 8-step model performance is >= 16-step and throughput is much better.
## Test Plan

```
pytest -s -v tests/model_executor/stage_input_processors/test_voxtral_tts_async_chunk.py \
tests/model_executor/models/voxtral_tts/test_cuda_graph_acoustic_transformer.py \
tests/model_executor/models/voxtral_tts/test_audio_tokenizer_parsing.py \
tests/e2e/online_serving/test_voxtral_tts.py \
tests/model_executor/models/voxtral_tts/test_text_preprocess.py
```
## Test Result
All pass
<img width="1431" height="1114" alt="image" src="https://github.com/user-attachments/assets/ff49ec88-5a11-4f22-98b6-276a0b4f8b0d" />
