### PR TITLE
[CI] Add on-demand performance test trigger via PR comments

### DIFF
--- a/.github/workflows/perf_test_trigger.yml
+++ b/.github/workflows/perf_test_trigger.yml
@@ -1,0 +1,79 @@
+name: Model-Specific Performance Test Trigger
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  run-perf-test:
+    name: Run On-Demand Perf Test
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/test-perf')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Command Args
+        id: parse-command
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          COMMAND_LINE=$(echo "$COMMENT_BODY" | grep -m 1 -o '/test-perf.*')
+          MODEL_NAME=$(echo "$COMMAND_LINE" | awk '{print $2}')
+          SPECIFIC_SCRIPT=$(echo "$COMMAND_LINE" | awk '{print $3}')
+          if [ -z "$MODEL_NAME" ]; then
+            echo "Error: No model name provided. Usage: /test-perf <model_name> [script_name]"
+            exit 1
+          fi
+          echo "Extracted model name: $MODEL_NAME"
+          echo "model_name=$MODEL_NAME" >> "$GITHUB_OUTPUT"
+          echo "specific_script=$SPECIFIC_SCRIPT" >> "$GITHUB_OUTPUT"
+      - name: Acknowledge Command
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+      - name: Checkout PR Code
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Execute Performance Test
+        env:
+          TARGET_MODEL: ${{ steps.parse-command.outputs.model_name }}
+          SPECIFIC_SCRIPT: ${{ steps.parse-command.outputs.specific_script }}
+        run: |
+          echo "Starting performance test for model: $TARGET_MODEL"
+          BASE_DIR="benchmarks/${TARGET_MODEL}/vllm_omni"
+          if [ ! -d "$BASE_DIR" ]; then
+            echo "Error: Directory $BASE_DIR not found!"
+            exit 1
+          fi
+          if [ -n "$SPECIFIC_SCRIPT" ]; then
+            SCRIPT_PATH="$BASE_DIR/$SPECIFIC_SCRIPT"
+          else
+            SH_FILES=("$BASE_DIR"/*.sh)
+            if [ -e "${SH_FILES[0]}" ]; then
+              SCRIPT_PATH="${SH_FILES[0]}"
+              echo "Auto-discovered script: $SCRIPT_PATH"
+            else
+              echo "Error: No .sh script found. Usage: /test-perf $TARGET_MODEL <script_name>"
+              exit 1
+            fi
+          fi
+          if [ ! -f "$SCRIPT_PATH" ]; then
+            echo "Error: Script $SCRIPT_PATH not found!"
+            exit 1
+          fi
+          if [[ "$SCRIPT_PATH" == *.py ]]; then
+            python "$SCRIPT_PATH"
+          else
+            chmod +x "$SCRIPT_PATH"
+            bash "$SCRIPT_PATH"
+          fi
+          echo "Performance test completed."


### PR DESCRIPTION
## Purpose
Fixes #2410

This PR introduces a lightweight, on-demand GitHub Action workflow to trigger model-specific performance tests via PR comments. This prevents running heavy benchmarks on all models for every PR, saving significant CI/GPU resources and developer waiting time.

**Key Features:**
1. **Flexible Triggering:** Uses regex (`grep -m 1 -o '/test-perf.*'`) to extract the command, allowing users to include natural text before the command (e.g., `LGTM! /test-perf qwen3-omni`).
2. **Auto-Discovery:** Automatically locates the `.sh` script under `benchmarks/<model_name>/vllm_omni/` if no specific script is provided.
3. **Specific Script Support:** Allows passing a specific script name (e.g., `/test-perf qwen3-tts bench_tts_serve.py`) to handle models with `.py` benchmark entry points.
4. **Visual Feedback:** Acknowledges the command instantly with a 👀 reaction.

## Test Plan
I have fully tested the workflow's trigger and routing logic in my own forked repository using a dummy PR. 
1. Commented `/test-perf <model_name>` and verified successful model name extraction and auto-discovery of `.sh` files.
2. Commented with prefix text and a specific python script, verifying the fallback logic and specific execution path.
3. Verified the GitHub API successfully adds the 👀 reaction.

## Test Result
The CI workflow successfully intercepts the comment, parses the arguments, and dynamically constructs the correct execution path according to the `benchmarks/README.md` architecture. 
*(Note: The actual successful execution of the benchmark scripts will rely on the upstream self-hosted runners having the necessary GPU environment, but the routing and trigger mechanisms work perfectly).*