### PR TITLE
[Bugfix] Fix tp and Quantization incompatible for Flux

### DIFF
--- a/vllm_omni/diffusion/models/flux/flux_transformer.py
+++ b/vllm_omni/diffusion/models/flux/flux_transformer.py
@@ -248,9 +248,10 @@ class FluxAttention(torch.nn.Module):
             encoder_hidden_states, hidden_states = hidden_states.split_with_sizes(
                 [encoder_hidden_states.shape[1], hidden_states.shape[1] - encoder_hidden_states.shape[1]], dim=1
             )
-            hidden_states = self.to_out[0](hidden_states)
+            # Contiguous for FP8 quantization in RowParallelLinear
+            hidden_states = self.to_out[0](hidden_states.contiguous())
             hidden_states = self.to_out[1](hidden_states)
-            encoder_hidden_states = self.to_add_out(encoder_hidden_states)
+            encoder_hidden_states = self.to_add_out(encoder_hidden_states.contiguous())
 
             return hidden_states, encoder_hidden_states
         else:

--- a/vllm_omni/diffusion/models/flux2/flux2_transformer.py
+++ b/vllm_omni/diffusion/models/flux2/flux2_transformer.py
@@ -209,9 +209,10 @@ class Flux2Attention(nn.Module):
                 [context_len, hidden_states.shape[1] - context_len],
                 dim=1,
             )
-            encoder_hidden_states = self.to_add_out(encoder_hidden_states)
+            # Contiguous for FP8 quantization in RowParallelLinear
+            encoder_hidden_states = self.to_add_out(encoder_hidden_states.contiguous())
 
-        hidden_states = self.to_out[0](hidden_states)
+        hidden_states = self.to_out[0](hidden_states.contiguous())
         hidden_states = self.to_out[1](hidden_states)
 
         if encoder_hidden_states is not None:

--- a/vllm_omni/diffusion/models/flux2_klein/flux2_klein_transformer.py
+++ b/vllm_omni/diffusion/models/flux2_klein/flux2_klein_transformer.py
@@ -255,7 +255,8 @@ class Flux2Attention(nn.Module):
                     [txt_len, hidden_states.shape[1] - txt_len],
                     dim=1,
                 )
-                encoder_hidden_states = self.to_add_out(encoder_hidden_states)
+                # Contiguous for FP8 quantization in RowParallelLinear
+                encoder_hidden_states = self.to_add_out(encoder_hidden_states.contiguous())
             else:
                 query = torch.cat([encoder_query, query], dim=1)
                 key = torch.cat([encoder_key, key], dim=1)
@@ -282,7 +283,8 @@ class Flux2Attention(nn.Module):
                     [context_len, hidden_states.shape[1] - context_len],
                     dim=1,
                 )
-                encoder_hidden_states = self.to_add_out(encoder_hidden_states)
+                # Contiguous for FP8 quantization in RowParallelLinear
+                encoder_hidden_states = self.to_add_out(encoder_hidden_states.contiguous())
         else:
             if image_rotary_emb is not None:
                 cos, sin = image_rotary_emb
@@ -300,7 +302,7 @@ class Flux2Attention(nn.Module):
             hidden_states = self.attn(query, key, value, attn_metadata)
             hidden_states = hidden_states.flatten(2, 3).to(query.dtype)
 
-        hidden_states = self.to_out[0](hidden_states)
+        hidden_states = self.to_out[0](hidden_states.contiguous())
         hidden_states = self.to_out[1](hidden_states)
 
         if encoder_hidden_states is not None:


### PR DESCRIPTION

## Purpose

```
curl -X POST http://localhost:8004/v1/images/generations   -H "Content-Type: application/json"   -d '{
    "prompt": "A beautiful sunset over the ocean with sailing boats",
    "size": "1024x1024",
    "num_inference_steps": 50,
    "guidance_scale": 2.5,
    "negative_prompt": "blurry, low quality",
    "seed": 42
  }' | jq -r '.data[0].b64_json' | base64 -d > output.png
```

```
**RuntimeError: Diffusion generation failed: Dynamo failed to run FX node with fake tensors: call_method view(*(FakeTensor(..., device='cuda:0', size=(s23, s31, 1536), dtype=torch.bfloat16), -1, 153
6), **{}): got ValueError('Cannot view a tensor with shape torch.Size([s23, s31, 1536]) and strides (1536*s31 + 1536*s87, 1536, 1) as a tensor with shape (s23*s31, 1536)!')**
```

In dual-stream attention, split_with_sizes() after flatten(2, 3) produces non-contiguous tensor views. When combined with TP + FP8 + torch.compile, PyTorch Dynamo's FakeTensor mode infers

## Test Plan

## Test Result


<img width="300" height="200" alt="output" src="https://github.com/user-attachments/assets/c4c21685-3f4e-4807-932a-9371a312ff33" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)