### PR TITLE
[Feature] Support DIFFUSION_CPU_OFFLOAD env var

### DIFF
--- a/docs/user_guide/diffusion/cpu_offload_diffusion.md
+++ b/docs/user_guide/diffusion/cpu_offload_diffusion.md
@@ -36,6 +36,14 @@ m = Omni(model="Wan-AI/Wan2.2-T2V-A14B-Diffusers", enable_cpu_offload=True)
 vllm-omni serve diffusion Wan-AI/Wan2.2-T2V-A14B-Diffusers --enable-cpu-offload
 ```
 
+**Environment variable:**
+
+Set `DIFFUSION_CPU_OFFLOAD=1` to enable model-level offload without touching code or CLI flags. The explicit `enable_cpu_offload` kwarg / `--enable-cpu-offload` flag takes precedence when provided.
+
+```bash
+DIFFUSION_CPU_OFFLOAD=1 vllm-omni serve diffusion Wan-AI/Wan2.2-T2V-A14B-Diffusers
+```
+
 ### Limitations
 - Cold start latency increases
 - Adds overhead from CPU-GPU transfers between encoder and denoising phases

--- a/tests/test_diffusion_cpu_offload_env.py
+++ b/tests/test_diffusion_cpu_offload_env.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the DIFFUSION_CPU_OFFLOAD env var (PR #2276).
+
+Both config construction paths must honor the env var, and an explicit
+`enable_cpu_offload` kwarg must win over it.
+"""
+
+import pytest
+
+from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
+
+
+def _from_kwargs(**kw) -> bool:
+    return OmniDiffusionConfig.from_kwargs(model="x", **kw).enable_cpu_offload
+
+
+def _stage_cfg(**kw) -> bool:
+    stages = AsyncOmniEngine._create_default_diffusion_stage_cfg({"model": "x", **kw})
+    return stages[0]["engine_args"]["enable_cpu_offload"]
+
+
+@pytest.mark.parametrize("build", [_from_kwargs, _stage_cfg], ids=["from_kwargs", "stage_cfg"])
+class TestDiffusionCpuOffloadEnv:
+    def test_env_enables_offload(self, monkeypatch, build):
+        monkeypatch.setenv("DIFFUSION_CPU_OFFLOAD", "1")
+        assert build() is True
+
+    def test_explicit_kwarg_overrides_env(self, monkeypatch, build):
+        monkeypatch.setenv("DIFFUSION_CPU_OFFLOAD", "1")
+        assert build(enable_cpu_offload=False) is False

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -609,7 +609,6 @@ class OmniDiffusionConfig:
                     f"got {type(self.quantization_config)!r}"
                 )
 
-
         if self.max_cpu_loras is None:
             self.max_cpu_loras = 1
         elif self.max_cpu_loras < 1:

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -609,6 +609,7 @@ class OmniDiffusionConfig:
                     f"got {type(self.quantization_config)!r}"
                 )
 
+
         if self.max_cpu_loras is None:
             self.max_cpu_loras = 1
         elif self.max_cpu_loras < 1:
@@ -633,6 +634,11 @@ class OmniDiffusionConfig:
             kwargs["quantization_config"] = kwargs.pop("quantization")
         else:
             kwargs.pop("quantization", None)
+
+        # Check environment variable as fallback for enable_cpu_offload
+        if "enable_cpu_offload" not in kwargs:
+            if os.environ.get("DIFFUSION_CPU_OFFLOAD", "0") == "1":
+                kwargs["enable_cpu_offload"] = True
 
         # Check environment variable as fallback for cache_backend
         # Support both old DIFFUSION_CACHE_ADAPTER and new DIFFUSION_CACHE_BACKEND for backwards compatibility

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -865,7 +865,10 @@ class AsyncOmniEngine:
                     "cache_backend": cache_backend,
                     "cache_config": cache_config,
                     "enable_cache_dit_summary": kwargs.get("enable_cache_dit_summary", False),
-                    "enable_cpu_offload": kwargs.get("enable_cpu_offload", False),
+                    "enable_cpu_offload": kwargs.get(
+                        "enable_cpu_offload",
+                        os.environ.get("DIFFUSION_CPU_OFFLOAD", "0") == "1",
+                    ),
                     "enable_layerwise_offload": kwargs.get("enable_layerwise_offload", False),
                     "enforce_eager": kwargs.get("enforce_eager", False),
                     "diffusion_load_format": kwargs.get("diffusion_load_format", "default"),


### PR DESCRIPTION
## Summary
- Add `DIFFUSION_CPU_OFFLOAD=1` environment variable to enable diffusion CPU offload without code or CLI changes.
- Applied in both `OmniDiffusionConfig.from_kwargs` and `AsyncOmniEngine`'s default stage config factory so direct-construction and `Omni()` paths behave identically.
- Explicit `enable_cpu_offload` kwarg (or `--enable-cpu-offload`) always wins over the env var; default remains `False`.

## Motivation
Developers with limited VRAM (e.g. 16GB consumer GPUs like RTX 5060 Ti) want a simple escape hatch to toggle diffusion CPU offload without patching call sites:

```bash
DIFFUSION_CPU_OFFLOAD=1 pytest tests/e2e/offline_inference/test_diffusion_lora.py
```

No impact on existing functionality — the env var defaults to `"0"` (disabled).

## Test plan
- [x] Unit tests: `tests/test_diffusion_cpu_offload_env.py` covers both construction paths and explicit-kwarg-overrides-env semantics.

> Note: this PR only changes how the `enable_cpu_offload` flag is wired. Runtime behavior of the offloader itself is unchanged and continues to be covered by `tests/e2e/offline_inference/test_diffusion_cpu_offload.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)