### PR TITLE
[Bugfix] Fix contradictory assertions in GPUGenerationModelRunner.sample_tokens

### DIFF
--- a/tests/worker/test_gpu_generation_model_runner.py
+++ b/tests/worker/test_gpu_generation_model_runner.py
@@ -7,14 +7,14 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
 class _DummyInputBatch:
-    def __init__(self):
-        self.req_ids = ["req-1"]
-        self.req_id_to_index = {"req-1": 0}
-        self.num_reqs = 1
+    def __init__(self, num_reqs=1):
+        self.req_ids = [f"req-{i}" for i in range(num_reqs)]
+        self.req_id_to_index = {rid: i for i, rid in enumerate(self.req_ids)}
+        self.num_reqs = num_reqs
         self.vocab_size = 10
 
 
-def _make_runner(multimodal_outputs):
+def _make_runner(multimodal_outputs, num_reqs=1):
     runner = object.__new__(GPUGenerationModelRunner)
     runner.execute_model_state = (
         None,
@@ -30,7 +30,7 @@ def _make_runner(multimodal_outputs):
         None,
     )
     runner.kv_connector_output = None
-    runner.input_batch = _DummyInputBatch()
+    runner.input_batch = _DummyInputBatch(num_reqs)
     runner.use_async_scheduling = False
     runner.device = torch.device("cpu")
     runner.supports_mm_inputs = False
@@ -78,3 +78,69 @@ def test_sample_tokens_dict_output():
     assert "audio" in output.pooler_output[0]
     assert "unused" not in output.pooler_output[0]
     assert output.pooler_output[0]["audio"].shape == (1, 4)
+
+
+# ------------------------------------------------------------------
+# Batched (num_reqs > 1) tests — these catch the contradictory
+# assertion bug where shape[0]==1 AND shape[0]==num_reqs were both
+# required simultaneously.
+# ------------------------------------------------------------------
+
+
+def test_sample_tokens_tensor_batched():
+    """Tensor output with batch dim matching num_reqs must work."""
+    num_reqs = 3
+    multimodal_outputs = torch.randn(num_reqs, 4, 5)
+    runner = _make_runner(multimodal_outputs, num_reqs=num_reqs)
+
+    output = GPUGenerationModelRunner.sample_tokens(runner)
+
+    assert len(output.pooler_output) == num_reqs
+    for i in range(num_reqs):
+        assert output.pooler_output[i]["model_outputs"].shape == (4, 5)
+
+
+def test_sample_tokens_list_batched():
+    """List output with one entry per request must work."""
+    num_reqs = 3
+    multimodal_outputs = [torch.randn(8) for _ in range(num_reqs)]
+    runner = _make_runner(multimodal_outputs, num_reqs=num_reqs)
+
+    output = GPUGenerationModelRunner.sample_tokens(runner)
+
+    assert len(output.pooler_output) == num_reqs
+    for i in range(num_reqs):
+        assert output.pooler_output[i]["model_outputs"].shape == (8,)
+
+
+def test_sample_tokens_dict_list_batched():
+    """Dict output with per-request lists must work."""
+    num_reqs = 2
+    multimodal_outputs = {
+        "model_outputs": [torch.randn(16) for _ in range(num_reqs)],
+    }
+    runner = _make_runner(multimodal_outputs, num_reqs=num_reqs)
+
+    output = GPUGenerationModelRunner.sample_tokens(runner)
+
+    assert len(output.pooler_output) == num_reqs
+    for i in range(num_reqs):
+        assert output.pooler_output[i]["model_outputs"].shape == (16,)
+
+
+def test_sample_tokens_tensor_mismatched_batch_raises():
+    """Tensor with wrong batch dim should raise AssertionError."""
+    multimodal_outputs = torch.randn(2, 4)
+    runner = _make_runner(multimodal_outputs, num_reqs=3)
+
+    with pytest.raises(AssertionError, match="num_reqs"):
+        GPUGenerationModelRunner.sample_tokens(runner)
+
+
+def test_sample_tokens_list_mismatched_batch_raises():
+    """List with wrong length should raise AssertionError."""
+    multimodal_outputs = [torch.randn(4), torch.randn(4)]
+    runner = _make_runner(multimodal_outputs, num_reqs=3)
+
+    with pytest.raises(AssertionError, match="num_reqs"):
+        GPUGenerationModelRunner.sample_tokens(runner)

