### PR TITLE
[Feat] support TeaCache for Ovis-Image

### DIFF
--- a/tests/diffusion/cache/test_teacache_extractors.py
+++ b/tests/diffusion/cache/test_teacache_extractors.py
@@ -137,12 +137,12 @@ class TestFlux2KleinExtractor(BaseExtractorTest):
         assert callable(context.postprocess)
 
     def test_extra_states_contains_full_transformer(self, flux2_klein_module, sample_inputs):
-        """Test that extra_states contains run_flux2_full_transformer_with_single."""
+        """Test that extra_states contains the generic full-transformer override."""
         context = extract_flux2_klein_context(flux2_klein_module, **sample_inputs)
 
         assert context.extra_states is not None
-        assert "run_flux2_full_transformer_with_single" in context.extra_states
-        assert callable(context.extra_states["run_flux2_full_transformer_with_single"])
+        assert "run_full_transformer_with_single" in context.extra_states
+        assert callable(context.extra_states["run_full_transformer_with_single"])
 
     def test_without_guidance(self, flux2_klein_module, sample_inputs):
         """Test context extraction works without guidance (no CFG)."""

--- a/vllm_omni/diffusion/cache/teacache/config.py
+++ b/vllm_omni/diffusion/cache/teacache/config.py
@@ -24,6 +24,15 @@ _MODEL_COEFFICIENTS = {
         -3.82021401e00,
         2.64230861e-01,
     ],
+    # Ovis-Image transformer coefficients
+    # Estimated via polyfit on 3920 data points (80 prompts x 50 steps)
+    "OvisImageTransformer2DModel": [
+        -2.349283489951150e03,
+        9.201816692707802e02,
+        -1.101012944687145e02,
+        6.273505263138824e00,
+        -1.114396215400739e-01,
+    ],
     # Qwen-Image transformer coefficients from ComfyUI-TeaCache
     # Tuned specifically for Qwen's dual-stream transformer architecture
     # Used for all Qwen-Image Family pipelines, in general

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -84,6 +84,13 @@ class CacheContext:
         extra_states: Optional dict for additional model-specific state.
             Use this for models that need to pass additional context beyond
             the standard fields.
