### PR TITLE
[Bugfix] restore legacy stage config precedence

### DIFF
--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -302,7 +302,7 @@ def load_stage_configs_from_model(model: str, base_engine_args: dict | None = No
     stage_configs = load_stage_configs_from_yaml(
         config_path=stage_config_path,
         base_engine_args=base_engine_args,
-        prefer_stage_engine_args=False,
+        prefer_stage_engine_args=True,
     )
     return stage_configs
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

This PR fixes an unintended behavior introduced by #2076 in the legacy
`load_and_resolve_stage_configs` path.

After #2076, CLI runtime args can override default stage configs. However,
CLI default values also started participating in the merge and could override
the YAML's default stage config values even when the user did not explicitly
set those CLI args.

This PR restores the previous behavior for the legacy loader by switching
`prefer_stage_engine_args` back to `True` when loading model-default stage
configs.

## Behavior

Before this fix:
- CLI defaults could override default stage YAML values
- default stage configs could be unintentionally polluted by CLI defaults

After this fix:
- stage YAML defaults take precedence again in the legacy model-default load path
- only intentional runtime overrides should affect resolved configs

## Rationale

The affected path is the legacy `load_and_resolve_stage_configs` chain, which
is planned to be removed by the config refactor tracked in #2072.

this pr is a minimal rollback of the legacy precedence behavior, intended as a temporary fix until the https://github.com/vllm-project/vllm-omni/issues/2072 refactor is completed.



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
