### PR TITLE
[Perf][Qwen3-TTS][Voxtral-TTS] Share CUDA graph memory pool across decoder capture sizes

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/cuda_graph_decoder_wrapper.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/cuda_graph_decoder_wrapper.py
@@ -10,6 +10,7 @@ reducing kernel launch overhead during inference.
 import torch
 from torch.cuda import CUDAGraph
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
@@ -129,7 +130,7 @@ class CUDAGraphDecoderWrapper:
 
         graph = CUDAGraph()
         with torch.no_grad():
-            with torch.cuda.graph(graph):
+            with torch.cuda.graph(graph, pool=current_platform.get_global_graph_pool()):
                 static_output = self.decoder(static_input)
 
         self.graphs[size] = graph

--- a/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
@@ -11,6 +11,7 @@ eliminating kernel launch overhead on every decode step.
 import torch
 from torch.cuda import CUDAGraph
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 
 from vllm_omni.model_executor.models.voxtral_tts.voxtral_tts_audio_generation import (
     AudioSpecialTokens,
@@ -196,7 +197,7 @@ class CUDAGraphAcousticTransformerWrapper:
 
         graph = CUDAGraph()
         with torch.no_grad():
-            with torch.cuda.graph(graph):
+            with torch.cuda.graph(graph, pool=current_platform.get_global_graph_pool()):
                 static_fake_eos, static_audio_codes = self._forward_cudagraph_compatible(
                     static_input, noise=static_noise
                 )


### PR DESCRIPTION
## Purpose

CUDAGraphDecoderWrapper (Qwen3-TTS) and
CUDAGraphAcousticTransformerWrapper (Voxtral-TTS) each captured CUDA graphs without a shared memory pool.  This meant each captured size allocated its own private copy of intermediate activation buffers. For Code2Wav with 11 capture sizes and a 1920x upsampling chain, this resulted in ~6.6 GiB of reserved GPU memory.

Use current_platform.get_global_graph_pool() so all captured sizes share the same underlying memory pool, matching the pattern used by qwen3_tts_code_predictor, mimo_audio, and upstream vLLM's CUDAGraphWrapper.  Only the largest graph's peak memory is physically allocated — the pool maps different graphs to the same memory region.

This is safe because:
- All graph replays within a wrapper are sequential (one chunk at a time in the decode loop), so two graphs from the same pool never execute concurrently on the same stream.
- Each stage runs in a separate process, so the global pool is per-process with no cross-stage interference.
- The static_inputs/static_outputs dicts remain per-graph — only the backing physical memory is shared, not the tensor objects.

Relates to #2318.

## Test Plan

Unit tests:
```bash
python -m pytest tests/model_executor/models/qwen3_tts/test_cuda_graph_decoder.py -v
python -m pytest tests/model_executor/stage_input_processors/test_voxtral_tts_async_chunk.py -v
```

E2E tests:
```bash
python -m pytest tests/e2e/online_serving/test_qwen3_tts.py -v --timeout=300
python -m pytest tests/e2e/online_serving/test_qwen3_tts_base.py -v --timeout=300
python -m pytest tests/e2e/online_serving/test_qwen3_tts_batch.py -v --timeout=30
```

## Test Result

All PASS

| Component | Without shared pool | With shared pool | Delta |
|-----------|---------------------|------------------|-------|
| Code2Wav | 8004 MiB | 4748 MiB | **-3256 MiB** |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
