### PR TITLE
[Bugfix] Add seed support to TTS API for deterministic Fish Speech voice generation

### DIFF
--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -69,6 +69,13 @@ class OpenAICreateSpeechRequest(BaseModel):
         default=None,
         description="Maximum tokens to generate",
     )
+    seed: int | None = Field(
+        default=None,
+        ge=0,
+        le=2**63,
+        description="Random seed for reproducible generation. When set, ensures "
+        "deterministic output for the same input text and seed value.",
+    )
     initial_codec_chunk_frames: int | None = Field(
         default=None,
         ge=0,

--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -72,7 +72,7 @@ class OpenAICreateSpeechRequest(BaseModel):
     seed: int | None = Field(
         default=None,
         ge=0,
-        le=2**63,
+        le=2**63 - 1,
         description="Random seed for reproducible generation. When set, ensures "
         "deterministic output for the same input text and seed value.",
     )

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -1672,6 +1672,22 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             sampling_params_list = copy.deepcopy(sampling_params_list)
             sampling_params_list[0].max_tokens = request.max_new_tokens
 
+        # Propagate per-request seed to sampling params so both Slow AR
+        # and Fast AR produce deterministic output for the same seed.
+        if request.seed is not None and sampling_params_list:
+            if not self._is_fish_speech:
+                logger.warning(
+                    "seed=%d requested but deterministic Fast AR seeding is "
+                    "only implemented for Fish Speech; other TTS models will "
+                    "use the seed for the main AR sampler only.",
+                    request.seed,
+                )
+            if sampling_params_list is self.engine_client.default_sampling_params_list:
+                import copy
+
+                sampling_params_list = copy.deepcopy(sampling_params_list)
+            sampling_params_list[0].seed = request.seed
+
         generator = self.engine_client.generate(
             prompt=prompt,
             request_id=request_id,

--- a/vllm_omni/model_executor/models/fish_speech/fish_speech_fast_ar.py
+++ b/vllm_omni/model_executor/models/fish_speech/fish_speech_fast_ar.py
@@ -400,6 +400,7 @@ class FishSpeechFastAR(nn.Module):
         temperature: float = 0.8,
         top_k: int = 30,
         top_p: float = 0.9,
+        seed: int | None = None,
     ) -> torch.Tensor:
         """Predict residual codebook codes 0..num_codebooks-1 autoregressively.
 
@@ -443,6 +444,12 @@ class FishSpeechFastAR(nn.Module):
         use_sampling = do_sample and temperature > 0
         inv_temperature = 1.0 / max(temperature, 1e-6) if use_sampling else 0.0
 
+        # Create a seeded generator for deterministic residual codebook sampling.
+        generator = None
+        if seed is not None and use_sampling:
+            generator = torch.Generator(device=device)
+            generator.manual_seed(seed)
+
         # Residual codebook size (1024) vs semantic codebook size (4096).
         # The fast_output head has codebook_size (4096) outputs, but residual
         # codebooks only have 1024 entries.  Truncate logits for steps > 0.
@@ -474,7 +481,7 @@ class FishSpeechFastAR(nn.Module):
                     sorted_logits[sorted_indices_to_remove] = float("-inf")
                     scaled = sorted_logits.scatter(1, sorted_indices, sorted_logits)
                 probs = F.softmax(scaled, dim=-1)
-                next_ids = torch.multinomial(probs, num_samples=1)
+                next_ids = torch.multinomial(probs, num_samples=1, generator=generator)
             else:
                 next_ids = logits.argmax(dim=-1, keepdim=True)
 

--- a/vllm_omni/model_executor/models/fish_speech/fish_speech_slow_ar.py
+++ b/vllm_omni/model_executor/models/fish_speech/fish_speech_slow_ar.py
@@ -649,6 +649,7 @@ class FishSpeechSlowARForConditionalGeneration(nn.Module):
         input_embeds: torch.Tensor,
         last_talker_hidden: torch.Tensor,
         text_step: torch.Tensor,
+        seed: int | None = None,
         **kwargs: Any,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """GPU fast-path: run Fast AR to predict residual codebook codes.
@@ -677,6 +678,7 @@ class FishSpeechSlowARForConditionalGeneration(nn.Module):
             temperature=0.8,
             top_k=30,
             top_p=0.9,
+            seed=seed,
         )  # [B, num_codebooks]
 
         # Add codebook embeddings to the input embedding (from preprocess).

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -1646,6 +1646,7 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         temperature: float | None = None,
         top_k: int | None = None,
         top_p: float | None = None,
