### PR TITLE
  [Core] Refactor stage config override resolution

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -38,21 +38,29 @@ def test_default_stage_id_is_concrete_int():
     assert cfg.stage_id == 0
 
 
-def test_multimodal_kwarg_overrides():
+def test_multimodal_kwarg_overrides(mocker):
     """Ensure that overrides in the multimodal config are preserved."""
     # Get a different value than the default for a multimodal field
     sig = inspect.signature(OmniEngineArgs)
     default_mm_cache = sig.parameters["mm_processor_cache_gb"].default
     override_val = default_mm_cache + 1
 
-    # NOTE: This needs to be a model that resolves to supports_multimodal=True
-    # in vLLM, otherwise we won't have an MM config
+    fake_model_config = SimpleNamespace(
+        multimodal_config=SimpleNamespace(mm_processor_cache_gb=override_val),
+    )
+
+    def _fake_parent_create_model_config(self):
+        assert self.mm_processor_cache_gb == override_val
+        return fake_model_config
+
+    mocker.patch.object(EngineArgs, "create_model_config", _fake_parent_create_model_config)
+    mocker.patch.object(OmniModelConfig, "from_vllm_model_config", side_effect=lambda model_config, **_: model_config)
+
     cfg = OmniEngineArgs(
         model="Qwen/Qwen2-VL-2B-Instruct",
         mm_processor_cache_gb=override_val,
     ).create_model_config()
 
