### PR TITLE
[v0.18.0.post1][Perf] Add layout field of attention metadata for short shape of attn

### DIFF
--- a/tests/entrypoints/openai_api/test_video_server.py
+++ b/tests/entrypoints/openai_api/test_video_server.py
@@ -14,8 +14,7 @@ import time
 from types import SimpleNamespace
 
 import pytest
-from fastapi import FastAPI
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from PIL import Image
 from pytest_mock import MockerFixture

--- a/vllm_omni/diffusion/attention/backends/abstract.py
+++ b/vllm_omni/diffusion/attention/backends/abstract.py
@@ -64,6 +64,8 @@ class AttentionMetadata:
     # a replicated tensor among processes appended to the front or rear of value, depends the joint_strategy
     joint_strategy: str = "front"
     # the strategy to joint the query, key, and value, can be "front" or "rear"
+    layout: str | None = None
+    # the layout of the input query, key, and value, can be "BSND" or "BNSD"
 
 
 T = TypeVar("T", bound=AttentionMetadata)

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -195,38 +195,8 @@ class FlashAttentionImpl(AttentionImpl):
         MINDIE_SD_FA_TYPE environment variable.
         """
         attention_mask = attn_metadata.attn_mask if attn_metadata else None
+        layout = attn_metadata.layout if attn_metadata else None
 
-        # Detect input layout based on num_heads position
-        # BSND: [B, S, N, D] -> shape[2] == num_heads
-        # BNSD: [B, N, S, D] -> shape[1] == num_heads
-        if query.shape[2] == self.num_heads:
-            layout = "BSND"
-            q_seqlen, k_seqlen = query.shape[1], key.shape[1]
-        else:
-            layout = "BNSD"
-            q_seqlen, k_seqlen = query.shape[2], key.shape[2]
-
-        # When Q/KV seqlen differ, LA will fail. Use torch_npu directly to bypass env var.
-        if q_seqlen != k_seqlen:
-            import torch_npu
-
-            if attention_mask is not None:
-                attention_mask = ~attention_mask.to(torch.bool)
-
-            output = torch_npu.npu_fusion_attention(
-                query,
-                key,
-                value,
-                atten_mask=attention_mask,
-                input_layout=layout,
-                scale=self.softmax_scale,
-                pre_tokens=2147483647,
-                next_tokens=2147483647,
-                head_num=self.num_heads,
-            )[0]
-            return output
-
-        # Self attention: use mindiesd which respects MINDIE_SD_FA_TYPE env var
         try:
             from mindiesd import attention_forward
         except ImportError:

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -187,7 +187,46 @@ class FlashAttentionImpl(AttentionImpl):
         value: torch.Tensor,
         attn_metadata: AttentionMetadata = None,
     ) -> torch.Tensor:
-        """NPU attention implementation using mindiesd."""
+        """NPU attention implementation.
+
+        When Q and KV have different seqlen (cross attention), uses torch_npu directly
+        to bypass environment variable and force fused_attn_score (LA doesn't support
+        different Q/KV seqlen). Otherwise uses mindiesd attention_forward which respects
+        MINDIE_SD_FA_TYPE environment variable.
+        """
+        attention_mask = attn_metadata.attn_mask if attn_metadata else None
+
+        # Detect input layout based on num_heads position
+        # BSND: [B, S, N, D] -> shape[2] == num_heads
+        # BNSD: [B, N, S, D] -> shape[1] == num_heads
+        if query.shape[2] == self.num_heads:
+            layout = "BSND"
+            q_seqlen, k_seqlen = query.shape[1], key.shape[1]
+        else:
+            layout = "BNSD"
+            q_seqlen, k_seqlen = query.shape[2], key.shape[2]
+
+        # When Q/KV seqlen differ, LA will fail. Use torch_npu directly to bypass env var.
+        if q_seqlen != k_seqlen:
+            import torch_npu
+
+            if attention_mask is not None:
+                attention_mask = ~attention_mask.to(torch.bool)
+
+            output = torch_npu.npu_fusion_attention(
+                query,
+                key,
+                value,
+                atten_mask=attention_mask,
+                input_layout=layout,
+                scale=self.softmax_scale,
+                pre_tokens=2147483647,
+                next_tokens=2147483647,
+                head_num=self.num_heads,
+            )[0]
+            return output
+
+        # Self attention: use mindiesd which respects MINDIE_SD_FA_TYPE env var
         try:
             from mindiesd import attention_forward
         except ImportError:
@@ -198,7 +237,6 @@ class FlashAttentionImpl(AttentionImpl):
                 "Otherwise, use SDPA backend by setting DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA"
             )
 
-        attention_mask = attn_metadata.attn_mask if attn_metadata else None
         output = attention_forward(
             query,
             key,
@@ -206,6 +244,6 @@ class FlashAttentionImpl(AttentionImpl):
             attn_mask=attention_mask,
             opt_mode="manual",
             op_type="fused_attn_score",
-            layout="BNSD",
+            layout=layout,
         )
         return output

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -23,6 +23,7 @@ from vllm.model_executor.layers.linear import ColumnParallelLinear, QKVParallelL
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.backends.sdpa import SDPAImpl
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelInput,
@@ -444,7 +445,7 @@ class WanSelfAttention(nn.Module):
 
 class WanCrossAttention(nn.Module):
     """
