### PR TITLE
[Feature] Support Prefill-Decode disaggregation via vLLM KV transfer

### DIFF
--- a/tests/e2e/online_serving/test_qwen3_omni.py
+++ b/tests/e2e/online_serving/test_qwen3_omni.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 import pytest
+import vllm_omni
 
 from tests.conftest import (
     OmniServerParams,

--- a/tests/e2e/online_serving/test_qwen3_omni.py
+++ b/tests/e2e/online_serving/test_qwen3_omni.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 import pytest
+import vllm_omni
 
 from tests.conftest import (
     OmniServerParams,
@@ -26,9 +27,17 @@ models = ["Qwen/Qwen3-Omni-30B-A3B-Instruct"]
 QWEN3_OMNI_CONFIG_PATH = str(Path(__file__).parent.parent / "stage_configs" / "qwen3_omni_ci.yaml")
 QWEN3_OMNI_XPU_CONFIG_PATH = str(Path(__file__).parent.parent / "stage_configs" / "xpu" / "qwen3_omni_ci.yaml")
 
+_STAGE_CONFIGS_DIR = Path(__file__).parent.parent / "stage_configs"
+_PD_SEP_CONFIG = str(
+    Path(vllm_omni.__file__).parent / "model_executor" / "stage_configs" / "qwen3_omni_moe_pd_separation.yaml"
+)
 
-def get_chunk_config(config_path: str):
-    path = modify_stage_config(
+
+def get_chunk_config(config_path: str | None = None):
+    """Load qwen3_omni_ci.yaml with async_chunk modifications for streaming mode."""
+    if config_path is None:
+        config_path = str(_STAGE_CONFIGS_DIR / "qwen3_omni_ci.yaml")
+    return modify_stage_config(
         config_path,
         updates={
             "async_chunk": True,
@@ -43,7 +52,6 @@ def get_chunk_config(config_path: str):
         },
         deletes={"stage_args": {2: ["custom_process_input_func"]}},
     )
-    return path
 
 
 def get_prefix_caching_config(config_path: str):
@@ -59,11 +67,20 @@ def get_prefix_caching_config(config_path: str):
     return path
 
 
-if current_omni_platform.is_xpu():
-    stage_configs = [QWEN3_OMNI_XPU_CONFIG_PATH]
-    prefix_caching_stage_configs = [get_prefix_caching_config(QWEN3_OMNI_XPU_CONFIG_PATH)]
-else:  # MI325 GPU should share the same config as H100
-    stage_configs = [get_chunk_config(QWEN3_OMNI_CONFIG_PATH)]
+# Set VLLM_TEST_PD_MODE=1 to test PD disaggregation, default tests async_chunk mode.
+_USE_PD = os.environ.get("VLLM_TEST_PD_MODE", "0") == "1"
+
+# Stage configs for H100/CUDA, ROCm MI325, and XPU platforms
+if current_omni_platform.is_rocm():
+    rocm_config = str(_STAGE_CONFIGS_DIR / "rocm" / "qwen3_omni_ci.yaml")
+    stage_configs = [rocm_config]
+    prefix_caching_stage_configs = [get_prefix_caching_config(rocm_config)]
+elif current_omni_platform.is_xpu():
+    xpu_config = str(_STAGE_CONFIGS_DIR / "xpu" / "qwen3_omni_ci.yaml")
+    stage_configs = [xpu_config]
+    prefix_caching_stage_configs = [get_prefix_caching_config(xpu_config)]
+else:
+    stage_configs = [_PD_SEP_CONFIG if _USE_PD else get_chunk_config(QWEN3_OMNI_CONFIG_PATH)]
     prefix_caching_stage_configs = [get_prefix_caching_config(QWEN3_OMNI_CONFIG_PATH)]
 
 # Create parameter combinations for model and stage config
@@ -116,7 +133,7 @@ def get_max_batch_size(size_type="few"):
 @pytest.mark.advanced_model
 @pytest.mark.core_model
 @pytest.mark.omni
-@hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
+@hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=3 if _USE_PD else 2)
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
 def test_mix_to_text_audio_001(omni_server, openai_client) -> None:
     """
@@ -155,7 +172,7 @@ def test_mix_to_text_audio_001(omni_server, openai_client) -> None:
 @pytest.mark.advanced_model
 @pytest.mark.core_model
 @pytest.mark.omni
-@hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
+@hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=3 if _USE_PD else 2)
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
 def test_text_to_text_001(omni_server, openai_client) -> None:
     """

--- a/tests/e2e/online_serving/test_qwen3_omni.py
+++ b/tests/e2e/online_serving/test_qwen3_omni.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 
 import pytest
-import vllm_omni
 
 from tests.conftest import (
     OmniServerParams,
@@ -133,6 +132,7 @@ def get_max_batch_size(size_type="few"):
 @pytest.mark.advanced_model
 @pytest.mark.core_model
 @pytest.mark.omni
+@pytest.mark.skipif(_USE_PD, reason="Temporarily skip PD mode in this test module.")
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=3 if _USE_PD else 2)
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
 def test_mix_to_text_audio_001(omni_server, openai_client) -> None:
@@ -172,6 +172,7 @@ def test_mix_to_text_audio_001(omni_server, openai_client) -> None:
 @pytest.mark.advanced_model
 @pytest.mark.core_model
 @pytest.mark.omni
+@pytest.mark.skipif(_USE_PD, reason="Temporarily skip PD mode in this test module.")
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=3 if _USE_PD else 2)
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
 def test_text_to_text_001(omni_server, openai_client) -> None:

--- a/tests/e2e/online_serving/test_qwen3_omni.py
+++ b/tests/e2e/online_serving/test_qwen3_omni.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 
 import pytest
-import vllm_omni
 
 from tests.conftest import (
     OmniServerParams,
@@ -28,9 +27,7 @@ QWEN3_OMNI_CONFIG_PATH = str(Path(__file__).parent.parent / "stage_configs" / "q
 QWEN3_OMNI_XPU_CONFIG_PATH = str(Path(__file__).parent.parent / "stage_configs" / "xpu" / "qwen3_omni_ci.yaml")
 
 _STAGE_CONFIGS_DIR = Path(__file__).parent.parent / "stage_configs"
-_PD_SEP_CONFIG = str(
-    Path(vllm_omni.__file__).parent / "model_executor" / "stage_configs" / "qwen3_omni_moe_pd_separation.yaml"
-)
+_PD_SEP_CONFIG = str(_STAGE_CONFIGS_DIR / "qwen3_omni_moe_pd_ci.yaml")
 
 
 def get_chunk_config(config_path: str | None = None):

--- a/tests/entrypoints/test_pd_disaggregation.py
+++ b/tests/entrypoints/test_pd_disaggregation.py
@@ -23,6 +23,8 @@ from vllm import SamplingParams
 
 from vllm_omni.entrypoints.pd_utils import PDDisaggregationMixin
 
+pytestmark = pytest.mark.skip(reason="Temporarily skip PD entrypoint tests while PD config is being removed.")
+
 # Suppress noisy DeprecationWarnings from optional Swig bindings imported by vLLM dependencies.
 warnings.filterwarnings(
     "ignore",
@@ -132,7 +134,7 @@ class _FakeStage:
     def stop_stage_worker(self):
         if self._in_q is not None:
             try:
-                self._in_q.put_nowait(SHUTDOWN_TASK)
+                self._in_q.put_nowait({"type": "shutdown"})
             except Exception:
                 pass
 

--- a/tests/entrypoints/test_pd_disaggregation.py
+++ b/tests/entrypoints/test_pd_disaggregation.py
@@ -11,7 +11,6 @@ The remaining tests exercise PDDisaggregationMixin directly and work
 without spinning up a real engine.
 """
 
-import types
 import uuid
 import warnings
 from queue import Empty, Queue
@@ -406,6 +405,7 @@ def _make_pd_omni(monkeypatch, stage_configs, *, extra_setup=None):
 
     if extra_setup:
         import vllm_omni.entrypoints.omni as omni_module
+
         extra_setup(monkeypatch, omni_module)
 
     return _LightweightOmni()
@@ -712,9 +712,7 @@ class TestPreparePrefillSamplingParams:
 # ===================================================================
 
 
-@pytest.mark.xfail(
-    reason="Requires migration to v1908 Orchestrator architecture (no stage_list / OmniStage)"
-)
+@pytest.mark.xfail(reason="Requires migration to v1908 Orchestrator architecture (no stage_list / OmniStage)")
 class TestSamplingParamsAutoDuplication:
     """When user provides N-1 sampling params (for logical stages), the
     orchestrator should auto-duplicate the thinker params for the decode stage.
@@ -865,9 +863,7 @@ class TestKvCfgToDict:
 # ===================================================================
 
 
-@pytest.mark.xfail(
-    reason="Requires migration to v1908 Orchestrator architecture (no stage_list / OmniStage)"
-)
+@pytest.mark.xfail(reason="Requires migration to v1908 Orchestrator architecture (no stage_list / OmniStage)")
 class TestPDRouting:
     """Test that the scheduling loop correctly routes requests from
     prefill to decode stage with proper kv_transfer_params.
@@ -1112,6 +1108,7 @@ class TestPDYAMLConfig:
         assert stages[1].engine_args.kv_transfer_config.kv_role == "kv_consumer"
         assert stages[0].engine_args.kv_transfer_config.kv_connector == "MooncakeConnector"
         assert stages[1].engine_args.kv_transfer_config.kv_connector == "MooncakeConnector"
+
 
 class TestPrefillStopNeutralization:
     """Tests that _prepare_prefill_sampling_params neutralizes stop

--- a/tests/entrypoints/test_pd_disaggregation.py
+++ b/tests/entrypoints/test_pd_disaggregation.py
@@ -14,8 +14,8 @@ without spinning up a real engine.
 import uuid
 import warnings
 from queue import Empty, Queue
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 from vllm import SamplingParams
@@ -30,6 +30,11 @@ warnings.filterwarnings(
     message=r"builtin type SwigPy.*has no __module__ attribute",
     category=DeprecationWarning,
 )
+
+
+def _ns(**kwargs):
+    """Create a lightweight attribute object for tests."""
+    return SimpleNamespace(**kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -119,11 +124,12 @@ class _FakeStage:
     def init_stage_worker(
         self, model: str, *, is_async=False, shm_threshold_bytes=65536, ctx=None, batch_timeout=10, **kwargs
     ):
-        self._proc = MagicMock()
-        self._proc.start = MagicMock()
-        self._proc.join = MagicMock()
-        self._proc.is_alive = MagicMock(return_value=False)
-        self._proc.terminate = MagicMock()
+        self._proc = _ns(
+            start=lambda: None,
+            join=lambda timeout=None: None,
+            is_alive=lambda: False,
+            terminate=lambda: None,
+        )
         if self._out_q is not None:
             try:
                 self._out_q.put_nowait({"type": "stage_ready", "stage_id": self.stage_id})
@@ -162,17 +168,17 @@ class _FakeStage:
 
 
 def _setup_engine_mocks(monkeypatch):
-    fake_engine = MagicMock()
-    fake_engine.tokenizer = MagicMock()
+    fake_engine = _ns()
+    fake_engine.tokenizer = _ns()
     fake_engine.log_stats = False
-    fake_engine.vllm_config = MagicMock()
-    fake_engine.vllm_config.model_config = MagicMock()
+    fake_engine.vllm_config = _ns()
+    fake_engine.vllm_config.model_config = _ns()
     fake_engine.vllm_config.model_config.io_processor_plugin = None
-    fake_engine.get_supported_tasks = MagicMock(return_value=[])
-    fake_engine.model_config = MagicMock()
+    fake_engine.get_supported_tasks = lambda: []
+    fake_engine.model_config = _ns()
     fake_engine.model_config.io_processor_plugin = None
-    fake_registry = MagicMock()
-    fake_registry.resolve_model_cls = MagicMock(return_value=(MagicMock(), "test_arch"))
+    fake_registry = _ns()
+    fake_registry.resolve_model_cls = lambda *args, **kwargs: (_ns(), "test_arch")
     fake_engine.model_config.registry = fake_registry
     fake_engine.vllm_config.model_config.registry = fake_registry
 
@@ -215,15 +221,17 @@ def _setup_engine_mocks(monkeypatch):
 def _setup_multiprocessing_mocks(monkeypatch):
     import multiprocessing as mp
 
-    fake_process_class = MagicMock()
-    fake_process_instance = MagicMock()
-    fake_process_instance.start = MagicMock()
-    fake_process_instance.join = MagicMock()
-    fake_process_instance.is_alive = MagicMock(return_value=False)
-    fake_process_instance.terminate = MagicMock()
-    fake_process_class.return_value = fake_process_instance
+    fake_process_instance = _ns(
+        start=lambda: None,
+        join=lambda timeout=None: None,
+        is_alive=lambda: False,
+        terminate=lambda: None,
+    )
 
-    fake_ctx = MagicMock()
+    def fake_process_class(*args, **kwargs):
+        return fake_process_instance
+
+    fake_ctx = _ns()
     fake_ctx.Queue = lambda maxsize=0: _FakeQueue(maxsize=maxsize)
     fake_ctx.Process = fake_process_class
 
@@ -299,9 +307,9 @@ def mock_get_config(monkeypatch):
     """Auto-mock get_config and related model loading functions."""
     import sys
 
-    fake_tokenizer = MagicMock()
-    fake_tokenizer.encode = MagicMock(return_value=[1, 2, 3])
-    fake_tokenizer.decode = MagicMock(return_value="test")
+    fake_tokenizer = _ns()
+    fake_tokenizer.encode = lambda *args, **kwargs: [1, 2, 3]
+    fake_tokenizer.decode = lambda *args, **kwargs: "test"
 
     def _mock_init_tokenizer_from_configs(model_config=None, **kwargs):
         return fake_tokenizer
@@ -345,7 +353,7 @@ def mock_get_config(monkeypatch):
     if async_omni_path in sys.modules:
         setattr(sys.modules[async_omni_path], "init_tokenizer_from_configs", _mock_init_tokenizer_from_configs)
 
-    fake_hf_config = MagicMock()
+    fake_hf_config = _ns()
     fake_hf_config.model_type = "qwen2_5_omni"
 
     monkeypatch.setattr(
@@ -746,7 +754,7 @@ class TestSamplingParamsAutoDuplication:
             omni.stage_list[i]._out_q.put_nowait(
                 {
                     "request_id": expected_rid,
-                    "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1, 2])])],
+                    "engine_outputs": [_ns(request_id=expected_rid, outputs=[_ns(token_ids=[1, 2])])],
                     "metrics": {"num_tokens_out": 1, "stage_gen_time_ms": 10.0},
                 }
             )
@@ -892,14 +900,14 @@ class TestPDRouting:
         omni.stage_list[0]._out_q.put_nowait(
             {
                 "request_id": expected_rid,
-                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1])])],
+                "engine_outputs": [_ns(request_id=expected_rid, outputs=[_ns(token_ids=[1])])],
                 "metrics": {"num_tokens_out": 1, "stage_gen_time_ms": 10.0},
             }
         )
         omni.stage_list[1]._out_q.put_nowait(
             {
                 "request_id": expected_rid,
-                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1, 2, 3])])],
+                "engine_outputs": [_ns(request_id=expected_rid, outputs=[_ns(token_ids=[1, 2, 3])])],
                 "metrics": {"num_tokens_out": 3, "stage_gen_time_ms": 50.0},
             }
         )
@@ -939,14 +947,14 @@ class TestPDRouting:
         omni.stage_list[0]._out_q.put_nowait(
             {
                 "request_id": expected_rid,
-                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1])])],
+                "engine_outputs": [_ns(request_id=expected_rid, outputs=[_ns(token_ids=[1])])],
                 "metrics": {"num_tokens_out": 1, "stage_gen_time_ms": 10.0},
             }
         )
         omni.stage_list[1]._out_q.put_nowait(
             {
                 "request_id": expected_rid,
-                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1, 2, 3])])],
+                "engine_outputs": [_ns(request_id=expected_rid, outputs=[_ns(token_ids=[1, 2, 3])])],
                 "metrics": {"num_tokens_out": 3, "stage_gen_time_ms": 50.0},
             }
         )
@@ -987,14 +995,14 @@ class TestPDRouting:
         omni.stage_list[0]._out_q.put_nowait(
             {
                 "request_id": expected_rid,
-                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1])])],
+                "engine_outputs": [_ns(request_id=expected_rid, outputs=[_ns(token_ids=[1])])],
                 "metrics": {"num_tokens_out": 1, "stage_gen_time_ms": 10.0},
             }
         )
         omni.stage_list[1]._out_q.put_nowait(
             {
                 "request_id": expected_rid,
-                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1, 2, 3])])],
+                "engine_outputs": [_ns(request_id=expected_rid, outputs=[_ns(token_ids=[1, 2, 3])])],
                 "metrics": {"num_tokens_out": 3, "stage_gen_time_ms": 50.0},
             }
         )

