### PR TITLE
Fix Qwen3-TTS gradio demo

### DIFF
--- a/examples/online_serving/qwen3_tts/gradio_demo.py
+++ b/examples/online_serving/qwen3_tts/gradio_demo.py
@@ -125,7 +125,7 @@ PLAYER_HTML = """
 def _build_player_js(sample_rate: int) -> str:
     """Build the JavaScript that powers the AudioWorklet player."""
     return f"""
-() => {{
+    <script>
     const SR = {sample_rate};
     const WC = {json.dumps(WORKLET_JS)};
     let ctx = null, node = null, abort = null, gen = false, st = {{}};
@@ -284,7 +284,7 @@ def _build_player_js(sample_rate: int) -> str:
             }}
         }}
     }};
-}}
+    </script>
 """
 
 
@@ -435,10 +435,7 @@ def create_app(api_base: str):
     )
 
     with gr.Blocks(
-        css=css,
         title="Qwen3-TTS Demo",
-        js=_build_player_js(PCM_SAMPLE_RATE),
-        theme=theme,
     ) as demo:
         gr.HTML(f"""
         <div style="display:flex; align-items:center; gap:16px; margin-bottom:8px;">
@@ -773,7 +770,14 @@ def create_app(api_base: str):
 
         demo.queue()
 
-    return gr.mount_gradio_app(fastapi_app, demo, path="/")
+    return gr.mount_gradio_app(
+        fastapi_app,
+        demo,
+        path="/",
+        css=css,
+        theme=theme,
+        head=_build_player_js(PCM_SAMPLE_RATE),
+    )
 
 
 def parse_args():

--- a/examples/online_serving/qwen3_tts/tts_common.py
+++ b/examples/online_serving/qwen3_tts/tts_common.py
@@ -103,7 +103,7 @@ def build_payload(
 
     if task_type == "CustomVoice":
         if voice:
-            payload["speaker"] = voice
+            payload["voice"] = voice
         if instructions and instructions.strip():
             payload["instructions"] = instructions.strip()
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

The Qwen3-TTS is not working as-is now. 2 issues:

- page-init JS path doesn't seem to be registered properly, so window.ttsGenerate was never registered and the browser never sent the speech request.
- for CustomVoice task, it's using "speaker" param field, which has no impact. 

Fixed the page-init JS path so it registered properly, and change the "speaker" param field to "voice"

## Test Plan

## Test Result

Tested it locally and the CustomVoice demo is working with different speaker. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
