### PR TITLE
[Feature] Refactor Qwen-Image pipeline to use structured trajectory_* fields

### DIFF
--- a/tests/e2e/offline_inference/custom_pipeline/qwen_image_pipeline_with_logprob.py
+++ b/tests/e2e/offline_inference/custom_pipeline/qwen_image_pipeline_with_logprob.py
@@ -393,10 +393,10 @@ class QwenImagePipelineWithLogProbForTest(QwenImagePipeline):
 
         return DiffusionOutput(
             output=_maybe_to_cpu(image),
+            trajectory_latents=_maybe_to_cpu(all_latents),
+            trajectory_timesteps=_maybe_to_cpu(all_timesteps),
+            trajectory_log_probs=_maybe_to_cpu(all_log_probs),
             custom_output={
-                "all_latents": _maybe_to_cpu(all_latents),
-                "all_log_probs": _maybe_to_cpu(all_log_probs),
-                "all_timesteps": _maybe_to_cpu(all_timesteps),
                 "prompt_embeds": _maybe_to_cpu(prompt_embeds),
                 "prompt_embeds_mask": _maybe_to_cpu(prompt_embeds_mask),
                 "negative_prompt_embeds": _maybe_to_cpu(negative_prompt_embeds),

--- a/tests/e2e/offline_inference/custom_pipeline/test_async_omni_qwen_image_generate.py
+++ b/tests/e2e/offline_inference/custom_pipeline/test_async_omni_qwen_image_generate.py
@@ -191,10 +191,10 @@ async def test_async_omni_generate_with_logprobs():
 
         _assert_valid_image_output(output)
 
-        all_log_probs = output.custom_output.get("all_log_probs")
-        assert all_log_probs is not None, "all_log_probs should be present when logprobs=True"
-        assert hasattr(all_log_probs, "shape")
-        assert all_log_probs.numel() > 0
+        trajectory_log_probs = output.trajectory_log_probs
+        assert trajectory_log_probs is not None, "trajectory_log_probs should be present when logprobs=True"
+        assert hasattr(trajectory_log_probs, "shape")
+        assert trajectory_log_probs.numel() > 0
 
 
 @pytest.mark.core_model


### PR DESCRIPTION
## Purpose

Refactor the Qwen-Image custom pipeline used in RL tests to use the structured `trajectory_latents`, `trajectory_timesteps`, and `trajectory_log_probs` fields introduced in PR #2483 and #2501, instead of stuffing them into `custom_output`.

As discussed in PR #2483, relying on `custom_output` for large tensors can cause silent serialization bugs across the IPC/ZMQ boundary. This brings Qwen-Image's outputs in line with BAGEL's structured format for consistent RL rollouts.

## Test Plan
python -m pytest tests/e2e/offline_inference/custom_pipeline/test_async_omni_qwen_image_generate.py -v
