### PR TITLE
[Bugfix] Fix default diffusion stage config generator drops runtime engine args

### DIFF
--- a/tests/entrypoints/test_async_omni_diffusion_config.py
+++ b/tests/entrypoints/test_async_omni_diffusion_config.py
@@ -139,6 +139,28 @@ def test_default_stage_config_engine_args():
     assert engine_args["trust_remote_code"] is True
 
 
+def test_default_stage_config_whitelist_none_fallback():
+    """DeployConfig / StageDeployConfig whitelist fields with value None
+    fall back to OmniDiffusionConfig dataclass defaults."""
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg(
+        {
+            # DeployConfig pipeline-wide
+            "trust_remote_code": None,
+            "distributed_executor_backend": None,
+            "dtype": None,
+            # StageDeployConfig
+            "enforce_eager": None,
+        }
+    )[0]
+
+    engine_args = stage_cfg["engine_args"]
+
+    assert engine_args["trust_remote_code"] is False
+    assert engine_args["distributed_executor_backend"] == "mp"
+    assert engine_args["dtype"] == "auto"
+    assert engine_args["enforce_eager"] is False
+
+
 def test_serve_cli_accepts_ulysses_mode():
     """Ensure diffusion serve CLI exposes ulysses_mode and wires it to parallel_config."""
     parser = FlexibleArgumentParser()

--- a/tests/entrypoints/test_async_omni_diffusion_config.py
+++ b/tests/entrypoints/test_async_omni_diffusion_config.py
@@ -121,6 +121,24 @@ def test_default_stage_config_includes_default_sampling_params():
     }
 
 
+def test_default_stage_config_engine_args():
+    """Ensure default diffusion-stage builder sets and propagates engine_args."""
+    stage_cfg = AsyncOmniEngine._create_default_diffusion_stage_cfg(
+        {
+            "distributed_executor_backend": "ray",
+            "boundary_ratio": 0.875,
+            "flow_shift": 5.0,
+            "trust_remote_code": True,
+        }
+    )[0]
+
+    engine_args = stage_cfg["engine_args"]
+    assert engine_args["distributed_executor_backend"] == "ray"
+    assert engine_args["boundary_ratio"] == 0.875
+    assert engine_args["flow_shift"] == 5.0
+    assert engine_args["trust_remote_code"] is True
+
+
 def test_serve_cli_accepts_ulysses_mode():
     """Ensure diffusion serve CLI exposes ulysses_mode and wires it to parallel_config."""
     parser = FlexibleArgumentParser()

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1348,8 +1348,6 @@ class AsyncOmniEngine:
             "worker_extension_cls": kwargs.get("worker_extension_cls", None),
             "trust_remote_code": kwargs.get("trust_remote_code", False),
             "distributed_executor_backend": kwargs.get("distributed_executor_backend", "mp"),
-            "boundary_ratio": kwargs.get("boundary_ratio", None),
-            "flow_shift": kwargs.get("flow_shift", None),
             "enable_sleep_mode": kwargs.get("enable_sleep_mode", False),
             "enable_multithread_weight_load": kwargs.get("enable_multithread_weight_load", True),
             "num_weight_load_threads": kwargs.get("num_weight_load_threads", 4),

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1347,6 +1347,9 @@ class AsyncOmniEngine:
             "custom_pipeline_args": kwargs.get("custom_pipeline_args", None),
             "worker_extension_cls": kwargs.get("worker_extension_cls", None),
             "trust_remote_code": kwargs.get("trust_remote_code", False),
+            "distributed_executor_backend": kwargs.get("distributed_executor_backend", "mp"),
+            "boundary_ratio": kwargs.get("boundary_ratio", None),
+            "flow_shift": kwargs.get("flow_shift", None),
             "enable_sleep_mode": kwargs.get("enable_sleep_mode", False),
             "enable_multithread_weight_load": kwargs.get("enable_multithread_weight_load", True),
             "num_weight_load_threads": kwargs.get("num_weight_load_threads", 4),
@@ -1363,14 +1366,6 @@ class AsyncOmniEngine:
                 else {}
             ),
         }
-        if "distributed_executor_backend" in kwargs and kwargs["distributed_executor_backend"] is not None:
-            stage_engine_args["distributed_executor_backend"] = kwargs["distributed_executor_backend"]
-        if "boundary_ratio" in kwargs and kwargs["boundary_ratio"] is not None:
-            stage_engine_args["boundary_ratio"] = kwargs["boundary_ratio"]
-        if "flow_shift" in kwargs and kwargs["flow_shift"] is not None:
-            stage_engine_args["flow_shift"] = kwargs["flow_shift"]
-        if "num_gpus" in kwargs and kwargs["num_gpus"] is not None:
-            stage_engine_args["num_gpus"] = kwargs["num_gpus"]
         # Only set dtype if it was already explicitly passed and normalized
         if "dtype" in normalized_kwargs:
             stage_engine_args["dtype"] = normalized_kwargs["dtype"]

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1346,6 +1346,7 @@ class AsyncOmniEngine:
             "diffusion_load_format": kwargs.get("diffusion_load_format", "default"),
             "custom_pipeline_args": kwargs.get("custom_pipeline_args", None),
             "worker_extension_cls": kwargs.get("worker_extension_cls", None),
