### PR TITLE
[Misc] DiffusionWorker, MultiprocDiffusionExecutor: cleanup unused references to zmq

### DIFF
--- a/docs/design/module/dit_module.md
+++ b/docs/design/module/dit_module.md
@@ -243,7 +243,7 @@ while True:
 
 ## 3. Worker
 
-**Location**: `vllm_omni/diffusion/worker/gpu_worker.py`
+**Location**: `vllm_omni/diffusion/worker/diffusion_worker.py`
 
 ### Architecture
 
@@ -256,9 +256,6 @@ Workers are **independent processes** that execute the actual model inference. E
 ```python
 class WorkerProc:
     def __init__(self, od_config, gpu_id, broadcast_handle):
-        # Initialize ZMQ context for IPC
-        self.context = zmq.Context(io_threads=2)
-
         # Connect to broadcast queue (receive requests)
         self.mq = MessageQueue.create_from_handle(broadcast_handle, gpu_id)
 
@@ -266,13 +263,13 @@ class WorkerProc:
         if gpu_id == 0:
             self.result_mq = MessageQueue(n_reader=1, ...)
 
-        # Initialize GPU worker
-        self.worker = GPUWorker(local_rank=gpu_id, rank=gpu_id, od_config=od_config)
+        # Initialize worker
+        self.worker = DiffusionWorker(local_rank=gpu_id, rank=gpu_id, od_config=od_config)
 ```
 
 **Initialization Steps**:
 
-1. **IPC Setup**: Creates ZMQ context and message queues
+1. **IPC Setup**: Creates shared-memory message queues for request broadcast and result collection
 
 2. **Distributed Environment Setup**: Initializes PyTorch distributed communication
 
@@ -286,11 +283,11 @@ class WorkerProc:
 
 4. **Cache Setup**: Enables cache backend if configured.
 
-#### 3.2 GPU Worker
+#### 3.2 DiffusionWorker
 
 ```python
-class GPUWorker:
-    def init_device_and_model(self):
+class DiffusionWorker:
+    def init_device(self):
         # Set distributed environment variables
         os.environ["RANK"] = str(rank)
         os.environ["WORLD_SIZE"] = str(world_size)
@@ -306,25 +303,22 @@ class GPUWorker:
             pipeline_parallel_size=parallel_config.pipeline_parallel_size,
         )
 
-        # Load model
-        model_loader = DiffusersPipelineLoader(load_config)
-        self.pipeline = model_loader.load_model(od_config, load_device=f"cuda:{rank}")
-
-        # Setup cache backend
-        from vllm_omni.diffusion.cache.selector import get_cache_backend
-        self.cache_backend = get_cache_backend(od_config.cache_backend, od_config.cache_config)
-
-        if self.cache_backend is not None:
-            self.cache_backend.enable(self.pipeline)
+    def load_model(self, load_format="default", custom_pipeline_name=None):
+        # Load model via DiffusionModelRunner
+        self.model_runner.load_model(
+            memory_pool_context_fn=self._maybe_get_memory_pool_context,
+            load_format=load_format,
+            custom_pipeline_name=custom_pipeline_name,
+        )
 ```
 
 **Key Features**:
 
 - **Tensor Parallelism**: Supports multi-GPU tensor parallelism via PyTorch distributed
 
-- **Model Loading**: Uses `DiffusersPipelineLoader` for efficient weight loading
+- **Model Loading**: Delegates to `DiffusionModelRunner` for model loading and execution
 
-- **Cache Integration**: Enables cache backends (TeaCache, cache-dit, etc.) transparently
+- **Separation of Concerns**: `DiffusionWorker` handles infrastructure (device, distributed env, memory), while `DiffusionModelRunner` handles model operations (loading, compilation, execution)
 
 #### 3.3 Worker Busy Loop
 
@@ -364,21 +358,9 @@ def worker_busy_loop(self):
 #### 3.4 Model Execution
 
 ```python
-@torch.inference_mode()
-def execute_model(self, reqs: list[OmniDiffusionRequest], od_config):
-    req = reqs[0]  # TODO: support batching
-
-    # Refresh cache backend if enabled
-    if self.cache_backend is not None and self.cache_backend.is_enabled():
-        self.cache_backend.refresh(self.pipeline, req.num_inference_steps)
-
-    # Set forward context for parallelism
-    with set_forward_context(
-        vllm_config=self.vllm_config,
-        omni_diffusion_config=self.od_config
-    ):
-        output = self.pipeline.forward(req)
-    return output
+def execute_model(self, req: OmniDiffusionRequest, od_config):
+    # Delegate to DiffusionModelRunner
+    return self.model_runner.execute_model(req)
 ```
 
 The model execution leverages multiple parallelism strategies that are transparently applied during the forward pass. The `set_forward_context()` context manager makes parallel group information available throughout the forward pass:
@@ -923,7 +905,7 @@ def initialize_model_parallel(
 
 4. Worker Execution
    └─> WorkerProc.worker_busy_loop()
-       └─> GPUWorker.execute_model(reqs)
+       └─> DiffusionWorker.execute_model(req)
            └─> Pipeline.forward(req)
                ├─> encode_prompt()
                ├─> prepare_latents()

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -6,7 +6,6 @@ import weakref
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-import zmq
 from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
 from vllm.logger import init_logger
 
@@ -303,8 +302,6 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                         )
 
                     responses.append(response)
-                except zmq.error.Again as e:
-                    raise TimeoutError(f"RPC call to {method} timed out.") from e
                 except TimeoutError as e:
                     raise TimeoutError(f"RPC call to {method} timed out.") from e
 

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -16,7 +16,6 @@ from contextlib import AbstractContextManager, nullcontext
 from typing import Any
 
 import torch
-import zmq
 from vllm.config import CompilationConfig, DeviceConfig, VllmConfig, set_current_vllm_config
 from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
 from vllm.logger import init_logger
@@ -384,9 +383,6 @@ class WorkerProc:
         self.od_config = od_config
         self.gpu_id = gpu_id
 
-        # Inter-process Communication
-        self.context = zmq.Context(io_threads=2)
-
         # Initialize MessageQueue reader from handle
         self.mq = MessageQueue.create_from_handle(broadcast_handle, gpu_id)
 
@@ -502,18 +498,13 @@ class WorkerProc:
                     )
                     output = DiffusionOutput(error=str(e))
 
-                try:
-                    self.return_result(output)
-                except zmq.ZMQError as e:
-                    logger.error(f"ZMQ error sending reply: {e}")
-                    continue
+                self.return_result(output)
 
         logger.info("event loop terminated.")
         try:
             self.worker.shutdown()
         except Exception as exc:
             logger.warning("Worker %s: Shutdown encountered an error: %s", self.gpu_id, exc)
-        self.context.term()
 
     @staticmethod
     def worker_main(
@@ -597,7 +588,7 @@ class WorkerWrapperBase:
     def _prepare_worker_class(self) -> type:
         """
         Prepare the worker class with optional extension.
-        Dynamically extends GPUWorker with worker_extension_cls if provided.
+        Dynamically extends DiffusionWorker with worker_extension_cls if provided.
 
         Returns:
             The worker class (potentially extended)


### PR DESCRIPTION
## Purpose

While reading zmq related code, I noticed that zmq context is initialized in several placed but never used, thus the cleanup.

## Test Plan

```
pytest -s -v tests/e2e/offline_inference/test_zimage_parallelism.py
```

## Test Result

```
================== 2 passed, 17 warnings in 123.94s (0:02:03) ==================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
