### PR TITLE
Fix: ensure input tensor is contiguous in GroupCoordinator.all_gather

### DIFF
--- a/vllm_omni/diffusion/distributed/group_coordinator.py
+++ b/vllm_omni/diffusion/distributed/group_coordinator.py
@@ -213,7 +213,7 @@ class GroupCoordinator:
         input_size[0] *= world_size
         output_tensor = torch.empty(input_size, dtype=input_.dtype, device=input_.device)
         # All-gather.
-        torch.distributed.all_gather_into_tensor(output_tensor, input_, group=self.device_group)
+        torch.distributed.all_gather_into_tensor(output_tensor, input_.contiguous(), group=self.device_group)
         if dim != 0:
             input_size[0] //= world_size
             output_tensor = output_tensor.reshape(


### PR DESCRIPTION
Add .contiguous() to the input tensor before passing it to torch.distributed.all_gather_into_tensor. This prevents potential errors or performance issues when the input tensor is non-contiguous, which is required for correct all-gather operations in distributed settings.

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix RuntimeError: Tensors must be contiguous when running HunyuanVideo-1.5 text-to-video inference with CFG (Classifier-Free Guidance) parallel enabled (cfg_parallel_size=2).

When CFG parallel is enabled, the predict_noise_maybe_with_cfg function in cfg_parallel.py calls cfg_group.all_gather() to gather noise predictions across CFG-parallel ranks.
 The all_gather method in GroupCoordinator calls torch.distributed.all_gather_into_tensor(), which requires the input tensor to be contiguous in memory. However, the tensors
passed from the HunyuanVideo-1.5 pipeline may be non-contiguous (e.g., due to prior transpose, permute, or view operations), causing the HCCL/NCCL collective to fail with:

RuntimeError: Tensors must be contiguous

The fix adds .contiguous() to the input tensor before passing it to all_gather_into_tensor.

## Test Plan

Run HunyuanVideo-1.5 480p text-to-video generation with CFG parallel on 4 NPUs (TP=2, CFG=2):

python examples/offline_inference/text_to_video/text_to_video.py \
    --model HunyuanVideo-1.5-Diffusers-480p_t2v \
    --prompt "A little girl wearing a straw hat runs through a summer meadow" \
    --num-frames 5 --num-inference-steps 30 --seed 42 \
    --tensor-parallel-size 2 --cfg-parallel-size 2

## Test Result

Test Result

Before fix: All workers crash with RuntimeError: Tensors must be contiguous at group_coordinator.py:216 during all_gather_into_tensor in the CFG gather phase. Generation
fails completely.

After fix: Generation completes successfully in ~13.73 seconds, video saved correctly. No errors in logs.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [√] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [√] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [√] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
