### PR TITLE
[BugFix][Qwen3-Omni]Fixed the issue of incorrect answers for single words.

### DIFF
--- a/vllm_omni/benchmarks/patch/patch.py
+++ b/vllm_omni/benchmarks/patch/patch.py
@@ -376,9 +376,8 @@ async def benchmark(
         limit_per_host=max_concurrency or 0,
         ttl_dns_cache=300,
         use_dns_cache=True,
-        keepalive_timeout=60,
         enable_cleanup_closed=True,
-        force_close=False,
+        force_close=True,
         ssl=ssl_setting,
     )
 

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -1047,9 +1047,7 @@ class Qwen3OmniMoeForConditionalGeneration(
                 dim=0,
             )
         else:
-            trailing_text_hidden = torch.zeros(
-                tts_eos_embed.shape, device=tts_eos_embed.device, dtype=tts_eos_embed.dtype
-            )
+            trailing_text_hidden = tts_eos_embed
 
         input_embeds = assistant_text_hidden + assistant_codec_hidden
         input_ids = torch.full(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

1. Fixed the issue of incorrect answers for single words.
2. Fix the benchmark server disconnect error issue

## Test Plan

pytest -sv test_qwen3_omni_expansion.py::test_one_word_prompt_001 -m "advanced_model" --run-level "advanced_model"

## Test Result
```
--- Running test: test_one_word_prompt_001[async_chunk]
the avg e2e latency is: 0.8250952590024099
audio content is:  Paris
text content is: Paris
similarity is: 1.0000000000000002
the avg e2e latency is: 0.0022777009871788323
audio content is:  Paris
text content is: Paris
similarity is: 1.0000000000000002
the avg e2e latency is: 0.0022065509692765772
audio content is:  Paris
text content is: Paris
similarity is: 1.0000000000000002
the avg e2e latency is: 0.00216514099156484
audio content is:  Paris
text content is: Paris
similarity is: 1.0000000000000002
the avg e2e latency is: 0.0025836509885266423
audio content is:  Paris
text content is: Paris
similarity is: 1.0000000000000002
PASSEDGPU cleanup disabled
```

```
INFO 03-27 02:31:51 [datasets.py:631] Sampling input_len from [100, 100] and output_len from [100, 100]
WARNING: vllm bench serve no longer sets temperature==0 (greedy) in requests by default. The default will be determined on the server side and can be model/API specific. For the old behavior, include --temperature=0.
Starting initial single prompt test run...
Skipping endpoint ready check.
Starting main benchmark run...
Traffic request rate: inf
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: 10
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [04:25<00:00,  2.66s/it]
tip: install termplotlib and gnuplot to plot the metrics
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Maximum request concurrency:             10
Benchmark duration (s):                  265.55
Request throughput (req/s):              0.38
Peak concurrent requests:                14.00
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
