### PR TITLE
[Qwen3TTS] [bugfix] [CodePredictor] Revert re-prefill

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code_predictor_vllm.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code_predictor_vllm.py
@@ -1,219 +1,235 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from vllm.config import VllmConfig
 from vllm.config.vllm import set_current_vllm_config
-from vllm.logger import init_logger
+from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import (
-    MergedColumnParallelLinear,
-    QKVParallelLinear,
-    RowParallelLinear,
-)
-from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
+from vllm.model_executor.models.qwen3 import Qwen3DecoderLayer
 from vllm.model_executor.models.utils import is_pp_missing_parameter
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec, KVCacheSpec, KVCacheTensor
+from vllm.v1.worker.gpu import attn_utils
 
 from vllm_omni.platforms import current_omni_platform
 
 from .configuration_qwen3_tts import Qwen3TTSTalkerCodePredictorConfig, Qwen3TTSTalkerConfig
 
-logger = init_logger(__name__)
 
-
-# ===================================================================
-#  Standalone Code Predictor Layers (no vLLM paged attention)
-# ===================================================================
-#
-# These replace vLLM's Qwen3DecoderLayer for the code predictor.
-# Input is batch-major [B, seq_len, H], attention uses F.scaled_dot_product_attention.
-# Weight names match the checkpoint (self_attn.qkv_proj, mlp.gate_up_proj, etc.)
-# so load_weights works unchanged.
-
-
-class _CodePredictorAttention(nn.Module):
-    """Standalone multi-head attention for code predictor.
-
-    Uses F.scaled_dot_product_attention (SDPA) instead of vLLM's paged Attention.
-    Supports fused QKV, RoPE, q/k normalization, and native GQA via enable_gqa.
-    Input: [B, seq_len, hidden_size], output: [B, seq_len, hidden_size].
-    """
+class _LocalPredictorKVCache:
+    """Minimal local KV cache + attention metadata for running
+    code_predictor inside one worker (independent of engine KV)."""
 
     def __init__(
         self,
-        config: Qwen3TTSTalkerCodePredictorConfig,
         *,
-        prefix: str = "",
+        vllm_config: VllmConfig,
+        max_seq_len: int,
+        max_batch_size: int,
+        device: torch.device,
     ) -> None:
-        super().__init__()
-        self.hidden_size = config.hidden_size
-        self.num_heads = config.num_attention_heads
-        self.num_kv_heads = config.num_key_value_heads
-        self.head_dim = getattr(
-            config,
-            "head_dim",
-            config.hidden_size // config.num_attention_heads,
-        )
-        self.q_size = self.num_heads * self.head_dim
-        self.kv_size = self.num_kv_heads * self.head_dim
-        self.scaling = self.head_dim**-0.5
-        self._use_gqa = self.num_kv_heads != self.num_heads
+        self.vllm_config = vllm_config
+        self.device = device
 
-        self.qkv_proj = QKVParallelLinear(
-            hidden_size=self.hidden_size,
-            head_size=self.head_dim,
-            total_num_heads=self.num_heads,
-            total_num_kv_heads=self.num_kv_heads,
-            bias=getattr(config, "attention_bias", False),
-            prefix=f"{prefix}.qkv_proj",
-            disable_tp=True,
-        )
-        self.o_proj = RowParallelLinear(
-            input_size=self.num_heads * self.head_dim,
-            output_size=self.hidden_size,
-            bias=False,
-            prefix=f"{prefix}.o_proj",
-            disable_tp=True,
-        )
-        self.rotary_emb = get_rope(
-            self.head_dim,
-            max_position=config.max_position_embeddings,
-            rope_parameters=getattr(config, "rope_parameters", None),
-            dual_chunk_attention_config=None,
-        )
-        self.q_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        # Collect attention layers registered in this vllm_config.
+        kv_cache_spec_by_layer = attn_utils.get_kv_cache_spec(vllm_config)
+        if not kv_cache_spec_by_layer:
+            raise RuntimeError("Local predictor KVCache requires vLLM Attention layers to be registered.")
 
