### PR TITLE
[Bugfix] Fix load_weights fallback for non-fused stacked_params_mapping entries

### DIFF
--- a/vllm_omni/diffusion/models/bagel/bagel_transformer.py
+++ b/vllm_omni/diffusion/models/bagel/bagel_transformer.py
@@ -951,8 +951,6 @@ class Qwen2MoTForCausalLM(Qwen2PreTrainedModel):
                 stacked_name = name.replace(weight_name, param_name)
                 param = params_dict.get(stacked_name)
                 if param is None:
-                    # Fused param doesn't exist (e.g. gate_up_proj on DiT);
-                    # fall through to non-stacked path below.
                     break
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight, shard_id)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

There is a preexisting pitfall in the weight-loading logic of `Qwen2MoTForCausalLM`: it uses `for...else` to try stacked param names first, then fall back to direct loading. However, when a stacked entry matches the weight name, but the fused param doesn't exist, the `break` skips the `else`, and the param is added to `loaded_params` while being empty. This was not an issue until #2490 tried to support LoRA on `gate_proj` and `up_proj`, and therefore added `gate_up_proj` into `stacked_params_mapping`. 

This PR uses an explicit `loaded` flag to detect the loading status and therefore ensures the default loading path always runs if the param is not loaded via the fused param. Fixes the issue and makes the loading more robust. 

## Test Plan

Pixel-exact reproduction test:
```bash
python -m pytest tests/e2e/offline_inference/test_bagel_text2img.py -v --run-level=advanced_model -k "shared_memory"
```

## Test Result

```
tests/e2e/offline_inference/test_bagel_text2img.py::test_bagel_text2img_shared_memory_connector PASSED
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
