### PR TITLE
[Doc] Add stage-based CLI guide

### DIFF
--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -1,5 +1,59 @@
 # vllm-omni serve
 
+`vllm serve ... --omni` is the main CLI entrypoint for both multi-stage omni models
+and diffusion models.
+
+## Stage-Based CLI Quick Start
+
+### Use bundled stage configs
+
+For supported omni models, vLLM-Omni can auto-resolve a bundled stage config when
+`--stage-configs-path` is not provided:
+
+```bash
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091
+```
+
+### Use a custom stage config
+
+If you need to change device placement, connectors, scheduler settings, or
+per-stage defaults, point the CLI at a custom YAML:
+
+```bash
+vllm serve Qwen/Qwen2.5-Omni-7B \
+  --omni \
+  --port 8091 \
+  --stage-configs-path /path/to/custom_stage_configs.yaml
+```
+
+### Use Ray for distributed execution
+
+For current multi-node or distributed stage deployments, prefer the Ray backend:
+
+```bash
+vllm serve Qwen/Qwen2.5-Omni-7B \
+  --omni \
+  --port 8091 \
+  --worker-backend ray \
+  --ray-address auto
+```
+
+### Legacy `--stage-id` note
+
+`--stage-id` belongs to the legacy stage-per-process flow and should not be used for
+new deployments in the current AsyncOmniEngine runtime.
+
+Older setups paired `--stage-id` with `--omni-master-address` and
+`--omni-master-port`.
+
+`--headless` is deprecated and not supported in the current AsyncOmniEngine runtime,
+so older stage-per-process examples that rely on `--headless` should be treated as
+historical reference only.
+
+For the recommended workflow, see
+[Stage configs for vLLM-Omni](../configuration/stage_configs.md) and
+[Ray-based execution notes](../design/feature/ray_based_execution.md).
+
 ## JSON CLI Arguments
 
 --8<-- "docs/cli/json_tip.inc.md"

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -6,9 +6,12 @@ For options within a vLLM Engine. Please refer to [vLLM Configuration](https://d
 
 Currently, the main options are maintained by stage configs for each model.
 
-For specific example, please refer to [Qwen2.5-omni stage config](stage_configs/qwen2_5_omni.yaml)
+For a start-to-finish guide to the stage-based CLI and stage config workflow, see
+[Stage configs for vLLM-Omni](./stage_configs.md).
 
-For introduction, please check [Introduction for stage config](./stage_configs.md)
+For a specific example, please refer to [Qwen2.5-Omni stage config](stage_configs/qwen2_5_omni.yaml).
+
+For a field-by-field introduction, please check [Introduction for stage config](./stage_configs.md).
 
 ## Memory Configuration
 

--- a/docs/configuration/stage_configs.md
+++ b/docs/configuration/stage_configs.md
@@ -1,9 +1,116 @@
 # Stage configs for vLLM-Omni
 
-In vLLM-Omni, the target model is separated into multiple stages, which are processed by different LLMEngines, DiffusionEngines or other types of engines. Depending on different types of stages, such as Autoregressive (AR) stage or Diffusion transformer (DiT) stage, each can choose corresponding schedulers, model workers to load with the Engines in a plug-in fashion.
+Stage configs are the control plane for the stage-based CLI in vLLM-Omni. They tell
+`vllm serve ... --omni` how to split a model into stages, what each stage runs, which
+devices each stage sees, and how data flows between stages.
+
+In vLLM-Omni, the target model can be separated into multiple stages, which are
+processed by different LLM engines, diffusion engines, or other specialized engines.
+Depending on the stage type, such as an autoregressive (AR) stage or a diffusion
+transformer (DiT) stage, each stage can choose its own scheduler, worker, runtime,
+and sampling defaults.
 
 !!! note
     Default stage config YAMLs (for example, `vllm_omni/model_executor/stage_configs/qwen2_5_omni.yaml` and `vllm_omni/model_executor/stage_configs/qwen3_omni_moe.yaml`) are bundled and loaded automatically when `stage_configs_path` is not provided. They have been verified to work on 1xH100 for Qwen2.5-Omni and 2xH100 for Qwen3-Omni.
+
+!!! note
+    Diffusion models follow the same CLI entrypoint, but if no stage config YAML is
+    found, vLLM-Omni will synthesize a default single-stage diffusion config from the
+    CLI arguments.
+
+## When to use stage configs
+
+Use a stage config when you need to:
+
+- run a multi-stage omni model with the correct bundled defaults
+- override device placement or memory allocation per stage
+- customize connectors, runtimes, or inter-stage topology
+- tune per-stage sampling defaults or stage-specific engine arguments
+- keep a reproducible deployment layout in version-controlled YAML
+
+## Stage-Based CLI Quick Start
+
+### 1. Start with bundled defaults
+
+For supported omni models, the simplest path is to let vLLM-Omni resolve the bundled
+stage config automatically:
+
+```bash
+vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091
+```
+
+The equivalent Python path is:
+
+```python
+from vllm_omni import AsyncOmni
+
+omni = AsyncOmni(model="Qwen/Qwen2.5-Omni-7B")
+```
+
+### 2. Point to a custom YAML
+
+If you want to modify stage placement or stage-specific engine arguments, start from a
+bundled YAML in `vllm_omni/model_executor/stage_configs/`, copy it, edit it, then pass
+it through `--stage-configs-path` or `stage_configs_path`.
+
+For offline (assuming the necessary dependencies have been imported):
+
+```python
+model_name = "Qwen/Qwen2.5-Omni-7B"
+omni = Omni(model=model_name, stage_configs_path="/path/to/custom_stage_configs.yaml")
+```
+
+For online serving:
+
+```bash
+vllm serve Qwen/Qwen2.5-Omni-7B \
+  --omni \
+  --port 8091 \
+  --stage-configs-path /path/to/custom_stage_configs.yaml
+```
+
+### 3. Use Ray for distributed execution
+
+For current multi-node or distributed stage deployments, prefer the Ray backend
+instead of the legacy stage-per-process flow:
+
+```bash
+vllm serve Qwen/Qwen2.5-Omni-7B \
+  --omni \
+  --port 8091 \
+  --worker-backend ray \
+  --ray-address auto
+```
+
+See [Ray-based execution notes](../design/feature/ray_based_execution.md) for cluster
+setup details.
+
+### 4. Understand the legacy `--stage-id` flow
+
+`--stage-id` belongs to the legacy stage-per-process flow. Do not treat it as the
+recommended way to select or launch stages in the current AsyncOmniEngine-based
+`vllm serve` runtime.
+
+Older setups paired `--stage-id` with both `--omni-master-address` and
+`--omni-master-port`.
+
+!!! warning
+    `--headless` is deprecated and not supported in the current AsyncOmniEngine-based
+    `vllm serve` runtime. Older documents or examples that use
+    `--stage-id ... --headless` should be treated as legacy reference, not as the
+    recommended deployment path for new setups.
+
+## Key CLI Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--omni` | Enable the vLLM-Omni entrypoint for multi-stage or diffusion models. |
+| `--stage-configs-path` | Load a custom stage config YAML instead of auto-resolving one from the model. |
+| `--stage-id` | Legacy stage-per-process parameter retained for historical compatibility notes; not part of the recommended current runtime workflow. |
+| `--worker-backend` | Choose the stage worker backend, such as `multi_process` or `ray`. |
+| `--ray-address` | Connect to an existing Ray cluster when `--worker-backend ray` is used. |
+| `--omni-master-address` / `--omni-master-port` | Legacy orchestrator endpoint required when `--stage-id` is used. |
+| `--default-sampling-params` | Override default per-stage sampling parameters from the CLI. |
 
 Therefore, as a core part of vLLM-Omni, the stage configs for a model have several main functions:
 
@@ -13,18 +120,6 @@ Therefore, as a core part of vLLM-Omni, the stage configs for a model have sever
 - Input and output dependencies for each stage.
 - Default input parameters.
 
-If users want to modify some part of it. The custom stage_configs file can be input as input argument in both online and offline. Just like examples below:
-
-For offline (Assume necessary dependencies have ben imported):
-```python
-model_name = "Qwen/Qwen2.5-Omni-7B"
-omni = Omni(model=model_name, stage_configs_path="/path/to/custom_stage_configs.yaml")
-```
-
-For online serving:
-```bash
-vllm serve Qwen/Qwen2.5-Omni-7B --omni --port 8091 --stage-configs-path /path/to/stage_configs_file
-```
 !!! important
     We are actively iterating on the definition of stage configs, and we welcome all feedbacks from both community users and developers to help us shape the development!
 

--- a/examples/online_serving/bagel/README.md
+++ b/examples/online_serving/bagel/README.md
@@ -97,6 +97,13 @@ Replace `<ORCHESTRATOR_IP>` below with the actual IP address of your orchestrato
 
 > [!WARNING]
 > **Before launching**, edit [`bagel_multiconnector.yaml`](../../../vllm_omni/model_executor/stage_configs/bagel_multiconnector.yaml) and replace the `metadata_server` and `master` addresses with your Mooncake master node's actual IP. Mismatched addresses will cause silent connection failures.
+>
+> The stage-per-process flow below relies on `--stage-id` together with `--headless`.
+> `--headless` is deprecated and currently not supported by the AsyncOmniEngine-based
+> `vllm serve` runtime, so treat the commands below as legacy reference only.
+> For new deployments, prefer the standard orchestrator flow or the Ray backend. See
+> the [stage config guide](../../../docs/configuration/stage_configs.md) and
+> [Ray-based execution notes](../../../docs/design/feature/ray_based_execution.md).
 
 **1. Start Mooncake Master** (on the orchestrator node):
 
@@ -145,13 +152,13 @@ vllm serve ByteDance-Seed/BAGEL-7B-MoT --omni \
 
 | Argument | Description |
 | :------- | :---------- |
-| `--stage-id` | Which stage this process runs (0 = Thinker, 1 = DiT) |
-| `--headless` | Run without the API server (worker-only mode) |
+| `--stage-id` | Legacy flow only: which stage this process runs (0 = Thinker, 1 = DiT) |
+| `--headless` | Legacy worker-only mode. Deprecated and not supported in the current runtime. |
 | `-oma` | Orchestrator master address |
 | `-omp` | Orchestrator master port for Stage 1 to connect to Stage 0 for task coordination |
 
 > [!IMPORTANT]
-> **Startup Order**: Stage 0 (orchestrator) must be launched **before** Stage 1 (headless).
+> **Legacy Startup Order**: Stage 0 (orchestrator) must be launched **before** Stage 1 (headless).
 > Stage 0 will appear to hang on startup until Stage 1 (worker) connects — this is expected behavior.
 
 **Network Requirements**


### PR DESCRIPTION
## Purpose

  Fixes #1462.

  This PR improves the documentation for the stage-based CLI in vLLM-Omni.

  Changes included:
  - add a Stage-Based CLI quick start to `docs/cli/serve.md`
  - expand `docs/configuration/stage_configs.md` into a practical guide for bundled configs, custom `--stage-configs-path` usage, Ray-based execution,
  and legacy `--stage-id` / `--headless` caveats
  - improve entry links in `docs/configuration/README.md`
  - clarify that the stage-per-process `--stage-id` + `--headless` flow in the BAGEL example is legacy reference only

  No code paths are changed in this PR.

  ## Test Plan

  This is a doc-only PR. No new runtime behavior is introduced.

  Validation performed:
  - reviewed the documentation changes against the current runtime behavior in:
    - `vllm_omni/entrypoints/cli/serve.py`
    - `vllm_omni/entrypoints/utils.py`
    - `vllm_omni/engine/async_omni_engine.py`
    - `vllm_omni/engine/orchestrator.py`
  - ran:
    ```bash
    uvx pre-commit run --files \
      docs/cli/serve.md \
      docs/configuration/README.md \
      docs/configuration/stage_configs.md \
      examples/online_serving/bagel/README.md

  - ran:

    uv run --extra docs mkdocs build

  ## Test Result

  - pre-commit passed for all changed files
  - mkdocs build completed successfully and generated the documentation site locally