### PR TITLE
[Frontend] Enable sleep/wake HTTP API without VLLM_SERVER_DEV_MODE

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,14 @@ build:
   jobs:
     post_checkout:
       - git fetch --unshallow || true
+    build:
+      html:
+        - |
+          if [ "$READTHEDOCS_VERSION_TYPE" = "external" ]; then
+            python -m mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file mkdocs.readthedocs.yml --strict
+          else
+            python -m mkdocs build --clean --site-dir $READTHEDOCS_OUTPUT/html --config-file mkdocs.yml --strict
+          fi
 
 mkdocs:
   configuration: mkdocs.yml

--- a/docs/features/sleep_mode.md
+++ b/docs/features/sleep_mode.md
@@ -66,7 +66,9 @@ Start the server with `--enable-sleep-mode`:
 vllm serve Qwen/Qwen-Image --omni --enable-sleep-mode --port 8091
 ```
 
-This registers the following whole-engine HTTP endpoints without requiring `VLLM_SERVER_DEV_MODE`:
+This registers vLLM-compatible HTTP endpoints without requiring `VLLM_SERVER_DEV_MODE`.
+Query-only requests operate on the whole engine. vLLM-Omni also accepts an optional JSON body with `stage_ids`
+and returns the ACK list produced by the Omni backend.
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -96,6 +98,12 @@ This registers the following whole-engine HTTP endpoints without requiring `VLLM
 # Put the whole engine to sleep (level 1, abort pending requests)
 curl -X POST "http://localhost:8091/sleep?level=1"
 
+# Put only stages 0 and 1 to sleep and return worker ACKs
+curl -X POST http://localhost:8091/sleep \
+     -H "Content-Type: application/json" \
+     -d '{"stage_ids": [0, 1], "level": 2, "mode": "abort"}'
+# {"status":"SUCCESS","acks":[...]}
+
 # Check sleep status
 curl http://localhost:8091/is_sleeping
 # {"is_sleeping": true}
@@ -105,11 +113,19 @@ curl -X POST http://localhost:8091/wake_up
 
 # Partial wake-up (only reload weights)
 curl -X POST "http://localhost:8091/wake_up?tags=weights"
+
+# Wake only stages 0 and 1
+curl -X POST http://localhost:8091/wake_up \
+     -H "Content-Type: application/json" \
+     -d '{"stage_ids": [0, 1]}'
+# {"status":"SUCCESS","acks":[...]}
 ```
 
 ### Omni ACK HTTP API
 
-The Omni ACK API supports stage-aware sleep and wake-up. It returns worker ACKs with reclaimed-memory telemetry.
+The canonical Omni ACK API paths are `/v1/omni/sleep` and `/v1/omni/wakeup`. They support stage-aware sleep
+and wake-up and return worker ACKs with reclaimed-memory telemetry. The `/sleep` and `/wake_up` endpoints above
+remain vLLM-compatible aliases with the same optional `stage_ids` extension.
 
 ### server command Example
 Start the server with sleep mode enabled:

--- a/docs/features/sleep_mode.md
+++ b/docs/features/sleep_mode.md
@@ -34,35 +34,82 @@ Omni Sleep Mode is optimized for high-performance computing backends:
 
 ---
 
-
 ## 2. Usage Examples
 
 ### Python API Example
 You can programmatically control the lifecycle of stages using the `AsyncOmni` engine.
 
 ```python
-
 import asyncio
+
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 
-async def run_sleep_demo():
-    # 1. initialization
-    engine = AsyncOmni(
-        model="ByteDance-Seed/BAGEL-7B-MoT",
-        enable_sleep_mode=True
-    )
 
-    # 2. sleep mode level2
+async def run_sleep_demo():
+    engine = AsyncOmni(model="ByteDance-Seed/BAGEL-7B-MoT", enable_sleep_mode=True)
+
     acks = await engine.sleep(stage_ids=[0], level=2)
     print(f"Freed {acks[0].freed_bytes / 1024**3:.2f} GiB on Stage 0")
 
-    # 3. wake up
     await engine.wake_up(stage_ids=[0])
+
 
 if __name__ == "__main__":
     asyncio.run(run_sleep_demo())
-
 ```
+
+### vLLM-Compatible HTTP API
+
+Start the server with `--enable-sleep-mode`:
+
+```bash
+vllm serve Qwen/Qwen-Image --omni --enable-sleep-mode --port 8091
+```
+
+This registers the following whole-engine HTTP endpoints without requiring `VLLM_SERVER_DEV_MODE`:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/sleep?level=1&mode=abort` | Put the engine to sleep |
+| POST | `/wake_up` | Wake up the engine |
+| GET  | `/is_sleeping` | Query sleep status |
+
+**Sleep levels:**
+
+- **Level 0** — Pause scheduling only (no GPU memory changes)
+- **Level 1** — Offload model weights to CPU, discard KV cache (default)
+- **Level 2** — Discard all GPU memory
+
+**Pause modes** (how to handle in-flight requests, inherited from upstream vLLM):
+
+- `abort` — Abort all pending requests (default)
+- `wait` — Wait for pending requests to complete before sleeping
+- `keep` — Keep pending requests in queue; they resume on wake-up
+
+> **Note:** The Omni backend currently only fully implements `abort` mode.
+> `wait` and `keep` set the paused flag but do not yet drain or freeze
+> requests. Full support is planned.
+
+**Examples:**
+
+```bash
+# Put the whole engine to sleep (level 1, abort pending requests)
+curl -X POST "http://localhost:8091/sleep?level=1"
+
+# Check sleep status
+curl http://localhost:8091/is_sleeping
+# {"is_sleeping": true}
+
+# Wake up the whole engine
+curl -X POST http://localhost:8091/wake_up
+
+# Partial wake-up (only reload weights)
+curl -X POST "http://localhost:8091/wake_up?tags=weights"
+```
+
+### Omni ACK HTTP API
+
+The Omni ACK API supports stage-aware sleep and wake-up. It returns worker ACKs with reclaimed-memory telemetry.
 
 ### server command Example
 Start the server with sleep mode enabled:

