### PR TITLE
[BugFix] Fix AR scheduler and chunk transfer adapter for MRV2 with Qwen3_tts

### DIFF
--- a/examples/offline_inference/qwen3_tts/end2end.py
+++ b/examples/offline_inference/qwen3_tts/end2end.py
@@ -119,17 +119,18 @@ def _estimate_prompt_len(
         return 2048
 
 
-def get_custom_voice_query(use_batch_sample: bool = False) -> QueryResult:
+def get_custom_voice_query(use_batch_sample: bool = False, model_name: str | None = None) -> QueryResult:
     """Build CustomVoice sample inputs.
 
     Args:
         use_batch_sample: When True, return a batch of prompts; otherwise a single prompt.
+        model_name: Override the default HF model path (e.g. with a local path).
 
     Returns:
         QueryResult with Omni inputs and the CustomVoice model path.
     """
     task_type = "CustomVoice"
-    model_name = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+    model_name = model_name or "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
     if use_batch_sample:
         texts = [
             "其实我真的有发现，我是一个特别善于观察别人情绪的人。",
@@ -180,17 +181,18 @@ def get_custom_voice_query(use_batch_sample: bool = False) -> QueryResult:
     )
 
 
-def get_voice_design_query(use_batch_sample: bool = False) -> QueryResult:
+def get_voice_design_query(use_batch_sample: bool = False, model_name: str | None = None) -> QueryResult:
     """Build VoiceDesign sample inputs.
 
     Args:
         use_batch_sample: When True, return a batch of prompts; otherwise a single prompt.
+        model_name: Override the default HF model path (e.g. with a local path).
 
     Returns:
         QueryResult with Omni inputs and the VoiceDesign model path.
     """
     task_type = "VoiceDesign"
-    model_name = "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign"
+    model_name = model_name or "Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign"
     if use_batch_sample:
         texts = [
             "哥哥，你回来啦，人家等了你好久好久了，要抱抱！",
@@ -239,18 +241,19 @@ def get_voice_design_query(use_batch_sample: bool = False) -> QueryResult:
     )
 
 
-def get_base_query(use_batch_sample: bool = False, mode_tag: str = "icl") -> QueryResult:
+def get_base_query(use_batch_sample: bool = False, mode_tag: str = "icl", model_name: str | None = None) -> QueryResult:
     """Build Base (voice clone) sample inputs.
 
     Args:
         use_batch_sample: When True, return a batch of prompts (Case 2).
         mode_tag: "icl" or "xvec_only" to control x_vector_only_mode behavior.
+        model_name: Override the default HF model path (e.g. with a local path).
 
     Returns:
         QueryResult with Omni inputs and the Base model path.
     """
     task_type = "Base"
-    model_name = "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    model_name = model_name or "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
     ref_audio_path_1 = "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-TTS-Repo/clone_2.wav"
     ref_audio_single = ref_audio_path_1
     ref_text_single = (
@@ -319,10 +322,11 @@ def _build_inputs(args) -> tuple[str, list]:
         )
 
     query_func = query_map[args.query_type]
+    model_override = args.model if args.model else None
     if args.query_type in {"CustomVoice", "VoiceDesign"}:
-        query_result = query_func(use_batch_sample=args.use_batch_sample)
+        query_result = query_func(use_batch_sample=args.use_batch_sample, model_name=model_override)
     elif args.query_type == "Base":
-        query_result = query_func(use_batch_sample=args.use_batch_sample, mode_tag=args.mode_tag)
+        query_result = query_func(use_batch_sample=args.use_batch_sample, mode_tag=args.mode_tag, model_name=model_override)
     else:
         query_result = query_func()
 

--- a/tests/examples/offline_inference/test_qwen3_tts_mr_v2.py
+++ b/tests/examples/offline_inference/test_qwen3_tts_mr_v2.py
@@ -52,7 +52,7 @@ def _assert_wav_output(output_dir: str) -> None:
 
 
 @pytest.mark.omni
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
 def test_custom_voice():
     """CustomVoice single prompt — the most common TTS use case."""
     with tempfile.TemporaryDirectory() as output_dir:
@@ -71,7 +71,7 @@ def test_custom_voice():
 
 
 @pytest.mark.omni
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
 def test_voice_design():
     """VoiceDesign single prompt — generates speech from a voice description."""
     with tempfile.TemporaryDirectory() as output_dir:
@@ -90,7 +90,7 @@ def test_voice_design():
 
 
 @pytest.mark.omni
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
 def test_base_icl():
     """Base ICL mode — voice cloning with reference audio and transcript."""
     with tempfile.TemporaryDirectory() as output_dir:
@@ -111,7 +111,7 @@ def test_base_icl():
 
 
 @pytest.mark.omni
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
 def test_custom_voice_streaming():
     """CustomVoice streaming — exercises the AsyncOmni streaming path."""
     with tempfile.TemporaryDirectory() as output_dir:

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from time import time
@@ -26,6 +27,8 @@ from vllm_omni.engine.serialization import deserialize_additional_information
 
 logger = init_logger(__name__)
 
+VLLM_OMNI_USE_V2_RUNNER = bool(int(os.environ.get("VLLM_OMNI_USE_V2_RUNNER", "0")))
+
 
 @dataclass
 class KVCacheTransferData:
@@ -49,6 +52,12 @@ class OmniARScheduler(VLLMScheduler):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Sync v2 model runner flag — same pattern as gpu_ar_worker.py:98.
+        # Upstream Scheduler.__init__ reads envs.VLLM_USE_V2_MODEL_RUNNER,
+        # but in subprocess contexts that env var may not be set yet.
+        # This ensures schedule() populates prefill_token_ids correctly.
+        if VLLM_OMNI_USE_V2_RUNNER and not self.use_v2_model_runner:
+            self.use_v2_model_runner = True
         # Track requests that need KV cache transfer when finished
         # Value is {"seq_len": int, "block_ids": list[int]}
         self.requests_needing_kv_transfer: dict[str, dict[str, Any]] = {}
@@ -213,6 +222,8 @@ class OmniARScheduler(VLLMScheduler):
                     lora_request=nr.lora_request,
                     # Enrich with omni payloads from the live request object
                     prompt_embeds=(getattr(request, "prompt_embeds", None) if request else None),
+                    # Propagate prefill_token_ids from base scheduler for v2 model runner
+                    prefill_token_ids=getattr(nr, "prefill_token_ids", None),
                     additional_information=(getattr(request, "additional_information", None) if request else None),
                 )
                 new_list.append(omni_nr)

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -1,3 +1,4 @@
+import os
 import time
 from collections import defaultdict
 
