### PR TITLE
Optimize cosine shape handling in rope.py to adapt Wan2.2

### DIFF
--- a/vllm_omni/diffusion/layers/rope.py
+++ b/vllm_omni/diffusion/layers/rope.py
@@ -51,7 +51,7 @@ def apply_rotary_emb_mindiesd(
         sin = sin[0]
     if cos.shape[-1] == x.shape[-1]:
         half_head_dim = False
-         # already expanded to (S, D), just use directly
+        # already expanded to (S, D), just use directly
     if interleaved:
         # if last dim of sin and cos is D/2, expand to (S, D) to adapt to mindiesd operators
         if half_head_dim:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Optimize cosine shape handling in rope.py, when the shape is [1,s,1,d], it can use rotary_position_embedding direclty
## Test Plan
verify the modification on Wan2.2 

## Test Result
1、verify the modification on vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py

add the below command:
from importlib.util import find_spec
from vllm_omni.diffusion.layers.rope import RotaryEmbedding
from vllm_omni.platforms import current_omni_platform

WanSelfAttention
init:
self.rope = RotaryEmbedding(is_neox_style=False)

forward:
if rotary_emb is not None:
            freqs_cos, freqs_sin = rotary_emb
            if find_spec("mindiesd") is not None and current_omni_platform.is_npu():
                query = self.rope(query,freqs_cos, freqs_sin)
                key = self.rope(key,freqs_cos, freqs_sin)
            else:
                query = apply_rotary_emb_wan(query, freqs_cos, freqs_sin)
                key = apply_rotary_emb_wan(key, freqs_cos, freqs_sin)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
