### PR TITLE
[Feature][NPU]Support NPU FlashComm1 for HunyuanImage3.0

### DIFF
--- a/vllm_omni/diffusion/models/hunyuan_image_3/hunyuan_image_3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image_3/hunyuan_image_3_transformer.py
@@ -99,6 +99,9 @@ def _is_moe(config: PretrainedConfig) -> bool:
     return False
 
 
+def _is_enable_flash_comm_v1() -> bool:
+    return bool(int(os.getenv("HY_IMAGE_3_ENABLE_FLASHCOMM1", 0)))
+
 def _get_cla_factor(config: PretrainedConfig) -> int:
     if not getattr(config, "use_cla", False):
         return 1
@@ -1529,7 +1532,6 @@ class HunYuanSparseMoeBlock(nn.Module):
             num_redundant_experts=self.n_redundant_experts,
             pcp_size=1,
         )
-        self.hunyuan_enable_flash_comm1 = bool(int(os.getenv("HY_IMAGE_3_ENABLE_FLASHCOMM1", 0)))
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # NOTE: hidden_states can have either 1D or 2D shape.
@@ -1545,11 +1547,11 @@ class HunYuanSparseMoeBlock(nn.Module):
 
         if self.tp_size > 1:
             # If enable FC1, moe_comm_type: ALLGATHER needs to do reduce_scatter
-            if self.hunyuan_enable_flash_comm1:
-                moe_comm_type = getattr(get_forward_context(), "moe_comm_type", None)
-                if moe_comm_type == MoECommType.ALLTOALL:
+            if _is_enable_flash_comm_v1():
+                moe_comm_type = getattr(get_forward_context(), "moe_comm_type_name", None)
+                if moe_comm_type == "ALLTOALL":
                     return final_hidden_states.view(orig_shape)
-                elif moe_comm_type == MoECommType.ALLGATHER:
+                elif moe_comm_type == "ALLGATHER":
                     tp_group = get_tp_group().device_group
 
                     ws = dist.get_world_size(tp_group)
@@ -1678,8 +1680,6 @@ class HunYuanAttention(nn.Module):
             self.query_layernorm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
             self.key_layernorm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
 
-        self.hunyuan_enable_flash_comm1 = bool(int(os.getenv("HY_IMAGE_3_ENABLE_FLASHCOMM1", 0)))
-
     def forward(
         self,
         positions: torch.Tensor,
@@ -1691,7 +1691,7 @@ class HunYuanAttention(nn.Module):
     ) -> torch.Tensor:
         bsz = len(kwargs.get("query_lens"))
         q_len = kwargs.get("query_lens")[0]
-        if self.hunyuan_enable_flash_comm1:
+        if _is_enable_flash_comm_v1():
             if not self.layer_id:
                 qkv, _ = self.qkv_proj(hidden_states)
             else:
@@ -1733,7 +1733,7 @@ class HunYuanAttention(nn.Module):
         # For o_proj
         attn_output = attn_output.view(q.shape[0], -1)
         output, _ = self.o_proj(attn_output)
-        if not self.hunyuan_enable_flash_comm1:
+        if not _is_enable_flash_comm_v1():
             output = output.reshape(bsz, q_len, -1)
         return output, None, past_key_value
 
@@ -1794,7 +1794,6 @@ class HunyuanImage3DecoderLayer(nn.Module):
 
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.hunyuan_enable_flash_comm1 = bool(int(os.getenv("HY_IMAGE_3_ENABLE_FLASHCOMM1", 0)))
 
     def forward(
         self,
@@ -1850,7 +1849,7 @@ class HunyuanImage3DecoderLayer(nn.Module):
             **kwargs,
         )
 
-        if self.hunyuan_enable_flash_comm1 and not self.layer_idx:
+        if _is_enable_flash_comm_v1() and not self.layer_idx:
             full_len = hidden_states.shape[0]*world_size
             origin_len = residual.shape[0]
             need_pad = origin_len != full_len
@@ -1868,7 +1867,7 @@ class HunyuanImage3DecoderLayer(nn.Module):
 
         hidden_states_ = self.post_attention_layernorm(hidden_states)
 
-        if self.hunyuan_enable_flash_comm1 and getattr(get_forward_context(), "moe_comm_type", None) == MoECommType.ALLGATHER:
+        if _is_enable_flash_comm_v1() and getattr(get_forward_context(), "moe_comm_type_name", None) == "ALLGATHER":
             # insert all gather here
             hidden_states = torch.zeros([world_size * hidden_states.shape[0], *hidden_states.shape[1:]], device=hidden_states.device, dtype=hidden_states.dtype)
             torch.distributed.all_gather_into_tensor(hidden_states, hidden_states_)
@@ -1878,8 +1877,8 @@ class HunyuanImage3DecoderLayer(nn.Module):
             hidden_states = self.mlp(hidden_states_)
 
         hidden_states = residual + hidden_states
-
-        if self.hunyuan_enable_flash_comm1:
+        
+        if _is_enable_flash_comm_v1():
             if self.layer_idx == self.num_hidden_layers - 1:
                 hidden_states_ = torch.zeros([world_size * hidden_states.shape[0], *hidden_states.shape[1:]], device=hidden_states.device, dtype=residual.dtype)
                 torch.distributed.all_gather_into_tensor(hidden_states_, hidden_states)
@@ -2026,7 +2025,6 @@ class HunyuanImage3Model(nn.Module):
         self.pre_processor = HunyuanImagePreprocessor()
         self.unifiled_cat = UnifiledCat()
         self.post_processor = HunyuanImagePostprocessor()
-        self.hunyuan_enable_flash_comm1 = bool(int(os.getenv("HY_IMAGE_3_ENABLE_FLASHCOMM1", 0)))
 
     def _split_qkv_weight(self, qkv: torch.Tensor):
         num_attention_heads = self.config.num_attention_heads
@@ -2386,7 +2384,7 @@ class HunyuanImage3Model(nn.Module):
                 k_pad = attention_mask.new_zeros(B, H, Q + pad, pad)
                 attention_mask = torch.cat((attention_mask, k_pad), dim=3)
 
-        if self.hunyuan_enable_flash_comm1:
+        if _is_enable_flash_comm_v1():
             hidden_states = hidden_states.reshape(len(query_lens)*query_lens[0], -1)
 
         for layer_idx, decoder_layer in enumerate(self.layers):
@@ -2420,7 +2418,7 @@ class HunyuanImage3Model(nn.Module):
             if output_attentions:
                 all_self_attns += (layer_outputs[1],)
 
-        if self.hunyuan_enable_flash_comm1:
+        if _is_enable_flash_comm_v1():
             hidden_states = hidden_states.reshape(len(query_lens), query_lens[0], -1)
 
         # add hidden states from the last decoder layer

--- a/vllm_omni/diffusion/models/hunyuan_image_3/hunyuan_image_3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image_3/hunyuan_image_3_transformer.py
@@ -8,9 +8,12 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any, cast
 
+import os
 import numpy as np
 import regex as re
 import torch
+import torch.nn.functional as F
+import torch.distributed as dist
 from diffusers.callbacks import MultiPipelineCallbacks, PipelineCallback
 from diffusers.image_processor import VaeImageProcessor
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
@@ -31,6 +34,7 @@ from transformers.modeling_utils import PreTrainedModel
 from vllm.config import CacheConfig
 from vllm.distributed import (
     get_tensor_model_parallel_world_size,
+    get_tp_group,
 )
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -55,6 +59,8 @@ from vllm.model_executor.models.utils import (
     make_layers,
 )
 from vllm.v1.attention.backend import AttentionType