+
+            Reserved keys:
+            - "run_full_transformer_with_single": Callable with signature
+              (hidden_states, encoder_hidden_states) -> tuple[torch.Tensor, torch.Tensor | None]
+              used by dual+single-stream models whose cacheable unit must
+              include both the main transformer blocks and follow-on
+              single-stream blocks.
     """
 
     modulated_input: torch.Tensor
@@ -672,7 +679,7 @@ def extract_flux2_klein_context(
             )
         return (h, c)
 
-    def run_flux2_full_transformer_with_single(ori_h, ori_c):
+    def run_full_transformer_with_single(ori_h, ori_c):
         h = ori_h
         c = ori_c
         for block in module.transformer_blocks:
@@ -716,7 +723,7 @@ def extract_flux2_klein_context(
         run_transformer_blocks=run_flux2_transformer_blocks,
         postprocess=postprocess,
         extra_states={
-            "run_flux2_full_transformer_with_single": run_flux2_full_transformer_with_single,
+            "run_full_transformer_with_single": run_full_transformer_with_single,
         },
     )
 
@@ -771,9 +778,7 @@ def extract_ovis_image_context(
     # ============================================================================
     # DEFINE TRANSFORMER EXECUTION (Ovis-specific)
     # ============================================================================
-    def run_ovis_transformer_blocks():
-        h = hidden_states
-        e = encoder_hidden_states
+    def run_dual_stream_transformer_blocks(h, e):
         for block in module.transformer_blocks:
             e, h = block(
                 hidden_states=h,
@@ -783,16 +788,11 @@ def extract_ovis_image_context(
             )
         return (h, e)
 
-    def run_ovis_full_transformer_with_single(ori_h, ori_e):
-        h = ori_h
-        e = ori_e
-        for block in module.transformer_blocks:
-            e, h = block(
-                hidden_states=h,
-                encoder_hidden_states=e,
-                temb=temb,
-                image_rotary_emb=image_rotary_emb,
-            )
+    def run_ovis_transformer_blocks():
+        return run_dual_stream_transformer_blocks(hidden_states, encoder_hidden_states)
+
+    def run_full_transformer_with_single(ori_h, ori_e):
+        h, e = run_dual_stream_transformer_blocks(ori_h, ori_e)
         for block in module.single_transformer_blocks:
             e, h = block(
                 hidden_states=h,
@@ -822,7 +822,7 @@ def extract_ovis_image_context(
         run_transformer_blocks=run_ovis_transformer_blocks,
         postprocess=postprocess,
         extra_states={
-            "run_ovis_full_transformer_with_single": run_ovis_full_transformer_with_single,
+            "run_full_transformer_with_single": run_full_transformer_with_single,
         },
     )
 

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -721,6 +721,112 @@ def extract_flux2_klein_context(
     )
 
 
+def extract_ovis_image_context(
+    module: nn.Module,
+    hidden_states: torch.Tensor,
+    encoder_hidden_states: torch.Tensor | None = None,
+    timestep: torch.LongTensor = None,
+    img_ids: torch.Tensor = None,
+    txt_ids: torch.Tensor = None,
+    **kwargs: Any,
+) -> CacheContext:
+    """
+    Extract cache context for OvisImageTransformer2DModel.
+
+    Ovis-Image uses a dual-stream transformer trunk followed by
+    single_transformer_blocks, so TeaCache should cache the full transformer
+    output and skip both stages on cache hits.
+    """
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+    if not hasattr(module, "transformer_blocks") or len(module.transformer_blocks) == 0:
+        raise ValueError("Module must have transformer_blocks")
+
+    # ============================================================================
+    # PREPROCESSING (Ovis-specific)
+    # ============================================================================
+    hidden_states = module.x_embedder(hidden_states)
+    timestep = timestep.to(device=hidden_states.device, dtype=hidden_states.dtype) * 1000
+
+    timesteps_proj = module.time_proj(timestep)
+    temb = module.timestep_embedder(timesteps_proj.to(device=hidden_states.device, dtype=hidden_states.dtype))
+
+    encoder_hidden_states = module.context_embedder_norm(encoder_hidden_states)
+    encoder_hidden_states = module.context_embedder(encoder_hidden_states)
+
+    if txt_ids.ndim == 3:
+        txt_ids = txt_ids[0]
+    if img_ids.ndim == 3:
+        img_ids = img_ids[0]
+
+    ids = torch.cat((txt_ids, img_ids), dim=0)
+    image_rotary_emb = module.pos_embed(ids)
+
+    # ============================================================================
+    # EXTRACT MODULATED INPUT (for cache decision)
+    # ============================================================================
+    block = module.transformer_blocks[0]
+    modulated_input = block.norm1(hidden_states, emb=temb)[0]
+
+    # ============================================================================
+    # DEFINE TRANSFORMER EXECUTION (Ovis-specific)
+    # ============================================================================
+    def run_ovis_transformer_blocks():
+        h = hidden_states
+        e = encoder_hidden_states
+        for block in module.transformer_blocks:
+            e, h = block(
+                hidden_states=h,
+                encoder_hidden_states=e,
+                temb=temb,
+                image_rotary_emb=image_rotary_emb,
+            )
+        return (h, e)
+
+    def run_ovis_full_transformer_with_single(ori_h, ori_e):
+        h = ori_h
+        e = ori_e
+        for block in module.transformer_blocks:
+            e, h = block(
+                hidden_states=h,
+                encoder_hidden_states=e,
+                temb=temb,
+                image_rotary_emb=image_rotary_emb,
+            )
+        for block in module.single_transformer_blocks:
+            e, h = block(
+                hidden_states=h,
+                encoder_hidden_states=e,
+                temb=temb,
+                image_rotary_emb=image_rotary_emb,
+            )
+        return h, e
+
+    # ============================================================================
+    # DEFINE POSTPROCESSING (Ovis-specific)
+    # ============================================================================
+    return_dict = kwargs.get("return_dict", True)
+
+    def postprocess(h):
+        h = module.norm_out(h, temb)
+        h = module.proj_out(h)
+        if not return_dict:
+            return (h,)
+        return Transformer2DModelOutput(sample=h)
+
+    return CacheContext(
+        modulated_input=modulated_input,
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        temb=temb,
+        run_transformer_blocks=run_ovis_transformer_blocks,
+        postprocess=postprocess,
+        extra_states={
+            "run_ovis_full_transformer_with_single": run_ovis_full_transformer_with_single,
+        },
+    )
+
+
 def extract_stable_audio_context(
     module: nn.Module,
     hidden_states: torch.Tensor,
@@ -838,6 +944,7 @@ EXTRACTOR_REGISTRY: dict[str, Callable] = {
     "Bagel": extract_bagel_context,
     "ZImageTransformer2DModel": extract_zimage_context,
     "Flux2Klein": extract_flux2_klein_context,
+    "OvisImageTransformer2DModel": extract_ovis_image_context,
     "StableAudioDiTModel": extract_stable_audio_context,
     # Future models:
     # "FluxTransformer2DModel": extract_flux_context,

--- a/vllm_omni/diffusion/cache/teacache/hook.py
+++ b/vllm_omni/diffusion/cache/teacache/hook.py
@@ -157,14 +157,12 @@ class TeaCacheHook(ModelHook):
                 ctx.encoder_hidden_states.clone() if ctx.encoder_hidden_states is not None else None
             )
 
-            # Handle models with additional blocks (e.g., Flux2 single_transformer_blocks)
-            if getattr(ctx, "extra_states", None) and "run_flux2_full_transformer_with_single" in ctx.extra_states:
-                run_full = ctx.extra_states["run_flux2_full_transformer_with_single"]
-                ctx.hidden_states, ctx.encoder_hidden_states = run_full(ori_hidden_states, ori_encoder_hidden_states)
-                output = ctx.hidden_states
-                state.previous_residual = (ctx.hidden_states - ori_hidden_states).detach()
-            elif getattr(ctx, "extra_states", None) and "run_ovis_full_transformer_with_single" in ctx.extra_states:
-                run_full = ctx.extra_states["run_ovis_full_transformer_with_single"]
+            extra_states = ctx.extra_states or {}
+
+            # Models whose cacheable unit includes both dual-stream trunk and
+            # follow-on single-stream blocks can override the slow path here.
+            if "run_full_transformer_with_single" in extra_states:
+                run_full = extra_states["run_full_transformer_with_single"]
                 ctx.hidden_states, ctx.encoder_hidden_states = run_full(ori_hidden_states, ori_encoder_hidden_states)
                 output = ctx.hidden_states
                 state.previous_residual = (ctx.hidden_states - ori_hidden_states).detach()

--- a/vllm_omni/diffusion/cache/teacache/hook.py
+++ b/vllm_omni/diffusion/cache/teacache/hook.py
@@ -163,6 +163,11 @@ class TeaCacheHook(ModelHook):
                 ctx.hidden_states, ctx.encoder_hidden_states = run_full(ori_hidden_states, ori_encoder_hidden_states)
                 output = ctx.hidden_states
                 state.previous_residual = (ctx.hidden_states - ori_hidden_states).detach()
+            elif getattr(ctx, "extra_states", None) and "run_ovis_full_transformer_with_single" in ctx.extra_states:
+                run_full = ctx.extra_states["run_ovis_full_transformer_with_single"]
+                ctx.hidden_states, ctx.encoder_hidden_states = run_full(ori_hidden_states, ori_encoder_hidden_states)
+                output = ctx.hidden_states
+                state.previous_residual = (ctx.hidden_states - ori_hidden_states).detach()
             else:
                 # Run transformer blocks using model-specific callable
                 outputs = ctx.run_transformer_blocks()

--- a/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
+++ b/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
@@ -466,6 +466,7 @@ class OvisImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMi
             Denoised latents
         """
         self.scheduler.set_begin_index(0)
