### PR TITLE
[Perf] Direct GPU-to-SHM tensor copy in diffusion IPC

### DIFF
--- a/tests/diffusion/test_diffusion_step_pipeline.py
+++ b/tests/diffusion/test_diffusion_step_pipeline.py
@@ -21,6 +21,7 @@ from vllm_omni.diffusion.distributed.parallel_state import (
     initialize_model_parallel,
 )
 from vllm_omni.diffusion.ipc import (
+    _SHM_TENSOR_THRESHOLD,
     pack_diffusion_output_shm,
     unpack_diffusion_output_shm,
 )
@@ -441,8 +442,12 @@ class TestWorker:
 
 @pytest.mark.cpu
 class TestIPC:
-    def test_pack_unpack_runner_output_shm(self):
-        tensor = torch.zeros(300_000, dtype=torch.float32)
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+    def test_pack_unpack_runner_output_shm(self, dtype):
+        # Use a tensor above the SHM threshold
+        numel = _SHM_TENSOR_THRESHOLD // dtype.itemsize + 1
+        tensor = torch.zeros(numel, dtype=dtype)
+        assert tensor.nelement() * tensor.element_size() > _SHM_TENSOR_THRESHOLD
         output = RunnerOutput(req_id="req-1", finished=True, result=DiffusionOutput(output=tensor))
 
         packed = pack_diffusion_output_shm(output)
@@ -451,7 +456,28 @@ class TestIPC:
 
         unpacked = unpack_diffusion_output_shm(packed)
         assert isinstance(unpacked.result.output, torch.Tensor)
+        assert unpacked.result.output.dtype == dtype
         torch.testing.assert_close(unpacked.result.output, tensor)
+
+    def test_pack_unpack_multidim(self):
+        tensor = torch.randn(1, 3, 512, 512, dtype=torch.bfloat16)
+        assert tensor.nelement() * tensor.element_size() > _SHM_TENSOR_THRESHOLD
+        output = RunnerOutput(req_id="req-2", finished=True, result=DiffusionOutput(output=tensor))
+
+        packed = pack_diffusion_output_shm(output)
+        unpacked = unpack_diffusion_output_shm(packed)
+        assert unpacked.result.output.shape == tensor.shape
+        torch.testing.assert_close(unpacked.result.output, tensor)
+
+    def test_small_tensor_not_packed(self):
+        # Use a tensor below the SHM threshold
+        numel = _SHM_TENSOR_THRESHOLD // torch.float32.itemsize - 1
+        tensor = torch.zeros(numel, dtype=torch.float32)
+        assert tensor.nelement() * tensor.element_size() <= _SHM_TENSOR_THRESHOLD
+        output = RunnerOutput(req_id="req-3", finished=True, result=DiffusionOutput(output=tensor))
+
+        packed = pack_diffusion_output_shm(output)
+        assert isinstance(packed.result.output, torch.Tensor)
 
 
 @pytest.mark.cpu

--- a/vllm_omni/diffusion/ipc.py
+++ b/vllm_omni/diffusion/ipc.py
@@ -28,20 +28,16 @@ def _tensor_to_shm(tensor: torch.Tensor) -> dict[str, Any]:
     """
     from multiprocessing import shared_memory
 
-    import numpy as np
-
-    tensor = tensor.detach().cpu().contiguous()
-    arr = tensor.numpy()
-    nbytes = arr.nbytes
+    tensor = tensor.detach().contiguous()
+    nbytes = tensor.nelement() * tensor.element_size()
     shm = shared_memory.SharedMemory(create=True, size=nbytes)
-    shm_arr = np.ndarray(arr.shape, dtype=arr.dtype, buffer=shm.buf[:nbytes])
-    np.copyto(shm_arr, arr)
+    shm_tensor = torch.frombuffer(shm.buf, dtype=tensor.dtype, count=tensor.nelement())
+    shm_tensor.reshape(tensor.shape).copy_(tensor)
     handle = {
         "__tensor_shm__": True,
         "name": shm.name,
         "shape": list(tensor.shape),
-        "torch_dtype": str(tensor.dtype),
-        "numpy_dtype": str(arr.dtype),
+        "torch_dtype": tensor.dtype,
         "nbytes": nbytes,
     }
     shm.close()
@@ -52,13 +48,11 @@ def _tensor_from_shm(handle: dict[str, Any]) -> torch.Tensor:
     """Reconstruct a tensor from a shared-memory handle and free the segment."""
     from multiprocessing import shared_memory
 
-    import numpy as np
-
     shm = shared_memory.SharedMemory(name=handle["name"])
     try:
-        np_dtype = np.dtype(handle["numpy_dtype"])
-        arr = np.ndarray(handle["shape"], dtype=np_dtype, buffer=shm.buf[: handle["nbytes"]])
-        tensor = torch.from_numpy(arr.copy())
+        dtype = handle["torch_dtype"]
+        shm_tensor = torch.frombuffer(shm.buf, dtype=dtype, count=handle["nbytes"] // dtype.itemsize)
+        tensor = shm_tensor.clone().reshape(handle["shape"])
     finally:
         shm.close()
         shm.unlink()


### PR DESCRIPTION
## Purpose

Replace the numpy-based GPU→CPU→SHM copy path with direct torch.frombuffer + copy_ for a minor speedup on pack/unpack. This also fixes bfloat16/float8 support which previously fell back to pickle serialization.

## Test Plan

```
pytest -s -v tests/diffusion/test_diffusion_step_pipeline.py::TestIPC
pytest -s -v tests/e2e/offline_inference/test_zimage_parallelism.py
```

## Test Result

```
PASS
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