-    def forward(
+        # We only need enough blocks for a tiny per-frame sequence (<= max_seq_len).
+        any_spec = next(iter(kv_cache_spec_by_layer.values()))
+        block_size = int(any_spec.block_size)
+        blocks_per_seq = (int(max_seq_len) + block_size - 1) // block_size
+        num_blocks = max(1, int(max_batch_size) * int(blocks_per_seq))
+
+        # Allocate per-layer KV caches (small, independent).
+        kv_cache_tensors: list[KVCacheTensor] = []
+        for layer_name, spec in kv_cache_spec_by_layer.items():
+            kv_cache_tensors.append(KVCacheTensor(size=int(spec.page_size_bytes) * num_blocks, shared_by=[layer_name]))
+
+        merged_spec: KVCacheSpec = KVCacheSpec.merge(list(kv_cache_spec_by_layer.values()))
+        self.kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=kv_cache_tensors,
+            kv_cache_groups=[
+                KVCacheGroupSpec(layer_names=list(kv_cache_spec_by_layer.keys()), kv_cache_spec=merged_spec)
+            ],
+        )
+
+        # Init backend + bind KV cache tensors to attention modules.
+        self.attn_backends, self.attn_groups = attn_utils.init_attn_backend(self.kv_cache_config, vllm_config, device)
+        self.runner_kv_caches: list[torch.Tensor] = []
+        attn_utils.init_kv_cache(
+            self.runner_kv_caches,
+            vllm_config.compilation_config.static_forward_context,
+            self.kv_cache_config,
+            self.attn_backends,
+            device,
+        )
+
+        # Precompute a fixed block table mapping for the maximum batch.
+        self.block_size = block_size
+        self.blocks_per_seq = blocks_per_seq
+        self.max_batch_size = int(max_batch_size)
+
+        bt = torch.full((self.max_batch_size, self.blocks_per_seq), -1, dtype=torch.int32, device=device)
+        for i in range(self.max_batch_size):
+            for j in range(self.blocks_per_seq):
+                bt[i, j] = i * self.blocks_per_seq + j
+        self._block_table = bt
+
+    def build_attn_metadata(
         self,
-        hidden_states: torch.Tensor,
-        position_ids: torch.Tensor,
-    ) -> torch.Tensor:
-        bsz, seq_len, _ = hidden_states.shape
-
-        qkv, _ = self.qkv_proj(hidden_states.reshape(bsz * seq_len, -1))
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-
-        q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view(q.shape)
-        k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view(k.shape)
-
-        q, k = self.rotary_emb(position_ids, q, k)
-
-        q = q.view(bsz, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
-        k = k.view(bsz, seq_len, self.num_kv_heads, self.head_dim).transpose(1, 2)
-        v = v.view(bsz, seq_len, self.num_kv_heads, self.head_dim).transpose(1, 2)
-
-        attn_out = F.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            scale=self.scaling,
-            is_causal=True,
-            enable_gqa=self._use_gqa,
-        )
-
-        attn_out = attn_out.transpose(1, 2).reshape(bsz * seq_len, -1)
-        output, _ = self.o_proj(attn_out)
-        return output.view(bsz, seq_len, -1)
-
-
-class _CodePredictorMLP(nn.Module):
-    """SiLU-gated MLP for code predictor, matching Qwen3MLP structure."""
-
-    def __init__(
-        self,
-        config: Qwen3TTSTalkerCodePredictorConfig,
         *,
-        prefix: str = "",
-    ) -> None:
-        super().__init__()
-        self.gate_up_proj = MergedColumnParallelLinear(
-            input_size=config.hidden_size,
-            output_sizes=[config.intermediate_size] * 2,
-            bias=False,
-            prefix=f"{prefix}.gate_up_proj",
-            disable_tp=True,
-        )
-        self.down_proj = RowParallelLinear(
-            input_size=config.intermediate_size,
-            output_size=config.hidden_size,
-            bias=False,
-            prefix=f"{prefix}.down_proj",
-            disable_tp=True,
-        )
+        num_reqs: int,
+        query_lens: torch.Tensor,  # (num_reqs,) int32 on cpu
+        seq_lens: torch.Tensor,  # (num_reqs,) int32 on cpu
+    ) -> tuple[dict[str, Any], torch.Tensor, dict[str, torch.Tensor]]:
+        """Build attention metadata, positions, and slot_mapping dict.
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        gate_up, _ = self.gate_up_proj(x)
-        gate, up = gate_up.chunk(2, dim=-1)
-        x = F.silu(gate) * up
-        x, _ = self.down_proj(x)
-        return x
+        Returns:
+            (attn_metadata, positions, slot_mappings_by_layer)
+            - attn_metadata: per-layer attention metadata for attn backends.
+            - positions: (num_tokens,) position IDs on device.
+            - slot_mappings_by_layer: {layer_name: slot_mapping_tensor} for
+              set_forward_context so that unified_kv_cache_update can write
+              the KV cache correctly.
+        """
+        num_reqs = int(num_reqs)
+        if num_reqs <= 0:
+            return {}, torch.empty((0,), dtype=torch.int64, device=self.device), {}
+        if num_reqs > self.max_batch_size:
+            raise ValueError(f"num_reqs={num_reqs} exceeds local predictor max_batch_size={self.max_batch_size}")
 
