### PR TITLE
[TeaCache] Add TeaCache support for HunyuanVideo-1.5 T2V and I2V pipelines

### DIFF
--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -96,13 +96,19 @@ def parse_args() -> argparse.Namespace:
         "--cache-backend",
         type=str,
         default=None,
-        choices=["cache_dit"],
-        help="Cache backend for acceleration (Wan2.2). Default: None.",
+        choices=["cache_dit", "tea_cache"],
+        help="Cache backend for acceleration. 'cache_dit': Wan2.2 only. 'tea_cache': HunyuanVideo-1.5. Default: None.",
     )
     parser.add_argument(
         "--enable-cache-dit-summary",
         action="store_true",
         help="Enable cache-dit summary logging after diffusion forward passes.",
+    )
+    parser.add_argument(
+        "--tea-cache-thresh",
+        type=float,
+        default=0.2,
+        help="TeaCache rel_l1 threshold. Higher = more aggressive caching. Range [0.1, 0.4]. Default: 0.2.",
     )
     parser.add_argument("--output", type=str, default=None, help="Output path (mp4). Default: model-specific.")
     parser.add_argument("--fps", type=int, default=None, help="Frames per second for the output video.")
@@ -185,6 +191,29 @@ def parse_args() -> argparse.Namespace:
         choices=["fp8", "gguf"],
         help="Quantization method for the transformer (fp8 for online FP8 quantization).",
     )
+    parser.add_argument(
+        "--use-hsdp",
+        action="store_true",
+        help=("Enable Hybrid Sharded Data Parallel to shard model weights across GPUs. "),
+    )
+    parser.add_argument(
+        "--hsdp-shard-size",
+        type=int,
+        default=-1,
+        help=(
+            "Number of GPUs to shard model weights across within each replica group. "
+            "-1 (default) auto-calculates as world_size / replicate_size. "
+        ),
+    )
+    parser.add_argument(
+        "--hsdp-replicate-size",
+        type=int,
+        default=1,
+        help=(
+            "Number of replica groups for HSDP. Each replica holds a full sharded copy. "
+            "Default 1 means pure sharding (no replication). "
+        ),
+    )
     return parser.parse_args()
 
 
@@ -213,6 +242,15 @@ def main():
             "scm_steps_mask_policy": None,
             "scm_steps_policy": "dynamic",
         }
+    elif args.cache_backend == "tea_cache":
+        # TeaCache for HunyuanVideo-1.5.
+        # rel_l1_thresh controls the cache aggressiveness:
+        #   0.1 ~ minimal speedup, best quality
+        #   0.2 ~ ~1.5x speedup, minimal quality loss  (recommended)
+        #   0.4 ~ ~1.8x speedup, slight quality loss
+        cache_config = {
+            "rel_l1_thresh": args.tea_cache_thresh,
+        }
 
     # Configure parallel settings
     parallel_config = DiffusionParallelConfig(
@@ -222,6 +260,9 @@ def main():
         tensor_parallel_size=args.tensor_parallel_size,
         vae_patch_parallel_size=args.vae_patch_parallel_size,
         enable_expert_parallel=args.enable_expert_parallel,
+        use_hsdp=args.use_hsdp,
+        hsdp_shard_size=args.hsdp_shard_size,
+        hsdp_replicate_size=args.hsdp_replicate_size,
     )
 
     # Check if profiling is requested via environment variable

--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -191,29 +191,6 @@ def parse_args() -> argparse.Namespace:
         choices=["fp8", "gguf"],
         help="Quantization method for the transformer (fp8 for online FP8 quantization).",
     )
-    parser.add_argument(
-        "--use-hsdp",
-        action="store_true",
-        help=("Enable Hybrid Sharded Data Parallel to shard model weights across GPUs. "),
-    )
-    parser.add_argument(
-        "--hsdp-shard-size",
-        type=int,
-        default=-1,
-        help=(
-            "Number of GPUs to shard model weights across within each replica group. "
-            "-1 (default) auto-calculates as world_size / replicate_size. "
-        ),
-    )
-    parser.add_argument(
-        "--hsdp-replicate-size",
-        type=int,
-        default=1,
-        help=(
-            "Number of replica groups for HSDP. Each replica holds a full sharded copy. "
-            "Default 1 means pure sharding (no replication). "
-        ),
-    )
     return parser.parse_args()
 
 
@@ -260,9 +237,6 @@ def main():
         tensor_parallel_size=args.tensor_parallel_size,
         vae_patch_parallel_size=args.vae_patch_parallel_size,
         enable_expert_parallel=args.enable_expert_parallel,
-        use_hsdp=args.use_hsdp,
-        hsdp_shard_size=args.hsdp_shard_size,
-        hsdp_replicate_size=args.hsdp_replicate_size,
     )
 
     # Check if profiling is requested via environment variable

--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -240,29 +240,6 @@ def parse_args() -> argparse.Namespace:
         default=1,
         help="Number of HSDP replica groups.",
     )
-    parser.add_argument(
-        "--use-hsdp",
-        action="store_true",
-        help=("Enable Hybrid Sharded Data Parallel to shard model weights across GPUs. "),
-    )
-    parser.add_argument(
-        "--hsdp-shard-size",
-        type=int,
-        default=-1,
-        help=(
-            "Number of GPUs to shard model weights across within each replica group. "
-            "-1 (default) auto-calculates as world_size / replicate_size. "
-        ),
-    )
-    parser.add_argument(
-        "--hsdp-replicate-size",
-        type=int,
-        default=1,
-        help=(
-            "Number of replica groups for HSDP. Each replica holds a full sharded copy. "
-            "Default 1 means pure sharding (no replication). "
-        ),
-    )
     return parser.parse_args()
 
 
@@ -331,9 +308,6 @@ def main():
         vae_patch_parallel_size=args.vae_patch_parallel_size,
         pipeline_parallel_size=args.pipeline_parallel_size,
         enable_expert_parallel=args.enable_expert_parallel,
-        use_hsdp=args.use_hsdp,
-        hsdp_shard_size=args.hsdp_shard_size,
-        hsdp_replicate_size=args.hsdp_replicate_size,
     )
 
     profiler_enabled = args.profiler_config is not None

--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -107,13 +107,19 @@ def parse_args() -> argparse.Namespace:
         "--cache-backend",
         type=str,
         default=None,
-        choices=["cache_dit"],
-        help="Cache backend for acceleration (Wan2.2). Default: None.",
+        choices=["cache_dit", "tea_cache"],
+        help="Cache backend for acceleration. 'cache_dit': Wan2.2 only. 'tea_cache': HunyuanVideo-1.5. Default: None.",
     )
     parser.add_argument(
         "--enable-cache-dit-summary",
         action="store_true",
         help="Enable cache-dit summary logging after diffusion forward passes.",
+    )
+    parser.add_argument(
+        "--tea-cache-thresh",
+        type=float,
+        default=0.2,
+        help="TeaCache rel_l1 threshold. Higher = more aggressive caching. Range [0.1, 0.4]. Default: 0.2.",
     )
     parser.add_argument("--output", type=str, default=None, help="Output path (mp4). Default: model-specific.")
     parser.add_argument("--fps", type=int, default=None, help="Frames per second for the output video.")
@@ -234,6 +240,29 @@ def parse_args() -> argparse.Namespace:
         default=1,
         help="Number of HSDP replica groups.",
     )
+    parser.add_argument(
+        "--use-hsdp",
+        action="store_true",
+        help=("Enable Hybrid Sharded Data Parallel to shard model weights across GPUs. "),
+    )
+    parser.add_argument(
+        "--hsdp-shard-size",
+        type=int,
+        default=-1,
+        help=(
+            "Number of GPUs to shard model weights across within each replica group. "
+            "-1 (default) auto-calculates as world_size / replicate_size. "
+        ),
+    )
+    parser.add_argument(
+        "--hsdp-replicate-size",
+        type=int,
+        default=1,
+        help=(
+            "Number of replica groups for HSDP. Each replica holds a full sharded copy. "
+            "Default 1 means pure sharding (no replication). "
+        ),
+    )
     return parser.parse_args()
 
 
@@ -283,6 +312,15 @@ def main():
             "scm_steps_mask_policy": None,
             "scm_steps_policy": "dynamic",
         }
+    elif args.cache_backend == "tea_cache":
+        # TeaCache for HunyuanVideo-1.5.
+        # rel_l1_thresh controls the cache aggressiveness:
+        #   0.1 ~ minimal speedup, best quality
+        #   0.2 ~ ~1.5x speedup, minimal quality loss  (recommended)
+        #   0.4 ~ ~1.8x speedup, slight quality loss
+        cache_config = {
+            "rel_l1_thresh": args.tea_cache_thresh,
+        }
 
     # Configure parallel settings
     parallel_config = DiffusionParallelConfig(
@@ -293,6 +331,9 @@ def main():
         vae_patch_parallel_size=args.vae_patch_parallel_size,
         pipeline_parallel_size=args.pipeline_parallel_size,
         enable_expert_parallel=args.enable_expert_parallel,
+        use_hsdp=args.use_hsdp,
+        hsdp_shard_size=args.hsdp_shard_size,
+        hsdp_replicate_size=args.hsdp_replicate_size,
     )
 
     profiler_enabled = args.profiler_config is not None

--- a/vllm_omni/diffusion/cache/teacache/backend.py
+++ b/vllm_omni/diffusion/cache/teacache/backend.py
@@ -11,6 +11,7 @@ interface using the hooks-based TeaCache system.
 from typing import Any
 
 import numpy as np
+import torch
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.cache.base import CacheBackend
@@ -101,7 +102,7 @@ def _teacache_init_loop_state(pipeline: Any) -> dict | None:
 
     Returns a state dict if TeaCache is configured on the pipeline, else None.
     The state dict tracks: rescale polynomial, accumulated distance, previous
-    timestep, previous noise prediction, and step counter.
+    modulated input, previous noise prediction, and step counter.
     """
     config = getattr(pipeline, "_tea_cache_config", None)
     if config is None:
@@ -110,35 +111,34 @@ def _teacache_init_loop_state(pipeline: Any) -> dict | None:
         "config": config,
         "rescale": np.poly1d(config.coefficients),
         "acc_dist": 0.0,
-        "prev_t": None,
+        "prev_modulated_input": None,
         "prev_noise_pred": None,
         "cnt": 0,
     }
 
 
-def _teacache_should_compute(state: dict | None, t: Any) -> bool:
+def _teacache_should_compute(state: dict | None, modulated_input: torch.Tensor | None) -> bool:
     """
     Decide whether to compute noise_pred or reuse the cached value.
 
