### PR TITLE
[Bugfix] Fix Flux2 Dev Guidance

### DIFF
--- a/vllm_omni/diffusion/models/flux2/flux2_transformer.py
+++ b/vllm_omni/diffusion/models/flux2/flux2_transformer.py
@@ -578,9 +578,11 @@ class Flux2Transformer2DModel(nn.Module):
         guidance_embeds: bool = True,
     ):
         super().__init__()
+        self.guidance_embeds = guidance_embeds
         self.stacked_params_mapping = None
         self.out_channels = out_channels or in_channels
         self.inner_dim = num_attention_heads * attention_head_dim
+
         self.config = SimpleNamespace(
             patch_size=patch_size,
             in_channels=in_channels,

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -1019,7 +1019,7 @@ class Flux2Pipeline(nn.Module, SupportImageInput):
         self._num_timesteps = len(timesteps)
 
         # handle guidance
-        if self.guidance_scale is not None:
+        if self.transformer.guidance_embeds is not None:
             guidance_tensor = torch.full([1], self.guidance_scale, device=device, dtype=torch.float32)
             guidance_tensor = guidance_tensor.expand(latents.shape[0])
 


### PR DESCRIPTION
## Purpose
Flux2 dev is currently not passing guidance through correctly; regardless of the sampling params, the guidance tensor passed to the transformer is hardcoded to `None`.

This PR creates the guidance tensor and passes it through to the timestep guidance embeddings (original pipeline for reference [here](https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/flux2/pipeline_flux2.py)).

## Test Result
To validate, you can run an example like this:
```python
from vllm_omni.inputs.data import OmniDiffusionSamplingParams
from vllm_omni.entrypoints.omni import Omni

MODEL = "black-forest-labs/FLUX.2-dev"

PROMPT = "A white cat sitting on a black table near a windows with visible sunlight."
SEED = 42
NUM_STEPS = 4

def generate_with_guidance(omni: Omni, guidance_scale: float, output_path: str):
    """Generate image with specific guidance_scale using existing Omni instance."""
    outputs = omni.generate(
        prompts=PROMPT,
        sampling_params_list=OmniDiffusionSamplingParams(
            seed=SEED,
            height=1024,
            width=1024,
            num_inference_steps=NUM_STEPS,
            guidance_scale=guidance_scale
        )
    )

    image = outputs[0].request_output.images[0]
    image.save(output_path)
    return image


if __name__ == "__main__":
    omni = Omni(
        model=MODEL,
        dtype="bfloat16",
        enable_cpu_offload=True,
    )

    img_low = generate_with_guidance(omni, 1.0, "guidance_1.0.png")
    img_mid = generate_with_guidance(omni, 4.0, "guidance_4.0.png")
```
In the current code, the result will be the same for both since the guidance isn't used, but we should see a poor result for guidance 1.0 and a pretty good one for 4.0.