### PR TITLE
[Model] Add Cosmos Predict 2.5 support.

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -73,5 +73,6 @@ th {
 |`DyninOmniForConditionalGeneration` | Dynin-Omni | `snu-aidas/Dynin-Omni` | ✅︎ | | | |
 | `ErnieImagePipeline` | ERNIE-Image | `baidu/ERNIE-Image`, `baidu/ERNIE-Image-Turbo` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 |`HiDreamImagePipeline` | HiDream-I1-Full | `HiDream-ai/HiDream-I1-Full` | ✅︎ | ✅︎ | | |
+| `Cosmos2_5_PredictBasePipeline` | Cosmos-Predict2.5 (Text2World, Image2World, Video2World) | `nvidia/Cosmos-Predict2.5-2B`, `nvidia/Cosmos-Predict2.5-14B` | ✅︎ | | | |
 
 ✅︎ indicates the model is supported on that backend. Empty cells mean not listed as supported on that backend.

--- a/examples/offline_inference/cosmos/cosmos_predict2_5.md
+++ b/examples/offline_inference/cosmos/cosmos_predict2_5.md
@@ -4,6 +4,16 @@ NVIDIA Cosmos-Predict2.5 supports text-to-video (T2W), image-to-video (I2W), and
 
 > **Note:** Model requires `--revision diffusers/base/post-trained` to locate weights inside the HF repo.
 
+## Prerequisites
+
+The pipeline runs the Cosmos Guardrail safety checker, which is mandatory under the
+[NVIDIA Open Model License Agreement](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license).
+Install it before running (it downloads additional guardrail models and uses extra VRAM):
+
+```bash
+pip install cosmos_guardrail
+```
+
 ## Run Examples
 
 ```bash
@@ -36,7 +46,6 @@ python cosmos_predict2_5.py \
   --mode video2world \
   --video /path/to/video.mp4 \
   --prompt "The robot continues pouring liquid into the container" \
-  --num-latent-conditional-frames 2 \
   --output output_v2w.mp4
 ```
 
@@ -51,7 +60,8 @@ python cosmos_predict2_5.py \
 | `--negative-prompt` | `""` | Negative prompt |
 | `--image` | — | Input image (required for `image2world`) |
 | `--video` | — | Input video (required for `video2world`) |
-| `--num-latent-conditional-frames` | — | V2W only; must be `1` or `2` |
+| `--num-latent-conditional-frames` | `2` | V2W only; must be `1` or `2` |
+| `--conditional-frame-timestep` | `0.0001` | Timestep value used for the conditional frames during denoising |
 | `--height` / `--width` | `704` / `1280` | Video resolution |
 | `--num-frames` | `93` | Number of output frames |
 | `--num-inference-steps` | `36` | Denoising steps |

--- a/examples/offline_inference/cosmos/cosmos_predict2_5.md
+++ b/examples/offline_inference/cosmos/cosmos_predict2_5.md
@@ -84,3 +84,16 @@ python cosmos_predict2_5.py \
 Input video must have at least `4 * (num_latent_conditional_frames - 1) + 1` frames:
 - `num_latent_conditional_frames=1` → minimum 1 frame
 - `num_latent_conditional_frames=2` → minimum 5 frames
+
+## Memory & Latency
+
+Measured on a single NVIDIA A100-SXM4-80GB at default settings (704×1280, 93 frames, 36 steps):
+
+| Model | Mode | Flags | Peak VRAM (BF16) | Wall time |
+|---|---|---|---|---|
+| `Cosmos-Predict2.5-2B` | Text2World | — | 36.6 GiB | ~13 min |
+| `Cosmos-Predict2.5-2B` | Image2World | — | 35.5 GiB | ~13 min |
+| `Cosmos-Predict2.5-2B` | Video2World | — | 36.5 GiB | ~13 min |
+| `Cosmos-Predict2.5-14B` | Text2World | `--enable-cpu-offload` | 49.2 GiB | ~48 min |
+
+At the default resolution the 2B model needs ~37 GiB; on smaller GPUs use `--enable-cpu-offload` and/or lower `--height`/`--width`/`--num-frames`.

--- a/examples/offline_inference/cosmos/cosmos_predict2_5.md
+++ b/examples/offline_inference/cosmos/cosmos_predict2_5.md
@@ -1,0 +1,76 @@
+# Cosmos-Predict2.5
+
+NVIDIA Cosmos-Predict2.5 supports text-to-video (T2W), image-to-video (I2W), and video-to-video (V2W) generation.
+
+> **Note:** Model requires `--revision diffusers/base/post-trained` to locate weights inside the HF repo.
+
+## Run Examples
+
+```bash
+cd examples/offline_inference/cosmos
+```
+
+### Text-to-Video (T2W)
+
+```bash
+python cosmos_predict2_5.py \
+  --mode text2world \
+  --prompt "A camera moving through a forest" \
+  --output output_t2w.mp4
+```
+
+### Image-to-Video (I2W)
+
+```bash
+python cosmos_predict2_5.py \
+  --mode image2world \
+  --image /path/to/image.jpg \
+  --prompt "The robot continues welding the metal structure" \
+  --output output_i2w.mp4
+```
+
+### Video-to-Video (V2W)
+
+```bash
+python cosmos_predict2_5.py \
+  --mode video2world \
+  --video /path/to/video.mp4 \
+  --prompt "The robot continues pouring liquid into the container" \
+  --num-latent-conditional-frames 2 \
+  --output output_v2w.mp4
+```
+
+## Arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `--mode` | required | `text2world`, `image2world`, or `video2world` |
+| `--model` | `nvidia/Cosmos-Predict2.5-2B` | Model ID or local path |
+| `--revision` | `diffusers/base/post-trained` | Required — model revision/branch |
+| `--prompt` | required | Text prompt |
+| `--negative-prompt` | `""` | Negative prompt |
+| `--image` | — | Input image (required for `image2world`) |
+| `--video` | — | Input video (required for `video2world`) |
+| `--num-latent-conditional-frames` | — | V2W only; must be `1` or `2` |
+| `--height` / `--width` | `704` / `1280` | Video resolution |
+| `--num-frames` | `93` | Number of output frames |
+| `--num-inference-steps` | `36` | Denoising steps |
+| `--guidance-scale` | `7.0` | CFG scale |
+| `--seed` | `42` | Random seed |
+| `--fps` | `16` | Output video frame rate |
+| `--output` | `./output.mp4` | Output file path |
+
+### Memory / Runtime
+
+| Argument | Description |
+|---|---|
+| `--vae-use-slicing` | Enable VAE slicing |
+| `--vae-use-tiling` | Enable VAE tiling |
+| `--enable-cpu-offload` | Offload diffusion modules to CPU |
+| `--enforce-eager` | Disable `torch.compile` |
+
+## V2W Frame Requirements
+
+Input video must have at least `4 * (num_latent_conditional_frames - 1) + 1` frames:
+- `num_latent_conditional_frames=1` → minimum 1 frame
+- `num_latent_conditional_frames=2` → minimum 5 frames

--- a/examples/offline_inference/cosmos/cosmos_predict2_5.py
+++ b/examples/offline_inference/cosmos/cosmos_predict2_5.py
@@ -39,9 +39,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--num-latent-conditional-frames",
         type=int,
-        default=None,
-        help="video2world only. Diffusers Cosmos supports 1 or 2.",
+        default=2,
+        help="video2world only. Must be 1 or 2.",
     )
+    parser.add_argument("--conditional-frame-timestep", type=float, default=0.0001)
 
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--guidance-scale", type=float, default=7.0)
@@ -72,13 +73,17 @@ def validate_args(args: argparse.Namespace) -> None:
 
 
 def build_extra_kwargs(args: argparse.Namespace) -> dict:
+    kwargs = {}
+    if args.conditional_frame_timestep is not None:
+        kwargs["conditional_frame_timestep"] = args.conditional_frame_timestep
     if args.mode == "image2world":
         image = Image.open(args.image).convert("RGB").resize((args.width, args.height))
-        return {"image": image}
+        kwargs["image"] = image
+        return kwargs
     if args.mode == "video2world":
         from diffusers.utils import load_video
 
-        kwargs = {"video": load_video(args.video)}
+        kwargs["video"] = load_video(args.video)
         if args.num_latent_conditional_frames is not None:
             kwargs["num_latent_conditional_frames"] = args.num_latent_conditional_frames
         return kwargs
@@ -118,10 +123,11 @@ def main() -> None:
         guidance_scale=args.guidance_scale,
         num_inference_steps=args.num_inference_steps,
         num_frames=args.num_frames,
+        extra_args=build_extra_kwargs(args),
     )
 
     start = time.perf_counter()
-    frames = omni.generate(prompt_dict, sampling, **build_extra_kwargs(args))
+    frames = omni.generate(prompt_dict, sampling)
     print(f"Generation time: {time.perf_counter() - start:.2f}s")
 
     if isinstance(frames, list):
@@ -132,34 +138,24 @@ def main() -> None:
             raise ValueError(
                 f"Unexpected output type '{frames.final_output_type}', expected 'image' for video generation."
             )
-        if frames.is_pipeline_output and frames.request_output is not None:
-            inner_output = frames.request_output
-            if isinstance(inner_output, OmniRequestOutput):
-                frames = inner_output
-        if isinstance(frames, OmniRequestOutput):
-            if frames.images:
-                if len(frames.images) == 1 and isinstance(frames.images[0], tuple) and len(frames.images[0]) == 2:
-                    frames = frames.images[0][0]
-                elif len(frames.images) == 1 and isinstance(frames.images[0], dict):
-                    frames = frames.images[0].get("frames") or frames.images[0].get("video")
-                else:
-                    frames = frames.images
-            else:
-                raise ValueError("No video frames found in OmniRequestOutput.")
+        if frames.is_pipeline_output and isinstance(frames.request_output, OmniRequestOutput):
+            frames = frames.request_output
+        frames = frames.images[0] if frames.images else None
 
-    if isinstance(frames, list) and frames:
-        first_item = frames[0]
-        if isinstance(first_item, tuple) and len(first_item) == 2:
-            frames = first_item[0]
-        elif isinstance(first_item, dict):
-            frames = first_item.get("frames") or first_item.get("video")
-        elif isinstance(first_item, list):
-            frames = first_item
-
-    if isinstance(frames, tuple) and len(frames) == 2:
+    # [numpy(T, H, W, C)] -> numpy(T, H, W, C)
+    if isinstance(frames, list) and frames and isinstance(frames[0], np.ndarray):
         frames = frames[0]
-    elif isinstance(frames, dict):
-        frames = frames.get("frames") or frames.get("video")
+
+    # Fallback for a raw tensor: -> numpy (T, H, W, C) in [0, 1]
+    if isinstance(frames, torch.Tensor):
+        frames = frames.detach().cpu()
+        if frames.dim() == 5:
+            frames = frames[0]
+        if frames.dim() == 4 and frames.shape[0] in (3, 4):
+            frames = frames.permute(1, 2, 3, 0)
+        if frames.is_floating_point():
+            frames = frames.clamp(-1, 1) * 0.5 + 0.5
+        frames = frames.float().numpy()
 
     if frames is None:
         raise ValueError("No video frames found in output.")
@@ -168,80 +164,7 @@ def main() -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     from diffusers.utils import export_to_video
 
-    def _normalize_frame(frame):
-        if isinstance(frame, torch.Tensor):
-            frame_tensor = frame.detach().cpu()
-            if frame_tensor.dim() == 4 and frame_tensor.shape[0] == 1:
-                frame_tensor = frame_tensor[0]
-            if frame_tensor.dim() == 3 and frame_tensor.shape[0] in (3, 4):
-                frame_tensor = frame_tensor.permute(1, 2, 0)
-            if frame_tensor.is_floating_point():
-                frame_tensor = frame_tensor.clamp(-1, 1) * 0.5 + 0.5
-            return frame_tensor.float().numpy()
-        if isinstance(frame, np.ndarray):
-            frame_array = frame
-            if frame_array.ndim == 4 and frame_array.shape[0] == 1:
-                frame_array = frame_array[0]
-            if np.issubdtype(frame_array.dtype, np.integer):
-                frame_array = frame_array.astype(np.float32) / 255.0
-            return frame_array
-        try:
-            from PIL import Image as _Image
-        except ImportError:
-            _Image = None
-        if _Image is not None and isinstance(frame, _Image.Image):
-            return np.asarray(frame).astype(np.float32) / 255.0
-        return frame
-
-    def _ensure_frame_list(video_array):
-        if isinstance(video_array, list):
-            if len(video_array) == 0:
-                return video_array
-            first_item = video_array[0]
-            if isinstance(first_item, np.ndarray):
-                if first_item.ndim == 5:
-                    return list(first_item[0])
-                if first_item.ndim == 4:
-                    return list(first_item)
-                if first_item.ndim == 3:
-                    return video_array
-            return video_array
-        if isinstance(video_array, np.ndarray):
-            if video_array.ndim == 5:
-                return list(video_array[0])
-            if video_array.ndim == 4:
-                return list(video_array)
-            if video_array.ndim == 3:
-                return [video_array]
-        return video_array
-
-    if isinstance(frames, torch.Tensor):
-        video_tensor = frames.detach().cpu()
-        if video_tensor.dim() == 5:
-            if video_tensor.shape[1] in (3, 4):
-                video_tensor = video_tensor[0].permute(1, 2, 3, 0)
-            else:
-                video_tensor = video_tensor[0]
-        elif video_tensor.dim() == 4 and video_tensor.shape[0] in (3, 4):
-            video_tensor = video_tensor.permute(1, 2, 3, 0)
-        if video_tensor.is_floating_point():
-            video_tensor = video_tensor.clamp(-1, 1) * 0.5 + 0.5
-        video_array = video_tensor.float().numpy()
-    elif isinstance(frames, np.ndarray):
-        video_array = frames
-        if video_array.ndim == 5:
-            video_array = video_array[0]
-        if np.issubdtype(video_array.dtype, np.integer):
-            video_array = video_array.astype(np.float32) / 255.0
-    elif isinstance(frames, list):
-        if len(frames) == 0:
-            raise ValueError("No video frames found in output.")
-        video_array = [_normalize_frame(frame) for frame in frames]
-    else:
-        video_array = frames
-
-    video_array = _ensure_frame_list(video_array)
-    export_to_video(video_array, str(out_path), fps=args.fps)
+    export_to_video(frames, str(out_path), fps=args.fps)
     print(f"Saved to {out_path}")
 
 

--- a/examples/offline_inference/cosmos/cosmos_predict2_5.py
+++ b/examples/offline_inference/cosmos/cosmos_predict2_5.py
@@ -157,6 +157,10 @@ def main() -> None:
             frames = frames.clamp(-1, 1) * 0.5 + 0.5
         frames = frames.float().numpy()
 
+    # postprocess_video returns a batched array: (B, T, H, W, C) -> (T, H, W, C)
+    if isinstance(frames, np.ndarray) and frames.ndim == 5:
+        frames = frames[0]
+
     if frames is None:
         raise ValueError("No video frames found in output.")
 

--- a/examples/offline_inference/cosmos/cosmos_predict2_5.py
+++ b/examples/offline_inference/cosmos/cosmos_predict2_5.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Cosmos-Predict2.5 offline inference: text2world (T2W), image2world (I2W), video2world (V2W).
+
+Note: this model requires --revision to locate weights inside the HF repo.
+"""
+
+import argparse
+import os
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+
+from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.platforms import current_omni_platform
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Cosmos-Predict2.5 unified script for text2world, image2world, and video2world."
+    )
+
+    parser.add_argument(
+        "--mode",
+        required=True,
+        choices=["text2world", "image2world", "video2world"],
+    )
+    parser.add_argument("--model", default="nvidia/Cosmos-Predict2.5-2B")
+    parser.add_argument("--revision", default="diffusers/base/post-trained")
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--negative-prompt", default="")
+    parser.add_argument("--image", help="Input image for image2world.")
+    parser.add_argument("--video", help="Input video for video2world.")
+    parser.add_argument(
+        "--num-latent-conditional-frames",
+        type=int,
+        default=None,
+        help="video2world only. Diffusers Cosmos supports 1 or 2.",
+    )
+
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--guidance-scale", type=float, default=7.0)
+    parser.add_argument("--height", type=int, default=704)
+    parser.add_argument("--width", type=int, default=1280)
+    parser.add_argument("--num-frames", type=int, default=93)
+    parser.add_argument("--num-inference-steps", type=int, default=36)
+    parser.add_argument("--fps", type=int, default=16)
+    parser.add_argument("--output", default="./output.mp4")
+
+    parser.add_argument("--vae-use-slicing", action="store_true")
+    parser.add_argument("--vae-use-tiling", action="store_true")
+    parser.add_argument("--enable-cpu-offload", action="store_true")
+    parser.add_argument("--enforce-eager", action="store_true")
+
+    return parser.parse_args()
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if args.mode == "image2world":
+        if not args.image or not os.path.exists(args.image):
+            raise ValueError(f"--image required and must exist for image2world: {args.image}")
+    if args.mode == "video2world":
+        if not args.video or not os.path.exists(args.video):
+            raise ValueError(f"--video required and must exist for video2world: {args.video}")
+        if args.num_latent_conditional_frames is not None and args.num_latent_conditional_frames not in (1, 2):
+            raise ValueError("--num-latent-conditional-frames must be 1 or 2")
+
+
+def build_extra_kwargs(args: argparse.Namespace) -> dict:
+    if args.mode == "image2world":
+        image = Image.open(args.image).convert("RGB").resize((args.width, args.height))
+        return {"image": image}
+    if args.mode == "video2world":
+        from diffusers.utils import load_video
+
+        kwargs = {"video": load_video(args.video)}
+        if args.num_latent_conditional_frames is not None:
+            kwargs["num_latent_conditional_frames"] = args.num_latent_conditional_frames
+        return kwargs
+    return {}
+
+
+def main() -> None:
+    args = parse_args()
+    validate_args(args)
+
+    generator = torch.Generator(device=current_omni_platform.device_type).manual_seed(args.seed)
+
+    print(f"\n{'=' * 60}")
+    print(f"Cosmos-Predict2.5 [{args.mode}] | {args.model}@{args.revision}")
+    print(f"  prompt:  {args.prompt}")
+    print(f"  size:    {args.width}x{args.height}, {args.num_frames} frames @ {args.fps}fps")
+    print(f"  steps:   {args.num_inference_steps}, cfg={args.guidance_scale}")
+    print(f"{'=' * 60}\n")
+
+    omni = Omni(
+        model=args.model,
+        revision=args.revision,
+        vae_use_slicing=args.vae_use_slicing,
+        vae_use_tiling=args.vae_use_tiling,
+        enable_cpu_offload=args.enable_cpu_offload,
+        enforce_eager=args.enforce_eager,
+    )
+
+    prompt_dict = {"prompt": args.prompt}
+    if args.negative_prompt:
+        prompt_dict["negative_prompt"] = args.negative_prompt
+
+    sampling = OmniDiffusionSamplingParams(
+        height=args.height,
+        width=args.width,
+        generator=generator,
+        guidance_scale=args.guidance_scale,
+        num_inference_steps=args.num_inference_steps,
+        num_frames=args.num_frames,
+    )
+
+    start = time.perf_counter()
+    frames = omni.generate(prompt_dict, sampling, **build_extra_kwargs(args))
+    print(f"Generation time: {time.perf_counter() - start:.2f}s")
+
+    if isinstance(frames, list):
+        frames = frames[0] if frames else None
+
+    if isinstance(frames, OmniRequestOutput):
+        if frames.final_output_type != "image":
+            raise ValueError(
+                f"Unexpected output type '{frames.final_output_type}', expected 'image' for video generation."
+            )
+        if frames.is_pipeline_output and frames.request_output is not None:
+            inner_output = frames.request_output
+            if isinstance(inner_output, OmniRequestOutput):
+                frames = inner_output
+        if isinstance(frames, OmniRequestOutput):
+            if frames.images:
+                if len(frames.images) == 1 and isinstance(frames.images[0], tuple) and len(frames.images[0]) == 2:
+                    frames = frames.images[0][0]
+                elif len(frames.images) == 1 and isinstance(frames.images[0], dict):
+                    frames = frames.images[0].get("frames") or frames.images[0].get("video")
+                else:
+                    frames = frames.images
+            else:
+                raise ValueError("No video frames found in OmniRequestOutput.")
+
+    if isinstance(frames, list) and frames:
+        first_item = frames[0]
+        if isinstance(first_item, tuple) and len(first_item) == 2:
+            frames = first_item[0]
+        elif isinstance(first_item, dict):
+            frames = first_item.get("frames") or first_item.get("video")
+        elif isinstance(first_item, list):
+            frames = first_item
+
+    if isinstance(frames, tuple) and len(frames) == 2:
+        frames = frames[0]
+    elif isinstance(frames, dict):
+        frames = frames.get("frames") or frames.get("video")
+
+    if frames is None:
+        raise ValueError("No video frames found in output.")
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    from diffusers.utils import export_to_video
+
+    def _normalize_frame(frame):
+        if isinstance(frame, torch.Tensor):
+            frame_tensor = frame.detach().cpu()
+            if frame_tensor.dim() == 4 and frame_tensor.shape[0] == 1:
+                frame_tensor = frame_tensor[0]
+            if frame_tensor.dim() == 3 and frame_tensor.shape[0] in (3, 4):
+                frame_tensor = frame_tensor.permute(1, 2, 0)
+            if frame_tensor.is_floating_point():
+                frame_tensor = frame_tensor.clamp(-1, 1) * 0.5 + 0.5
+            return frame_tensor.float().numpy()
+        if isinstance(frame, np.ndarray):
+            frame_array = frame
+            if frame_array.ndim == 4 and frame_array.shape[0] == 1:
+                frame_array = frame_array[0]
+            if np.issubdtype(frame_array.dtype, np.integer):
+                frame_array = frame_array.astype(np.float32) / 255.0
+            return frame_array
+        try:
+            from PIL import Image as _Image
+        except ImportError:
+            _Image = None
+        if _Image is not None and isinstance(frame, _Image.Image):
+            return np.asarray(frame).astype(np.float32) / 255.0
+        return frame
+
+    def _ensure_frame_list(video_array):
+        if isinstance(video_array, list):
+            if len(video_array) == 0:
+                return video_array
+            first_item = video_array[0]
+            if isinstance(first_item, np.ndarray):
+                if first_item.ndim == 5:
+                    return list(first_item[0])
+                if first_item.ndim == 4:
+                    return list(first_item)
+                if first_item.ndim == 3:
+                    return video_array
+            return video_array
+        if isinstance(video_array, np.ndarray):
+            if video_array.ndim == 5:
+                return list(video_array[0])
+            if video_array.ndim == 4:
+                return list(video_array)
+            if video_array.ndim == 3:
+                return [video_array]
+        return video_array
+
+    if isinstance(frames, torch.Tensor):
+        video_tensor = frames.detach().cpu()
+        if video_tensor.dim() == 5:
+            if video_tensor.shape[1] in (3, 4):
+                video_tensor = video_tensor[0].permute(1, 2, 3, 0)
+            else:
+                video_tensor = video_tensor[0]
+        elif video_tensor.dim() == 4 and video_tensor.shape[0] in (3, 4):
+            video_tensor = video_tensor.permute(1, 2, 3, 0)
+        if video_tensor.is_floating_point():
+            video_tensor = video_tensor.clamp(-1, 1) * 0.5 + 0.5
+        video_array = video_tensor.float().numpy()
+    elif isinstance(frames, np.ndarray):
+        video_array = frames
+        if video_array.ndim == 5:
+            video_array = video_array[0]
+        if np.issubdtype(video_array.dtype, np.integer):
+            video_array = video_array.astype(np.float32) / 255.0
+    elif isinstance(frames, list):
+        if len(frames) == 0:
+            raise ValueError("No video frames found in output.")
+        video_array = [_normalize_frame(frame) for frame in frames]
+    else:
+        video_array = frames
+
+    video_array = _ensure_frame_list(video_array)
+    export_to_video(video_array, str(out_path), fps=args.fps)
+    print(f"Saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -838,7 +838,7 @@ class OmniDiffusionConfig:
             self.model_class_name = "DiffusersAdapterPipeline"
 
         try:
-            config_dict = get_hf_file_to_dict("model_index.json", self.model)
+            config_dict = get_hf_file_to_dict("model_index.json", self.model, revision=self.revision)
             if config_dict is not None:
                 if self.model_class_name is None:
                     self.model_class_name = config_dict.get("_class_name", None)
@@ -858,7 +858,7 @@ class OmniDiffusionConfig:
                             exc,
                         )
                 else:
-                    tf_config_dict = get_hf_file_to_dict("transformer/config.json", self.model)
+                    tf_config_dict = get_hf_file_to_dict("transformer/config.json", self.model, revision=self.revision)
                     self.set_tf_model_config(TransformerConfig.from_dict(tf_config_dict))
             else:
                 raise FileNotFoundError("model_index.json not found")
@@ -875,7 +875,7 @@ class OmniDiffusionConfig:
                     "that require additional inputs."
                 )
             else:
-                cfg = get_hf_file_to_dict("config.json", self.model)
+                cfg = get_hf_file_to_dict("config.json", self.model, revision=self.revision)
                 if cfg is None:
                     raise ValueError(f"Could not find config.json or model_index.json for model {self.model}")
 

--- a/vllm_omni/diffusion/models/cosmos/__init__.py
+++ b/vllm_omni/diffusion/models/cosmos/__init__.py
@@ -1,15 +1,12 @@
+from .cosmos_transformer import CosmosTransformer3DModel
 from .pipeline_cosmos_predict2_5 import (
     CosmosPredict25Pipeline,
     get_cosmos_predict25_post_process_func,
 )
-from .cosmos_transformer import CosmosTransformer3DModel
 
 __all__ = [
     "CosmosTransformer3DModel",
     "CosmosPredict25Pipeline",
     "get_cosmos_predict25_post_process_func",
-    "retrieve_latents",
-    "load_transformer_config",
-    "create_transformer_from_config",
-    "CosmosTransformer3DModel",    
+    "CosmosTransformer3DModel",
 ]

--- a/vllm_omni/diffusion/models/cosmos/__init__.py
+++ b/vllm_omni/diffusion/models/cosmos/__init__.py
@@ -1,0 +1,15 @@
+from .pipeline_cosmos_predict2_5 import (
+    CosmosPredict25Pipeline,
+    get_cosmos_predict25_post_process_func,
+)
+from .cosmos_transformer import CosmosTransformer3DModel
+
+__all__ = [
+    "CosmosTransformer3DModel",
+    "CosmosPredict25Pipeline",
+    "get_cosmos_predict25_post_process_func",
+    "retrieve_latents",
+    "load_transformer_config",
+    "create_transformer_from_config",
+    "CosmosTransformer3DModel",    
+]

--- a/vllm_omni/diffusion/models/cosmos/__init__.py
+++ b/vllm_omni/diffusion/models/cosmos/__init__.py
@@ -8,5 +8,4 @@ __all__ = [
     "CosmosTransformer3DModel",
     "CosmosPredict25Pipeline",
     "get_cosmos_predict25_post_process_func",
-    "CosmosTransformer3DModel",
 ]

--- a/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
+++ b/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
@@ -17,55 +17,412 @@
 
 
 from collections.abc import Iterable
+from typing import Any
 
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from diffusers.models.embeddings import Timesteps
-from vllm.logger import init_logger
-from vllm.model_executor.layers.layernorm import RMSNorm as DistributedRMSNorm
-from vllm.model_executor.layers.linear import (
-    ColumnParallelLinear,
-    QKVParallelLinear,
-    RowParallelLinear,
-)
 
-from vllm_omni.diffusion.data import OmniDiffusionConfig
+from diffusers.models.embeddings import Timesteps
+from diffusers.models.attention import FeedForward
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+from vllm.logger import init_logger
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import QKVParallelLinear, ReplicatedLinear
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm_omni.diffusion.attention.layer import Attention
 
 logger = init_logger(__name__)
 
 
-def apply_rotary_emb_cosmos(
-    hidden_states: torch.Tensor,
-    freqs_cos: torch.Tensor,
-    freqs_sin: torch.Tensor,
-) -> torch.Tensor:
-    """
-    Apply rotary embeddings to input tensors using the given frequency tensors.
+class CosmosPatchEmbed(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        patch_size: tuple[int, int, int],
+        bias: bool = True,
+    ):
+        super().__init__()
+        self.patch_size = patch_size
+        self.proj = nn.Linear(
+            in_channels * patch_size[0] * patch_size[1] * patch_size[2],
+            out_channels,
+            bias=bias,
+        )
 
-    Args:
-        hidden_states: Input tensor of shape [B, S, H, D]
-        freqs_cos: Cosine frequencies
-        freqs_sin: Sine frequencies
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        p_t, p_h, p_w = self.patch_size
 
