### PR TITLE
[Bugfix] Fix VoxtralTTSConfig AttributeError from transformers @strict decorator validation

### DIFF
--- a/vllm_omni/model_executor/models/voxtral_tts/configuration_voxtral_tts.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/configuration_voxtral_tts.py
@@ -21,14 +21,16 @@ class VoxtralTTSConfig(PretrainedConfig):
         audio_config: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(**kwargs)
-
-        if isinstance(text_config, PretrainedConfig):
+        if text_config is None:
+            self.text_config = PretrainedConfig()
+        elif isinstance(text_config, PretrainedConfig):
             self.text_config = text_config
         elif isinstance(text_config, dict):
             self.text_config = PretrainedConfig.from_dict(text_config)
         else:
             self.text_config = PretrainedConfig()
+
+        super().__init__(**kwargs)
 
         self.audio_config = audio_config or {}
 


### PR DESCRIPTION

## Purpose

transformers: 5.3.0
vllm: 0.18.0
vllm-omni: 0.18.0

`vllm serve --model mistralai/Voxtral-4B-TTS-2603 --tokenizer-mode mistral  --stage-configs-path vllm_omni/model_executor/stage_configs/voxtral_tts.yaml --omni --port 8004`

`(APIServer pid=1199902) RuntimeError: Orchestrator initialization failed: 'VoxtralTTSConfig' object has no attribute 'text_confi`

Fix VoxtralTTSConfig AttributeError: same issue as PR #2306 caused by newer transformers(5.x) @ strict decorator validation, compatible with transformers 4.57.x (tested in 4.57.1)

Also checked all other model configs - no similar issues found. All Config classes with get_text_config() already initialize sub-configs before super().__init__().

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