--- a/tests/worker/test_gpu_generation_model_runner.py
+++ b/tests/worker/test_gpu_generation_model_runner.py
@@ -129,18 +129,18 @@ def test_sample_tokens_dict_list_batched():
 
 
 def test_sample_tokens_tensor_mismatched_batch_raises():
-    """Tensor with wrong batch dim should raise AssertionError."""
+    """Tensor with wrong batch dim should raise ValueError."""
     multimodal_outputs = torch.randn(2, 4)
     runner = _make_runner(multimodal_outputs, num_reqs=3)
 
-    with pytest.raises(AssertionError, match="num_reqs"):
+    with pytest.raises(ValueError, match="num_reqs"):
         GPUGenerationModelRunner.sample_tokens(runner)
 
 
 def test_sample_tokens_list_mismatched_batch_raises():
-    """List with wrong length should raise AssertionError."""
+    """List with wrong length should raise ValueError."""
     multimodal_outputs = [torch.randn(4), torch.randn(4)]
     runner = _make_runner(multimodal_outputs, num_reqs=3)
 
-    with pytest.raises(AssertionError, match="num_reqs"):
+    with pytest.raises(ValueError, match="num_reqs"):
         GPUGenerationModelRunner.sample_tokens(runner)

--- a/vllm_omni/worker/gpu_generation_model_runner.py
+++ b/vllm_omni/worker/gpu_generation_model_runner.py
@@ -359,15 +359,15 @@ class GPUGenerationModelRunner(OmniGPUModelRunner):
 
         pooler_output: list[object] = []
         if isinstance(multimodal_outputs, torch.Tensor):
