### PR TITLE
[Misc] Warn When vLLM / vLLM-Omni Have Mismatched Versions

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for version compatibility warnings."""
+
+import warnings
+from unittest import mock
+
+import pytest
+
+from vllm_omni.version import warn_if_misaligned_vllm_version
+
+
+@mock.patch("vllm_omni.version.__version_tuple__", (0, 19, 0))
+@mock.patch("vllm_omni.version.__version__", "0.19.0")
+@mock.patch("vllm.__version_tuple__", (0, 18, 0))
+@mock.patch("vllm.__version__", "0.18.0")
+def test_version_mismatch_warning():
+    """Ensure that we warn when vLLM and vLLM-Omni major/minor versions differ."""
+    with pytest.warns(RuntimeWarning, match="mismatched major/minor versions"):
+        warn_if_misaligned_vllm_version()
+
+
+@pytest.mark.parametrize(
+    "vllm_ver,vllm_tuple,omni_ver,omni_tuple",
+    [
+        ("0.19.0", (0, 19, 0), "0.19.5", (0, 19, 5)),  # Patch differs
+        ("0.18.0", (0, 18, 0), "dev", (0, 0, "dev")),  # Omni dev
+        ("dev", (0, 0, "dev"), "0.19.0", (0, 19, 0)),  # vLLM dev
+        # Ensure local identifies don't matter for the warning
+        ("0.19.0+foo", (0, 19, 0, "foo"), "0.19.5", (0, 19, 0)),
+        ("0.19.0", (0, 19, 0), "0.19.5+bar", (0, 19, 0, "bar")),
+        ("0.19.0+foo", (0, 19, 0, "foo"), "0.19.5+bar", (0, 19, 0, "bar")),
+    ],
+)
+def test_no_warning_cases(vllm_ver, vllm_tuple, omni_ver, omni_tuple):
+    """Ensure we don't warn when minor versions match or either is a dev build."""
+    with (
+        mock.patch.multiple("vllm", __version__=vllm_ver, __version_tuple__=vllm_tuple),
+        mock.patch.multiple("vllm_omni.version", __version__=omni_ver, __version_tuple__=omni_tuple),
+    ):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            warn_if_misaligned_vllm_version()
+
+
+@mock.patch("vllm_omni.version.__version_tuple__", (0, 19, 0))
+@mock.patch("vllm_omni.version.__version__", "0.19.0rc2.dev21")
+@mock.patch("vllm.__version_tuple__", (0, 18, 0))
+@mock.patch("vllm.__version__", "0.18.0")
+def test_warning_contains_version_strings():
+    """Ensure that the warning contains the full version strings."""
+    with pytest.warns(RuntimeWarning) as record:
+        warn_if_misaligned_vllm_version()
+
+    assert len(record) == 1
+    msg = str(record[0].message)
+    assert "0.19.0rc2.dev21" in msg
+    assert "0.18.0" in msg

--- a/vllm_omni/__init__.py
+++ b/vllm_omni/__init__.py
@@ -12,6 +12,12 @@ Architecture:
   processing
 """
 
+# We import version early, because it will warn if vLLM / vLLM Omni
+# are not using the same major + minor version (if vLLM is installed).
+# We should do this before applying patch, because vLLM imports might
+# throw in patch if the versions differ.
+from .version import __version__, __version_tuple__  # isort:skip # noqa: F401
+
 try:
     from . import patch  # noqa: F401
 except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
@@ -24,8 +30,6 @@ except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
 from vllm_omni.transformers_utils import configs as _configs  # noqa: F401, E402
 
 from .config import OmniModelConfig
-
-from .version import __version__, __version_tuple__  # isort:skip
 
 
 def __getattr__(name: str):

--- a/vllm_omni/version.py
+++ b/vllm_omni/version.py
@@ -5,12 +5,12 @@ The version is automatically generated from git tags via setuptools_scm
 and written to _version.py during package build.
 """
 
+import warnings
+
 try:
     # Import auto-generated version from _version.py (created by setuptools_scm)
     from ._version import __version__, __version_tuple__
 except ImportError as e:
-    import warnings
-
     warnings.warn(
         f"Failed to import version from _version.py: {e}\n"
         "This typically happens in development mode before building.\n"
@@ -22,4 +22,37 @@ except ImportError as e:
     __version__ = "dev"
     __version_tuple__ = (0, 0, "dev")
 
+
+def warn_if_misaligned_vllm_version():
+    """Warn if vLLM and vllm-omni versions don't match (major.minor)."""
+    # Import vllm lazily since import order may be sensitive with current monkeypatching,
+    # but we want to check this before potentially breaking imports run.
+    from vllm import __version__ as vllm_version
+    from vllm import __version_tuple__ as vllm_version_tuple
+
+    omni_ver: tuple[str | int, ...] = __version_tuple__[:2]
+    vllm_ver: tuple[str | int, ...] = vllm_version_tuple[:2]
+    # Skip if either version is dev (0, 0)
+    if omni_ver == (0, 0) or vllm_ver == (0, 0):
+        return
+
+    # Compare major.minor
+    if omni_ver != vllm_ver:
+        warnings.warn(
+            "vLLM and vLLM-Omni appear to have mismatched major/minor versions:\n"
+            f" --> vLLM-Omni version {__version__}\n"
+            f" --> vLLM version {vllm_version}\n"
+            "This will likely cause compatibility issues.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
 __all__ = ["__version__", "__version_tuple__"]
+
+# Run version check automatically when this module is imported
+try:
+    warn_if_misaligned_vllm_version()
+except ModuleNotFoundError:
+    # vLLM not installed (e.g., documentation builds)
+    pass


### PR DESCRIPTION
## Purpose
Mismatched vLLM Omni / vLLM versions are a very common source of errors for users. This PR adds a warning if the major / minor version for vLLM Omni & vLLM aren't the fallback for `_version` not being created (0.0) and are mismatched. This runs on import of the version module, which is now done before running monkeypatching on vLLM, because the imports in monkey patch will frequently break with incompatible versions.

Example (with my current omni build and vLLM 0.18 instead of 0.19), where it will warn before crashing due to patch issues:
```
>>> import vllm_omni

/home/alex-jw-brooks/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
 --> vLLM-Omni version 0.19.0rc2.dev21+gb30172916.d20260406
 --> vLLM version 0.18.0
This will likely cause compatibility issues.
  warn_if_misaligned_vllm_version()

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/alex-jw-brooks/vllm-omni/vllm_omni/__init__.py", line 22, in <module>
    from . import patch  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^
  File "/home/alex-jw-brooks/vllm-omni/vllm_omni/patch.py", line 16, in <module>
    from vllm_omni.inputs.data import OmniTokensPrompt
  File "/home/alex-jw-brooks/vllm-omni/vllm_omni/inputs/data.py", line 19, in <module>
    from vllm.inputs import EmbedsPrompt, TextPrompt, TokensInput, TokensPrompt
ImportError: cannot import name 'TokensInput' from 'vllm.inputs' (/home/alex-jw-brooks/vllm-omni/.venv/lib/python3.12/site-packages/vllm/inputs/__init__.py). Did you mean: 'TokenInputs'?
```

This is a joint contribution with @lengrongfu