### PR TITLE
[Bugfix] Fix T5EncoderModel load_weights corrupting key weight names

### DIFF
--- a/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
+++ b/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
@@ -369,7 +369,7 @@ class T5EncoderModel(nn.Module):
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if f".{weight_name}." not in name:
                     continue
-                lookup_name = name.replace(weight_name, param_name)
+                lookup_name = name.replace(f".{weight_name}.", f".{param_name}.")
                 if lookup_name not in params_dict:
                     continue
                 param = params_dict[lookup_name]


### PR DESCRIPTION
## Purpose
- Fix `T5EncoderModel.load_weights` silently failing to load K-projection weights into the fused `qkv_proj` layer due to a `str.replace` bug that corrupts parameter names.
- The bare `name.replace("k", "qkv_proj")` replaces every occurrence of `"k"` in the name — including the `"k"` in `"block"` — producing a corrupted lookup name (`encoder.blocqkv_proj.0.layer...`) that matches no parameter. As a result, K weights are never loaded.
- Fix: use dotted replacement (`.k.` → `.qkv_proj.`) so only the full component is matched, consistent with the guard that already checks `f".{weight_name}."`.

## Test plan
- [x] Verified that all 5 stacked weight entries (`q`, `k`, `v`, `wi_0`, `wi_1`) now produce correct lookup names
- [x] Compared T5 encoder output against HuggingFace `transformers.T5EncoderModel` — cosine similarity improves from ~0.71 to ~0.999 after fix

## Test Result
- All 5 stacked weight entries now produce correct lookup names
- Cosine similarity between T5 ecnoder and `transformers.T5EncoderModel` rises from ~0.71 to ~0.999 after fix 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
