### PR TITLE
[Bugfix] Fix CPU busy-wait, telemetry, audio batching and CPU offload in diffusion engine (#2335)

### DIFF
--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -3,11 +3,14 @@
 
 import queue
 import threading
+from dataclasses import dataclass
 from types import SimpleNamespace
+from typing import NamedTuple
 from unittest.mock import Mock, patch
 
 import pytest
 import torch
+from diffusers.utils import BaseOutput
 
 from vllm_omni.diffusion.data import DiffusionOutput, DiffusionRequestAbortedError
 from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
@@ -55,6 +58,19 @@ def _make_step_output(
         finished=finished,
         result=DiffusionOutput(output=None, error=error) if error is not None else None,
     )
+
+
+class _FakeCudaTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, value):
+        return torch.Tensor._make_subclass(cls, torch.as_tensor(value), require_grad=False)
+
+    @property
+    def device(self):
+        return torch.device("cuda")
+
+    def cpu(self):
+        return self.as_subclass(torch.Tensor).clone()
 
 
 def _make_step_request(
@@ -676,6 +692,106 @@ class TestStepScheduler:
             outputs[1].multimodal_output["audio"],
             torch.arange(6, 12, dtype=torch.float32).reshape(2, 3),
         )
+
+    def test_step_cpu_offload_moves_tuple_output_to_cpu(self) -> None:
+        engine = DiffusionEngine.__new__(DiffusionEngine)
+        engine.od_config = Mock(model_class_name="mock_image_model", enable_cpu_offload=True)
+        engine.pre_process_func = None
+        engine.add_req_and_wait_for_response = Mock(
+            return_value=DiffusionOutput(
+                output=(
+                    _FakeCudaTensor([1.0]),
+                    _FakeCudaTensor([2.0]),
+                ),
+            )
+        )
+
+        seen = {}
+
+        def post_process_func(output_data):
+            seen["output_data"] = output_data
+            return ["image"]
+
+        engine.post_process_func = post_process_func
+
+        with patch("vllm_omni.diffusion.diffusion_engine.supports_audio_output", return_value=False):
+            outputs = engine.step(_make_request("cpu-offload-tuple"))
+
+        output_data = seen["output_data"]
+        assert type(output_data) is tuple
+        assert output_data[0].device.type == "cpu"
+        assert output_data[1].device.type == "cpu"
+        assert outputs[0].images == ["image"]
+
+    def test_step_cpu_offload_preserves_namedtuple_output_type(self) -> None:
+        class PipelineOutput(NamedTuple):
+            video: torch.Tensor
+            audio: torch.Tensor
+
+        engine = DiffusionEngine.__new__(DiffusionEngine)
+        engine.od_config = Mock(model_class_name="mock_image_model", enable_cpu_offload=True)
+        engine.pre_process_func = None
+        engine.add_req_and_wait_for_response = Mock(
+            return_value=DiffusionOutput(
+                output=PipelineOutput(
+                    video=_FakeCudaTensor([1.0]),
+                    audio=_FakeCudaTensor([2.0]),
+                ),
+            )
+        )
+
+        seen = {}
+
+        def post_process_func(output_data):
+            seen["output_data"] = output_data
+            return ["image"]
+
+        engine.post_process_func = post_process_func
+
+        with patch("vllm_omni.diffusion.diffusion_engine.supports_audio_output", return_value=False):
+            outputs = engine.step(_make_request("cpu-offload-namedtuple"))
+
+        output_data = seen["output_data"]
+        assert isinstance(output_data, PipelineOutput)
+        assert output_data.video.device.type == "cpu"
+        assert output_data.audio.device.type == "cpu"
+        assert outputs[0].images == ["image"]
+
+    def test_step_cpu_offload_preserves_base_output_type(self) -> None:
+        @dataclass
+        class PipelineOutput(BaseOutput):
+            sample: torch.Tensor
+            audio_sample: torch.Tensor | None = None
+
+        engine = DiffusionEngine.__new__(DiffusionEngine)
+        engine.od_config = Mock(model_class_name="mock_image_model", enable_cpu_offload=True)
+        engine.pre_process_func = None
+        engine.add_req_and_wait_for_response = Mock(
+            return_value=DiffusionOutput(
+                output=PipelineOutput(
+                    sample=_FakeCudaTensor([1.0]),
+                    audio_sample=_FakeCudaTensor([2.0]),
+                ),
+            )
+        )
+
+        seen = {}
+
+        def post_process_func(output_data):
+            seen["output_data"] = output_data
+            return ["image"]
+
+        engine.post_process_func = post_process_func
+
+        with patch("vllm_omni.diffusion.diffusion_engine.supports_audio_output", return_value=False):
+            outputs = engine.step(_make_request("cpu-offload-base-output"))
+
+        output_data = seen["output_data"]
+        assert isinstance(output_data, PipelineOutput)
+        assert output_data.sample.device.type == "cpu"
+        assert output_data.audio_sample is not None
+        assert output_data.audio_sample.device.type == "cpu"
+        assert outputs[0].images == ["image"]
 
     def test_step_reports_exec_and_total_time_with_correct_names(self) -> None:
         engine = DiffusionEngine.__new__(DiffusionEngine)

