### PR TITLE
[BUgFix]Qwen Image Layered test fails: expected number of output images mismatch

### DIFF
--- a/tests/e2e/online_serving/test_qwen_image_layered_expansion.py
+++ b/tests/e2e/online_serving/test_qwen_image_layered_expansion.py
@@ -78,6 +78,7 @@ def test_feature(omni_server: OmniServer, openai_client: OpenAIClientHandler):
         "model": omni_server.model,
         "messages": messages,
         "extra_body": {
+            "num_outputs_per_prompt": 4,
             "num_inference_steps": 2,
             "negative_prompt": NEGATIVE_PROMPT,
             "true_cfg_scale": 4.0,
@@ -231,6 +232,7 @@ def test_empty_prompt(omni_server: OmniServer, openai_client: OpenAIClientHandle
         "model": omni_server.model,
         "messages": messages,
         "extra_body": {
+            "num_outputs_per_prompt": 4,
             "num_inference_steps": 2,
             "negative_prompt": NEGATIVE_PROMPT,
             "true_cfg_scale": 4.0,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
pass CI
## Test Plan
Run pytest -s -v tests/e2e/online_serving/test_qwen_image_layered_expansion.py
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
