### PR TITLE
fix(diffusion): correct metric keys, remove duplication, minor cleanup

### DIFF
--- a/tests/diffusion/test_diffusion_engine_metrics.py
+++ b/tests/diffusion/test_diffusion_engine_metrics.py
@@ -3,8 +3,9 @@
 """Source-level regression tests for DiffusionEngine.
 
 These tests verify naming conventions and patterns by inspecting source code
-directly. They are intentionally coupled to the source layout and should be
-updated whenever the metrics construction code is refactored.
+at the function level using AST. They are intentionally coupled to the source
+layout and should be updated whenever the metrics construction code is
+refactored.
 """
 
 from __future__ import annotations
@@ -29,29 +30,51 @@ def _read_engine_source() -> str:
         return f.read()
 
 
+def _get_function_source(source: str, class_name: str | None, func_name: str) -> str:
+    """Extract the source of a specific function/method using AST.
+
+    Args:
+        source: Full file source code.
+        class_name: Enclosing class name, or None for module-level functions.
+        func_name: Function/method name.
+
+    Returns:
+        Source code of the function body.
+    """
+    tree = ast.parse(source)
+    if class_name is not None:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                for item in node.body:
+                    if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == func_name:
+                        result = ast.get_source_segment(source, item)
+                        assert result is not None, f"{class_name}.{func_name} source not found"
+                        return result
+    else:
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+                result = ast.get_source_segment(source, node)
+                assert result is not None, f"{func_name} source not found"
+                return result
+    raise AssertionError(f"Function {class_name + '.' if class_name else ''}{func_name} not found in source")
+
+
 class TestMetricKeys:
-    """Verify metric naming conventions in DiffusionEngine.step() output."""
+    """Verify metric naming conventions in DiffusionEngine.step()."""
 
     def test_no_duplicate_preprocess_key(self) -> None:
-        """The metrics dict should not contain both
-        'preprocess_time_ms' and 'preprocessing_time_ms'."""
+        """step() should not contain 'preprocessing_time_ms' (duplicate of 'preprocess_time_ms')."""
         source = _read_engine_source()
-        tree = ast.parse(source)
-
-        for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == "step":
-                step_source = ast.get_source_segment(source, node)
-                assert step_source is not None
-                assert "preprocessing_time_ms" not in step_source, (
-                    "Found duplicate key 'preprocessing_time_ms' in step() — should only use 'preprocess_time_ms'"
-                )
-                break
+        step_source = _get_function_source(source, "DiffusionEngine", "step")
+        assert "preprocessing_time_ms" not in step_source, (
+            "Found duplicate key 'preprocessing_time_ms' in step() — should only use 'preprocess_time_ms'"
+        )
 
     def test_metric_key_naming_consistency(self) -> None:
-        """exec_time should measure execution only, total_time should
-        measure the full step including pre/post processing."""
+        """In step(): exec_time should use exec_total_time, total_time should use step_total_ms."""
         source = _read_engine_source()
-        lines = source.split("\n")
+        step_source = _get_function_source(source, "DiffusionEngine", "step")
+        lines = step_source.split("\n")
 
         found_exec = False
         found_total = False
@@ -66,8 +89,8 @@ class TestMetricKeys:
                 assert "step_total_ms" in line, (
                     "diffusion_engine_total_time_ms should measure full step time (step_total_ms)"
                 )
-        assert found_exec, "diffusion_engine_exec_time_ms key not found in source"
-        assert found_total, "diffusion_engine_total_time_ms key not found in source"
+        assert found_exec, "diffusion_engine_exec_time_ms key not found in step()"
+        assert found_total, "diffusion_engine_total_time_ms key not found in step()"
 
 
 class TestDummyRunAllocation:
@@ -76,6 +99,7 @@ class TestDummyRunAllocation:
     def test_no_oversized_allocation(self) -> None:
         """_dummy_run should not allocate more audio than needed."""
         source = _read_engine_source()
