### PR TITLE
[Perf] Skip Wan2.2 cross attn Ulysses SP

### DIFF
--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -36,6 +36,7 @@ class Attention(nn.Module):
         scatter_idx: int = 2,
         gather_idx: int = 1,
         use_sync: bool = False,
+        skip_sequence_parallel: bool = False,
     ):
         super().__init__()
         self.attn_backend = get_attn_backend(-1)
@@ -62,6 +63,7 @@ class Attention(nn.Module):
         self.gather_idx = gather_idx
         self.use_sync = use_sync
         self.causal = causal
+        self.skip_sequence_parallel = skip_sequence_parallel
 
         self.use_ring = False
         self.ring_pg = None
@@ -98,6 +100,8 @@ class Attention(nn.Module):
         (e.g., in noise_refiner/context_refiner before unified_prepare in Z-Image).
         This avoids unnecessary SP communication for layers not covered by _sp_plan.
         """
+        if self.skip_sequence_parallel:
+            return self._no_parallel_strategy
         if is_forward_context_available():
             ctx = get_forward_context()
             if not ctx.sp_active:

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -539,6 +539,7 @@ class WanCrossAttention(nn.Module):
             num_kv_heads=self.num_heads,
             softmax_scale=1.0 / (head_dim**0.5),
             causal=False,
+            skip_sequence_parallel=True,
         )
 
     def forward(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Skip Wan2.2 cross attn Ulysses SP and support other models able to skip as well.

## Test Plan

```
python image_to_video.py   --model Wan-AI/Wan2.2-I2V-A14B-Diffusers   --image cherry_blossom.jpg   --prompt "Cherry blossoms swaying gently in the breeze, petals falling, smooth motion"   --negative-prompt "<optional quality filter>"   --height 512   --width 768   --num-frames 49   --guidance-scale 4.0   --num-inference-steps 20   --flow-shift 12.0   --fps 16   --output i2v_output.mp4   --enable-layerwise-offload   --ulysses-degree 8   --vae-patch-parallel-size 8   --vae-use-tiling
```

## Test Result

Before: 44s

After: 40s

Before:

https://github.com/user-attachments/assets/5cf25e12-3341-405e-982d-7f1f24a1dfc5

After:

https://github.com/user-attachments/assets/f9ed9291-d49f-4474-8786-fd7dde8aa53b


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
