### PR TITLE
[POC] Add Turbo Quant 

### DIFF
--- a/tests/diffusion/quantization/bench_turboquant_needle.py
+++ b/tests/diffusion/quantization/bench_turboquant_needle.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TurboQuant Needle-in-a-Haystack benchmark.
+
+Reproduces the evaluation from Blaizzy/mlx-vlm#858:
+  - Multiple context lengths
+  - Needle hidden at different depths
+  - Measures: exact match, avg KV cache size, compression ratio
+
+Approach: single forward pass per test, compare if the model's next-token
+prediction contains the needle answer. No decode loop needed — if the model
+"sees" the needle in the KV cache, the first tokens will reference it.
+
+Usage:
+    python tests/diffusion/quantization/bench_turboquant_needle.py
+    python tests/diffusion/quantization/bench_turboquant_needle.py --model Qwen/Qwen2.5-7B-Instruct
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import sys
+import time
+import types
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Import TurboQuant
+# ---------------------------------------------------------------------------
+_tq = types.ModuleType("vllm_omni.quantization.turboquant")
+sys.modules[_tq.__name__] = _tq
+_spec = importlib.util.spec_from_file_location(
+    _tq.__name__,
+    os.path.join(
+        os.path.dirname(__file__),
+        "..", "..", "..", "vllm_omni", "quantization", "turboquant.py",
+    ),
+)
+_spec.loader.exec_module(_tq)
+TurboQuantConfig = _tq.TurboQuantConfig
+TurboQuantState = _tq.TurboQuantState
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder
+# ---------------------------------------------------------------------------
+
+NEEDLE = "The secret project code name is AURORA-7749."
+ANSWER_KEY = "AURORA-7749"
+
+FILLER = (
+    "The quarterly financial review meeting covered several topics including "
+    "budget allocations for the upcoming fiscal year, departmental spending "
+    "reports, and projected revenue streams from various business units. "
+    "The committee discussed infrastructure upgrades planned for the western "
+    "regional offices and noted that maintenance schedules should be "
+    "coordinated with the facilities management team. Several action items "
+    "were assigned to team leads for follow-up before the next meeting.\n\n"
+)
+
+
+def build_haystack(tokenizer, target_tokens: int, needle_depth: float) -> str:
+    filler_len = len(tokenizer.encode(FILLER))
+    n_reps = max(1, target_tokens // filler_len)
+    needle_idx = max(0, int(n_reps * needle_depth))
+    parts = []
+    for i in range(n_reps):
+        if i == needle_idx:
+            parts.append(f"\n--- Important Memo ---\n{NEEDLE}\n--- End Memo ---\n\n")
+        parts.append(FILLER)
+    haystack = "".join(parts)
+    question = "What is the secret project code name mentioned in the memo?"
+    return (
+        f"<|im_start|>user\n{haystack}\n{question}<|im_end|>\n"
+        f"<|im_start|>assistant\nThe secret project code name is"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core test function
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+def run_needle_test(
+    model, tokenizer, target_tokens: int, needle_depth: float,
+    kv_bits: int | None, device: torch.device,
+) -> tuple[bool, int]:
+    """Run one needle test. Returns (found, kv_cache_bytes)."""
+    cfg = model.config
+    num_layers = cfg.num_hidden_layers
+    head_dim = cfg.hidden_size // cfg.num_attention_heads
+
+    prompt = build_haystack(tokenizer, target_tokens, needle_depth)
+    inputs = tokenizer(
+        prompt, return_tensors="pt",
+        truncation=True, max_length=target_tokens + 512,
+    ).to(device)
+
+    # Forward pass
+    outputs = model(**inputs, use_cache=True)
+    past_kv = outputs.past_key_values
+
+    if kv_bits is None:
+        # Baseline: measure FP16 KV size, greedy decode 20 tokens
+        kv_bytes = 0
+        for i in range(num_layers):
+            k, v = past_kv[i]
+            kv_bytes += k.nelement() * k.element_size()
+            kv_bytes += v.nelement() * v.element_size()
+
+        # Greedy decode
+        answer_tokens = []
+        next_logits = outputs.logits[:, -1, :]
+        for _ in range(20):
+            next_id = next_logits.argmax(dim=-1, keepdim=True)
+            if next_id.item() == tokenizer.eos_token_id:
+                break
+            answer_tokens.append(next_id)
+            out = model(input_ids=next_id, past_key_values=past_kv)
+            next_logits = out.logits[:, -1, :]
+            past_kv = out.past_key_values
+
+        answer = tokenizer.decode(
+            torch.cat(answer_tokens, dim=-1)[0] if answer_tokens else torch.tensor([]),
+            skip_special_tokens=True,
+        )
+        found = ANSWER_KEY in answer
+        if not found:
+            print(f"\n    [DEBUG full] generated: '{answer[:80]}'", end="")
+        del past_kv
+        return found, kv_bytes
+
+    else:
+        # TurboQuant: compress KV, decompress, replace in-place, decode
+        config = TurboQuantConfig(bit_width=kv_bits, use_qjl=False)
+        tq_bytes = 0
+
+        # Compress each layer's KV, then decompress and write back
+        # into the ORIGINAL cache to preserve all metadata
+        for i in range(num_layers):
+            k, v = past_kv[i]
+            k_st = TurboQuantState(config, head_dim, i, device)
+            v_st = TurboQuantState(config, head_dim, i + 10000, device)
+            k_c = k_st.quantize(k)
+            v_c = v_st.quantize(v)
+            for t in k_c.values():
+                if isinstance(t, torch.Tensor):
+                    tq_bytes += t.nelement() * t.element_size()
+            for t in v_c.values():
+                if isinstance(t, torch.Tensor):
+                    tq_bytes += t.nelement() * t.element_size()
+            # Decompress and replace in the original cache in-place
+            k_deq = k_st.dequantize(k_c)
+            v_deq = v_st.dequantize(v_c)
+            # Overwrite the cache tensors directly
+            if hasattr(past_kv, 'key_cache'):
+                past_kv.key_cache[i] = k_deq
+                past_kv.value_cache[i] = v_deq
+            elif hasattr(past_kv, '_data'):
+                past_kv._data[i] = (k_deq, v_deq)
+
+        # Greedy decode using the modified original cache
+        answer_tokens = []
+        next_logits = outputs.logits[:, -1, :]
+        for _ in range(20):
+            next_id = next_logits.argmax(dim=-1, keepdim=True)
+            if next_id.item() == tokenizer.eos_token_id:
+                break
+            answer_tokens.append(next_id)
+            out = model(input_ids=next_id, past_key_values=past_kv)
+            next_logits = out.logits[:, -1, :]
+            past_kv = out.past_key_values
+
+        answer = tokenizer.decode(
+            torch.cat(answer_tokens, dim=-1)[0] if answer_tokens else torch.tensor([]),
+            skip_special_tokens=True,
+        )
+        found = ANSWER_KEY in answer
+        if not found:
+            print(f"\n    [DEBUG TQ {kv_bits}-bit] generated: '{answer[:80]}'", end="")
+        del past_kv
+        return found, tq_bytes
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="TurboQuant Needle-in-a-Haystack")
+    parser.add_argument("--model", default="Qwen/Qwen2.5-1.5B-Instruct")
+    parser.add_argument("--contexts", type=int, nargs="+", default=[4096, 8192, 16384])
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"GPU: {torch.cuda.get_device_name(device) if device.type == 'cuda' else 'CPU'}")
+
+    print(f"\nLoading {args.model}...")
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model, torch_dtype=torch.bfloat16, device_map=device,
+        trust_remote_code=True,
+    )
+    model.eval()
+
+    cfg = model.config
+    print(f"  layers={cfg.num_hidden_layers}, "
+          f"kv_heads={getattr(cfg, 'num_key_value_heads', cfg.num_attention_heads)}, "
+          f"head_dim={cfg.hidden_size // cfg.num_attention_heads}")
+
+    depths = [0.25, 0.5]
+    total_tests = len(args.contexts) * len(depths)
+
+    configs = [
+        ("full", None),
+        ("TurboQuant 2-bit", 2),
+        ("TurboQuant 2.5", 2.5),
+        ("TurboQuant 3-bit", 3),
+        ("TurboQuant 3.5", 3.5),
+        ("TurboQuant 4-bit", 4),
+    ]
+
+    print(f"\nModel: {args.model} (bf16)")
+    print(f"Device: {torch.cuda.get_device_name(device) if device.type == 'cuda' else 'CPU'}")
+    print(f"Context: {', '.join(f'{c // 1024}k' for c in args.contexts)}")
+    print(f"Test: Needle-in-a-haystack style\n")
+
+    results = {name: {"matches": 0, "bytes": []} for name, _ in configs}
+
+    for ctx in args.contexts:
+        for depth in depths:
+            label = f"ctx={ctx}, depth={depth:.0%}"
+            print(f"  {label}:", end="", flush=True)
+            for name, bits in configs:
+                torch.cuda.empty_cache()
+                try:
+                    found, cache_bytes = run_needle_test(
+                        model, tokenizer, ctx, depth, bits, device,
+                    )
+                    results[name]["matches"] += int(found)
+                    results[name]["bytes"].append(cache_bytes)
+                    sym = "Y" if found else "N"
+                except Exception as e:
+                    sym = "E"
+                    print(f"\n    {name} error: {e}", end="")
+                print(f" [{name}: {sym}]", end="", flush=True)
+            print()
+
+    # Results table
+    full_avg = sum(results["full"]["bytes"]) / max(len(results["full"]["bytes"]), 1)
+
+    print(f"\n{'='*65}")
+    print("Results\n")
+    print(f"{'config':<22} {'exact match':>14} {'avg cache GB':>14} {'vs full':>14}")
+    print("-" * 65)
+
+    for name, _ in configs:
+        r = results[name]
+        m = r["matches"]
+        if r["bytes"]:
+            avg_b = sum(r["bytes"]) / len(r["bytes"])
+            avg_gb = avg_b / 1024**3
+            if name == "full":
+                ratio = "1.0x"
+            else:
+                ratio = f"{full_avg / avg_b:.1f}x smaller"
+        else:
+            avg_gb = 0
+            ratio = "N/A"
+        print(f"{name:<22} {m}/{total_tests:>13} {avg_gb:>14.3f} {ratio:>14}")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/diffusion/quantization/test_turboquant_standalone.py
+++ b/tests/diffusion/quantization/test_turboquant_standalone.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Standalone TurboQuant tests — requires only PyTorch, no vLLM.
+
+Usage:
+    python tests/diffusion/quantization/test_turboquant_standalone.py
+"""
+
+import math
+import os
+import sys
+import types
+
+import torch
+
+# Direct import to avoid vllm_omni.__init__ pulling in vLLM.
+_mod = types.ModuleType("vllm_omni.quantization.turboquant")
+sys.modules[_mod.__name__] = _mod
+
+import importlib.util as _ilu
+
+_spec = _ilu.spec_from_file_location(
+    _mod.__name__,
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "vllm_omni",
+                 "quantization", "turboquant.py"),
+)
+_spec.loader.exec_module(_mod)
+
+EXPECTED_MSE_NORMALIZED = _mod.EXPECTED_MSE_NORMALIZED
+TurboQuantConfig = _mod.TurboQuantConfig
+TurboQuantState = _mod.TurboQuantState
+_get_codebook = _mod._get_codebook
+_hadamard_transform = _mod._hadamard_transform
+compute_distortion = _mod.compute_distortion
+random_rotate = _mod.random_rotate
+random_rotate_inverse = _mod.random_rotate_inverse
+scalar_dequantize = _mod.scalar_dequantize
+scalar_quantize = _mod.scalar_quantize
+
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, condition: bool, detail: str = ""):
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        FAIL += 1
+        print(f"  FAIL  {name}  {detail}")
+
+
+def test_codebook():
+    print("\n--- Codebook ---")
+    for bits in [1, 2, 3, 4]:
+        cb = _get_codebook(bits, 128, DEVICE)
+        check(f"{bits}-bit symmetric", torch.allclose(cb, -cb.flip(0), atol=1e-5))
+        check(f"{bits}-bit sorted", bool((cb[1:] > cb[:-1]).all()))
+
+
+def test_hadamard():
+    print("\n--- Hadamard ---")
+    x = torch.randn(64, device=DEVICE)
+    y = _hadamard_transform(_hadamard_transform(x))
+    check("self-inverse", torch.allclose(x, y, atol=1e-4),
+          f"max diff={( x - y).abs().max():.6f}")
+
+    check("norm-preserving", torch.allclose(
+        x.norm(), _hadamard_transform(x).norm(), atol=1e-4))
+
+
+def test_rotation():
+    print("\n--- Random rotation ---")
+    d = 128
+    sf = (torch.randint(0, 2, (d,), device=DEVICE).float() * 2 - 1)
+    x = torch.randn(10, d, device=DEVICE)
+
+    y = random_rotate(x, sf)
+    check("norm-preserving",
+          torch.allclose(x.norm(dim=-1), y.norm(dim=-1), atol=1e-4))
+
+    x_rec = random_rotate_inverse(y, sf)
+    check("invertible", torch.allclose(x, x_rec, atol=1e-4),
+          f"max diff={(x - x_rec).abs().max():.6f}")
+
+
+def test_scalar_quantize():
+    print("\n--- Scalar quantization ---")
+    cb = _get_codebook(3, 128, DEVICE)
+    indices = scalar_quantize(cb, cb)
+    recovered = scalar_dequantize(indices, cb)
+    check("centroid roundtrip", torch.allclose(cb, recovered))
+
+    x = torch.randn(100, device=DEVICE) / math.sqrt(128)
+    idx = scalar_quantize(x, cb)
+    check("index range", int(idx.min()) >= 0 and int(idx.max()) <= 7)
+
+
+def test_roundtrip_mse():
+    print("\n--- Roundtrip MSE (paper Theorem 1) ---")
+    torch.manual_seed(0)
+    n, d = 500, 128
+
+    for bits in [1, 2, 3, 4]:
+        config = TurboQuantConfig(bit_width=bits, use_qjl=False)
+        state = TurboQuantState(config, d, layer_idx=0, device=DEVICE)
+
+        x = torch.randn(n, 1, d, device=DEVICE)
+        x = x / x.norm(dim=-1, keepdim=True)
+
+        x_hat = state.dequantize(state.quantize(x))
+        mse = (x - x_hat).pow(2).sum(dim=-1).mean().item()
+        bound = EXPECTED_MSE_NORMALIZED[bits]
+
+        check(f"{bits}-bit MSE={mse:.4f} (bound={bound:.4f})",
+              mse < bound * 3.0,
+              f"ratio={mse / bound:.2f}x")
+
+
+def test_qjl_unbiased():
+    print("\n--- QJL unbiasedness (paper Theorem 2) ---")
+    torch.manual_seed(42)
+    d = 128
+    n = 300
+
+    x = torch.randn(n, 1, d, device=DEVICE)
+    x = x / x.norm(dim=-1, keepdim=True)
+    y = torch.randn(n, 1, d, device=DEVICE)
+
+    state = TurboQuantState(
+        TurboQuantConfig(bit_width=2, use_qjl=True),
+        d, layer_idx=0, device=DEVICE,
+    )
+    x_hat = state.dequantize(state.quantize(x))
+
+    ip_true = (y * x).sum(dim=-1)
+    ip_est = (y * x_hat).sum(dim=-1)
+    bias = (ip_est - ip_true).mean().abs().item()
+    check(f"bias={bias:.4f}", bias < 0.05)
+
+
+def test_nonstandard_head_size():
+    print("\n--- Non-power-of-2 head sizes ---")
+    for hs in [96, 80, 192]:
+        config = TurboQuantConfig(bit_width=2, use_qjl=False)
+        state = TurboQuantState(config, hs, layer_idx=0, device=DEVICE)
+        x = torch.randn(2, 4, hs, device=DEVICE)
+        x_hat = state.dequantize(state.quantize(x))
+        check(f"head_size={hs} shape", x_hat.shape == x.shape)
+
+
+def test_determinism():
+    print("\n--- Determinism ---")
+    config = TurboQuantConfig(bit_width=3)
+    state = TurboQuantState(config, 128, layer_idx=0, device=DEVICE)
+    x = torch.randn(2, 4, 128, device=DEVICE)
+    q1 = state.quantize(x)
+    q2 = state.quantize(x)
+    check("same input -> same indices", torch.equal(q1["indices"], q2["indices"]))
+
+
+def test_compression_ratio():
+    print("\n--- Compression ratio ---")
+    d = 128
+    for bits in [2, 3, 4]:
+        fp16_bytes = d * 2
+        tq_bytes = math.ceil(d * bits / 8) + 2  # +2 for norm (float16)
+        ratio = fp16_bytes / tq_bytes
+        check(f"{bits}-bit ratio={ratio:.1f}x vs FP16", ratio > 1.5)
+
+
+if __name__ == "__main__":
+    print(f"Device: {DEVICE}")
+    test_codebook()
+    test_hadamard()
+    test_rotation()
+    test_scalar_quantize()
+    test_roundtrip_mse()
+    test_qjl_unbiased()
+    test_nonstandard_head_size()
+    test_determinism()
+    test_compression_ratio()
+
+    print(f"\n{'=' * 40}")
+    print(f"Results: {PASS} passed, {FAIL} failed")
+    sys.exit(1 if FAIL else 0)

--- a/vllm_omni/model_executor/stage_configs/qwen3_omni_moe.yaml
+++ b/vllm_omni/model_executor/stage_configs/qwen3_omni_moe.yaml
@@ -25,6 +25,11 @@ stage_args:
       max_num_batched_tokens: 32768
       hf_config_name: thinker_config
       tensor_parallel_size: 1
+      # TurboQuant KV cache compression (Phase 2 — requires vLLM core integration)
+      # Reduces KV cache by 4-5x with zero quality loss on needle-in-a-haystack.
+      # Supported bit_widths: 2, 2.5, 3, 3.5, 4
+      # See: https://arxiv.org/abs/2504.19874
+      # kv_bits: 3.5
     final_output: true
     final_output_type: text
     is_comprehension: true

--- a/vllm_omni/quantization/__init__.py
+++ b/vllm_omni/quantization/__init__.py
@@ -17,8 +17,14 @@ from .factory import SUPPORTED_QUANTIZATION_METHODS, build_quant_config
 # DiffusionGGUFConfig is NOT imported here to avoid pulling in
 # GGUF -> fused_moe -> pynvml at module load time.
 
+# TurboQuant KV cache compression (not weight quantization).
+# Imported separately since it operates on KV tensors, not model weights.
+from .turboquant import TurboQuantConfig, TurboQuantState
+
 __all__ = [
     "build_quant_config",
     "ComponentQuantizationConfig",
     "SUPPORTED_QUANTIZATION_METHODS",
+    "TurboQuantConfig",
+    "TurboQuantState",
 ]

--- a/vllm_omni/quantization/turboquant.py
+++ b/vllm_omni/quantization/turboquant.py
@@ -1,0 +1,529 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TurboQuant: online vector quantization for KV cache compression.
+
+Implements the TurboQuant algorithm (https://arxiv.org/abs/2504.19874)
+for sub-4-bit KV cache quantization with near-optimal distortion.
+
+Two-stage approach:
+  1. Random rotation + Lloyd-Max scalar quantization (b-1 bits)
+  2. QJL 1-bit transform on residual for unbiased inner products
+
+Adapted from:
+  - https://github.com/tonbistudio/turboquant-pytorch
+  - https://github.com/TheTom/turboquant_plus
+  - https://github.com/Blaizzy/mlx-vlm/pull/858
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+
+# ---------------------------------------------------------------------------
+# Precomputed Lloyd-Max codebooks (Gaussian approximation N(0, 1/d)).
+#
+# Normalized centroids: multiply by 1/sqrt(d) to get actual values.
+# Solved via Lloyd-Max algorithm on the Gaussian PDF.
+# ---------------------------------------------------------------------------
+
+CODEBOOKS_NORMALIZED: dict[int, list[float]] = {
+    1: [-0.7979, 0.7979],  # ±sqrt(2/pi)
+    2: [-1.5104, -0.4528, 0.4528, 1.5104],
+    3: [
+        -2.1520, -1.3440, -0.7560, -0.2451,
+        0.2451, 0.7560, 1.3440, 2.1520,
+    ],
+    4: [
+        -2.7326, -2.0690, -1.6180, -1.2562,
+        -0.9424, -0.6568, -0.3880, -0.1284,
+        0.1284, 0.3880, 0.6568, 0.9424,
+        1.2562, 1.6180, 2.0690, 2.7326,
+    ],
+}
+
+EXPECTED_MSE_NORMALIZED: dict[int, float] = {
+    1: 0.3634,
+    2: 0.1175,
+    3: 0.03454,
+    4: 0.009497,
+}
+
+
+@dataclass
+class TurboQuantConfig:
+    """Configuration for TurboQuant KV cache quantization.
+
+    Supports fractional bit-widths (2.5, 3.5) via mixed-precision
+    channel splitting:
+      - 2.5-bit: 50% channels at 3-bit + 50% at 2-bit
+      - 3.5-bit: 25% channels at 4-bit + 75% at 3-bit
+    """
+
+    bit_width: float = 3
+    use_qjl: bool = False
+    seed: int = 42
+
+    def __post_init__(self) -> None:
+        valid = {1, 2, 2.5, 3, 3.5, 4}
+        if self.bit_width not in valid:
+            raise ValueError(
+                f"bit_width must be one of {sorted(valid)}, got {self.bit_width}"
+            )
+
+    @property
+    def is_fractional(self) -> bool:
+        return self.bit_width != int(self.bit_width)
+
+    @property
+    def channel_split(self) -> tuple[tuple[int, float], tuple[int, float]] | None:
+        """Return ((hi_bits, hi_ratio), (lo_bits, lo_ratio)) for fractional.
+
+        E.g. 3.5 -> ((4, 0.25), (3, 0.75)) meaning 25% at 4-bit, 75% at 3-bit.
+        """
+        if not self.is_fractional:
+            return None
+        if self.bit_width == 2.5:
+            return ((3, 0.5), (2, 0.5))
+        if self.bit_width == 3.5:
+            return ((4, 0.25), (3, 0.75))
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Random rotation via QR decomposition (Haar-distributed orthogonal matrix).
+#
+# All three reference implementations use this approach, NOT Hadamard.
+# O(d^2) storage and compute per vector, but d=128 is small enough.
+# ---------------------------------------------------------------------------
+
+
+def _generate_rotation_matrix(
+    d: int, seed: int, device: torch.device
+) -> Tensor:
+    """Generate a Haar-distributed random rotation matrix via QR."""
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(seed)
+    G = torch.randn(d, d, generator=gen)
+    Q, R = torch.linalg.qr(G)
+    # Fix sign ambiguity in QR to get proper rotation
+    diag_sign = torch.sign(torch.diag(R))
+    diag_sign[diag_sign == 0] = 1.0
+    Q = Q * diag_sign.unsqueeze(0)
+    return Q.to(device)
+
+
+def _get_codebook(bit_width: int, dim: int, device: torch.device) -> Tensor:
+    """Return Lloyd-Max codebook scaled to dimension d."""
+    normalized = CODEBOOKS_NORMALIZED[bit_width]
+    scale = 1.0 / math.sqrt(dim)
+    return torch.tensor(
+        [c * scale for c in normalized],
+        device=device,
+        dtype=torch.float32,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core TurboQuant state — one per attention layer
+# ---------------------------------------------------------------------------
+
+
+class TurboQuantState:
+    """Stores per-layer random state for TurboQuant.
+
+    Create one per attention layer. The rotation matrix is generated
+    deterministically from seed + layer_idx.
+
+    For fractional bit-widths (2.5, 3.5), channels are split into
+    two groups quantized at different bit-widths.
+    """
+
+    def __init__(
+        self,
+        config: TurboQuantConfig,
+        head_size: int,
+        layer_idx: int,
+        device: torch.device,
+    ) -> None:
+        self.config = config
+        self.head_size = head_size
+        self.device = device
+
+        # Deterministic rotation matrix per layer (d x d)
+        self.Pi = _generate_rotation_matrix(
+            head_size, config.seed + layer_idx, device
+        )
+        self.PiT = self.Pi.T.contiguous()
+
+        # QJL projection matrix
+        if config.use_qjl:
+            gen = torch.Generator(device="cpu")
+            gen.manual_seed(config.seed + layer_idx + 10000)
+            self.S = torch.randn(
+                head_size, head_size, generator=gen
+            ).to(device)
+        else:
+            self.S = None
+
+        # Setup codebooks for integer or fractional bit-widths
+        if config.is_fractional:
+            split = config.channel_split
+            (hi_bits, hi_ratio), (lo_bits, lo_ratio) = split
+            self.hi_bits = hi_bits
+            self.lo_bits = lo_bits
+            self.hi_channels = int(head_size * hi_ratio)
+            self.lo_channels = head_size - self.hi_channels
+            self.codebook_hi = _get_codebook(hi_bits, head_size, device)
+            self.codebook_lo = _get_codebook(lo_bits, head_size, device)
+            self.boundaries_hi = (self.codebook_hi[:-1] + self.codebook_hi[1:]) / 2.0
+            self.boundaries_lo = (self.codebook_lo[:-1] + self.codebook_lo[1:]) / 2.0
+            self.mse_bits = None  # not used for fractional
+        else:
+            mse_bits = int(config.bit_width) - 1 if config.use_qjl else int(config.bit_width)
+            mse_bits = max(mse_bits, 1)
+            self.mse_bits = mse_bits
+            self.codebook = _get_codebook(mse_bits, head_size, device)
+            self.boundaries = (self.codebook[:-1] + self.codebook[1:]) / 2.0
+            self.hi_bits = None
+
+    @torch.no_grad()
+    def quantize(self, x: Tensor) -> dict[str, Tensor]:
+        """Quantize KV head vectors."""
+        orig_shape = x.shape
+        flat = x.reshape(-1, self.head_size).float()
+
+        # Extract norms, normalize to unit sphere
+        norms = torch.norm(flat, dim=-1, keepdim=True)
+        flat_norm = flat / (norms + 1e-8)
+
+        # Rotate
+        rotated = flat_norm @ self.PiT
+
+        if self.config.is_fractional:
+            return self._quantize_fractional(rotated, norms, orig_shape, x.device)
+        else:
+            return self._quantize_integer(rotated, norms, orig_shape, x.device)
+
+    def _quantize_integer(self, rotated: Tensor, norms: Tensor,
+                          orig_shape: tuple, device: torch.device) -> dict:
+        indices = torch.bucketize(rotated.contiguous(), self.boundaries).to(torch.uint8)
+        packed = pack_indices(indices.reshape(-1), self.mse_bits)
+
+        result: dict[str, Tensor] = {
+            "packed": packed,
+            "n_elements": torch.tensor(indices.numel(), device=device),
+            "orig_shape": torch.tensor(orig_shape, device=device),
+            "norms": norms.squeeze(-1).to(torch.float16).reshape(orig_shape[:-1]),
+        }
+
+        if self.config.use_qjl and self.S is not None:
+            reconstructed = self.codebook[indices.long()]
+            residual_rotated = rotated - reconstructed
+            residual = residual_rotated @ self.Pi
+            r_norm = torch.norm(residual, dim=-1)
+            projected = residual @ self.S.T
+            signs = (projected >= 0).to(torch.int8) * 2 - 1
+            result["qjl_signs"] = signs.reshape(
+                orig_shape[:-1] + (self.head_size,)
+            )
+            result["qjl_norms"] = r_norm.to(torch.float16).reshape(
+                orig_shape[:-1]
+            )
+        return result
+
+    def _quantize_fractional(self, rotated: Tensor, norms: Tensor,
+                             orig_shape: tuple, device: torch.device) -> dict:
+        """Split channels and quantize each group at different bit-widths."""
+        hi_part = rotated[:, :self.hi_channels]
+        lo_part = rotated[:, self.hi_channels:]
+
+        hi_idx = torch.bucketize(hi_part.contiguous(), self.boundaries_hi).to(torch.uint8)
+        lo_idx = torch.bucketize(lo_part.contiguous(), self.boundaries_lo).to(torch.uint8)
+
+        hi_packed = pack_indices(hi_idx.reshape(-1), self.hi_bits)
+        lo_packed = pack_indices(lo_idx.reshape(-1), self.lo_bits)
+
+        return {
+            "hi_packed": hi_packed,
+            "lo_packed": lo_packed,
+            "hi_n": torch.tensor(hi_idx.numel(), device=device),
+            "lo_n": torch.tensor(lo_idx.numel(), device=device),
+            "orig_shape": torch.tensor(orig_shape, device=device),
+            "norms": norms.squeeze(-1).to(torch.float16).reshape(orig_shape[:-1]),
+        }
+
+    @torch.no_grad()
+    def dequantize(self, state: dict[str, Tensor]) -> Tensor:
+        """Dequantize back to full-precision vectors."""
+        orig_shape = tuple(state["orig_shape"].tolist())
+        norms = state["norms"].float()
+        flat_norms = norms.reshape(-1)
+
+        if self.config.is_fractional:
+            x_hat = self._dequantize_fractional(state, flat_norms)
+        else:
+            x_hat = self._dequantize_integer(state, flat_norms)
+
+        return x_hat.to(torch.bfloat16).reshape(orig_shape)
+
+    def _dequantize_integer(self, state: dict, flat_norms: Tensor) -> Tensor:
+        packed = state["packed"]
+        n_elements = state["n_elements"].item()
+
+        indices = unpack_indices(packed, self.mse_bits, n_elements)
+        flat_indices = indices.reshape(-1, self.head_size).long()
+
+        reconstructed = self.codebook[flat_indices]
+        x_hat = reconstructed @ self.Pi  # unrotate
+
+        if (self.config.use_qjl and self.S is not None
+                and "qjl_signs" in state):
+            signs = state["qjl_signs"].reshape(-1, self.head_size).float()
+            r_norms = state["qjl_norms"].float().reshape(-1)
+            scale = math.sqrt(math.pi / 2.0) / self.head_size
+            qjl_recon = scale * r_norms.unsqueeze(-1) * (signs @ self.S)
+            x_hat = x_hat + qjl_recon
+
+        x_hat = x_hat * flat_norms.unsqueeze(-1)
+        return x_hat
+
+    def _dequantize_fractional(self, state: dict, flat_norms: Tensor) -> Tensor:
+        hi_indices = unpack_indices(
+            state["hi_packed"], self.hi_bits, state["hi_n"].item()
+        ).reshape(-1, self.hi_channels).long()
+        lo_indices = unpack_indices(
+            state["lo_packed"], self.lo_bits, state["lo_n"].item()
+        ).reshape(-1, self.lo_channels).long()
+
+        hi_recon = self.codebook_hi[hi_indices]
+        lo_recon = self.codebook_lo[lo_indices]
+
+        # Concatenate channels and unrotate
+        rotated_recon = torch.cat([hi_recon, lo_recon], dim=-1)
+        x_hat = rotated_recon @ self.Pi
+        x_hat = x_hat * flat_norms.unsqueeze(-1)
+        return x_hat
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric attention: compute scores from compressed K, decompress V only.
+# Adapted from turboquant-pytorch V2 compressor.
+# ---------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def turboquant_asymmetric_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    k_state: TurboQuantState,
+    v_state: TurboQuantState,
+    scale: float,
+) -> Tensor:
+    """Compute attention with TurboQuant-compressed K/V.
+
+    1. Compress K (store k_mse fp16 + QJL signs for unbiased scores)
+    2. Compress V (store indices + norms, much smaller than bf16)
+    3. Delete original K, V
+    4. Compute attention scores from compressed K (asymmetric)
+    5. Decompress V and apply attention weights
+
+    Args:
+        query: (B, S_q, H, D) — queries
+        key: (B, S_kv, H_kv, D) — keys
+        value: (B, S_kv, H_kv, D) — values
+        k_state: TurboQuantState for keys (should have use_qjl=True)
+        v_state: TurboQuantState for values (MSE-only)
+        scale: attention scale factor (1/sqrt(d))
+
+    Returns:
+        (B, S_q, H, D) attention output
+    """
+    B, S_q, H, D = query.shape
+    _, S_kv, H_kv, _ = key.shape
+    n_rep = H // H_kv  # GQA repeat factor
+
+    # --- Compress K: store dequantized MSE + QJL metadata ---
+    k_comp = k_state.quantize(key)
+    k_mse = k_state.dequantize(k_comp).float()  # (B, S_kv, H_kv, D)
+
+    # --- Compress V: only indices + norms (smaller than bf16) ---
+    v_comp = v_state.quantize(value)
+
+    # Free original K, V
+    del key, value
+
+    # --- Asymmetric attention scores ---
+    # Expand KV heads for GQA
+    if n_rep > 1:
+        k_mse = k_mse.unsqueeze(3).expand(B, S_kv, H_kv, n_rep, D)
+        k_mse = k_mse.reshape(B, S_kv, H, D)
+
+    # score = Q @ K_mse^T  (standard part)
+    q_f = query.float()  # (B, S_q, H, D)
+    scores = torch.einsum("bqhd,bkhd->bhqk", q_f, k_mse) * scale
+
+    # QJL correction for unbiased inner product
+    if "qjl_signs" in k_comp and k_state.S is not None:
+        signs = k_comp["qjl_signs"].float()  # (B, S_kv, H_kv, D)
+        r_norms = k_comp["qjl_norms"].float()  # (B, S_kv, H_kv)
+        m = D
+        correction_scale = math.sqrt(math.pi / 2.0) / m * scale
+
+        # Project queries through QJL matrix
+        q_flat = q_f.reshape(-1, D)
+        q_proj = (q_flat @ k_state.S.T).reshape(B, S_q, H, D)
+
+        if n_rep > 1:
+            signs = signs.unsqueeze(3).expand(B, S_kv, H_kv, n_rep, D)
+            signs = signs.reshape(B, S_kv, H, D)
+            r_norms = r_norms.unsqueeze(3).expand(B, S_kv, H_kv, n_rep)
+            r_norms = r_norms.reshape(B, S_kv, H)
+
+        # qjl_ip[b,h,q,k] = sum_d(q_proj[b,q,h,d] * signs[b,k,h,d])
+        qjl_ip = torch.einsum("bqhd,bkhd->bhqk", q_proj, signs)
+        scores = scores + correction_scale * qjl_ip * r_norms.permute(0, 2, 1).unsqueeze(2)
+
+    del k_mse, k_comp
+
+    # --- Softmax ---
+    attn_weights = torch.softmax(scores, dim=-1).to(torch.bfloat16)
+    del scores
+
+    # --- Decompress V and apply weights ---
+    v_deq = v_state.dequantize(v_comp)  # (B, S_kv, H_kv, D)
+    del v_comp
+
+    if n_rep > 1:
+        v_deq = v_deq.unsqueeze(3).expand(B, S_kv, H_kv, n_rep, D)
+        v_deq = v_deq.reshape(B, S_kv, H, D)
+
+    # output[b,q,h,d] = sum_k(attn_weights[b,h,q,k] * v_deq[b,k,h,d])
+    output = torch.einsum("bhqk,bkhd->bqhd", attn_weights.float(), v_deq.float())
+
+    return output.to(torch.bfloat16)
+
+
+# ---------------------------------------------------------------------------
+# Bit packing: store sub-byte indices in packed uint8 tensors
+# ---------------------------------------------------------------------------
+
+
+def pack_indices(indices: Tensor, bits: int) -> Tensor:
+    """Pack b-bit indices into uint8 tensor.
+
+    For 4-bit: 2 values per byte.  For 2-bit: 4 values per byte.
+    For 3-bit: pack into uint32 then view as uint8.
+    """
+    flat = indices.reshape(-1).to(torch.int32)
+    n = flat.numel()
+
+    if bits == 4:
+        # Nibble packing: 2 values per byte
+        pad = (2 - n % 2) % 2
+        if pad:
+            flat = torch.nn.functional.pad(flat, (0, pad))
+        even = flat[0::2].to(torch.uint8)
+        odd = flat[1::2].to(torch.uint8)
+        packed = even | (odd << 4)
+        return packed
+
+    if bits == 2:
+        # 4 values per byte
+        pad = (4 - n % 4) % 4
+        if pad:
+            flat = torch.nn.functional.pad(flat, (0, pad))
+        packed = (flat[0::4].to(torch.uint8)
+                  | (flat[1::4].to(torch.uint8) << 2)
+                  | (flat[2::4].to(torch.uint8) << 4)
+                  | (flat[3::4].to(torch.uint8) << 6))
+        return packed
+
+    if bits == 3:
+        # Pack into uint32: 10 values per 32 bits (30 used, 2 wasted)
+        group = 10
+        pad = (group - n % group) % group
+        if pad:
+            flat = torch.nn.functional.pad(flat, (0, pad))
+        flat = flat.reshape(-1, group)
+        packed32 = torch.zeros(flat.shape[0], dtype=torch.int32,
+                               device=flat.device)
+        for i in range(group):
+            packed32 |= (flat[:, i] << (i * 3))
+        return packed32.view(torch.uint8)
+
+    if bits == 1:
+        # 8 values per byte
+        pad = (8 - n % 8) % 8
+        if pad:
+            flat = torch.nn.functional.pad(flat, (0, pad))
+        packed = torch.zeros(flat.numel() // 8, dtype=torch.uint8,
+                             device=flat.device)
+        for i in range(8):
+            packed |= (flat[i::8].to(torch.uint8) << i)
+        return packed
+
+    return indices.to(torch.uint8)
+
+
+def unpack_indices(packed: Tensor, bits: int, n_elements: int) -> Tensor:
+    """Unpack bit-packed tensor back to indices."""
+    if bits == 4:
+        low = packed & 0x0F
+        high = (packed >> 4) & 0x0F
+        unpacked = torch.stack([low, high], dim=-1).reshape(-1)
+        return unpacked[:n_elements]
+
+    if bits == 2:
+        b0 = packed & 0x03
+        b1 = (packed >> 2) & 0x03
+        b2 = (packed >> 4) & 0x03
+        b3 = (packed >> 6) & 0x03
+        unpacked = torch.stack([b0, b1, b2, b3], dim=-1).reshape(-1)
+        return unpacked[:n_elements]
+
+    if bits == 3:
+        packed32 = packed.view(torch.int32)
+        parts = []
+        for i in range(10):
+            parts.append((packed32 >> (i * 3)) & 0x07)
+        unpacked = torch.stack(parts, dim=-1).reshape(-1)
+        return unpacked[:n_elements]
+
+    if bits == 1:
+        parts = []
+        for i in range(8):
+            parts.append((packed >> i) & 0x01)
+        unpacked = torch.stack(parts, dim=-1).reshape(-1)
+        return unpacked[:n_elements]
+
+    return packed.long()
+
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+
+def compute_distortion(
+    original: Tensor,
+    reconstructed: Tensor,
+) -> dict[str, float]:
+    """Compute MSE and inner-product distortion metrics."""
+    mse = (original - reconstructed).pow(2).sum(dim=-1).mean().item()
+    d = original.shape[-1]
+    ip_orig = (original * original).sum(dim=-1)
+    ip_recon = (original * reconstructed).sum(dim=-1)
+    ip_distortion = (ip_orig - ip_recon).pow(2).mean().item()
+
+    return {
+        "mse": mse,
+        "inner_product_distortion": ip_distortion,
+        "mse_per_dim": mse / d,
+    }


### PR DESCRIPTION
## Purpose

KV cache is the primary memory bottleneck for long-context multimodal inference in vllm-omni. This PR implements [TurboQuant](https://arxiv.org/abs/2504.19874) (ICLR 2026) — an online vector quantization algorithm that compresses KV cache to 2–4 bits with zero quality loss.

RFC: #2215 | Upstream vLLM: vllm-project/vllm#38171

## Results

**Needle-in-a-Haystack** — Qwen2.5-7B-Instruct (bf16), NVIDIA H200, context 4K–16K

| config | exact match | avg cache GB | vs full |
|--------|------------|-------------|---------|
| full | 6/6 | 0.510 | 1.0x |
| TurboQuant 2-bit | 6/6 | 0.068 | **7.5x smaller** |
| TurboQuant 2.5 | 6/6 | 0.087 | **5.9x smaller** |
| TurboQuant 3-bit | 6/6 | 0.106 | **4.8x smaller** |
| TurboQuant 3.5 | 6/6 | 0.112 | **4.5x smaller** |
| TurboQuant 4-bit | 6/6 | 0.132 | **3.9x smaller** |

## Phase Plan

### Phase 1 — Algorithm PoC ✅ (this PR)
- Core algorithm with bit packing and fractional bit-widths (2.5, 3.5)
- Needle-in-a-haystack: 6/6 exact match across all bit-widths
- Exported as `TurboQuantConfig` / `TurboQuantState` from `vllm_omni.quantization`

### Phase 2 — vLLM KV Cache Integration
| | Option A: vllm-omni fork | Option B: Upstream vLLM |
|--|--------------------------|------------------------|
| Scope | Modify vLLM submodule locally | Contribute to vllm-project/vllm |
| Speed | Fast, test on Qwen3-Omni immediately | Longer review cycle |
| Maintenance | Carries fork diff | No fork, inherits updates |

Both options require: `CacheDType` enum extension, `TurboQuantKVCacheMethod`, paged KV block layout changes, attention layer wiring.

### Phase 3 — Performance
Triton kernels for fused rotation + quantize. Fused attention on packed data. Stack with FP8 weight quantization.

## Test Plan

```bash
python tests/diffusion/quantization/test_turboquant_standalone.py          # correctness
python tests/diffusion/quantization/bench_turboquant_needle.py \
  --model Qwen/Qwen2.5-7B-Instruct --contexts 4096 8192 16384             # needle E2E
python tests/diffusion/quantization/bench_turboquant_kvcache.py \
  --model qwen2.5-omni                                                     # storage benchmark
```

## Test Result

- Correctness: 26/26 pass, MSE matches paper Theorem 1
- Needle: **6/6 exact match** at all bit-widths
- KV cache: up to **7.5x compression** vs FP16

Related: #1854, #1867, #2207