### PR TITLE
[Fix] Limit Qwen-Image-Edit-2511 input images to 3

### DIFF
--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -128,3 +128,51 @@ def test_attach_llm_stage_uses_omni_input_preprocessor(monkeypatch):
     assert input_processor is not None
     assert isinstance(input_processor.input_preprocessor, DummyOmniInputPreprocessor)
     assert input_processor.input_preprocessor.renderer is input_processor.renderer
+
+
+def test_initialize_diffusion_stage_populates_multimodal_limits(monkeypatch):
+    """Diffusion serving should expose enriched image-count limits to the API layer."""
+    import vllm_omni.engine.stage_init_utils as init_mod
+    from vllm_omni.engine.stage_init_utils import StageMetadata, initialize_diffusion_stage
+
+    captured = {}
+
+    class DummyStageDiffusionClient:
+        def __init__(self, model, od_config, metadata, batch_size=1):
+            captured["model"] = model
+            captured["od_config"] = od_config
+            captured["metadata"] = metadata
+            captured["batch_size"] = batch_size
+
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.stage_diffusion_client.StageDiffusionClient",
+        DummyStageDiffusionClient,
+    )
+    monkeypatch.setattr(
+        init_mod,
+        "get_hf_file_to_dict",
+        lambda filename, _model: {"_class_name": "QwenImageEditPlusPipeline"} if filename == "model_index.json" else None,
+    )
+
+    metadata = StageMetadata(
+        stage_id=0,
+        stage_type="diffusion",
+        engine_output_type="image",
+        is_comprehension=False,
+        requires_multimodal_data=False,
+        engine_input_source=[],
+        final_output=True,
+        final_output_type="image",
+        default_sampling_params=types.SimpleNamespace(),
+        custom_process_input_func=None,
+        model_stage=None,
+        runtime_cfg=None,
+    )
+    stage_cfg = types.SimpleNamespace(engine_args={})
+
+    initialize_diffusion_stage("Qwen/Qwen-Image-Edit-2511", stage_cfg, metadata, batch_size=1)
+
+    assert captured["model"] == "Qwen/Qwen-Image-Edit-2511"
+    assert captured["od_config"].model_class_name == "QwenImageEditPlusPipeline"
+    assert captured["od_config"].supports_multimodal_inputs is True
+    assert captured["od_config"].max_input_images == 3

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -782,6 +782,54 @@ def test_image_edit_rejects_multiple_images_when_model_does_not_support_them(asy
     assert engine.captured_prompt is None
 
 
+def test_image_edit_allows_up_to_model_max_input_images(async_omni_test_client):
+    img_bytes_1 = make_test_image_bytes((16, 16))
+    img_bytes_2 = make_test_image_bytes((32, 32))
+    img_bytes_3 = make_test_image_bytes((48, 48))
+
+    engine = async_omni_test_client.app.state.engine_client
+    engine.get_diffusion_od_config = lambda: SimpleNamespace(supports_multimodal_inputs=True, max_input_images=3)
+
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[
+            ("image", img_bytes_1),
+            ("image", img_bytes_2),
+            ("image", img_bytes_3),
+        ],
+        data={"prompt": "hello world."},
+    )
+
+    assert response.status_code == 200
+    processed_images = engine.captured_prompt["multi_modal_data"]["image"]
+    assert len(processed_images) == 3
+
+
+def test_image_edit_rejects_input_images_above_model_max(async_omni_test_client):
+    img_bytes_1 = make_test_image_bytes((16, 16))
+    img_bytes_2 = make_test_image_bytes((32, 32))
+    img_bytes_3 = make_test_image_bytes((48, 48))
+    img_bytes_4 = make_test_image_bytes((64, 64))
+
+    engine = async_omni_test_client.app.state.engine_client
+    engine.get_diffusion_od_config = lambda: SimpleNamespace(supports_multimodal_inputs=True, max_input_images=3)
+
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[
+            ("image", img_bytes_1),
+            ("image", img_bytes_2),
+            ("image", img_bytes_3),
+            ("image", img_bytes_4),
+        ],
+        data={"prompt": "hello world."},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Received 4 input images. This model supports at most 3 input images."
+    assert engine.captured_prompt is None
+
+
 def test_image_edit_parameter_pass(async_omni_test_client):
     img_bytes_1 = make_test_image_bytes((16, 16))
 