+        query_lens_i32 = query_lens.to(dtype=torch.int32, device="cpu")
+        seq_lens_i32 = seq_lens.to(dtype=torch.int32, device="cpu")
 
-class _CodePredictorDecoderLayer(nn.Module):
-    """Transformer decoder layer for code predictor (SDPA, no KV cache)."""
+        # query_start_loc: prefix sums of query_lens.
+        qsl = torch.zeros((num_reqs + 1,), dtype=torch.int32, device="cpu")
+        qsl[1:] = torch.cumsum(query_lens_i32, dim=0)
+        num_tokens = int(qsl[-1].item())
+        if num_tokens <= 0:
+            return {}, torch.empty((0,), dtype=torch.int64, device=self.device), {}
 
-    def __init__(
-        self,
-        config: Qwen3TTSTalkerCodePredictorConfig,
-        *,
-        prefix: str = "",
-    ) -> None:
-        super().__init__()
-        self.self_attn = _CodePredictorAttention(config, prefix=f"{prefix}.self_attn")
-        self.mlp = _CodePredictorMLP(config, prefix=f"{prefix}.mlp")
-        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        # Convert tensors to Python lists once to avoid per-element .item()
+        # calls (each .item() on a GPU tensor forces a GPU→CPU sync).
+        query_lens_list = query_lens_i32[:num_reqs].tolist()
+        seq_lens_list = seq_lens_i32[:num_reqs].tolist()
+        block_table_cpu = self._block_table[:num_reqs].cpu().tolist()
 
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        position_ids: torch.Tensor,
-    ) -> torch.Tensor:
-        residual = hidden_states
-        hidden_states = self.input_layernorm(hidden_states)
-        hidden_states = self.self_attn(hidden_states, position_ids)
-        hidden_states = residual + hidden_states
+        # positions: for each request i, emit positions [seq_len-query_len .. seq_len-1]
+        pos_list: list[torch.Tensor] = []
+        for i in range(num_reqs):
+            ql = query_lens_list[i]
+            sl = seq_lens_list[i]
+            start = sl - ql
+            pos_list.append(torch.arange(start, sl, dtype=torch.int64))
+        positions_cpu = torch.cat(pos_list, dim=0)
 
-        residual = hidden_states
-        hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
-        return hidden_states
+        # slot_mapping: map each query token to a physical slot in the paged KV cache.
+        # We allocate per-request contiguous blocks; slot = base + position.
+        slot_mapping = torch.empty((num_tokens,), dtype=torch.int64, device="cpu")
+        cursor = 0
+        for i in range(num_reqs):
+            ql = query_lens_list[i]
+            sl = seq_lens_list[i]
+            start = sl - ql
+            for p in range(start, sl):
+                block_idx = p // self.block_size
+                offset = p % self.block_size
+                block_id = block_table_cpu[i][block_idx]
+                slot_mapping[cursor] = block_id * self.block_size + offset
+                cursor += 1
 
+        max_seq_len = int(seq_lens_i32[:num_reqs].max().item())
+        query_start_loc_gpu = qsl.to(device=self.device)
+        seq_lens_gpu = seq_lens_i32.to(device=self.device)
+        block_table = self._block_table[:num_reqs].contiguous()
+        slot_mapping_gpu = slot_mapping.to(device=self.device)
 
