### PR TITLE
[CI] Update pytest command to exclude specific test in nightly build

### DIFF
--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -77,7 +77,7 @@ steps:
     if: build.env("NIGHTLY") == "1" || build.pull_request.labels includes "nightly-test"
     commands:
       - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-      - pytest -s -v tests/e2e/online_serving/test_*_expansion.py --ignore tests/e2e/online_serving/test_wan22_expansion.py -m "advanced_model and diffusion and H100" --run-level "advanced_model"
+      - pytest -s -v tests/e2e/online_serving/test_*_expansion.py -k "not test_wan22_expansion" -m "advanced_model and diffusion and H100" --run-level "advanced_model"
     agents:
       queue: "mithril-h100-pool"
     plugins:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Update pytest command to exclude specific test in nightly build
## Test Plan
Before: 
 ```
pytest --collect-only -vv tests/e2e/online_serving/test_*_expansion.py --ignore tests/e2e/online_serving/test_wan22_expansion.py 2>&1 | grep -B5 -A5 "wan22"
 ```

Now:
 ```
pytest --collect-only -vv tests/e2e/online_serving/test_*_expansion.py -k "not test_wan22_expansion" 2>&1 | grep -B5 -A5 "wan22"
```
## Test Result
Before:
```
Expected: API response content must be a list containing exactly
            ``layers`` image_url items, one per decomposed layer.
        <Module test_sd3_expansion.py>
          Tests for Stable Diffusion 3.5 medium model.
          <Function test_sd3_medium[omni_server0]>
        <Module test_wan22_expansion.py>
          Comprehensive tests of diffusion features that are available in online serving mode
          and are supported by the following models:
          - Wan-AI/Wan2.2-T2V-A14B-Diffusers
          - Wan-AI/Wan2.2-I2V-A14B-Diffusers
          - Wan-AI/Wan2.2-TI2V-5B-Diffusers
--
          - VAE-Patch-Parallel
          - HSDP
          - Ring-Attn

          assert_diffusion_response validates successful generation
          <Function test_wan22_diffusion_features[t2v_cache_dit]>
          <Function test_wan22_diffusion_features[i2v_cache_dit]>
          <Function test_wan22_diffusion_features[ti2v_cache_dit]>
          <Function test_wan22_diffusion_features[t2v_cfg_parallel]>
          <Function test_wan22_diffusion_features[t2v_ulysses_sp]>
          <Function test_wan22_diffusion_features[t2v_tp_vae_patch]>
          <Function test_wan22_diffusion_features[t2v_hsdp]>
          <Function test_wan22_diffusion_features[t2v_ring_atten]>
          <Function test_wan22_diffusion_features[i2v_cfg_parallel]>
          <Function test_wan22_diffusion_features[i2v_ulysses_sp]>
          <Function test_wan22_diffusion_features[i2v_tp_vae_patch]>
          <Function test_wan22_diffusion_features[i2v_hsdp]>
          <Function test_wan22_diffusion_features[i2v_ring_atten]>
          <Function test_wan22_diffusion_features[ti2v_cfg_parallel]>
          <Function test_wan22_diffusion_features[ti2v_ulysses_sp]>
          <Function test_wan22_diffusion_features[ti2v_tp_vae_patch]>
          <Function test_wan22_diffusion_features[ti2v_hsdp]>
          <Function test_wan22_diffusion_features[ti2v_ring_atten]>
        <Module test_zimage_expansion.py>
          Tests of common diffusion feature combinations in online serving mode
          for Z-Image.

          Coverage is intentionally limited to the minimal 4xL4 cases that
```
Now:
```
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