--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -398,6 +398,7 @@ class TestDiffusionEngine:
         with pytest.raises(RuntimeError, match="Dummy run failed: boom"):
             engine._dummy_run()
 
+
 class TestStepScheduler:
     def setup_method(self) -> None:
         self.scheduler: StepScheduler = StepScheduler()
@@ -704,9 +705,10 @@ class TestStepScheduler:
         engine = DiffusionEngine.__new__(DiffusionEngine)
         engine.executor = Mock()
         engine._rpc_lock = threading.Lock()
+        engine.abort_queue = queue.Queue()
 
         request = _make_request("sleepy")
-        expected = DiffusionOutput(output=None)
+        runner_output = _make_request_output("sched-sleepy")
         state = Mock(sched_req_id="sched-sleepy", req=request)
         sched_output = Mock(
             scheduled_new_reqs=[NewRequestData.from_state(state)],
@@ -722,18 +724,19 @@ class TestStepScheduler:
                 scheduled_new_reqs=[],
                 scheduled_cached_reqs=CachedRequestData.make_empty(),
                 scheduled_req_ids=[],
+                finished_req_ids=[],
                 is_empty=True,
             ),
             sched_output,
         ]
         engine.scheduler.has_requests.return_value = True
         engine.scheduler.update_from_output.return_value = {"sched-sleepy"}
-        engine.executor.add_req.return_value = expected
+        engine.execute_fn = Mock(return_value=runner_output)
 
         with patch("vllm_omni.diffusion.diffusion_engine.time.sleep") as sleep_mock:
             output = engine.add_req_and_wait_for_response(request)
 
-        assert output is expected
+        assert output is runner_output.result
         sleep_mock.assert_called_once_with(0.001)
-        engine.executor.add_req.assert_called_once_with(request)
+        engine.execute_fn.assert_called_once_with(sched_output)
         engine.scheduler.pop_request_state.assert_called_once_with("sched-sleepy")

--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -664,14 +664,15 @@ class TestStepScheduler:
         assert outputs[1].request_id == "req-b"
         assert outputs[0].final_output_type == "audio"
         assert outputs[1].final_output_type == "audio"
-        assert len(outputs[0].multimodal_output["audio"]) == 2
-        assert len(outputs[1].multimodal_output["audio"]) == 2
+        # Each payload must be a (K, ...) slice with the batch dim preserved.
+        assert outputs[0].multimodal_output["audio"].shape == (2, 3)
+        assert outputs[1].multimodal_output["audio"].shape == (2, 3)
         torch.testing.assert_close(
-            torch.stack(outputs[0].multimodal_output["audio"]),
+            outputs[0].multimodal_output["audio"],
             torch.arange(6, dtype=torch.float32).reshape(2, 3),
         )
         torch.testing.assert_close(
-            torch.stack(outputs[1].multimodal_output["audio"]),
+            outputs[1].multimodal_output["audio"],
             torch.arange(6, 12, dtype=torch.float32).reshape(2, 3),
         )
 
@@ -680,9 +681,7 @@ class TestStepScheduler:
         engine.od_config = Mock(model_class_name="mock_image_model", enable_cpu_offload=False)
         engine.pre_process_func = None
         engine.post_process_func = None
-        engine.add_req_and_wait_for_response = Mock(
-            return_value=DiffusionOutput(output="image-bytes")
-        )
+        engine.add_req_and_wait_for_response = Mock(return_value=DiffusionOutput(output="image-bytes"))
 
         request = _make_request("timing")
 

--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -686,6 +686,15 @@ class TestStepScheduler:
 
         request = _make_request("timing")
 