+        **kwargs: Any,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """GPU fast-path used by OmniGPUModelRunner to predict residual codebooks (1..Q-1).
         Returns (inputs_embeds, audio_codes) for the current step."""

--- a/vllm_omni/platforms/npu/worker/npu_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_model_runner.py
@@ -420,6 +420,15 @@ class OmniNPUModelRunner(OmniGPUModelRunner, NPUModelRunner):
         subtalker_params = getattr(self.vllm_config.model_config, "subtalker_sampling_params", None)
         if not isinstance(subtalker_params, dict):
             subtalker_params = {}
+        # Extract seed from the first request's sampling params for Fast AR
+        # determinism.  NOTE: when batch_size > 1, all requests share the first
+        # request's seed.  Per-request Fast AR seeding requires row-by-row
+        # torch.multinomial calls and is left as a follow-up optimisation.
+        _seed = None
+        if decode_req_ids:
+            _first_sp = self.requests[decode_req_ids[0]].sampling_params
+            if _first_sp is not None and getattr(_first_sp, "seed", None) is not None:
+                _seed = _first_sp.seed
         with set_ascend_forward_context(
             None, self.vllm_config, aclgraph_runtime_mode=_cudagraph_mode, batch_descriptor=batch_desc
         ):
@@ -432,6 +441,7 @@ class OmniNPUModelRunner(OmniGPUModelRunner, NPUModelRunner):
                 temperature=subtalker_params.get("temperature"),
                 top_k=subtalker_params.get("top_k"),
                 top_p=subtalker_params.get("top_p"),
+                seed=_seed,
             )
         # code_predictor_codes stays on GPU here; _update_intermediate_buffer
         # keeps it device-resident when the key is in gpu_resident_buffer_keys.

--- a/vllm_omni/platforms/npu/worker/npu_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_model_runner.py
@@ -426,18 +426,29 @@ class OmniNPUModelRunner(OmniGPUModelRunner, NPUModelRunner):
         # torch.multinomial calls and is left as a follow-up optimisation.
         _seed = None
         if decode_req_ids:
-            _first_sp = self.requests[decode_req_ids[0]].sampling_params
+            _first_sp = getattr(self.requests[decode_req_ids[0]], "sampling_params", None)
             if _first_sp is not None and getattr(_first_sp, "seed", None) is not None:
                 _seed = _first_sp.seed
             # Warn when batched requests have different seeds.
             if len(decode_req_ids) > 1 and _seed is not None:
-                _other_seeds = {getattr(self.requests[rid].sampling_params, "seed", None) for rid in decode_req_ids[1:]}
+                _other_seeds = {
+                    getattr(getattr(self.requests[rid], "sampling_params", None), "seed", None)
+                    for rid in decode_req_ids[1:]
+                }
                 if _other_seeds != {_seed}:
                     logger.warning(
                         "Fast AR seed: batch has mixed seeds; using first request's seed=%d for all %d requests.",
                         _seed,
                         len(decode_req_ids),
                     )
+        talker_kwargs = {
+            "do_sample": subtalker_params.get("do_sample"),
+            "temperature": subtalker_params.get("temperature"),
+            "top_k": subtalker_params.get("top_k"),
+            "top_p": subtalker_params.get("top_p"),
+        }
+        if _seed is not None:
+            talker_kwargs["seed"] = _seed
         with set_ascend_forward_context(
             None, self.vllm_config, aclgraph_runtime_mode=_cudagraph_mode, batch_descriptor=batch_desc
         ):
