### PR TITLE
[Cleanup] Remove dead runtime.defaults config parameters

### DIFF
--- a/benchmarks/qwen3-tts/vllm_omni/configs/qwen3_tts_bs1.yaml
+++ b/benchmarks/qwen3-tts/vllm_omni/configs/qwen3_tts_bs1.yaml
@@ -71,10 +71,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
-
   connectors:
     connector_of_shared_memory:
       name: SharedMemoryConnector
@@ -90,4 +86,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/benchmarks/qwen3-tts/vllm_omni/configs/qwen3_tts_bs16.yaml
+++ b/benchmarks/qwen3-tts/vllm_omni/configs/qwen3_tts_bs16.yaml
@@ -72,10 +72,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 16
-
   connectors:
     connector_of_shared_memory:
       name: SharedMemoryConnector
@@ -91,4 +87,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/benchmarks/qwen3-tts/vllm_omni/configs/qwen3_tts_bs4.yaml
+++ b/benchmarks/qwen3-tts/vllm_omni/configs/qwen3_tts_bs4.yaml
@@ -72,10 +72,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 4
-
   connectors:
     connector_of_shared_memory:
       name: SharedMemoryConnector
@@ -91,4 +87,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/docs/configuration/pd_disaggregation.md
+++ b/docs/configuration/pd_disaggregation.md
@@ -145,19 +145,13 @@ Compared with the default Qwen3-Omni config:
 ```yaml
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
   edges:
     - from: 0
       to: 1
-      window_size: -1
     - from: 1
       to: 2
-      window_size: -1
     - from: 2
       to: 3
-      window_size: -1
 ```
 
 ## 4. Launch with your custom config

--- a/docs/configuration/stage_configs.md
+++ b/docs/configuration/stage_configs.md
@@ -114,16 +114,12 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
+
   edges:
     - from: 0                   # thinker → talker: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1
     - from: 1                   # talker → code2wav: trigger only after receiving full input (-1)
       to: 2
