### PR TITLE
[BugFix] Fix NoneType' object has no attribute 'detach'

### DIFF
--- a/tests/e2e/online_serving/test_qwen3_omni.py
+++ b/tests/e2e/online_serving/test_qwen3_omni.py
@@ -120,7 +120,7 @@ def test_mix_to_text_audio_001(omni_server, openai_client) -> None:
     }
 
     # Test single completion
-    openai_client.send_omni_request(request_config)
+    openai_client.send_omni_request(request_config, request_num=get_max_batch_size())
 
 
 @pytest.mark.advanced_model

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -797,12 +797,11 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                     elif isinstance(v, dict):
                         mm_payload[k] = {sk: sv[start:end].contiguous() for sk, sv in v.items()}
                     elif isinstance(v, list):
-                        if idx < len(v):
-                            element = v[idx]
-                            if element is not None:
-                                if isinstance(element, torch.Tensor):
-                                    element = element.clone()
-                                mm_payload[k] = element
+                        element = v[idx] if idx < len(v) else v[0]
+                        if element is not None:
+                            if isinstance(element, torch.Tensor):
+                                element = element.clone()
+                            mm_payload[k] = element
                         # Skip None elements: msgspec cannot serialize None
                         # in dict[str, torch.Tensor] typed fields.
                     elif isinstance(v, torch.Tensor):


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

fix https://github.com/vllm-project/vllm-omni/issues/2788

```
k:tts_bos_embed, v:[tensor([[[ 0.0003, -0.0022,  0.0005,  ...,  0.0018,  0.0003,  0.0007]]],
(Worker pid=77251) INFO 04-14 12:29:51 [gpu_ar_model_runner.py:800]        dtype=torch.bfloat16)], idx:3, len(v):1
```
When the key is something like tts_bos_embed, idx will be greater than len(v), causing the key to not be assigned a value, thus resulting in None when detaching.

## Test Plan

```
vllm bench serve \
    --omni \
  --dataset-name random \
  --port 28889 \
  --max-concurrency 4 \
  --model /home/models/Qwen/Qwen3-Omni-30B-A3B-Instruct \
  --endpoint /v1/chat/completions \
  --backend openai-chat-omni \
  --num-prompts 8 \
  --random-input-len 2500 \
  --ignore-eos \
  --percentile-metrics ttft,tpot,itl,e2el,audio_ttfp,audio_rtf \
  --random-output-len 900 \
  --extra_body '{"modalities": ["text", "audio"]}'
```
## Test Result

```
============ Serving Benchmark Result ============
Successful requests:                     8
Failed requests:                         0
Maximum request concurrency:             4
Benchmark duration (s):                  199.45
Request throughput (req/s):              0.04
Peak concurrent requests:                5.00
----------------End-to-end Latency----------------
Mean E2EL (ms):                          87468.74
Median E2EL (ms):                        87588.02
P99 E2EL (ms):                           106065.05
================== Text Result ===================
Total input tokens:                      20112
Total generated tokens:                  6304
Output token throughput (tok/s):         31.61
Peak output token throughput (tok/s):    206.00
Peak concurrent requests:                5.00
Total Token throughput (tok/s):          132.45
---------------Time to First Token----------------
Mean TTFT (ms):                          1393.74
Median TTFT (ms):                        512.06
P99 TTFT (ms):                           3004.43
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          27.19
Median TPOT (ms):                        22.15
P99 TPOT (ms):                           52.22
---------------Inter-token Latency----------------
Mean ITL (ms):                           21.44
Median ITL (ms):                         0.01
P99 ITL (ms):                            330.02
================== Audio Result ==================
Total audio duration generated(s):       2153.29
Total audio frames generated:            51678825
Audio throughput(audio duration/s):      10.80
---------------Time to First Packet---------------
Mean AUDIO_TTFP (ms):                    3382.07
Median AUDIO_TTFP (ms):                  3047.07
P99 AUDIO_TTFP (ms):                     5916.30
-----------------Real Time Factor-----------------
Mean AUDIO_RTF:                          0.33
Median AUDIO_RTF:                        0.33
P99 AUDIO_RTF:                           0.34
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
