### PR TITLE
fix: respect user stage_init_timeout during diffusion stage initialization (#2518)

### DIFF
--- a/vllm_omni/diffusion/stage_diffusion_client.py
+++ b/vllm_omni/diffusion/stage_diffusion_client.py
@@ -51,6 +51,7 @@ class StageDiffusionClient:
         od_config: OmniDiffusionConfig,
         metadata: StageMetadata,
         batch_size: int = 1,
+        stage_init_timeout: int = 300,
     ) -> None:
         self.stage_id = metadata.stage_id
         self.final_output = metadata.final_output
@@ -61,7 +62,7 @@ class StageDiffusionClient:
 
         # Spawn StageDiffusionProc subprocess and wait for READY.
         proc, handshake_address, request_address, response_address = spawn_diffusion_proc(model, od_config)
-        complete_diffusion_handshake(proc, handshake_address)
+        complete_diffusion_handshake(proc, handshake_address, timeout_s=stage_init_timeout)
         self._proc = proc
 
         # ZMQ sockets (sync) for communicating with the subprocess.

--- a/vllm_omni/diffusion/stage_diffusion_proc.py
+++ b/vllm_omni/diffusion/stage_diffusion_proc.py
@@ -567,13 +567,14 @@ def spawn_diffusion_proc(
 def complete_diffusion_handshake(
     proc: BaseProcess,
     handshake_address: str,
+    timeout_s: int,
 ) -> None:
     """Wait for the diffusion subprocess to signal READY.
 
     On failure the process is terminated before re-raising.
     """
     try:
-        _perform_diffusion_handshake(proc, handshake_address)
+        _perform_diffusion_handshake(proc, handshake_address, timeout_s)
     except Exception:
         shutdown([proc])
         raise
@@ -582,6 +583,7 @@ def complete_diffusion_handshake(
 def _perform_diffusion_handshake(
     proc: BaseProcess,
     handshake_address: str,
+    timeout_s: int,
 ) -> None:
     """Run the handshake with the diffusion subprocess."""
     with zmq_socket_ctx(handshake_address, zmq.ROUTER, bind=True) as handshake_socket:
@@ -589,7 +591,7 @@ def _perform_diffusion_handshake(
         poller.register(handshake_socket, zmq.POLLIN)
         poller.register(proc.sentinel, zmq.POLLIN)
 
-        timeout_ms = _HANDSHAKE_POLL_TIMEOUT_S * 1000
+        timeout_ms = timeout_s * 1000
         while True:
             events = dict(poller.poll(timeout=timeout_ms))
             if not events:

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -540,6 +540,7 @@ class AsyncOmniEngine:
                                     stage_cfg,
                                     metadata,
                                     batch_size=self.diffusion_batch_size,
+                                    stage_init_timeout=stage_init_timeout,
                                 )
                                 logger.info(
                                     "[AsyncOmniEngine] Stage %s initialized (diffusion, batch_size=%d)",

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -444,6 +444,7 @@ def initialize_diffusion_stage(
     stage_cfg: Any,
     metadata: StageMetadata,
     batch_size: int = 1,
+    stage_init_timeout: int = 300,
 ) -> Any:
     """Build a diffusion stage client.
 
@@ -454,6 +455,7 @@ def initialize_diffusion_stage(
         batch_size: Maximum number of requests to batch together in the
             diffusion engine.  Passed through to ``StageDiffusionClient``
             and ultimately to ``AsyncOmni``.
+        stage_init_timeout: Timeout for stage initialization (seconds).
     """
     from vllm_omni.diffusion.data import OmniDiffusionConfig
     from vllm_omni.diffusion.stage_diffusion_client import StageDiffusionClient
@@ -464,7 +466,7 @@ def initialize_diffusion_stage(
     )
     if metadata.cfg_kv_collect_func is not None:
         od_config.cfg_kv_collect_func = metadata.cfg_kv_collect_func
-    return StageDiffusionClient(model, od_config, metadata, batch_size=batch_size)
+    return StageDiffusionClient(model, od_config, metadata, batch_size=batch_size, stage_init_timeout=stage_init_timeout)
 
 
 def _shutdown_or_close_resource(resource: Any, resource_name: str, stage_id: int) -> None:


### PR DESCRIPTION
## Description

When initializing the diffusion stage, the user's \stage_init_timeout\ parameter was being ignored. The diffusion stage handshake was using a hardcoded 600-second timeout instead of respecting the user-configured \stage_init_timeout\.

## Root Cause

The \stage_init_timeout\ parameter was passed to \_launch_llm_stage\ for LLM stages but was **not passed** to \initialize_diffusion_stage\ for diffusion stages. Additionally, \complete_diffusion_handshake\ used a hardcoded \_HANDSHAKE_POLL_TIMEOUT_S = 600\.

## Fix

Pass \stage_init_timeout\ through the diffusion stage initialization chain:

1. \_initialize_stages\ → \initialize_diffusion_stage\ (new \stage_init_timeout\ parameter)
2. \initialize_diffusion_stage\ → \StageDiffusionClient.__init__\ (new \stage_init_timeout\ parameter)  
3. \StageDiffusionClient.__init__\ → \complete_diffusion_handshake\ (new \	imeout_s\ parameter)
4. \complete_diffusion_handshake\ → \_perform_diffusion_handshake\ (uses \	imeout_s\ instead of hardcoded value)

## Files Changed

- \llm_omni/engine/async_omni_engine.py\ - pass \stage_init_timeout\ to \initialize_diffusion_stage\
- \llm_omni/engine/stage_init_utils.py\ - add \stage_init_timeout\ parameter to \initialize_diffusion_stage\
- \llm_omni/diffusion/stage_diffusion_client.py\ - add \stage_init_timeout\ to \StageDiffusionClient.__init__\ and pass to \complete_diffusion_handshake\
- \llm_omni/diffusion/stage_diffusion_proc.py\ - add \	imeout_s\ parameter to \complete_diffusion_handshake\ and \_perform_diffusion_handshake\

Fixes #2518