+from vllm.forward_context import get_forward_context
+from vllm_ascend.ascend_forward_context import MoECommType
 
 from vllm_omni.diffusion.attention.backends.abstract import (
     AttentionMetadata,
@@ -75,6 +81,7 @@ from vllm_omni.diffusion.distributed.sp_plan import (
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
 from vllm_omni.diffusion.models.hunyuan_image_3.hunyuan_fused_moe import HunyuanFusedMoE
+from vllm_omni.diffusion.models.hunyuan_image_3.hunyuan_row_parallel_linear import HunyuanRowParallelLinear
 
 logger = logging.getLogger(__name__)
 
@@ -1522,6 +1529,7 @@ class HunYuanSparseMoeBlock(nn.Module):
             num_redundant_experts=self.n_redundant_experts,
             pcp_size=1,
         )
+        self.hunyuan_enable_flash_comm1 = bool(int(os.getenv("HY_IMAGE_3_ENABLE_FLASHCOMM1", 0)))
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # NOTE: hidden_states can have either 1D or 2D shape.
@@ -1536,7 +1544,28 @@ class HunYuanSparseMoeBlock(nn.Module):
             final_hidden_states = final_hidden_states[0] + final_hidden_states[1]
 
         if self.tp_size > 1:
-            final_hidden_states = self.experts.maybe_all_reduce_tensor_model_parallel(final_hidden_states)
+            # If enable FC1, moe_comm_type: ALLGATHER needs to do reduce_scatter
+            if self.hunyuan_enable_flash_comm1:
+                moe_comm_type = getattr(get_forward_context(), "moe_comm_type", None)
+                if moe_comm_type == MoECommType.ALLTOALL:
+                    return final_hidden_states.view(orig_shape)
+                elif moe_comm_type == MoECommType.ALLGATHER:
+                    tp_group = get_tp_group().device_group
+
+                    ws = dist.get_world_size(tp_group)
+                    assert final_hidden_states.size(0) % ws == 0
+
+                    out_shape = (final_hidden_states.size(0) // ws, *final_hidden_states.shape[1:])
+                    out = torch.empty(out_shape, device=final_hidden_states.device, dtype=final_hidden_states.dtype)
+
+                    chunks = list(torch.chunk(final_hidden_states, ws, dim=0))
+                    dist.reduce_scatter(out, chunks, group=tp_group)
+                    final_hidden_states = out
+                    return final_hidden_states
+                else:
+                    ValueError(f"moe_comm_type must be ALLGATHER or ALLTOALL when enable FlashComm v1, but got {moe_comm_type}")
+            else:
+                final_hidden_states = self.experts.maybe_all_reduce_tensor_model_parallel(final_hidden_states)
 
         return final_hidden_states.view(orig_shape)
 
@@ -1601,7 +1630,7 @@ class HunYuanAttention(nn.Module):
             prefix=f"{prefix}.qkv_proj",
         )
 
-        self.o_proj = RowParallelLinear(
+        self.o_proj = HunyuanRowParallelLinear(
             input_size=self.total_num_heads * self.head_dim,
             output_size=hidden_size,
             bias=bias,
@@ -1649,6 +1678,8 @@ class HunYuanAttention(nn.Module):
             self.query_layernorm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
             self.key_layernorm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
 
+        self.hunyuan_enable_flash_comm1 = bool(int(os.getenv("HY_IMAGE_3_ENABLE_FLASHCOMM1", 0)))
+
     def forward(
         self,
         positions: torch.Tensor,
@@ -1658,8 +1689,24 @@ class HunYuanAttention(nn.Module):
         custom_pos_emb: tuple[torch.FloatTensor] | None = None,
         **kwargs,
     ) -> torch.Tensor:
-        bsz, q_len, _ = hidden_states.size()
-        qkv, _ = self.qkv_proj(hidden_states)
+        bsz = len(kwargs.get("query_lens"))
+        q_len = kwargs.get("query_lens")[0]
+        if self.hunyuan_enable_flash_comm1:
+            if not self.layer_id:
+                qkv, _ = self.qkv_proj(hidden_states)
+            else:
+                world_size = dist.get_world_size()
+                hidden_states_gathered = torch.zeros([world_size * hidden_states.shape[0], *hidden_states.shape[1:]],
+                                                    device=hidden_states.device, dtype=hidden_states.dtype)
+                torch.distributed.all_gather_into_tensor(hidden_states_gathered, hidden_states.contiguous())
+                hidden_states = hidden_states_gathered.contiguous()
+                pad_size = (world_size - (bsz*q_len % world_size)) % world_size
+                if pad_size:
+                    hidden_states = hidden_states[:-pad_size]
+                qkv, _ = self.qkv_proj(hidden_states)
+        else:
+            qkv, _ = self.qkv_proj(hidden_states)
+
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
         past_key_value: Cache | None = kwargs.get("past_key_value", None)
@@ -1686,7 +1733,8 @@ class HunYuanAttention(nn.Module):
         # For o_proj
         attn_output = attn_output.view(q.shape[0], -1)
         output, _ = self.o_proj(attn_output)
-        output = output.reshape(bsz, q_len, -1)
+        if not self.hunyuan_enable_flash_comm1:
+            output = output.reshape(bsz, q_len, -1)
         return output, None, past_key_value
 
 
@@ -1697,6 +1745,7 @@ class HunyuanImage3DecoderLayer(nn.Module):
         super().__init__()
         self.hidden_size = config.hidden_size
         self.layer_idx = layer_idx
+        self.num_hidden_layers = config.num_hidden_layers
         self.intermediate_size = (
             config.intermediate_size
             if isinstance(config.intermediate_size, int)
@@ -1745,6 +1794,7 @@ class HunyuanImage3DecoderLayer(nn.Module):
 
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hunyuan_enable_flash_comm1 = bool(int(os.getenv("HY_IMAGE_3_ENABLE_FLASHCOMM1", 0)))
 
     def forward(
         self,
@@ -1781,6 +1831,11 @@ class HunyuanImage3DecoderLayer(nn.Module):
                 "`attention_mask` instead.`"
             )
 
+        rank, world_size = dist.get_rank(), dist.get_world_size()
+        bs = len(kwargs.get("query_lens"))
+        q_len = kwargs.get("query_lens")[0]
+        origin_len = bs*q_len
+
         residual = hidden_states
 
         hidden_states = self.input_layernorm(hidden_states)
@@ -1794,13 +1849,42 @@ class HunyuanImage3DecoderLayer(nn.Module):
             use_cache=use_cache,
             **kwargs,
         )
-        hidden_states = residual + hidden_states
+
+        if self.hunyuan_enable_flash_comm1 and not self.layer_idx:
+            full_len = hidden_states.shape[0]*world_size
+            origin_len = residual.shape[0]
+            need_pad = origin_len != full_len
+            pad_size = (world_size - (bs*q_len % world_size)) % world_size
+            if need_pad:
+                residual = F.pad(residual, (0, 0, 0, pad_size))
+            residual_chunk = torch.chunk(residual, world_size, dim=0)[rank]
+            hs = hidden_states[:residual_chunk.shape[0]]
+            hidden_states = residual_chunk + hs
+        else:
+            hidden_states = residual + hidden_states
+
         # Fully Connected
         residual = hidden_states
-        hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+
+        hidden_states_ = self.post_attention_layernorm(hidden_states)
+
+        if self.hunyuan_enable_flash_comm1 and getattr(get_forward_context(), "moe_comm_type", None) == MoECommType.ALLGATHER:
+            # insert all gather here
+            hidden_states = torch.zeros([world_size * hidden_states.shape[0], *hidden_states.shape[1:]], device=hidden_states.device, dtype=hidden_states.dtype)
+            torch.distributed.all_gather_into_tensor(hidden_states, hidden_states_)
+            # Fully Connected
+            hidden_states = self.mlp(hidden_states)
+        else:
+            hidden_states = self.mlp(hidden_states_)
 
         hidden_states = residual + hidden_states
+
+        if self.hunyuan_enable_flash_comm1:
+            if self.layer_idx == self.num_hidden_layers - 1:
+                hidden_states_ = torch.zeros([world_size * hidden_states.shape[0], *hidden_states.shape[1:]], device=hidden_states.device, dtype=residual.dtype)
+                torch.distributed.all_gather_into_tensor(hidden_states_, hidden_states)
+                hidden_states = hidden_states_.contiguous()
+            hidden_states = hidden_states[:origin_len,:]
 
         outputs = (hidden_states,)
 
@@ -1942,6 +2026,7 @@ class HunyuanImage3Model(nn.Module):
         self.pre_processor = HunyuanImagePreprocessor()
         self.unifiled_cat = UnifiledCat()
         self.post_processor = HunyuanImagePostprocessor()
+        self.hunyuan_enable_flash_comm1 = bool(int(os.getenv("HY_IMAGE_3_ENABLE_FLASHCOMM1", 0)))
 
     def _split_qkv_weight(self, qkv: torch.Tensor):
         num_attention_heads = self.config.num_attention_heads
@@ -2036,7 +2121,7 @@ class HunyuanImage3Model(nn.Module):
         for name, loaded_weight in weights:
             # print(f"Loading weight name: {name}, tp_rank: {tp_rank}", flush=True)
             if contains_unexpected_keyword(name, unexpected_keywords):
-                logger.warning("Skipping unexpected weight name: %s", name)
+                print(f"Skipping unexpected weight name: {name}")
                 continue
             if "rotary_emb.inv_freq" in name:
                 continue
@@ -2301,6 +2386,9 @@ class HunyuanImage3Model(nn.Module):
                 k_pad = attention_mask.new_zeros(B, H, Q + pad, pad)
                 attention_mask = torch.cat((attention_mask, k_pad), dim=3)
 
+        if self.hunyuan_enable_flash_comm1:
+            hidden_states = hidden_states.reshape(len(query_lens)*query_lens[0], -1)
+
         for layer_idx, decoder_layer in enumerate(self.layers):
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
@@ -2331,6 +2419,9 @@ class HunyuanImage3Model(nn.Module):
 
             if output_attentions:
                 all_self_attns += (layer_outputs[1],)
+
+        if self.hunyuan_enable_flash_comm1:
+            hidden_states = hidden_states.reshape(len(query_lens), query_lens[0], -1)
 
         # add hidden states from the last decoder layer
         if output_hidden_states:
@@ -2679,8 +2770,7 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
         self._guidance_scale = guidance_scale
         self._guidance_rescale = guidance_rescale
 
-        # Detect CFG parallel configuration (only 2-branch layout is supported)
-        cfg_parallel_ready = self.do_classifier_free_guidance and get_classifier_free_guidance_world_size() == 2
+        cfg_factor = 1 + self.do_classifier_free_guidance
 
         # Define call parameters
         device = self._execution_device
@@ -2708,9 +2798,7 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
         # Prepare extra step kwargs.
         _scheduler_step_extra_kwargs = self.prepare_extra_func_kwargs(self.scheduler.step, {"generator": generator})
 
-        # Prepare model kwargs — attention mask is built from the full
-        # (cfg_factor=2) batch before any splitting so that each rank's
-        # slice is correct.
+        # Prepare model kwargs
         input_ids = model_kwargs.pop("input_ids")
         attention_mask = self.model._prepare_attention_mask_for_generation(  # noqa
             input_ids,
@@ -2757,64 +2845,33 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
 
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
-                if cfg_parallel_ready:
-                    # CFG parallel: each rank forwards its own branch (no batch doubling)
-                    latent_model_input = latents
-                else:
-                    # Sequential CFG: double the batch
-                    latent_model_input = torch.cat([latents] * cfg_factor)
+                # expand the latents if we are doing classifier free guidance
+                latent_model_input = torch.cat([latents] * cfg_factor)
+                # latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
 
                 t_expand = t.repeat(latent_model_input.shape[0])
 
-                # ---- TeaCache: decide whether to compute or reuse ----
-                should_compute = True
-                if tea_cache_config is not None:
-                    with torch.no_grad():
-                        # Use timestep embedding as the modulated input for cache decision
-                        cur_mod = self.model.time_embed(t.unsqueeze(0))
-                    if tc_cnt > 0 and tc_prev_mod is not None:
-                        rel_dist = (
-                            ((cur_mod - tc_prev_mod).abs().mean() / (tc_prev_mod.abs().mean() + 1e-8)).cpu().item()
-                        )
-                        rescaled = float(tc_rescale(rel_dist))
-                        tc_acc_dist += abs(rescaled)
-                        if tc_acc_dist < tea_cache_config.rel_l1_thresh:
-                            should_compute = False
-                        else:
-                            tc_acc_dist = 0.0
-                    tc_prev_mod = cur_mod.detach()
+                model_inputs = self.model.prepare_inputs_for_generation(
+                    input_ids,
+                    images=latent_model_input,
+                    timestep=t_expand,
+                    **model_kwargs,
+                )
 
-                if should_compute:
-                    model_inputs = self.model.prepare_inputs_for_generation(
-                        input_ids,
-                        images=latent_model_input,
-                        timestep=t_expand,
-                        **model_kwargs,
-                    )
+                with torch.autocast(device_type=self.device.type, dtype=torch.bfloat16, enabled=True):
+                    model_output = self.model.forward_call(**model_inputs, first_step=(i == 0))
+                    pred = model_output["diffusion_prediction"]
+                pred = pred.to(dtype=torch.float32)
 
-                    with torch.autocast(device_type=self.device.type, dtype=torch.bfloat16, enabled=True):
-                        model_output = self.model.forward_call(**model_inputs, first_step=(i == 0))
-                        pred = model_output["diffusion_prediction"]
-                    pred = pred.to(dtype=torch.float32)
-
-                    if tea_cache_config is not None:
-                        tc_prev_pred = pred.clone()
-                else:
-                    # TeaCache fast path: reuse previous prediction
-                    pred = tc_prev_pred
-
-                # Perform guidance
-                if cfg_parallel_ready:
-                    # CFG parallel: all_gather → all ranks combine locally (no broadcast needed)
-                    gathered = cfg_group.all_gather(pred, separate_tensors=True)
-                    pred = self.cfg_operator(gathered[0], gathered[1], self.guidance_scale, step=i)
-                elif self.do_classifier_free_guidance:
+                # perform guidance
+                if self.do_classifier_free_guidance:
                     pred_cond, pred_uncond = pred.chunk(2)
                     pred = self.cfg_operator(pred_cond, pred_uncond, self.guidance_scale, step=i)
 
-                # Scheduler step (all ranks compute locally in CFG parallel)
+                # compute the previous noisy sample x_t -> x_t-1
                 latents = self.scheduler.step(pred, t, latents, **_scheduler_step_extra_kwargs, return_dict=False)[0]
-                if i != len(timesteps) - 1 and should_compute:
+
+                if i != len(timesteps) - 1:
                     model_kwargs = self.model._update_model_kwargs_for_generation(  # noqa
                         model_output,
                         model_kwargs,

--- a/vllm_omni/diffusion/models/hunyuan_image_3/hunyuan_image_3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image_3/hunyuan_image_3_transformer.py
@@ -60,7 +60,6 @@ from vllm.model_executor.models.utils import (
 )
 from vllm.v1.attention.backend import AttentionType
 from vllm.forward_context import get_forward_context
-from vllm_ascend.ascend_forward_context import MoECommType
 
 from vllm_omni.diffusion.attention.backends.abstract import (
     AttentionMetadata,

--- a/vllm_omni/diffusion/models/hunyuan_image_3/hunyuan_row_parallel_linear.py
+++ b/vllm_omni/diffusion/models/hunyuan_image_3/hunyuan_row_parallel_linear.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import vllm.forward_context as _vllm_fc
+from vllm.model_executor.layers.linear import RowParallelLinear
+from vllm.utils.import_utils import resolve_obj_by_qualname
+
+from vllm_omni.platforms import current_omni_platform
+
+
+class HunyuanRowParallelLinearDefault(RowParallelLinear):
+    def __init__(self, *args: Any, prefix: str = "", **kwargs: Any) -> None:
+        super().__init__(*args, prefix=prefix, **kwargs)
+        self._prefix = prefix
+        self._init_hook_handle = self.register_forward_pre_hook(
+            self._initialize_kernel_hook,
+            with_kwargs=True,
+        )
+
+    def _initialize_kernel_hook(self, module: Any, args: Any, kwargs: Any) -> None:
+        if self.quant_method:
+            self.quant_method.process_weights_after_loading(self)
+        self._init_hook_handle.remove()
+
+    def forward(
+        self,
+        input_: Any,
+        **kwargs: Any,
+    ) -> Any:
+        return super().forward(input_, **kwargs)
+
+
+class HunyuanRowParallelLinear:
+    def __new__(cls, *args: Any, **kwargs: Any) -> Any:
+        op_name = "hunyuan_row_parallel_linear"
+        current_omni_platform.prepare_diffusion_op_runtime(op_name)
+        impl = resolve_obj_by_qualname(
+            current_omni_platform.get_diffusion_model_impl_qualname(op_name),
+        )
+        return impl(*args, **kwargs)

--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -65,6 +65,8 @@ class OmniPlatform(Platform):
     def get_diffusion_model_impl_qualname(cls, op_name: str) -> str:
         if op_name == "hunyuan_fused_moe":
             return "vllm_omni.diffusion.models.hunyuan_image_3.hunyuan_fused_moe.HunyuanFusedMoEDefault"
+        if op_name == "hunyuan_row_parallel_linear":
+            return "vllm_omni.diffusion.models.hunyuan_image_3.hunyuan_row_parallel_linear.HunyuanRowParallelLinearDefault"
         raise NotImplementedError(f"Unsupported diffusion model op: {op_name}")
 
     @classmethod

--- a/vllm_omni/platforms/npu/models/hunyuan_fused_moe.py
+++ b/vllm_omni/platforms/npu/models/hunyuan_fused_moe.py
@@ -3,18 +3,34 @@
 
 from typing import Any
 
+import os
 import torch
+import torch.distributed as dist
 import vllm.forward_context as _vllm_fc
+from vllm.forward_context import get_forward_context
 from vllm.config import VllmConfig
 from vllm.distributed import get_ep_group
 from vllm.distributed.parallel_state import get_tensor_model_parallel_world_size
 from vllm.distributed.parallel_state import (
     init_model_parallel_group as vllm_init_model_parallel_group,
 )
+from vllm.distributed import get_ep_group, tensor_model_parallel_all_reduce
+
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.ops.fused_moe.fused_moe import AscendSharedFusedMoE
 from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.flash_common3_context import get_flash_common3_context, set_flash_common3_context
+from vllm_ascend.ops.fused_moe.experts_selector import select_experts
+from vllm_ascend.ops.fused_moe.moe_comm_method import AllGatherCommImpl, FusedExpertsResult
+from vllm_ascend.utils import (
+    npu_stream_switch,
+    shared_expert_dp_enabled,
+)
+from vllm_ascend.ops.fused_moe.fused_moe import FusedMoEEvents, FusedMoEResult
 
 from vllm_omni.diffusion.distributed.parallel_state import (
     get_data_parallel_world_size,
@@ -103,9 +119,153 @@ def prepare_hunyuan_fused_moe_runtime() -> None:
     _ensure_forward_context_attr("flash_comm_v1_enabled", bool, False)
 
 
-class AscendHunyuanFusedMoE(AscendSharedFusedMoE):
+class AscendHunyuanFusedMoE(AscendFusedMoE):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+    
+    def forward_impl(  # type: ignore[override]
+        self, hidden_states: torch.Tensor, router_logits: torch.Tensor, return_with_event: bool = False
+    ) -> torch.Tensor | FusedMoEResult:
+        assert self.quant_method is not None
+
+        forward_context = get_forward_context()
+        # When static kernels are enabled, the forward pass runs twice (compilation + capture),
+        # causing moe_layer_index to overflow. Wrap the index to prevent out-of-bounds errors.
+        if self.enable_npugraph_ex_static_kernel:
+            moe_layer_index = forward_context.moe_layer_index % (len(forward_context.all_moe_layers))
+            forward_context.moe_layer_index = moe_layer_index
+
+        # Load balancing for token distribution among experts in dummy_run
+        # TODO: The community only considers load balancing when DP > 1.
+        # This approach may overlook some extreme scenarios.
+        enable_force_load_balance = _EXTRA_CTX.in_profile_run
+
+        forward_context = get_forward_context()
+        if self.multistream_overlap_gate:
+            assert AscendFusedMoE.gate_stream is not None
+            fc3_context = get_flash_common3_context()
+            assert fc3_context is not None
+            AscendFusedMoE.gate_stream.wait_stream(torch.npu.current_stream())
+            with npu_stream_switch(AscendFusedMoE.gate_stream, enabled=self.multistream_overlap_gate):
+                # share_expert
+                assert fc3_context.shared_experts is not None
+                shared_out = fc3_context.shared_experts(hidden_states)
+                # NOTE: This is exactly the opposite of `maybe_all_reduce_tensor_model_parallel`
+                moe_comm_type = _EXTRA_CTX.moe_comm_type
+                if (
+                    moe_comm_type in {MoECommType.ALLTOALL, MoECommType.MC2, MoECommType.FUSED_MC2}
+                    and not shared_expert_dp_enabled()
+                ):
+                    shared_out = tensor_model_parallel_all_reduce(shared_out)
+                set_flash_common3_context(shared_out=shared_out)
+
+                topk_weights, topk_ids = select_experts(
+                    hidden_states=hidden_states,
+                    router_logits=router_logits,
+                    top_k=self.top_k,
+                    use_grouped_topk=self.use_grouped_topk,
+                    renormalize=self.renormalize,
+                    topk_group=self.topk_group,
+                    num_expert_group=self.num_expert_group,
+                    custom_routing_function=self.custom_routing_function,
+                    scoring_func=self.scoring_func,
+                    routed_scaling_factor=self.routed_scaling_factor,
+                    e_score_correction_bias=self.e_score_correction_bias,
+                    global_num_experts=self.global_num_experts,
+                )
+
+                if isinstance(_EXTRA_CTX.moe_comm_method, AllGatherCommImpl):
+                    topk_weights = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(topk_weights, True, True)
+                    topk_ids = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(topk_ids, True, True)
+
+                set_flash_common3_context(topk_weights=topk_weights, topk_ids=topk_ids)
+
+        if getattr(forward_context, "moe_comm_type", None) == MoECommType.ALLTOALL:
+            replace_allreduce = getattr(forward_context, "row_parallel_linear_fc1_enabled", None)
+        else:
+            replace_allreduce = _EXTRA_CTX.flash_comm_v1_enabled
+
+        hidden_states, router_logits, mc2_mask, context_metadata = _EXTRA_CTX.moe_comm_method.prepare(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            replace_allreduce=replace_allreduce,
+            enable_shared_expert_dp=self.enable_shared_expert_dp,
+            quant_type=self.quant_type,
+        )
+
+        # Make sure the default stream waits for the gate stream to finish.
+        if self.multistream_overlap_gate:
+            torch.npu.current_stream().wait_stream(AscendFusedMoE.gate_stream)
+
+        if isinstance(hidden_states, tuple):
+            hidden_states, pertoken_scale = hidden_states
+        else:
+            pertoken_scale = None
+
+        # Matrix multiply.
+        fused_experts_results: FusedExpertsResult = self.quant_method.apply(
+            layer=self,
+            x=hidden_states,
+            router_logits=router_logits,
+            pertoken_scale=pertoken_scale,
+            top_k=self.top_k,
+            renormalize=self.renormalize,
+            use_grouped_topk=self.use_grouped_topk,
+            global_num_experts=self.global_num_experts,
+            expert_map=self._expert_map,
+            topk_group=self.topk_group,
+            num_expert_group=self.num_expert_group,
+            custom_routing_function=self.custom_routing_function,
+            scoring_func=self.scoring_func,
+            routed_scaling_factor=self.routed_scaling_factor,
+            e_score_correction_bias=self.e_score_correction_bias,
+            activation=self.activation,
+            apply_router_weight_on_input=self.apply_router_weight_on_input,
+            enable_force_load_balance=enable_force_load_balance,
+            log2phy=self.log2phy,
+            global_redundant_expert_num=self.global_redundant_expert_num,
+            mc2_mask=mc2_mask,
+        )
+
+        if self.dynamic_eplb:
+            expert_tokens = fused_experts_results.expert_tokens
+            group_list_type = fused_experts_results.group_list_type
+            assert expert_tokens is not None and group_list_type is not None, (
+                "expert_tokens and group_list_type should not be None when dynamic_eplb is enabled."
+            )
+            local_load = (
+                expert_tokens
+                if group_list_type == 1
+                else torch.cat([expert_tokens[:1], expert_tokens[1:] - expert_tokens[:-1]])
+            )
+            if self.multi_stage:
+                cur_iter = torch.remainder(self.load_counter, self.num_iter)
+                self.moe_load.index_add_(
+                    dim=0, index=cur_iter, source=local_load.to(torch.int32, non_blocking=True).view(1, -1)
+                )
+                self.load_counter.add_(1)
+            else:
+                self.moe_load.add_(local_load)
+        routed_out = _EXTRA_CTX.moe_comm_method.finalize(
+            hidden_states=fused_experts_results.routed_out,
+            reduce_results=self.reduce_results,
+            context_metadata=context_metadata,
+        )
+
+        if return_with_event:
+            return FusedMoEResult(
+                routed_out=routed_out,
+                before_dispatch_evt=fused_experts_results.before_dispatch_evt,
+                before_combine_evt=fused_experts_results.before_combine_evt,
+            )
+        else:
+            # The vLLM FusedMoE forward_impl does not return events.
+            return routed_out
+
+
+class AscendHunyuanSharedFusedMoE(AscendSharedFusedMoE, AscendHunyuanFusedMoE):
     def __init__(self, *, prefix: str = "", **kwargs: Any) -> None:
-        super().__init__(prefix=prefix, **kwargs)
+        AscendSharedFusedMoE.__init__(self, prefix=prefix, **kwargs)
         self._prefix = prefix
         self._init_hook_handle = self.register_forward_pre_hook(self._initialize_kernel_hook, with_kwargs=True)
 
@@ -116,7 +276,63 @@ class AscendHunyuanFusedMoE(AscendSharedFusedMoE):
 
     def forward(self, hidden_states: Any, router_logits: Any) -> Any:
         _set_hunyuan_fused_moe_forward_context(hidden_states.shape[0])
-        return super().forward(hidden_states, router_logits)
+        if self._shared_experts is None:
+            fused_out = self.forward_impl(hidden_states=hidden_states, router_logits=router_logits,)
+            shared_out = None
+            return shared_out, fused_out
+        return self.forward_impl(hidden_states=hidden_states, router_logits=router_logits)
+    
+    def forward_impl(  # type: ignore[override]
+        self, hidden_states: torch.Tensor, router_logits: torch.Tensor
+    ):  
+        if self.multistream_overlap_gate:
+            set_flash_common3_context(shared_experts=self._shared_experts)
+
+        before_routed_experts = torch.npu.current_stream().record_event()
+        fused_moe_results = AscendHunyuanFusedMoE.forward_impl(
+            self,
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            return_with_event=True,
+        )
+        routed_out = fused_moe_results.routed_out
+        if self._shared_experts is None:
+            return routed_out
+        
+        if self.multistream_overlap_gate:
+            fc3_context = get_flash_common3_context()
+            assert fc3_context is not None
+            shared_out = fc3_context.shared_out
+        else:
+            forward_context = get_forward_context()
+            if forward_context.moe_comm_type == MoECommType.ALLTOALL and forward_context.row_parallel_linear_fc1_enabled:
+                world_size = dist.get_world_size()
+                local_rank, world_size = dist.get_rank(), dist.get_world_size()
+                hidden_states_ = torch.zeros([world_size * hidden_states.shape[0], *hidden_states.shape[1:]], device=hidden_states.device, dtype=hidden_states.dtype)
+                torch.distributed.all_gather_into_tensor(hidden_states_, hidden_states)
+                hidden_states = hidden_states_
+                hidden_states = hidden_states.contiguous()
+                
+                shared_out = self._forward_shared_experts(
+                    hidden_states,
+                    FusedMoEEvents(
+                        before_routed_experts=before_routed_experts,
+                        before_dispatch=fused_moe_results.before_dispatch_evt,
+                        before_combine=fused_moe_results.before_combine_evt,
+                    ),
+                )   
+                shared_out_chunk = torch.chunk(shared_out, world_size, dim=0)
+                shared_out = shared_out_chunk[local_rank]
+            else:
+                shared_out = self._forward_shared_experts(
+                    hidden_states,
+                    FusedMoEEvents(
+                        before_routed_experts=before_routed_experts,
+                        before_dispatch=fused_moe_results.before_dispatch_evt,
+                        before_combine=fused_moe_results.before_combine_evt,
+                    ),
+                )
+        return shared_out, routed_out
 
     def __del__(self):
         import vllm_ascend.distributed.parallel_state as vllm_ascend_parallel_state

--- a/vllm_omni/platforms/npu/models/hunyuan_fused_moe.py
+++ b/vllm_omni/platforms/npu/models/hunyuan_fused_moe.py
@@ -14,23 +14,17 @@ from vllm.distributed.parallel_state import get_tensor_model_parallel_world_size
 from vllm.distributed.parallel_state import (
     init_model_parallel_group as vllm_init_model_parallel_group,
 )
-from vllm.distributed import get_ep_group, tensor_model_parallel_all_reduce
+from vllm.distributed import get_ep_group
 
 from vllm_ascend.ascend_forward_context import MoECommType
-from vllm_ascend.ops.fused_moe.fused_moe import AscendSharedFusedMoE
+from vllm_ascend.ops.fused_moe.fused_moe import AscendSharedFusedMoE, AscendFusedMoE
 from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.flash_common3_context import get_flash_common3_context, set_flash_common3_context
-from vllm_ascend.ops.fused_moe.experts_selector import select_experts
-from vllm_ascend.ops.fused_moe.moe_comm_method import AllGatherCommImpl, FusedExpertsResult
-from vllm_ascend.utils import (
-    npu_stream_switch,
-    shared_expert_dp_enabled,
-)
-from vllm_ascend.ops.fused_moe.fused_moe import FusedMoEEvents, FusedMoEResult
+from vllm_ascend.ops.fused_moe.fused_moe import FusedMoEEvents
 
 from vllm_omni.diffusion.distributed.parallel_state import (
     get_data_parallel_world_size,
@@ -54,7 +48,6 @@ def _set_hunyuan_fused_moe_forward_context(num_tokens: int) -> None:
     forward_context.num_tokens = num_tokens
     forward_context.moe_comm_type = _select_moe_comm_method(vllm_config=omni_get_ctx().vllm_config)
     forward_context.moe_comm_method = _MoECommMethods.get(forward_context.moe_comm_type)
-    forward_context.flash_comm_v1_enabled = False
 
 
 def _init_mc2_group_for_diffusion(
@@ -112,158 +105,19 @@ def prepare_hunyuan_fused_moe_runtime() -> None:
     )
 
     moe_comm_type = _select_moe_comm_method(vllm_config=omni_get_ctx().vllm_config)
+    if moe_comm_type == MoECommType.ALLTOALL:
+        moe_comm_type_name = "ALLTOALL"
+    else:
+        moe_comm_type_name = "ALLGATHER"
     _ensure_forward_context_attr("num_tokens", int | None, None)
     _ensure_forward_context_attr("in_profile_run", bool, False)
     _ensure_forward_context_attr("moe_comm_type", MoECommType | None, moe_comm_type)
+    _ensure_forward_context_attr("moe_comm_type_name", str | None, moe_comm_type_name)
     _ensure_forward_context_attr("moe_comm_method", Any, _MoECommMethods.get(moe_comm_type))
     _ensure_forward_context_attr("flash_comm_v1_enabled", bool, False)
-
-
-class AscendHunyuanFusedMoE(AscendFusedMoE):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
     
-    def forward_impl(  # type: ignore[override]
-        self, hidden_states: torch.Tensor, router_logits: torch.Tensor, return_with_event: bool = False
-    ) -> torch.Tensor | FusedMoEResult:
-        assert self.quant_method is not None
-
-        forward_context = get_forward_context()
-        # When static kernels are enabled, the forward pass runs twice (compilation + capture),
-        # causing moe_layer_index to overflow. Wrap the index to prevent out-of-bounds errors.
-        if self.enable_npugraph_ex_static_kernel:
-            moe_layer_index = forward_context.moe_layer_index % (len(forward_context.all_moe_layers))
-            forward_context.moe_layer_index = moe_layer_index
-
-        # Load balancing for token distribution among experts in dummy_run
-        # TODO: The community only considers load balancing when DP > 1.
-        # This approach may overlook some extreme scenarios.
-        enable_force_load_balance = _EXTRA_CTX.in_profile_run
-
-        forward_context = get_forward_context()
-        if self.multistream_overlap_gate:
-            assert AscendFusedMoE.gate_stream is not None
-            fc3_context = get_flash_common3_context()
-            assert fc3_context is not None
-            AscendFusedMoE.gate_stream.wait_stream(torch.npu.current_stream())
-            with npu_stream_switch(AscendFusedMoE.gate_stream, enabled=self.multistream_overlap_gate):
-                # share_expert
-                assert fc3_context.shared_experts is not None
-                shared_out = fc3_context.shared_experts(hidden_states)
-                # NOTE: This is exactly the opposite of `maybe_all_reduce_tensor_model_parallel`
-                moe_comm_type = _EXTRA_CTX.moe_comm_type
-                if (
-                    moe_comm_type in {MoECommType.ALLTOALL, MoECommType.MC2, MoECommType.FUSED_MC2}
-                    and not shared_expert_dp_enabled()
-                ):
-                    shared_out = tensor_model_parallel_all_reduce(shared_out)
-                set_flash_common3_context(shared_out=shared_out)
-
-                topk_weights, topk_ids = select_experts(
-                    hidden_states=hidden_states,
-                    router_logits=router_logits,
-                    top_k=self.top_k,
-                    use_grouped_topk=self.use_grouped_topk,
-                    renormalize=self.renormalize,
-                    topk_group=self.topk_group,
-                    num_expert_group=self.num_expert_group,
-                    custom_routing_function=self.custom_routing_function,
-                    scoring_func=self.scoring_func,
-                    routed_scaling_factor=self.routed_scaling_factor,
-                    e_score_correction_bias=self.e_score_correction_bias,
-                    global_num_experts=self.global_num_experts,
-                )
-
-                if isinstance(_EXTRA_CTX.moe_comm_method, AllGatherCommImpl):
-                    topk_weights = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(topk_weights, True, True)
-                    topk_ids = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(topk_ids, True, True)
-
-                set_flash_common3_context(topk_weights=topk_weights, topk_ids=topk_ids)
-
-        if getattr(forward_context, "moe_comm_type", None) == MoECommType.ALLTOALL:
-            replace_allreduce = getattr(forward_context, "row_parallel_linear_fc1_enabled", None)
-        else:
-            replace_allreduce = _EXTRA_CTX.flash_comm_v1_enabled
-
-        hidden_states, router_logits, mc2_mask, context_metadata = _EXTRA_CTX.moe_comm_method.prepare(
-            hidden_states=hidden_states,
-            router_logits=router_logits,
-            replace_allreduce=replace_allreduce,
-            enable_shared_expert_dp=self.enable_shared_expert_dp,
-            quant_type=self.quant_type,
-        )
-
-        # Make sure the default stream waits for the gate stream to finish.
-        if self.multistream_overlap_gate:
-            torch.npu.current_stream().wait_stream(AscendFusedMoE.gate_stream)
-
-        if isinstance(hidden_states, tuple):
-            hidden_states, pertoken_scale = hidden_states
-        else:
-            pertoken_scale = None
-
-        # Matrix multiply.
-        fused_experts_results: FusedExpertsResult = self.quant_method.apply(
-            layer=self,
-            x=hidden_states,
-            router_logits=router_logits,
-            pertoken_scale=pertoken_scale,
-            top_k=self.top_k,
-            renormalize=self.renormalize,
-            use_grouped_topk=self.use_grouped_topk,
-            global_num_experts=self.global_num_experts,
-            expert_map=self._expert_map,
-            topk_group=self.topk_group,
-            num_expert_group=self.num_expert_group,
-            custom_routing_function=self.custom_routing_function,
-            scoring_func=self.scoring_func,
-            routed_scaling_factor=self.routed_scaling_factor,
-            e_score_correction_bias=self.e_score_correction_bias,
-            activation=self.activation,
-            apply_router_weight_on_input=self.apply_router_weight_on_input,
-            enable_force_load_balance=enable_force_load_balance,
-            log2phy=self.log2phy,
-            global_redundant_expert_num=self.global_redundant_expert_num,
-            mc2_mask=mc2_mask,
-        )
-
-        if self.dynamic_eplb:
-            expert_tokens = fused_experts_results.expert_tokens
-            group_list_type = fused_experts_results.group_list_type
-            assert expert_tokens is not None and group_list_type is not None, (
-                "expert_tokens and group_list_type should not be None when dynamic_eplb is enabled."
-            )
-            local_load = (
-                expert_tokens
-                if group_list_type == 1
-                else torch.cat([expert_tokens[:1], expert_tokens[1:] - expert_tokens[:-1]])
-            )
-            if self.multi_stage:
-                cur_iter = torch.remainder(self.load_counter, self.num_iter)
-                self.moe_load.index_add_(
-                    dim=0, index=cur_iter, source=local_load.to(torch.int32, non_blocking=True).view(1, -1)
-                )
-                self.load_counter.add_(1)
-            else:
-                self.moe_load.add_(local_load)
-        routed_out = _EXTRA_CTX.moe_comm_method.finalize(
-            hidden_states=fused_experts_results.routed_out,
-            reduce_results=self.reduce_results,
-            context_metadata=context_metadata,
-        )
-
-        if return_with_event:
-            return FusedMoEResult(
-                routed_out=routed_out,
-                before_dispatch_evt=fused_experts_results.before_dispatch_evt,
-                before_combine_evt=fused_experts_results.before_combine_evt,
-            )
-        else:
-            # The vLLM FusedMoE forward_impl does not return events.
-            return routed_out
-
-
-class AscendHunyuanSharedFusedMoE(AscendSharedFusedMoE, AscendHunyuanFusedMoE):
+    
+class AscendHunyuanSharedFusedMoE(AscendSharedFusedMoE, AscendFusedMoE):
     def __init__(self, *, prefix: str = "", **kwargs: Any) -> None:
         AscendSharedFusedMoE.__init__(self, prefix=prefix, **kwargs)
         self._prefix = prefix
@@ -276,12 +130,18 @@ class AscendHunyuanSharedFusedMoE(AscendSharedFusedMoE, AscendHunyuanFusedMoE):
 
     def forward(self, hidden_states: Any, router_logits: Any) -> Any:
         _set_hunyuan_fused_moe_forward_context(hidden_states.shape[0])
+        forward_context = _vllm_fc.get_forward_context()
+        ascend_flash_comm_v1_enabled = _EXTRA_CTX.flash_comm_v1_enabled
+        _EXTRA_CTX.flash_comm_v1_enabled = forward_context.row_parallel_linear_fc1_enabled
         if self._shared_experts is None:
             fused_out = self.forward_impl(hidden_states=hidden_states, router_logits=router_logits,)
             shared_out = None
             return shared_out, fused_out
-        return self.forward_impl(hidden_states=hidden_states, router_logits=router_logits)
-    
+        try:
+            return self.forward_impl(hidden_states=hidden_states, router_logits=router_logits,)
+        finally:
+            _EXTRA_CTX.flash_comm_v1_enabled = ascend_flash_comm_v1_enabled
+            
     def forward_impl(  # type: ignore[override]
         self, hidden_states: torch.Tensor, router_logits: torch.Tensor
     ):  
@@ -289,7 +149,7 @@ class AscendHunyuanSharedFusedMoE(AscendSharedFusedMoE, AscendHunyuanFusedMoE):
             set_flash_common3_context(shared_experts=self._shared_experts)
 
         before_routed_experts = torch.npu.current_stream().record_event()
-        fused_moe_results = AscendHunyuanFusedMoE.forward_impl(
+        fused_moe_results = AscendFusedMoE.forward_impl(
             self,
             hidden_states=hidden_states,
             router_logits=router_logits,

--- a/vllm_omni/platforms/npu/models/hunyuan_row_parallel_linear.py
+++ b/vllm_omni/platforms/npu/models/hunyuan_row_parallel_linear.py
@@ -6,6 +6,23 @@ from typing import Any
 import vllm.forward_context as _vllm_fc
 from vllm_ascend.ops.linear import AscendRowParallelLinear
 from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm_ascend.ops.linear_op import CustomRowParallelOp
+from vllm.distributed import (
+    split_tensor_along_last_dim,
+    tensor_model_parallel_all_reduce,
+    tensor_model_parallel_reduce_scatter,
+)
+from vllm.distributed.parallel_state import get_tp_group
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+from vllm_ascend.quantization.methods import AscendW8A8LinearMethod
+
+import torch
+import torch_npu
+import torch.nn.functional as F
+from torch.nn.parameter import Parameter
+import os
 
 def _ensure_forward_context_attr(name: str, annotation: Any, default: Any) -> None:
     if name not in _vllm_fc.ForwardContext.__annotations__:
@@ -25,8 +42,6 @@ def _set_hunyuan_row_parallel_linear_forward_context(num_tokens: int) -> None:
         return
 
     forward_context = _vllm_fc.get_forward_context()
-    # forward_context.num_tokens = num_tokens
-    import os
     forward_context.row_parallel_linear_fc1_enabled = bool(int(os.getenv("HY_IMAGE_3_ENABLE_FLASHCOMM1", 0)))
     forward_context.mmrs_fusion = True
     if forward_context.row_parallel_linear_fc1_enabled:
@@ -34,9 +49,127 @@ def _set_hunyuan_row_parallel_linear_forward_context(num_tokens: int) -> None:
         fc1_pad_size = (tp_world_size - (num_tokens % tp_world_size)) % tp_world_size
         forward_context.fc1_pad_size = fc1_pad_size
 
+class HunyuanSequenceRowParallelOp(CustomRowParallelOp):
+    def __init__(self, layer):
+        super().__init__(layer)
+        self.unique_prefix = None
+
+    def apply(self, input_):
+        output, output_bias = self.apply_impl(input_)
+
+        if not self.return_bias:
+            return output
+        return output, output_bias
+    
+    def apply_impl(self, input_: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        """Linear layer with column parallelism.
+
+        Implemented multiple optimization projects for dense models, such as FlashComm and
+        communication-computation fusion.
+        """
+        if self.input_is_parallel:
+            input_parallel = input_
+        else:
+            splitted_input = split_tensor_along_last_dim(input_, num_partitions=self.tp_size)
+            input_parallel = splitted_input[self.tp_rank].contiguous()
+
+        assert self.quant_method is not None
+        bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
+
+        if self.tp_size == 1 or not self.reduce_results:
+            output = self.quant_method.apply(self.layer, input_parallel, bias=bias_)
+        else:
+            output = self.matmul_and_reduce(input_parallel, bias_)
+
+        output_bias = self.bias if self.skip_bias_add else None
+        return output, output_bias
+
+    def matmul_and_reduce(self, input_parallel: torch.Tensor, bias_: Parameter | None) -> torch.Tensor:
+        assert self.quant_method is not None
+        forward_context = get_forward_context()
+        try:
+            flash_comm_v1_enabled = forward_context.row_parallel_linear_fc1_enabled
+            mmrs_fusion = forward_context.mmrs_fusion
+            pad_size = forward_context.fc1_pad_size
+        except AssertionError:
+            flash_comm_v1_enabled = False
+            mmrs_fusion = False
+            pad_size = 0
+
+        x = input_parallel
+
+        if not flash_comm_v1_enabled:
+            output_parallel = self.layer.quant_method.apply(self.layer, x, bias=bias_)
+            return tensor_model_parallel_all_reduce(output_parallel)
+
+        if pad_size > 0:
+            x = F.pad(x, (0, 0, 0, pad_size))
+        world_size = self.layer.tp_size
+        comm_mode = "aiv"
+        hcom_name = get_tp_group().device_group._get_backend(torch.device("npu")).get_hccl_comm_name(self.layer.tp_rank)
+
+        # For unquant
+        if mmrs_fusion and isinstance(self.layer.quant_method, UnquantizedLinearMethod):
+            output = torch_npu.npu_mm_reduce_scatter_base(
+                x,
+                self.layer.weight.t(),
+                hcom_name,
+                world_size,
+                reduce_op="sum",
+                # bias=None,
+                bias=bias_,
+                comm_turn=0,
+                comm_mode=comm_mode,
+            )
+            if bias_ is not None:
+                output.add_(bias_)
+        # For w8a8 quant
+        elif mmrs_fusion and (
+            isinstance(self.layer.quant_method, AscendLinearMethod)
+            and isinstance(self.layer.quant_method.quant_method, AscendW8A8LinearMethod)
+        ):
+            if x.dtype != torch.int8:
+                x_quant = torch.ops.vllm.quantize(
+                    x,
+                    self.layer.aclnn_input_scale,
+                    self.layer.aclnn_input_scale_reciprocal,
+                    self.layer.aclnn_input_offset,
+                )
+            else:
+                x_quant = x
+            quant_bias = self.layer.quant_bias
+            deq_scale = self.layer.deq_scale
+            output_dtype = torch.bfloat16
+            output = torch_npu.npu_mm_reduce_scatter_base(
+                x_quant,
+                self.layer.weight,
+                hcom_name,
+                world_size,
+                reduce_op="sum",
+                bias=None,
+                comm_turn=0,
+                x2_scale=deq_scale,
+                output_dtype=output_dtype,
+                comm_mode=comm_mode,
+            )
+            output = torch.add(output, torch.mul(quant_bias, deq_scale).to(self.layer.params_dtype))
+        else:
+            output_parallel = self.layer.quant_method.apply(self.layer, x, bias=bias_)
+            output = tensor_model_parallel_reduce_scatter(output_parallel, 0)
+        return output
+
+    def update_attrs(self):
+        super().update_attrs()
+        self.input_is_parallel = self.layer.input_is_parallel
+        self.reduce_results = self.layer.reduce_results
+
+
 class AscendHunyuanRowParallelLinear(AscendRowParallelLinear):
     def __init__(self, *args: Any, prefix: str = "", **kwargs: Any) -> None:
         super().__init__(*args, prefix=prefix, **kwargs)
+        self.custom_op = HunyuanSequenceRowParallelOp(self)
+        if self.custom_op is not None:
+            self.custom_op.update_attrs()
         self._prefix = prefix
         self._init_hook_handle = self.register_forward_pre_hook(
             self._initialize_kernel_hook,
@@ -54,5 +187,7 @@ class AscendHunyuanRowParallelLinear(AscendRowParallelLinear):
         **kwargs: Any,
     ) -> Any:
         _set_hunyuan_row_parallel_linear_forward_context(input_.shape[0])
-        return super().forward(input_, **kwargs)
+        if self.custom_op is not None:
+            return self.custom_op.apply(input_)
 
+        return super().forward(input_, **kwargs)

--- a/vllm_omni/platforms/npu/models/hunyuan_row_parallel_linear.py
+++ b/vllm_omni/platforms/npu/models/hunyuan_row_parallel_linear.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import vllm.forward_context as _vllm_fc
+from vllm_ascend.ops.linear import AscendRowParallelLinear
+from vllm.distributed import get_tensor_model_parallel_world_size
+
+def _ensure_forward_context_attr(name: str, annotation: Any, default: Any) -> None:
+    if name not in _vllm_fc.ForwardContext.__annotations__:
+        _vllm_fc.ForwardContext.__annotations__[name] = annotation
+    if not hasattr(_vllm_fc.ForwardContext, name):
+        setattr(_vllm_fc.ForwardContext, name, default)
+
+
+def prepare_hunyuan_row_parallel_linear_runtime() -> None:
+    _ensure_forward_context_attr("row_parallel_linear_fc1_enabled", bool, False)
+    _ensure_forward_context_attr("mmrs_fusion", bool, False)
+    _ensure_forward_context_attr("fc1_pad_size", bool, 0)
+
+
+def _set_hunyuan_row_parallel_linear_forward_context(num_tokens: int) -> None:
+    if not _vllm_fc.is_forward_context_available():
+        return
+
+    forward_context = _vllm_fc.get_forward_context()
+    # forward_context.num_tokens = num_tokens
+    import os
+    forward_context.row_parallel_linear_fc1_enabled = bool(int(os.getenv("HY_IMAGE_3_ENABLE_FLASHCOMM1", 0)))
+    forward_context.mmrs_fusion = True
+    if forward_context.row_parallel_linear_fc1_enabled:
+        tp_world_size = get_tensor_model_parallel_world_size()
+        fc1_pad_size = (tp_world_size - (num_tokens % tp_world_size)) % tp_world_size
+        forward_context.fc1_pad_size = fc1_pad_size
+
+class AscendHunyuanRowParallelLinear(AscendRowParallelLinear):
+    def __init__(self, *args: Any, prefix: str = "", **kwargs: Any) -> None:
+        super().__init__(*args, prefix=prefix, **kwargs)
+        self._prefix = prefix
+        self._init_hook_handle = self.register_forward_pre_hook(
+            self._initialize_kernel_hook,
+            with_kwargs=True,
+        )
+
+    def _initialize_kernel_hook(self, module: Any, args: Any, kwargs: Any) -> None:
+        if self.quant_method:
+            self.quant_method.process_weights_after_loading(self)
+        self._init_hook_handle.remove()
+
+    def forward(
+        self,
+        input_: Any,
+        **kwargs: Any,
+    ) -> Any:
+        _set_hunyuan_row_parallel_linear_forward_context(input_.shape[0])
+        return super().forward(input_, **kwargs)
+

--- a/vllm_omni/platforms/npu/models/hunyuan_row_parallel_linear.py
+++ b/vllm_omni/platforms/npu/models/hunyuan_row_parallel_linear.py
@@ -6,21 +6,13 @@ from typing import Any
 import vllm.forward_context as _vllm_fc
 from vllm_ascend.ops.linear import AscendRowParallelLinear
 from vllm.distributed import get_tensor_model_parallel_world_size
-from vllm_ascend.ops.linear_op import CustomRowParallelOp
+from vllm_ascend.ops.linear_op import SequenceRowParallelOp
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm.distributed import (
     split_tensor_along_last_dim,
-    tensor_model_parallel_all_reduce,
-    tensor_model_parallel_reduce_scatter,
 )
-from vllm.distributed.parallel_state import get_tp_group
-from vllm.forward_context import get_forward_context
-from vllm.model_executor.layers.linear import UnquantizedLinearMethod
-from vllm_ascend.quantization.method_adapters import AscendLinearMethod
-from vllm_ascend.quantization.methods import AscendW8A8LinearMethod
 
 import torch
-import torch_npu
-import torch.nn.functional as F
 from torch.nn.parameter import Parameter
 import os
 
@@ -49,7 +41,27 @@ def _set_hunyuan_row_parallel_linear_forward_context(num_tokens: int) -> None:
         fc1_pad_size = (tp_world_size - (num_tokens % tp_world_size)) % tp_world_size
         forward_context.fc1_pad_size = fc1_pad_size
 
-class HunyuanSequenceRowParallelOp(CustomRowParallelOp):
+def _set_hunyuan_row_parallel_linear_ascend_forward_context() -> None:
+    try:
+        flash_comm_v1_enabled = _EXTRA_CTX.flash_comm_v1_enabled
+        mmrs_fusion = _EXTRA_CTX.mmrs_fusion
+    except AssertionError:
+        flash_comm_v1_enabled = False
+        mmrs_fusion = False
+
+    try:
+        pad_size = _EXTRA_CTX.pad_size
+    except AttributeError:
+        pad_size = 0
+
+    forward_context = _vllm_fc.get_forward_context()
+    _EXTRA_CTX.flash_comm_v1_enabled = forward_context.row_parallel_linear_fc1_enabled
+    _EXTRA_CTX.mmrs_fusion = forward_context.mmrs_fusion
+    _EXTRA_CTX.pad_size = forward_context.fc1_pad_size
+    return flash_comm_v1_enabled, mmrs_fusion, pad_size
+
+
+class HunyuanSequenceRowParallelOp(SequenceRowParallelOp):
     def __init__(self, layer):
         super().__init__(layer)
         self.unique_prefix = None
@@ -62,11 +74,6 @@ class HunyuanSequenceRowParallelOp(CustomRowParallelOp):
         return output, output_bias
     
     def apply_impl(self, input_: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
-        """Linear layer with column parallelism.
-
-        Implemented multiple optimization projects for dense models, such as FlashComm and
-        communication-computation fusion.
-        """
         if self.input_is_parallel:
             input_parallel = input_
         else:
@@ -84,80 +91,6 @@ class HunyuanSequenceRowParallelOp(CustomRowParallelOp):
         output_bias = self.bias if self.skip_bias_add else None
         return output, output_bias
 
-    def matmul_and_reduce(self, input_parallel: torch.Tensor, bias_: Parameter | None) -> torch.Tensor:
-        assert self.quant_method is not None
-        forward_context = get_forward_context()
-        try:
-            flash_comm_v1_enabled = forward_context.row_parallel_linear_fc1_enabled
-            mmrs_fusion = forward_context.mmrs_fusion
-            pad_size = forward_context.fc1_pad_size
-        except AssertionError:
-            flash_comm_v1_enabled = False
-            mmrs_fusion = False
-            pad_size = 0
-
-        x = input_parallel
-
-        if not flash_comm_v1_enabled:
-            output_parallel = self.layer.quant_method.apply(self.layer, x, bias=bias_)
-            return tensor_model_parallel_all_reduce(output_parallel)
-
-        if pad_size > 0:
-            x = F.pad(x, (0, 0, 0, pad_size))
-        world_size = self.layer.tp_size
-        comm_mode = "aiv"
-        hcom_name = get_tp_group().device_group._get_backend(torch.device("npu")).get_hccl_comm_name(self.layer.tp_rank)
-
-        # For unquant
-        if mmrs_fusion and isinstance(self.layer.quant_method, UnquantizedLinearMethod):
-            output = torch_npu.npu_mm_reduce_scatter_base(
-                x,
-                self.layer.weight.t(),
-                hcom_name,
-                world_size,
-                reduce_op="sum",
-                # bias=None,
-                bias=bias_,
-                comm_turn=0,
-                comm_mode=comm_mode,
-            )
-            if bias_ is not None:
-                output.add_(bias_)
-        # For w8a8 quant
-        elif mmrs_fusion and (
-            isinstance(self.layer.quant_method, AscendLinearMethod)
-            and isinstance(self.layer.quant_method.quant_method, AscendW8A8LinearMethod)
-        ):
-            if x.dtype != torch.int8:
-                x_quant = torch.ops.vllm.quantize(
-                    x,
-                    self.layer.aclnn_input_scale,
-                    self.layer.aclnn_input_scale_reciprocal,
-                    self.layer.aclnn_input_offset,
-                )
-            else:
-                x_quant = x
-            quant_bias = self.layer.quant_bias
-            deq_scale = self.layer.deq_scale
-            output_dtype = torch.bfloat16
-            output = torch_npu.npu_mm_reduce_scatter_base(
-                x_quant,
-                self.layer.weight,
-                hcom_name,
-                world_size,
-                reduce_op="sum",
-                bias=None,
-                comm_turn=0,
-                x2_scale=deq_scale,
-                output_dtype=output_dtype,
-                comm_mode=comm_mode,
-            )
-            output = torch.add(output, torch.mul(quant_bias, deq_scale).to(self.layer.params_dtype))
-        else:
-            output_parallel = self.layer.quant_method.apply(self.layer, x, bias=bias_)
-            output = tensor_model_parallel_reduce_scatter(output_parallel, 0)
-        return output
-
     def update_attrs(self):
         super().update_attrs()
         self.input_is_parallel = self.layer.input_is_parallel
@@ -167,6 +100,7 @@ class HunyuanSequenceRowParallelOp(CustomRowParallelOp):
 class AscendHunyuanRowParallelLinear(AscendRowParallelLinear):
     def __init__(self, *args: Any, prefix: str = "", **kwargs: Any) -> None:
         super().__init__(*args, prefix=prefix, **kwargs)
+        self.unique_prefix=None
         self.custom_op = HunyuanSequenceRowParallelOp(self)
         if self.custom_op is not None:
             self.custom_op.update_attrs()
@@ -187,7 +121,12 @@ class AscendHunyuanRowParallelLinear(AscendRowParallelLinear):
         **kwargs: Any,
     ) -> Any:
         _set_hunyuan_row_parallel_linear_forward_context(input_.shape[0])
+        flash_comm_v1_enabled, mmrs_fusion, pad_size = _set_hunyuan_row_parallel_linear_ascend_forward_context()
         if self.custom_op is not None:
             return self.custom_op.apply(input_)
-
-        return super().forward(input_, **kwargs)
+        try:
+            return super().forward(input_, **kwargs)
+        finally:
+            _EXTRA_CTX.flash_comm_v1_enabled = flash_comm_v1_enabled
+            _EXTRA_CTX.mmrs_fusion = mmrs_fusion
+            _EXTRA_CTX.pad_size = pad_size

--- a/vllm_omni/platforms/npu/platform.py
+++ b/vllm_omni/platforms/npu/platform.py
@@ -39,19 +39,27 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
     @classmethod
     def get_diffusion_model_impl_qualname(cls, op_name: str) -> str:
         if op_name == "hunyuan_fused_moe":
-            return "vllm_omni.platforms.npu.models.hunyuan_fused_moe.AscendHunyuanFusedMoE"
+            return "vllm_omni.platforms.npu.models.hunyuan_fused_moe.AscendHunyuanSharedFusedMoE"
+        if op_name == "hunyuan_row_parallel_linear":
+            return "vllm_omni.platforms.npu.models.hunyuan_row_parallel_linear.AscendHunyuanRowParallelLinear"
         return super().get_diffusion_model_impl_qualname(op_name)
 
     @classmethod
     def prepare_diffusion_op_runtime(cls, op_name: str, **kwargs: Any) -> None:
-        if op_name != "hunyuan_fused_moe":
+        if op_name == "hunyuan_fused_moe":
+            from vllm_omni.platforms.npu.models.hunyuan_fused_moe import (
+                prepare_hunyuan_fused_moe_runtime,
+            )
+            prepare_hunyuan_fused_moe_runtime()
+
+        elif op_name == "hunyuan_row_parallel_linear":
+            from vllm_omni.platforms.npu.models.hunyuan_row_parallel_linear import (
+                prepare_hunyuan_row_parallel_linear_runtime,
+            )
+
+            prepare_hunyuan_row_parallel_linear_runtime()
+        else:
             return
-
-        from vllm_omni.platforms.npu.models.hunyuan_fused_moe import (
-            prepare_hunyuan_fused_moe_runtime,
-        )
-
-        prepare_hunyuan_fused_moe_runtime()
 
     @classmethod
     def get_diffusion_attn_backend_cls(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Support NPU FlashComm_v1 for HunyuanImage3.0 to accelerating model inference performance when tp size >1.

FlashComm_v1(FC1) is a NPU Feature to transform all_reduce to reduce_scatter + all_gather,  which needs to use NPU operator 'mm_reduce_scatter' in o_linear of HunyuanImage3.0, and insert all_gather before MoE module when MoE communication type is all_gather or insert all_gather in  when MoE communication type is all_to_all. An important change is adding all_gather before qkv_linear to ensure full hidden_states in rope and follow-up attention caculation.

## Test Plan
```
python examples/offline_inference/text_to_image/text_to_image.py --model /data/models/tencent/HunyuanImage-3.0 --prompt "A brown and white dog is running on the grass" --output output_without_tp.png --num-inference-steps 50 --guidance-scale 5.0 --seed 1234 --enable-diffusion-pipeline-profiler
```

## Test Result
910B
| case | image | step | enable_FC1 | dit time | output |
| ----- | ----- | ----- | ----- | ----- | ----- |
| TP4+EP | 1024*1024 | 50 | False | 27.95s | 
| TP4+EP | 1024*1024 | 50 | True | 26.30s |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
