### PR TITLE
[CI] Skip img2img test due to L3 CI failure

### DIFF
--- a/tests/e2e/online_serving/test_bagel_online.py
+++ b/tests/e2e/online_serving/test_bagel_online.py
@@ -101,6 +101,7 @@ def test_bagel_text2img_online(omni_server, openai_client) -> None:
     openai_client.send_diffusion_request(request_config)
 
 
+@pytest.mark.skip(reason="L3 CI failed")
 @pytest.mark.core_model
 @pytest.mark.advanced_model
 @pytest.mark.diffusion


### PR DESCRIPTION
## Purpose
Skip the L3 CI test due to failure https://buildkite.com/vllm/vllm-omni/builds/5364/steps/canvas
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
