### PR TITLE
[Feat] Override single stage CLI args when stage_configs_path is set in OmniEngineArgs

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -193,15 +193,17 @@ def test_strip_single_engine_args():
 
     filtered = AsyncOmniEngine._strip_single_engine_args(kwargs)
 
-    # Stripped
+    # Stripped — parent EngineArgs fields
     assert "compilation_config" not in filtered
     assert "tensor_parallel_size" not in filtered
     assert "gpu_memory_utilization" not in filtered
     assert "model" not in filtered
 
+    # Stripped — orchestrator-level OmniEngineArgs field
+    assert "stage_configs_path" not in filtered
+
     # Kept
     assert filtered["worker_extension_cls"] == "some.Extension"
-    assert filtered["stage_configs_path"] == "/path/to/yaml"
     assert filtered["custom_pipeline_args"] == {"pipeline_class": "my.Pipeline"}
     assert filtered["mode"] == "text-to-image"
     assert filtered["lora_path"] == "/some/lora"

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -207,3 +207,33 @@ def test_strip_single_engine_args():
     assert filtered["custom_pipeline_args"] == {"pipeline_class": "my.Pipeline"}
     assert filtered["mode"] == "text-to-image"
     assert filtered["lora_path"] == "/some/lora"
+
+
+def test_strip_single_engine_args_model_does_not_trigger_warning(mocker):
+    """model is always in kwargs (callers set it via from_cli_args/asdict),
+    so it should not cause the override warning by itself or appear in it."""
+    mock_warn = mocker.patch("vllm_omni.engine.async_omni_engine.logger.warning")
+
+    # Typical caller kwargs: model is always present, no other parent
+    # EngineArgs fields are explicitly overridden.
+    AsyncOmniEngine._strip_single_engine_args(
+        {
+            "model": "some/model",
+            "custom_pipeline_args": {"pipeline_class": "my.Pipeline"},
+        }
+    )
+    mock_warn.assert_not_called()
+
+    # When there *are* genuinely surprising overrides alongside model,
+    # the warning should mention them but not model.
+    AsyncOmniEngine._strip_single_engine_args(
+        {
+            "model": "some/model",
+            "tensor_parallel_size": 4,
+            "custom_pipeline_args": {"pipeline_class": "my.Pipeline"},
+        }
+    )
+    mock_warn.assert_called_once()
+    warned_args = mock_warn.call_args[0][-1]  # the formatted arg list
+    assert "tensor_parallel_size" in warned_args
+    assert "model" not in warned_args

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -15,6 +15,7 @@ from vllm.engine.arg_utils import EngineArgs
 
 from vllm_omni.config.model import OmniModelConfig
 from vllm_omni.engine.arg_utils import OmniEngineArgs
+from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -165,3 +166,42 @@ def test_stage_specific_text_config_override():
     assert omni_config.attention_chunk_size == 2048
     assert omni_config.max_model_len == 4096
     assert omni_config.hf_text_config.sliding_window is None