-      window_size: -1
 
 ```
 

--- a/docs/configuration/stage_configs/qwen2_5_omni.yaml
+++ b/docs/configuration/stage_configs/qwen2_5_omni.yaml
@@ -82,13 +82,8 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
   edges:
     - from: 0                   # thinker → talker: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1
     - from: 1                   # talker → code2wav: trigger only after receiving full input (-1)
       to: 2
-      window_size: -1

--- a/docs/user_guide/examples/offline_inference/bagel.md
+++ b/docs/user_guide/examples/offline_inference/bagel.md
@@ -176,8 +176,6 @@ Example configuration for TP=2 on GPUs 0 and 1:
 
 | Parameter             | Value   | Description                      |
 | :-------------------- | :------ | :------------------------------- |
-| `window_size`         | `-1`    | Window size (-1 means unlimited) |
-| `max_inflight`        | `1`     | Maximum inflight requests        |
 | `shm_threshold_bytes` | `65536` | Shared memory threshold (64KB)   |
 
 ## Using Mooncake Connector

--- a/examples/offline_inference/bagel/README.md
+++ b/examples/offline_inference/bagel/README.md
@@ -173,8 +173,6 @@ Example configuration for TP=2 on GPUs 0 and 1:
 
 | Parameter             | Value   | Description                      |
 | :-------------------- | :------ | :------------------------------- |
-| `window_size`         | `-1`    | Window size (-1 means unlimited) |
-| `max_inflight`        | `1`     | Maximum inflight requests        |
 | `shm_threshold_bytes` | `65536` | Shared memory threshold (64KB)   |
 
 ## Using Mooncake Connector

--- a/tests/dfx/perf/stage_configs/qwen3_tts.yaml
+++ b/tests/dfx/perf/stage_configs/qwen3_tts.yaml
@@ -74,10 +74,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 4
-
   connectors:
     connector_of_shared_memory:
       name: SharedMemoryConnector
@@ -93,4 +89,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/tests/e2e/offline_inference/stage_configs/bagel_mooncake_ci.yaml
+++ b/tests/e2e/offline_inference/stage_configs/bagel_mooncake_ci.yaml
@@ -64,9 +64,6 @@ stage_args:
 # Top-level runtime config with Mooncake connector
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
   connectors:
     mooncake_connector:
       name: MooncakeConnector
@@ -80,4 +77,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/tests/e2e/offline_inference/stage_configs/bagel_sharedmemory_ci.yaml
+++ b/tests/e2e/offline_inference/stage_configs/bagel_sharedmemory_ci.yaml
@@ -62,10 +62,6 @@ stage_args:
 # Runtime edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
-
   # Distributed connectors configuration (optional)
   # More connectors will be supported in the future.
   connectors:
@@ -78,4 +74,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/tests/e2e/offline_inference/stage_configs/npu/qwen2_5_omni_ci.yaml
+++ b/tests/e2e/offline_inference/stage_configs/npu/qwen2_5_omni_ci.yaml
@@ -91,13 +91,8 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
   edges:
     - from: 0                   # thinker → talker: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1
     - from: 1                   # talker → code2wav: trigger only after receiving full input (-1)
       to: 2
-      window_size: -1

--- a/tests/e2e/stage_configs/dynin_omni_ci.yaml
+++ b/tests/e2e/stage_configs/dynin_omni_ci.yaml
@@ -72,13 +72,8 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
   edges:
     - from: 0
       to: 1
-      window_size: -1
     - from: 1
       to: 2
-      window_size: -1

--- a/tests/e2e/stage_configs/qwen2_5_omni_ci.yaml
+++ b/tests/e2e/stage_configs/qwen2_5_omni_ci.yaml
@@ -97,13 +97,8 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
   edges:
     - from: 0                   # thinker → talker: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1
     - from: 1                   # talker → code2wav: trigger only after receiving full input (-1)
       to: 2
-      window_size: -1

--- a/tests/e2e/stage_configs/rocm/qwen2_5_omni_ci.yaml
+++ b/tests/e2e/stage_configs/rocm/qwen2_5_omni_ci.yaml
@@ -94,13 +94,8 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
   edges:
     - from: 0                   # thinker → talker: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1
     - from: 1                   # talker → code2wav: trigger only after receiving full input (-1)
       to: 2
-      window_size: -1

--- a/tests/e2e/stage_configs/xpu/qwen2_5_omni_ci.yaml
+++ b/tests/e2e/stage_configs/xpu/qwen2_5_omni_ci.yaml
@@ -95,14 +95,8 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1 # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1 # Simplified: process serially within each stage
-
   edges:
     - from: 0 # thinker → talker: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1
     - from: 1 # talker → code2wav: trigger only after receiving full input (-1)
       to: 2
-      window_size: -1

--- a/vllm_omni/model_executor/models/qwen3_tts/pipeline.yaml
+++ b/vllm_omni/model_executor/models/qwen3_tts/pipeline.yaml
@@ -90,4 +90,3 @@ connectors:
 edges:
   - from: 0
     to: 1
-    window_size: -1

--- a/vllm_omni/model_executor/stage_configs/bagel.yaml
+++ b/vllm_omni/model_executor/stage_configs/bagel.yaml
@@ -71,10 +71,6 @@ stage_args:
 # Runtime edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
-
   # Distributed connectors configuration (optional)
   # More connectors will be supported in the future.
   connectors:
@@ -104,4 +100,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/bagel_multiconnector.yaml
+++ b/vllm_omni/model_executor/stage_configs/bagel_multiconnector.yaml
@@ -64,10 +64,6 @@ stage_args:
 # Runtime edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
-
   # Distributed connectors configuration (optional)
   # More connectors will be supported in the future.
   connectors:
@@ -104,4 +100,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/bagel_single_stage.yaml
+++ b/vllm_omni/model_executor/stage_configs/bagel_single_stage.yaml
@@ -22,6 +22,3 @@ stage_args:
 # Runtime edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1

--- a/vllm_omni/model_executor/stage_configs/bagel_think.yaml
+++ b/vllm_omni/model_executor/stage_configs/bagel_think.yaml
@@ -65,9 +65,6 @@ stage_args:
 # Runtime edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
 
   connectors:
     shared_memory_connector:
@@ -78,4 +75,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/bagel_usp2.yaml
+++ b/vllm_omni/model_executor/stage_configs/bagel_usp2.yaml
@@ -62,9 +62,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
   connectors:
     shared_memory_connector:
       name: SharedMemoryConnector
@@ -73,4 +70,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/cosyvoice3_async_chunk.yaml
+++ b/vllm_omni/model_executor/stage_configs/cosyvoice3_async_chunk.yaml
@@ -63,9 +63,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
 
   connectors:
     connector_of_shared_memory:
@@ -82,4 +79,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/dynin_omni.yaml
+++ b/vllm_omni/model_executor/stage_configs/dynin_omni.yaml
@@ -67,14 +67,9 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
 
   edges:
     - from: 0
       to: 1
-      window_size: -1
     - from: 1
       to: 2
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/dynin_omni_multiconnector.yaml
+++ b/vllm_omni/model_executor/stage_configs/dynin_omni_multiconnector.yaml
@@ -71,9 +71,6 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
   ####
   # same as Qwen2.5_omni version
   # Distributed connectors configuration (optional)
@@ -108,7 +105,5 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1
     - from: 1
       to: 2
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/fish_speech_s2_pro.yaml
+++ b/vllm_omni/model_executor/stage_configs/fish_speech_s2_pro.yaml
@@ -71,10 +71,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 16
-
   connectors:
     connector_of_shared_memory:
       name: SharedMemoryConnector
@@ -93,4 +89,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/glm_image.yaml
+++ b/vllm_omni/model_executor/stage_configs/glm_image.yaml
@@ -70,11 +70,6 @@ stage_args:
 # Top-level runtime config
 runtime:
   enabled: true
-  defaults:
-    window_size: -1 # Trigger downstream only after full upstream completion
-    max_inflight: 1 # Process serially within each stage
-
   edges:
     - from: 0 # AR → Diffusion: trigger after AR completes
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/glm_image_muilticonnector.yaml
+++ b/vllm_omni/model_executor/stage_configs/glm_image_muilticonnector.yaml
@@ -70,14 +70,9 @@ stage_args:
 # Top-level runtime config with MultiConnector support
 runtime:
   enabled: true
-  defaults:
-    window_size: -1 # Trigger downstream only after full upstream completion
-    max_inflight: 1 # Process serially within each stage
-
   edges:
     - from: 0 # AR → Diffusion
       to: 1
-      window_size: -1
 
 # OmniConnector configuration for efficient inter-stage tensor transfer
 connectors:

--- a/vllm_omni/model_executor/stage_configs/hunyuan_image3_i2t.yaml
+++ b/vllm_omni/model_executor/stage_configs/hunyuan_image3_i2t.yaml
@@ -39,6 +39,3 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1

--- a/vllm_omni/model_executor/stage_configs/hunyuan_image3_it2i.yaml
+++ b/vllm_omni/model_executor/stage_configs/hunyuan_image3_it2i.yaml
@@ -69,10 +69,6 @@ stage_args:
 # Top-level runtime config
 runtime:
   enabled: true
-  defaults:
-    window_size: -1  # Trigger downstream only after full upstream completion
-    max_inflight: 1  # Process serially within each stage
   edges:
     - from: 0  # AR → Diffusion
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/hunyuan_image3_moe_dit_2gpu_fp8.yaml
+++ b/vllm_omni/model_executor/stage_configs/hunyuan_image3_moe_dit_2gpu_fp8.yaml
@@ -30,6 +30,3 @@ stage_args:
 # Runtime edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1

--- a/vllm_omni/model_executor/stage_configs/hunyuan_image3_t2i.yaml
+++ b/vllm_omni/model_executor/stage_configs/hunyuan_image3_t2i.yaml
@@ -29,6 +29,3 @@ stage_args:
 # Runtime edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1

--- a/vllm_omni/model_executor/stage_configs/hunyuan_image3_t2i_2gpu.yaml
+++ b/vllm_omni/model_executor/stage_configs/hunyuan_image3_t2i_2gpu.yaml
@@ -39,6 +39,3 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1

--- a/vllm_omni/model_executor/stage_configs/hunyuan_image3_t2t.yaml
+++ b/vllm_omni/model_executor/stage_configs/hunyuan_image3_t2t.yaml
@@ -40,6 +40,3 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1

--- a/vllm_omni/model_executor/stage_configs/mimo_audio_async_chunk.yaml
+++ b/vllm_omni/model_executor/stage_configs/mimo_audio_async_chunk.yaml
@@ -74,10 +74,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
-
   connectors:
     connector_of_shared_memory:
       name: SharedMemoryConnector
@@ -93,4 +89,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/qwen2_5_omni.yaml
+++ b/vllm_omni/model_executor/stage_configs/qwen2_5_omni.yaml
@@ -94,14 +94,8 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
-
   edges:
     - from: 0                   # thinker → talker: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1
     - from: 1                   # talker → code2wav: trigger only after receiving full input (-1)
       to: 2
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/qwen2_5_omni_multiconnector.yaml
+++ b/vllm_omni/model_executor/stage_configs/qwen2_5_omni_multiconnector.yaml
@@ -100,10 +100,6 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
-
   # Distributed connectors configuration (optional)
   # More connectors will be supported in the future.
   connectors:
@@ -135,7 +131,5 @@ runtime:
   edges:
     - from: 0                   # thinker → talker: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1
     - from: 1                   # talker → code2wav: trigger only after receiving full input (-1)
       to: 2
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/qwen3_omni_moe_multiconnector.yaml
+++ b/vllm_omni/model_executor/stage_configs/qwen3_omni_moe_multiconnector.yaml
@@ -111,10 +111,6 @@ stage_args:
 # Top-level runtime config: default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
-
   # Distributed connectors configuration
   connectors:
     # Mooncake connector for cross-node/intra-node communication
@@ -137,7 +133,5 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1
     - from: 1
       to: 2
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/qwen3_tts.yaml
+++ b/vllm_omni/model_executor/stage_configs/qwen3_tts.yaml
@@ -74,10 +74,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
-
   connectors:
     connector_of_shared_memory:
       name: SharedMemoryConnector
@@ -96,4 +92,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/qwen3_tts_batch.yaml
+++ b/vllm_omni/model_executor/stage_configs/qwen3_tts_batch.yaml
@@ -75,10 +75,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
-
   connectors:
     connector_of_shared_memory:
       name: SharedMemoryConnector
@@ -97,4 +93,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/qwen3_tts_uniproc.yaml
+++ b/vllm_omni/model_executor/stage_configs/qwen3_tts_uniproc.yaml
@@ -72,9 +72,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
 
   connectors:
     connector_of_shared_memory:
@@ -94,4 +91,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/voxcpm_async_chunk.yaml
+++ b/vllm_omni/model_executor/stage_configs/voxcpm_async_chunk.yaml
@@ -77,9 +77,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
 
   connectors:
     voxcpm_shm:
@@ -99,4 +96,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/model_executor/stage_configs/voxtral_tts.yaml
+++ b/vllm_omni/model_executor/stage_configs/voxtral_tts.yaml
@@ -82,10 +82,6 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
-
   connectors:
     connector_of_shared_memory:
       name: SharedMemoryConnector
@@ -102,4 +98,3 @@ runtime:
   edges:
     - from: 0                   # language_model → acoustic_transformer: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1

--- a/vllm_omni/platforms/npu/stage_configs/hunyuan_image3_t2i.yaml
+++ b/vllm_omni/platforms/npu/stage_configs/hunyuan_image3_t2i.yaml
@@ -33,6 +33,3 @@ stage_args:
 # Runtime defaults
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1

--- a/vllm_omni/platforms/npu/stage_configs/qwen2_5_omni.yaml
+++ b/vllm_omni/platforms/npu/stage_configs/qwen2_5_omni.yaml
@@ -85,13 +85,8 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
   edges:
     - from: 0                   # thinker → talker: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1
     - from: 1                   # talker → code2wav: trigger only after receiving full input (-1)
       to: 2
-      window_size: -1

--- a/vllm_omni/platforms/npu/stage_configs/qwen3_tts.yaml
+++ b/vllm_omni/platforms/npu/stage_configs/qwen3_tts.yaml
@@ -71,10 +71,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
-
   connectors:
     connector_of_shared_memory:
       name: SharedMemoryConnector
@@ -93,4 +89,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/platforms/npu/stage_configs/voxcpm_async_chunk.yaml
+++ b/vllm_omni/platforms/npu/stage_configs/voxcpm_async_chunk.yaml
@@ -73,9 +73,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
 
   connectors:
     connector_of_shared_memory:
@@ -90,4 +87,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/platforms/rocm/stage_configs/qwen2_5_omni.yaml
+++ b/vllm_omni/platforms/rocm/stage_configs/qwen2_5_omni.yaml
@@ -89,14 +89,8 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1             # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1             # Simplified: process serially within each stage
-
   edges:
     - from: 0                   # thinker → talker: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1
     - from: 1                   # talker → code2wav: trigger only after receiving full input (-1)
       to: 2
-      window_size: -1

--- a/vllm_omni/platforms/xpu/stage_configs/bagel.yaml
+++ b/vllm_omni/platforms/xpu/stage_configs/bagel.yaml
@@ -67,10 +67,6 @@ stage_args:
 # Runtime edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
-
   # Distributed connectors configuration (optional)
   # More connectors will be supported in the future.
   connectors:
@@ -83,4 +79,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1

--- a/vllm_omni/platforms/xpu/stage_configs/hunyuan_image3_t2i.yaml
+++ b/vllm_omni/platforms/xpu/stage_configs/hunyuan_image3_t2i.yaml
@@ -78,6 +78,3 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1  # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1  # Simplified: process serially within each stage

--- a/vllm_omni/platforms/xpu/stage_configs/qwen2_5_omni.yaml
+++ b/vllm_omni/platforms/xpu/stage_configs/qwen2_5_omni.yaml
@@ -88,14 +88,8 @@ stage_args:
 # Top-level runtime config (concise): default windows and stage edges
 runtime:
   enabled: true
-  defaults:
-    window_size: -1 # Simplified: trigger downstream only after full upstream completion
-    max_inflight: 1 # Simplified: process serially within each stage
-
   edges:
     - from: 0 # thinker → talker: trigger only after receiving full input (-1)
       to: 1
-      window_size: -1
     - from: 1 # talker → code2wav: trigger only after receiving full input (-1)
       to: 2
-      window_size: -1

--- a/vllm_omni/platforms/xpu/stage_configs/voxtral_tts.yaml
+++ b/vllm_omni/platforms/xpu/stage_configs/voxtral_tts.yaml
@@ -88,9 +88,6 @@ stage_args:
 
 runtime:
   enabled: true
-  defaults:
-    window_size: -1
-    max_inflight: 1
 
   connectors:
     connector_of_shared_memory:
@@ -108,4 +105,3 @@ runtime:
   edges:
     - from: 0
       to: 1
-      window_size: -1


### PR DESCRIPTION
## Purpose

Remove dead `runtime.defaults` config parameters (`max_inflight` and `window_size`) from all stage config YAMLs, benchmark configs, test configs, platform configs, and documentation.
Neither parameter is read by any Python code:
- **`max_inflight`** was introduced in [PR #51](https://github.com/vllm-project/vllm-omni/pull/51) (Nov 2025, MRS design) to limit concurrent in-flight requests per stage. When the architecture was rewritten to the current orchestrator in [PR #391](https://github.com/vllm-project/vllm-omni/pull/391) (Dec 2025), all Python references were removed but the YAML configs were left untouched. Concurrency is already managed by `max_num_seqs` (scheduler-level) for non-AR stages and KV cache capacity (memory-level) for AR stages.
- **`window_size`** (under both `runtime.defaults` and `runtime.edges[]`) is also not read by any Python code — the edge parsing in connector initialization (`initialization.py:225-231`) only uses the `from` and `to` fields.
Some benchmark configs set `max_inflight` to 4/8/16 (e.g. [PR #1852](https://github.com/vllm-project/vllm-omni/pull/1852), [PR #1913](https://github.com/vllm-project/vllm-omni/pull/1913)) expecting it to control concurrency, but it has no effect.
The `shm_threshold_bytes` and other connector-level config under `runtime.connectors.extra` remain untouched — those are actively used by `SharedMemoryConnector`.

## Test Plan

Config-only change (YAML + docs). No Python code modified.
```bash
# Verify no Python code references these parameters
grep -rn 'max_inflight' vllm_omni/ --include='*.py'
# expect: 0 results
grep -rn 'window_size' vllm_omni/config/ vllm_omni/engine/ vllm_omni/distributed/ --include='*.py'
# expect: 0 results (runtime config; unrelated attention/audio window_size remain)
```

## Test Result

No Python behavior change — parameters were never read by any code.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
