### PR TITLE
[CI] Fix missing queue for Voxtral-TTS E2E test step

### DIFF
--- a/.buildkite/test-merge.yml
+++ b/.buildkite/test-merge.yml
@@ -390,6 +390,39 @@ steps:
           export VLLM_WORKER_MULTIPROC_METHOD=spawn
           pytest -s -v tests/e2e/online_serving/test_voxtral_tts.py tests/e2e/offline_inference/test_voxtral_tts.py -m "advanced_model" --run-level "advanced_model"
         '
+    agents:
+      queue: "mithril-h100-pool"
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+                volumeMounts:
+                  - name: devshm
+                    mountPath: /dev/shm
+                  - name: hf-cache
+                    mountPath: /root/.cache/huggingface
+                env:
+                  - name: HF_HOME
+                    value: /root/.cache/huggingface
+                  - name: HF_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: hf-token-secret
+                        key: token
+            nodeSelector:
+              node.kubernetes.io/instance-type: gpu-h100-sxm
+            volumes:
+              - name: devshm
+                emptyDir:
+                  medium: Memory
+              - name: hf-cache
+                hostPath:
+                  path: /mnt/hf-cache
+                  type: DirectoryOrCreate
 
   - label: "CosyVoice3-TTS E2E Test"
     timeout_in_minutes: 20


### PR DESCRIPTION
## Summary
- #2431 accidentally inserted the CosyVoice3 step between Voxtral's `commands` block and its `agents`/`plugins` block in `test-merge.yml`
- This caused `agents`/`plugins` to attach to CosyVoice3 instead of Voxtral, leaving Voxtral without a queue
- Buildkite rejects the entire pipeline with "No queue specified", blocking all merge CI

## Fix
Add back the kubernetes `agents`/`plugins` block for the Voxtral-TTS step.

## Test plan
- [x] Verified all steps in `test-merge.yml` have queues via YAML parsing