+
+
+def test_stage_configs_path_field():
+    """OmniEngineArgs with stage_configs_path should construct without error."""
+    args = OmniEngineArgs(stage_configs_path="/some/path.yaml")
+    assert args.stage_configs_path == "/some/path.yaml"
+
+
+def test_strip_single_engine_args():
+    """_strip_single_engine_args should remove EngineArgs fields but keep omni fields."""
+    kwargs = {
+        # Parent EngineArgs fields — should be stripped
+        "compilation_config": '{"cudagraph_mode": "FULL_AND_PIECEWISE"}',
+        "tensor_parallel_size": 4,
+        "gpu_memory_utilization": 0.9,
+        "model": "some/model",
+        # Parent field that should be kept (allowlisted)
+        "worker_extension_cls": "some.Extension",
+        # OmniEngineArgs-only / non-engine fields — should pass through
+        "stage_configs_path": "/path/to/yaml",
+        "custom_pipeline_args": {"pipeline_class": "my.Pipeline"},
+        "mode": "text-to-image",
+        "lora_path": "/some/lora",
+    }
+
+    filtered = AsyncOmniEngine._strip_single_engine_args(kwargs)
+
+    # Stripped
+    assert "compilation_config" not in filtered
+    assert "tensor_parallel_size" not in filtered
+    assert "gpu_memory_utilization" not in filtered
+    assert "model" not in filtered
+
+    # Kept
+    assert filtered["worker_extension_cls"] == "some.Extension"
+    assert filtered["stage_configs_path"] == "/path/to/yaml"
+    assert filtered["custom_pipeline_args"] == {"pipeline_class": "my.Pipeline"}
+    assert filtered["mode"] == "text-to-image"
+    assert filtered["lora_path"] == "/some/lora"

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -4,6 +4,7 @@ invariant to the specific attributes of vLLM config except in cases where we
 explicitly patch values that differ from vLLM.
 """
 
+import argparse
 import inspect
 from unittest.mock import Mock
 
@@ -114,6 +115,26 @@ def test_qwen3_tts_codec_frame_rate_patching():
 
     # Verify codec_frame_rate_hz was patched
     assert omni_config.codec_frame_rate_hz == 12.3
+
+
+def test_stage_configs_path_blocks_create_model_config():
+    """create_model_config() should raise when stage_configs_path is set."""
+    args = OmniEngineArgs(stage_configs_path="/some/path.yaml")
+    with pytest.raises(RuntimeError, match="stage_configs_path"):
+        args.create_model_config()
+
+
+def test_from_cli_args_picks_up_stage_configs_path():
+    """from_cli_args should pick up stage_configs_path from namespace."""
+    ns = argparse.Namespace(
+        model="facebook/opt-125m",
+        stage_configs_path="/some/path.yaml",
+        custom_pipeline_args=None,
+    )
+
+    args = OmniEngineArgs.from_cli_args(ns)
+    assert args.stage_configs_path == "/some/path.yaml"
+    assert args.custom_pipeline_args is None
 
 
 def test_stage_specific_text_config_override():

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -115,10 +115,8 @@ class OmniEngineArgs(EngineArgs):
         omni_master_port: TCP port for the OmniMasterServer registration
             socket.  Required when single-stage mode is active.
         stage_configs_path: Optional path to a JSON/YAML file containing
-            stage configurations for the multi-stage pipeline. When set,
-            each stage defines its own engine args and single-engine fields
-            are stripped before the per-stage merge. If None, stage configs
-            are resolved from the model's default configuration.
+            stage configurations for the multi-stage pipeline. If None,
+            stage configs are resolved from the model's default configuration.
         output_modalities: Optional list of output modality names to enable
             (e.g. ["text", "audio"]). If None, all modalities supported by
             the model are used.

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -115,12 +115,17 @@ class OmniEngineArgs(EngineArgs):
         omni_master_port: TCP port for the OmniMasterServer registration
             socket.  Required when single-stage mode is active.
         stage_configs_path: Optional path to a JSON/YAML file containing
-            stage configurations for the multi-stage pipeline. If None,
-            stage configs are resolved from the model's default configuration.
+            stage configurations for the multi-stage pipeline. When set,
+            each stage defines its own engine args and single-engine fields
+            are stripped before the per-stage merge. If None, stage configs
+            are resolved from the model's default configuration.
         output_modalities: Optional list of output modality names to enable
             (e.g. ["text", "audio"]). If None, all modalities supported by
             the model are used.
         log_stats: Whether to log engine statistics. Defaults to False.
+        custom_pipeline_args: Dictionary of arguments for custom pipeline
+            initialization (e.g., ``{"pipeline_class": "my.Module"}``).
+            Passed through to the diffusion stage engine.
     """
 
     stage_id: int = 0
@@ -140,6 +145,7 @@ class OmniEngineArgs(EngineArgs):
     stage_configs_path: str | None = None
     output_modalities: list[str] | None = None
     log_stats: bool = False