--- a/tests/entrypoints/test_omni_entrypoints.py
+++ b/tests/entrypoints/test_omni_entrypoints.py
@@ -386,6 +386,19 @@ def test_get_diffusion_od_config_returns_diffusion_stage_config():
     omni.engine = SimpleNamespace(
         stage_clients=[
             SimpleNamespace(stage_type="llm"),
+            SimpleNamespace(stage_type="diffusion", od_config=diffusion_od_config),
+        ]
+    )
+
+    assert omni.get_diffusion_od_config() is diffusion_od_config
+
+
+def test_get_diffusion_od_config_falls_back_to_inner_engine():
+    diffusion_od_config = object()
+    omni = object.__new__(AsyncOmni)
+    omni.engine = SimpleNamespace(
+        stage_clients=[
+            SimpleNamespace(stage_type="llm"),
             SimpleNamespace(stage_type="diffusion", _engine=SimpleNamespace(od_config=diffusion_od_config)),
         ]
     )

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -483,6 +483,7 @@ class OmniDiffusionConfig:
 
     # support multi images input
     supports_multimodal_inputs: bool = False
+    max_input_images: int | None = 1
 
     log_level: str = "info"
 
@@ -664,7 +665,11 @@ class OmniDiffusionConfig:
             )
 
     def update_multimodal_support(self) -> None:
