### PR TITLE
add diskcache to persistence video metadata

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -18,4 +18,5 @@ prettytable>=3.8.0
 aenum==3.1.16
 pyzmq>=25.0.0
 janus>=1.0.0
+diskcache>=5.6.0
 pydub

--- a/tests/entrypoints/openai_api/test_stores.py
+++ b/tests/entrypoints/openai_api/test_stores.py
@@ -1,137 +1,311 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for stores.py — based on current implementation."""
+
+import asyncio
+import threading
+
 import pytest
-from pytest_mock import MockerFixture
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
-def _make_store(tmp_path):
-    from vllm_omni.entrypoints.openai.stores import VideoStore
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
-    return VideoStore(directory=str(tmp_path / "video_store"))
 
-
-def _make_video(video_id: str = "video_gen_abc123", model: str = "test-model"):
+def _video(video_id: str = "vid_abc", model: str = "test-model", prompt: str = "a cat"):
     from vllm_omni.entrypoints.openai.protocol.videos import VideoResponse
 
-    return VideoResponse(id=video_id, model=model, prompt="a cat running")
+    return VideoResponse(id=video_id, model=model, prompt=prompt)
+
+
+def _memory_store():
+    from vllm_omni.entrypoints.openai.stores import InMemoryVideoMetadataStore
+
+    return InMemoryVideoMetadataStore()
+
+
+def _disk_store(tmp_path):
+    from vllm_omni.entrypoints.openai.stores import DiskCacheVideoMetadataStore
+
+    return DiskCacheVideoMetadataStore(directory=str(tmp_path / "store"))
 
 
 # ---------------------------------------------------------------------------
-# VideoStore
+# AsyncDictStore — exercised via InMemoryVideoMetadataStore
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_upsert_and_get(tmp_path, mocker: MockerFixture) -> None:
-    store = _make_store(tmp_path)
-    video = _make_video()
-
-    await store.upsert(video.id, video)
-    result = await store.get(video.id)
-
+async def test_dict_upsert_and_get():
+    store = _memory_store()
+    v = _video()
+    await store.upsert(v.id, v)
+    result = await store.get(v.id)
     assert result is not None
-    assert result.id == video.id
-    assert result.model == video.model
-    assert result.prompt == video.prompt
+    assert result.id == v.id
 
 
-@pytest.mark.asyncio
-async def test_get_missing_key_returns_none(tmp_path, mocker: MockerFixture) -> None:
-    store = _make_store(tmp_path)
-    result = await store.get("nonexistent")
-    assert result is None
+async def test_dict_get_missing_returns_none():
+    assert await _memory_store().get("ghost") is None
 
 
-@pytest.mark.asyncio
-async def test_pop_removes_and_returns(tmp_path, mocker: MockerFixture):
-    store = _make_store(tmp_path)
-    video = _make_video()
-
-    await store.upsert(video.id, video)
-    popped = await store.pop(video.id)
+async def test_dict_pop_removes_and_returns():
+    store = _memory_store()
+    v = _video()
+    await store.upsert(v.id, v)
+    popped = await store.pop(v.id)
     assert popped is not None
-    assert popped.id == video.id
-
-    # should be gone now
-    assert await store.get(video.id) is None
+    assert await store.get(v.id) is None
 
 
-@pytest.mark.asyncio
-async def test_pop_missing_key_returns_none(tmp_path):
-    store = _make_store(tmp_path)
-    assert await store.pop("nonexistent") is None
+async def test_dict_pop_missing_returns_none():
+    assert await _memory_store().pop("ghost") is None
 
 
-@pytest.mark.asyncio
-async def test_update_fields(tmp_path):
+async def test_dict_update_fields():
     from vllm_omni.entrypoints.openai.protocol.videos import VideoGenerationStatus
 
-    store = _make_store(tmp_path)
-    video = _make_video()
-    await store.upsert(video.id, video)
+    store = _memory_store()
+    v = _video()
+    await store.upsert(v.id, v)
 
-    updated = await store.update_fields(video.id, {"status": VideoGenerationStatus.IN_PROGRESS, "progress": 50})
+    updated = await store.update_fields(v.id, {"status": VideoGenerationStatus.IN_PROGRESS, "progress": 42})
     assert updated is not None
     assert updated.status == VideoGenerationStatus.IN_PROGRESS
-    assert updated.progress == 50
+    assert updated.progress == 42
 
-    # persisted
-    fetched = await store.get(video.id)
+    fetched = await store.get(v.id)
     assert fetched.status == VideoGenerationStatus.IN_PROGRESS
-    assert fetched.progress == 50
+    assert fetched.progress == 42
 
 
-@pytest.mark.asyncio
-async def test_update_fields_missing_key_returns_none(tmp_path):
-    store = _make_store(tmp_path)
-    result = await store.update_fields("nonexistent", {"progress": 10})
-    assert result is None
+async def test_dict_update_fields_missing_returns_none():
+    assert await _memory_store().update_fields("ghost", {"progress": 1}) is None
 
 
-@pytest.mark.asyncio
-async def test_list_values(tmp_path):
-    store = _make_store(tmp_path)
-    v1 = _make_video("id_1")
-    v2 = _make_video("id_2")
-
+async def test_dict_list_values():
+    store = _memory_store()
+    v1, v2 = _video("id_1"), _video("id_2")
     await store.upsert(v1.id, v1)
     await store.upsert(v2.id, v2)
-
-    values = await store.list_values()
-    ids = {v.id for v in values}
-    assert ids == {"id_1", "id_2"}
+    assert {v.id for v in await store.list_values()} == {"id_1", "id_2"}
 
 
-@pytest.mark.asyncio
-async def test_upsert_overwrites(tmp_path):
-    store = _make_store(tmp_path)
-    video = _make_video()
-    await store.upsert(video.id, video)
-
-    updated = video.model_copy(update={"prompt": "a dog running"})
-    await store.upsert(video.id, updated)
-
-    result = await store.get(video.id)
-    assert result.prompt == "a dog running"
+async def test_dict_upsert_overwrites():
+    store = _memory_store()
+    v = _video()
+    await store.upsert(v.id, v)
+    await store.upsert(v.id, v.model_copy(update={"prompt": "a dog"}))
+    assert (await store.get(v.id)).prompt == "a dog"
 
 
-@pytest.mark.asyncio
-async def test_persistence_across_instances(tmp_path):
-    """Data written by one VideoStore instance is readable by another on the same directory."""
-    directory = str(tmp_path / "video_store")
-    from vllm_omni.entrypoints.openai.stores import VideoStore
+async def test_dict_update_fields_original_unchanged():
+    """update_fields must not mutate the previously stored object."""
+    store = _memory_store()
+    v = _video()
+    await store.upsert(v.id, v)
 
-    video = _make_video()
+    await store.update_fields(v.id, {"progress": 99})
 
-    store1 = VideoStore(directory=directory)
-    await store1.upsert(video.id, video)
-    store1.close()
+    assert v.progress == 0  # original object untouched
+    assert (await store.get(v.id)).progress == 99  # store reflects the change
 
-    store2 = VideoStore(directory=directory)
-    result = await store2.get(video.id)
-    store2.close()
+
+# ---------------------------------------------------------------------------
+# DiskCacheVideoMetadataStore
+# ---------------------------------------------------------------------------
+
+
+async def test_disk_upsert_and_get(tmp_path):
+    store = _disk_store(tmp_path)
+    v = _video()
+    await store.upsert(v.id, v)
+    result = await store.get(v.id)
+    assert result is not None
+    assert result.id == v.id
+    store.close()
+
+
+async def test_disk_get_missing_returns_none(tmp_path):
+    store = _disk_store(tmp_path)
+    assert await store.get("ghost") is None
+    store.close()
+
+
+async def test_disk_pop_removes_and_returns(tmp_path):
+    store = _disk_store(tmp_path)
+    v = _video()
+    await store.upsert(v.id, v)
+    popped = await store.pop(v.id)
+    assert popped is not None
+    assert popped.id == v.id
+    assert await store.get(v.id) is None
+    store.close()
+
+
+async def test_disk_pop_missing_returns_none(tmp_path):
+    store = _disk_store(tmp_path)
+    assert await store.pop("ghost") is None
+    store.close()
+
+
+async def test_disk_update_fields(tmp_path):
+    from vllm_omni.entrypoints.openai.protocol.videos import VideoGenerationStatus
+
+    store = _disk_store(tmp_path)
+    v = _video()
+    await store.upsert(v.id, v)
+
+    updated = await store.update_fields(v.id, {"status": VideoGenerationStatus.IN_PROGRESS, "progress": 77})
+    assert updated is not None
+    assert updated.progress == 77
+    assert (await store.get(v.id)).progress == 77
+    store.close()
+
+
+async def test_disk_update_fields_missing_returns_none(tmp_path):
+    store = _disk_store(tmp_path)
+    assert await store.update_fields("ghost", {"progress": 1}) is None
+    store.close()
+
+
+async def test_disk_list_values(tmp_path):
+    store = _disk_store(tmp_path)
+    v1, v2 = _video("id_1"), _video("id_2")
+    await store.upsert(v1.id, v1)
+    await store.upsert(v2.id, v2)
+    assert {v.id for v in await store.list_values()} == {"id_1", "id_2"}
+    store.close()
+
+
+async def test_disk_upsert_overwrites(tmp_path):
+    store = _disk_store(tmp_path)
+    v = _video()
+    await store.upsert(v.id, v)
+    await store.upsert(v.id, v.model_copy(update={"prompt": "a dog"}))
+    assert (await store.get(v.id)).prompt == "a dog"
+    store.close()
+
+
+async def test_disk_persistence_across_instances(tmp_path):
+    """Data survives close + reopen on the same directory."""
+    from vllm_omni.entrypoints.openai.stores import DiskCacheVideoMetadataStore
+
+    directory = str(tmp_path / "store")
+    v = _video()
+
+    s1 = DiskCacheVideoMetadataStore(directory=directory)
+    await s1.upsert(v.id, v)
+    s1.close()
+
+    s2 = DiskCacheVideoMetadataStore(directory=directory)
+    result = await s2.get(v.id)
+    s2.close()
 
     assert result is not None
-    assert result.id == video.id
+    assert result.id == v.id
+
+
+async def test_disk_list_values_no_keyerror_on_concurrent_delete(tmp_path):
+    """list_values must not raise when a key is deleted mid-iteration."""
+    from vllm_omni.entrypoints.openai.stores import DiskCacheVideoMetadataStore
+
+    store = DiskCacheVideoMetadataStore(directory=str(tmp_path / "store"))
+    for i in range(10):
+        await store.upsert(f"id_{i}", _video(f"id_{i}"))
+
+    def _delete_half():
+        for i in range(0, 10, 2):
+            store._cache.delete(f"id_{i}")
+
+    t = threading.Thread(target=_delete_half)
+    t.start()
+    values = await store.list_values()  # must not raise KeyError
+    t.join()
+
+    assert isinstance(values, list)
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# init_video_store — parameter validation
+# ---------------------------------------------------------------------------
+
+
+async def test_init_video_store_diskcache_requires_directory():
+    from vllm_omni.entrypoints.openai.stores import init_video_store
+
+    with pytest.raises(ValueError, match="directory cannot be empty"):
+        init_video_store("diskcache")
+
+
+async def test_init_video_store_unknown_backend():
+    from vllm_omni.entrypoints.openai.stores import init_video_store
+
+    with pytest.raises(ValueError, match="Unknown video-metadata-store backend"):
+        init_video_store("redis")
+
+
+# ---------------------------------------------------------------------------
+# TaskRegistry
+# ---------------------------------------------------------------------------
+
+
+async def test_task_registry_upsert_and_get():
+    from vllm_omni.entrypoints.openai.stores import TaskRegistry
+
+    reg = TaskRegistry()
+
+    async def _noop():
+        pass
+
+    task = asyncio.create_task(_noop())
+    await reg.upsert("t1", task)
+    assert await reg.get("t1") is task
+    await task
+
+
+async def test_task_registry_get_missing_returns_none():
+    from vllm_omni.entrypoints.openai.stores import TaskRegistry
+
+    assert await TaskRegistry().get("ghost") is None
+
+
+async def test_task_registry_pop_removes_and_returns():
+    from vllm_omni.entrypoints.openai.stores import TaskRegistry
+
+    reg = TaskRegistry()
+
+    async def _long():
+        await asyncio.sleep(100)
+
+    task = asyncio.create_task(_long())
+    await reg.upsert("t1", task)
+    popped = await reg.pop("t1")
+    assert popped is task
+    assert await reg.get("t1") is None
+    task.cancel()
+
+
+async def test_task_registry_pop_missing_returns_none():
+    from vllm_omni.entrypoints.openai.stores import TaskRegistry
+
+    assert await TaskRegistry().pop("ghost") is None
+
+
+async def test_task_registry_auto_cleanup_on_done():
+    from vllm_omni.entrypoints.openai.stores import TaskRegistry
+
+    reg = TaskRegistry()
+
+    async def _noop():
+        pass
+
+    task = asyncio.create_task(_noop())
+    await reg.upsert("t1", task)
+    await task
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)  # let done-callback coroutine flush
+
+    assert await reg.get("t1") is None

--- a/tests/entrypoints/openai_api/test_stores.py
+++ b/tests/entrypoints/openai_api/test_stores.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+from pytest_mock import MockerFixture
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _make_store(tmp_path):
+    from vllm_omni.entrypoints.openai.stores import VideoStore
+
+    return VideoStore(directory=str(tmp_path / "video_store"))
+
+
+def _make_video(video_id: str = "video_gen_abc123", model: str = "test-model"):
+    from vllm_omni.entrypoints.openai.protocol.videos import VideoResponse
+
+    return VideoResponse(id=video_id, model=model, prompt="a cat running")
+
+
+# ---------------------------------------------------------------------------
+# VideoStore
+# ---------------------------------------------------------------------------
+
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_get(tmp_path,mocker: MockerFixture) -> None:
+    store = _make_store(tmp_path)
+    video = _make_video()
+
+    await store.upsert(video.id, video)
+    result = await store.get(video.id)
+
+    assert result is not None
+    assert result.id == video.id
+    assert result.model == video.model
+    assert result.prompt == video.prompt
+
+
+
+
+@pytest.mark.asyncio
+async def test_get_missing_key_returns_none(tmp_path,mocker: MockerFixture) -> None:
+    store = _make_store(tmp_path)
+    result = await store.get("nonexistent")
+    assert result is None
+
+
+
+
+@pytest.mark.asyncio
+async def test_pop_removes_and_returns(tmp_path,mocker: MockerFixture):
+    store = _make_store(tmp_path)
+    video = _make_video()
+
+    await store.upsert(video.id, video)
+    popped = await store.pop(video.id)
+    assert popped is not None
+    assert popped.id == video.id
+
+    # should be gone now
+    assert await store.get(video.id) is None
+
+
+
+
+@pytest.mark.asyncio
+async def test_pop_missing_key_returns_none(tmp_path):
+    store = _make_store(tmp_path)
+    assert await store.pop("nonexistent") is None
+
+
+
+
+@pytest.mark.asyncio
+async def test_update_fields(tmp_path):
+    from vllm_omni.entrypoints.openai.protocol.videos import VideoGenerationStatus
+
+    store = _make_store(tmp_path)
+    video = _make_video()
+    await store.upsert(video.id, video)
+
+    updated = await store.update_fields(video.id, {"status": VideoGenerationStatus.IN_PROGRESS, "progress": 50})
+    assert updated is not None
+    assert updated.status == VideoGenerationStatus.IN_PROGRESS
+    assert updated.progress == 50
+
+    # persisted
+    fetched = await store.get(video.id)
+    assert fetched.status == VideoGenerationStatus.IN_PROGRESS
+    assert fetched.progress == 50
+
+
+
+
+@pytest.mark.asyncio
+async def test_update_fields_missing_key_returns_none(tmp_path):
+    store = _make_store(tmp_path)
+    result = await store.update_fields("nonexistent", {"progress": 10})
+    assert result is None
+
+
+
+
+@pytest.mark.asyncio
+async def test_list_values(tmp_path):
+    store = _make_store(tmp_path)
+    v1 = _make_video("id_1")
+    v2 = _make_video("id_2")
+
+    await store.upsert(v1.id, v1)
+    await store.upsert(v2.id, v2)
+
+    values = await store.list_values()
+    ids = {v.id for v in values}
+    assert ids == {"id_1", "id_2"}
+
+
+
+
+@pytest.mark.asyncio
+async def test_upsert_overwrites(tmp_path):
+    store = _make_store(tmp_path)
+    video = _make_video()
+    await store.upsert(video.id, video)
+
+    updated = video.model_copy(update={"prompt": "a dog running"})
+    await store.upsert(video.id, updated)
+
+    result = await store.get(video.id)
+    assert result.prompt == "a dog running"
+
+
+
+
+@pytest.mark.asyncio
+async def test_persistence_across_instances(tmp_path):
+    """Data written by one VideoStore instance is readable by another on the same directory."""
+    directory = str(tmp_path / "video_store")
+    from vllm_omni.entrypoints.openai.stores import VideoStore
+
+    video = _make_video()
+
+    store1 = VideoStore(directory=directory)
+    await store1.upsert(video.id, video)
+    store1.close()
+
+    store2 = VideoStore(directory=directory)
+    result = await store2.get(video.id)
+    store2.close()
+
+    assert result is not None
+    assert result.id == video.id

--- a/tests/entrypoints/openai_api/test_stores.py
+++ b/tests/entrypoints/openai_api/test_stores.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import pytest
 from pytest_mock import MockerFixture
+
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
@@ -22,9 +23,8 @@ def _make_video(video_id: str = "video_gen_abc123", model: str = "test-model"):
 # ---------------------------------------------------------------------------
 
 
-
 @pytest.mark.asyncio
-async def test_upsert_and_get(tmp_path,mocker: MockerFixture) -> None:
+async def test_upsert_and_get(tmp_path, mocker: MockerFixture) -> None:
     store = _make_store(tmp_path)
     video = _make_video()
 
@@ -37,19 +37,15 @@ async def test_upsert_and_get(tmp_path,mocker: MockerFixture) -> None:
     assert result.prompt == video.prompt
 
 
-
-
 @pytest.mark.asyncio
-async def test_get_missing_key_returns_none(tmp_path,mocker: MockerFixture) -> None:
+async def test_get_missing_key_returns_none(tmp_path, mocker: MockerFixture) -> None:
     store = _make_store(tmp_path)
     result = await store.get("nonexistent")
     assert result is None
 
 
-
-
 @pytest.mark.asyncio
-async def test_pop_removes_and_returns(tmp_path,mocker: MockerFixture):
+async def test_pop_removes_and_returns(tmp_path, mocker: MockerFixture):
     store = _make_store(tmp_path)
     video = _make_video()
 
@@ -62,14 +58,10 @@ async def test_pop_removes_and_returns(tmp_path,mocker: MockerFixture):
     assert await store.get(video.id) is None
 
 
-
-
 @pytest.mark.asyncio
 async def test_pop_missing_key_returns_none(tmp_path):
     store = _make_store(tmp_path)
     assert await store.pop("nonexistent") is None
-
-
 
 
 @pytest.mark.asyncio
@@ -91,15 +83,11 @@ async def test_update_fields(tmp_path):
     assert fetched.progress == 50
 
 
-
-
 @pytest.mark.asyncio
 async def test_update_fields_missing_key_returns_none(tmp_path):
     store = _make_store(tmp_path)
     result = await store.update_fields("nonexistent", {"progress": 10})
     assert result is None
-
-
 
 
 @pytest.mark.asyncio
@@ -116,8 +104,6 @@ async def test_list_values(tmp_path):
     assert ids == {"id_1", "id_2"}
 
 
-
-
 @pytest.mark.asyncio
 async def test_upsert_overwrites(tmp_path):
     store = _make_store(tmp_path)
@@ -129,8 +115,6 @@ async def test_upsert_overwrites(tmp_path):
 
     result = await store.get(video.id)
     assert result.prompt == "a dog running"
-
-
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai_api/test_video_server.py
+++ b/tests/entrypoints/openai_api/test_video_server.py
@@ -28,7 +28,7 @@ from vllm_omni.entrypoints.openai.protocol.videos import (
 )
 from vllm_omni.entrypoints.openai.serving_video import OmniOpenAIServingVideo
 from vllm_omni.entrypoints.openai.storage import LocalStorageManager
-from vllm_omni.entrypoints.openai.stores import AsyncDictStore, TaskRegistry
+from vllm_omni.entrypoints.openai.stores import TaskRegistry, VideoStore
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -79,7 +79,7 @@ class BlockingVideoHandler:
 @pytest.fixture(autouse=True)
 def isolated_video_backends(tmp_path, monkeypatch):
     """Use isolated in-memory metadata and local storage for each test."""
-    store: AsyncDictStore[VideoResponse] = AsyncDictStore()
+    store = VideoStore(directory=str(tmp_path / "video_metadata"))
     tasks = TaskRegistry()
     storage = LocalStorageManager(storage_path=str(tmp_path / "storage"))
     monkeypatch.setattr(api_server, "VIDEO_STORE", store)

--- a/tests/entrypoints/openai_api/test_video_server.py
+++ b/tests/entrypoints/openai_api/test_video_server.py
@@ -28,7 +28,7 @@ from vllm_omni.entrypoints.openai.protocol.videos import (
 )
 from vllm_omni.entrypoints.openai.serving_video import OmniOpenAIServingVideo
 from vllm_omni.entrypoints.openai.storage import LocalStorageManager
-from vllm_omni.entrypoints.openai.stores import TaskRegistry, VideoStore
+from vllm_omni.entrypoints.openai.stores import InMemoryVideoMetadataStore, TaskRegistry
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -79,7 +79,7 @@ class BlockingVideoHandler:
 @pytest.fixture(autouse=True)
 def isolated_video_backends(tmp_path, monkeypatch):
     """Use isolated in-memory metadata and local storage for each test."""
-    store = VideoStore(directory=str(tmp_path / "video_metadata"))
+    store = InMemoryVideoMetadataStore()
     tasks = TaskRegistry()
     storage = LocalStorageManager(storage_path=str(tmp_path / "storage"))
     monkeypatch.setattr(api_server, "VIDEO_STORE", store)

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -404,6 +404,23 @@ class OmniServeCommand(CLISubcommand):
             action="store_true",
             help="Enable diffusion pipeline profiler to display stage durations.",
         )
+
+        # Video metadata store
+        omni_config_group.add_argument(
+            "--video-metadata-store",
+            type=str,
+            default="memory",
+            choices=["memory", "diskcache"],
+            help="Backend for storing video generation job metadata. "
+            "'memory' (default) keeps records in-process; "
+            "'diskcache' persists them to disk and survives process restarts.",
+        )
+        omni_config_group.add_argument(
+            "--video-metadata-store-dir",
+            type=str,
+            default="/tmp/storage/metadata",
+            help="Directory used by the 'diskcache' backend (default: /tmp/storage/metadata).",
+        )
         return serve_parser
 
 

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -356,6 +356,7 @@ async def omni_run_server_worker(listen_address, sock, args, client_config=None,
         serving_speech = getattr(getattr(app, "state", None), "openai_serving_speech", None)
         if serving_speech is not None:
             serving_speech.shutdown()
+        VIDEO_STORE.close()
         sock.close()
 
 

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -306,6 +306,8 @@ async def omni_run_server_worker(listen_address, sock, args, client_config=None,
         app.include_router(router)
 
         await omni_init_app_state(engine_client, app.state, args)
+        # When restart after update video job status
+        await _reconcile_video_store_on_startup()
 
         # Conditionally register profiler endpoints based on stage YAML configs
         stage_configs = engine_client.stage_configs if hasattr(engine_client, "stage_configs") else None
@@ -1974,6 +1976,36 @@ def _cleanup_video(video_id: str, output_path: str | None):
         logger.warning("Failed to cleanup partial video file '%s' for id=%s", output_path, video_id)
 
 
+async def _reconcile_video_store_on_startup() -> None:
+    """Mark orphaned QUEUED/IN_PROGRESS records as FAILED on startup.
+
+    Because VIDEO_TASKS is in-memory, any job that was running or queued when
+    the process last exited has no corresponding task after a restart.
+    """
+    import time as _time
+
+    orphaned_statuses = (VideoGenerationStatus.QUEUED, VideoGenerationStatus.IN_PROGRESS)
+    jobs = await VIDEO_STORE.list_values()
+    for job in jobs:
+        if job.status in orphaned_statuses:
+            await VIDEO_STORE.update_fields(
+                job.id,
+                {
+                    "status": VideoGenerationStatus.FAILED,
+                    "completed_at": int(_time.time()),
+                    "error": VideoError(
+                        code="ProcessRestart",
+                        message="Job was interrupted by a server restart and cannot be resumed.",
+                    ),
+                },
+            )
+            logger.warning(
+                "Reconciled orphaned video job %s (was %s) → FAILED on startup.",
+                job.id,
+                job.status,
+            )
+
+
 async def _run_video_generation_job(
     handler: OmniOpenAIServingVideo,
     request: VideoGenerationRequest,
@@ -2298,9 +2330,17 @@ async def delete_video(video_id: str) -> VideoDeleteResponse:
                 raise HTTPException(status_code=409, detail="Cancellation in progress. Please try again later.")
             except asyncio.CancelledError:
                 pass
+        else:
+            # No task found: this record was orphaned by a previous process restart.
+            # There is nothing to cancel; fall through to remove it from the store.
+            logger.warning(
+                "Video job %s has status %s but no associated task (likely orphaned by restart); removing.",
+                video_id,
+                job.status,
+            )
 
-            await VIDEO_STORE.pop(video_id)
-            return VideoDeleteResponse(id=job.id, deleted=True)
+        await VIDEO_STORE.pop(video_id)
+        return VideoDeleteResponse(id=job.id, deleted=True)
     elif job.status is VideoGenerationStatus.FAILED:
         if job.file_name is not None:
             try:

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -112,7 +112,7 @@ from vllm_omni.entrypoints.openai.serving_speech import OmniOpenAIServingSpeech
 from vllm_omni.entrypoints.openai.serving_speech_stream import OmniStreamingSpeechHandler
 from vllm_omni.entrypoints.openai.serving_video import OmniOpenAIServingVideo, ReferenceImage
 from vllm_omni.entrypoints.openai.storage import STORAGE_MANAGER
-from vllm_omni.entrypoints.openai.stores import VIDEO_STORE, VIDEO_TASKS
+from vllm_omni.entrypoints.openai.stores import VIDEO_STORE, VIDEO_TASKS, init_video_store
 from vllm_omni.entrypoints.openai.utils import get_stage_type, parse_lora_request
 from vllm_omni.entrypoints.openai.video_api_utils import decode_input_reference
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniSamplingParams, OmniTextPrompt
@@ -306,8 +306,18 @@ async def omni_run_server_worker(listen_address, sock, args, client_config=None,
         app.include_router(router)
 
         await omni_init_app_state(engine_client, app.state, args)
+        video_metadata_backend = getattr(args, "video_metadata_store", "memory")
+        init_video_store(
+            backend=video_metadata_backend,
+            directory=getattr(
+                args,
+                "video_metadata_store_dir",
+                os.path.join(os.getenv("VLLM_OMNI_STORAGE_PATH", "/tmp/storage"), "metadata"),
+            ),
+        )
         # When restart after update video job status
-        await _reconcile_video_store_on_startup()
+        if video_metadata_backend == "diskcache":
+            await _reconcile_video_store_on_startup()
 
         # Conditionally register profiler endpoints based on stage YAML configs
         stage_configs = engine_client.stage_configs if hasattr(engine_client, "stage_configs") else None
@@ -1982,7 +1992,6 @@ async def _reconcile_video_store_on_startup() -> None:
     Because VIDEO_TASKS is in-memory, any job that was running or queued when
     the process last exited has no corresponding task after a restart.
     """
