### PR TITLE
fix(runner): pass request_id to model.preprocess() for per-request state

### DIFF
--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1241,6 +1241,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 span_len = int(e) - int(s)
 
                 # call the custom process function
+                req_infos["request_id"] = req_id
                 embed_slice = inputs_embeds[s:e] if inputs_embeds is not None else None
                 req_input_ids, req_embeds, update_dict = self.model.preprocess(
                     input_ids=input_ids[s:e], input_embeds=embed_slice, **req_infos


### PR DESCRIPTION
## Summary

- `OmniGPUModelRunner._preprocess()` iterates over `self.input_batch.req_ids` but never passes the request ID to `model.preprocess()`. Models that maintain per-request state (e.g. VoxCPM2) fall back to a hardcoded `"default"` ID, so **all concurrent requests share a single state object**.

This one-line fix injects `req_infos["request_id"] = req_id` before the `preprocess()` call.

**Bugs fixed (found while testing #2690):**

| Bug | Symptom | Root cause |
|-----|---------|------------|
| Stop logic failure | 2 concurrent requests produce ~58s audio for ~4s sentences | Shared state mixes stop signals; stop never cleanly triggers |
| Prefill shape mismatch | 4 concurrent requests crash with `RuntimeError: size mismatch` | Second `preprocess()` overwrites first's `prefill_masks`; `forward()` reads stale dimensions |

**Known remaining issue (not addressed here):** 4 concurrent requests hit `msgspec.ValidationError: cannot unpack non-iterable NoneType object` in the orchestrator IPC layer when requests finish at different times and `mm_payload` contains `None` audio entries. This is a separate orchestrator-level serialization bug.

## Test plan

Tested on H20 (single GPU, enforce_eager=true):
- [x] Single request: RTF ~0.21, audio correct (unchanged)
- [x] 2 concurrent requests: 2.72s + 5.28s audio (was 57s + 58s)
- [ ] 4 concurrent requests: prefill shape mismatch fixed, but blocked by orchestrator `msgspec` bug