-        self.supports_multimodal_inputs = self.model_class_name in {"QwenImageEditPlusPipeline"}
+        multimodal_input_limits = {
+            "QwenImageEditPlusPipeline": 3,
+        }
+        self.max_input_images = multimodal_input_limits.get(self.model_class_name, 1)
+        self.supports_multimodal_inputs = self.max_input_images > 1
 
     @classmethod
     def from_kwargs(cls, **kwargs: Any) -> "OmniDiffusionConfig":

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -44,6 +44,7 @@ from vllm_omni.diffusion.utils.size_utils import (
     normalize_min_aligned_size,
 )
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.entrypoints.openai.image_api_utils import get_input_image_limit_error
 from vllm_omni.inputs.data import OmniTextPrompt
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
@@ -90,6 +91,9 @@ def get_qwen_image_edit_plus_pre_process_func(
 
             if not isinstance(raw_image, list):
                 raw_image = [raw_image]
+            limit_error = get_input_image_limit_error(len(raw_image), od_config.max_input_images)
+            if limit_error is not None:
+                raise ValueError(limit_error)
             image = [
                 PIL.Image.open(im) if isinstance(im, str) else cast(PIL.Image.Image | np.ndarray | torch.Tensor, im)
                 for im in raw_image

--- a/vllm_omni/diffusion/stage_diffusion_client.py
+++ b/vllm_omni/diffusion/stage_diffusion_client.py
@@ -58,6 +58,7 @@ class StageDiffusionClient:
         self.default_sampling_params = metadata.default_sampling_params
         self.custom_process_input_func = metadata.custom_process_input_func
         self.engine_input_source = metadata.engine_input_source
+        self.od_config = od_config
 
         # Spawn StageDiffusionProc subprocess and wait for READY.
         proc, handshake_address, request_address, response_address = spawn_diffusion_proc(model, od_config)

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -19,6 +19,7 @@ from typing import Any, Literal
 
 from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
+from vllm.transformers_utils.config import get_hf_file_to_dict
 from vllm.usage.usage_lib import UsageContext
 from vllm.v1.engine.input_processor import InputProcessor
 from vllm.v1.executor import Executor
@@ -30,6 +31,20 @@ from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniSamplingParam
 from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
+
+
+def _populate_diffusion_multimodal_support(od_config: Any) -> None:
+    """Populate model_class_name and input-image limits for serving-time validation."""
+    if od_config.model_class_name is None:
+        try:
+            config_dict = get_hf_file_to_dict("model_index.json", od_config.model)
+        except Exception:
+            config_dict = None
+
+        if config_dict is not None:
+            od_config.model_class_name = config_dict.get("_class_name", None)
+
+    od_config.update_multimodal_support()
 
 
 def _resolve_model_to_local_path(model: str) -> str:
@@ -468,6 +483,7 @@ def initialize_diffusion_stage(
         model=model,
         **_to_dict(stage_cfg.engine_args),
     )
+    _populate_diffusion_multimodal_support(od_config)
     num_devices_per_stage = od_config.parallel_config.world_size
     device_control_env = current_omni_platform.device_control_env_var
     visible_devices_str = os.environ.get(device_control_env)

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -88,7 +88,9 @@ from vllm_omni.entrypoints.openai.errors import InvalidInputReferenceError
 from vllm_omni.entrypoints.openai.image_api_utils import (
     SUPPORTED_LAYERED_RESOLUTIONS,
     encode_image_base64,
+    get_input_image_limit_error,
     parse_size,
+    resolve_max_input_images,
     validate_layered_layers,
 )
 from vllm_omni.entrypoints.openai.protocol.audio import BatchSpeechRequest, OpenAICreateSpeechRequest
@@ -1469,10 +1471,12 @@ async def edit_images(
         if not input_images_list:
             raise HTTPException(status_code=422, detail="Field 'image' or 'url' is required")
         pil_images = await _load_input_images(input_images_list)
-        if len(pil_images) > 1 and not _supports_multimodal_image_inputs(raw_request, engine_client):
+        max_input_images = _get_max_input_images(raw_request, engine_client)
+        limit_error = get_input_image_limit_error(len(pil_images), max_input_images)
+        if limit_error is not None:
             raise HTTPException(
                 status_code=HTTPStatus.BAD_REQUEST.value,
-                detail="Received multiple input images. Only a single image is supported by this model.",
+                detail=limit_error,
             )
         prompt["multi_modal_data"] = {}
         prompt["multi_modal_data"]["image"] = pil_images
@@ -1638,7 +1642,7 @@ def _get_engine_and_model(raw_request: Request):
     return engine_client, model_name, normalized_stage_configs
 
 
-def _supports_multimodal_image_inputs(raw_request: Request, engine_client: Any) -> bool:
+def _get_max_input_images(raw_request: Request, engine_client: Any) -> int | None:
     diffusion_engine = getattr(raw_request.app.state, "diffusion_engine", None) or engine_client
     get_diffusion_od_config = getattr(diffusion_engine, "get_diffusion_od_config", None)
     od_config = (
@@ -1648,8 +1652,8 @@ def _supports_multimodal_image_inputs(raw_request: Request, engine_client: Any) 
     if od_config is None:
         # Preserve the existing compatibility behavior when the diffusion
         # config is not exposed on the serving surface.
-        return True
-    return bool(getattr(od_config, "supports_multimodal_inputs", False))
+        return None
+    return resolve_max_input_images(od_config)
 
 
 def _get_lora_from_json_str(lora_body):

--- a/vllm_omni/entrypoints/openai/image_api_utils.py
+++ b/vllm_omni/entrypoints/openai/image_api_utils.py
@@ -10,6 +10,7 @@ FastAPI HTTP layer.
 
 import base64
 import io
+from typing import Any
 
 import PIL.Image
 
@@ -66,6 +67,35 @@ def encode_image_base64(image: PIL.Image.Image) -> str:
     image.save(buffer, format="PNG")
     buffer.seek(0)
     return base64.b64encode(buffer.read()).decode("utf-8")
+
+
+def resolve_max_input_images(od_config: Any | None) -> int | None:
+    """Resolve the maximum number of input images supported by a model."""
+    if od_config is None:
+        return None
+
+    max_input_images = getattr(od_config, "max_input_images", None)
+    if max_input_images is not None:
+        return int(max_input_images)
+
+    if not bool(getattr(od_config, "supports_multimodal_inputs", False)):
+        return 1
+
+    return None
+
+
+def get_input_image_limit_error(input_image_count: int, max_input_images: int | None) -> str | None:
+    """Return a user-facing validation error when the model limit is exceeded."""
+    if max_input_images is None or input_image_count <= max_input_images:
+        return None
+
+    if max_input_images == 1:
+        return "Received multiple input images. Only a single image is supported by this model."
+
+    return (
+        f"Received {input_image_count} input images. "
+        f"This model supports at most {max_input_images} input images."
+    )
 
 
 def validate_layered_layers(layers: int | None) -> int | None:

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -82,7 +82,11 @@ from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
 from vllm.utils.collection_utils import as_list
 
 from vllm_omni.entrypoints.openai.audio_utils_mixin import AudioMixin
-from vllm_omni.entrypoints.openai.image_api_utils import validate_layered_layers
+from vllm_omni.entrypoints.openai.image_api_utils import (
+    get_input_image_limit_error,
+    resolve_max_input_images,
+    validate_layered_layers,
+)
 from vllm_omni.entrypoints.openai.protocol import OmniChatCompletionStreamResponse
 from vllm_omni.entrypoints.openai.protocol.audio import AudioResponse, CreateAudio
 from vllm_omni.entrypoints.openai.utils import parse_lora_request
@@ -2168,20 +2172,17 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     gen_prompt["multi_modal_data"]["image"] = pil_images[0]
                 else:
                     od_config = getattr(self._diffusion_engine, "od_config", None)
-                    supports_multimodal_inputs = getattr(od_config, "supports_multimodal_inputs", False)
                     if od_config is None:
                         # TODO: entry is asyncOmni. We hack the od config here.
-                        supports_multimodal_inputs = True
-                    if supports_multimodal_inputs:
+                        max_input_images = None
+                    else:
+                        max_input_images = resolve_max_input_images(od_config)
+                    limit_error = get_input_image_limit_error(len(pil_images), max_input_images)
+                    if limit_error is None:
                         gen_prompt["multi_modal_data"] = {}
                         gen_prompt["multi_modal_data"]["image"] = pil_images
                     else:
-                        return self._create_error_response(
-                            "Multiple input images are not supported by the current diffusion model. "
-                            "For multi-image editing, start the server with Qwen-Image-Edit-2509 "
-                            "and send multiple images in the user message content.",
-                            status_code=400,
-                        )
+                        return self._create_error_response(limit_error, status_code=400)
 
             # Generate image
             diffusion_engine = cast(AsyncOmni, self._diffusion_engine)


### PR DESCRIPTION
## Purpose

Fixes #2679.

This PR enforces the documented 1-3 input image limit for Qwen-Image-Edit multi-image editing by:
- adding a model-configured `max_input_images` limit for diffusion models
- setting `QwenImageEditPlusPipeline` to allow at most 3 input images
- reusing the same validation for `/v1/images/edits` and diffusion chat serving
- returning HTTP 400 with a clear error when the request exceeds the model limit
- adding endpoint tests that cover the 3-image success case and the 4-image rejection case

## Test Plan

Static validation:
```bash
python -m py_compile \
  vllm_omni/entrypoints/openai/image_api_utils.py \
  vllm_omni/diffusion/data.py \
  vllm_omni/entrypoints/openai/api_server.py \
  vllm_omni/entrypoints/openai/serving_chat.py \
  vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py \
  tests/entrypoints/openai_api/test_image_server.py
```

Targeted test intended for this change:
```bash
pytest tests/entrypoints/openai_api/test_image_server.py -k "model_does_not_support_them or model_max_input_images or above_model_max"
```

## Test Result

- `python -m py_compile ...` passed locally.
- The targeted `pytest` command could not be completed in the local environment because repository-level test setup imports `cv2`, which is not installed here:

```text
ImportError while loading conftest 'tests/conftest.py'.
tests/conftest.py:34: in <module>
    import cv2
E   ModuleNotFoundError: No module named 'cv2'
```

- Added unit coverage for:
  - allowing up to 3 input images when the model limit is 3
  - rejecting 4 input images with HTTP 400 and a clear error message

```
vllm serve /workspace/models/Qwen/Qwen-Image-Edit-2511 --omni --port 8091

curl -s -X POST "http://localhost:8091/v1/images/edits" \
  -H "Content-Type: multipart/form-data" \
  -F "model=/workspace/models/Qwen/Qwen-Image-Edit-2511" \
  -F "image=@1.png" \
  -F "image=@2.png" \
  -F "image=@3.png" \
  -F "image=@4.png" \
  -F "prompt=this bear is wearing sportwear. holding a basketball, and bending one leg." \
  -F "size=1024x1024" \
  -F "response_format=b64_json" \
  | jq -r '.data[0].b64_json' | base64 --decode > gift-basket.png
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>**