-        assert "audio_sr * audio_duration_sec" not in source, (
+        dummy_source = _get_function_source(source, "DiffusionEngine", "_dummy_run")
+        assert "audio_sr * audio_duration_sec" not in dummy_source, (
             "_dummy_run should generate exact-sized audio, not allocate and slice"
         )

--- a/tests/diffusion/test_diffusion_engine_metrics.py
+++ b/tests/diffusion/test_diffusion_engine_metrics.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Source-level regression tests for DiffusionEngine.
+
+These tests verify naming conventions and patterns by inspecting source code
+directly. They are intentionally coupled to the source layout and should be
+updated whenever the metrics construction code is refactored.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+
+_ENGINE_PATH = os.path.normpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        os.pardir,
+        os.pardir,
+        "vllm_omni",
+        "diffusion",
+        "diffusion_engine.py",
+    )
+)
+
+
+def _read_engine_source() -> str:
+    with open(_ENGINE_PATH) as f:
+        return f.read()
+
+
+class TestMetricKeys:
+    """Verify metric naming conventions in DiffusionEngine.step() output."""
+
+    def test_no_duplicate_preprocess_key(self) -> None:
+        """The metrics dict should not contain both
+        'preprocess_time_ms' and 'preprocessing_time_ms'."""
+        source = _read_engine_source()
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "step":
+                step_source = ast.get_source_segment(source, node)
+                assert step_source is not None
+                assert "preprocessing_time_ms" not in step_source, (
+                    "Found duplicate key 'preprocessing_time_ms' in step() — should only use 'preprocess_time_ms'"
+                )
+                break
+
+    def test_metric_key_naming_consistency(self) -> None:
+        """exec_time should measure execution only, total_time should
+        measure the full step including pre/post processing."""
+        source = _read_engine_source()
+        lines = source.split("\n")
+
+        found_exec = False
+        found_total = False
+        for line in lines:
+            if '"diffusion_engine_exec_time_ms"' in line:
+                found_exec = True
+                assert "exec_total_time" in line, (
+                    "diffusion_engine_exec_time_ms should measure executor time only (exec_total_time)"
+                )
+            if '"diffusion_engine_total_time_ms"' in line:
+                found_total = True
+                assert "step_total_ms" in line, (
+                    "diffusion_engine_total_time_ms should measure full step time (step_total_ms)"
+                )
+        assert found_exec, "diffusion_engine_exec_time_ms key not found in source"
+        assert found_total, "diffusion_engine_total_time_ms key not found in source"
+
+
+class TestDummyRunAllocation:
+    """Verify _dummy_run generates exact-sized audio arrays."""
+
+    def test_no_oversized_allocation(self) -> None:
+        """_dummy_run should not allocate more audio than needed."""
+        source = _read_engine_source()
+        assert "audio_sr * audio_duration_sec" not in source, (
+            "_dummy_run should generate exact-sized audio, not allocate and slice"
+        )

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -189,22 +189,21 @@ class DiffusionEngine:
 
         metrics = {
             "preprocess_time_ms": preprocess_time * 1000,
-            "diffusion_engine_exec_time_ms": (time.perf_counter() - diffusion_engine_start_time) * 1000,
-            "diffusion_engine_total_time_ms": exec_total_time * 1000,
+            "diffusion_engine_exec_time_ms": exec_total_time * 1000,
+            "diffusion_engine_total_time_ms": step_total_ms,
             "image_num": int(request.sampling_params.num_outputs_per_prompt),
             "resolution": int(request.sampling_params.resolution),
             "postprocess_time_ms": postprocess_time * 1000,
         }
-        if self.pre_process_func is not None:
-            metrics["preprocessing_time_ms"] = preprocess_time * 1000
 
         # Handle single request or multiple requests
+        is_audio_output = supports_audio_output(self.od_config.model_class_name)
         if len(request.prompts) == 1:
             # Single request: return single OmniRequestOutput
             prompt = request.prompts[0]
             request_id = request.request_ids[0] if request.request_ids else ""
 
-            if supports_audio_output(self.od_config.model_class_name):
+            if is_audio_output:
                 request_audio_payload = outputs[0] if len(outputs) == 1 else outputs
                 return [
                     OmniRequestOutput.from_diffusion(
@@ -264,7 +263,7 @@ class DiffusionEngine:
                 request_outputs = outputs[start_idx:end_idx] if output_idx < len(outputs) else []
                 output_idx = end_idx
 
-                if supports_audio_output(self.od_config.model_class_name):
+                if is_audio_output:
                     request_audio_payload = request_outputs[0] if len(request_outputs) == 1 else request_outputs
                     results.append(
                         OmniRequestOutput.from_diffusion(
@@ -413,9 +412,7 @@ class DiffusionEngine:
 
         if supports_audio_input(self.od_config.model_class_name):
             audio_sr = 16000
-            audio_duration_sec = 4
-            audio_array = np.random.randn(audio_sr * audio_duration_sec).astype(np.float32)
-            dummy_audio = audio_array[audio_sr * 1 : audio_sr * 3]
+            dummy_audio = np.random.randn(audio_sr * 2).astype(np.float32)
         else:
             dummy_audio = None
 


### PR DESCRIPTION
## Summary

Phase 1 of #2335 — low-risk fixes for `DiffusionEngine` telemetry and code quality.

- **Fix swapped metric keys**: `diffusion_engine_exec_time_ms` now correctly measures executor time only, `diffusion_engine_total_time_ms` now correctly measures full step (pre+exec+post)
- **Remove duplicate key**: `preprocessing_time_ms` was identical to `preprocess_time_ms`
- **Hoist loop-invariant call**: `supports_audio_output()` moved outside per-prompt loop (same result each iteration)
- **Fix `_dummy_run` allocation**: Generate exact 2s audio instead of allocating 4s then slicing

> **Note**: The metric key swap changes the semantics of `diffusion_engine_exec_time_ms` and `diffusion_engine_total_time_ms`. If external dashboards reference these keys, they should be updated accordingly.

## Test plan

- [x] 3 source-level regression tests pass (`pytest tests/diffusion/test_diffusion_engine_metrics.py`)
- [x] Tests verify: no duplicate key, correct key-to-variable mapping, no oversized allocation
- [x] `ruff check` + `ruff format --check` pass
- [ ] CI: pre-commit, build, DCO checks

🤖 Generated with [Claude Code](https://claude.ai/code)