### PR TITLE
[BugFix] Remove stage_configs_path validation

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -118,13 +118,6 @@ def test_qwen3_tts_codec_frame_rate_patching():
     assert omni_config.codec_frame_rate_hz == 12.3
 
 
-def test_stage_configs_path_blocks_create_model_config():
-    """create_model_config() should raise when stage_configs_path is set."""
-    args = OmniEngineArgs(stage_configs_path="/some/path.yaml")
-    with pytest.raises(RuntimeError, match="stage_configs_path"):
-        args.create_model_config()
-
-
 def test_from_cli_args_picks_up_stage_configs_path():
     """from_cli_args should pick up stage_configs_path from namespace."""
     ns = argparse.Namespace(

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -194,11 +194,6 @@ class OmniEngineArgs(EngineArgs):
         Returns:
             OmniModelConfig instance with all configuration fields set
         """
-        if self.stage_configs_path is not None:
-            raise RuntimeError(
-                "create_model_config() should not be called when stage_configs_path is set. "
-                "Per-stage model configs are resolved from the stage config YAML."
-            )
         # register omni models to avoid model not found error
         self._ensure_omni_models_registered()
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Remove the stage_configs_path check to avoid throwing a runtime error during L4 test cases.
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/vllm-omni/vllm_omni/entrypoints/cli/main.py", line 63, in <module>
    main()
  File "/vllm-omni/vllm_omni/entrypoints/cli/main.py", line 57, in main
    args.dispatch_function(args)
  File "/vllm-omni/vllm_omni/entrypoints/cli/serve.py", line 94, in cmd
    run_headless(args)
  File "/vllm-omni/vllm_omni/entrypoints/cli/serve.py", line 552, in run_headless
    vllm_config, executor_class = build_vllm_config(
                                  ^^^^^^^^^^^^^^^^^^
  File "/vllm-omni/vllm_omni/engine/stage_init_utils.py", line 326, in build_vllm_config
    vllm_config = omni_engine_args.create_engine_config(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/vllm/engine/arg_utils.py", line 1549, in create_engine_config
    model_config = self.create_model_config()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/vllm-omni/vllm_omni/engine/arg_utils.py", line 198, in create_model_config
    raise RuntimeError(
RuntimeError: create_model_config() should not be called when stage_configs_path is set. Per-stage model configs are resolved from the stage config YAML.
```
## Test Plan
`pytest -sv test_qwen3_omni_expansion.py -m "advanced_model" --run-level "advanced_model"`
## Test Result

```
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/audio/speech, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/audio/speech/batch, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/audio/voices, Methods: GET
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/audio/voices, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/audio/voices/{name}, Methods: DELETE
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/images/generations, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/images/edits, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/videos, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/videos/sync, Methods: POST
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/videos, Methods: GET
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: GET
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: DELETE
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:46] Route: /v1/videos/{video_id}/content, Methods: GET
(APIServer pid=3242233) INFO 04-13 14:51:47 [launcher.py:57] Route: /v1/audio/speech/stream, Endpoint: streaming_speech
OmniServerStageCli ready on 127.0.0.1:35405
OmniServer started successfully
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