-    Returns:
-        Tensor with rotary embeddings applied
+        hidden_states = hidden_states.reshape(
+            batch_size,
+            num_channels,
+            num_frames // p_t,
+            p_t,
+            height // p_h,
+            p_h,
+            width // p_w,
+            p_w,
+        )
+
+        hidden_states = hidden_states.permute(0, 2, 4, 6, 1, 3, 5, 7).flatten(4, 7)
+        hidden_states = self.proj(hidden_states)
+        return hidden_states
+
+
+class CosmosTimestepEmbedding(nn.Module):
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self.linear_1 = nn.Linear(in_features, out_features, bias=False)
+        self.activation = nn.SiLU()
+        self.linear_2 = nn.Linear(out_features, 3 * out_features, bias=False)
+
+    def forward(self, timesteps: torch.Tensor) -> torch.Tensor:
+        emb = self.linear_1(timesteps)
+        emb = self.activation(emb)
+        emb = self.linear_2(emb)
+        return emb
+
+
+class CosmosEmbedding(nn.Module):
+    def __init__(self, embedding_dim: int, condition_dim: int):
+        super().__init__()
+
+        self.time_proj = Timesteps(
+            embedding_dim,
+            flip_sin_to_cos=True,
+            downscale_freq_shift=0.0,
+        )
+        self.t_embedder = CosmosTimestepEmbedding(embedding_dim, condition_dim)
+        self.norm = RMSNorm(embedding_dim, eps=1e-6)
+
+    def forward(self, hidden_states: torch.Tensor, timestep: torch.LongTensor) -> torch.Tensor:
+        timesteps_proj = self.time_proj(timestep).type_as(hidden_states)
+        temb = self.t_embedder(timesteps_proj)
+        embedded_timestep = self.norm(timesteps_proj)
+        return temb, embedded_timestep
+
+
+class CosmosAdaLayerNorm(nn.Module):
+    def __init__(self, in_features: int, hidden_features: int):
+        super().__init__()
+        self.embedding_dim = in_features
+
+        self.activation = nn.SiLU()
+        self.norm = nn.LayerNorm(in_features, elementwise_affine=False, eps=1e-6)
+        self.linear_1 = nn.Linear(in_features, hidden_features, bias=False)
+        self.linear_2 = nn.Linear(hidden_features, 2 * in_features, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        embedded_timestep: torch.Tensor,
+        temb: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        embedded_timestep = self.activation(embedded_timestep)
+        embedded_timestep = self.linear_1(embedded_timestep)
+        embedded_timestep = self.linear_2(embedded_timestep)
+
+        if temb is not None:
+            embedded_timestep = embedded_timestep + temb[..., : 2 * self.embedding_dim]
+
+        shift, scale = embedded_timestep.chunk(2, dim=-1)
+        hidden_states = self.norm(hidden_states)
+
+        if embedded_timestep.ndim == 2:
+            shift, scale = (x.unsqueeze(1) for x in (shift, scale))
+
+        hidden_states = hidden_states * (1 + scale) + shift
+        return hidden_states
+
+
+class CosmosAdaLayerNormZero(nn.Module):
+    def __init__(self, in_features: int, hidden_features: int | None = None):
+        super().__init__()
+
+        self.norm = nn.LayerNorm(in_features, elementwise_affine=False, eps=1e-6)
+        self.activation = nn.SiLU()
+
+        if hidden_features is None:
+            self.linear_1 = nn.Identity()
+        else:
+            self.linear_1 = nn.Linear(in_features, hidden_features, bias=False)
+
+        self.linear_2 = nn.Linear(hidden_features, 3 * in_features, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        embedded_timestep: torch.Tensor,
+        temb: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        embedded_timestep = self.activation(embedded_timestep)
+        embedded_timestep = self.linear_1(embedded_timestep)
+        embedded_timestep = self.linear_2(embedded_timestep)
+
+        if temb is not None:
+            embedded_timestep = embedded_timestep + temb
+
+        shift, scale, gate = embedded_timestep.chunk(3, dim=-1)
+        hidden_states = self.norm(hidden_states)
+
+        if embedded_timestep.ndim == 2:
+            shift, scale, gate = (x.unsqueeze(1) for x in (shift, scale, gate))
+
+        hidden_states = hidden_states * (1 + scale) + shift
+        return hidden_states, gate
+
+
+class CosmosSelfAttention(nn.Module):
     """
-    x1, x2 = hidden_states.unflatten(-1, (-1, 2)).unbind(-1)
-    cos = freqs_cos[..., 0::2]
-    sin = freqs_sin[..., 1::2]
-    out = torch.empty_like(hidden_states)
-    out[..., 0::2] = x1 * cos - x2 * sin
-    out[..., 1::2] = x1 * sin + x2 * cos
-    return out.type_as(hidden_states)
+    Optimized self-attention module using vLLM layers.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        head_dim: int,
+        eps: float = 1e-5,
+        dropout: float = 0.0,
+        bias: bool = False,
+    ):
+        super().__init__()
+
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.inner_dim = num_heads * head_dim
+
+        # QK normalization using vLLM's RMSNorm
+        self.norm_q = RMSNorm(self.head_dim, eps=eps)
+        self.norm_k = RMSNorm(self.head_dim, eps=eps)
+
+        # Fused QKV projection using vLLM's optimized layer
+        self.to_qkv = QKVParallelLinear(
+            hidden_size=dim,
+            head_size=head_dim,
+            total_num_heads=num_heads,
+            bias=bias,
+            disable_tp=True,
+        )
+
+        # Output projection
+        self.to_out = nn.ModuleList(
+            [
+                ReplicatedLinear(self.inner_dim, dim, bias=bias),
+                nn.Dropout(dropout),
+            ]
+        )
+
+        self.attn = Attention(
+             num_heads=num_heads,
+             head_size=head_dim,
+             softmax_scale=1.0 / (head_dim**0.5),
+             causal=False,
+        )
+
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        # Fused QKV projection
+        qkv, _ = self.to_qkv(hidden_states)
+        query, key, value = qkv.chunk(3, dim=-1)
+
+        query = query.unflatten(2, (self.num_heads, -1)).transpose(1, 2)
+        key = key.unflatten(2, (self.num_heads, -1)).transpose(1, 2)
+        value = value.unflatten(2, (self.num_heads, -1)).transpose(1, 2)
+
+        # Apply QK normalization
+        query = self.norm_q(query)
+        key = self.norm_k(key)
+
+        # Apply rotary embeddings
+        if image_rotary_emb is not None:
+            from diffusers.models.embeddings import apply_rotary_emb
+
+            query = apply_rotary_emb(query, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
+            key = apply_rotary_emb(key, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
+
+        # Attention
+        hidden_states = self.attn(query.transpose(1, 2), key.transpose(1, 2), value.transpose(1, 2))
+
+        hidden_states = hidden_states.flatten(2, 3).type_as(query)
+
+        # Output projection
+        hidden_states, _ = self.to_out[0](hidden_states)
+        hidden_states = self.to_out[1](hidden_states)
+
+        return hidden_states
+
+
+class CosmosCrossAttention(nn.Module):
+    """
+    Optimized cross-attention module using vLLM layers.
+    """
+
+    def __init__(
+        self,
+        query_dim: int,
+        cross_attention_dim: int,
+        heads: int = 16,
+        kv_heads: int | None = None,
+        dim_head: int = 128,
+        dropout: float = 0.0,
+        bias: bool = False,
+        eps: float = 1e-5,
+        out_dim: int | None = None,
+    ):
+        super().__init__()
+
+        self.inner_dim = out_dim if out_dim is not None else dim_head * heads
+        self.inner_kv_dim = self.inner_dim if kv_heads is None else dim_head * kv_heads
+        self.out_dim = out_dim if out_dim is not None else query_dim
+        self.heads = heads
+        self.dim_head = dim_head
+        self.cross_attention_dim = cross_attention_dim
+
+        # QK normalization
+        self.norm_q = RMSNorm(self.dim_head, eps=eps)
+        self.norm_k = RMSNorm(self.dim_head, eps=eps)
+
+        # Query projection
+        self.to_q = ReplicatedLinear(query_dim, self.inner_dim, bias=bias)
+        
+        # Separate K and V projections for cross-attention
+        self.to_k = ReplicatedLinear(self.cross_attention_dim, self.inner_kv_dim, bias=bias)
+        self.to_v = ReplicatedLinear(self.cross_attention_dim, self.inner_kv_dim, bias=bias)
+
+        # Output projection
+        self.to_out = nn.ModuleList(
+            [
+                ReplicatedLinear(self.inner_dim, self.out_dim, bias=bias),
+                nn.Dropout(dropout),
+            ]
+        )
+
+        self.attn = Attention(
+             num_heads=heads,
+             head_size=dim_head,
+             softmax_scale=1.0 / (dim_head**0.5),
+             causal=False,
+        )
+
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        image_rotary_emb=None,
+    ) -> torch.Tensor:
+        # Query projection
+        query, _ = self.to_q(hidden_states)
+
+        # KV projection from encoder
+        key, _ = self.to_k(encoder_hidden_states)
+        value, _ = self.to_v(encoder_hidden_states)
+
+        query = query.unflatten(2, (self.heads, -1)).transpose(1, 2)
+        key = key.unflatten(2, (self.heads, -1)).transpose(1, 2)
+        value = value.unflatten(2, (self.heads, -1)).transpose(1, 2)
+
+        query = self.norm_q(query)
+        key = self.norm_k(key)
+
+        if image_rotary_emb is not None:
+            from diffusers.models.embeddings import apply_rotary_emb
+
+            query = apply_rotary_emb(query, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
+            key = apply_rotary_emb(key, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
+
+        hidden_states = self.attn(query.transpose(1, 2), key.transpose(1, 2), value.transpose(1, 2))
+        hidden_states = hidden_states.flatten(2, 3).type_as(query)
+
+        # Output projection
+        hidden_states, _ = self.to_out[0](hidden_states)
+        hidden_states = self.to_out[1](hidden_states)
+                
+        return hidden_states
+
+class CosmosTransformerBlock(nn.Module):
+    """
+    Cosmos Transformer Block with self-attention, cross-attention, and feedforward.
+    """
+
+    def __init__(
+        self,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        cross_attention_dim: int,
+        mlp_ratio: float = 4.0,
+        adaln_lora_dim: int = 256,
+        out_bias: bool = False,
+    ):
+        super().__init__()
+
+        hidden_size = num_attention_heads * attention_head_dim
+
+        self.norm1 = CosmosAdaLayerNormZero(in_features=hidden_size, hidden_features=adaln_lora_dim)
+        self.attn1 = CosmosSelfAttention(
+            dim=hidden_size,
+            num_heads=num_attention_heads,
+            head_dim=attention_head_dim,         
+            dropout=0.0,
+            bias=False,
+            eps=1e-5,
+        )
+
+        self.norm2 = CosmosAdaLayerNormZero(in_features=hidden_size, hidden_features=adaln_lora_dim)
+        self.attn2 = CosmosCrossAttention(
+            query_dim=hidden_size,
+            cross_attention_dim=cross_attention_dim,
+            heads=num_attention_heads,
+            dim_head=attention_head_dim,            
+            dropout=0.0,
+            bias=False,
+            eps=1e-5,
+        )
+
+        self.norm3 = CosmosAdaLayerNormZero(in_features=hidden_size, hidden_features=adaln_lora_dim)
+        self.ff = FeedForward(hidden_size, mult=mlp_ratio, activation_fn="gelu", bias=out_bias)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        embedded_timestep: torch.Tensor,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
+        temb: torch.Tensor | None = None,
+        extra_pos_emb: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        embedded_timestep = embedded_timestep.type_as(hidden_states)
+
+        if extra_pos_emb is not None:
+            hidden_states = hidden_states + extra_pos_emb
+
+        # Self Attention
+        norm_hidden, gate = self.norm1(hidden_states, embedded_timestep, temb)
+        attn_output = self.attn1(norm_hidden, image_rotary_emb=image_rotary_emb)
+        hidden_states = hidden_states + gate * attn_output
+
+        # Cross Attention
+        norm_hidden, gate = self.norm2(hidden_states, embedded_timestep, temb)
+        attn_output = self.attn2(norm_hidden, encoder_hidden_states=encoder_hidden_states)
+        hidden_states = hidden_states + gate * attn_output
+
+        # Feed Forward
+        norm_hidden, gate = self.norm3(hidden_states, embedded_timestep, temb)
+        ff_output = self.ff(norm_hidden)
+        hidden_states = hidden_states + gate * ff_output
+
+        return hidden_states
 
 
 class CosmosRotaryPosEmbed(nn.Module):
-    """
-    Rotary Position Embeddings (RoPE) for 3D video data with NTK-aware scaling.
-    """
-
     def __init__(
         self,
         hidden_size: int,
@@ -124,15 +481,16 @@ class CosmosRotaryPosEmbed(nn.Module):
         emb_h = torch.outer(seq[: pe_size[1]], h_spatial_freqs)[None, :, None, :].repeat(pe_size[0], 1, pe_size[2], 1)
         emb_w = torch.outer(seq[: pe_size[2]], w_spatial_freqs)[None, None, :, :].repeat(pe_size[0], pe_size[1], 1, 1)
 
+        # Apply sequence scaling in temporal dimension
         if fps is None:
+            # Images
             emb_t = torch.outer(seq[: pe_size[0]], temporal_freqs)
         else:
+            # Videos
             emb_t = torch.outer(seq[: pe_size[0]] / fps * self.base_fps, temporal_freqs)
 
         emb_t = emb_t[:, None, None, :].repeat(1, pe_size[1], pe_size[2], 1)
-
         freqs = torch.cat([emb_t, emb_h, emb_w] * 2, dim=-1).flatten(0, 2).float()
-
         cos = torch.cos(freqs)
         sin = torch.sin(freqs)
 
@@ -140,10 +498,6 @@ class CosmosRotaryPosEmbed(nn.Module):
 
 
 class CosmosLearnablePositionalEmbed(nn.Module):
-    """
-    Learnable 3D positional embeddings for temporal, height, and width dimensions.
-    """
-
     def __init__(
         self,
         hidden_size: int,
@@ -172,7 +526,6 @@ class CosmosLearnablePositionalEmbed(nn.Module):
         emb_t = self.pos_emb_t[: pe_size[0]][None, :, None, None, :].repeat(batch_size, 1, pe_size[1], pe_size[2], 1)
         emb_h = self.pos_emb_h[: pe_size[1]][None, None, :, None, :].repeat(batch_size, pe_size[0], 1, pe_size[2], 1)
         emb_w = self.pos_emb_w[: pe_size[2]][None, None, None, :, :].repeat(batch_size, pe_size[0], pe_size[1], 1, 1)
-
         emb = emb_t + emb_h + emb_w
         emb = emb.flatten(1, 3)
 
@@ -182,449 +535,39 @@ class CosmosLearnablePositionalEmbed(nn.Module):
         return (emb / norm).type_as(hidden_states)
 
 
-class CosmosPatchEmbed(nn.Module):
-    """
-    Patch embedding for 3D video inputs.
-    """
-
-    def __init__(
-        self,
-        in_channels: int,
-        out_channels: int,
-        patch_size: tuple[int, int, int],
-        bias: bool = True,
-    ):
-        super().__init__()
-        self.patch_size = patch_size
-        self.proj = nn.Linear(
-            in_channels * patch_size[0] * patch_size[1] * patch_size[2],
-            out_channels,
-            bias=bias,
-        )
-
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        batch_size, num_channels, num_frames, height, width = hidden_states.shape
-        p_t, p_h, p_w = self.patch_size
-
-        hidden_states = hidden_states.reshape(
-            batch_size,
-            num_channels,
-            num_frames // p_t,
-            p_t,
-            height // p_h,
-            p_h,
-            width // p_w,
-            p_w,
-        )
-
-        hidden_states = hidden_states.permute(0, 2, 4, 6, 1, 3, 5, 7).flatten(4, 7)
-        hidden_states = hidden_states.type_as(self.proj.weight)
-        hidden_states = self.proj(hidden_states)
-        return hidden_states
-
-
-class CosmosTimestepEmbedding(nn.Module):
-    """
-    MLP for processing timestep embeddings.
-    """
-
-    def __init__(self, in_features: int, out_features: int):
-        super().__init__()
-        self.linear_1 = nn.Linear(in_features, out_features, bias=False)
-        self.activation = nn.SiLU()
-        self.linear_2 = nn.Linear(out_features, 3 * out_features, bias=False)
-
-    def forward(self, timesteps: torch.Tensor) -> torch.Tensor:
-        emb = self.linear_1(timesteps.to(self.linear_1.weight.dtype))
-        emb = self.activation(emb)
-        emb = self.linear_2(emb)
-        return emb
-
-
-class CosmosEmbedding(nn.Module):
-    """
-    Complete timestep conditioning module.
-    """
-
-    def __init__(self, embedding_dim: int, condition_dim: int):
-        super().__init__()
-
-        self.time_proj = Timesteps(
-            embedding_dim,
-            flip_sin_to_cos=True,
-            downscale_freq_shift=0.0,
-        )
-        self.t_embedder = CosmosTimestepEmbedding(embedding_dim, condition_dim)
-        self.norm = nn.RMSNorm(embedding_dim, eps=1e-6, elementwise_affine=True)
-
-    def forward(self, hidden_states: torch.Tensor, timestep: torch.LongTensor) -> torch.Tensor:
-        timesteps_proj = self.time_proj(timestep).type_as(hidden_states)
-        temb = self.t_embedder(timesteps_proj)
-        embedded_timestep = self.norm(timesteps_proj)
-        return temb, embedded_timestep
-
-
-class CosmosAdaLayerNorm(nn.Module):
-    """
-    Adaptive Layer Normalization (AdaLN) without gate.
-    """
-
-    def __init__(self, in_features: int, hidden_features: int):
-        super().__init__()
-
-        self.embedding_dim = in_features
-        self.norm = nn.LayerNorm(in_features, elementwise_affine=False, eps=1e-6)
-        self.activation = nn.SiLU()
-
-        self.linear_1 = nn.Linear(in_features, hidden_features, bias=False)
-        self.linear_2 = nn.Linear(hidden_features, 2 * in_features, bias=False)
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        embedded_timestep: torch.Tensor,
-        temb: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        embedded_timestep = self.activation(embedded_timestep)
-        embedded_timestep = self.linear_1(embedded_timestep)
-        embedded_timestep = self.linear_2(embedded_timestep)
-
-        if temb is not None:
-            embedded_timestep = embedded_timestep + temb[..., : 2 * self.embedding_dim]
-
-        shift, scale = embedded_timestep.chunk(2, dim=-1)
-        hidden_states = self.norm(hidden_states)
-
-        if embedded_timestep.ndim == 2:
-            shift, scale = (x.unsqueeze(1) for x in (shift, scale))
-
-        hidden_states = hidden_states * (1 + scale) + shift
-        return hidden_states
-
-
-class CosmosAdaLayerNormZero(nn.Module):
-    """
-    Adaptive Layer Normalization with zero initialization (AdaLN-Zero).
-    """
-
-    def __init__(self, in_features: int, hidden_features: int | None = None):
-        super().__init__()
-
-        self.norm = nn.LayerNorm(in_features, elementwise_affine=False, eps=1e-6)
-        self.activation = nn.SiLU()
-
-        if hidden_features is None:
-            self.linear_1 = nn.Identity()
-        else:
-            self.linear_1 = nn.Linear(in_features, hidden_features, bias=False)
-
-        self.linear_2 = nn.Linear(hidden_features, 3 * in_features, bias=False)
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        embedded_timestep: torch.Tensor,
-        temb: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        embedded_timestep = self.activation(embedded_timestep)
-        embedded_timestep = self.linear_1(embedded_timestep)
-        embedded_timestep = self.linear_2(embedded_timestep)
-
-        if temb is not None:
-            embedded_timestep = embedded_timestep + temb
-
-        shift, scale, gate = embedded_timestep.chunk(3, dim=-1)
-        hidden_states = self.norm(hidden_states)
-
-        if embedded_timestep.ndim == 2:
-            shift, scale, gate = (x.unsqueeze(1) for x in (shift, scale, gate))
-
-        hidden_states = hidden_states * (1 + scale) + shift
-        return hidden_states, gate
-
-
-class CosmosAttention(nn.Module):
-    """
-    Cosmos Attention module wrapping vLLM parallel layers.
-    """
-
-    def __init__(
-        self,
-        query_dim: int,
-        cross_attention_dim: int | None = None,
-        heads: int = 16,
-        kv_heads: int | None = None,
-        dim_head: int = 128,
-        dropout: float = 0.0,
-        bias: bool = False,
-        eps: float = 1e-5,
-        out_dim: int = None,
-    ):
-        super().__init__()
-        from vllm.distributed import get_tensor_model_parallel_world_size
-
-        from vllm_omni.diffusion.attention.layer import Attention
-
-        self.inner_dim = out_dim if out_dim is not None else dim_head * heads
-        self.inner_kv_dim = self.inner_dim if kv_heads is None else dim_head * kv_heads
-        self.out_dim = out_dim if out_dim is not None else query_dim
-        self.heads = heads
-        self.dim_head = dim_head
-        self.is_cross_attention = True
-        self.cross_attention_dim = cross_attention_dim if cross_attention_dim is not None else query_dim
-
-        tp_size = get_tensor_model_parallel_world_size()
-        self.num_heads_per_partition = heads // tp_size
-        self.tp_inner_dim = self.num_heads_per_partition * dim_head
-
-        self.norm_q = DistributedRMSNorm(self.dim_head, eps=eps)
-        self.norm_k = DistributedRMSNorm(self.dim_head, eps=eps)
-
-        if self.is_cross_attention:
-            self.to_q = ColumnParallelLinear(
-                query_dim,
-                self.inner_dim,
-                bias=bias,
-                gather_output=False,
-                return_bias=False,
-            )
-            self.to_k = ColumnParallelLinear(
-                self.cross_attention_dim,
-                self.inner_kv_dim,
-                bias=bias,
-                gather_output=False,
-                return_bias=False,
-            )
-            self.to_v = ColumnParallelLinear(
-                self.cross_attention_dim,
-                self.inner_kv_dim,
-                bias=bias,
-                gather_output=False,
-                return_bias=False,
-            )
-        else:
-            self._qkv_proj = QKVParallelLinear(
-                hidden_size=query_dim,
-                head_size=dim_head,
-                total_num_heads=heads,
-                bias=bias,
-            )
-            self.to_q = self._qkv_proj
-            self.to_k = self._qkv_proj
-            self.to_v = self._qkv_proj
-
-        self.to_out = RowParallelLinear(
-            self.inner_dim,
-            self.out_dim,
-            bias=bias,
-            input_is_parallel=True,
-            return_bias=False,
-        )
-        self.dropout = nn.Dropout(dropout)
-
-        self._attn = Attention(
-            num_heads=self.num_heads_per_partition,
-            head_size=dim_head,
-            softmax_scale=1.0 / (dim_head**0.5),
-            causal=False,
-            num_kv_heads=self.num_heads_per_partition,
-        )
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        encoder_hidden_states: torch.Tensor | None = None,
-        image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
-    ) -> torch.Tensor:
-        if encoder_hidden_states is None:
-            encoder_hidden_states = hidden_states
-
-        query = self.to_q(hidden_states)
-        key = self.to_k(encoder_hidden_states)
-        value = self.to_v(encoder_hidden_states)
-
-        query = query.unflatten(2, (self.heads, -1)).transpose(1, 2)
-        key = key.unflatten(2, (self.heads, -1)).transpose(1, 2)
-        value = value.unflatten(2, (self.heads, -1)).transpose(1, 2)
-
-        query = self.norm_q(query)
-        key = self.norm_k(key)
-
-        if image_rotary_emb is not None:
-            from diffusers.models.embeddings import apply_rotary_emb
-
-            query = apply_rotary_emb(query, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
-            key = apply_rotary_emb(key, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
-
-        hidden_states = self._attn(query.transpose(1, 2), key.transpose(1, 2), value.transpose(1, 2))
-        hidden_states = hidden_states.flatten(2, 3)
-        hidden_states = hidden_states.type_as(query)
-        hidden_states = self.to_out(hidden_states)
-        hidden_states = self.dropout(hidden_states)
-
-        return hidden_states
-
-
-class ColumnParallelGELU(nn.Module):
-    """Column parallel linear with GELU activation."""
-
-    def __init__(self, dim_in: int, dim_out: int, *, approximate: str = "tanh", bias: bool = True):
-        super().__init__()
-        self.proj = ColumnParallelLinear(
-            dim_in,
-            dim_out,
-            bias=bias,
-            gather_output=False,
-            return_bias=False,
-        )
-        self.approximate = approximate
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.proj(x)
-        return F.gelu(x, approximate=self.approximate)
-
-
-class CosmosFeedForward(nn.Module):
-    """
-    Cosmos FeedForward module wrapping vLLM parallel layers.
-    """
-
-    def __init__(
-        self,
-        dim: int,
-        dim_out: int | None = None,
-        mult: int = 4,
-        dropout: float = 0.0,
-        activation_fn: str = "gelu",
-        final_dropout: bool = False,
-        inner_dim=None,
-        bias: bool = True,
-    ):
-        super().__init__()
-        if inner_dim is None:
-            inner_dim = int(dim * mult)
-        dim_out = dim_out if dim_out is not None else dim
-
-        if activation_fn == "gelu":
-            act_fn = ColumnParallelGELU(dim, inner_dim, approximate="tanh", bias=bias)
-        else:
-            raise ValueError(f"Unsupported activation_fn: {activation_fn}")
-
-        self.net = nn.ModuleList([])
-        self.net.append(act_fn)
-        self.net.append(nn.Dropout(dropout))
-        self.net.append(
-            RowParallelLinear(
-                inner_dim,
-                dim,
-                bias=bias,
-                input_is_parallel=True,
-                return_bias=False,
-            )
-        )
-
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        for module in self.net:
-            hidden_states = module(hidden_states)
-        return hidden_states
-
-
-class CosmosTransformerBlock(nn.Module):
-    """
-    Cosmos Transformer Block with self-attention, cross-attention, and feedforward.
-    """
-
-    def __init__(
-        self,
-        hidden_size: int,
-        num_attention_heads: int,
-        attention_head_dim: int,
-        cross_attention_dim: int = 1024,
-        mlp_ratio: float = 4.0,
-        adaln_lora_dim: int = 256,
-        od_config: OmniDiffusionConfig | None = None,
-        block_index: int = 0,
-    ):
-        super().__init__()
-
-        self.hidden_size = hidden_size
-        self.num_attention_heads = num_attention_heads
-        self.attention_head_dim = attention_head_dim
-        self.block_index = block_index
-        self.od_config = od_config
-
-        self.norm1 = CosmosAdaLayerNormZero(hidden_size, adaln_lora_dim)
-
-        self.attn1 = CosmosAttention(
-            query_dim=hidden_size,
-            cross_attention_dim=None,
-            heads=num_attention_heads,
-            dim_head=attention_head_dim,
-            dropout=0.0,
-            bias=False,
-            eps=1e-5,
-        )
-
-        self.norm2 = CosmosAdaLayerNormZero(hidden_size, adaln_lora_dim)
-
-        self.attn2 = CosmosAttention(
-            query_dim=hidden_size,
-            cross_attention_dim=cross_attention_dim,
-            heads=num_attention_heads,
-            dim_head=attention_head_dim,
-            dropout=0.0,
-            bias=False,
-            eps=1e-5,
-        )
-
-        self.norm3 = CosmosAdaLayerNormZero(hidden_size, adaln_lora_dim)
-
-        self.ff = CosmosFeedForward(
-            dim=hidden_size,
-            mult=mlp_ratio,
-            dropout=0.0,
-            bias=False,
-        )
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        encoder_hidden_states: torch.Tensor,
-        embedded_timestep: torch.Tensor,
-        freqs_cos: torch.Tensor,
-        freqs_sin: torch.Tensor,
-        temb: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        embedded_timestep = embedded_timestep.type_as(hidden_states)
-        image_rotary_emb = (freqs_cos, freqs_sin)
-
-        norm_hidden, gate1 = self.norm1(hidden_states, embedded_timestep, temb)
-        attn_output = self.attn1(norm_hidden, image_rotary_emb=image_rotary_emb)
-        hidden_states = hidden_states + gate1 * attn_output
-
-        norm_hidden, gate2 = self.norm2(hidden_states, embedded_timestep, temb)
-        attn_output = self.attn2(norm_hidden, encoder_hidden_states=encoder_hidden_states)
-        hidden_states = hidden_states + gate2 * attn_output
-
-        norm_hidden, gate3 = self.norm3(hidden_states, embedded_timestep, temb)
-        ff_output = self.ff(norm_hidden)
-        hidden_states = hidden_states + gate3 * ff_output
-
-        return hidden_states
-
-
 class CosmosTransformer3DModel(nn.Module):
+    r"""
+    A Transformer model for video-like data used in [Cosmos](https://github.com/NVIDIA/Cosmos).
+
+    This is an optimized version of the diffusers CosmosTransformer3DModel that uses
+    vLLM's efficient QKVParallelLinear and RMSNorm implementations.    
+
+    Args:
+        patch_size: 3D patch dimensions for patchifying the input latent tensors (t_patch, h_patch, w_patch).    
+        num_attention_heads: The number of heads to use for multi-head attention.        
+        attention_head_dim: The number of channels in each attention head.
+        in_channels: The number of channels in the input.
+        out_channels: The number of channels in the output.
+        num_layers: The number of layers of transformer blocks to use.
+        mlp_ratio: The ratio of the hidden layer size to the input size in the feedforward network.
+        text_embed_dim: Input dimension of text embeddings from the text encoder.
+        adaln_lora_dim: The hidden dimension of the Adaptive LayerNorm LoRA layer.
+        max_size: The maximum size of the input latent tensors in the temporal, height, and width dimensions.
+        rope_scale: The scaling factor to use for RoPE in the temporal, height, and width dimensions.
+        concat_padding_mask: Whether to concatenate the padding mask to the input latent tensors.
+        extra_pos_embed_type: The type of extra positional embeddings to use. Can be one of `None` or `learnable`.
     """
-    Cosmos Predict 2.5 3D Video Transformer.
-    """
+
 
     _repeated_blocks = ["CosmosTransformerBlock"]
-    _layerwise_offload_blocks_attr = "blocks"
-
+    _layerwise_offload_blocks_attr = "transformer_blocks"
+    packed_modules_mapping = {
+        "to_qkv": ["to_q", "to_k", "to_v"],
+    }
+    
     def __init__(
         self,
         *,
-        od_config: OmniDiffusionConfig | None = None,
         patch_size: tuple[int, int, int] = (1, 2, 2),
         num_attention_heads: int = 32,
         attention_head_dim: int = 128,
@@ -632,94 +575,101 @@ class CosmosTransformer3DModel(nn.Module):
         out_channels: int = 16,
         num_layers: int = 28,
         mlp_ratio: float = 4.0,
-        text_embed_dim: int = 4096,
+        text_embed_dim: int = 1024,
         adaln_lora_dim: int = 256,
         max_size: tuple[int, int, int] = (128, 240, 240),
         rope_scale: tuple[float, float, float] = (2.0, 1.0, 1.0),
         concat_padding_mask: bool = True,
         extra_pos_embed_type: str | None = "learnable",
         use_crossattn_projection: bool = False,
-        crossattn_proj_in_channels: int | None = None,
+        crossattn_proj_in_channels: int = 1024,
         encoder_hidden_states_channels: int = 1024,
         **kwargs,
     ):
         super().__init__()
+        hidden_size = num_attention_heads * attention_head_dim
 
-        self.od_config = od_config
-        self.parallel_config = od_config.parallel_config if od_config else None
+        # Store config for compatibility
+        self.config = type(
+            "Config",
+            (),
+            {
+                "patch_size": patch_size,
+                "num_attention_heads": num_attention_heads,
+                "attention_head_dim": attention_head_dim,
+                "in_channels": in_channels,
+                "out_channels": out_channels,
+                "num_layers": num_layers,
+                "mlp_ratio": mlp_ratio,
+                "text_embed_dim": text_embed_dim,
+                "adaln_lora_dim": adaln_lora_dim,
+                "max_size": max_size,
+                "rope_scale": rope_scale,
+                "concat_padding_mask": concat_padding_mask,
+                "extra_pos_embed_type": extra_pos_embed_type,
+                "use_crossattn_projection": use_crossattn_projection,
+                "crossattn_proj_in_channels": crossattn_proj_in_channels,
+                "encoder_hidden_states_channels": encoder_hidden_states_channels,                                                                                                                                               
+            },
+        )()
 
-        self.in_channels = in_channels
-        self.out_channels = out_channels
-        self.num_attention_heads = num_attention_heads
-        self.attention_head_dim = attention_head_dim
-        self.num_layers = num_layers
-        self.hidden_size = num_attention_heads * attention_head_dim
-        self.concat_padding_mask = concat_padding_mask
-
+        # Patch Embedding
+        patch_embed_in_channels = in_channels + 1 if concat_padding_mask else in_channels
         self.patch_embed = CosmosPatchEmbed(
-            in_channels=18,
-            out_channels=self.hidden_size,
+            in_channels=patch_embed_in_channels,
+            out_channels=hidden_size,
             patch_size=patch_size,
             bias=False,
         )
 
+        # Positional Embedding
         self.rope = CosmosRotaryPosEmbed(
             hidden_size=attention_head_dim,
             max_size=max_size,
             patch_size=patch_size,
-            base_fps=24,
             rope_scale=rope_scale,
         )
 
+        self.learnable_pos_embed = None
         if extra_pos_embed_type == "learnable":
             self.learnable_pos_embed = CosmosLearnablePositionalEmbed(
-                hidden_size=self.hidden_size,
+                hidden_size=hidden_size,
                 max_size=max_size,
                 patch_size=patch_size,
-                eps=1e-6,
             )
-        else:
-            self.learnable_pos_embed = None
 
+        # Time Embedding
         self.time_embed = CosmosEmbedding(
-            embedding_dim=self.hidden_size,
-            condition_dim=self.hidden_size,
+            embedding_dim=hidden_size,
+            condition_dim=hidden_size,            
         )
 
+        # Transformer Blocks
         self.transformer_blocks = nn.ModuleList(
             [
                 CosmosTransformerBlock(
-                    hidden_size=self.hidden_size,
                     num_attention_heads=num_attention_heads,
                     attention_head_dim=attention_head_dim,
-                    cross_attention_dim=encoder_hidden_states_channels,
+                    cross_attention_dim=text_embed_dim,
                     mlp_ratio=mlp_ratio,
                     adaln_lora_dim=adaln_lora_dim,
-                    od_config=od_config,
-                    block_index=i,
+                    out_bias=False,
                 )
-                for i in range(num_layers)
+                for _ in range(num_layers)
             ]
         )
 
-        self.norm_out = CosmosAdaLayerNorm(self.hidden_size, adaln_lora_dim)
+        # Output norm & projection
+        self.norm_out = CosmosAdaLayerNorm(hidden_size, adaln_lora_dim)
+        self.proj_out = nn.Linear(
+            hidden_size, patch_size[0] * patch_size[1] * patch_size[2] * out_channels, bias=False
+        )
 
-        patch_volume = patch_size[0] * patch_size[1] * patch_size[2]
-        self.proj_out = nn.Linear(self.hidden_size, patch_volume * out_channels, bias=False)
-
-        if use_crossattn_projection and crossattn_proj_in_channels is not None:
+        if self.config.use_crossattn_projection:    
             self.crossattn_proj = nn.Sequential(
                 nn.Linear(crossattn_proj_in_channels, encoder_hidden_states_channels, bias=True),
                 nn.GELU(),
             )
-        else:
-            self.crossattn_proj = None
-
-        logger.info(
-            f"Initialized CosmosTransformer3DModel: "
-            f"{num_layers} layers, {num_attention_heads} heads, "
-            f"{attention_head_dim} head_dim, hidden_size={self.hidden_size}"
-        )
 
     @property
     def dtype(self) -> torch.dtype:
@@ -730,56 +680,43 @@ class CosmosTransformer3DModel(nn.Module):
         hidden_states: torch.Tensor,
         timestep: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
-        block_controlnet_hidden_states: list[torch.Tensor] | None = None,
-        attention_mask: torch.Tensor | None = None,
         fps: int | None = None,
         condition_mask: torch.Tensor | None = None,
         padding_mask: torch.Tensor | None = None,
         return_dict: bool = True,
-    ) -> torch.Tensor:
-        latents = hidden_states
-
-        if condition_mask is not None:
-            latents = torch.cat([latents, condition_mask], dim=1)
-
-        if padding_mask is not None:
-            from torchvision import transforms
-
-            batch_size, num_channels, num_frames, height, width = latents.shape
-            padding_mask_resized = transforms.functional.resize(
-                padding_mask,
-                list(latents.shape[-2:]),
-                interpolation=transforms.InterpolationMode.NEAREST,
-            )
-            hidden_states = torch.cat(
-                [latents, padding_mask_resized.unsqueeze(2).repeat(batch_size, 1, num_frames, 1, 1)],
-                dim=1,
-            )
-        else:
-            hidden_states = latents
+        attention_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor] | Transformer2DModelOutput:
 
         batch_size, num_channels, num_frames, height, width = hidden_states.shape
-        latent_shape = hidden_states.shape
 
-        hidden_states = self.patch_embed(hidden_states)
-        hidden_states = hidden_states.flatten(1, 3)
+        # oncatenate padding mask if needed & prepare attention mask
+        if condition_mask is not None:
+            hidden_states = torch.cat([hidden_states, condition_mask], dim=1)
 
-        if self.learnable_pos_embed is not None:
-            learnable_pos = self.learnable_pos_embed(
-                torch.zeros(latent_shape, device=hidden_states.device, dtype=hidden_states.dtype)
+        if self.config.concat_padding_mask:
+            from torchvision import transforms
+            padding_mask_resized = transforms.functional.resize(
+                padding_mask, list(hidden_states.shape[-2:]), interpolation=transforms.InterpolationMode.NEAREST
             )
-            hidden_states = hidden_states + learnable_pos
+            hidden_states = torch.cat(
+                [hidden_states, padding_mask_resized.unsqueeze(2).repeat(batch_size, 1, num_frames, 1, 1)], dim=1
+            )
 
-        freqs_cos, freqs_sin = self.rope(
-            torch.zeros(latent_shape, device=hidden_states.device),
-            fps=fps,
-        )
+        # Generate positional embeddings
+        image_rotary_emb = self.rope(hidden_states, fps=fps)
+        extra_pos_emb = self.learnable_pos_embed(hidden_states) if self.config.extra_pos_embed_type else None
 
-        p_t, p_h, p_w = self.od_config.tf_model_config.params["patch_size"]
+
+        # Patchify input
+        p_t, p_h, p_w = self.config.patch_size
         post_patch_num_frames = num_frames // p_t
         post_patch_height = height // p_h
         post_patch_width = width // p_w
 
+        hidden_states = self.patch_embed(hidden_states)
+        hidden_states = hidden_states.flatten(1, 3)  # [B, T, H, W, C] -> [B, THW, C]
+
+        # Timestep embeddings
         if timestep.ndim == 1:
             temb, embedded_timestep = self.time_embed(hidden_states, timestep)
         elif timestep.ndim == 5:
@@ -788,68 +725,52 @@ class CosmosTransformer3DModel(nn.Module):
             )
             timestep = timestep.flatten()
             temb, embedded_timestep = self.time_embed(hidden_states, timestep)
-
+            # We can do this because num_frames == post_patch_num_frames, as p_t is 1
             temb, embedded_timestep = (
                 x.view(batch_size, post_patch_num_frames, 1, 1, -1)
                 .expand(-1, -1, post_patch_height, post_patch_width, -1)
                 .flatten(1, 3)
                 for x in (temb, embedded_timestep)
-            )
+            )  # [BT, C] -> [B, T, 1, 1, C] -> [B, T, H, W, C] -> [B, THW, C]
         else:
             raise ValueError(f"Expected timestep to have shape [B, 1, T, 1, 1] or [T], but got {timestep.shape}")
 
