### PR TITLE
Enable quantization for Qwen-Image-Edit

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -251,7 +251,9 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
             self.device
         )
         transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, QwenImageTransformer2DModel)
-        self.transformer = QwenImageTransformer2DModel(od_config=od_config, **transformer_kwargs)
+        self.transformer = QwenImageTransformer2DModel(
+            od_config=od_config, quant_config=od_config.quantization_config, **transformer_kwargs
+        )
         self.tokenizer = Qwen2Tokenizer.from_pretrained(model, subfolder="tokenizer", local_files_only=local_files_only)
         self.processor = Qwen2VLProcessor.from_pretrained(
             model, subfolder="processor", local_files_only=local_files_only


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Qwen-Image-Edit currently does not pass quant config through when initalizing `QwenImageTransformer2DModel`. Add `quant_config` to the instantiation

## Test Plan
Run a sample query with int8 quantization configured

## Test Result

Input image:
![input](https://github.com/user-attachments/assets/6cce8044-3ff8-48a8-a5e4-9a438e01cbc8)

Prompt is "Place him in New York City, standing on a busy street with skyscrapers and yellow taxis in the background"

Broken (e.g. no quantization, 1x speedup):
<img width="512" height="512" alt="sample-nyc-broken" src="https://github.com/user-attachments/assets/100c79fc-4f54-403a-a4d9-076fabb40982" />

Fixed (1.24x speedup):
<img width="512" height="512" alt="sample-nyc-fixed" src="https://github.com/user-attachments/assets/fe5d3112-e8c4-4c0e-ba89-95599663e5b1" />

Obviously, the "fixed" image is much worse quality. I assume this actually int8 working as intended, just with very poor performance. Though I still assume it's a bug to not actually do anything when the user configures quantization.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [*] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [*] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [*] The test results. Please paste the results comparison before and after, or the e2e results.
- [*] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [*] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
