### PR TITLE
[Bugfix] Reject /v1/audio/speech for Qwen omni models

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -684,6 +684,32 @@ class TestTTSMethods:
         assert server._is_tts is True
         assert server._tts_stage is mock_stage
 
+    def test_prepare_speech_rejects_non_tts_omni_model(self, mocker: MockerFixture):
+        """Multi-stage omni models (e.g. Qwen3-Omni) must not use /v1/audio/speech."""
+        mock_engine_client = mocker.MagicMock()
+        mock_engine_client.errored = False
+        mock_engine_client.tts_max_instructions_length = None
+
+        # Simulate Qwen3-Omni: multiple stages, none in _TTS_MODEL_STAGES
+        thinker = SimpleNamespace(engine_args=SimpleNamespace(model_stage="thinker"), tts_args={})
+        talker = SimpleNamespace(engine_args=SimpleNamespace(model_stage="talker"), tts_args={})
+        code2wav = SimpleNamespace(engine_args=SimpleNamespace(model_stage="code2wav"), tts_args={})
+        mock_engine_client.stage_configs = [thinker, talker, code2wav]
+
+        mock_models = mocker.MagicMock()
+        mock_models.is_base_model.return_value = True
+        server = OmniOpenAIServingSpeech(
+            engine_client=mock_engine_client,
+            models=mock_models,
+            request_logger=mocker.MagicMock(),
+        )
+        assert server._is_tts is False
+
+        request = OpenAICreateSpeechRequest(input="Hello world")
+        with pytest.raises(ValueError, match="only supported for dedicated TTS models"):
+            asyncio.run(server._prepare_speech_generation(request))
+        server.shutdown()
+
     def test_estimate_prompt_len_fallback(self, speech_server):
         """Test prompt length estimation falls back to 2048 when model is unavailable."""
         tts_params = {"text": ["Hello"], "task_type": ["CustomVoice"]}

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -1471,6 +1471,24 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                 ph_len = await self._estimate_prompt_len_async(tts_params)
                 prompt = {"prompt_token_ids": [1] * ph_len, "additional_information": tts_params}
         else:
+            # Qwen omni models (Qwen3-Omni, Qwen2.5-Omni) use a "talker"
+            # stage whose preprocess requires chat-templated tokens.  The
+            # async-chunk orchestrator prewarms the talker via
+            # compute_talker_prompt_ids_length(), which scans for Qwen
+            # chat-template markers (im_start_token_id 151644).  A raw-text
+            # prompt produces a 1-token placeholder that crashes the talker's
+            # prefill/decode handoff.  Reject early with an actionable message.
+            stage_names = {
+                getattr(getattr(s, "engine_args", None), "model_stage", None) for s in self.engine_client.stage_configs
+            }
+            if "talker" in stage_names:
+                raise ValueError(
+                    "The /v1/audio/speech endpoint is only supported for "
+                    "dedicated TTS models (e.g., Qwen3-TTS, Voxtral, Fish "
+                    "Speech, CosyVoice3, OmniVoice, VoxCPM2). For omni "
+                    "models like Qwen3-Omni, use /v1/chat/completions with "
+                    '\'"modalities": ["audio"]\' instead.'
+                )
             tts_params = {}
             prompt = {"prompt": request.input}
 


### PR DESCRIPTION
Closes https://github.com/vllm-project/vllm-omni/issues/2747

## Purpose

`/v1/audio/speech` crashes with `RuntimeError: Missing prefill_consumed_text_tokens` when called on Qwen3-Omni with async_chunk.

The generic fallback in `_prepare_speech_generation()` sent raw text without a chat template, causing `compute_talker_prompt_ids_length()` to return 0. This produced a 1-token placeholder that made the talker enter the decode path without a prior prefill.

This PR adds a guard: when the engine advertises a `"talker"` stage (Qwen3-Omni, Qwen2.5-Omni), raise a clear `ValueError` directing users to `/v1/chat/completions` with `"modalities": ["audio"]`. Other multi-stage audio backends (Dynin-Omni, MiMo-Audio) and generic single-stage backends are unaffected.

## Test Plan

Added `test_prepare_speech_rejects_non_tts_omni_model` in `tests/entrypoints/openai_api/test_serving_speech.py` which simulates the Qwen3-Omni stage layout (thinker/talker/code2wav) and asserts the `ValueError` is raised.

```bash
pytest tests/entrypoints/openai_api/test_serving_speech.py::TestTTSMethods::test_prepare_speech_rejects_non_tts_omni_model -v
```

Existing tests (`test_create_speech_success`, `test_streaming`, `test_batch_success`) are unaffected since their fixtures have no `"talker"` stage.

## Test Result

- New test verifies the `ValueError` is raised for Qwen omni stage layouts.
- Existing speech endpoint tests remain green (guard only triggers on `"talker"` stage, not on generic/empty stage configs).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>