--- a/mkdocs.readthedocs.yml
+++ b/mkdocs.readthedocs.yml
@@ -1,0 +1,55 @@
+INHERIT: mkdocs.yml
+
+# Pull request previews on Read the Docs have a 15-minute total build limit.
+# Keep the full API reference for regular version builds, but skip api-autonav
+# for external PR builds so docs changes can be validated within the limit.
+hooks:
+  - docs/mkdocs/hooks/url_schemes.py
+  - docs/mkdocs/hooks/generate_examples.py
+  - docs/mkdocs/hooks/generate_argparse.py
+
+exclude_docs: |
+  **/*.inc.md
+  api/**
+
+plugins:
+  - meta
+  - search
+  - autorefs
+  - glightbox
+  - git-revision-date-localized:
+      exclude:
+        - api/*
+        - generated/**
+        - user_guide/examples/**
+        - contributing/design_documents/api_design_template.md
+        - DOCS_GUIDE.md
+  - minify:
+      minify_html: true
+      minify_js: true
+      minify_css: true
+      cache_safe: true
+      js_files: [docs/mkdocs/javascript/*.js]
+      css_files: [docs/mkdocs/stylesheets/*.css]
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            filters:
+              - "!^_"
+            summary:
+              modules: true
+            show_if_no_docstring: true
+            show_signature_annotations: true
+            separate_signature: true
+            show_overloads: true
+            signature_crossrefs: true
+          inventories:
+            - https://docs.python.org/3/objects.inv
+            - https://typing-extensions.readthedocs.io/en/latest/objects.inv
+            - https://docs.aiohttp.org/en/stable/objects.inv
+            - https://pillow.readthedocs.io/en/stable/objects.inv
+            - https://numpy.org/doc/stable/objects.inv
+            - https://psutil.readthedocs.io/stable/objects.inv

--- a/tests/entrypoints/test_sleep_api.py
+++ b/tests/entrypoints/test_sleep_api.py
@@ -7,6 +7,7 @@ based on ``--enable-sleep-mode``, without requiring ``VLLM_SERVER_DEV_MODE``.
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 from unittest.mock import AsyncMock
 
 import pytest
@@ -23,6 +24,13 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 # ---------------------------------------------------------------------------
 
 SLEEP_PATHS = {"/sleep", "/wake_up", "/is_sleeping"}
+
+
+@dataclass
+class FakeAck:
+    task_id: str
+    status: str = "SUCCESS"
+    freed_bytes: int = 1024
 
 
 def _get_route_paths(app: FastAPI) -> set[str]:
@@ -72,6 +80,18 @@ class TestSleepRouterRegistration:
         count_after = sum(1 for r in app.routes if isinstance(r, Route) and r.path in SLEEP_PATHS)
         assert count_after == count_before, "Sleep routes were duplicated"
 
+    def test_stage_aware_omni_routes_are_preserved(self):
+        app = FastAPI()
+
+        @app.post("/v1/omni/sleep")
+        async def omni_sleep():
+            return {"status": "SUCCESS"}
+
+        include_sleep_router_if_enabled(app, argparse.Namespace(enable_sleep_mode=True))
+
+        paths = _get_route_paths(app)
+        assert "/v1/omni/sleep" in paths
+
 
 class TestSleepEndpoints:
     """Test the actual HTTP endpoint behaviour using a test client."""
@@ -82,8 +102,8 @@ class TestSleepEndpoints:
 
         # Provide a mock engine_client on app.state
         mock_engine = AsyncMock()
-        mock_engine.sleep = AsyncMock(return_value=None)
-        mock_engine.wake_up = AsyncMock(return_value=None)
+        mock_engine.sleep = AsyncMock(return_value=[])
+        mock_engine.wake_up = AsyncMock(return_value=[])
         mock_engine.is_sleeping = AsyncMock(return_value=False)
         app.state.engine_client = mock_engine
 
@@ -97,10 +117,12 @@ class TestSleepEndpoints:
     def test_sleep_returns_200(self, client: TestClient):
         resp = client.post("/sleep?level=1")
         assert resp.status_code == 200
+        assert resp.json() == {"status": "SUCCESS", "acks": []}
 
     def test_wake_up_returns_200(self, client: TestClient):
         resp = client.post("/wake_up")
         assert resp.status_code == 200
+        assert resp.json() == {"status": "SUCCESS", "acks": []}
 
     def test_sleep_passes_level(self, client: TestClient):
         client.post("/sleep?level=2")
@@ -112,6 +134,28 @@ class TestSleepEndpoints:
         engine = client.app.state.engine_client
         engine.sleep.assert_awaited_once_with(level=2, mode="wait")
 
+    def test_sleep_body_passes_stage_ids_level_and_mode(self, client: TestClient):
+        client.post("/sleep", json={"stage_ids": [0, 1], "level": 2, "mode": "wait"})
+        engine = client.app.state.engine_client
+        engine.sleep.assert_awaited_once_with(stage_ids=[0, 1], level=2, mode="wait")
+
+    def test_sleep_query_params_override_body_level_and_mode(self, client: TestClient):
+        client.post("/sleep?level=1&mode=abort", json={"stage_ids": [0], "level": 2, "mode": "wait"})
+        engine = client.app.state.engine_client
+        engine.sleep.assert_awaited_once_with(stage_ids=[0], level=1, mode="abort")
+
+    def test_sleep_returns_ack_json(self, client: TestClient):
+        engine = client.app.state.engine_client
+        engine.sleep.return_value = [FakeAck(task_id="sleep-task")]
+
+        resp = client.post("/sleep", json={"stage_ids": [0], "level": 2})
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "status": "SUCCESS",
+            "acks": [{"task_id": "sleep-task", "status": "SUCCESS", "freed_bytes": 1024}],
+        }
+
     def test_wake_up_passes_tags(self, client: TestClient):
         client.post("/wake_up?tags=weights")
         engine = client.app.state.engine_client
@@ -121,3 +165,25 @@ class TestSleepEndpoints:
         client.post("/wake_up")
         engine = client.app.state.engine_client
         engine.wake_up.assert_awaited_once_with(tags=None)
+
+    def test_wake_up_body_passes_stage_ids_and_tags(self, client: TestClient):
+        client.post("/wake_up", json={"stage_ids": [0, 1], "tags": ["weights"]})
+        engine = client.app.state.engine_client
+        engine.wake_up.assert_awaited_once_with(stage_ids=[0, 1], tags=["weights"])
+
+    def test_wake_up_query_tags_override_body_tags(self, client: TestClient):
+        client.post("/wake_up?tags=weights", json={"stage_ids": [0], "tags": ["kv_cache"]})
+        engine = client.app.state.engine_client
+        engine.wake_up.assert_awaited_once_with(stage_ids=[0], tags=["weights"])
+
+    def test_wake_up_returns_ack_json(self, client: TestClient):
+        engine = client.app.state.engine_client
+        engine.wake_up.return_value = [FakeAck(task_id="wake-task")]
+
+        resp = client.post("/wake_up", json={"stage_ids": [0]})
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "status": "SUCCESS",
+            "acks": [{"task_id": "wake-task", "status": "SUCCESS", "freed_bytes": 1024}],
+        }

--- a/tests/entrypoints/test_sleep_api.py
+++ b/tests/entrypoints/test_sleep_api.py
@@ -1,0 +1,123 @@
+"""Tests for sleep/wake HTTP endpoint registration in vLLM-Omni.
+
+Verifies that the sleep router is conditionally attached to the FastAPI app
+based on ``--enable-sleep-mode``, without requiring ``VLLM_SERVER_DEV_MODE``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.routing import Route
+
+from vllm_omni.entrypoints.sleep_api import include_sleep_router_if_enabled, sleep_router
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SLEEP_PATHS = {"/sleep", "/wake_up", "/is_sleeping"}
+
+
+def _get_route_paths(app: FastAPI) -> set[str]:
+    """Extract all route paths from a FastAPI application."""
+    return {r.path for r in app.routes if isinstance(r, Route)}
+
+
+def _build_app_with_sleep(enable_sleep: bool) -> FastAPI:
+    """Build a minimal FastAPI app that mirrors the omni server's
+    sleep-router registration logic."""
+    app = FastAPI()
+    args = argparse.Namespace(enable_sleep_mode=enable_sleep)
+    include_sleep_router_if_enabled(app, args)
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSleepRouterRegistration:
+    """Verify sleep/wake routes are registered iff enable_sleep_mode=True."""
+
+    def test_sleep_routes_registered_when_enabled(self):
+        app = _build_app_with_sleep(enable_sleep=True)
+        paths = _get_route_paths(app)
+        for p in SLEEP_PATHS:
+            assert p in paths, f"Expected {p} in app routes"
+
+    def test_sleep_routes_absent_when_disabled(self):
+        app = _build_app_with_sleep(enable_sleep=False)
+        paths = _get_route_paths(app)
+        for p in SLEEP_PATHS:
+            assert p not in paths, f"Did not expect {p} in app routes"
+
+    def test_no_duplicate_routes_when_already_registered(self):
+        """If upstream DEV_MODE already registered the router, we should
+        not add duplicate routes."""
+        app = FastAPI()
+        app.include_router(sleep_router)  # simulate DEV_MODE registration
+        count_before = sum(1 for r in app.routes if isinstance(r, Route) and r.path in SLEEP_PATHS)
+
+        include_sleep_router_if_enabled(app, argparse.Namespace(enable_sleep_mode=True))
+
+        count_after = sum(1 for r in app.routes if isinstance(r, Route) and r.path in SLEEP_PATHS)
+        assert count_after == count_before, "Sleep routes were duplicated"
+
+
+class TestSleepEndpoints:
+    """Test the actual HTTP endpoint behaviour using a test client."""
+
+    @pytest.fixture()
+    def client(self):
+        app = _build_app_with_sleep(enable_sleep=True)
+
+        # Provide a mock engine_client on app.state
+        mock_engine = AsyncMock()
+        mock_engine.sleep = AsyncMock(return_value=None)
+        mock_engine.wake_up = AsyncMock(return_value=None)
+        mock_engine.is_sleeping = AsyncMock(return_value=False)
+        app.state.engine_client = mock_engine
+
+        return TestClient(app)
+
+    def test_is_sleeping_returns_json(self, client: TestClient):
+        resp = client.get("/is_sleeping")
+        assert resp.status_code == 200
+        assert resp.json() == {"is_sleeping": False}
+
+    def test_sleep_returns_200(self, client: TestClient):
+        resp = client.post("/sleep?level=1")
+        assert resp.status_code == 200
+
+    def test_wake_up_returns_200(self, client: TestClient):
+        resp = client.post("/wake_up")
+        assert resp.status_code == 200
+
+    def test_sleep_passes_level(self, client: TestClient):
+        client.post("/sleep?level=2")
+        engine = client.app.state.engine_client
+        engine.sleep.assert_awaited_once_with(level=2, mode="abort")
+
+    def test_sleep_passes_mode(self, client: TestClient):
+        client.post("/sleep?level=2&mode=wait")
+        engine = client.app.state.engine_client
+        engine.sleep.assert_awaited_once_with(level=2, mode="wait")
+
+    def test_wake_up_passes_tags(self, client: TestClient):
+        client.post("/wake_up?tags=weights")
+        engine = client.app.state.engine_client
+        engine.wake_up.assert_awaited_once_with(tags=["weights"])
+
+    def test_wake_up_no_tags_passes_none(self, client: TestClient):
+        client.post("/wake_up")
+        engine = client.app.state.engine_client
+        engine.wake_up.assert_awaited_once_with(tags=None)

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -691,18 +691,35 @@ class AsyncOmni(EngineClient, OmniBase):
         wait_for_inflight_requests: bool = False,
         clear_cache: bool = True,
     ) -> None:
-        """Pause generation."""
+        """Pause generation.
+
+        Args:
+            mode: How to handle in-flight requests:
+                - ``"abort"``: Abort all in-flight requests immediately.
+                - ``"wait"``: Wait for in-flight requests to complete.
+                - ``"keep"``: Freeze requests in queue; they resume on
+                  :meth:`resume_generation`.
+            wait_for_inflight_requests: DEPRECATED. Use ``mode="wait"``.
+            clear_cache: Whether to clear prefix/mm/encoder caches.
+        """
+        # Handle deprecated parameter.
+        if wait_for_inflight_requests:
+            mode = "wait"
+
         async with self._pause_cond:
             if self._paused:
                 return
             self._paused = True
 
-        # TODO: Implement request draining if wait_for_inflight_requests
+        # TODO(AsyncOmni): Implement full mode handling (wait/keep).
+        # For now, "abort" aborts in-flight requests; "wait" and "keep"
+        # set the paused flag but do not yet drain or freeze requests.
 
         if clear_cache:
             # Clear caches for all stages.
+            reset_running = mode == "abort"
             await self.reset_prefix_cache(
-                reset_running_requests=not wait_for_inflight_requests,
+                reset_running_requests=reset_running,
                 reset_connector=True,
             )
             await self.reset_mm_cache()
@@ -788,6 +805,9 @@ class AsyncOmni(EngineClient, OmniBase):
                 actual_tp = config.parallel_config.tensor_parallel_size if config else 1
                 total_workers += actual_tp
 
+        clear_prefix_cache = level >= 1
+        await self.pause_generation(mode=mode, clear_cache=clear_prefix_cache)
+
         task_id = str(uuid.uuid4())
         self.event_resolver.watch_task(task_id, expected_count=total_workers)
         logger.info(f"[{self._name}] Sleep initiated (Task: {task_id}). Awaiting {total_workers} ACKs...")
@@ -829,6 +849,7 @@ class AsyncOmni(EngineClient, OmniBase):
                     final_acks.append(ack)
         current_omni_platform.synchronize()
         await asyncio.sleep(0.1)
+        await self.resume_generation()
         self._is_sleeping = False
         logger.info(f"[{self._name}] All {len(final_acks)}/{total_workers} workers reported WARM for task {task_id}.")
         return final_acks

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -130,6 +130,7 @@ from vllm_omni.entrypoints.openai.storage import STORAGE_MANAGER
 from vllm_omni.entrypoints.openai.stores import VIDEO_STORE, VIDEO_TASKS
 from vllm_omni.entrypoints.openai.utils import get_stage_type, parse_lora_request
 from vllm_omni.entrypoints.openai.video_api_utils import decode_input_reference
+from vllm_omni.entrypoints.sleep_api import include_sleep_router_if_enabled
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
 
 logger = init_logger(__name__)
@@ -410,6 +411,10 @@ async def omni_run_server_worker(listen_address, sock, args, client_config=None,
         if _should_enable_profiler_endpoints(stage_configs):
             logger.warning("Profiler endpoints are enabled. This should ONLY be used for local development!")
             app.include_router(profiler_router)
+
+        # Register vLLM-compatible sleep/wake HTTP endpoints when sleep mode is
+        # enabled, without requiring VLLM_SERVER_DEV_MODE.
+        include_sleep_router_if_enabled(app, args)
 
         vllm_config = await _get_vllm_config(engine_client)
 

--- a/vllm_omni/entrypoints/sleep_api.py
+++ b/vllm_omni/entrypoints/sleep_api.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import dataclasses
 from argparse import Namespace
+from typing import Any
 
-from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi import APIRouter, Body, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 from starlette.routing import Route
 from vllm.engine.protocol import EngineClient
 from vllm.logger import init_logger
@@ -15,8 +18,27 @@ SLEEP_ROUTE_PATHS = {"/sleep", "/wake_up", "/is_sleeping"}
 sleep_router = APIRouter()
 
 
+class SleepRequest(BaseModel):
+    stage_ids: list[int] | None = None
+    level: int | None = None
+    mode: str | None = None
+
+
+class WakeUpRequest(BaseModel):
+    stage_ids: list[int] | None = None
+    tags: list[str] | None = None
+
+
 def _engine_client(request: Request) -> EngineClient:
     return request.app.state.engine_client
+
+
+def _serialize_acks(acks: Any) -> list[Any]:
+    if acks is None:
+        return []
+    if not isinstance(acks, list):
+        acks = [acks]
+    return [dataclasses.asdict(ack) if dataclasses.is_dataclass(ack) else ack for ack in acks]
 
 
 def _remove_route_from_app(app, path: str, methods: set[str] | None = None) -> None:
@@ -31,21 +53,31 @@ def _remove_route_from_app(app, path: str, methods: set[str] | None = None) -> N
 
 
 @sleep_router.post("/sleep")
-async def sleep(raw_request: Request):
-    level = int(raw_request.query_params.get("level", "1"))
-    mode = raw_request.query_params.get("mode", "abort")
-    await _engine_client(raw_request).sleep(level=level, mode=mode)
-    return Response(status_code=200)
+async def sleep(raw_request: Request, request: SleepRequest | None = Body(default=None)):
+    level = int(raw_request.query_params.get("level", request.level if request and request.level is not None else "1"))
+    mode = raw_request.query_params.get("mode", request.mode if request and request.mode is not None else "abort")
+
+    kwargs: dict[str, Any] = {"level": level, "mode": mode}
+    if request and request.stage_ids is not None:
+        kwargs["stage_ids"] = request.stage_ids
+
+    acks = await _engine_client(raw_request).sleep(**kwargs)
+    return JSONResponse(content={"status": "SUCCESS", "acks": _serialize_acks(acks)})
 
 
 @sleep_router.post("/wake_up")
-async def wake_up(raw_request: Request):
-    tags = raw_request.query_params.getlist("tags")
+async def wake_up(raw_request: Request, request: WakeUpRequest | None = Body(default=None)):
+    tags = raw_request.query_params.getlist("tags") or (request.tags if request else None)
     if tags == []:
         tags = None
     logger.info("wake up the engine with tags: %s", tags)
-    await _engine_client(raw_request).wake_up(tags=tags)
-    return Response(status_code=200)
+
+    kwargs: dict[str, Any] = {"tags": tags}
+    if request and request.stage_ids is not None:
+        kwargs["stage_ids"] = request.stage_ids
+
+    acks = await _engine_client(raw_request).wake_up(**kwargs)
+    return JSONResponse(content={"status": "SUCCESS", "acks": _serialize_acks(acks)})
 
 
 @sleep_router.get("/is_sleeping")

--- a/vllm_omni/entrypoints/sleep_api.py
+++ b/vllm_omni/entrypoints/sleep_api.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from argparse import Namespace
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, Response
+from starlette.routing import Route
+from vllm.engine.protocol import EngineClient
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+SLEEP_ROUTE_PATHS = {"/sleep", "/wake_up", "/is_sleeping"}
+sleep_router = APIRouter()
+
+
+def _engine_client(request: Request) -> EngineClient:
+    return request.app.state.engine_client
+
+
+def _remove_route_from_app(app, path: str, methods: set[str] | None = None) -> None:
+    routes_to_remove = []
+    for route in app.routes:
+        if isinstance(route, Route) and route.path == path:
+            if methods is None or (hasattr(route, "methods") and route.methods & methods):
+                routes_to_remove.append(route)
+
+    for route in routes_to_remove:
+        app.routes.remove(route)
+
+
+@sleep_router.post("/sleep")
+async def sleep(raw_request: Request):
+    level = int(raw_request.query_params.get("level", "1"))
+    mode = raw_request.query_params.get("mode", "abort")
+    await _engine_client(raw_request).sleep(level=level, mode=mode)
+    return Response(status_code=200)
+
+
+@sleep_router.post("/wake_up")
+async def wake_up(raw_request: Request):
+    tags = raw_request.query_params.getlist("tags")
+    if tags == []:
+        tags = None
+    logger.info("wake up the engine with tags: %s", tags)
+    await _engine_client(raw_request).wake_up(tags=tags)
+    return Response(status_code=200)
+
+
+@sleep_router.get("/is_sleeping")
+async def is_sleeping(raw_request: Request):
+    is_sleeping = await _engine_client(raw_request).is_sleeping()
+    return JSONResponse(content={"is_sleeping": is_sleeping})
+
+
+def include_sleep_router_if_enabled(app, args: Namespace) -> None:
+    if not getattr(args, "enable_sleep_mode", False):
+        return
+
+    for path in SLEEP_ROUTE_PATHS:
+        _remove_route_from_app(app, path)
+    app.include_router(sleep_router)
+    logger.info("Sleep/wake HTTP endpoints enabled (/sleep, /wake_up, /is_sleeping)")


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Address reviewer feedback from @SamitHuang ([review comment](https://github.com/vllm-project/vllm-omni/pull/2224#pullrequestreview-4021962515)): **`mode` parameter was ignored by the Omni backend**.

**Root cause**: `AsyncOmni.sleep()` accepted the `mode` parameter but never called `pause_generation(mode=mode)` before offloading GPU memory. This meant in-flight request handling (abort/wait/keep) was silently ignored.

**Fix**: Mirror upstream `EngineCore.sleep()` behavior:
- `sleep()`: Call `pause_generation(mode=mode)` before `collective_rpc("sleep")`, only call `collective_rpc` when `level >= 1`
- `wake_up()`: Call `resume_generation()` after `collective_rpc("wake_up")`
- `pause_generation()`: Use `mode` parameter to determine `reset_running_requests` behavior (abort mode resets running requests, wait/keep modes do not)

Also includes the original PR changes:
- Register sleep router conditionally via `--enable-sleep-mode` (without requiring `VLLM_SERVER_DEV_MODE`)
- Add documentation for HTTP API endpoints in `docs/features/sleep_mode.md`

> **Note:** The Omni backend currently only fully implements `abort` mode. `wait` and `keep` set the paused flag but do not yet drain or freeze requests. Full support is planned.

Fixes #2169

Latest update for @Flink-ddd feedback:
- `/sleep` and `/wake_up` now accept an optional JSON body with `stage_ids`, so callers can target specific Omni stages.
- Both endpoints now return the Omni ACK list as JSON: `{"status": "SUCCESS", "acks": [...]}`.
- `/v1/omni/sleep` and `/v1/omni/wakeup` remain the canonical stage-aware Omni ACK API paths; `/sleep` and `/wake_up` are vLLM-compatible aliases with the same optional stage extension.


## Test Plan

### Unit tests

```bash
pytest tests/entrypoints/test_sleep_api.py -v
```

17 tests covering:
- Route registration when `enable_sleep_mode=True` / `False`
- No duplicate routes when `VLLM_SERVER_DEV_MODE` already registered them
- Preservation of canonical `/v1/omni/sleep` stage-aware routes
- HTTP endpoint behavior: `/is_sleeping`, `/sleep`, `/wake_up`
- `mode` / `level` / `tags` parameter forwarding
- Optional `stage_ids` JSON body forwarding for `/sleep` and `/wake_up`
- ACK JSON response serialization

### E2E test (vllm-omni server)

**Model**: `Qwen/Qwen3-TTS-12Hz-0.6B-Base` (2-stage TTS pipeline)
**GPU**: NVIDIA RTX 3050 Ti (4GB VRAM)

**Before** (without `--enable-sleep-mode`):
```bash
vllm-omni serve Qwen/Qwen3-TTS-12Hz-0.6B-Base --omni \
    --stage-configs-path qwen3_tts_4gb.yaml \
    --host 127.0.0.1 --port 8091 --trust-remote-code
```
→ No sleep/wake routes registered (verified via route listing in server log)

**After** (with `--enable-sleep-mode`):
```bash
vllm-omni serve Qwen/Qwen3-TTS-12Hz-0.6B-Base --omni \
    --stage-configs-path qwen3_tts_4gb.yaml \
    --enable-sleep-mode \
    --host 127.0.0.1 --port 8091 --trust-remote-code
```
→ Sleep/wake routes registered: `/sleep`, `/wake_up`, `/is_sleeping`

## Test Result

### Unit tests: 17/17 passed

```
$ pytest tests/entrypoints/test_sleep_api.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /home/devuser/myenv/bin/python
cachedir: .pytest_cache
rootdir: /home/devuser/workspace/public-oss/vllm-omni
configfile: pyproject.toml
plugins: anyio-4.13.0, cov-4.1.0, mock-3.15.1, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 17 items

tests/entrypoints/test_sleep_api.py::TestSleepRouterRegistration::test_sleep_routes_registered_when_enabled PASSED [  5%]
tests/entrypoints/test_sleep_api.py::TestSleepRouterRegistration::test_sleep_routes_absent_when_disabled PASSED [ 11%]
tests/entrypoints/test_sleep_api.py::TestSleepRouterRegistration::test_no_duplicate_routes_when_already_registered PASSED [ 17%]
tests/entrypoints/test_sleep_api.py::TestSleepRouterRegistration::test_stage_aware_omni_routes_are_preserved PASSED [ 23%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_is_sleeping_returns_json PASSED [ 29%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_sleep_returns_200 PASSED [ 35%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_wake_up_returns_200 PASSED [ 41%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_sleep_passes_level PASSED [ 47%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_sleep_passes_mode PASSED [ 52%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_sleep_body_passes_stage_ids_level_and_mode PASSED [ 58%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_sleep_query_params_override_body_level_and_mode PASSED [ 64%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_sleep_returns_ack_json PASSED [ 70%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_wake_up_passes_tags PASSED [ 76%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_wake_up_no_tags_passes_none PASSED [ 82%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_wake_up_body_passes_stage_ids_and_tags PASSED [ 88%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_wake_up_query_tags_override_body_tags PASSED [ 94%]
tests/entrypoints/test_sleep_api.py::TestSleepEndpoints::test_wake_up_returns_ack_json PASSED [100%]

======================= 17 passed, 18 warnings in 5.91s ========================
```

### E2E: vllm-omni server route registration


<details>
<summary>Before: vllm-omni server WITHOUT --enable-sleep-mode (full log)</summary>

```
$VENV/lib/python3.12/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
INFO 03-28 12:34:40 [logo.py:45]        █     █     █▄   ▄█       ▄▀▀▀▀▄ █▄   ▄█ █▄    █ ▀█▀ 
INFO 03-28 12:34:40 [logo.py:45]  ▄▄ ▄█ █     █     █ ▀▄▀ █  ▄▄▄  █    █ █ ▀▄▀ █ █ ▀▄  █  █  
INFO 03-28 12:34:40 [logo.py:45]   █▄█▀ █     █     █     █       █    █ █     █ █   ▀▄█  █  
INFO 03-28 12:34:40 [logo.py:45]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀        ▀▀▀▀  ▀     ▀ ▀     ▀ ▀▀▀ 
INFO 03-28 12:34:40 [logo.py:45] 
(APIServer pid=374330) INFO 03-28 12:34:40 [utils.py:297] vLLM server version 0.18.0, serving model Qwen/Qwen3-TTS-12Hz-0.6B-Base
(APIServer pid=374330) INFO 03-28 12:34:40 [utils.py:233] non-default args: {'model_tag': 'Qwen/Qwen3-TTS-12Hz-0.6B-Base', 'host': '127.0.0.1', 'port': 8091, 'model': 'Qwen/Qwen3-TTS-12Hz-0.6B-Base', 'trust_remote_code': True}
(APIServer pid=374330) INFO 03-28 12:34:40 [omni_base.py:93] [AsyncOmni] Initializing with model Qwen/Qwen3-TTS-12Hz-0.6B-Base
(APIServer pid=374330) INFO 03-28 12:34:40 [async_omni_engine.py:215] [AsyncOmniEngine] Initializing with model Qwen/Qwen3-TTS-12Hz-0.6B-Base
(APIServer pid=374330) WARNING 03-28 12:34:40 [utils.py:115] Filtered out 1 callable object(s) from base_engine_args that are not compatible with OmegaConf: ['dispatch_function']. 
(APIServer pid=374330) INFO 03-28 12:34:40 [async_omni_engine.py:247] [AsyncOmniEngine] Launching Orchestrator thread with 2 stages
(APIServer pid=374330) INFO 03-28 12:34:40 [initialization.py:270] Loaded OmniTransferConfig with 1 connector configurations
(APIServer pid=374330) INFO 03-28 12:34:40 [async_omni_engine.py:458] [AsyncOmniEngine] Initializing stage 0
(APIServer pid=374330) INFO 03-28 12:34:40 [stage_init_utils.py:222] [stage_init] Stage-0 set runtime devices: 0
(APIServer pid=374330) INFO 03-28 12:34:40 [async_omni_engine.py:458] [AsyncOmniEngine] Initializing stage 1
(APIServer pid=374330) WARNING 03-28 12:34:40 [config.py:338] Config format `mistral` is already registered, and will be overwritten by the new parser class `<class 'vllm_omni.model_executor.models.voxtral_tts.configuration_voxtral_tts.VoxtralTTSConfigParser'>`.
(APIServer pid=374330) INFO 03-28 12:34:40 [config.py:349] Registered config parser `<class 'vllm_omni.model_executor.models.voxtral_tts.configuration_voxtral_tts.VoxtralTTSConfigParser'>` with config format `mistral`
(APIServer pid=374330) INFO 03-28 12:34:40 [configuration_qwen3_tts.py:489] talker_config is None. Initializing talker model with default values
(APIServer pid=374330) INFO 03-28 12:34:40 [configuration_qwen3_tts.py:492] speaker_encoder_config is None. Initializing talker model with default values
(APIServer pid=374330) INFO 03-28 12:34:40 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=374330) INFO 03-28 12:34:40 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=374330) INFO 03-28 12:34:54 [model.py:533] Resolved architecture: Qwen3TTSTalkerForConditionalGeneration
(APIServer pid=374330) INFO 03-28 12:34:54 [model.py:1582] Using max model len 256
(APIServer pid=374330) INFO 03-28 12:34:54 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=128.
(APIServer pid=374330) INFO 03-28 12:34:54 [vllm.py:754] Asynchronous scheduling is disabled.
(APIServer pid=374330) WARNING 03-28 12:34:54 [vllm.py:788] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(APIServer pid=374330) WARNING 03-28 12:34:54 [vllm.py:799] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(APIServer pid=374330) INFO 03-28 12:34:54 [vllm.py:964] Cudagraph is disabled under eager mode
(APIServer pid=374330) INFO 03-28 12:34:54 [compilation.py:289] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=374330) INFO 03-28 12:34:54 [async_omni_engine.py:359] [AsyncOmniEngine] Stage 0 engine launch started
(APIServer pid=374330) INFO 03-28 12:34:54 [stage_init_utils.py:222] [stage_init] Stage-1 set runtime devices: 0
(APIServer pid=374330) INFO 03-28 12:34:54 [configuration_qwen3_tts.py:489] talker_config is None. Initializing talker model with default values
(APIServer pid=374330) INFO 03-28 12:34:54 [configuration_qwen3_tts.py:492] speaker_encoder_config is None. Initializing talker model with default values
(APIServer pid=374330) INFO 03-28 12:34:54 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=374330) INFO 03-28 12:34:54 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
$VENV/lib/python3.12/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
(EngineCore pid=374854) INFO 03-28 12:35:03 [core.py:103] Initializing a V1 LLM engine (v0.18.0) with config: model='Qwen/Qwen3-TTS-12Hz-0.6B-Base', speculative_config=None, tokenizer='Qwen/Qwen3-TTS-12Hz-0.6B-Base', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=256, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen3-TTS-12Hz-0.6B-Base, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_endpoints': [128], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore pid=374854) WARNING 03-28 12:35:03 [multiproc_executor.py:997] Reducing Torch parallelism from 8 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
(EngineCore pid=374854) INFO 03-28 12:35:03 [multiproc_executor.py:134] DP group leader: node_rank=0, node_rank_within_dp=0, master_addr=127.0.0.1, mq_connect_ip=<LOCAL_IP> (local), world_size=1, local_world_size=1
(APIServer pid=374330) INFO 03-28 12:35:05 [model.py:533] Resolved architecture: Qwen3TTSCode2Wav
(APIServer pid=374330) INFO 03-28 12:35:05 [model.py:1582] Using max model len 4096
(APIServer pid=374330) INFO 03-28 12:35:05 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=2048.
(APIServer pid=374330) WARNING 03-28 12:35:05 [vllm.py:788] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(APIServer pid=374330) WARNING 03-28 12:35:05 [vllm.py:799] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(APIServer pid=374330) INFO 03-28 12:35:05 [vllm.py:964] Cudagraph is disabled under eager mode
$VENV/lib/python3.12/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
WARNING 03-28 12:35:12 [interface.py:525] Using 'pin_memory=False' as WSL is detected. This may slow down the performance.
(Worker pid=375072) INFO 03-28 12:35:12 [parallel_state.py:1395] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:<PORT> backend=nccl
(Worker pid=375072) INFO 03-28 12:35:13 [parallel_state.py:1717] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
/bin/sh: 1: sox: not found
(Worker pid=375072) SoX could not be found!
(Worker pid=375072) 
(Worker pid=375072)     If you do not have SoX, proceed here:
(Worker pid=375072)      - - - http://sox.sourceforge.net/ - - -
(Worker pid=375072) 
(Worker pid=375072)     If you do (or think that you should) have SoX, double-check your
(Worker pid=375072)     path variables.
(Worker pid=375072)     
(Worker pid=375072) INFO 03-28 12:35:13 [gpu_model_runner.py:4481] Starting to load model Qwen/Qwen3-TTS-12Hz-0.6B-Base...
(Worker pid=375072) INFO 03-28 12:35:15 [cuda.py:317] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(Worker pid=375072) INFO 03-28 12:35:15 [flash_attn.py:598] Using FlashAttention version 2
(Worker pid=375072) INFO 03-28 12:35:15 [vllm.py:754] Asynchronous scheduling is disabled.
(Worker pid=375072) WARNING 03-28 12:35:15 [vllm.py:788] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(Worker pid=375072) WARNING 03-28 12:35:15 [vllm.py:799] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(Worker pid=375072) INFO 03-28 12:35:15 [vllm.py:964] Cudagraph is disabled under eager mode
(Worker pid=375072) INFO 03-28 12:35:15 [compilation.py:289] Enabled custom fusions: norm_quant, act_quant
(Worker pid=375072) 
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
(Worker pid=375072) 
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:10<00:00, 10.26s/it]
(Worker pid=375072) 
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:10<00:00, 10.26s/it]
(Worker pid=375072) 
(Worker pid=375072) INFO 03-28 12:35:25 [qwen3_tts_talker.py:1578] Loaded 379 weights for Qwen3TTSTalkerForConditionalGeneration
(Worker pid=375072) INFO 03-28 12:35:25 [default_loader.py:384] Loading weights took 10.48 seconds
(Worker pid=375072) INFO 03-28 12:35:26 [gpu_model_runner.py:4566] Model loading took 1.73 GiB memory and 11.734950 seconds
(Worker pid=375072) INFO 03-28 12:35:31 [base.py:150] Available KV cache memory: 0.21 GiB (profiling fallback)
(EngineCore pid=374854) INFO 03-28 12:35:31 [kv_cache_utils.py:1316] GPU KV cache size: 2,000 tokens
(EngineCore pid=374854) INFO 03-28 12:35:31 [kv_cache_utils.py:1321] Maximum concurrency for 256 tokens per request: 7.81x
(EngineCore pid=374854) INFO 03-28 12:35:31 [core.py:281] init engine (profile, create kv cache, warmup model) took 4.76 seconds
(EngineCore pid=374854) The tokenizer you are loading from 'Qwen/Qwen3-TTS-12Hz-0.6B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(EngineCore pid=374854) WARNING 03-28 12:35:33 [scheduler.py:173] Using custom scheduler class vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore pid=374854) INFO 03-28 12:35:33 [factory.py:46] Created connector: SharedMemoryConnector
(EngineCore pid=374854) WARNING 03-28 12:35:33 [interface.py:525] Using 'pin_memory=False' as WSL is detected. This may slow down the performance.
(EngineCore pid=374854) INFO 03-28 12:35:33 [vllm.py:754] Asynchronous scheduling is disabled.
(EngineCore pid=374854) WARNING 03-28 12:35:33 [vllm.py:788] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(EngineCore pid=374854) WARNING 03-28 12:35:33 [vllm.py:799] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore pid=374854) INFO 03-28 12:35:33 [vllm.py:964] Cudagraph is disabled under eager mode
(EngineCore pid=374854) INFO 03-28 12:35:33 [compilation.py:289] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=374330) INFO 03-28 12:35:33 [async_omni_engine.py:361] [AsyncOmniEngine] Stage 0 engine startup completed
(APIServer pid=374330) INFO 03-28 12:35:33 [async_omni_engine.py:359] [AsyncOmniEngine] Stage 1 engine launch started
$VENV/lib/python3.12/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
(EngineCore pid=375566) INFO 03-28 12:35:44 [core.py:103] Initializing a V1 LLM engine (v0.18.0) with config: model='Qwen/Qwen3-TTS-12Hz-0.6B-Base', speculative_config=None, tokenizer='Qwen/Qwen3-TTS-12Hz-0.6B-Base', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen3-TTS-12Hz-0.6B-Base, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_endpoints': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore pid=375566) WARNING 03-28 12:35:44 [multiproc_executor.py:997] Reducing Torch parallelism from 8 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
(EngineCore pid=375566) INFO 03-28 12:35:44 [multiproc_executor.py:134] DP group leader: node_rank=0, node_rank_within_dp=0, master_addr=127.0.0.1, mq_connect_ip=<LOCAL_IP> (local), world_size=1, local_world_size=1
$VENV/lib/python3.12/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
WARNING 03-28 12:35:52 [interface.py:525] Using 'pin_memory=False' as WSL is detected. This may slow down the performance.
(Worker pid=375770) INFO 03-28 12:35:52 [parallel_state.py:1395] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:<PORT> backend=nccl
(Worker pid=375770) INFO 03-28 12:35:53 [parallel_state.py:1717] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
/bin/sh: 1: sox: not found
(Worker pid=375770) SoX could not be found!
(Worker pid=375770) 
(Worker pid=375770)     If you do not have SoX, proceed here:
(Worker pid=375770)      - - - http://sox.sourceforge.net/ - - -
(Worker pid=375770) 
(Worker pid=375770)     If you do (or think that you should) have SoX, double-check your
(Worker pid=375770)     path variables.
(Worker pid=375770)     
(Worker pid=375770) INFO 03-28 12:35:54 [gpu_model_runner.py:4481] Starting to load model Qwen/Qwen3-TTS-12Hz-0.6B-Base...
(Worker pid=375770) INFO 03-28 12:35:54 [default_loader.py:384] Loading weights took 11538.96 seconds
(Worker pid=375770) INFO 03-28 12:35:54 [gpu_model_runner.py:4566] Model loading took 0.0 GiB memory and 0.001175 seconds
(Worker pid=375770) `torch_dtype` is deprecated! Use `dtype` instead!
(Worker pid=375770) INFO 03-28 12:35:54 [configuration_qwen3_tts_tokenizer_v2.py:156] encoder_config is None. Initializing encoder with default values
(Worker pid=375770) INFO 03-28 12:35:54 [configuration_qwen3_tts_tokenizer_v2.py:159] decoder_config is None. Initializing decoder with default values
(Worker pid=375770) INFO 03-28 12:35:59 [modeling_qwen3_tts_tokenizer_v2.py:969] Precomputed exp caches for 29 SnakeBeta activations
(Worker pid=375770) INFO 03-28 12:35:59 [cuda_graph_decoder_wrapper.py:104] Starting CUDA Graph warmup for 11 sizes: [2, 4, 8, 16, 25, 32, 50, 64, 128, 256, 325]
(Worker pid=375770) INFO 03-28 12:36:11 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=2
(Worker pid=375770) INFO 03-28 12:36:11 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=4
(Worker pid=375770) INFO 03-28 12:36:11 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=8
(Worker pid=375770) INFO 03-28 12:36:11 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=16
(Worker pid=375770) INFO 03-28 12:36:11 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=25
(Worker pid=375770) INFO 03-28 12:36:12 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=32
(Worker pid=375770) INFO 03-28 12:36:12 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=50
(Worker pid=375770) INFO 03-28 12:36:12 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=64
(Worker pid=375770) INFO 03-28 12:36:12 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=128
(Worker pid=375770) INFO 03-28 12:36:21 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=256
(Worker pid=375770) INFO 03-28 12:36:37 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=325
(Worker pid=375770) INFO 03-28 12:36:37 [cuda_graph_decoder_wrapper.py:122] CUDA Graph warmup complete: 11/11 captured
(Worker pid=375770) INFO 03-28 12:36:37 [modeling_qwen3_tts_tokenizer_v2.py:999] CUDA Graph enabled for decoder: seq_lens=[2, 4, 8, 16, 25, 32, 50, 64, 128, 256, 325]
(Worker pid=375770) INFO 03-28 12:36:37 [qwen3_tts_code2wav.py:137] Code2Wav decoder CUDA Graph enabled
(Worker pid=375770) WARNING 03-28 12:36:37 [qwen3_tts_code2wav.py:238] Code2Wav input_ids length 1 not divisible by num_quantizers 16, likely a warmup run; returning empty audio.
(Worker pid=375770) WARNING 03-28 12:36:37 [gpu_generation_model_runner.py:464] Dummy sampler run is not implemented for generation model
(EngineCore pid=375566) INFO 03-28 12:36:37 [core.py:281] init engine (profile, create kv cache, warmup model) took 42.34 seconds
(EngineCore pid=375566) The tokenizer you are loading from 'Qwen/Qwen3-TTS-12Hz-0.6B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(EngineCore pid=375566) WARNING 03-28 12:36:38 [scheduler.py:173] Using custom scheduler class vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore pid=375566) WARNING 03-28 12:36:38 [core.py:132] Disabling chunked prefill for model without KVCache
(EngineCore pid=375566) INFO 03-28 12:36:38 [factory.py:46] Created connector: SharedMemoryConnector
(EngineCore pid=375566) WARNING 03-28 12:36:41 [interface.py:525] Using 'pin_memory=False' as WSL is detected. This may slow down the performance.
(EngineCore pid=375566) INFO 03-28 12:36:41 [vllm.py:754] Asynchronous scheduling is disabled.
(EngineCore pid=375566) WARNING 03-28 12:36:41 [vllm.py:788] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(EngineCore pid=375566) WARNING 03-28 12:36:41 [vllm.py:799] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore pid=375566) INFO 03-28 12:36:41 [vllm.py:964] Cudagraph is disabled under eager mode
(EngineCore pid=375566) INFO 03-28 12:36:41 [compilation.py:289] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=374330) INFO 03-28 12:36:41 [async_omni_engine.py:361] [AsyncOmniEngine] Stage 1 engine startup completed
(APIServer pid=374330) INFO 03-28 12:36:41 [stage_engine_core_client.py:73] [StageEngineCoreClient] Stage-0 initializing EngineCore
(APIServer pid=374330) WARNING 03-28 12:36:41 [interface.py:525] Using 'pin_memory=False' as WSL is detected. This may slow down the performance.
(APIServer pid=374330) INFO 03-28 12:36:41 [stage_engine_core_client.py:104] [StageEngineCoreClient] Stage-0 EngineCore running
(APIServer pid=374330) The tokenizer you are loading from 'Qwen/Qwen3-TTS-12Hz-0.6B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(APIServer pid=374330) The tokenizer you are loading from 'Qwen/Qwen3-TTS-12Hz-0.6B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(APIServer pid=374330) INFO 03-28 12:36:43 [async_omni_engine.py:426] [AsyncOmniEngine] Stage 0 initialized
(APIServer pid=374330) INFO 03-28 12:36:43 [stage_engine_core_client.py:73] [StageEngineCoreClient] Stage-1 initializing EngineCore
(APIServer pid=374330) INFO 03-28 12:36:43 [stage_engine_core_client.py:104] [StageEngineCoreClient] Stage-1 EngineCore running
(APIServer pid=374330) INFO 03-28 12:36:43 [async_omni_engine.py:426] [AsyncOmniEngine] Stage 1 initialized
(APIServer pid=374330) INFO 03-28 12:36:43 [orchestrator.py:158] [Orchestrator] Starting event loop
(APIServer pid=374330) INFO 03-28 12:36:43 [async_omni_engine.py:289] [AsyncOmniEngine] Orchestrator ready with 2 stages
(APIServer pid=374330) INFO 03-28 12:36:43 [omni_base.py:106] [AsyncOmni] AsyncOmniEngine initialized in 123.68 seconds
(APIServer pid=374330) INFO 03-28 12:36:43 [omni_base.py:121] [AsyncOmni] Initialized with 2 stages for model Qwen/Qwen3-TTS-12Hz-0.6B-Base
(APIServer pid=374330) INFO 03-28 12:36:44 [api_server.py:551] Supported tasks: {'generate', 'speech'}
(APIServer pid=374330) INFO 03-28 12:36:44 [api_server.py:617] Initialized io_processor for AsyncOmni
(APIServer pid=374330) WARNING 03-28 12:36:44 [model.py:1376] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'repetition_penalty': 1.05, 'temperature': 0.9, 'max_tokens': 8192}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=374330) The tokenizer you are loading from 'Qwen/Qwen3-TTS-12Hz-0.6B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(APIServer pid=374330) INFO 03-28 12:36:45 [hf.py:320] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=374330) WARNING 03-28 12:36:45 [serving_speech.py:273] No speakers found in config (checked spk_id and speaker_id)
(APIServer pid=374330) INFO 03-28 12:36:45 [serving_speech.py:174] Loaded 0 supported speakers: []
(APIServer pid=374330) INFO 03-28 12:36:45 [serving_speech.py:175] Loaded 0 uploaded speakers
(APIServer pid=374330) INFO 03-28 12:36:45 [serving_speech.py:197] Loaded codec frame rate: 12.5 Hz (output_sample_rate=24000, encode_downsample_rate=1920)
(APIServer pid=374330) INFO 03-28 12:36:45 [api_server.py:346] Starting vLLM API server 0 on http://127.0.0.1:8091
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:37] Available routes are:
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/audio/speech, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/audio/speech/batch, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/audio/voices, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/audio/voices, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/audio/voices/{name}, Methods: DELETE
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/images/generations, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/images/edits, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/videos, Methods: POST
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/videos, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: DELETE
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:46] Route: /v1/videos/{video_id}/content, Methods: GET
(APIServer pid=374330) INFO 03-28 12:36:45 [launcher.py:57] Route: /v1/audio/speech/stream, Endpoint: streaming_speech
(APIServer pid=374330) INFO:     Started server process [374330]
(APIServer pid=374330) INFO:     Waiting for application startup.
(APIServer pid=374330) INFO:     Application startup complete.
(EngineCore pid=375566) ERROR 03-28 12:39:07 [multiproc_executor.py:273] Worker proc VllmWorker-0 died unexpectedly, shutting down executor.
(EngineCore pid=374854) ERROR 03-28 12:39:07 [multiproc_executor.py:273] Worker proc VllmWorker-0 died unexpectedly, shutting down executor.
(EngineCore pid=375566) ERROR 03-28 12:39:08 [core.py:1101] EngineCore encountered a fatal error.
(EngineCore pid=375566) ERROR 03-28 12:39:08 [core.py:1101] Traceback (most recent call last):
(EngineCore pid=375566) ERROR 03-28 12:39:08 [core.py:1101]   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1092, in run_engine_core
(EngineCore pid=375566) ERROR 03-28 12:39:08 [core.py:1101]     engine_core.run_busy_loop()
(EngineCore pid=375566) ERROR 03-28 12:39:08 [core.py:1101]   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1131, in run_busy_loop
(EngineCore pid=375566) ERROR 03-28 12:39:08 [core.py:1101]     self._process_input_queue()
(EngineCore pid=375566) ERROR 03-28 12:39:08 [core.py:1101]   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1154, in _process_input_queue
(EngineCore pid=375566) ERROR 03-28 12:39:08 [core.py:1101]     self._handle_client_request(*req)
(EngineCore pid=375566) ERROR 03-28 12:39:08 [core.py:1101]   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1257, in _handle_client_request
(EngineCore pid=375566) ERROR 03-28 12:39:08 [core.py:1101]     raise RuntimeError("Executor failed.")
(EngineCore pid=375566) ERROR 03-28 12:39:08 [core.py:1101] RuntimeError: Executor failed.
(EngineCore pid=374854) ERROR 03-28 12:39:08 [core.py:1101] EngineCore encountered a fatal error.
(EngineCore pid=374854) ERROR 03-28 12:39:08 [core.py:1101] Traceback (most recent call last):
(EngineCore pid=374854) ERROR 03-28 12:39:08 [core.py:1101]   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1092, in run_engine_core
(EngineCore pid=374854) ERROR 03-28 12:39:08 [core.py:1101]     engine_core.run_busy_loop()
(EngineCore pid=374854) ERROR 03-28 12:39:08 [core.py:1101]   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1131, in run_busy_loop
(EngineCore pid=374854) ERROR 03-28 12:39:08 [core.py:1101]     self._process_input_queue()
(EngineCore pid=374854) ERROR 03-28 12:39:08 [core.py:1101]   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1154, in _process_input_queue
(EngineCore pid=374854) ERROR 03-28 12:39:08 [core.py:1101]     self._handle_client_request(*req)
(EngineCore pid=374854) ERROR 03-28 12:39:08 [core.py:1101]   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1257, in _handle_client_request
(EngineCore pid=374854) ERROR 03-28 12:39:08 [core.py:1101]     raise RuntimeError("Executor failed.")
(EngineCore pid=374854) ERROR 03-28 12:39:08 [core.py:1101] RuntimeError: Executor failed.
(EngineCore pid=375566) Process EngineCore:
(EngineCore pid=375566) Traceback (most recent call last):
(EngineCore pid=375566)   File "$HOME/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore pid=375566)     self.run()
(EngineCore pid=375566)   File "$HOME/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore pid=375566)     self._target(*self._args, **self._kwargs)
(EngineCore pid=375566)   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1103, in run_engine_core
(EngineCore pid=375566)     raise e
(EngineCore pid=375566)   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1092, in run_engine_core
(EngineCore pid=375566)     engine_core.run_busy_loop()
(EngineCore pid=375566)   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1131, in run_busy_loop
(EngineCore pid=375566)     self._process_input_queue()
(EngineCore pid=375566)   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1154, in _process_input_queue
(EngineCore pid=375566)     self._handle_client_request(*req)
(EngineCore pid=375566)   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1257, in _handle_client_request
(EngineCore pid=375566)     raise RuntimeError("Executor failed.")
(EngineCore pid=375566) RuntimeError: Executor failed.
(EngineCore pid=374854) Process EngineCore:
(EngineCore pid=374854) Traceback (most recent call last):
(EngineCore pid=374854)   File "$HOME/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore pid=374854)     self.run()
(EngineCore pid=374854)   File "$HOME/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore pid=374854)     self._target(*self._args, **self._kwargs)
(EngineCore pid=374854)   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1103, in run_engine_core
(EngineCore pid=374854)     raise e
(EngineCore pid=374854)   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1092, in run_engine_core
(EngineCore pid=374854)     engine_core.run_busy_loop()
(EngineCore pid=374854)   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1131, in run_busy_loop
(EngineCore pid=374854)     self._process_input_queue()
(EngineCore pid=374854)   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1154, in _process_input_queue
(EngineCore pid=374854)     self._handle_client_request(*req)
(EngineCore pid=374854)   File "$VENV/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 1257, in _handle_client_request
(EngineCore pid=374854)     raise RuntimeError("Executor failed.")
(EngineCore pid=374854) RuntimeError: Executor failed.
$HOME/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/multiprocessing/resource_tracker.py:279: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
$HOME/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/multiprocessing/resource_tracker.py:279: UserWarning: resource_tracker: There appear to be 2 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```

**Key observation**: No `/sleep`, `/wake_up`, `/is_sleeping` routes in the route listing.

</details>

<details>
<summary>After: vllm-omni server WITH --enable-sleep-mode (full log)</summary>

```
$HOME/myenv/lib/python3.12/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
INFO 04-04 11:34:52 [logo.py:45]        █     █     █▄   ▄█       ▄▀▀▀▀▄ █▄   ▄█ █▄    █ ▀█▀ 
INFO 04-04 11:34:52 [logo.py:45]  ▄▄ ▄█ █     █     █ ▀▄▀ █  ▄▄▄  █    █ █ ▀▄▀ █ █ ▀▄  █  █  
INFO 04-04 11:34:52 [logo.py:45]   █▄█▀ █     █     █     █       █    █ █     █ █   ▀▄█  █  
INFO 04-04 11:34:52 [logo.py:45]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀        ▀▀▀▀  ▀     ▀ ▀     ▀ ▀▀▀ 
INFO 04-04 11:34:52 [logo.py:45] 
(APIServer pid=231141) INFO 04-04 11:34:52 [utils.py:297] vLLM server version 0.18.0, serving model Qwen/Qwen3-TTS-12Hz-0.6B-Base
(APIServer pid=231141) INFO 04-04 11:34:52 [utils.py:233] non-default args: {'model_tag': 'Qwen/Qwen3-TTS-12Hz-0.6B-Base', 'host': '0.0.0.0', 'port': 8091, 'model': 'Qwen/Qwen3-TTS-12Hz-0.6B-Base', 'trust_remote_code': True, 'enable_sleep_mode': True}
(APIServer pid=231141) INFO 04-04 11:34:52 [omni_base.py:93] [AsyncOmni] Initializing with model Qwen/Qwen3-TTS-12Hz-0.6B-Base
(APIServer pid=231141) INFO 04-04 11:34:52 [async_omni_engine.py:215] [AsyncOmniEngine] Initializing with model Qwen/Qwen3-TTS-12Hz-0.6B-Base
(APIServer pid=231141) WARNING 04-04 11:34:52 [utils.py:115] Filtered out 1 callable object(s) from base_engine_args that are not compatible with OmegaConf: ['dispatch_function']. 
(APIServer pid=231141) INFO 04-04 11:34:52 [async_omni_engine.py:247] [AsyncOmniEngine] Launching Orchestrator thread with 2 stages
(APIServer pid=231141) INFO 04-04 11:34:52 [initialization.py:270] Loaded OmniTransferConfig with 1 connector configurations
(APIServer pid=231141) INFO 04-04 11:34:52 [async_omni_engine.py:458] [AsyncOmniEngine] Initializing stage 0
(APIServer pid=231141) INFO 04-04 11:34:52 [stage_init_utils.py:222] [stage_init] Stage-0 set runtime devices: 0
(APIServer pid=231141) INFO 04-04 11:34:52 [async_omni_engine.py:458] [AsyncOmniEngine] Initializing stage 1
(APIServer pid=231141) WARNING 04-04 11:34:52 [config.py:338] Config format `mistral` is already registered, and will be overwritten by the new parser class `<class 'vllm_omni.model_executor.models.voxtral_tts.configuration_voxtral_tts.VoxtralTTSConfigParser'>`.
(APIServer pid=231141) INFO 04-04 11:34:52 [config.py:349] Registered config parser `<class 'vllm_omni.model_executor.models.voxtral_tts.configuration_voxtral_tts.VoxtralTTSConfigParser'>` with config format `mistral`
(APIServer pid=231141) INFO 04-04 11:34:52 [configuration_qwen3_tts.py:489] talker_config is None. Initializing talker model with default values
(APIServer pid=231141) INFO 04-04 11:34:52 [configuration_qwen3_tts.py:492] speaker_encoder_config is None. Initializing talker model with default values
(APIServer pid=231141) INFO 04-04 11:34:52 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=231141) INFO 04-04 11:34:52 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=231141) INFO 04-04 11:35:05 [model.py:533] Resolved architecture: Qwen3TTSTalkerForConditionalGeneration
(APIServer pid=231141) INFO 04-04 11:35:05 [model.py:1582] Using max model len 256
(APIServer pid=231141) INFO 04-04 11:35:05 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=128.
(APIServer pid=231141) INFO 04-04 11:35:05 [vllm.py:754] Asynchronous scheduling is disabled.
(APIServer pid=231141) WARNING 04-04 11:35:05 [vllm.py:788] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(APIServer pid=231141) WARNING 04-04 11:35:05 [vllm.py:799] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(APIServer pid=231141) INFO 04-04 11:35:05 [vllm.py:964] Cudagraph is disabled under eager mode
(APIServer pid=231141) INFO 04-04 11:35:05 [compilation.py:289] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=231141) INFO 04-04 11:35:05 [async_omni_engine.py:359] [AsyncOmniEngine] Stage 0 engine launch started
(APIServer pid=231141) INFO 04-04 11:35:05 [stage_init_utils.py:222] [stage_init] Stage-1 set runtime devices: 0
(APIServer pid=231141) INFO 04-04 11:35:05 [configuration_qwen3_tts.py:489] talker_config is None. Initializing talker model with default values
(APIServer pid=231141) INFO 04-04 11:35:05 [configuration_qwen3_tts.py:492] speaker_encoder_config is None. Initializing talker model with default values
(APIServer pid=231141) INFO 04-04 11:35:05 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=231141) INFO 04-04 11:35:05 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
$HOME/myenv/lib/python3.12/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
(EngineCore pid=231541) INFO 04-04 11:35:16 [core.py:103] Initializing a V1 LLM engine (v0.18.0) with config: model='Qwen/Qwen3-TTS-12Hz-0.6B-Base', speculative_config=None, tokenizer='Qwen/Qwen3-TTS-12Hz-0.6B-Base', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=256, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen3-TTS-12Hz-0.6B-Base, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_endpoints': [128], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore pid=231541) WARNING 04-04 11:35:16 [multiproc_executor.py:997] Reducing Torch parallelism from 8 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
(EngineCore pid=231541) INFO 04-04 11:35:16 [multiproc_executor.py:134] DP group leader: node_rank=0, node_rank_within_dp=0, master_addr=127.0.0.1, mq_connect_ip=<HOST_IP> (local), world_size=1, local_world_size=1
(APIServer pid=231141) INFO 04-04 11:35:16 [model.py:533] Resolved architecture: Qwen3TTSCode2Wav
(APIServer pid=231141) INFO 04-04 11:35:16 [model.py:1582] Using max model len 4096
(APIServer pid=231141) INFO 04-04 11:35:16 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=2048.
(APIServer pid=231141) WARNING 04-04 11:35:16 [vllm.py:788] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(APIServer pid=231141) WARNING 04-04 11:35:16 [vllm.py:799] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(APIServer pid=231141) INFO 04-04 11:35:16 [vllm.py:964] Cudagraph is disabled under eager mode
$HOME/myenv/lib/python3.12/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
WARNING 04-04 11:35:24 [interface.py:525] Using 'pin_memory=False' as WSL is detected. This may slow down the performance.
(Worker pid=231783) INFO 04-04 11:35:24 [parallel_state.py:1395] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:48283 backend=nccl
(Worker pid=231783) INFO 04-04 11:35:25 [parallel_state.py:1717] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
/bin/sh: 1: sox: not found
(Worker pid=231783) SoX could not be found!
(Worker pid=231783) 
(Worker pid=231783)     If you do not have SoX, proceed here:
(Worker pid=231783)      - - - http://sox.sourceforge.net/ - - -
(Worker pid=231783) 
(Worker pid=231783)     If you do (or think that you should) have SoX, double-check your
(Worker pid=231783)     path variables.
(Worker pid=231783)     
(Worker pid=231783) INFO 04-04 11:35:26 [gpu_model_runner.py:4481] Starting to load model Qwen/Qwen3-TTS-12Hz-0.6B-Base...
(Worker pid=231783) INFO 04-04 11:35:27 [cuda.py:317] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(Worker pid=231783) INFO 04-04 11:35:27 [flash_attn.py:598] Using FlashAttention version 2
(Worker pid=231783) INFO 04-04 11:35:27 [vllm.py:754] Asynchronous scheduling is disabled.
(Worker pid=231783) WARNING 04-04 11:35:27 [vllm.py:788] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(Worker pid=231783) WARNING 04-04 11:35:27 [vllm.py:799] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(Worker pid=231783) INFO 04-04 11:35:27 [vllm.py:964] Cudagraph is disabled under eager mode
(Worker pid=231783) INFO 04-04 11:35:27 [compilation.py:289] Enabled custom fusions: norm_quant, act_quant
(Worker pid=231783) 
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
(Worker pid=231783) 
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:06<00:00,  6.80s/it]
(Worker pid=231783) 
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:06<00:00,  6.80s/it]
(Worker pid=231783) 
(Worker pid=231783) INFO 04-04 11:35:34 [qwen3_tts_talker.py:1578] Loaded 379 weights for Qwen3TTSTalkerForConditionalGeneration
(Worker pid=231783) INFO 04-04 11:35:34 [default_loader.py:384] Loading weights took 6.95 seconds
(Worker pid=231783) INFO 04-04 11:35:35 [gpu_model_runner.py:4566] Model loading took 1.73 GiB memory and 8.190098 seconds
(Worker pid=231783) INFO 04-04 11:35:39 [base.py:150] Available KV cache memory: 0.42 GiB (profiling fallback)
(EngineCore pid=231541) INFO 04-04 11:35:39 [kv_cache_utils.py:1316] GPU KV cache size: 3,872 tokens
(EngineCore pid=231541) INFO 04-04 11:35:39 [kv_cache_utils.py:1321] Maximum concurrency for 256 tokens per request: 15.12x
(EngineCore pid=231541) INFO 04-04 11:35:40 [core.py:281] init engine (profile, create kv cache, warmup model) took 4.46 seconds
(EngineCore pid=231541) The tokenizer you are loading from 'Qwen/Qwen3-TTS-12Hz-0.6B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(EngineCore pid=231541) WARNING 04-04 11:35:40 [scheduler.py:173] Using custom scheduler class vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore pid=231541) INFO 04-04 11:35:40 [factory.py:46] Created connector: SharedMemoryConnector
(EngineCore pid=231541) WARNING 04-04 11:35:41 [interface.py:525] Using 'pin_memory=False' as WSL is detected. This may slow down the performance.
(EngineCore pid=231541) INFO 04-04 11:35:41 [vllm.py:754] Asynchronous scheduling is disabled.
(EngineCore pid=231541) WARNING 04-04 11:35:41 [vllm.py:788] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(EngineCore pid=231541) WARNING 04-04 11:35:41 [vllm.py:799] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore pid=231541) INFO 04-04 11:35:41 [vllm.py:964] Cudagraph is disabled under eager mode
(EngineCore pid=231541) INFO 04-04 11:35:41 [compilation.py:289] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=231141) INFO 04-04 11:35:41 [async_omni_engine.py:361] [AsyncOmniEngine] Stage 0 engine startup completed
(APIServer pid=231141) INFO 04-04 11:35:41 [async_omni_engine.py:359] [AsyncOmniEngine] Stage 1 engine launch started
$HOME/myenv/lib/python3.12/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
(EngineCore pid=232144) INFO 04-04 11:35:53 [core.py:103] Initializing a V1 LLM engine (v0.18.0) with config: model='Qwen/Qwen3-TTS-12Hz-0.6B-Base', speculative_config=None, tokenizer='Qwen/Qwen3-TTS-12Hz-0.6B-Base', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=Qwen/Qwen3-TTS-12Hz-0.6B-Base, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_endpoints': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore pid=232144) WARNING 04-04 11:35:53 [multiproc_executor.py:997] Reducing Torch parallelism from 8 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
(EngineCore pid=232144) INFO 04-04 11:35:53 [multiproc_executor.py:134] DP group leader: node_rank=0, node_rank_within_dp=0, master_addr=127.0.0.1, mq_connect_ip=<HOST_IP> (local), world_size=1, local_world_size=1
$HOME/myenv/lib/python3.12/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
WARNING 04-04 11:36:02 [interface.py:525] Using 'pin_memory=False' as WSL is detected. This may slow down the performance.
(Worker pid=232348) INFO 04-04 11:36:02 [parallel_state.py:1395] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:47577 backend=nccl
(Worker pid=232348) INFO 04-04 11:36:02 [parallel_state.py:1717] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
/bin/sh: 1: sox: not found
(Worker pid=232348) SoX could not be found!
(Worker pid=232348) 
(Worker pid=232348)     If you do not have SoX, proceed here:
(Worker pid=232348)      - - - http://sox.sourceforge.net/ - - -
(Worker pid=232348) 
(Worker pid=232348)     If you do (or think that you should) have SoX, double-check your
(Worker pid=232348)     path variables.
(Worker pid=232348)     
(Worker pid=232348) INFO 04-04 11:36:03 [gpu_model_runner.py:4481] Starting to load model Qwen/Qwen3-TTS-12Hz-0.6B-Base...
(Worker pid=232348) INFO 04-04 11:36:03 [default_loader.py:384] Loading weights took 8863.77 seconds
(Worker pid=232348) INFO 04-04 11:36:04 [gpu_model_runner.py:4566] Model loading took 0.0 GiB memory and 0.002126 seconds
(Worker pid=232348) `torch_dtype` is deprecated! Use `dtype` instead!
(Worker pid=232348) INFO 04-04 11:36:04 [configuration_qwen3_tts_tokenizer_v2.py:156] encoder_config is None. Initializing encoder with default values
(Worker pid=232348) INFO 04-04 11:36:04 [configuration_qwen3_tts_tokenizer_v2.py:159] decoder_config is None. Initializing decoder with default values
(Worker pid=232348) INFO 04-04 11:36:08 [modeling_qwen3_tts_tokenizer_v2.py:969] Precomputed exp caches for 29 SnakeBeta activations
(Worker pid=232348) INFO 04-04 11:36:08 [cuda_graph_decoder_wrapper.py:104] Starting CUDA Graph warmup for 11 sizes: [2, 4, 8, 16, 25, 32, 50, 64, 128, 256, 325]
(Worker pid=232348) INFO 04-04 11:36:22 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=2
(Worker pid=232348) INFO 04-04 11:36:23 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=4
(Worker pid=232348) INFO 04-04 11:36:23 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=8
(Worker pid=232348) INFO 04-04 11:36:23 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=16
(Worker pid=232348) INFO 04-04 11:36:23 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=25
(Worker pid=232348) INFO 04-04 11:36:23 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=32
(Worker pid=232348) INFO 04-04 11:36:23 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=50
(Worker pid=232348) INFO 04-04 11:36:24 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=64
(Worker pid=232348) INFO 04-04 11:36:24 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=128
(Worker pid=232348) INFO 04-04 11:36:33 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=256
(Worker pid=232348) INFO 04-04 11:36:50 [cuda_graph_decoder_wrapper.py:117]   Captured CUDA Graph for size=325
(Worker pid=232348) INFO 04-04 11:36:50 [cuda_graph_decoder_wrapper.py:122] CUDA Graph warmup complete: 11/11 captured
(Worker pid=232348) INFO 04-04 11:36:50 [modeling_qwen3_tts_tokenizer_v2.py:999] CUDA Graph enabled for decoder: seq_lens=[2, 4, 8, 16, 25, 32, 50, 64, 128, 256, 325]
(Worker pid=232348) INFO 04-04 11:36:50 [qwen3_tts_code2wav.py:137] Code2Wav decoder CUDA Graph enabled
(Worker pid=232348) WARNING 04-04 11:36:50 [qwen3_tts_code2wav.py:238] Code2Wav input_ids length 1 not divisible by num_quantizers 16, likely a warmup run; returning empty audio.
(Worker pid=232348) WARNING 04-04 11:36:50 [gpu_generation_model_runner.py:464] Dummy sampler run is not implemented for generation model
(EngineCore pid=232144) INFO 04-04 11:36:50 [core.py:281] init engine (profile, create kv cache, warmup model) took 45.78 seconds
(EngineCore pid=232144) The tokenizer you are loading from 'Qwen/Qwen3-TTS-12Hz-0.6B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(EngineCore pid=232144) WARNING 04-04 11:36:51 [scheduler.py:173] Using custom scheduler class vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore pid=232144) WARNING 04-04 11:36:51 [core.py:132] Disabling chunked prefill for model without KVCache
(EngineCore pid=232144) INFO 04-04 11:36:51 [factory.py:46] Created connector: SharedMemoryConnector
(EngineCore pid=232144) WARNING 04-04 11:36:54 [interface.py:525] Using 'pin_memory=False' as WSL is detected. This may slow down the performance.
(EngineCore pid=232144) INFO 04-04 11:36:54 [vllm.py:754] Asynchronous scheduling is disabled.
(EngineCore pid=232144) WARNING 04-04 11:36:54 [vllm.py:788] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(EngineCore pid=232144) WARNING 04-04 11:36:54 [vllm.py:799] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore pid=232144) INFO 04-04 11:36:54 [vllm.py:964] Cudagraph is disabled under eager mode
(EngineCore pid=232144) INFO 04-04 11:36:54 [compilation.py:289] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=231141) INFO 04-04 11:36:54 [async_omni_engine.py:361] [AsyncOmniEngine] Stage 1 engine startup completed
(APIServer pid=231141) INFO 04-04 11:36:54 [stage_engine_core_client.py:73] [StageEngineCoreClient] Stage-0 initializing EngineCore
(APIServer pid=231141) WARNING 04-04 11:36:54 [interface.py:525] Using 'pin_memory=False' as WSL is detected. This may slow down the performance.
(APIServer pid=231141) INFO 04-04 11:36:54 [stage_engine_core_client.py:104] [StageEngineCoreClient] Stage-0 EngineCore running
(APIServer pid=231141) The tokenizer you are loading from 'Qwen/Qwen3-TTS-12Hz-0.6B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(APIServer pid=231141) The tokenizer you are loading from 'Qwen/Qwen3-TTS-12Hz-0.6B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(APIServer pid=231141) INFO 04-04 11:36:56 [async_omni_engine.py:426] [AsyncOmniEngine] Stage 0 initialized
(APIServer pid=231141) INFO 04-04 11:36:56 [stage_engine_core_client.py:73] [StageEngineCoreClient] Stage-1 initializing EngineCore
(APIServer pid=231141) INFO 04-04 11:36:56 [stage_engine_core_client.py:104] [StageEngineCoreClient] Stage-1 EngineCore running
(APIServer pid=231141) INFO 04-04 11:36:56 [async_omni_engine.py:426] [AsyncOmniEngine] Stage 1 initialized
(APIServer pid=231141) INFO 04-04 11:36:56 [orchestrator.py:158] [Orchestrator] Starting event loop
(APIServer pid=231141) INFO 04-04 11:36:56 [async_omni_engine.py:289] [AsyncOmniEngine] Orchestrator ready with 2 stages
(APIServer pid=231141) INFO 04-04 11:36:56 [omni_base.py:106] [AsyncOmni] AsyncOmniEngine initialized in 124.53 seconds
(APIServer pid=231141) INFO 04-04 11:36:56 [omni_base.py:121] [AsyncOmni] Initialized with 2 stages for model Qwen/Qwen3-TTS-12Hz-0.6B-Base
(APIServer pid=231141) INFO 04-04 11:36:57 [api_server.py:551] Supported tasks: {'generate', 'speech'}
(APIServer pid=231141) INFO 04-04 11:36:57 [api_server.py:617] Initialized io_processor for AsyncOmni
(APIServer pid=231141) WARNING 04-04 11:36:57 [model.py:1376] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'repetition_penalty': 1.05, 'temperature': 0.9, 'max_tokens': 8192}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=231141) The tokenizer you are loading from 'Qwen/Qwen3-TTS-12Hz-0.6B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(APIServer pid=231141) INFO 04-04 11:36:58 [hf.py:320] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=231141) WARNING 04-04 11:36:58 [serving_speech.py:273] No speakers found in config (checked spk_id and speaker_id)
(APIServer pid=231141) INFO 04-04 11:36:58 [serving_speech.py:174] Loaded 0 supported speakers: []
(APIServer pid=231141) INFO 04-04 11:36:58 [serving_speech.py:175] Loaded 0 uploaded speakers
(APIServer pid=231141) INFO 04-04 11:36:58 [serving_speech.py:197] Loaded codec frame rate: 12.5 Hz (output_sample_rate=24000, encode_downsample_rate=1920)
(APIServer pid=231141) INFO 04-04 11:36:58 [api_server.py:334] Sleep/wake HTTP endpoints enabled (/sleep, /wake_up, /is_sleeping)
(APIServer pid=231141) INFO 04-04 11:36:58 [api_server.py:346] Starting vLLM API server 0 on http://0.0.0.0:8091
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:37] Available routes are:
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/audio/speech, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/audio/speech/batch, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/audio/voices, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/audio/voices, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/audio/voices/{name}, Methods: DELETE
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/images/generations, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/images/edits, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/videos, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/videos, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: DELETE
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /v1/videos/{video_id}/content, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /sleep, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /wake_up, Methods: POST
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:46] Route: /is_sleeping, Methods: GET
(APIServer pid=231141) INFO 04-04 11:36:58 [launcher.py:57] Route: /v1/audio/speech/stream, Endpoint: streaming_speech
(APIServer pid=231141) INFO:     Started server process [231141]
(APIServer pid=231141) INFO:     Waiting for application startup.
(APIServer pid=231141) INFO:     Application startup complete.
(APIServer pid=231141) INFO:     <HOST_IP>:45152 - "GET /is_sleeping HTTP/1.1" 200 OK
(APIServer pid=231141) INFO:     <HOST_IP>:45154 - "POST /sleep?level=0&mode=abort HTTP/1.1" 200 OK
(APIServer pid=231141) INFO:     <HOST_IP>:45158 - "GET /is_sleeping HTTP/1.1" 200 OK
(APIServer pid=231141) INFO 04-04 11:37:13 [api_router.py:39] wake up the engine with tags: None
(APIServer pid=231141) INFO:     <HOST_IP>:45162 - "POST /wake_up HTTP/1.1" 200 OK
(APIServer pid=231141) INFO:     <HOST_IP>:45168 - "GET /is_sleeping HTTP/1.1" 200 OK

# Client-side curl output:
$ curl -s http://HOST:8091/is_sleeping
{"is_sleeping":false}

$ curl -s -X POST "http://HOST:8091/sleep?level=0&mode=abort"
  (HTTP 200)

$ curl -s http://HOST:8091/is_sleeping
{"is_sleeping":true}

$ curl -s -X POST http://HOST:8091/wake_up
  (HTTP 200)

$ curl -s http://HOST:8091/is_sleeping
{"is_sleeping":false}
```

</details>

### E2E: Sleep/wake cycle via HTTP

```bash
$ curl -s http://HOST:8091/is_sleeping
{"is_sleeping":false}

$ curl -s -X POST "http://HOST:8091/sleep?level=0&mode=abort"
  # HTTP 200

$ curl -s http://HOST:8091/is_sleeping
{"is_sleeping":true}

$ curl -s -X POST http://HOST:8091/wake_up
  # HTTP 200

$ curl -s http://HOST:8091/is_sleeping
{"is_sleeping":false}
```

Full cycle: `false` → sleep → `true` → wake_up → `false` ✓
Server remains stable with 0 errors after the cycle.

### ruff check: clean

```bash
$ ruff check vllm_omni/entrypoints/sleep_api.py tests/entrypoints/test_sleep_api.py
All checks passed!
```

## Checklist
- [x] I have read the [Contributor Guide](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md).
- [x] Changes follow the project coding standards (ruff).
- [x] Unit tests added and passing (17/17).
- [x] E2E validated: sleep/wake cycle via HTTP (`false` → sleep → `true` → wake_up → `false`), 0 errors.
- [x] Documentation updated (`docs/features/sleep_mode.md`).

Signed-off-by: Lidang Jiang <lidangjiang@gmail.com>