@@ -446,11 +457,7 @@ class OmniNPUModelRunner(OmniGPUModelRunner, NPUModelRunner):
                 req_embeds,
                 last_talker_hidden,
                 text_step,
-                do_sample=subtalker_params.get("do_sample"),
-                temperature=subtalker_params.get("temperature"),
-                top_k=subtalker_params.get("top_k"),
-                top_p=subtalker_params.get("top_p"),
-                seed=_seed,
+                **talker_kwargs,
             )
         # code_predictor_codes stays on GPU here; _update_intermediate_buffer
         # keeps it device-resident when the key is in gpu_resident_buffer_keys.

--- a/vllm_omni/platforms/npu/worker/npu_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_model_runner.py
@@ -429,6 +429,15 @@ class OmniNPUModelRunner(OmniGPUModelRunner, NPUModelRunner):
             _first_sp = self.requests[decode_req_ids[0]].sampling_params
             if _first_sp is not None and getattr(_first_sp, "seed", None) is not None:
                 _seed = _first_sp.seed
+            # Warn when batched requests have different seeds.
+            if len(decode_req_ids) > 1 and _seed is not None:
+                _other_seeds = {getattr(self.requests[rid].sampling_params, "seed", None) for rid in decode_req_ids[1:]}
+                if _other_seeds != {_seed}:
+                    logger.warning(
+                        "Fast AR seed: batch has mixed seeds; using first request's seed=%d for all %d requests.",
+                        _seed,
+                        len(decode_req_ids),
+                    )
         with set_ascend_forward_context(
             None, self.vllm_config, aclgraph_runtime_mode=_cudagraph_mode, batch_descriptor=batch_desc
         ):

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1364,18 +1364,29 @@ class OmniGPUModelRunner(GPUModelRunner):
         # torch.multinomial calls and is left as a follow-up optimisation.
         _seed = None
         if decode_req_ids:
-            _first_sp = self.requests[decode_req_ids[0]].sampling_params
+            _first_sp = getattr(self.requests[decode_req_ids[0]], "sampling_params", None)
             if _first_sp is not None and getattr(_first_sp, "seed", None) is not None:
                 _seed = _first_sp.seed
             # Warn when batched requests have different seeds.
             if len(decode_req_ids) > 1 and _seed is not None:
-                _other_seeds = {getattr(self.requests[rid].sampling_params, "seed", None) for rid in decode_req_ids[1:]}
+                _other_seeds = {
+                    getattr(getattr(self.requests[rid], "sampling_params", None), "seed", None)
+                    for rid in decode_req_ids[1:]
+                }
                 if _other_seeds != {_seed}:
                     logger.warning(
                         "Fast AR seed: batch has mixed seeds; using first request's seed=%d for all %d requests.",
                         _seed,
                         len(decode_req_ids),
                     )
+        talker_kwargs = {
+            "do_sample": subtalker_params.get("do_sample"),
+            "temperature": subtalker_params.get("temperature"),
+            "top_k": subtalker_params.get("top_k"),
+            "top_p": subtalker_params.get("top_p"),
+        }
+        if _seed is not None:
+            talker_kwargs["seed"] = _seed
         with set_forward_context(
             None, self.vllm_config, cudagraph_runtime_mode=_cudagraph_mode, batch_descriptor=batch_desc
         ):
@@ -1384,11 +1395,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 req_embeds,
                 last_talker_hidden,
                 text_step,
-                do_sample=subtalker_params.get("do_sample"),
-                temperature=subtalker_params.get("temperature"),
-                top_k=subtalker_params.get("top_k"),
-                top_p=subtalker_params.get("top_p"),
-                seed=_seed,
+                **talker_kwargs,
             )
         # code_predictor_codes stays on GPU here; _update_intermediate_buffer
         # keeps it device-resident when the key is in gpu_resident_buffer_keys.

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1358,6 +1358,15 @@ class OmniGPUModelRunner(GPUModelRunner):
         subtalker_params = getattr(self.vllm_config.model_config, "subtalker_sampling_params", None)
         if not isinstance(subtalker_params, dict):
             subtalker_params = {}