@@ -24,10 +25,14 @@ from vllm_omni.outputs import OmniModelRunnerOutput
 
 logger = init_logger(__name__)
 
+VLLM_OMNI_USE_V2_RUNNER = bool(int(os.environ.get("VLLM_OMNI_USE_V2_RUNNER", "0")))
+
 
 class OmniGenerationScheduler(VLLMScheduler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if VLLM_OMNI_USE_V2_RUNNER and not self.use_v2_model_runner:
+            self.use_v2_model_runner = True
         model_config = self.vllm_config.model_config
         self.chunk_transfer_adapter = None
         if getattr(model_config, "async_chunk", False):
@@ -303,6 +308,8 @@ class OmniGenerationScheduler(VLLMScheduler):
                     lora_request=nr.lora_request,
                     # Enrich with omni payloads from the live request object
                     prompt_embeds=(getattr(request, "prompt_embeds", None) if request else None),
+                    # Propagate prefill_token_ids from base scheduler for v2 model runner
+                    prefill_token_ids=getattr(nr, "prefill_token_ids", None),
                     additional_information=(getattr(request, "additional_information", None) if request else None),
                 )
                 new_list.append(omni_nr)

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -160,6 +160,9 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
                 new_ids = payload_data.get("code_predictor_codes", [])
                 request.prompt_token_ids = new_ids
+                # Keep _all_token_ids in sync so the v2 model runner's
+                # prefill_token_ids length matches prompt_token_ids.
+                request._all_token_ids = list(new_ids)
                 # Preserve previously attached request metadata (e.g. prompt
                 # conditioning tensors) and update only per-chunk fields.
                 prev_info = getattr(request, "additional_information", None)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

### Problem
 
When using v2 model runner, `OmniARScheduler.schedule()` calls `super().schedule()`, which returns `NewRequestData` with `prefill_token_ids` already set. However, the AR scheduler's fallback path rewraps it into `OmniNewRequestData` **without propagating `prefill_token_ids`**, causing it to be `None`. The v2 `GPUModelRunner.add_requests()` then hits:

```
assert new_req_data.prefill_token_ids is not None
```
 
Additionally, `chunk_transfer_adapter.py` had a related issue: when a new chunk arrives, `request.prompt_token_ids` was replaced with new codes (32 tokens), but `request._all_token_ids` was never synced and still held the old placeholder (1 token). This caused `prefill_token_ids` (derived from `_all_token_ids`) to be shorter than `prompt_token_ids`, triggering failures in the v2 model runner.
 
---
 
### Root Cause
 
Two code paths exist in `omni_generation_scheduler.py`:
 
1. **Fast path (line 218–227):** Correctly passes `prefill_token_ids` via `getattr(req, "_all_token_ids", None)`.
 
2. **Fallback path (line 291–313):** Rewraps `NewRequestData` into `OmniNewRequestData` but **does NOT** propagate `prefill_token_ids` — it was missing from the constructor call.
 
By contrast, `OmniGenerationScheduler` handles this correctly via `OmniNewRequestData.from_request()` with explicit `prefill_token_ids` passing, while the AR scheduler constructs fields manually and missed this one.
 
---
 
### Fix
 
1. **`omni_generation_scheduler.py:312`** — Propagate `prefill_token_ids` in the fallback rewrapping path, consistent with the fast path and the generation scheduler.
 
2. **`chunk_transfer_adapter.py:163`** — Sync `_all_token_ids` with `prompt_token_ids` when a chunk updates the request, ensuring `prefill_token_ids` stays consistent.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)

cc @Sy0307 