-    Optimized cross-attention module using vLLM layers.
+    Optimized cross-attention module using vLLM layers with SDPA.
     Handles both text cross-attention and optional image cross-attention (I2V).
     """
 
@@ -532,14 +533,12 @@ class WanCrossAttention(nn.Module):
         )
         self.dropout = nn.Dropout(dropout)
 
-        # Unified attention layer
-        self.attn = Attention(
+        # Force SDPA backend for cross-attention (workaround)
+        self.sdpa_impl = SDPAImpl(
             num_heads=self.num_heads,
             head_size=head_dim,
-            num_kv_heads=self.num_heads,
             softmax_scale=1.0 / (head_dim**0.5),
             causal=False,
-            skip_sequence_parallel=True,
         )
 
     def forward(
@@ -564,7 +563,7 @@ class WanCrossAttention(nn.Module):
         value = self.to_v(encoder_hidden_states)
         key = self.norm_k(key)
 
-        # Reshape for multi-head attention
+        # Reshape for multi-head attention: [B, S, H, D]
         query = query.unflatten(2, (self.num_heads, self.head_dim))
         key = key.unflatten(2, (self.num_heads, self.head_dim))
         value = value.unflatten(2, (self.num_heads, self.head_dim))
@@ -579,12 +578,12 @@ class WanCrossAttention(nn.Module):
             key_img = key_img.unflatten(2, (self.num_heads, self.head_dim))
             value_img = value_img.unflatten(2, (self.num_heads, self.head_dim))
 
-            hidden_states_img = self.attn(query, key_img, value_img)
+            hidden_states_img = self.sdpa_impl.forward(query, key_img, value_img)
             hidden_states_img = hidden_states_img.flatten(2, 3)
             hidden_states_img = hidden_states_img.type_as(query)
 
-        # Main cross-attention using unified attention layer
-        hidden_states = self.attn(query, key, value)
+        # Main cross-attention using SDPA (forced)
+        hidden_states = self.sdpa_impl.forward(query, key, value)
         hidden_states = hidden_states.flatten(2, 3)
         hidden_states = hidden_states.type_as(query)
 

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -583,8 +583,10 @@ class WanCrossAttention(nn.Module):
             hidden_states_img = hidden_states_img.flatten(2, 3)
             hidden_states_img = hidden_states_img.type_as(query)
 
+        attn_metadata = AttentionMetadata(layout="BSND")
+
         # Main cross-attention using unified attention layer
-        hidden_states = self.attn(query, key, value)
+        hidden_states = self.attn(query, key, value, attn_metadata)
         hidden_states = hidden_states.flatten(2, 3)
         hidden_states = hidden_states.type_as(query)
 

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -563,7 +563,7 @@ class WanCrossAttention(nn.Module):
         value = self.to_v(encoder_hidden_states)
         key = self.norm_k(key)
 
-        # Reshape for multi-head attention: [B, S, H, D]
+        # Reshape for multi-head attention
         query = query.unflatten(2, (self.num_heads, self.head_dim))
         key = key.unflatten(2, (self.num_heads, self.head_dim))
         value = value.unflatten(2, (self.num_heads, self.head_dim))

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -23,7 +23,6 @@ from vllm.model_executor.layers.linear import ColumnParallelLinear, QKVParallelL
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
-from vllm_omni.diffusion.attention.backends.sdpa import SDPAImpl
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelInput,
@@ -445,7 +444,7 @@ class WanSelfAttention(nn.Module):
 
 class WanCrossAttention(nn.Module):
     """
-    Optimized cross-attention module using vLLM layers with SDPA.
+    Optimized cross-attention module using vLLM layers.
     Handles both text cross-attention and optional image cross-attention (I2V).
     """
 
@@ -533,12 +532,14 @@ class WanCrossAttention(nn.Module):
         )
         self.dropout = nn.Dropout(dropout)
 
-        # Force SDPA backend for cross-attention (workaround)
-        self.sdpa_impl = SDPAImpl(
+        # Unified attention layer
+        self.attn = Attention(
             num_heads=self.num_heads,
             head_size=head_dim,
+            num_kv_heads=self.num_heads,
             softmax_scale=1.0 / (head_dim**0.5),
             causal=False,
+            skip_sequence_parallel=True,
         )
 
     def forward(
@@ -578,12 +579,12 @@ class WanCrossAttention(nn.Module):
             key_img = key_img.unflatten(2, (self.num_heads, self.head_dim))
             value_img = value_img.unflatten(2, (self.num_heads, self.head_dim))
 
-            hidden_states_img = self.sdpa_impl.forward(query, key_img, value_img)
+            hidden_states_img = self.attn(query, key_img, value_img)
             hidden_states_img = hidden_states_img.flatten(2, 3)
             hidden_states_img = hidden_states_img.type_as(query)
 
-        # Main cross-attention using SDPA (forced)
-        hidden_states = self.sdpa_impl.forward(query, key, value)
+        # Main cross-attention using unified attention layer
+        hidden_states = self.attn(query, key, value)
         hidden_states = hidden_states.flatten(2, 3)
         hidden_states = hidden_states.type_as(query)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

ascend_laser_attention (LA) doesn't support different Q/KV sequence lengths, which causes errors for cross attention where Q comes from decoder (long seq) and KV comes from encoder (short seq, e.g. 512 text tokens).

This change:
- Detects Q/KV seqlen mismatch in forward_npu and bypasses mindiesd to use torch_npu.npu_fusion_attention directly with fused_attn_score
- Auto-detects input layout (BSND/BNSD) based on num_heads position
- Self attention (same Q/KV seqlen) still respects MINDIE_SD_FA_TYPE env var
- Reverts WanCrossAttention to use unified Attention layer

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
