### PR TITLE
[Voxtral TTS] Fix Voxtral TTS input with text and ref_audio

### DIFF
--- a/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
@@ -864,6 +864,29 @@ class VoxtralTTSMultiModalProcessor(BaseMultiModalProcessor[VoxtralTTSProcessing
             ),
         ]
 
+    def _apply_hf_processor_mm_only(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        tokenization_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        """
+        Apply the HF processor on the multi-modal data only.
+
+        Issue: Voxtral TTS use Mistral Tokenizer with a custom audio encoder so it
+        does not work with HF call_hf_processor_mm_only directly.
+
+        Solution: Override this method to call _apply_hf_processor_text_mm directly.
+        """
+        mm_counts = mm_items.get_all_counts()
+        _, mm_processed_data, _ = self._apply_hf_processor_text_mm(
+            prompt_text=self.dummy_inputs.get_dummy_text(mm_counts),
+            mm_items=mm_items,
+            hf_processor_mm_kwargs=hf_processor_mm_kwargs,
+            tokenization_kwargs=tokenization_kwargs,
+        )
+        return mm_processed_data
+
     def _cached_apply_hf_processor(
         self,
         inputs: ProcessorInputs,

--- a/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_generation.py
@@ -873,8 +873,8 @@ class VoxtralTTSMultiModalProcessor(BaseMultiModalProcessor[VoxtralTTSProcessing
         """
         Apply the HF processor on the multi-modal data only.
 
-        Issue: Voxtral TTS use Mistral Tokenizer with a custom audio encoder so it
-        does not work with HF call_hf_processor_mm_only directly.
+        Issue: Voxtral TTS use Mistral Tokenizer with custom audio encoder. It doesn't
+        inherit Transformers ProcessorMixin and can't use call_hf_processor_mm_only.
 
         Solution: Override this method to call _apply_hf_processor_text_mm directly.
         """


### PR DESCRIPTION
## Purpose
- ref_audio (mm_data) + text input fails bc `VoxtralTTSMultiModalProcessor` doesn't work with HF `_apply_hf_processor_mm_only` directly (the class didn't inherit from Transformers ProcessorMixin since it use mistral tokenizer to handle preprocess)
- prefix voice clone still work bc it send text + voice id (no mm_input)

## Test Plan
```
pytest -s -v   tests/model_executor/stage_input_processors/test_voxtral_tts_async_chunk.py   \
tests/model_executor/models/voxtral_tts/test_cuda_graph_acoustic_transformer.py   \
tests/model_executor/models/voxtral_tts/test_audio_tokenizer_parsing.py   \
tests/e2e/online_serving/test_voxtral_tts.py \
tests/model_executor/models/voxtral_tts/test_text_preprocess.py  \
tests/e2e/offline_inference/test_voxtral_tts.py
```

## Test Result
<img width="857" height="828" alt="image" src="https://github.com/user-attachments/assets/1f66d195-9f42-45bb-8fc1-f52f046c3567" />