+        # perf_counter call order in step() (pre_process_func is None, so no
+        # preprocess calls):
+        #   0 → diffusion_engine_start_time
+        #   1 → exec_start_time
+        #   2 → exec_total_time  (exec = 2-1 = 1.0 s → 1000 ms)
+        #   3 → postprocess_start_time
+        #   4 → postprocess_time (post = 4-3 = 1.0 s)
+        #   5 → step_total_ms log line
+        #   6 → diffusion_engine_total_time_ms in metrics (total = 6-0 = 6.0 s → 6000 ms)
         with (
             patch("vllm_omni.diffusion.diffusion_engine.supports_audio_output", return_value=False),
             patch(

--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -398,7 +398,6 @@ class TestDiffusionEngine:
         with pytest.raises(RuntimeError, match="Dummy run failed: boom"):
             engine._dummy_run()
 
-
 class TestStepScheduler:
     def setup_method(self) -> None:
         self.scheduler: StepScheduler = StepScheduler()
@@ -634,3 +633,108 @@ class TestStepScheduler:
 
         with pytest.raises(ValueError):
             self.scheduler.add_request(request)
+
+    def test_step_splits_multi_prompt_audio_batch_per_request(self) -> None:
+        engine = DiffusionEngine.__new__(DiffusionEngine)
+        engine.od_config = Mock(model_class_name="mock_audio_model", enable_cpu_offload=False)
+        engine.pre_process_func = None
+        engine.post_process_func = None
+        engine.add_req_and_wait_for_response = Mock(
+            return_value=DiffusionOutput(
+                output=torch.arange(12, dtype=torch.float32).reshape(4, 3),
+                stage_durations={"decode": 1.0},
+                peak_memory_mb=123.0,
+            )
+        )
+
+        request = OmniDiffusionRequest(
+            prompts=["prompt_a", "prompt_b"],
+            sampling_params=OmniDiffusionSamplingParams(
+                num_inference_steps=1,
+                num_outputs_per_prompt=2,
+            ),
+            request_ids=["req-a", "req-b"],
+        )
+
+        with patch("vllm_omni.diffusion.diffusion_engine.supports_audio_output", return_value=True):
+            outputs = engine.step(request)
+
+        assert len(outputs) == 2
+        assert outputs[0].request_id == "req-a"
+        assert outputs[1].request_id == "req-b"
+        assert outputs[0].final_output_type == "audio"
+        assert outputs[1].final_output_type == "audio"
+        assert len(outputs[0].multimodal_output["audio"]) == 2
+        assert len(outputs[1].multimodal_output["audio"]) == 2
+        torch.testing.assert_close(
+            torch.stack(outputs[0].multimodal_output["audio"]),
+            torch.arange(6, dtype=torch.float32).reshape(2, 3),
+        )
+        torch.testing.assert_close(
+            torch.stack(outputs[1].multimodal_output["audio"]),
+            torch.arange(6, 12, dtype=torch.float32).reshape(2, 3),
+        )
+
+    def test_step_reports_exec_and_total_time_with_correct_names(self) -> None:
+        engine = DiffusionEngine.__new__(DiffusionEngine)
+        engine.od_config = Mock(model_class_name="mock_image_model", enable_cpu_offload=False)
+        engine.pre_process_func = None
+        engine.post_process_func = None
+        engine.add_req_and_wait_for_response = Mock(
+            return_value=DiffusionOutput(output="image-bytes")
+        )
+
+        request = _make_request("timing")
+
+        with (
+            patch("vllm_omni.diffusion.diffusion_engine.supports_audio_output", return_value=False),
+            patch(
+                "vllm_omni.diffusion.diffusion_engine.time.perf_counter",
+                side_effect=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            ),
+        ):
+            outputs = engine.step(request)
+
+        metrics = outputs[0].metrics
+        assert metrics["diffusion_engine_exec_time_ms"] == pytest.approx(1000.0)
+        assert metrics["diffusion_engine_total_time_ms"] == pytest.approx(6000.0)
+        assert metrics["diffusion_engine_total_time_ms"] > metrics["diffusion_engine_exec_time_ms"]
+        assert "preprocessing_time_ms" not in metrics
+
+    def test_add_req_and_wait_for_response_sleeps_when_scheduler_temporarily_empty(self) -> None:
+        engine = DiffusionEngine.__new__(DiffusionEngine)
+        engine.executor = Mock()
+        engine._rpc_lock = threading.Lock()
+
+        request = _make_request("sleepy")
+        expected = DiffusionOutput(output=None)
+        state = Mock(sched_req_id="sched-sleepy", req=request)
+        sched_output = Mock(
+            scheduled_new_reqs=[NewRequestData.from_state(state)],
+            scheduled_cached_reqs=CachedRequestData.make_empty(),
+            scheduled_req_ids=["sched-sleepy"],
+            is_empty=False,
+        )
+
+        engine.scheduler = Mock()
+        engine.scheduler.add_request.return_value = "sched-sleepy"
+        engine.scheduler.schedule.side_effect = [
+            Mock(
+                scheduled_new_reqs=[],
+                scheduled_cached_reqs=CachedRequestData.make_empty(),
+                scheduled_req_ids=[],
+                is_empty=True,
+            ),
+            sched_output,
+        ]
+        engine.scheduler.has_requests.return_value = True
+        engine.scheduler.update_from_output.return_value = {"sched-sleepy"}
+        engine.executor.add_req.return_value = expected
+
+        with patch("vllm_omni.diffusion.diffusion_engine.time.sleep") as sleep_mock:
+            output = engine.add_req_and_wait_for_response(request)
+
+        assert output is expected
+        sleep_mock.assert_called_once_with(0.001)
+        engine.executor.add_req.assert_called_once_with(request)
+        engine.scheduler.pop_request_state.assert_called_once_with("sched-sleepy")

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -7,6 +7,7 @@ import queue
 import threading
 import time
 from collections.abc import Iterable
+from dataclasses import fields, is_dataclass
 from typing import Any
 
 import numpy as np
@@ -59,6 +60,41 @@ def supports_audio_output(model_class_name: str) -> bool:
     if model_cls is None:
         return False
     return bool(getattr(model_cls, "support_audio_output", False))
+
+
+def _move_tensors_to_cpu(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.cpu() if value.device.type != "cpu" else value
+
+    if is_dataclass(value) and not isinstance(value, type):
+        kwargs = {
+            field.name: _move_tensors_to_cpu(getattr(value, field.name))
+            for field in fields(value)
+            if field.init and hasattr(value, field.name)
+        }
+        return type(value)(**kwargs)
+
+    if isinstance(value, tuple):
+        items = tuple(_move_tensors_to_cpu(item) for item in value)
+        if hasattr(value, "_fields"):
+            return type(value)(*items)
+        if type(value) is tuple:
+            return items
+        try:
+            return type(value)(items)
+        except TypeError:
+            try:
+                return type(value)(*items)
+            except TypeError:
+                return items
+
+    if isinstance(value, list):
+        return [_move_tensors_to_cpu(item) for item in value]
+
+    if type(value) is dict:
+        return {key: _move_tensors_to_cpu(item) for key, item in value.items()}
+
+    return value
 
 
 class DiffusionEngine:
@@ -136,12 +172,7 @@ class DiffusionEngine:
         # reside on the device and leave no headroom for intermediates.
         output_data = output.output
         if self.od_config.enable_cpu_offload:
-            if isinstance(output_data, torch.Tensor) and output_data.device.type != "cpu":
-                output_data = output_data.cpu()
-            elif isinstance(output_data, tuple):
-                output_data = tuple(
-                    t.cpu() if isinstance(t, torch.Tensor) and t.device.type != "cpu" else t for t in output_data
-                )
+            output_data = _move_tensors_to_cpu(output_data)
 
         postprocess_start_time = time.perf_counter()
         outputs = self.post_process_func(output_data) if self.post_process_func is not None else output_data
@@ -229,13 +260,14 @@ class DiffusionEngine:
             for i, prompt in enumerate(request.prompts):
                 request_id = request.request_ids[i] if i < len(request.request_ids) else ""
 
+                # Get images for this request
                 num_outputs = request.sampling_params.num_outputs_per_prompt
                 start_idx = output_idx
                 end_idx = start_idx + num_outputs
+                request_outputs = outputs[start_idx:end_idx] if output_idx < len(outputs) else []
                 output_idx = end_idx
 
                 if is_audio_output:
-                    # Slice batched tensor directly; batch dim is preserved.
                     request_audio_payload = outputs[start_idx:end_idx] if outputs is not None else None
                     results.append(
                         OmniRequestOutput.from_diffusion(
@@ -251,7 +283,6 @@ class DiffusionEngine:
                         ),
                     )
                 else:
-                    request_outputs = outputs[start_idx:end_idx] if start_idx < len(outputs) else []
                     mm_output = {}
                     if audio_payload is not None:
                         sliced_audio = audio_payload

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -229,14 +229,13 @@ class DiffusionEngine:
             for i, prompt in enumerate(request.prompts):
                 request_id = request.request_ids[i] if i < len(request.request_ids) else ""
 
-                # Get images for this request
                 num_outputs = request.sampling_params.num_outputs_per_prompt
                 start_idx = output_idx
                 end_idx = start_idx + num_outputs
-                request_outputs = outputs[start_idx:end_idx] if output_idx < len(outputs) else []
                 output_idx = end_idx
 
                 if is_audio_output:
+                    # Slice batched tensor directly; batch dim is preserved.
                     request_audio_payload = outputs[start_idx:end_idx] if outputs is not None else None
                     results.append(
                         OmniRequestOutput.from_diffusion(
@@ -252,6 +251,7 @@ class DiffusionEngine:
                         ),
                     )
                 else:
+                    request_outputs = outputs[start_idx:end_idx] if start_idx < len(outputs) else []
                     mm_output = {}
                     if audio_payload is not None:
                         sliced_audio = audio_payload

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -135,12 +135,14 @@ class DiffusionEngine:
         # post-processing to avoid device OOM — model weights may still
         # reside on the device and leave no headroom for intermediates.
         output_data = output.output
-        if (
-            self.od_config.enable_cpu_offload
-            and isinstance(output_data, torch.Tensor)
-            and output_data.device.type != "cpu"
-        ):
-            output_data = output_data.cpu()
+        if self.od_config.enable_cpu_offload:
+            if isinstance(output_data, torch.Tensor) and output_data.device.type != "cpu":
+                output_data = output_data.cpu()
+            elif isinstance(output_data, tuple):
+                output_data = tuple(
+                    t.cpu() if isinstance(t, torch.Tensor) and t.device.type != "cpu" else t
+                    for t in output_data
+                )
 
         postprocess_start_time = time.perf_counter()
         outputs = self.post_process_func(output_data) if self.post_process_func is not None else output_data
@@ -161,21 +163,30 @@ class DiffusionEngine:
             step_total_ms,
         )
 
-        # Convert to OmniRequestOutput format
-        # Ensure outputs is a list
-        if not isinstance(outputs, list):
+        # Evaluate once; used in both single- and multi-prompt branches below.
+        is_audio_output = supports_audio_output(self.od_config.model_class_name)
+
+        # Normalize outputs to a flat per-sample list.
+        # Audio models return a batched tensor [N*K, ...]; split along dim-0 so
+        # per-prompt slicing works uniformly for single and multiple prompts.
+        if is_audio_output and not isinstance(outputs, list):
+            if outputs is not None and hasattr(outputs, "__len__") and hasattr(outputs, "__getitem__"):
+                outputs = list(outputs)  # splits tensor/ndarray along axis-0
+            elif outputs is not None:
+                outputs = [outputs]
+            else:
+                outputs = []
+        elif not isinstance(outputs, list):
             outputs = [outputs] if outputs is not None else []
 
         metrics = {
             "preprocess_time_ms": preprocess_time * 1000,
-            "diffusion_engine_exec_time_ms": (time.perf_counter() - diffusion_engine_start_time) * 1000,
-            "diffusion_engine_total_time_ms": exec_total_time * 1000,
+            "diffusion_engine_exec_time_ms": exec_total_time * 1000,
+            "diffusion_engine_total_time_ms": (time.perf_counter() - diffusion_engine_start_time) * 1000,
             "image_num": int(request.sampling_params.num_outputs_per_prompt),
             "resolution": int(request.sampling_params.resolution),
             "postprocess_time_ms": postprocess_time * 1000,
         }
-        if self.pre_process_func is not None:
-            metrics["preprocessing_time_ms"] = preprocess_time * 1000
 
         # Handle single request or multiple requests
         if len(request.prompts) == 1:
@@ -183,7 +194,7 @@ class DiffusionEngine:
             prompt = request.prompts[0]
             request_id = request.request_ids[0] if request.request_ids else ""
 
-            if supports_audio_output(self.od_config.model_class_name):
+            if is_audio_output:
                 request_audio_payload = outputs[0] if len(outputs) == 1 else outputs
                 return [
                     OmniRequestOutput.from_diffusion(
@@ -231,7 +242,7 @@ class DiffusionEngine:
                 request_outputs = outputs[start_idx:end_idx] if output_idx < len(outputs) else []
                 output_idx = end_idx
 
-                if supports_audio_output(self.od_config.model_class_name):
+                if is_audio_output:
                     request_audio_payload = request_outputs[0] if len(request_outputs) == 1 else request_outputs
                     results.append(
                         OmniRequestOutput.from_diffusion(
@@ -304,6 +315,7 @@ class DiffusionEngine:
                         return self._finalize_finished_request(target_sched_req_id)
                     if not self.scheduler.has_requests():
                         raise RuntimeError("Diffusion scheduler has no runnable requests.")
+                    time.sleep(0.001)
                     continue
 
                 # NOTE: add_req_and_wait_for_response() is synchronous, and
@@ -372,9 +384,7 @@ class DiffusionEngine:
 
         if supports_audio_input(self.od_config.model_class_name):
             audio_sr = 16000
-            audio_duration_sec = 4
-            audio_array = np.random.randn(audio_sr * audio_duration_sec).astype(np.float32)
-            dummy_audio = audio_array[audio_sr * 1 : audio_sr * 3]
+            dummy_audio = np.random.randn(audio_sr * 2).astype(np.float32)
         else:
             dummy_audio = None
 

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -140,8 +140,7 @@ class DiffusionEngine:
                 output_data = output_data.cpu()
             elif isinstance(output_data, tuple):
                 output_data = tuple(
-                    t.cpu() if isinstance(t, torch.Tensor) and t.device.type != "cpu" else t
-                    for t in output_data
+                    t.cpu() if isinstance(t, torch.Tensor) and t.device.type != "cpu" else t for t in output_data
                 )
 
         postprocess_start_time = time.perf_counter()
@@ -166,17 +165,11 @@ class DiffusionEngine:
         # Evaluate once; used in both single- and multi-prompt branches below.
         is_audio_output = supports_audio_output(self.od_config.model_class_name)
 
-        # Normalize outputs to a flat per-sample list.
-        # Audio models return a batched tensor [N*K, ...]; split along dim-0 so
-        # per-prompt slicing works uniformly for single and multiple prompts.
-        if is_audio_output and not isinstance(outputs, list):
-            if outputs is not None and hasattr(outputs, "__len__") and hasattr(outputs, "__getitem__"):
-                outputs = list(outputs)  # splits tensor/ndarray along axis-0
-            elif outputs is not None:
-                outputs = [outputs]
-            else:
-                outputs = []
-        elif not isinstance(outputs, list):
+        # For image models, normalize to a flat list of per-output items.
+        # Audio models return a batched tensor shaped (N*K, C, T); keep it
+        # as-is and slice per-prompt below so the batch dimension is preserved
+        # in every per-request payload (e.g. (K, C, T) per prompt).
+        if not is_audio_output and not isinstance(outputs, list):
             outputs = [outputs] if outputs is not None else []
 
         metrics = {
@@ -195,7 +188,8 @@ class DiffusionEngine:
             request_id = request.request_ids[0] if request.request_ids else ""
 
             if is_audio_output:
-                request_audio_payload = outputs[0] if len(outputs) == 1 else outputs
+                num_outputs = request.sampling_params.num_outputs_per_prompt
+                request_audio_payload = outputs[0:num_outputs] if outputs is not None else None
                 return [
                     OmniRequestOutput.from_diffusion(
                         request_id=request_id,
@@ -243,7 +237,7 @@ class DiffusionEngine:
                 output_idx = end_idx
 
                 if is_audio_output:
-                    request_audio_payload = request_outputs[0] if len(request_outputs) == 1 else request_outputs
+                    request_audio_payload = outputs[start_idx:end_idx] if outputs is not None else None
                     results.append(
                         OmniRequestOutput.from_diffusion(
                             request_id=request_id,


### PR DESCRIPTION
## What
Fixes #2335

## Changes
- Add `time.sleep(0.001)` in polling loop to prevent CPU starvation
- Fix swapped exec/total time metrics + duplicate `preprocessing_time_ms`
- Fix multi-prompt audio: normalize batched tensor before per-request slicing
- Extend CPU offload guard to handle tuple outputs (LTX2 video+audio)
- Hoist `supports_audio_output()` outside per-prompt loop
- Simplify `_dummy_run` to exact-size allocation

## Out of scope (deferred)
`_rpc_lock` scope reduction requires deeper refactor — executor uses shared
FIFO queue with no per-request correlation, relaxing lock would cause
response misrouting. Tracked separately.