### PR TITLE
[Bugfix][Model] Fix Qwen3-TTS Code2Wav max_model_len validation

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -139,6 +139,41 @@ def test_from_cli_args_picks_up_stage_configs_path():
     assert args.custom_pipeline_args is None
 
 
+def test_qwen3_tts_code2wav_injects_max_position_embeddings(monkeypatch):
+    """Ensure Code2Wav mirrors stage max_model_len into nested HF overrides.
+
+    Qwen3-TTS Code2Wav is a pure decoder stage whose runtime max_model_len can
+    legitimately exceed the base checkpoint's default text max length. Recent
+    vLLM validates these values during ModelConfig creation, so we inject
+    ``talker_config.max_position_embeddings`` before delegating to vLLM.
+    """
+    captured: dict[str, object] = {}
+    baseline_config = Mock()
+
+    def fake_create_model_config(self):
+        captured["hf_overrides"] = self.hf_overrides
+        return baseline_config
+
+    monkeypatch.setattr(EngineArgs, "create_model_config", fake_create_model_config)
+    monkeypatch.setattr(
+        OmniModelConfig,
+        "from_vllm_model_config",
+        classmethod(lambda cls, model_config, **omni_kwargs: model_config),
+    )
+
+    OmniEngineArgs(
+        model_arch="Qwen3TTSCode2Wav",
+        max_model_len=65536,
+    ).create_model_config()
+
+    assert captured["hf_overrides"] == {
+        "architectures": ["Qwen3TTSCode2Wav"],
+        "talker_config": {
+            "max_position_embeddings": 65536,
+        },
+    }
+
+
 def test_stage_specific_text_config_override():
     """Ensure dependent attributes are updated when using stage-specific config."""
     vllm_config = EngineArgs().create_model_config()

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -30,6 +30,25 @@ _TOKENIZER_SUBFOLDER_MAP: dict[str, str] = {
 }
 
 
+def _apply_stage_specific_hf_overrides(engine_args: "OmniEngineArgs") -> None:
+    """Inject HF config overrides required by stage-specific wrappers.
+
+    Some Omni stages intentionally reuse a checkpoint config whose default text
+    metadata does not reflect the stage runtime semantics. For example,
+    ``Qwen3TTSCode2Wav`` is a pure waveform decoder wrapper, but recent vLLM
+    validates ``max_model_len`` against the config's derived text length.
+    Mirror the stage max length into ``hf_overrides`` so ModelConfig creation
+    doesn't incorrectly reject the stage.
+    """
+    if not isinstance(engine_args.hf_overrides, dict):
+        return
+
+    if engine_args.model_arch == "Qwen3TTSCode2Wav" and engine_args.max_model_len is not None:
+        talker_overrides = engine_args.hf_overrides.setdefault("talker_config", {})
+        if isinstance(talker_overrides, dict):
+            talker_overrides.setdefault("max_position_embeddings", int(engine_args.max_model_len))
+
+
 def _register_omni_hf_configs() -> None:
     try:
         from transformers import AutoConfig
@@ -220,6 +239,8 @@ class OmniEngineArgs(EngineArgs):
                     model_type = _ARCH_TO_MODEL_TYPE.get(self.model_arch)
                     if model_type is not None:
                         self.hf_overrides.setdefault("model_type", model_type)
+
+            _apply_stage_specific_hf_overrides(self)
 
             # For models whose HF config.json is empty or lacks model_type
             # (e.g. CosyVoice3), AutoConfig.from_pretrained fails because it

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -30,25 +30,6 @@ _TOKENIZER_SUBFOLDER_MAP: dict[str, str] = {
 }
 
 
-def _apply_stage_specific_hf_overrides(engine_args: "OmniEngineArgs") -> None:
-    """Inject HF config overrides required by stage-specific wrappers.
-
-    Some Omni stages intentionally reuse a checkpoint config whose default text
-    metadata does not reflect the stage runtime semantics. For example,
-    ``Qwen3TTSCode2Wav`` is a pure waveform decoder wrapper, but recent vLLM
-    validates ``max_model_len`` against the config's derived text length.
-    Mirror the stage max length into ``hf_overrides`` so ModelConfig creation
-    doesn't incorrectly reject the stage.
-    """
-    if not isinstance(engine_args.hf_overrides, dict):
-        return
-
-    if engine_args.model_arch == "Qwen3TTSCode2Wav" and engine_args.max_model_len is not None:
-        talker_overrides = engine_args.hf_overrides.setdefault("talker_config", {})
-        if isinstance(talker_overrides, dict):
-            talker_overrides.setdefault("max_position_embeddings", int(engine_args.max_model_len))
-
-
 def _register_omni_hf_configs() -> None:
     try:
         from transformers import AutoConfig
@@ -240,7 +221,12 @@ class OmniEngineArgs(EngineArgs):
                     if model_type is not None:
                         self.hf_overrides.setdefault("model_type", model_type)
 
-            _apply_stage_specific_hf_overrides(self)
+                # Stage wrappers (e.g. Code2Wav) may need max_model_len larger
+                # than the base checkpoint's text max_position_embeddings.
+                if self.model_arch == "Qwen3TTSCode2Wav" and self.max_model_len is not None:
+                    self.hf_overrides.setdefault("talker_config", {}).setdefault(
+                        "max_position_embeddings", int(self.max_model_len)
+                    )
 
             # For models whose HF config.json is empty or lacks model_type
             # (e.g. CosyVoice3), AutoConfig.from_pretrained fails because it


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix Qwen3-TTS startup failure in the `Qwen3TTSCode2Wav` stage on recent vLLM versions.

This PR fixes the mismatch between the Code2Wav stage config (`max_model_len=65536`) and the derived HF text max length (`32768`) that causes `ModelConfig` validation to fail during stage initialization.

## Test Plan

Local checks performed:
```bash
pytest -q tests/engine/test_arg_utils.py::test_qwen3_tts_code2wav_injects_max_position_embeddings
```

Offline reproduction / verification command:
```bash
python examples/offline_inference/qwen3_tts/end2end.py \
  --query-type CustomVoice 
```

## Test Result

- Added a regression test covering the stage-specific HF override injection for `Qwen3TTSCode2Wav`
- Verified the offline reproduction path and confirmed the failure happens during `ModelConfig` max length validation before this fix
- After the fix, the Code2Wav stage uses stage-specific nested HF overrides instead of the default derived text limit path

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
