### PR TITLE
[Model] Add native support for OmniWeaving with on-the-fly weight translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,6 +267,8 @@ vllm_omni/_version.py
 *.wav
 # Vendored test reference audio (small, intentionally checked in)
 !tests/assets/**/*.wav
+# Machine-local batch path overrides (see examples/offline_inference/omniweaving/local_batch_paths.example.sh)
+examples/offline_inference/omniweaving/local_batch_paths.sh
 .worktrees/
 # CI overlay yamls materialized from tests/utils.py:_CI_OVERLAYS at test time
 tests/.ci_generated/

--- a/docs/mkdocs/hooks/generate_api_readme.py
+++ b/docs/mkdocs/hooks/generate_api_readme.py
@@ -139,6 +139,7 @@ def scan_package(package_name: str = "vllm_omni") -> dict[str, list[str]]:
             # Skip excluded modules (avoid importing vllm during docs build)
             excluded_prefixes = [
                 "vllm_omni.diffusion.models.qwen_image",
+                "vllm_omni.diffusion.models.omniweaving",
                 "vllm_omni.diffusion.quantization",
                 "vllm_omni.quantization",
                 "vllm_omni.entrypoints.async_diffusion",

--- a/docs/mkdocs/hooks/mock_heavy_imports.py
+++ b/docs/mkdocs/hooks/mock_heavy_imports.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""Hook to mock heavy packages before any module import during docs build.
+
+ReadTheDocs build environment has limited RAM (~7 GB). When mkdocstrings/griffe
+falls back to dynamic inspection (import), loading torch + vllm + CUDA libraries
+exhausts memory and the build is OOM-killed.
+
+This hook installs sys.modules stubs and a meta-path finder to intercept imports
+of heavy packages, replacing them with lightweight MagicMock objects.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from importlib.machinery import ModuleSpec
+from unittest.mock import MagicMock
+
+logger = logging.getLogger("mkdocs")
+
+# Packages that pull in native extensions / large ML libraries.
+# Any sub-module of these is also intercepted.
+HEAVY_PACKAGES = [
+    "torch",
+    "torchaudio",
+    "torchvision",
+    "torchcre",
+    "vllm",
+    "vllm_ascend",
+    "vllm_platform",
+    "transformers",
+    "diffusers",
+    "accelerate",
+    "einops",
+    "triton",
+    "tritonserver",
+    "xformers",
+    "flash_attn",
+    "flashinfer",
+    "cuda",
+    "cuda_toolkit",
+    "nvidia",
+    "numba",
+    "onnx",
+    "onnxruntime",
+    "megablocks",
+    "stability",
+    "sentencepiece",
+    "tokenizers",
+    "tiktoken",
+    "safetensors",
+    "soundfile",
+    "librosa",
+    "scipy",
+    "sklearn",
+    "cv2",
+    "decord",
+    "av",
+    "PIL",
+    "pillow",
+    "pynvml",
+    "pycuda",
+    "cutlass",
+    "mamba_ssm",
+    "causal_conv1d",
+    "timm",
+    "open_clip",
+    "zmq",
+    "janus",
+    "msgspec",
+    "numpy",
+    "aenum",
+]
+
+
+def _make_mock_module(fullname: str, loader: _HeavyImportsLoader | None = None) -> MagicMock:
+    """Create a MagicMock that looks enough like a module to satisfy import machinery."""
+    mock = MagicMock()
+    mock.__name__ = fullname
+    mock.__file__ = f"<mocked {fullname}>"
+    mock.__loader__ = loader
+    mock.__package__ = fullname.rsplit(".", 1)[0] if "." in fullname else None
+    mock.__path__ = [f"<mocked {fullname}>"]
+    # MagicMock raises AttributeError for dunder names like __spec__ in Py3.12+,
+    # so we must explicitly set it.  Without a valid __spec__, the import system
+    # cannot traverse sub-modules (it needs __spec__.submodule_search_locations).
+    mock.__spec__ = ModuleSpec(fullname, loader, is_package=True)
+    mock.__spec__.submodule_search_locations = [f"<mocked {fullname}>"]
+    return mock
+
+
+def _install_mock(name: str) -> MagicMock:
+    mock = _make_mock_module(name)
+    sys.modules[name] = mock
+    return mock
+
+
+class _HeavyImportsLoader:
+    """Modern loader that replaces the module with a MagicMock during exec_module."""
+
+    def __init__(self, fullname: str) -> None:
+        self.fullname = fullname
+
+    def create_module(self, spec):
+        return None  # Let importlib create a default module
+
+    def exec_module(self, module) -> None:
+        mock = _make_mock_module(self.fullname, loader=self)
+        sys.modules[self.fullname] = mock
+
+
+class _HeavyImportsFinder:
+    """Meta-path finder that intercepts heavy packages using find_spec protocol."""
+
+    def find_spec(self, fullname: str, path=None, target=None):
+        # Already a MagicMock in sys.modules — nothing to do
+        existing = sys.modules.get(fullname)
+        if existing is not None:
+            if isinstance(existing, MagicMock):
+                return None
+            # If a real (pre-allocated) module exists but not mocked yet,
+            # we still intercept to replace it with a mock.
+            for pkg in HEAVY_PACKAGES:
+                if fullname == pkg or fullname.startswith(pkg + "."):
+                    loader = _HeavyImportsLoader(fullname)
+                    return ModuleSpec(fullname, loader, is_package=True)
+            return None
+
+        for pkg in HEAVY_PACKAGES:
+            if fullname == pkg or fullname.startswith(pkg + "."):
+                loader = _HeavyImportsLoader(fullname)
+                return ModuleSpec(fullname, loader, is_package=True)
+        return None
+
+
+def on_startup(*args, **kwargs) -> None:
+    logger.info("Mocking heavy packages for docs build (torch, vllm, transformers, …)")
+
+    # Pre-populate top-level packages so "import torch" hits sys.modules first.
+    for pkg in HEAVY_PACKAGES:
+        if pkg not in sys.modules:
+            _install_mock(pkg)
+
+    # Install a meta-path finder to catch sub-modules (e.g. torch.nn, vllm.engine)
+    # that haven't been pre-populated.
+    sys.meta_path.insert(0, _HeavyImportsFinder())
+
+    logger.info("Heavy package mocking installed")

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -76,5 +76,5 @@ th {
 |`DyninOmniForConditionalGeneration` | Dynin-Omni | `snu-aidas/Dynin-Omni` | ✅︎ | | | |
 | `ErnieImagePipeline` | ERNIE-Image | `baidu/ERNIE-Image`, `baidu/ERNIE-Image-Turbo` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 |`HiDreamImagePipeline` | HiDream-I1-Full | `HiDream-ai/HiDream-I1-Full` | ✅︎ | ✅︎ | | |
-
+| `OmniWeavingPipeline` | OmniWeaving | `Tencent-Hunyuan/OmniWeaving` | ✅︎ | ✅︎ |   |   |
 ✅︎ indicates the model is supported on that backend. Empty cells mean not listed as supported on that backend.

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -73,7 +73,7 @@ th {
 | `HunyuanVideo15ImageToVideoPipeline` | HunyuanVideo-1.5-I2V | `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_i2v`, `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_i2v` | ✅︎ | ✅︎ | | |
 | `VoxtralTTSForConditionalGeneration` | Voxtral TTS | `mistralai/Voxtral-4B-TTS-2603` | ✅︎ | ✅︎ | | |
 | `CovoAudioForConditionalGeneration` | Covo-Audio-Chat | `tencent/Covo-Audio-Chat` | ✅︎ | | | |
-|`DyninOmniForConditionalGeneration` | Dynin-Omni | `snu-aidas/Dynin-Omni` | ✅︎ | | | |
+| `DyninOmniForConditionalGeneration` | Dynin-Omni | `snu-aidas/Dynin-Omni` | ✅︎ | | | |
 | `ErnieImagePipeline` | ERNIE-Image | `baidu/ERNIE-Image`, `baidu/ERNIE-Image-Turbo` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 |`HiDreamImagePipeline` | HiDream-I1-Full | `HiDream-ai/HiDream-I1-Full` | ✅︎ | ✅︎ | | |
 | `OmniWeavingPipeline` | OmniWeaving | `Tencent-Hunyuan/OmniWeaving` | ✅︎ | ✅︎ |   |   |

--- a/docs/user_guide/diffusion_features.md
+++ b/docs/user_guide/diffusion_features.md
@@ -151,6 +151,7 @@ The following tables show which models support each feature:
 | **LTX-2.3**                  |     ❌     |     ✅      |           ✅           |       ✅        |         ✅         |         ❌         |   ❌    |             ✅             |          ❌           |       ❌        |        ❌         |
 | **Helios**                   |     ❌     |     ✅      |           ✅           |       ✅        |         ✅         |         ❌         |   ✅    |             ✅             |          ❌           |       ❌        |        ❌         |
 | **HunyuanVideo-1.5 T2V I2V** |     ❌     |     ✅      |           ✅           |       ✅        |         ✅         |         ❌         |   ✅    |             ✅             |  ✅ (encode/decode)   |       ✅        |        ❌         |
+| **OmniWeaving**              |     ✅     |     ✅      |           ✅           |       ✅        |         ✅         |         ❓         |   ❓    |             ✅             |      ✅ (decode)      |       ❌        |        ❌         |
 | **DreamID-Omni**             |     ❌     |     ❌      |           ❌           |       ✅        |         ❌         |         ❌         |   ✅    |             ✅             |          ❌           |       ❌        |        ❌         |
 | **Cosmos3**                  |     ❌     |     ✅      |           ✅           |       ✅        |         ✅         |         ❌         |   ✅    |             ✅             |  ✅ (encode/decode)   |       ✅        |        ❌         |
 

--- a/examples/offline_inference/image_to_video/README.md
+++ b/examples/offline_inference/image_to_video/README.md
@@ -48,6 +48,24 @@ python image_to_video.py \
   --output i2v_output.mp4
 ```
 
+### OmniWeaving I2V (Offline)
+
+Use the offline wrapper script in this directory to run OmniWeaving with a
+single reference image:
+
+```bash
+bash run_i2v_omniweaving.sh
+```
+
+The script defaults to a 480p OmniWeaving setup and uses this prompt:
+
+```text
+The cartoon character in the picture suddenly bursts into laughter, clutching their stomach with exaggerated movements.
+```
+
+You can override the defaults with environment variables such as `IMAGE_PATH`,
+`MODEL`, `TENSOR_PARALLEL_SIZE`, and `OUTPUT`.
+
 Key arguments:
 
 - `--model`: Model ID (I2V-A14B for MoE, TI2V-5B for unified T2V+I2V).

--- a/examples/offline_inference/image_to_video/image_to_video_omniweaving.py
+++ b/examples/offline_inference/image_to_video/image_to_video_omniweaving.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from examples.offline_inference.omniweaving.end2end import build_parser, main
+
+
+def parse_args():
+    parser = build_parser()
+    parser.description = "Image-to-video offline inference example for OmniWeaving."
+    parser.add_argument(
+        "--image",
+        dest="image_path",
+        type=str,
+        default=None,
+        help="Alias of --image-path for consistency with other image-to-video examples.",
+    )
+    args = parser.parse_args()
+    if not args.image_path and not args.image_paths:
+        parser.error("image-to-video mode requires --image-path/--image or --image-paths.")
+    return args
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/examples/offline_inference/image_to_video/run_i2v_omniweaving.sh
+++ b/examples/offline_inference/image_to_video/run_i2v_omniweaving.sh
@@ -28,8 +28,9 @@ FLOW_SHIFT="${FLOW_SHIFT:-}"
 
 case "${RESOLUTION}" in
     480p)
-        RESOLUTION_DIMS="480x832"
-        DEFAULT_FLOW_SHIFT="5.0"
+        # Match official / OMNIWEAVING_I2V_MI2V_PERF aligned case: 26:15, flow_shift=7.0
+        RESOLUTION_DIMS="480x848"
+        DEFAULT_FLOW_SHIFT="7.0"
         TEST_LABEL="I2V 480p"
         DEFAULT_OUTPUT="omniweaving_i2v_480p.mp4"
         ;;

--- a/examples/offline_inference/image_to_video/run_i2v_omniweaving.sh
+++ b/examples/offline_inference/image_to_video/run_i2v_omniweaving.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+# Offline OmniWeaving I2V launcher.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+METRICS_DOC="${REPO_ROOT}/examples/offline_inference/omniweaving/OMNIWEAVING_I2V_MI2V_PERF.md"
+METRICS_LOG_DIR="${REPO_ROOT}/examples/offline_inference/omniweaving/perf_logs"
+. "${REPO_ROOT}/examples/offline_inference/omniweaving/gpu_preflight.sh"
+
+MODEL="${MODEL:-/root/autodl-tmp/HY-OmniWeaving}"
+QWEN_PATH="${QWEN_PATH:-/root/autodl-tmp/hf_cache/models--Qwen--Qwen2.5-VL-7B-Instruct/snapshots/cc594898137f460bfe9f0759e9844b3ce807cfb5}"
+SIGLIP_PATH="${SIGLIP_PATH:-/root/autodl-tmp/hf_cache/models--google--siglip-so400m-patch14-384/snapshots/9fdffc58afc957d1a03a25b10dba0329ab15c2a3}"
+T2V_PATH="${T2V_PATH:-/root/autodl-tmp/hf_cache/models--hunyuanvideo-community--HunyuanVideo-1.5-Diffusers-480p_t2v/snapshots/286be7ce72277246578a3e3cc2487e95ddae5bcf}"
+
+IMAGE_PATH="${IMAGE_PATH:-/root/.cursor/projects/root-autodl-tmp/assets/c__Users_Z250911-3_AppData_Roaming_Cursor_User_workspaceStorage_6d70d8bc908833ca4a807cbaeeda4c91_images_naiwa_480p-085c9bb1-01b4-40a4-b3e2-b0c81ce1b928.png}"
+PROMPT="${PROMPT:-The cartoon character in the picture suddenly bursts into laughter, clutching their stomach with exaggerated movements.}"
+
+RESOLUTION="${RESOLUTION:-480p}"
+PRECISION_LABEL="${PRECISION_LABEL:-BF16}"
+TENSOR_PARALLEL_SIZE="${TENSOR_PARALLEL_SIZE:-2}"
+NUM_FRAMES="${NUM_FRAMES:-33}"
+NUM_INFERENCE_STEPS="${NUM_INFERENCE_STEPS:-30}"
+GUIDANCE_SCALE="${GUIDANCE_SCALE:-6.0}"
+SEED="${SEED:-42}"
+FLOW_SHIFT="${FLOW_SHIFT:-}"
+
+case "${RESOLUTION}" in
+    480p)
+        RESOLUTION_DIMS="480x832"
+        DEFAULT_FLOW_SHIFT="5.0"
+        TEST_LABEL="I2V 480p"
+        DEFAULT_OUTPUT="omniweaving_i2v_480p.mp4"
+        ;;
+    720p)
+        RESOLUTION_DIMS="720x1280"
+        DEFAULT_FLOW_SHIFT="7.0"
+        TEST_LABEL="I2V 720p"
+        DEFAULT_OUTPUT="omniweaving_i2v_720p.mp4"
+        ;;
+    *)
+        echo "Unsupported RESOLUTION: ${RESOLUTION}. Expected 480p or 720p."
+        exit 1
+        ;;
+esac
+
+FLOW_SHIFT_LABEL="${FLOW_SHIFT_LABEL:-${FLOW_SHIFT:-${DEFAULT_FLOW_SHIFT}}}"
+OUTPUT="${OUTPUT:-${DEFAULT_OUTPUT}}"
+
+for path_var in MODEL QWEN_PATH SIGLIP_PATH T2V_PATH IMAGE_PATH; do
+    if [ ! -e "${!path_var}" ]; then
+        echo "Required path does not exist: ${path_var}=${!path_var}"
+        exit 1
+    fi
+done
+
+# A single OmniWeaving TP=2 job can peak near the full memory of both GPUs.
+# Fail early with a clear message instead of crashing later during warmup.
+ensure_omniweaving_gpus_idle "${TENSOR_PARALLEL_SIZE}"
+
+echo "Running OmniWeaving I2V 480p..."
+echo "Model: ${MODEL}"
+echo "Image: ${IMAGE_PATH}"
+echo "Resolution: ${RESOLUTION} (${RESOLUTION_DIMS})"
+echo "Tensor parallel size: ${TENSOR_PARALLEL_SIZE}"
+echo "Output: ${OUTPUT}"
+
+cd "${REPO_ROOT}"
+mkdir -p "${METRICS_LOG_DIR}"
+
+RUN_TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+LOG_STAMP="$(date -u +"%Y%m%dT%H%M%SZ")"
+LOG_PATH="${METRICS_LOG_DIR}/i2v_${RESOLUTION}_${LOG_STAMP}.log"
+
+CMD=(
+    python examples/offline_inference/image_to_video/image_to_video_omniweaving.py
+    --model "${MODEL}"
+    --qwen-path "${QWEN_PATH}"
+    --siglip-path "${SIGLIP_PATH}"
+    --t2v-path "${T2V_PATH}"
+    --image "${IMAGE_PATH}"
+    --prompt "${PROMPT}"
+    --resolution "${RESOLUTION}"
+    --guidance-scale "${GUIDANCE_SCALE}"
+    --num-frames "${NUM_FRAMES}"
+    --num-inference-steps "${NUM_INFERENCE_STEPS}"
+    --seed "${SEED}"
+    --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}"
+    --output "${OUTPUT}"
+)
+
+if [ -n "${FLOW_SHIFT}" ]; then
+    CMD+=(--flow-shift "${FLOW_SHIFT}")
+fi
+
+set +e
+HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-1}" \
+TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE:-1}" \
+VLLM_NO_DEEP_GEMM="${VLLM_NO_DEEP_GEMM:-1}" \
+TORCHDYNAMO_DISABLE="${TORCHDYNAMO_DISABLE:-1}" \
+TORCH_COMPILE_DISABLE="${TORCH_COMPILE_DISABLE:-1}" \
+PYTORCH_ALLOC_CONF="${PYTORCH_ALLOC_CONF:-expandable_segments:True}" \
+PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}" \
+"${CMD[@]}" 2>&1 | tee "${LOG_PATH}"
+CMD_STATUS=${PIPESTATUS[0]}
+set -e
+
+if [ "${CMD_STATUS}" -ne 0 ]; then
+    echo "Run failed; metrics doc was not updated."
+    echo "Log saved to ${LOG_PATH}"
+    exit "${CMD_STATUS}"
+fi
+
+export METRICS_DOC LOG_PATH RUN_TIMESTAMP TEST_LABEL RESOLUTION_DIMS NUM_FRAMES NUM_INFERENCE_STEPS
+export PRECISION_LABEL FLOW_SHIFT_LABEL OUTPUT REPO_ROOT
+python - <<'PY'
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+def extract_float(cell: str) -> float | None:
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)", cell)
+    return float(match.group(1)) if match else None
+
+
+def parse_table(lines: list[str]) -> tuple[list[str], list[list[str]]]:
+    header = lines[:2]
+    rows = []
+    for line in lines[2:]:
+        if not line.startswith("|"):
+            continue
+        rows.append([cell.strip() for cell in line.strip().strip("|").split("|")])
+    return header, rows
+
+
+def format_table(header: list[str], rows: list[list[str]]) -> list[str]:
+    return header + [f"| {' | '.join(row)} |" for row in rows]
+
+
+def replace_section(text: str, title: str, new_lines: list[str], next_title: str | None) -> str:
+    start = text.index(title)
+    end = text.index(next_title, start) if next_title else len(text)
+    prefix = text[:start]
+    suffix = text[end:]
+    body = title + "\n\n" + "\n".join(new_lines).rstrip() + "\n\n"
+    return prefix + body + suffix.lstrip("\n")
+
+
+doc_path = Path(os.environ["METRICS_DOC"])
+log_path = Path(os.environ["LOG_PATH"])
+text = doc_path.read_text(encoding="utf-8")
+log_text = log_path.read_text(encoding="utf-8")
+
+latency_match = re.search(r"Latency:\s*([0-9]+(?:\.[0-9]+)?)s", log_text)
+peak_match = re.search(r"Peak VRAM:\s*([0-9]+(?:\.[0-9]+)?)\s*GiB", log_text)
+if latency_match is None:
+    raise SystemExit(f"Could not parse latency from log: {log_path}")
+
+latency_value = float(latency_match.group(1))
+peak_value = float(peak_match.group(1)) if peak_match else None
+
+latency_start = text.index("## Latency")
+peak_start = text.index("## Peak VRAM")
+history_start = text.index("## Run History")
+
+latency_header, latency_rows = parse_table(
+    [line for line in text[latency_start:peak_start].splitlines() if line.startswith("|")]
+)
+peak_header, peak_rows = parse_table(
+    [line for line in text[peak_start:history_start].splitlines() if line.startswith("|")]
+)
+history_header, history_rows = parse_table(
+    [line for line in text[history_start:].splitlines() if line.startswith("|")]
+)
+
+test_label = os.environ["TEST_LABEL"]
+resolution_dims = os.environ["RESOLUTION_DIMS"]
+frames = os.environ["NUM_FRAMES"]
+steps = os.environ["NUM_INFERENCE_STEPS"]
+precision = os.environ["PRECISION_LABEL"]
+flow_shift = os.environ["FLOW_SHIFT_LABEL"]
+output = os.path.relpath(os.environ["OUTPUT"], os.environ["REPO_ROOT"])
+log_rel = os.path.relpath(str(log_path), os.environ["REPO_ROOT"])
+
+diffusers_latency = None
+for row in latency_rows:
+    if row[0] == test_label and row[1] == "diffusers":
+        diffusers_latency = extract_float(row[7])
+        break
+
+speedup_cell = "**TBDx**"
+if diffusers_latency is not None and latency_value > 0:
+    speedup_cell = f"**{diffusers_latency / latency_value:.2f}x**"
+
+for idx, row in enumerate(latency_rows):
+    if row[0] == test_label and row[1] == "**vLLM-OMNI**":
+        latency_rows[idx] = [
+            test_label,
+            "**vLLM-OMNI**",
+            resolution_dims,
+            frames,
+            steps,
+            precision,
+            flow_shift,
+            f"**{latency_value:.2f}**",
+            speedup_cell,
+        ]
+        break
+else:
+    raise SystemExit(f"Latency row not found for {test_label}")
+
+for idx, row in enumerate(peak_rows):
+    if row[0] == test_label:
+        peak_rows[idx] = [test_label, row[1], f"{peak_value:.2f}" if peak_value is not None else "TBD"]
+        break
+else:
+    raise SystemExit(f"Peak VRAM row not found for {test_label}")
+
+history_row = [
+    os.environ["RUN_TIMESTAMP"],
+    test_label,
+    resolution_dims,
+    frames,
+    steps,
+    precision,
+    flow_shift,
+    f"{latency_value:.2f}",
+    f"{peak_value:.2f}" if peak_value is not None else "TBD",
+    f"`{output}`",
+    f"`{log_rel}`",
+]
+
+if history_row not in history_rows:
+    history_rows.insert(0, history_row)
+
+text = replace_section(text, "## Latency", format_table(latency_header, latency_rows), "## Peak VRAM")
+text = replace_section(text, "## Peak VRAM", format_table(peak_header, peak_rows), "## Run History")
+text = replace_section(text, "## Run History", format_table(history_header, history_rows), None)
+doc_path.write_text(text, encoding="utf-8")
+PY
+
+echo "Updated metrics doc: ${METRICS_DOC}"
+echo "Saved run log: ${LOG_PATH}"

--- a/examples/offline_inference/omniweaving/README.md
+++ b/examples/offline_inference/omniweaving/README.md
@@ -1,0 +1,26 @@
+# OmniWeaving Offline Inference Example
+
+This directory contains end-to-end examples of running offline inference with the OmniWeaving (Qwen2.5-VL + HunyuanVideo 1.5) model using the `vllm-omni` unified API.
+
+## Text-to-Video (T2V) Generation
+To generate a video from a text prompt only, run:
+
+```bash
+python end2end.py \
+    --model "Tencent-Hunyuan/OmniWeaving" \
+    --prompt "A cute bear wearing a Christmas hat moving naturally." \
+    --tensor-parallel-size 1 \
+    --output "t2v_output.mp4"
+```
+
+Image-to-Video (I2V) Generation
+To generate a video conditioned on an input image, provide the --image-path argument:
+
+```bash
+python end2end.py \
+    --model "Tencent-Hunyuan/OmniWeaving" \
+    --prompt "A cute bear wearing a Christmas hat moving naturally." \
+    --image-path "path/to/your/reference_image.jpg" \
+    --tensor-parallel-size 1 \
+    --output "i2v_output.mp4"
+```

--- a/examples/offline_inference/omniweaving/README.md
+++ b/examples/offline_inference/omniweaving/README.md
@@ -2,6 +2,22 @@
 
 This directory contains end-to-end examples of running offline inference with the OmniWeaving (Qwen2.5-VL + HunyuanVideo 1.5) model using the `vllm-omni` unified API.
 
+**Alignment with the official / benchmark setup** (see `OMNIWEAVING_I2V_MI2V_PERF.md` and `OMNIWEAVING_ARCHITECTURE_NOTES.md`):
+
+- **I2V 480p** in `bench_omniweaving_*.py` uses **`assets/p1` / `p2` (.png + .txt)**; both portrait (**480×848**) and T2V-like grid (**832×480**) use **`flow_shift=7.0`** to match the official `generate.py` default `omniweaving` preset (`--assets-dir` overrides the asset folder).
+- **T2V 480p** bench rows are **`t2v_1`…`t2v_5`** (prompts in `../text_to_video/T2V_data/`), **832×480** and **flow_shift=5.0** by default.
+- **Multimodal Qwen for I2V** requires `qwen-vl-utils` (e.g. `pip install qwen-vl-utils` or `pip install vllm-omni[omniweaving]` in dev setups). The pipeline also applies **560 max-edge thumbnailing** and (by default) **setclip-style** trimming on Qwen2-VL hidden states to follow the official `hunyuan_video_pipeline` + `TextEncoder.encode` behavior; see `custom_pipeline_args` in `OMNIWEAVING_ARCHITECTURE_NOTES.md`. VAE decode defaults to **tiling on** in `end2end.py` to match the documented memory behavior.
+
+## Official vs vLLM-Omni performance (latency / VRAM)
+
+On a **CUDA** machine with the Tencent **OmniWeaving** repo checkout (`generate.py`) and the same checkpoint paths as `run_i2v_t2v_batch.sh`, run the paired harness:
+
+```bash
+bash examples/offline_inference/omniweaving/run_official_vs_vllm_bench.sh
+```
+
+Defaults: `CASES=i2v_480p` and `VLLM_FLOW_SHIFT=7.0` (for T2V rows use e.g. `VLLM_FLOW_SHIFT=5.0` and `CASES=t2v_1` or a comma list). Override `CASES` (comma-separated) or `ASSETS_DIR` / `TENSOR_PARALLEL_SIZE` / `OUT_BASE` as needed. It writes `bench_outputs/official_vs_vllm_<UTC>/official_baseline/` and `.../vllm_omni/`, each with `summary.json` and `summary.md`. See `OMNIWEAVING_I2V_MI2V_PERF.md` for how **official** vs **vLLM** numbers are measured.
+
 ## Text-to-Video (T2V) Generation
 To generate a video from a text prompt only, run:
 

--- a/examples/offline_inference/omniweaving/README.md
+++ b/examples/offline_inference/omniweaving/README.md
@@ -6,7 +6,9 @@ This directory contains end-to-end examples of running offline inference with th
 
 - **I2V 480p** in `bench_omniweaving_*.py` uses **`assets/p1` / `p2` (.png + .txt)**; both portrait (**480×848**) and T2V-like grid (**832×480**) use **`flow_shift=7.0`** to match the official `generate.py` default `omniweaving` preset (`--assets-dir` overrides the asset folder).
 - **T2V 480p** bench rows are **`t2v_1`…`t2v_5`** (prompts in `../text_to_video/T2V_data/`), **832×480** and **flow_shift=5.0** by default.
-- **Multimodal Qwen for I2V** requires `qwen-vl-utils` (e.g. `pip install qwen-vl-utils` or `pip install vllm-omni[omniweaving]` in dev setups). The pipeline also applies **560 max-edge thumbnailing** and (by default) **setclip-style** trimming on Qwen2-VL hidden states to follow the official `hunyuan_video_pipeline` + `TextEncoder.encode` behavior; see `custom_pipeline_args` in `OMNIWEAVING_ARCHITECTURE_NOTES.md`. VAE decode defaults to **tiling on** in `end2end.py` to match the documented memory behavior.
+- **Export / mux**: default **`--mux-preset high`** (**12 Mbps** H.264) — **same tensors** as inference, clearer MP4 for side‑by‑side viewing. Use **`--mux-preset official`** when you want no explicit ffmpeg bitrate (closest to OmniWeaving ``generate.py`` ``imageio.mimwrite``). Override with **`--video-bitrate`** (e.g. `8M`).
+- **Dtype**: default **`bfloat16`** (`--dtype bfloat16`) matching official ``generate.py --dtype bf16``. Optional **`--dtype float32`** matches official **`--dtype fp32`** when you want maximum numerical precision (slower, more VRAM).
+- **Multimodal Qwen for I2V** requires `qwen-vl-utils` (e.g. `pip install qwen-vl-utils` or `pip install vllm-omni[omniweaving]` in dev setups). The pipeline also applies **560 max-edge thumbnailing** and (by default) **setclip-style** trimming on Qwen2-VL hidden states to follow the official `hunyuan_video_pipeline` + `TextEncoder.encode` behavior; see `custom_pipeline_args` in `OMNIWEAVING_ARCHITECTURE_NOTES.md`.
 
 ## Official vs vLLM-Omni performance (latency / VRAM)
 

--- a/examples/offline_inference/omniweaving/end2end.py
+++ b/examples/offline_inference/omniweaving/end2end.py
@@ -1,0 +1,139 @@
+import argparse
+
+import imageio
+import numpy as np
+import torch
+from PIL import Image
+
+# Use official top-level API
+from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+
+def main(args):
+    print(f"🚀 Loading OmniWeaving model from {args.model} (TP={args.tensor_parallel_size})...")
+
+    # 1. Initialize engine
+    omni = Omni(
+        model=args.model,
+        tensor_parallel_size=args.tensor_parallel_size,
+        dtype="bfloat16",
+        trust_remote_code=True,
+    )
+
+    # 2. Prepare multimodal inputs
+    multi_modal_data = {}
+    if args.image_path:
+        multi_modal_data["image"] = Image.open(args.image_path).convert("RGB")
+        print(f"🖼️ Loaded input image from {args.image_path}")
+
+    # 3. Set sampling parameters
+    sampling_params = OmniDiffusionSamplingParams(
+        num_inference_steps=args.num_inference_steps,
+        guidance_scale=args.guidance_scale,
+        height=args.height,
+        width=args.width,
+        num_frames=args.num_frames,
+        seed=args.seed,
+    )
+
+    # 4. Execute inference
+    # [FIXED] Proper vLLM multimodal dictionary structure
+    if multi_modal_data:
+        inputs = [{"prompt": args.prompt, "multi_modal_data": multi_modal_data}]
+    else:
+        inputs = [args.prompt]
+
+    print(f"📡 Dispatching request with {args.num_frames} frames to orchestrator...")
+
+    # [FIXED] Use the exact parameter name found in the source code: 'sampling_params_list'
+    outputs = omni.generate(
+        prompts=inputs,
+        sampling_params_list=sampling_params,
+    )
+
+    # 5. Post-process and save
+    if not outputs:
+        raise RuntimeError("❌ Omni.generate() returned an empty list!")
+
+    req_output = outputs[0]
+
+    # Safely unbox the vLLM object
+    if hasattr(req_output, "outputs") and isinstance(req_output.outputs, list) and len(req_output.outputs) > 0:
+        raw_data = req_output.outputs[0]
+    else:
+        raw_data = req_output
+
+    # Find the actual tensor payload
+    if hasattr(raw_data, "data"):
+        tensor_obj = raw_data.data
+    elif hasattr(raw_data, "video"):
+        tensor_obj = raw_data.video
+    elif isinstance(raw_data, dict) and "video" in raw_data:
+        tensor_obj = raw_data["video"]
+    else:
+        tensor_obj = raw_data  # Fallback: the object itself is the tensor
+
+    # Convert to standard Numpy array safely
+    if hasattr(tensor_obj, "cpu"):
+        video_tensor = tensor_obj.detach().cpu().float().numpy()
+    else:
+        video_tensor = np.array(tensor_obj)
+
+    print(f"🔍 Extracted Raw Tensor Shape: {video_tensor.shape}, Dimensions: {video_tensor.ndim}D")
+
+    # Handle NaNs or Infs
+    if not np.isfinite(video_tensor).all():
+        video_tensor = np.nan_to_num(video_tensor, nan=0.0, posinf=1.0, neginf=-1.0)
+
+    # Remove the Batch dimension if it exists (e.g., [1, C, F, H, W] -> [C, F, H, W])
+    if video_tensor.ndim == 5:
+        video_tensor = np.squeeze(video_tensor, axis=0)
+
+    if video_tensor.ndim != 4:
+        raise ValueError(f"❌ Expected 4D tensor after squeeze, got {video_tensor.ndim}D: {video_tensor.shape}")
+
+    # Determine channel position and transpose for ImageIO ([F, H, W, C])
+    if video_tensor.shape[0] == 3:
+        video_np = np.transpose(video_tensor, (1, 2, 3, 0))  # [C, F, H, W] -> [F, H, W, C]
+    elif video_tensor.shape[1] == 3:
+        video_np = np.transpose(video_tensor, (0, 2, 3, 1))  # [F, C, H, W] -> [F, H, W, C]
+    else:
+        video_np = np.transpose(video_tensor, (1, 2, 3, 0))  # Blind fallback
+
+    # Normalize to [0, 1] then scale to [0, 255]
+    v_min, v_max = video_np.min(), video_np.max()
+    if v_max > v_min:
+        video_np = (video_np - v_min) / (v_max - v_min)
+    else:
+        video_np = np.zeros_like(video_np)
+
+    video_uint8 = (video_np * 255).clip(0, 255).astype(np.uint8)
+
+    # Save to MP4 file
+    output_filename = args.output
+    imageio.mimsave(output_filename, video_uint8, fps=8)
+    print(f"🎉 SUCCESS: Video successfully saved to {output_filename}!")
+
+    peak_memory_gb = torch.cuda.max_memory_allocated() / (1024**3)
+    print(f"📊 Peak VRAM usage: {peak_memory_gb:.2f} GB")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Offline inference example for OmniWeaving.")
+    parser.add_argument("--model", type=str, required=True, help="Path to the OmniWeaving model.")
+    parser.add_argument(
+        "--prompt", type=str, default="A cute bear wearing a Christmas hat moving naturally.", help="Text prompt."
+    )
+    parser.add_argument("--image-path", type=str, default=None, help="Path to the input reference image (optional).")
+    parser.add_argument("--output", type=str, default="omniweaving_output.mp4", help="Output file name.")
+    parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1, help="Tensor parallel size.")
+    parser.add_argument("--num-inference-steps", type=int, default=30, help="Number of diffusion steps.")
+    parser.add_argument("--guidance-scale", type=float, default=6.0, help="CFG guidance scale.")
+    parser.add_argument("--height", type=int, default=256, help="Video height.")
+    parser.add_argument("--width", type=int, default=256, help="Video width.")
+    parser.add_argument("--num-frames", type=int, default=9, help="Number of frames.")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
+
+    args = parser.parse_args()
+    main(args)

--- a/examples/offline_inference/omniweaving/end2end.py
+++ b/examples/offline_inference/omniweaving/end2end.py
@@ -100,8 +100,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--height", type=int, default=None, help="Video height.")
     parser.add_argument("--width", type=int, default=None, help="Video width.")
     parser.add_argument("--num-frames", type=int, default=33, help="Number of frames.")
-    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
-    parser.add_argument("--fps", type=int, default=8, help="Output video FPS.")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed (official generate.py CLI default is 123).")
+    parser.add_argument(
+        "--fps",
+        type=int,
+        default=16,
+        help="Output video FPS (official generate.py uses 16 when --fps omitted and num_frames<=81).",
+    )
     parser.add_argument(
         "--video-bitrate",
         type=str,

--- a/examples/offline_inference/omniweaving/end2end.py
+++ b/examples/offline_inference/omniweaving/end2end.py
@@ -1,139 +1,280 @@
+from __future__ import annotations
+
 import argparse
+import time
 
-import imageio
-import numpy as np
-import torch
-from PIL import Image
+try:
+    from omniweaving_common import (
+        build_prompt_payload,
+        ensure_cuda_available,
+        extract_stage_metrics,
+        save_video,
+        video_payload_to_uint8,
+    )
+except ModuleNotFoundError:
+    from examples.offline_inference.omniweaving.omniweaving_common import (
+        build_prompt_payload,
+        ensure_cuda_available,
+        extract_stage_metrics,
+        save_video,
+        video_payload_to_uint8,
+    )
 
-# Use official top-level API
-from vllm_omni.entrypoints.omni import Omni
-from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+# T2V 480p: landscape grid (common diffusers 832-wide convention).
+# I2V 480p (official / bench): `aspect_ratio=26:15` → 480×848 (see OMNIWEAVING_I2V_MI2V_PERF.md).
+RESOLUTION_PRESETS = {
+    "480p": {"height": 480, "width": 832},
+    "720p": {"height": 720, "width": 1280},
+}
+RESOLUTION_PRESETS_I2V_480P = {"height": 480, "width": 848}
+
+FLOW_SHIFT_PRESETS = {
+    "t2v": {"480p": 5.0, "720p": 9.0},
+    # Official OmniWeaving I2V 480p aligned case uses flow_shift=7.0 (same table as perf doc).
+    "i2v": {"480p": 7.0, "720p": 7.0},
+    "mi2v": {"480p": 7.0, "720p": 7.0},
+}
+
+# Required by DiffusionWorker.re_init_pipeline whenever custom_pipeline_args is non-empty.
+_OMNIWEAVING_PIPELINE_CLASS = "vllm_omni.diffusion.models.omniweaving.pipeline_omniweaving.OmniWeavingPipeline"
+
+VIDEO_BITRATE_PRESETS = {
+    "480p": "6M",
+    "720p": "12M",
+}
 
 
-def main(args):
-    print(f"🚀 Loading OmniWeaving model from {args.model} (TP={args.tensor_parallel_size})...")
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Offline inference example for OmniWeaving.")
+    parser.add_argument(
+        "--model", type=str, required=True, help="Path or HuggingFace repo ID of the OmniWeaving model."
+    )
+    parser.add_argument(
+        "--qwen-path",
+        type=str,
+        default=None,
+        help="Optional local path for Qwen2.5-VL when running in offline environments.",
+    )
+    parser.add_argument(
+        "--siglip-path",
+        type=str,
+        default=None,
+        help="Optional local path for SigLIP when running in offline environments.",
+    )
+    parser.add_argument(
+        "--t2v-path",
+        type=str,
+        default=None,
+        help="Optional local path for HunyuanVideo-1.5 Diffusers assets (VAE/scheduler).",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default="A cute bear wearing a Christmas hat moving naturally.",
+        help="Text prompt.",
+    )
+    parser.add_argument("--negative-prompt", type=str, default=None, help="Optional negative prompt for CFG.")
+    parser.add_argument(
+        "--image-path", type=str, default=None, help="Optional image path for image-to-video generation."
+    )
+    parser.add_argument(
+        "--image-paths",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Optional multiple image paths for multi-image conditioning.",
+    )
+    parser.add_argument("--output", type=str, default="omniweaving_output.mp4", help="Output MP4 path.")
+    parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1, help="Tensor parallel size.")
+    parser.add_argument("--num-inference-steps", type=int, default=30, help="Number of diffusion steps.")
+    parser.add_argument("--guidance-scale", type=float, default=6.0, help="CFG guidance scale.")
+    parser.add_argument(
+        "--resolution",
+        type=str,
+        choices=sorted(RESOLUTION_PRESETS),
+        default="480p",
+        help="Resolution preset. For I2V/MI2V with 480p and no explicit --height/--width, uses official-aligned "
+        "480×848 (26:15). T2V 480p remains 480×832. --height/--width override.",
+    )
+    parser.add_argument("--height", type=int, default=None, help="Video height.")
+    parser.add_argument("--width", type=int, default=None, help="Video width.")
+    parser.add_argument("--num-frames", type=int, default=33, help="Number of frames.")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
+    parser.add_argument("--fps", type=int, default=8, help="Output video FPS.")
+    parser.add_argument(
+        "--video-bitrate",
+        type=str,
+        default=None,
+        help="Optional ffmpeg video bitrate override, e.g. 12M. Defaults to a resolution-aware quality preset.",
+    )
+    parser.add_argument(
+        "--video-codec",
+        type=str,
+        default="libx264",
+        help="ffmpeg codec used when writing the output MP4.",
+    )
+    parser.add_argument(
+        "--vae-use-slicing",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="VAE spatial slicing during decode (default: off; lowers peak VRAM on some VAEs).",
+    )
+    parser.add_argument(
+        "--vae-use-tiling",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="VAE spatial tiling during decode (default: on; use --no-vae-use-tiling to disable).",
+    )
+    parser.add_argument(
+        "--vae-patch-parallel-size",
+        type=int,
+        default=1,
+        help="Optional VAE patch-parallel size for decode.",
+    )
+    parser.add_argument(
+        "--quantization",
+        type=str,
+        default=None,
+        choices=["fp8", "gguf"],
+        help="Optional transformer quantization method.",
+    )
+    parser.add_argument(
+        "--enforce-eager",
+        action="store_true",
+        help="Disable torch.compile and force eager execution.",
+    )
+    parser.add_argument(
+        "--flow-shift",
+        type=float,
+        default=None,
+        help="Scheduler flow shift. Defaults to a mode-aware value based on the selected resolution.",
+    )
+    parser.add_argument(
+        "--enable-diffusion-pipeline-profiler",
+        action="store_true",
+        help="Enable diffusion pipeline profiler to expose stage durations in the output.",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        default=True,
+        help="Trust remote code when loading the model.",
+    )
+    return parser
 
-    # 1. Initialize engine
+
+def _infer_mode(args: argparse.Namespace) -> str:
+    if args.image_paths:
+        return "mi2v" if len(args.image_paths) > 1 else "i2v"
+    if args.image_path:
+        return "i2v"
+    return "t2v"
+
+
+def _infer_resolution(height: int, width: int, fallback: str) -> str:
+    if height == RESOLUTION_PRESETS_I2V_480P["height"] and width == RESOLUTION_PRESETS_I2V_480P["width"]:
+        return "480p"
+    for name, preset in RESOLUTION_PRESETS.items():
+        if preset["height"] == height and preset["width"] == width:
+            return name
+    return fallback
+
+
+def main(args: argparse.Namespace) -> None:
+    ensure_cuda_available()
+    from vllm_omni.entrypoints.omni import Omni
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    mode = _infer_mode(args)
+    resolution_preset = dict(RESOLUTION_PRESETS[args.resolution])
+    # Match official 480p I2V / MI2V output size (26:15) when user does not override dimensions.
+    if args.resolution == "480p" and mode in ("i2v", "mi2v") and not args.height and not args.width:
+        resolution_preset.update(RESOLUTION_PRESETS_I2V_480P)
+    args.height = args.height or resolution_preset["height"]
+    args.width = args.width or resolution_preset["width"]
+    resolved_resolution = _infer_resolution(args.height, args.width, args.resolution)
+    flow_shift = args.flow_shift
+    if flow_shift is None:
+        flow_shift = FLOW_SHIFT_PRESETS[mode][resolved_resolution]
+    video_bitrate = args.video_bitrate or VIDEO_BITRATE_PRESETS.get(resolved_resolution)
+
+    print(f"Loading OmniWeaving model from {args.model} (TP={args.tensor_parallel_size})...")
+
+    custom_pipeline_args = {}
+    if args.qwen_path:
+        custom_pipeline_args["qwen_path"] = args.qwen_path
+    if args.siglip_path:
+        custom_pipeline_args["siglip_path"] = args.siglip_path
+    if args.t2v_path:
+        custom_pipeline_args["t2v_path"] = args.t2v_path
+    if custom_pipeline_args:
+        custom_pipeline_args["pipeline_class"] = _OMNIWEAVING_PIPELINE_CLASS
+
     omni = Omni(
         model=args.model,
         tensor_parallel_size=args.tensor_parallel_size,
         dtype="bfloat16",
-        trust_remote_code=True,
+        trust_remote_code=args.trust_remote_code,
+        flow_shift=flow_shift,
+        vae_use_slicing=args.vae_use_slicing,
+        vae_use_tiling=args.vae_use_tiling,
+        vae_patch_parallel_size=args.vae_patch_parallel_size,
+        quantization=args.quantization,
+        enforce_eager=args.enforce_eager,
+        enable_diffusion_pipeline_profiler=args.enable_diffusion_pipeline_profiler,
+        custom_pipeline_args=custom_pipeline_args or None,
     )
+    try:
+        prompt_payload = build_prompt_payload(
+            args.prompt,
+            negative_prompt=args.negative_prompt,
+            image_path=args.image_path,
+            image_paths=args.image_paths,
+        )
+        sampling_params = OmniDiffusionSamplingParams(
+            num_inference_steps=args.num_inference_steps,
+            guidance_scale=args.guidance_scale,
+            height=args.height,
+            width=args.width,
+            num_frames=args.num_frames,
+            seed=args.seed,
+            fps=args.fps,
+        )
 
-    # 2. Prepare multimodal inputs
-    multi_modal_data = {}
-    if args.image_path:
-        multi_modal_data["image"] = Image.open(args.image_path).convert("RGB")
-        print(f"🖼️ Loaded input image from {args.image_path}")
+        print(
+            f"Dispatching request: {args.width}x{args.height}, "
+            f"{args.num_frames} frames, steps={args.num_inference_steps}, "
+            f"flow_shift={flow_shift}, video_bitrate={video_bitrate or 'auto'}."
+        )
+        started_at = time.perf_counter()
+        outputs = omni.generate(
+            prompts=prompt_payload,
+            sampling_params_list=sampling_params,
+        )
+        latency_s = time.perf_counter() - started_at
+        if not outputs:
+            raise RuntimeError("Omni.generate() returned an empty output list.")
 
-    # 3. Set sampling parameters
-    sampling_params = OmniDiffusionSamplingParams(
-        num_inference_steps=args.num_inference_steps,
-        guidance_scale=args.guidance_scale,
-        height=args.height,
-        width=args.width,
-        num_frames=args.num_frames,
-        seed=args.seed,
-    )
+        video_uint8 = video_payload_to_uint8(outputs[0])
+        save_video(
+            video_uint8,
+            args.output,
+            fps=args.fps,
+            codec=args.video_codec,
+            bitrate=video_bitrate,
+        )
+        stage_durations, peak_memory_gib = extract_stage_metrics(outputs[0])
 
-    # 4. Execute inference
-    # [FIXED] Proper vLLM multimodal dictionary structure
-    if multi_modal_data:
-        inputs = [{"prompt": args.prompt, "multi_modal_data": multi_modal_data}]
-    else:
-        inputs = [args.prompt]
-
-    print(f"📡 Dispatching request with {args.num_frames} frames to orchestrator...")
-
-    # [FIXED] Use the exact parameter name found in the source code: 'sampling_params_list'
-    outputs = omni.generate(
-        prompts=inputs,
-        sampling_params_list=sampling_params,
-    )
-
-    # 5. Post-process and save
-    if not outputs:
-        raise RuntimeError("❌ Omni.generate() returned an empty list!")
-
-    req_output = outputs[0]
-
-    # Safely unbox the vLLM object
-    if hasattr(req_output, "outputs") and isinstance(req_output.outputs, list) and len(req_output.outputs) > 0:
-        raw_data = req_output.outputs[0]
-    else:
-        raw_data = req_output
-
-    # Find the actual tensor payload
-    if hasattr(raw_data, "data"):
-        tensor_obj = raw_data.data
-    elif hasattr(raw_data, "video"):
-        tensor_obj = raw_data.video
-    elif isinstance(raw_data, dict) and "video" in raw_data:
-        tensor_obj = raw_data["video"]
-    else:
-        tensor_obj = raw_data  # Fallback: the object itself is the tensor
-
-    # Convert to standard Numpy array safely
-    if hasattr(tensor_obj, "cpu"):
-        video_tensor = tensor_obj.detach().cpu().float().numpy()
-    else:
-        video_tensor = np.array(tensor_obj)
-
-    print(f"🔍 Extracted Raw Tensor Shape: {video_tensor.shape}, Dimensions: {video_tensor.ndim}D")
-
-    # Handle NaNs or Infs
-    if not np.isfinite(video_tensor).all():
-        video_tensor = np.nan_to_num(video_tensor, nan=0.0, posinf=1.0, neginf=-1.0)
-
-    # Remove the Batch dimension if it exists (e.g., [1, C, F, H, W] -> [C, F, H, W])
-    if video_tensor.ndim == 5:
-        video_tensor = np.squeeze(video_tensor, axis=0)
-
-    if video_tensor.ndim != 4:
-        raise ValueError(f"❌ Expected 4D tensor after squeeze, got {video_tensor.ndim}D: {video_tensor.shape}")
-
-    # Determine channel position and transpose for ImageIO ([F, H, W, C])
-    if video_tensor.shape[0] == 3:
-        video_np = np.transpose(video_tensor, (1, 2, 3, 0))  # [C, F, H, W] -> [F, H, W, C]
-    elif video_tensor.shape[1] == 3:
-        video_np = np.transpose(video_tensor, (0, 2, 3, 1))  # [F, C, H, W] -> [F, H, W, C]
-    else:
-        video_np = np.transpose(video_tensor, (1, 2, 3, 0))  # Blind fallback
-
-    # Normalize to [0, 1] then scale to [0, 255]
-    v_min, v_max = video_np.min(), video_np.max()
-    if v_max > v_min:
-        video_np = (video_np - v_min) / (v_max - v_min)
-    else:
-        video_np = np.zeros_like(video_np)
-
-    video_uint8 = (video_np * 255).clip(0, 255).astype(np.uint8)
-
-    # Save to MP4 file
-    output_filename = args.output
-    imageio.mimsave(output_filename, video_uint8, fps=8)
-    print(f"🎉 SUCCESS: Video successfully saved to {output_filename}!")
-
-    peak_memory_gb = torch.cuda.max_memory_allocated() / (1024**3)
-    print(f"📊 Peak VRAM usage: {peak_memory_gb:.2f} GB")
+        print(f"Saved video to {args.output}")
+        print(f"Latency: {latency_s:.2f}s")
+        if peak_memory_gib is not None:
+            print(f"Peak VRAM: {peak_memory_gib:.2f} GiB")
+        if stage_durations:
+            print(f"Stage durations: {stage_durations}")
+    finally:
+        omni.close()
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Offline inference example for OmniWeaving.")
-    parser.add_argument("--model", type=str, required=True, help="Path to the OmniWeaving model.")
-    parser.add_argument(
-        "--prompt", type=str, default="A cute bear wearing a Christmas hat moving naturally.", help="Text prompt."
-    )
-    parser.add_argument("--image-path", type=str, default=None, help="Path to the input reference image (optional).")
-    parser.add_argument("--output", type=str, default="omniweaving_output.mp4", help="Output file name.")
-    parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1, help="Tensor parallel size.")
-    parser.add_argument("--num-inference-steps", type=int, default=30, help="Number of diffusion steps.")
-    parser.add_argument("--guidance-scale", type=float, default=6.0, help="CFG guidance scale.")
-    parser.add_argument("--height", type=int, default=256, help="Video height.")
-    parser.add_argument("--width", type=int, default=256, help="Video width.")
-    parser.add_argument("--num-frames", type=int, default=9, help="Number of frames.")
-    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
-
-    args = parser.parse_args()
-    main(args)
+    main(build_parser().parse_args())

--- a/examples/offline_inference/omniweaving/end2end.py
+++ b/examples/offline_inference/omniweaving/end2end.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:
 
 
 # T2V 480p: landscape grid (common diffusers 832-wide convention).
-# I2V 480p (official / bench): `aspect_ratio=26:15` → 480×848 (see OMNIWEAVING_I2V_MI2V_PERF.md).
+# I2V 480p follows the official 26:15 portrait preset, 480x848.
 RESOLUTION_PRESETS = {
     "480p": {"height": 480, "width": 832},
     "720p": {"height": 720, "width": 1280},
@@ -31,9 +31,8 @@ RESOLUTION_PRESETS_I2V_480P = {"height": 480, "width": 848}
 
 FLOW_SHIFT_PRESETS = {
     "t2v": {"480p": 5.0, "720p": 9.0},
-    # Official OmniWeaving I2V 480p aligned case uses flow_shift=7.0 (same table as perf doc).
+    # Official OmniWeaving I2V presets use flow_shift=7.0.
     "i2v": {"480p": 7.0, "720p": 7.0},
-    "mi2v": {"480p": 7.0, "720p": 7.0},
 }
 
 # Required by DiffusionWorker.re_init_pipeline whenever custom_pipeline_args is non-empty.
@@ -83,7 +82,10 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         nargs="+",
         default=None,
-        help="Optional multiple image paths for multi-image conditioning.",
+        help=(
+            "Optional image path list. vLLM-Omni currently accepts one conditioning image for OmniWeaving; "
+            "passing more than one path raises an error."
+        ),
     )
     parser.add_argument("--output", type=str, default="omniweaving_output.mp4", help="Output MP4 path.")
     parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1, help="Tensor parallel size.")
@@ -94,7 +96,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         choices=sorted(RESOLUTION_PRESETS),
         default="480p",
-        help="Resolution preset. For I2V/MI2V with 480p and no explicit --height/--width, uses official-aligned "
+        help="Resolution preset. For I2V with 480p and no explicit --height/--width, uses official-aligned "
         "480×848 (26:15). T2V 480p remains 480×832. --height/--width override.",
     )
     parser.add_argument("--height", type=int, default=None, help="Video height.")
@@ -171,7 +173,12 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _infer_mode(args: argparse.Namespace) -> str:
     if args.image_paths:
-        return "mi2v" if len(args.image_paths) > 1 else "i2v"
+        if len(args.image_paths) > 1:
+            raise ValueError(
+                "vLLM-Omni OmniWeaving currently supports at most one conditioning image. "
+                "Multi-image OmniWeaving requests are not implemented yet."
+            )
+        return "i2v"
     if args.image_path:
         return "i2v"
     return "t2v"
@@ -187,14 +194,14 @@ def _infer_resolution(height: int, width: int, fallback: str) -> str:
 
 
 def main(args: argparse.Namespace) -> None:
+    mode = _infer_mode(args)
     ensure_cuda_available()
     from vllm_omni.entrypoints.omni import Omni
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
-    mode = _infer_mode(args)
     resolution_preset = dict(RESOLUTION_PRESETS[args.resolution])
-    # Match official 480p I2V / MI2V output size (26:15) when user does not override dimensions.
-    if args.resolution == "480p" and mode in ("i2v", "mi2v") and not args.height and not args.width:
+    # Match official 480p I2V output size (26:15) when user does not override dimensions.
+    if args.resolution == "480p" and mode == "i2v" and not args.height and not args.width:
         resolution_preset.update(RESOLUTION_PRESETS_I2V_480P)
     args.height = args.height or resolution_preset["height"]
     args.width = args.width or resolution_preset["width"]

--- a/examples/offline_inference/omniweaving/omniweaving_common.py
+++ b/examples/offline_inference/omniweaving/omniweaving_common.py
@@ -29,7 +29,7 @@ class BenchmarkCase:
     image_path: str | None = None
     image_paths: list[str] | None = None
     flow_shift: float | None = None
-    fps: int = 8
+    fps: int = 16
     notes: str | None = None
     # If set, passed to official `generate.py --aspect_ratio` instead of inferring from width/height.
     aspect_ratio: str | None = None
@@ -163,8 +163,8 @@ def load_prompt_file(path: str | Path) -> tuple[str, str | None]:
 def extract_stage_metrics(output: Any) -> tuple[dict[str, float], float | None]:
     stage_durations = dict(getattr(output, "stage_durations", {}) or {})
     peak_memory_mb = getattr(output, "peak_memory_mb", 0.0) or 0.0
-    if peak_memory_mb <= 0 and torch.cuda.is_available():
-        peak_memory_mb = torch.cuda.max_memory_allocated() / (1024**2)
+    if peak_memory_mb <= 0 and torch.cuda.is_available() and hasattr(torch, "accelerator"):
+        peak_memory_mb = torch.accelerator.max_memory_allocated() / (1024**2)
     peak_memory_gib = peak_memory_mb / 1024 if peak_memory_mb > 0 else None
     return stage_durations, peak_memory_gib
 
@@ -206,7 +206,12 @@ def _unwrap_payload(obj: Any) -> Any:
             current = current.request_output
             continue
         if hasattr(current, "images") and current.images:
-            current = current.images[0]
+            imgs = current.images
+            if isinstance(imgs, (list, tuple)) and imgs and isinstance(imgs[0], Image.Image):
+                # Video: keep all frames — `images[0]` would truncate to one frame before numpy stacking.
+                current = imgs
+                continue
+            current = imgs[0] if isinstance(imgs, (list, tuple)) else imgs
             continue
         if hasattr(current, "outputs") and current.outputs:
             current = current.outputs[0]
@@ -246,9 +251,41 @@ def _to_numpy(payload: Any) -> np.ndarray:
     return array
 
 
+def _stack_pil_frames_if_any(candidate: Any) -> np.ndarray | None:
+    if not isinstance(candidate, (list, tuple)) or not candidate:
+        return None
+    head = candidate[0]
+    if not isinstance(head, Image.Image):
+        return None
+    return np.stack([np.asarray(f) for f in candidate], axis=0)
+
+
+def _probe_diffusion_frames(output: Any) -> np.ndarray | None:
+    """Prefer `OmniRequestOutput.images` (one PIL per decoded frame); avoids fragile unwrap to a single tensor."""
+    probe: Any = output
+    for _ in range(14):
+        if hasattr(probe, "images") and probe.images:
+            stacked = _stack_pil_frames_if_any(probe.images)
+            if stacked is not None:
+                return stacked
+        next_probe = None
+        if hasattr(probe, "request_output") and probe.request_output is not None:
+            next_probe = probe.request_output
+        elif hasattr(probe, "outputs") and probe.outputs:
+            next_probe = probe.outputs[0]
+        if next_probe is None:
+            break
+        probe = next_probe
+    return None
+
+
 def extract_video_array(output: Any) -> np.ndarray:
-    payload = _unwrap_payload(output)
-    array = _to_numpy(payload)
+    direct = _probe_diffusion_frames(output)
+    if direct is not None:
+        array = direct
+    else:
+        payload = _unwrap_payload(output)
+        array = _to_numpy(payload)
     if array.ndim == 5 and array.shape[0] == 1:
         array = np.squeeze(array, axis=0)
     if array.ndim != 4:
@@ -278,11 +315,18 @@ def video_payload_to_uint8(payload: Any) -> np.ndarray:
     if np.issubdtype(video_fhwc.dtype, np.integer):
         return np.clip(video_fhwc, 0, 255).astype(np.uint8)
 
-    if video_fhwc.max() <= 1.0 and video_fhwc.min() >= 0.0:
-        return np.clip(video_fhwc * 255.0, 0, 255).astype(np.uint8)
-
+    # Float video: prefer fixed linear maps used by Diffusers/VAE (not per-clip min–max,
+    # which stretches contrast over [T,H,W] and amplifies grain / banding).
     v_min = float(video_fhwc.min())
     v_max = float(video_fhwc.max())
+    _eps = 1e-3
+    # [0, 1] (allow tiny slack for fp noise)
+    if v_min >= -_eps and v_max <= 1.0 + _eps:
+        return np.clip(video_fhwc * 255.0, 0, 255).astype(np.uint8)
+    # [-1, 1] typical pre-`VideoProcessor.postprocess_video` RGB
+    if v_min >= -1.0 - _eps and v_max <= 1.0 + _eps and v_min < -_eps:
+        return np.clip((video_fhwc * 0.5 + 0.5) * 255.0, 0, 255).astype(np.uint8)
+
     if math.isclose(v_min, v_max):
         return np.zeros_like(video_fhwc, dtype=np.uint8)
     normalized = (video_fhwc - v_min) / (v_max - v_min)

--- a/examples/offline_inference/omniweaving/omniweaving_common.py
+++ b/examples/offline_inference/omniweaving/omniweaving_common.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+import threading
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import imageio.v2 as imageio
+import numpy as np
+import torch
+from PIL import Image
+
+
+@dataclass
+class BenchmarkCase:
+    name: str
+    prompt: str
+    width: int
+    height: int
+    num_frames: int
+    num_inference_steps: int
+    guidance_scale: float = 6.0
+    negative_prompt: str | None = None
+    image_path: str | None = None
+    image_paths: list[str] | None = None
+    flow_shift: float | None = None
+    fps: int = 8
+    notes: str | None = None
+    # If set, passed to official `generate.py --aspect_ratio` instead of inferring from width/height.
+    aspect_ratio: str | None = None
+    # If set, passed to official `generate.py --pipeline_config` (e.g. `omniweaving2` for flow_shift=5.0 T2V).
+    pipeline_config: str | None = None
+
+
+@dataclass
+class BenchmarkResult:
+    name: str
+    status: str
+    latency_s: float | None = None
+    peak_memory_gib: float | None = None
+    output_path: str | None = None
+    stage_durations: dict[str, float] = field(default_factory=dict)
+    error: str | None = None
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def ensure_cuda_available() -> None:
+    if torch.cuda.is_available():
+        return
+    raise RuntimeError(
+        "OmniWeaving video generation requires a CUDA GPU. "
+        "This machine is currently in no-GPU mode, so local execution is expected "
+        "to stop at the CUDA availability check."
+    )
+
+
+def query_max_gpu_memory_gib() -> float | None:
+    """Max GPU memory used (MiB) across devices, converted to GiB (via 1024).
+
+    Matches `bench_omniweaving_baseline.py`: `nvidia-smi --query-gpu=memory.used`.
+    """
+    proc = subprocess.run(
+        ["nvidia-smi", "--query-gpu=memory.used", "--format=csv,noheader,nounits"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    values = [int(line.strip()) for line in proc.stdout.splitlines() if line.strip()]
+    if not values:
+        return None
+    return max(values) / 1024.0
+
+
+def nvidia_smi_peak_memory_delta_gib(
+    fn: Callable[[], Any],
+    *,
+    poll_interval_s: float = 0.2,
+) -> tuple[Any, float]:
+    """Run ``fn()`` while polling `nvidia-smi`; return (result, delta_gib).
+
+    ``delta_gib`` is ``max(observed max across GPUs) - baseline`` before ``fn``,
+    floored at 0 — the same convention as `bench_omniweaving_baseline.py` for the
+    baseline subprocess (incremental VRAM attributable to the measured window).
+
+    Note: For a subprocess-based baseline, the window includes model load in the
+    child. For an in-process ``Omni.generate()`` call, the window is usually
+    **with the model already resident**; document which window you use.
+    """
+    baseline = query_max_gpu_memory_gib() or 0.0
+    peak = baseline
+    stop = threading.Event()
+
+    def poll_worker() -> None:
+        nonlocal peak
+        while not stop.is_set():
+            v = query_max_gpu_memory_gib()
+            if v is not None and v > peak:
+                peak = v
+            time.sleep(poll_interval_s)
+
+    worker = threading.Thread(target=poll_worker, daemon=True)
+    worker.start()
+    try:
+        result = fn()
+    finally:
+        stop.set()
+        worker.join(timeout=10.0)
+    delta = max(peak - baseline, 0.0)
+    return result, delta
+
+
+def build_prompt_payload(
+    prompt: str,
+    *,
+    negative_prompt: str | None = None,
+    image_path: str | None = None,
+    image_paths: list[str] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"prompt": prompt}
+    if negative_prompt:
+        payload["negative_prompt"] = negative_prompt
+    resolved_image_paths = image_paths or ([image_path] if image_path else [])
+    if resolved_image_paths:
+        images = [Image.open(path).convert("RGB") for path in resolved_image_paths]
+        payload["multi_modal_data"] = {"image": images[0] if len(images) == 1 else images}
+    return payload
+
+
+def parse_prompt_text(text: str) -> tuple[str, str | None]:
+    prompt_lines: list[str] = []
+    negative_lines: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.lower().startswith("negative:"):
+            negative_lines.append(line.split(":", 1)[1].strip().strip("\"'"))
+            continue
+        prompt_lines.append(line.strip().strip("\"'"))
+
+    prompt = " ".join(prompt_lines).strip()
+    if not prompt:
+        raise ValueError("Prompt text is empty after stripping blank lines and Negative: entries.")
+
+    negative_prompt = " ".join(part for part in negative_lines if part).strip() or None
+    return prompt, negative_prompt
+
+
+def load_prompt_file(path: str | Path) -> tuple[str, str | None]:
+    return parse_prompt_text(Path(path).read_text(encoding="utf-8"))
+
+
+def extract_stage_metrics(output: Any) -> tuple[dict[str, float], float | None]:
+    stage_durations = dict(getattr(output, "stage_durations", {}) or {})
+    peak_memory_mb = getattr(output, "peak_memory_mb", 0.0) or 0.0
+    if peak_memory_mb <= 0 and torch.cuda.is_available():
+        peak_memory_mb = torch.cuda.max_memory_allocated() / (1024**2)
+    peak_memory_gib = peak_memory_mb / 1024 if peak_memory_mb > 0 else None
+    return stage_durations, peak_memory_gib
+
+
+def _unwrap_payload(obj: Any) -> Any:
+    seen: set[int] = set()
+    current = obj
+    for _ in range(12):
+        obj_id = id(current)
+        if obj_id in seen:
+            break
+        seen.add(obj_id)
+
+        if hasattr(current, "data"):
+            current = current.data
+            continue
+        if hasattr(current, "video"):
+            current = current.video
+            continue
+        if hasattr(current, "multimodal_output") and isinstance(current.multimodal_output, dict):
+            multimodal_output = current.multimodal_output
+            for key in ("video", "frames", "image", "images", "latents"):
+                if key in multimodal_output and multimodal_output[key] is not None:
+                    current = multimodal_output[key]
+                    break
+            else:
+                if hasattr(current, "images") and current.images:
+                    current = current.images
+                    continue
+                if hasattr(current, "outputs") and current.outputs:
+                    current = current.outputs[0]
+                    continue
+                if hasattr(current, "request_output") and current.request_output is not None:
+                    current = current.request_output
+                    continue
+                break
+            continue
+        if hasattr(current, "request_output") and current.request_output is not None:
+            current = current.request_output
+            continue
+        if hasattr(current, "images") and current.images:
+            current = current.images[0]
+            continue
+        if hasattr(current, "outputs") and current.outputs:
+            current = current.outputs[0]
+            continue
+        if isinstance(current, dict):
+            for key in ("video", "frames", "data", "tensor", "images"):
+                if key in current and current[key] is not None:
+                    current = current[key]
+                    break
+            else:
+                break
+            continue
+        if isinstance(current, (list, tuple)) and len(current) == 1:
+            current = current[0]
+            continue
+        break
+    return current
+
+
+def _to_numpy(payload: Any) -> np.ndarray:
+    if isinstance(payload, np.ndarray):
+        return payload
+    if hasattr(payload, "detach") and hasattr(payload, "cpu"):
+        return payload.detach().cpu().float().numpy()
+    if isinstance(payload, Image.Image):
+        return np.asarray(payload)
+    if isinstance(payload, (list, tuple)):
+        if payload and isinstance(payload[0], Image.Image):
+            return np.stack([np.asarray(frame) for frame in payload], axis=0)
+        return np.asarray(payload)
+    array = np.asarray(payload)
+    if array.dtype == object and array.ndim == 0:
+        inner = array.item()
+        if inner is payload:
+            raise TypeError(f"Unsupported payload type: {type(payload)!r}")
+        return _to_numpy(inner)
+    return array
+
+
+def extract_video_array(output: Any) -> np.ndarray:
+    payload = _unwrap_payload(output)
+    array = _to_numpy(payload)
+    if array.ndim == 5 and array.shape[0] == 1:
+        array = np.squeeze(array, axis=0)
+    if array.ndim != 4:
+        raise ValueError(f"Expected a 4D video tensor, but received shape={array.shape!r}.")
+    return array
+
+
+def video_payload_to_uint8(payload: Any) -> np.ndarray:
+    video = extract_video_array(payload)
+    if not np.isfinite(video).all():
+        video = np.nan_to_num(video, nan=0.0, posinf=1.0, neginf=0.0)
+
+    if video.shape[-1] in (1, 3, 4):
+        video_fhwc = video
+    elif video.shape[0] in (1, 3, 4):
+        video_fhwc = np.transpose(video, (1, 2, 3, 0))
+    elif video.shape[1] in (1, 3, 4):
+        video_fhwc = np.transpose(video, (0, 2, 3, 1))
+    else:
+        raise ValueError(f"Unable to infer video channel layout from shape={video.shape!r}.")
+
+    if video_fhwc.shape[-1] == 1:
+        video_fhwc = np.repeat(video_fhwc, 3, axis=-1)
+    elif video_fhwc.shape[-1] == 4:
+        video_fhwc = video_fhwc[..., :3]
+
+    if np.issubdtype(video_fhwc.dtype, np.integer):
+        return np.clip(video_fhwc, 0, 255).astype(np.uint8)
+
+    if video_fhwc.max() <= 1.0 and video_fhwc.min() >= 0.0:
+        return np.clip(video_fhwc * 255.0, 0, 255).astype(np.uint8)
+
+    v_min = float(video_fhwc.min())
+    v_max = float(video_fhwc.max())
+    if math.isclose(v_min, v_max):
+        return np.zeros_like(video_fhwc, dtype=np.uint8)
+    normalized = (video_fhwc - v_min) / (v_max - v_min)
+    return np.clip(normalized * 255.0, 0, 255).astype(np.uint8)
+
+
+def save_video(
+    video_uint8: np.ndarray,
+    output_path: str | Path,
+    *,
+    fps: int,
+    codec: str | None = "libx264",
+    bitrate: str | None = None,
+) -> Path:
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    save_kwargs: dict[str, Any] = {"fps": fps}
+    if codec:
+        save_kwargs["codec"] = codec
+    if bitrate:
+        save_kwargs["bitrate"] = bitrate
+    imageio.mimsave(path, video_uint8, **save_kwargs)
+    return path
+
+
+def infer_aspect_ratio(width: int, height: int) -> str:
+    if width <= 0 or height <= 0:
+        raise ValueError("width and height must both be positive integers.")
+    gcd = math.gcd(width, height)
+    return f"{width // gcd}:{height // gcd}"
+
+
+def write_json(path: str | Path, payload: dict[str, Any]) -> Path:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return output_path
+
+
+def render_benchmark_markdown(results: Iterable[BenchmarkResult]) -> str:
+    rows = list(results)
+    lines = [
+        "# OmniWeaving Benchmark Summary",
+        "",
+        "| Case | Status | Latency (s) | Peak VRAM (GiB) | Output | Notes |",
+        "|------|--------|-------------|-----------------|--------|-------|",
+    ]
+    for row in rows:
+        latency = f"{row.latency_s:.2f}" if row.latency_s is not None else "N/A"
+        peak_memory = f"{row.peak_memory_gib:.2f}" if row.peak_memory_gib is not None else "N/A"
+        output = row.output_path or "-"
+        notes = row.notes or row.error or "-"
+        lines.append(f"| {row.name} | {row.status} | {latency} | {peak_memory} | {output} | {notes} |")
+    return "\n".join(lines) + "\n"
+
+
+def load_video_frames(video_path: str | Path) -> np.ndarray:
+    reader = imageio.get_reader(video_path)
+    frames = [np.asarray(frame)[..., :3] for frame in reader]
+    if not frames:
+        raise ValueError(f"No frames found in video: {video_path}")
+    return np.stack(frames, axis=0)
+
+
+def compute_video_similarity(
+    candidate_path: str | Path,
+    reference_path: str | Path,
+) -> dict[str, float | int]:
+    try:
+        from skimage.metrics import peak_signal_noise_ratio, structural_similarity
+    except ImportError as exc:
+        raise ImportError(
+            "scikit-image is required for accuracy comparison. Install it with `pip install scikit-image`."
+        ) from exc
+
+    candidate = load_video_frames(candidate_path)
+    reference = load_video_frames(reference_path)
+    if candidate.shape != reference.shape:
+        raise ValueError(
+            f"Video shapes do not match for comparison: candidate={candidate.shape}, reference={reference.shape}"
+        )
+
+    psnr_scores: list[float] = []
+    ssim_scores: list[float] = []
+    for cand_frame, ref_frame in zip(candidate, reference, strict=True):
+        psnr_scores.append(float(peak_signal_noise_ratio(ref_frame, cand_frame, data_range=255)))
+        ssim_scores.append(float(structural_similarity(ref_frame, cand_frame, channel_axis=2, data_range=255)))
+
+    return {
+        "frames": int(candidate.shape[0]),
+        "psnr_mean_db": float(np.mean(psnr_scores)),
+        "psnr_min_db": float(np.min(psnr_scores)),
+        "ssim_mean": float(np.mean(ssim_scores)),
+        "ssim_min": float(np.min(ssim_scores)),
+    }

--- a/examples/offline_inference/omniweaving/omniweaving_common.py
+++ b/examples/offline_inference/omniweaving/omniweaving_common.py
@@ -130,6 +130,11 @@ def build_prompt_payload(
     if negative_prompt:
         payload["negative_prompt"] = negative_prompt
     resolved_image_paths = image_paths or ([image_path] if image_path else [])
+    if len(resolved_image_paths) > 1:
+        raise ValueError(
+            "vLLM-Omni OmniWeaving currently supports at most one conditioning image. "
+            "Multi-image OmniWeaving requests are not implemented yet."
+        )
     if resolved_image_paths:
         images = [Image.open(path).convert("RGB") for path in resolved_image_paths]
         payload["multi_modal_data"] = {"image": images[0] if len(images) == 1 else images}

--- a/examples/offline_inference/text_to_video/text_to_video_omniweaving.py
+++ b/examples/offline_inference/text_to_video/text_to_video_omniweaving.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from examples.offline_inference.omniweaving.end2end import build_parser, main
+
+
+def parse_args():
+    parser = build_parser()
+    parser.description = "Text-to-video offline inference example for OmniWeaving."
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/examples/online_serving/image_to_video/run_curl_omniweaving.sh
+++ b/examples/online_serving/image_to_video/run_curl_omniweaving.sh
@@ -24,7 +24,7 @@ create_response=$(
     -F "fps=8" \
     -F "num_inference_steps=30" \
     -F "guidance_scale=6.0" \
-    -F "flow_shift=5.0" \
+    -F "flow_shift=7.0" \
     -F "seed=42"
 )
 

--- a/examples/online_serving/image_to_video/run_curl_omniweaving.sh
+++ b/examples/online_serving/image_to_video/run_curl_omniweaving.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# OmniWeaving image-to-video curl example using the async video job API.
+
+set -euo pipefail
+
+INPUT_IMAGE="${INPUT_IMAGE:-test_input.jpg}"
+BASE_URL="${BASE_URL:-http://localhost:8096}"
+OUTPUT_PATH="${OUTPUT_PATH:-omniweaving_i2v.mp4}"
+POLL_INTERVAL="${POLL_INTERVAL:-2}"
+
+if [ ! -f "$INPUT_IMAGE" ]; then
+    echo "Input image not found: $INPUT_IMAGE"
+    echo "Provide an image via INPUT_IMAGE env var."
+    exit 1
+fi
+
+create_response=$(
+  curl -sS -X POST "${BASE_URL}/v1/videos" \
+    -H "Accept: application/json" \
+    -F "prompt=The camera follows the puppy as it runs forward on the grass." \
+    -F "input_reference=@${INPUT_IMAGE}" \
+    -F "size=832x480" \
+    -F "num_frames=33" \
+    -F "fps=8" \
+    -F "num_inference_steps=30" \
+    -F "guidance_scale=6.0" \
+    -F "flow_shift=5.0" \
+    -F "seed=42"
+)
+
+video_id="$(echo "${create_response}" | jq -r '.id')"
+if [ -z "${video_id}" ] || [ "${video_id}" = "null" ]; then
+  echo "Failed to create video job:"
+  echo "${create_response}" | jq .
+  exit 1
+fi
+
+echo "Created video job ${video_id}"
+echo "${create_response}" | jq .
+
+while true; do
+  status_response="$(curl -sS "${BASE_URL}/v1/videos/${video_id}")"
+  status="$(echo "${status_response}" | jq -r '.status')"
+
+  case "${status}" in
+    queued|in_progress)
+      echo "Video job ${video_id} status: ${status}"
+      sleep "${POLL_INTERVAL}"
+      ;;
+    completed)
+      echo "${status_response}" | jq .
+      break
+      ;;
+    failed)
+      echo "Video generation failed:"
+      echo "${status_response}" | jq .
+      exit 1
+      ;;
+    *)
+      echo "Unexpected status response:"
+      echo "${status_response}" | jq .
+      exit 1
+      ;;
+  esac
+done
+
+curl -sS -L "${BASE_URL}/v1/videos/${video_id}/content" -o "${OUTPUT_PATH}"
+echo "Saved video to ${OUTPUT_PATH}"

--- a/examples/online_serving/image_to_video/run_server_omniweaving.sh
+++ b/examples/online_serving/image_to_video/run_server_omniweaving.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# OmniWeaving image-to-video online serving startup script
+
+set -euo pipefail
+
+MODEL="${MODEL:-Tencent-Hunyuan/OmniWeaving}"
+PORT="${PORT:-8096}"
+TENSOR_PARALLEL_SIZE="${TENSOR_PARALLEL_SIZE:-1}"
+FLOW_SHIFT="${FLOW_SHIFT:-5.0}"
+
+echo "Starting OmniWeaving I2V server..."
+echo "Model: $MODEL"
+echo "Port: $PORT"
+echo "Tensor parallel size: $TENSOR_PARALLEL_SIZE"
+echo "Flow shift: $FLOW_SHIFT"
+
+VLLM_NO_DEEP_GEMM=1 TORCHDYNAMO_DISABLE=1 TORCH_COMPILE_DISABLE=1 \
+vllm serve "$MODEL" --omni \
+    --port "$PORT" \
+    --tensor-parallel-size "$TENSOR_PARALLEL_SIZE" \
+    --flow-shift "$FLOW_SHIFT"

--- a/examples/online_serving/image_to_video/run_server_omniweaving.sh
+++ b/examples/online_serving/image_to_video/run_server_omniweaving.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 MODEL="${MODEL:-Tencent-Hunyuan/OmniWeaving}"
 PORT="${PORT:-8096}"
 TENSOR_PARALLEL_SIZE="${TENSOR_PARALLEL_SIZE:-1}"
-FLOW_SHIFT="${FLOW_SHIFT:-5.0}"
+# I2V aligned defaults: same as offline end2end / OMNIWEAVING_I2V_MI2V_PERF (I2V 480p uses 7.0)
+FLOW_SHIFT="${FLOW_SHIFT:-7.0}"
 
 echo "Starting OmniWeaving I2V server..."
 echo "Model: $MODEL"

--- a/examples/online_serving/omniweaving/README.md
+++ b/examples/online_serving/omniweaving/README.md
@@ -1,0 +1,18 @@
+# OmniWeaving Online Serving Example
+
+This directory demonstrates how to deploy OmniWeaving as an OpenAI-compatible API server.
+
+## 1. Start the Server
+Run the following script to start the vLLM API server:
+```bash
+bash run_server.sh
+```
+
+## 2. Run the Client
+Once the server is ready, send a sample request with:
+
+```bash
+python client.py
+```
+
+The client writes the generated video to `output_online.mp4`.

--- a/examples/online_serving/omniweaving/client.py
+++ b/examples/online_serving/omniweaving/client.py
@@ -1,0 +1,24 @@
+import base64
+
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")
+
+print("Sending request to OmniWeaving API...")
+response = client.chat.completions.create(
+    model="Tencent-Hunyuan/OmniWeaving",
+    messages=[{"role": "user", "content": "A cute bear wearing a Christmas hat moving naturally."}],
+    # Special sampling parameters for vLLM-Omni
+    extra_body={
+        "num_inference_steps": 30,
+        "height": 256,
+        "width": 256,
+        "num_frames": 9,
+    },
+)
+
+video_base64 = response.choices[0].message.content
+if video_base64:
+    with open("output_online.mp4", "wb") as f:
+        f.write(base64.b64decode(video_base64))
+    print("✅ Successfully generated and saved output_online.mp4")

--- a/examples/online_serving/omniweaving/run_server.sh
+++ b/examples/online_serving/omniweaving/run_server.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+VLLM_NO_DEEP_GEMM=1 TORCHDYNAMO_DISABLE=1 TORCH_COMPILE_DISABLE=1 vllm serve "Tencent-Hunyuan/OmniWeaving" \
+    --omni \
+    --tensor-parallel-size 1 \
+    --port 8000

--- a/examples/online_serving/text_to_video/run_curl_omniweaving.sh
+++ b/examples/online_serving/text_to_video/run_curl_omniweaving.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# OmniWeaving text-to-video curl example using the async video job API.
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8097}"
+OUTPUT_PATH="${OUTPUT_PATH:-omniweaving_t2v.mp4}"
+POLL_INTERVAL="${POLL_INTERVAL:-2}"
+
+create_response=$(
+  curl -sS -X POST "${BASE_URL}/v1/videos" \
+    -H "Accept: application/json" \
+    -F "prompt=A cute bear wearing a Christmas hat moving naturally." \
+    -F "size=256x256" \
+    -F "num_frames=33" \
+    -F "fps=8" \
+    -F "num_inference_steps=30" \
+    -F "guidance_scale=6.0" \
+    -F "flow_shift=5.0" \
+    -F "seed=42"
+)
+
+video_id="$(echo "${create_response}" | jq -r '.id')"
+if [ -z "${video_id}" ] || [ "${video_id}" = "null" ]; then
+  echo "Failed to create video job:"
+  echo "${create_response}" | jq .
+  exit 1
+fi
+
+echo "Created video job ${video_id}"
+echo "${create_response}" | jq .
+
+while true; do
+  status_response="$(curl -sS "${BASE_URL}/v1/videos/${video_id}")"
+  status="$(echo "${status_response}" | jq -r '.status')"
+
+  case "${status}" in
+    queued|in_progress)
+      echo "Video job ${video_id} status: ${status}"
+      sleep "${POLL_INTERVAL}"
+      ;;
+    completed)
+      echo "${status_response}" | jq .
+      break
+      ;;
+    failed)
+      echo "Video generation failed:"
+      echo "${status_response}" | jq .
+      exit 1
+      ;;
+    *)
+      echo "Unexpected status response:"
+      echo "${status_response}" | jq .
+      exit 1
+      ;;
+  esac
+done
+
+curl -sS -L "${BASE_URL}/v1/videos/${video_id}/content" -o "${OUTPUT_PATH}"
+echo "Saved video to ${OUTPUT_PATH}"

--- a/examples/online_serving/text_to_video/run_server_omniweaving.sh
+++ b/examples/online_serving/text_to_video/run_server_omniweaving.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# OmniWeaving text-to-video online serving startup script
+
+set -euo pipefail
+
+MODEL="${MODEL:-Tencent-Hunyuan/OmniWeaving}"
+PORT="${PORT:-8097}"
+TENSOR_PARALLEL_SIZE="${TENSOR_PARALLEL_SIZE:-1}"
+FLOW_SHIFT="${FLOW_SHIFT:-5.0}"
+
+echo "Starting OmniWeaving T2V server..."
+echo "Model: $MODEL"
+echo "Port: $PORT"
+echo "Tensor parallel size: $TENSOR_PARALLEL_SIZE"
+echo "Flow shift: $FLOW_SHIFT"
+
+VLLM_NO_DEEP_GEMM=1 TORCHDYNAMO_DISABLE=1 TORCH_COMPILE_DISABLE=1 \
+vllm serve "$MODEL" --omni \
+    --port "$PORT" \
+    --tensor-parallel-size "$TENSOR_PARALLEL_SIZE" \
+    --flow-shift "$FLOW_SHIFT"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ theme:
   custom_dir: docs/mkdocs/overrides
 
 hooks:
+  - docs/mkdocs/hooks/mock_heavy_imports.py
   - docs/mkdocs/hooks/search_index.py
   - docs/mkdocs/hooks/generate_api_readme.py
   - docs/mkdocs/hooks/url_schemes.py
@@ -97,6 +98,7 @@ plugins:
       exclude:
         - "re:vllm_omni\\._.*"  # Internal modules
         - "vllm_omni.diffusion.models.qwen_image"  # avoid importing vllm in mkdocs building
+        - "vllm_omni.diffusion.models.omniweaving"  # avoid importing vllm in mkdocs building
         - "vllm_omni.diffusion.quantization"  # avoid importing vllm in mkdocs building
         - "vllm_omni.quantization"  # avoid importing vllm in mkdocs building
         - "vllm_omni.entrypoints.async_diffusion"  # avoid importing vllm in mkdocs building
@@ -106,6 +108,8 @@ plugins:
       handlers:
         python:
           options:
+            allow_inspection: false
+            force_inspection: false
             show_symbol_type_heading: true
             show_symbol_type_toc: true
             filters:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,11 @@ minicpmo = [
     "stepaudio2-minicpmo",
 ]
 
+# Official-style OmniWeaving I2V: multimodal Qwen uses `qwen_vl_utils.process_vision_info`.
+omniweaving = [
+    "qwen-vl-utils>=0.0.8",
+]
+
 docs = [
     "mkdocs>=1.5.0",
     "mkdocs-api-autonav",

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -48,6 +48,7 @@ recipes/
 | [`SenseNova/SenseNova-U1.md`](./SenseNova/SenseNova-U1.md) | Unified image generation and understanding | 1x H200 (144GB) |
 | [`Tencent/Covo-Audio-Chat.md`](./Tencent/Covo-Audio-Chat.md) | Online serving for audio chat | 1x A100 80GB |
 | [`Tencent/HunyuanImage-3.0-Instruct.md`](./Tencent/HunyuanImage-3.0-Instruct.md) | DiT-only text-to-image serving and benchmark, including ModelOpt mixed FP8/NVFP4 | 4x H100/H800 80GB / 2x B200 |
+| [`Tencent/OmniWeaving.md`](./Tencent/OmniWeaving.md) | Text-to-video and image-to-video generation | 1x or 2x CUDA GPU |
 | [`Wan-AI/Wan2.2-I2V.md`](./Wan-AI/Wan2.2-I2V.md) | Image-to-video serving (Wan2.2 14B) | 8x Ascend NPU (A2/A3) |
 | [`Wan-AI/Wan2.2-S2V.md`](./Wan-AI/Wan2.2-S2V.md) | Speech-to-video serving (Wan2.2 14B) | 2x A100/H100 80GB |
 | [`StabilityAI/Stable-Diffusion-3.5.md`](./StabilityAI/Stable-Diffusion-3.5.md) | Text-to-image serving (SD 3.5-medium and SD 3.5-large) | 1x RTX A6000 48GB |

--- a/recipes/Tencent/OmniWeaving.md
+++ b/recipes/Tencent/OmniWeaving.md
@@ -1,0 +1,119 @@
+# OmniWeaving
+
+> Text-to-video and image-to-video generation with Tencent Hunyuan OmniWeaving
+> through the vLLM-Omni diffusion pipeline.
+
+## Summary
+
+- Vendor: Tencent Hunyuan
+- Model: `Tencent-Hunyuan/OmniWeaving`
+- Task: Text-to-video and image-to-video generation
+- Mode: Offline examples and online OpenAI-compatible serving
+- Maintainer: Community
+
+## When to use this recipe
+
+Use this recipe when you want to run OmniWeaving through vLLM-Omni instead of
+the upstream `generate.py` script. The pipeline supports T2V and single-image
+I2V requests. Multi-image I2V is rejected early because that path is not
+implemented in vLLM-Omni yet.
+
+## References
+
+- Model: <https://huggingface.co/Tencent-Hunyuan/OmniWeaving>
+- Offline example:
+  [`examples/offline_inference/omniweaving`](../../examples/offline_inference/omniweaving)
+- Online example:
+  [`examples/online_serving/omniweaving`](../../examples/online_serving/omniweaving)
+
+## Hardware Support
+
+## GPU
+
+### 1x or 2x CUDA GPU
+
+#### Environment
+
+- OS: Linux
+- Python: 3.10+
+- Runtime: CUDA-capable vLLM-Omni environment
+- Optional dependency: `qwen-vl-utils` for Qwen2.5-VL vision preprocessing
+
+Install the optional dependency through the model extra:
+
+```bash
+pip install 'vllm-omni[omniweaving]'
+```
+
+For local offline cache validation, set the usual Hugging Face cache variables
+for your environment, for example:
+
+```bash
+export HF_HOME=/path/to/hf-cache
+export HF_HUB_OFFLINE=1
+export TRANSFORMERS_OFFLINE=1
+export DIFFUSERS_OFFLINE=1
+```
+
+#### Offline T2V
+
+```bash
+python examples/offline_inference/omniweaving/end2end.py \
+  --model Tencent-Hunyuan/OmniWeaving \
+  --prompt "A cute bear wearing a Christmas hat moving naturally." \
+  --tensor-parallel-size 1 \
+  --flow-shift 5.0 \
+  --output t2v_output.mp4
+```
+
+#### Offline I2V
+
+```bash
+python examples/offline_inference/omniweaving/end2end.py \
+  --model Tencent-Hunyuan/OmniWeaving \
+  --prompt "Animate the reference image with gentle motion." \
+  --image-path /path/to/reference.png \
+  --tensor-parallel-size 1 \
+  --flow-shift 7.0 \
+  --output i2v_output.mp4
+```
+
+#### Online Serving
+
+```bash
+MODEL=Tencent-Hunyuan/OmniWeaving \
+PORT=8096 \
+TENSOR_PARALLEL_SIZE=1 \
+bash examples/online_serving/omniweaving/run_server.sh
+```
+
+Then run the sample client:
+
+```bash
+python examples/online_serving/omniweaving/client.py
+```
+
+#### Verification
+
+The PR validation used short 128x128, 5-frame smoke tests:
+
+```bash
+pytest -q -s \
+  'tests/e2e/online_serving/test_omniweaving_expansion.py::test_omniweaving_t2v_expansion[2]' \
+  'tests/e2e/online_serving/test_omniweaving_expansion.py::test_omniweaving_cfg_parallel[1]'
+```
+
+Validated result on 2x NVIDIA RTX PRO 6000 Blackwell GPUs:
+
+```text
+2 passed
+```
+
+#### Notes
+
+- T2V 480p defaults to `flow_shift=5.0`.
+- I2V 480p defaults to `flow_shift=7.0` and uses the official-aligned
+  480x848 shape when no explicit height or width is provided.
+- Use `--tensor-parallel-size 2` for TP=2.
+- Use `--cfg-parallel-size 2` in online serving or API construction when you
+  want CFG branches to run across two GPUs.

--- a/tests/diffusion/models/omniweaving/test_omniweaving_regressions.py
+++ b/tests/diffusion/models/omniweaving/test_omniweaving_regressions.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from PIL import Image
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+PIPELINE_PATH = REPO_ROOT / "vllm_omni/diffusion/models/omniweaving/pipeline_omniweaving.py"
+TRANSFORMER_PATH = REPO_ROOT / "vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py"
+COMMON_PATH = REPO_ROOT / "examples/offline_inference/omniweaving/omniweaving_common.py"
+END2END_PATH = REPO_ROOT / "examples/offline_inference/omniweaving/end2end.py"
+
+
+def _load_common_module():
+    spec = importlib.util.spec_from_file_location("omniweaving_common_for_tests", COMMON_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_end2end_module():
+    spec = importlib.util.spec_from_file_location("omniweaving_end2end_for_tests", END2END_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _find_node(tree: ast.AST, name: str) -> ast.FunctionDef | ast.ClassDef:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef)) and node.name == name:
+            return node
+    raise AssertionError(f"Could not find AST node {name!r}")
+
+
+def _load_resolve_single_conditioning_image():
+    tree = ast.parse(PIPELINE_PATH.read_text(encoding="utf-8"))
+    node = _find_node(tree, "_resolve_single_conditioning_image")
+    module = ast.Module(body=[node], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict[str, Any] = {"Any": Any}
+    exec(compile(module, str(PIPELINE_PATH), "exec"), namespace)
+    return namespace["_resolve_single_conditioning_image"]
+
+
+def _load_offline_snapshot_helpers():
+    tree = ast.parse(PIPELINE_PATH.read_text(encoding="utf-8"))
+    nodes = [
+        _find_node(tree, "_offline_env_enabled"),
+        _find_node(tree, "_resolve_cached_hub_snapshot_if_offline"),
+    ]
+    module = ast.Module(body=nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict[str, Any] = {
+        "logger": SimpleNamespace(debug=lambda *args, **kwargs: None),
+        "os": __import__("os"),
+    }
+    exec(compile(module, str(PIPELINE_PATH), "exec"), namespace)
+    return namespace
+
+
+def test_omniweaving_rejects_multi_image_payloads_before_generation():
+    resolve_single_image = _load_resolve_single_conditioning_image()
+
+    assert resolve_single_image([]) is None
+    assert resolve_single_image(["only.png"]) == "only.png"
+    with pytest.raises(ValueError, match="Multi-image OmniWeaving requests are not implemented"):
+        resolve_single_image(["first.png", "second.png"])
+
+
+def test_omniweaving_example_rejects_multi_image_paths(tmp_path: Path):
+    common = _load_common_module()
+    first = tmp_path / "first.png"
+    second = tmp_path / "second.png"
+    Image.new("RGB", (4, 4), color=(255, 0, 0)).save(first)
+    Image.new("RGB", (4, 4), color=(0, 255, 0)).save(second)
+
+    with pytest.raises(ValueError, match="Multi-image OmniWeaving requests are not implemented"):
+        common.build_prompt_payload("animate", image_paths=[str(first), str(second)])
+
+
+def test_omniweaving_offline_external_paths_use_cached_hub_snapshots(monkeypatch, tmp_path: Path):
+    helpers = _load_offline_snapshot_helpers()
+    resolve_cached_snapshot = helpers["_resolve_cached_hub_snapshot_if_offline"]
+    calls = []
+
+    def fake_snapshot_download(model_path: str, *, local_files_only: bool):
+        calls.append((model_path, local_files_only))
+        return f"/cached/{model_path.replace('/', '--')}"
+
+    monkeypatch.setitem(sys.modules, "huggingface_hub", SimpleNamespace(snapshot_download=fake_snapshot_download))
+
+    assert resolve_cached_snapshot("Qwen/Qwen2.5-VL-7B-Instruct") == "Qwen/Qwen2.5-VL-7B-Instruct"
+    assert calls == []
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    assert resolve_cached_snapshot("Qwen/Qwen2.5-VL-7B-Instruct") == "/cached/Qwen--Qwen2.5-VL-7B-Instruct"
+    assert calls == [("Qwen/Qwen2.5-VL-7B-Instruct", True)]
+
+    local_model = tmp_path / "model"
+    local_model.mkdir()
+    assert resolve_cached_snapshot(str(local_model)) == str(local_model)
+    assert calls == [("Qwen/Qwen2.5-VL-7B-Instruct", True)]
+
+
+def test_omniweaving_end2end_rejects_multi_image_mode():
+    end2end = _load_end2end_module()
+
+    assert "mi2v" not in end2end.FLOW_SHIFT_PRESETS
+    args = SimpleNamespace(image_path=None, image_paths=["first.png", "second.png"])
+    with pytest.raises(ValueError, match="Multi-image OmniWeaving requests are not implemented"):
+        end2end._infer_mode(args)
+
+
+def test_omniweaving_empty_glyph_byt5_mask_is_inactive():
+    source = PIPELINE_PATH.read_text(encoding="utf-8")
+    assert "glyph_text_embeds_mask = torch.zeros" in source
+    assert "glyph_text_embeds_mask = torch.ones((1, self.tokenizer_2_max_length)" not in source
+
+
+def test_hunyuan_single_attention_has_loadable_output_projection():
+    tree = ast.parse(TRANSFORMER_PATH.read_text(encoding="utf-8"))
+    single_attention = _find_node(tree, "HunyuanVideo15SingleAttention")
+    assert isinstance(single_attention, ast.ClassDef)
+
+    source = ast.get_source_segment(TRANSFORMER_PATH.read_text(encoding="utf-8"), single_attention)
+    assert source is not None
+    assert "self.to_out = nn.ModuleList" in source
+    assert "RowParallelLinear" in source
+    assert "return self.to_out[0](hidden_states)" in source
+
+    pipeline_source = PIPELINE_PATH.read_text(encoding="utf-8")
+    assert 'map_k(f"{p}.attn_proj.weight", f"{t_p}.attn.to_out.0.weight")' in pipeline_source
+    assert 'map_k(f"{p}.attn_proj.bias", f"{t_p}.attn.to_out.0.bias")' in pipeline_source

--- a/tests/e2e/online_serving/test_omniweaving_expansion.py
+++ b/tests/e2e/online_serving/test_omniweaving_expansion.py
@@ -1,10 +1,14 @@
 import pytest
+import torch
 
 from vllm_omni.entrypoints.omni import Omni
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
+pytestmark = [pytest.mark.diffusion, pytest.mark.gpu]
+
 
 @pytest.mark.parametrize("tensor_parallel_size", [1, 2])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA GPU for OmniWeaving E2E test.")
 def test_omniweaving_t2v_expansion(tensor_parallel_size):
     """
     E2E test to verify OmniWeaving T2V generation works correctly
@@ -26,7 +30,11 @@ def test_omniweaving_t2v_expansion(tensor_parallel_size):
         seed=42,
     )
 
-    outputs = omni.generate(prompts=["A simple test prompt for CI."], sampling_params=sampling_params)
+    prompt = {
+        "prompt": "A simple test prompt for CI.",
+        "negative_prompt": "blurry, distorted",
+    }
+    outputs = omni.generate(prompts=prompt, sampling_params_list=sampling_params)
 
     assert outputs is not None, "Output should not be None"
     assert len(outputs) > 0, "Output list should not be empty"
@@ -36,6 +44,7 @@ def test_omniweaving_t2v_expansion(tensor_parallel_size):
 
 
 @pytest.mark.parametrize("tensor_parallel_size", [1])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA GPU for OmniWeaving E2E test.")
 def test_omniweaving_cfg_parallel(tensor_parallel_size):
     """
     E2E test to verify CFG Parallelism works for OmniWeaving.
@@ -56,7 +65,11 @@ def test_omniweaving_cfg_parallel(tensor_parallel_size):
         num_frames=5,
     )
 
-    outputs = omni.generate(prompts=["Testing CFG parallel generation."], sampling_params=sampling_params)
+    prompt = {
+        "prompt": "Testing CFG parallel generation.",
+        "negative_prompt": "blurry, low quality",
+    }
+    outputs = omni.generate(prompts=prompt, sampling_params_list=sampling_params)
 
     assert outputs is not None
     assert len(outputs) > 0

--- a/tests/e2e/online_serving/test_omniweaving_expansion.py
+++ b/tests/e2e/online_serving/test_omniweaving_expansion.py
@@ -1,0 +1,63 @@
+import pytest
+
+from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+
+@pytest.mark.parametrize("tensor_parallel_size", [1, 2])
+def test_omniweaving_t2v_expansion(tensor_parallel_size):
+    """
+    E2E test to verify OmniWeaving T2V generation works correctly
+    under both Single-GPU (TP=1) and Multi-GPU (TP=2) configurations.
+    """
+    omni = Omni(
+        model="Tencent-Hunyuan/OmniWeaving",
+        tensor_parallel_size=tensor_parallel_size,
+        dtype="bfloat16",
+        trust_remote_code=True,
+    )
+
+    sampling_params = OmniDiffusionSamplingParams(
+        num_inference_steps=2,
+        guidance_scale=6.0,
+        height=128,
+        width=128,
+        num_frames=5,
+        seed=42,
+    )
+
+    outputs = omni.generate(prompts=["A simple test prompt for CI."], sampling_params=sampling_params)
+
+    assert outputs is not None, "Output should not be None"
+    assert len(outputs) > 0, "Output list should not be empty"
+
+    output_data = outputs[0].outputs[0]
+    assert output_data is not None, "Generated video tensor should not be None"
+
+
+@pytest.mark.parametrize("tensor_parallel_size", [1])
+def test_omniweaving_cfg_parallel(tensor_parallel_size):
+    """
+    E2E test to verify CFG Parallelism works for OmniWeaving.
+    """
+    omni = Omni(
+        model="Tencent-Hunyuan/OmniWeaving",
+        tensor_parallel_size=tensor_parallel_size,
+        cfg_parallel_size=2,
+        dtype="bfloat16",
+        trust_remote_code=True,
+    )
+
+    sampling_params = OmniDiffusionSamplingParams(
+        num_inference_steps=2,
+        guidance_scale=6.0,
+        height=128,
+        width=128,
+        num_frames=5,
+    )
+
+    outputs = omni.generate(prompts=["Testing CFG parallel generation."], sampling_params=sampling_params)
+
+    assert outputs is not None
+    assert len(outputs) > 0
+    assert outputs[0].outputs[0] is not None

--- a/tests/e2e/online_serving/test_omniweaving_expansion.py
+++ b/tests/e2e/online_serving/test_omniweaving_expansion.py
@@ -1,21 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""OmniWeaving diffusion feature coverage."""
+
 import pytest
 import torch
 
-from vllm_omni.entrypoints.omni import Omni
-from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from tests.helpers.mark import hardware_marks
 
-pytestmark = [pytest.mark.diffusion, pytest.mark.gpu]
+pytestmark = [pytest.mark.diffusion, pytest.mark.full_model]
+
+MODEL = "Tencent-Hunyuan/OmniWeaving"
+PROMPT = "A simple test prompt for CI."
+NEGATIVE_PROMPT = "blurry, distorted"
+SINGLE_CARD_MARKS = hardware_marks(res={"cuda": "H100"})
+PARALLEL_MARKS = hardware_marks(res={"cuda": "H100"}, num_cards=2)
 
 
-@pytest.mark.parametrize("tensor_parallel_size", [1, 2])
+def _assert_has_generated_diffusion_payload(outputs):
+    from vllm_omni.outputs import OmniRequestOutput
+
+    assert outputs is not None, "Output should not be None"
+    assert len(outputs) > 0, "Output list should not be empty"
+
+    output_data = OmniRequestOutput.unwrap_result(outputs)
+    assert output_data is not None, "Generated output should not be None"
+    assert output_data.images or output_data.multimodal_output or output_data.latents is not None
+
+
+@pytest.mark.parametrize(
+    "tensor_parallel_size",
+    [
+        pytest.param(1, marks=SINGLE_CARD_MARKS),
+        pytest.param(2, marks=PARALLEL_MARKS),
+    ],
+)
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA GPU for OmniWeaving E2E test.")
 def test_omniweaving_t2v_expansion(tensor_parallel_size):
     """
     E2E test to verify OmniWeaving T2V generation works correctly
     under both Single-GPU (TP=1) and Multi-GPU (TP=2) configurations.
     """
+    if torch.accelerator.device_count() < tensor_parallel_size:
+        pytest.skip(f"Need {tensor_parallel_size} CUDA GPUs for OmniWeaving TP={tensor_parallel_size}.")
+
+    from vllm_omni.entrypoints.omni import Omni
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
     omni = Omni(
-        model="Tencent-Hunyuan/OmniWeaving",
+        model=MODEL,
         tensor_parallel_size=tensor_parallel_size,
         dtype="bfloat16",
         trust_remote_code=True,
@@ -31,26 +63,26 @@ def test_omniweaving_t2v_expansion(tensor_parallel_size):
     )
 
     prompt = {
-        "prompt": "A simple test prompt for CI.",
-        "negative_prompt": "blurry, distorted",
+        "prompt": PROMPT,
+        "negative_prompt": NEGATIVE_PROMPT,
     }
     outputs = omni.generate(prompts=prompt, sampling_params_list=sampling_params)
 
-    assert outputs is not None, "Output should not be None"
-    assert len(outputs) > 0, "Output list should not be empty"
-
-    output_data = outputs[0].outputs[0]
-    assert output_data is not None, "Generated video tensor should not be None"
+    _assert_has_generated_diffusion_payload(outputs)
 
 
-@pytest.mark.parametrize("tensor_parallel_size", [1])
+@pytest.mark.parametrize("tensor_parallel_size", [pytest.param(1, marks=PARALLEL_MARKS)])
+@pytest.mark.skipif(torch.accelerator.device_count() < 2, reason="Need 2 CUDA GPUs for OmniWeaving CFG parallelism.")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA GPU for OmniWeaving E2E test.")
 def test_omniweaving_cfg_parallel(tensor_parallel_size):
     """
     E2E test to verify CFG Parallelism works for OmniWeaving.
     """
+    from vllm_omni.entrypoints.omni import Omni
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
     omni = Omni(
-        model="Tencent-Hunyuan/OmniWeaving",
+        model=MODEL,
         tensor_parallel_size=tensor_parallel_size,
         cfg_parallel_size=2,
         dtype="bfloat16",
@@ -71,6 +103,38 @@ def test_omniweaving_cfg_parallel(tensor_parallel_size):
     }
     outputs = omni.generate(prompts=prompt, sampling_params_list=sampling_params)
 
-    assert outputs is not None
-    assert len(outputs) > 0
-    assert outputs[0].outputs[0] is not None
+    _assert_has_generated_diffusion_payload(outputs)
+
+
+@pytest.mark.parametrize("tensor_parallel_size", [pytest.param(1, marks=SINGLE_CARD_MARKS)])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Need CUDA GPU for OmniWeaving E2E test.")
+def test_omniweaving_i2v_expansion(tensor_parallel_size):
+    """E2E test to verify OmniWeaving accepts image-conditioned video requests."""
+    from tests.helpers.media import generate_synthetic_image
+    from vllm_omni.entrypoints.omni import Omni
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    omni = Omni(
+        model=MODEL,
+        tensor_parallel_size=tensor_parallel_size,
+        dtype="bfloat16",
+        trust_remote_code=True,
+    )
+
+    sampling_params = OmniDiffusionSamplingParams(
+        num_inference_steps=2,
+        guidance_scale=6.0,
+        height=128,
+        width=128,
+        num_frames=5,
+        seed=42,
+    )
+
+    prompt = {
+        "prompt": "Animate the geometric shapes with gentle motion.",
+        "negative_prompt": NEGATIVE_PROMPT,
+        "multi_modal_data": {"image": generate_synthetic_image(128, 128)["file_path"]},
+    }
+    outputs = omni.generate(prompts=prompt, sampling_params_list=sampling_params)
+
+    _assert_has_generated_diffusion_payload(outputs)

--- a/vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py
@@ -375,6 +375,18 @@ class HunyuanVideo15SingleAttention(nn.Module):
             total_num_heads=heads,
             bias=bias,
         )
+        self.to_out = nn.ModuleList(
+            [
+                RowParallelLinear(
+                    self.inner_dim,
+                    query_dim,
+                    bias=bias,
+                    input_is_parallel=True,
+                    return_bias=False,
+                ),
+                nn.Identity(),
+            ]
+        )
         self.rope = RotaryEmbedding(is_neox_style=False)
         self.attn = Attention(
             num_heads=self.to_qkv.num_heads,
@@ -422,7 +434,8 @@ class HunyuanVideo15SingleAttention(nn.Module):
 
         hidden_states = self.attn(query, key, value, attn_metadata)
         hidden_states = hidden_states.flatten(2, 3)
-        return hidden_states.to(query.dtype)
+        hidden_states = hidden_states.to(query.dtype)
+        return self.to_out[0](hidden_states)
 
 
 class HunyuanVideo15SingleTransformerBlock(nn.Module):
@@ -1082,7 +1095,9 @@ class HunyuanVideo15Transformer3DModel(nn.Module):
             else:
                 # Handle .to_out.0. -> .to_out. remapping
                 if lookup_name not in params_dict and ".to_out.0." in lookup_name:
-                    lookup_name = lookup_name.replace(".to_out.0.", ".to_out.")
+                    legacy_lookup_name = lookup_name.replace(".to_out.0.", ".to_out.")
+                    if legacy_lookup_name in params_dict:
+                        lookup_name = legacy_lookup_name
                 if lookup_name not in params_dict:
                     continue
                 param = params_dict[lookup_name]

--- a/vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py
@@ -279,6 +279,22 @@ class HunyuanVideo15TokenRefiner(nn.Module):
         return hidden_states
 
 
+class HunyuanVideo15TextProjection(nn.Module):
+    """Official OmniWeaving deepstack projection (`mm_in`)."""
+
+    def __init__(self, in_channels: int, hidden_size: int):
+        super().__init__()
+        self.linear_1 = nn.Linear(in_channels, hidden_size)
+        self.act_1 = nn.SiLU()
+        self.linear_2 = nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, caption: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.linear_1(caption)
+        hidden_states = self.act_1(hidden_states)
+        hidden_states = self.linear_2(hidden_states)
+        return hidden_states
+
+
 class HunyuanVideo15ByT5TextProjection(nn.Module):
     def __init__(self, in_features: int, hidden_size: int, out_features: int):
         super().__init__()
@@ -314,6 +330,143 @@ class HunyuanVideo15ImageProjection(nn.Module):
         hidden_states = self.linear_2(hidden_states)
         hidden_states = self.norm_out(hidden_states)
         return hidden_states
+
+
+class HunyuanVideo15SingleAdaLayerNorm(nn.Module):
+    """Single-stream pre-norm plus official 3-way DiT modulation."""
+
+    def __init__(self, hidden_size: int) -> None:
+        super().__init__()
+        self.norm = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+        self.linear = nn.Linear(hidden_size, 3 * hidden_size)
+        self.nonlinearity = nn.SiLU()
+
+    def forward(self, hidden_states: torch.Tensor, emb: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        shift, scale, gate = self.linear(self.nonlinearity(emb)).chunk(3, dim=-1)
+        hidden_states = self.norm(hidden_states)
+        hidden_states = hidden_states * (1 + scale[:, None]) + shift[:, None]
+        return hidden_states, gate
+
+
+class HunyuanVideo15SingleAttention(nn.Module):
+    """Single-stream attention used by Tencent HunyuanVideo-1.5/OmniWeaving.
+
+    The sequence layout is ``[video_tokens, text_tokens]``. RoPE is applied only
+    to the video-token Q/K prefix, matching the official implementation.
+    """
+
+    def __init__(
+        self,
+        query_dim: int,
+        heads: int,
+        dim_head: int,
+        bias: bool = True,
+        eps: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        self.head_dim = dim_head
+        self.inner_dim = heads * dim_head
+
+        self.norm_q = RMSNorm(dim_head, eps=eps)
+        self.norm_k = RMSNorm(dim_head, eps=eps)
+        self.to_qkv = QKVParallelLinear(
+            hidden_size=query_dim,
+            head_size=self.head_dim,
+            total_num_heads=heads,
+            bias=bias,
+        )
+        self.rope = RotaryEmbedding(is_neox_style=False)
+        self.attn = Attention(
+            num_heads=self.to_qkv.num_heads,
+            head_size=self.head_dim,
+            softmax_scale=1.0 / (self.head_dim**0.5),
+            causal=False,
+            num_kv_heads=self.to_qkv.num_kv_heads,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        img_seq_len: int,
+        attention_mask: torch.Tensor | None = None,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        qkv, _ = self.to_qkv(hidden_states)
+        q_size = self.to_qkv.num_heads * self.head_dim
+        kv_size = self.to_qkv.num_kv_heads * self.head_dim
+        query, key, value = qkv.split([q_size, kv_size, kv_size], dim=-1)
+
+        query = query.unflatten(-1, (self.to_qkv.num_heads, -1))
+        key = key.unflatten(-1, (self.to_qkv.num_kv_heads, -1))
+        value = value.unflatten(-1, (self.to_qkv.num_kv_heads, -1))
+
+        query = self.norm_q(query)
+        key = self.norm_k(key)
+
+        if image_rotary_emb is not None:
+            img_query, text_query = query[:, :img_seq_len], query[:, img_seq_len:]
+            img_key, text_key = key[:, :img_seq_len], key[:, img_seq_len:]
+            cos, sin = image_rotary_emb
+            cos = cos.to(img_query.dtype)
+            sin = sin.to(img_query.dtype)
+            img_query = self.rope(img_query, cos, sin)
+            img_key = self.rope(img_key, cos, sin)
+            query = torch.cat([img_query, text_query], dim=1)
+            key = torch.cat([img_key, text_key], dim=1)
+
+        attn_metadata = None
+        if attention_mask is not None:
+            # attention_mask covers text tokens only; video tokens are always valid.
+            attention_mask = F.pad(attention_mask, (img_seq_len, 0), value=True)
+            attn_metadata = AttentionMetadata(attn_mask=attention_mask.bool())
+
+        hidden_states = self.attn(query, key, value, attn_metadata)
+        hidden_states = hidden_states.flatten(2, 3)
+        return hidden_states.to(query.dtype)
+
+
+class HunyuanVideo15SingleTransformerBlock(nn.Module):
+    def __init__(
+        self,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        mlp_ratio: float = 4.0,
+        qk_norm: str = "rms_norm",
+    ) -> None:
+        super().__init__()
+        hidden_size = num_attention_heads * attention_head_dim
+        mlp_hidden_size = int(hidden_size * mlp_ratio)
+
+        self.norm = HunyuanVideo15SingleAdaLayerNorm(hidden_size)
+        self.attn = HunyuanVideo15SingleAttention(
+            query_dim=hidden_size,
+            heads=num_attention_heads,
+            dim_head=attention_head_dim,
+            bias=True,
+            eps=1e-6,
+        )
+        self.proj_mlp = nn.Linear(hidden_size, mlp_hidden_size)
+        self.act_mlp = nn.GELU(approximate="tanh")
+        self.proj_out = nn.Linear(hidden_size + mlp_hidden_size, hidden_size)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        img_seq_len: int,
+        attention_mask: torch.Tensor | None = None,
+        freqs_cis: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        norm_hidden_states, gate = self.norm(hidden_states, emb=temb)
+        attn_output = self.attn(
+            norm_hidden_states,
+            img_seq_len=img_seq_len,
+            attention_mask=attention_mask,
+            image_rotary_emb=freqs_cis,
+        )
+        mlp_output = self.act_mlp(self.proj_mlp(norm_hidden_states))
+        output = self.proj_out(torch.cat([attn_output, mlp_output], dim=-1))
+        return hidden_states + gate.unsqueeze(1) * output
 
 
 class HunyuanVideo15Attention(nn.Module):
@@ -591,8 +744,8 @@ class HunyuanVideo15Transformer3DModel(nn.Module):
     tensor-parallel layers for the 54 main transformer blocks.
     """
 
-    _repeated_blocks = ["HunyuanVideo15TransformerBlock"]
-    _layerwise_offload_blocks_attrs = ["transformer_blocks"]
+    _repeated_blocks = ["HunyuanVideo15TransformerBlock", "HunyuanVideo15SingleTransformerBlock"]
+    _layerwise_offload_blocks_attrs = ["transformer_blocks", "single_transformer_blocks"]
     packed_modules_mapping = {
         "to_qkv": ["to_q", "to_k", "to_v"],
         "add_kv_proj": ["add_q_proj", "add_k_proj", "add_v_proj"],
@@ -616,6 +769,7 @@ class HunyuanVideo15Transformer3DModel(nn.Module):
         num_attention_heads: int = 16,
         attention_head_dim: int = 128,
         num_layers: int = 54,
+        num_single_layers: int = 0,
         num_refiner_layers: int = 2,
         mlp_ratio: float = 4.0,
         patch_size: int = 1,
@@ -630,12 +784,18 @@ class HunyuanVideo15Transformer3DModel(nn.Module):
         task_type: str = "i2v",
         use_meanflow: bool = False,
         quant_config: "QuantizationConfig | None" = None,
+        deepstack: list[int] | tuple[int, ...] | None = None,
     ):
         super().__init__()
 
-        # Allow tf_model_config to override num_layers
+        # Allow tf_model_config to override Tencent/Diffusers layer counts.
         model_config = od_config.tf_model_config
-        num_layers = getattr(model_config, "num_layers", num_layers)
+        num_layers = getattr(model_config, "mm_double_blocks_depth", getattr(model_config, "num_layers", num_layers))
+        num_single_layers = getattr(
+            model_config,
+            "mm_single_blocks_depth",
+            getattr(model_config, "num_single_layers", num_single_layers),
+        )
 
         self.parallel_config = od_config.parallel_config
         self.in_channels = in_channels
@@ -671,6 +831,16 @@ class HunyuanVideo15Transformer3DModel(nn.Module):
                 for i in range(num_layers)
             ]
         )
+        self.single_transformer_blocks = nn.ModuleList(
+            [
+                HunyuanVideo15SingleTransformerBlock(
+                    num_attention_heads, attention_head_dim, mlp_ratio=mlp_ratio, qk_norm=qk_norm
+                )
+                for _ in range(num_single_layers)
+            ]
+        )
+        self.deep_stack = list(deepstack or [])
+        self.mm_in = HunyuanVideo15TextProjection(text_embed_dim, inner_dim) if self.deep_stack else None
 
         self.norm_out = AdaLayerNormContinuous(inner_dim, inner_dim, elementwise_affine=False, eps=1e-6)
         self.proj_out = nn.Linear(inner_dim, patch_size_t * patch_size * patch_size * self.out_channels)
@@ -686,6 +856,7 @@ class HunyuanVideo15Transformer3DModel(nn.Module):
         encoder_attention_mask_2: torch.Tensor | None = None,
         image_embeds: torch.Tensor | None = None,
         image_embeds_mask: torch.Tensor | None = None,
+        all_stack_text_states: torch.Tensor | None = None,
         attention_kwargs: dict[str, Any] | None = None,
         return_dict: bool = True,
     ) -> torch.Tensor | Transformer2DModelOutput:
@@ -819,7 +990,11 @@ class HunyuanVideo15Transformer3DModel(nn.Module):
             if hidden_states_mask.all():
                 hidden_states_mask = None
 
-        for block in self.transformer_blocks:
+        all_stack_text_states_in = None
+        if all_stack_text_states is not None and self.mm_in is not None:
+            all_stack_text_states_in = self.mm_in(all_stack_text_states.to(dtype=encoder_hidden_states.dtype))
+
+        for index, block in enumerate(self.transformer_blocks):
             hidden_states, encoder_hidden_states = block(
                 hidden_states,
                 encoder_hidden_states,
@@ -828,6 +1003,32 @@ class HunyuanVideo15Transformer3DModel(nn.Module):
                 image_rotary_emb,
                 hidden_states_mask=hidden_states_mask,
             )
+            # Official OmniWeaving injects selected Qwen hidden states into the tail
+            # of the text stream after double blocks.  The MLLM text tokens are the
+            # final valid/padded segment in our [image, ByT5, MLLM, padding] layout.
+            if all_stack_text_states_in is not None and index < all_stack_text_states_in.shape[0]:
+                n_slice = all_stack_text_states_in[index].shape[-2]
+                n_keep = encoder_hidden_states.shape[1] - n_slice
+                encoder_hidden_states = torch.cat(
+                    [
+                        encoder_hidden_states[:, :n_keep],
+                        encoder_hidden_states[:, n_keep:] + all_stack_text_states_in[index].detach(),
+                    ],
+                    dim=1,
+                )
+
+        img_seq_len = hidden_states.shape[1]
+        if len(self.single_transformer_blocks) > 0:
+            hidden_states = torch.cat([hidden_states, encoder_hidden_states], dim=1)
+            for block in self.single_transformer_blocks:
+                hidden_states = block(
+                    hidden_states,
+                    temb,
+                    img_seq_len=img_seq_len,
+                    attention_mask=encoder_attention_mask,
+                    freqs_cis=image_rotary_emb,
+                )
+            hidden_states = hidden_states[:, :img_seq_len]
 
         hidden_states = self.norm_out(hidden_states, temb)
         hidden_states = self.proj_out(hidden_states)

--- a/vllm_omni/diffusion/models/omniweaving/__init__.py
+++ b/vllm_omni/diffusion/models/omniweaving/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+"""OmniWeaving image-to-video diffusion pipeline."""

--- a/vllm_omni/diffusion/models/omniweaving/pipeline_omniweaving.py
+++ b/vllm_omni/diffusion/models/omniweaving/pipeline_omniweaving.py
@@ -258,6 +258,22 @@ class OmniWeavingPipeline(
         # `sampling_params.extra_args['flow_shift']`. Reset in `forward` before `set_timesteps`.
         self._default_scheduler_shift = float(getattr(self.scheduler, "_shift", 1.0))
 
+        # When model_index.json is absent (Tencent-format repos), OmniDiffusionConfig falls back
+        # to the top-level config.json which lacks transformer-specific keys like `deepstack`.
+        # Patch only the missing keys from transformer/config.json into the existing tf_model_config.
+        if not getattr(od_config.tf_model_config, "deepstack", None):
+            import json as _json
+
+            _tf_cfg_path = os.path.join(od_config.model, "transformer", "config.json")
+            if os.path.isfile(_tf_cfg_path):
+                _tf_cfg = _json.loads(open(_tf_cfg_path).read())
+                if _tf_cfg.get("deepstack"):
+                    od_config.tf_model_config.params["deepstack"] = _tf_cfg["deepstack"]
+                    logger.info(
+                        "OmniWeaving: patched deepstack=%s from transformer/config.json",
+                        od_config.tf_model_config.get("deepstack"),
+                    )
+
         transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, HunyuanVideo15Transformer3DModel)
         self.transformer = HunyuanVideo15Transformer3DModel(od_config=od_config, **transformer_kwargs)
         self.use_meanflow = getattr(od_config.tf_model_config, "use_meanflow", False)
@@ -552,6 +568,184 @@ class OmniWeavingPipeline(
             attention_mask,
         )
 
+    def _extract_deepstack_from_outputs(
+        self,
+        outputs: Any,
+        attention_mask: torch.Tensor,
+        input_ids: torch.Tensor | None,
+        crop_start: int,
+        deepstack_indices: list[int],
+        apply_setclip: bool,
+        setclip_token_id: int,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Extract and process deepstack hidden states from Qwen outputs.
+
+        Returns tensor of shape (num_deepstack_layers, B, L, D).
+        Mirrors official TextEncoder.encode deepstack path (lines 506-573).
+        """
+        # Stack selected hidden layers: (num_layers, B, full_seq, D)
+        stacked = torch.stack([outputs.hidden_states[i] for i in deepstack_indices], dim=0)
+        # Crop system/template prefix
+        stacked = stacked[:, :, crop_start:, :]
+        # Zero-out padding positions using the (already-cropped) attention_mask
+        stacked = stacked * attention_mask.unsqueeze(0).unsqueeze(-1)
+
+        if apply_setclip and input_ids is not None:
+            # Mirror official setclip path: find last occurrence of token_id per batch item,
+            # drop everything up to and including it (vision prefix removal).
+            num_layers, B, L, D = stacked.shape
+            device = stacked.device
+            all_slices: list[torch.Tensor] = []
+            for k in range(B):
+                mask = input_ids[k] == setclip_token_id
+                if mask.any():
+                    last_pos = int(mask.nonzero()[-1, 0].item())
+                    if last_pos < L - 1:
+                        all_slices.append(stacked[:, k, last_pos + 1 :])
+                    else:
+                        all_slices.append(stacked[:, k])
+                else:
+                    all_slices.append(stacked[:, k])
+            max_len = max(s.shape[1] for s in all_slices)
+            padded = torch.zeros(num_layers, B, max_len, D, device=device, dtype=stacked.dtype)
+            for i, s in enumerate(all_slices):
+                padded[:, i, : s.shape[1]] = s
+            stacked = padded
+
+        return stacked.to(dtype=dtype)
+
+    def _get_mllm_deepstack_hidden_states_text_only(
+        self,
+        prompt: list[str],
+        device: torch.device,
+        dtype: torch.dtype,
+        deepstack_indices: list[int],
+        num_hidden_layers_to_skip: int = 2,
+    ) -> torch.Tensor:
+        prompt_formatted = format_text_input(prompt, self.system_message)
+        text_inputs = self.tokenizer.apply_chat_template(
+            prompt_formatted,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            padding="max_length",
+            max_length=self.tokenizer_max_length + self.prompt_template_encode_start_idx,
+            truncation=True,
+            return_tensors="pt",
+        )
+        text_input_ids = text_inputs.input_ids.to(device=device)
+        prompt_attention_mask = text_inputs.attention_mask.to(device=device)
+        with torch.no_grad():
+            outputs = self.mllm(
+                input_ids=text_input_ids,
+                attention_mask=prompt_attention_mask,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+        crop_start = self.prompt_template_encode_start_idx
+        cropped_mask = prompt_attention_mask[:, crop_start:]
+        return self._extract_deepstack_from_outputs(
+            outputs,
+            cropped_mask,
+            None,
+            crop_start,
+            deepstack_indices,
+            apply_setclip=False,
+            setclip_token_id=0,
+            dtype=dtype,
+        )
+
+    def _get_mllm_deepstack_hidden_states_i2v_vision(
+        self,
+        prompt: list[str],
+        device: torch.device,
+        dtype: torch.dtype,
+        images: list[PIL.Image.Image],
+        deepstack_indices: list[int],
+        num_hidden_layers_to_skip: int = 2,
+    ) -> torch.Tensor:
+        assert self.qwen_processor is not None and self._process_vision_info is not None
+        system_block = {
+            "role": "system",
+            "content": [{"type": "text", "text": OMNIWEAVING_I2V_SYSTEM_MESSAGE}],
+        }
+        max_length = self.tokenizer_max_length + self._mllm_i2v_crop_start + self._mllm_i2v_vision_token_budget
+        batch_conversations: list[list[dict[str, Any]]] = []
+        text_for_proc: list[str] = []
+        tmax = self._mllm_i2v_qwen_thumbnail_max
+        for p, img in zip(prompt, images, strict=True):
+            txt = p if p else " "
+            vis = self._resize_pil_for_qwen_mllm(img, tmax)
+            user_block: dict[str, Any] = {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": vis},
+                    {"type": "text", "text": txt},
+                ],
+            }
+            conv = [system_block, user_block]
+            batch_conversations.append(conv)
+            text_for_proc.append(
+                self.qwen_processor.apply_chat_template(conv, tokenize=False, add_generation_prompt=True)
+            )
+        image_inputs, video_inputs = self._process_vision_info(batch_conversations)
+        proc_inputs = self.qwen_processor(
+            text=text_for_proc,
+            images=image_inputs,
+            videos=video_inputs,
+            return_tensors="pt",
+            padding="max_length",
+            truncation=True,
+            max_length=max_length,
+        )
+        model_kw = self._mllm_inputs_to_device(dict(proc_inputs), device)
+        fwd_kw = self._mllm_forward_kwargs(model_kw)
+        with torch.no_grad():
+            outputs = self.mllm(**fwd_kw, output_hidden_states=True, return_dict=True)
+        crop_start = self._mllm_i2v_crop_start
+        attention_mask = fwd_kw["attention_mask"]
+        input_ids = fwd_kw["input_ids"]
+        cropped_mask = attention_mask[:, crop_start:]
+        cropped_ids = input_ids[:, crop_start:]
+        apply_setclip = self._mllm_i2v_setclip and "pixel_values" in fwd_kw
+        return self._extract_deepstack_from_outputs(
+            outputs,
+            cropped_mask,
+            cropped_ids,
+            crop_start,
+            deepstack_indices,
+            apply_setclip=apply_setclip,
+            setclip_token_id=self._mllm_i2v_setclip_token_id,
+            dtype=dtype,
+        )
+
+    def _get_mllm_deepstack_hidden_states(
+        self,
+        prompt: list[str],
+        device: torch.device,
+        dtype: torch.dtype,
+        deepstack_indices: list[int],
+        images: list[PIL.Image.Image] | None = None,
+        num_hidden_layers_to_skip: int = 2,
+    ) -> torch.Tensor:
+        """Return deepstack tensor (num_layers, B, L, D) for the given prompts."""
+        use_i2v_vision = (
+            self._mllm_i2v_use_vision
+            and images is not None
+            and len(images) == len(prompt)
+            and all(im is not None for im in images)
+            and self.qwen_processor is not None
+            and self._process_vision_info is not None
+        )
+        if use_i2v_vision:
+            return self._get_mllm_deepstack_hidden_states_i2v_vision(
+                prompt, device, dtype, images, deepstack_indices, num_hidden_layers_to_skip
+            )
+        return self._get_mllm_deepstack_hidden_states_text_only(
+            prompt, device, dtype, deepstack_indices, num_hidden_layers_to_skip
+        )
+
     def _get_t5_2_prompt_embeds(
         self, prompt: list[str], device: torch.device, dtype: torch.dtype
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -601,6 +795,19 @@ class OmniWeavingPipeline(
         prompt_embeds_mask = prompt_embeds_mask.to(dtype=dtype)
         prompt_embeds_mask_2 = prompt_embeds_mask_2.to(dtype=dtype)
 
+        deepstack_indices: list[int] = list(getattr(self.transformer, "deep_stack", []))
+        deepstack_states: torch.Tensor | None = None
+        negative_deepstack_states: torch.Tensor | None = None
+        if deepstack_indices:
+            deepstack_states = self._get_mllm_deepstack_hidden_states(
+                prompt, device, dtype, deepstack_indices, images=mllm_images
+            )
+            logger.info(
+                "OmniWeaving deepstack: indices=%s, states_shape=%s",
+                deepstack_indices,
+                tuple(deepstack_states.shape),
+            )
+
         negative_prompt_embeds = None
         negative_prompt_embeds_mask = None
         negative_prompt_embeds_2 = None
@@ -626,6 +833,10 @@ class OmniWeavingPipeline(
             ) = self._get_t5_2_prompt_embeds(neg_p, device, dtype)
             negative_prompt_embeds_mask = negative_prompt_embeds_mask.to(dtype=dtype)
             negative_prompt_embeds_mask_2 = negative_prompt_embeds_mask_2.to(dtype=dtype)
+            if deepstack_indices:
+                negative_deepstack_states = self._get_mllm_deepstack_hidden_states(
+                    neg_p, device, dtype, deepstack_indices, images=neg_mllm_images
+                )
         return (
             prompt_embeds,
             prompt_embeds_mask,
@@ -635,6 +846,8 @@ class OmniWeavingPipeline(
             negative_prompt_embeds_mask,
             negative_prompt_embeds_2,
             negative_prompt_embeds_mask_2,
+            deepstack_states,
+            negative_deepstack_states,
         )
 
     def _get_image_embeds(self, image: PIL.Image.Image, device: torch.device) -> torch.Tensor:
@@ -790,6 +1003,7 @@ class OmniWeavingPipeline(
                     "encoder_hidden_states_2": enc_tuple[2],
                     "encoder_attention_mask_2": enc_tuple[3],
                     "image_embeds": image_embeds,
+                    "all_stack_text_states": enc_tuple[8],
                     "return_dict": False,
                 }
                 negative_kwargs = (
@@ -802,6 +1016,7 @@ class OmniWeavingPipeline(
                         "encoder_hidden_states_2": enc_tuple[6],
                         "encoder_attention_mask_2": enc_tuple[7],
                         "image_embeds": image_embeds,
+                        "all_stack_text_states": enc_tuple[9],
                         "return_dict": False,
                     }
                     if do_cfg and enc_tuple[4] is not None
@@ -987,6 +1202,12 @@ class OmniWeavingPipeline(
             map_k(f"{p}.img_mod.linear.bias", f"{t_p}.norm1.linear.bias")
             map_k(f"{p}.txt_mod.linear.weight", f"{t_p}.norm1_context.linear.weight")
             map_k(f"{p}.txt_mod.linear.bias", f"{t_p}.norm1_context.linear.bias")
+
+        # OmniWeaving deepstack projection (mm_in) — same key names on both sides
+        map_k("mm_in.linear_1.weight", "mm_in.linear_1.weight")
+        map_k("mm_in.linear_1.bias", "mm_in.linear_1.bias")
+        map_k("mm_in.linear_2.weight", "mm_in.linear_2.weight")
+        map_k("mm_in.linear_2.bias", "mm_in.linear_2.bias")
 
         # Single Blocks
         single_block_keys = set(k.split(".")[1] for k in raw_tf.keys() if k.startswith("single_blocks."))

--- a/vllm_omni/diffusion/models/omniweaving/pipeline_omniweaving.py
+++ b/vllm_omni/diffusion/models/omniweaving/pipeline_omniweaving.py
@@ -1,0 +1,780 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import glob
+import logging
+import os
+from collections.abc import Iterable
+from typing import Any
+
+import numpy as np
+import PIL.Image
+import torch
+from diffusers import AutoencoderKLHunyuanVideo15
+from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
+    FlowMatchEulerDiscreteScheduler,
+)
+from diffusers.utils.torch_utils import randn_tensor
+from diffusers.video_processor import VideoProcessor
+from torch import nn
+from transformers import (
+    AutoConfig,
+    AutoTokenizer,
+    Qwen2_5_VLForConditionalGeneration,
+    Qwen2Tokenizer,
+    SiglipImageProcessor,
+    SiglipVisionModel,
+)
+from vllm.model_executor.models.utils import AutoWeightsLoader
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.hunyuan_video.hunyuan_video_15_transformer import (
+    HunyuanVideo15Transformer3DModel,
+)
+from vllm_omni.diffusion.models.hunyuan_video.pipeline_hunyuan_video_1_5 import (
+    extract_glyph_texts,
+    format_text_input,
+    get_hunyuan_video_15_post_process_func,
+    retrieve_latents,
+)
+from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
+from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import (
+    DiffusionPipelineProfilerMixin,
+)
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.platforms import current_omni_platform
+
+logger = logging.getLogger(__name__)
+
+
+def get_omniweaving_post_process_func(od_config: OmniDiffusionConfig):
+    return get_hunyuan_video_15_post_process_func(od_config)
+
+
+def get_omniweaving_pre_process_func(od_config: OmniDiffusionConfig):
+    max_area = 480 * 832
+    divisor = 16
+
+    def pre_process_func(req: OmniDiffusionRequest) -> OmniDiffusionRequest:
+        if not req.prompts:
+            return req
+        prompt_data = req.prompts[0]
+        if isinstance(prompt_data, str):
+            return req
+
+        multi_modal_data = prompt_data.get("multi_modal_data", {})
+        raw_image = multi_modal_data.get("image", None)
+        if raw_image is None:
+            return req
+        if isinstance(raw_image, list):
+            raw_image = raw_image[0]
+
+        if isinstance(raw_image, str):
+            image = PIL.Image.open(raw_image).convert("RGB")
+        elif isinstance(raw_image, PIL.Image.Image):
+            image = raw_image.convert("RGB")
+        else:
+            return req
+
+        height, width = req.sampling_params.height, req.sampling_params.width
+        if height is None or width is None:
+            w, h = image.size
+            aspect = w / h
+            target_h = int((max_area / aspect) ** 0.5)
+            target_w = int(target_h * aspect)
+            req.sampling_params.height = height or ((target_h + divisor - 1) // divisor * divisor)
+            req.sampling_params.width = width or ((target_w + divisor - 1) // divisor * divisor)
+        return req
+
+    return pre_process_func
+
+
+class OmniWeavingPipeline(
+    nn.Module,
+    CFGParallelMixin,
+    SupportImageInput,
+    ProgressBarMixin,
+    DiffusionPipelineProfilerMixin,
+):
+    support_image_input = True
+    color_format = "RGB"
+
+    # Default external sub-model paths
+    DEFAULT_QWEN_PATH = "Qwen/Qwen2.5-VL-7B-Instruct"
+    DEFAULT_SIGLIP_PATH = "google/siglip-so400m-patch14-384"
+    DEFAULT_T2V_PATH = "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v"
+
+    @staticmethod
+    def _resolve_external_model_path(
+        od_config: OmniDiffusionConfig,
+        arg_name: str,
+        default_path: str,
+    ) -> str:
+        custom_args = od_config.custom_pipeline_args or {}
+        if isinstance(custom_args, dict):
+            value = custom_args.get(arg_name)
+            if isinstance(value, str) and value:
+                return value
+        return default_path
+
+    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
+        super().__init__()
+        self.od_config = od_config
+        self.device = get_local_device()
+        dtype = getattr(od_config, "dtype", torch.bfloat16)
+        model = od_config.model
+        local_files_only = os.path.exists(model)
+        self.qwen_path = self._resolve_external_model_path(od_config, "qwen_path", self.DEFAULT_QWEN_PATH)
+        self.siglip_path = self._resolve_external_model_path(od_config, "siglip_path", self.DEFAULT_SIGLIP_PATH)
+        self.t2v_path = self._resolve_external_model_path(od_config, "t2v_path", self.DEFAULT_T2V_PATH)
+
+        self.tokenizer = Qwen2Tokenizer.from_pretrained(self.qwen_path)
+        self.mllm = Qwen2_5_VLForConditionalGeneration.from_pretrained(self.qwen_path, torch_dtype=dtype).to(
+            self.device
+        )
+
+        ckpt_dir = os.path.join(model, "text_encoder")
+        safetensors_files = glob.glob(os.path.join(ckpt_dir, "**", "*.safetensors"), recursive=True)
+        if safetensors_files:
+            from safetensors.torch import load_file
+
+            for f in safetensors_files:
+                te_weights = load_file(f)
+                if "__metadata__" in te_weights:
+                    del te_weights["__metadata__"]
+                self.mllm.load_state_dict(te_weights, strict=False)
+
+        try:
+            self.tokenizer_2 = AutoTokenizer.from_pretrained(
+                model, subfolder="tokenizer_2", local_files_only=local_files_only
+            )
+            t5_config = AutoConfig.from_pretrained(model, subfolder="text_encoder_2", local_files_only=local_files_only)
+            self.text_encoder_2 = T5EncoderModel(t5_config, prefix="text_encoder_2").to(dtype=dtype, device=self.device)
+            self.has_t5_2 = True
+        except Exception:
+            self.tokenizer_2 = None
+            self.text_encoder_2 = None
+            self.has_t5_2 = False
+            self.t5_2_d_model = 1472
+
+        try:
+            self.image_encoder = SiglipVisionModel.from_pretrained(
+                model,
+                subfolder="image_encoder",
+                torch_dtype=dtype,
+                local_files_only=local_files_only,
+            ).to(self.device)
+            self.feature_extractor = SiglipImageProcessor.from_pretrained(
+                model,
+                subfolder="feature_extractor",
+                local_files_only=local_files_only,
+            )
+        except Exception:
+            self.image_encoder = SiglipVisionModel.from_pretrained(self.siglip_path, torch_dtype=dtype).to(self.device)
+            self.feature_extractor = SiglipImageProcessor.from_pretrained(self.siglip_path)
+
+        self.vae = AutoencoderKLHunyuanVideo15.from_pretrained(
+            self.t2v_path, subfolder="vae", torch_dtype=torch.float32
+        ).to(self.device)
+        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(self.t2v_path, subfolder="scheduler")
+        if od_config.flow_shift is not None:
+            self.scheduler._shift = od_config.flow_shift
+
+        transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, HunyuanVideo15Transformer3DModel)
+        self.transformer = HunyuanVideo15Transformer3DModel(od_config=od_config, **transformer_kwargs)
+        self.use_meanflow = getattr(od_config.tf_model_config, "use_meanflow", False)
+
+        self.weights_sources = [
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
+                subfolder="transformer",
+                revision=None,
+                prefix="transformer.",
+                fall_back_to_pt=True,
+            ),
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
+                subfolder="text_encoder_2",
+                revision=None,
+                prefix="text_encoder_2.",
+                fall_back_to_pt=True,
+            ),
+        ]
+
+        self.vae_scale_factor_temporal = (
+            self.vae.temporal_compression_ratio if hasattr(self.vae, "temporal_compression_ratio") else 4
+        )
+        self.vae_scale_factor_spatial = (
+            self.vae.spatial_compression_ratio if hasattr(self.vae, "spatial_compression_ratio") else 16
+        )
+        self.num_channels_latents = self.vae.config.latent_channels if hasattr(self.vae, "config") else 32
+
+        self.system_message = (
+            "You are a helpful assistant. Describe the video by detailing the following aspects: "
+            "1. The main content and theme of the video. "
+            "2. The color, shape, size, texture, quantity, text, and spatial relationships of the objects. "
+            "3. Actions, events, behaviors temporal relationships, physical movement changes of the objects. "
+            "4. background environment, light, style and atmosphere. "
+            "5. camera angles, movements, and transitions used in the video."
+        )
+
+        self.prompt_template_encode_start_idx = 108
+        self.tokenizer_max_length = 1000
+        self.tokenizer_2_max_length = 256
+        self._guidance_scale = None
+        self._num_timesteps = None
+        self._current_timestep = None
+        self.setup_diffusion_pipeline_profiler(
+            enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
+        )
+
+    @property
+    def guidance_scale(self):
+        return self._guidance_scale
+
+    @property
+    def num_timesteps(self):
+        return self._num_timesteps
+
+    @property
+    def current_timestep(self):
+        return self._current_timestep
+
+    def _get_mllm_prompt_embeds(
+        self,
+        prompt: list[str],
+        device: torch.device,
+        dtype: torch.dtype,
+        num_hidden_layers_to_skip: int = 2,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        prompt_formatted = format_text_input(prompt, self.system_message)
+        text_inputs = self.tokenizer.apply_chat_template(
+            prompt_formatted,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            padding="max_length",
+            max_length=self.tokenizer_max_length + self.prompt_template_encode_start_idx,
+            truncation=True,
+            return_tensors="pt",
+        )
+        text_input_ids = text_inputs.input_ids.to(device=device)
+        prompt_attention_mask = text_inputs.attention_mask.to(device=device)
+        with torch.no_grad():
+            outputs = self.mllm.model(
+                input_ids=text_input_ids,
+                attention_mask=prompt_attention_mask,
+                output_hidden_states=True,
+            )
+        prompt_embeds = outputs.hidden_states[-(num_hidden_layers_to_skip + 1)]
+        crop_start = self.prompt_template_encode_start_idx
+        if crop_start is not None and crop_start > 0:
+            prompt_embeds = prompt_embeds[:, crop_start:]
+            prompt_attention_mask = prompt_attention_mask[:, crop_start:]
+        return (
+            torch.clamp(prompt_embeds, min=-65504.0, max=65504.0).to(dtype=dtype),
+            prompt_attention_mask,
+        )
+
+    def _get_t5_2_prompt_embeds(
+        self, prompt: list[str], device: torch.device, dtype: torch.dtype
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        prompt_embeds_list, prompt_embeds_mask_list = [], []
+        for p in prompt:
+            glyph_text = extract_glyph_texts(p)
+            if glyph_text is None or not self.has_t5_2:
+                glyph_text_embeds = torch.zeros(
+                    (1, self.tokenizer_2_max_length, self.t5_2_d_model),
+                    device=device,
+                    dtype=dtype,
+                )
+                glyph_text_embeds_mask = torch.ones((1, self.tokenizer_2_max_length), device=device, dtype=torch.int64)
+            else:
+                txt_tokens = self.tokenizer_2(
+                    glyph_text,
+                    padding="max_length",
+                    max_length=self.tokenizer_2_max_length,
+                    truncation=True,
+                    add_special_tokens=True,
+                    return_tensors="pt",
+                ).to(device)
+                glyph_text_embeds = self.text_encoder_2(
+                    input_ids=txt_tokens.input_ids,
+                    attention_mask=txt_tokens.attention_mask.float(),
+                )[0].to(device=device, dtype=dtype)
+                glyph_text_embeds_mask = txt_tokens.attention_mask.to(device=device)
+            prompt_embeds_list.append(glyph_text_embeds)
+            prompt_embeds_mask_list.append(glyph_text_embeds_mask)
+        return torch.cat(prompt_embeds_list, dim=0), torch.cat(prompt_embeds_mask_list, dim=0)
+
+    def encode_prompt(
+        self,
+        prompt: str | list[str],
+        image: PIL.Image.Image | None,
+        device: torch.device,
+        dtype: torch.dtype,
+        negative_prompt: str | list[str] | None = None,
+        do_classifier_free_guidance: bool = False,
+    ) -> tuple:
+        prompt = [prompt] if isinstance(prompt, str) else prompt
+        prompt_embeds, prompt_embeds_mask = self._get_mllm_prompt_embeds(prompt, device, dtype)
+        prompt_embeds_2, prompt_embeds_mask_2 = self._get_t5_2_prompt_embeds(prompt, device, dtype)
+        prompt_embeds_mask = prompt_embeds_mask.to(dtype=dtype)
+        prompt_embeds_mask_2 = prompt_embeds_mask_2.to(dtype=dtype)
+
+        negative_prompt_embeds = None
+        negative_prompt_embeds_mask = None
+        negative_prompt_embeds_2 = None
+        negative_prompt_embeds_mask_2 = None
+
+        if do_classifier_free_guidance:
+            neg_p = (
+                [negative_prompt]
+                if isinstance(negative_prompt, str)
+                else (negative_prompt if negative_prompt else [""])
+            )
+            (
+                negative_prompt_embeds,
+                negative_prompt_embeds_mask,
+            ) = self._get_mllm_prompt_embeds(neg_p, device, dtype)
+            (
+                negative_prompt_embeds_2,
+                negative_prompt_embeds_mask_2,
+            ) = self._get_t5_2_prompt_embeds(neg_p, device, dtype)
+            negative_prompt_embeds_mask = negative_prompt_embeds_mask.to(dtype=dtype)
+            negative_prompt_embeds_mask_2 = negative_prompt_embeds_mask_2.to(dtype=dtype)
+        return (
+            prompt_embeds,
+            prompt_embeds_mask,
+            prompt_embeds_2,
+            prompt_embeds_mask_2,
+            negative_prompt_embeds,
+            negative_prompt_embeds_mask,
+            negative_prompt_embeds_2,
+            negative_prompt_embeds_mask_2,
+        )
+
+    def _get_image_embeds(self, image: PIL.Image.Image, device: torch.device) -> torch.Tensor:
+        image_encoder_dtype = next(self.image_encoder.parameters()).dtype
+        pixel_values = self.feature_extractor(images=image, do_resize=True, return_tensors="pt").pixel_values.to(
+            device=device, dtype=image_encoder_dtype
+        )
+        return torch.clamp(
+            self.image_encoder(pixel_values).last_hidden_state,
+            min=-65504.0,
+            max=65504.0,
+        )
+
+    def _get_image_latents(self, image: PIL.Image.Image, height: int, width: int, device: torch.device) -> torch.Tensor:
+        image_tensor = (
+            VideoProcessor(vae_scale_factor=self.vae_scale_factor_spatial)
+            .preprocess(image, height=height, width=width)
+            .unsqueeze(2)
+            .to(device=device, dtype=self.vae.dtype)
+        )
+        return retrieve_latents(self.vae.encode(image_tensor), sample_mode="argmax") * self.vae.config.scaling_factor
+
+    def prepare_cond_latents_and_mask(
+        self,
+        latents: torch.Tensor,
+        image: PIL.Image.Image,
+        height: int,
+        width: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch, channels, frames, lat_height, lat_width = latents.shape
+        latent_condition = self._get_image_latents(image, height, width, device).repeat(batch, 1, frames, 1, 1)
+        latent_condition[:, :, 1:, :, :] = 0
+        latent_mask = torch.zeros(batch, 1, frames, lat_height, lat_width, dtype=dtype, device=device)
+        latent_mask[:, :, 0, :, :] = 1.0
+        return latent_condition.to(device=device, dtype=dtype), latent_mask
+
+    def prepare_latents(
+        self,
+        batch_size: int,
+        height: int,
+        width: int,
+        num_frames: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if latents is not None:
+            return latents.to(device=device, dtype=dtype)
+        shape = (
+            batch_size,
+            self.num_channels_latents,
+            (num_frames - 1) // self.vae_scale_factor_temporal + 1,
+            int(height) // self.vae_scale_factor_spatial,
+            int(width) // self.vae_scale_factor_spatial,
+        )
+        return randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+
+    def predict_noise(self, **kwargs: Any) -> torch.Tensor:
+        return self.transformer(**kwargs)[0]
+
+    def forward(
+        self,
+        req: OmniDiffusionRequest,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 6.0,
+        height: int = 480,
+        width: int = 832,
+        num_frames: int = 121,
+        output_type: str | None = "np",
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        **kwargs,
+    ) -> DiffusionOutput:
+        if not req.prompts:
+            raise ValueError("Prompt is required.")
+        prompt_data = req.prompts[0]
+        prompt = prompt_data if isinstance(prompt_data, str) else prompt_data.get("prompt")
+        negative_prompt = None if isinstance(prompt_data, str) else prompt_data.get("negative_prompt")
+        multi_modal_data = prompt_data.get("multi_modal_data", {}) if not isinstance(prompt_data, str) else {}
+
+        raw_image = multi_modal_data.get("image", None)
+        if isinstance(raw_image, list):
+            raw_image = raw_image[0]
+
+        image = None
+        if raw_image is not None:
+            image = PIL.Image.open(raw_image).convert("RGB") if isinstance(raw_image, str) else raw_image.convert("RGB")
+
+        height = req.sampling_params.height or height
+        width = req.sampling_params.width or width
+        num_frames_val = req.sampling_params.num_frames or num_frames
+        num_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        guidance_scale = (
+            req.sampling_params.guidance_scale if req.sampling_params.guidance_scale_provided else guidance_scale
+        )
+        do_cfg = guidance_scale > 1.0
+
+        device = self.device
+        dtype = self.transformer.transformer_blocks[0].norm1.linear.weight.dtype
+        if generator is None and req.sampling_params.seed is not None:
+            generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
+
+        enc_tuple = self.encode_prompt(prompt, image, device, dtype, negative_prompt, do_cfg)
+
+        latents = self.prepare_latents(
+            enc_tuple[0].shape[0],
+            height,
+            width,
+            num_frames_val,
+            dtype,
+            device,
+            generator,
+            req.sampling_params.latents,
+        )
+
+        if image is not None:
+            image_embeds = self._get_image_embeds(image, device).to(dtype=dtype)
+            cond_latents, mask = self.prepare_cond_latents_and_mask(latents, image, height, width, dtype, device)
+        else:
+            batch, channels, frames, lat_height, lat_width = latents.shape
+            cond_latents = torch.zeros_like(latents)
+            mask = torch.zeros(batch, 1, frames, lat_height, lat_width, dtype=dtype, device=device)
+            image_embeds = torch.zeros((batch, 729, 1152), dtype=dtype, device=device)
+
+        self.scheduler.set_timesteps(sigmas=np.linspace(1.0, 0.0, num_steps + 1)[:-1], device=device)
+        timesteps = self.scheduler.timesteps
+
+        with self.progress_bar(total=len(timesteps)) as pbar:
+            for i, t in enumerate(timesteps):
+                latent_model_input = torch.cat([latents, cond_latents, mask], dim=1)
+                timestep = t.expand(latent_model_input.shape[0]).to(latent_model_input.dtype)
+                timestep_r = torch.tensor([0.0], device=device) if i == len(timesteps) - 1 else timesteps[i + 1]
+                timestep_r = timestep_r.expand(latents.shape[0]).to(latents.dtype) if self.use_meanflow else None
+
+                positive_kwargs = {
+                    "hidden_states": latent_model_input,
+                    "timestep": timestep,
+                    "timestep_r": timestep_r,
+                    "encoder_hidden_states": enc_tuple[0],
+                    "encoder_attention_mask": enc_tuple[1],
+                    "encoder_hidden_states_2": enc_tuple[2],
+                    "encoder_attention_mask_2": enc_tuple[3],
+                    "image_embeds": image_embeds,
+                    "return_dict": False,
+                }
+                negative_kwargs = (
+                    {
+                        "hidden_states": latent_model_input,
+                        "timestep": timestep,
+                        "timestep_r": timestep_r,
+                        "encoder_hidden_states": enc_tuple[4],
+                        "encoder_attention_mask": enc_tuple[5],
+                        "encoder_hidden_states_2": enc_tuple[6],
+                        "encoder_attention_mask_2": enc_tuple[7],
+                        "image_embeds": image_embeds,
+                        "return_dict": False,
+                    }
+                    if do_cfg and enc_tuple[4] is not None
+                    else None
+                )
+
+                noise_pred = self.predict_noise_maybe_with_cfg(
+                    do_true_cfg=bool(negative_kwargs),
+                    true_cfg_scale=guidance_scale,
+                    positive_kwargs=positive_kwargs,
+                    negative_kwargs=negative_kwargs,
+                    cfg_normalize=req.sampling_params.cfg_normalize,
+                )
+                latents = self.scheduler_step_maybe_with_cfg(noise_pred, t, latents, do_true_cfg=bool(negative_kwargs))
+                pbar.update()
+
+        if current_omni_platform.is_available():
+            current_omni_platform.empty_cache()
+        if output_type == "latent":
+            return DiffusionOutput(output=latents)
+        return DiffusionOutput(
+            output=self.vae.decode(
+                latents.to(self.vae.dtype) / self.vae.config.scaling_factor,
+                return_dict=False,
+            )[0]
+        )
+
+    # NATIVE ARCHITECTURE ROUTER: Tencent Original -> HF Diffusers
+    def _translate_tencent_to_hf(self, raw_tf: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        mapped_tf = {}
+
+        def map_k(src: str, dst: str):
+            if src in raw_tf:
+                mapped_tf[dst] = raw_tf[src]
+
+        map_k("img_in.proj.weight", "x_embedder.proj.weight")
+        map_k("img_in.proj.bias", "x_embedder.proj.bias")
+        map_k("final_layer.linear.weight", "proj_out.weight")
+        map_k("final_layer.linear.bias", "proj_out.bias")
+        map_k("final_layer.adaLN_modulation.1.weight", "norm_out.linear.weight")
+        map_k("final_layer.adaLN_modulation.1.bias", "norm_out.linear.bias")
+        map_k("txt_in.input_embedder.weight", "context_embedder.proj_in.weight")
+        map_k("txt_in.input_embedder.bias", "context_embedder.proj_in.bias")
+
+        # Time Text Embedder
+        map_k(
+            "txt_in.c_embedder.linear_1.weight",
+            "context_embedder.time_text_embed.text_embedder.linear_1.weight",
+        )
+        map_k(
+            "txt_in.c_embedder.linear_1.bias",
+            "context_embedder.time_text_embed.text_embedder.linear_1.bias",
+        )
+        map_k(
+            "txt_in.c_embedder.linear_2.weight",
+            "context_embedder.time_text_embed.text_embedder.linear_2.weight",
+        )
+        map_k(
+            "txt_in.c_embedder.linear_2.bias",
+            "context_embedder.time_text_embed.text_embedder.linear_2.bias",
+        )
+        map_k(
+            "txt_in.t_embedder.mlp.0.weight",
+            "context_embedder.time_text_embed.timestep_embedder.linear_1.weight",
+        )
+        map_k(
+            "txt_in.t_embedder.mlp.0.bias",
+            "context_embedder.time_text_embed.timestep_embedder.linear_1.bias",
+        )
+        map_k(
+            "txt_in.t_embedder.mlp.2.weight",
+            "context_embedder.time_text_embed.timestep_embedder.linear_2.weight",
+        )
+        map_k(
+            "txt_in.t_embedder.mlp.2.bias",
+            "context_embedder.time_text_embed.timestep_embedder.linear_2.bias",
+        )
+
+        # Time Embedder
+        map_k("time_in.mlp.0.weight", "time_embed.timestep_embedder.linear_1.weight")
+        map_k("time_in.mlp.0.bias", "time_embed.timestep_embedder.linear_1.bias")
+        map_k("time_in.mlp.2.weight", "time_embed.timestep_embedder.linear_2.weight")
+        map_k("time_in.mlp.2.bias", "time_embed.timestep_embedder.linear_2.bias")
+        map_k("cond_type_embedding.weight", "cond_type_embed.weight")
+
+        # Vision Embedder
+        vision_proj_map = {
+            "vision_in.proj.0.weight": "image_embedder.norm_in.weight",
+            "vision_in.proj.0.bias": "image_embedder.norm_in.bias",
+            "vision_in.proj.1.weight": "image_embedder.linear_1.weight",
+            "vision_in.proj.1.bias": "image_embedder.linear_1.bias",
+            "vision_in.proj.3.weight": "image_embedder.linear_2.weight",
+            "vision_in.proj.3.bias": "image_embedder.linear_2.bias",
+            "vision_in.proj.4.weight": "image_embedder.norm_out.weight",
+            "vision_in.proj.4.bias": "image_embedder.norm_out.bias",
+        }
+        for s_k, d_k in vision_proj_map.items():
+            map_k(s_k, d_k)
+
+        # T5-2 Projections
+        t5_2_prefix = "by" + "t5_in"
+        if f"{t5_2_prefix}.fc1.weight" in raw_tf:
+            w1 = raw_tf[f"{t5_2_prefix}.fc1.weight"]
+            mapped_tf["context_embedder_2.linear_1.weight"] = w1
+
+            map_k(f"{t5_2_prefix}.fc1.bias", "context_embedder_2.linear_1.bias")
+            map_k(f"{t5_2_prefix}.fc2.weight", "context_embedder_2.linear_2.weight")
+            map_k(f"{t5_2_prefix}.fc2.bias", "context_embedder_2.linear_2.bias")
+            map_k(f"{t5_2_prefix}.fc3.weight", "context_embedder_2.linear_3.weight")
+            map_k(f"{t5_2_prefix}.fc3.bias", "context_embedder_2.linear_3.bias")
+            map_k(f"{t5_2_prefix}.layernorm.weight", "context_embedder_2.norm.weight")
+            map_k(f"{t5_2_prefix}.layernorm.bias", "context_embedder_2.norm.bias")
+
+        # Refiner Blocks
+        for layer in range(2):
+            p = f"txt_in.individual_token_refiner.blocks.{layer}"
+            if f"{p}.self_attn_qkv.weight" in raw_tf:
+                q_w, k_w, v_w = raw_tf[f"{p}.self_attn_qkv.weight"].chunk(3, dim=0)
+                q_b, k_b, v_b = raw_tf[f"{p}.self_attn_qkv.bias"].chunk(3, dim=0)
+                pref = f"context_embedder.token_refiner.refiner_blocks.{layer}"
+
+                mapped_tf[f"{pref}.attn.to_q.weight"] = q_w
+                mapped_tf[f"{pref}.attn.to_k.weight"] = k_w
+                mapped_tf[f"{pref}.attn.to_v.weight"] = v_w
+                mapped_tf[f"{pref}.attn.to_q.bias"] = q_b
+                mapped_tf[f"{pref}.attn.to_k.bias"] = k_b
+                mapped_tf[f"{pref}.attn.to_v.bias"] = v_b
+
+                map_k(f"{p}.self_attn_proj.weight", f"{pref}.attn.to_out.0.weight")
+                map_k(f"{p}.self_attn_proj.bias", f"{pref}.attn.to_out.0.bias")
+                map_k(f"{p}.norm1.weight", f"{pref}.norm1.weight")
+                map_k(f"{p}.norm1.bias", f"{pref}.norm1.bias")
+                map_k(f"{p}.norm2.weight", f"{pref}.norm2.weight")
+                map_k(f"{p}.norm2.bias", f"{pref}.norm2.bias")
+                map_k(f"{p}.mlp.fc1.weight", f"{pref}.ff.net.0.proj.weight")
+                map_k(f"{p}.mlp.fc1.bias", f"{pref}.ff.net.0.proj.bias")
+                map_k(f"{p}.mlp.fc2.weight", f"{pref}.ff.net.2.weight")
+                map_k(f"{p}.mlp.fc2.bias", f"{pref}.ff.net.2.bias")
+                map_k(f"{p}.adaLN_modulation.1.weight", f"{pref}.norm_out.linear.weight")
+                map_k(f"{p}.adaLN_modulation.1.bias", f"{pref}.norm_out.linear.bias")
+
+        # Double Blocks
+        double_block_keys = set(k.split(".")[1] for k in raw_tf.keys() if k.startswith("double_blocks."))
+        for i_str in double_block_keys:
+            p = f"double_blocks.{i_str}"
+            t_p = f"transformer_blocks.{i_str}"
+
+            map_k(f"{p}.img_attn_q.weight", f"{t_p}.attn.to_q.weight")
+            map_k(f"{p}.img_attn_k.weight", f"{t_p}.attn.to_k.weight")
+            map_k(f"{p}.img_attn_v.weight", f"{t_p}.attn.to_v.weight")
+            map_k(f"{p}.img_attn_q.bias", f"{t_p}.attn.to_q.bias")
+            map_k(f"{p}.img_attn_k.bias", f"{t_p}.attn.to_k.bias")
+            map_k(f"{p}.img_attn_v.bias", f"{t_p}.attn.to_v.bias")
+
+            map_k(f"{p}.txt_attn_q.weight", f"{t_p}.attn.add_q_proj.weight")
+            map_k(f"{p}.txt_attn_k.weight", f"{t_p}.attn.add_k_proj.weight")
+            map_k(f"{p}.txt_attn_v.weight", f"{t_p}.attn.add_v_proj.weight")
+            map_k(f"{p}.txt_attn_q.bias", f"{t_p}.attn.add_q_proj.bias")
+            map_k(f"{p}.txt_attn_k.bias", f"{t_p}.attn.add_k_proj.bias")
+            map_k(f"{p}.txt_attn_v.bias", f"{t_p}.attn.add_v_proj.bias")
+
+            map_k(f"{p}.img_attn_q_norm.weight", f"{t_p}.attn.norm_q.weight")
+            map_k(f"{p}.img_attn_k_norm.weight", f"{t_p}.attn.norm_k.weight")
+            map_k(f"{p}.txt_attn_q_norm.weight", f"{t_p}.attn.norm_added_q.weight")
+            map_k(f"{p}.txt_attn_k_norm.weight", f"{t_p}.attn.norm_added_k.weight")
+
+            map_k(f"{p}.img_attn_proj.weight", f"{t_p}.attn.to_out.0.weight")
+            map_k(f"{p}.img_attn_proj.bias", f"{t_p}.attn.to_out.0.bias")
+            map_k(f"{p}.txt_attn_proj.weight", f"{t_p}.attn.to_add_out.weight")
+            map_k(f"{p}.txt_attn_proj.bias", f"{t_p}.attn.to_add_out.bias")
+
+            map_k(f"{p}.img_mlp.fc1.weight", f"{t_p}.ff.net.0.proj.weight")
+            map_k(f"{p}.img_mlp.fc1.bias", f"{t_p}.ff.net.0.proj.bias")
+            map_k(f"{p}.img_mlp.fc2.weight", f"{t_p}.ff.net.2.weight")
+            map_k(f"{p}.img_mlp.fc2.bias", f"{t_p}.ff.net.2.bias")
+
+            map_k(f"{p}.txt_mlp.fc1.weight", f"{t_p}.ff_context.net.0.proj.weight")
+            map_k(f"{p}.txt_mlp.fc1.bias", f"{t_p}.ff_context.net.0.proj.bias")
+            map_k(f"{p}.txt_mlp.fc2.weight", f"{t_p}.ff_context.net.2.weight")
+            map_k(f"{p}.txt_mlp.fc2.bias", f"{t_p}.ff_context.net.2.bias")
+
+            map_k(f"{p}.img_mod.linear.weight", f"{t_p}.norm1.linear.weight")
+            map_k(f"{p}.img_mod.linear.bias", f"{t_p}.norm1.linear.bias")
+            map_k(f"{p}.txt_mod.linear.weight", f"{t_p}.norm1_context.linear.weight")
+            map_k(f"{p}.txt_mod.linear.bias", f"{t_p}.norm1_context.linear.bias")
+
+        # Single Blocks
+        single_block_keys = set(k.split(".")[1] for k in raw_tf.keys() if k.startswith("single_blocks."))
+        for i_str in single_block_keys:
+            p = f"single_blocks.{i_str}"
+            t_p = f"single_transformer_blocks.{i_str}"
+
+            map_k(f"{p}.attn_q.weight", f"{t_p}.attn.to_q.weight")
+            map_k(f"{p}.attn_k.weight", f"{t_p}.attn.to_k.weight")
+            map_k(f"{p}.attn_v.weight", f"{t_p}.attn.to_v.weight")
+            map_k(f"{p}.attn_q.bias", f"{t_p}.attn.to_q.bias")
+            map_k(f"{p}.attn_k.bias", f"{t_p}.attn.to_k.bias")
+            map_k(f"{p}.attn_v.bias", f"{t_p}.attn.to_v.bias")
+
+            map_k(f"{p}.attn_proj.weight", f"{t_p}.attn.to_out.0.weight")
+            map_k(f"{p}.attn_proj.bias", f"{t_p}.attn.to_out.0.bias")
+            map_k(f"{p}.mlp.fc1.weight", f"{t_p}.proj_mlp.weight")
+            map_k(f"{p}.mlp.fc1.bias", f"{t_p}.proj_mlp.bias")
+            map_k(f"{p}.mlp.fc2.weight", f"{t_p}.proj_out.weight")
+            map_k(f"{p}.mlp.fc2.bias", f"{t_p}.proj_out.bias")
+            map_k(f"{p}.mod.linear.weight", f"{t_p}.norm.linear.weight")
+            map_k(f"{p}.mod.linear.bias", f"{t_p}.norm.linear.bias")
+
+        return mapped_tf
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        raw_tf, raw_t5, other_weights = {}, {}, []
+        for k, v in weights:
+            if k.startswith("transformer."):
+                raw_tf[k[len("transformer.") :]] = v
+            elif k.startswith("text_encoder_2."):
+                raw_t5[k[len("text_encoder_2.") :]] = v
+            else:
+                other_weights.append((k, v))
+
+        if any(k.startswith("double_blocks.") for k in raw_tf.keys()):
+            logger.info("Detecting Tencent original weight format. Routing through native Auto-Translator...")
+            tf_weights_to_load = self._translate_tencent_to_hf(raw_tf).items()
+        else:
+            tf_weights_to_load = raw_tf.items()
+
+        loaded_keys = set()
+
+        # Load Main Backbone
+        if hasattr(self.transformer, "load_weights"):
+            tf_loaded = self.transformer.load_weights(tf_weights_to_load)
+            loaded_keys.update([f"transformer.{k}" for k in tf_loaded])
+        else:
+            loader = AutoWeightsLoader(self.transformer)
+            tf_loaded = loader.load_weights(tf_weights_to_load)
+            loaded_keys.update([f"transformer.{k}" for k in tf_loaded])
+
+        # Load T5-2
+        if self.has_t5_2 and raw_t5:
+            t5_items = raw_t5.items()
+            if hasattr(self.text_encoder_2, "load_weights"):
+                t5_loaded = self.text_encoder_2.load_weights(t5_items)
+                loaded_keys.update([f"text_encoder_2.{k}" for k in t5_loaded])
+            else:
+                loader = AutoWeightsLoader(self.text_encoder_2)
+                t5_loaded = loader.load_weights(t5_items)
+                loaded_keys.update([f"text_encoder_2.{k}" for k in t5_loaded])
+
+        # Load Everything Else
+        if other_weights:
+            loader = AutoWeightsLoader(self)
+            loaded_keys.update(loader.load_weights(other_weights))
+
+        for name, p in self.transformer.named_parameters():
+            if f"transformer.{name}" not in loaded_keys and (torch.isnan(p).any() or p.std().item() == 0.0):
+                logger.warning(
+                    f"Parameter transformer.{name} was not loaded from the checkpoint. "
+                    "This might cause incorrect outputs."
+                )
+
+        return loaded_keys

--- a/vllm_omni/diffusion/models/omniweaving/pipeline_omniweaving.py
+++ b/vllm_omni/diffusion/models/omniweaving/pipeline_omniweaving.py
@@ -21,6 +21,7 @@ from diffusers.video_processor import VideoProcessor
 from torch import nn
 from transformers import (
     AutoConfig,
+    AutoProcessor,
     AutoTokenizer,
     Qwen2_5_VLForConditionalGeneration,
     Qwen2Tokenizer,
@@ -54,13 +55,23 @@ from vllm_omni.platforms import current_omni_platform
 
 logger = logging.getLogger(__name__)
 
+# Official OmniWeaving I2V `prompt_mode=2` system prompt (see `OmniWeaving/hyvideo/models/text_encoders/__init__.py`).
+OMNIWEAVING_I2V_SYSTEM_MESSAGE = (
+    "You are a helpful assistant. Describe the key features of the input image (color, shape, size, "
+    "texture, objects, background), then explain how the user's text instruction should alter the image "
+    "to introduce motion and evolution over time. Generate a video using this image as the first frame that "
+    "meets the user's requirements, ensuring the specified elements evolve or move in a way that fulfills the "
+    "text description while maintaining consistency."
+)
+
 
 def get_omniweaving_post_process_func(od_config: OmniDiffusionConfig):
     return get_hunyuan_video_15_post_process_func(od_config)
 
 
 def get_omniweaving_pre_process_func(od_config: OmniDiffusionConfig):
-    max_area = 480 * 832
+    # Official aligned I2V 480p: 480×848 (26:15). Use the same area target when inferring WxH from the image.
+    max_area = 480 * 848
     divisor = 16
 
     def pre_process_func(req: OmniDiffusionRequest) -> OmniDiffusionRequest:
@@ -135,11 +146,56 @@ class OmniWeavingPipeline(
         self.qwen_path = self._resolve_external_model_path(od_config, "qwen_path", self.DEFAULT_QWEN_PATH)
         self.siglip_path = self._resolve_external_model_path(od_config, "siglip_path", self.DEFAULT_SIGLIP_PATH)
         self.t2v_path = self._resolve_external_model_path(od_config, "t2v_path", self.DEFAULT_T2V_PATH)
+        # Only force offline HF when the *Qwen* path itself is a local directory/file; do not use the
+        # OmniWeaving checkpoint's local_files_only (that would break Hub IDs when the main model is local).
+        qwen_local_files_only: bool = os.path.isdir(self.qwen_path)
 
-        self.tokenizer = Qwen2Tokenizer.from_pretrained(self.qwen_path)
-        self.mllm = Qwen2_5_VLForConditionalGeneration.from_pretrained(self.qwen_path, torch_dtype=dtype).to(
-            self.device
-        )
+        custom_args = od_config.custom_pipeline_args if isinstance(od_config.custom_pipeline_args, dict) else {}
+        self._mllm_i2v_use_vision: bool = bool(custom_args.get("mllm_i2v_use_vision", True))
+        self._mllm_i2v_crop_start: int = int(custom_args.get("mllm_i2v_crop_start", 92))
+        self._mllm_i2v_vision_token_budget: int = int(custom_args.get("mllm_i2v_vision_token_budget", 400))
+        # `hunyuan_video_pipeline` throttles MLLM vision to max edge 560 before `prepare_input` (I2V).
+        self._mllm_i2v_qwen_thumbnail_max: int = int(custom_args.get("mllm_i2v_qwen_thumbnail_max", 560))
+        # `TextEncoder.encode(..., setclip=True)`: after crop_start, drop vision
+        # prefix up to last `token_id` (Qwen2-VL).
+        self._mllm_i2v_setclip: bool = bool(custom_args.get("mllm_i2v_setclip", True))
+        self._mllm_i2v_setclip_token_id: int = int(custom_args.get("mllm_i2v_setclip_token_id", 151653))
+        # Official-style bench: use slow Qwen2-VL image path unless explicitly
+        # overridden (OMNIWEAVING_I2V_MI2V_PERF.md).
+        self._qwen_image_processor_use_fast: bool = bool(custom_args.get("qwen_image_processor_use_fast", False))
+        # VAE first-frame `cond_latents`: diffusers `resize_mode="default"` =
+        # independent scale to H×W (aspect not kept).
+        # Portrait or AR-mismatched refs get stretched, harming I2V temporal
+        # consistency. Prefer letterboxing ("fill").
+        self._i2v_cond_resize_mode: str = str(custom_args.get("i2v_cond_resize_mode", "fill"))
+        trust = bool(getattr(od_config, "trust_remote_code", True))
+
+        self.qwen_processor: Any | None = None
+        try:
+            self.qwen_processor = AutoProcessor.from_pretrained(
+                self.qwen_path,
+                local_files_only=qwen_local_files_only,
+                trust_remote_code=trust,
+            )
+            self.tokenizer = self.qwen_processor.tokenizer
+            _ip = getattr(self.qwen_processor, "image_processor", None)
+            if _ip is not None and hasattr(_ip, "use_fast") and not self._qwen_image_processor_use_fast:
+                _ip.use_fast = False
+        except Exception as e:
+            logger.warning(
+                "AutoProcessor could not be loaded for Qwen2.5-VL (%s); I2V multimodal Qwen path disabled. %s",
+                self.qwen_path,
+                e,
+            )
+            self.qwen_processor = None
+            self.tokenizer = Qwen2Tokenizer.from_pretrained(self.qwen_path, local_files_only=qwen_local_files_only)
+
+        self.mllm = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+            self.qwen_path,
+            torch_dtype=dtype,
+            local_files_only=qwen_local_files_only,
+            trust_remote_code=trust,
+        ).to(self.device)
 
         ckpt_dir = os.path.join(model, "text_encoder")
         safetensors_files = glob.glob(os.path.join(ckpt_dir, "**", "*.safetensors"), recursive=True)
@@ -151,6 +207,17 @@ class OmniWeavingPipeline(
                 if "__metadata__" in te_weights:
                     del te_weights["__metadata__"]
                 self.mllm.load_state_dict(te_weights, strict=False)
+
+        self._process_vision_info = None
+        try:
+            from qwen_vl_utils import process_vision_info as _pvi
+
+            self._process_vision_info = _pvi
+        except ImportError:
+            logger.warning(
+                "qwen_vl_utils is not installed; OmniWeaving I2V will not feed images into Qwen. "
+                "Install with: pip install qwen-vl-utils"
+            )
 
         try:
             self.tokenizer_2 = AutoTokenizer.from_pretrained(
@@ -187,6 +254,9 @@ class OmniWeavingPipeline(
         self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(self.t2v_path, subfolder="scheduler")
         if od_config.flow_shift is not None:
             self.scheduler._shift = od_config.flow_shift
+        # `Omni` sets `od_config.flow_shift` once; offline bench may vary per case via
+        # `sampling_params.extra_args['flow_shift']`. Reset in `forward` before `set_timesteps`.
+        self._default_scheduler_shift = float(getattr(self.scheduler, "_shift", 1.0))
 
         transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, HunyuanVideo15Transformer3DModel)
         self.transformer = HunyuanVideo15Transformer3DModel(od_config=od_config, **transformer_kwargs)
@@ -235,6 +305,7 @@ class OmniWeavingPipeline(
         self.setup_diffusion_pipeline_profiler(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
+        self._logged_i2v_text_only_mllm = False
 
     @property
     def guidance_scale(self):
@@ -248,7 +319,124 @@ class OmniWeavingPipeline(
     def current_timestep(self):
         return self._current_timestep
 
+    def _mllm_inputs_to_device(self, proc_inputs: dict[str, Any], device: torch.device) -> dict[str, Any]:
+        """Map processor outputs to Qwen2.5-VL forward kwargs; move tensors to device with correct dtype."""
+        out: dict[str, Any] = {}
+        mllm_dtype = next(self.mllm.model.parameters()).dtype
+        for key in (
+            "input_ids",
+            "attention_mask",
+            "pixel_values",
+            "image_grid_thw",
+            "video_grid_thw",
+            "pixel_values_videos",
+            "second_per_grid_ts",
+            "position_ids",
+        ):
+            if key not in proc_inputs or proc_inputs[key] is None:
+                continue
+            v = proc_inputs[key]
+            if not isinstance(v, torch.Tensor):
+                out[key] = v
+                continue
+            v = v.to(device)
+            if key in ("image_grid_thw", "video_grid_thw"):
+                out[key] = v.long()
+            elif key in ("pixel_values", "pixel_values_videos"):
+                out[key] = v.to(dtype=mllm_dtype)
+            else:
+                out[key] = v
+        return out
+
+    @staticmethod
+    def _mllm_forward_kwargs(model_kw: dict[str, Any]) -> dict[str, Any]:
+        allowed = {
+            "input_ids",
+            "attention_mask",
+            "pixel_values",
+            "image_grid_thw",
+            "video_grid_thw",
+            "pixel_values_videos",
+            "second_per_grid_ts",
+            "position_ids",
+        }
+        return {k: v for k, v in model_kw.items() if k in allowed and v is not None}
+
+    @staticmethod
+    def _resize_pil_for_qwen_mllm(img: PIL.Image.Image, max_edge: int) -> PIL.Image.Image:
+        if max_edge <= 0:
+            return img
+        out = img.copy()
+        out.thumbnail((max_edge, max_edge))
+        return out
+
+    @staticmethod
+    def _apply_omniweaving_mllm_setclip(
+        last_hidden: torch.Tensor,
+        attention: torch.Tensor,
+        input_ids: torch.Tensor,
+        token_id: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Port of `TextEncoder.encode(..., setclip=True)` post-crop path (official OmniWeaving)."""
+        b, s, d = last_hidden.shape
+        device, dtype_h = last_hidden.device, last_hidden.dtype
+        idt = input_ids
+        all_h: list[torch.Tensor] = []
+        all_a: list[torch.Tensor] = []
+        for k in range(b):
+            mask = idt[k] == token_id
+            if not mask.any():
+                all_h.append(last_hidden[k])
+                all_a.append(attention[k])
+                continue
+            last_pos = int(mask.nonzero()[-1, 0].item())
+            if last_pos < s - 1:
+                all_h.append(last_hidden[k, last_pos + 1 :])
+                all_a.append(attention[k, last_pos + 1 :])
+            else:
+                all_h.append(last_hidden[k])
+                all_a.append(attention[k])
+        max_len = max(t.shape[0] for t in all_h)
+        padded_h = torch.zeros(b, max_len, d, device=device, dtype=dtype_h)
+        padded_a = torch.zeros(b, max_len, device=device, dtype=attention.dtype)
+        for i in range(b):
+            c = all_h[i].size(0)
+            padded_h[i, :c] = all_h[i]
+            padded_a[i, :c] = all_a[i]
+        return padded_h, padded_a
+
     def _get_mllm_prompt_embeds(
+        self,
+        prompt: list[str],
+        device: torch.device,
+        dtype: torch.dtype,
+        images: list[PIL.Image.Image] | None = None,
+        num_hidden_layers_to_skip: int = 2,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        use_i2v_vision = (
+            self._mllm_i2v_use_vision
+            and images is not None
+            and len(images) == len(prompt)
+            and all(im is not None for im in images)
+            and self.qwen_processor is not None
+            and self._process_vision_info is not None
+        )
+        if (
+            not use_i2v_vision
+            and images is not None
+            and any(im is not None for im in images)
+            and not self._logged_i2v_text_only_mllm
+        ):
+            self._logged_i2v_text_only_mllm = True
+            logger.info(
+                "OmniWeaving I2V: Qwen is running in text-only mode; install qwen-vl-utils and ensure "
+                "AutoProcessor loads to align with the official prompt_mode=2 multimodal MLLM path."
+            )
+        if use_i2v_vision:
+            return self._get_mllm_prompt_embeds_i2v_vision(prompt, device, dtype, images, num_hidden_layers_to_skip)
+        return self._get_mllm_prompt_embeds_text_only(prompt, device, dtype, num_hidden_layers_to_skip)
+
+    def _get_mllm_prompt_embeds_text_only(
         self,
         prompt: list[str],
         device: torch.device,
@@ -269,11 +457,14 @@ class OmniWeavingPipeline(
         text_input_ids = text_inputs.input_ids.to(device=device)
         prompt_attention_mask = text_inputs.attention_mask.to(device=device)
         with torch.no_grad():
-            outputs = self.mllm.model(
+            outputs = self.mllm(
                 input_ids=text_input_ids,
                 attention_mask=prompt_attention_mask,
                 output_hidden_states=True,
+                return_dict=True,
             )
+        if not outputs.hidden_states:
+            raise RuntimeError("Qwen2.5-VL forward did not return hidden_states (output_hidden_states=True).")
         prompt_embeds = outputs.hidden_states[-(num_hidden_layers_to_skip + 1)]
         crop_start = self.prompt_template_encode_start_idx
         if crop_start is not None and crop_start > 0:
@@ -282,6 +473,83 @@ class OmniWeavingPipeline(
         return (
             torch.clamp(prompt_embeds, min=-65504.0, max=65504.0).to(dtype=dtype),
             prompt_attention_mask,
+        )
+
+    def _get_mllm_prompt_embeds_i2v_vision(
+        self,
+        prompt: list[str],
+        device: torch.device,
+        dtype: torch.dtype,
+        images: list[PIL.Image.Image],
+        num_hidden_layers_to_skip: int = 2,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert self.qwen_processor is not None and self._process_vision_info is not None
+        system_block = {
+            "role": "system",
+            "content": [{"type": "text", "text": OMNIWEAVING_I2V_SYSTEM_MESSAGE}],
+        }
+        max_length = self.tokenizer_max_length + self._mllm_i2v_crop_start + self._mllm_i2v_vision_token_budget
+        batch_conversations: list[list[dict[str, Any]]] = []
+        text_for_proc: list[str] = []
+        tmax = self._mllm_i2v_qwen_thumbnail_max
+        for p, img in zip(prompt, images, strict=True):
+            txt = p if p else " "
+            vis = self._resize_pil_for_qwen_mllm(img, tmax)
+            user_block: dict[str, Any] = {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": vis},
+                    {"type": "text", "text": txt},
+                ],
+            }
+            conv = [system_block, user_block]
+            batch_conversations.append(conv)
+            text_for_proc.append(
+                self.qwen_processor.apply_chat_template(
+                    conv,
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+            )
+        assert self._process_vision_info is not None
+        image_inputs, video_inputs = self._process_vision_info(batch_conversations)
+        proc_inputs = self.qwen_processor(
+            text=text_for_proc,
+            images=image_inputs,
+            videos=video_inputs,
+            return_tensors="pt",
+            padding="max_length",
+            truncation=True,
+            max_length=max_length,
+        )
+        model_kw = self._mllm_inputs_to_device(dict(proc_inputs), device)
+        fwd_kw = self._mllm_forward_kwargs(model_kw)
+        with torch.no_grad():
+            outputs = self.mllm(
+                **fwd_kw,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+        if not outputs.hidden_states:
+            raise RuntimeError("Qwen2.5-VL forward did not return hidden_states (output_hidden_states=True).")
+        prompt_embeds = outputs.hidden_states[-(num_hidden_layers_to_skip + 1)]
+        attention_mask = fwd_kw["attention_mask"]
+        input_ids = fwd_kw["input_ids"]
+        crop_start = self._mllm_i2v_crop_start
+        if crop_start and crop_start > 0:
+            prompt_embeds = prompt_embeds[:, crop_start:]
+            attention_mask = attention_mask[:, crop_start:]
+            input_ids = input_ids[:, crop_start:]
+        if self._mllm_i2v_setclip and "pixel_values" in fwd_kw and input_ids.numel() > 0:
+            prompt_embeds, attention_mask = self._apply_omniweaving_mllm_setclip(
+                prompt_embeds,
+                attention_mask,
+                input_ids,
+                self._mllm_i2v_setclip_token_id,
+            )
+        return (
+            torch.clamp(prompt_embeds, min=-65504.0, max=65504.0).to(dtype=dtype),
+            attention_mask,
         )
 
     def _get_t5_2_prompt_embeds(
@@ -325,7 +593,10 @@ class OmniWeavingPipeline(
         do_classifier_free_guidance: bool = False,
     ) -> tuple:
         prompt = [prompt] if isinstance(prompt, str) else prompt
-        prompt_embeds, prompt_embeds_mask = self._get_mllm_prompt_embeds(prompt, device, dtype)
+        mllm_images: list[PIL.Image.Image] | None = None
+        if image is not None:
+            mllm_images = [image] * len(prompt)
+        prompt_embeds, prompt_embeds_mask = self._get_mllm_prompt_embeds(prompt, device, dtype, images=mllm_images)
         prompt_embeds_2, prompt_embeds_mask_2 = self._get_t5_2_prompt_embeds(prompt, device, dtype)
         prompt_embeds_mask = prompt_embeds_mask.to(dtype=dtype)
         prompt_embeds_mask_2 = prompt_embeds_mask_2.to(dtype=dtype)
@@ -341,10 +612,14 @@ class OmniWeavingPipeline(
                 if isinstance(negative_prompt, str)
                 else (negative_prompt if negative_prompt else [""])
             )
+            if mllm_images is not None and len(mllm_images) != len(neg_p):
+                neg_mllm_images = [mllm_images[0]] * len(neg_p)
+            else:
+                neg_mllm_images = mllm_images
             (
                 negative_prompt_embeds,
                 negative_prompt_embeds_mask,
-            ) = self._get_mllm_prompt_embeds(neg_p, device, dtype)
+            ) = self._get_mllm_prompt_embeds(neg_p, device, dtype, images=neg_mllm_images)
             (
                 negative_prompt_embeds_2,
                 negative_prompt_embeds_mask_2,
@@ -376,7 +651,12 @@ class OmniWeavingPipeline(
     def _get_image_latents(self, image: PIL.Image.Image, height: int, width: int, device: torch.device) -> torch.Tensor:
         image_tensor = (
             VideoProcessor(vae_scale_factor=self.vae_scale_factor_spatial)
-            .preprocess(image, height=height, width=width)
+            .preprocess(
+                image,
+                height=height,
+                width=width,
+                resize_mode=self._i2v_cond_resize_mode,
+            )
             .unsqueeze(2)
             .to(device=device, dtype=self.vae.dtype)
         )
@@ -463,6 +743,11 @@ class OmniWeavingPipeline(
         dtype = self.transformer.transformer_blocks[0].norm1.linear.weight.dtype
         if generator is None and req.sampling_params.seed is not None:
             generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
+
+        self.scheduler._shift = self._default_scheduler_shift
+        extra = getattr(req.sampling_params, "extra_args", None) or {}
+        if isinstance(extra, dict) and extra.get("flow_shift") is not None:
+            self.scheduler._shift = float(extra["flow_shift"])
 
         enc_tuple = self.encode_prompt(prompt, image, device, dtype, negative_prompt, do_cfg)
 

--- a/vllm_omni/diffusion/models/omniweaving/pipeline_omniweaving.py
+++ b/vllm_omni/diffusion/models/omniweaving/pipeline_omniweaving.py
@@ -69,6 +69,39 @@ def get_omniweaving_post_process_func(od_config: OmniDiffusionConfig):
     return get_hunyuan_video_15_post_process_func(od_config)
 
 
+def _resolve_single_conditioning_image(raw_image: Any) -> Any | None:
+    if isinstance(raw_image, (list, tuple)):
+        if len(raw_image) == 0:
+            return None
+        if len(raw_image) > 1:
+            raise ValueError(
+                "OmniWeaving currently supports at most one conditioning image in vLLM-Omni. "
+                "Multi-image OmniWeaving requests are not implemented yet."
+            )
+        return raw_image[0]
+    return raw_image
+
+
+def _offline_env_enabled() -> bool:
+    truthy = {"1", "ON", "TRUE", "YES"}
+    return any(
+        os.environ.get(name, "").strip().upper() in truthy
+        for name in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "DIFFUSERS_OFFLINE")
+    )
+
+
+def _resolve_cached_hub_snapshot_if_offline(model_path: str) -> str:
+    if os.path.exists(model_path) or not _offline_env_enabled():
+        return model_path
+    try:
+        from huggingface_hub import snapshot_download
+
+        return snapshot_download(model_path, local_files_only=True)
+    except Exception as e:
+        logger.debug("Could not resolve cached Hub snapshot for %s in offline mode: %s", model_path, e)
+        return model_path
+
+
 def get_omniweaving_pre_process_func(od_config: OmniDiffusionConfig):
     # Official aligned I2V 480p: 480×848 (26:15). Use the same area target when inferring WxH from the image.
     max_area = 480 * 848
@@ -85,8 +118,9 @@ def get_omniweaving_pre_process_func(od_config: OmniDiffusionConfig):
         raw_image = multi_modal_data.get("image", None)
         if raw_image is None:
             return req
-        if isinstance(raw_image, list):
-            raw_image = raw_image[0]
+        raw_image = _resolve_single_conditioning_image(raw_image)
+        if raw_image is None:
+            return req
 
         if isinstance(raw_image, str):
             image = PIL.Image.open(raw_image).convert("RGB")
@@ -143,9 +177,15 @@ class OmniWeavingPipeline(
         dtype = getattr(od_config, "dtype", torch.bfloat16)
         model = od_config.model
         local_files_only = os.path.exists(model)
-        self.qwen_path = self._resolve_external_model_path(od_config, "qwen_path", self.DEFAULT_QWEN_PATH)
-        self.siglip_path = self._resolve_external_model_path(od_config, "siglip_path", self.DEFAULT_SIGLIP_PATH)
-        self.t2v_path = self._resolve_external_model_path(od_config, "t2v_path", self.DEFAULT_T2V_PATH)
+        self.qwen_path = _resolve_cached_hub_snapshot_if_offline(
+            self._resolve_external_model_path(od_config, "qwen_path", self.DEFAULT_QWEN_PATH)
+        )
+        self.siglip_path = _resolve_cached_hub_snapshot_if_offline(
+            self._resolve_external_model_path(od_config, "siglip_path", self.DEFAULT_SIGLIP_PATH)
+        )
+        self.t2v_path = _resolve_cached_hub_snapshot_if_offline(
+            self._resolve_external_model_path(od_config, "t2v_path", self.DEFAULT_T2V_PATH)
+        )
         # Only force offline HF when the *Qwen* path itself is a local directory/file; do not use the
         # OmniWeaving checkpoint's local_files_only (that would break Hub IDs when the main model is local).
         qwen_local_files_only: bool = os.path.isdir(self.qwen_path)
@@ -758,7 +798,7 @@ class OmniWeavingPipeline(
                     device=device,
                     dtype=dtype,
                 )
-                glyph_text_embeds_mask = torch.ones((1, self.tokenizer_2_max_length), device=device, dtype=torch.int64)
+                glyph_text_embeds_mask = torch.zeros((1, self.tokenizer_2_max_length), device=device, dtype=torch.int64)
             else:
                 txt_tokens = self.tokenizer_2(
                     glyph_text,
@@ -936,8 +976,7 @@ class OmniWeavingPipeline(
         multi_modal_data = prompt_data.get("multi_modal_data", {}) if not isinstance(prompt_data, str) else {}
 
         raw_image = multi_modal_data.get("image", None)
-        if isinstance(raw_image, list):
-            raw_image = raw_image[0]
+        raw_image = _resolve_single_conditioning_image(raw_image)
 
         image = None
         if raw_image is not None:

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -271,6 +271,11 @@ _DIFFUSION_MODELS = {
         "pipeline_cosmos3",
         "Cosmos3OmniDiffusersPipeline",
     ),
+    "OmniWeavingPipeline": (
+        "omniweaving",
+        "pipeline_omniweaving",
+        "OmniWeavingPipeline",
+    ),
     "DiffusersAdapterPipeline": (
         "diffusers_adapter",
         "pipeline_diffusers_adapter",
@@ -506,6 +511,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "HunyuanVideo15ImageToVideoPipeline": "get_hunyuan_video_15_i2v_post_process_func",
     "MagiHumanPipeline": "get_magi_human_post_process_func",
     "OmniVoicePipeline": "get_omnivoice_post_process_func",
+    "OmniWeavingPipeline": "get_omniweaving_post_process_func",
     "DreamIDOmniPipeline": "get_dreamid_omni_post_process_func",
     "SenseNovaU1Pipeline": "get_sensenova_u1_post_process_func",
     "Cosmos3OmniDiffusersPipeline": "get_cosmos3_post_process_func",
@@ -534,6 +540,7 @@ _DIFFUSION_PRE_PROCESS_FUNCS = {
     "HunyuanImage3ForCausalMM": "get_hunyuan_image_3_pre_process_func",
     "MagiHumanPipeline": "get_magi_human_pre_process_func",
     "Cosmos3OmniDiffusersPipeline": "get_cosmos3_pre_process_func",
+    "OmniWeavingPipeline": "get_omniweaving_pre_process_func",
 }
 
 

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -538,7 +538,7 @@ class OmniBase(PDDisaggregationMixin):
         self.prom_metrics.set_running(running)
         self.prom_metrics.set_waiting(max(0, total - running))
 
-        images = getattr(engine_outputs, "images", []) if output_type == "image" else []
+        images = getattr(engine_outputs, "images", []) if output_type in {"image", "images", "video", "videos"} else []
         response_metrics: dict[str, Any] = {}
         stage_metrics: dict[str, dict[str, Any]] = {}
         rid_key = str(req_id)

--- a/vllm_omni/outputs.py
+++ b/vllm_omni/outputs.py
@@ -300,7 +300,7 @@ class OmniRequestOutput:
     @property
     def is_diffusion_output(self) -> bool:
         """Check if this is a diffusion model output."""
-        return len(self.images) > 0 or self.final_output_type == "image"
+        return len(self.images) > 0 or self.final_output_type in {"image", "images", "video", "videos"}
 
     @property
     def is_pipeline_output(self) -> bool:


### PR DESCRIPTION
### Description

This PR introduces native support for **OmniWeaving** (https://github.com/Tencent-Hunyuan/OmniWeaving), addressing the request to run its **MLLM (Qwen2.5-VL) + MMDiT (HunyuanVideo 1.5)** stack inside vLLM-Omni.

**The core challenge resolved:** OmniWeaving's public checkpoints use Tencent's **original Safetensors** layout (for example `double_blocks`, `single_blocks`, and split Q/K/V projections). The in-tree **HunyuanVideo 1.5** transformer path expects the vLLM/Diffusers-style module layout and fused parallel-linear projections. Naive loading drops or mismatches important weights, which prevents correct generations.

This PR does **not** require an offline one-shot conversion script. **`OmniWeavingPipeline`** applies on-the-fly weight translation while loading, then passes the translated tensors through the standard vLLM-Omni loader path.

On the data path, the pipeline wires together **Qwen2.5-VL**, **SigLIP**, **T5/ByT5**, the **HunyuanVideo 1.5 transformer**, and **VAE decode** for OmniWeaving T2V and single-image I2V requests. I2V uses the OmniWeaving-style system prompt and image/text conditioning flow used by the upstream implementation.

### Key implementations

1. **Native OmniWeaving pipeline**
   - Adds `vllm_omni/diffusion/models/omniweaving/pipeline_omniweaving.py`.
   - Registers `OmniWeavingPipeline` in the diffusion registry.
   - Supports T2V and single-image I2V through `Omni.generate`.
   - Rejects unsupported multi-image requests early with a clear `ValueError`.

2. **On-the-fly Tencent checkpoint translation**
   - Maps Tencent original transformer keys to the vLLM-Omni HunyuanVideo 1.5 module layout.
   - Fuses or remaps Q/K/V projections where the target vLLM modules expect fused parallel-linear weights.
   - Handles OmniWeaving deepstack projection weights.
   - Maps Tencent `single_blocks.*.attn_proj.*` weights to the single-attention output projection.

3. **HunyuanVideo 1.5 transformer compatibility**
   - Adds OmniWeaving deepstack text-state injection support.
   - Adds single-stream transformer block support used by OmniWeaving.
   - Adds a loadable `to_out.0` projection to `HunyuanVideo15SingleAttention`.
   - Keeps the current upstream quantization-related transformer changes after rebasing.

4. **Request preprocessing and output handling**
   - Normalizes single conditioning image inputs.
   - Treats an empty image list as no image.
   - Rejects multiple images before generation.
   - Treats `video` / `videos` final output types as diffusion outputs.
   - Updates E2E tests to unwrap `OmniRequestOutput` before checking generated diffusion payloads.

5. **Offline cache recovery**
   - When `HF_HUB_OFFLINE`, `TRANSFORMERS_OFFLINE`, or `DIFFUSERS_OFFLINE` is enabled, cached Hub model IDs are resolved to local snapshot paths when possible.
   - This avoids runtime `model_info()` calls for cached external dependencies.

6. **Docs, examples, and recipe**
   - Adds offline and online OmniWeaving examples.
   - Adds T2V/I2V task-specific wrappers.
   - Adds supported model and diffusion feature table entries.
   - Adds `vllm-omni[omniweaving]` optional dependency for `qwen-vl-utils`.
   - Adds `recipes/Tencent/OmniWeaving.md`.
   - Adds docs-build safeguards to avoid importing heavy ML modules during mkdocs API generation.

### Repro & examples (this PR)

Offline T2V:

```bash
python examples/offline_inference/omniweaving/end2end.py \
  --model Tencent-Hunyuan/OmniWeaving \
  --prompt "A cute bear wearing a Christmas hat moving naturally." \
  --tensor-parallel-size 1 \
  --output t2v_output.mp4
```

Offline I2V:

```bash
python examples/offline_inference/omniweaving/end2end.py \
  --model Tencent-Hunyuan/OmniWeaving \
  --prompt "Animate the reference image with gentle motion." \
  --image-path /path/to/reference.png \
  --tensor-parallel-size 1 \
  --output i2v_output.mp4
```

Task-specific wrappers:

```bash
python examples/offline_inference/text_to_video/text_to_video_omniweaving.py \
  --model Tencent-Hunyuan/OmniWeaving \
  --prompt "A cinematic robot walking through rain." \
  --output t2v_output.mp4

python examples/offline_inference/image_to_video/image_to_video_omniweaving.py \
  --model Tencent-Hunyuan/OmniWeaving \
  --image /path/to/reference.png \
  --prompt "Animate the image with a slow camera move." \
  --output i2v_output.mp4
```

Online serving:

```bash
MODEL=Tencent-Hunyuan/OmniWeaving \
PORT=8096 \
TENSOR_PARALLEL_SIZE=1 \
bash examples/online_serving/omniweaving/run_server.sh

python examples/online_serving/omniweaving/client.py
```

### Supported features (OmniWeaving path)

- **T2V** generation through the vLLM-Omni diffusion path.
- **Single-image I2V** generation through `multi_modal_data={"image": ...}`.
- **Negative prompts / CFG guidance** through the existing diffusion sampling params.
- **CFG parallel** through `cfg_parallel_size=2`.
- **Tensor parallel** for the diffusion stack, validated with `tensor_parallel_size=2`.
- **VAE tiling / slicing knobs** as exposed by the existing `Omni` / diffusion configuration.
- **Flow-shift alignment**:
  - T2V 480p default: `flow_shift=5.0`
  - I2V 480p default: `flow_shift=7.0`
- **Offline cache mode** for locally cached Qwen / SigLIP / T2V VAE dependencies.


Command:

```bash
GOPROXY=https://goproxy.cn,direct \
pre-commit run --files $(git diff --name-only upstream/main)
```

### Regression tests

Command:

```bash
pytest -q tests/diffusion/models/omniweaving/test_omniweaving_regressions.py
```

Result:

```text
6 passed, 17 warnings in 0.12s
```

Coverage:

- Reject multi-image OmniWeaving payloads before generation.
- Reject multi-image offline example inputs.
- Resolve cached Hub snapshots in offline mode.
- Ensure no-glyph ByT5 mask is inactive.
- Ensure HunyuanVideo single attention has a loadable output projection.

### Single-GPU E2E validation

Command:

```bash
LD_LIBRARY_PATH=/root/miniconda3/lib/python3.12/site-packages/nvidia/cu13/lib \
HF_HOME=/root/autodl-tmp/hf-cache \
HF_HUB_OFFLINE=1 \
TRANSFORMERS_OFFLINE=1 \
VLLM_NO_DEEP_GEMM=1 \
TORCHDYNAMO_DISABLE=1 \
TORCH_COMPILE_DISABLE=1 \
CUDA_VISIBLE_DEVICES=0 \
pytest -q -s tests/e2e/online_serving/test_omniweaving_expansion.py
```

Result:

```text
2 passed, 2 skipped
```

Passed:

- `test_omniweaving_t2v_expansion[1]`
- `test_omniweaving_i2v_expansion[1]`

Skipped on one GPU:

- `test_omniweaving_t2v_expansion[2]`
- `test_omniweaving_cfg_parallel[1]`

### Two-GPU E2E validation

Hardware:

```text
2x NVIDIA RTX PRO 6000 Blackwell Server Edition
```

Command:

```bash
LD_LIBRARY_PATH=/root/miniconda3/lib/python3.12/site-packages/nvidia/cu13/lib \
HF_HOME=/root/autodl-tmp/hf-cache \
HF_HUB_OFFLINE=1 \
TRANSFORMERS_OFFLINE=1 \
DIFFUSERS_OFFLINE=1 \
VLLM_NO_DEEP_GEMM=1 \
TORCHDYNAMO_DISABLE=1 \
TORCH_COMPILE_DISABLE=1 \
CUDA_VISIBLE_DEVICES=0,1 \
pytest -q -s \
  'tests/e2e/online_serving/test_omniweaving_expansion.py::test_omniweaving_t2v_expansion[2]' \
  'tests/e2e/online_serving/test_omniweaving_expansion.py::test_omniweaving_cfg_parallel[1]'
```

Result:

```text
2 passed, 8 warnings in 62.72s
```

Passed:

- `test_omniweaving_t2v_expansion[2]`
- `test_omniweaving_cfg_parallel[1]`

### Test videos

The following videos were uploaded from local qualitative OmniWeaving validation runs. They are included as visual smoke references for generated T2V/I2V behavior; the automated pass/fail signal for this PR is the E2E and regression test output above.

#### Test 1 — `t2v_1` (T2V, 832×480)

**Prompt:** Heavily armored knight at a cavern mouth, backlit by cold blue light as a silhouette.

https://github.com/user-attachments/assets/fd3fa5bc-9042-4090-9a4e-250ce95f0813

#### Test 2 — `t2v_4` (T2V + negative prompt)

**Prompt / negative:** Watercolor of three women toasting with wine, plus `Negative: blurry, low quality, distorted`.

https://github.com/user-attachments/assets/23d461ab-3fbc-411c-8d3c-1134f4b035cc

#### Test 3 — `t2v_5` (T2V)

**Prompt:** Night stadium, DJ in midfield, medium shot with long description.

https://github.com/user-attachments/assets/226fe103-7450-4da3-a5ac-9624a11ab91a

#### Test 4 — `i2v_480p` (I2V portrait 480×848)

**Input image / prompt:** Pikachu on a city street, waves, then camera tilts up to the night sky.

https://github.com/user-attachments/assets/3654a180-51b5-4d32-9f74-33e0de603421

#### Test 5 — `i2v_480p_t2v_grid` (I2V 832×480)

**Input image / prompt:** Hard cut to an arena; orbiting camera over the space.

https://github.com/user-attachments/assets/d199d056-8015-40c3-bdcc-c9cbe71794a6

### Feature support matrix (OmniWeaving)

| Feature | Status | Notes |
|--------|:------:|-------|
| T2V | ✅ | Supported through `OmniWeavingPipeline` and offline/online examples |
| Single-image I2V | ✅ | Supported through `multi_modal_data={"image": ...}` |
| Multi-image I2V / MI2V | ❌ | Rejected early; not implemented in this PR |
| Negative prompt / CFG | ✅ | Uses existing diffusion CFG path |
| CFG parallel | ✅ | Validated with `cfg_parallel_size=2` on two GPUs |
| Tensor parallel | ✅ | Validated with `tensor_parallel_size=2` |
| VAE tiling / slicing knobs | ✅ | Uses existing diffusion controls |
| Offline cached model loading | ✅ | Resolves cached Hub snapshots in offline mode |
| 720p benchmark matrix | ⏸️ | Not part of this PR's validation scope |
| Model recipe | ✅ | Added `recipes/Tencent/OmniWeaving.md` |

### TODO (follow-up)

- [ ] Optional: add a full long-form benchmark matrix for 480p / 720p T2V and I2V.
- [ ] Optional: add MI2V support when the vLLM-Omni request and model path are ready for multi-image conditioning.
- [ ] Optional: collect long-run quality/performance numbers against upstream `generate.py` on identical prompts and seeds.
- [x] Add native OmniWeaving pipeline.
- [x] Add offline and online examples.
- [x] Add docs, recipe, E2E tests, and regression tests.