+        # Extract seed from the first request's sampling params for Fast AR
+        # determinism.  NOTE: when batch_size > 1, all requests share the first
+        # request's seed.  Per-request Fast AR seeding requires row-by-row
+        # torch.multinomial calls and is left as a follow-up optimisation.
+        _seed = None
+        if decode_req_ids:
+            _first_sp = self.requests[decode_req_ids[0]].sampling_params
+            if _first_sp is not None and getattr(_first_sp, "seed", None) is not None:
+                _seed = _first_sp.seed
         with set_forward_context(
             None, self.vllm_config, cudagraph_runtime_mode=_cudagraph_mode, batch_descriptor=batch_desc
         ):
@@ -1370,6 +1379,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 temperature=subtalker_params.get("temperature"),
                 top_k=subtalker_params.get("top_k"),
                 top_p=subtalker_params.get("top_p"),
+                seed=_seed,
             )
         # code_predictor_codes stays on GPU here; _update_intermediate_buffer
         # keeps it device-resident when the key is in gpu_resident_buffer_keys.

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1367,6 +1367,15 @@ class OmniGPUModelRunner(GPUModelRunner):
             _first_sp = self.requests[decode_req_ids[0]].sampling_params
             if _first_sp is not None and getattr(_first_sp, "seed", None) is not None:
                 _seed = _first_sp.seed
+            # Warn when batched requests have different seeds.
+            if len(decode_req_ids) > 1 and _seed is not None:
+                _other_seeds = {getattr(self.requests[rid].sampling_params, "seed", None) for rid in decode_req_ids[1:]}
+                if _other_seeds != {_seed}:
+                    logger.warning(
+                        "Fast AR seed: batch has mixed seeds; using first request's seed=%d for all %d requests.",
+                        _seed,
+                        len(decode_req_ids),
+                    )
         with set_forward_context(
             None, self.vllm_config, cudagraph_runtime_mode=_cudagraph_mode, batch_descriptor=batch_desc
         ):


### PR DESCRIPTION
I traced through the full code path and found the root cause. Here's a breakdown.

## What's happening?

When you use Fish Speech TTS with the default voice (no cloning), **every request produces a different-sounding voice**, even if you send the exact same text and seed.

## Why does it happen?

Fish Speech generates audio in a pipeline — think of it as a two-person relay:

```
Text → [Slow AR] → semantic tokens → [Fast AR] → audio codebook codes → [DAC Decoder] → waveform
         ↑                              ↑                                    ↑
   "What to say"               "How it sounds"                     "Math, no randomness"
```

- **Slow AR** decides *what* to say — pronunciation, rhythm, which syllables in which order. Think of it as writing a script.
- **Fast AR** decides *how it sounds* — voice timbre, texture, warmth. Think of it as choosing which actor reads the script.
- **DAC Decoder** converts the result into a waveform. Pure math, no randomness.

Both Slow AR and Fast AR use **random sampling** — like rolling dice to pick the next token from a probability distribution. To make this reproducible, you need a **seed**: a "script" for the dice rolls. Same seed = same rolls = same output every time.

## Where are the bugs?

**Bug 1 — The API doesn't know what `seed` is.**

The TTS request model (`OpenAICreateSpeechRequest` in `protocol/audio.py`) has no `seed` field. When you send `"seed": 58842` in your payload, Pydantic silently drops it. The value never reaches the engine. Your seed is thrown away before anything even starts.

(Fun fact: the image and video APIs already have `seed` fields. TTS was just never given one.)

**Bug 2 — Fast AR rolls unseeded dice.**

Even when a seed *does* reach the engine (e.g., from the YAML default `seed: 42`), only Slow AR uses it. vLLM's standard sampler creates a per-request `torch.Generator` for Slow AR — that part is deterministic. ✅

But Fast AR has its own inline sampling: `torch.multinomial(probs, num_samples=1)` at [`fish_speech_fast_ar.py:467`] with **no `generator` argument**. This means it pulls from the global CUDA random state, which is different on every call. Since Fast AR controls codebooks 1–9 (the "which actor" part), the voice character changes every time. ❌

