### PR TITLE
[Perf] Enhance benchmark script to support baseline thresholds and proved result handling

### DIFF
--- a/tests/dfx/perf/scripts/run_benchmark.py
+++ b/tests/dfx/perf/scripts/run_benchmark.py
@@ -56,6 +56,16 @@ def omni_server(request):
         print("OmniServer stopped")
 
 
+def _safe_filename_token(value: Any | None, *, default: str = "na") -> str:
+    """Make a single path segment safe for result filenames on common filesystems."""
+    if value is None:
+        return default
+    s = str(value).strip()
+    for bad in ("/", "\\", ":", "*", "?", '"', "<", ">", "|"):
+        s = s.replace(bad, "_")
+    return s if s else default
+
+
 def run_benchmark(
     args: list,
     test_name: str,
@@ -67,14 +77,20 @@ def run_benchmark(
     sweep_index: int | None = None,
     request_rate: Any | None = None,
     max_concurrency: Any | None = None,
+    random_input_len: Any | None = None,
+    random_output_len: Any | None = None,
 ) -> Any:
     """Run a single benchmark iteration and return the parsed result JSON.
 
     After ``vllm bench`` writes the JSON, ``result["baseline"]`` holds the same
     per-metric resolved thresholds as ``assert_result`` (via ``_baseline_thresholds_for_step``).
+    When ``random_input_len`` / ``random_output_len`` are set, they are also written into the result JSON;
+    omitted keys when not configured.
     """
     current_dt = datetime.now().strftime("%Y%m%d-%H%M%S")
-    result_filename = f"result_{test_name}_{dataset_name}_{flow}_{num_prompt}_{current_dt}.json"
+    ri = _safe_filename_token(random_input_len)
+    ro = _safe_filename_token(random_output_len)
+    result_filename = f"result_{test_name}_{dataset_name}_{flow}_{num_prompt}_in{ri}_out{ro}_{current_dt}.json"
     if "--result-filename" in args:
         print(f"The result file will be overwritten by {result_filename}")
     command = (
@@ -119,6 +135,10 @@ def run_benchmark(
         )
     else:
         result["baseline"] = {}
+    if random_input_len is not None:
+        result["random_input_len"] = random_input_len
+    if random_output_len is not None:
+        result["random_output_len"] = random_output_len
     with open(result_path, "w", encoding="utf-8") as f:
         json.dump(result, f, ensure_ascii=False, indent=2)
 
@@ -308,6 +328,8 @@ def test_performance_benchmark(omni_server, benchmark_params):
             sweep_index=i,
             request_rate=qps,
             max_concurrency=None,
+            random_input_len=params.get("random_input_len"),
+            random_output_len=params.get("random_output_len"),
         )
         assert_result(
             result,
@@ -330,6 +352,8 @@ def test_performance_benchmark(omni_server, benchmark_params):
             sweep_index=i,
             request_rate=None,
             max_concurrency=concurrency,
+            random_input_len=params.get("random_input_len"),
+            random_output_len=params.get("random_output_len"),
         )
         assert_result(
             result,

--- a/tests/dfx/perf/scripts/run_benchmark.py
+++ b/tests/dfx/perf/scripts/run_benchmark.py
@@ -62,8 +62,17 @@ def run_benchmark(
     flow,
     dataset_name: str,
     num_prompt,
+    *,
+    baseline_config: dict[str, Any] | None = None,
+    sweep_index: int | None = None,
+    request_rate: Any | None = None,
+    max_concurrency: Any | None = None,
 ) -> Any:
-    """Run a single benchmark iteration and return the parsed result JSON."""
+    """Run a single benchmark iteration and return the parsed result JSON.
+
+    After ``vllm bench`` writes the JSON, ``result["baseline"]`` holds the same
+    per-metric resolved thresholds as ``assert_result`` (via ``_baseline_thresholds_for_step``).
+    """
     current_dt = datetime.now().strftime("%Y%m%d-%H%M%S")
     result_filename = f"result_{test_name}_{dataset_name}_{flow}_{num_prompt}_{current_dt}.json"
     if "--result-filename" in args:
@@ -97,8 +106,22 @@ def run_benchmark(
     else:
         result_dir = "./"
 
-    with open(os.path.join(result_dir, result_filename), encoding="utf-8") as f:
+    result_path = os.path.join(result_dir, result_filename)
+    with open(result_path, encoding="utf-8") as f:
         result = json.load(f)
+
+    if baseline_config:
+        result["baseline"] = _baseline_thresholds_for_step(
+            baseline_config,
+            sweep_index=sweep_index,
+            request_rate=request_rate,
+            max_concurrency=max_concurrency,
+        )
+    else:
+        result["baseline"] = {}
+    with open(result_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
     return result
 
 
@@ -164,8 +187,31 @@ def _resolve_baseline_value(
             f"or request_rate={request_rate!r}; keys={list(baseline_raw.keys())!r}"
         )
     if isinstance(baseline_raw, (list, tuple)):
+        if sweep_index is None:
+            raise ValueError("list baseline requires sweep_index")
+        if not (0 <= sweep_index < len(baseline_raw)):
+            raise IndexError(f"baseline list len={len(baseline_raw)} has no index {sweep_index}")
         return baseline_raw[sweep_index]
     return baseline_raw
+
+
+def _baseline_thresholds_for_step(
+    baseline_data: dict[str, Any],
+    *,
+    sweep_index: int | None = None,
+    max_concurrency: Any = None,
+    request_rate: Any = None,
+) -> dict[str, Any]:
+    """Resolve ``test.json`` ``baseline`` block to one threshold per metric (same as ``assert_result``)."""
+    return {
+        metric_name: _resolve_baseline_value(
+            baseline_raw,
+            sweep_index=sweep_index,
+            max_concurrency=max_concurrency,
+            request_rate=request_rate,
+        )
+        for metric_name, baseline_raw in baseline_data.items()
+    }
 
 
 def assert_result(
@@ -179,14 +225,14 @@ def assert_result(
 ) -> None:
     assert result["completed"] == num_prompt, "Request failures exist"
     baseline_data = params.get("baseline", {})
-    for metric_name, baseline_raw in baseline_data.items():
+    thresholds = _baseline_thresholds_for_step(
+        baseline_data,
+        sweep_index=sweep_index,
+        max_concurrency=max_concurrency,
+        request_rate=request_rate,
+    )
+    for metric_name, baseline_value in thresholds.items():
         current_value = result[metric_name]
-        baseline_value = _resolve_baseline_value(
-            baseline_raw,
-            sweep_index=sweep_index,
-            max_concurrency=max_concurrency,
-            request_rate=request_rate,
-        )
         if "throughput" in metric_name:
             if current_value <= baseline_value:
                 print(
@@ -258,6 +304,10 @@ def test_performance_benchmark(omni_server, benchmark_params):
             flow=qps,
             dataset_name=dataset_name,
             num_prompt=num_prompt,
+            baseline_config=params.get("baseline"),
+            sweep_index=i,
+            request_rate=qps,
+            max_concurrency=None,
         )
         assert_result(
             result,
@@ -276,6 +326,10 @@ def test_performance_benchmark(omni_server, benchmark_params):
             flow=concurrency,
             dataset_name=dataset_name,
             num_prompt=num_prompt,
+            baseline_config=params.get("baseline"),
+            sweep_index=i,
+            request_rate=None,
+            max_concurrency=concurrency,
         )
         assert_result(
             result,

--- a/tests/dfx/stability/scripts/test_benchmark_stability.py
+++ b/tests/dfx/stability/scripts/test_benchmark_stability.py
@@ -112,6 +112,8 @@ def _run_one_benchmark_batch(
             flow=flow,
             dataset_name=dataset_name,
             num_prompt=num_prompts,
+            random_input_len=params.get("random_input_len"),
+            random_output_len=params.get("random_output_len"),
         )
         return result
     except (FileNotFoundError, OSError) as e:

--- a/tools/nightly/generate_nightly_perf_excel.py
+++ b/tools/nightly/generate_nightly_perf_excel.py
@@ -319,10 +319,10 @@ def _load_json_file(path: str) -> dict[str, Any] | list[Any] | None:
 
 
 def _parse_from_filename(filename: str) -> dict[str, Any]:
-    """Parse test-related metadata from a result JSON filename.
+    """Parse test-related metadata from a ``result_test_*.json`` filename.
 
-    Expected pattern (after prefix/suffix stripped):
-    <test_name>_<dataset_name>_<max_concurrency>_<num_prompts>_<timestamp>
+    Matches ``tests/dfx/perf/scripts/run_benchmark.py`` naming, including optional
+    ``_in{X}_out{Y}_`` before the timestamp (``na`` when unset).
     """
     name, ext = os.path.splitext(filename)
     if ext != ".json" or not name.startswith(_RESULT_JSON_PREFIX):
@@ -331,22 +331,42 @@ def _parse_from_filename(filename: str) -> dict[str, Any]:
     core = name[len(_RESULT_JSON_PREFIX) :]
     parts = core.split("_")
     if len(parts) < 5:
-        LOGGER.warning("filename '%s' does not match expected pattern, skip parsing test metadata", filename)
+        LOGGER.warning(
+            "filename '%s' does not match expected pattern (need >= 5 segments), skip parsing",
+            filename,
+        )
         return {}
 
-    timestamp = parts[-1]
-    num_prompts_str = parts[-2]
-    max_concurrency_str = parts[-3]
-    dataset_name = parts[-4]
-    test_name = "_".join(parts[:-4]) if parts[:-4] else ""
+    idx = len(parts) - 1
+    timestamp = parts[idx]
+    idx -= 1
 
     parsed: dict[str, Any] = {}
-
     if len(timestamp) >= 15:
         parsed["date"] = timestamp
 
-    if dataset_name in DATASET_NAME_ALLOWED:
-        parsed["dataset_name"] = dataset_name
+    if idx >= 0 and parts[idx].startswith("out"):
+        parsed["random_output_len"] = parts[idx][3:]
+        idx -= 1
+    if idx >= 0 and parts[idx].startswith("in"):
+        parsed["random_input_len"] = parts[idx][2:]
+        idx -= 1
+
+    if idx < 3:
+        LOGGER.warning(
+            "filename '%s' has too few segments after timestamp / optional in-out (idx=%s)",
+            filename,
+            idx,
+        )
+        return parsed
+
+    num_prompts_str = parts[idx]
+    idx -= 1
+    flow_str = parts[idx]
+    idx -= 1
+    dataset_name = parts[idx]
+    idx -= 1
+    test_name = "_".join(parts[: idx + 1]) if idx >= 0 else ""
 
     try:
         parsed["num_prompts"] = int(num_prompts_str)
@@ -354,12 +374,15 @@ def _parse_from_filename(filename: str) -> dict[str, Any]:
         pass
 
     try:
-        parsed["max_concurrency"] = int(max_concurrency_str)
+        parsed["max_concurrency"] = int(flow_str)
     except (TypeError, ValueError):
         pass
 
     if test_name:
         parsed["test_name"] = test_name
+
+    if dataset_name in DATASET_NAME_ALLOWED:
+        parsed["dataset_name"] = dataset_name
 
     return parsed
 

--- a/tools/nightly/generate_nightly_perf_html.py
+++ b/tools/nightly/generate_nightly_perf_html.py
@@ -67,6 +67,7 @@ def _load_json_file(path: str) -> dict[str, Any] | None:
 
 
 def _parse_from_filename(filename: str) -> dict[str, Any]:
+    """Parse ``result_test_*.json`` filenames; same rules as ``generate_nightly_perf_excel``."""
     name, ext = os.path.splitext(filename)
     if ext != ".json" or not name.startswith(_RESULT_JSON_PREFIX):
         return {}
@@ -75,32 +76,58 @@ def _parse_from_filename(filename: str) -> dict[str, Any]:
     parts = core.split("_")
     if len(parts) < 5:
         LOGGER.warning(
-            "filename '%s' does not match expected pattern, skip parsing test metadata",
+            "filename '%s' does not match expected pattern (need >= 5 segments), skip parsing",
             filename,
         )
         return {}
 
-    timestamp = parts[-1]
-    num_prompts_str = parts[-2]
-    max_concurrency_str = parts[-3]
-    dataset_name = parts[-4]
-    test_name = "_".join(parts[:-4]) if parts[:-4] else ""
+    idx = len(parts) - 1
+    timestamp = parts[idx]
+    idx -= 1
 
     parsed: dict[str, Any] = {}
     if len(timestamp) >= 15:
         parsed["date"] = timestamp
-    if dataset_name in ("random", "random-mm"):
-        parsed["dataset_name"] = dataset_name
+
+    if idx >= 0 and parts[idx].startswith("out"):
+        parsed["random_output_len"] = parts[idx][3:]
+        idx -= 1
+    if idx >= 0 and parts[idx].startswith("in"):
+        parsed["random_input_len"] = parts[idx][2:]
+        idx -= 1
+
+    if idx < 3:
+        LOGGER.warning(
+            "filename '%s' has too few segments after timestamp / optional in-out (idx=%s)",
+            filename,
+            idx,
+        )
+        return parsed
+
+    num_prompts_str = parts[idx]
+    idx -= 1
+    flow_str = parts[idx]
+    idx -= 1
+    dataset_name = parts[idx]
+    idx -= 1
+    test_name = "_".join(parts[: idx + 1]) if idx >= 0 else ""
+
     try:
         parsed["num_prompts"] = int(num_prompts_str)
     except (TypeError, ValueError):
         pass
+
     try:
-        parsed["max_concurrency"] = int(max_concurrency_str)
+        parsed["max_concurrency"] = int(flow_str)
     except (TypeError, ValueError):
         pass
+
     if test_name:
         parsed["test_name"] = test_name
+
+    if dataset_name in ("random", "random-mm"):
+        parsed["dataset_name"] = dataset_name
+
     return parsed
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Backfill the baseline results to support subsequent performance dashboard display.
## Test Plan
1.run in local: `pytest -s -v tests/dfx/perf/scripts/run_benchmark.py`
2.run in ci
## Test Result
1.result_test_qwen3_omni_chunk_random_1_4_in2500_out900_20260414-115141.json:
```
{
  "date": "20260414-115421",
  "endpoint_type": "openai-chat-omni",
  "backend": "openai-chat-omni",
  "label": null,
  "model_id": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
  "tokenizer_id": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
  "num_prompts": 4,
  "request_rate": "inf",
  "burstiness": 1.0,
  "max_concurrency": 1,
  "duration": 96.41330943070352,
  "completed": 4,
  "failed": 0,
  "total_input_tokens": 10056,
  "total_output_tokens": 2089,
  "request_throughput": 0.04148804790146713,
  "request_goodput": null,
  "output_throughput": 21.667133016541207,
  "total_token_throughput": 125.96808544082957,
  "total_audio_duration_s": 610.248,
  "total_audio_frames": 14645955,
  "audio_throughput": 6.329499563943628,
  "max_output_tokens_per_s": 121.0,
  "max_concurrent_requests": 2,
  "rtfx": 0.0,
  "mean_ttft_ms": 190.51335100084543,
  "median_ttft_ms": 188.03051859140396,
  "p99_ttft_ms": 204.03383573517203,
  "mean_tpot_ms": 16.716146084536746,
  "median_tpot_ms": 15.577114351130701,
  "p99_tpot_ms": 23.77890689445718,
  "mean_itl_ms": 9.042201210553857,
  "median_itl_ms": 7.153265178203583,
  "p99_itl_ms": 119.36150997877121,
  "mean_e2el_ms": 24102.67499741167,
  "median_e2el_ms": 20842.348203994334,
  "p99_e2el_ms": 45948.880513571195,
  "mean_audio_rtf": 0.15867145652317455,
  "median_audio_rtf": 0.1585054270144013,
  "p99_audio_rtf": 0.16161648396797398,
  "mean_audio_ttfp_ms": 677.8255556710064,
  "median_audio_ttfp_ms": 669.5264661684632,
  "p99_audio_ttfp_ms": 708.548574373126,
  "mean_audio_duration_s": 152.562,
  "median_audio_duration_s": 132.199,
  "p99_audio_duration_s": 292.24005,
  "baseline": {
    "mean_ttft_ms": 1000,
    "mean_audio_ttfp_ms": 1000,
    "mean_audio_rtf": 0.2
  },
  "random_input_len": 2500,
  "random_output_len": 900
}
```
2.
<img width="500" height="35" alt="image" src="https://github.com/user-attachments/assets/e8f0ff87-4004-4a27-b694-0461726d5f42" />
<img width="1261" height="45" alt="image" src="https://github.com/user-attachments/assets/b5d94937-a08f-4718-8288-27e9b474eaf5" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
