### PR TITLE
[Misc] clean Temporary CI Configs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import atexit
 import base64
 import datetime
 import io
@@ -1362,9 +1363,10 @@ def modify_stage_config(
                             continue
 
                         # Delete specified paths in this stage
-                        for path in delete_paths:
-                            if path:  # Skip empty paths
-                                delete_by_path(target_stage, path)
+                        # Avoid shadowing the original YAML Path used for the output filename below.
+                        for delete_path in delete_paths:
+                            if delete_path:  # Skip empty paths
+                                delete_by_path(target_stage, delete_path)
             elif "." in key:
                 # Delete using dot-separated path
                 delete_by_path(config, key)
@@ -1394,15 +1396,15 @@ def modify_stage_config(
                             raise KeyError(f"Stage ID {stage_id} not found, available: {available_ids}")
 
                         # Apply updates to this stage
-                        for path, val in stage_updates.items():
+                        for update_path, val in stage_updates.items():
                             # Check if this is a simple key (not dot-separated)
                             # Example: 'engine_input_source' vs 'engine_args.max_model_len'
-                            if "." not in path:
+                            if "." not in update_path:
                                 # Direct key assignment (e.g., updating a list value)
-                                target_stage[path] = val
+                                target_stage[update_path] = val
                             else:
                                 # Dot-separated path (e.g., nested dict access)
-                                apply_update(target_stage, path, val)
+                                apply_update(target_stage, update_path, val)
             elif "." in key:
                 # Apply using dot-separated path
                 apply_update(config, key, value)
@@ -1414,13 +1416,14 @@ def modify_stage_config(
     # within the same second (e.g. test_qwen3_omni_expansion imports both
     # get_chunk_config and get_batch_token_config). int(time.time()) would collide
     # and the later write would overwrite the earlier YAML on disk.
-    base_name = yaml_path.rsplit(".", 1)[0] if "." in yaml_path else yaml_path
-    output_path = f"{base_name}_{time.time_ns()}.yaml"
+    # Keep generated configs outside the repo and delete them when pytest exits.
+    output_fd, output_path = tempfile.mkstemp(prefix=f"{path.stem}_", suffix=".yaml")
+    atexit.register(Path(output_path).unlink, missing_ok=True)
 
-    with open(output_path, "w", encoding="utf-8") as f:
+    with os.fdopen(output_fd, "w", encoding="utf-8") as f:
         yaml.dump(config, f, default_flow_style=None, sort_keys=False, allow_unicode=True, indent=2)
 
-    return output_path
+    return str(output_path)
 
 
 class OmniServer:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes #2755.

This PR prevents temporary stage config files generated during test runs from being left behind in the working tree. The affected test fixtures now keep generated config files under pytest-managed temporary paths and/or clean them up after the fixture finishes, so running tests no longer pollutes `tests/e2e/stage_configs` or `tests/dfx/stability/stage_configs` with untracked CI config files.

## Test Plan

Ran the targeted test collection command and checked whether temporary stage config files were left in the working tree:

```bash
python -m pytest --collect-only -q tests/e2e/online_serving/test_qwen2_5_omni.py
git status --short -- tests/e2e/stage_configs tests/dfx/stability/stage_configs
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