+    custom_pipeline_args: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         load_omni_general_plugins()
@@ -187,6 +193,11 @@ class OmniEngineArgs(EngineArgs):
         Returns:
             OmniModelConfig instance with all configuration fields set
         """
+        if self.stage_configs_path is not None:
+            raise RuntimeError(
+                "create_model_config() should not be called when stage_configs_path is set. "
+                "Per-stage model configs are resolved from the stage config YAML."
+            )
         # register omni models to avoid model not found error
         self._ensure_omni_models_registered()
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1242,11 +1242,17 @@ class AsyncOmniEngine:
         # worker_extension_cls is a parent field but must pass through to
         # diffusion stages for colocate worker setup.
         _keep = {"worker_extension_cls"}
+        # Orchestrator-level OmniEngineArgs fields that are consumed by
+        # _resolve_stage_configs and must not leak into per-stage configs
+        # (stage_configs_path would trigger the create_model_config guard).
+        _strip_omni = {"stage_configs_path"}
 
         parent_fields: dict[str, dataclasses.Field] = {f.name: f for f in dataclasses.fields(EngineArgs)}
         overridden: list[str] = []
         result: dict[str, Any] = {}
         for k, v in kwargs.items():
+            if k in _strip_omni:
+                continue
             if k not in parent_fields or k in _keep:
                 result[k] = v
                 continue

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1246,6 +1246,10 @@ class AsyncOmniEngine:
         # _resolve_stage_configs and must not leak into per-stage configs
         # (stage_configs_path would trigger the create_model_config guard).
         _strip_omni = {"stage_configs_path"}
+        # Fields that are always set by callers (via from_cli_args / asdict)
+        # and would always appear as overridden — suppress from the warning
+        # so it only surfaces genuinely surprising overrides.
+        _no_warn = {"model"}
 
         parent_fields: dict[str, dataclasses.Field] = {f.name: f for f in dataclasses.fields(EngineArgs)}
         overridden: list[str] = []
@@ -1271,7 +1275,7 @@ class AsyncOmniEngine:
             # Normalise dataclass defaults to dicts for comparison
             if dataclasses.is_dataclass(default) and not isinstance(default, type):
                 default = dataclasses.asdict(default)
-            if v != default:
+            if v != default and k not in _no_warn:
                 overridden.append(k)
 
         if overridden:

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 import janus
 import torch
 from omegaconf import OmegaConf
+from vllm.engine.arg_utils import EngineArgs
 from vllm.inputs import PromptType
 from vllm.logger import init_logger
 from vllm.tokenizers import cached_tokenizer_from_config
@@ -1224,6 +1225,58 @@ class AsyncOmniEngine:
         default_stage_cfg[0]["engine_args"]["model_stage"] = "diffusion"
         return default_stage_cfg
 
+    @staticmethod
+    def _strip_single_engine_args(kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Remove parent ``EngineArgs`` fields from *kwargs*.
+
+        When ``stage_configs_path`` is set, per-stage engine args are defined
+        in the YAML.  Top-level single-engine fields (``compilation_config``,
+        ``tensor_parallel_size``, …) must not leak into per-stage configs via
+        the ``base_engine_args`` merge in ``load_stage_configs_from_yaml`` —
+        they can cause type errors (e.g. ``compilation_config`` as a JSON
+        string rejected by ``VllmConfig``) or silently override YAML values.
+
+        Logs a warning for any parent field whose value differs from the
+        dataclass default, so users know their explicit overrides are ignored.
+        """
+        # worker_extension_cls is a parent field but must pass through to
+        # diffusion stages for colocate worker setup.
+        _keep = {"worker_extension_cls"}
+
+        parent_fields: dict[str, dataclasses.Field] = {f.name: f for f in dataclasses.fields(EngineArgs)}
+        overridden: list[str] = []
+        result: dict[str, Any] = {}
+        for k, v in kwargs.items():
+            if k not in parent_fields or k in _keep:
+                result[k] = v
+                continue
+            # Detect explicitly-set values that differ from the default.
+            # Values may have been through asdict() which converts dataclass
+            # defaults to dicts, so normalise before comparing.
+            field = parent_fields[k]
+            if field.default is not dataclasses.MISSING:
+                default = field.default
+            elif field.default_factory is not dataclasses.MISSING:
+                default = field.default_factory()
+            else:
+                default = dataclasses.MISSING
+            if default is dataclasses.MISSING or v is None:
+                continue
+            # Normalise dataclass defaults to dicts for comparison
+            if dataclasses.is_dataclass(default) and not isinstance(default, type):
+                default = dataclasses.asdict(default)
+            if v != default:
+                overridden.append(k)
+
+        if overridden:
+            logger.warning(
+                "stage_configs_path is set — the following top-level engine "
+                "args are ignored (per-stage YAML takes precedence): %s",
+                ", ".join(sorted(overridden)),
+            )
+
+        return result
+
     def _resolve_stage_configs(self, model: str, kwargs: dict[str, Any]) -> tuple[str, list[Any]]:
         """Resolve stage configs and inject defaults shared by orchestrator/headless."""
 
@@ -1235,12 +1288,17 @@ class AsyncOmniEngine:
                 "Ignoring it and resolving stages from stage_configs_path/model factory."
             )
 
+        if stage_configs_path is not None:
+            base_kwargs = self._strip_single_engine_args(kwargs)
+        else:
+            base_kwargs = kwargs
+
         # Use the legacy config loading path (load_and_resolve_stage_configs).
         # StageConfigFactory wiring will be done in config refactor [2/N].
         config_path, stage_configs = load_and_resolve_stage_configs(
             model,
             stage_configs_path,
-            kwargs,
+            base_kwargs,
             default_stage_cfg_factory=lambda: self._create_default_diffusion_stage_cfg(kwargs),
         )
 


### PR DESCRIPTION
Companion to verl-project/verl#5947.

## Purpose

Add `custom_pipeline_args` field to `OmniEngineArgs` and strip single-engine args when `stage_configs_path` is set, so verl can use a single unified code path for both single-stage and multi-stage engine initialization:

```python
engine_args = asdict(OmniEngineArgs.from_cli_args(args))
engine_client = AsyncOmni(**engine_args)
```

Key changes:
- Add `custom_pipeline_args` field to `OmniEngineArgs` (passed through to diffusion stage engine).
- Guard `create_model_config()` when `stage_configs_path` is set (per-stage configs resolve their own).
- Add `_strip_single_engine_args()` to `AsyncOmniEngine`: when `stage_configs_path` is set, strip parent `EngineArgs` fields and `stage_configs_path` from kwargs before the per-stage merge. `custom_pipeline_args` and `worker_extension_cls` are kept (consumed by `_create_default_diffusion_stage_cfg`).
- Warn when explicitly-set top-level engine args are ignored.

## Test Plan

```bash
python -m pytest tests/engine/test_arg_utils.py -v
```

- `test_stage_configs_path_field` — construction with `stage_configs_path`
- `test_stage_configs_path_blocks_create_model_config` — guard on `create_model_config()`
- `test_from_cli_args_picks_up_stage_configs_path` — CLI namespace propagation
- `test_strip_single_engine_args` — stripping, allowlist, and passthrough

## Test Result

```
tests/engine/test_arg_utils.py  12 passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands.
- [x] The test results.
- [ ] (Optional) The necessary documentation update.
- [ ] (Optional) Release notes update.
</details>