### PR TITLE
[Feat] support quantization for Flux Kontext

### DIFF
--- a/vllm_omni/diffusion/models/flux/flux_transformer.py
+++ b/vllm_omni/diffusion/models/flux/flux_transformer.py
@@ -196,6 +196,8 @@ class FluxAttention(torch.nn.Module):
         attention_mask: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        # Ensure contiguous for FP8 quantized linear layers
+        hidden_states = hidden_states.contiguous()
         qkv, _ = self.to_qkv(hidden_states)
         q_size = self.to_qkv.num_heads * self.head_dim
         kv_size = self.to_qkv.num_kv_heads * self.head_dim
@@ -209,6 +211,7 @@ class FluxAttention(torch.nn.Module):
         key = self.norm_k(key)
 
         if self.added_kv_proj_dim is not None:
+            encoder_hidden_states = encoder_hidden_states.contiguous()
             encoder_qkv, _ = self.add_kv_proj(encoder_hidden_states)
             add_q_size = self.add_kv_proj.num_heads * self.head_dim
             add_kv_size = self.add_kv_proj.num_kv_heads * self.head_dim
@@ -719,6 +722,7 @@ class FluxKontextTransformer2DModel(FluxTransformer2DModel):
         guidance_embeds: bool = True,
         axes_dims_rope: tuple[int, int, int] = (16, 56, 56),
         theta: float = 10000.0,
+        quant_config: "QuantizationConfig | None" = None,
     ):
         super().__init__(
             od_config=od_config,
@@ -734,6 +738,7 @@ class FluxKontextTransformer2DModel(FluxTransformer2DModel):
             guidance_embeds=guidance_embeds,
             axes_dims_rope=axes_dims_rope,
             theta=theta,
+            quant_config=quant_config,
         )
 
     def forward(

--- a/vllm_omni/diffusion/models/flux/pipeline_flux_kontext.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux_kontext.py
@@ -130,6 +130,8 @@ class FluxKontextPipeline(nn.Module, FluxPipelineMixin, SupportImageInput):
         ).to(self._execution_device)
 
         transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, FluxKontextTransformer2DModel)
+        transformer_kwargs["od_config"] = od_config
+        transformer_kwargs["quant_config"] = od_config.quantization_config
         self.transformer = FluxKontextTransformer2DModel(**transformer_kwargs)
 
         self.vae_scale_factor = 2 ** (len(self.vae.config.block_out_channels) - 1) if getattr(self, "vae", None) else 8


### PR DESCRIPTION

## Purpose
RT

## Test Plan

## Test Result

TP=2 (24G/GPU) + CPU offload + FP8

Prompt: Add a hat to the dog

<img width="300" height="300" alt="dog" src="https://github.com/user-attachments/assets/0bcb5411-3a43-451f-9412-41e4870704da" />


| Metric                    | NO quantization | quantization | 
|----------------------------|-------------|------------------------------|
|  Image            | <img width="1024" height="512" alt="output" src="https://github.com/user-attachments/assets/d53786f1-2cfa-4eaf-92c8-61400a3f4786" /> | <img width="1024" height="512" alt="output" src="https://github.com/user-attachments/assets/d53786f1-2cfa-4eaf-92c8-61400a3f4786" />| 
|  Latency            | 62.866s | 49.392s | 
| VRAM            |23.0GiB    | 18.197GiB  | 


- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