**In short:**
- Slow AR (what to say): seeded ✅ → same script every time
- Fast AR (how it sounds): unseeded ❌ → different actor every time
- That's why you get consistent *content* but inconsistent *voice*.

## How does the fix work?

**Before vs After — where the seed reaches:**

| Component | Role | Before | After |
|-----------|------|--------|-------|
| API (`protocol/audio.py`) | Accept seed from user | ❌ No `seed` field — silently dropped | ✅ `seed: int` field added |
| Serving (`serving_speech.py`) | Pass seed to engine | ❌ Never set | ✅ Writes seed into `SamplingParams` |
| Runner (`gpu_model_runner.py`) | Thread seed to model | ❌ No seed passed | ✅ Extracts seed, passes to `talker_mtp()` |
| Slow AR (`fish_speech_slow_ar.py`) | "What to say" sampling | ✅ Already seeded via vLLM sampler | ✅ Same + forwards seed to Fast AR |
| **Fast AR** (`fish_speech_fast_ar.py`) | **"How it sounds" sampling** | **❌ Global CUDA RNG, no seed** | **✅ `torch.Generator(seed)` → `torch.multinomial`** |
| DAC Decoder | Waveform output | ✅ Deterministic (no sampling) | ✅ Same |

The core change: Fast AR's `torch.multinomial(probs)` → `torch.multinomial(probs, generator=seeded_generator)`.

```
User sends seed in API request
  → protocol/audio.py accepts it
    → serving_speech.py writes it into SamplingParams
      → gpu_model_runner.py extracts it, passes to talker_mtp()
        → fish_speech_slow_ar.py forwards to fast_ar()
          → fish_speech_fast_ar.py creates torch.Generator(seed)
            → torch.multinomial uses it
              → same seed = same voice ✅
```

### Files changed (8 files, +57/−3)

| Layer | File | What changed |
|-------|------|-------------|
| API | `protocol/audio.py` | Added `seed` field to request model |
| API | `serving_speech.py` | Propagates seed to `SamplingParams`; warns if used with non-Fish-Speech models |
| Model | `fish_speech_fast_ar.py` | Creates seeded `torch.Generator`, passes to `torch.multinomial` |
| Model | `fish_speech_slow_ar.py` | Forwards seed from `talker_mtp()` to `fast_ar()` |
| Runner | `gpu_model_runner.py` | Extracts seed from request, passes to `talker_mtp()` |
| Runner | `npu_model_runner.py` | Same as GPU runner |
| Compat | `qwen3_omni.py` | Added `**kwargs` so it won't crash when seed is passed |
| Compat | `qwen3_tts_talker.py` | Same `**kwargs` addition |

## Who is affected?

- **Fish Speech users who want consistent voices** — this is the direct fix.
- **All TTS users** — the `seed` field is now available in the API for all models. For non-Fish-Speech models (Qwen3-TTS, CosyVoice3, etc.), seed is propagated to the main AR sampler but not to model-specific code predictors (a warning is logged).
- **Existing users who don't send seed** — nothing changes. `seed` defaults to `None`, which preserves the original random behavior.

## When does it NOT work perfectly?

**Known limitation:** When multiple TTS requests are batched together (batch size > 1), all requests in the batch share the first request's seed for the Fast AR path. This means if request A has `seed=42` and request B has `seed=99`, request B silently gets seed 42. Per-request seeding within a batch requires row-by-row `torch.multinomial` calls — left as a follow-up.

In practice, TTS workloads are usually single-request, so this rarely matters.

## How to use it

Pass `"seed": <int>` in your `/v1/audio/speech` request body. That's it.

```python
# Before: seed was silently ignored
payload = {"input": "Hello world", "seed": 58842}  # ❌ dropped by Pydantic

# After: seed is accepted and used
payload = {"input": "Hello world", "seed": 58842}  # ✅ deterministic output
```

Even without an explicit seed, the YAML config default (`seed: 42`) now applies to **both** Slow AR and Fast AR, so out-of-the-box behavior is already more consistent than before.

Working on a PR — will link it here.

Closes #2552