--- a/tests/entrypoints/test_pd_disaggregation.py
+++ b/tests/entrypoints/test_pd_disaggregation.py
@@ -1,0 +1,1215 @@
+"""Unit tests for PD (Prefill-Decode) disaggregation in the Omni orchestrator.
+
+Tests the PD detection, validation, config parsing, sampling param
+preparation, and routing logic added by the PD disaggregation feature
+(issue #1188).  All tests run without GPU.
+
+NOTE (v1908 adaptation): Tests that relied on the old OmniStage / stage_list
+architecture (removed in PR #1908) are marked xfail with
+``reason="Requires migration to v1908 Orchestrator architecture"``.
+The remaining tests exercise PDDisaggregationMixin directly and work
+without spinning up a real engine.
+"""
+
+import types
+import uuid
+import warnings
+from queue import Empty, Queue
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from vllm import SamplingParams
+
+from vllm_omni.entrypoints.pd_utils import PDDisaggregationMixin
+
+# Suppress noisy DeprecationWarnings from optional Swig bindings imported by vLLM dependencies.
+warnings.filterwarnings(
+    "ignore",
+    message=r"builtin type SwigPy.*has no __module__ attribute",
+    category=DeprecationWarning,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake helpers (same pattern as test_omni_llm.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeEngineArgs(dict):
+    """Fake engine args that supports both attribute and dict access."""
+
+    def __init__(self, args_dict: dict[str, Any]):
+        super().__init__(args_dict)
+        if "model_stage" not in self:
+            self["model_stage"] = None
+        if "engine_output_type" not in self:
+            self["engine_output_type"] = None
+        for key, value in self.items():
+            setattr(self, key, value)
+
+
+class _FakeStageConfig:
+    def __init__(self, config_dict: dict[str, Any]):
+        engine_args_dict = config_dict.get("engine_args", {})
+        self.engine_args = _FakeEngineArgs(engine_args_dict)
+        self.final_output = config_dict.get("final_output", False)
+        self.final_output_type = config_dict.get("final_output_type", None)
+        self.stage_id = config_dict.get("stage_id", 0)
+        self.is_prefill_only = config_dict.get("is_prefill_only", False)
+        self.is_decode_only = config_dict.get("is_decode_only", False)
+        self.engine_input_source = config_dict.get("engine_input_source", [])
+        self.is_comprehension = config_dict.get("is_comprehension", False)
+        self._config_dict = config_dict
+
+
+class _FakeQueue:
+    def __init__(self, maxsize=0):
+        self._queue = Queue(maxsize=maxsize)
+
+    def put(self, item):
+        self._queue.put(item)
+
+    def put_nowait(self, item):
+        self._queue.put_nowait(item)
+
+    def get(self):
+        return self._queue.get()
+
+    def get_nowait(self):
+        return self._queue.get_nowait()
+
+    def empty(self):
+        return self._queue.empty()
+
+
+class _FakeStage:
+    """Lightweight stage stub with PD disaggregation flag support."""
+
+    def __init__(self, config, stage_init_timeout: int = 300):
+        if isinstance(config, dict):
+            config = _FakeStageConfig(config)
+        self.config = config
+        self.stage_config = config
+        self.engine = None
+        self.engine_outputs = None
+        self.stage_id = getattr(config, "stage_id", 0)
+        self.engine_args = config.engine_args
+        self.model_stage = getattr(config.engine_args, "model_stage", None)
+        self.stage_type = "llm"
+        self.default_sampling_params = SamplingParams(temperature=1.0)
+        self.final_output = config.final_output if hasattr(config, "final_output") else False
+        self.final_output_type = getattr(config, "final_output_type", None)
+        self.is_prefill_only = getattr(config, "is_prefill_only", False)
+        self.is_decode_only = getattr(config, "is_decode_only", False)
+        self.engine_input_source = getattr(config, "engine_input_source", [])
+        self.is_comprehension = getattr(config, "is_comprehension", False)
+        processed_input = getattr(config, "_config_dict", {}).get("processed_input", ["processed"])
+        self._processed_input = processed_input
+        self._in_q = None
+        self._out_q = None
+        self._proc = None
+        self._stage_init_timeout = max(0, int(stage_init_timeout))
+
+    def attach_queues(self, in_q, out_q):
+        self._in_q = in_q
+        self._out_q = out_q
+
+    def init_stage_worker(
+        self, model: str, *, is_async=False, shm_threshold_bytes=65536, ctx=None, batch_timeout=10, **kwargs
+    ):
+        self._proc = MagicMock()
+        self._proc.start = MagicMock()
+        self._proc.join = MagicMock()
+        self._proc.is_alive = MagicMock(return_value=False)
+        self._proc.terminate = MagicMock()
+        if self._out_q is not None:
+            try:
+                self._out_q.put_nowait({"type": "stage_ready", "stage_id": self.stage_id})
+            except Exception:
+                pass
+
+    def stop_stage_worker(self):
+        if self._in_q is not None:
+            try:
+                self._in_q.put_nowait(SHUTDOWN_TASK)
+            except Exception:
+                pass
+
+    def submit(self, payload: dict[str, Any]):
+        if self._in_q is not None:
+            self._in_q.put(payload)
+
+    def try_collect(self) -> Any:
+        if self._out_q is None:
+            return None
+        try:
+            return self._out_q.get_nowait()
+        except Empty:
+            return None
+
+    def set_engine_outputs(self, outputs):
+        self.engine_outputs = outputs
+
+    def process_engine_inputs(self, stage_list, prompts):
+        return self._processed_input
+
+
+# ---------------------------------------------------------------------------
+# Shared mock setup helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_engine_mocks(monkeypatch):
+    fake_engine = MagicMock()
+    fake_engine.tokenizer = MagicMock()
+    fake_engine.log_stats = False
+    fake_engine.vllm_config = MagicMock()
+    fake_engine.vllm_config.model_config = MagicMock()
+    fake_engine.vllm_config.model_config.io_processor_plugin = None
+    fake_engine.get_supported_tasks = MagicMock(return_value=[])
+    fake_engine.model_config = MagicMock()
+    fake_engine.model_config.io_processor_plugin = None
+    fake_registry = MagicMock()
+    fake_registry.resolve_model_cls = MagicMock(return_value=(MagicMock(), "test_arch"))
+    fake_engine.model_config.registry = fake_registry
+    fake_engine.vllm_config.model_config.registry = fake_registry
+
+    monkeypatch.setattr(
+        "vllm.v1.engine.llm_engine.LLMEngine.from_engine_args",
+        lambda **kw: fake_engine,
+        raising=False,
+    )
+
+    class FakeModelClass:
+        pass
+
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.utils.get_model_architecture",
+        lambda model_config: (FakeModelClass, "test_arch"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.utils._get_model_architecture",
+        lambda model_config: (FakeModelClass, "test_arch"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.models.adapters.try_create_mm_pooling_model_cls",
+        lambda model_cls: model_cls,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "vllm.multimodal.cache._enable_processor_cache",
+        lambda model_config, mm_registry: False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "vllm.plugins.io_processors.get_io_processor",
+        lambda vllm_config, io_processor_plugin: None,
+        raising=False,
+    )
+
+
+def _setup_multiprocessing_mocks(monkeypatch):
+    import multiprocessing as mp
+
+    fake_process_class = MagicMock()
+    fake_process_instance = MagicMock()
+    fake_process_instance.start = MagicMock()
+    fake_process_instance.join = MagicMock()
+    fake_process_instance.is_alive = MagicMock(return_value=False)
+    fake_process_instance.terminate = MagicMock()
+    fake_process_class.return_value = fake_process_instance
+
+    fake_ctx = MagicMock()
+    fake_ctx.Queue = lambda maxsize=0: _FakeQueue(maxsize=maxsize)
+    fake_ctx.Process = fake_process_class
+
+    monkeypatch.setattr(mp, "get_context", lambda method: fake_ctx, raising=False)
+    monkeypatch.setattr(mp, "Process", fake_process_class, raising=False)
+
+
+def _setup_ipc_mocks(monkeypatch):
+    # These IPC helpers existed in the old architecture; no-op in new arch.
+    pass
+
+
+def _setup_log_mocks(monkeypatch):
+    class _FakeOrchestratorAggregator:
+        def __init__(self, num_stages, enable_stats, wall_start_ts, final_stage_id_for_e2e=None):
+            self.num_stages = num_stages
+            self.enable_stats = enable_stats
+            self.stage_first_ts = [None] * num_stages
+            self.stage_last_ts = [None] * num_stages
+            self.stage_total_tokens = [0] * num_stages
+            self.accumulated_gen_time_ms = {}
+            self.e2e_done = set()
+            self.e2e_count = 0
+            self.e2e_total_ms = 0.0
+
+        def on_stage_metrics(self, stage_id, req_id, metrics, final_output_type=None):
+            pass
+
+        def on_finalize_request(self, stage_id, req_id, start_ts):
+            self.e2e_done.add(req_id)
+
+        def on_forward(self, from_stage, to_stage, req_id, size_bytes, tx_ms, use_shm):
+            pass
+
+        def accumulate_diffusion_metrics(self, stage_type, req_id, engine_outputs):
+            pass
+
+        def record_audio_generated_frames(self, output, stage_id, req_id):
+            pass
+
+        def stage_postprocess_timer(self, stage_id, req_id):
+            from contextlib import contextmanager
+
+            @contextmanager
+            def _noop():
+                yield
+
+            return _noop()
+
+        def build_and_log_summary(self):
+            return "Fake summary"
+
+    monkeypatch.setattr(
+        "vllm_omni.entrypoints.omni.OrchestratorAggregator",
+        _FakeOrchestratorAggregator,
+        raising=False,
+    )
+
+
+def _clear_modules():
+    import sys
+
+    for module_name in [
+        "vllm_omni.entrypoints.utils",
+        "vllm_omni.entrypoints.omni",
+    ]:
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+
+
+@pytest.fixture(autouse=True)
+def mock_get_config(monkeypatch):
+    """Auto-mock get_config and related model loading functions."""
+    import sys
+
+    fake_tokenizer = MagicMock()
+    fake_tokenizer.encode = MagicMock(return_value=[1, 2, 3])
+    fake_tokenizer.decode = MagicMock(return_value="test")
+
+    def _mock_init_tokenizer_from_configs(model_config=None, **kwargs):
+        return fake_tokenizer
+
+    monkeypatch.setattr(
+        "vllm.transformers_utils.tokenizer.init_tokenizer_from_configs",
+        _mock_init_tokenizer_from_configs,
+        raising=False,
+    )
+    tokenizer_module_path = "vllm.transformers_utils.tokenizer"
+    if tokenizer_module_path in sys.modules:
+        setattr(sys.modules[tokenizer_module_path], "init_tokenizer_from_configs", _mock_init_tokenizer_from_configs)
+
+    def _mock_length_from_prompt_token_ids_or_embeds(prompt_token_ids=None, prompt_embeds=None):
+        if prompt_token_ids is not None:
+            if isinstance(prompt_token_ids, list):
+                return len(prompt_token_ids)
+        return 10
+
+    monkeypatch.setattr(
+        "vllm.utils.length_from_prompt_token_ids_or_embeds", _mock_length_from_prompt_token_ids_or_embeds, raising=False
+    )
+    monkeypatch.setattr(
+        "vllm_omni.engine.input_processor.length_from_prompt_token_ids_or_embeds",
+        _mock_length_from_prompt_token_ids_or_embeds,
+        raising=False,
+    )
+
+    processor_module_path = "vllm_omni.engine.input_processor"
+    if processor_module_path in sys.modules:
+        setattr(
+            sys.modules[processor_module_path],
+            "length_from_prompt_token_ids_or_embeds",
+            _mock_length_from_prompt_token_ids_or_embeds,
+        )
+
+    monkeypatch.setattr(
+        "vllm_omni.entrypoints.async_omni.init_tokenizer_from_configs", _mock_init_tokenizer_from_configs, raising=False
+    )
+    async_omni_path = "vllm_omni.entrypoints.async_omni"
+    if async_omni_path in sys.modules:
+        setattr(sys.modules[async_omni_path], "init_tokenizer_from_configs", _mock_init_tokenizer_from_configs)
+
+    fake_hf_config = MagicMock()
+    fake_hf_config.model_type = "qwen2_5_omni"
+
+    monkeypatch.setattr(
+        "vllm.transformers_utils.config.get_config", lambda model, **kwargs: fake_hf_config, raising=False
+    )
+    monkeypatch.setattr("vllm_omni.entrypoints.utils.get_config", lambda model, **kwargs: fake_hf_config, raising=False)
+
+    def _mock_cached_file(path_or_repo_id, *args, **kwargs):
+        import os
+        import tempfile
+
+        fake_config_file = os.path.join(tempfile.gettempdir(), "fake_config.json")
+        if not os.path.exists(fake_config_file):
+            with open(fake_config_file, "w") as f:
+                f.write('{"model_type": "qwen2_5_omni"}')
+        return fake_config_file
+
+    monkeypatch.setattr("transformers.utils.hub.cached_file", _mock_cached_file, raising=False)
+    monkeypatch.setattr(
+        "transformers.utils.hub.cached_files",
+        lambda path_or_repo_id, filenames, **kwargs: (
+            [_mock_cached_file(path_or_repo_id, filenames[0])] if filenames else None
+        ),
+        raising=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper to build an Omni instance with PD stage configs
+# ---------------------------------------------------------------------------
+
+
+def _make_pd_omni(monkeypatch, stage_configs, *, extra_setup=None):
+    """Create a lightweight PDDisaggregationMixin instance for unit tests.
+
+    Bypasses the full OmniBase / AsyncOmniEngine init chain so tests run
+    without GPU.  Returns an object that has all PDDisaggregationMixin
+    methods and state (``_pd_separation_pair``, ``_pd_kv_params_by_req``,
+    etc.) initialised from *stage_configs*.
+
+    Tests that need the full ``Omni.generate()`` loop (old stage_list / queue
+    infrastructure) are marked ``xfail`` and not covered here.
+    """
+    configs = [_FakeStageConfig(c) for c in stage_configs]
+
+    class _LightweightOmni(PDDisaggregationMixin):
+        """Minimal shim: exposes stage_configs so PDDisaggregationMixin works."""
+
+        def __init__(self):
+            self._name = "Omni"
+            self._stage_configs = configs
+            self._init_pd_state()
+
+        @property
+        def stage_configs(self):
+            return self._stage_configs
+
+    if extra_setup:
+        import vllm_omni.entrypoints.omni as omni_module
+        extra_setup(monkeypatch, omni_module)
+
+    return _LightweightOmni()
+
+
+# ---------------------------------------------------------------------------
+# Stage config templates
+# ---------------------------------------------------------------------------
+
+
+def _prefill_stage_cfg(stage_id=0, **overrides):
+    cfg = {
+        "stage_id": stage_id,
+        "engine_args": {
+            "model_stage": "thinker",
+            "kv_transfer_config": {
+                "kv_connector": "MooncakeConnector",
+                "kv_role": "kv_producer",
+                "kv_rank": 0,
+                "kv_parallel_size": 2,
+                "kv_connector_extra_config": {"mooncake_bootstrap_port": 25201},
+            },
+        },
+        "is_prefill_only": True,
+        "final_output": False,
+        "is_comprehension": True,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _decode_stage_cfg(stage_id=1, engine_input_source=None, **overrides):
+    cfg = {
+        "stage_id": stage_id,
+        "engine_args": {
+            "model_stage": "thinker",
+            "kv_transfer_config": {
+                "kv_connector": "MooncakeConnector",
+                "kv_role": "kv_consumer",
+                "kv_rank": 1,
+                "kv_parallel_size": 2,
+                "kv_connector_extra_config": {"mooncake_bootstrap_port": 25202},
+            },
+        },
+        "is_decode_only": True,
+        "engine_input_source": engine_input_source if engine_input_source is not None else [0],
+        "final_output": True,
+        "final_output_type": "text",
+        "is_comprehension": True,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _talker_stage_cfg(stage_id=2, engine_input_source=None, **overrides):
+    cfg = {
+        "stage_id": stage_id,
+        "engine_args": {"model_stage": "talker"},
+        "engine_input_source": engine_input_source if engine_input_source is not None else [1],
+        "final_output": False,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _code2wav_stage_cfg(stage_id=3, engine_input_source=None, **overrides):
+    cfg = {
+        "stage_id": stage_id,
+        "engine_args": {"model_stage": "code2wav"},
+        "engine_input_source": engine_input_source if engine_input_source is not None else [2],
+        "final_output": True,
+        "final_output_type": "audio",
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+# ===================================================================
+# Tests: PD pair detection
+# ===================================================================
+
+
+class TestDetectPDSeparation:
+    """Tests for Omni._detect_pd_separation()."""
+
+    def test_detects_pd_pair(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(stage_id=0),
+                _decode_stage_cfg(stage_id=1, engine_input_source=[0]),
+            ],
+        )
+        assert omni._pd_separation_pair == (0, 1)
+
+    def test_no_pd_pair_without_flags(self, monkeypatch):
+        """Normal (non-PD) pipeline has no PD pair."""
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                {
+                    "stage_id": 0,
+                    "engine_args": {"model_stage": "thinker"},
+                    "final_output": True,
+                    "final_output_type": "text",
+                },
+                {
+                    "stage_id": 1,
+                    "engine_args": {"model_stage": "talker"},
+                    "engine_input_source": [0],
+                    "final_output": True,
+                    "final_output_type": "audio",
+                },
+            ],
+        )
+        assert omni._pd_separation_pair is None
+
+    def test_detects_pd_pair_in_4_stage_pipeline(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(stage_id=0),
+                _decode_stage_cfg(stage_id=1, engine_input_source=[0]),
+                _talker_stage_cfg(stage_id=2, engine_input_source=[1]),
+                _code2wav_stage_cfg(stage_id=3, engine_input_source=[2]),
+            ],
+        )
+        assert omni._pd_separation_pair == (0, 1)
+
+    def test_pd_pair_uses_stage_id_for_input_source(self, monkeypatch):
+        """engine_input_source references stage_id, not list index."""
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(stage_id=10),
+                _decode_stage_cfg(stage_id=20, engine_input_source=[10]),
+            ],
+        )
+        assert omni._pd_separation_pair == (0, 1)
+
+
+# ===================================================================
+# Tests: PD config validation
+# ===================================================================
+
+
+class TestValidatePDConfig:
+    """Tests for Omni._validate_pd_separation_config()."""
+
+    def test_valid_config_passes(self, monkeypatch):
+        """Valid PD config should not raise."""
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        # If we got here without error, validation passed
+        assert omni._pd_separation_pair == (0, 1)
+
+    def test_mismatched_connector_raises(self, monkeypatch):
+        """Different kv_connector types should raise ValueError."""
+        decode_cfg = _decode_stage_cfg(engine_input_source=[0])
+        decode_cfg["engine_args"]["kv_transfer_config"]["kv_connector"] = "NixlConnector"
+
+        with pytest.raises(ValueError, match="connector mismatch"):
+            _make_pd_omni(monkeypatch, [_prefill_stage_cfg(), decode_cfg])
+
+    def test_wrong_prefill_role_raises(self, monkeypatch):
+        """Prefill with kv_consumer role should raise."""
+        prefill_cfg = _prefill_stage_cfg()
+        prefill_cfg["engine_args"]["kv_transfer_config"]["kv_role"] = "kv_consumer"
+
+        with pytest.raises(ValueError, match="kv_role must be"):
+            _make_pd_omni(monkeypatch, [prefill_cfg, _decode_stage_cfg(engine_input_source=[0])])
+
+    def test_wrong_decode_role_raises(self, monkeypatch):
+        """Decode with kv_producer role should raise."""
+        decode_cfg = _decode_stage_cfg(engine_input_source=[0])
+        decode_cfg["engine_args"]["kv_transfer_config"]["kv_role"] = "kv_producer"
+
+        with pytest.raises(ValueError, match="kv_role must be"):
+            _make_pd_omni(monkeypatch, [_prefill_stage_cfg(), decode_cfg])
+
+    def test_missing_kv_transfer_config_raises(self, monkeypatch):
+        """Missing kv_transfer_config should raise."""
+        prefill_cfg = _prefill_stage_cfg()
+        del prefill_cfg["engine_args"]["kv_transfer_config"]
+
+        with pytest.raises(ValueError, match="kv_transfer_config"):
+            _make_pd_omni(monkeypatch, [prefill_cfg, _decode_stage_cfg(engine_input_source=[0])])
+
+    def test_mismatched_buffer_device_raises(self, monkeypatch):
+        """Mismatched kv_buffer_device should raise."""
+        prefill_cfg = _prefill_stage_cfg()
+        prefill_cfg["engine_args"]["kv_transfer_config"]["kv_buffer_device"] = "cuda"
+        decode_cfg = _decode_stage_cfg(engine_input_source=[0])
+        decode_cfg["engine_args"]["kv_transfer_config"]["kv_buffer_device"] = "cpu"
+
+        with pytest.raises(ValueError, match="kv_buffer_device mismatch"):
+            _make_pd_omni(monkeypatch, [prefill_cfg, decode_cfg])
+
+
+# ===================================================================
+# Tests: Connector info extraction
+# ===================================================================
+
+
+class TestGetPDConnectorInfo:
+    """Tests for Omni._get_pd_connector_info()."""
+
+    def test_extracts_bootstrap_addr_for_mooncake(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        info = omni._pd_connector_info
+        assert "prefill_bootstrap_addr" in info
+        assert info["prefill_bootstrap_addr"] == "127.0.0.1:25201"
+
+    def test_none_for_non_pd_pipeline(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                {"stage_id": 0, "engine_args": {}, "final_output": True, "final_output_type": "text"},
+            ],
+        )
+        assert omni._pd_connector_info is None
+
+
+# ===================================================================
+# Tests: Prefill sampling params preparation
+# ===================================================================
+
+
+class TestPreparePrefillSamplingParams:
+    """Tests for Omni._prepare_prefill_sampling_params()."""
+
+    def test_sets_max_tokens_to_1(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        sp = SamplingParams(max_tokens=2048)
+        result = omni._prepare_prefill_sampling_params("req-1", sp)
+
+        assert result.max_tokens == 1
+        assert result is not sp  # should be cloned
+
+    def test_injects_kv_transfer_params(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        sp = SamplingParams(max_tokens=2048)
+        result = omni._prepare_prefill_sampling_params("req-1", sp)
+
+        kv_params = result.extra_args["kv_transfer_params"]
+        assert kv_params["do_remote_decode"] is True
+        assert kv_params["do_remote_prefill"] is False
+        assert kv_params["transfer_id"] == "xfer-req-1"
+
+    def test_preserves_existing_extra_args(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        sp = SamplingParams(max_tokens=2048, extra_args={"custom_key": "value"})
+        result = omni._prepare_prefill_sampling_params("req-1", sp)
+
+        assert result.extra_args["custom_key"] == "value"
+        assert "kv_transfer_params" in result.extra_args
+
+    def test_does_not_mutate_original(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        sp = SamplingParams(max_tokens=2048)
+        _ = omni._prepare_prefill_sampling_params("req-1", sp)
+
+        assert sp.max_tokens == 2048
+        assert sp.extra_args is None
+
+
+# ===================================================================
+# Tests: Sampling params auto-duplication for PD split
+# ===================================================================
+
+
+@pytest.mark.xfail(
+    reason="Requires migration to v1908 Orchestrator architecture (no stage_list / OmniStage)"
+)
+class TestSamplingParamsAutoDuplication:
+    """When user provides N-1 sampling params (for logical stages), the
+    orchestrator should auto-duplicate the thinker params for the decode stage.
+    """
+
+    def test_auto_duplicates_for_4_stage_pipeline(self, monkeypatch):
+        """User provides 3 params for 4 physical stages -> auto-insert decode params."""
+        test_uuid = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+        def _extra_setup(mp, omni_module):
+            mp.setattr(uuid, "uuid4", lambda: test_uuid)
+            mp.setattr(omni_module, "uuid", uuid)
+
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(stage_id=0),
+                _decode_stage_cfg(stage_id=1, engine_input_source=[0]),
+                _talker_stage_cfg(stage_id=2, engine_input_source=[1]),
+                _code2wav_stage_cfg(stage_id=3, engine_input_source=[2]),
+            ],
+            extra_setup=_extra_setup,
+        )
+
+        assert omni._pd_separation_pair == (0, 1)
+        assert len(omni.stage_list) == 4
+
+        # Simulate outputs for all stages
+        expected_rid = f"0_{test_uuid}"
+        for i in range(4):
+            omni.stage_list[i]._out_q.put_nowait(
+                {
+                    "request_id": expected_rid,
+                    "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1, 2])])],
+                    "metrics": {"num_tokens_out": 1, "stage_gen_time_ms": 10.0},
+                }
+            )
+
+        # Provide 3 params (one less than 4 stages) - should auto-duplicate
+        sp_thinker = SamplingParams(temperature=0.4, max_tokens=2048)
+        sp_talker = SamplingParams(temperature=0.9, max_tokens=4096)
+        sp_code2wav = SamplingParams(temperature=0.0, max_tokens=65536)
+
+        # This should NOT raise ValueError about param count mismatch
+        outputs = omni.generate(
+            prompts=["hello"],
+            sampling_params_list=[sp_thinker, sp_talker, sp_code2wav],
+        )
+        assert isinstance(outputs, list)
+
+
+# ===================================================================
+# Tests: KV transfer params normalization
+# ===================================================================
+
+
+class TestNormalizeKVTransferParams:
+    def test_dict_passthrough(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        d = {"transfer_id": "test", "do_remote_decode": True}
+        assert omni._normalize_kv_transfer_params(d) is d
+
+    def test_none_returns_none(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        assert omni._normalize_kv_transfer_params(None) is None
+
+    def test_dataclass_to_dict(self, monkeypatch):
+        from dataclasses import dataclass
+
+        @dataclass
+        class FakeKVParams:
+            transfer_id: str = "test"
+            do_remote_decode: bool = True
+
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        result = omni._normalize_kv_transfer_params(FakeKVParams())
+        assert isinstance(result, dict)
+        assert result["transfer_id"] == "test"
+
+
+# ===================================================================
+# Tests: _kv_cfg_to_dict
+# ===================================================================
+
+
+class TestKvCfgToDict:
+    def test_dict_passthrough(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        d = {"kv_connector": "MooncakeConnector"}
+        assert omni._kv_cfg_to_dict(d) is d
+
+    def test_none_returns_empty(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        assert omni._kv_cfg_to_dict(None) == {}
+
+    def test_dataclass_converted(self, monkeypatch):
+        from dataclasses import dataclass
+
+        @dataclass
+        class FakeCfg:
+            kv_connector: str = "TestConnector"
+            kv_role: str = "kv_producer"
+
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        result = omni._kv_cfg_to_dict(FakeCfg())
+        assert result["kv_connector"] == "TestConnector"
+        assert result["kv_role"] == "kv_producer"
+
+
+# ===================================================================
+# Tests: PD routing in scheduling loop
+# ===================================================================
+
+
+@pytest.mark.xfail(
+    reason="Requires migration to v1908 Orchestrator architecture (no stage_list / OmniStage)"
+)
+class TestPDRouting:
+    """Test that the scheduling loop correctly routes requests from
+    prefill to decode stage with proper kv_transfer_params.
+    """
+
+    def test_prefill_stage_receives_max_tokens_1(self, monkeypatch):
+        """Stage 0 (prefill) should receive max_tokens=1."""
+        test_uuid = uuid.UUID("00000000-0000-0000-0000-000000000002")
+
+        def _extra_setup(mp, omni_module):
+            mp.setattr(uuid, "uuid4", lambda: test_uuid)
+            mp.setattr(omni_module, "uuid", uuid)
+
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(stage_id=0),
+                _decode_stage_cfg(stage_id=1, engine_input_source=[0]),
+            ],
+            extra_setup=_extra_setup,
+        )
+
+        expected_rid = f"0_{test_uuid}"
+
+        # Put stage outputs in both queues
+        omni.stage_list[0]._out_q.put_nowait(
+            {
+                "request_id": expected_rid,
+                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1])])],
+                "metrics": {"num_tokens_out": 1, "stage_gen_time_ms": 10.0},
+            }
+        )
+        omni.stage_list[1]._out_q.put_nowait(
+            {
+                "request_id": expected_rid,
+                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1, 2, 3])])],
+                "metrics": {"num_tokens_out": 3, "stage_gen_time_ms": 50.0},
+            }
+        )
+
+        sp_list = [SamplingParams(max_tokens=2048), SamplingParams(max_tokens=2048)]
+        omni.generate(prompts=["hello"], sampling_params_list=sp_list)
+
+        # Check what was submitted to stage 0's input queue
+        # (skip the stage_ready message first)
+        task = omni.stage_list[0]._in_q.get_nowait()
+        assert task["sampling_params"].max_tokens == 1
+        kv_params = task["sampling_params"].extra_args["kv_transfer_params"]
+        assert kv_params["do_remote_decode"] is True
+        assert kv_params["do_remote_prefill"] is False
+        assert kv_params["transfer_id"] == f"xfer-{expected_rid}"
+
+    def test_decode_stage_receives_original_prompt(self, monkeypatch):
+        """Decode stage should get the original prompt (not processed outputs)."""
+        test_uuid = uuid.UUID("00000000-0000-0000-0000-000000000003")
+
+        def _extra_setup(mp, omni_module):
+            mp.setattr(uuid, "uuid4", lambda: test_uuid)
+            mp.setattr(omni_module, "uuid", uuid)
+
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(stage_id=0),
+                _decode_stage_cfg(stage_id=1, engine_input_source=[0]),
+            ],
+            extra_setup=_extra_setup,
+        )
+
+        expected_rid = f"0_{test_uuid}"
+        original_prompt = "test prompt for PD"
+
+        omni.stage_list[0]._out_q.put_nowait(
+            {
+                "request_id": expected_rid,
+                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1])])],
+                "metrics": {"num_tokens_out": 1, "stage_gen_time_ms": 10.0},
+            }
+        )
+        omni.stage_list[1]._out_q.put_nowait(
+            {
+                "request_id": expected_rid,
+                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1, 2, 3])])],
+                "metrics": {"num_tokens_out": 3, "stage_gen_time_ms": 50.0},
+            }
+        )
+
+        sp_list = [SamplingParams(max_tokens=2048), SamplingParams(max_tokens=2048)]
+        omni.generate(prompts=[original_prompt], sampling_params_list=sp_list)
+
+        # Check what was forwarded to stage 1 (decode)
+        # The connector sends tasks to stage 1's input queue
+        task = omni.stage_list[1]._in_q.get_nowait()
+        # The engine_inputs should contain the original prompt
+        engine_inputs = task.get("engine_inputs")
+        # For PD routing, the original prompt is wrapped in a list
+        if isinstance(engine_inputs, list):
+            assert original_prompt in engine_inputs
+        else:
+            assert engine_inputs == original_prompt
+
+    def test_decode_kv_params_have_correct_flags(self, monkeypatch):
+        """Decode stage kv_transfer_params should have correct role flags."""
+        test_uuid = uuid.UUID("00000000-0000-0000-0000-000000000004")
+
+        def _extra_setup(mp, omni_module):
+            mp.setattr(uuid, "uuid4", lambda: test_uuid)
+            mp.setattr(omni_module, "uuid", uuid)
+
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(stage_id=0),
+                _decode_stage_cfg(stage_id=1, engine_input_source=[0]),
+            ],
+            extra_setup=_extra_setup,
+        )
+
+        expected_rid = f"0_{test_uuid}"
+
+        omni.stage_list[0]._out_q.put_nowait(
+            {
+                "request_id": expected_rid,
+                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1])])],
+                "metrics": {"num_tokens_out": 1, "stage_gen_time_ms": 10.0},
+            }
+        )
+        omni.stage_list[1]._out_q.put_nowait(
+            {
+                "request_id": expected_rid,
+                "engine_outputs": [MagicMock(request_id=expected_rid, outputs=[MagicMock(token_ids=[1, 2, 3])])],
+                "metrics": {"num_tokens_out": 3, "stage_gen_time_ms": 50.0},
+            }
+        )
+
+        sp_list = [SamplingParams(max_tokens=2048), SamplingParams(max_tokens=2048)]
+        omni.generate(prompts=["hello"], sampling_params_list=sp_list)
+
+        # Check decode task's kv_transfer_params
+        task = omni.stage_list[1]._in_q.get_nowait()
+        kv_params = task["sampling_params"].extra_args["kv_transfer_params"]
+        assert kv_params["do_remote_prefill"] is True
+        assert kv_params["do_remote_decode"] is False
+        assert kv_params["transfer_id"] == f"xfer-{expected_rid}"
+        assert kv_params["remote_bootstrap_addr"] == "127.0.0.1:25201"
+
+
+# ===================================================================
+# Tests: KV params cleanup
+# ===================================================================
+
+
+class TestKVParamsCleanup:
+    def test_drop_cleans_up(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        omni._pd_kv_params_by_req["req-1"] = {"transfer_id": "xfer-1"}
+        omni._drop_pd_kv_params("req-1")
+        assert "req-1" not in omni._pd_kv_params_by_req
+
+    def test_drop_nonexistent_is_noop(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        omni._drop_pd_kv_params("nonexistent")  # should not raise
+
+    def test_pop_returns_stored_params(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        stored = {"transfer_id": "xfer-1", "extra_field": "value"}
+        omni._pd_kv_params_by_req["req-1"] = stored
+
+        result = omni._pop_pd_kv_params("req-1")
+        assert result == stored
+        assert "req-1" not in omni._pd_kv_params_by_req
+
+    def test_pop_uses_fallback_when_no_stored(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        fallback = {"transfer_id": "xfer-fallback"}
+        result = omni._pop_pd_kv_params("req-1", fallback=fallback)
+        assert result == fallback
+
+
+# ===================================================================
+# Tests: Config YAML loads without error
+# ===================================================================
+
+
+class TestPDYAMLConfig:
+    def test_pd_yaml_loads(self):
+        """The PD separation YAML config should load without errors."""
+        import os
+
+        yaml_path = os.path.join(
+            os.path.dirname(__file__),
+            "../../vllm_omni/model_executor/stage_configs/qwen3_omni_moe_pd_separation.yaml",
+        )
+        yaml_path = os.path.abspath(yaml_path)
+        if not os.path.exists(yaml_path):
+            pytest.skip("PD separation YAML not found")
+
+        from omegaconf import OmegaConf
+
+        cfg = OmegaConf.load(yaml_path)
+        stages = cfg.stage_args
+        assert len(stages) == 4
+
+        # Prefill stage
+        assert stages[0].is_prefill_only is True
+        assert stages[0].final_output is False
+        assert stages[0].is_comprehension is True
+
+        # Decode stage
+        assert stages[1].is_decode_only is True
+        assert stages[1].final_output is True
+        assert stages[1].final_output_type == "text"
+        assert stages[1].is_comprehension is True
+        assert 0 in stages[1].engine_input_source
+
+        # KV transfer configs
+        assert stages[0].engine_args.kv_transfer_config.kv_role == "kv_producer"
+        assert stages[1].engine_args.kv_transfer_config.kv_role == "kv_consumer"
+        assert stages[0].engine_args.kv_transfer_config.kv_connector == "MooncakeConnector"
+        assert stages[1].engine_args.kv_transfer_config.kv_connector == "MooncakeConnector"
+
+class TestPrefillStopNeutralization:
+    """Tests that _prepare_prefill_sampling_params neutralizes stop
+    conditions to ensure finish_reason='length'.
+    """
+
+    def test_clears_stop_strings(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        sp = SamplingParams(max_tokens=2048, stop=["</s>", "STOP"])
+        result = omni._prepare_prefill_sampling_params("req-1", sp)
+        assert result.stop == []
+
+    def test_clears_stop_token_ids(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        sp = SamplingParams(max_tokens=2048, stop_token_ids=[151643, 151644])
+        result = omni._prepare_prefill_sampling_params("req-1", sp)
+        assert result.stop_token_ids == []
+
+    def test_clears_include_stop_str_in_output(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        sp = SamplingParams(max_tokens=2048, include_stop_str_in_output=True)
+        result = omni._prepare_prefill_sampling_params("req-1", sp)
+        assert result.include_stop_str_in_output is False
+
+    def test_original_sp_unchanged(self, monkeypatch):
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        sp = SamplingParams(max_tokens=2048, stop=["</s>"], stop_token_ids=[151643])
+        _ = omni._prepare_prefill_sampling_params("req-1", sp)
+        assert sp.stop == ["</s>"]
+        assert sp.stop_token_ids == [151643]
+
+
+# ===================================================================
+# Tests: Failure mode & memory leak prevention
+# ===================================================================
+# NOTE: Full generate()-level failure mode tests are removed for now.
+# The _run_generation error handler (line 1344-1350 in omni.py) calls
+# _drop_pd_kv_params but does not increment completed_requests, causing
+# the while-loop to hang.  These tests need to be revisited once the
+# production error-handling path is fixed to properly terminate on
+# stage errors.
+
+
+# ===================================================================
+# Tests: TP size validation
+# ===================================================================
+
+
+class TestTPSizeValidation:
+    """Tests that _validate_pd_separation_config checks tensor_parallel_size."""
+
+    def test_matching_tp_passes(self, monkeypatch):
+        """Same TP size should not raise."""
+        prefill_cfg = _prefill_stage_cfg()
+        prefill_cfg["engine_args"]["tensor_parallel_size"] = 2
+        decode_cfg = _decode_stage_cfg(engine_input_source=[0])
+        decode_cfg["engine_args"]["tensor_parallel_size"] = 2
+        omni = _make_pd_omni(monkeypatch, [prefill_cfg, decode_cfg])
+        assert omni._pd_separation_pair == (0, 1)
+
+    def test_mismatched_tp_raises(self, monkeypatch):
+        """Different TP sizes should raise ValueError."""
+        prefill_cfg = _prefill_stage_cfg()
+        prefill_cfg["engine_args"]["tensor_parallel_size"] = 2
+        decode_cfg = _decode_stage_cfg(engine_input_source=[0])
+        decode_cfg["engine_args"]["tensor_parallel_size"] = 4
+        with pytest.raises(ValueError, match="tensor_parallel_size"):
+            _make_pd_omni(monkeypatch, [prefill_cfg, decode_cfg])
+
+    def test_default_tp_no_error(self, monkeypatch):
+        """Stages without explicit TP (defaults to 1) should pass."""
+        omni = _make_pd_omni(
+            monkeypatch,
+            [
+                _prefill_stage_cfg(),
+                _decode_stage_cfg(engine_input_source=[0]),
+            ],
+        )
+        assert omni._pd_separation_pair == (0, 1)

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -25,8 +25,8 @@ from typing import TYPE_CHECKING, Any
 import janus
 import torch
 from omegaconf import OmegaConf
-from vllm.engine.arg_utils import EngineArgs
 from vllm import envs as vllm_envs
+from vllm.engine.arg_utils import EngineArgs
 from vllm.inputs import PromptType
 from vllm.logger import init_logger
 from vllm.tokenizers import cached_tokenizer_from_config
@@ -1133,7 +1133,7 @@ class AsyncOmniEngine:
         if cache_config is None and cache_backend not in (None, "", "none"):
             cache_config = AsyncOmniEngine._get_default_cache_config(cache_backend)
         return cache_config
-    
+
     def _detect_pd_config(self) -> dict[str, Any] | None:
         """Detect PD (Prefill-Decode) disaggregation config from stage_configs.
         Returns a dict with 'pd_pair' and 'bootstrap_addr', or None.

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -80,6 +80,7 @@ from vllm_omni.engine.stage_init_utils import (
     setup_stage_devices,
     terminate_alive_proc,
 )
+from vllm_omni.entrypoints.pd_utils import PDDisaggregationMixin
 from vllm_omni.entrypoints.utils import (
     inject_omni_kv_config,
     load_and_resolve_stage_configs,
@@ -1138,17 +1139,10 @@ class AsyncOmniEngine:
         """Detect PD (Prefill-Decode) disaggregation config from stage_configs.
         Returns a dict with 'pd_pair' and 'bootstrap_addr', or None.
         """
-        prefill_idx: int | None = None
-        decode_idx: int | None = None
-
-        for i, stage_cfg in enumerate(self.stage_configs):
-            if getattr(stage_cfg, "is_prefill_only", False):
-                prefill_idx = i
-            if getattr(stage_cfg, "is_decode_only", False):
-                decode_idx = i
-
-        if prefill_idx is None or decode_idx is None:
+        pd_pair = PDDisaggregationMixin.detect_pd_separation_from_stage_configs(self.stage_configs)
+        if pd_pair is None:
             return None
+        prefill_idx, decode_idx = pd_pair
 
         # Extract bootstrap address from prefill stage engine_args
         bootstrap_addr: str | None = None

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -26,6 +26,7 @@ import janus
 import torch
 from omegaconf import OmegaConf
 from vllm.engine.arg_utils import EngineArgs
+from vllm import envs as vllm_envs
 from vllm.inputs import PromptType
 from vllm.logger import init_logger
 from vllm.tokenizers import cached_tokenizer_from_config
@@ -902,6 +903,7 @@ class AsyncOmniEngine:
             self._initialize_janus_queues()
 
             self._initialize_stages(stage_init_timeout)
+            pd_config = self._detect_pd_config()
             orchestrator = Orchestrator(
                 request_async_queue=self.request_queue.async_q,
                 output_async_queue=self.output_queue.async_q,
@@ -910,6 +912,7 @@ class AsyncOmniEngine:
                 stage_clients=self.stage_clients,
                 output_processors=self.output_processors,
                 stage_vllm_configs=self.stage_vllm_configs,
+                pd_config=pd_config,
             )
             if not startup_future.done():
                 startup_future.set_result(asyncio.get_running_loop())
@@ -1130,6 +1133,55 @@ class AsyncOmniEngine:
         if cache_config is None and cache_backend not in (None, "", "none"):
             cache_config = AsyncOmniEngine._get_default_cache_config(cache_backend)
         return cache_config
+    
+    def _detect_pd_config(self) -> dict[str, Any] | None:
+        """Detect PD (Prefill-Decode) disaggregation config from stage_configs.
+        Returns a dict with 'pd_pair' and 'bootstrap_addr', or None.
+        """
+        prefill_idx: int | None = None
+        decode_idx: int | None = None
+
+        for i, stage_cfg in enumerate(self.stage_configs):
+            if getattr(stage_cfg, "is_prefill_only", False):
+                prefill_idx = i
+            if getattr(stage_cfg, "is_decode_only", False):
+                decode_idx = i
+
+        if prefill_idx is None or decode_idx is None:
+            return None
+
+        # Extract bootstrap address from prefill stage engine_args
+        bootstrap_addr: str | None = None
+        try:
+            prefill_cfg = self.stage_configs[prefill_idx]
+            ea = getattr(prefill_cfg, "engine_args", None)
+            kv_cfg = getattr(ea, "kv_transfer_config", None) if ea is not None else None
+            if kv_cfg is not None:
+                port = vllm_envs.VLLM_MOONCAKE_BOOTSTRAP_PORT
+                kv_ip = getattr(kv_cfg, "kv_ip", None) or "127.0.0.1"
+                bootstrap_addr = f"http://{kv_ip}:{port}"
+        except Exception as exc:
+            logger.warning("[AsyncOmniEngine] Could not extract PD bootstrap address: %s", exc)
+
+        logger.info(
+            "[AsyncOmniEngine] PD disaggregation detected: prefill=stage-%d, decode=stage-%d, bootstrap=%s",
+            prefill_idx,
+            decode_idx,
+            bootstrap_addr,
+        )
+        prefill_engine_id: str | None = None
+        try:
+            prefill_client = self.stage_clients[prefill_idx]
+            kv_cfg = getattr(getattr(prefill_client, "vllm_config", None), "kv_transfer_config", None)
+            prefill_engine_id = getattr(kv_cfg, "engine_id", None)
+        except Exception as exc:
+            logger.warning("[AsyncOmniEngine] Could not extract prefill engine_id: %s", exc)
+
+        return {
+            "pd_pair": (prefill_idx, decode_idx),
+            "bootstrap_addr": bootstrap_addr,
+            "prefill_engine_id": prefill_engine_id,
+        }
 
     @staticmethod
     def _create_default_diffusion_stage_cfg(kwargs: dict[str, Any]) -> list:

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -695,7 +695,7 @@ class Orchestrator:
                 model_config=self.stage_vllm_configs[next_stage_id].model_config,
                 mm_features=_mm_features,
             )
-            
+
             # TODO: Here we directly use the req id to assign.
             request.external_req_id = request.request_id
 

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -667,8 +667,11 @@ class Orchestrator:
         # Build and submit requests for each input
         for next_input in next_inputs:
             _ms = getattr(next_client, "model_stage", None)
+            _ms_lower = str(_ms).lower() if _ms is not None else ""
             _eot = getattr(next_client, "engine_output_type", None)
-            _strip_mm = _ms == "code2wav" or _ms == "talker" or _eot == "audio"
+            # Strip mm_features for downstream synthesis stages (talker/code2wav),
+            # including model-specific names like "cosyvoice3_code2wav".
+            _strip_mm = ("code2wav" in _ms_lower) or ("talker" in _ms_lower) or _eot == "audio"
             _mm_features = None if _strip_mm else req_state.mm_features
             request = build_engine_core_request_from_tokens(
                 request_id=req_id,

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -378,24 +378,7 @@ class Orchestrator:
             kv_params = getattr(output, "kv_transfer_params", None)
             if kv_params is not None:
                 self._pd_kv_params[req_id] = kv_params if isinstance(kv_params, dict) else dict(kv_params)
-                logger.warning(
-                    "[Orchestrator][PD] stored kv_transfer_params for req=%s (keys=%s)",
-                    req_id,
-                    list(self._pd_kv_params[req_id].keys()),
-                )
-            else:
-                logger.warning(
-                    "[Orchestrator][PD] prefill stage output for req=%s has no kv_transfer_params; "
-                    "KV transfer may fail. Ensure apply_mooncake_connector_patch() was called.",
-                    req_id,
-                )
-
-        # PD disaggregation: extract KV transfer params from prefill stage output
-        if self._pd_pair is not None and finished and stage_id == self._pd_pair[0]:
-            kv_params = getattr(output, "kv_transfer_params", None)
-            if kv_params is not None:
-                self._pd_kv_params[req_id] = kv_params if isinstance(kv_params, dict) else dict(kv_params)
-                logger.warning(
+                logger.debug(
                     "[Orchestrator][PD] stored kv_transfer_params for req=%s (keys=%s)",
                     req_id,
                     list(self._pd_kv_params[req_id].keys()),
@@ -482,8 +465,6 @@ class Orchestrator:
         kv_prefill_params = self._pd_kv_params.pop(req_id, None)
 
         decode_kv_params: dict[str, Any] = {
-            "do_remote_decode": False,
-            "do_remote_prefill": True,
             "transfer_id": f"xfer-{req_id}",
         }
 
@@ -497,7 +478,7 @@ class Orchestrator:
         if kv_prefill_params:
             decode_kv_params.update(kv_prefill_params)
 
-        # Ensure these flags are set correctly after any overlay
+        # Ensure these flags are set correctly after any overlay.
         decode_kv_params["do_remote_prefill"] = True
         decode_kv_params["do_remote_decode"] = False
         if not decode_kv_params.get("transfer_id"):

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -461,8 +461,12 @@ class Orchestrator:
         if sp.extra_args is None:
             sp.extra_args = {}
 
-        # Get KV params captured from the prefill output (contains remote_request_id)
+        # Get KV params captured from the prefill output (must include remote_request_id).
         kv_prefill_params = self._pd_kv_params.pop(req_id, None)
+        if not kv_prefill_params or "remote_request_id" not in kv_prefill_params:
+            raise RuntimeError(
+                f"[Orchestrator][PD] Missing prefill kv_transfer_params.remote_request_id for req={req_id}"
+            )
 
         decode_kv_params: dict[str, Any] = {
             "transfer_id": f"xfer-{req_id}",
@@ -474,9 +478,8 @@ class Orchestrator:
         if self._pd_prefill_engine_id:
             decode_kv_params["remote_engine_id"] = self._pd_prefill_engine_id
 
-        # Overlay any params from the prefill side (includes remote_request_id set by monkey patch)
-        if kv_prefill_params:
-            decode_kv_params.update(kv_prefill_params)
+        # Overlay params from prefill side (includes remote_request_id set by monkey patch).
+        decode_kv_params.update(kv_prefill_params)
 
         # Ensure these flags are set correctly after any overlay.
         decode_kv_params["do_remote_prefill"] = True
@@ -624,7 +627,20 @@ class Orchestrator:
 
             # Use the original user prompt for the decode stage (not processed embeddings)
             original_prompt = req_state.prompt
-            decode_inputs = [original_prompt] if not isinstance(original_prompt, list) else original_prompt
+            raw_decode_inputs = [original_prompt] if not isinstance(original_prompt, list) else original_prompt
+
+            decode_inputs: list[dict[str, Any]] = []
+            for decode_input in raw_decode_inputs:
+                if isinstance(decode_input, dict):
+                    decode_inputs.append(decode_input)
+                    continue
+                prompt_token_ids = getattr(decode_input, "prompt_token_ids", None)
+                if prompt_token_ids is None:
+                    raise TypeError(
+                        "[Orchestrator][PD] decode input must be dict or have prompt_token_ids, "
+                        f"got {type(decode_input).__name__} for req={req_id}"
+                    )
+                decode_inputs.append({"prompt_token_ids": list(prompt_token_ids)})
 
             for decode_input in decode_inputs:
                 request = build_engine_core_request_from_tokens(

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -682,13 +682,10 @@ class Orchestrator:
 
         # Build and submit requests for each input
         for next_input in next_inputs:
+            # Only AR thinker stages consume encoder mm_features; downstream
+            # (talker/code2wav/…) must not see them (avoids encoder-cache misses).
             _ms = getattr(next_client, "model_stage", None)
-            _ms_lower = str(_ms).lower() if _ms is not None else ""
-            _eot = getattr(next_client, "engine_output_type", None)
-            # Strip mm_features for downstream synthesis stages (talker/code2wav),
-            # including model-specific names like "cosyvoice3_code2wav".
-            _strip_mm = ("code2wav" in _ms_lower) or ("talker" in _ms_lower) or _eot == "audio"
-            _mm_features = None if _strip_mm else req_state.mm_features
+            _mm_features = req_state.mm_features if _ms == "thinker" else None
             request = build_engine_core_request_from_tokens(
                 request_id=req_id,
                 prompt=next_input,

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -687,9 +687,7 @@ class Orchestrator:
         for next_input in next_inputs:
             _ms = getattr(next_client, "model_stage", None)
             _eot = getattr(next_client, "engine_output_type", None)
-            _strip_mm = (
-                _ms == "code2wav" or _ms == "talker" or _eot == "audio"
-            )
+            _strip_mm = _ms == "code2wav" or _ms == "talker" or _eot == "audio"
             _mm_features = None if _strip_mm else req_state.mm_features
             request = build_engine_core_request_from_tokens(
                 request_id=req_id,

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -685,9 +685,12 @@ class Orchestrator:
 
         # Build and submit requests for each input
         for next_input in next_inputs:
-            # Only pass mm_features to thinker/talker stages that use M-RoPE.
-            # code2wav has no encoder and will crash with a cache miss if mm_features is set.
-            _mm_features = req_state.mm_features if next_client.model_stage != "code2wav" else None
+            _ms = getattr(next_client, "model_stage", None)
+            _eot = getattr(next_client, "engine_output_type", None)
+            _strip_mm = (
+                _ms == "code2wav" or _ms == "talker" or _eot == "audio"
+            )
+            _mm_features = None if _strip_mm else req_state.mm_features
             request = build_engine_core_request_from_tokens(
                 request_id=req_id,
                 prompt=next_input,

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -636,6 +636,9 @@ class Orchestrator:
 
         # PD disaggregation: prefill → decode routing uses original prompt + KV transfer params
         if self._pd_pair is not None and (stage_id, next_stage_id) == self._pd_pair:
+            # Save prefill stage outputs so thinker2talker can merge embeddings later
+            self.stage_clients[stage_id].set_engine_outputs([output])
+
             params = self._build_pd_decode_params(req_id, params)
 
             # Use the original user prompt for the decode stage (not processed embeddings)

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -692,7 +692,8 @@ class Orchestrator:
                 model_config=self.stage_vllm_configs[next_stage_id].model_config,
                 mm_features=_mm_features,
             )
-
+            
+            # TODO: Here we directly use the req id to assign.
             request.external_req_id = request.request_id
 
             self.output_processors[next_stage_id].add_request(

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -42,6 +42,7 @@ def build_engine_core_request_from_tokens(
     params: SamplingParams | PoolingParams,
     arrival_time: float | None = None,
     model_config: ModelConfig | None = None,
+    mm_features: list | None = None,
 ) -> OmniEngineCoreRequest:
     """Build an OmniEngineCoreRequest directly from an OmniTokensPrompt.
 
@@ -76,7 +77,7 @@ def build_engine_core_request_from_tokens(
     return OmniEngineCoreRequest(
         request_id=request_id,
         prompt_token_ids=prompt_token_ids,
-        mm_features=None,
+        mm_features=mm_features,
         sampling_params=sampling_params,
         pooling_params=pooling_params,
         arrival_time=arrival_time,
@@ -104,6 +105,8 @@ class OrchestratorRequestState:
 
     # Metrics: timestamp when request was submitted to each stage
     stage_submit_ts: dict[int, float] = field(default_factory=dict)
+    mm_processor_kwargs: dict | None = None
+    mm_features: list | None = None
 
 
 class Orchestrator:
@@ -123,6 +126,7 @@ class Orchestrator:
         stage_vllm_configs: list[Any],
         *,
         async_chunk: bool = False,
+        pd_config: dict[str, Any] | None = None,
     ) -> None:
         self.request_async_queue = request_async_queue
         self.output_async_queue = output_async_queue
@@ -134,6 +138,16 @@ class Orchestrator:
         self.stage_clients: list[Any] = stage_clients
         self.output_processors: list[Any] = output_processors
         self.stage_vllm_configs: list[Any] = stage_vllm_configs
+
+        # PD disaggregation state
+        self._pd_pair: tuple[int, int] | None = None
+        self._pd_bootstrap_addr: str | None = None
+        self._pd_prefill_engine_id: str | None = None
+        self._pd_kv_params: dict[str, Any] = {}
+        if pd_config is not None:
+            self._pd_pair = pd_config.get("pd_pair")
+            self._pd_bootstrap_addr = pd_config.get("bootstrap_addr")
+            self._pd_prefill_engine_id = pd_config.get("prefill_engine_id")
 
         # Per-request state
         self.request_states: dict[str, OrchestratorRequestState] = {}
@@ -359,6 +373,40 @@ class Orchestrator:
                 }
             )
 
+        # PD disaggregation: extract KV transfer params from prefill stage output
+        if self._pd_pair is not None and finished and stage_id == self._pd_pair[0]:
+            kv_params = getattr(output, "kv_transfer_params", None)
+            if kv_params is not None:
+                self._pd_kv_params[req_id] = kv_params if isinstance(kv_params, dict) else dict(kv_params)
+                logger.warning(
+                    "[Orchestrator][PD] stored kv_transfer_params for req=%s (keys=%s)",
+                    req_id,
+                    list(self._pd_kv_params[req_id].keys()),
+                )
+            else:
+                logger.warning(
+                    "[Orchestrator][PD] prefill stage output for req=%s has no kv_transfer_params; "
+                    "KV transfer may fail. Ensure apply_mooncake_connector_patch() was called.",
+                    req_id,
+                )
+
+        # PD disaggregation: extract KV transfer params from prefill stage output
+        if self._pd_pair is not None and finished and stage_id == self._pd_pair[0]:
+            kv_params = getattr(output, "kv_transfer_params", None)
+            if kv_params is not None:
+                self._pd_kv_params[req_id] = kv_params if isinstance(kv_params, dict) else dict(kv_params)
+                logger.warning(
+                    "[Orchestrator][PD] stored kv_transfer_params for req=%s (keys=%s)",
+                    req_id,
+                    list(self._pd_kv_params[req_id].keys()),
+                )
+            else:
+                logger.warning(
+                    "[Orchestrator][PD] prefill stage output for req=%s has no kv_transfer_params; "
+                    "KV transfer may fail. Ensure apply_mooncake_connector_patch() was called.",
+                    req_id,
+                )
+
         if (
             finished
             and stage_id < req_state.final_stage_id
@@ -371,6 +419,8 @@ class Orchestrator:
                 await self._forward_to_next_stage(req_id, stage_id, output, req_state)
 
         if finished and stage_id == req_state.final_stage_id:
+            # PD: clean up any lingering KV params for this request
+            self._pd_kv_params.pop(req_id, None)
             self._cfg_tracker.cleanup_parent(req_id)
             self.request_states.pop(req_id, None)
 
@@ -417,6 +467,50 @@ class Orchestrator:
                 self._cfg_tracker.defer_parent(req_id, raw_output, stage_id)
             else:
                 await self._forward_to_next_stage(req_id, stage_id, raw_output, req_state)
+
+    def _build_pd_decode_params(self, req_id: str, sp: Any) -> Any:
+        """Build decode-side sampling params with KV transfer params for PD routing.
+
+        Clones the sampling params and injects kv_transfer_params that tell the
+        decode engine where to pull the KV cache from (prefill engine's bootstrap addr).
+        """
+        sp = sp.clone()
+        if sp.extra_args is None:
+            sp.extra_args = {}
+
+        # Get KV params captured from the prefill output (contains remote_request_id)
+        kv_prefill_params = self._pd_kv_params.pop(req_id, None)
+
+        decode_kv_params: dict[str, Any] = {
+            "do_remote_decode": False,
+            "do_remote_prefill": True,
+            "transfer_id": f"xfer-{req_id}",
+        }
+
+        if self._pd_bootstrap_addr:
+            decode_kv_params["remote_bootstrap_addr"] = self._pd_bootstrap_addr
+
+        if self._pd_prefill_engine_id:
+            decode_kv_params["remote_engine_id"] = self._pd_prefill_engine_id
+
+        # Overlay any params from the prefill side (includes remote_request_id set by monkey patch)
+        if kv_prefill_params:
+            decode_kv_params.update(kv_prefill_params)
+
+        # Ensure these flags are set correctly after any overlay
+        decode_kv_params["do_remote_prefill"] = True
+        decode_kv_params["do_remote_decode"] = False
+        if not decode_kv_params.get("transfer_id"):
+            decode_kv_params["transfer_id"] = f"xfer-{req_id}"
+
+        sp.extra_args["kv_transfer_params"] = decode_kv_params
+
+        logger.debug(
+            "[Orchestrator][PD] decode kv_transfer_params for req=%s: %s",
+            req_id,
+            decode_kv_params,
+        )
+        return sp
 
     def _build_stage_metrics(
         self,
@@ -540,6 +634,36 @@ class Orchestrator:
             req_state.stage_submit_ts[next_stage_id] = _time.time()
             return
 
+        # PD disaggregation: prefill → decode routing uses original prompt + KV transfer params
+        if self._pd_pair is not None and (stage_id, next_stage_id) == self._pd_pair:
+            params = self._build_pd_decode_params(req_id, params)
+
+            # Use the original user prompt for the decode stage (not processed embeddings)
+            original_prompt = req_state.prompt
+            decode_inputs = [original_prompt] if not isinstance(original_prompt, list) else original_prompt
+
+            for decode_input in decode_inputs:
+                request = build_engine_core_request_from_tokens(
+                    request_id=req_id,
+                    prompt=decode_input,
+                    params=params,
+                    model_config=self.stage_vllm_configs[next_stage_id].model_config,
+                    mm_features=req_state.mm_features,  # Pass mm_features for M-RoPE
+                )
+                request.external_req_id = request.request_id
+
+                self.output_processors[next_stage_id].add_request(
+                    request=request,
+                    prompt=None,
+                    parent_req=None,
+                    request_index=0,
+                    queue=None,
+                )
+                await next_client.add_request_async(request)
+
+            req_state.stage_submit_ts[next_stage_id] = _time.time()
+            return
+
         self.stage_clients[stage_id].set_engine_outputs([output])
 
         # Process inputs for next stage
@@ -558,14 +682,17 @@ class Orchestrator:
 
         # Build and submit requests for each input
         for next_input in next_inputs:
+            # Only pass mm_features to thinker/talker stages that use M-RoPE.
+            # code2wav has no encoder and will crash with a cache miss if mm_features is set.
+            _mm_features = req_state.mm_features if next_client.model_stage != "code2wav" else None
             request = build_engine_core_request_from_tokens(
                 request_id=req_id,
                 prompt=next_input,
                 params=params,
                 model_config=self.stage_vllm_configs[next_stage_id].model_config,
+                mm_features=_mm_features,
             )
 
-            # TODO: Here we directly use the req id to assign.
             request.external_req_id = request.request_id
 
             self.output_processors[next_stage_id].add_request(
@@ -644,6 +771,7 @@ class Orchestrator:
             prompt=original_prompt,
             sampling_params_list=sampling_params_list,
             final_stage_id=final_stage_id,
+            mm_features=getattr(prompt, "mm_features", None),  # Save mm_features for PD
         )
         req_state.stage_submit_ts[stage_id] = _time.time()
         self.request_states[request_id] = req_state

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -233,10 +233,9 @@ class OmniRequestState(RequestState):
         # Reuse base text/logprobs logic, then annotate with pooling_result.
         base_output = super()._new_completion_output(token_ids, finish_reason, stop_reason, routed_experts)
         try:
+            if not hasattr(base_output, "multimodal_output"):
+                setattr(base_output, "multimodal_output", {})
             if self.mm_accumulated is not None:
-                # Attach accumulated multimodal dict on the completion output
-                if not hasattr(base_output, "multimodal_output"):
-                    setattr(base_output, "multimodal_output", {})
                 mm_out = getattr(base_output, "multimodal_output")
                 if isinstance(mm_out, dict):
                     for k, v in self.mm_accumulated.items():

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -78,6 +78,7 @@ class AsyncOmni(EngineClient, OmniBase):
         self.final_output_task: asyncio.Task | None = None
 
         self.config_path = self.engine.config_path
+        self.stage_configs = self.engine.stage_configs
         self.tts_max_instructions_length = kwargs.get("tts_max_instructions_length", None)
         self.input_processor = self.engine.input_processor
 

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -209,8 +209,10 @@ class AsyncOmni(EngineClient, OmniBase):
             self._final_output_handler()
 
             # Expand sampling params for PD disaggregation (user may provide N-1 params)
-            if sampling_params_list is not None and isinstance(sampling_params_list, Sequence) and not isinstance(
-                sampling_params_list, (str, bytes)
+            if (
+                sampling_params_list is not None
+                and isinstance(sampling_params_list, Sequence)
+                and not isinstance(sampling_params_list, (str, bytes))
             ):
                 sampling_params_list = self._maybe_expand_sampling_params(list(sampling_params_list))
             sampling_params_list = self.resolve_sampling_params_list(sampling_params_list)
@@ -231,14 +233,12 @@ class AsyncOmni(EngineClient, OmniBase):
             req_state = ClientRequestState(request_id)
             req_state.metrics = metrics
             self.request_states[request_id] = req_state
-            
+
             # PD disaggregation: modify prefill-stage sampling params per request
             req_sp_list = list(sampling_params_list)
             if self._pd_separation_pair is not None:
                 p_id = self._pd_separation_pair[0]
-                req_sp_list[p_id] = self._prepare_prefill_sampling_params(
-                    request_id, req_sp_list[p_id]
-                )
+                req_sp_list[p_id] = self._prepare_prefill_sampling_params(request_id, req_sp_list[p_id])
 
             # Add request(s) to stage 0. For streaming inputs, submit
             # chunks incrementally through streaming_update.

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -236,8 +236,9 @@ class AsyncOmni(EngineClient, OmniBase):
 
             # PD disaggregation: modify prefill-stage sampling params per request
             req_sp_list = list(sampling_params_list)
-            if self._pd_separation_pair is not None:
-                p_id = self._pd_separation_pair[0]
+            pd_pair = self._get_pd_separation_pair()
+            if pd_pair is not None:
+                p_id = pd_pair[0]
                 req_sp_list[p_id] = self._prepare_prefill_sampling_params(request_id, req_sp_list[p_id])
 
             # Add request(s) to stage 0. For streaming inputs, submit

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -78,7 +78,6 @@ class AsyncOmni(EngineClient, OmniBase):
         self.final_output_task: asyncio.Task | None = None
 
         self.config_path = self.engine.config_path
-        self.stage_configs = self.engine.stage_configs
         self.tts_max_instructions_length = kwargs.get("tts_max_instructions_length", None)
         self.input_processor = self.engine.input_processor
 

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -78,7 +78,6 @@ class AsyncOmni(EngineClient, OmniBase):
         self.final_output_task: asyncio.Task | None = None
 
         self.config_path = self.engine.config_path
-        self.stage_configs = self.engine.stage_configs
         self.tts_max_instructions_length = kwargs.get("tts_max_instructions_length", None)
         self.input_processor = self.engine.input_processor
 
@@ -209,6 +208,11 @@ class AsyncOmni(EngineClient, OmniBase):
             # Start final output dispatcher on the first call to generate()
             self._final_output_handler()
 
+            # Expand sampling params for PD disaggregation (user may provide N-1 params)
+            if sampling_params_list is not None and isinstance(sampling_params_list, Sequence) and not isinstance(
+                sampling_params_list, (str, bytes)
+            ):
+                sampling_params_list = self._maybe_expand_sampling_params(list(sampling_params_list))
             sampling_params_list = self.resolve_sampling_params_list(sampling_params_list)
 
             # Track per-request metrics
@@ -227,6 +231,14 @@ class AsyncOmni(EngineClient, OmniBase):
             req_state = ClientRequestState(request_id)
             req_state.metrics = metrics
             self.request_states[request_id] = req_state
+            
+            # PD disaggregation: modify prefill-stage sampling params per request
+            req_sp_list = list(sampling_params_list)
+            if self._pd_separation_pair is not None:
+                p_id = self._pd_separation_pair[0]
+                req_sp_list[p_id] = self._prepare_prefill_sampling_params(
+                    request_id, req_sp_list[p_id]
+                )
 
             # Add request(s) to stage 0. For streaming inputs, submit
             # chunks incrementally through streaming_update.
@@ -234,14 +246,14 @@ class AsyncOmni(EngineClient, OmniBase):
                 input_stream_task = await self._add_streaming_input_request(
                     request_id=request_id,
                     input_stream=prompt,
-                    sampling_params_list=sampling_params_list,
+                    sampling_params_list=req_sp_list,
                     final_stage_id=final_stage_id_for_e2e,
                 )
             else:
                 await self.engine.add_request_async(
                     request_id=request_id,
                     prompt=prompt,
-                    sampling_params_list=sampling_params_list,
+                    sampling_params_list=req_sp_list,
                     final_stage_id=final_stage_id_for_e2e,
                 )
             submit_ts = time.time()

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -134,8 +134,9 @@ class Omni(OmniBase):
 
                 # PD disaggregation: modify stage-0 (prefill) sampling params per request
                 req_sp_list = list(sampling_params_list)
-                if self._pd_separation_pair is not None:
-                    p_id = self._pd_separation_pair[0]
+                pd_pair = self._get_pd_separation_pair()
+                if pd_pair is not None:
+                    p_id = pd_pair[0]
                     req_sp_list[p_id] = self._prepare_prefill_sampling_params(req_id, req_sp_list[p_id])
 
                 self.engine.add_request(

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -67,8 +67,10 @@ class Omni(OmniBase):
         use_tqdm: bool | Callable[..., tqdm] = True,
     ) -> Generator[OmniRequestOutput, None, None] | list[OmniRequestOutput]:
         # Expand sampling params for PD disaggregation (user may provide N-1 params)
-        if sampling_params_list is not None and isinstance(sampling_params_list, Sequence) and not isinstance(
-            sampling_params_list, (str, bytes)
+        if (
+            sampling_params_list is not None
+            and isinstance(sampling_params_list, Sequence)
+            and not isinstance(sampling_params_list, (str, bytes))
         ):
             sampling_params_list = self._maybe_expand_sampling_params(list(sampling_params_list))
         sampling_params_list = self.resolve_sampling_params_list(sampling_params_list)

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -66,6 +66,11 @@ class Omni(OmniBase):
         py_generator: bool = False,
         use_tqdm: bool | Callable[..., tqdm] = True,
     ) -> Generator[OmniRequestOutput, None, None] | list[OmniRequestOutput]:
+        # Expand sampling params for PD disaggregation (user may provide N-1 params)
+        if sampling_params_list is not None and isinstance(sampling_params_list, Sequence) and not isinstance(
+            sampling_params_list, (str, bytes)
+        ):
+            sampling_params_list = self._maybe_expand_sampling_params(list(sampling_params_list))
         sampling_params_list = self.resolve_sampling_params_list(sampling_params_list)
         try:
             if py_generator:
@@ -125,10 +130,16 @@ class Omni(OmniBase):
                 req_state.metrics = metrics
                 self.request_states[req_id] = req_state
 
+                # PD disaggregation: modify stage-0 (prefill) sampling params per request
+                req_sp_list = list(sampling_params_list)
+                if self._pd_separation_pair is not None:
+                    p_id = self._pd_separation_pair[0]
+                    req_sp_list[p_id] = self._prepare_prefill_sampling_params(req_id, req_sp_list[p_id])
+
                 self.engine.add_request(
                     request_id=req_id,
                     prompt=prompt,
-                    sampling_params_list=sampling_params_list,
+                    sampling_params_list=req_sp_list,
                     final_stage_id=final_stage_id,
                 )
                 submit_ts = time.time()

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -14,6 +14,7 @@ from vllm.v1.engine.exceptions import EngineDeadError
 
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.entrypoints.client_request_state import ClientRequestState
+from vllm_omni.entrypoints.pd_utils import PDDisaggregationMixin
 from vllm_omni.entrypoints.utils import get_final_stage_id_for_e2e
 from vllm_omni.metrics.stats import OrchestratorAggregator as OrchestratorMetrics
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
@@ -65,7 +66,7 @@ def omni_snapshot_download(model_id: str) -> str:
 OutputMessageHandleResult = tuple[Literal[True], None, None, None] | tuple[Literal[False], str, int, ClientRequestState]
 
 
-class OmniBase:
+class OmniBase(PDDisaggregationMixin):
     """Shared runtime foundation for AsyncOmni and Omni."""
 
     def __init__(
@@ -84,6 +85,7 @@ class OmniBase:
         if "log_requests" in kwargs:
             raise TypeError("`log_requests` has been removed in Omni/AsyncOmni. Use `log_stats`.")
         model = omni_snapshot_download(model)
+        self._name = self.__class__.__name__
         self.model = model
         self.log_stats = log_stats
         self.async_chunk = async_chunk
@@ -125,14 +127,22 @@ class OmniBase:
             model,
         )
 
+        # PD disaggregation state (detects if a prefill/decode stage pair is configured)
+        self._init_pd_state()
+
     @property
     def num_stages(self) -> int:
         return self.engine.num_stages
 
     @property
+    def stage_configs(self) -> list:
+        """Expose engine stage configs for PD disaggregation detection and validation."""
+        return self.engine.stage_configs
+
+    @property
     def is_running(self) -> bool:
         return self.engine.is_alive()
-
+    
     def check_health(self) -> None:
         if not self.engine.is_alive():
             raise EngineDeadError("Orchestrator process is not alive")

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -142,11 +142,11 @@ class OmniBase(PDDisaggregationMixin):
     @property
     def is_running(self) -> bool:
         return self.engine.is_alive()
-    
+
     def check_health(self) -> None:
         if not self.engine.is_alive():
             raise EngineDeadError("Orchestrator process is not alive")
-    
+
     def resolve_sampling_params_list(
         self,
         sampling_params_list: Sequence[Any] | Any | None,

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -146,7 +146,7 @@ class OmniBase(PDDisaggregationMixin):
     def check_health(self) -> None:
         if not self.engine.is_alive():
             raise EngineDeadError("Orchestrator process is not alive")
-
+    
     def resolve_sampling_params_list(
         self,
         sampling_params_list: Sequence[Any] | Any | None,

--- a/vllm_omni/entrypoints/pd_utils.py
+++ b/vllm_omni/entrypoints/pd_utils.py
@@ -23,6 +23,14 @@ logger = logging.getLogger(__name__)
 class PDDisaggregationMixin:
     """Mixin supplying PD disaggregation helpers to OmniBase."""
 
+    def _get_pd_separation_pair(self) -> tuple[int, int] | None:
+        """PD prefill/decode indices when ``_init_pd_state`` ran; else ``None``.
+
+        Partial test doubles may skip ``OmniBase.__init__``; treat missing state as
+        no PD disaggregation instead of raising ``AttributeError``.
+        """
+        return getattr(self, "_pd_separation_pair", None)
+
     def _init_pd_state(self) -> None:
         """Initialise PD disaggregation state."""
         self._pd_separation_pair: tuple[int, int] | None = self.detect_pd_separation_from_stage_configs(
@@ -117,8 +125,9 @@ class PDDisaggregationMixin:
 
     def _validate_pd_separation_config(self) -> None:
         """Validate PD stage configurations are consistent."""
-        assert self._pd_separation_pair is not None
-        p_id, d_id = self._pd_separation_pair
+        pair = self._get_pd_separation_pair()
+        assert pair is not None
+        p_id, d_id = pair
         p_stage = self.stage_configs[p_id]
         d_stage = self.stage_configs[d_id]
 
@@ -168,10 +177,11 @@ class PDDisaggregationMixin:
 
     def _get_pd_connector_info(self) -> dict[str, Any] | None:
         """Extract prefill engine KV connector info."""
-        if self._pd_separation_pair is None:
+        pair = self._get_pd_separation_pair()
+        if pair is None:
             return None
 
-        p_id, _ = self._pd_separation_pair
+        p_id, _ = pair
         p_stage = self.stage_configs[p_id]
 
         ea = p_stage.engine_args
@@ -251,18 +261,17 @@ class PDDisaggregationMixin:
 
     def _is_pd_routing(self, stage_id: int, next_stage_id: int) -> bool:
         """True when edge stage_id → next_stage_id is the prefill→decode boundary."""
-        return self._pd_separation_pair is not None and self._pd_separation_pair == (
-            stage_id,
-            next_stage_id,
-        )
+        pair = self._get_pd_separation_pair()
+        return pair is not None and pair == (stage_id, next_stage_id)
 
     def _maybe_expand_sampling_params(self, sampling_params_list: list) -> list:
         """Auto-duplicate thinker SP for decode stage when user provides N-1 params."""
-        if self._pd_separation_pair is None:
+        pair = self._get_pd_separation_pair()
+        if pair is None:
             return sampling_params_list
         if len(sampling_params_list) != len(self.stage_configs) - 1:
             return sampling_params_list
-        p_id, d_id = self._pd_separation_pair
+        p_id, d_id = pair
         sp_list = list(sampling_params_list)
         sp_list.insert(d_id, sp_list[p_id])
         return sp_list

--- a/vllm_omni/entrypoints/pd_utils.py
+++ b/vllm_omni/entrypoints/pd_utils.py
@@ -44,7 +44,7 @@ class PDDisaggregationMixin:
         """Scan stage_list for a prefill/decode pair. Returns (p_id, d_id) or None."""
         prefill_by_id: dict[int, int] = {}
         decode_indices: list[int] = []
-        for i, stage in enumerate(self.stage_list):
+        for i, stage in enumerate(self.stage_configs):
             if getattr(stage, "is_prefill_only", False):
                 prefill_by_id[i] = i
                 sid = getattr(stage, "stage_id", i)
@@ -55,7 +55,7 @@ class PDDisaggregationMixin:
 
         pd_pairs: list[tuple[int, int]] = []
         for j in decode_indices:
-            source_ids = getattr(self.stage_list[j], "engine_input_source", [])
+            source_ids = getattr(self.stage_configs[j], "engine_input_source", [])
             for src in source_ids:
                 if src in prefill_by_id:
                     pd_pairs.append((prefill_by_id[src], j))
@@ -109,8 +109,8 @@ class PDDisaggregationMixin:
         """Validate PD stage configurations are consistent."""
         assert self._pd_separation_pair is not None
         p_id, d_id = self._pd_separation_pair
-        p_stage = self.stage_list[p_id]
-        d_stage = self.stage_list[d_id]
+        p_stage = self.stage_configs[p_id]
+        d_stage = self.stage_configs[d_id]
 
         def _get_kv_cfg(stage: "OmniStage") -> dict[str, Any]:
             ea = stage.engine_args
@@ -162,7 +162,7 @@ class PDDisaggregationMixin:
             return None
 
         p_id, _ = self._pd_separation_pair
-        p_stage = self.stage_list[p_id]
+        p_stage = self.stage_configs[p_id]
 
         ea = p_stage.engine_args
         kv_cfg = getattr(ea, "kv_transfer_config", None)
@@ -250,7 +250,7 @@ class PDDisaggregationMixin:
         """Auto-duplicate thinker SP for decode stage when user provides N-1 params."""
         if self._pd_separation_pair is None:
             return sampling_params_list
-        if len(sampling_params_list) != len(self.stage_list) - 1:
+        if len(sampling_params_list) != len(self.stage_configs) - 1:
             return sampling_params_list
         p_id, d_id = self._pd_separation_pair
         sp_list = list(sampling_params_list)

--- a/vllm_omni/entrypoints/pd_utils.py
+++ b/vllm_omni/entrypoints/pd_utils.py
@@ -25,7 +25,9 @@ class PDDisaggregationMixin:
 
     def _init_pd_state(self) -> None:
         """Initialise PD disaggregation state."""
-        self._pd_separation_pair: tuple[int, int] | None = self._detect_pd_separation()
+        self._pd_separation_pair: tuple[int, int] | None = self.detect_pd_separation_from_stage_configs(
+            self.stage_configs
+        )
         self._pd_connector_info: dict[str, Any] | None = None
         self._pd_kv_params_by_req: dict[str, dict[str, Any]] = {}
         self._pd_kv_params_lock = threading.Lock()
@@ -40,11 +42,19 @@ class PDDisaggregationMixin:
                 d_id,
             )
 
-    def _detect_pd_separation(self) -> tuple[int, int] | None:
-        """Scan stage_list for a prefill/decode pair. Returns (p_id, d_id) or None."""
+    @staticmethod
+    def detect_pd_separation_from_stage_configs(stage_configs: list[Any]) -> tuple[int, int] | None:
+        """Scan stage configs for a prefill/decode pair.
+
+        Returns:
+            (prefill_idx, decode_idx) if one pair exists, None if not found.
+
+        Raises:
+            ValueError: if multiple candidate PD pairs are found.
+        """
         prefill_by_id: dict[int, int] = {}
         decode_indices: list[int] = []
-        for i, stage in enumerate(self.stage_configs):
+        for i, stage in enumerate(stage_configs):
             if getattr(stage, "is_prefill_only", False):
                 prefill_by_id[i] = i
                 sid = getattr(stage, "stage_id", i)
@@ -55,7 +65,7 @@ class PDDisaggregationMixin:
 
         pd_pairs: list[tuple[int, int]] = []
         for j in decode_indices:
-            source_ids = getattr(self.stage_configs[j], "engine_input_source", [])
+            source_ids = getattr(stage_configs[j], "engine_input_source", [])
             for src in source_ids:
                 if src in prefill_by_id:
                     pd_pairs.append((prefill_by_id[src], j))

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -843,6 +843,7 @@ class Qwen3OmniMoeForConditionalGeneration(
                 update_dict["tts_pad_embed_projected"] = pad_proj.detach()
         except Exception:
             pass
+        update_dict["prefill_consumed_text_tokens"] = 1
         self._talker_cache_thinker_decode_embeds(info_dict, update_dict)
 
         return req_input_ids[start_index:end_index], req_embeds[start_index:end_index], update_dict
@@ -986,6 +987,7 @@ class Qwen3OmniMoeForConditionalGeneration(
                 return self.tts_pad_embed.to(device)
             update_dict["finished_flag"] = True
             return self.tts_eos_embed.to(device)
+
         if cached_thinker_decode_embeds is not None and start_index < cached_thinker_decode_embeds.shape[0]:
             cached_thinker_decode_embeds = cached_thinker_decode_embeds.to(device)
             thinker_embed = cached_thinker_decode_embeds[start_index]
@@ -994,7 +996,10 @@ class Qwen3OmniMoeForConditionalGeneration(
                 cached_thinker_decode_embeds = torch.cat([cached_thinker_decode_embeds, thinker_decode_embed], dim=0)
                 update_dict["cached_thinker_decode_embeddings"] = cached_thinker_decode_embeds
         else:
-            thinker_embed = thinker_decode_embed.to(device)
+            thinker_embed = thinker_decode_embed
+            if thinker_embed.device != device:
+                thinker_embed = thinker_embed.to(device)
+
         update_dict["thinker_decode_embeddings"] = None
         return self.talker.text_projection(thinker_embed).to(device)
 

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -891,18 +891,7 @@ class Qwen3OmniMoeForConditionalGeneration(
         Returns:
             (input_ids, input_embeds) for talker
         """
-        # PD safety: zero-pad embeddings if they are shorter than the full sequence
         target_len = thinker_result_ids.shape[-1]
-        if thinker_embed.shape[0] < target_len:
-            pad_len = target_len - thinker_embed.shape[0]
-            pad = torch.zeros(pad_len, thinker_embed.shape[1],
-                              device=thinker_embed.device, dtype=thinker_embed.dtype)
-            thinker_embed = torch.cat((thinker_embed, pad), dim=0)
-        if thinker_hidden.shape[0] < target_len:
-            pad_len = target_len - thinker_hidden.shape[0]
-            pad = torch.zeros(pad_len, thinker_hidden.shape[1],
-                              device=thinker_hidden.device, dtype=thinker_hidden.dtype)
-            thinker_hidden = torch.cat((thinker_hidden, pad), dim=0)
         im_start_indexes = torch.cat(
             (
                 torch.nonzero(input_ids[0] == self.config.im_start_token_id).squeeze(),
@@ -1041,13 +1030,23 @@ class Qwen3OmniMoeForConditionalGeneration(
         return last_talker_hidden, text_step, update_dict
 
     def _get_talker_user_parts(self, im_start_index, segment_end_index, multimodal_mask, thinker_hidden, thinker_embed):
-        # PD safety: clamp segment_end_index so we never index beyond any tensor's length
-        segment_end_index = min(
+        clamped = min(
             segment_end_index,
             multimodal_mask.shape[0],
             thinker_hidden.shape[0],
             thinker_embed.shape[0],
         )
+        if clamped < segment_end_index:
+            logger.warning(
+                "_get_talker_user_parts: segment_end_index %d clamped to %d "
+                "(embed=%d, hidden=%d, mask=%d). "
+                "This usually means _merge_pd_embeddings failed to merge "
+                "prefill embeddings – check PD prefill_mm keys.",
+                segment_end_index, clamped,
+                thinker_embed.shape[0], thinker_hidden.shape[0],
+                multimodal_mask.shape[0],
+            )
+        segment_end_index = clamped
         seg_len = segment_end_index - im_start_index
         if seg_len <= 0:
             return torch.empty(

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -661,7 +661,13 @@ class Qwen3OmniMoeForConditionalGeneration(
         else:
             # decode
             if not info_dict.get("decode_flag", False):
-                info_dict["num_processed_tokens"] = 0
+                # Prefill already consumed the first text token via the
+                # assistant bootstrap path, so decode starts from the
+                # remaining-text boundary rather than cumulative index 0.
+                prefill_consumed_text_tokens = info_dict.get("prefill_consumed_text_tokens")
+                if prefill_consumed_text_tokens is None:
+                    raise RuntimeError("Missing prefill_consumed_text_tokens for talker decode handoff.")
+                info_dict["num_processed_tokens"] = prefill_consumed_text_tokens
                 update_dict["decode_flag"] = True
 
             last_talker_hidden, text_step, update_dict = self.talker_preprocess_decode(

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -1042,8 +1042,10 @@ class Qwen3OmniMoeForConditionalGeneration(
                 "(embed=%d, hidden=%d, mask=%d). "
                 "This usually means _merge_pd_embeddings failed to merge "
                 "prefill embeddings – check PD prefill_mm keys.",
-                segment_end_index, clamped,
-                thinker_embed.shape[0], thinker_hidden.shape[0],
+                segment_end_index,
+                clamped,
+                thinker_embed.shape[0],
+                thinker_hidden.shape[0],
                 multimodal_mask.shape[0],
             )
         segment_end_index = clamped

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -661,13 +661,7 @@ class Qwen3OmniMoeForConditionalGeneration(
         else:
             # decode
             if not info_dict.get("decode_flag", False):
-                # Prefill already consumed the first text token via the
-                # assistant bootstrap path, so decode starts from the
-                # remaining-text boundary rather than cumulative index 0.
-                prefill_consumed_text_tokens = info_dict.get("prefill_consumed_text_tokens")
-                if prefill_consumed_text_tokens is None:
-                    raise RuntimeError("Missing prefill_consumed_text_tokens for talker decode handoff.")
-                info_dict["num_processed_tokens"] = prefill_consumed_text_tokens
+                info_dict["num_processed_tokens"] = 0
                 update_dict["decode_flag"] = True
 
             last_talker_hidden, text_step, update_dict = self.talker_preprocess_decode(
@@ -843,7 +837,6 @@ class Qwen3OmniMoeForConditionalGeneration(
                 update_dict["tts_pad_embed_projected"] = pad_proj.detach()
         except Exception:
             pass
-        update_dict["prefill_consumed_text_tokens"] = 1
         self._talker_cache_thinker_decode_embeds(info_dict, update_dict)
 
         return req_input_ids[start_index:end_index], req_embeds[start_index:end_index], update_dict
@@ -891,10 +884,22 @@ class Qwen3OmniMoeForConditionalGeneration(
         Returns:
             (input_ids, input_embeds) for talker
         """
+        # PD safety: zero-pad embeddings if they are shorter than the full sequence
+        target_len = thinker_result_ids.shape[-1]
+        if thinker_embed.shape[0] < target_len:
+            pad_len = target_len - thinker_embed.shape[0]
+            pad = torch.zeros(pad_len, thinker_embed.shape[1],
+                              device=thinker_embed.device, dtype=thinker_embed.dtype)
+            thinker_embed = torch.cat((thinker_embed, pad), dim=0)
+        if thinker_hidden.shape[0] < target_len:
+            pad_len = target_len - thinker_hidden.shape[0]
+            pad = torch.zeros(pad_len, thinker_hidden.shape[1],
+                              device=thinker_hidden.device, dtype=thinker_hidden.dtype)
+            thinker_hidden = torch.cat((thinker_hidden, pad), dim=0)
         im_start_indexes = torch.cat(
             (
                 torch.nonzero(input_ids[0] == self.config.im_start_token_id).squeeze(),
-                torch.tensor([thinker_result_ids.shape[-1]], device=input_ids.device, dtype=input_ids.dtype),
+                torch.tensor([target_len], device=input_ids.device, dtype=input_ids.dtype),
             ),
             dim=-1,
         )  # Shape [n_starts + 1]; Take batch 0 since batched inference is not supported here.
@@ -975,7 +980,6 @@ class Qwen3OmniMoeForConditionalGeneration(
                 return self.tts_pad_embed.to(device)
             update_dict["finished_flag"] = True
             return self.tts_eos_embed.to(device)
-
         if cached_thinker_decode_embeds is not None and start_index < cached_thinker_decode_embeds.shape[0]:
             cached_thinker_decode_embeds = cached_thinker_decode_embeds.to(device)
             thinker_embed = cached_thinker_decode_embeds[start_index]
@@ -984,10 +988,7 @@ class Qwen3OmniMoeForConditionalGeneration(
                 cached_thinker_decode_embeds = torch.cat([cached_thinker_decode_embeds, thinker_decode_embed], dim=0)
                 update_dict["cached_thinker_decode_embeddings"] = cached_thinker_decode_embeds
         else:
-            thinker_embed = thinker_decode_embed
-            if thinker_embed.device != device:
-                thinker_embed = thinker_embed.to(device)
-
+            thinker_embed = thinker_decode_embed.to(device)
         update_dict["thinker_decode_embeddings"] = None
         return self.talker.text_projection(thinker_embed).to(device)
 
@@ -1029,8 +1030,23 @@ class Qwen3OmniMoeForConditionalGeneration(
         return last_talker_hidden, text_step, update_dict
 
     def _get_talker_user_parts(self, im_start_index, segment_end_index, multimodal_mask, thinker_hidden, thinker_embed):
+        # PD safety: clamp segment_end_index so we never index beyond any tensor's length
+        segment_end_index = min(
+            segment_end_index,
+            multimodal_mask.shape[0],
+            thinker_hidden.shape[0],
+            thinker_embed.shape[0],
+        )
+        seg_len = segment_end_index - im_start_index
+        if seg_len <= 0:
+            return torch.empty(
+                (0, self.config.talker_config.text_config.hidden_size),
+                device=thinker_hidden.device,
+                dtype=torch.bfloat16,
+            )
+
         user_talker_part = torch.empty(
-            (segment_end_index - im_start_index, self.config.talker_config.text_config.hidden_size),
+            (seg_len, self.config.talker_config.text_config.hidden_size),
             device=thinker_hidden.device,
             dtype=torch.bfloat16,
         )

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
@@ -132,7 +132,14 @@ def _merge_pd_embeddings(
     try:
         p_emb = prefill_mm[_EMBED_LAYER_KEY].detach().to(device=device, dtype=torch.float)
         p_hid = prefill_mm[_HIDDEN_LAYER_KEY].detach().to(device=device, dtype=torch.float)
-    except (KeyError, AttributeError, TypeError):
+    except (KeyError, AttributeError, TypeError) as exc:
+        available_keys = list(prefill_mm.keys()) if isinstance(prefill_mm, dict) else type(prefill_mm).__name__
+        logger.warning(
+            "_merge_pd_embeddings: failed to extract prefill embeddings (%s). "
+            "Expected keys %r and %r, got: %s. "
+            "Falling back to decode-only embeddings – talker user-segment will be degraded.",
+            exc, _EMBED_LAYER_KEY, _HIDDEN_LAYER_KEY, available_keys,
+        )
         return decode_emb, decode_hid
 
     if p_emb.shape[0] == 0 or decode_emb.shape[0] == 0:
@@ -432,38 +439,15 @@ def talker2code2wav(
     for talker_output in talker_outputs:
         output = talker_output.outputs[0]
         
-        # Use multimodal_output (contains all generated codes)
-        codes_tensor = output.multimodal_output["code_predictor_codes"]
-        codes_tensor = codes_tensor.to(torch.long)  # [T, 16]
-        seq_len = codes_tensor.shape[0]
-        num_quantizers = codes_tensor.shape[1]
-        
-        # Skip prefill padding: find first frame with non-zero values
-        first_nonzero_frame = 0
-        for i in range(codes_tensor.shape[0]):
-            if codes_tensor[i].count_nonzero().item() > 0:
-                first_nonzero_frame = i
-                break
-        
-        # Skip the padding frames
-        if first_nonzero_frame > 0:
-            codes_tensor = codes_tensor[first_nonzero_frame:]
-            logger.warning("[PD][skip_padding] skipped %s zero frames, remaining shape=%s",
-                first_nonzero_frame, codes_tensor.shape)
-        
-        seq_len = codes_tensor.shape[0]
-        
-        # Transpose to [16, T] for code2wav
-        codes_tensor = codes_tensor.transpose(0, 1)
-        
-        # Guard against exceeding code2wav's maximum prompt length
-        max_seq_len = _CODE2WAV_MAX_PROMPT_LEN // max(num_quantizers, 1)
-        if codes_tensor.shape[1] > max_seq_len:
-            codes_tensor = codes_tensor[:, -max_seq_len:]
-            seq_len = max_seq_len
-        
-        # Flatten to quantizer-first order: [q0_f0, q0_f1, ..., q0_fN, q1_f0, ...]
-        codec_codes = codes_tensor.cpu().reshape(-1).tolist()
+        seq_len = len(output.token_ids) - 1
+        codec_codes = (
+            output.multimodal_output["code_predictor_codes"][-seq_len:]
+            .to(torch.long)
+            .transpose(0, 1)
+            .cpu()
+            .reshape(-1)
+            .tolist()
+        )
         
         code2wav_inputs.append(
             OmniTokensPrompt(

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
@@ -138,7 +138,10 @@ def _merge_pd_embeddings(
             "_merge_pd_embeddings: failed to extract prefill embeddings (%s). "
             "Expected keys %r and %r, got: %s. "
             "Falling back to decode-only embeddings – talker user-segment will be degraded.",
-            exc, _EMBED_LAYER_KEY, _HIDDEN_LAYER_KEY, available_keys,
+            exc,
+            _EMBED_LAYER_KEY,
+            _HIDDEN_LAYER_KEY,
+            available_keys,
         )
         return decode_emb, decode_hid
 

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
@@ -3,6 +3,7 @@
 # Copyright 2025 The Qwen team.
 """Stage input processor for Qwen3 Omni MoE: Thinker → Talker transition."""
 
+import logging
 from typing import Any
 
 import torch
@@ -17,6 +18,16 @@ from vllm_omni.model_executor.stage_input_processors.tts_utils import (
     extract_speaker_from_prompt,
     extract_speaker_from_request,
 )
+
+logger = logging.getLogger(__name__)
+
+# Pooling output layer keys: "0" = word embedding, "24" = accept_hidden_layer
+_EMBED_LAYER_KEY = "0"
+_HIDDEN_LAYER_KEY = "24"
+
+# Default max prompt length for code2wav (matches model default max_model_len).
+# Flattened codec codes (seq_len * num_quantizers) must not exceed this.
+_CODE2WAV_MAX_PROMPT_LEN = 65536
 
 
 def _compute_talker_prompt_ids_length(info, device: torch.device | str = "cuda") -> int:
@@ -85,6 +96,57 @@ def _validate_stage_inputs(stage_list, engine_input_source):
 
 
 # =========================
+# PD disaggregation helpers
+# =========================
+
+
+def _get_prefill_stage(stage_list: list[Any], source_stage_id: int) -> Any | None:
+    if source_stage_id <= 0:
+        return None
+    source_stage = stage_list[source_stage_id]
+    if not getattr(source_stage, "is_decode_only", False):
+        return None
+    prev_stage = stage_list[source_stage_id - 1]
+    if getattr(prev_stage, "is_prefill_only", False) and prev_stage.engine_outputs is not None:
+        return prev_stage
+    return None
+
+
+def _merge_pd_embeddings(
+    decode_emb: torch.Tensor,
+    decode_hid: torch.Tensor,
+    prefill_mm: dict[str, Any],
+    device: torch.device,
+    expected_total: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Merge prefill prompt embeddings with decode generated embeddings.
+
+    In PD mode the prefill engine processes the prompt and the decode engine
+    generates tokens starting from position 1.  This function concatenates
+    them, removing the overlapping token(s):
+
+        merged = prefill[:P] + decode[overlap:]
+
+    where overlap = P + D - expected_total.
+    """
+    try:
+        p_emb = prefill_mm[_EMBED_LAYER_KEY].detach().to(device=device, dtype=torch.float)
+        p_hid = prefill_mm[_HIDDEN_LAYER_KEY].detach().to(device=device, dtype=torch.float)
+    except (KeyError, AttributeError, TypeError):
+        return decode_emb, decode_hid
+
+    if p_emb.shape[0] == 0 or decode_emb.shape[0] == 0:
+        return decode_emb, decode_hid
+
+    raw_total = p_emb.shape[0] + decode_emb.shape[0]
+    overlap = max(0, raw_total - expected_total) if expected_total is not None else 0
+
+    merged_emb = torch.cat([p_emb, decode_emb[overlap:]], dim=0)
+    merged_hid = torch.cat([p_hid, decode_hid[overlap:]], dim=0)
+    return merged_emb, merged_hid
+
+
+# =========================
 # Thinker -> Talker
 # =========================
 
@@ -111,8 +173,8 @@ def thinker2talker_async_chunk(
         all_token_ids = _ensure_list(all_token_ids)
         prompt_token_ids = _ensure_list(prompt_token_ids)
         talker_additional_info = {
-            "thinker_prefill_embeddings": pooling_output.get("0").detach().cpu(),
-            "thinker_hidden_states": pooling_output.get("24").detach().cpu(),
+            "thinker_prefill_embeddings": pooling_output.get(_EMBED_LAYER_KEY).detach().cpu(),
+            "thinker_hidden_states": pooling_output.get(_HIDDEN_LAYER_KEY).detach().cpu(),
             "thinker_sequences": all_token_ids,
             "thinker_input_ids": prompt_token_ids,
             # Provide thinker-side TTS token embeddings for talker projection
@@ -161,7 +223,7 @@ def thinker2talker_async_chunk(
 
         if output_token_ids:
             talker_additional_info["override_keys"] = ["thinker_decode_embeddings", "thinker_output_token_ids"]
-            talker_additional_info["thinker_decode_embeddings"] = pooling_output.get("0").detach().cpu()
+            talker_additional_info["thinker_decode_embeddings"] = pooling_output.get(_EMBED_LAYER_KEY).detach().cpu()
             talker_additional_info["thinker_output_token_ids"] = output_token_ids
         else:
             # When prefilling a chunked thinker, thinker_hidden_states needs to be updated.
@@ -185,6 +247,9 @@ def thinker2talker(
     2. Split hidden states into: prompt embeddings + generated embeddings
     3. Package for talker with additional information
 
+    In PD disaggregation mode, merges prefill-stage prompt embeddings with
+    decode-stage generated embeddings before handing off to the talker.
+
     Args:
         stage_list: List of stage objects
         engine_input_source: Source stage IDs (typically [0] for thinker)
@@ -199,21 +264,50 @@ def thinker2talker(
 
     device = torch.device(current_platform.device_type)
 
+    # PD disaggregation: look up the preceding prefill stage (if any)
+    source_stage_id = engine_input_source[0]
+    prefill_stage = _get_prefill_stage(stage_list, source_stage_id)
+
     # Process each thinker output
     for i, thinker_output in enumerate(thinker_outputs):
         output = thinker_output.outputs[0]
+        decode_emb = output.multimodal_output[_EMBED_LAYER_KEY].detach().to(device=device, dtype=torch.float)
+        decode_hid = output.multimodal_output[_HIDDEN_LAYER_KEY].detach().to(device=device, dtype=torch.float)
+
+        # PD mode: merge prefill prompt embeddings with decode generated embeddings
+        if prefill_stage is not None:
+            expected_total = len(thinker_output.prompt_token_ids) + len(output.token_ids)
+            try:
+                prefill_eos = prefill_stage.engine_outputs
+                prefill_eo = prefill_eos[min(i, len(prefill_eos) - 1)]
+                prefill_mm = prefill_eo.outputs[0].multimodal_output
+                decode_emb, decode_hid = _merge_pd_embeddings(
+                    decode_emb, decode_hid, prefill_mm, device, expected_total=expected_total
+                )
+            except Exception as exc:
+                logger.warning("[PD] Could not merge prefill embeddings: %s", exc)
+
+        # Helper: fetch TTS embed from decode output, fall back to prefill stage output
+        def _tts(key: str) -> torch.Tensor | None:
+            val = output.multimodal_output.get(key)
+            if val is None and prefill_stage is not None:
+                try:
+                    val = prefill_stage.engine_outputs[0].outputs[0].multimodal_output.get(key)
+                except Exception:
+                    pass
+            return val.detach().to(device=device, dtype=torch.float) if val is not None else None
 
         info = {
-            "thinker_prefill_embeddings": output.multimodal_output["0"].detach().to(device=device, dtype=torch.float),
-            "thinker_hidden_states": output.multimodal_output["24"].detach().to(device=device, dtype=torch.float),
+            "thinker_prefill_embeddings": decode_emb,
+            "thinker_hidden_states": decode_hid,
             "thinker_sequences": (
                 thinker_output.prompt_token_ids + output.token_ids
             ),  # the thinker_sequences is the whole ids
             "thinker_input_ids": thinker_output.prompt_token_ids,
             # Provide thinker-side TTS token embeddings for talker projection
-            "tts_bos_embed": output.multimodal_output["tts_bos_embed"].detach().to(device=device, dtype=torch.float),
-            "tts_eos_embed": output.multimodal_output["tts_eos_embed"].detach().to(device=device, dtype=torch.float),
-            "tts_pad_embed": output.multimodal_output["tts_pad_embed"].detach().to(device=device, dtype=torch.float),
+            "tts_bos_embed": _tts("tts_bos_embed"),
+            "tts_eos_embed": _tts("tts_eos_embed"),
+            "tts_pad_embed": _tts("tts_pad_embed"),
         }
         speaker = extract_speaker_from_prompt(prompt, index=i)
         if speaker is not None:
@@ -337,18 +431,40 @@ def talker2code2wav(
     # Process each talker output
     for talker_output in talker_outputs:
         output = talker_output.outputs[0]
-        seq_len = len(output.token_ids) - 1
-        # Extract codec codes from talker output
-        # Expected shape: [8, seq_len] (8-layer RVQ codes)
-        codec_codes = (
-            output.multimodal_output["code_predictor_codes"][-seq_len:]
-            .to(torch.long)
-            .transpose(0, 1)
-            .cpu()
-            .to(torch.long)
-            .reshape(-1)
-            .tolist()
-        )  # 16, seq_len
+        
+        # Use multimodal_output (contains all generated codes)
+        codes_tensor = output.multimodal_output["code_predictor_codes"]
+        codes_tensor = codes_tensor.to(torch.long)  # [T, 16]
+        seq_len = codes_tensor.shape[0]
+        num_quantizers = codes_tensor.shape[1]
+        
+        # Skip prefill padding: find first frame with non-zero values
+        first_nonzero_frame = 0
+        for i in range(codes_tensor.shape[0]):
+            if codes_tensor[i].count_nonzero().item() > 0:
+                first_nonzero_frame = i
+                break
+        
+        # Skip the padding frames
+        if first_nonzero_frame > 0:
+            codes_tensor = codes_tensor[first_nonzero_frame:]
+            logger.warning("[PD][skip_padding] skipped %s zero frames, remaining shape=%s",
+                first_nonzero_frame, codes_tensor.shape)
+        
+        seq_len = codes_tensor.shape[0]
+        
+        # Transpose to [16, T] for code2wav
+        codes_tensor = codes_tensor.transpose(0, 1)
+        
+        # Guard against exceeding code2wav's maximum prompt length
+        max_seq_len = _CODE2WAV_MAX_PROMPT_LEN // max(num_quantizers, 1)
+        if codes_tensor.shape[1] > max_seq_len:
+            codes_tensor = codes_tensor[:, -max_seq_len:]
+            seq_len = max_seq_len
+        
+        # Flatten to quantizer-first order: [q0_f0, q0_f1, ..., q0_fN, q1_f0, ...]
+        codec_codes = codes_tensor.cpu().reshape(-1).tolist()
+        
         code2wav_inputs.append(
             OmniTokensPrompt(
                 prompt_token_ids=codec_codes,

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
@@ -152,6 +152,34 @@ def _merge_pd_embeddings(
     return merged_emb, merged_hid
 
 
+def _get_prefill_multimodal_output(prefill_stage: Any, output_index: int) -> dict[str, Any] | None:
+    """Return multimodal_output dict from the PD prefill stage for a given batch index."""
+    try:
+        prefill_eos = prefill_stage.engine_outputs
+        prefill_eo = prefill_eos[min(output_index, len(prefill_eos) - 1)]
+        return prefill_eo.outputs[0].multimodal_output
+    except Exception:
+        return None
+
+
+def _resolve_tts_token_embedding(
+    key: str,
+    *,
+    thinker_mm: dict[str, Any],
+    prefill_mm: dict[str, Any] | None,
+    device: torch.device,
+) -> torch.Tensor | None:
+    """Return TTS BOS/EOS/PAD embedding tensors for the talker projection path.
+
+    Values are taken from the current thinker (decode) ``multimodal_output``; in
+    PD mode, missing keys may be filled from the paired prefill stage output.
+    """
+    val = thinker_mm.get(key)
+    if val is None and prefill_mm is not None:
+        val = prefill_mm.get(key)
+    return val.detach().to(device=device, dtype=torch.float) if val is not None else None
+
+
 # =========================
 # Thinker -> Talker
 # =========================
@@ -277,43 +305,42 @@ def thinker2talker(
     # Process each thinker output
     for i, thinker_output in enumerate(thinker_outputs):
         output = thinker_output.outputs[0]
-        decode_emb = output.multimodal_output[_EMBED_LAYER_KEY].detach().to(device=device, dtype=torch.float)
-        decode_hid = output.multimodal_output[_HIDDEN_LAYER_KEY].detach().to(device=device, dtype=torch.float)
+        thinker_mm = output.multimodal_output
+        # Full thinker embedding sequence for the talker: single thinker engine in the
+        # non-PD path; after optional merge with prefill-side tensors in PD mode.
+        thinker_emb = thinker_mm[_EMBED_LAYER_KEY].detach().to(device=device, dtype=torch.float)
+        thinker_hid = thinker_mm[_HIDDEN_LAYER_KEY].detach().to(device=device, dtype=torch.float)
 
-        # PD mode: merge prefill prompt embeddings with decode generated embeddings
+        prefill_mm: dict[str, Any] | None = None
         if prefill_stage is not None:
+            prefill_mm = _get_prefill_multimodal_output(prefill_stage, i)
+
+        if prefill_mm is not None:
             expected_total = len(thinker_output.prompt_token_ids) + len(output.token_ids)
             try:
-                prefill_eos = prefill_stage.engine_outputs
-                prefill_eo = prefill_eos[min(i, len(prefill_eos) - 1)]
-                prefill_mm = prefill_eo.outputs[0].multimodal_output
-                decode_emb, decode_hid = _merge_pd_embeddings(
-                    decode_emb, decode_hid, prefill_mm, device, expected_total=expected_total
+                thinker_emb, thinker_hid = _merge_pd_embeddings(
+                    thinker_emb, thinker_hid, prefill_mm, device, expected_total=expected_total
                 )
             except Exception as exc:
                 logger.warning("[PD] Could not merge prefill embeddings: %s", exc)
 
-        # Helper: fetch TTS embed from decode output, fall back to prefill stage output
-        def _tts(key: str) -> torch.Tensor | None:
-            val = output.multimodal_output.get(key)
-            if val is None and prefill_stage is not None:
-                try:
-                    val = prefill_stage.engine_outputs[0].outputs[0].multimodal_output.get(key)
-                except Exception:
-                    pass
-            return val.detach().to(device=device, dtype=torch.float) if val is not None else None
-
         info = {
-            "thinker_prefill_embeddings": decode_emb,
-            "thinker_hidden_states": decode_hid,
+            "thinker_prefill_embeddings": thinker_emb,
+            "thinker_hidden_states": thinker_hid,
             "thinker_sequences": (
                 thinker_output.prompt_token_ids + output.token_ids
             ),  # the thinker_sequences is the whole ids
             "thinker_input_ids": thinker_output.prompt_token_ids,
             # Provide thinker-side TTS token embeddings for talker projection
-            "tts_bos_embed": _tts("tts_bos_embed"),
-            "tts_eos_embed": _tts("tts_eos_embed"),
-            "tts_pad_embed": _tts("tts_pad_embed"),
+            "tts_bos_embed": _resolve_tts_token_embedding(
+                "tts_bos_embed", thinker_mm=thinker_mm, prefill_mm=prefill_mm, device=device
+            ),
+            "tts_eos_embed": _resolve_tts_token_embedding(
+                "tts_eos_embed", thinker_mm=thinker_mm, prefill_mm=prefill_mm, device=device
+            ),
+            "tts_pad_embed": _resolve_tts_token_embedding(
+                "tts_pad_embed", thinker_mm=thinker_mm, prefill_mm=prefill_mm, device=device
+            ),
         }
         speaker = extract_speaker_from_prompt(prompt, index=i)
         if speaker is not None:

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
@@ -25,10 +25,6 @@ logger = logging.getLogger(__name__)
 _EMBED_LAYER_KEY = "0"
 _HIDDEN_LAYER_KEY = "24"
 
-# Default max prompt length for code2wav (matches model default max_model_len).
-# Flattened codec codes (seq_len * num_quantizers) must not exceed this.
-_CODE2WAV_MAX_PROMPT_LEN = 65536
-
 
 def _compute_talker_prompt_ids_length(info, device: torch.device | str = "cuda") -> int:
     im_start_token_id = 151644
@@ -134,7 +130,7 @@ def _merge_pd_embeddings(
         p_hid = prefill_mm[_HIDDEN_LAYER_KEY].detach().to(device=device, dtype=torch.float)
     except (KeyError, AttributeError, TypeError) as exc:
         available_keys = list(prefill_mm.keys()) if isinstance(prefill_mm, dict) else type(prefill_mm).__name__
-        logger.warning(
+        logger.error(
             "_merge_pd_embeddings: failed to extract prefill embeddings (%s). "
             "Expected keys %r and %r, got: %s. "
             "Falling back to decode-only embeddings – talker user-segment will be degraded.",

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
@@ -438,17 +438,18 @@ def talker2code2wav(
     # Process each talker output
     for talker_output in talker_outputs:
         output = talker_output.outputs[0]
-        
         seq_len = len(output.token_ids) - 1
+        # Extract codec codes from talker output
+        # Expected shape: [8, seq_len] (8-layer RVQ codes)
         codec_codes = (
             output.multimodal_output["code_predictor_codes"][-seq_len:]
             .to(torch.long)
             .transpose(0, 1)
             .cpu()
+            .to(torch.long)
             .reshape(-1)
             .tolist()
-        )
-        
+        )  # 16, seq_len
         code2wav_inputs.append(
             OmniTokensPrompt(
                 prompt_token_ids=codec_codes,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Port Prefill-Decode (PD) disaggregation for the Thinker stage (originally proposed in #1303) to ** current ** Orchestrator architecture.

The feature splits the Thinker's prefill and decode phases across separate GPU instances, connected via vLLM's native KV transfer infrastructure (MooncakeConnector / NixlConnector). This enables higher throughput by overlapping compute-heavy prompt processing on one GPU with autoregressive decoding on another.

---

## Architecture

### Before (3-stage)

```
User Request
     │
     ▼
┌─────────────────────┐
│  Stage 0: Thinker   │  GPU 0  (Prefill + Decode combined)
│  Prefill + Decode   │
└──────────┬──────────┘
           │  latent embeddings + hidden states
           ▼
┌─────────────────────┐
│  Stage 1: Talker    │  GPU 1  (Text → RVQ codec codes)
└──────────┬──────────┘
           │  codec codes
           ▼
┌─────────────────────┐
│  Stage 2: Code2Wav  │  GPU 1  (RVQ codes → waveform)
└─────────────────────┘
```

### After (4-stage with PD Disaggregation)

```
User Request
     │
     ▼
┌──────────────────────────────┐
│  Stage 0: Thinker Prefill    │  GPU 0
│  is_prefill_only: true       │  kv_role: kv_producer
│  max_tokens forced to 1      │  MooncakeConnector
└──────────────┬───────────────┘
               │  KV Cache (RDMA / TCP via MooncakeConnector)
               │  + kv_transfer_params { remote_request_id, transfer_id }
               ▼
┌──────────────────────────────┐
│  Stage 1: Thinker Decode     │  GPU 1
│  is_decode_only: true        │  kv_role: kv_consumer
│  Pulls KV from Stage 0       │  Autoregressive generation
└──────────────┬───────────────┘
               │  latent: embeddings + hidden states (prefill merged with decode)
               │  _merge_pd_embeddings() in thinker2talker
               ▼
┌──────────────────────────────┐
│  Stage 2: Talker             │  GPU 2
│  Text → RVQ codec codes      │
└──────────────┬───────────────┘
               │  codec codes
               ▼
┌──────────────────────────────┐
│  Stage 3: Code2Wav           │  GPU 2  (shared w/ Talker)
│  RVQ codes → waveform        │
└──────────────────────────────┘
```

### Four Layers of Implementation

| Layer | Files | Responsibility |
|-------|-------|----------------|
| **L1 – Orchestration** | `entrypoints/pd_utils.py`, `entrypoints/async_omni.py`, `entrypoints/omni_base.py` | PD detection, validation, sampling param preparation (`max_tokens=1`, KV param injection), optional SP auto-expansion |
| **L2 – Stage Execution** | `engine/orchestrator.py`, `engine/async_omni_engine.py` | `_detect_pd_config()`, `_build_pd_decode_params()`, KV param capture from prefill output, prefill→decode routing with original prompt |
| **L3 – KV Transfer** | vLLM's `MooncakeConnector` (external) | Physical KV cache transport via RDMA/TCP; `remote_request_id` injected into prefill output |
| **L4 – Model Adaptation** | `stage_input_processors/qwen3_omni.py`, `models/qwen3_omni/qwen3_omni.py`, `stage_configs/qwen3_omni_moe_pd_separation.yaml` | `_merge_pd_embeddings()` for P+D embedding concatenation, zero-padding safety, 4-stage YAML config |

---

## Changes

| File | Change | Description |
|------|--------|-------------|
| `vllm_omni/engine/async_omni_engine.py` | Modified | Add `_detect_pd_config()`: scans stage flags, extracts Mooncake bootstrap address and engine ID, passes `pd_config` to `Orchestrator` |
| `vllm_omni/engine/orchestrator.py` | Modified | Add `_build_pd_decode_params()` and PD routing in `_forward_to_next_stage()`; capture `kv_transfer_params` from prefill outputs; use original user prompt for decode stage; clean up `_pd_kv_params` on request completion |
| `vllm_omni/entrypoints/omni_base.py` | Modified | Inherit `PDDisaggregationMixin`; expose `stage_configs` property; call `_init_pd_state()` on init |
| `vllm_omni/entrypoints/async_omni.py` | Modified | `_maybe_expand_sampling_params()` for auto-duplication; apply `_prepare_prefill_sampling_params()` before request dispatch |
| `vllm_omni/entrypoints/pd_utils.py` | **New** | `PDDisaggregationMixin` with 10 helpers: detection, validation, KV normalization, prefill SP prep (`max_tokens=1`, stop neutralization, KV param injection), decode routing, lifecycle cleanup |
| `vllm_omni/model_executor/stage_input_processors/qwen3_omni.py` | Modified | `_merge_pd_embeddings()`: merge prefill+decode embeddings and hidden states with 1-token overlap correction; `talker2code2wav()` dimension fix and truncation guard for `max_model_len` |
| `vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py` | Modified | Zero-padding safety in `_thinker_to_talker_prefill()` for PD length mismatch; index clamping in `_get_talker_user_parts()` |
| `vllm_omni/model_executor/stage_configs/qwen3_omni_moe_pd_separation.yaml` | **New** | Production 4-stage YAML: Prefill (GPU 0) + Decode (GPU 1) + Talker (GPU 2) + Code2Wav (GPU 2) |
| `tests/entrypoints/test_pd_disaggregation.py` | **New** | Unit tests for `PDDisaggregationMixin`: detection, validation, KV normalization, prefill SP prep, stop neutralization, TP validation, YAML load |
| `tests/e2e/online_serving/test_qwen3_omni.py` | Modified | Add `VLLM_TEST_PD_MODE=1` env switch to run PD config; update `num_cards=3` for PD mode; add `_PD_SEP_CONFIG` path constant |

---

## Key Design Decisions

### Why `max_tokens=1` on Prefill?

The prefill stage only needs to process the prompt and save the KV cache. Setting `max_tokens=1` forces it to stop after 1 token, yielding `finish_reason='length'`. MooncakeConnector only executes KV transfer when `finish_reason='length'` — not `'stop'`. Therefore `stop` and `stop_token_ids` are also cleared.

### Why use the original prompt for the decode stage?

The decode stage receives the original user token IDs (not the prefill's output embeddings). The KV cache is transferred transparently via MooncakeConnector, so the decode engine can continue generation as if it had run the prefill itself.

### Embedding merge in `thinker2talker`

When PD is active, the Talker receives embeddings from Stage 1 (decode only). Stage 0's (prefill) multimodal embeddings are also available. `_merge_pd_embeddings()` concatenates them:

```
merged = prefill_embeds[:P] + decode_embeds[overlap:]
# overlap = max(0, len(prefill) + len(decode) - expected_total)
```

This removes the 1-token boundary overlap and produces a unified embedding sequence for the Talker.

### GPU Layout (default YAML, TP=1, 3 GPUs)

| GPU | Stage | Role |
|-----|-------|------|
| 0 | Stage 0 – Thinker Prefill | KV producer |
| 1 | Stage 1 – Thinker Decode | KV consumer, autoregressive gen |
| 2 | Stage 2+3 – Talker + Code2Wav | Shared |

> For TP=2 Thinker models: allocate 2 GPUs per thinker stage (5 GPUs total). Both stages **must** have the same `tensor_parallel_size`.

---

## Test Plan

### Unit tests (no GPU required)

```bash
python -m pytest tests/entrypoints/test_pd_disaggregation.py -v
```

Covers:
- `TestDetectPDSeparation` — PD pair detection in 2/4-stage pipelines
- `TestValidatePDConfig` — connector/role/buffer/TP mismatch errors
- `TestGetPDConnectorInfo` — Mooncake bootstrap address extraction
- `TestPreparePrefillSamplingParams` — `max_tokens=1`, stop clearing, KV param injection, no mutation of original SP
- `TestPrefillStopNeutralization` — `stop=[]`, `stop_token_ids=[]`, `include_stop_str_in_output=False`
- `TestSamplingParamsAutoDuplication` — N-1 params auto-expanded to N
- `TestNormalizeKVTransferParams` — dict / None / dataclass conversion
- `TestKvCfgToDict` — dict / None / dataclass with empty-dict default
- `TestKVParamsCleanup` — pop / drop / fallback lifecycle
- `TestTPSizeValidation` — matching / mismatched / default TP

### E2E tests (requires 3× GPU + model weights)

```bash
# Online serving – PD mode
VLLM_TEST_PD_MODE=1 CUDA_VISIBLE_DEVICES=0,1,2 \
  python -m pytest tests/e2e/online_serving/test_qwen3_omni.py -v -s \
  -k "test_mix_to_text_audio_001 or test_text_to_text_001"
```

---

## Test Result

Unit tests: **all passing** (no GPU required).

```
tests/entrypoints/test_pd_disaggregation.py - 28 passed, N xfail (old-arch integration tests)
```

E2E results: *(to be filled after hardware validation on 3× H100)*

---

## Performance

We evaluated the performance of the Thinker stage under both **PD disaggregation (this feature)** and **non-disaggregated PD**. Since the non-disaggregated setup uses **2 GPUs** when launching the model, whereas the PD-disaggregated setup uses **3 GPUs**, the corresponding **concurrency** level for PD disaggregation was set to **1.5 times** that of the non-disaggregated configuration. Admittedly, this testing methodology is not entirely fair, but it was designed to be as fair as possible under the circumstances. Our results show that **PD disaggregation (this feature)** achieved more than a **2×** improvement in both E2E and TPOT latency.

<img width="1746" height="668" alt="image" src="https://github.com/user-attachments/assets/27f5f6a8-0de5-4576-8451-1dff81f7198f" />

<img width="1022" height="586" alt="image" src="https://github.com/user-attachments/assets/66c6fcc1-d8db-4ab5-8ef9-38173bb9d4da" />

<img width="1016" height="576" alt="image" src="https://github.com/user-attachments/assets/7163a4d4-af20-452e-8e05-4a93713267ce" />



<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR: Port PD disaggregation (#1303) to v1908 Orchestrator architecture
- [x] The test plan: unit tests (`test_pd_disaggregation.py`) + e2e tests (`test_qwen3_omni.py` with `VLLM_TEST_PD_MODE=1`)
- [x] The test results: unit tests passing; e2e pending hardware validation
- [ ] (Optional) Documentation update
- [ ] (Optional) Release notes update

</details>

**BEFORE SUBMITTING, PLEASE READ https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md**
