### PR TITLE
use mindiesd fused rope and use rope cache

### DIFF
--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -874,6 +874,10 @@ class WanTransformer3DModel(nn.Module):
         self.timestep_proj_prepare = TimestepProjPrepare()
         self.output_scale_shift_prepare = OutputScaleShiftPrepare(inner_dim)
 
+        # ROPE helper
+        self._cached_rope_emb = None
+        self._hidden_states_shape = None
+
     @property
     def dtype(self) -> torch.dtype:
         """Return the dtype of the model parameters."""
@@ -895,7 +899,12 @@ class WanTransformer3DModel(nn.Module):
         post_patch_width = width // p_w
 
         # Compute RoPE embeddings (sharded by _sp_plan via split_output=True)
-        rotary_emb = self.rope(hidden_states)
+        if hidden_states.shape == self._hidden_states_shape and self._cached_rope_emb is not None:
+            rotary_emb = self._cached_rope_emb
+        else:
+            rotary_emb = self.rope(hidden_states)
+            self._hidden_states_shape = hidden_states.shape
+            self._cached_rope_emb = rotary_emb
 
         # Patch embedding and flatten to sequence
         # (hidden_states is sharded at blocks.0 input by _sp_plan)

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -49,9 +49,23 @@ def apply_rotary_emb_wan(
     Returns:
         Tensor with rotary embeddings applied
     """
-    x1, x2 = hidden_states.unflatten(-1, (-1, 2)).unbind(-1)
+    from importlib.util import find_spec
+
     cos = freqs_cos[..., 0::2]
     sin = freqs_sin[..., 1::2]
+
+    if find_spec("mindiesd"):
+        from vllm_omni.diffusion.layers.rope import apply_rotary_emb_mindiesd
+
+        logger.info("Using MindIE-SD fused ROPE")
+        if cos.dim() > 2:
+            cos = cos.reshape(-1, cos.shape[-1])
+            sin = sin.reshape(-1, sin.shape[-1])
+
+            rotated = apply_rotary_emb_mindiesd(x=hidden_states, cos=cos, sin=sin, interleaved=True, half_head_dim=True)
+            return rotated.to(hidden_states.dtype)
+
+    x1, x2 = hidden_states.unflatten(-1, (-1, 2)).unbind(-1)
     rotated = torch.stack(
         (
             x1 * cos - x2 * sin,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
commit 1 : use mindiesd fused rope
commit 2 : The calculation results of the rope are cached in the forward direction of the model for storage and subsequent use.

## Test Plan
server
vllm serve wan2.2-i2v-diffusers \
  --omni \
  --port 8099 \
  --usp 8 \
  --use-hsdp \
  --vae-patch-parallel-size 8 \
  --vae-use-tiling \
  --log-stats \
  --profiler-config '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile"}' 
curl
curl -X POST http://localhost:8099/v1/videos \
    -F "prompt=**********" \
    -F "input_reference=image" \
    -F "size=720x1280" \
    -F "fps=24" \
    -F "num_frames=121" \
    -F "guidance_scale=1.0" \
    -F "flow_shift=5.0" \
    -F "num_inference_steps=4" \
    -F "seed=42"

## Test Result
commit 1
Implementing the small operator by replacing the rope with the fusion operator.
<img width="1098" height="108" alt="image" src="https://github.com/user-attachments/assets/26c980b0-3ea4-47ef-87b0-752e44798ad1" />
commit 2
step 1
<img width="1366" height="616" alt="image" src="https://github.com/user-attachments/assets/22895e70-e553-4e9d-a4a2-614227c082fc" />
step 2
<img width="1390" height="480" alt="image" src="https://github.com/user-attachments/assets/efa0ef45-c91f-4ad7-a2e9-177c42f30056" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
