### PR TITLE
[Feat] support layerwise offload for Bagel

### DIFF
--- a/vllm_omni/diffusion/models/bagel/bagel_transformer.py
+++ b/vllm_omni/diffusion/models/bagel/bagel_transformer.py
@@ -738,6 +738,8 @@ class Qwen2MoTDecoderLayer(nn.Module):
 
 
 class Qwen2MoTModel(Qwen2PreTrainedModel):
+    _layerwise_offload_blocks_attrs = ["layers"]
+    
     def __init__(
         self,
         config,

--- a/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
+++ b/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
@@ -25,6 +25,7 @@ from vllm.transformers_utils.configs.bagel import BagelConfig
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.offloader.module_collector import PipelineModules
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -273,7 +274,7 @@ class BagelPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         # device until the weight loader materializes them. Calling
         # .to(device) would fail on those meta tensors, so we skip it
         # entirely and let the weight loader handle device placement.
-        if quant_config is None:
+        if quant_config is None and not(od_config.enable_layerwise_offload):
             self.to(self.device)
         self.setup_diffusion_pipeline_profiler(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
@@ -813,3 +814,31 @@ class BagelPipeline(nn.Module, DiffusionPipelineProfilerMixin):
 
         loader = AutoWeightsLoader(self)
         return loader.load_weights(_filtered_weights())
+    
+    def discover_offload_modules(self) -> PipelineModules:
+        resident_modules: list[nn.Module] = []
+        resident_names: list[str] = []
+        
+        def add_resident(name: str, module: nn.Module | None) -> None:
+            if module is None:
+                return
+            resident_modules.append(module)
+            resident_names.append(name)
+            
+        add_resident("bagel.time_embedder", getattr(self.bagel, "time_embedder", None))
+        add_resident("bagel.vae2llm", getattr(self.bagel, "vae2llm", None))
+        add_resident("bagel.llm2vae", getattr(self.bagel, "llm2vae", None))
+        add_resident("bagel.latent_pos_embed", getattr(self.bagel, "latent_pos_embed", None))
+        add_resident("bagel.vit_model", getattr(self.bagel, "vit_model", None))
+        add_resident("bagel.connector", getattr(self.bagel, "connector", None))
+        add_resident("bagel.vit_pos_embed", getattr(self.bagel, "vit_pos_embed", None))
+        
+        return PipelineModules(
+            dits=[self.language_model.model],
+            dit_names=["bagel.language_model.model"],
+            encoders=[],
+            encoder_names=[],
+            vae=self.vae,
+            resident_modules=resident_modules,
+            resident_names=resident_names,
+    )

--- a/vllm_omni/diffusion/offloader/layerwise_backend.py
+++ b/vllm_omni/diffusion/offloader/layerwise_backend.py
@@ -303,6 +303,11 @@ class LayerWiseOffloadBackend(OffloadBackend):
                 modules.vae.to(self.device, non_blocking=True)
             except Exception as exc:
                 logger.debug("Failed to move VAE to GPU: %s", exc)
+                
+        # Move resident modules to GPU
+        for name, module in zip(modules.resident_names, modules.resident_modules):
+            logger.debug(f"Moving resident module {name} to device {self.device}")
+            module.to(self.device)
 
         logger.info("Applying layer-wise offloading on %s", modules.dit_names)
 

--- a/vllm_omni/diffusion/offloader/module_collector.py
+++ b/vllm_omni/diffusion/offloader/module_collector.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from torch import nn
 from vllm.logger import init_logger
@@ -16,7 +16,8 @@ class PipelineModules:
     encoders: list[nn.Module]
     encoder_names: list[str]
     vae: nn.Module | None = None
-
+    resident_modules: list[nn.Module] = field(default_factory=list)
+    resident_names: list[str] = field(default_factory=list)
 
 class ModuleDiscovery:
     """Discovers pipeline components for offloading"""
@@ -35,6 +36,16 @@ class ModuleDiscovery:
         Returns:
             PipelineModules with lists of discovered modules and names
         """
+        # Custom discovery
+        custom_discover = getattr(pipeline, "discover_offload_modules", None)
+        if callable(custom_discover):
+            modules = custom_discover()
+            if not isinstance(modules, PipelineModules):
+                raise TypeError(
+                    f"discover_offload_modules() must return PipelineModules, got {type(modules)!r}"
+                )
+            return modules
+    
         # Collect DiT/transformer modules
         dit_modules: list[nn.Module] = []
         dit_names: list[str] = []


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Add Bagel layerwise CPU offload support.
This PR resolves the Bagel gap in CPU Offload (Layerwise) support from RFC #1217 by:
- adding Bagel-specific offload module discovery so the backend can distinguish block modules, VAE, and resident modules
- moving Bagel resident modules to GPU while applying layerwise hooks only to the LLM transformer blocks
- avoiding the eager `self.to(self.device)` path in `BagelPipeline` when layerwise offload is enabled
## Test Plan
## Test Result
vllm serve --model /satadata/Bagel/BAGEL-7B-MoT/ --omni --enable_layerwise_offload --port 8004

python3 examples/online_serving/bagel/openai_chat_client.py   --server http://localhost:8004   --modality text2img   --prompt "a majestic dragon perched on the mountain ridge of Vermont, misty morning atmosphere, photorealistic style"   --height 1024   --width 1024   --steps 50   --seed 42   --output docs/examples/dragon_chat.png

Offload VS no offload

Model | No Offload |   | With Offload |  
-- | -- | -- | -- | --
  | Image | VRAM | Image | VRAM
FLUX.2-klein-4B |   | 19.7GB |   | 13.8GB
Z-Image |   | 22.7GB |   | 15.5GB


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