-# ===================================================================
-#  Code Predictor Transformer Model
-# ===================================================================
+        # FIXME(gcanlin): Refactor build_attn_metadata to avoid special-casing NPU backends here.
+        if current_omni_platform.is_npu():
+            # NPU requires AscendCommonAttentionMetadata with extra attributes
+            from vllm_ascend.worker.v2 import attn_utils as attn_utils_npu
+
+            max_query_len = int(query_lens_i32[:num_reqs].max().item())
+            # NPU version expects slot_mappings as a stacked tensor, not a list
+            slot_mappings_tensor = slot_mapping_gpu.unsqueeze(0)
+            attn_metadata = attn_utils_npu.build_attn_metadata(
+                attn_metadata_builders=self.attn_groups,
+                num_reqs=num_reqs,
+                num_tokens=num_tokens,
+                query_start_loc_gpu=query_start_loc_gpu,
+                query_start_loc_cpu=qsl,
+                max_query_len=max_query_len,
+                seq_lens=seq_lens_gpu,
+                max_seq_len=max_seq_len,
+                block_tables=[block_table],
+                slot_mappings=slot_mappings_tensor,
+                kv_cache_config=self.kv_cache_config,
+            )
+        else:
+            max_query_len = int(query_lens_i32[:num_reqs].max().item())
+            attn_metadata = attn_utils.build_attn_metadata(
+                self.attn_groups,
+                num_reqs=num_reqs,
+                num_tokens=num_tokens,
+                query_start_loc_gpu=query_start_loc_gpu,
+                query_start_loc_cpu=qsl,
+                max_query_len=max_query_len,
+                seq_lens=seq_lens_gpu,
+                max_seq_len=max_seq_len,
+                block_tables=[block_table],
+                slot_mappings=slot_mapping_gpu,
+                kv_cache_config=self.kv_cache_config,
+            )
+
+        # Build slot_mappings_by_layer for set_forward_context.
+        # Fix for vllm 0.15.0
+        slot_mappings_by_layer: dict[str, torch.Tensor] = {}
+        for kv_cache_group in self.kv_cache_config.kv_cache_groups:
+            for layer_name in kv_cache_group.layer_names:
+                slot_mappings_by_layer[layer_name] = slot_mapping_gpu
+
+        return attn_metadata, positions_cpu.to(device=self.device), slot_mappings_by_layer
 
 
 class Qwen3TTSTalkerCodePredictorModelVLLM(nn.Module):
-    """Transformer model for the code predictor (re-prefill, no KV cache)."""
-
     def __init__(
         self,
         config: Qwen3TTSTalkerCodePredictorConfig,
         *,
         talker_hidden_size: int | None = None,
+        cache_config=None,
+        quant_config=None,
         prefix: str = "",
     ) -> None:
         super().__init__()
         self.config = config
