### PR TITLE
[Enhancement] Support RunAI Model Streamer for diffusion weight loading

### DIFF
--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -412,6 +412,7 @@ class OmniDiffusionConfig:
     # Parallel weight loading (for faster diffusion model startup)
     enable_multithread_weight_load: bool = True
     num_weight_load_threads: int = 4
+    enable_runai_streamer: bool = False
 
     # Enable sleep mode
     enable_sleep_mode: bool = False

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -24,6 +24,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     filter_files_not_needed_for_inference,
     maybe_download_from_modelscope,
     multi_thread_safetensors_weights_iterator,
+    runai_safetensors_weights_iterator,
     safetensors_weights_iterator,
 )
 from vllm.utils.import_utils import resolve_obj_by_qualname
@@ -180,13 +181,20 @@ class DiffusersPipelineLoader:
         )
 
         od_config = self.od_config
+        use_runai = use_safetensors and od_config is not None and getattr(od_config, "enable_runai_streamer", False)
         use_multithread = (
             use_safetensors
             and od_config is not None
             and getattr(od_config, "enable_multithread_weight_load", False)
             and self.load_config.safetensors_load_strategy != "torchao"
         )
-        if use_multithread:
+        if use_runai:
+            sorted_hf_weights_files = sorted(hf_weights_files, key=_natural_sort_key)
+            weights_iterator = runai_safetensors_weights_iterator(
+                sorted_hf_weights_files,
+                self.load_config.use_tqdm_on_load,
+            )
+        elif use_multithread:
             num_threads = getattr(od_config, "num_weight_load_threads", 4)
             # Keep deterministic shard order before passing to vLLM helper.
             sorted_hf_weights_files = sorted(hf_weights_files, key=_natural_sort_key)

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -865,6 +865,7 @@ class AsyncOmniEngine:
                     "enable_sleep_mode": kwargs.get("enable_sleep_mode", False),
                     "enable_multithread_weight_load": kwargs.get("enable_multithread_weight_load", True),
                     "num_weight_load_threads": kwargs.get("num_weight_load_threads", 4),
+                    "enable_runai_streamer": kwargs.get("enable_runai_streamer", False),
                     "quantization": kwargs.get("quantization", None),
                     "enable_diffusion_pipeline_profiler": kwargs.get("enable_diffusion_pipeline_profiler", False),
                     **(

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -294,6 +294,12 @@ class OmniServeCommand(CLISubcommand):
             default=4,
             help="Number of threads for parallel weight loading (default: 4).",
         )
+        omni_config_group.add_argument(
+            "--enable-runai-streamer",
+            action="store_true",
+            default=False,
+            help="Use RunAI Model Streamer for loading diffusion safetensors weights.",
+        )
 
         # diffusion model offload parameters
         omni_config_group.add_argument(


### PR DESCRIPTION
## Purpose

Add enable_runai_streamer flag to OmniDiffusionConfig so diffusion models can use the runai_model_streamer library for streaming safetensors weights, matching the support already available in the LLM weight loading path.

## Test Plan

```
vllm-omni serve --omni Tongyi-MAI/Z-Image-Turbo --port 8000
vllm-omni serve --omni Tongyi-MAI/Z-Image-Turbo --port 8000 --enable-runai-streamer
```

## Test Result

It runs. Reducing model load time from 55.68s to 39.45s.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