+        self.transformer.do_true_cfg = do_true_cfg
 
         for i, t in enumerate(timesteps):
             if self.interrupt:


### PR DESCRIPTION
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
TeaCache inference acceleration support for Ovis-Image  #1217 
## Test Plan
1 * NVIDIA RTX6000 Ada (48G)

### Ovis-Image coefficient estimation
- **Prompts times**: 80
- **Diffusion steps**: 50
- **Image pixels**: 1024 * 1024

### Teacache test
- **Diffusion steps**: 50
- **Image pixels**: 1024 * 1024
- **Prompt**: A cinematic night scene of a rain-soaked neo-futuristic street market beneath a glass observatory dome, with glowing holographic signs, polished reflections on wet stone, intricate storefront details, layered depth, soft volumetric fog, and a lone white cat sitting beside a brass tea set. 
## Test Result
NO TeaCache | TeaCache (0.2) | TeaCache (0.4) | TeaCache (0.6) |
|:---:|:---:|:---:|:---:|
|<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/c0615b78-55cc-426d-b2e0-64f58399569b" />|<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/cec93e6f-208d-4ff4-a2cc-5a15f93e5467" />| <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/7a8f2e34-e44f-4814-b02a-05c86f26fd8c" />| <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/1e499975-0738-41f6-8cca-b6ec477a3312" />|
| 54.19s | 15.61s(3.47x) | 9.07s (5.97x) | 6.95s(7.79x) |
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