+        self.quant_config = quant_config
 
         self.layers = nn.ModuleList(
-            [_CodePredictorDecoderLayer(config, prefix=f"{prefix}.layers.{i}") for i in range(config.num_hidden_layers)]
+            [
+                Qwen3DecoderLayer(
+                    config, cache_config=cache_config, quant_config=quant_config, prefix=f"{prefix}.layers.{i}"
+                )
+                for i in range(config.num_hidden_layers)
+            ]
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
-        # Codec embeddings: one per residual group. Stored in talker hidden dim
-        # (some checkpoints use talker_hidden_size != code_predictor hidden_size).
+        # Official code_predictor uses one embedding table per residual group.
+        # Some Qwen3-TTS checkpoints store codec embeddings in the talker hidden
+        # space, even when `code_predictor_config.hidden_size` is smaller.
+        # We keep the embedding dim aligned with the checkpoint and project down
+        # via `small_to_mtp_projection` in the wrapper module.
         emb_dim = int(talker_hidden_size) if talker_hidden_size is not None else int(config.hidden_size)
         self.codec_embedding = nn.ModuleList(
             [nn.Embedding(config.vocab_size, emb_dim) for _ in range(config.num_code_groups - 1)]
@@ -222,18 +238,18 @@ class Qwen3TTSTalkerCodePredictorModelVLLM(nn.Module):
     def get_input_embeddings(self) -> nn.ModuleList:
         return self.codec_embedding
 
-    def forward(
-        self,
-        inputs_embeds: torch.Tensor,
-        position_ids: torch.Tensor,
-    ) -> torch.Tensor:
+    def forward(self, positions: torch.Tensor, inputs_embeds: torch.Tensor) -> torch.Tensor:
+        # Token-major: [num_tokens, hidden]
         hidden_states = inputs_embeds
+        residual = None
         for layer in self.layers:
-            hidden_states = layer(hidden_states, position_ids)
-        hidden_states = self.norm(hidden_states)
+            hidden_states, residual = layer(positions, hidden_states, residual)
+        hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # Match vLLM Qwen2/Qwen3 packing conventions: q_proj/k_proj/v_proj -> qkv_proj,
+        # gate_proj/up_proj -> gate_up_proj.
         stacked_params_mapping = [
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
@@ -245,6 +261,13 @@ class Qwen3TTSTalkerCodePredictorModelVLLM(nn.Module):
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
+                continue
+            if self.quant_config is not None and (scale_name := self.quant_config.get_cache_scale(name)):
+                param = params_dict[scale_name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                loaded_weight = loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
+                weight_loader(param, loaded_weight)
+                loaded_params.add(scale_name)
                 continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:
@@ -286,31 +309,8 @@ class Qwen3TTSTalkerCodePredictorModelVLLM(nn.Module):
         return loaded_params
 
 
-# ===================================================================
-#  Code Predictor Wrapper (optimized re-prefill + torch.compile)
-# ===================================================================
-
-
 class Qwen3TTSTalkerCodePredictorForConditionalGenerationVLLM(nn.Module):
-    """vLLM-native code_predictor for the AR talker (residual codebooks).
-
-    Re-prefill approach: each AR step forwards the full growing sequence
-    through the 5-layer transformer. No KV cache needed. This trades
-    ~O(T^2) extra attention FLOPs (negligible for T=16, 5 layers) for
-    zero KV cache management overhead and a simpler execution model.
-
-    Optimizations over baseline:
-      1. torch.compile on model forward -- fuses 60+ small kernel launches per step
-         into fewer fused kernels (4x speedup on model_fwd, ~75% of total time).
-      2. Pre-allocated embedding buffer [B, max_seq, H] -- no torch.cat per step.
-      3. Projection caching -- each token projected once and cached, avoids O(T^2)
-         redundant projections.
-      4. Pre-allocated position_ids [max_seq] -- no torch.arange per step.
-      5. Inline sampling -- no custom op / forward_context overhead.
-      6. No context managers in forward().
-      7. Cached module references -- bypass nn.Module.__call__ and ModuleList indexing.
-      8. Pre-allocated output tensor.
-    """
+    """vLLM-native code_predictor used by the AR talker (residual codebooks)."""
 
     def __init__(
         self,
@@ -325,12 +325,16 @@ class Qwen3TTSTalkerCodePredictorForConditionalGenerationVLLM(nn.Module):
         self.config = config
         self.talker_config = talker_config
 
+        # Keep module/weight names aligned with official checkpoint (talker.code_predictor.model.*).
         self.model = Qwen3TTSTalkerCodePredictorModelVLLM(
             config,
             talker_hidden_size=int(talker_config.hidden_size),
+            cache_config=vllm_config.cache_config,
+            quant_config=vllm_config.quant_config,
             prefix=f"{prefix}.model",
         )
 
+        # One head per residual group.
         self.lm_head = nn.ModuleList(
             [nn.Linear(config.hidden_size, config.vocab_size, bias=False) for _ in range(config.num_code_groups - 1)]
         )
@@ -340,25 +344,14 @@ class Qwen3TTSTalkerCodePredictorForConditionalGenerationVLLM(nn.Module):
         else:
             self.small_to_mtp_projection = nn.Identity()
 
-        self._num_groups = int(config.num_code_groups)
-        self._talker_hidden = int(talker_config.hidden_size)
-        self._cp_hidden = int(config.hidden_size)
-
-        # Pre-allocated buffers (lazily initialized on first forward).
-        self._proj_buf: torch.Tensor | None = None
-
-        # torch.compile + warmup state (lazily initialized in _setup_compile).
-        self._compiled_model_fwd = None
-        self._bucket_sizes: list[int] = []
-        self._bucket_pos_ids: dict[int, torch.Tensor] = {}
-        self._lm_heads_list: list[nn.Module] | None = None
-        self._codec_embeds_list: list[nn.Module] | None = None
-        self._cuda_graphs: dict[int, tuple[torch.cuda.CUDAGraph, torch.Tensor]] = {}
+        self._kv_cache: _LocalPredictorKVCache | None = None
 
     def get_input_embeddings(self) -> nn.ModuleList:
         return self.model.get_input_embeddings()
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # Ensure all vLLM custom layers consult the predictor vllm_config
+        # (esp. for Attention static_forward_context).
         with set_current_vllm_config(self._vllm_config):
             loaded: set[str] = set()
             model_weights: list[tuple[str, torch.Tensor]] = []
@@ -378,92 +371,97 @@ class Qwen3TTSTalkerCodePredictorForConditionalGenerationVLLM(nn.Module):
                     continue
                 default_weight_loader(params[name], w)
                 loaded.add(name)
-
             return loaded
 
-    # ------------------------------------------------------------------
-    #  Pre-allocated buffer management
-    # ------------------------------------------------------------------
-
-    def _ensure_buffers(self, device: torch.device, dtype: torch.dtype) -> None:
-        max_seq = self._num_groups + 1
-        if self._proj_buf is not None and self._proj_buf.device == device and self._proj_buf.dtype == dtype:
+    def _maybe_init_kv_cache(self, device: torch.device) -> None:
+        if self._kv_cache is not None:
             return
-        max_bsz = self._vllm_config.scheduler_config.max_num_seqs
-        self._proj_buf = torch.zeros(
-            max_bsz,
-            max_seq,
-            self._cp_hidden,
-            dtype=dtype,
-            device=device,
+        with set_current_vllm_config(self._vllm_config):
+            max_seq_len = int(getattr(self.config, "num_code_groups", 16) or 16)
+            # Upper bound on batch size: vLLM scheduler max_num_seqs (fallback 8).
+            max_batch = int(getattr(self._vllm_config.scheduler_config, "max_num_seqs", 8) or 8)
+            max_batch = max(1, max_batch)
+            self._kv_cache = _LocalPredictorKVCache(
+                vllm_config=self._vllm_config,
+                max_seq_len=max_seq_len,
+                max_batch_size=max_batch,
+                device=device,
+            )
+
+    @torch.inference_mode()
+    def reset_cache(self) -> None:
+        # We reuse a fixed kv cache buffer and overwrite starting at slot 0.
+        # No action required here (seq_lens controls what is read).
+        return
+
+    @torch.inference_mode()
+    def prefill_logits(self, inputs_embeds: torch.Tensor) -> torch.Tensor:
+        """Prefill with 2 tokens: [past_hidden, layer0_embed]. Returns logits for residual group 0."""
+        self._maybe_init_kv_cache(inputs_embeds.device)
+        assert self._kv_cache is not None
+
+        bsz = int(inputs_embeds.shape[0])
+        qlen = 2
+        # Flatten to token-major.
+        model_dtype = next(self.model.parameters()).dtype
+        hs = inputs_embeds.to(dtype=model_dtype).reshape(bsz * qlen, -1)
+        hs = self.small_to_mtp_projection(hs)
+
+        query_lens = torch.full((bsz,), qlen, dtype=torch.int32)
+        seq_lens = query_lens.clone()
+        attn_metadata, positions, slot_mappings = self._kv_cache.build_attn_metadata(
+            num_reqs=bsz, query_lens=query_lens, seq_lens=seq_lens
         )
 
-    def _setup_compile(self) -> None:
-        """Lazily set up torch.compile with manual CUDA graph capture."""
-        if self._compiled_model_fwd is not None:
-            return
-        self._lm_heads_list = list(self.lm_head)
-        self._codec_embeds_list = list(self.model.codec_embedding)
-        if not current_omni_platform.supports_torch_inductor():
-            logger.warning_once("code_predictor: torch.compile disabled")
-            self._compiled_model_fwd = self.model.forward
-            return
+        with (
+            set_current_vllm_config(self._vllm_config),
+            set_forward_context(
+                attn_metadata,
+                self._vllm_config,
+                num_tokens=int(hs.shape[0]),
+                slot_mapping=slot_mappings,
+            ),
+        ):
+            out = self.model(positions=positions, inputs_embeds=hs)
 
-        self._compiled_model_fwd = torch.compile(self.model.forward, mode="default", dynamic=False)
-        self._warmup_buckets()
-        self._capture_cuda_graphs()
-        logger.info("code_predictor: torch.compile (mode=default) + CUDA graphs")
+        # Gather last token per request.
+        last_idx = torch.arange(qlen - 1, bsz * qlen, step=qlen, device=out.device, dtype=torch.long)
+        last_h = out.index_select(0, last_idx)
+        logits = self.lm_head[0](last_h)
+        return logits
 
-    def _padded_bsz(self, bsz: int) -> int:
-        for bucket in self._bucket_sizes:
-            if bsz <= bucket:
-                return bucket
-        return bsz
+    @torch.inference_mode()
+    def decode_logits(self, input_ids: torch.Tensor, *, generation_step: int, past_seq_len: int) -> torch.Tensor:
+        """Decode one new token for residual group `generation_step` (1..Q-1)."""
+        self._maybe_init_kv_cache(input_ids.device)
+        assert self._kv_cache is not None
+        bsz = int(input_ids.shape[0])
+        if generation_step <= 0:
+            raise ValueError("generation_step must be >= 1 for decode_logits")
 
-    def _warmup_buckets(self) -> None:
-        """Warmup power-of-2 batch-size buckets to front-load Inductor compilation."""
-        max_bsz = self._vllm_config.scheduler_config.max_num_seqs
-        bucket_sizes = [1 << i for i in range(max_bsz.bit_length()) if (1 << i) <= max_bsz]
-        if max_bsz not in bucket_sizes:
-            bucket_sizes.append(max_bsz)
-        self._bucket_sizes = sorted(bucket_sizes)
+        embed_idx = generation_step - 1
+        hs = self.model.get_input_embeddings()[embed_idx](input_ids.to(dtype=torch.long).reshape(bsz, 1))
+        hs = self.small_to_mtp_projection(hs.reshape(bsz, -1))
 
-        max_seq = self._num_groups + 1
-        device = next(self.model.parameters()).device
-        base_pos = torch.arange(max_seq, device=device, dtype=torch.long)
+        query_lens = torch.ones((bsz,), dtype=torch.int32)
+        seq_lens = torch.full((bsz,), int(past_seq_len) + 1, dtype=torch.int32)
+        attn_metadata, positions, slot_mappings = self._kv_cache.build_attn_metadata(
+            num_reqs=bsz, query_lens=query_lens, seq_lens=seq_lens
+        )
 
-        proj_buf = self._proj_buf
-        for bsz in self._bucket_sizes:
-            pos_ids = base_pos if bsz == 1 else base_pos.repeat(bsz)
-            self._bucket_pos_ids[bsz] = pos_ids
-            for _ in range(3):
-                self._compiled_model_fwd(proj_buf[:bsz, :max_seq, :], pos_ids)
-        logger.info("code_predictor: warmup done for buckets %s", self._bucket_sizes)
+        with (
+            set_current_vllm_config(self._vllm_config),
+            set_forward_context(
+                attn_metadata,
+                self._vllm_config,
+                num_tokens=int(hs.shape[0]),
+                slot_mapping=slot_mappings,
+            ),
+        ):
+            out = self.model(positions=positions, inputs_embeds=hs)
 
-    def _capture_cuda_graphs(self) -> None:
-        """Capture a CUDA graph per bucket using vLLM's global graph pool."""
-        from vllm.platforms import current_platform
-
-        pool = current_platform.get_global_graph_pool()
-
-        max_seq = self._num_groups + 1
-        proj_buf = self._proj_buf
-
-        for bsz in self._bucket_sizes:
-            static_input = proj_buf[:bsz, :max_seq, :]
-            pos_ids = self._bucket_pos_ids[bsz]
-
-            g = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(g, pool=pool):
-                static_output = self._compiled_model_fwd(static_input, pos_ids)
-
-            self._cuda_graphs[bsz] = (g, static_output)
-
-        logger.info("code_predictor: captured CUDA graphs for buckets %s", self._bucket_sizes)
-
-    # ------------------------------------------------------------------
-    #  Optimized forward: re-prefill + torch.compile + projection cache
-    # ------------------------------------------------------------------
+        logits = self.lm_head[generation_step](out)
+        return logits
 
     @torch.inference_mode()
     def forward(
@@ -472,79 +470,62 @@ class Qwen3TTSTalkerCodePredictorForConditionalGenerationVLLM(nn.Module):
         layer0_embed: torch.Tensor,
         last_talker_hidden: torch.Tensor,
         do_sample: bool = True,
-        temperature: float = 0.9,
+        temperature: float = 1.0,
         top_k: int = 50,
         top_p: float = 1.0,
     ) -> torch.Tensor:
-        """Predict residual codebooks 1..Q-1 autoregressively via re-prefill.
+        """Full autoregressive prediction of residual codebooks 1..Q-1.
 
-        torch.compile fuses the ~60 small kernel launches per step into fewer
-        fused kernels, reducing kernel launch overhead by ~75%.
+        Args:
+            layer0_code: [B, 1] first-layer codec token ids.
+            layer0_embed: [B, 1, H] embedding of layer0_code.
+            last_talker_hidden: [B, 1, H] hidden state from the talker.
+            do_sample: whether to sample or take argmax.
+            temperature: sampling temperature.
+            top_k: top-k filtering.
+            top_p: top-p (nucleus) filtering.
 
-        Projection caching: each token is projected once via small_to_mtp_projection
-        and cached in _proj_buf, avoiding redundant re-projection of past tokens.
+        Returns:
+            audio_codes: [B, Q] all codebook tokens (layer0 + residuals).
         """
         bsz = int(layer0_code.shape[0])
-        num_groups = self._num_groups
-        device = layer0_code.device
-        dtype = layer0_embed.dtype
+        num_groups = int(self.config.num_code_groups)
+        max_steps = num_groups - 1
 
-        all_codes = torch.empty(bsz, num_groups, dtype=torch.long, device=device)
-        all_codes[:, 0] = layer0_code.reshape(bsz)
+        # Reset KV cache for a fresh sequence.
+        self.reset_cache()
 
-        self._ensure_buffers(device, dtype)
-        self._setup_compile()
+        # Prefill: feed [last_talker_hidden, layer0_embed] → logits for group 1.
+        prefill_input = torch.cat([last_talker_hidden, layer0_embed], dim=1)  # [B, 2, H]
+        logits = self.prefill_logits(prefill_input)  # [B, vocab]
 
-        proj_buf = self._proj_buf
-        max_seq = self._num_groups + 1
-
-        projection = self.small_to_mtp_projection
-        model_fwd = self._compiled_model_fwd
-        lm_heads = self._lm_heads_list
-        codec_embeds = self._codec_embeds_list
-
-        use_sampling = do_sample and temperature > 0
-        inv_temperature = 1.0 / max(temperature, 1e-6) if use_sampling else 0.0
-        if use_sampling and top_p != 1.0:
-            raise NotImplementedError(
-                "top_p sampling is not implemented for the vLLM-native code predictor; please set top_p=1.0."
-            )
-
-        padded_bsz = self._padded_bsz(bsz)
-        proj_buf[:padded_bsz].zero_()
-
-        proj_buf[:bsz, 0, :] = projection(last_talker_hidden.reshape(bsz, 1, -1)).reshape(bsz, -1)
-        proj_buf[:bsz, 1, :] = projection(layer0_embed.reshape(bsz, 1, -1)).reshape(bsz, -1)
-        full_pos_ids = self._bucket_pos_ids.get(padded_bsz)
-        if full_pos_ids is None:
-            base_pos = torch.arange(max_seq, device=device, dtype=torch.long)
-            full_pos_ids = base_pos if padded_bsz == 1 else base_pos.repeat(padded_bsz)
-
-        # Use captured CUDA graph if available, otherwise call compiled fn.
-        cuda_graph_entry = self._cuda_graphs.get(padded_bsz)
+        all_codes = [layer0_code.reshape(bsz, 1)]
+        past_seq_len = 2
 
         for step in range(1, num_groups):
-            if cuda_graph_entry is not None:
-                cuda_graph_entry[0].replay()
-                hidden_out = cuda_graph_entry[1]
-            else:
-                hidden_out = model_fwd(proj_buf[:padded_bsz, :max_seq, :], full_pos_ids)
-            logits = lm_heads[step - 1](hidden_out[:bsz, step, :])
-
-            if use_sampling:
-                scaled = logits * inv_temperature
+            # Sample or argmax from logits.
+            if do_sample and temperature > 0:
+                scaled = logits.float() / temperature
                 if top_k > 0:
                     topk_vals, _ = scaled.topk(top_k, dim=-1)
                     scaled = scaled.masked_fill(scaled < topk_vals[:, -1:], float("-inf"))
-                probs = F.softmax(scaled, dim=-1)
-                next_ids = torch.multinomial(probs, num_samples=1)
+                probs = torch.softmax(scaled, dim=-1)
+                # Guard against NaN/Inf from lower-precision dtypes.
+                probs = probs.clamp(min=0.0)
+                row_sums = probs.sum(dim=-1, keepdim=True)
+                probs = torch.where(row_sums > 0, probs / row_sums, torch.ones_like(probs) / probs.shape[-1])
+                next_ids = torch.multinomial(probs, num_samples=1)  # [B, 1]
             else:
-                next_ids = logits.argmax(dim=-1, keepdim=True)
+                next_ids = logits.argmax(dim=-1, keepdim=True)  # [B, 1]
+            all_codes.append(next_ids)
 
-            all_codes[:, step] = next_ids.reshape(bsz)
+            # If not the last step, decode one more token.
+            if step < max_steps:
+                logits = self.decode_logits(
+                    next_ids.reshape(bsz),
+                    generation_step=step,
+                    past_seq_len=past_seq_len,
+                )
+                past_seq_len += 1
 
-            if step < num_groups - 1:
-                new_embed = codec_embeds[step - 1](next_ids)
-                proj_buf[:bsz, step + 1, :] = projection(new_embed.reshape(bsz, 1, -1)).reshape(bsz, -1)
-
-        return all_codes
+        return torch.cat(all_codes, dim=1)  # [B, Q]


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

- Reverts PR #1617 code predictor rewrite (re-prefill + torch.compile) back to the original KV-cache incremental decode approach.
- Fixes severe audio quality regression: UTMOS dropped (still working on this)
- Mirrors PR #2009 which reverted the same change for Qwen3-Omni.

the main cause:

The re-prefill approach forwards the full growing sequence through standalone SDPA attention each AR step. Over 15 autoregressive steps, small numerical differences between SDPA and vLLM's paged attention compound, producing degraded residual codes and significantly worse audio.

Fixes #2274

Still working on this, to see what we can salvage in speed. 

(the line changes can be seen by: 

```bash
diff <(git show 90ec499b^:vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code_predictor_vllm.py) vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code_predictor_vllm.py
```
)

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
