### PR TITLE
[Bugfix]: qwen3_tts bugfix and add run_test.sh for MR v2

### DIFF
--- a/examples/offline_inference/qwen3_tts/end2end.py
+++ b/examples/offline_inference/qwen3_tts/end2end.py
@@ -326,7 +326,7 @@ def _build_inputs(args) -> tuple[str, list]:
     else:
         query_result = query_func()
 
-    model_name = query_result.model_name
+    model_name = args.model if args.model else query_result.model_name
 
     if args.txt_prompts:
         with open(args.txt_prompts) as f:
@@ -343,7 +343,10 @@ def _build_inputs(args) -> tuple[str, list]:
             for t in lines
         ]
     else:
-        inputs = query_result.inputs if isinstance(query_result.inputs, list) else [query_result.inputs]
+        if isinstance(query_result.inputs, list):
+            inputs = query_result.inputs * args.num_prompts
+        else:
+            inputs = [query_result.inputs] * args.num_prompts
 
     return model_name, inputs
 
@@ -422,6 +425,12 @@ async def main_streaming(args):
 
 def parse_args():
     parser = FlexibleArgumentParser(description="Demo on using vLLM for offline inference with audio language models")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="Override the default model path for the selected query type.",
+    )
     parser.add_argument(
         "--query-type",
         "-q",

--- a/examples/offline_inference/qwen3_tts/run_tests.sh
+++ b/examples/offline_inference/qwen3_tts/run_tests.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Qwen3-TTS end2end functional test script
+# Iterates over query-type and mode combinations for qwen3_tts/end2end.py
+#
+# Usage:
+#   ./run_tests.sh --custom-voice-model /path/a --voice-design-model /path/b --base-model /path/c
+#   ./run_tests.sh --custom-voice-model /path/a                # only run CustomVoice tests
+#   ./run_tests.sh --base-model /path/c                        # only run Base tests
+# =============================================================================
+
+set -euo pipefail
+
+export VLLM_OMNI_USE_V2_RUNNER=1
+# export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
+
+# ---- Parse named arguments ----
+CUSTOM_VOICE_MODEL=""
+VOICE_DESIGN_MODEL=""
+BASE_MODEL=""
+
+usage() {
+    echo "Usage: $0 [--custom-voice-model PATH] [--voice-design-model PATH] [--base-model PATH]"
+    echo ""
+    echo "Pass one or more model paths. Only the query types with a model provided will be tested."
+    exit 1
+}
+
+if [[ $# -eq 0 ]]; then
+    usage
+fi
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --custom-voice-model) CUSTOM_VOICE_MODEL="$2"; shift 2 ;;
+        --voice-design-model) VOICE_DESIGN_MODEL="$2"; shift 2 ;;
+        --base-model)         BASE_MODEL="$2";         shift 2 ;;
+        -h|--help)            usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+if [[ -z "$CUSTOM_VOICE_MODEL" && -z "$VOICE_DESIGN_MODEL" && -z "$BASE_MODEL" ]]; then
+    echo "Error: at least one model path must be provided."
+    usage
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+END2END="$SCRIPT_DIR/end2end.py"
+LOG_DIR="$SCRIPT_DIR/test_logs"
+SUMMARY_FILE="$LOG_DIR/summary.log"
+
+rm -rf "$LOG_DIR"
+mkdir -p "$LOG_DIR"
+> "$SUMMARY_FILE"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+run_test() {
+    local name="$1"
+    shift
+    local log_file="$LOG_DIR/${name}.log"
+    local output_dir="$LOG_DIR/${name}_output"
+
+    TOTAL=$((TOTAL + 1))
+    echo "========================================"
+    echo "[${TOTAL}] Running: ${name}"
+    echo "  Command: python $END2END $*"
+    echo "========================================"
+
+    local start_time
+    start_time=$(date +%s)
+
+    if python "$END2END" "$@" --output-dir "$output_dir" > "$log_file" 2>&1; then
+        local end_time
+        end_time=$(date +%s)
+        local elapsed=$((end_time - start_time))
+        echo "  => PASS (${elapsed}s)"
+        echo "[PASS] ${name} (${elapsed}s)" >> "$SUMMARY_FILE"
+        PASS=$((PASS + 1))
+    else
+        local exit_code=$?
+        local end_time
+        end_time=$(date +%s)
+        local elapsed=$((end_time - start_time))
+        echo "  => FAIL (exit code: ${exit_code}, ${elapsed}s)"
+        echo "[FAIL] ${name} (exit code: ${exit_code}, ${elapsed}s)" >> "$SUMMARY_FILE"
+        echo "  --- last 30 lines of log ---" >> "$SUMMARY_FILE"
+        tail -n 30 "$log_file" >> "$SUMMARY_FILE"
+        echo "  --- end ---" >> "$SUMMARY_FILE"
+        FAIL=$((FAIL + 1))
+    fi
+    echo ""
+}
+
+# =============================================================================
+# Test cases — only run sections whose model path was provided
+# =============================================================================
+
+# --- 1. CustomVoice ---
+if [[ -n "$CUSTOM_VOICE_MODEL" ]]; then
+    run_test "custom_voice" \
+        --model "$CUSTOM_VOICE_MODEL" --query-type CustomVoice
+
+    run_test "custom_voice_batch_sample" \
+        --model "$CUSTOM_VOICE_MODEL" --query-type CustomVoice --use-batch-sample
+
+    run_test "custom_voice_py_generator" \
+        --model "$CUSTOM_VOICE_MODEL" --query-type CustomVoice --py-generator
+
+    run_test "custom_voice_streaming" \
+        --model "$CUSTOM_VOICE_MODEL" --query-type CustomVoice --streaming
+
+    run_test "custom_voice_batch4" \
+        --model "$CUSTOM_VOICE_MODEL" --query-type CustomVoice --batch-size 4
+
+    run_test "custom_voice_batch4_batch_sample" \
+        --model "$CUSTOM_VOICE_MODEL" --query-type CustomVoice --batch-size 4 --use-batch-sample --stage-configs-path "$SCRIPT_DIR/../../../vllm_omni/model_executor/stage_configs/qwen3_tts_batch.yaml"
+
+    run_test "custom_voice_num_prompts3" \
+        --model "$CUSTOM_VOICE_MODEL" --query-type CustomVoice --num-prompts 3
+fi
+
+# --- 2. VoiceDesign ---
+if [[ -n "$VOICE_DESIGN_MODEL" ]]; then
+    run_test "voice_design" \
+        --model "$VOICE_DESIGN_MODEL" --query-type VoiceDesign
+
+    run_test "voice_design_batch_sample" \
+        --model "$VOICE_DESIGN_MODEL" --query-type VoiceDesign --use-batch-sample
+
+    run_test "voice_design_py_generator" \
+        --model "$VOICE_DESIGN_MODEL" --query-type VoiceDesign --py-generator
+
+    run_test "voice_design_streaming" \
+        --model "$VOICE_DESIGN_MODEL" --query-type VoiceDesign --streaming
+fi
+
+# --- 3. Base (icl mode) ---
+if [[ -n "$BASE_MODEL" ]]; then
+    run_test "base_icl" \
+        --model "$BASE_MODEL" --query-type Base --mode-tag icl
+
+    run_test "base_icl_batch_sample" \
+        --model "$BASE_MODEL" --query-type Base --mode-tag icl --use-batch-sample
+
+    run_test "base_icl_py_generator" \
+        --model "$BASE_MODEL" --query-type Base --mode-tag icl --py-generator
+
+    run_test "base_icl_streaming" \
+        --model "$BASE_MODEL" --query-type Base --mode-tag icl --streaming
+
+    # --- 4. Base (xvec_only mode) ---
+    run_test "base_xvec_only" \
+        --model "$BASE_MODEL" --query-type Base --mode-tag xvec_only
+
+    run_test "base_xvec_only_batch_sample" \
+        --model "$BASE_MODEL" --query-type Base --mode-tag xvec_only --use-batch-sample
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo "========================================" | tee -a "$SUMMARY_FILE"
+echo "Tests done: total ${TOTAL}, passed ${PASS}, failed ${FAIL}" | tee -a "$SUMMARY_FILE"
+echo "========================================" | tee -a "$SUMMARY_FILE"
+echo ""
+echo "Detailed logs: $LOG_DIR"
+echo "Summary report: $SUMMARY_FILE"
+
+exit $FAIL

