### PR TITLE
[Bugfix] Update Flux2-dev & Dynin_omni L4 e2e test

### DIFF
--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -72,7 +72,7 @@
                 "enable-negative-prompt": true,
                 "baseline": {
                     "throughput_qps": 0.1,
-                    "latency_mean": 2.34,
+                    "latency_mean": 2.7,
                     "peak_memory_mb_mean": 61000
                 }
             },

--- a/tests/e2e/online_serving/test_dynin_omni_expansion.py
+++ b/tests/e2e/online_serving/test_dynin_omni_expansion.py
@@ -120,7 +120,7 @@ def _build_i2i_messages(prompt: str) -> list[dict]:
 
 @pytest.mark.advanced_model
 @pytest.mark.omni
-@hardware_test(res={"cuda": "L4", "rocm": "MI325"})
+@hardware_test(res={"cuda": "H100", "rocm": "MI325"})
 @pytest.mark.parametrize("omni_server", TEST_PARAMS, indirect=True)
 def test_send_i2i_request_001(omni_server, openai_client) -> None:
     request_config = {
@@ -136,7 +136,7 @@ def test_send_i2i_request_001(omni_server, openai_client) -> None:
 
 @pytest.mark.advanced_model
 @pytest.mark.omni
-@hardware_test(res={"cuda": "L4", "rocm": "MI325"})
+@hardware_test(res={"cuda": "H100", "rocm": "MI325"})
 @pytest.mark.parametrize("omni_server", TEST_PARAMS, indirect=True)
 def test_send_t2i_request_001(omni_server, openai_client) -> None:
     request_config = {
@@ -149,7 +149,7 @@ def test_send_t2i_request_001(omni_server, openai_client) -> None:
 
 @pytest.mark.core_model
 @pytest.mark.omni
-@hardware_test(res={"cuda": "L4", "rocm": "MI325"})
+@hardware_test(res={"cuda": "H100", "rocm": "MI325"})
 @pytest.mark.parametrize("omni_server", TEST_PARAMS, indirect=True)
 def test_send_t2s_request_001(omni_server, dynin_t2s_openai_client) -> None:
     request_config = {

--- a/tests/e2e/online_serving/test_flux_2_dev_expansion.py
+++ b/tests/e2e/online_serving/test_flux_2_dev_expansion.py
@@ -27,7 +27,7 @@ PROMPT = "A cinematic mountain landscape at sunrise, dramatic clouds, ultra-deta
 NEGATIVE_PROMPT = "low quality, blurry, distorted, deformed, watermark"
 
 SINGLE_CARD_FEATURE_MARKS = hardware_marks(res={"cuda": "H100"})
-PARALLEL_FEATURE_MARKS = hardware_marks(res={"cuda": "L4"}, num_cards=2)
+PARALLEL_FEATURE_MARKS = hardware_marks(res={"cuda": "H100"}, num_cards=2)
 
 
 def _get_flux_2_dev_feature_cases(model: str):
@@ -48,8 +48,6 @@ def _get_flux_2_dev_feature_cases(model: str):
             OmniServerParams(
                 model=model,
                 server_args=[
-                    "--cache-backend",
-                    "cache_dit",
                     "--enable-cpu-offload",
                     "--cfg-parallel-size",
                     "2",


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

1. Solving #2722. The main reason is that Flux.2-dev model parameters are too large to fit in L4 (24GB). 

This PR:
- changes the hardware from L4 to H100;
- remove cache-dit argument, because Flux.2-dev does not support cache-dit yet.


2. Solving #2721. The major reason is the  Dynin_omni model weights are too large to fit in L4 card.

This PR:
- changes the hardware from L4 to H100;

3. Additional edit: enlarge diffusion perf test baseline threshold

In [buildkite test ](https://buildkite.com/vllm/vllm-omni/builds/6188/steps/canvas?sid=019d712f-452c-4a90-a4d5-125365162cfa), it indicates the threshold for `test_qwen_image_ulysses2_cfg2_vae_patch4` is a little too tight, which can cause failure occasionally. 

This PR enlarges the baseline threshold from 2.34 to 2.7.
## Test Plan

Run it in nightly CI.
```bash
pytest -s -v tests/e2e/online_serving/test_*_expansion.py -m "advanced_model and diffusion and L4" --run-level "advanced_model"
```
## Test Result

Nightly tests were all passed. See results in this [url](https://buildkite.com/vllm/vllm-omni/builds/6470/steps/canvas?sid=019d85a8-0fda-4f68-9c16-9fc385ee21a6).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