-        if self.crossattn_proj is not None:
+        # Process encoder hidden states
+        if self.config.use_crossattn_projection:
             encoder_hidden_states = self.crossattn_proj(encoder_hidden_states)
 
-        if encoder_hidden_states is None:
-            raise ValueError("encoder_hidden_states cannot be None")
-
+        # Transformer blocks
         for block in self.transformer_blocks:
             hidden_states = block(
                 hidden_states,
                 encoder_hidden_states,
                 embedded_timestep,
-                freqs_cos,
-                freqs_sin,
-                temb,
+                image_rotary_emb=image_rotary_emb,
+                temb=temb,
+                extra_pos_emb=extra_pos_emb,
             )
 
+        # Output norm & projection & unpatchify
         hidden_states = self.norm_out(hidden_states, embedded_timestep, temb)
         hidden_states = self.proj_out(hidden_states)
-        hidden_states = self._unpatchify(hidden_states, latent_shape)
-
-        return hidden_states
-
-    def _unpatchify(
-        self,
-        hidden_states: torch.Tensor,
-        latent_shape: tuple[int, int, int, int, int],
-    ) -> torch.Tensor:
-        batch_size, _, num_frames, height, width = latent_shape
-        p_t, p_h, p_w = self.patch_embed.patch_size
-
-        num_patches_t = num_frames // p_t
-        num_patches_h = height // p_h
-        num_patches_w = width // p_w
-
         hidden_states = hidden_states.unflatten(2, (p_h, p_w, p_t, -1))
-        hidden_states = hidden_states.unflatten(1, (num_patches_t, num_patches_h, num_patches_w))
+        hidden_states = hidden_states.unflatten(1, (post_patch_num_frames, post_patch_height, post_patch_width))
         hidden_states = hidden_states.permute(0, 7, 1, 6, 2, 4, 3, 5)
         hidden_states = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
 
-        return hidden_states
+        if not return_dict:
+            return (hidden_states,)
+
+        return Transformer2DModelOutput(sample=hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        from vllm.distributed import (
-            get_tensor_model_parallel_rank,
-            get_tensor_model_parallel_world_size,
-        )
-        from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
-        tp_rank = get_tensor_model_parallel_rank()
-        tp_size = get_tensor_model_parallel_world_size()
-
-        stacked_params_mapping = []
+        # Map separate Q/K/V weights from checkpoint to fused QKV parameter in model
+        stacked_params_mapping = [
+            (".attn1.to_qkv", ".attn1.to_q", "q"),
+            (".attn1.to_qkv", ".attn1.to_k", "k"),
+            (".attn1.to_qkv", ".attn1.to_v", "v"),
+        ]
 
         weight_name_remapping = {}
 
@@ -861,6 +782,7 @@ class CosmosTransformer3DModel(nn.Module):
             original_name = name
             lookup_name = name
 
+            # Check if this weight should be loaded into a stacked parameter (QKV fusion)
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in original_name:
                     continue
@@ -870,27 +792,11 @@ class CosmosTransformer3DModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                if ".to_out.0." in lookup_name:
-                    lookup_name = lookup_name.replace(".to_out.0.", ".to_out.")
-
                 if lookup_name not in params_dict:
                     logger.warning(f"Skipping weight {original_name} -> {lookup_name}")
                     continue
 
                 param = params_dict[lookup_name]
-
-                if tp_size > 1 and any(
-                    norm_name in lookup_name
-                    for norm_name in [
-                        ".attn1.norm_q.",
-                        ".attn1.norm_k.",
-                        ".attn2.norm_q.",
-                        ".attn2.norm_k.",
-                        ".attn2.norm_added_k.",
-                    ]
-                ):
-                    shard_size = loaded_weight.shape[0] // tp_size
-                    loaded_weight = loaded_weight[tp_rank * shard_size : (tp_rank + 1) * shard_size]
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)

--- a/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
+++ b/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
@@ -22,15 +22,14 @@ from typing import Any
 import numpy as np
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-
-from diffusers.models.embeddings import Timesteps
 from diffusers.models.attention import FeedForward
+from diffusers.models.embeddings import Timesteps
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import QKVParallelLinear, ReplicatedLinear
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
 from vllm_omni.diffusion.attention.layer import Attention
 
 logger = init_logger(__name__)
@@ -217,12 +216,11 @@ class CosmosSelfAttention(nn.Module):
         )
 
         self.attn = Attention(
-             num_heads=num_heads,
-             head_size=head_dim,
-             softmax_scale=1.0 / (head_dim**0.5),
-             causal=False,
+            num_heads=num_heads,
+            head_size=head_dim,
+            softmax_scale=1.0 / (head_dim**0.5),
+            causal=False,
         )