-    # Ensure that the override was applied correctly
     assert cfg.multimodal_config is not None
     assert cfg.multimodal_config.mm_processor_cache_gb == override_val
 

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -4,11 +4,18 @@
 Unit tests for StageConfigFactory and related classes.
 """
 
+from dataclasses import fields
+
+from vllm.engine.arg_utils import EngineArgs
+
 from vllm_omni.config.stage_config import (
+    INTERNAL_STAGE_OVERRIDE_KEYS,
     ModelPipeline,
     StageConfig,
     StageConfigFactory,
     StageType,
+    build_stage_runtime_overrides,
+    strip_parent_engine_args,
 )
 
 
@@ -309,6 +316,49 @@ class TestStageConfigFactory:
         assert overrides["gpu_memory_utilization"] == 0.9
         assert "model" not in overrides
         assert "batch_timeout" not in overrides
+
+
+class TestStageResolutionHelpers:
+    """Tests for shared stage override / filtering helpers."""
+
+    def test_build_stage_runtime_overrides_ignores_other_stage_and_internal_keys(self):
+        overrides = build_stage_runtime_overrides(
+            0,
+            {
+                "gpu_memory_utilization": 0.5,
+                "stage_0_gpu_memory_utilization": 0.9,
+                "stage_1_gpu_memory_utilization": 0.1,
+                "stage_0_model": "should_be_ignored",
+                "parallel_config": {"world_size": 2},
+            },
+            internal_keys=INTERNAL_STAGE_OVERRIDE_KEYS,
+        )
+
+        assert overrides["gpu_memory_utilization"] == 0.9
+        assert "model" not in overrides
+        assert "parallel_config" not in overrides
+
+    def test_strip_parent_engine_args_reports_only_surprising_parent_overrides(self):
+        parent_fields = {f.name: f for f in fields(EngineArgs)}
+        filtered, overridden = strip_parent_engine_args(
+            {
+                "model": "some/model",
+                "stage_configs_path": "/tmp/stages.yaml",
+                "tensor_parallel_size": 4,
+                "worker_extension_cls": "some.Extension",
+                "custom_pipeline_args": {"pipeline_class": "demo.Pipeline"},
+            },
+            parent_fields=parent_fields,
+            keep_keys={"worker_extension_cls"},
+            strip_keys={"stage_configs_path"},
+            no_warn_keys={"model"},
+        )
+
+        assert filtered == {
+            "worker_extension_cls": "some.Extension",
+            "custom_pipeline_args": {"pipeline_class": "demo.Pipeline"},
+        }
+        assert overridden == ["tensor_parallel_size"]
 
 
 class TestPipelineYamlParsing:

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -10,6 +10,7 @@ Runtime parameters (gpu_memory_utilization, tp_size, etc.) come from CLI.
 
 from __future__ import annotations
 
+import dataclasses
 import re
 import warnings
 from dataclasses import asdict, dataclass, field
@@ -39,6 +40,93 @@ def get_pipeline_path(model_dir: str, filename: str) -> Path:
 
 
 logger = init_logger(__name__)
+
+_STAGE_OVERRIDE_PATTERN = re.compile(r"^stage_(\d+)_(.+)$")
+
+# Keys that belong to orchestrator/runtime wiring and must never be forwarded
+# into per-stage engine args.
+INTERNAL_STAGE_OVERRIDE_KEYS: frozenset[str] = frozenset(
+    {
+        "model",
+        "stage_configs_path",
+        "stage_id",
+        "stage_init_timeout",
+        "init_timeout",
+        "shm_threshold_bytes",
+        "worker_backend",
+        "ray_address",
+        "batch_timeout",
+        "log_stats",
+        "tokenizer",
+        "parallel_config",
+    }
+)
+
+
+def build_stage_runtime_overrides(
+    stage_id: int,
+    cli_overrides: dict[str, Any],
+    *,
+    internal_keys: set[str] | frozenset[str] = INTERNAL_STAGE_OVERRIDE_KEYS,
+) -> dict[str, Any]:
+    """Build per-stage runtime overrides from global and stage-scoped kwargs."""
+    result: dict[str, Any] = {}
+
+    for key, value in cli_overrides.items():
+        if value is None or key in internal_keys:
+            continue
+
+        match = _STAGE_OVERRIDE_PATTERN.match(key)
+        if match is not None:
+            override_stage_id = int(match.group(1))
+            param_name = match.group(2)
+            if override_stage_id == stage_id and param_name not in internal_keys:
+                result[param_name] = value
+            continue
+
+        result[key] = value
+
+    return result
+
+
+def strip_parent_engine_args(
+    kwargs: dict[str, Any],
+    *,
+    parent_fields: dict[str, dataclasses.Field],
+    keep_keys: set[str] | frozenset[str] = frozenset(),
+    strip_keys: set[str] | frozenset[str] = frozenset(),
+    no_warn_keys: set[str] | frozenset[str] = frozenset(),
+) -> tuple[dict[str, Any], list[str]]:
+    """Strip parent ``EngineArgs`` fields before merging into stage YAML."""
+    overridden: list[str] = []
+    result: dict[str, Any] = {}
+
+    for key, value in kwargs.items():
+        if key in strip_keys:
+            continue
+
+        if key not in parent_fields or key in keep_keys:
+            result[key] = value
+            continue
+
+        field = parent_fields[key]
+        if field.default is not dataclasses.MISSING:
+            default = field.default
+        elif field.default_factory is not dataclasses.MISSING:
+            default = field.default_factory()
+        else:
+            default = dataclasses.MISSING
+
+        if default is dataclasses.MISSING or value is None:
+            continue
+
+        if dataclasses.is_dataclass(default) and not isinstance(default, type):
+            default = asdict(default)
+
+        if value != default and key not in no_warn_keys:
+            overridden.append(key)
+
+    return result, sorted(overridden)
 
 
 class StageType(str, Enum):
@@ -322,9 +410,17 @@ class StageConfigFactory:
                 continue
             engine_args[key] = value
 
-        # Serialize parallel_config as dict for OmegaConf compatibility
+        # Serialize parallel_config as dict for OmegaConf compatibility.
+        # Test helpers sometimes pass lightweight objects rather than dataclasses,
+        # so fall back to their ``__dict__`` when needed.
         if "parallel_config" in kwargs:
-            engine_args["parallel_config"] = asdict(kwargs["parallel_config"])
+            parallel_config = kwargs["parallel_config"]
+            if dataclasses.is_dataclass(parallel_config) and not isinstance(parallel_config, type):
+                engine_args["parallel_config"] = asdict(parallel_config)
+            elif hasattr(parallel_config, "__dict__"):
+                engine_args["parallel_config"] = dict(vars(parallel_config))
+            else:
+                engine_args["parallel_config"] = parallel_config
 
         engine_args.setdefault("cache_backend", "none")
         engine_args["model_stage"] = "diffusion"
@@ -544,20 +640,7 @@ class StageConfigFactory:
 
     # Keys that should never be forwarded as engine overrides (internal /
     # orchestrator-only knobs, complex objects, etc.).
-    _INTERNAL_KEYS: set[str] = {
-        "model",
-        "stage_configs_path",
-        "stage_id",
-        "stage_init_timeout",
-        "init_timeout",
-        "shm_threshold_bytes",
-        "worker_backend",
-        "ray_address",
-        "batch_timeout",
-        "log_stats",
-        "tokenizer",
-        "parallel_config",
-    }
+    _INTERNAL_KEYS: set[str] = set(INTERNAL_STAGE_OVERRIDE_KEYS)
 
     @classmethod
     def _merge_cli_overrides(
@@ -582,26 +665,8 @@ class StageConfigFactory:
         Returns:
             Dict of runtime overrides for this stage.
         """
-        result: dict[str, Any] = {}
-
-        # Apply global overrides – any key not in the internal blocklist
-        # is forwarded so that engine-registered params work out of the box.
-        for key, value in cli_overrides.items():
-            if key in cls._INTERNAL_KEYS:
-                continue
-            if re.match(r"stage_\d+_", key):
-                # Per-stage keys handled below
-                continue
-            if value is not None:
-                result[key] = value
-
-        # Apply per-stage overrides (--stage-N-* format, take precedence)
-        stage_prefix = f"stage_{stage.stage_id}_"
-        for key, value in cli_overrides.items():
-            if key.startswith(stage_prefix) and value is not None:
-                param_name = key[len(stage_prefix) :]
-                if param_name in cls._INTERNAL_KEYS:
-                    continue
-                result[param_name] = value
-
-        return result
+        return build_stage_runtime_overrides(
+            stage.stage_id,
+            cli_overrides,
+            internal_keys=cls._INTERNAL_KEYS,
+        )

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -32,6 +32,7 @@ from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.input_processor import InputProcessor
 
