### PR TITLE
[Test] Fix 4 broken Qwen3-TTS async chunk unit tests

### DIFF
--- a/tests/model_executor/stage_input_processors/test_qwen3_tts_async_chunk.py
+++ b/tests/model_executor/stage_input_processors/test_qwen3_tts_async_chunk.py
@@ -16,6 +16,8 @@ from vllm_omni.model_executor.stage_input_processors.qwen3_tts import (
     talker2code2wav_async_chunk,
 )
 
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
 _FRAME = [1, 2, 3, 4]
 _Q = len(_FRAME)
 
@@ -176,7 +178,9 @@ def test_ic_load_change_mid_request():
     p3 = _call(tm, "r", n_frames=49)
     assert p3 is not None
 
-    # A *new* request under high load gets IC=16
+    # A *new* request under high load gets IC=16 (not IC=2).
+    # Frame 2 would emit under IC=2 but must hold under IC=16.
+    assert _call(tm, "new_req", n_frames=2) is None
     p4 = _call(tm, "new_req", n_frames=16)
     assert p4 is not None
 


### PR DESCRIPTION
## Summary
- Fix 4 test failures in `test_qwen3_tts_async_chunk.py` that were introduced by source changes in PRs #1930, #1852, and #2104 without corresponding test updates
- `test_flush_on_finish`: `finished` is now a plain `bool`, not a tensor; removed `.item()` call
- `test_ic_load_change_mid_request`: IC is cached per request since #1930; updated expected emission frames
- `test_non_async_processor_*` (x2): added missing `finished=True` and `token_ids` to mocks (required since #2104 added `talker_output.finished` check)

## Test plan
- [x] All 36 tests in `test_qwen3_tts_async_chunk.py` pass (was 32 pass / 4 fail)

Note: these tests are not currently run in CI I add the marker.