### PR TITLE
feat(platforms): add MetaX MACA support and vllm-upstream extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,14 @@ classifiers = [
 # Dependencies are now managed dynamically via setup.py based on detected hardware platform.
 # This allows automatic installation of the correct platform-specific dependencies (CUDA/ROCm/CPU/XPU/NPU)
 # without requiring extras like [cuda]. See requirements/ directory for platform-specific dependencies.
-# Note: vllm is intentionally excluded due to entrypoints overwrite issue.
+# vLLM is omitted by default so vendor wheels (MACA/MUSA/ROCm/NPU) and console_scripts order stay explicit.
+# CUDA / generic PyPI stack: pip install -e ".[vllm-upstream]"  (do not combine with vllm-metax / vendor vLLM in the same env).
 
 [project.optional-dependencies]
+
+vllm-upstream = [
+    "vllm==0.19.0",
+]
 
 dev = [
     "pytest>=7.0.0",
@@ -178,6 +183,7 @@ markers = [
     "xpu: Tests that run on XPU (auto-added)",
     "npu: Tests that run on NPU/Ascend (auto-added)",
     "musa: Tests that run on MUSA/Moore Threads (auto-added)",
+    "maca: Tests that run on MACA/MetaX (auto-added)",
     # specified computation resources marks (auto-added)
     "H100: Tests that require H100 GPU",
     "L4: Tests that require L4 GPU",
@@ -190,11 +196,13 @@ markers = [
     "distributed_xpu: Tests that require multi cards on XPU platform",
     "distributed_npu: Tests that require multi cards on NPU platform",
     "distributed_musa: Tests that require multi cards on MUSA platform",
+    "distributed_maca: Tests that require multi cards on MACA/MetaX platform",
     "skipif_cuda: Skip if the num of CUDA cards is less than the required",
     "skipif_rocm: Skip if the num of ROCm cards is less than the required",
     "skipif_xpu: Skip if the num of XPU cards is less than the required",
     "skipif_npu: Skip if the num of NPU cards is less than the required",
     "skipif_musa: Skip if the num of MUSA cards is less than the required",
+    "skipif_maca: Skip if the num of MACA cards is less than the required",
     # more detailed markers
     "slow: Slow tests (may skip in quick CI)",
     "benchmark: Benchmark tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,14 +32,9 @@ classifiers = [
 # Dependencies are now managed dynamically via setup.py based on detected hardware platform.
 # This allows automatic installation of the correct platform-specific dependencies (CUDA/ROCm/CPU/XPU/NPU)
 # without requiring extras like [cuda]. See requirements/ directory for platform-specific dependencies.
-# vLLM is omitted by default so vendor wheels (MACA/MUSA/ROCm/NPU) and console_scripts order stay explicit.
-# CUDA / generic PyPI stack: pip install -e ".[vllm-upstream]"  (do not combine with vllm-metax / vendor vLLM in the same env).
+# Note: vllm is intentionally excluded due to entrypoints overwrite issue.
 
 [project.optional-dependencies]
-
-vllm-upstream = [
-    "vllm==0.19.0",
-]
 
 dev = [
     "pytest>=7.0.0",

--- a/requirements/maca.txt
+++ b/requirements/maca.txt
@@ -1,0 +1,4 @@
+-r common.txt
+# MetaX MACA: install matching `vllm` + `vllm-metax` wheels or from source per
+# https://github.com/MetaX-MACA/vLLM-metax — not published as a single PyPI extra here.
+onnxruntime>=1.23.2

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def detect_target_device() -> str:
         except ImportError:
             pass
         else:
-            if torch.cuda.is_available() and _nvidia_nvml_gpu_count_for_setup() == 0:
+            if torch.cuda.is_available():
                 print("Detected MACA (MetaX) backend from vllm-metax")
                 return "maca"
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ def uninstall_onnxruntime() -> None:
     except Exception as e:
         print(f"Warning: Failed to uninstall onnxruntime: {e}")
 
+
 def detect_target_device() -> str:
     """
     Detect the target device for installation following RFC priority rules.

--- a/setup.py
+++ b/setup.py
@@ -41,20 +41,6 @@ def uninstall_onnxruntime() -> None:
     except Exception as e:
         print(f"Warning: Failed to uninstall onnxruntime: {e}")
 
-
-def _nvidia_nvml_gpu_count_for_setup() -> int:
-    try:
-        import pynvml
-
-        pynvml.nvmlInit()
-        try:
-            return int(pynvml.nvmlDeviceGetCount())
-        finally:
-            pynvml.nvmlShutdown()
-    except Exception:
-        return 0
-
-
 def detect_target_device() -> str:
     """
     Detect the target device for installation following RFC priority rules.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,9 @@ Setup script for vLLM-Omni with hardware-dependent installation.
 
 This setup.py implements platform-aware dependency routing so users can run
 `pip install vllm-omni` and automatically receive the correct platform-specific
-dependencies (CUDA/ROCm/CPU/XPU/NPU/MUSA) without requiring extras like `[cuda]`.
+dependencies (CUDA/ROCm/CPU/XPU/NPU/MUSA/MACA) without requiring extras like `[cuda]`.
+
+Optional PyPI vLLM pin (CUDA): ``pip install -e ".[vllm-upstream]"`` (see pyproject.toml).
 """
 
 import os
@@ -40,22 +42,35 @@ def uninstall_onnxruntime() -> None:
         print(f"Warning: Failed to uninstall onnxruntime: {e}")
 
 
+def _nvidia_nvml_gpu_count_for_setup() -> int:
+    try:
+        import pynvml
+
+        pynvml.nvmlInit()
+        try:
+            return int(pynvml.nvmlDeviceGetCount())
+        finally:
+            pynvml.nvmlShutdown()
+    except Exception:
+        return 0
+
+
 def detect_target_device() -> str:
     """
     Detect the target device for installation following RFC priority rules.
 
     Priority order:
     1. VLLM_OMNI_TARGET_DEVICE environment variable (highest priority)
-    2. Torch backend detection (cuda, rocm, npu, xpu, musa)
+    2. Torch backend detection (maca, cuda, rocm, npu, xpu, musa)
     3. CPU fallback (default)
 
     Returns:
-        str: Device name ('cuda', 'rocm', 'npu', 'xpu', 'musa', or 'cpu')
+        str: Device name ('cuda', 'rocm', 'npu', 'xpu', 'musa', 'maca', or 'cpu')
     """
     # Priority 1: Explicit override via environment variable
     target_device = os.environ.get("VLLM_OMNI_TARGET_DEVICE")
     if target_device:
-        valid_devices = ["cuda", "rocm", "npu", "xpu", "musa", "cpu"]
+        valid_devices = ["cuda", "rocm", "npu", "xpu", "musa", "maca", "cpu"]
         if target_device.lower() in valid_devices:
             print(f"Using target device from VLLM_OMNI_TARGET_DEVICE: {target_device.lower()}")
             return target_device.lower()
@@ -68,7 +83,17 @@ def detect_target_device() -> str:
     try:
         import torch
 
-        # Check for CUDA
+        # MACA (MetaX): mcPyTorch may set torch.version.cuda; detect before generic CUDA.
+        try:
+            import vllm_metax  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            if torch.cuda.is_available() and _nvidia_nvml_gpu_count_for_setup() == 0:
+                print("Detected MACA (MetaX) backend from vllm-metax")
+                return "maca"
+
+        # Check for CUDA (NVIDIA)
         if torch.version.cuda is not None:
             print("Detected CUDA backend from torch")
             return "cuda"
@@ -163,6 +188,8 @@ def get_vllm_omni_version() -> str:
             version += f"{sep}xpu"
         elif device == "musa":
             version += f"{sep}musa"
+        elif device == "maca":
+            version += f"{sep}maca"
         elif device == "cpu":
             version += f"{sep}cpu"
         else:

--- a/vllm_omni/diffusion/attention/backends/abstract.py
+++ b/vllm_omni/diffusion/attention/backends/abstract.py
@@ -95,6 +95,8 @@ class AttentionImpl(ABC, Generic[T]):
             return self.forward_hip(query, key, value, attn_metadata)
         elif current_omni_platform.is_cuda():
             return self.forward_cuda(query, key, value, attn_metadata)
+        elif current_omni_platform.is_maca():
+            return self.forward_maca(query, key, value, attn_metadata)
         elif current_omni_platform.is_npu():
             return self.forward_npu(query, key, value, attn_metadata)
         elif current_omni_platform.is_xpu():
@@ -149,4 +151,14 @@ class AttentionImpl(ABC, Generic[T]):
         attn_metadata: T | None = None,
     ) -> torch.Tensor:
         # By default, MUSA ops are compatible with CUDA ops.
+        return self.forward_cuda(query, key, value, attn_metadata)
+
+    def forward_maca(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: T | None = None,
+    ) -> torch.Tensor:
+        # MetaX MACA uses the CUDA-compatible runtime (vLLM-metax).
         return self.forward_cuda(query, key, value, attn_metadata)

--- a/vllm_omni/diffusion/layers/custom_op.py
+++ b/vllm_omni/diffusion/layers/custom_op.py
@@ -21,6 +21,8 @@ class CustomOp(nn.Module):
             return self.forward_hip
         elif current_omni_platform.is_cuda():
             return self.forward_cuda
+        elif current_omni_platform.is_maca():
+            return self.forward_maca
         elif current_omni_platform.is_npu():
             return self.forward_npu
         elif current_omni_platform.is_xpu():
@@ -56,4 +58,8 @@ class CustomOp(nn.Module):
 
     def forward_musa(self, *args, **kwargs):
         # By default, we assume that MUSA ops are compatible with CUDA ops.
+        return self.forward_cuda(*args, **kwargs)
+
+    def forward_maca(self, *args, **kwargs):
+        # MetaX MACA uses the CUDA-compatible runtime (vLLM-metax).
         return self.forward_cuda(*args, **kwargs)

--- a/vllm_omni/platforms/__init__.py
+++ b/vllm_omni/platforms/__init__.py
@@ -18,7 +18,6 @@ from vllm_omni.plugins import (
 logger = logging.getLogger(__name__)
 
 
-
 def cuda_omni_platform_plugin() -> str | None:
     """Check if CUDA OmniPlatform should be activated."""
     is_cuda = False
@@ -125,8 +124,9 @@ def musa_omni_platform_plugin() -> str | None:
 def maca_omni_platform_plugin() -> str | None:
     """Check if MACA (MetaX) OmniPlatform should be activated.
 
-    Requires vLLM-metax and a CUDA-compatible torch runtime without discrete
-    NVIDIA GPUs visible to NVML (so we do not collide with CudaOmniPlatform).
+    Requires vLLM-metax and a CUDA-compatible torch runtime. If multiple Omni
+    platform plugins match, set ``VLLM_OMNI_TARGET_DEVICE`` (or adjust the
+    environment) so only one activates.
     """
     logger.debug("Checking if MACA OmniPlatform is available.")
     try:
@@ -140,11 +140,6 @@ def maca_omni_platform_plugin() -> str | None:
         return None
     if not torch.cuda.is_available():
         logger.debug("MACA OmniPlatform is not available: CUDA runtime not available.")
-        return None
-    if _nvidia_nvml_device_count() > 0:
-        logger.debug(
-            "MACA OmniPlatform skipped: NVIDIA GPUs reported by NVML; using CUDA OmniPlatform instead."
-        )
         return None
     logger.debug("Confirmed MACA OmniPlatform is available.")
     return "vllm_omni.platforms.maca.platform.MacaOmniPlatform"

--- a/vllm_omni/platforms/__init__.py
+++ b/vllm_omni/platforms/__init__.py
@@ -18,6 +18,20 @@ from vllm_omni.plugins import (
 logger = logging.getLogger(__name__)
 
 
+def _nvidia_nvml_device_count() -> int:
+    try:
+        from vllm.utils.import_utils import import_pynvml
+
+        pynvml = import_pynvml()
+        pynvml.nvmlInit()
+        try:
+            return int(pynvml.nvmlDeviceGetCount())
+        finally:
+            pynvml.nvmlShutdown()
+    except Exception:
+        return 0
+
+
 def cuda_omni_platform_plugin() -> str | None:
     """Check if CUDA OmniPlatform should be activated."""
     is_cuda = False
@@ -121,12 +135,41 @@ def musa_omni_platform_plugin() -> str | None:
     return "vllm_omni.platforms.musa.platform.MUSAOmniPlatform" if is_musa else None
 
 
+def maca_omni_platform_plugin() -> str | None:
+    """Check if MACA (MetaX) OmniPlatform should be activated.
+
+    Requires vLLM-metax and a CUDA-compatible torch runtime without discrete
+    NVIDIA GPUs visible to NVML (so we do not collide with CudaOmniPlatform).
+    """
+    logger.debug("Checking if MACA OmniPlatform is available.")
+    try:
+        import torch
+    except Exception as e:
+        logger.debug("MACA OmniPlatform is not available because: %s", str(e))
+        return None
+    try:
+        import vllm_metax  # noqa: F401
+    except ImportError:
+        return None
+    if not torch.cuda.is_available():
+        logger.debug("MACA OmniPlatform is not available: CUDA runtime not available.")
+        return None
+    if _nvidia_nvml_device_count() > 0:
+        logger.debug(
+            "MACA OmniPlatform skipped: NVIDIA GPUs reported by NVML; using CUDA OmniPlatform instead."
+        )
+        return None
+    logger.debug("Confirmed MACA OmniPlatform is available.")
+    return "vllm_omni.platforms.maca.platform.MacaOmniPlatform"
+
+
 builtin_omni_platform_plugins = {
     "cuda": cuda_omni_platform_plugin,
     "rocm": rocm_omni_platform_plugin,
     "npu": npu_omni_platform_plugin,
     "xpu": xpu_omni_platform_plugin,
     "musa": musa_omni_platform_plugin,
+    "maca": maca_omni_platform_plugin,
 }
 
 

--- a/vllm_omni/platforms/__init__.py
+++ b/vllm_omni/platforms/__init__.py
@@ -18,19 +18,6 @@ from vllm_omni.plugins import (
 logger = logging.getLogger(__name__)
 
 
-def _nvidia_nvml_device_count() -> int:
-    try:
-        from vllm.utils.import_utils import import_pynvml
-
-        pynvml = import_pynvml()
-        pynvml.nvmlInit()
-        try:
-            return int(pynvml.nvmlDeviceGetCount())
-        finally:
-            pynvml.nvmlShutdown()
-    except Exception:
-        return 0
-
 
 def cuda_omni_platform_plugin() -> str | None:
     """Check if CUDA OmniPlatform should be activated."""

--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -20,6 +20,7 @@ class OmniPlatformEnum(Enum):
     NPU = "npu"
     XPU = "xpu"
     MUSA = "musa"
+    MACA = "maca"
     UNSPECIFIED = "unspecified"
 
 
@@ -48,6 +49,9 @@ class OmniPlatform(Platform):
 
     def is_musa(self) -> bool:
         return self._omni_enum == OmniPlatformEnum.MUSA
+
+    def is_maca(self) -> bool:
+        return self._omni_enum == OmniPlatformEnum.MACA
 
     @classmethod
     def get_omni_ar_worker_cls(cls) -> str:

--- a/vllm_omni/platforms/maca/__init__.py
+++ b/vllm_omni/platforms/maca/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm_omni.platforms.maca.platform import MacaOmniPlatform
+
+__all__ = ["MacaOmniPlatform"]

--- a/vllm_omni/platforms/maca/platform.py
+++ b/vllm_omni/platforms/maca/platform.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from vllm.logger import init_logger
+from vllm.utils.torch_utils import cuda_device_count_stateless
+from vllm_metax.platform import MacaPlatform as MacaPlatformBase
+
+from vllm_omni.diffusion.attention.backends.registry import DiffusionAttentionBackendEnum
+from vllm_omni.diffusion.envs import PACKAGES_CHECKER
+from vllm_omni.platforms.interface import OmniPlatform, OmniPlatformEnum
+
+logger = init_logger(__name__)
+
+
+class MacaOmniPlatform(OmniPlatform, MacaPlatformBase):
+    """MetaX MACA implementation of OmniPlatform.
+
+    Inherits MACA-specific behavior from vLLM-metax and adds Omni worker / diffusion hooks.
+    """
+
+    _omni_enum = OmniPlatformEnum.MACA
+
+    @classmethod
+    def get_omni_ar_worker_cls(cls) -> str:
+        return "vllm_omni.platforms.maca.worker.maca_ar_worker.MacaARWorker"
+
+    @classmethod
+    def get_omni_generation_worker_cls(cls) -> str:
+        return "vllm_omni.platforms.maca.worker.maca_generation_worker.MacaGenerationWorker"
+
+    @classmethod
+    def get_default_stage_config_path(cls) -> str:
+        return "vllm_omni/model_executor/stage_configs"
+
+    @classmethod
+    def get_diffusion_model_impl_qualname(cls, op_name: str) -> str:
+        if op_name == "hunyuan_fused_moe":
+            return "vllm_omni.diffusion.models.hunyuan_image_3.hunyuan_fused_moe.HunyuanFusedMoEDefault"
+        return super().get_diffusion_model_impl_qualname(op_name)
+
+    @classmethod
+    def get_diffusion_attn_backend_cls(
+        cls,
+        selected_backend: str | None,
+        head_size: int,
+    ) -> str:
+        """Diffusion attention backend selection (CUDA-compatible path, like CudaOmniPlatform)."""
+
+        compute_capability = cls.get_device_capability()
+        compute_supported = False
+        if compute_capability is not None:
+            major, minor = compute_capability
+            capability = major * 10 + minor
+            compute_supported = 80 <= capability < 100
+
+        packages_info = PACKAGES_CHECKER.get_packages_info()
+        packages_available = packages_info.get("has_flash_attn", False)
+        flash_attn_supported = compute_supported and packages_available
+
+        if selected_backend is not None:
+            backend_upper = selected_backend.upper()
+            if backend_upper == "FLASH_ATTN" and not flash_attn_supported:
+                if not compute_supported:
+                    logger.warning(
+                        "Flash Attention expects compute capability >= 8.0 and < 10.0. "
+                        "Falling back to TORCH_SDPA backend."
+                    )
+                elif not packages_available:
+                    logger.warning("Flash Attention packages not available. Falling back to TORCH_SDPA backend.")
+                logger.info("Defaulting to diffusion attention backend SDPA")
+                return DiffusionAttentionBackendEnum.TORCH_SDPA.get_path()
+            backend = DiffusionAttentionBackendEnum[backend_upper]
+            logger.info("Using diffusion attention backend '%s'", backend_upper)
+            return backend.get_path()
+
+        if flash_attn_supported:
+            logger.info("Defaulting to diffusion attention backend FLASH_ATTN")
+            return DiffusionAttentionBackendEnum.FLASH_ATTN.get_path()
+
+        logger.info("Defaulting to diffusion attention backend SDPA")
+        return DiffusionAttentionBackendEnum.TORCH_SDPA.get_path()
+
+    @classmethod
+    def supports_torch_inductor(cls) -> bool:
+        # vLLM-metax currently disables generic Triton kernel paths; keep inductor off by default.
+        return False
+
+    @classmethod
+    def get_torch_device(cls, local_rank: int | None = None) -> torch.device:
+        if local_rank is None:
+            return torch.device("cuda")
+        return torch.device("cuda", local_rank)
+
+    @classmethod
+    def get_device_count(cls) -> int:
+        return cuda_device_count_stateless()
+
+    @classmethod
+    def get_device_version(cls) -> str | None:
+        return torch.version.cuda
+
+    @classmethod
+    def synchronize(cls) -> None:
+        torch.cuda.synchronize()
+
+    @classmethod
+    def get_free_memory(cls, device: torch.device | None = None) -> int:
+        free, _ = torch.cuda.mem_get_info(device)
+        return free

--- a/vllm_omni/platforms/maca/worker/__init__.py
+++ b/vllm_omni/platforms/maca/worker/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm_omni.platforms.maca.worker.maca_ar_worker import MacaARWorker
+from vllm_omni.platforms.maca.worker.maca_generation_worker import MacaGenerationWorker
+
+__all__ = ["MacaARWorker", "MacaGenerationWorker"]

--- a/vllm_omni/platforms/maca/worker/maca_ar_worker.py
+++ b/vllm_omni/platforms/maca/worker/maca_ar_worker.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""MACA (MetaX) AR worker for vLLM-Omni.
+
+MetaX uses the CUDA-compatible runtime (``device_type="cuda"`` in vLLM-metax); this
+worker reuses the standard Omni GPU AR worker implementation.
+"""
+
+from vllm_omni.worker.gpu_ar_worker import GPUARWorker
+
+
+class MacaARWorker(GPUARWorker):
+    """Autoregressive omni stages on MetaX MACA via vLLM-metax."""

--- a/vllm_omni/platforms/maca/worker/maca_generation_worker.py
+++ b/vllm_omni/platforms/maca/worker/maca_generation_worker.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""MACA (MetaX) generation worker for vLLM-Omni.
+
+Non-AR stages use the same CUDA-compatible device path as ``GPUGenerationWorker``.
+"""
+
+from vllm_omni.worker.gpu_generation_worker import GPUGenerationWorker
+
+
+class MacaGenerationWorker(GPUGenerationWorker):
+    """Non-autoregressive generation stages on MetaX MACA via vLLM-metax."""

--- a/vllm_omni/quantization/int8_config.py
+++ b/vllm_omni/quantization/int8_config.py
@@ -148,6 +148,8 @@ class DiffusionInt8Config(QuantizationConfig):
             if not self.is_checkpoint_int8_serialized:
                 if current_omni_platform.is_cuda():
                     online_method = Int8OnlineLinearMethod(self)
+                elif current_omni_platform.is_maca():
+                    online_method = Int8OnlineLinearMethod(self)
                 elif current_omni_platform.is_npu():
                     online_method = NPUInt8OnlineLinearMethod(self)
                 else:
@@ -155,6 +157,8 @@ class DiffusionInt8Config(QuantizationConfig):
                 return online_method
             else:
                 if current_omni_platform.is_cuda():
+                    offline_method = Int8LinearMethod(self)
+                elif current_omni_platform.is_maca():
                     offline_method = Int8LinearMethod(self)
                 elif current_omni_platform.is_npu():
                     offline_method = NPUInt8LinearMethod(self)


### PR DESCRIPTION
- Add MacaOmniPlatform on vllm_metax with maca workers (CUDA-compatible path).

- Add OmniPlatformEnum.MACA, forward_maca / is_maca branches for diffusion and int8.

<!-- markdownlint-disable -->
## Purpose

- Add first-class **MetaX (MACA)** support in vLLM-Omni, mirroring the existing MUSA-style platform layout: `MacaOmniPlatform` built on `vllm_metax.platform.MacaPlatform`, dedicated worker entrypoints, and platform auto-detection that avoids colliding with NVIDIA CUDA when NVML reports discrete NVIDIA GPUs.
- Extend **install routing** for `maca` (`requirements/maca.txt`, `setup.py` / `VLLM_OMNI_TARGET_DEVICE=maca`, and maca-before-cuda heuristic when `vllm_metax` is importable).
- Wire **diffusion / int8** dispatch to `is_maca()` and `forward_maca()` (aligned with other platforms instead of folding maca into `is_cuda()`).
- Add optional **`vllm-upstream`** extra (`vllm==0.19.0`) for environments that install upstream vLLM from PyPI; document that it must not be mixed with `vllm-metax` in the same environment.

## Test Plan

- **Syntax / packaging:** `python -m compileall -q vllm_omni` (and `python -m build` with `VLLM_OMNI_TARGET_DEVICE=cpu` if validating wheel metadata).
- **Unit (CPU, no GPU):** `pytest tests/distributed/omni_connectors/test_kv_flow.py -q` — exercises omni connector logic without requiring MACA hardware.
- **MACA (vendor stack, post-merge validation on MetaX machines):** Install aligned **mcPyTorch + vLLM + vLLM-metax** per MetaX docs, then `pip install -e .` with `VLLM_OMNI_TARGET_DEVICE=maca` (or rely on auto-detection), and smoke-run `vllm serve <model> --omni` or a minimal omni offline script from docs.

Reason we do not add MACA-specific CI in this PR: full correctness depends on **vendor images and vLLM-metax version alignment**, which cannot be reproduced in generic upstream CI without dedicated runners.

## Test Result

- Local / headless: `compileall` OK; `pytest tests/distributed/omni_connectors/test_kv_flow.py` **18 passed** (CPU, no `libcuda`).
- **MACA hardware / vLLM-metax:** not executed in this PR’s default CI environment; to be confirmed on MetaX CI or a MetaX-provided container with matching `vllm_metax` + vLLM.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.** *(Not done in this PR; MACA install path is vendor-documented. Follow-up: add a short GPU install tab for MACA if maintainers want parity with MUSA.)*
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft. *(Optional follow-up if release process requires a user-facing line for MetaX.)*

</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)