+from vllm_omni.config.stage_config import strip_parent_engine_args
 from vllm_omni.diffusion.data import DiffusionParallelConfig
 from vllm_omni.diffusion.stage_diffusion_client import StageDiffusionClient
 from vllm_omni.diffusion.stage_diffusion_proc import (
@@ -1258,31 +1259,13 @@ class AsyncOmniEngine:
         _no_warn = {"model"}
 
         parent_fields: dict[str, dataclasses.Field] = {f.name: f for f in dataclasses.fields(EngineArgs)}
-        overridden: list[str] = []
-        result: dict[str, Any] = {}
-        for k, v in kwargs.items():
-            if k in _strip_omni:
-                continue
-            if k not in parent_fields or k in _keep:
-                result[k] = v
-                continue
-            # Detect explicitly-set values that differ from the default.
-            # Values may have been through asdict() which converts dataclass
-            # defaults to dicts, so normalise before comparing.
-            field = parent_fields[k]
-            if field.default is not dataclasses.MISSING:
-                default = field.default
-            elif field.default_factory is not dataclasses.MISSING:
-                default = field.default_factory()
-            else:
-                default = dataclasses.MISSING
-            if default is dataclasses.MISSING or v is None:
-                continue
-            # Normalise dataclass defaults to dicts for comparison
-            if dataclasses.is_dataclass(default) and not isinstance(default, type):
-                default = dataclasses.asdict(default)
-            if v != default and k not in _no_warn:
-                overridden.append(k)
+        result, overridden = strip_parent_engine_args(
+            kwargs,
+            parent_fields=parent_fields,
+            keep_keys=_keep,
+            strip_keys=_strip_omni,
+            no_warn_keys=_no_warn,
+        )
 
         if overridden:
             logger.warning(


### PR DESCRIPTION


<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

  This PR refactors stage config override resolution without changing runtime behavior.

  It centralizes two pieces of logic that were previously split across call sites:

  1. Stage-scoped runtime override merging
     - Shared handling for global overrides and `stage_<id>_*` overrides
     - Shared filtering for internal orchestrator-only keys

  2. Parent `EngineArgs` stripping before YAML merge
     - Shared filtering for top-level engine args that must not leak into per-stage configs
     - Shared warning behavior for explicit parent overrides that are ignored when `stage_configs_path` is
  used

  It also makes `create_default_diffusion()` more robust when `parallel_config` is provided by lightweight
  test helpers rather than a dataclass instance.

  This change is intended to be behavior-preserving. Its goal is to make stage config precedence and
  filtering rules explicit, reusable, and easier to test.

## Test Plan

```
  ./.venv/bin/python -m pytest -q \
    tests/test_config_factory.py \
    tests/engine/test_arg_utils.py \
    tests/entrypoints/test_utils.py

  ./.venv/bin/python -m pytest -q \
    tests/engine/test_async_omni_engine_stage_init.py

  ./.venv/bin/python -m pytest -q \
    tests/entrypoints/test_serve.py

  ./.venv/bin/python -m pytest -q \
    tests/test_diffusion_config_propagation.py \
    tests/distributed/omni_connectors/test_adapter_and_flow.py

  ./.venv/bin/python -m pytest -q \
    tests/engine/test_single_stage_mode.py::TestSingleStageModeDetection
```

## Test Result

```
./.venv/bin/python -m pytest -q \
    tests/test_config_factory.py \
    tests/engine/test_arg_utils.py \
    tests/entrypoints/test_utils.py

  .......................................................................  [100%]
  71 passed, 16 warnings in 11.38s

  ./.venv/bin/python -m pytest -q \
    tests/engine/test_async_omni_engine_stage_init.py

  ......                                                                   [100%]
  6 passed, 16 warnings in 0.01s

  ./.venv/bin/python -m pytest -q \
    tests/entrypoints/test_serve.py

  ...                                                                      [100%]
  3 passed, 18 warnings in 0.73s

  ./.venv/bin/python -m pytest -q \
    tests/test_diffusion_config_propagation.py \
    tests/distributed/omni_connectors/test_adapter_and_flow.py

  ..................                                                       [100%]
  18 passed, 16 warnings in 0.03s

  ./.venv/bin/python -m pytest -q \
    tests/engine/test_single_stage_mode.py::TestSingleStageModeDetection

  .......                                                                  [100%]
  7 passed, 16 warnings in 0.04s
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