-            assert multimodal_outputs.shape[0] == 1, (
-                "model should return a single tensor, to return multiple tensors, use a dict"
+            assert multimodal_outputs.shape[0] == self.input_batch.num_reqs, (
+                f"Tensor multimodal_outputs batch dim ({multimodal_outputs.shape[0]}) "
+                f"!= num_reqs ({self.input_batch.num_reqs})"
             )
-            assert multimodal_outputs.shape[0] == self.input_batch.num_reqs
             for i in range(self.input_batch.num_reqs):
                 pooler_output.append({"model_outputs": multimodal_outputs[i].detach().to("cpu").contiguous()})
         elif isinstance(multimodal_outputs, list):
-            assert len(multimodal_outputs) == 1, (
-                "model should return a single list, to return multiple lists, use a dict"
+            assert len(multimodal_outputs) == self.input_batch.num_reqs, (
+                f"List multimodal_outputs length ({len(multimodal_outputs)}) != num_reqs ({self.input_batch.num_reqs})"
             )
             for out in multimodal_outputs:
                 pooler_output.append(

--- a/vllm_omni/worker/gpu_generation_model_runner.py
+++ b/vllm_omni/worker/gpu_generation_model_runner.py
@@ -359,16 +359,19 @@ class GPUGenerationModelRunner(OmniGPUModelRunner):
 
         pooler_output: list[object] = []
         if isinstance(multimodal_outputs, torch.Tensor):
-            assert multimodal_outputs.shape[0] == self.input_batch.num_reqs, (
-                f"Tensor multimodal_outputs batch dim ({multimodal_outputs.shape[0]}) "
-                f"!= num_reqs ({self.input_batch.num_reqs})"
-            )
+            if multimodal_outputs.shape[0] != self.input_batch.num_reqs:
+                raise ValueError(
+                    f"Tensor multimodal_outputs batch dim ({multimodal_outputs.shape[0]}) "
+                    f"!= num_reqs ({self.input_batch.num_reqs})"
+                )
             for i in range(self.input_batch.num_reqs):
                 pooler_output.append({"model_outputs": multimodal_outputs[i].detach().to("cpu").contiguous()})
         elif isinstance(multimodal_outputs, list):
-            assert len(multimodal_outputs) == self.input_batch.num_reqs, (
-                f"List multimodal_outputs length ({len(multimodal_outputs)}) != num_reqs ({self.input_batch.num_reqs})"
-            )
+            if len(multimodal_outputs) != self.input_batch.num_reqs:
+                raise ValueError(
+                    f"List multimodal_outputs length ({len(multimodal_outputs)}) "
+                    f"!= num_reqs ({self.input_batch.num_reqs})"
+                )
             for out in multimodal_outputs:
                 pooler_output.append(
                     {"model_outputs": out.detach().to("cpu").contiguous() if out is not None else None}


### PR DESCRIPTION
Now here's the PR body:

---

## Purpose

Fix contradictory assertions in `GPUGenerationModelRunner.sample_tokens()` that make the `torch.Tensor` and `list` multimodal output branches impossible to use with batched inference (`num_reqs > 1`).

The tensor branch (lines 362–365) had:
```python
assert multimodal_outputs.shape[0] == 1, "model should return a single tensor..."
assert multimodal_outputs.shape[0] == self.input_batch.num_reqs
```
These two conditions can only both be true when `num_reqs == 1`. The list branch had the same pattern with `len(multimodal_outputs) == 1` followed by iteration over all elements.

This was likely a leftover from single-request development — the `shape[0] == 1` guard was never removed when batch support was added. The fix consolidates each pair into a single `== num_reqs` assertion with a descriptive error message, matching the semantics already used in the `dict` branch.

Currently all production models (MiMo-Audio, Qwen3-Omni, FishSpeech, etc.) return `dict` outputs via `OmniOutput` so the broken branches are not hit in practice, but any new model returning a plain tensor or list would crash at `num_reqs > 1`.

## Test Plan

```bash
# Run the unit tests (CPU only, no GPU required)
pytest tests/worker/test_gpu_generation_model_runner.py -v
```

5 new test cases added to `tests/worker/test_gpu_generation_model_runner.py`:

- `test_sample_tokens_tensor_batched` — tensor output with batch dim = 3
- `test_sample_tokens_list_batched` — list output with 3 entries
- `test_sample_tokens_dict_list_batched` — dict with per-request lists, batch = 2
- `test_sample_tokens_tensor_mismatched_batch_raises` — asserts on tensor dim mismatch
- `test_sample_tokens_list_mismatched_batch_raises` — asserts on list length mismatch

The existing 4 tests (`test_sample_tokens_tensor_output`, `test_sample_tokens_list_output`, `test_sample_tokens_list_allows_none_output`, `test_sample_tokens_dict_output`) continue to pass since they use `num_reqs=1`.

## Test Result

```
tests/worker/test_gpu_generation_model_runner.py::test_sample_tokens_tensor_output PASSED
tests/worker/test_gpu_generation_model_runner.py::test_sample_tokens_list_output PASSED
tests/worker/test_gpu_generation_model_runner.py::test_sample_tokens_list_allows_none_output PASSED
tests/worker/test_gpu_generation_model_runner.py::test_sample_tokens_dict_output PASSED
tests/worker/test_gpu_generation_model_runner.py::test_sample_tokens_tensor_batched PASSED
tests/worker/test_gpu_generation_model_runner.py::test_sample_tokens_list_batched PASSED
tests/worker/test_gpu_generation_model_runner.py::test_sample_tokens_dict_list_batched PASSED
tests/worker/test_gpu_generation_model_runner.py::test_sample_tokens_tensor_mismatched_batch_raises PASSED
tests/worker/test_gpu_generation_model_runner.py::test_sample_tokens_list_mismatched_batch_raises PASSED

9 passed
```