-
 
     def forward(
         self,
@@ -245,6 +243,7 @@ class CosmosSelfAttention(nn.Module):
         # Apply RoPE
         if image_rotary_emb is not None:
             from diffusers.models.embeddings import apply_rotary_emb
+
             query = apply_rotary_emb(query, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
             key = apply_rotary_emb(key, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
 
@@ -291,7 +290,7 @@ class CosmosCrossAttention(nn.Module):
 
         # Query projection
         self.to_q = ReplicatedLinear(query_dim, self.inner_dim, bias=bias)
-        
+
         # Separate K and V projections for cross-attention
         self.to_k = ReplicatedLinear(self.cross_attention_dim, self.inner_kv_dim, bias=bias)
         self.to_v = ReplicatedLinear(self.cross_attention_dim, self.inner_kv_dim, bias=bias)
@@ -305,12 +304,11 @@ class CosmosCrossAttention(nn.Module):
         )
 
         self.attn = Attention(
-             num_heads=num_heads,
-             head_size=head_dim,
-             softmax_scale=1.0 / (head_dim**0.5),
-             causal=False,
+            num_heads=num_heads,
+            head_size=head_dim,
+            softmax_scale=1.0 / (head_dim**0.5),
+            causal=False,
         )
-
 
     def forward(
         self,
@@ -337,6 +335,7 @@ class CosmosCrossAttention(nn.Module):
         # Apply RoPE
         if image_rotary_emb is not None:
             from diffusers.models.embeddings import apply_rotary_emb
+
             query = apply_rotary_emb(query, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
             key = apply_rotary_emb(key, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
 
@@ -347,8 +346,9 @@ class CosmosCrossAttention(nn.Module):
         # Output projection
         hidden_states, _ = self.to_out[0](hidden_states)
         hidden_states = self.to_out[1](hidden_states)
-                
+
         return hidden_states
+
 
 class CosmosTransformerBlock(nn.Module):
     """
@@ -372,7 +372,7 @@ class CosmosTransformerBlock(nn.Module):
         self.attn1 = CosmosSelfAttention(
             dim=hidden_size,
             num_heads=num_attention_heads,
-            head_dim=attention_head_dim,         
+            head_dim=attention_head_dim,
             dropout=0.0,
             bias=False,
             eps=1e-5,
@@ -383,7 +383,7 @@ class CosmosTransformerBlock(nn.Module):
             query_dim=hidden_size,
             cross_attention_dim=cross_attention_dim,
             num_heads=num_attention_heads,
-            head_dim=attention_head_dim,            
+            head_dim=attention_head_dim,
             dropout=0.0,
             bias=False,
             eps=1e-5,
@@ -542,11 +542,11 @@ class CosmosTransformer3DModel(nn.Module):
     A Transformer model for video-like data used in [Cosmos](https://github.com/NVIDIA/Cosmos).
 
     This is an optimized version of the diffusers CosmosTransformer3DModel that uses
-    vLLM's efficient QKVParallelLinear and RMSNorm implementations.    
+    vLLM's efficient QKVParallelLinear and RMSNorm implementations.
 
     Args:
-        patch_size: 3D patch dimensions for patchifying the input latent tensors (t_patch, h_patch, w_patch).    
-        num_attention_heads: The number of heads to use for multi-head attention.        
+        patch_size: 3D patch dimensions for patchifying the input latent tensors (t_patch, h_patch, w_patch).
+        num_attention_heads: The number of heads to use for multi-head attention.
         attention_head_dim: The number of channels in each attention head.
         in_channels: The number of channels in the input.
         out_channels: The number of channels in the output.
@@ -560,13 +560,12 @@ class CosmosTransformer3DModel(nn.Module):
         extra_pos_embed_type: The type of extra positional embeddings to use. Can be one of `None` or `learnable`.
     """
 
-
     _repeated_blocks = ["CosmosTransformerBlock"]
     _layerwise_offload_blocks_attr = "transformer_blocks"
     packed_modules_mapping = {
         "to_qkv": ["to_q", "to_k", "to_v"],
     }
-    
+
     def __init__(
         self,
         *,
@@ -611,7 +610,7 @@ class CosmosTransformer3DModel(nn.Module):
                 "extra_pos_embed_type": extra_pos_embed_type,
                 "use_crossattn_projection": use_crossattn_projection,
                 "crossattn_proj_in_channels": crossattn_proj_in_channels,
-                "encoder_hidden_states_channels": encoder_hidden_states_channels,                                                                                                                                               
+                "encoder_hidden_states_channels": encoder_hidden_states_channels,
             },
         )()
 
@@ -643,7 +642,7 @@ class CosmosTransformer3DModel(nn.Module):
         # Time Embedding
         self.time_embed = CosmosEmbedding(
             embedding_dim=hidden_size,
-            condition_dim=hidden_size,            
+            condition_dim=hidden_size,
         )
 
         # Transformer Blocks
@@ -663,11 +662,9 @@ class CosmosTransformer3DModel(nn.Module):
 
         # Output norm & projection
         self.norm_out = CosmosAdaLayerNorm(hidden_size, adaln_lora_dim)
-        self.proj_out = nn.Linear(
-            hidden_size, patch_size[0] * patch_size[1] * patch_size[2] * out_channels, bias=False
-        )
+        self.proj_out = nn.Linear(hidden_size, patch_size[0] * patch_size[1] * patch_size[2] * out_channels, bias=False)
 
-        if self.config.use_crossattn_projection:    
+        if self.config.use_crossattn_projection:
             self.crossattn_proj = nn.Sequential(
                 nn.Linear(crossattn_proj_in_channels, encoder_hidden_states_channels, bias=True),
                 nn.GELU(),
@@ -688,7 +685,6 @@ class CosmosTransformer3DModel(nn.Module):
         return_dict: bool = True,
         attention_kwargs: dict[str, Any] | None = None,
     ) -> tuple[torch.Tensor] | Transformer2DModelOutput:
-
         batch_size, num_channels, num_frames, height, width = hidden_states.shape
 
         # oncatenate padding mask if needed & prepare attention mask
@@ -697,6 +693,7 @@ class CosmosTransformer3DModel(nn.Module):
 
         if self.config.concat_padding_mask:
             from torchvision import transforms
+
             padding_mask_resized = transforms.functional.resize(
                 padding_mask, list(hidden_states.shape[-2:]), interpolation=transforms.InterpolationMode.NEAREST
             )
@@ -707,7 +704,6 @@ class CosmosTransformer3DModel(nn.Module):
         # Generate positional embeddings
         image_rotary_emb = self.rope(hidden_states, fps=fps)
         extra_pos_emb = self.learnable_pos_embed(hidden_states) if self.config.extra_pos_embed_type else None
-
 
         # Patchify input
         p_t, p_h, p_w = self.config.patch_size
@@ -766,7 +762,6 @@ class CosmosTransformer3DModel(nn.Module):
         return Transformer2DModelOutput(sample=hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-
         # Map separate Q/K/V weights from checkpoint to fused QKV parameter in model
         stacked_params_mapping = [
             (".attn1.to_qkv", ".attn1.to_q", "q"),

--- a/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
+++ b/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
@@ -15,23 +15,22 @@
 # Adapted from Diffusers implementation:
 # https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/transformers/transformer_cosmos.py
 
-from pathlib import Path
-from typing import Any, Iterable, Optional, Tuple
+
+from collections.abc import Iterable
 
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 from diffusers.models.embeddings import Timesteps
-
 from vllm.logger import init_logger
+from vllm.model_executor.layers.layernorm import RMSNorm as DistributedRMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
     QKVParallelLinear,
     RowParallelLinear,
 )
-from vllm.model_executor.layers.layernorm import RMSNorm as DistributedRMSNorm
+
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 
 logger = init_logger(__name__)
@@ -70,10 +69,10 @@ class CosmosRotaryPosEmbed(nn.Module):
     def __init__(
         self,
         hidden_size: int,
-        max_size: Tuple[int, int, int] = (128, 240, 240),
-        patch_size: Tuple[int, int, int] = (1, 2, 2),
+        max_size: tuple[int, int, int] = (128, 240, 240),
+        patch_size: tuple[int, int, int] = (1, 2, 2),
         base_fps: int = 24,
-        rope_scale: Tuple[float, float, float] = (2.0, 1.0, 1.0),
+        rope_scale: tuple[float, float, float] = (2.0, 1.0, 1.0),
     ):
         super().__init__()
 
@@ -92,8 +91,8 @@ class CosmosRotaryPosEmbed(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        fps: Optional[int] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        fps: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_channels, num_frames, height, width = hidden_states.shape
         pe_size = [
             num_frames // self.patch_size[0],
@@ -109,28 +108,21 @@ class CosmosRotaryPosEmbed(nn.Module):
         seq = torch.arange(max(self.max_size), device=device, dtype=torch.float32)
 
         dim_h_range = (
-            torch.arange(0, self.dim_h, 2, device=device, dtype=torch.float32)[: (self.dim_h // 2)]
-            / self.dim_h
+            torch.arange(0, self.dim_h, 2, device=device, dtype=torch.float32)[: (self.dim_h // 2)] / self.dim_h
         )
         dim_w_range = (
-            torch.arange(0, self.dim_w, 2, device=device, dtype=torch.float32)[: (self.dim_w // 2)]
-            / self.dim_w
+            torch.arange(0, self.dim_w, 2, device=device, dtype=torch.float32)[: (self.dim_w // 2)] / self.dim_w
         )
         dim_t_range = (
-            torch.arange(0, self.dim_t, 2, device=device, dtype=torch.float32)[: (self.dim_t // 2)]
-            / self.dim_t
+            torch.arange(0, self.dim_t, 2, device=device, dtype=torch.float32)[: (self.dim_t // 2)] / self.dim_t
         )
 
-        h_spatial_freqs = 1.0 / (h_theta ** dim_h_range)
-        w_spatial_freqs = 1.0 / (w_theta ** dim_w_range)
-        temporal_freqs = 1.0 / (t_theta ** dim_t_range)
+        h_spatial_freqs = 1.0 / (h_theta**dim_h_range)
+        w_spatial_freqs = 1.0 / (w_theta**dim_w_range)
+        temporal_freqs = 1.0 / (t_theta**dim_t_range)
 
-        emb_h = torch.outer(seq[: pe_size[1]], h_spatial_freqs)[None, :, None, :].repeat(
-            pe_size[0], 1, pe_size[2], 1
-        )
-        emb_w = torch.outer(seq[: pe_size[2]], w_spatial_freqs)[None, None, :, :].repeat(
-            pe_size[0], pe_size[1], 1, 1
-        )
+        emb_h = torch.outer(seq[: pe_size[1]], h_spatial_freqs)[None, :, None, :].repeat(pe_size[0], 1, pe_size[2], 1)
+        emb_w = torch.outer(seq[: pe_size[2]], w_spatial_freqs)[None, None, :, :].repeat(pe_size[0], pe_size[1], 1, 1)
 
         if fps is None:
             emb_t = torch.outer(seq[: pe_size[0]], temporal_freqs)
@@ -155,8 +147,8 @@ class CosmosLearnablePositionalEmbed(nn.Module):
     def __init__(
         self,
         hidden_size: int,
-        max_size: Tuple[int, int, int],
-        patch_size: Tuple[int, int, int],
+        max_size: tuple[int, int, int],
+        patch_size: tuple[int, int, int],
         eps: float = 1e-6,
     ):
         super().__init__()
@@ -177,15 +169,9 @@ class CosmosLearnablePositionalEmbed(nn.Module):
             width // self.patch_size[2],
         ]
 
-        emb_t = self.pos_emb_t[: pe_size[0]][None, :, None, None, :].repeat(
-            batch_size, 1, pe_size[1], pe_size[2], 1
-        )
-        emb_h = self.pos_emb_h[: pe_size[1]][None, None, :, None, :].repeat(
-            batch_size, pe_size[0], 1, pe_size[2], 1
-        )
-        emb_w = self.pos_emb_w[: pe_size[2]][None, None, None, :, :].repeat(
-            batch_size, pe_size[0], pe_size[1], 1, 1
-        )
+        emb_t = self.pos_emb_t[: pe_size[0]][None, :, None, None, :].repeat(batch_size, 1, pe_size[1], pe_size[2], 1)
+        emb_h = self.pos_emb_h[: pe_size[1]][None, None, :, None, :].repeat(batch_size, pe_size[0], 1, pe_size[2], 1)
+        emb_w = self.pos_emb_w[: pe_size[2]][None, None, None, :, :].repeat(batch_size, pe_size[0], pe_size[1], 1, 1)
 
         emb = emb_t + emb_h + emb_w
         emb = emb.flatten(1, 3)
@@ -205,7 +191,7 @@ class CosmosPatchEmbed(nn.Module):
         self,
         in_channels: int,
         out_channels: int,
-        patch_size: Tuple[int, int, int],
+        patch_size: tuple[int, int, int],
         bias: bool = True,
     ):
         super().__init__()
@@ -249,7 +235,7 @@ class CosmosTimestepEmbedding(nn.Module):
         self.linear_2 = nn.Linear(out_features, 3 * out_features, bias=False)
 
     def forward(self, timesteps: torch.Tensor) -> torch.Tensor:
-        emb = self.linear_1(timesteps.to(torch.bfloat16))
+        emb = self.linear_1(timesteps.to(self.linear_1.weight.dtype))
         emb = self.activation(emb)
         emb = self.linear_2(emb)
         return emb
@@ -278,7 +264,6 @@ class CosmosEmbedding(nn.Module):
         return temb, embedded_timestep
 
 
-
 class CosmosAdaLayerNorm(nn.Module):
     """
     Adaptive Layer Normalization (AdaLN) without gate.
@@ -298,7 +283,7 @@ class CosmosAdaLayerNorm(nn.Module):
         self,
         hidden_states: torch.Tensor,
         embedded_timestep: torch.Tensor,
-        temb: Optional[torch.Tensor] = None,
+        temb: torch.Tensor | None = None,
     ) -> torch.Tensor:
         embedded_timestep = self.activation(embedded_timestep)
         embedded_timestep = self.linear_1(embedded_timestep)
@@ -322,7 +307,7 @@ class CosmosAdaLayerNormZero(nn.Module):
     Adaptive Layer Normalization with zero initialization (AdaLN-Zero).
     """
 
-    def __init__(self, in_features: int, hidden_features: Optional[int] = None):
+    def __init__(self, in_features: int, hidden_features: int | None = None):
         super().__init__()
 
         self.norm = nn.LayerNorm(in_features, elementwise_affine=False, eps=1e-6)
@@ -339,8 +324,8 @@ class CosmosAdaLayerNormZero(nn.Module):
         self,
         hidden_states: torch.Tensor,
         embedded_timestep: torch.Tensor,
-        temb: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        temb: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         embedded_timestep = self.activation(embedded_timestep)
         embedded_timestep = self.linear_1(embedded_timestep)
         embedded_timestep = self.linear_2(embedded_timestep)
@@ -366,7 +351,7 @@ class CosmosAttention(nn.Module):
     def __init__(
         self,
         query_dim: int,
-        cross_attention_dim: Optional[int] = None,
+        cross_attention_dim: int | None = None,
         heads: int = 16,
         kv_heads: int | None = None,
         dim_head: int = 128,
@@ -377,6 +362,7 @@ class CosmosAttention(nn.Module):
     ):
         super().__init__()
         from vllm.distributed import get_tensor_model_parallel_world_size
+
         from vllm_omni.diffusion.attention.layer import Attention
 
         self.inner_dim = out_dim if out_dim is not None else dim_head * heads
@@ -447,8 +433,8 @@ class CosmosAttention(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        encoder_hidden_states: Optional[torch.Tensor] = None,
-        image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        encoder_hidden_states: torch.Tensor | None = None,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
     ) -> torch.Tensor:
         if encoder_hidden_states is None:
             encoder_hidden_states = hidden_states
@@ -556,7 +542,7 @@ class CosmosTransformerBlock(nn.Module):
         cross_attention_dim: int = 1024,
         mlp_ratio: float = 4.0,
         adaln_lora_dim: int = 256,
-        od_config: Optional[OmniDiffusionConfig] = None,
+        od_config: OmniDiffusionConfig | None = None,
         block_index: int = 0,
     ):
         super().__init__()
@@ -607,7 +593,7 @@ class CosmosTransformerBlock(nn.Module):
         embedded_timestep: torch.Tensor,
         freqs_cos: torch.Tensor,
         freqs_sin: torch.Tensor,
-        temb: Optional[torch.Tensor] = None,
+        temb: torch.Tensor | None = None,
     ) -> torch.Tensor:
         embedded_timestep = embedded_timestep.type_as(hidden_states)
         image_rotary_emb = (freqs_cos, freqs_sin)
@@ -638,22 +624,22 @@ class CosmosTransformer3DModel(nn.Module):
     def __init__(
         self,
         *,
-        od_config: Optional[OmniDiffusionConfig] = None,
-        patch_size: Tuple[int, int, int] = (1, 2, 2),        
+        od_config: OmniDiffusionConfig | None = None,
+        patch_size: tuple[int, int, int] = (1, 2, 2),
         num_attention_heads: int = 32,
-        attention_head_dim: int = 128,                
+        attention_head_dim: int = 128,
         in_channels: int = 16,
         out_channels: int = 16,
         num_layers: int = 28,
         mlp_ratio: float = 4.0,
         text_embed_dim: int = 4096,
         adaln_lora_dim: int = 256,
-        max_size: Tuple[int, int, int] = (128, 240, 240),
-        rope_scale: Tuple[float, float, float] = (2.0, 1.0, 1.0),
+        max_size: tuple[int, int, int] = (128, 240, 240),
+        rope_scale: tuple[float, float, float] = (2.0, 1.0, 1.0),
         concat_padding_mask: bool = True,
-        extra_pos_embed_type: Optional[str] = "learnable",
+        extra_pos_embed_type: str | None = "learnable",
         use_crossattn_projection: bool = False,
-        crossattn_proj_in_channels: Optional[int] = None,
+        crossattn_proj_in_channels: int | None = None,
         encoder_hidden_states_channels: int = 1024,
         **kwargs,
     ):
@@ -810,9 +796,7 @@ class CosmosTransformer3DModel(nn.Module):
                 for x in (temb, embedded_timestep)
             )
         else:
-            raise ValueError(
-                f"Expected timestep to have shape [B, 1, T, 1, 1] or [T], but got {timestep.shape}"
-            )
+            raise ValueError(f"Expected timestep to have shape [B, 1, T, 1, 1] or [T], but got {timestep.shape}")
 
         if self.crossattn_proj is not None:
             encoder_hidden_states = self.crossattn_proj(encoder_hidden_states)
@@ -839,7 +823,7 @@ class CosmosTransformer3DModel(nn.Module):
     def _unpatchify(
         self,
         hidden_states: torch.Tensor,
-        latent_shape: Tuple[int, int, int, int, int],
+        latent_shape: tuple[int, int, int, int, int],
     ) -> torch.Tensor:
         batch_size, _, num_frames, height, width = latent_shape
         p_t, p_h, p_w = self.patch_embed.patch_size
@@ -886,11 +870,6 @@ class CosmosTransformer3DModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                if ".ffn.net.0." in lookup_name:
-                    lookup_name = lookup_name.replace(".ffn.net.0.", ".ffn.net_0.")
-                elif ".ffn.net.2." in lookup_name:
-                    lookup_name = lookup_name.replace(".ffn.net.2.", ".ffn.net_2.")
-
                 if ".to_out.0." in lookup_name:
                     lookup_name = lookup_name.replace(".to_out.0.", ".to_out.")
 

--- a/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
+++ b/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
@@ -237,20 +237,19 @@ class CosmosSelfAttention(nn.Module):
         key = key.unflatten(2, (self.num_heads, -1)).transpose(1, 2)
         value = value.unflatten(2, (self.num_heads, -1)).transpose(1, 2)
 
-        # Apply QK normalization
-        query = self.norm_q(query)
-        key = self.norm_k(key)
+        # QK normalization
+        q_shape, k_shape = query.shape, key.shape
+        query = self.norm_q(query.reshape(-1, self.head_dim)).view(q_shape)
+        key = self.norm_k(key.reshape(-1, self.head_dim)).view(k_shape)
 
-        # Apply rotary embeddings
+        # Apply RoPE
         if image_rotary_emb is not None:
             from diffusers.models.embeddings import apply_rotary_emb
-
             query = apply_rotary_emb(query, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
             key = apply_rotary_emb(key, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
 
         # Attention
         hidden_states = self.attn(query.transpose(1, 2), key.transpose(1, 2), value.transpose(1, 2))
-
         hidden_states = hidden_states.flatten(2, 3).type_as(query)
 
         # Output projection
@@ -269,9 +268,9 @@ class CosmosCrossAttention(nn.Module):
         self,
         query_dim: int,
         cross_attention_dim: int,
-        heads: int = 16,
+        num_heads: int = 16,
         kv_heads: int | None = None,
-        dim_head: int = 128,
+        head_dim: int = 128,
         dropout: float = 0.0,
         bias: bool = False,
         eps: float = 1e-5,
@@ -279,16 +278,16 @@ class CosmosCrossAttention(nn.Module):
     ):
         super().__init__()
 
-        self.inner_dim = out_dim if out_dim is not None else dim_head * heads
-        self.inner_kv_dim = self.inner_dim if kv_heads is None else dim_head * kv_heads
+        self.inner_dim = out_dim if out_dim is not None else head_dim * num_heads
+        self.inner_kv_dim = self.inner_dim if kv_heads is None else head_dim * kv_heads
         self.out_dim = out_dim if out_dim is not None else query_dim
-        self.heads = heads
-        self.dim_head = dim_head
+        self.num_heads = num_heads
+        self.head_dim = head_dim
         self.cross_attention_dim = cross_attention_dim
 
         # QK normalization
-        self.norm_q = RMSNorm(self.dim_head, eps=eps)
-        self.norm_k = RMSNorm(self.dim_head, eps=eps)
+        self.norm_q = RMSNorm(self.head_dim, eps=eps)
+        self.norm_k = RMSNorm(self.head_dim, eps=eps)
 
         # Query projection
         self.to_q = ReplicatedLinear(query_dim, self.inner_dim, bias=bias)
@@ -306,9 +305,9 @@ class CosmosCrossAttention(nn.Module):
         )
 
         self.attn = Attention(
-             num_heads=heads,
-             head_size=dim_head,
-             softmax_scale=1.0 / (dim_head**0.5),
+             num_heads=num_heads,
+             head_size=head_dim,
+             softmax_scale=1.0 / (head_dim**0.5),
              causal=False,
         )
 
@@ -326,19 +325,22 @@ class CosmosCrossAttention(nn.Module):
         key, _ = self.to_k(encoder_hidden_states)
         value, _ = self.to_v(encoder_hidden_states)
 
-        query = query.unflatten(2, (self.heads, -1)).transpose(1, 2)
-        key = key.unflatten(2, (self.heads, -1)).transpose(1, 2)
-        value = value.unflatten(2, (self.heads, -1)).transpose(1, 2)
+        query = query.unflatten(2, (self.num_heads, -1)).transpose(1, 2)
+        key = key.unflatten(2, (self.num_heads, -1)).transpose(1, 2)
+        value = value.unflatten(2, (self.num_heads, -1)).transpose(1, 2)
 
-        query = self.norm_q(query)
-        key = self.norm_k(key)
+        # QK normalization
+        q_shape, k_shape = query.shape, key.shape
+        query = self.norm_q(query.reshape(-1, self.head_dim)).view(q_shape)
+        key = self.norm_k(key.reshape(-1, self.head_dim)).view(k_shape)
 
+        # Apply RoPE
         if image_rotary_emb is not None:
             from diffusers.models.embeddings import apply_rotary_emb
-
             query = apply_rotary_emb(query, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
             key = apply_rotary_emb(key, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
 
+        # Attention
         hidden_states = self.attn(query.transpose(1, 2), key.transpose(1, 2), value.transpose(1, 2))
         hidden_states = hidden_states.flatten(2, 3).type_as(query)
 
@@ -380,8 +382,8 @@ class CosmosTransformerBlock(nn.Module):
         self.attn2 = CosmosCrossAttention(
             query_dim=hidden_size,
             cross_attention_dim=cross_attention_dim,
-            heads=num_attention_heads,
-            dim_head=attention_head_dim,            
+            num_heads=num_attention_heads,
+            head_dim=attention_head_dim,            
             dropout=0.0,
             bias=False,
             eps=1e-5,

--- a/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
+++ b/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
@@ -712,7 +712,7 @@ class CosmosTransformer3DModel(nn.Module):
         post_patch_width = width // p_w
 
         hidden_states = self.patch_embed(hidden_states)
-        hidden_states = hidden_states.flatten(1, 3)  # [B, T, H, W, C] -> [B, THW, C]
+        hidden_states = hidden_states.flatten(1, 3)  # [B, T, H, W, C] -> [B, T*H*W, C]
 
         # Timestep embeddings
         if timestep.ndim == 1:
@@ -729,7 +729,7 @@ class CosmosTransformer3DModel(nn.Module):
                 .expand(-1, -1, post_patch_height, post_patch_width, -1)
                 .flatten(1, 3)
                 for x in (temb, embedded_timestep)
-            )  # [BT, C] -> [B, T, 1, 1, C] -> [B, T, H, W, C] -> [B, THW, C]
+            )  # [BT, C] -> [B, T, 1, 1, C] -> [B, T, H, W, C] -> [B, T*H*W, C]
         else:
             raise ValueError(f"Expected timestep to have shape [B, 1, T, 1, 1] or [T], but got {timestep.shape}")
 

--- a/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
+++ b/vllm_omni/diffusion/models/cosmos/cosmos_transformer.py
@@ -1,0 +1,922 @@
+# Copyright 2025 The NVIDIA Team and The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Adapted from Diffusers implementation:
+# https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/transformers/transformer_cosmos.py
+
+from pathlib import Path
+from typing import Any, Iterable, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from diffusers.models.embeddings import Timesteps
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.layernorm import RMSNorm as DistributedRMSNorm
+from vllm_omni.diffusion.data import OmniDiffusionConfig
+
+logger = init_logger(__name__)
+
+
+def apply_rotary_emb_cosmos(
+    hidden_states: torch.Tensor,
+    freqs_cos: torch.Tensor,
+    freqs_sin: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Apply rotary embeddings to input tensors using the given frequency tensors.
+
+    Args:
+        hidden_states: Input tensor of shape [B, S, H, D]
+        freqs_cos: Cosine frequencies
+        freqs_sin: Sine frequencies
+
+    Returns:
+        Tensor with rotary embeddings applied
+    """
+    x1, x2 = hidden_states.unflatten(-1, (-1, 2)).unbind(-1)
+    cos = freqs_cos[..., 0::2]
+    sin = freqs_sin[..., 1::2]
+    out = torch.empty_like(hidden_states)
+    out[..., 0::2] = x1 * cos - x2 * sin
+    out[..., 1::2] = x1 * sin + x2 * cos
+    return out.type_as(hidden_states)
+
+
+class CosmosRotaryPosEmbed(nn.Module):
+    """
+    Rotary Position Embeddings (RoPE) for 3D video data with NTK-aware scaling.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        max_size: Tuple[int, int, int] = (128, 240, 240),
+        patch_size: Tuple[int, int, int] = (1, 2, 2),
+        base_fps: int = 24,
+        rope_scale: Tuple[float, float, float] = (2.0, 1.0, 1.0),
+    ):
+        super().__init__()
+
+        self.max_size = [size // patch for size, patch in zip(max_size, patch_size)]
+        self.patch_size = patch_size
+        self.base_fps = base_fps
+
+        self.dim_h = hidden_size // 6 * 2
+        self.dim_w = hidden_size // 6 * 2
+        self.dim_t = hidden_size - self.dim_h - self.dim_w
+
+        self.h_ntk_factor = rope_scale[1] ** (self.dim_h / (self.dim_h - 2))
+        self.w_ntk_factor = rope_scale[2] ** (self.dim_w / (self.dim_w - 2))
+        self.t_ntk_factor = rope_scale[0] ** (self.dim_t / (self.dim_t - 2))
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        fps: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        pe_size = [
+            num_frames // self.patch_size[0],
+            height // self.patch_size[1],
+            width // self.patch_size[2],
+        ]
+        device = hidden_states.device
+
+        h_theta = 10000.0 * self.h_ntk_factor
+        w_theta = 10000.0 * self.w_ntk_factor
+        t_theta = 10000.0 * self.t_ntk_factor
+
+        seq = torch.arange(max(self.max_size), device=device, dtype=torch.float32)
+
+        dim_h_range = (
+            torch.arange(0, self.dim_h, 2, device=device, dtype=torch.float32)[: (self.dim_h // 2)]
+            / self.dim_h
+        )
+        dim_w_range = (
+            torch.arange(0, self.dim_w, 2, device=device, dtype=torch.float32)[: (self.dim_w // 2)]
+            / self.dim_w
+        )
+        dim_t_range = (
+            torch.arange(0, self.dim_t, 2, device=device, dtype=torch.float32)[: (self.dim_t // 2)]
+            / self.dim_t
+        )
+
+        h_spatial_freqs = 1.0 / (h_theta ** dim_h_range)
+        w_spatial_freqs = 1.0 / (w_theta ** dim_w_range)
+        temporal_freqs = 1.0 / (t_theta ** dim_t_range)
+
+        emb_h = torch.outer(seq[: pe_size[1]], h_spatial_freqs)[None, :, None, :].repeat(
+            pe_size[0], 1, pe_size[2], 1
+        )
+        emb_w = torch.outer(seq[: pe_size[2]], w_spatial_freqs)[None, None, :, :].repeat(
+            pe_size[0], pe_size[1], 1, 1
+        )
+
+        if fps is None:
+            emb_t = torch.outer(seq[: pe_size[0]], temporal_freqs)
+        else:
+            emb_t = torch.outer(seq[: pe_size[0]] / fps * self.base_fps, temporal_freqs)
+
+        emb_t = emb_t[:, None, None, :].repeat(1, pe_size[1], pe_size[2], 1)
+
+        freqs = torch.cat([emb_t, emb_h, emb_w] * 2, dim=-1).flatten(0, 2).float()
+
+        cos = torch.cos(freqs)
+        sin = torch.sin(freqs)
+
+        return cos, sin
+
+
+class CosmosLearnablePositionalEmbed(nn.Module):
+    """
+    Learnable 3D positional embeddings for temporal, height, and width dimensions.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        max_size: Tuple[int, int, int],
+        patch_size: Tuple[int, int, int],
+        eps: float = 1e-6,
+    ):
+        super().__init__()
+
+        self.max_size = [size // patch for size, patch in zip(max_size, patch_size)]
+        self.patch_size = patch_size
+        self.eps = eps
+
+        self.pos_emb_t = nn.Parameter(torch.zeros(self.max_size[0], hidden_size))
+        self.pos_emb_h = nn.Parameter(torch.zeros(self.max_size[1], hidden_size))
+        self.pos_emb_w = nn.Parameter(torch.zeros(self.max_size[2], hidden_size))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        pe_size = [
+            num_frames // self.patch_size[0],
+            height // self.patch_size[1],
+            width // self.patch_size[2],
+        ]
+
+        emb_t = self.pos_emb_t[: pe_size[0]][None, :, None, None, :].repeat(
+            batch_size, 1, pe_size[1], pe_size[2], 1
+        )
+        emb_h = self.pos_emb_h[: pe_size[1]][None, None, :, None, :].repeat(
+            batch_size, pe_size[0], 1, pe_size[2], 1
+        )
+        emb_w = self.pos_emb_w[: pe_size[2]][None, None, None, :, :].repeat(
+            batch_size, pe_size[0], pe_size[1], 1, 1
+        )
+
+        emb = emb_t + emb_h + emb_w
+        emb = emb.flatten(1, 3)
+
+        norm = torch.linalg.vector_norm(emb, dim=-1, keepdim=True, dtype=torch.float32)
+        norm = torch.add(self.eps, norm, alpha=np.sqrt(norm.numel() / emb.numel()))
+
+        return (emb / norm).type_as(hidden_states)
+
+
+class CosmosPatchEmbed(nn.Module):
+    """
+    Patch embedding for 3D video inputs.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        patch_size: Tuple[int, int, int],
+        bias: bool = True,
+    ):
+        super().__init__()
+        self.patch_size = patch_size
+        self.proj = nn.Linear(
+            in_channels * patch_size[0] * patch_size[1] * patch_size[2],
+            out_channels,
+            bias=bias,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        p_t, p_h, p_w = self.patch_size
+
+        hidden_states = hidden_states.reshape(
+            batch_size,
+            num_channels,
+            num_frames // p_t,
+            p_t,
+            height // p_h,
+            p_h,
+            width // p_w,
+            p_w,
+        )
+
+        hidden_states = hidden_states.permute(0, 2, 4, 6, 1, 3, 5, 7).flatten(4, 7)
+        hidden_states = hidden_states.type_as(self.proj.weight)
+        hidden_states = self.proj(hidden_states)
+        return hidden_states
+
+
+class CosmosTimestepEmbedding(nn.Module):
+    """
+    MLP for processing timestep embeddings.
+    """
+
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self.linear_1 = nn.Linear(in_features, out_features, bias=False)
+        self.activation = nn.SiLU()
+        self.linear_2 = nn.Linear(out_features, 3 * out_features, bias=False)
+
+    def forward(self, timesteps: torch.Tensor) -> torch.Tensor:
+        emb = self.linear_1(timesteps.to(torch.bfloat16))
+        emb = self.activation(emb)
+        emb = self.linear_2(emb)
+        return emb
+
+
+class CosmosEmbedding(nn.Module):
+    """
+    Complete timestep conditioning module.
+    """
+
+    def __init__(self, embedding_dim: int, condition_dim: int):
+        super().__init__()
+
+        self.time_proj = Timesteps(
+            embedding_dim,
+            flip_sin_to_cos=True,
+            downscale_freq_shift=0.0,
+        )
+        self.t_embedder = CosmosTimestepEmbedding(embedding_dim, condition_dim)
+        self.norm = nn.RMSNorm(embedding_dim, eps=1e-6, elementwise_affine=True)
+
+    def forward(self, hidden_states: torch.Tensor, timestep: torch.LongTensor) -> torch.Tensor:
+        timesteps_proj = self.time_proj(timestep).type_as(hidden_states)
+        temb = self.t_embedder(timesteps_proj)
+        embedded_timestep = self.norm(timesteps_proj)
+        return temb, embedded_timestep
+
+
+
+class CosmosAdaLayerNorm(nn.Module):
+    """
+    Adaptive Layer Normalization (AdaLN) without gate.
+    """
+
+    def __init__(self, in_features: int, hidden_features: int):
+        super().__init__()
+
+        self.embedding_dim = in_features
+        self.norm = nn.LayerNorm(in_features, elementwise_affine=False, eps=1e-6)
+        self.activation = nn.SiLU()
+
+        self.linear_1 = nn.Linear(in_features, hidden_features, bias=False)
+        self.linear_2 = nn.Linear(hidden_features, 2 * in_features, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        embedded_timestep: torch.Tensor,
+        temb: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        embedded_timestep = self.activation(embedded_timestep)
+        embedded_timestep = self.linear_1(embedded_timestep)
+        embedded_timestep = self.linear_2(embedded_timestep)
+
+        if temb is not None:
+            embedded_timestep = embedded_timestep + temb[..., : 2 * self.embedding_dim]
+
+        shift, scale = embedded_timestep.chunk(2, dim=-1)
+        hidden_states = self.norm(hidden_states)
+
+        if embedded_timestep.ndim == 2:
+            shift, scale = (x.unsqueeze(1) for x in (shift, scale))
+
+        hidden_states = hidden_states * (1 + scale) + shift
+        return hidden_states
+
+
+class CosmosAdaLayerNormZero(nn.Module):
+    """
+    Adaptive Layer Normalization with zero initialization (AdaLN-Zero).
+    """
+
+    def __init__(self, in_features: int, hidden_features: Optional[int] = None):
+        super().__init__()
+
+        self.norm = nn.LayerNorm(in_features, elementwise_affine=False, eps=1e-6)
+        self.activation = nn.SiLU()
+
+        if hidden_features is None:
+            self.linear_1 = nn.Identity()
+        else:
+            self.linear_1 = nn.Linear(in_features, hidden_features, bias=False)
+
+        self.linear_2 = nn.Linear(hidden_features, 3 * in_features, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        embedded_timestep: torch.Tensor,
+        temb: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        embedded_timestep = self.activation(embedded_timestep)
+        embedded_timestep = self.linear_1(embedded_timestep)
+        embedded_timestep = self.linear_2(embedded_timestep)
+
+        if temb is not None:
+            embedded_timestep = embedded_timestep + temb
+
+        shift, scale, gate = embedded_timestep.chunk(3, dim=-1)
+        hidden_states = self.norm(hidden_states)
+
+        if embedded_timestep.ndim == 2:
+            shift, scale, gate = (x.unsqueeze(1) for x in (shift, scale, gate))
+
+        hidden_states = hidden_states * (1 + scale) + shift
+        return hidden_states, gate
+
+
+class CosmosAttention(nn.Module):
+    """
+    Cosmos Attention module wrapping vLLM parallel layers.
+    """
+
+    def __init__(
+        self,
+        query_dim: int,
+        cross_attention_dim: Optional[int] = None,
+        heads: int = 16,
+        kv_heads: int | None = None,
+        dim_head: int = 128,
+        dropout: float = 0.0,
+        bias: bool = False,
+        eps: float = 1e-5,
+        out_dim: int = None,
+    ):
+        super().__init__()
+        from vllm.distributed import get_tensor_model_parallel_world_size
+        from vllm_omni.diffusion.attention.layer import Attention
+
+        self.inner_dim = out_dim if out_dim is not None else dim_head * heads
+        self.inner_kv_dim = self.inner_dim if kv_heads is None else dim_head * kv_heads
+        self.out_dim = out_dim if out_dim is not None else query_dim
+        self.heads = heads
+        self.dim_head = dim_head
+        self.is_cross_attention = True
+        self.cross_attention_dim = cross_attention_dim if cross_attention_dim is not None else query_dim
+
+        tp_size = get_tensor_model_parallel_world_size()
+        self.num_heads_per_partition = heads // tp_size
+        self.tp_inner_dim = self.num_heads_per_partition * dim_head
+
+        self.norm_q = DistributedRMSNorm(self.dim_head, eps=eps)
+        self.norm_k = DistributedRMSNorm(self.dim_head, eps=eps)
+
+        if self.is_cross_attention:
+            self.to_q = ColumnParallelLinear(
+                query_dim,
+                self.inner_dim,
+                bias=bias,
+                gather_output=False,
+                return_bias=False,
+            )
+            self.to_k = ColumnParallelLinear(
+                self.cross_attention_dim,
+                self.inner_kv_dim,
+                bias=bias,
+                gather_output=False,
+                return_bias=False,
+            )
+            self.to_v = ColumnParallelLinear(
+                self.cross_attention_dim,
+                self.inner_kv_dim,
+                bias=bias,
+                gather_output=False,
+                return_bias=False,
+            )
+        else:
+            self._qkv_proj = QKVParallelLinear(
+                hidden_size=query_dim,
+                head_size=dim_head,
+                total_num_heads=heads,
+                bias=bias,
+            )
+            self.to_q = self._qkv_proj
+            self.to_k = self._qkv_proj
+            self.to_v = self._qkv_proj
+
+        self.to_out = RowParallelLinear(
+            self.inner_dim,
+            self.out_dim,
+            bias=bias,
+            input_is_parallel=True,
+            return_bias=False,
+        )
+        self.dropout = nn.Dropout(dropout)
+
+        self._attn = Attention(
+            num_heads=self.num_heads_per_partition,
+            head_size=dim_head,
+            softmax_scale=1.0 / (dim_head**0.5),
+            causal=False,
+            num_kv_heads=self.num_heads_per_partition,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    ) -> torch.Tensor:
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+
+        query = self.to_q(hidden_states)
+        key = self.to_k(encoder_hidden_states)
+        value = self.to_v(encoder_hidden_states)
+
+        query = query.unflatten(2, (self.heads, -1)).transpose(1, 2)
+        key = key.unflatten(2, (self.heads, -1)).transpose(1, 2)
+        value = value.unflatten(2, (self.heads, -1)).transpose(1, 2)
+
+        query = self.norm_q(query)
+        key = self.norm_k(key)
+
+        if image_rotary_emb is not None:
+            from diffusers.models.embeddings import apply_rotary_emb
+
+            query = apply_rotary_emb(query, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
+            key = apply_rotary_emb(key, image_rotary_emb, use_real=True, use_real_unbind_dim=-2)
+
+        hidden_states = self._attn(query.transpose(1, 2), key.transpose(1, 2), value.transpose(1, 2))
+        hidden_states = hidden_states.flatten(2, 3)
+        hidden_states = hidden_states.type_as(query)
+        hidden_states = self.to_out(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+
+        return hidden_states
+
+
+class ColumnParallelGELU(nn.Module):
+    """Column parallel linear with GELU activation."""
+
+    def __init__(self, dim_in: int, dim_out: int, *, approximate: str = "tanh", bias: bool = True):
+        super().__init__()
+        self.proj = ColumnParallelLinear(
+            dim_in,
+            dim_out,
+            bias=bias,
+            gather_output=False,
+            return_bias=False,
+        )
+        self.approximate = approximate
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.proj(x)
+        return F.gelu(x, approximate=self.approximate)
+
+
+class CosmosFeedForward(nn.Module):
+    """
+    Cosmos FeedForward module wrapping vLLM parallel layers.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        dim_out: int | None = None,
+        mult: int = 4,
+        dropout: float = 0.0,
+        activation_fn: str = "gelu",
+        final_dropout: bool = False,
+        inner_dim=None,
+        bias: bool = True,
+    ):
+        super().__init__()
+        if inner_dim is None:
+            inner_dim = int(dim * mult)
+        dim_out = dim_out if dim_out is not None else dim
+
+        if activation_fn == "gelu":
+            act_fn = ColumnParallelGELU(dim, inner_dim, approximate="tanh", bias=bias)
+        else:
+            raise ValueError(f"Unsupported activation_fn: {activation_fn}")
+
+        self.net = nn.ModuleList([])
+        self.net.append(act_fn)
+        self.net.append(nn.Dropout(dropout))
+        self.net.append(
+            RowParallelLinear(
+                inner_dim,
+                dim,
+                bias=bias,
+                input_is_parallel=True,
+                return_bias=False,
+            )
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        for module in self.net:
+            hidden_states = module(hidden_states)
+        return hidden_states
+
+
+class CosmosTransformerBlock(nn.Module):
+    """
+    Cosmos Transformer Block with self-attention, cross-attention, and feedforward.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        cross_attention_dim: int = 1024,
+        mlp_ratio: float = 4.0,
+        adaln_lora_dim: int = 256,
+        od_config: Optional[OmniDiffusionConfig] = None,
+        block_index: int = 0,
+    ):
+        super().__init__()
+
+        self.hidden_size = hidden_size
+        self.num_attention_heads = num_attention_heads
+        self.attention_head_dim = attention_head_dim
+        self.block_index = block_index
+        self.od_config = od_config
+
+        self.norm1 = CosmosAdaLayerNormZero(hidden_size, adaln_lora_dim)
+
+        self.attn1 = CosmosAttention(
+            query_dim=hidden_size,
+            cross_attention_dim=None,
+            heads=num_attention_heads,
+            dim_head=attention_head_dim,
+            dropout=0.0,
+            bias=False,
+            eps=1e-5,
+        )
+
+        self.norm2 = CosmosAdaLayerNormZero(hidden_size, adaln_lora_dim)
+
+        self.attn2 = CosmosAttention(
+            query_dim=hidden_size,
+            cross_attention_dim=cross_attention_dim,
+            heads=num_attention_heads,
+            dim_head=attention_head_dim,
+            dropout=0.0,
+            bias=False,
+            eps=1e-5,
+        )
+
+        self.norm3 = CosmosAdaLayerNormZero(hidden_size, adaln_lora_dim)
+
+        self.ff = CosmosFeedForward(
+            dim=hidden_size,
+            mult=mlp_ratio,
+            dropout=0.0,
+            bias=False,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        embedded_timestep: torch.Tensor,
+        freqs_cos: torch.Tensor,
+        freqs_sin: torch.Tensor,
+        temb: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        embedded_timestep = embedded_timestep.type_as(hidden_states)
+        image_rotary_emb = (freqs_cos, freqs_sin)
+
+        norm_hidden, gate1 = self.norm1(hidden_states, embedded_timestep, temb)
+        attn_output = self.attn1(norm_hidden, image_rotary_emb=image_rotary_emb)
+        hidden_states = hidden_states + gate1 * attn_output
+
+        norm_hidden, gate2 = self.norm2(hidden_states, embedded_timestep, temb)
+        attn_output = self.attn2(norm_hidden, encoder_hidden_states=encoder_hidden_states)
+        hidden_states = hidden_states + gate2 * attn_output
+
+        norm_hidden, gate3 = self.norm3(hidden_states, embedded_timestep, temb)
+        ff_output = self.ff(norm_hidden)
+        hidden_states = hidden_states + gate3 * ff_output
+
+        return hidden_states
+
+
+class CosmosTransformer3DModel(nn.Module):
+    """
+    Cosmos Predict 2.5 3D Video Transformer.
+    """
+
+    _repeated_blocks = ["CosmosTransformerBlock"]
+    _layerwise_offload_blocks_attr = "blocks"
+
+    def __init__(
+        self,
+        *,
+        od_config: Optional[OmniDiffusionConfig] = None,
+        patch_size: Tuple[int, int, int] = (1, 2, 2),        
+        num_attention_heads: int = 32,
+        attention_head_dim: int = 128,                
+        in_channels: int = 16,
+        out_channels: int = 16,
+        num_layers: int = 28,
+        mlp_ratio: float = 4.0,
+        text_embed_dim: int = 4096,
+        adaln_lora_dim: int = 256,
+        max_size: Tuple[int, int, int] = (128, 240, 240),
+        rope_scale: Tuple[float, float, float] = (2.0, 1.0, 1.0),
+        concat_padding_mask: bool = True,
+        extra_pos_embed_type: Optional[str] = "learnable",
+        use_crossattn_projection: bool = False,
+        crossattn_proj_in_channels: Optional[int] = None,
+        encoder_hidden_states_channels: int = 1024,
+        **kwargs,
+    ):
+        super().__init__()
+
+        self.od_config = od_config
+        self.parallel_config = od_config.parallel_config if od_config else None
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.num_attention_heads = num_attention_heads
+        self.attention_head_dim = attention_head_dim
+        self.num_layers = num_layers
+        self.hidden_size = num_attention_heads * attention_head_dim
+        self.concat_padding_mask = concat_padding_mask
+
+        self.patch_embed = CosmosPatchEmbed(
+            in_channels=18,
+            out_channels=self.hidden_size,
+            patch_size=patch_size,
+            bias=False,
+        )
+
+        self.rope = CosmosRotaryPosEmbed(
+            hidden_size=attention_head_dim,
+            max_size=max_size,
+            patch_size=patch_size,
+            base_fps=24,
+            rope_scale=rope_scale,
+        )
+
+        if extra_pos_embed_type == "learnable":
+            self.learnable_pos_embed = CosmosLearnablePositionalEmbed(
+                hidden_size=self.hidden_size,
+                max_size=max_size,
+                patch_size=patch_size,
+                eps=1e-6,
+            )
+        else:
+            self.learnable_pos_embed = None
+
+        self.time_embed = CosmosEmbedding(
+            embedding_dim=self.hidden_size,
+            condition_dim=self.hidden_size,
+        )
+
+        self.transformer_blocks = nn.ModuleList(
+            [
+                CosmosTransformerBlock(
+                    hidden_size=self.hidden_size,
+                    num_attention_heads=num_attention_heads,
+                    attention_head_dim=attention_head_dim,
+                    cross_attention_dim=encoder_hidden_states_channels,
+                    mlp_ratio=mlp_ratio,
+                    adaln_lora_dim=adaln_lora_dim,
+                    od_config=od_config,
+                    block_index=i,
+                )
+                for i in range(num_layers)
+            ]
+        )
+
+        self.norm_out = CosmosAdaLayerNorm(self.hidden_size, adaln_lora_dim)
+
+        patch_volume = patch_size[0] * patch_size[1] * patch_size[2]
+        self.proj_out = nn.Linear(self.hidden_size, patch_volume * out_channels, bias=False)
+
+        if use_crossattn_projection and crossattn_proj_in_channels is not None:
+            self.crossattn_proj = nn.Sequential(
+                nn.Linear(crossattn_proj_in_channels, encoder_hidden_states_channels, bias=True),
+                nn.GELU(),
+            )
+        else:
+            self.crossattn_proj = None
+
+        logger.info(
+            f"Initialized CosmosTransformer3DModel: "
+            f"{num_layers} layers, {num_attention_heads} heads, "
+            f"{attention_head_dim} head_dim, hidden_size={self.hidden_size}"
+        )
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(self.parameters()).dtype
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        block_controlnet_hidden_states: list[torch.Tensor] | None = None,
+        attention_mask: torch.Tensor | None = None,
+        fps: int | None = None,
+        condition_mask: torch.Tensor | None = None,
+        padding_mask: torch.Tensor | None = None,
+        return_dict: bool = True,
+    ) -> torch.Tensor:
+        latents = hidden_states
+
+        if condition_mask is not None:
+            latents = torch.cat([latents, condition_mask], dim=1)
+
+        if padding_mask is not None:
+            from torchvision import transforms
+
+            batch_size, num_channels, num_frames, height, width = latents.shape
+            padding_mask_resized = transforms.functional.resize(
+                padding_mask,
+                list(latents.shape[-2:]),
+                interpolation=transforms.InterpolationMode.NEAREST,
+            )
+            hidden_states = torch.cat(
+                [latents, padding_mask_resized.unsqueeze(2).repeat(batch_size, 1, num_frames, 1, 1)],
+                dim=1,
+            )
+        else:
+            hidden_states = latents
+
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        latent_shape = hidden_states.shape
+
+        hidden_states = self.patch_embed(hidden_states)
+        hidden_states = hidden_states.flatten(1, 3)
+
+        if self.learnable_pos_embed is not None:
+            learnable_pos = self.learnable_pos_embed(
+                torch.zeros(latent_shape, device=hidden_states.device, dtype=hidden_states.dtype)
+            )
+            hidden_states = hidden_states + learnable_pos
+
+        freqs_cos, freqs_sin = self.rope(
+            torch.zeros(latent_shape, device=hidden_states.device),
+            fps=fps,
+        )
+
+        p_t, p_h, p_w = self.od_config.tf_model_config.params["patch_size"]
+        post_patch_num_frames = num_frames // p_t
+        post_patch_height = height // p_h
+        post_patch_width = width // p_w
+
+        if timestep.ndim == 1:
+            temb, embedded_timestep = self.time_embed(hidden_states, timestep)
+        elif timestep.ndim == 5:
+            assert timestep.shape == (batch_size, 1, num_frames, 1, 1), (
+                f"Expected timestep to have shape [B, 1, T, 1, 1], but got {timestep.shape}"
+            )
+            timestep = timestep.flatten()
+            temb, embedded_timestep = self.time_embed(hidden_states, timestep)
+
+            temb, embedded_timestep = (
+                x.view(batch_size, post_patch_num_frames, 1, 1, -1)
+                .expand(-1, -1, post_patch_height, post_patch_width, -1)
+                .flatten(1, 3)
+                for x in (temb, embedded_timestep)
+            )
+        else:
+            raise ValueError(
+                f"Expected timestep to have shape [B, 1, T, 1, 1] or [T], but got {timestep.shape}"
+            )
+
+        if self.crossattn_proj is not None:
+            encoder_hidden_states = self.crossattn_proj(encoder_hidden_states)
+
+        if encoder_hidden_states is None:
+            raise ValueError("encoder_hidden_states cannot be None")
+
+        for block in self.transformer_blocks:
+            hidden_states = block(
+                hidden_states,
+                encoder_hidden_states,
+                embedded_timestep,
+                freqs_cos,
+                freqs_sin,
+                temb,
+            )
+
+        hidden_states = self.norm_out(hidden_states, embedded_timestep, temb)
+        hidden_states = self.proj_out(hidden_states)
+        hidden_states = self._unpatchify(hidden_states, latent_shape)
+
+        return hidden_states
+
+    def _unpatchify(
+        self,
+        hidden_states: torch.Tensor,
+        latent_shape: Tuple[int, int, int, int, int],
+    ) -> torch.Tensor:
+        batch_size, _, num_frames, height, width = latent_shape
+        p_t, p_h, p_w = self.patch_embed.patch_size
+
+        num_patches_t = num_frames // p_t
+        num_patches_h = height // p_h
+        num_patches_w = width // p_w
+
+        hidden_states = hidden_states.unflatten(2, (p_h, p_w, p_t, -1))
+        hidden_states = hidden_states.unflatten(1, (num_patches_t, num_patches_h, num_patches_w))
+        hidden_states = hidden_states.permute(0, 7, 1, 6, 2, 4, 3, 5)
+        hidden_states = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        from vllm.distributed import (
+            get_tensor_model_parallel_rank,
+            get_tensor_model_parallel_world_size,
+        )
+        from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
+
+        stacked_params_mapping = []
+
+        weight_name_remapping = {}
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            name = weight_name_remapping.get(name, name)
+            original_name = name
+            lookup_name = name
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in original_name:
+                    continue
+                lookup_name = original_name.replace(weight_name, param_name)
+                param = params_dict[lookup_name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if ".ffn.net.0." in lookup_name:
+                    lookup_name = lookup_name.replace(".ffn.net.0.", ".ffn.net_0.")
+                elif ".ffn.net.2." in lookup_name:
+                    lookup_name = lookup_name.replace(".ffn.net.2.", ".ffn.net_2.")
+
+                if ".to_out.0." in lookup_name:
+                    lookup_name = lookup_name.replace(".to_out.0.", ".to_out.")
+
+                if lookup_name not in params_dict:
+                    logger.warning(f"Skipping weight {original_name} -> {lookup_name}")
+                    continue
+
+                param = params_dict[lookup_name]
+
+                if tp_size > 1 and any(
+                    norm_name in lookup_name
+                    for norm_name in [
+                        ".attn1.norm_q.",
+                        ".attn1.norm_k.",
+                        ".attn2.norm_q.",
+                        ".attn2.norm_k.",
+                        ".attn2.norm_added_k.",
+                    ]
+                ):
+                    shard_size = loaded_weight.shape[0] // tp_size
+                    loaded_weight = loaded_weight[tp_rank * shard_size : (tp_rank + 1) * shard_size]
+
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+
+            loaded_params.add(original_name)
+            loaded_params.add(lookup_name)
+
+        return loaded_params

--- a/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
+++ b/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
@@ -84,7 +84,7 @@ def retrieve_latents(
         raise AttributeError("Could not access latents of provided encoder_output")
 
 
-def load_transformer_config(model_path: str, subfolder: str = "transformer", local_files_only: bool = True) -> dict:
+def load_transformer_config(model_path: str, subfolder: str = "transformer", local_files_only: bool = True, revision: str | None = None) -> dict:
     """Load transformer config from model directory or HF Hub."""
     if local_files_only:
         config_path = os.path.join(model_path, subfolder, "config.json")
@@ -99,6 +99,7 @@ def load_transformer_config(model_path: str, subfolder: str = "transformer", loc
             config_path = hf_hub_download(
                 repo_id=model_path,
                 filename=f"{subfolder}/config.json",
+                revision=revision,
             )
             with open(config_path) as f:
                 return json.load(f)
@@ -188,7 +189,7 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             DiffusersPipelineLoader.ComponentSource(
                 model_or_path=od_config.model,
                 subfolder="transformer",
-                revision=None,
+                revision=od_config.revision,
                 prefix="transformer.",
                 fall_back_to_pt=True,
             )
@@ -198,12 +199,14 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             model,
             subfolder="tokenizer",
             local_files_only=local_files_only,
+            revision=od_config.revision,
             use_fast=False,
         )
         self.text_encoder = Qwen2_5_VLForConditionalGeneration.from_pretrained(
             model,
             subfolder="text_encoder",
             torch_dtype=dtype,
+            revision=od_config.revision,
             local_files_only=local_files_only,
         ).to(self.device)
 
@@ -211,6 +214,7 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             model,
             subfolder="vae",
             torch_dtype=dtype,
+            revision=od_config.revision,
             local_files_only=local_files_only,
         ).to(self.device)
 
@@ -239,13 +243,14 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             model,
             subfolder="transformer",
             local_files_only=local_files_only,
+            revision=od_config.revision,
         )
 
         self.transformer = CosmosTransformer3DModel(
             od_config=od_config,
             **transformer_config,
         )
-        
+
         #self.transformer = create_transformer_from_config(transformer_config)
 
         # Store the active transformer config
@@ -255,6 +260,7 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             model,
             subfolder="scheduler",
             local_files_only=local_files_only,
+            revision=od_config.revision,
         )
 
         if hasattr(self.scheduler, 'alphas_cumprod') and isinstance(self.scheduler.alphas_cumprod, torch.Tensor):

--- a/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
+++ b/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
@@ -25,16 +25,17 @@ from typing import Any
 
 import numpy as np
 import torch
+from torch import nn
+import torchvision.transforms.functional
+
 from diffusers import AutoencoderKLWan
 from diffusers.schedulers import UniPCMultistepScheduler
 from diffusers.utils.torch_utils import randn_tensor
 from diffusers.video_processor import VideoProcessor
-from torch import nn
 from transformers import AutoTokenizer, Qwen2_5_VLForConditionalGeneration
-from vllm.model_executor.models.utils import AutoWeightsLoader
 
+from vllm.model_executor.models.utils import AutoWeightsLoader
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
-from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.cosmos.cosmos_transformer import CosmosTransformer3DModel
@@ -74,7 +75,6 @@ def load_transformer_config(
 def get_cosmos_predict25_post_process_func(
     od_config: OmniDiffusionConfig,
 ):
-    from diffusers.video_processor import VideoProcessor
 
     video_processor = VideoProcessor(vae_scale_factor=8)
 
@@ -89,7 +89,7 @@ def get_cosmos_predict25_post_process_func(
     return post_process_func
 
 
-class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
+class CosmosPredict25Pipeline(nn.Module):
     def __init__(
         self,
         *,
@@ -164,23 +164,16 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         if self.latents_mean is None or self.latents_std is None:
             raise ValueError("VAE configuration must define both `latents_mean` and `latents_std`.")
 
-        # Load vLLM-omni transformer with config
         transformer_config = load_transformer_config(
             model,
             subfolder="transformer",
             local_files_only=local_files_only,
             revision=od_config.revision,
         )
-
         self.transformer = CosmosTransformer3DModel(
             od_config=od_config,
             **transformer_config,
         )
-
-        # self.transformer = create_transformer_from_config(transformer_config)
-
-        # Store the active transformer config
-        # self.transformer_config = self.transformer.config
 
         self.scheduler = UniPCMultistepScheduler.from_pretrained(
             model,
@@ -195,6 +188,9 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         if hasattr(self.scheduler, "betas") and isinstance(self.scheduler.betas, torch.Tensor):
             if self.scheduler.betas.is_cuda:
                 self.scheduler.betas = self.scheduler.betas.cpu()
+
+        self._guidance_scale = None
+        self._num_timesteps = None                
 
     @property
     def guidance_scale(self):
@@ -212,14 +208,20 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
     def current_timestep(self):
         return self._current_timestep
 
-    def _build_input_ids_batch(
-        self,
-        prompt_texts: list[str],
-        max_sequence_length: int,
-    ) -> torch.Tensor:
-        batch = []
 
-        for text in prompt_texts:
+    def _get_prompt_embeds(
+        self,
+        prompt: str | list[str] = None,
+        max_sequence_length: int = 512,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ):
+        device = device or self.device
+        dtype = dtype or self.text_encoder.dtype
+
+        input_ids_batch = []
+
+        for sample_idx in range(len(prompt)):
             conversations = [
                 {
                     "role": "system",
@@ -235,12 +237,11 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
                     "content": [
                         {
                             "type": "text",
-                            "text": text,
+                            "text": prompt[sample_idx],
                         }
                     ],
                 },
             ]
-
             input_ids = self.tokenizer.apply_chat_template(
                 conversations,
                 tokenize=True,
@@ -250,29 +251,31 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
                 truncation=True,
                 padding="max_length",
             )
-
             input_ids = (
                 input_ids["input_ids"] if not isinstance(input_ids, list) and "input_ids" in input_ids else input_ids
             )
-            batch.append(torch.tensor(input_ids, dtype=torch.long))
+            input_ids = torch.LongTensor(input_ids)
+            input_ids_batch.append(input_ids)
 
-        input_ids_batch = torch.stack(batch, dim=0)
-        return input_ids_batch
+        input_ids_batch = torch.stack(input_ids_batch, dim=0)
 
-    def _hidden_states_to_prompt_embeds(
-        self,
-        hidden_states: tuple[torch.Tensor, ...],
-        *,
-        device: torch.device,
-        dtype: torch.dtype,
-    ) -> torch.Tensor:
+        outputs = self.text_encoder(
+            input_ids_batch.to(device),
+            output_hidden_states=True,
+        )
+        hidden_states = outputs.hidden_states
+
         normalized_hidden_states = []
-        for h in hidden_states[1:]:
-            normalized = (h - h.mean(dim=-1, keepdim=True)) / (h.std(dim=-1, keepdim=True) + 1e-8)
-            normalized_hidden_states.append(normalized)
+        for layer_idx in range(1, len(hidden_states)):
+            normalized_state = (hidden_states[layer_idx] - hidden_states[layer_idx].mean(dim=-1, keepdim=True)) / (
+                hidden_states[layer_idx].std(dim=-1, keepdim=True) + 1e-8
+            )
+            normalized_hidden_states.append(normalized_state)
 
         prompt_embeds = torch.cat(normalized_hidden_states, dim=-1)
-        return prompt_embeds.to(dtype=dtype, device=device)
+        prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
+
+        return prompt_embeds
 
     def encode_prompt(
         self,
@@ -284,25 +287,13 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
     ):
-        device = device or self.device
-        dtype = dtype or self.text_encoder.dtype
+
 
         prompt = [prompt] if isinstance(prompt, str) else prompt
         batch_size = len(prompt)
 
-        input_ids_batch = self._build_input_ids_batch(prompt, max_sequence_length)
-
-        with torch.no_grad():
-            outputs = self.text_encoder(
-                input_ids_batch.to(device),
-                output_hidden_states=True,
-            )
-        hidden_states = outputs.hidden_states
-
-        prompt_embeds = self._hidden_states_to_prompt_embeds(
-            hidden_states,
-            device=device,
-            dtype=dtype,
+        prompt_embeds = self._get_prompt_embeds(
+            prompt=prompt, max_sequence_length=max_sequence_length, device=device, dtype=dtype
         )
 
         _, seq_len, _ = prompt_embeds.shape
@@ -313,19 +304,9 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         if do_classifier_free_guidance:
             negative_prompt = negative_prompt or DEFAULT_NEGATIVE_PROMPT
             negative_prompt = batch_size * [negative_prompt] if isinstance(negative_prompt, str) else negative_prompt
-            neg_input_ids_batch = self._build_input_ids_batch(negative_prompt, max_sequence_length)
 
-            with torch.no_grad():
-                neg_outputs = self.text_encoder(
-                    neg_input_ids_batch.to(device),
-                    output_hidden_states=True,
-                )
-            neg_hidden_states = neg_outputs.hidden_states
-
-            negative_prompt_embeds = self._hidden_states_to_prompt_embeds(
-                neg_hidden_states,
-                device=device,
-                dtype=dtype,
+            negative_prompt_embeds = self._get_prompt_embeds(
+                prompt=negative_prompt, max_sequence_length=max_sequence_length, device=device, dtype=dtype
             )
 
             _, seq_len, _ = negative_prompt_embeds.shape
@@ -348,6 +329,9 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         generator: torch.Generator | list[torch.Generator] | None = None,        
         latents: torch.Tensor | None = None,
     ):
+        if isinstance(generator, list) and len(generator) != batch_size:
+            raise ValueError(f"Generator list length {len(generator)} does not match batch size {batch_size}.")
+                
         B = batch_size
         C = num_channels_latents
         T = (num_frames_out - 1) // self.vae_scale_factor_temporal + 1
@@ -355,11 +339,12 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         W = width // self.vae_scale_factor_spatial
         shape = (B, C, T, H, W)
 
-        #generator=torch.Generator().manual_seed(1)
         if num_frames_in == 0:
             if latents is None:
                 latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
-
+            else:
+                latents = latents.to(device=device, dtype=dtype)
+                
             cond_mask = torch.zeros((B, 1, T, H, W), dtype=latents.dtype, device=latents.device)
             cond_indicator = torch.zeros((B, 1, T, 1, 1), dtype=latents.dtype, device=latents.device)
 
@@ -373,7 +358,7 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             )
         else:
             if video is None:
-                raise ValueError("`video` must be provided when `num_frames_in` is greater than 0.")
+                raise ValueError("`video` must be provided when `num_frames_in` is greater than 0.")            
             needs_preprocessing = not (isinstance(video, torch.Tensor) and video.ndim == 5 and video.shape[1] == 3)
             if needs_preprocessing:
                 video = self.video_processor.preprocess_video(video, height, width)
@@ -419,11 +404,8 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         negative_prompt,
         height,
         width,
-        num_frames,
         prompt_embeds=None,
         negative_prompt_embeds=None,
-        image=None,
-        video=None,
     ):
         if height % 16 != 0 or width % 16 != 0:
             raise ValueError(f"`height` and `width` have to be divisible by 16 but are {height} and {width}.")
@@ -450,119 +432,50 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         ):
             raise ValueError(f"`negative_prompt` has to be of type `str` or `list` but is {type(negative_prompt)}")
 
-        if image is not None and video is not None:
-            raise ValueError(
-                "Cannot provide both `image` and `video`. "
-                "Use `image` for Image2World or `video` for Video2World, but not both."
-            )
-
-    def predict_noise(
-        self,
-        cond_mask: torch.Tensor | None = None,
-        gt_velocity: torch.Tensor | None = None,
-        **kwargs: Any,
-    ) -> torch.Tensor:
-        """
-        Predict noise with velocity replacement for conditioning.
-
-        Args:
-            cond_mask: Conditioning mask (B, 1, T, H, W)
-            gt_velocity: Ground truth velocity for conditioning frames
-            **kwargs: Arguments to pass to transformer
-
-        Returns:
-            Predicted noise with velocity replacement applied
-        """
-        noise_pred_raw = self.transformer(**kwargs)
-
-        if cond_mask is not None and gt_velocity is not None:
-            noise_pred = gt_velocity + noise_pred_raw * (1 - cond_mask)
-        else:
-            noise_pred = noise_pred_raw
-
-        return noise_pred
 
     def forward(
         self,
         req: OmniDiffusionRequest,
         prompt: str | None = None,
         negative_prompt: str | None = None,
-        image: torch.Tensor | None = None,
-        video: torch.Tensor | None = None,
         height: int = 704,
         width: int = 1280,
         num_inference_steps: int = 36,
-        guidance_scale: float | tuple[float, float] = 7.0,
+        guidance_scale: float = 7.0,
         frame_num: int = 93,
-        num_latent_conditional_frames: int = 2,
         output_type: str | None = "np",
         generator: torch.Generator | list[torch.Generator] | None = None,
         prompt_embeds: torch.Tensor | None = None,
         negative_prompt_embeds: torch.Tensor | None = None,
-        conditional_frame_timestep: float = 0.1,
+        # Cosmos-specific
+        image: torch.Tensor | None = None,
+        video: torch.Tensor | None = None,
+        num_latent_conditional_frames: int = 2,
+        conditional_frame_timestep: float = 0.1,                
         **kwargs,
     ) -> DiffusionOutput:
         # Enforce safety checker requirement (NVIDIA Open Model License Agreement)
         if self.safety_checker is None:
-            message = (
+            raise ValueError(
                 f"You have disabled the safety checker for {self.__class__}. This is in violation of the "
-                "[NVIDIA Open Model License Agreement](https://www.nvidia.com/en-us/agreements/"
-                "enterprise-software/nvidia-open-model-license). "
+                "[NVIDIA Open Model License Agreement](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license). "
                 f"Please ensure that you are compliant with the license agreement."
             )
-            raise ValueError(message)
 
-        # Get parameters from request or arguments
+        extra = getattr(req.sampling_params, "extra_args", {}) or {}
+        image = extra.get("image", image)
+        video = extra.get("video", video)        
+
+        if image is not None and video is not None:
+            raise ValueError("image and video cannot be provided simultaneously")
+        
         if len(req.prompts) == 1:  # If req.prompt is empty, default to prompt & neg_prompt in param list
             prompt = req.prompts[0] if isinstance(req.prompts[0], str) else req.prompts[0].get("prompt")
             negative_prompt = None if isinstance(req.prompts[0], str) else req.prompts[0].get("negative_prompt")
         if prompt is None and prompt_embeds is None:
             raise ValueError("Prompt or prompt_embeds is required for Cosmos Predict 2.5 generation.")
-        extra = getattr(req.sampling_params, "extra_args", {}) or {}
-        image = extra.get("image", image)
-        video = extra.get("video", video)        
-
-        # Validate mutual exclusivity of image and video inputs
-        if image is not None and video is not None:
-            raise ValueError(
-                "Cannot provide both `image` and `video`. "
-                "Use `image` for Image2World or `video` for Video2World, but not both."
-            )
-
-        # Validate num_latent_conditional_frames
-        if num_latent_conditional_frames not in [1, 2]:
-            raise ValueError(
-                f"num_latent_conditional_frames must be 1 or 2, but got {num_latent_conditional_frames}"
-            )
-
-        height = req.sampling_params.height or height
-        width = req.sampling_params.width or width
-        num_frames = req.sampling_params.num_frames if req.sampling_params.num_frames else frame_num
-
-        # Ensure dimensions are compatible with VAE and patch size
-        # patch_size = self.transformer_config.patch_size
-        mod_value = 32  # self.vae_scale_factor_spatial * patch_size[1]  # 16*2=32 for TI2V, 8*2=16 for I2V
-        height = (height // mod_value) * mod_value
-        width = (width // mod_value) * mod_value
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
-
-        # num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
-        guidance_scale = (
-            req.sampling_params.guidance_scale if req.sampling_params.guidance_scale_provided else guidance_scale
-        )
-        num_videos_per_prompt = 1  # req.sampling_params.num_outputs_per_prompt or 1,
-
-        self._guidance_scale = guidance_scale
-        self._current_timestep = None
 
         device = self.device
-        dtype = self.transformer.dtype if self.transformer is not None else self.text_encoder.dtype
-
-        # Seed / generator
-        if generator is None:
-            generator = req.sampling_params.generator
-        if generator is None and req.sampling_params.seed is not None:
-            generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
 
         # Check text safety before generation (required by NVIDIA Open Model License Agreement)
         if self.safety_checker is not None:
@@ -576,21 +489,46 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
                             f"prompt abides by the NVIDIA Open Model License Agreement."
                         )
 
+        height = req.sampling_params.height or height
+        width = req.sampling_params.width or width
+        num_frames = req.sampling_params.num_frames if req.sampling_params.num_frames else frame_num
+        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_videos_per_prompt = req.sampling_params.num_outputs_per_prompt or 1
+        max_sequence_length=req.sampling_params.max_sequence_length or 512
+
+        # Ensure dimensions are compatible with VAE and patch size
+        patch_size = self.transformer.config.patch_size
+        mod_value = self.vae_scale_factor_spatial * patch_size[1]
+        height = (height // mod_value) * mod_value
+        width = (width // mod_value) * mod_value
+
+        if req.sampling_params.guidance_scale_provided:
+            guidance_scale = req.sampling_params.guidance_scale
+
+        self._guidance_scale = guidance_scale
+
         self.check_inputs(
             prompt=prompt,
             negative_prompt=negative_prompt,
             height=height,
             width=width,
-            num_frames=num_frames,
             prompt_embeds=prompt_embeds,
             negative_prompt_embeds=negative_prompt_embeds,
-            image=image,
-            video=video,
         )
+
+        transformer_dtype = self.transformer.dtype
+        vae_dtype = self.vae.dtype
+        dtype = self.transformer.dtype if self.transformer is not None else self.text_encoder.dtype
 
         if num_frames % self.vae_scale_factor_temporal != 1:
             num_frames = num_frames // self.vae_scale_factor_temporal * self.vae_scale_factor_temporal + 1
         num_frames = max(num_frames, 1)
+
+        # Seed / generator
+        if generator is None:
+            generator = req.sampling_params.generator
+        if generator is None and req.sampling_params.seed is not None:
+            generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
 
         if prompt_embeds is None:
             prompt_embeds, negative_prompt_embeds = self.encode_prompt(
@@ -598,6 +536,7 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
                 negative_prompt=negative_prompt,
                 do_classifier_free_guidance=self.do_classifier_free_guidance,
                 num_videos_per_prompt=num_videos_per_prompt,
+                max_sequence_length=max_sequence_length,
                 device=device,
                 dtype=dtype,
             )
@@ -612,7 +551,6 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
 
         batch_size = prompt_embeds.shape[0]
 
-        import torchvision.transforms.functional
         num_frames_in = None
         if image is not None:
             if batch_size != 1:
@@ -663,14 +601,12 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
 
         assert num_frames_in <= num_frames_out, f"expected ({num_frames_in=}) <= ({num_frames_out=})"
 
-        # Empty cache before VAE encoding to prevent OOM (similar to line 843 before decode)
-        if num_frames_in > 0 and current_omni_platform.is_available():
-            current_omni_platform.empty_cache()
-
-        num_channels_latents = self.transformer.in_channels - 1
+        video = video.to(device=device, dtype=vae_dtype)
+                           
+        num_channels_latents = self.transformer.config.in_channels - 1
         latents, cond_latent, cond_mask, cond_indicator = self.prepare_latents(
             video=video,
-            batch_size=batch_size * num_videos_per_prompt,
+            batch_size=batch_size,
             num_channels_latents=num_channels_latents,            
             height=height,
             width=width,
@@ -679,17 +615,16 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             dtype=torch.float32,
             device=self.device,
             generator=generator,
-            #latents=latents,
+            latents=req.sampling_params.latents,
         )
-
-        transformer_dtype = self.transformer.dtype
 
         cond_timestep = torch.ones_like(cond_indicator) * conditional_frame_timestep
         cond_mask = cond_mask.to(transformer_dtype)
 
         padding_mask = latents.new_zeros(1, 1, height, width, dtype=transformer_dtype)
 
-        self.scheduler.set_timesteps(num_inference_steps, device=self.device)
+        # Timesteps
+        self.scheduler.set_timesteps(num_inference_steps, device=device)
         timesteps = self.scheduler.timesteps
         self._num_timesteps = len(timesteps)
 
@@ -697,6 +632,7 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
 
         for i, t in enumerate(timesteps):
             self._current_timestep = t
+
             sigma_t = (
                 torch.tensor(self.scheduler.sigmas[i].item())
                 .unsqueeze(0)
@@ -706,40 +642,31 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             in_latents = cond_mask * cond_latent + (1 - cond_mask) * latents
             in_latents = in_latents.to(transformer_dtype)
             in_timestep = cond_indicator * cond_timestep + (1 - cond_indicator) * sigma_t
+            noise_pred = self.transformer(
+                hidden_states=in_latents,
+                condition_mask=cond_mask,
+                timestep=in_timestep,
+                encoder_hidden_states=prompt_embeds,
+                padding_mask=padding_mask,
+                return_dict=False,
+            )[0]            
 
-            do_true_cfg = self.do_classifier_free_guidance and negative_prompt_embeds is not None
-            positive_kwargs = {
-                "cond_mask": cond_mask,
-                "gt_velocity": gt_velocity,
-                "hidden_states": in_latents,
-                "condition_mask": cond_mask,
-                "timestep": in_timestep,
-                "encoder_hidden_states": prompt_embeds,
-                "padding_mask": padding_mask,
-            }
+            noise_pred = gt_velocity + noise_pred * (1 - cond_mask)
 
-            if do_true_cfg:
-                negative_kwargs = {
-                    "cond_mask": cond_mask,
-                    "gt_velocity": gt_velocity,
-                    "hidden_states": in_latents,
-                    "condition_mask": cond_mask,
-                    "timestep": in_timestep,
-                    "encoder_hidden_states": negative_prompt_embeds,
-                    "padding_mask": padding_mask,
-                }
-            else:
-                negative_kwargs = None
+            if self.do_classifier_free_guidance:
+                noise_pred_neg = self.transformer(
+                    hidden_states=in_latents,
+                    condition_mask=cond_mask,
+                    timestep=in_timestep,
+                    encoder_hidden_states=negative_prompt_embeds,
+                    padding_mask=padding_mask,
+                    return_dict=False,
+                )[0]                
 
-            noise_pred = self.predict_noise_maybe_with_cfg(
-                do_true_cfg=do_true_cfg,
-                true_cfg_scale=guidance_scale,
-                positive_kwargs=positive_kwargs,
-                negative_kwargs=negative_kwargs,
-                cfg_normalize=False,
-            )
+                noise_pred_neg = gt_velocity + noise_pred_neg * (1 - cond_mask)
+                noise_pred = noise_pred + self.guidance_scale * (noise_pred - noise_pred_neg)
 
-            latents = self.scheduler_step_maybe_with_cfg(noise_pred, t, latents, do_true_cfg)
+            latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
 
         # Empty cache before VAE decoding to avoid OOM errors
         if current_omni_platform.is_available():
@@ -750,21 +677,17 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         if output_type == "latent":
             video = latents
         else:
-            # Denormalize latents
             latents_mean = self.latents_mean.to(latents.device, latents.dtype)
             latents_std = self.latents_std.to(latents.device, latents.dtype)
             latents = latents * latents_std + latents_mean
-
-            # Decode to video
             video = self.vae.decode(latents.to(self.vae.dtype), return_dict=False)[0]
 
             # Check video safety after decode (required by NVIDIA Open Model License Agreement)
             assert self.safety_checker is not None
-            self.safety_checker.to(device, dtype=torch.float32)
+
+            self.safety_checker.to(device)
             video_np = self.video_processor.postprocess_video(video, output_type="np")
             video_np = (video_np * 255).astype(np.uint8)
-
-            # Check safety for each video in batch
             video_batch = []
             for vid in video_np:
                 vid = self.safety_checker.check_video_safety(vid)
@@ -776,5 +699,6 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         return DiffusionOutput(output=video)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # Load weights using AutoWeightsLoader for vLLM transformer
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)

--- a/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
+++ b/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
@@ -1,0 +1,707 @@
+# Copyright 2025 The NVIDIA Team and The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Adapted from Diffusers implementation:
+# https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/cosmos/pipeline_cosmos2_5_predict.py
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from diffusers import AutoencoderKLWan
+from diffusers.schedulers import UniPCMultistepScheduler
+from diffusers.utils import is_cosmos_guardrail_available
+from diffusers.utils.torch_utils import randn_tensor
+from diffusers.video_processor import VideoProcessor
+from torch import nn
+from transformers import AutoTokenizer, Qwen2_5_VLForConditionalGeneration
+from vllm.model_executor.models.utils import AutoWeightsLoader
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.platforms import current_omni_platform
+
+from vllm_omni.diffusion.models.cosmos.cosmos_transformer import CosmosTransformer3DModel
+
+if is_cosmos_guardrail_available():
+    from cosmos_guardrail import CosmosSafetyChecker
+else:
+
+    class CosmosSafetyChecker:
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "`cosmos_guardrail` is not installed. Please install it to use the safety checker for Cosmos: `pip install cosmos_guardrail`."
+            )
+
+
+DEFAULT_NEGATIVE_PROMPT = (
+    "The video captures a series of frames showing ugly scenes, static with no motion, motion blur, "
+    "over-saturation, shaky footage, low resolution, grainy texture, pixelated images, poorly lit areas, "
+    "underexposed and overexposed scenes, poor color balance, washed out colors, choppy sequences, "
+    "jerky movements, low frame rate, artifacting, color banding, unnatural transitions, outdated special effects, "
+    "fake elements, unconvincing visuals, poorly edited content, jump cuts, visual noise, and flickering. "
+    "Overall, the video is of poor quality."
+)
+
+logger = logging.getLogger(__name__)
+
+
+
+def retrieve_latents(
+    encoder_output: torch.Tensor,
+    generator: torch.Generator | None = None,
+    sample_mode: str = "sample",
+):
+    """Retrieve latents from VAE encoder output."""
+    if hasattr(encoder_output, "latent_dist") and sample_mode == "sample":
+        return encoder_output.latent_dist.sample(generator)
+    elif hasattr(encoder_output, "latent_dist") and sample_mode == "argmax":
+        return encoder_output.latent_dist.mode()
+    elif hasattr(encoder_output, "latents"):
+        return encoder_output.latents
+    else:
+        raise AttributeError("Could not access latents of provided encoder_output")
+
+
+def load_transformer_config(model_path: str, subfolder: str = "transformer", local_files_only: bool = True) -> dict:
+    """Load transformer config from model directory or HF Hub."""
+    if local_files_only:
+        config_path = os.path.join(model_path, subfolder, "config.json")
+        if os.path.exists(config_path):
+            with open(config_path) as f:
+                return json.load(f)
+    else:
+        # Try to download config from HF Hub
+        try:
+            from huggingface_hub import hf_hub_download
+
+            config_path = hf_hub_download(
+                repo_id=model_path,
+                filename=f"{subfolder}/config.json",
+            )
+            with open(config_path) as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}
+
+
+def create_transformer_from_config(config: dict) -> CosmosTransformer3DModel:
+    """Create WanTransformer3DModel from config dict."""
+    kwargs = {}
+
+    if "patch_size" in config:
+        kwargs["patch_size"] = tuple(config["patch_size"])
+    if "num_attention_heads" in config:
+        kwargs["num_attention_heads"] = config["num_attention_heads"]
+    if "attention_head_dim" in config:
+        kwargs["attention_head_dim"] = config["attention_head_dim"]
+    if "in_channels" in config:
+        kwargs["in_channels"] = config["in_channels"]
+    if "out_channels" in config:
+        kwargs["out_channels"] = config["out_channels"]
+    if "text_dim" in config:
+        kwargs["text_dim"] = config["text_dim"]
+    if "freq_dim" in config:
+        kwargs["freq_dim"] = config["freq_dim"]
+    if "ffn_dim" in config:
+        kwargs["ffn_dim"] = config["ffn_dim"]
+    if "num_layers" in config:
+        kwargs["num_layers"] = config["num_layers"]
+    if "cross_attn_norm" in config:
+        kwargs["cross_attn_norm"] = config["cross_attn_norm"]
+    if "eps" in config:
+        kwargs["eps"] = config["eps"]
+    if "image_dim" in config:
+        kwargs["image_dim"] = config["image_dim"]
+    if "added_kv_proj_dim" in config:
+        kwargs["added_kv_proj_dim"] = config["added_kv_proj_dim"]
+    if "rope_max_seq_len" in config:
+        kwargs["rope_max_seq_len"] = config["rope_max_seq_len"]
+    if "pos_embed_seq_len" in config:
+        kwargs["pos_embed_seq_len"] = config["pos_embed_seq_len"]
+
+    return CosmosTransformer3DModel(**kwargs)
+
+def get_cosmos_predict25_post_process_func(
+    od_config: OmniDiffusionConfig,
+):
+    from diffusers.video_processor import VideoProcessor
+
+    video_processor = VideoProcessor(vae_scale_factor=8)
+
+    def post_process_func(
+        video: torch.Tensor,
+        output_type: str = "np",
+    ):
+        if output_type == "latent":
+            return video
+        return video_processor.postprocess_video(video, output_type=output_type)
+
+    return post_process_func
+
+
+class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
+    def __init__(
+        self,
+        *,
+        od_config: OmniDiffusionConfig,
+        prefix: str = "",
+    ):
+        super().__init__()
+
+        # Initialize safety checker (required by NVIDIA Open Model License Agreement)
+        self.safety_checker = CosmosSafetyChecker()
+
+        self.od_config = od_config
+        
+        self.device = get_local_device()
+        dtype = getattr(od_config, "dtype", torch.bfloat16)
+
+        model = od_config.model
+        local_files_only = os.path.exists(model)
+
+        # Set up weights sources for transformer(s)
+        self.weights_sources = []
+        self.weights_sources.append(
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
+                subfolder="transformer",
+                revision=None,
+                prefix="transformer.",
+                fall_back_to_pt=True,
+            )
+        )
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model,
+            subfolder="tokenizer",
+            local_files_only=local_files_only,
+            use_fast=False,
+        )
+        self.text_encoder = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+            model,
+            subfolder="text_encoder",
+            torch_dtype=dtype,
+            local_files_only=local_files_only,
+        ).to(self.device)
+
+        self.vae = AutoencoderKLWan.from_pretrained(
+            model,
+            subfolder="vae",
+            torch_dtype=dtype,
+            local_files_only=local_files_only,
+        ).to(self.device)
+
+        self.vae_scale_factor_temporal = 2 ** sum(self.vae.temperal_downsample) if getattr(self, "vae", None) else 4
+        self.vae_scale_factor_spatial = 2 ** len(self.vae.temperal_downsample) if getattr(self, "vae", None) else 8
+        self.video_processor = VideoProcessor(vae_scale_factor=self.vae_scale_factor_spatial)
+
+        latents_mean = (
+            torch.tensor(self.vae.config.latents_mean).view(1, self.vae.config.z_dim, 1, 1, 1).float()
+            if getattr(self.vae.config, "latents_mean", None) is not None
+            else None
+        )
+        latents_std = (
+            torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).float()
+            if getattr(self.vae.config, "latents_std", None) is not None
+            else None
+        )
+        self.latents_mean = latents_mean
+        self.latents_std = latents_std
+
+        if self.latents_mean is None or self.latents_std is None:
+            raise ValueError("VAE configuration must define both `latents_mean` and `latents_std`.")
+
+        # Load vLLM-omni transformer with config
+        transformer_config = load_transformer_config(
+            model,
+            subfolder="transformer",
+            local_files_only=local_files_only,
+        )
+
+        self.transformer = CosmosTransformer3DModel(
+            od_config=od_config,
+            **transformer_config,
+        )
+        
+        #self.transformer = create_transformer_from_config(transformer_config)
+
+        # Store the active transformer config
+        #self.transformer_config = self.transformer.config
+
+        self.scheduler = UniPCMultistepScheduler.from_pretrained(
+            model,
+            subfolder="scheduler",
+            local_files_only=local_files_only,
+        )
+
+        if hasattr(self.scheduler, 'alphas_cumprod') and isinstance(self.scheduler.alphas_cumprod, torch.Tensor):
+            if self.scheduler.alphas_cumprod.is_cuda:
+                self.scheduler.alphas_cumprod = self.scheduler.alphas_cumprod.cpu()
+        if hasattr(self.scheduler, 'betas') and isinstance(self.scheduler.betas, torch.Tensor):
+            if self.scheduler.betas.is_cuda:
+                self.scheduler.betas = self.scheduler.betas.cpu()
+
+    @property
+    def guidance_scale(self):
+        return self._guidance_scale
+
+    @property
+    def do_classifier_free_guidance(self):
+        return self._guidance_scale is not None and self._guidance_scale > 1.0
+
+    @property
+    def num_timesteps(self):
+        return self._num_timesteps
+
+    @property
+    def current_timestep(self):
+        return self._current_timestep
+
+    def _build_input_ids_batch(
+        self,
+        prompt_texts: list[str],
+        max_sequence_length: int,
+    ) -> torch.Tensor:
+        batch = []
+
+        for text in prompt_texts:
+            conversations = [
+                {
+                    "role": "system",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "You are a helpful assistant who will provide prompts to an image generator.",
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": text,
+                        }
+                    ],
+                },
+            ]
+
+            input_ids = self.tokenizer.apply_chat_template(
+                conversations,
+                tokenize=True,
+                add_generation_prompt=False,
+                add_vision_id=False,
+                max_length=max_sequence_length,
+                truncation=True,
+                padding="max_length",
+            )
+
+            input_ids = (
+                input_ids["input_ids"] if not isinstance(input_ids, list) and "input_ids" in input_ids else input_ids
+            )
+            batch.append(torch.tensor(input_ids, dtype=torch.long))
+
+        input_ids_batch = torch.stack(batch, dim=0)
+        return input_ids_batch
+
+    def _hidden_states_to_prompt_embeds(
+        self,
+        hidden_states: tuple[torch.Tensor, ...],
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        normalized_hidden_states = []
+        for h in hidden_states[1:]:
+            normalized = (h - h.mean(dim=-1, keepdim=True)) / (h.std(dim=-1, keepdim=True) + 1e-8)
+            normalized_hidden_states.append(normalized)
+
+        prompt_embeds = torch.cat(normalized_hidden_states, dim=-1)
+        return prompt_embeds.to(dtype=dtype, device=device)
+
+    def encode_prompt(
+        self,
+        prompt: str | list[str],
+        negative_prompt: str | list[str] | None = None,
+        do_classifier_free_guidance: bool = True,
+        num_videos_per_prompt: int = 1,
+        max_sequence_length: int = 512,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ):
+        device = device or self.device
+        dtype = dtype or self.text_encoder.dtype
+
+        prompt = [prompt] if isinstance(prompt, str) else prompt
+        batch_size = len(prompt)
+
+        input_ids_batch = self._build_input_ids_batch(prompt, max_sequence_length)
+
+        with torch.no_grad():
+            outputs = self.text_encoder(
+                input_ids_batch.to(device),
+                output_hidden_states=True,
+            )
+        hidden_states = outputs.hidden_states
+
+        prompt_embeds = self._hidden_states_to_prompt_embeds(
+            hidden_states,
+            device=device,
+            dtype=dtype,
+        )
+
+        _, seq_len, _ = prompt_embeds.shape
+        prompt_embeds = prompt_embeds.repeat(1, num_videos_per_prompt, 1)
+        prompt_embeds = prompt_embeds.view(batch_size * num_videos_per_prompt, seq_len, -1)
+
+        negative_prompt_embeds = None
+        if do_classifier_free_guidance:
+            negative_prompt = negative_prompt or DEFAULT_NEGATIVE_PROMPT
+            negative_prompt = batch_size * [negative_prompt] if isinstance(negative_prompt, str) else negative_prompt
+            neg_input_ids_batch = self._build_input_ids_batch(negative_prompt, max_sequence_length)
+
+            with torch.no_grad():
+                neg_outputs = self.text_encoder(
+                    neg_input_ids_batch.to(device),
+                    output_hidden_states=True,
+                )
+            neg_hidden_states = neg_outputs.hidden_states
+
+            negative_prompt_embeds = self._hidden_states_to_prompt_embeds(
+                neg_hidden_states,
+                device=device,
+                dtype=dtype,
+            )
+
+            _, seq_len, _ = negative_prompt_embeds.shape
+            negative_prompt_embeds = negative_prompt_embeds.repeat(1, num_videos_per_prompt, 1)
+            negative_prompt_embeds = negative_prompt_embeds.view(batch_size * num_videos_per_prompt, seq_len, -1)
+
+        return prompt_embeds, negative_prompt_embeds
+
+    def prepare_latents(
+        self,
+        batch_size: int,
+        num_frames_out: int,
+        height: int,
+        width: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        generator: torch.Generator | None = None,
+        latents: torch.Tensor | None = None,
+    ):
+        B = batch_size
+        C = 16
+        T = (num_frames_out - 1) // self.vae_scale_factor_temporal + 1
+        H = height // self.vae_scale_factor_spatial
+        W = width // self.vae_scale_factor_spatial
+        shape = (B, C, T, H, W)
+
+        if latents is None:
+            latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+
+        cond_mask = torch.zeros((B, 1, T, H, W), dtype=latents.dtype, device=latents.device)
+        cond_indicator = torch.zeros((B, 1, T, 1, 1), dtype=latents.dtype, device=latents.device)
+        cond_latents = torch.zeros_like(latents)
+
+        return latents, cond_latents, cond_mask, cond_indicator
+
+
+    def check_inputs(
+        self,
+        prompt,
+        negative_prompt,
+        height,
+        width,
+        num_frames,
+        prompt_embeds=None,
+        negative_prompt_embeds=None,
+    ):
+        if height % 16 != 0 or width % 16 != 0:
+            raise ValueError(f"`height` and `width` have to be divisible by 16 but are {height} and {width}.")
+
+        if prompt is not None and prompt_embeds is not None:
+            raise ValueError(
+                f"Cannot forward both `prompt`: {prompt} and `prompt_embeds`: {prompt_embeds}. Please make sure to"
+                " only forward one of the two."
+            )
+        elif negative_prompt is not None and negative_prompt_embeds is not None:
+            raise ValueError(
+                f"Cannot forward both `negative_prompt`: {negative_prompt} and "
+                f"`negative_prompt_embeds`: {negative_prompt_embeds}. "
+                "Please make sure to only forward one of the two."
+            )
+        elif prompt is None and prompt_embeds is None:
+            raise ValueError(
+                "Provide either `prompt` or `prompt_embeds`. Cannot leave both `prompt` and `prompt_embeds` undefined."
+            )
+        elif prompt is not None and (not isinstance(prompt, str) and not isinstance(prompt, list)):
+            raise ValueError(f"`prompt` has to be of type `str` or `list` but is {type(prompt)}")
+        elif negative_prompt is not None and (
+            not isinstance(negative_prompt, str) and not isinstance(negative_prompt, list)
+        ):
+            raise ValueError(f"`negative_prompt` has to be of type `str` or `list` but is {type(negative_prompt)}")
+     
+
+    def predict_noise(
+        self,
+        cond_mask: torch.Tensor | None = None,
+        gt_velocity: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        """
+        Predict noise with velocity replacement for conditioning.
+
+        Args:
+            cond_mask: Conditioning mask (B, 1, T, H, W)
+            gt_velocity: Ground truth velocity for conditioning frames
+            **kwargs: Arguments to pass to transformer
+
+        Returns:
+            Predicted noise with velocity replacement applied
+        """
+        noise_pred_raw = self.transformer(**kwargs)
+
+        if cond_mask is not None and gt_velocity is not None:
+            noise_pred = gt_velocity + noise_pred_raw * (1 - cond_mask)
+        else:
+            noise_pred = noise_pred_raw
+
+        return noise_pred
+
+    def forward(
+        self,
+        req: OmniDiffusionRequest,
+        prompt: str | None = None,
+        negative_prompt: str | None = None,
+        height: int = 704,
+        width: int = 1280,
+        num_inference_steps: int = 36,
+        guidance_scale: float | tuple[float, float] = 7.0,
+        frame_num: int = 93,
+        output_type: str | None = "np",
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        prompt_embeds: torch.Tensor | None = None,
+        negative_prompt_embeds: torch.Tensor | None = None,
+        conditional_frame_timestep: float = 0.1,
+        **kwargs,
+    ) -> DiffusionOutput:
+        
+        # Enforce safety checker requirement (NVIDIA Open Model License Agreement)
+        if self.safety_checker is None:
+            raise ValueError(
+                f"You have disabled the safety checker for {self.__class__}. This is in violation of the "
+                "[NVIDIA Open Model License Agreement](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license). "
+                f"Please ensure that you are compliant with the license agreement."
+            )
+
+        # Get parameters from request or arguments
+        if len(req.prompts) == 1:  # If req.prompt is empty, default to prompt & neg_prompt in param list
+            prompt = req.prompts[0] if isinstance(req.prompts[0], str) else req.prompts[0].get("prompt")
+            negative_prompt = None if isinstance(req.prompts[0], str) else req.prompts[0].get("negative_prompt")
+        if prompt is None and prompt_embeds is None:
+            raise ValueError("Prompt or prompt_embeds is required for Wan2.2 generation.")
+
+        height = req.sampling_params.height or height
+        width = req.sampling_params.width or width
+        num_frames = req.sampling_params.num_frames if req.sampling_params.num_frames else frame_num
+
+        # Ensure dimensions are compatible with VAE and patch size
+        #patch_size = self.transformer_config.patch_size
+        mod_value = 32#self.vae_scale_factor_spatial * patch_size[1]  # 16*2=32 for TI2V, 8*2=16 for I2V
+        height = (height // mod_value) * mod_value
+        width = (width // mod_value) * mod_value
+        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+
+        #num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        guidance_scale = req.sampling_params.guidance_scale if req.sampling_params.guidance_scale_provided else guidance_scale
+        num_videos_per_prompt=1#req.sampling_params.num_outputs_per_prompt or 1,
+
+        self._guidance_scale = guidance_scale
+        self._current_timestep = None
+
+        device = self.device
+        dtype = self.transformer.dtype if self.transformer is not None else self.text_encoder.dtype
+
+        # Seed / generator
+        if generator is None:
+            generator = req.sampling_params.generator
+        if generator is None and req.sampling_params.seed is not None:
+            generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
+
+        do_classifier_free_guidance = guidance_scale > 1.0
+
+        # Check text safety before generation (required by NVIDIA Open Model License Agreement)
+        if self.safety_checker is not None:
+            self.safety_checker.to(device, dtype=torch.float32)
+            if prompt is not None:
+                prompt_list = [prompt] if isinstance(prompt, str) else prompt
+                for p in prompt_list:
+                    if not self.safety_checker.check_text_safety(p):
+                        raise ValueError(
+                            f"Cosmos Guardrail detected unsafe text in the prompt: {p}. Please ensure that the "
+                            f"prompt abides by the NVIDIA Open Model License Agreement."
+                        )
+
+        self.check_inputs(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+        )
+
+        if num_frames % self.vae_scale_factor_temporal != 1:
+            num_frames = num_frames // self.vae_scale_factor_temporal * self.vae_scale_factor_temporal + 1
+        num_frames = max(num_frames, 1)
+
+        if prompt_embeds is None:
+            prompt_embeds, negative_prompt_embeds = self.encode_prompt(
+                prompt,
+                negative_prompt=negative_prompt,
+                do_classifier_free_guidance=do_classifier_free_guidance,
+                num_videos_per_prompt=num_videos_per_prompt,
+                device=device,
+                dtype=dtype,
+            )
+        else:
+            prompt_embeds = prompt_embeds.to(device=device, dtype=dtype)
+            if negative_prompt_embeds is not None:
+                negative_prompt_embeds = negative_prompt_embeds.to(device=device, dtype=dtype)
+            elif do_classifier_free_guidance:
+                raise ValueError(
+                    "negative_prompt_embeds must be provided when prompt_embeds are given and guidance_scale > 1."
+                )
+
+        batch_size = prompt_embeds.shape[0]
+        latents, cond_latent, cond_mask, cond_indicator = self.prepare_latents(
+            batch_size=batch_size * num_videos_per_prompt,
+            num_frames_out=num_frames,
+            height=height,
+            width=width,
+            dtype=torch.float32,
+            device=self.device,
+            generator=generator,
+        )
+
+        transformer_dtype = self.transformer.dtype
+
+        cond_timestep = torch.ones_like(cond_indicator) * conditional_frame_timestep
+        cond_mask = cond_mask.to(transformer_dtype)
+
+        padding_mask = latents.new_zeros(1, 1, height, width, dtype=transformer_dtype)
+
+        self.scheduler.set_timesteps(num_inference_steps, device=self.device)
+        timesteps = self.scheduler.timesteps
+        self._num_timesteps = len(timesteps)
+
+        gt_velocity = (latents - cond_latent) * cond_mask
+
+        for i, t in enumerate(timesteps):
+            self._current_timestep = t
+            sigma_t = (
+                torch.tensor(self.scheduler.sigmas[i].item())
+                .unsqueeze(0)
+                .to(device=self.device, dtype=transformer_dtype)
+            )
+
+            in_latents = cond_mask * cond_latent + (1 - cond_mask) * latents
+            in_latents = in_latents.to(transformer_dtype)
+            in_timestep = cond_indicator * cond_timestep + (1 - cond_indicator) * sigma_t
+
+            do_true_cfg = do_classifier_free_guidance and negative_prompt_embeds is not None
+            positive_kwargs = {
+                "cond_mask": cond_mask,
+                "gt_velocity": gt_velocity,
+                "hidden_states": in_latents,
+                "condition_mask": cond_mask,
+                "timestep": in_timestep,
+                "encoder_hidden_states": prompt_embeds,
+                "padding_mask": padding_mask,
+            }
+
+            if do_true_cfg:
+                negative_kwargs = {
+                    "cond_mask": cond_mask,
+                    "gt_velocity": gt_velocity,
+                    "hidden_states": in_latents,
+                    "condition_mask": cond_mask,
+                    "timestep": in_timestep,
+                    "encoder_hidden_states": negative_prompt_embeds,
+                    "padding_mask": padding_mask,
+                }
+            else:
+                negative_kwargs = None
+
+            noise_pred = self.predict_noise_maybe_with_cfg(
+                do_true_cfg=do_true_cfg,
+                true_cfg_scale=guidance_scale,
+                positive_kwargs=positive_kwargs,
+                negative_kwargs=negative_kwargs,
+                cfg_normalize=False,
+            )
+
+            latents = self.scheduler_step_maybe_with_cfg(noise_pred, t, latents, do_true_cfg)
+
+        # Empty cache before VAE decoding to avoid OOM errors
+        if current_omni_platform.is_available():
+            current_omni_platform.empty_cache()
+        self._current_timestep = None
+
+        # Decode
+        if output_type == "latent":
+            video = latents
+        else:
+            # Denormalize latents
+            latents_mean = self.latents_mean.to(latents.device, latents.dtype)
+            latents_std = self.latents_std.to(latents.device, latents.dtype)
+            latents = latents * latents_std + latents_mean
+
+            # Decode to video
+            video = self.vae.decode(latents.to(self.vae.dtype), return_dict=False)[0]
+
+            # Check video safety after decode (required by NVIDIA Open Model License Agreement)
+            assert self.safety_checker is not None
+            self.safety_checker.to(device, dtype=torch.float32)
+            video_np = self.video_processor.postprocess_video(video, output_type="np")
+            video_np = (video_np * 255).astype(np.uint8)
+
+            # Check safety for each video in batch
+            video_batch = []
+            for vid in video_np:
+                vid = self.safety_checker.check_video_safety(vid)
+                video_batch.append(vid)
+
+            video = np.stack(video_batch).astype(np.float32) / 255.0 * 2 - 1
+            video = torch.from_numpy(video).permute(0, 4, 1, 2, 3).to(device)
+
+        return DiffusionOutput(output=video)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)

--- a/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
+++ b/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
@@ -27,7 +27,6 @@ import numpy as np
 import torch
 from diffusers import AutoencoderKLWan
 from diffusers.schedulers import UniPCMultistepScheduler
-from diffusers.utils import is_cosmos_guardrail_available
 from diffusers.utils.torch_utils import randn_tensor
 from diffusers.video_processor import VideoProcessor
 from torch import nn
@@ -39,48 +38,11 @@ from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.cosmos.cosmos_transformer import CosmosTransformer3DModel
+from vllm_omni.diffusion.models.cosmos.utils import DEFAULT_NEGATIVE_PROMPT, CosmosSafetyChecker
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.platforms import current_omni_platform
 
-if is_cosmos_guardrail_available():
-    from cosmos_guardrail import CosmosSafetyChecker
-else:
-
-    class CosmosSafetyChecker:
-        def __init__(self, *args, **kwargs):
-            message = (
-                "`cosmos_guardrail` is not installed. Please install it to use "
-                "the safety checker for Cosmos: `pip install cosmos_guardrail`."
-            )
-            raise ImportError(message)
-
-
-DEFAULT_NEGATIVE_PROMPT = (
-    "The video captures a series of frames showing ugly scenes, static with no motion, motion blur, "
-    "over-saturation, shaky footage, low resolution, grainy texture, pixelated images, poorly lit areas, "
-    "underexposed and overexposed scenes, poor color balance, washed out colors, choppy sequences, "
-    "jerky movements, low frame rate, artifacting, color banding, unnatural transitions, outdated special effects, "
-    "fake elements, unconvincing visuals, poorly edited content, jump cuts, visual noise, and flickering. "
-    "Overall, the video is of poor quality."
-)
-
 logger = logging.getLogger(__name__)
-
-
-def retrieve_latents(
-    encoder_output: torch.Tensor,
-    generator: torch.Generator | None = None,
-    sample_mode: str = "sample",
-):
-    """Retrieve latents from VAE encoder output."""
-    if hasattr(encoder_output, "latent_dist") and sample_mode == "sample":
-        return encoder_output.latent_dist.sample(generator)
-    elif hasattr(encoder_output, "latent_dist") and sample_mode == "argmax":
-        return encoder_output.latent_dist.mode()
-    elif hasattr(encoder_output, "latents"):
-        return encoder_output.latents
-    else:
-        raise AttributeError("Could not access latents of provided encoder_output")
 
 
 def load_transformer_config(

--- a/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
+++ b/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
@@ -21,20 +21,18 @@ import json
 import logging
 import os
 from collections.abc import Iterable
-from typing import Any
 
 import numpy as np
 import torch
-from torch import nn
 import torchvision.transforms.functional
-
 from diffusers import AutoencoderKLWan
 from diffusers.schedulers import UniPCMultistepScheduler
 from diffusers.utils.torch_utils import randn_tensor
 from diffusers.video_processor import VideoProcessor
+from torch import nn
 from transformers import AutoTokenizer, Qwen2_5_VLForConditionalGeneration
-
 from vllm.model_executor.models.utils import AutoWeightsLoader
+
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
@@ -75,7 +73,6 @@ def load_transformer_config(
 def get_cosmos_predict25_post_process_func(
     od_config: OmniDiffusionConfig,
 ):
-
     video_processor = VideoProcessor(vae_scale_factor=8)
 
     def post_process_func(
@@ -179,7 +176,7 @@ class CosmosPredict25Pipeline(nn.Module):
                 self.scheduler.betas = self.scheduler.betas.cpu()
 
         self._guidance_scale = None
-        self._num_timesteps = None                
+        self._num_timesteps = None
 
     @property
     def guidance_scale(self):
@@ -291,8 +288,6 @@ class CosmosPredict25Pipeline(nn.Module):
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
     ):
-
-
         prompt = [prompt] if isinstance(prompt, str) else prompt
         batch_size = len(prompt)
 
@@ -321,21 +316,21 @@ class CosmosPredict25Pipeline(nn.Module):
 
     def prepare_latents(
         self,
-        video: torch.Tensor | None,        
+        video: torch.Tensor | None,
         batch_size: int,
-        num_channels_latents: int = 16,        
+        num_channels_latents: int = 16,
         height: int = 704,
         width: int = 1280,
         num_frames_in: int = 93,
-        num_frames_out: int = 93,                
+        num_frames_out: int = 93,
         dtype: torch.dtype | None = None,
         device: torch.device | None = None,
-        generator: torch.Generator | list[torch.Generator] | None = None,        
+        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.Tensor | None = None,
     ):
         if isinstance(generator, list) and len(generator) != batch_size:
             raise ValueError(f"Generator list length {len(generator)} does not match batch size {batch_size}.")
-                
+
         B = batch_size
         C = num_channels_latents
         T = (num_frames_out - 1) // self.vae_scale_factor_temporal + 1
@@ -425,7 +420,6 @@ class CosmosPredict25Pipeline(nn.Module):
         ):
             raise ValueError(f"`negative_prompt` has to be of type `str` or `list` but is {type(negative_prompt)}")
 
-
     def forward(
         self,
         req: OmniDiffusionRequest,
@@ -450,19 +444,20 @@ class CosmosPredict25Pipeline(nn.Module):
         if self.safety_checker is None:
             raise ValueError(
                 f"You have disabled the safety checker for {self.__class__}. This is in violation of the "
-                "[NVIDIA Open Model License Agreement](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license). "
-                f"Please ensure that you are compliant with the license agreement."
+                "[NVIDIA Open Model License Agreement]"
+                "(https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license). "
+                "Please ensure that you are compliant with the license agreement."
             )
 
         extra = getattr(req.sampling_params, "extra_args", {}) or {}
         image = extra.get("image", image)
         video = extra.get("video", video)
         num_latent_conditional_frames = extra.get("num_latent_conditional_frames", num_latent_conditional_frames)
-        conditional_frame_timestep = extra.get("conditional_frame_timestep", conditional_frame_timestep)        
+        conditional_frame_timestep = extra.get("conditional_frame_timestep", conditional_frame_timestep)
 
         if image is not None and video is not None:
             raise ValueError("image and video cannot be provided simultaneously")
-        
+
         if len(req.prompts) == 1:  # If req.prompt is empty, default to prompt & neg_prompt in param list
             prompt = req.prompts[0] if isinstance(req.prompts[0], str) else req.prompts[0].get("prompt")
             negative_prompt = None if isinstance(req.prompts[0], str) else req.prompts[0].get("negative_prompt")
@@ -488,7 +483,7 @@ class CosmosPredict25Pipeline(nn.Module):
         num_frames = req.sampling_params.num_frames if req.sampling_params.num_frames else frame_num
         num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
         num_videos_per_prompt = req.sampling_params.num_outputs_per_prompt or 1
-        max_sequence_length=req.sampling_params.max_sequence_length or 512
+        max_sequence_length = req.sampling_params.max_sequence_length or 512
 
         # Ensure dimensions are compatible with VAE and patch size
         patch_size = self.transformer.config.patch_size
@@ -588,16 +583,16 @@ class CosmosPredict25Pipeline(nn.Module):
         num_frames_out = num_frames
         assert num_frames_in <= num_frames_out, f"expected ({num_frames_in=}) <= ({num_frames_out=})"
         video = video.to(device=device, dtype=self.vae.dtype)
-                           
+
         num_channels_latents = self.transformer.config.in_channels - 1
         latents, cond_latent, cond_mask, cond_indicator = self.prepare_latents(
             video=video,
             batch_size=batch_size,
-            num_channels_latents=num_channels_latents,            
+            num_channels_latents=num_channels_latents,
             height=height,
             width=width,
             num_frames_in=num_frames_in,
-            num_frames_out=num_frames,                                   
+            num_frames_out=num_frames,
             dtype=torch.float32,
             device=self.device,
             generator=generator,
@@ -625,7 +620,7 @@ class CosmosPredict25Pipeline(nn.Module):
                 )
             else:
                 in_timestep = sigma_t
-            
+
             in_latents = cond_mask * cond_latent + (1 - cond_mask) * latents
             in_latents = in_latents.to(dtype)
 
@@ -636,7 +631,7 @@ class CosmosPredict25Pipeline(nn.Module):
                 encoder_hidden_states=prompt_embeds,
                 padding_mask=padding_mask,
                 return_dict=False,
-            )[0]            
+            )[0]
 
             noise_pred = gt_velocity + noise_pred * (1 - cond_mask)
 
@@ -648,7 +643,7 @@ class CosmosPredict25Pipeline(nn.Module):
                     encoder_hidden_states=negative_prompt_embeds,
                     padding_mask=padding_mask,
                     return_dict=False,
-                )[0]                
+                )[0]
 
                 noise_pred_neg = gt_velocity + noise_pred_neg * (1 - cond_mask)
                 noise_pred = noise_pred + self.guidance_scale * (noise_pred - noise_pred_neg)

--- a/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
+++ b/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
@@ -146,23 +146,12 @@ class CosmosPredict25Pipeline(nn.Module):
 
         self.vae_scale_factor_temporal = 2 ** sum(self.vae.temperal_downsample) if getattr(self, "vae", None) else 4
         self.vae_scale_factor_spatial = 2 ** len(self.vae.temperal_downsample) if getattr(self, "vae", None) else 8
-        self.video_processor = VideoProcessor(vae_scale_factor=self.vae_scale_factor_spatial)
+        self.video_processor = VideoProcessor(vae_scale_factor=self.vae_scale_factor_spatial, resample="bilinear")
 
-        latents_mean = (
-            torch.tensor(self.vae.config.latents_mean).view(1, self.vae.config.z_dim, 1, 1, 1).float()
-            if getattr(self.vae.config, "latents_mean", None) is not None
-            else None
-        )
-        latents_std = (
-            torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).float()
-            if getattr(self.vae.config, "latents_std", None) is not None
-            else None
-        )
+        latents_mean = torch.tensor(self.vae.config.latents_mean).view(1, self.vae.config.z_dim, 1, 1, 1).float()
+        latents_std = torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).float()
         self.latents_mean = latents_mean
-        self.latents_std = latents_std
-
-        if self.latents_mean is None or self.latents_std is None:
-            raise ValueError("VAE configuration must define both `latents_mean` and `latents_std`.")
+        self.latents_std = 1.0 / latents_std
 
         transformer_config = load_transformer_config(
             model,
@@ -208,6 +197,21 @@ class CosmosPredict25Pipeline(nn.Module):
     def current_timestep(self):
         return self._current_timestep
 
+    def create_condition_mask(
+        self,
+        latent_shape: tuple,
+        device: torch.device,
+        dtype: torch.dtype,
+        num_cond_latent_frames: int | list[int],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        bsz, C, T, H, W = latent_shape
+        cond_indicator = torch.zeros(bsz, 1, T, 1, 1, dtype=dtype, device=device)
+        if isinstance(num_cond_latent_frames, int):
+            num_cond_latent_frames = [num_cond_latent_frames] * bsz
+        for idx in range(bsz):
+            cond_indicator[idx, :, : num_cond_latent_frames[idx], :, :] = 1.0
+        cond_mask = cond_indicator.expand(-1, -1, -1, H, W)
+        return cond_indicator, cond_mask
 
     def _get_prompt_embeds(
         self,
@@ -344,59 +348,48 @@ class CosmosPredict25Pipeline(nn.Module):
                 latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
             else:
                 latents = latents.to(device=device, dtype=dtype)
-                
-            cond_mask = torch.zeros((B, 1, T, H, W), dtype=latents.dtype, device=latents.device)
-            cond_indicator = torch.zeros((B, 1, T, 1, 1), dtype=latents.dtype, device=latents.device)
 
+            cond_indicator, cond_mask = self.create_condition_mask(shape, device, dtype, 0)
             cond_latents = torch.zeros_like(latents)
 
-            return (
-                latents,
-                cond_latents,
-                cond_mask,
-                cond_indicator,
-            )
+            return latents, cond_latents, cond_mask, cond_indicator
+
         else:
             if video is None:
-                raise ValueError("`video` must be provided when `num_frames_in` is greater than 0.")            
+                raise ValueError("`video` must be provided when `num_frames_in` is greater than 0.")
             needs_preprocessing = not (isinstance(video, torch.Tensor) and video.ndim == 5 and video.shape[1] == 3)
             if needs_preprocessing:
                 video = self.video_processor.preprocess_video(video, height, width)
             video = video.to(device=device, dtype=self.vae.dtype)
+
             if isinstance(generator, list):
                 cond_latents = [
-                    retrieve_latents(self.vae.encode(video[i].unsqueeze(0)), generator=generator[i])
+                    retrieve_latents(
+                        self.vae.encode(video[i].unsqueeze(0)), generator=generator[i], sample_mode="argmax"
+                    )
                     for i in range(batch_size)
                 ]
             else:
-                cond_latents = [retrieve_latents(self.vae.encode(vid.unsqueeze(0)), generator) for vid in video]
+                cond_latents = [
+                    retrieve_latents(self.vae.encode(vid.unsqueeze(0)), generator, sample_mode="argmax")
+                    for vid in video
+                ]
 
             cond_latents = torch.cat(cond_latents, dim=0).to(dtype)
 
             latents_mean = self.latents_mean.to(device=device, dtype=dtype)
             latents_std = self.latents_std.to(device=device, dtype=dtype)
-            cond_latents = (cond_latents - latents_mean) / latents_std
+            cond_latents = (cond_latents - latents_mean) * latents_std
 
             if latents is None:
                 latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
             else:
                 latents = latents.to(device=device, dtype=dtype)
 
-            padding_shape = (B, 1, T, H, W)
-            ones_padding = latents.new_ones(padding_shape)
-            zeros_padding = latents.new_zeros(padding_shape)
-
             num_cond_latent_frames = (num_frames_in - 1) // self.vae_scale_factor_temporal + 1
-            cond_indicator = latents.new_zeros(1, 1, latents.size(2), 1, 1)
-            cond_indicator[:, :, 0:num_cond_latent_frames] = 1.0
-            cond_mask = cond_indicator * ones_padding + (1 - cond_indicator) * zeros_padding
+            cond_indicator, cond_mask = self.create_condition_mask(shape, device, dtype, num_cond_latent_frames)
 
-            return (
-                latents,
-                cond_latents,
-                cond_mask,
-                cond_indicator,
-            )
+            return latents, cond_latents, cond_mask, cond_indicator
 
     def check_inputs(
         self,
@@ -451,10 +444,9 @@ class CosmosPredict25Pipeline(nn.Module):
         image: torch.Tensor | None = None,
         video: torch.Tensor | None = None,
         num_latent_conditional_frames: int = 2,
-        conditional_frame_timestep: float = 0.1,                
+        conditional_frame_timestep: float = 0.0001,
         **kwargs,
     ) -> DiffusionOutput:
-        # Enforce safety checker requirement (NVIDIA Open Model License Agreement)
         if self.safety_checker is None:
             raise ValueError(
                 f"You have disabled the safety checker for {self.__class__}. This is in violation of the "
@@ -464,7 +456,9 @@ class CosmosPredict25Pipeline(nn.Module):
 
         extra = getattr(req.sampling_params, "extra_args", {}) or {}
         image = extra.get("image", image)
-        video = extra.get("video", video)        
+        video = extra.get("video", video)
+        num_latent_conditional_frames = extra.get("num_latent_conditional_frames", num_latent_conditional_frames)
+        conditional_frame_timestep = extra.get("conditional_frame_timestep", conditional_frame_timestep)        
 
         if image is not None and video is not None:
             raise ValueError("image and video cannot be provided simultaneously")
@@ -476,10 +470,10 @@ class CosmosPredict25Pipeline(nn.Module):
             raise ValueError("Prompt or prompt_embeds is required for Cosmos Predict 2.5 generation.")
 
         device = self.device
+        dtype = self.transformer.dtype if self.transformer is not None else self.text_encoder.dtype
 
-        # Check text safety before generation (required by NVIDIA Open Model License Agreement)
-        if self.safety_checker is not None:
-            self.safety_checker.to(device, dtype=torch.float32)
+        if isinstance(self.safety_checker, CosmosSafetyChecker):
+            self.safety_checker.to(device, dtype=dtype)
             if prompt is not None:
                 prompt_list = [prompt] if isinstance(prompt, str) else prompt
                 for p in prompt_list:
@@ -516,10 +510,6 @@ class CosmosPredict25Pipeline(nn.Module):
             negative_prompt_embeds=negative_prompt_embeds,
         )
 
-        transformer_dtype = self.transformer.dtype
-        vae_dtype = self.vae.dtype
-        dtype = self.transformer.dtype if self.transformer is not None else self.text_encoder.dtype
-
         if num_frames % self.vae_scale_factor_temporal != 1:
             num_frames = num_frames // self.vae_scale_factor_temporal * self.vae_scale_factor_temporal + 1
         num_frames = max(num_frames, 1)
@@ -551,19 +541,17 @@ class CosmosPredict25Pipeline(nn.Module):
 
         batch_size = prompt_embeds.shape[0]
 
-        num_frames_in = None
-        if image is not None:
-            if batch_size != 1:
-                raise ValueError(f"batch_size must be 1 for image input (given {batch_size})")
+        is_image = image is not None
+        is_video = video is not None
 
+        if is_image:
             image = torchvision.transforms.functional.to_tensor(image).unsqueeze(0)
             video = torch.cat([image, torch.zeros_like(image).repeat(num_frames - 1, 1, 1, 1)], dim=0)
             video = video.unsqueeze(0)
+            video = self.video_processor.preprocess_video(video, height, width)
             num_frames_in = 1
-        elif video is None:
-            video = torch.zeros(batch_size, num_frames, 3, height, width, dtype=torch.uint8)
-            num_frames_in = 0
-        else:
+
+        elif is_video:
             if batch_size != 1:
                 raise ValueError(f"batch_size must be 1 for video input (given {batch_size})")
 
@@ -572,36 +560,34 @@ class CosmosPredict25Pipeline(nn.Module):
                     f"num_latent_conditional_frames must be 1 or 2, but got {num_latent_conditional_frames}"
                 )
 
+            needs_preprocessing = not (isinstance(video, torch.Tensor) and video.ndim == 5 and video.shape[1] == 3)
+            if needs_preprocessing:
+                video = self.video_processor.preprocess_video(video, height, width)
+
             frames_to_extract = 4 * (num_latent_conditional_frames - 1) + 1
-
-            total_input_frames = len(video)
-
+            total_input_frames = video.shape[2]
             if total_input_frames < frames_to_extract:
                 raise ValueError(
                     f"Input video has only {total_input_frames} frames but Video2World requires at least "
                     f"{frames_to_extract} frames for conditioning."
                 )
 
+            video = video[:, :, -frames_to_extract:, :, :]
+            if video.shape[2] < num_frames:
+                n_pad_frames = num_frames - video.shape[2]
+                last_frame = video[:, :, -1:, :, :]
+                pad_frames = last_frame.repeat(1, 1, n_pad_frames, 1, 1)
+                video = torch.cat((video, pad_frames), dim=2)
+
             num_frames_in = frames_to_extract
 
-        assert video is not None
-        video = self.video_processor.preprocess_video(video, height, width)
-
-        # For Video2World: extract last frames_to_extract frames from input, then pad
-        if image is None and num_frames_in > 0 and num_frames_in < video.shape[2]:
-            video = video[:, :, -num_frames_in:, :, :]
+        else:
+            video = torch.zeros(batch_size, 3, num_frames, height, width, dtype=torch.uint8)
+            num_frames_in = 0
 
         num_frames_out = num_frames
-
-        if video.shape[2] < num_frames_out:
-            n_pad_frames = num_frames_out - video.shape[2]
-            last_frame = video[:, :, -1:, :, :]  # [B, C, T==1, H, W]
-            pad_frames = last_frame.repeat(1, 1, n_pad_frames, 1, 1)  # [B, C, T, H, W]
-            video = torch.cat((video, pad_frames), dim=2)
-
         assert num_frames_in <= num_frames_out, f"expected ({num_frames_in=}) <= ({num_frames_out=})"
-
-        video = video.to(device=device, dtype=vae_dtype)
+        video = video.to(device=device, dtype=self.vae.dtype)
                            
         num_channels_latents = self.transformer.config.in_channels - 1
         latents, cond_latent, cond_mask, cond_indicator = self.prepare_latents(
@@ -618,10 +604,8 @@ class CosmosPredict25Pipeline(nn.Module):
             latents=req.sampling_params.latents,
         )
 
-        cond_timestep = torch.ones_like(cond_indicator) * conditional_frame_timestep
-        cond_mask = cond_mask.to(transformer_dtype)
-
-        padding_mask = latents.new_zeros(1, 1, height, width, dtype=transformer_dtype)
+        padding_mask = latents.new_zeros(1, 1, height, width, dtype=dtype)
+        cond_mask = cond_mask.to(dtype)
 
         # Timesteps
         self.scheduler.set_timesteps(num_inference_steps, device=device)
@@ -633,15 +617,18 @@ class CosmosPredict25Pipeline(nn.Module):
         for i, t in enumerate(timesteps):
             self._current_timestep = t
 
-            sigma_t = (
-                torch.tensor(self.scheduler.sigmas[i].item())
-                .unsqueeze(0)
-                .to(device=self.device, dtype=transformer_dtype)
-            )
+            sigma_t = self.scheduler.sigmas[i].expand(batch_size).to(device=device, dtype=torch.float32)
 
+            if conditional_frame_timestep >= 0:
+                in_timestep = cond_indicator * conditional_frame_timestep + (1 - cond_indicator) * sigma_t.view(
+                    batch_size, 1, 1, 1, 1
+                )
+            else:
+                in_timestep = sigma_t
+            
             in_latents = cond_mask * cond_latent + (1 - cond_mask) * latents
-            in_latents = in_latents.to(transformer_dtype)
-            in_timestep = cond_indicator * cond_timestep + (1 - cond_indicator) * sigma_t
+            in_latents = in_latents.to(dtype)
+
             noise_pred = self.transformer(
                 hidden_states=in_latents,
                 condition_mask=cond_mask,
@@ -679,22 +666,19 @@ class CosmosPredict25Pipeline(nn.Module):
         else:
             latents_mean = self.latents_mean.to(latents.device, latents.dtype)
             latents_std = self.latents_std.to(latents.device, latents.dtype)
-            latents = latents * latents_std + latents_mean
+            latents = latents / latents_std + latents_mean
             video = self.vae.decode(latents.to(self.vae.dtype), return_dict=False)[0]
 
-            # Check video safety after decode (required by NVIDIA Open Model License Agreement)
-            assert self.safety_checker is not None
-
-            self.safety_checker.to(device)
-            video_np = self.video_processor.postprocess_video(video, output_type="np")
-            video_np = (video_np * 255).astype(np.uint8)
-            video_batch = []
-            for vid in video_np:
-                vid = self.safety_checker.check_video_safety(vid)
-                video_batch.append(vid)
-
-            video = np.stack(video_batch).astype(np.float32) / 255.0 * 2 - 1
-            video = torch.from_numpy(video).permute(0, 4, 1, 2, 3).to(device)
+            if isinstance(self.safety_checker, CosmosSafetyChecker):
+                self.safety_checker.to(device, dtype=torch.float32)
+                video_np = self.video_processor.postprocess_video(video, output_type="np")
+                video_np = (video_np * 255).astype(np.uint8)
+                video_batch = []
+                for vid in video_np:
+                    vid = self.safety_checker.check_video_safety(vid)
+                    video_batch.append(vid)
+                video = np.stack(video_batch).astype(np.float32) / 255.0 * 2 - 1
+                video = torch.from_numpy(video).permute(0, 4, 1, 2, 3).to(device)
 
         return DiffusionOutput(output=video)
 

--- a/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
+++ b/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
@@ -21,7 +21,6 @@ import json
 import logging
 import os
 from collections.abc import Iterable
-from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -39,10 +38,9 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.cosmos.cosmos_transformer import CosmosTransformer3DModel
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.platforms import current_omni_platform
-
-from vllm_omni.diffusion.models.cosmos.cosmos_transformer import CosmosTransformer3DModel
 
 if is_cosmos_guardrail_available():
     from cosmos_guardrail import CosmosSafetyChecker
@@ -50,9 +48,11 @@ else:
 
     class CosmosSafetyChecker:
         def __init__(self, *args, **kwargs):
-            raise ImportError(
-                "`cosmos_guardrail` is not installed. Please install it to use the safety checker for Cosmos: `pip install cosmos_guardrail`."
+            message = (
+                "`cosmos_guardrail` is not installed. Please install it to use "
+                "the safety checker for Cosmos: `pip install cosmos_guardrail`."
             )
+            raise ImportError(message)
 
 
 DEFAULT_NEGATIVE_PROMPT = (
@@ -65,7 +65,6 @@ DEFAULT_NEGATIVE_PROMPT = (
 )
 
 logger = logging.getLogger(__name__)
-
 
 
 def retrieve_latents(
@@ -84,7 +83,9 @@ def retrieve_latents(
         raise AttributeError("Could not access latents of provided encoder_output")
 
 
-def load_transformer_config(model_path: str, subfolder: str = "transformer", local_files_only: bool = True, revision: str | None = None) -> dict:
+def load_transformer_config(
+    model_path: str, subfolder: str = "transformer", local_files_only: bool = True, revision: str | None = None
+) -> dict:
     """Load transformer config from model directory or HF Hub."""
     if local_files_only:
         config_path = os.path.join(model_path, subfolder, "config.json")
@@ -107,43 +108,6 @@ def load_transformer_config(model_path: str, subfolder: str = "transformer", loc
             pass
     return {}
 
-
-def create_transformer_from_config(config: dict) -> CosmosTransformer3DModel:
-    """Create WanTransformer3DModel from config dict."""
-    kwargs = {}
-
-    if "patch_size" in config:
-        kwargs["patch_size"] = tuple(config["patch_size"])
-    if "num_attention_heads" in config:
-        kwargs["num_attention_heads"] = config["num_attention_heads"]
-    if "attention_head_dim" in config:
-        kwargs["attention_head_dim"] = config["attention_head_dim"]
-    if "in_channels" in config:
-        kwargs["in_channels"] = config["in_channels"]
-    if "out_channels" in config:
-        kwargs["out_channels"] = config["out_channels"]
-    if "text_dim" in config:
-        kwargs["text_dim"] = config["text_dim"]
-    if "freq_dim" in config:
-        kwargs["freq_dim"] = config["freq_dim"]
-    if "ffn_dim" in config:
-        kwargs["ffn_dim"] = config["ffn_dim"]
-    if "num_layers" in config:
-        kwargs["num_layers"] = config["num_layers"]
-    if "cross_attn_norm" in config:
-        kwargs["cross_attn_norm"] = config["cross_attn_norm"]
-    if "eps" in config:
-        kwargs["eps"] = config["eps"]
-    if "image_dim" in config:
-        kwargs["image_dim"] = config["image_dim"]
-    if "added_kv_proj_dim" in config:
-        kwargs["added_kv_proj_dim"] = config["added_kv_proj_dim"]
-    if "rope_max_seq_len" in config:
-        kwargs["rope_max_seq_len"] = config["rope_max_seq_len"]
-    if "pos_embed_seq_len" in config:
-        kwargs["pos_embed_seq_len"] = config["pos_embed_seq_len"]
-
-    return CosmosTransformer3DModel(**kwargs)
 
 def get_cosmos_predict25_post_process_func(
     od_config: OmniDiffusionConfig,
@@ -176,7 +140,7 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         self.safety_checker = CosmosSafetyChecker()
 
         self.od_config = od_config
-        
+
         self.device = get_local_device()
         dtype = getattr(od_config, "dtype", torch.bfloat16)
 
@@ -251,10 +215,10 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             **transformer_config,
         )
 
-        #self.transformer = create_transformer_from_config(transformer_config)
+        # self.transformer = create_transformer_from_config(transformer_config)
 
         # Store the active transformer config
-        #self.transformer_config = self.transformer.config
+        # self.transformer_config = self.transformer.config
 
         self.scheduler = UniPCMultistepScheduler.from_pretrained(
             model,
@@ -263,10 +227,10 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             revision=od_config.revision,
         )
 
-        if hasattr(self.scheduler, 'alphas_cumprod') and isinstance(self.scheduler.alphas_cumprod, torch.Tensor):
+        if hasattr(self.scheduler, "alphas_cumprod") and isinstance(self.scheduler.alphas_cumprod, torch.Tensor):
             if self.scheduler.alphas_cumprod.is_cuda:
                 self.scheduler.alphas_cumprod = self.scheduler.alphas_cumprod.cpu()
-        if hasattr(self.scheduler, 'betas') and isinstance(self.scheduler.betas, torch.Tensor):
+        if hasattr(self.scheduler, "betas") and isinstance(self.scheduler.betas, torch.Tensor):
             if self.scheduler.betas.is_cuda:
                 self.scheduler.betas = self.scheduler.betas.cpu()
 
@@ -435,7 +399,6 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
 
         return latents, cond_latents, cond_mask, cond_indicator
 
-
     def check_inputs(
         self,
         prompt,
@@ -470,7 +433,6 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             not isinstance(negative_prompt, str) and not isinstance(negative_prompt, list)
         ):
             raise ValueError(f"`negative_prompt` has to be of type `str` or `list` but is {type(negative_prompt)}")
-     
 
     def predict_noise(
         self,
@@ -515,36 +477,39 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         conditional_frame_timestep: float = 0.1,
         **kwargs,
     ) -> DiffusionOutput:
-        
         # Enforce safety checker requirement (NVIDIA Open Model License Agreement)
         if self.safety_checker is None:
-            raise ValueError(
+            message = (
                 f"You have disabled the safety checker for {self.__class__}. This is in violation of the "
-                "[NVIDIA Open Model License Agreement](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license). "
+                "[NVIDIA Open Model License Agreement](https://www.nvidia.com/en-us/agreements/"
+                "enterprise-software/nvidia-open-model-license). "
                 f"Please ensure that you are compliant with the license agreement."
             )
+            raise ValueError(message)
 
         # Get parameters from request or arguments
         if len(req.prompts) == 1:  # If req.prompt is empty, default to prompt & neg_prompt in param list
             prompt = req.prompts[0] if isinstance(req.prompts[0], str) else req.prompts[0].get("prompt")
             negative_prompt = None if isinstance(req.prompts[0], str) else req.prompts[0].get("negative_prompt")
         if prompt is None and prompt_embeds is None:
-            raise ValueError("Prompt or prompt_embeds is required for Wan2.2 generation.")
+            raise ValueError("Prompt or prompt_embeds is required for Cosmos Predict 2.5 generation.")
 
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
         num_frames = req.sampling_params.num_frames if req.sampling_params.num_frames else frame_num
 
         # Ensure dimensions are compatible with VAE and patch size
-        #patch_size = self.transformer_config.patch_size
-        mod_value = 32#self.vae_scale_factor_spatial * patch_size[1]  # 16*2=32 for TI2V, 8*2=16 for I2V
+        # patch_size = self.transformer_config.patch_size
+        mod_value = 32  # self.vae_scale_factor_spatial * patch_size[1]  # 16*2=32 for TI2V, 8*2=16 for I2V
         height = (height // mod_value) * mod_value
         width = (width // mod_value) * mod_value
         num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
 
-        #num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
-        guidance_scale = req.sampling_params.guidance_scale if req.sampling_params.guidance_scale_provided else guidance_scale
-        num_videos_per_prompt=1#req.sampling_params.num_outputs_per_prompt or 1,
+        # num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        guidance_scale = (
+            req.sampling_params.guidance_scale if req.sampling_params.guidance_scale_provided else guidance_scale
+        )
+        num_videos_per_prompt = 1  # req.sampling_params.num_outputs_per_prompt or 1,
 
         self._guidance_scale = guidance_scale
         self._current_timestep = None

--- a/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
+++ b/vllm_omni/diffusion/models/cosmos/pipeline_cosmos_predict2_5.py
@@ -38,7 +38,7 @@ from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.cosmos.cosmos_transformer import CosmosTransformer3DModel
-from vllm_omni.diffusion.models.cosmos.utils import DEFAULT_NEGATIVE_PROMPT, CosmosSafetyChecker
+from vllm_omni.diffusion.models.cosmos.utils import DEFAULT_NEGATIVE_PROMPT, CosmosSafetyChecker, retrieve_latents
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.platforms import current_omni_platform
 
@@ -336,30 +336,82 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
 
     def prepare_latents(
         self,
+        video: torch.Tensor | None,        
         batch_size: int,
-        num_frames_out: int,
-        height: int,
-        width: int,
-        dtype: torch.dtype,
-        device: torch.device,
-        generator: torch.Generator | None = None,
+        num_channels_latents: int = 16,        
+        height: int = 704,
+        width: int = 1280,
+        num_frames_in: int = 93,
+        num_frames_out: int = 93,                
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        generator: torch.Generator | list[torch.Generator] | None = None,        
         latents: torch.Tensor | None = None,
     ):
         B = batch_size
-        C = 16
+        C = num_channels_latents
         T = (num_frames_out - 1) // self.vae_scale_factor_temporal + 1
         H = height // self.vae_scale_factor_spatial
         W = width // self.vae_scale_factor_spatial
         shape = (B, C, T, H, W)
 
-        if latents is None:
-            latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+        #generator=torch.Generator().manual_seed(1)
+        if num_frames_in == 0:
+            if latents is None:
+                latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
 
-        cond_mask = torch.zeros((B, 1, T, H, W), dtype=latents.dtype, device=latents.device)
-        cond_indicator = torch.zeros((B, 1, T, 1, 1), dtype=latents.dtype, device=latents.device)
-        cond_latents = torch.zeros_like(latents)
+            cond_mask = torch.zeros((B, 1, T, H, W), dtype=latents.dtype, device=latents.device)
+            cond_indicator = torch.zeros((B, 1, T, 1, 1), dtype=latents.dtype, device=latents.device)
 
-        return latents, cond_latents, cond_mask, cond_indicator
+            cond_latents = torch.zeros_like(latents)
+
+            return (
+                latents,
+                cond_latents,
+                cond_mask,
+                cond_indicator,
+            )
+        else:
+            if video is None:
+                raise ValueError("`video` must be provided when `num_frames_in` is greater than 0.")
+            needs_preprocessing = not (isinstance(video, torch.Tensor) and video.ndim == 5 and video.shape[1] == 3)
+            if needs_preprocessing:
+                video = self.video_processor.preprocess_video(video, height, width)
+            video = video.to(device=device, dtype=self.vae.dtype)
+            if isinstance(generator, list):
+                cond_latents = [
+                    retrieve_latents(self.vae.encode(video[i].unsqueeze(0)), generator=generator[i])
+                    for i in range(batch_size)
+                ]
+            else:
+                cond_latents = [retrieve_latents(self.vae.encode(vid.unsqueeze(0)), generator) for vid in video]
+
+            cond_latents = torch.cat(cond_latents, dim=0).to(dtype)
+
+            latents_mean = self.latents_mean.to(device=device, dtype=dtype)
+            latents_std = self.latents_std.to(device=device, dtype=dtype)
+            cond_latents = (cond_latents - latents_mean) / latents_std
+
+            if latents is None:
+                latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+            else:
+                latents = latents.to(device=device, dtype=dtype)
+
+            padding_shape = (B, 1, T, H, W)
+            ones_padding = latents.new_ones(padding_shape)
+            zeros_padding = latents.new_zeros(padding_shape)
+
+            num_cond_latent_frames = (num_frames_in - 1) // self.vae_scale_factor_temporal + 1
+            cond_indicator = latents.new_zeros(1, 1, latents.size(2), 1, 1)
+            cond_indicator[:, :, 0:num_cond_latent_frames] = 1.0
+            cond_mask = cond_indicator * ones_padding + (1 - cond_indicator) * zeros_padding
+
+            return (
+                latents,
+                cond_latents,
+                cond_mask,
+                cond_indicator,
+            )
 
     def check_inputs(
         self,
@@ -370,6 +422,8 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         num_frames,
         prompt_embeds=None,
         negative_prompt_embeds=None,
+        image=None,
+        video=None,
     ):
         if height % 16 != 0 or width % 16 != 0:
             raise ValueError(f"`height` and `width` have to be divisible by 16 but are {height} and {width}.")
@@ -395,6 +449,12 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             not isinstance(negative_prompt, str) and not isinstance(negative_prompt, list)
         ):
             raise ValueError(f"`negative_prompt` has to be of type `str` or `list` but is {type(negative_prompt)}")
+
+        if image is not None and video is not None:
+            raise ValueError(
+                "Cannot provide both `image` and `video`. "
+                "Use `image` for Image2World or `video` for Video2World, but not both."
+            )
 
     def predict_noise(
         self,
@@ -427,11 +487,14 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         req: OmniDiffusionRequest,
         prompt: str | None = None,
         negative_prompt: str | None = None,
+        image: torch.Tensor | None = None,
+        video: torch.Tensor | None = None,
         height: int = 704,
         width: int = 1280,
         num_inference_steps: int = 36,
         guidance_scale: float | tuple[float, float] = 7.0,
         frame_num: int = 93,
+        num_latent_conditional_frames: int = 2,
         output_type: str | None = "np",
         generator: torch.Generator | list[torch.Generator] | None = None,
         prompt_embeds: torch.Tensor | None = None,
@@ -455,6 +518,22 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             negative_prompt = None if isinstance(req.prompts[0], str) else req.prompts[0].get("negative_prompt")
         if prompt is None and prompt_embeds is None:
             raise ValueError("Prompt or prompt_embeds is required for Cosmos Predict 2.5 generation.")
+        extra = getattr(req.sampling_params, "extra_args", {}) or {}
+        image = extra.get("image", image)
+        video = extra.get("video", video)        
+
+        # Validate mutual exclusivity of image and video inputs
+        if image is not None and video is not None:
+            raise ValueError(
+                "Cannot provide both `image` and `video`. "
+                "Use `image` for Image2World or `video` for Video2World, but not both."
+            )
+
+        # Validate num_latent_conditional_frames
+        if num_latent_conditional_frames not in [1, 2]:
+            raise ValueError(
+                f"num_latent_conditional_frames must be 1 or 2, but got {num_latent_conditional_frames}"
+            )
 
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
@@ -485,8 +564,6 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
         if generator is None and req.sampling_params.seed is not None:
             generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
 
-        do_classifier_free_guidance = guidance_scale > 1.0
-
         # Check text safety before generation (required by NVIDIA Open Model License Agreement)
         if self.safety_checker is not None:
             self.safety_checker.to(device, dtype=torch.float32)
@@ -507,6 +584,8 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             num_frames=num_frames,
             prompt_embeds=prompt_embeds,
             negative_prompt_embeds=negative_prompt_embeds,
+            image=image,
+            video=video,
         )
 
         if num_frames % self.vae_scale_factor_temporal != 1:
@@ -517,7 +596,7 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             prompt_embeds, negative_prompt_embeds = self.encode_prompt(
                 prompt,
                 negative_prompt=negative_prompt,
-                do_classifier_free_guidance=do_classifier_free_guidance,
+                do_classifier_free_guidance=self.do_classifier_free_guidance,
                 num_videos_per_prompt=num_videos_per_prompt,
                 device=device,
                 dtype=dtype,
@@ -526,20 +605,81 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             prompt_embeds = prompt_embeds.to(device=device, dtype=dtype)
             if negative_prompt_embeds is not None:
                 negative_prompt_embeds = negative_prompt_embeds.to(device=device, dtype=dtype)
-            elif do_classifier_free_guidance:
+            elif self.do_classifier_free_guidance:
                 raise ValueError(
                     "negative_prompt_embeds must be provided when prompt_embeds are given and guidance_scale > 1."
                 )
 
         batch_size = prompt_embeds.shape[0]
+
+        import torchvision.transforms.functional
+        num_frames_in = None
+        if image is not None:
+            if batch_size != 1:
+                raise ValueError(f"batch_size must be 1 for image input (given {batch_size})")
+
+            image = torchvision.transforms.functional.to_tensor(image).unsqueeze(0)
+            video = torch.cat([image, torch.zeros_like(image).repeat(num_frames - 1, 1, 1, 1)], dim=0)
+            video = video.unsqueeze(0)
+            num_frames_in = 1
+        elif video is None:
+            video = torch.zeros(batch_size, num_frames, 3, height, width, dtype=torch.uint8)
+            num_frames_in = 0
+        else:
+            if batch_size != 1:
+                raise ValueError(f"batch_size must be 1 for video input (given {batch_size})")
+
+            if num_latent_conditional_frames not in [1, 2]:
+                raise ValueError(
+                    f"num_latent_conditional_frames must be 1 or 2, but got {num_latent_conditional_frames}"
+                )
+
+            frames_to_extract = 4 * (num_latent_conditional_frames - 1) + 1
+
+            total_input_frames = len(video)
+
+            if total_input_frames < frames_to_extract:
+                raise ValueError(
+                    f"Input video has only {total_input_frames} frames but Video2World requires at least "
+                    f"{frames_to_extract} frames for conditioning."
+                )
+
+            num_frames_in = frames_to_extract
+
+        assert video is not None
+        video = self.video_processor.preprocess_video(video, height, width)
+
+        # For Video2World: extract last frames_to_extract frames from input, then pad
+        if image is None and num_frames_in > 0 and num_frames_in < video.shape[2]:
+            video = video[:, :, -num_frames_in:, :, :]
+
+        num_frames_out = num_frames
+
+        if video.shape[2] < num_frames_out:
+            n_pad_frames = num_frames_out - video.shape[2]
+            last_frame = video[:, :, -1:, :, :]  # [B, C, T==1, H, W]
+            pad_frames = last_frame.repeat(1, 1, n_pad_frames, 1, 1)  # [B, C, T, H, W]
+            video = torch.cat((video, pad_frames), dim=2)
+
+        assert num_frames_in <= num_frames_out, f"expected ({num_frames_in=}) <= ({num_frames_out=})"
+
+        # Empty cache before VAE encoding to prevent OOM (similar to line 843 before decode)
+        if num_frames_in > 0 and current_omni_platform.is_available():
+            current_omni_platform.empty_cache()
+
+        num_channels_latents = self.transformer.in_channels - 1
         latents, cond_latent, cond_mask, cond_indicator = self.prepare_latents(
+            video=video,
             batch_size=batch_size * num_videos_per_prompt,
-            num_frames_out=num_frames,
+            num_channels_latents=num_channels_latents,            
             height=height,
             width=width,
+            num_frames_in=num_frames_in,
+            num_frames_out=num_frames,                                   
             dtype=torch.float32,
             device=self.device,
             generator=generator,
+            #latents=latents,
         )
 
         transformer_dtype = self.transformer.dtype
@@ -567,7 +707,7 @@ class CosmosPredict25Pipeline(nn.Module, CFGParallelMixin):
             in_latents = in_latents.to(transformer_dtype)
             in_timestep = cond_indicator * cond_timestep + (1 - cond_indicator) * sigma_t
 
-            do_true_cfg = do_classifier_free_guidance and negative_prompt_embeds is not None
+            do_true_cfg = self.do_classifier_free_guidance and negative_prompt_embeds is not None
             positive_kwargs = {
                 "cond_mask": cond_mask,
                 "gt_velocity": gt_velocity,

--- a/vllm_omni/diffusion/models/cosmos/utils.py
+++ b/vllm_omni/diffusion/models/cosmos/utils.py
@@ -1,58 +1,8 @@
-import functools
 import importlib.util
-import logging
-import os
 
 import torch
 
-logger = logging.getLogger(__name__)
-
-
-def _patch_cosmos_guardrail_snapshot_download() -> None:
-    """Avoid materializing nested ``.locks/`` files as cache symlinks."""
-
-    import cosmos_guardrail.cosmos_guardrail as _cg
-
-    original = _cg.snapshot_download
-    if getattr(original, "_vllm_omni_lock_patched", False):
-        return
-
-    @functools.wraps(original)
-    def patched(*args, **kwargs):
-        extra = ["**/.locks/**", "**/.locks/**/*"]
-        existing = kwargs.get("ignore_patterns") or []
-        if isinstance(existing, str):
-            existing = [existing]
-        kwargs["ignore_patterns"] = list(existing) + extra
-        checkpoint_dir = original(*args, **kwargs)
-        _strip_bogus_aegis_locks(checkpoint_dir)
-        return checkpoint_dir
-
-    patched._vllm_omni_lock_patched = True  # type: ignore[attr-defined]
-    _cg.snapshot_download = patched
-
-
-def _strip_bogus_aegis_locks(checkpoint_dir: str) -> None:
-    """Remove pre-baked ``.lock`` symlinks under ``aegis/`` in a cached snapshot."""
-    aegis_dir = os.path.join(checkpoint_dir, "aegis")
-    if not os.path.isdir(aegis_dir):
-        return
-    for root, _, files in os.walk(aegis_dir):
-        if os.path.basename(root) != ".locks" and ".locks" not in root.split(os.sep):
-            continue
-        for name in files:
-            if not name.endswith(".lock"):
-                continue
-            path = os.path.join(root, name)
-            if os.path.islink(path):
-                try:
-                    os.unlink(path)
-                except OSError as exc:
-                    logger.debug("Failed to remove bogus lock symlink %s: %s", path, exc)
-
-
 if importlib.util.find_spec("cosmos_guardrail") is not None:
-    _patch_cosmos_guardrail_snapshot_download()
     from cosmos_guardrail import CosmosSafetyChecker
 else:
 

--- a/vllm_omni/diffusion/models/cosmos/utils.py
+++ b/vllm_omni/diffusion/models/cosmos/utils.py
@@ -1,8 +1,58 @@
+import functools
 import importlib.util
+import logging
+import os
 
 import torch
 
+logger = logging.getLogger(__name__)
+
+
+def _patch_cosmos_guardrail_snapshot_download() -> None:
+    """Avoid materializing nested ``.locks/`` files as cache symlinks."""
+    
+    import cosmos_guardrail.cosmos_guardrail as _cg
+
+    original = _cg.snapshot_download
+    if getattr(original, "_vllm_omni_lock_patched", False):
+        return
+
+    @functools.wraps(original)
+    def patched(*args, **kwargs):
+        extra = ["**/.locks/**", "**/.locks/**/*"]
+        existing = kwargs.get("ignore_patterns") or []
+        if isinstance(existing, str):
+            existing = [existing]
+        kwargs["ignore_patterns"] = list(existing) + extra
+        checkpoint_dir = original(*args, **kwargs)
+        _strip_bogus_aegis_locks(checkpoint_dir)
+        return checkpoint_dir
+
+    patched._vllm_omni_lock_patched = True  # type: ignore[attr-defined]
+    _cg.snapshot_download = patched
+
+
+def _strip_bogus_aegis_locks(checkpoint_dir: str) -> None:
+    """Remove pre-baked ``.lock`` symlinks under ``aegis/`` in a cached snapshot."""
+    aegis_dir = os.path.join(checkpoint_dir, "aegis")
+    if not os.path.isdir(aegis_dir):
+        return
+    for root, _, files in os.walk(aegis_dir):
+        if os.path.basename(root) != ".locks" and ".locks" not in root.split(os.sep):
+            continue
+        for name in files:
+            if not name.endswith(".lock"):
+                continue
+            path = os.path.join(root, name)
+            if os.path.islink(path):
+                try:
+                    os.unlink(path)
+                except OSError as exc:
+                    logger.debug("Failed to remove bogus lock symlink %s: %s", path, exc)
+
+
 if importlib.util.find_spec("cosmos_guardrail") is not None:
+    _patch_cosmos_guardrail_snapshot_download()
     from cosmos_guardrail import CosmosSafetyChecker
 else:
 
@@ -13,17 +63,6 @@ else:
                 "the safety checker for Cosmos: `pip install cosmos_guardrail`."
             )
             raise ImportError(message)
-
-
-if importlib.util.find_spec("torch_xla") is not None:
-    import torch_xla.core.xla_model as xm
-else:
-
-    class xm:
-        @staticmethod
-        def mark_step(*args, **kwargs):
-            # noop
-            pass
 
 
 def retrieve_latents(

--- a/vllm_omni/diffusion/models/cosmos/utils.py
+++ b/vllm_omni/diffusion/models/cosmos/utils.py
@@ -1,0 +1,51 @@
+import importlib.util
+
+import torch
+
+if importlib.util.find_spec("cosmos_guardrail") is not None:
+    from cosmos_guardrail import CosmosSafetyChecker
+else:
+
+    class CosmosSafetyChecker:
+        def __init__(self, *args, **kwargs):
+            message = (
+                "`cosmos_guardrail` is not installed. Please install it to use "
+                "the safety checker for Cosmos: `pip install cosmos_guardrail`."
+            )
+            raise ImportError(message)
+
+
+if importlib.util.find_spec("torch_xla") is not None:
+    import torch_xla.core.xla_model as xm
+else:
+
+    class xm:
+        @staticmethod
+        def mark_step(*args, **kwargs):
+            # noop
+            pass
+
+
+def retrieve_latents(
+    encoder_output: torch.Tensor,
+    generator: torch.Generator | None = None,
+    sample_mode: str = "sample",
+):
+    """Retrieve latents from VAE encoder output."""
+    if hasattr(encoder_output, "latent_dist") and sample_mode == "sample":
+        return encoder_output.latent_dist.sample(generator)
+    elif hasattr(encoder_output, "latent_dist") and sample_mode == "argmax":
+        return encoder_output.latent_dist.mode()
+    elif hasattr(encoder_output, "latents"):
+        return encoder_output.latents
+    else:
+        raise AttributeError("Could not access latents of provided encoder_output")
+
+
+DEFAULT_NEGATIVE_PROMPT = (
+    "The video captures a series of frames showing ugly scenes, static with no motion, motion blur, over-saturation, "
+    "shaky footage, low resolution, grainy texture, pixelated images, poorly lit areas, underexposed and overexposed "
+    "scenes, poor color balance, washed out colors, choppy sequences, jerky movements, low frame rate, artifacting, "
+    "color banding, unnatural transitions, outdated special effects, fake elements, unconvincing visuals, "
+    "poorly edited content, jump cuts, visual noise, and flickering. Overall, the video is of poor quality."
+)

--- a/vllm_omni/diffusion/models/cosmos/utils.py
+++ b/vllm_omni/diffusion/models/cosmos/utils.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 def _patch_cosmos_guardrail_snapshot_download() -> None:
     """Avoid materializing nested ``.locks/`` files as cache symlinks."""
-    
+
     import cosmos_guardrail.cosmos_guardrail as _cg
 
     original = _cg.snapshot_download

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -256,6 +256,11 @@ _DIFFUSION_MODELS = {
         "pipeline_omnivoice",
         "OmniVoicePipeline",
     ),
+    "Cosmos2_5_PredictBasePipeline": (
+        "cosmos",
+        "pipeline_cosmos_predict2_5",
+        "CosmosPredict25Pipeline",
+    ),
     "DiffusersAdapterPipeline": (
         "diffusers_adapter",
         "pipeline_diffusers_adapter",
@@ -488,6 +493,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "DreamIDOmniPipeline": "get_dreamid_omni_post_process_func",
     "SenseNovaU1Pipeline": "get_sensenova_u1_post_process_func",
     "HiDreamImagePipeline": "get_hidream_image_post_process_func",
+    "Cosmos2_5_PredictBasePipeline": "get_cosmos_predict25_post_process_func",
 }
 
 _DIFFUSION_PRE_PROCESS_FUNCS = {

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1921,6 +1921,7 @@ class AsyncOmniEngine:
             "parallel_config": parallel_config,
             "model_class_name": kwargs.get("model_class_name", None),
             "additional_config": kwargs.get("additional_config", None),
+            "revision": kwargs.get("revision", None),
             "step_execution": kwargs.get("step_execution", False),
             "vae_use_slicing": kwargs.get("vae_use_slicing", False),
             "vae_use_tiling": kwargs.get("vae_use_tiling", False),

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -58,7 +58,7 @@ def _weak_shutdown_engine(engine: AsyncOmniEngine) -> None:
         pass
 
 
-def omni_snapshot_download(model_id: str) -> str:
+def omni_snapshot_download(model_id: str, revision: str | None = None) -> str:
     if os.path.exists(model_id):
         return model_id
 
@@ -74,6 +74,7 @@ def omni_snapshot_download(model_id: str) -> str:
             model_name_or_path=model_id,
             cache_dir=None,
             allow_patterns=["*"],
+            revision=revision,
             require_all=True,
         )
     except huggingface_hub.errors.GatedRepoError:
@@ -155,10 +156,11 @@ class OmniBase(PDDisaggregationMixin):
         async_chunk = kwargs.get("async_chunk")
         output_modalities = kwargs.pop("output_modalities", None)
         diffusion_batch_size: int = kwargs.pop("diffusion_batch_size", 1)
+        revision = kwargs.get("revision", None)
 
         if "log_requests" in kwargs:
             raise TypeError("`log_requests` has been removed in Omni/AsyncOmni. Use `log_stats`.")
-        model = omni_snapshot_download(model)
+        model = omni_snapshot_download(model, revision=revision)
         self.__dict__["_name"] = self.__class__.__name__
         self.model = model
         self.log_stats = log_stats

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -132,16 +132,17 @@ def inject_omni_kv_config(stage: Any, omni_conn_cfg: dict[str, Any], omni_from: 
         logger.error(f"Failed to inject omni connector config into stage: {e}")
 
 
-def _try_get_class_name_from_diffusers_config(model: str) -> str | None:
+def _try_get_class_name_from_diffusers_config(model: str, revision: str | None = None) -> str | None:
     """Try to get class name from diffusers model configuration files.
 
     Args:
         model: Model name or path
+        revision: Model revision (branch, tag, or commit hash)
 
     Returns:
         Model type string if found, None otherwise
     """
-    model_index = get_hf_file_to_dict("model_index.json", model, revision=None)
+    model_index = get_hf_file_to_dict("model_index.json", model, revision=revision)
     if model_index and isinstance(model_index, dict) and "_class_name" in model_index:
         logger.debug(f"Found model_type '{model_index['_class_name']}' in model_index.json")
         return model_index["_class_name"]
@@ -283,7 +284,7 @@ def _try_resolve_omni_model_type(model: str) -> str | None:
     return best_match
 
 
-def resolve_model_config_path(model: str) -> str:
+def resolve_model_config_path(model: str, revision: str | None = None) -> str:
     """Resolve the stage config file path from the model name.
 
     Resolves stage configuration path based on the model type and device type.
@@ -292,6 +293,7 @@ def resolve_model_config_path(model: str) -> str:
 
     Args:
         model: Model name or path (used to determine model_type)
+        revision: Model revision (branch, tag, or commit hash)
 
     Returns:
         String path to the stage configuration file
@@ -306,18 +308,18 @@ def resolve_model_config_path(model: str) -> str:
         model_type = hf_config.model_type
     except (ValueError, Exception):
         # If standard transformers format fails, try diffusers format
-        if file_or_path_exists(model, "model_index.json", revision=None):
-            model_type = _try_get_class_name_from_diffusers_config(model)
+        if file_or_path_exists(model, "model_index.json", revision=revision):
+            model_type = _try_get_class_name_from_diffusers_config(model, revision=revision)
             if model_type is None:
                 raise ValueError(
                     f"Could not determine model_type for diffusers model: {model}. "
                     f"Please ensure the model has 'model_type' in transformer/config.json or model_index.json"
                 )
-        elif file_or_path_exists(model, "config.json", revision=None):
+        elif file_or_path_exists(model, "config.json", revision=revision):
             # Try to read config.json manually for custom models like Bagel that fail get_config
             # but have a valid config.json with model_type
             try:
-                config_dict = get_hf_file_to_dict("config.json", model, revision=None)
+                config_dict = get_hf_file_to_dict("config.json", model, revision=revision)
                 if config_dict and "model_type" in config_dict:
                     model_type = config_dict["model_type"]
                 else:
@@ -390,6 +392,8 @@ def load_stage_configs_from_model(
     if base_engine_args is None:
         base_engine_args = {}
 
+    revision = base_engine_args.get("revision", None) if isinstance(base_engine_args, dict) else None
+
     cli_overrides = _convert_dataclasses_to_dict(dict(base_engine_args))
     if stage_overrides:
         for stage_id_str, overrides in stage_overrides.items():
@@ -406,7 +410,7 @@ def load_stage_configs_from_model(
         return [stage.to_omegaconf() for stage in stages]
 
     # Legacy fallback: load from YAML
-    stage_config_path = resolve_model_config_path(model)
+    stage_config_path = resolve_model_config_path(model, revision=revision)
     if stage_config_path is None:
         return []
     stage_configs = load_stage_configs_from_yaml(
@@ -621,7 +625,8 @@ def load_and_resolve_stage_configs(
             else:
                 stage_configs = []
     elif stage_configs_path is None:
-        config_path = resolve_model_config_path(model)
+        revision = kwargs.get("revision", None) if kwargs and isinstance(kwargs, dict) else None
+        config_path = resolve_model_config_path(model, revision=revision)
         stage_configs = load_stage_configs_from_model(
             model,
             base_engine_args=kwargs,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Add Cosmos-Predict2.5 model (text2world, image2world, and video2world) support to address issue #1747

This PR covers single-GPU offline inference. Advanced features and Cosmos-Transfer2.5 are left for follow-up PRs.

The only change beyond the Cosmos-Predict2.5 model is passing `revision` through the model loader (`diffusion/data.py`, `engine/async_omni_engine.py`, `entrypoints/omni_base.py`, `entrypoints/utils.py`), since the weights live on a non-default HF branch (`diffusers/base/post-trained`).

 | Size | Pipeline class                  | Supported tasks                          |
 |------|---------------------------------|------------------------------------------|
 | 2B   | `Cosmos2_5_PredictBasePipeline` | Text2World, Image2World, Video2World     |
 | 14B  | `Cosmos2_5_PredictBasePipeline` | Text2World, Image2World, Video2World     |

## Test Plan
End-to-end manual runs against the upstream diffusers `Cosmos2_5_PredictBasePipeline` for visual parity. Same prompt / seed / resolution per pair.

  **Text2World — 2B**

```bash
python examples/offline_inference/cosmos/cosmos_predict2_5.py \
--mode text2world \
--model nvidia/Cosmos-Predict2.5-2B \
--revision diffusers/base/post-trained \
--prompt "As the red light shifts to green, the red bus at the intersection begins to move forward, its headlights cutting through the falling snow. The snowy tire tracks deepen as the vehicle inches ahead, casting fresh lines onto the slushy road. Around it, streetlights glow warmer, illuminating the drifting flakes and wet reflections on the asphalt. Other cars behind start to edge forward, their beams joining the scene. The stillness of the urban street transitions into motion as the quiet snowfall is punctuated by the slow advance of traffic through the frosty city corridor." \
--num-frames 93 --seed 1 \
--output cosmos_predict_2_5_2B_t2v_out.mp4
```

  Text2World — 14B (CPU offload)

```bash
python examples/offline_inference/cosmos/cosmos_predict2_5.py \
--mode text2world \
--model nvidia/Cosmos-Predict2.5-14B \
--revision diffusers/base/post-trained \
--prompt "As the red light shifts to green, the red bus at the intersection begins to move forward, its headlights cutting through the falling snow. The snowy tire tracks deepen as the vehicle inches ahead, casting fresh lines onto the slushy road. Around it, streetlights glow warmer, illuminating the drifting flakes and wet reflections on the asphalt. Other cars behind start to edge forward, their beams joining the scene. The stillness of the urban street transitions into motion as the quiet snowfall is punctuated by the slow advance of traffic through the frosty city corridor." \
--num-frames 93 --seed 1 \
--enable-cpu-offload \
--height 480 --width 832 \
--output cosmos_predict_2_5_14B_t2v_out.mp4
```

  Image2World — 2B

```bash
python examples/offline_inference/cosmos/cosmos_predict2_5.py \
--mode image2world \
--model nvidia/Cosmos-Predict2.5-2B \
--revision diffusers/base/post-trained \
--prompt "A nighttime city bus terminal gradually shifts from stillness to subtle movement. At first, multiple double-decker buses are parked under the glow of overhead lights, with a central bus labeled '87D' facing forward and stationary. As the video progresses, the bus in the middle moves ahead slowly, its headlights brightening the surrounding area and casting reflections onto adjacent vehicles. The motion creates space in the lineup, signaling activity within the otherwise quiet station. It then comes to a smooth stop, resuming its position in line. Overhead signage in Chinese characters remains illuminated, enhancing the vibrant, urban night scene." \
--image ./bus_terminal.jpg \
--num-frames 93 --seed 1 \
--output cosmos_predict_2_5_2B_i2v_out.mp4
```

  Video2World — 2B

```sh
python examples/offline_inference/cosmos/cosmos_predict2_5.py \
--mode video2world \
--model nvidia/Cosmos-Predict2.5-2B \
--revision diffusers/base/post-trained \
--prompt "A robotic arm, primarily white with black joints and cables, is shown in a clean, modern indoor setting with a white tabletop. The arm, equipped with a gripper holding a small, light green pitcher, is positioned above a clear glass containing a reddish-brown liquid and a spoon. The robotic arm is in the process of pouring a transparent liquid into the glass. To the left of the pitcher, there is an opened jar with a similar reddish-brown substance visible through its transparent body. In the background, a vase with white flowers and a brown couch are partially visible, adding to the contemporary ambiance. The lighting is bright, casting soft shadows on the table. The robotic arm's movements are smooth and controlled, demonstrating precision in its task. As the video progresses, the robotic arm completes the pour, leaving the glass half-filled with the reddish-brown liquid. The jar remains untouched throughout the sequence, and the spoon inside the glass remains stationary. The other robotic arm on the right side also stays stationary throughout the video. The final frame captures the robotic arm with the pitcher finishing the pour, with the glass now filled to a higher level, while the pitcher is slightly tilted but still held securely by the gripper."
--video ./robot_pouring_1.mp4 \
--num-frames 93 --seed 1 \
--output cosmos_predict_2_5_2B_v2w_out.mp4
```

## Test Result

<strong>Text2World — 2B</strong>

<details>
<summary>Details</summary>

<table>
<tr>
<th>vLLM-Omni</th>
<th>Diffusers Reference</th>
</tr>

<tr>
<td>
<video src="https://github.com/user-attachments/assets/437d56c6-60cb-4330-b663-946c19759778"
controls width="420"></video>
</td>

<td>
<video src="https://github.com/user-attachments/assets/5cd59a1a-8854-4cd3-aeff-fdf713ddbb71"
controls width="420"></video>
</td>
</tr>
</table>

</details>

<strong>Text2World — 14B</strong>

<details>
<summary>Details</summary>

<table>
<tr>
<th>vLLM-Omni</th>
<th>Diffusers Reference</th>
</tr>

<tr>
<td>
<video src="https://github.com/user-attachments/assets/d1ee7c15-d8eb-4f86-aa83-7c042332ea4b"
controls width="420"></video>
</td>

<td>
<video src="https://github.com/user-attachments/assets/153f3275-40f2-407c-a4d1-628c1ae39f41"
controls width="420"></video>
</td>
</tr>
</table>

</details>

<strong>Image2World — 2B</strong>

<details>
<summary>Details</summary>

<table>
<tr>
<th>vLLM-Omni</th>
<th>Diffusers Reference</th>
</tr>

<tr>
<td>
<video src="https://github.com/user-attachments/assets/ff9918ae-1c6b-4095-bebe-18b8f629a4e2"
controls width="420"></video>
</td>

<td>
<video src="https://github.com/user-attachments/assets/9e8e265f-ffb3-47a5-a884-1bb53bfe555a"
controls width="420"></video>
</td>
</tr>
</table>

</details>

<strong>Video2World — 2B</strong>

<details>
<summary>Details</summary>

<table>
<tr>
<th>vLLM-Omni</th>
<th>Diffusers Reference</th>
</tr>

<tr>
<td>
<video src="https://github.com/user-attachments/assets/3b590c3d-2399-4b16-ad1a-5406b7d7d4a9"
controls width="420"></video>
</td>

<td>
<video src="https://github.com/user-attachments/assets/9901911e-8151-473d-bba0-ae2dc36af9e2"
controls width="420"></video>
</td>
</tr>
</table>

</details>

## Memory & Latency

Measured on a single NVIDIA A100-SXM4-80GB at default settings (704×1280, 93 frames, 36 steps):

| Model | Mode | Flags | Peak VRAM (BF16) | Wall time |
|---|---|---|---|---|
| `Cosmos-Predict2.5-2B` | Text2World | — | 36.6 GiB | ~13 min |
| `Cosmos-Predict2.5-2B` | Image2World | — | 35.5 GiB | ~13 min |
| `Cosmos-Predict2.5-2B` | Video2World | — | 36.5 GiB | ~13 min |
| `Cosmos-Predict2.5-14B` | Text2World | `--enable-cpu-offload` | 49.2 GiB | ~48 min |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
