### PR TITLE
[Voxtral TTS] Correct decode steps param in Voxtral TTS

### DIFF
--- a/tests/model_executor/models/voxtral_tts/test_cuda_graph_acoustic_transformer.py
+++ b/tests/model_executor/models/voxtral_tts/test_cuda_graph_acoustic_transformer.py
@@ -78,13 +78,19 @@ except Exception:
     AudioSpecialTokens = _mod2.AudioSpecialTokens
 
 
+class SyntheticAcousticTransformerArgs:
+    """Mimics AcousticTransformerArgs interface."""
+
+    def __init__(self):
+        self.n_decoding_steps = 7
+
+
 class SyntheticModelArgs:
     """Mimics MultimodalAudioModelArgs interface."""
 
     def __init__(self):
         self.semantic_codebook_size = SEMANTIC_CODEBOOK_SIZE
         self.n_acoustic_codebook = N_ACOUSTIC_CODEBOOK
-        self.n_decoding_steps = 7
 
 
 class SyntheticAcousticTransformer(nn.Module):
@@ -97,6 +103,7 @@ class SyntheticAcousticTransformer(nn.Module):
     def __init__(self):
         super().__init__()
         self.model_args = SyntheticModelArgs()
+        self.acoustic_transformer_args = SyntheticAcousticTransformerArgs()
         self.acoustic_embeddings_levels = ACOUSTIC_EMBEDDINGS_LEVELS
 
         # semantic_codebook_output: hidden_dim -> padded_codebook_size

--- a/tests/model_executor/models/voxtral_tts/test_cuda_graph_acoustic_transformer.py
+++ b/tests/model_executor/models/voxtral_tts/test_cuda_graph_acoustic_transformer.py
@@ -84,6 +84,7 @@ class SyntheticModelArgs:
     def __init__(self):
         self.semantic_codebook_size = SEMANTIC_CODEBOOK_SIZE
         self.n_acoustic_codebook = N_ACOUSTIC_CODEBOOK
+        self.n_decoding_steps = 7
 
 
 class SyntheticAcousticTransformer(nn.Module):

--- a/vllm_omni/model_executor/models/voxtral_tts/configuration_voxtral_tts.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/configuration_voxtral_tts.py
@@ -48,6 +48,15 @@ class VoxtralTTSConfigParser(MistralConfigParser):
         audio_tokenizer_args = config_dict["multimodal"].pop("audio_tokenizer_args", None)
         audio_config = {}
         if encoder_args is not None:
+            # Default n_decoding_steps if not provided
+            acoustic_args = encoder_args.get("acoustic_transformer_args", {})
+            if acoustic_args.get("n_decoding_steps") is None:
+                logger.warning(
+                    "n_decoding_steps not provided in acoustic_transformer_args, defaulting to 7. "
+                    "Please add 'n_decoding_steps' to params.json under acoustic_transformer_args."
+                )
+                acoustic_args["n_decoding_steps"] = 7
+
             audio_config = {
                 "sampling_rate": encoder_args["audio_encoding_args"]["sampling_rate"],
                 "codec_args": audio_tokenizer_args,

--- a/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
@@ -48,7 +48,7 @@ class CUDAGraphAcousticTransformerWrapper:
         self.acoustic_embeddings_levels = self.acoustic_transformer.acoustic_embeddings_levels
 
         self.cfg_alpha = 1.2
-        self.n_steps = 7
+        self.n_steps = self.acoustic_transformer.model_args.acoustic_transformer_args.n_decoding_steps
 
         # Graph storage
         self.graphs: dict[int, CUDAGraph] = {}

--- a/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
@@ -48,7 +48,7 @@ class CUDAGraphAcousticTransformerWrapper:
         self.acoustic_embeddings_levels = self.acoustic_transformer.acoustic_embeddings_levels
 
         self.cfg_alpha = 1.2
-        self.n_steps = 8
+        self.n_steps = 7
 
         # Graph storage
         self.graphs: dict[int, CUDAGraph] = {}
@@ -72,7 +72,7 @@ class CUDAGraphAcousticTransformerWrapper:
         )
 
         # Pre-create persistent buffers
