### PR TITLE
[Bugfix] Fix delayed decoding bug for Bagel AR/DIT workflow (L3 test_bagel_img2img error)

### DIFF
--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -98,20 +98,20 @@ class OmniARScheduler(VLLMScheduler):
         stop_decode_on_trigger = self.kv_transfer_criteria.get("stop_after_transfer", True)
 
         if request.request_id in self.transfer_triggered_requests:
-            # Already triggered; if stop_after_transfer is enabled, wait for
-            # KV extraction to finish then stop.  (Fallback for special_token
-            # or any path that did not stop immediately at trigger time.)
-            if stop_decode_on_trigger and request.request_id not in self.active_kv_transfers:
-                request.status = RequestStatus.FINISHED_STOPPED
-                return True
+            # Already triggered.  When stop_decode_on_trigger is True AND
+            # transfer was actually queued, the request was already stopped
+            # at trigger time (see below).  Any request that reaches this
+            # point either has stop_decode_on_trigger=False (continue
+            # decoding) or was not actually queued (should not be stopped).
             return False
 
         if criteria_type == "prefill_finished":
             if request.num_computed_tokens >= request.num_prompt_tokens:
                 self.transfer_triggered_requests.add(request.request_id)
                 self._mark_request_for_kv_transfer(request.request_id, request.num_computed_tokens)
+                actually_queued = request.request_id in self.requests_needing_kv_transfer
 
-                if stop_decode_on_trigger:
+                if stop_decode_on_trigger and actually_queued:
                     # Stop immediately so the request is NOT scheduled in
                     # the next step, freeing scheduling budget for companion
                     # requests whose chunked-prefill boundaries must be
@@ -128,7 +128,6 @@ class OmniARScheduler(VLLMScheduler):
             if target_token_id is not None and target_token_id in new_token_ids:
                 self.transfer_triggered_requests.add(request.request_id)
 
-                # Calculate precise snapshot length (trim to sentinel)
                 try:
                     idx = new_token_ids.index(target_token_id)
                     tokens_to_exclude = len(new_token_ids) - (idx + 1)
@@ -137,8 +136,9 @@ class OmniARScheduler(VLLMScheduler):
                     snapshot_len = request.num_computed_tokens
 
                 self._mark_request_for_kv_transfer(request.request_id, snapshot_len)
+                actually_queued = request.request_id in self.requests_needing_kv_transfer
 
-                if stop_decode_on_trigger:
+                if stop_decode_on_trigger and actually_queued:
                     self.waiting_for_transfer_free.add(request.request_id)
                     request.status = RequestStatus.FINISHED_STOPPED
                     return True


### PR DESCRIPTION


<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

When stop_after_transfer is enabled (default), the AR scheduler previously continued decoding for 1–2 extra steps after the KV transfer trigger fired. The request was only stopped in a subsequent update_from_output call, after KV extraction completed. During those extra steps, the still-running parent request consumed scheduling budget, causing companion requests (e.g., cfg_text) to receive different chunked-prefill boundaries. This led to floating-point divergence in the KV cache and visibly degraded image quality in the DiT stage.

With this PR, the following modes should be supported. 

| | `prefill_finished` | `special_token` |
|---|---|---|
| **`stop_after_transfer: true`** (default) | **Supported** — Stops decode immediately on trigger. `waiting_for_transfer_free` holds blocks until KV extraction completes. Orchestrator forwards to the next stage via the `finished` output path. | **Supported** — Computes `snapshot_len`, then immediately stops decode with the same `waiting_for_transfer_free` protection. Fully aligned with `prefill_finished` semantics. |
| **`stop_after_transfer: false`** | **Supported** — Continues decoding after trigger until natural termination (e.g. `max_tokens`). `kv_ready` signal is emitted once KV extraction completes (request still running), allowing the orchestrator to forward early. | **Supported** — Continues decoding after the special token is detected. KV extraction triggers a `kv_ready` signal for early forwarding; the request finishes naturally and resources are freed on completion. |

All four combinations are supported. The `stop_after_transfer` flag applies the same stop/continue semantics uniformly across both criteria types.




## Test Plan

1. Using prompt “Let the woman wear a blue dress”
2. L3 test
```
VLLM_WORKER_MULTIPROC_METHOD=spawn VLLM_TEST_CLEAN_GPU_MEMORY=1 VLLM_IMAGE_FETCH_TIMEOUT=60 pytest -s -v tests/e2e/offline_inference/test_bagel_img2img.py -m "advanced_model" --run-level "advanced_model"
```

## Test Result
1. 
| Input| output |
| :--- | :--- |
|  <img width="800" height="1024" alt="image" src="https://github.com/user-attachments/assets/e518c3cd-6a82-4567-a6c4-478016243cb2" />| <img width="800" height="1024" alt="image" src="https://github.com/user-attachments/assets/c0c096a3-380c-48c2-93c3-9cf706d8b0f8" /> |
2.
<img width="1748" height="604" alt="Screenshot from 2026-04-01 21-41-20" src="https://github.com/user-attachments/assets/8fff2cad-d6c3-4eba-8a62-bd77a893782f" />



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)

---
@princepride 