-    Uses timestep value directly (no sub-module calls) to avoid triggering
-    FSDP unshard during cache evaluation. Updates state["prev_t"] in-place.
+    Computes rel_l1 on the modulated first-block norm output (content-aware signal)
+    rather than a raw timestep delta. Updates state["prev_modulated_input"] in-place.
 
     Returns True if noise_pred must be computed, False if cached value can be reused.
     """
     if state is None:
         return True
     should_compute = True
-    if state["cnt"] > 0 and state["prev_t"] is not None:
-        t_val = t.float().item()
-        prev_t_val = state["prev_t"].float().item()
-        rel_dist = abs(t_val - prev_t_val) / (abs(prev_t_val) + 1e-8)
-        rescaled = float(state["rescale"](rel_dist))
+    if state["cnt"] > 0 and state["prev_modulated_input"] is not None:
+        prev = state["prev_modulated_input"]
+        rel_l1 = (modulated_input - prev).abs().mean() / (prev.abs().mean() + 1e-8)
+        rescaled = float(state["rescale"](rel_l1.item()))
         state["acc_dist"] += abs(rescaled)
         if state["acc_dist"] < state["config"].rel_l1_thresh:
             should_compute = False
         else:
             state["acc_dist"] = 0.0
-    state["prev_t"] = t.detach().clone()
+    state["prev_modulated_input"] = modulated_input.detach().clone()  # type: ignore[union-attr]
     return should_compute
 
 

--- a/vllm_omni/diffusion/cache/teacache/backend.py
+++ b/vllm_omni/diffusion/cache/teacache/backend.py
@@ -10,7 +10,6 @@ interface using the hooks-based TeaCache system.
 
 from typing import Any
 
-import numpy as np
 import torch
 from vllm.logger import init_logger
 
@@ -83,8 +82,10 @@ def enable_hunyuan_video_15_teacache(pipeline: Any, config: DiffusionCacheConfig
     Enable TeaCache for HunyuanVideo15Pipeline (T2V) and HunyuanVideo15I2VPipeline (I2V).
 
     Both pipelines share the same transformer architecture (HunyuanVideo15Transformer3DModel)
-    and use the same pipeline-level TeaCache approach to avoid FSDP/HCCL port conflicts
-    caused by HookRegistry replacing FSDP-wrapped forward().
+    and use the same pipeline-level TeaCache approach. Hook-based TeaCache intercepts the
+    full transformer forward before the USP SP-split hook fires, causing a shape mismatch
+    between image_rotary_emb (computed on unsharded hidden_states) and the sharded
+    hidden_states seen by transformer blocks.
     """
     teacache_config = TeaCacheConfig(
         transformer_type="HunyuanVideo15Transformer3DModel",
@@ -104,6 +105,8 @@ def _teacache_init_loop_state(pipeline: Any) -> dict | None:
     The state dict tracks: rescale polynomial, accumulated distance, previous
     modulated input, previous noise prediction, and step counter.
     """
+    import numpy as np
+
     config = getattr(pipeline, "_tea_cache_config", None)
     if config is None:
         return None
@@ -117,7 +120,7 @@ def _teacache_init_loop_state(pipeline: Any) -> dict | None:
     }
 
 
-def _teacache_should_compute(state: dict | None, modulated_input: torch.Tensor | None) -> bool:
+def _teacache_should_compute(state: dict | None, modulated_input: torch.Tensor) -> bool:
     """
     Decide whether to compute noise_pred or reuse the cached value.
 
@@ -138,7 +141,7 @@ def _teacache_should_compute(state: dict | None, modulated_input: torch.Tensor |
             should_compute = False
         else:
             state["acc_dist"] = 0.0
-    state["prev_modulated_input"] = modulated_input.detach().clone()  # type: ignore[union-attr]
+    state["prev_modulated_input"] = modulated_input.detach().clone()
     return should_compute
 
 

--- a/vllm_omni/diffusion/cache/teacache/backend.py
+++ b/vllm_omni/diffusion/cache/teacache/backend.py
@@ -10,6 +10,7 @@ interface using the hooks-based TeaCache system.
 
 from typing import Any
 
+import numpy as np
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.cache.base import CacheBackend
@@ -76,10 +77,77 @@ def enable_flux2_klein_teacache(pipeline: Any, config: DiffusionCacheConfig) -> 
     )
 
 
+def enable_hunyuan_video_15_teacache(pipeline: Any, config: DiffusionCacheConfig) -> None:
+    """
+    Enable TeaCache for HunyuanVideo15Pipeline (T2V) and HunyuanVideo15I2VPipeline (I2V).
+
+    Both pipelines share the same transformer architecture (HunyuanVideo15Transformer3DModel)
+    and use the same pipeline-level TeaCache approach to avoid FSDP/HCCL port conflicts
+    caused by HookRegistry replacing FSDP-wrapped forward().
+    """
+    teacache_config = TeaCacheConfig(
+        transformer_type="HunyuanVideo15Transformer3DModel",
+        rel_l1_thresh=config.rel_l1_thresh,
+        coefficients=config.coefficients,
+    )
+    pipeline._tea_cache_config = teacache_config
+
+    logger.info(f"TeaCache enabled for {type(pipeline).__name__} with rel_l1_thresh={teacache_config.rel_l1_thresh}")
+
+
+def _teacache_init_loop_state(pipeline: Any) -> dict | None:
+    """
+    Initialize TeaCache loop state from pipeline config.
+
+    Returns a state dict if TeaCache is configured on the pipeline, else None.
+    The state dict tracks: rescale polynomial, accumulated distance, previous
+    timestep, previous noise prediction, and step counter.
+    """
+    config = getattr(pipeline, "_tea_cache_config", None)
+    if config is None:
+        return None
+    return {
+        "config": config,
+        "rescale": np.poly1d(config.coefficients),
+        "acc_dist": 0.0,
+        "prev_t": None,
+        "prev_noise_pred": None,
+        "cnt": 0,
+    }
+
+
+def _teacache_should_compute(state: dict | None, t: Any) -> bool:
+    """
+    Decide whether to compute noise_pred or reuse the cached value.
+
+    Uses timestep value directly (no sub-module calls) to avoid triggering
+    FSDP unshard during cache evaluation. Updates state["prev_t"] in-place.
+
+    Returns True if noise_pred must be computed, False if cached value can be reused.
+    """
+    if state is None:
+        return True
+    should_compute = True
+    if state["cnt"] > 0 and state["prev_t"] is not None:
+        t_val = t.float().item()
+        prev_t_val = state["prev_t"].float().item()
+        rel_dist = abs(t_val - prev_t_val) / (abs(prev_t_val) + 1e-8)
+        rescaled = float(state["rescale"](rel_dist))
+        state["acc_dist"] += abs(rescaled)
+        if state["acc_dist"] < state["config"].rel_l1_thresh:
+            should_compute = False
+        else:
+            state["acc_dist"] = 0.0
+    state["prev_t"] = t.detach().clone()
+    return should_compute
+
+
 CUSTOM_TEACACHE_ENABLERS = {
     "BagelPipeline": enable_bagel_teacache,
     "Flux2KleinPipeline": enable_flux2_klein_teacache,
     "HunyuanImage3Pipeline": enable_hunyuan_image3_teacache,
+    "HunyuanVideo15Pipeline": enable_hunyuan_video_15_teacache,
+    "HunyuanVideo15I2VPipeline": enable_hunyuan_video_15_teacache,
 }
 
 
@@ -167,15 +235,19 @@ class TeaCacheBackend(CacheBackend):
                                 Currently not used by TeaCache but accepted for interface consistency.
             verbose: Whether to log refresh operations (default: True)
         """
-        # HunyuanImage3: tea cache state is managed inside the denoising loop,
-        # so refresh is a no-op (state is re-initialized every __call__).
+        # Pipeline-level TeaCache (HunyuanImage3, HunyuanVideo15 T2V/I2V): state is managed
+        # inside the denoising loop, so refresh is a no-op (state is re-initialized every __call__).
         if (
             hasattr(pipeline, "_tea_cache_config")
             and isinstance(pipeline._tea_cache_config, TeaCacheConfig)
-            and pipeline.__class__.__name__ == "HunyuanImage3Pipeline"
+            and pipeline.__class__.__name__
+            in ("HunyuanImage3Pipeline", "HunyuanVideo15Pipeline", "HunyuanVideo15I2VPipeline")
         ):
             if verbose:
-                logger.debug(f"TeaCache state refreshed for HunyuanImage3 (num_inference_steps={num_inference_steps})")
+                logger.debug(
+                    f"TeaCache state refreshed for {pipeline.__class__.__name__} "
+                    f"(num_inference_steps={num_inference_steps})"
+                )
             return
 
         # Extract transformer from pipeline

--- a/vllm_omni/diffusion/cache/teacache/config.py
+++ b/vllm_omni/diffusion/cache/teacache/config.py
@@ -76,7 +76,8 @@ _MODEL_COEFFICIENTS = {
     # HunyuanVideo-1.5 transformer coefficients
     # Source: TeaCache paper (https://arxiv.org/abs/2411.19108), Table 2 / official repo
     # Maps time_embed rel_l1 distance to output rel_l1 distance for HunyuanVideo architecture.
-    # Shared between HunyuanVideo and HunyuanVideo-1.5 (same dual-stream transformer design).
+    # Inherited from HunyuanVideo-1.0 (same dual-stream transformer design); not yet
+    # empirically validated on 1.5-specific checkpoints.
     "HunyuanVideo15Transformer3DModel": [
         -3.03318725e05,
         4.33749085e04,

--- a/vllm_omni/diffusion/cache/teacache/config.py
+++ b/vllm_omni/diffusion/cache/teacache/config.py
@@ -72,6 +72,16 @@ _MODEL_COEFFICIENTS = {
         -4.50000000e01,
         3.20000000e00,
         -2.00000000e-02,
+    # HunyuanVideo-1.5 transformer coefficients
+    # Source: TeaCache paper (https://arxiv.org/abs/2411.19108), Table 2 / official repo
+    # Maps time_embed rel_l1 distance to output rel_l1 distance for HunyuanVideo architecture.
+    # Shared between HunyuanVideo and HunyuanVideo-1.5 (same dual-stream transformer design).
+    "HunyuanVideo15Transformer3DModel": [
+        -3.03318725e05,
+        4.33749085e04,
+        -2.43574639e03,
+        6.41855817e01,
+        -6.37294591e-01,
     ],
     # LongCat Image transformer coefficients
     "LongCatImageTransformer2DModel": [652.5980, -424.1615, 84.5526, -4.5923, 0.1694],

--- a/vllm_omni/diffusion/cache/teacache/config.py
+++ b/vllm_omni/diffusion/cache/teacache/config.py
@@ -72,6 +72,7 @@ _MODEL_COEFFICIENTS = {
         -4.50000000e01,
         3.20000000e00,
         -2.00000000e-02,
+    ],
     # HunyuanVideo-1.5 transformer coefficients
     # Source: TeaCache paper (https://arxiv.org/abs/2411.19108), Table 2 / official repo
     # Maps time_embed rel_l1 distance to output rel_l1 distance for HunyuanVideo architecture.

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -931,8 +931,6 @@ def extract_stable_audio_context(
     )
 
 
-
-
 def extract_flux2_context(
     module: nn.Module,
     hidden_states: torch.Tensor,
@@ -1285,6 +1283,7 @@ EXTRACTOR_REGISTRY: dict[str, Callable] = {
     # "FluxTransformer2DModel": extract_flux_context,
     # "CogVideoXTransformer3DModel": extract_cogvideox_context,
 }
+
 
 def register_extractor(transformer_cls_name: str, extractor_fn: Callable) -> None:
     """

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -94,8 +94,8 @@ class CacheContext:
     hidden_states: torch.Tensor
     encoder_hidden_states: torch.Tensor | None
     temb: torch.Tensor
-    run_transformer_blocks: Callable[[], tuple[torch.Tensor, ...]]
-    postprocess: Callable[[torch.Tensor], Any]
+    run_transformer_blocks: Callable[[], tuple[torch.Tensor, ...]] | None = None
+    postprocess: Callable[[torch.Tensor], Any] | None = None
     extra_states: dict[str, Any] | None = None
 
     def validate(self) -> None:
@@ -125,11 +125,11 @@ class CacheContext:
         if not isinstance(self.temb, torch.Tensor):
             raise TypeError(f"temb must be torch.Tensor, got {type(self.temb)}")
 
-        # Validate callables
-        if not callable(self.run_transformer_blocks):
+        # Validate callables (optional for pipeline-level TeaCache models)
+        if self.run_transformer_blocks is not None and not callable(self.run_transformer_blocks):
             raise TypeError(f"run_transformer_blocks must be callable, got {type(self.run_transformer_blocks)}")
 
-        if not callable(self.postprocess):
+        if self.postprocess is not None and not callable(self.postprocess):
             raise TypeError(f"postprocess must be callable, got {type(self.postprocess)}")
 
         # Validate tensor shapes are compatible
@@ -1110,7 +1110,6 @@ def extract_hunyuan_video_15_context(
     Returns:
         CacheContext with all information needed for generic caching
     """
-    from diffusers.models.modeling_outputs import Transformer2DModelOutput
 
     if not hasattr(module, "transformer_blocks") or len(module.transformer_blocks) == 0:
         raise ValueError("Module must have transformer_blocks")
@@ -1119,16 +1118,11 @@ def extract_hunyuan_video_15_context(
     # PREPROCESSING (mirrors HunyuanVideo15Transformer3DModel.forward)
     # ============================================================================
     batch_size, num_channels, num_frames, height, width = hidden_states.shape
-    p_t, p_h, p_w = module.patch_size_t, module.patch_size, module.patch_size
-    post_patch_num_frames = num_frames // p_t
-    post_patch_height = height // p_h
-    post_patch_width = width // p_w
 
-    # When HSDP is active the extractor is called outside the root FSDP __call__
-    # (either directly from the pipeline TeaCache probe, or via TeaCacheHook which
-    # replaces forward() but still runs outside the FSDP pre-forward hook chain).
-    # Manually unshard root-level params (time_embed, x_embedder, etc.) and
-    # transformer_blocks[0] params (norm1) so submodules can be called directly.
+    # The extractor is called from the pipeline-level TeaCache probe, outside the
+    # transformer's own forward(). Manually unshard root-level params (time_embed,
+    # x_embedder, etc.) and transformer_blocks[0] params (norm1) so submodules
+    # can be called directly without going through the FSDP pre-forward hook chain.
     try:
         from torch.distributed.fsdp._fully_shard._fully_shard import FSDPModule as _FSDPModule
     except ImportError:
@@ -1138,152 +1132,113 @@ def extract_hunyuan_video_15_context(
     _root_is_fsdp = _FSDPModule is not None and isinstance(module, _FSDPModule)
     _block0_is_fsdp = _FSDPModule is not None and isinstance(block0, _FSDPModule)
 
-    if _root_is_fsdp:
-        module.unshard()
-    if _block0_is_fsdp:
-        block0.unshard()
+    try:
+        if _root_is_fsdp:
+            module.unshard()
+        if _block0_is_fsdp:
+            block0.unshard()
 
-    image_rotary_emb = module.rope(hidden_states)
-    temb = module.time_embed(timestep, timestep_r=timestep_r)
-    hidden_states = module.x_embedder(hidden_states)
+        temb = module.time_embed(timestep, timestep_r=timestep_r)
+        hidden_states = module.x_embedder(hidden_states)
 
-    enc_hs = module.context_embedder(encoder_hidden_states, timestep, encoder_attention_mask)
-    enc_hs = enc_hs + module.cond_type_embed(torch.zeros_like(enc_hs[:, :, 0], dtype=torch.long))
+        enc_hs = module.context_embedder(encoder_hidden_states, timestep, encoder_attention_mask)
+        enc_hs = enc_hs + module.cond_type_embed(torch.zeros_like(enc_hs[:, :, 0], dtype=torch.long))
 
-    enc_hs_2 = module.context_embedder_2(encoder_hidden_states_2)
-    enc_hs_2 = enc_hs_2 + module.cond_type_embed(torch.ones_like(enc_hs_2[:, :, 0], dtype=torch.long))
+        enc_hs_2 = module.context_embedder_2(encoder_hidden_states_2)
+        enc_hs_2 = enc_hs_2 + module.cond_type_embed(torch.ones_like(enc_hs_2[:, :, 0], dtype=torch.long))
 
-    enc_hs_3 = module.image_embedder(image_embeds)
-    if image_embeds_mask is not None:
-        enc_attn_mask_3 = image_embeds_mask
-    else:
-        is_t2v = torch.all(image_embeds == 0)
-        if is_t2v:
-            enc_hs_3 = enc_hs_3 * 0.0
-            enc_attn_mask_3 = torch.zeros(
-                (batch_size, enc_hs_3.shape[1]),
-                dtype=encoder_attention_mask.dtype,
-                device=encoder_attention_mask.device,
-            )
+        enc_hs_3 = module.image_embedder(image_embeds)
+        if image_embeds_mask is not None:
+            enc_attn_mask_3 = image_embeds_mask
         else:
-            enc_attn_mask_3 = torch.ones(
-                (batch_size, enc_hs_3.shape[1]),
-                dtype=encoder_attention_mask.dtype,
-                device=encoder_attention_mask.device,
+            is_t2v = torch.all(image_embeds == 0)
+            if is_t2v:
+                enc_hs_3 = enc_hs_3 * 0.0
+                enc_attn_mask_3 = torch.zeros(
+                    (batch_size, enc_hs_3.shape[1]),
+                    dtype=encoder_attention_mask.dtype,
+                    device=encoder_attention_mask.device,
+                )
+            else:
+                enc_attn_mask_3 = torch.ones(
+                    (batch_size, enc_hs_3.shape[1]),
+                    dtype=encoder_attention_mask.dtype,
+                    device=encoder_attention_mask.device,
+                )
+        enc_hs_3 = enc_hs_3 + module.cond_type_embed(2 * torch.ones_like(enc_hs_3[:, :, 0], dtype=torch.long))
+
+        # Token reordering: [valid_image, valid_byte5, valid_mllm, padding]
+        enc_attn_mask_bool = encoder_attention_mask.bool()
+        enc_attn_mask_2_bool = encoder_attention_mask_2.bool()
+        enc_attn_mask_3_bool = enc_attn_mask_3.bool()
+        new_enc_hs = []
+        new_enc_attn_mask = []
+        for text, text_mask, text_2, text_mask_2, image, image_mask in zip(
+            enc_hs,
+            enc_attn_mask_bool,
+            enc_hs_2,
+            enc_attn_mask_2_bool,
+            enc_hs_3,
+            enc_attn_mask_3_bool,
+        ):
+            new_enc_hs.append(
+                torch.cat(
+                    [
+                        image[image_mask],
+                        text_2[text_mask_2],
+                        text[text_mask],
+                        image[~image_mask],
+                        torch.zeros_like(text_2[~text_mask_2]),
+                        torch.zeros_like(text[~text_mask]),
+                    ],
+                    dim=0,
+                )
             )
-    enc_hs_3 = enc_hs_3 + module.cond_type_embed(2 * torch.ones_like(enc_hs_3[:, :, 0], dtype=torch.long))
-
-    # Token reordering: [valid_image, valid_byte5, valid_mllm, padding]
-    enc_attn_mask_bool = encoder_attention_mask.bool()
-    enc_attn_mask_2_bool = encoder_attention_mask_2.bool()
-    enc_attn_mask_3_bool = enc_attn_mask_3.bool()
-    new_enc_hs = []
-    new_enc_attn_mask = []
-    for text, text_mask, text_2, text_mask_2, image, image_mask in zip(
-        enc_hs,
-        enc_attn_mask_bool,
-        enc_hs_2,
-        enc_attn_mask_2_bool,
-        enc_hs_3,
-        enc_attn_mask_3_bool,
-    ):
-        new_enc_hs.append(
-            torch.cat(
-                [
-                    image[image_mask],
-                    text_2[text_mask_2],
-                    text[text_mask],
-                    image[~image_mask],
-                    torch.zeros_like(text_2[~text_mask_2]),
-                    torch.zeros_like(text[~text_mask]),
-                ],
-                dim=0,
+            new_enc_attn_mask.append(
+                torch.cat(
+                    [
+                        image_mask[image_mask],
+                        text_mask_2[text_mask_2],
+                        text_mask[text_mask],
+                        image_mask[~image_mask],
+                        text_mask_2[~text_mask_2],
+                        text_mask[~text_mask],
+                    ],
+                    dim=0,
+                )
             )
-        )
-        new_enc_attn_mask.append(
-            torch.cat(
-                [
-                    image_mask[image_mask],
-                    text_mask_2[text_mask_2],
-                    text_mask[text_mask],
-                    image_mask[~image_mask],
-                    text_mask_2[~text_mask_2],
-                    text_mask[~text_mask],
-                ],
-                dim=0,
-            )
-        )
-    encoder_hidden_states = torch.stack(new_enc_hs)
-    encoder_attention_mask = torch.stack(new_enc_attn_mask)
+        encoder_hidden_states = torch.stack(new_enc_hs)
+        encoder_attention_mask = torch.stack(new_enc_attn_mask)
 
-    # SP padding mask (same logic as transformer forward)
-    hidden_states_mask = getattr(module, "_cached_sp_mask", None)
-    if hidden_states_mask is None:
-        ctx_fwd = get_forward_context()
-        if ctx_fwd.sp_original_seq_len is not None and ctx_fwd.sp_padding_size > 0:
-            padded_seq_len = ctx_fwd.sp_original_seq_len + ctx_fwd.sp_padding_size
-            hidden_states_mask = torch.ones(batch_size, padded_seq_len, dtype=torch.bool, device=hidden_states.device)
-            hidden_states_mask[:, ctx_fwd.sp_original_seq_len :] = False
-            module._cached_sp_mask = hidden_states_mask
+        # SP padding mask (same logic as transformer forward)
+        hidden_states_mask = getattr(module, "_cached_sp_mask", None)
+        if hidden_states_mask is None:
+            ctx_fwd = get_forward_context()
+            if ctx_fwd.sp_original_seq_len is not None and ctx_fwd.sp_padding_size > 0:
+                padded_seq_len = ctx_fwd.sp_original_seq_len + ctx_fwd.sp_padding_size
+                hidden_states_mask = torch.ones(
+                    batch_size, padded_seq_len, dtype=torch.bool, device=hidden_states.device
+                )
+                hidden_states_mask[:, ctx_fwd.sp_original_seq_len :] = False
+                module._cached_sp_mask = hidden_states_mask
 
-    # ============================================================================
-    # EXTRACT MODULATED INPUT (for cache decision)
-    # Use first transformer block's norm1 output on image hidden states.
-    # ============================================================================
-    # AdaLayerNormZero returns (norm_hs, gate_msa, shift_mlp, scale_mlp, gate_mlp)
-    norm_hidden_states, _, _, _, _ = block0.norm1(hidden_states, emb=temb)
-
-    if _block0_is_fsdp:
-        block0.reshard()
-    if _root_is_fsdp:
-        module.reshard()
-
-    # ============================================================================
-    # DEFINE TRANSFORMER EXECUTION
-    # ============================================================================
-    def run_transformer_blocks():
-        h = hidden_states
-        e = encoder_hidden_states
-        for block in module.transformer_blocks:
-            h, e = block(
-                h,
-                e,
-                temb,
-                encoder_attention_mask,
-                image_rotary_emb,
-                hidden_states_mask=hidden_states_mask,
-            )
-        return (h, e)
-
-    # ============================================================================
-    # DEFINE POSTPROCESSING
-    # ============================================================================
-    def postprocess(h):
-        h = module.norm_out(h, temb)
-        h = module.proj_out(h)
-        h = h.reshape(
-            batch_size,
-            post_patch_num_frames,
-            post_patch_height,
-            post_patch_width,
-            -1,
-            p_t,
-            p_h,
-            p_w,
-        )
-        h = h.permute(0, 4, 1, 5, 2, 6, 3, 7)
-        h = h.flatten(6, 7).flatten(4, 5).flatten(2, 3)
-        if not return_dict:
-            return (h,)
-        return Transformer2DModelOutput(sample=h)
+        # ============================================================================
+        # EXTRACT MODULATED INPUT (for cache decision)
+        # Use first transformer block's norm1 output on image hidden states.
+        # ============================================================================
+        # AdaLayerNormZero returns (norm_hs, gate_msa, shift_mlp, scale_mlp, gate_mlp)
+        norm_hidden_states, _, _, _, _ = block0.norm1(hidden_states, emb=temb)
+    finally:
+        if _block0_is_fsdp:
+            block0.reshard()
+        if _root_is_fsdp:
+            module.reshard()
 
     return CacheContext(
         modulated_input=norm_hidden_states,
         hidden_states=hidden_states,
         encoder_hidden_states=encoder_hidden_states,
         temb=temb,
-        run_transformer_blocks=run_transformer_blocks,
-        postprocess=postprocess,
     )
 
 

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -931,6 +931,8 @@ def extract_stable_audio_context(
     )
 
 
+
+
 def extract_flux2_context(
     module: nn.Module,
     hidden_states: torch.Tensor,
@@ -1069,6 +1071,201 @@ def extract_flux2_context(
     )
 
 
+def extract_hunyuan_video_15_context(
+    module: nn.Module,
+    hidden_states: torch.Tensor,
+    timestep: torch.LongTensor,
+    encoder_hidden_states: torch.Tensor,
+    encoder_attention_mask: torch.Tensor,
+    timestep_r: torch.LongTensor | None = None,
+    encoder_hidden_states_2: torch.Tensor | None = None,
+    encoder_attention_mask_2: torch.Tensor | None = None,
+    image_embeds: torch.Tensor | None = None,
+    image_embeds_mask: torch.Tensor | None = None,
+    attention_kwargs: dict[str, Any] | None = None,
+    return_dict: bool = True,
+    **kwargs: Any,
+) -> CacheContext:
+    """
+    Extract cache context for HunyuanVideo15Transformer3DModel.
+
+    HunyuanVideo-1.5 uses a dual-stream transformer (image + text tokens processed
+    jointly). The modulated input is extracted from the first transformer block's
+    AdaLayerNormZero output on the image hidden states, which is sensitive to the
+    timestep embedding and serves as a reliable cache decision signal.
+
+    Args:
+        module: HunyuanVideo15Transformer3DModel instance
+        hidden_states: Video latent tensor [B, C, T, H, W]
+        timestep: Diffusion timestep
+        encoder_hidden_states: Primary text encoder outputs
+        encoder_attention_mask: Mask for primary text encoder
+        timestep_r: Optional second timestep (for flow matching)
+        encoder_hidden_states_2: Secondary text encoder outputs (ByT5)
+        encoder_attention_mask_2: Mask for secondary text encoder
+        image_embeds: Image conditioning embeddings (zeros for T2V)
+        image_embeds_mask: Mask for image embeddings
+        attention_kwargs: Additional attention arguments
+        return_dict: Whether to return Transformer2DModelOutput
+        **kwargs: Additional keyword arguments
+
+    Returns:
+        CacheContext with all information needed for generic caching
+    """
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+    if not hasattr(module, "transformer_blocks") or len(module.transformer_blocks) == 0:
+        raise ValueError("Module must have transformer_blocks")
+
+    # ============================================================================
+    # PREPROCESSING (mirrors HunyuanVideo15Transformer3DModel.forward)
+    # ============================================================================
+    batch_size, num_channels, num_frames, height, width = hidden_states.shape
+    p_t, p_h, p_w = module.patch_size_t, module.patch_size, module.patch_size
+    post_patch_num_frames = num_frames // p_t
+    post_patch_height = height // p_h
+    post_patch_width = width // p_w
+
+    image_rotary_emb = module.rope(hidden_states)
+    temb = module.time_embed(timestep, timestep_r=timestep_r)
+    hidden_states = module.x_embedder(hidden_states)
+
+    enc_hs = module.context_embedder(encoder_hidden_states, timestep, encoder_attention_mask)
+    enc_hs = enc_hs + module.cond_type_embed(torch.zeros_like(enc_hs[:, :, 0], dtype=torch.long))
+
+    enc_hs_2 = module.context_embedder_2(encoder_hidden_states_2)
+    enc_hs_2 = enc_hs_2 + module.cond_type_embed(torch.ones_like(enc_hs_2[:, :, 0], dtype=torch.long))
+
+    enc_hs_3 = module.image_embedder(image_embeds)
+    if image_embeds_mask is not None:
+        enc_attn_mask_3 = image_embeds_mask
+    else:
+        is_t2v = torch.all(image_embeds == 0)
+        if is_t2v:
+            enc_hs_3 = enc_hs_3 * 0.0
+            enc_attn_mask_3 = torch.zeros(
+                (batch_size, enc_hs_3.shape[1]),
+                dtype=encoder_attention_mask.dtype,
+                device=encoder_attention_mask.device,
+            )
+        else:
+            enc_attn_mask_3 = torch.ones(
+                (batch_size, enc_hs_3.shape[1]),
+                dtype=encoder_attention_mask.dtype,
+                device=encoder_attention_mask.device,
+            )
+    enc_hs_3 = enc_hs_3 + module.cond_type_embed(2 * torch.ones_like(enc_hs_3[:, :, 0], dtype=torch.long))
+
+    # Token reordering: [valid_image, valid_byte5, valid_mllm, padding]
+    enc_attn_mask_bool = encoder_attention_mask.bool()
+    enc_attn_mask_2_bool = encoder_attention_mask_2.bool()
+    enc_attn_mask_3_bool = enc_attn_mask_3.bool()
+    new_enc_hs = []
+    new_enc_attn_mask = []
+    for text, text_mask, text_2, text_mask_2, image, image_mask in zip(
+        enc_hs,
+        enc_attn_mask_bool,
+        enc_hs_2,
+        enc_attn_mask_2_bool,
+        enc_hs_3,
+        enc_attn_mask_3_bool,
+    ):
+        new_enc_hs.append(
+            torch.cat(
+                [
+                    image[image_mask],
+                    text_2[text_mask_2],
+                    text[text_mask],
+                    image[~image_mask],
+                    torch.zeros_like(text_2[~text_mask_2]),
+                    torch.zeros_like(text[~text_mask]),
+                ],
+                dim=0,
+            )
+        )
+        new_enc_attn_mask.append(
+            torch.cat(
+                [
+                    image_mask[image_mask],
+                    text_mask_2[text_mask_2],
+                    text_mask[text_mask],
+                    image_mask[~image_mask],
+                    text_mask_2[~text_mask_2],
+                    text_mask[~text_mask],
+                ],
+                dim=0,
+            )
+        )
+    encoder_hidden_states = torch.stack(new_enc_hs)
+    encoder_attention_mask = torch.stack(new_enc_attn_mask)
+
+    # SP padding mask (same logic as transformer forward)
+    hidden_states_mask = getattr(module, "_cached_sp_mask", None)
+    if hidden_states_mask is None:
+        ctx_fwd = get_forward_context()
+        if ctx_fwd.sp_original_seq_len is not None and ctx_fwd.sp_padding_size > 0:
+            padded_seq_len = ctx_fwd.sp_original_seq_len + ctx_fwd.sp_padding_size
+            hidden_states_mask = torch.ones(batch_size, padded_seq_len, dtype=torch.bool, device=hidden_states.device)
+            hidden_states_mask[:, ctx_fwd.sp_original_seq_len :] = False
+            module._cached_sp_mask = hidden_states_mask
+
+    # ============================================================================
+    # EXTRACT MODULATED INPUT (for cache decision)
+    # Use first transformer block's norm1 output on image hidden states.
+    # ============================================================================
+    block0 = module.transformer_blocks[0]
+    # AdaLayerNormZero returns (norm_hs, gate_msa, shift_mlp, scale_mlp, gate_mlp)
+    norm_hidden_states, _, _, _, _ = block0.norm1(hidden_states, emb=temb)
+
+    # ============================================================================
+    # DEFINE TRANSFORMER EXECUTION
+    # ============================================================================
+    def run_transformer_blocks():
+        h = hidden_states
+        e = encoder_hidden_states
+        for block in module.transformer_blocks:
+            h, e = block(
+                h,
+                e,
+                temb,
+                encoder_attention_mask,
+                image_rotary_emb,
+                hidden_states_mask=hidden_states_mask,
+            )
+        return (h, e)
+
+    # ============================================================================
+    # DEFINE POSTPROCESSING
+    # ============================================================================
+    def postprocess(h):
+        h = module.norm_out(h, temb)
+        h = module.proj_out(h)
+        h = h.reshape(
+            batch_size,
+            post_patch_num_frames,
+            post_patch_height,
+            post_patch_width,
+            -1,
+            p_t,
+            p_h,
+            p_w,
+        )
+        h = h.permute(0, 4, 1, 5, 2, 6, 3, 7)
+        h = h.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+        if not return_dict:
+            return (h,)
+        return Transformer2DModelOutput(sample=h)
+
+    return CacheContext(
+        modulated_input=norm_hidden_states,
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        temb=temb,
+        run_transformer_blocks=run_transformer_blocks,
+        postprocess=postprocess,
+    )
+
+
 # Registry for model-specific extractors
 # Key: Transformer class name
 # Value: extractor function with signature (module, *args, **kwargs) -> CacheContext
@@ -1083,11 +1280,11 @@ EXTRACTOR_REGISTRY: dict[str, Callable] = {
     "StableAudioDiTModel": extract_stable_audio_context,
     "Flux2Transformer2DModel": extract_flux2_context,
     "LongCatImageTransformer2DModel": extract_longcat_context,
+    "HunyuanVideo15Transformer3DModel": extract_hunyuan_video_15_context,
     # Future models:
     # "FluxTransformer2DModel": extract_flux_context,
     # "CogVideoXTransformer3DModel": extract_cogvideox_context,
 }
-
 
 def register_extractor(transformer_cls_name: str, extractor_fn: Callable) -> None:
     """

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -1124,6 +1124,25 @@ def extract_hunyuan_video_15_context(
     post_patch_height = height // p_h
     post_patch_width = width // p_w
 
+    # When HSDP is active the extractor is called outside the root FSDP __call__
+    # (either directly from the pipeline TeaCache probe, or via TeaCacheHook which
+    # replaces forward() but still runs outside the FSDP pre-forward hook chain).
+    # Manually unshard root-level params (time_embed, x_embedder, etc.) and
+    # transformer_blocks[0] params (norm1) so submodules can be called directly.
+    try:
+        from torch.distributed.fsdp._fully_shard._fully_shard import FSDPModule as _FSDPModule
+    except ImportError:
+        _FSDPModule = None
+
+    block0 = module.transformer_blocks[0]
+    _root_is_fsdp = _FSDPModule is not None and isinstance(module, _FSDPModule)
+    _block0_is_fsdp = _FSDPModule is not None and isinstance(block0, _FSDPModule)
+
+    if _root_is_fsdp:
+        module.unshard()
+    if _block0_is_fsdp:
+        block0.unshard()
+
     image_rotary_emb = module.rope(hidden_states)
     temb = module.time_embed(timestep, timestep_r=timestep_r)
     hidden_states = module.x_embedder(hidden_states)
@@ -1211,9 +1230,13 @@ def extract_hunyuan_video_15_context(
     # EXTRACT MODULATED INPUT (for cache decision)
     # Use first transformer block's norm1 output on image hidden states.
     # ============================================================================
-    block0 = module.transformer_blocks[0]
     # AdaLayerNormZero returns (norm_hs, gate_msa, shift_mlp, scale_mlp, gate_mlp)
     norm_hidden_states, _, _, _, _ = block0.norm1(hidden_states, emb=temb)
+
+    if _block0_is_fsdp:
+        block0.reshard()
+    if _root_is_fsdp:
+        module.reshard()
 
     # ============================================================================
     # DEFINE TRANSFORMER EXECUTION

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -277,7 +277,10 @@ def extract_qwen_context(
 
     def postprocess(h):
         """Apply Qwen-specific output postprocessing."""
-        h = module.norm_out(h, temb)
+        if getattr(module, "zero_cond_t", False):
+            h = module.norm_out(h, temb.chunk(2, dim=0)[0])
+        else:
+            h = module.norm_out(h, temb)
         output = module.proj_out(h)
         if not return_dict:
             return (output,)
@@ -304,12 +307,9 @@ def extract_bagel_context(
     packed_vae_position_ids: torch.LongTensor,
     packed_text_ids: torch.LongTensor,
     packed_text_indexes: torch.LongTensor,
-    packed_indexes: torch.LongTensor,
     packed_position_ids: torch.LongTensor,
     packed_seqlens: torch.IntTensor,
-    key_values_lens: torch.IntTensor,
     past_key_values: Any,
-    packed_key_value_indexes: torch.LongTensor,
     **kwargs: Any,
 ) -> CacheContext:
     """
@@ -323,12 +323,9 @@ def extract_bagel_context(
         packed_vae_position_ids: Position IDs for VAE tokens
         packed_text_ids: Text token IDs
         packed_text_indexes: Indexes for text tokens in packed sequence
-        packed_indexes: Global indexes
         packed_position_ids: Global position IDs
         packed_seqlens: Sequence lengths
-        key_values_lens: KV cache lengths
         past_key_values: KV cache
-        packed_key_value_indexes: KV cache indexes
         **kwargs: Additional keyword arguments
 
     Returns:
@@ -372,10 +369,7 @@ def extract_bagel_context(
             packed_query_sequence=packed_sequence,
             query_lens=packed_seqlens,
             packed_query_position_ids=packed_position_ids,
-            packed_query_indexes=packed_indexes,
             past_key_values=past_key_values,
-            key_values_lens=key_values_lens,
-            packed_key_value_indexes=packed_key_value_indexes,
             update_past_key_values=False,
             is_causal=False,
             **extra_inputs,
@@ -1069,6 +1063,130 @@ def extract_flux2_context(
     )
 
 
+def extract_flux_context(
+    module: nn.Module,
+    hidden_states: torch.Tensor,
+    encoder_hidden_states: torch.Tensor,
+    pooled_projections: torch.Tensor,
+    timestep: torch.LongTensor,
+    img_ids: torch.Tensor,
+    txt_ids: torch.Tensor,
+    guidance: torch.Tensor | None = None,
+    joint_attention_kwargs: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> CacheContext:
+    """
+    Extract cache context for FluxTransformer2DModel.
+
+    This mirrors the standard FLUX.1 transformer forward path while exposing
+    the first modulated image stream tensor as TeaCache's similarity signal.
+
+    Args:
+        module: FluxTransformer2DModel instance
+        hidden_states: Input image hidden states tensor
+        encoder_hidden_states: Text encoder outputs
+        pooled_projections: Pooled text conditioning
+        timestep: Current diffusion timestep
+        img_ids: Image position IDs for RoPE
+        txt_ids: Text position IDs for RoPE
+        guidance: Optional guidance scale for guidance-distilled variants
+        joint_attention_kwargs: Additional attention kwargs
+        **kwargs: Additional keyword arguments
+
+    Returns:
+        CacheContext with all information needed for generic caching
+    """
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+    if not hasattr(module, "transformer_blocks") or len(module.transformer_blocks) == 0:
+        raise ValueError("Module must have transformer_blocks")
+
+    # ============================================================================
+    # PREPROCESSING (Flux1-specific)
+    # ============================================================================
+    hidden_states = module.x_embedder(hidden_states)
+    timestep = timestep.to(device=hidden_states.device, dtype=hidden_states.dtype) * 1000
+
+    if guidance is not None:
+        guidance = guidance.to(device=hidden_states.device, dtype=hidden_states.dtype) * 1000
+
+    temb = (
+        module.time_text_embed(timestep, pooled_projections)
+        if guidance is None
+        else module.time_text_embed(timestep, guidance, pooled_projections)
+    )
+    encoder_hidden_states = module.context_embedder(encoder_hidden_states)
+
+    if txt_ids.ndim == 3:
+        txt_ids = txt_ids[0]
+    if img_ids.ndim == 3:
+        img_ids = img_ids[0]
+
+    ids = torch.cat((txt_ids, img_ids), dim=0)
+    if current_omni_platform.is_npu():
+        freqs_cos, freqs_sin = module.pos_embed(ids.cpu())
+        image_rotary_emb = (freqs_cos.npu(), freqs_sin.npu())
+    else:
+        image_rotary_emb = module.pos_embed(ids)
+
+    # ============================================================================
+    # EXTRACT MODULATED INPUT (for cache decision)
+    # ============================================================================
+    first_block = module.transformer_blocks[0]
+    modulated_input, *_ = first_block.norm1(hidden_states, emb=temb)
+
+    # ============================================================================
+    # DEFINE TRANSFORMER EXECUTION (Flux1-specific)
+    # ============================================================================
+    def run_transformer_blocks() -> tuple[torch.Tensor, torch.Tensor]:
+        h = hidden_states
+        e = encoder_hidden_states
+
+        for block in module.transformer_blocks:
+            e, h = block(
+                hidden_states=h,
+                encoder_hidden_states=e,
+                temb=temb,
+                image_rotary_emb=image_rotary_emb,
+                joint_attention_kwargs=joint_attention_kwargs,
+            )
+
+        for block in module.single_transformer_blocks:
+            e, h = block(
+                hidden_states=h,
+                encoder_hidden_states=e,
+                temb=temb,
+                image_rotary_emb=image_rotary_emb,
+                joint_attention_kwargs=joint_attention_kwargs,
+            )
+
+        return (h, e)
+
+    return_dict = kwargs.get("return_dict", True)
+
+    # ============================================================================
+    # DEFINE POSTPROCESSING
+    # ============================================================================
+    def postprocess(h: torch.Tensor) -> Any:
+        h = module.norm_out(h, temb)
+        output = module.proj_out(h)
+        if not return_dict:
+            return (output,)
+        return Transformer2DModelOutput(sample=output)
+
+    # ============================================================================
+    # RETURN CONTEXT
+    # ============================================================================
+    return CacheContext(
+        modulated_input=modulated_input,
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        temb=temb,
+        run_transformer_blocks=run_transformer_blocks,
+        postprocess=postprocess,
+    )
+
+
 def extract_hunyuan_video_15_context(
     module: nn.Module,
     hidden_states: torch.Tensor,
@@ -1110,7 +1228,6 @@ def extract_hunyuan_video_15_context(
     Returns:
         CacheContext with all information needed for generic caching
     """
-    from diffusers.models.modeling_outputs import Transformer2DModelOutput
 
     if not hasattr(module, "transformer_blocks") or len(module.transformer_blocks) == 0:
         raise ValueError("Module must have transformer_blocks")
@@ -1119,16 +1236,11 @@ def extract_hunyuan_video_15_context(
     # PREPROCESSING (mirrors HunyuanVideo15Transformer3DModel.forward)
     # ============================================================================
     batch_size, num_channels, num_frames, height, width = hidden_states.shape
-    p_t, p_h, p_w = module.patch_size_t, module.patch_size, module.patch_size
-    post_patch_num_frames = num_frames // p_t
-    post_patch_height = height // p_h
-    post_patch_width = width // p_w
 
-    # When HSDP is active the extractor is called outside the root FSDP __call__
-    # (either directly from the pipeline TeaCache probe, or via TeaCacheHook which
-    # replaces forward() but still runs outside the FSDP pre-forward hook chain).
-    # Manually unshard root-level params (time_embed, x_embedder, etc.) and
-    # transformer_blocks[0] params (norm1) so submodules can be called directly.
+    # The extractor is called from the pipeline-level TeaCache probe, outside the
+    # transformer's own forward(). Manually unshard root-level params (time_embed,
+    # x_embedder, etc.) and transformer_blocks[0] params (norm1) so submodules
+    # can be called directly without going through the FSDP pre-forward hook chain.
     try:
         from torch.distributed.fsdp._fully_shard._fully_shard import FSDPModule as _FSDPModule
     except ImportError:
@@ -1138,152 +1250,113 @@ def extract_hunyuan_video_15_context(
     _root_is_fsdp = _FSDPModule is not None and isinstance(module, _FSDPModule)
     _block0_is_fsdp = _FSDPModule is not None and isinstance(block0, _FSDPModule)
 
-    if _root_is_fsdp:
-        module.unshard()
-    if _block0_is_fsdp:
-        block0.unshard()
+    try:
+        if _root_is_fsdp:
+            module.unshard()
+        if _block0_is_fsdp:
+            block0.unshard()
 
-    image_rotary_emb = module.rope(hidden_states)
-    temb = module.time_embed(timestep, timestep_r=timestep_r)
-    hidden_states = module.x_embedder(hidden_states)
+        temb = module.time_embed(timestep, timestep_r=timestep_r)
+        hidden_states = module.x_embedder(hidden_states)
 
-    enc_hs = module.context_embedder(encoder_hidden_states, timestep, encoder_attention_mask)
-    enc_hs = enc_hs + module.cond_type_embed(torch.zeros_like(enc_hs[:, :, 0], dtype=torch.long))
+        enc_hs = module.context_embedder(encoder_hidden_states, timestep, encoder_attention_mask)
+        enc_hs = enc_hs + module.cond_type_embed(torch.zeros_like(enc_hs[:, :, 0], dtype=torch.long))
 
-    enc_hs_2 = module.context_embedder_2(encoder_hidden_states_2)
-    enc_hs_2 = enc_hs_2 + module.cond_type_embed(torch.ones_like(enc_hs_2[:, :, 0], dtype=torch.long))
+        enc_hs_2 = module.context_embedder_2(encoder_hidden_states_2)
+        enc_hs_2 = enc_hs_2 + module.cond_type_embed(torch.ones_like(enc_hs_2[:, :, 0], dtype=torch.long))
 
-    enc_hs_3 = module.image_embedder(image_embeds)
-    if image_embeds_mask is not None:
-        enc_attn_mask_3 = image_embeds_mask
-    else:
-        is_t2v = torch.all(image_embeds == 0)
-        if is_t2v:
-            enc_hs_3 = enc_hs_3 * 0.0
-            enc_attn_mask_3 = torch.zeros(
-                (batch_size, enc_hs_3.shape[1]),
-                dtype=encoder_attention_mask.dtype,
-                device=encoder_attention_mask.device,
-            )
+        enc_hs_3 = module.image_embedder(image_embeds)
+        if image_embeds_mask is not None:
+            enc_attn_mask_3 = image_embeds_mask
         else:
-            enc_attn_mask_3 = torch.ones(
-                (batch_size, enc_hs_3.shape[1]),
-                dtype=encoder_attention_mask.dtype,
-                device=encoder_attention_mask.device,
+            is_t2v = torch.all(image_embeds == 0)
+            if is_t2v:
+                enc_hs_3 = enc_hs_3 * 0.0
+                enc_attn_mask_3 = torch.zeros(
+                    (batch_size, enc_hs_3.shape[1]),
+                    dtype=encoder_attention_mask.dtype,
+                    device=encoder_attention_mask.device,
+                )
+            else:
+                enc_attn_mask_3 = torch.ones(
+                    (batch_size, enc_hs_3.shape[1]),
+                    dtype=encoder_attention_mask.dtype,
+                    device=encoder_attention_mask.device,
+                )
+        enc_hs_3 = enc_hs_3 + module.cond_type_embed(2 * torch.ones_like(enc_hs_3[:, :, 0], dtype=torch.long))
+
+        # Token reordering: [valid_image, valid_byte5, valid_mllm, padding]
+        enc_attn_mask_bool = encoder_attention_mask.bool()
+        enc_attn_mask_2_bool = encoder_attention_mask_2.bool()
+        enc_attn_mask_3_bool = enc_attn_mask_3.bool()
+        new_enc_hs = []
+        new_enc_attn_mask = []
+        for text, text_mask, text_2, text_mask_2, image, image_mask in zip(
+            enc_hs,
+            enc_attn_mask_bool,
+            enc_hs_2,
+            enc_attn_mask_2_bool,
+            enc_hs_3,
+            enc_attn_mask_3_bool,
+        ):
+            new_enc_hs.append(
+                torch.cat(
+                    [
+                        image[image_mask],
+                        text_2[text_mask_2],
+                        text[text_mask],
+                        image[~image_mask],
+                        torch.zeros_like(text_2[~text_mask_2]),
+                        torch.zeros_like(text[~text_mask]),
+                    ],
+                    dim=0,
+                )
             )
-    enc_hs_3 = enc_hs_3 + module.cond_type_embed(2 * torch.ones_like(enc_hs_3[:, :, 0], dtype=torch.long))
-
-    # Token reordering: [valid_image, valid_byte5, valid_mllm, padding]
-    enc_attn_mask_bool = encoder_attention_mask.bool()
-    enc_attn_mask_2_bool = encoder_attention_mask_2.bool()
-    enc_attn_mask_3_bool = enc_attn_mask_3.bool()
-    new_enc_hs = []
-    new_enc_attn_mask = []
-    for text, text_mask, text_2, text_mask_2, image, image_mask in zip(
-        enc_hs,
-        enc_attn_mask_bool,
-        enc_hs_2,
-        enc_attn_mask_2_bool,
-        enc_hs_3,
-        enc_attn_mask_3_bool,
-    ):
-        new_enc_hs.append(
-            torch.cat(
-                [
-                    image[image_mask],
-                    text_2[text_mask_2],
-                    text[text_mask],
-                    image[~image_mask],
-                    torch.zeros_like(text_2[~text_mask_2]),
-                    torch.zeros_like(text[~text_mask]),
-                ],
-                dim=0,
+            new_enc_attn_mask.append(
+                torch.cat(
+                    [
+                        image_mask[image_mask],
+                        text_mask_2[text_mask_2],
+                        text_mask[text_mask],
+                        image_mask[~image_mask],
+                        text_mask_2[~text_mask_2],
+                        text_mask[~text_mask],
+                    ],
+                    dim=0,
+                )
             )
-        )
-        new_enc_attn_mask.append(
-            torch.cat(
-                [
-                    image_mask[image_mask],
-                    text_mask_2[text_mask_2],
-                    text_mask[text_mask],
-                    image_mask[~image_mask],
-                    text_mask_2[~text_mask_2],
-                    text_mask[~text_mask],
-                ],
-                dim=0,
-            )
-        )
-    encoder_hidden_states = torch.stack(new_enc_hs)
-    encoder_attention_mask = torch.stack(new_enc_attn_mask)
+        encoder_hidden_states = torch.stack(new_enc_hs)
+        encoder_attention_mask = torch.stack(new_enc_attn_mask)
 
-    # SP padding mask (same logic as transformer forward)
-    hidden_states_mask = getattr(module, "_cached_sp_mask", None)
-    if hidden_states_mask is None:
-        ctx_fwd = get_forward_context()
-        if ctx_fwd.sp_original_seq_len is not None and ctx_fwd.sp_padding_size > 0:
-            padded_seq_len = ctx_fwd.sp_original_seq_len + ctx_fwd.sp_padding_size
-            hidden_states_mask = torch.ones(batch_size, padded_seq_len, dtype=torch.bool, device=hidden_states.device)
-            hidden_states_mask[:, ctx_fwd.sp_original_seq_len :] = False
-            module._cached_sp_mask = hidden_states_mask
+        # SP padding mask (same logic as transformer forward)
+        hidden_states_mask = getattr(module, "_cached_sp_mask", None)
+        if hidden_states_mask is None:
+            ctx_fwd = get_forward_context()
+            if ctx_fwd.sp_original_seq_len is not None and ctx_fwd.sp_padding_size > 0:
+                padded_seq_len = ctx_fwd.sp_original_seq_len + ctx_fwd.sp_padding_size
+                hidden_states_mask = torch.ones(
+                    batch_size, padded_seq_len, dtype=torch.bool, device=hidden_states.device
+                )
+                hidden_states_mask[:, ctx_fwd.sp_original_seq_len :] = False
+                module._cached_sp_mask = hidden_states_mask
 
-    # ============================================================================
-    # EXTRACT MODULATED INPUT (for cache decision)
-    # Use first transformer block's norm1 output on image hidden states.
-    # ============================================================================
-    # AdaLayerNormZero returns (norm_hs, gate_msa, shift_mlp, scale_mlp, gate_mlp)
-    norm_hidden_states, _, _, _, _ = block0.norm1(hidden_states, emb=temb)
-
-    if _block0_is_fsdp:
-        block0.reshard()
-    if _root_is_fsdp:
-        module.reshard()
-
-    # ============================================================================
-    # DEFINE TRANSFORMER EXECUTION
-    # ============================================================================
-    def run_transformer_blocks():
-        h = hidden_states
-        e = encoder_hidden_states
-        for block in module.transformer_blocks:
-            h, e = block(
-                h,
-                e,
-                temb,
-                encoder_attention_mask,
-                image_rotary_emb,
-                hidden_states_mask=hidden_states_mask,
-            )
-        return (h, e)
-
-    # ============================================================================
-    # DEFINE POSTPROCESSING
-    # ============================================================================
-    def postprocess(h):
-        h = module.norm_out(h, temb)
-        h = module.proj_out(h)
-        h = h.reshape(
-            batch_size,
-            post_patch_num_frames,
-            post_patch_height,
-            post_patch_width,
-            -1,
-            p_t,
-            p_h,
-            p_w,
-        )
-        h = h.permute(0, 4, 1, 5, 2, 6, 3, 7)
-        h = h.flatten(6, 7).flatten(4, 5).flatten(2, 3)
-        if not return_dict:
-            return (h,)
-        return Transformer2DModelOutput(sample=h)
+        # ============================================================================
+        # EXTRACT MODULATED INPUT (for cache decision)
+        # Use first transformer block's norm1 output on image hidden states.
+        # ============================================================================
+        # AdaLayerNormZero returns (norm_hs, gate_msa, shift_mlp, scale_mlp, gate_mlp)
+        norm_hidden_states, _, _, _, _ = block0.norm1(hidden_states, emb=temb)
+    finally:
+        if _block0_is_fsdp:
+            block0.reshard()
+        if _root_is_fsdp:
+            module.reshard()
 
     return CacheContext(
         modulated_input=norm_hidden_states,
         hidden_states=hidden_states,
         encoder_hidden_states=encoder_hidden_states,
         temb=temb,
-        run_transformer_blocks=run_transformer_blocks,
-        postprocess=postprocess,
     )
 
 
@@ -1301,9 +1374,9 @@ EXTRACTOR_REGISTRY: dict[str, Callable] = {
     "StableAudioDiTModel": extract_stable_audio_context,
     "Flux2Transformer2DModel": extract_flux2_context,
     "LongCatImageTransformer2DModel": extract_longcat_context,
+    "FluxTransformer2DModel": extract_flux_context,
     "HunyuanVideo15Transformer3DModel": extract_hunyuan_video_15_context,
     # Future models:
-    # "FluxTransformer2DModel": extract_flux_context,
     # "CogVideoXTransformer3DModel": extract_cogvideox_context,
 }
 

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -277,10 +277,7 @@ def extract_qwen_context(
 
     def postprocess(h):
         """Apply Qwen-specific output postprocessing."""
-        if getattr(module, "zero_cond_t", False):
-            h = module.norm_out(h, temb.chunk(2, dim=0)[0])
-        else:
-            h = module.norm_out(h, temb)
+        h = module.norm_out(h, temb)
         output = module.proj_out(h)
         if not return_dict:
             return (output,)
@@ -307,9 +304,12 @@ def extract_bagel_context(
     packed_vae_position_ids: torch.LongTensor,
     packed_text_ids: torch.LongTensor,
     packed_text_indexes: torch.LongTensor,
+    packed_indexes: torch.LongTensor,
     packed_position_ids: torch.LongTensor,
     packed_seqlens: torch.IntTensor,
+    key_values_lens: torch.IntTensor,
     past_key_values: Any,
+    packed_key_value_indexes: torch.LongTensor,
     **kwargs: Any,
 ) -> CacheContext:
     """
@@ -323,9 +323,12 @@ def extract_bagel_context(
         packed_vae_position_ids: Position IDs for VAE tokens
         packed_text_ids: Text token IDs
         packed_text_indexes: Indexes for text tokens in packed sequence
+        packed_indexes: Global indexes
         packed_position_ids: Global position IDs
         packed_seqlens: Sequence lengths
+        key_values_lens: KV cache lengths
         past_key_values: KV cache
+        packed_key_value_indexes: KV cache indexes
         **kwargs: Additional keyword arguments
 
     Returns:
@@ -369,7 +372,10 @@ def extract_bagel_context(
             packed_query_sequence=packed_sequence,
             query_lens=packed_seqlens,
             packed_query_position_ids=packed_position_ids,
+            packed_query_indexes=packed_indexes,
             past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
             update_past_key_values=False,
             is_causal=False,
             **extra_inputs,
@@ -1202,9 +1208,192 @@ EXTRACTOR_REGISTRY: dict[str, Callable] = {
     "Flux2Transformer2DModel": extract_flux2_context,
     "LongCatImageTransformer2DModel": extract_longcat_context,
     "FluxTransformer2DModel": extract_flux_context,
+    "HunyuanVideo15Transformer3DModel": extract_hunyuan_video_15_context,
     # Future models:
     # "CogVideoXTransformer3DModel": extract_cogvideox_context,
 }
+
+
+
+def extract_hunyuan_video_15_context(
+    module: nn.Module,
+    hidden_states: torch.Tensor,
+    timestep: torch.LongTensor,
+    encoder_hidden_states: torch.Tensor,
+    encoder_attention_mask: torch.Tensor,
+    timestep_r: torch.LongTensor | None = None,
+    encoder_hidden_states_2: torch.Tensor | None = None,
+    encoder_attention_mask_2: torch.Tensor | None = None,
+    image_embeds: torch.Tensor | None = None,
+    image_embeds_mask: torch.Tensor | None = None,
+    attention_kwargs: dict[str, Any] | None = None,
+    return_dict: bool = True,
+    **kwargs: Any,
+) -> CacheContext:
+    """
+    Extract cache context for HunyuanVideo15Transformer3DModel.
+
+    HunyuanVideo-1.5 uses a dual-stream transformer (image + text tokens processed
+    jointly). The modulated input is extracted from the first transformer block's
+    AdaLayerNormZero output on the image hidden states, which is sensitive to the
+    timestep embedding and serves as a reliable cache decision signal.
+
+    Args:
+        module: HunyuanVideo15Transformer3DModel instance
+        hidden_states: Video latent tensor [B, C, T, H, W]
+        timestep: Diffusion timestep
+        encoder_hidden_states: Primary text encoder outputs
+        encoder_attention_mask: Mask for primary text encoder
+        timestep_r: Optional second timestep (for flow matching)
+        encoder_hidden_states_2: Secondary text encoder outputs (ByT5)
+        encoder_attention_mask_2: Mask for secondary text encoder
+        image_embeds: Image conditioning embeddings (zeros for T2V)
+        image_embeds_mask: Mask for image embeddings
+        attention_kwargs: Additional attention arguments
+        return_dict: Whether to return Transformer2DModelOutput
+        **kwargs: Additional keyword arguments
+
+    Returns:
+        CacheContext with all information needed for generic caching
+    """
+
+    if not hasattr(module, "transformer_blocks") or len(module.transformer_blocks) == 0:
+        raise ValueError("Module must have transformer_blocks")
+
+    # ============================================================================
+    # PREPROCESSING (mirrors HunyuanVideo15Transformer3DModel.forward)
+    # ============================================================================
+    batch_size, num_channels, num_frames, height, width = hidden_states.shape
+
+    # The extractor is called from the pipeline-level TeaCache probe, outside the
+    # transformer's own forward(). Manually unshard root-level params (time_embed,
+    # x_embedder, etc.) and transformer_blocks[0] params (norm1) so submodules
+    # can be called directly without going through the FSDP pre-forward hook chain.
+    try:
+        from torch.distributed.fsdp._fully_shard._fully_shard import FSDPModule as _FSDPModule
+    except ImportError:
+        _FSDPModule = None
+
+    block0 = module.transformer_blocks[0]
+    _root_is_fsdp = _FSDPModule is not None and isinstance(module, _FSDPModule)
+    _block0_is_fsdp = _FSDPModule is not None and isinstance(block0, _FSDPModule)
+
+    try:
+        if _root_is_fsdp:
+            module.unshard()
+        if _block0_is_fsdp:
+            block0.unshard()
+
+        temb = module.time_embed(timestep, timestep_r=timestep_r)
+        hidden_states = module.x_embedder(hidden_states)
+
+        enc_hs = module.context_embedder(encoder_hidden_states, timestep, encoder_attention_mask)
+        enc_hs = enc_hs + module.cond_type_embed(torch.zeros_like(enc_hs[:, :, 0], dtype=torch.long))
+
+        enc_hs_2 = module.context_embedder_2(encoder_hidden_states_2)
+        enc_hs_2 = enc_hs_2 + module.cond_type_embed(torch.ones_like(enc_hs_2[:, :, 0], dtype=torch.long))
+
+        enc_hs_3 = module.image_embedder(image_embeds)
+        if image_embeds_mask is not None:
+            enc_attn_mask_3 = image_embeds_mask
+        else:
+            is_t2v = torch.all(image_embeds == 0)
+            if is_t2v:
+                enc_hs_3 = enc_hs_3 * 0.0
+                enc_attn_mask_3 = torch.zeros(
+                    (batch_size, enc_hs_3.shape[1]),
+                    dtype=encoder_attention_mask.dtype,
+                    device=encoder_attention_mask.device,
+                )
+            else:
+                enc_attn_mask_3 = torch.ones(
+                    (batch_size, enc_hs_3.shape[1]),
+                    dtype=encoder_attention_mask.dtype,
+                    device=encoder_attention_mask.device,
+                )
+        enc_hs_3 = enc_hs_3 + module.cond_type_embed(2 * torch.ones_like(enc_hs_3[:, :, 0], dtype=torch.long))
+
+        # Token reordering: [valid_image, valid_byte5, valid_mllm, padding]
+        enc_attn_mask_bool = encoder_attention_mask.bool()
+        enc_attn_mask_2_bool = encoder_attention_mask_2.bool()
+        enc_attn_mask_3_bool = enc_attn_mask_3.bool()
+        new_enc_hs = []
+        new_enc_attn_mask = []
+        for text, text_mask, text_2, text_mask_2, image, image_mask in zip(
+            enc_hs,
+            enc_attn_mask_bool,
+            enc_hs_2,
+            enc_attn_mask_2_bool,
+            enc_hs_3,
+            enc_attn_mask_3_bool,
+        ):
+            new_enc_hs.append(
+                torch.cat(
+                    [
+                        image[image_mask],
+                        text_2[text_mask_2],
+                        text[text_mask],
+                        image[~image_mask],
+                        torch.zeros_like(text_2[~text_mask_2]),
+                        torch.zeros_like(text[~text_mask]),
+                    ],
+                    dim=0,
+                )
+            )
+            new_enc_attn_mask.append(
+                torch.cat(
+                    [
+                        image_mask[image_mask],
+                        text_mask_2[text_mask_2],
+                        text_mask[text_mask],
+                        image_mask[~image_mask],
+                        text_mask_2[~text_mask_2],
+                        text_mask[~text_mask],
+                    ],
+                    dim=0,
+                )
+            )
+        encoder_hidden_states = torch.stack(new_enc_hs)
+        encoder_attention_mask = torch.stack(new_enc_attn_mask)
+
+        # SP padding mask (same logic as transformer forward)
+        hidden_states_mask = getattr(module, "_cached_sp_mask", None)
+        if hidden_states_mask is None:
+            ctx_fwd = get_forward_context()
+            if ctx_fwd.sp_original_seq_len is not None and ctx_fwd.sp_padding_size > 0:
+                padded_seq_len = ctx_fwd.sp_original_seq_len + ctx_fwd.sp_padding_size
+                hidden_states_mask = torch.ones(
+                    batch_size, padded_seq_len, dtype=torch.bool, device=hidden_states.device
+                )
+                hidden_states_mask[:, ctx_fwd.sp_original_seq_len :] = False
+                module._cached_sp_mask = hidden_states_mask
+
+        # ============================================================================
+        # EXTRACT MODULATED INPUT (for cache decision)
+        # Use first transformer block's norm1 output on image hidden states.
+        # ============================================================================
+        # AdaLayerNormZero returns (norm_hs, gate_msa, shift_mlp, scale_mlp, gate_mlp)
+        norm_hidden_states, _, _, _, _ = block0.norm1(hidden_states, emb=temb)
+    finally:
+        if _block0_is_fsdp:
+            block0.reshard()
+        if _root_is_fsdp:
+            module.reshard()
+
+    return CacheContext(
+        modulated_input=norm_hidden_states,
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        temb=temb,
+    )
+
+
+# Registry for model-specific extractors
+# Key: Transformer class name
+# Value: extractor function with signature (module, *args, **kwargs) -> CacheContext
+#
+# Note: Use the transformer class name as specified in pipelines as TeaCache hooks operate
+# on the transformer module and multiple pipelines can share the same transformer.
 
 
 def register_extractor(transformer_cls_name: str, extractor_fn: Callable) -> None:

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -1069,152 +1069,6 @@ def extract_flux2_context(
     )
 
 
-def extract_flux_context(
-    module: nn.Module,
-    hidden_states: torch.Tensor,
-    encoder_hidden_states: torch.Tensor,
-    pooled_projections: torch.Tensor,
-    timestep: torch.LongTensor,
-    img_ids: torch.Tensor,
-    txt_ids: torch.Tensor,
-    guidance: torch.Tensor | None = None,
-    joint_attention_kwargs: dict[str, Any] | None = None,
-    **kwargs: Any,
-) -> CacheContext:
-    """
-    Extract cache context for FluxTransformer2DModel.
-
-    This mirrors the standard FLUX.1 transformer forward path while exposing
-    the first modulated image stream tensor as TeaCache's similarity signal.
-
-    Args:
-        module: FluxTransformer2DModel instance
-        hidden_states: Input image hidden states tensor
-        encoder_hidden_states: Text encoder outputs
-        pooled_projections: Pooled text conditioning
-        timestep: Current diffusion timestep
-        img_ids: Image position IDs for RoPE
-        txt_ids: Text position IDs for RoPE
-        guidance: Optional guidance scale for guidance-distilled variants
-        joint_attention_kwargs: Additional attention kwargs
-        **kwargs: Additional keyword arguments
-
-    Returns:
-        CacheContext with all information needed for generic caching
-    """
-    from diffusers.models.modeling_outputs import Transformer2DModelOutput
-
-    if not hasattr(module, "transformer_blocks") or len(module.transformer_blocks) == 0:
-        raise ValueError("Module must have transformer_blocks")
-
-    # ============================================================================
-    # PREPROCESSING (Flux1-specific)
-    # ============================================================================
-    hidden_states = module.x_embedder(hidden_states)
-    timestep = timestep.to(device=hidden_states.device, dtype=hidden_states.dtype) * 1000
-
-    if guidance is not None:
-        guidance = guidance.to(device=hidden_states.device, dtype=hidden_states.dtype) * 1000
-
-    temb = (
-        module.time_text_embed(timestep, pooled_projections)
-        if guidance is None
-        else module.time_text_embed(timestep, guidance, pooled_projections)
-    )
-    encoder_hidden_states = module.context_embedder(encoder_hidden_states)
-
-    if txt_ids.ndim == 3:
-        txt_ids = txt_ids[0]
-    if img_ids.ndim == 3:
-        img_ids = img_ids[0]
-
-    ids = torch.cat((txt_ids, img_ids), dim=0)
-    if current_omni_platform.is_npu():
-        freqs_cos, freqs_sin = module.pos_embed(ids.cpu())
-        image_rotary_emb = (freqs_cos.npu(), freqs_sin.npu())
-    else:
-        image_rotary_emb = module.pos_embed(ids)
-
-    # ============================================================================
-    # EXTRACT MODULATED INPUT (for cache decision)
-    # ============================================================================
-    first_block = module.transformer_blocks[0]
-    modulated_input, *_ = first_block.norm1(hidden_states, emb=temb)
-
-    # ============================================================================
-    # DEFINE TRANSFORMER EXECUTION (Flux1-specific)
-    # ============================================================================
-    def run_transformer_blocks() -> tuple[torch.Tensor, torch.Tensor]:
-        h = hidden_states
-        e = encoder_hidden_states
-
-        for block in module.transformer_blocks:
-            e, h = block(
-                hidden_states=h,
-                encoder_hidden_states=e,
-                temb=temb,
-                image_rotary_emb=image_rotary_emb,
-                joint_attention_kwargs=joint_attention_kwargs,
-            )
-
-        for block in module.single_transformer_blocks:
-            e, h = block(
-                hidden_states=h,
-                encoder_hidden_states=e,
-                temb=temb,
-                image_rotary_emb=image_rotary_emb,
-                joint_attention_kwargs=joint_attention_kwargs,
-            )
-
-        return (h, e)
-
-    return_dict = kwargs.get("return_dict", True)
-
-    # ============================================================================
-    # DEFINE POSTPROCESSING
-    # ============================================================================
-    def postprocess(h: torch.Tensor) -> Any:
-        h = module.norm_out(h, temb)
-        output = module.proj_out(h)
-        if not return_dict:
-            return (output,)
-        return Transformer2DModelOutput(sample=output)
-
-    # ============================================================================
-    # RETURN CONTEXT
-    # ============================================================================
-    return CacheContext(
-        modulated_input=modulated_input,
-        hidden_states=hidden_states,
-        encoder_hidden_states=encoder_hidden_states,
-        temb=temb,
-        run_transformer_blocks=run_transformer_blocks,
-        postprocess=postprocess,
-    )
-
-
-# Registry for model-specific extractors
-# Key: Transformer class name
-# Value: extractor function with signature (module, *args, **kwargs) -> CacheContext
-#
-# Note: Use the transformer class name as specified in pipelines as TeaCache hooks operate
-# on the transformer module and multiple pipelines can share the same transformer.
-EXTRACTOR_REGISTRY: dict[str, Callable] = {
-    "QwenImageTransformer2DModel": extract_qwen_context,
-    "Bagel": extract_bagel_context,
-    "ZImageTransformer2DModel": extract_zimage_context,
-    "Flux2Klein": extract_flux2_klein_context,
-    "StableAudioDiTModel": extract_stable_audio_context,
-    "Flux2Transformer2DModel": extract_flux2_context,
-    "LongCatImageTransformer2DModel": extract_longcat_context,
-    "FluxTransformer2DModel": extract_flux_context,
-    "HunyuanVideo15Transformer3DModel": extract_hunyuan_video_15_context,
-    # Future models:
-    # "CogVideoXTransformer3DModel": extract_cogvideox_context,
-}
-
-
-
 def extract_hunyuan_video_15_context(
     module: nn.Module,
     hidden_states: torch.Tensor,
@@ -1256,6 +1110,7 @@ def extract_hunyuan_video_15_context(
     Returns:
         CacheContext with all information needed for generic caching
     """
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
 
     if not hasattr(module, "transformer_blocks") or len(module.transformer_blocks) == 0:
         raise ValueError("Module must have transformer_blocks")
@@ -1264,127 +1119,148 @@ def extract_hunyuan_video_15_context(
     # PREPROCESSING (mirrors HunyuanVideo15Transformer3DModel.forward)
     # ============================================================================
     batch_size, num_channels, num_frames, height, width = hidden_states.shape
+    p_t, p_h, p_w = module.patch_size_t, module.patch_size, module.patch_size
+    post_patch_num_frames = num_frames // p_t
+    post_patch_height = height // p_h
+    post_patch_width = width // p_w
 
-    # The extractor is called from the pipeline-level TeaCache probe, outside the
-    # transformer's own forward(). Manually unshard root-level params (time_embed,
-    # x_embedder, etc.) and transformer_blocks[0] params (norm1) so submodules
-    # can be called directly without going through the FSDP pre-forward hook chain.
-    try:
-        from torch.distributed.fsdp._fully_shard._fully_shard import FSDPModule as _FSDPModule
-    except ImportError:
-        _FSDPModule = None
+    image_rotary_emb = module.rope(hidden_states)
+    temb = module.time_embed(timestep, timestep_r=timestep_r)
+    hidden_states = module.x_embedder(hidden_states)
 
-    block0 = module.transformer_blocks[0]
-    _root_is_fsdp = _FSDPModule is not None and isinstance(module, _FSDPModule)
-    _block0_is_fsdp = _FSDPModule is not None and isinstance(block0, _FSDPModule)
+    enc_hs = module.context_embedder(encoder_hidden_states, timestep, encoder_attention_mask)
+    enc_hs = enc_hs + module.cond_type_embed(torch.zeros_like(enc_hs[:, :, 0], dtype=torch.long))
 
-    try:
-        if _root_is_fsdp:
-            module.unshard()
-        if _block0_is_fsdp:
-            block0.unshard()
+    enc_hs_2 = module.context_embedder_2(encoder_hidden_states_2)
+    enc_hs_2 = enc_hs_2 + module.cond_type_embed(torch.ones_like(enc_hs_2[:, :, 0], dtype=torch.long))
 
-        temb = module.time_embed(timestep, timestep_r=timestep_r)
-        hidden_states = module.x_embedder(hidden_states)
-
-        enc_hs = module.context_embedder(encoder_hidden_states, timestep, encoder_attention_mask)
-        enc_hs = enc_hs + module.cond_type_embed(torch.zeros_like(enc_hs[:, :, 0], dtype=torch.long))
-
-        enc_hs_2 = module.context_embedder_2(encoder_hidden_states_2)
-        enc_hs_2 = enc_hs_2 + module.cond_type_embed(torch.ones_like(enc_hs_2[:, :, 0], dtype=torch.long))
-
-        enc_hs_3 = module.image_embedder(image_embeds)
-        if image_embeds_mask is not None:
-            enc_attn_mask_3 = image_embeds_mask
+    enc_hs_3 = module.image_embedder(image_embeds)
+    if image_embeds_mask is not None:
+        enc_attn_mask_3 = image_embeds_mask
+    else:
+        is_t2v = torch.all(image_embeds == 0)
+        if is_t2v:
+            enc_hs_3 = enc_hs_3 * 0.0
+            enc_attn_mask_3 = torch.zeros(
+                (batch_size, enc_hs_3.shape[1]),
+                dtype=encoder_attention_mask.dtype,
+                device=encoder_attention_mask.device,
+            )
         else:
-            is_t2v = torch.all(image_embeds == 0)
-            if is_t2v:
-                enc_hs_3 = enc_hs_3 * 0.0
-                enc_attn_mask_3 = torch.zeros(
-                    (batch_size, enc_hs_3.shape[1]),
-                    dtype=encoder_attention_mask.dtype,
-                    device=encoder_attention_mask.device,
-                )
-            else:
-                enc_attn_mask_3 = torch.ones(
-                    (batch_size, enc_hs_3.shape[1]),
-                    dtype=encoder_attention_mask.dtype,
-                    device=encoder_attention_mask.device,
-                )
-        enc_hs_3 = enc_hs_3 + module.cond_type_embed(2 * torch.ones_like(enc_hs_3[:, :, 0], dtype=torch.long))
-
-        # Token reordering: [valid_image, valid_byte5, valid_mllm, padding]
-        enc_attn_mask_bool = encoder_attention_mask.bool()
-        enc_attn_mask_2_bool = encoder_attention_mask_2.bool()
-        enc_attn_mask_3_bool = enc_attn_mask_3.bool()
-        new_enc_hs = []
-        new_enc_attn_mask = []
-        for text, text_mask, text_2, text_mask_2, image, image_mask in zip(
-            enc_hs,
-            enc_attn_mask_bool,
-            enc_hs_2,
-            enc_attn_mask_2_bool,
-            enc_hs_3,
-            enc_attn_mask_3_bool,
-        ):
-            new_enc_hs.append(
-                torch.cat(
-                    [
-                        image[image_mask],
-                        text_2[text_mask_2],
-                        text[text_mask],
-                        image[~image_mask],
-                        torch.zeros_like(text_2[~text_mask_2]),
-                        torch.zeros_like(text[~text_mask]),
-                    ],
-                    dim=0,
-                )
+            enc_attn_mask_3 = torch.ones(
+                (batch_size, enc_hs_3.shape[1]),
+                dtype=encoder_attention_mask.dtype,
+                device=encoder_attention_mask.device,
             )
-            new_enc_attn_mask.append(
-                torch.cat(
-                    [
-                        image_mask[image_mask],
-                        text_mask_2[text_mask_2],
-                        text_mask[text_mask],
-                        image_mask[~image_mask],
-                        text_mask_2[~text_mask_2],
-                        text_mask[~text_mask],
-                    ],
-                    dim=0,
-                )
+    enc_hs_3 = enc_hs_3 + module.cond_type_embed(2 * torch.ones_like(enc_hs_3[:, :, 0], dtype=torch.long))
+
+    # Token reordering: [valid_image, valid_byte5, valid_mllm, padding]
+    enc_attn_mask_bool = encoder_attention_mask.bool()
+    enc_attn_mask_2_bool = encoder_attention_mask_2.bool()
+    enc_attn_mask_3_bool = enc_attn_mask_3.bool()
+    new_enc_hs = []
+    new_enc_attn_mask = []
+    for text, text_mask, text_2, text_mask_2, image, image_mask in zip(
+        enc_hs,
+        enc_attn_mask_bool,
+        enc_hs_2,
+        enc_attn_mask_2_bool,
+        enc_hs_3,
+        enc_attn_mask_3_bool,
+    ):
+        new_enc_hs.append(
+            torch.cat(
+                [
+                    image[image_mask],
+                    text_2[text_mask_2],
+                    text[text_mask],
+                    image[~image_mask],
+                    torch.zeros_like(text_2[~text_mask_2]),
+                    torch.zeros_like(text[~text_mask]),
+                ],
+                dim=0,
             )
-        encoder_hidden_states = torch.stack(new_enc_hs)
-        encoder_attention_mask = torch.stack(new_enc_attn_mask)
+        )
+        new_enc_attn_mask.append(
+            torch.cat(
+                [
+                    image_mask[image_mask],
+                    text_mask_2[text_mask_2],
+                    text_mask[text_mask],
+                    image_mask[~image_mask],
+                    text_mask_2[~text_mask_2],
+                    text_mask[~text_mask],
+                ],
+                dim=0,
+            )
+        )
+    encoder_hidden_states = torch.stack(new_enc_hs)
+    encoder_attention_mask = torch.stack(new_enc_attn_mask)
 
-        # SP padding mask (same logic as transformer forward)
-        hidden_states_mask = getattr(module, "_cached_sp_mask", None)
-        if hidden_states_mask is None:
-            ctx_fwd = get_forward_context()
-            if ctx_fwd.sp_original_seq_len is not None and ctx_fwd.sp_padding_size > 0:
-                padded_seq_len = ctx_fwd.sp_original_seq_len + ctx_fwd.sp_padding_size
-                hidden_states_mask = torch.ones(
-                    batch_size, padded_seq_len, dtype=torch.bool, device=hidden_states.device
-                )
-                hidden_states_mask[:, ctx_fwd.sp_original_seq_len :] = False
-                module._cached_sp_mask = hidden_states_mask
+    # SP padding mask (same logic as transformer forward)
+    hidden_states_mask = getattr(module, "_cached_sp_mask", None)
+    if hidden_states_mask is None:
+        ctx_fwd = get_forward_context()
+        if ctx_fwd.sp_original_seq_len is not None and ctx_fwd.sp_padding_size > 0:
+            padded_seq_len = ctx_fwd.sp_original_seq_len + ctx_fwd.sp_padding_size
+            hidden_states_mask = torch.ones(batch_size, padded_seq_len, dtype=torch.bool, device=hidden_states.device)
+            hidden_states_mask[:, ctx_fwd.sp_original_seq_len :] = False
+            module._cached_sp_mask = hidden_states_mask
 
-        # ============================================================================
-        # EXTRACT MODULATED INPUT (for cache decision)
-        # Use first transformer block's norm1 output on image hidden states.
-        # ============================================================================
-        # AdaLayerNormZero returns (norm_hs, gate_msa, shift_mlp, scale_mlp, gate_mlp)
-        norm_hidden_states, _, _, _, _ = block0.norm1(hidden_states, emb=temb)
-    finally:
-        if _block0_is_fsdp:
-            block0.reshard()
-        if _root_is_fsdp:
-            module.reshard()
+    # ============================================================================
+    # EXTRACT MODULATED INPUT (for cache decision)
+    # Use first transformer block's norm1 output on image hidden states.
+    # ============================================================================
+    block0 = module.transformer_blocks[0]
+    # AdaLayerNormZero returns (norm_hs, gate_msa, shift_mlp, scale_mlp, gate_mlp)
+    norm_hidden_states, _, _, _, _ = block0.norm1(hidden_states, emb=temb)
+
+    # ============================================================================
+    # DEFINE TRANSFORMER EXECUTION
+    # ============================================================================
+    def run_transformer_blocks():
+        h = hidden_states
+        e = encoder_hidden_states
+        for block in module.transformer_blocks:
+            h, e = block(
+                h,
+                e,
+                temb,
+                encoder_attention_mask,
+                image_rotary_emb,
+                hidden_states_mask=hidden_states_mask,
+            )
+        return (h, e)
+
+    # ============================================================================
+    # DEFINE POSTPROCESSING
+    # ============================================================================
+    def postprocess(h):
+        h = module.norm_out(h, temb)
+        h = module.proj_out(h)
+        h = h.reshape(
+            batch_size,
+            post_patch_num_frames,
+            post_patch_height,
+            post_patch_width,
+            -1,
+            p_t,
+            p_h,
+            p_w,
+        )
+        h = h.permute(0, 4, 1, 5, 2, 6, 3, 7)
+        h = h.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+        if not return_dict:
+            return (h,)
+        return Transformer2DModelOutput(sample=h)
 
     return CacheContext(
         modulated_input=norm_hidden_states,
         hidden_states=hidden_states,
         encoder_hidden_states=encoder_hidden_states,
         temb=temb,
+        run_transformer_blocks=run_transformer_blocks,
+        postprocess=postprocess,
     )
 
 
@@ -1394,6 +1270,19 @@ def extract_hunyuan_video_15_context(
 #
 # Note: Use the transformer class name as specified in pipelines as TeaCache hooks operate
 # on the transformer module and multiple pipelines can share the same transformer.
+EXTRACTOR_REGISTRY: dict[str, Callable] = {
+    "QwenImageTransformer2DModel": extract_qwen_context,
+    "Bagel": extract_bagel_context,
+    "ZImageTransformer2DModel": extract_zimage_context,
+    "Flux2Klein": extract_flux2_klein_context,
+    "StableAudioDiTModel": extract_stable_audio_context,
+    "Flux2Transformer2DModel": extract_flux2_context,
+    "LongCatImageTransformer2DModel": extract_longcat_context,
+    "HunyuanVideo15Transformer3DModel": extract_hunyuan_video_15_context,
+    # Future models:
+    # "FluxTransformer2DModel": extract_flux_context,
+    # "CogVideoXTransformer3DModel": extract_cogvideox_context,
+}
 
 
 def register_extractor(transformer_cls_name: str, extractor_fn: Callable) -> None:

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
@@ -19,6 +19,7 @@ from torch import nn
 from transformers import AutoConfig, ByT5Tokenizer, Qwen2_5_VLTextModel, Qwen2Tokenizer
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
+from vllm_omni.diffusion.cache.teacache.backend import _teacache_init_loop_state, _teacache_should_compute
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
@@ -451,6 +452,9 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
         timesteps = self.scheduler.timesteps
         self._num_timesteps = len(timesteps)
 
+        # ---- TeaCache initialization ----
+        _tc_state = _teacache_init_loop_state(self)
+
         with self.progress_bar(total=len(timesteps)) as pbar:
             for i, t in enumerate(timesteps):
                 self._current_timestep = t
@@ -492,13 +496,19 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
                         "return_dict": False,
                     }
 
-                noise_pred = self.predict_noise_maybe_with_cfg(
-                    do_true_cfg=do_cfg and negative_kwargs is not None,
-                    true_cfg_scale=guidance_scale,
-                    positive_kwargs=positive_kwargs,
-                    negative_kwargs=negative_kwargs,
-                    cfg_normalize=req.sampling_params.cfg_normalize,
-                )
+                # ---- TeaCache: decide whether to compute or reuse ----
+                if _teacache_should_compute(_tc_state, t):
+                    noise_pred = self.predict_noise_maybe_with_cfg(
+                        do_true_cfg=do_cfg and negative_kwargs is not None,
+                        true_cfg_scale=guidance_scale,
+                        positive_kwargs=positive_kwargs,
+                        negative_kwargs=negative_kwargs,
+                        cfg_normalize=req.sampling_params.cfg_normalize,
+                    )
+                    if _tc_state is not None:
+                        _tc_state["prev_noise_pred"] = noise_pred
+                else:
+                    noise_pred = _tc_state["prev_noise_pred"]
 
                 latents = self.scheduler_step_maybe_with_cfg(
                     noise_pred,
@@ -507,6 +517,8 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
                     do_true_cfg=do_cfg and negative_kwargs is not None,
                 )
 
+                if _tc_state is not None:
+                    _tc_state["cnt"] += 1
                 pbar.update()
 
         self._current_timestep = None

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
@@ -497,7 +497,12 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
                     }
 
                 # ---- TeaCache: decide whether to compute or reuse ----
-                if _teacache_should_compute(_tc_state, t):
+                _mod_input = None
+                if _tc_state is not None:
+                    _temb = self.transformer.time_embed(timestep, timestep_r=timestep_r)
+                    _hs = self.transformer.x_embedder(latent_model_input)
+                    _mod_input, _, _, _, _ = self.transformer.transformer_blocks[0].norm1(_hs, emb=_temb)
+                if _teacache_should_compute(_tc_state, _mod_input):
                     noise_pred = self.predict_noise_maybe_with_cfg(
                         do_true_cfg=do_cfg and negative_kwargs is not None,
                         true_cfg_scale=guidance_scale,

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
@@ -20,6 +20,9 @@ from transformers import AutoConfig, ByT5Tokenizer, Qwen2_5_VLTextModel, Qwen2To
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.cache.teacache.backend import _teacache_init_loop_state, _teacache_should_compute
+from vllm_omni.diffusion.cache.teacache.extractors import (
+    extract_hunyuan_video_15_context as _hunyuan_video_15_extractor,
+)
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
@@ -499,9 +502,8 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
                 # ---- TeaCache: decide whether to compute or reuse ----
                 _mod_input = None
                 if _tc_state is not None:
-                    _temb = self.transformer.time_embed(timestep, timestep_r=timestep_r)
-                    _hs = self.transformer.x_embedder(latent_model_input)
-                    _mod_input, _, _, _, _ = self.transformer.transformer_blocks[0].norm1(_hs, emb=_temb)
+                    _cache_ctx = _hunyuan_video_15_extractor(self.transformer, **positive_kwargs)
+                    _mod_input = _cache_ctx.modulated_input
                 if _teacache_should_compute(_tc_state, _mod_input):
                     noise_pred = self.predict_noise_maybe_with_cfg(
                         do_true_cfg=do_cfg and negative_kwargs is not None,

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
@@ -18,6 +18,7 @@ from torch import nn
 from transformers import AutoConfig, ByT5Tokenizer, Qwen2_5_VLTextModel, Qwen2Tokenizer
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
+from vllm_omni.diffusion.cache.teacache.backend import _teacache_init_loop_state, _teacache_should_compute
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_hunyuan_video_15 import (
     DistributedAutoencoderKLHunyuanVideo15,
@@ -470,6 +471,9 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
         timesteps = self.scheduler.timesteps
         self._num_timesteps = len(timesteps)
 
+        # ---- TeaCache initialization ----
+        _tc_state = _teacache_init_loop_state(self)
+
         with self.progress_bar(total=len(timesteps)) as pbar:
             for i, t in enumerate(timesteps):
                 self._current_timestep = t
@@ -511,13 +515,19 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
                         "return_dict": False,
                     }
 
-                noise_pred = self.predict_noise_maybe_with_cfg(
-                    do_true_cfg=do_cfg and negative_kwargs is not None,
-                    true_cfg_scale=guidance_scale,
-                    positive_kwargs=positive_kwargs,
-                    negative_kwargs=negative_kwargs,
-                    cfg_normalize=req.sampling_params.cfg_normalize,
-                )
+                # ---- TeaCache: decide whether to compute or reuse ----
+                if _teacache_should_compute(_tc_state, t):
+                    noise_pred = self.predict_noise_maybe_with_cfg(
+                        do_true_cfg=do_cfg and negative_kwargs is not None,
+                        true_cfg_scale=guidance_scale,
+                        positive_kwargs=positive_kwargs,
+                        negative_kwargs=negative_kwargs,
+                        cfg_normalize=req.sampling_params.cfg_normalize,
+                    )
+                    if _tc_state is not None:
+                        _tc_state["prev_noise_pred"] = noise_pred
+                else:
+                    noise_pred = _tc_state["prev_noise_pred"]
 
                 latents = self.scheduler_step_maybe_with_cfg(
                     noise_pred,
@@ -526,6 +536,8 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
                     do_true_cfg=do_cfg and negative_kwargs is not None,
                 )
 
+                if _tc_state is not None:
+                    _tc_state["cnt"] += 1
                 pbar.update()
 
         self._current_timestep = None

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
@@ -516,7 +516,12 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
                     }
 
                 # ---- TeaCache: decide whether to compute or reuse ----
-                if _teacache_should_compute(_tc_state, t):
+                _mod_input = None
+                if _tc_state is not None:
+                    _temb = self.transformer.time_embed(timestep, timestep_r=timestep_r)
+                    _hs = self.transformer.x_embedder(latent_model_input)
+                    _mod_input, _, _, _, _ = self.transformer.transformer_blocks[0].norm1(_hs, emb=_temb)
+                if _teacache_should_compute(_tc_state, _mod_input):
                     noise_pred = self.predict_noise_maybe_with_cfg(
                         do_true_cfg=do_cfg and negative_kwargs is not None,
                         true_cfg_scale=guidance_scale,

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
@@ -19,6 +19,9 @@ from transformers import AutoConfig, ByT5Tokenizer, Qwen2_5_VLTextModel, Qwen2To
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.cache.teacache.backend import _teacache_init_loop_state, _teacache_should_compute
+from vllm_omni.diffusion.cache.teacache.extractors import (
+    extract_hunyuan_video_15_context as _hunyuan_video_15_extractor,
+)
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_hunyuan_video_15 import (
     DistributedAutoencoderKLHunyuanVideo15,
@@ -518,9 +521,8 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
                 # ---- TeaCache: decide whether to compute or reuse ----
                 _mod_input = None
                 if _tc_state is not None:
-                    _temb = self.transformer.time_embed(timestep, timestep_r=timestep_r)
-                    _hs = self.transformer.x_embedder(latent_model_input)
-                    _mod_input, _, _, _, _ = self.transformer.transformer_blocks[0].norm1(_hs, emb=_temb)
+                    _cache_ctx = _hunyuan_video_15_extractor(self.transformer, **positive_kwargs)
+                    _mod_input = _cache_ctx.modulated_input
                 if _teacache_should_compute(_tc_state, _mod_input):
                     noise_pred = self.predict_noise_maybe_with_cfg(
                         do_true_cfg=do_cfg and negative_kwargs is not None,

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
@@ -26,6 +26,7 @@ from transformers import (
 )
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
+from vllm_omni.diffusion.cache.teacache.backend import _teacache_init_loop_state, _teacache_should_compute
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
@@ -528,6 +529,9 @@ class HunyuanVideo15I2VPipeline(
         timesteps = self.scheduler.timesteps
         self._num_timesteps = len(timesteps)
 
+        # ---- TeaCache initialization ----
+        _tc_state = _teacache_init_loop_state(self)
+
         with self.progress_bar(total=len(timesteps)) as pbar:
             for i, t in enumerate(timesteps):
                 self._current_timestep = t
@@ -570,13 +574,19 @@ class HunyuanVideo15I2VPipeline(
                         "return_dict": False,
                     }
 
-                noise_pred = self.predict_noise_maybe_with_cfg(
-                    do_true_cfg=do_cfg and negative_kwargs is not None,
-                    true_cfg_scale=guidance_scale,
-                    positive_kwargs=positive_kwargs,
-                    negative_kwargs=negative_kwargs,
-                    cfg_normalize=req.sampling_params.cfg_normalize,
-                )
+                # ---- TeaCache: decide whether to compute or reuse ----
+                if _teacache_should_compute(_tc_state, t):
+                    noise_pred = self.predict_noise_maybe_with_cfg(
+                        do_true_cfg=do_cfg and negative_kwargs is not None,
+                        true_cfg_scale=guidance_scale,
+                        positive_kwargs=positive_kwargs,
+                        negative_kwargs=negative_kwargs,
+                        cfg_normalize=req.sampling_params.cfg_normalize,
+                    )
+                    if _tc_state is not None:
+                        _tc_state["prev_noise_pred"] = noise_pred
+                else:
+                    noise_pred = _tc_state["prev_noise_pred"]
 
                 latents = self.scheduler_step_maybe_with_cfg(
                     noise_pred,
@@ -585,6 +595,8 @@ class HunyuanVideo15I2VPipeline(
                     do_true_cfg=do_cfg and negative_kwargs is not None,
                 )
 
+                if _tc_state is not None:
+                    _tc_state["cnt"] += 1
                 pbar.update()
 
         self._current_timestep = None

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
@@ -27,6 +27,9 @@ from transformers import (
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.cache.teacache.backend import _teacache_init_loop_state, _teacache_should_compute
+from vllm_omni.diffusion.cache.teacache.extractors import (
+    extract_hunyuan_video_15_context as _hunyuan_video_15_extractor,
+)
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
@@ -577,9 +580,8 @@ class HunyuanVideo15I2VPipeline(
                 # ---- TeaCache: decide whether to compute or reuse ----
                 _mod_input = None
                 if _tc_state is not None:
-                    _temb = self.transformer.time_embed(timestep, timestep_r=timestep_r)
-                    _hs = self.transformer.x_embedder(latent_model_input)
-                    _mod_input, _, _, _, _ = self.transformer.transformer_blocks[0].norm1(_hs, emb=_temb)
+                    _cache_ctx = _hunyuan_video_15_extractor(self.transformer, **positive_kwargs)
+                    _mod_input = _cache_ctx.modulated_input
                 if _teacache_should_compute(_tc_state, _mod_input):
                     noise_pred = self.predict_noise_maybe_with_cfg(
                         do_true_cfg=do_cfg and negative_kwargs is not None,

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
@@ -575,7 +575,12 @@ class HunyuanVideo15I2VPipeline(
                     }
 
                 # ---- TeaCache: decide whether to compute or reuse ----
-                if _teacache_should_compute(_tc_state, t):
+                _mod_input = None
+                if _tc_state is not None:
+                    _temb = self.transformer.time_embed(timestep, timestep_r=timestep_r)
+                    _hs = self.transformer.x_embedder(latent_model_input)
+                    _mod_input, _, _, _, _ = self.transformer.transformer_blocks[0].norm1(_hs, emb=_temb)
+                if _teacache_should_compute(_tc_state, _mod_input):
                     noise_pred = self.predict_noise_maybe_with_cfg(
                         do_true_cfg=do_cfg and negative_kwargs is not None,
                         true_cfg_scale=guidance_scale,

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
@@ -608,7 +608,12 @@ class HunyuanVideo15I2VPipeline(
                     }
 
                 # ---- TeaCache: decide whether to compute or reuse ----
-                if _teacache_should_compute(_tc_state, t):
+                _mod_input = None
+                if _tc_state is not None:
+                    _temb = self.transformer.time_embed(timestep, timestep_r=timestep_r)
+                    _hs = self.transformer.x_embedder(latent_model_input)
+                    _mod_input, _, _, _, _ = self.transformer.transformer_blocks[0].norm1(_hs, emb=_temb)
+                if _teacache_should_compute(_tc_state, _mod_input):
                     noise_pred = self.predict_noise_maybe_with_cfg(
                         do_true_cfg=do_cfg and negative_kwargs is not None,
                         true_cfg_scale=guidance_scale,

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
@@ -26,6 +26,9 @@ from transformers import (
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.cache.teacache.backend import _teacache_init_loop_state, _teacache_should_compute
+from vllm_omni.diffusion.cache.teacache.extractors import (
+    extract_hunyuan_video_15_context as _hunyuan_video_15_extractor,
+)
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_hunyuan_video_15 import (
     DistributedAutoencoderKLHunyuanVideo15,
@@ -610,9 +613,8 @@ class HunyuanVideo15I2VPipeline(
                 # ---- TeaCache: decide whether to compute or reuse ----
                 _mod_input = None
                 if _tc_state is not None:
-                    _temb = self.transformer.time_embed(timestep, timestep_r=timestep_r)
-                    _hs = self.transformer.x_embedder(latent_model_input)
-                    _mod_input, _, _, _, _ = self.transformer.transformer_blocks[0].norm1(_hs, emb=_temb)
+                    _cache_ctx = _hunyuan_video_15_extractor(self.transformer, **positive_kwargs)
+                    _mod_input = _cache_ctx.modulated_input
                 if _teacache_should_compute(_tc_state, _mod_input):
                     noise_pred = self.predict_noise_maybe_with_cfg(
                         do_true_cfg=do_cfg and negative_kwargs is not None,

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
@@ -25,6 +25,7 @@ from transformers import (
 )
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
+from vllm_omni.diffusion.cache.teacache.backend import _teacache_init_loop_state, _teacache_should_compute
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_hunyuan_video_15 import (
     DistributedAutoencoderKLHunyuanVideo15,
@@ -561,6 +562,9 @@ class HunyuanVideo15I2VPipeline(
         timesteps = self.scheduler.timesteps
         self._num_timesteps = len(timesteps)
 
+        # ---- TeaCache initialization ----
+        _tc_state = _teacache_init_loop_state(self)
+
         with self.progress_bar(total=len(timesteps)) as pbar:
             for i, t in enumerate(timesteps):
                 self._current_timestep = t
@@ -603,13 +607,19 @@ class HunyuanVideo15I2VPipeline(
                         "return_dict": False,
                     }
 
-                noise_pred = self.predict_noise_maybe_with_cfg(
-                    do_true_cfg=do_cfg and negative_kwargs is not None,
-                    true_cfg_scale=guidance_scale,
-                    positive_kwargs=positive_kwargs,
-                    negative_kwargs=negative_kwargs,
-                    cfg_normalize=req.sampling_params.cfg_normalize,
-                )
+                # ---- TeaCache: decide whether to compute or reuse ----
+                if _teacache_should_compute(_tc_state, t):
+                    noise_pred = self.predict_noise_maybe_with_cfg(
+                        do_true_cfg=do_cfg and negative_kwargs is not None,
+                        true_cfg_scale=guidance_scale,
+                        positive_kwargs=positive_kwargs,
+                        negative_kwargs=negative_kwargs,
+                        cfg_normalize=req.sampling_params.cfg_normalize,
+                    )
+                    if _tc_state is not None:
+                        _tc_state["prev_noise_pred"] = noise_pred
+                else:
+                    noise_pred = _tc_state["prev_noise_pred"]
 
                 latents = self.scheduler_step_maybe_with_cfg(
                     noise_pred,
@@ -618,6 +628,8 @@ class HunyuanVideo15I2VPipeline(
                     do_true_cfg=do_cfg and negative_kwargs is not None,
                 )
 
+                if _tc_state is not None:
+                    _tc_state["cnt"] += 1
                 pbar.update()
 
         self._current_timestep = None


### PR DESCRIPTION
## Purpose

Add TeaCache support for HunyuanVideo-1.5 Text-to-Video (T2V) and Image-to-Video (I2V) pipelines.

- `config.py`: add polynomial coefficients for `HunyuanVideo15Transformer3DModel`
- `backend.py`: unified `enable_hunyuan_video_15_teacache()` for T2V and I2V, add `_teacache_init_loop_state()` / `_teacache_should_compute()` shared helpers, register both pipelines in `CUSTOM_TEACACHE_ENABLERS`, extend `refresh()` no-op
- `pipeline_hunyuan_video_1_5.py`: pipeline-level TeaCache via shared helpers
- `pipeline_hunyuan_video_1_5_i2v.py`: same pattern as T2V via shared helpers
- `text_to_video.py`: add `--cache-backend tea_cache` and `--tea-cache-thresh`

## Test Plan

**T2V baseline:**
```bash
python examples/offline_inference/text_to_video/text_to_video.py  \
       --model /home/ckpts/HunyuanVideo-1.5-Diffusers-480p_t2v    \
       --prompt "A little girl wearing a straw hat runs through a summer meadow full of wildflowers. A wide shot is used, with the camera panning right to follow her."     \
       --num-frames 33 --num-inference-steps 50 --seed 42         \
       --tensor-parallel-size 2     \
       --cfg-parallel-size 2        \
       --vae-use-tiling             \
       --vae-use-slicing            \
       --output t2v_480p_na.mp4
```

**T2V with TeaCache:**
```bash
python examples/offline_inference/text_to_video/text_to_video.py   \
       --model /home/ckpts/HunyuanVideo-1.5-Diffusers-480p_t2v     \
       --prompt "A little girl wearing a straw hat runs through a summer meadow full of wildflowers. A wide shot is used, with the camera panning right to follow her." \
       --num-frames 33 --num-inference-steps 50 --seed 42          \
       --tensor-parallel-size 2     \
       --cfg-parallel-size 2     \
       --vae-use-tiling          \
       --vae-use-slicing         \
       --cache-backend tea_cache \
       --output t2v_480p_teacache.mp4
```

**I2V baseline:**
```bash
python examples/offline_inference/image_to_video/image_to_video.py \
       --image test_input.jpg                                       \
       --model /home/ckpts/HunyuanVideo-1.5-Diffusers-480p_i2v     \
       --prompt "The camera follows the puppy as it runs forward on the grass, its four legs alternating steps, its tail held high and wagging side to side." \
       --height 480 --width 832 --num-frames 61 --num-inference-steps 50 \
       --guidance-scale 6.0 --seed 42       \
       --tensor-parallel-size 2             \
       --cfg-parallel-size 2               \
       --vae-use-tiling                     \
       --output i2v_480p_na.mp4
```

**I2V with TeaCache:**
```bash
python examples/offline_inference/image_to_video/image_to_video.py \
       --image test_input.jpg                                       \
       --model /home/ckpts/HunyuanVideo-1.5-Diffusers-480p_i2v     \
       --prompt "The camera follows the puppy as it runs forward on the grass, its four legs alternating steps, its tail held high and wagging side to side." \
       --height 480 --width 832 --num-frames 61 --num-inference-steps 50 \
       --guidance-scale 6.0 --seed 42       \
       --tensor-parallel-size 2             \
       --cfg-parallel-size 2               \
       --vae-use-tiling                     \
       --cache-backend tea_cache            \
       --output i2v_480p_teacache.mp4
```

**Comparison:**
```bash
python compare_videos.py t2v_480p_na.mp4 t2v_480p_teacache.mp4 --label1 no_cache --label2 teacache
python compare_videos.py i2v_480p_na.mp4 i2v_480p_teacache.mp4 --label1 no_cache --label2 teacache
```

## Test Result

### T2V (HunyuanVideo-1.5 480p, 33 frames, 50 steps)

| | no_cache | teacache | speedup |
|---|---|---|---|
| Total generation time | 284.1s | 200.1s | **1.42x** |

| Metric | Value |
|---|---|
| LPIPS mean | 0.0513 |
| LPIPS std | 0.0049 |
| LPIPS min/max | 0.0434 / 0.0616 |
| LPIPS p95 | 0.0601 |
| MaxAbsDiff (mean/max) | 180 / 224 |

Videos: 
t2v_480p_nocache.mp4

https://github.com/user-attachments/assets/ea810d88-bfd6-4c4b-a1c4-55610c37a133

t2v_480p_teacache.mp4

https://github.com/user-attachments/assets/9d3b20c6-2f98-45ea-824f-dac419d96d1d

### I2V (HunyuanVideo-1.5 480p, 61 frames, 50 steps)

| | no_cache | teacache | speedup |
|---|---|---|---|
| Total generation time | 190.3s | 134.0s | **1.42x** |

| Metric | Value |
|---|---|
| LPIPS mean | 0.0251 |
| LPIPS std | 0.0061 |
| LPIPS min/max | 0.0084 / 0.0352 |
| LPIPS p95 | 0.0335 |
| MaxAbsDiff (mean/max) | 172 / 217 |

Videos: 
i2v_480p_nocache.mp4

https://github.com/user-attachments/assets/aaa6a222-78a4-4f1d-a1fd-40f593fe6291

i2v_480p_teacache.mp4

https://github.com/user-attachments/assets/30f38e00-6e11-475d-a622-60dd2a5d57f8