-        self.timesteps = torch.linspace(0, 1, self.n_steps, device=device, dtype=dtype)
+        self.timesteps = torch.linspace(0, 1, self.n_steps + 1, device=device, dtype=dtype)
         self.fake_eos_one = torch.tensor(1.0, dtype=dtype, device=device)
         self.fake_eos_zero = torch.tensor(0.0, dtype=dtype, device=device)
 

--- a/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/cuda_graph_acoustic_transformer_wrapper.py
@@ -48,7 +48,7 @@ class CUDAGraphAcousticTransformerWrapper:
         self.acoustic_embeddings_levels = self.acoustic_transformer.acoustic_embeddings_levels
 
         self.cfg_alpha = 1.2
-        self.n_steps = self.acoustic_transformer.model_args.acoustic_transformer_args.n_decoding_steps
+        self.n_steps = self.acoustic_transformer.acoustic_transformer_args.n_decoding_steps
 
         # Graph storage
         self.graphs: dict[int, CUDAGraph] = {}

--- a/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
@@ -437,13 +437,13 @@ class FlowMatchingAudioTransformer(nn.Module):
 
         # Flow matching constants
         # TODO(chenyo): hardcoded, need to fix
-        self._acoustic_decode_iters = 8
+        self._acoustic_decode_iters = 7
         # TODO(chenyo): hardcoded, need to fix
         self._cfg_alpha = 1.2
         self._noise_scale = 1.0
         self.register_buffer(
             "_timesteps",
-            torch.linspace(0, 1, self._acoustic_decode_iters),
+            torch.linspace(0, 1, self._acoustic_decode_iters + 1),
             persistent=False,
         )
 

--- a/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
@@ -108,6 +108,7 @@ class AcousticTransformerArgs:
     use_biases: bool = False
     norm_eps: float = 1e-5
     sigma: float = 1e-5  # was 0.01 in beta version
+    n_decoding_steps: int | None = None  # Number of Euler ODE steps for flow matching
 
 
 @dataclass
@@ -436,14 +437,13 @@ class FlowMatchingAudioTransformer(nn.Module):
         self._empty_audio_token_id = AudioSpecialTokens.id(AudioSpecialTokens.empty_audio)
 
         # Flow matching constants
-        # TODO(chenyo): hardcoded, need to fix
-        self._acoustic_decode_iters = 7
+        self._n_steps = args.n_decoding_steps
         # TODO(chenyo): hardcoded, need to fix
         self._cfg_alpha = 1.2
         self._noise_scale = 1.0
         self.register_buffer(
             "_timesteps",
-            torch.linspace(0, 1, self._acoustic_decode_iters + 1),
+            torch.linspace(0, 1, self._n_steps + 1),
             persistent=False,
         )
 


### PR DESCRIPTION
## Purpose
- Remove hardcoded decoding steps and added a new `n_decoding_step` args
- In current voxtral tts we are actually doing `n_decoding_step - 1` steps `(8-1 = 7)`. Correct the param to call it 7 step
## Test Plan
```
pytest -s -v   tests/model_executor/stage_input_processors/test_voxtral_tts_async_chunk.py   \
tests/model_executor/models/voxtral_tts/test_cuda_graph_acoustic_transformer.py   \
tests/model_executor/models/voxtral_tts/test_audio_tokenizer_parsing.py   \
tests/e2e/online_serving/test_voxtral_tts.py \
tests/model_executor/models/voxtral_tts/test_text_preprocess.py  \
tests/e2e/offline_inference/test_voxtral_tts.py
```
## Test Result
<img width="1710" height="421" alt="image" src="https://github.com/user-attachments/assets/dedbe5d4-289a-4a3b-bcf8-43ee13991a2f" />