+            "trust_remote_code": kwargs.get("trust_remote_code", False),
             "enable_sleep_mode": kwargs.get("enable_sleep_mode", False),
             "enable_multithread_weight_load": kwargs.get("enable_multithread_weight_load", True),
             "num_weight_load_threads": kwargs.get("num_weight_load_threads", 4),
@@ -1362,6 +1363,14 @@ class AsyncOmniEngine:
                 else {}
             ),
         }
+        if "distributed_executor_backend" in kwargs and kwargs["distributed_executor_backend"] is not None:
+            stage_engine_args["distributed_executor_backend"] = kwargs["distributed_executor_backend"]
+        if "boundary_ratio" in kwargs and kwargs["boundary_ratio"] is not None:
+            stage_engine_args["boundary_ratio"] = kwargs["boundary_ratio"]
+        if "flow_shift" in kwargs and kwargs["flow_shift"] is not None:
+            stage_engine_args["flow_shift"] = kwargs["flow_shift"]
+        if "num_gpus" in kwargs and kwargs["num_gpus"] is not None:
+            stage_engine_args["num_gpus"] = kwargs["num_gpus"]
         # Only set dtype if it was already explicitly passed and normalized
         if "dtype" in normalized_kwargs:
             stage_engine_args["dtype"] = normalized_kwargs["dtype"]

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1346,8 +1346,10 @@ class AsyncOmniEngine:
             "diffusion_load_format": kwargs.get("diffusion_load_format", "default"),
             "custom_pipeline_args": kwargs.get("custom_pipeline_args", None),
             "worker_extension_cls": kwargs.get("worker_extension_cls", None),
-            "trust_remote_code": kwargs.get("trust_remote_code", False),
-            "distributed_executor_backend": kwargs.get("distributed_executor_backend", "mp"),
+            "trust_remote_code": (False if kwargs.get("trust_remote_code") is None else kwargs["trust_remote_code"]),
+            "distributed_executor_backend": (
+                "mp" if kwargs.get("distributed_executor_backend") is None else kwargs["distributed_executor_backend"]
+            ),
             "enable_sleep_mode": kwargs.get("enable_sleep_mode", False),
             "enable_multithread_weight_load": kwargs.get("enable_multithread_weight_load", True),
             "num_weight_load_threads": kwargs.get("num_weight_load_threads", 4),


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose


As #2539 #2544, and discussed in #2076, when loading a model without a default stage config and no stage config YAML is explicitly provided via CLI arguments, the current `AsyncOmniEngine` constructs `self.stage_configs` through `self._create_default_diffusion_stage_cfg`. The resulting config is then passed into:

```python
od_config = OmniDiffusionConfig.from_kwargs(
    model=model,
    **_to_dict(stage_cfg.engine_args),
)
```

which is later consumed by the diffusion components, such as `StageDiffusionClient`.

However, the current implementation of `self._create_default_diffusion_stage_cfg` does not fully propagate CLI arguments into the constructed config. 
The affected arguments include:

* `distributed_executor_backend`
https://github.com/vllm-project/vllm-omni/blob/408365fa0d542ccffbf659c82b06b374d02dfc4c/vllm_omni/diffusion/executor/abstract.py#L22-L24
* `boundary_ratio`
https://github.com/vllm-project/vllm-omni/blob/408365fa0d542ccffbf659c82b06b374d02dfc4c/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py#L236
* `flow_shift`
https://github.com/vllm-project/vllm-omni/blob/408365fa0d542ccffbf659c82b06b374d02dfc4c/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py#L300
* `trust_remote_code`
https://github.com/vllm-project/vllm-omni/blob/408365fa0d542ccffbf659c82b06b374d02dfc4c/vllm_omni/config/stage_config.py#L270-L271
* `num_gpus`
https://github.com/vllm-project/vllm-omni/blob/408365fa0d542ccffbf659c82b06b374d02dfc4c/vllm_omni/diffusion/executor/multiproc_executor.py#L67-L70

Although these fields have default values defined in `OmniDiffusionConfig`, the CLI-provided values are not injected into `od_config`, resulting in the user-specified arguments being ignored and default values always being used.



## Test Plan
```
python -m pytest  tests/entrypoints/test_async_omni_diffusion_config.py

```
## Test Result
```
(vllm-omni) root@autodl-container-2201459dc8-f8f44d5f:~/vllm-omni# python -m pytest  tests/entrypoints/test_async_omni_diffusion_config.py
============================================================================ test session starts ==========================================================================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /root/vllm-omni
configfile: pyproject.toml
plugins: anyio-4.13.0, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 6 items                                                                                                                                                                                                                                                       

tests/entrypoints/test_async_omni_diffusion_config.py ......                                                                                                                                                                                                      [100%]

===================================================================== 6 passed, 19 warnings in 0.70s =====================================================================================================================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