--- a/tests/examples/offline_inference/test_qwen3_tts.py
+++ b/tests/examples/offline_inference/test_qwen3_tts.py
@@ -1,0 +1,97 @@
+"""
+Offline inference tests: Qwen3-TTS.
+See examples/offline_inference/qwen3_tts/README.md
+
+Picks classic test examples covering all three query types (CustomVoice,
+VoiceDesign, Base) and the streaming execution path.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+import pytest
+
+from tests.examples.conftest import run_cmd
+from tests.utils import hardware_test
+
+pytestmark = [pytest.mark.advanced_model, pytest.mark.example]
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[3] / "examples"
+END2END = str(EXAMPLES_DIR / "offline_inference" / "qwen3_tts" / "end2end.py")
+
+CUSTOM_VOICE_MODEL = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+VOICE_DESIGN_MODEL = "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign"
+BASE_MODEL = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
+
+
+def _assert_wav_output(output_dir: str) -> None:
+    """Assert that at least one non-empty .wav file was produced."""
+    wav_files = list(Path(output_dir).glob("*.wav"))
+    assert len(wav_files) > 0, f"No .wav files found in {output_dir}"
+    for wav in wav_files:
+        assert wav.stat().st_size > 0, f"Empty wav file: {wav}"
+
+
+@pytest.mark.omni
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+def test_custom_voice():
+    """CustomVoice single prompt — the most common TTS use case."""
+    with tempfile.TemporaryDirectory() as output_dir:
+        command = [
+            "python", END2END,
+            "--model", CUSTOM_VOICE_MODEL,
+            "--query-type", "CustomVoice",
+            "--output-dir", output_dir,
+        ]
+        run_cmd(command)
+        _assert_wav_output(output_dir)
+
+
+@pytest.mark.omni
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+def test_voice_design():
+    """VoiceDesign single prompt — generates speech from a voice description."""
+    with tempfile.TemporaryDirectory() as output_dir:
+        command = [
+            "python", END2END,
+            "--model", VOICE_DESIGN_MODEL,
+            "--query-type", "VoiceDesign",
+            "--output-dir", output_dir,
+        ]
+        run_cmd(command)
+        _assert_wav_output(output_dir)
+
+
+@pytest.mark.omni
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+def test_base_icl():
+    """Base ICL mode — voice cloning with reference audio and transcript."""
+    with tempfile.TemporaryDirectory() as output_dir:
+        command = [
+            "python", END2END,
+            "--model", BASE_MODEL,
+            "--query-type", "Base",
+            "--mode-tag", "icl",
+            "--output-dir", output_dir,
+        ]
+        run_cmd(command)
+        _assert_wav_output(output_dir)
+
+
+@pytest.mark.omni
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+def test_custom_voice_streaming():
+    """CustomVoice streaming — exercises the AsyncOmni streaming path."""
+    with tempfile.TemporaryDirectory() as output_dir:
+        command = [
+            "python", END2END,
+            "--model", CUSTOM_VOICE_MODEL,
+            "--query-type", "CustomVoice",
+            "--streaming",
+            "--output-dir", output_dir,
+        ]
+        run_cmd(command)
+        _assert_wav_output(output_dir)

--- a/tests/examples/offline_inference/test_qwen3_tts_MR_V2.py
+++ b/tests/examples/offline_inference/test_qwen3_tts_MR_V2.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Offline inference tests: Qwen3-TTS.
 See examples/offline_inference/qwen3_tts/README.md
@@ -10,29 +12,47 @@ import os
 import tempfile
 from pathlib import Path
 
+import numpy as np
+import soundfile as sf
+
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+os.environ["VLLM_OMNI_USE_V2_RUNNER"] = "1"
 
 import pytest
 
-from tests.examples.conftest import run_cmd
+from tests.examples.conftest import EXAMPLES, run_cmd
 from tests.utils import hardware_test
 
 pytestmark = [pytest.mark.advanced_model, pytest.mark.example]
 
-EXAMPLES_DIR = Path(__file__).resolve().parents[3] / "examples"
-END2END = str(EXAMPLES_DIR / "offline_inference" / "qwen3_tts" / "end2end.py")
+END2END = str(EXAMPLES / "offline_inference" / "qwen3_tts" / "end2end.py")
 
 CUSTOM_VOICE_MODEL = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
 VOICE_DESIGN_MODEL = "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign"
 BASE_MODEL = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
 
 
+MIN_DURATION_S = 0.5
+EXPECTED_SAMPLE_RATE = 24000
+
+
 def _assert_wav_output(output_dir: str) -> None:
-    """Assert that at least one non-empty .wav file was produced."""
+    """Assert that at least one valid .wav file was produced.
+
+    Checks: file exists, sample rate, minimum duration, and not silence.
+    """
     wav_files = list(Path(output_dir).glob("*.wav"))
     assert len(wav_files) > 0, f"No .wav files found in {output_dir}"
     for wav in wav_files:
-        assert wav.stat().st_size > 0, f"Empty wav file: {wav}"
+        data, sr = sf.read(wav, dtype="float32")
+        assert sr == EXPECTED_SAMPLE_RATE, (
+            f"{wav.name}: sample_rate={sr}, expected {EXPECTED_SAMPLE_RATE}"
+        )
+        duration = len(data) / sr
+        assert duration >= MIN_DURATION_S, (
+            f"{wav.name}: duration={duration:.3f}s, expected >= {MIN_DURATION_S}s"
+        )
+        assert np.max(np.abs(data)) > 0.01, f"{wav.name}: audio appears to be silence"
 
 
 @pytest.mark.omni

--- a/vllm_omni/model_executor/models/qwen3_tts/configuration_qwen3_tts.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/configuration_qwen3_tts.py
@@ -537,6 +537,10 @@ class Qwen3TTSConfig(PretrainedConfig):
         if any("Code2Wav" in str(a) for a in archs):
             if hasattr(config, "rope_parameters"):
                 delattr(config, "rope_parameters")
+            # Code2Wav doesn't use position embeddings, but vLLM validates
+            # max_model_len <= max_position_embeddings. Set a large value
+            # to allow the pipeline.yaml max_model_len (65536) to pass validation.
+            config.max_position_embeddings = 131072
         return config
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
### 1. Fix `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` requirement for Code2Wav
 
Previously, running Code2Wav required setting `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` because Code2Wav reuses `talker_config`, which has `max_position_embeddings=32768`.
 
**Fix:** In the `get_text_config()` method, when the model is detected as Code2Wav, `max_position_embeddings` is now overridden accordingly. This eliminates the need for the environment variable workaround.
 
**File changed:** `vllm_omni/model_executor/models/qwen3_tts/configuration_qwen3_tts.py`
 
### 2. Make `--num-prompts` configurable in Qwen3-TTS `end2end.py`
 
The `--num-prompts` argument in `end2end.py` was previously hardcoded. Updated the logic to handle it dynamically, consistent with the approach used in Qwen2.5-Omni and Qwen3-Omni.
 
### 3. Add `run_tests.sh` for Qwen3-TTS functional testing
 
Added `vllm-omni/examples/offline_inference/qwen3_tts/run_tests.sh` as a test runner script that wraps `end2end.py` to verify code functionality and completeness. This provides a convenient one-command entry point for running end-to-end tests on Qwen3-TTS.

## Known Issue
 
### Audio artifact at the beginning of Base model output (ICL mode)
 
When running the Base model in ICL mode, the generated audio contains a brief noise/artifact at the very beginning.
 
**Reproduce:**
 
```bash
python vllm-omni/examples/offline_inference/qwen3_tts/end2end.py \
  --model /workspace/fattysand/models/Qwen3-TTS-12Hz-1.7B-Base \
  --query-type Base \
  --mode-tag icl
```
 
**Symptoms:**
 
- Execution time is excessively long
- A short audio artifact (noise) is present at the start of the generated audio

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)

cc @Sy0307 