-    import time as _time
 
     orphaned_statuses = (VideoGenerationStatus.QUEUED, VideoGenerationStatus.IN_PROGRESS)
     jobs = await VIDEO_STORE.list_values()
@@ -1992,7 +2001,7 @@ async def _reconcile_video_store_on_startup() -> None:
                 job.id,
                 {
                     "status": VideoGenerationStatus.FAILED,
-                    "completed_at": int(_time.time()),
+                    "completed_at": int(time.time()),
                     "error": VideoError(
                         code="ProcessRestart",
                         message="Job was interrupted by a server restart and cannot be resumed.",

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -306,18 +306,6 @@ async def omni_run_server_worker(listen_address, sock, args, client_config=None,
         app.include_router(router)
 
         await omni_init_app_state(engine_client, app.state, args)
-        video_metadata_backend = getattr(args, "video_metadata_store", "memory")
-        init_video_store(
-            backend=video_metadata_backend,
-            directory=getattr(
-                args,
-                "video_metadata_store_dir",
-                os.path.join(os.getenv("VLLM_OMNI_STORAGE_PATH", "/tmp/storage"), "metadata"),
-            ),
-        )
-        # When restart after update video job status
-        if video_metadata_backend == "diskcache":
-            await _reconcile_video_store_on_startup()
 
         # Conditionally register profiler endpoints based on stage YAML configs
         stage_configs = engine_client.stage_configs if hasattr(engine_client, "stage_configs") else None
@@ -846,6 +834,20 @@ async def omni_init_app_state(
 
     state.enable_server_load_tracking = args.enable_server_load_tracking
     state.server_load_metrics = 0
+
+    # init video metadata save backend
+    video_metadata_backend = getattr(args, "video_metadata_store", "memory")
+    init_video_store(
+        backend=video_metadata_backend,
+        directory=getattr(
+            args,
+            "video_metadata_store_dir",
+            os.path.join(os.getenv("VLLM_OMNI_STORAGE_PATH", "/tmp/storage"), "metadata"),
+        ),
+    )
+    # When restart after update video job status
+    if video_metadata_backend == "diskcache":
+        await _reconcile_video_store_on_startup()
 
 
 def Omnivideo(request: Request) -> OmniOpenAIServingVideo | None:

--- a/vllm_omni/entrypoints/openai/stores.py
+++ b/vllm_omni/entrypoints/openai/stores.py
@@ -1,10 +1,131 @@
 import asyncio
-import os
-from typing import Any
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar
 
-import diskcache
+from pydantic import BaseModel
 
 from vllm_omni.entrypoints.openai.protocol.videos import VideoResponse
+
+T = TypeVar("T", bound=BaseModel)
+U = TypeVar("U")
+
+
+class AsyncDictStore(Generic[T]):
+    """A small async-safe in-memory key-value store for dict items.
+
+    This encapsulates the usual pattern of a module-level dict guarded by
+    an asyncio.Lock and provides simple CRUD methods that are safe to call
+    concurrently from FastAPI request handlers and background tasks.
+    """
+
+    def __init__(self) -> None:
+        self._items: dict[str, T] = {}
+        self._lock = asyncio.Lock()
+
+    async def upsert(self, key: str, value: T) -> None:
+        async with self._lock:
+            self._items[key] = value
+
+    async def update_fields(self, key: str, updates: dict[str, Any]) -> T | None:
+        async with self._lock:
+            item: T | None = self._items.get(key)
+            if item is None:
+                return None
+            new_item = item.model_copy(update=updates)
+            self._items[key] = new_item
+            return new_item
+
+    async def get(self, key: str) -> T | None:
+        async with self._lock:
+            return self._items.get(key)
+
+    async def pop(self, key: str) -> T | None:
+        async with self._lock:
+            return self._items.pop(key, None)
+
+    async def list_values(self) -> list[T]:
+        async with self._lock:
+            return list(self._items.values())
+
+
+class VideoMetadataStore(ABC):
+    """Pluggable persistence interface for VideoResponse records."""
+
+    @abstractmethod
+    async def upsert(self, key: str, value: VideoResponse) -> None: ...
+
+    @abstractmethod
+    async def get(self, key: str) -> VideoResponse | None: ...
+
+    @abstractmethod
+    async def pop(self, key: str) -> VideoResponse | None: ...
+
+    @abstractmethod
+    async def update_fields(self, key: str, updates: dict[str, Any]) -> VideoResponse | None: ...
+
+    @abstractmethod
+    async def list_values(self) -> list[VideoResponse]: ...
+
+    def close(self) -> None:
+        """Optional teardown hook. Override if the backend holds resources."""
+
+
+class InMemoryVideoMetadataStore(AsyncDictStore[VideoResponse], VideoMetadataStore):
+    """In-memory VideoMetadataStore backed by AsyncDictStore."""
+
+
+class DiskCacheVideoMetadataStore(VideoMetadataStore):
+    """Persistent backend backed by diskcache.Cache."""
+
+    def __init__(self, directory: str) -> None:
+        import diskcache
+
+        self._cache = diskcache.Cache(directory)
+
+    async def upsert(self, key: str, value: VideoResponse) -> None:
+        await asyncio.to_thread(self._cache.set, key, value.model_dump_json())
+
+    async def get(self, key: str) -> VideoResponse | None:
+        raw = await asyncio.to_thread(self._cache.get, key)
+        return VideoResponse.model_validate_json(raw) if raw is not None else None
+
+    async def pop(self, key: str) -> VideoResponse | None:
+        def _pop() -> str | None:
+            with self._cache.transact():
+                raw = self._cache.get(key)
+                if raw is None:
+                    return None
+                del self._cache[key]
+                return raw
+
+        raw = await asyncio.to_thread(_pop)
+        return VideoResponse.model_validate_json(raw) if raw is not None else None
+
+    async def update_fields(self, key: str, updates: dict[str, Any]) -> VideoResponse | None:
+        def _update() -> VideoResponse | None:
+            with self._cache.transact():
+                raw = self._cache.get(key)
+                if raw is None:
+                    return None
+                new = VideoResponse.model_validate_json(raw).model_copy(update=updates)
+                self._cache.set(key, new.model_dump_json())
+                return new
+
+        return await asyncio.to_thread(_update)
+
+    async def list_values(self) -> list[VideoResponse]:
+        def _list() -> list[VideoResponse]:
+            result = []
+            for k in self._cache:
+                raw = self._cache.get(k)  # returns None if key was concurrently deleted
+                if raw is not None:
+                    result.append(VideoResponse.model_validate_json(raw))
+            return result
+
+        return await asyncio.to_thread(_list)
+
+    def close(self) -> None:
+        self._cache.close()
 
 
 class TaskRegistry:
@@ -30,52 +151,16 @@ class TaskRegistry:
             self._tasks[key] = task
 
 
-class VideoStore:
-    """Persistent async-safe store for VideoResponse objects backed by diskcache."""
-
-    def __init__(self, directory: str) -> None:
-        self._cache = diskcache.Cache(directory)
-
-    async def upsert(self, key: str, value: VideoResponse) -> None:
-        await asyncio.to_thread(self._cache.set, key, value.model_dump_json())
-
-    async def get(self, key: str) -> VideoResponse | None:
-        raw = await asyncio.to_thread(self._cache.get, key)
-        return VideoResponse.model_validate_json(raw) if raw is not None else None
-
-    async def pop(self, key: str) -> VideoResponse | None:
-        def _pop() -> VideoResponse | None:
-            with self._cache.transact():
-                raw = self._cache.get(key)
-                if raw is None:
-                    return None
-                del self._cache[key]
-                return VideoResponse.model_validate_json(raw)
-
-        return await asyncio.to_thread(_pop)
-
-    async def update_fields(self, key: str, updates: dict[str, Any]) -> VideoResponse | None:
-        def _update() -> VideoResponse | None:
-            with self._cache.transact():
-                raw = self._cache.get(key)
-                if raw is None:
-                    return None
-                new = VideoResponse.model_validate_json(raw).model_copy(update=updates)
-                self._cache.set(key, new.model_dump_json())
-                return new
-
-        return await asyncio.to_thread(_update)
-
-    async def list_values(self) -> list[VideoResponse]:
-        def _list() -> list[VideoResponse]:
-            return [VideoResponse.model_validate_json(self._cache[k]) for k in self._cache]
-
-        return await asyncio.to_thread(_list)
-
-    def close(self) -> None:
-        self._cache.close()
-
-
-metadata_path = os.path.join(os.getenv("VLLM_OMNI_STORAGE_PATH", "/tmp/storage"), "metadata")
-VIDEO_STORE = VideoStore(directory=metadata_path)
+VIDEO_STORE: VideoMetadataStore = InMemoryVideoMetadataStore()
 VIDEO_TASKS: TaskRegistry = TaskRegistry()
+
+
+def init_video_store(backend: str, directory: str = None) -> None:
+    if directory is None and backend == "diskcache":
+        raise ValueError("when backend is diskcache, directory cannot be empty.")
+    if backend == "diskcache":
+        VIDEO_STORE._swap(DiskCacheVideoMetadataStore(directory=directory))
+    elif backend == "memory":
+        VIDEO_STORE._swap(InMemoryVideoMetadataStore())
+    else:
+        raise ValueError(f"Unknown video-metadata-store backend: {backend!r}. Choose 'memory' or 'diskcache'.")

--- a/vllm_omni/entrypoints/openai/stores.py
+++ b/vllm_omni/entrypoints/openai/stores.py
@@ -1,12 +1,10 @@
 import asyncio
-from typing import Any, Generic, TypeVar
+import os
+from typing import Any
 
-from pydantic import BaseModel
+import diskcache
 
 from vllm_omni.entrypoints.openai.protocol.videos import VideoResponse
-
-T = TypeVar("T", bound=BaseModel)
-U = TypeVar("U")
 
 
 class TaskRegistry:
@@ -32,43 +30,52 @@ class TaskRegistry:
             self._tasks[key] = task
 
 
-class AsyncDictStore(Generic[T]):
-    """A small async-safe in-memory key-value store for dict items.
+class VideoStore:
+    """Persistent async-safe store for VideoResponse objects backed by diskcache."""
 
-    This encapsulates the usual pattern of a module-level dict guarded by
-    an asyncio.Lock and provides simple CRUD methods that are safe to call
-    concurrently from FastAPI request handlers and background tasks.
-    """
+    def __init__(self, directory: str) -> None:
+        self._cache = diskcache.Cache(directory)
 
-    def __init__(self) -> None:
-        self._items: dict[str, T] = {}
-        self._lock = asyncio.Lock()
+    async def upsert(self, key: str, value: VideoResponse) -> None:
+        await asyncio.to_thread(self._cache.set, key, value.model_dump_json())
 
-    async def upsert(self, key: str, value: T) -> None:
-        async with self._lock:
-            self._items[key] = value
+    async def get(self, key: str) -> VideoResponse | None:
+        raw = await asyncio.to_thread(self._cache.get, key)
+        return VideoResponse.model_validate_json(raw) if raw is not None else None
 
-    async def update_fields(self, key: str, updates: dict[str, Any]) -> T | None:
-        async with self._lock:
-            item: T | None = self._items.get(key)
-            if item is None:
-                return None
-            new_item = item.model_copy(update=updates)
-            self._items[key] = new_item
-            return new_item
+    async def pop(self, key: str) -> VideoResponse | None:
+        def _pop() -> VideoResponse | None:
+            with self._cache.transact():
+                raw = self._cache.get(key)
+                if raw is None:
+                    return None
+                del self._cache[key]
+                return VideoResponse.model_validate_json(raw)
 
-    async def get(self, key: str) -> T | None:
-        async with self._lock:
-            return self._items.get(key)
+        return await asyncio.to_thread(_pop)
 
-    async def pop(self, key: str) -> T | None:
-        async with self._lock:
-            return self._items.pop(key, None)
+    async def update_fields(self, key: str, updates: dict[str, Any]) -> VideoResponse | None:
+        def _update() -> VideoResponse | None:
+            with self._cache.transact():
+                raw = self._cache.get(key)
+                if raw is None:
+                    return None
+                new = VideoResponse.model_validate_json(raw).model_copy(update=updates)
+                self._cache.set(key, new.model_dump_json())
+                return new
 
-    async def list_values(self) -> list[T]:
-        async with self._lock:
-            return list(self._items.values())
+        return await asyncio.to_thread(_update)
+
+    async def list_values(self) -> list[VideoResponse]:
+        def _list() -> list[VideoResponse]:
+            return [VideoResponse.model_validate_json(self._cache[k]) for k in self._cache]
+
+        return await asyncio.to_thread(_list)
+
+    def close(self) -> None:
+        self._cache.close()
 
 
-VIDEO_STORE: AsyncDictStore[VideoResponse] = AsyncDictStore()
+metadata_path = os.path.join(os.getenv("VLLM_OMNI_STORAGE_PATH", "/tmp/storage"), "metadata")
+VIDEO_STORE = VideoStore(directory=metadata_path)
 VIDEO_TASKS: TaskRegistry = TaskRegistry()


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fixes: https://github.com/vllm-project/vllm-omni/issues/2227

## Test Plan

1. Step one start a omni serve, then create a video, when status is completed, stop omni serve.
2. Again start omni serve, we can call `/api/videos` to list all video. or `/api/videos/{video_id}` to get video metadata or `/api/videos/{video_id}/content` to download this video.

## Test Result

When reboot omni server after, we can download before completed video.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
