### PR TITLE
[Test] Add performance tests for Qwen-Image-Layered model

### DIFF
--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -415,7 +415,9 @@ steps:
             EXIT2=$$?
             pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_qwen_image_edit_2509_vllm_omni.json
             EXIT3=$$?
-            if [ $$EXIT1 -eq 0 ] || [ $$EXIT2 -eq 0 ] || [ $$EXIT3 -eq 0 ]; then
+            pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_qwen_image_layered_vllm_omni.json
+            EXIT4=$$?
+            if [ $$EXIT1 -eq 0 ] || [ $$EXIT2 -eq 0 ] || [ $$EXIT3 -eq 0 ] || [ $$EXIT4 -eq 0 ]; then
               buildkite-agent artifact upload "tests/dfx/perf/results/diffusion_result_*.json"
               buildkite-agent artifact upload "tests/dfx/perf/results/logs/*.log"
             fi

--- a/tests/dfx/perf/tests/test_qwen_image_layered_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_layered_vllm_omni.json
@@ -23,8 +23,8 @@
                 "baseline": {
                     "throughput_qps": 0.02,
                     "latency_mean": 40.0,
-                    "peak_memory_mb_max": 82000,
-                    "peak_memory_mb_mean": 82000
+                    "peak_memory_mb_max": 70000,
+                    "peak_memory_mb_mean": 70000
                 }
             },
             {
@@ -39,9 +39,9 @@
                 "enable-negative-prompt": true,
                 "baseline": {
                     "throughput_qps": 0.005,
-                    "latency_mean": 150.0,
-                    "peak_memory_mb_max": 90000,
-                    "peak_memory_mb_mean": 90000
+                    "latency_mean": 80.0,
+                    "peak_memory_mb_max": 70000,
+                    "peak_memory_mb_mean": 70000
                 }
             }
         ]

--- a/tests/dfx/perf/tests/test_qwen_image_layered_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_layered_vllm_omni.json
@@ -1,0 +1,49 @@
+[
+    {
+        "test_name": "test_qwen_image_layered_single_device",
+        "description": "Single-device baseline",
+        "server_type": "vllm-omni",
+        "server_params": {
+            "model": "Qwen/Qwen-Image-Layered",
+            "serve_args": {
+                "enable-diffusion-pipeline-profiler": true
+            }
+        },
+        "benchmark_params": [
+            {
+                "name": "640x640_steps20_i2i",
+                "dataset": "random",
+                "task": "i2i",
+                "width": 640,
+                "height": 640,
+                "num-inference-steps": 20,
+                "num-prompts": 10,
+                "max-concurrency": 1,
+                "enable-negative-prompt": true,
+                "baseline": {
+                    "throughput_qps": 0.02,
+                    "latency_mean": 40.0,
+                    "peak_memory_mb_max": 82000,
+                    "peak_memory_mb_mean": 82000
+                }
+            },
+            {
+                "name": "1024x1024_steps35_i2i",
+                "dataset": "random",
+                "task": "i2i",
+                "width": 1024,
+                "height": 1024,
+                "num-inference-steps": 35,
+                "num-prompts": 10,
+                "max-concurrency": 1,
+                "enable-negative-prompt": true,
+                "baseline": {
+                    "throughput_qps": 0.005,
+                    "latency_mean": 150.0,
+                    "peak_memory_mb_max": 90000,
+                    "peak_memory_mb_mean": 90000
+                }
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This pull request adds a new performance test configuration for the Qwen Image Layered model using the vLLM-Omni server. The test includes single-device baselines for two different image sizes and step counts, with detailed benchmark parameters and expected baseline metrics.

Performance testing:

* Added `test_qwen_image_layered_single_device` to `test_qwen_image_layered_vllm_omni.json`, providing single-device performance baselines for the Qwen Image Layered model on the vLLM-Omni server, including two benchmark scenarios with different image resolutions and inference steps.