### PR TITLE
[Bugfix] Fix Qwen3TTSConfig init order to be compatible with newer Tansformers(5.x)

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/configuration_qwen3_tts.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/configuration_qwen3_tts.py
@@ -482,8 +482,6 @@ class Qwen3TTSConfig(PretrainedConfig):
         tts_eos_token_id=151673,
         **kwargs,
     ):
-        super().__init__(**kwargs)
-
         if talker_config is None:
             talker_config = {}
             logger.info("talker_config is None. Initializing talker model with default values")
@@ -493,6 +491,8 @@ class Qwen3TTSConfig(PretrainedConfig):
 
         self.talker_config = Qwen3TTSTalkerConfig(**talker_config)
         self.speaker_encoder_config = Qwen3TTSSpeakerEncoderConfig(**speaker_encoder_config)
+
+        super().__init__(**kwargs)
 
         self.tokenizer_type = tokenizer_type
         self.tts_model_size = tts_model_size


### PR DESCRIPTION
## Purpose
transformers: 5.3.0
vllm: 0.18.0
vllm-omni: 0.18.0

vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice     --stage-configs-path vllm_omni/model_executor/stage_configs/qwen3_tts.yaml     --omni --port 8004     --trust-remote-code

`
RuntimeError: Orchestrator initialization failed: 'Qwen3TTSConfig' object has no attribute 'talker_config'.`

**Root cause：**
Qwen3TTSConfig declares sub_configs, but talker_config and speaker_encoder_config were initialized after super().__init__(). In newer transformers, PreTrainedConfig accesses sub_configs during base initialization (for recursive config handling), so talker_config was referenced before it existed, causing the AttributeError.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
