### PR TITLE
[WIP] [Refactor]Add Base Class for Diffusion Pipelines

### DIFF
--- a/tests/diffusion/inputs/test_data.py
+++ b/tests/diffusion/inputs/test_data.py
@@ -1,0 +1,90 @@
+"""
+Tests for sampling parameter override behaviors.
+"""
+
+from copy import deepcopy
+
+from vllm_omni.inputs.data import DiffusionParamOverrides, OmniDiffusionSamplingParams
+
+
+def test_merge_nothing():
+    """Ensure that merging nothing doesn't break anything."""
+    user_params = OmniDiffusionSamplingParams()
+    overrides = DiffusionParamOverrides()
+    orig_params = deepcopy(user_params)
+    user_params.merge_with_def_params(overrides)
+    assert user_params.__dict__ == orig_params.__dict__
+    assert user_params._init_kwargs == set()
+
+
+def test_merge_unset():
+    """Ensure that we can override fields that are unset."""
+    default_steps = 777
+    user_params = OmniDiffusionSamplingParams()
+    overrides = DiffusionParamOverrides(num_inference_steps=default_steps)
+    user_params.merge_with_def_params(overrides)
+    assert user_params.num_inference_steps == 777
+    assert user_params._init_kwargs == set()
+
+
+def test_merge_priority():
+    """Ensure that explicitly passed values won't be overridden by pipelines."""
+    user_steps = 888
+    model_steps = 777
+    user_params = OmniDiffusionSamplingParams(
+        num_inference_steps=user_steps,
+    )
+    overrides = DiffusionParamOverrides(num_inference_steps=model_steps)
+    user_params.merge_with_def_params(overrides)
+    assert user_params.num_inference_steps == user_steps
+    assert user_params._init_kwargs == {"num_inference_steps"}
+
+
+def test_merge_multiple():
+    """Ensure that we can merge over truthy or falsy default values."""
+    model_steps = 888
+    model_resolution = 320
+    user_params = OmniDiffusionSamplingParams()
+    overrides = DiffusionParamOverrides(
+        num_inference_steps=model_steps,  # Falsy (None) by default
+        resolution=model_resolution,  # 640 by default
+    )
+    user_params.merge_with_def_params(overrides)
+    assert user_params.num_inference_steps == model_steps
+    assert user_params.resolution == model_resolution
+    assert user_params._init_kwargs == set()
+
+
+def test_hierarchical_merge_complex():
+    """Tests merge priority with multiple values."""
+    user_steps = 100
+    user_height = 100
+    user_width = 100
+    model_steps = 888  # clobbered by user steps
+    model_resolution = 320
+
+    user_params = OmniDiffusionSamplingParams(
+        num_inference_steps=user_steps,
+        height=user_height,
+        width=user_width,
+    )
+    overrides = DiffusionParamOverrides(
+        num_inference_steps=model_steps,  # lower priority than user param
+        resolution=model_resolution,
+    )
+    user_params.merge_with_def_params(overrides)
+    assert user_params.num_inference_steps == user_steps
+    assert user_params.height == user_height
+    assert user_params.width == user_width
+    assert user_params.resolution == model_resolution
+    assert user_params._init_kwargs == {"num_inference_steps", "height", "width"}
+
+
+def test_can_pass_falsy_override():
+    user_params = OmniDiffusionSamplingParams(num_inference_steps=None)
+    overrides = DiffusionParamOverrides(
+        num_inference_steps=100,
+    )
+    user_params.merge_with_def_params(overrides)
+    assert user_params.num_inference_steps is None
+    assert user_params._init_kwargs == {"num_inference_steps"}

--- a/tests/diffusion/models/test_base.py
+++ b/tests/diffusion/models/test_base.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Fast interface checks for all Diffusion pipelines."""
 
+from typing import cast
+
 import pytest
 
 from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
@@ -56,3 +58,31 @@ def test_pipeline_sampling_params_are_valid(pipeline_type):
     for attr_name, val in defaults.validated_overrides.items():
         assert hasattr(params, attr_name)
         assert getattr(params, attr_name) == val
+
+
+@pytest.mark.parametrize("pipeline_type", TEST_PIPELINES)
+def test_merge_sampling_params(pipeline_type):
+    """Test sampling param / override merging."""
+    USER_STEPS = 999  # overrides all pipeline defaults
+    pipe_class = DiffusionModelRegistry._try_load_model_cls(pipeline_type)
+    params = OmniDiffusionSamplingParams(num_inference_steps=USER_STEPS)
+    assert pipe_class is not None
+
+    # Create an uninitialized instance; this is easier than going through init/model load
+    # since the vast majority of models do not use instance vars in their default params
+    pipe_instance = cast(VllmDiffusionPipeline, object.__new__(pipe_class))
+
+    # Patch instance variables for any pipelines that do need it
+    if pipeline_type in INSTANCE_VAR_MOCKS:
+        for attr_name, attr_value in INSTANCE_VAR_MOCKS[pipeline_type].items():
+            setattr(pipe_instance, attr_name, attr_value)
+
+    defaults = pipe_instance.sampling_param_defaults
+    params.merge_with_def_params(defaults)
+
+    # Ensure the user override is prioritized for all models
+    assert params.num_inference_steps == USER_STEPS
+    # For every other property, it should match the pipeline defaults since user didn't pass it
+    for attr_name, val in defaults.validated_overrides.items():
+        if attr_name != "num_inference_steps":
+            assert getattr(params, attr_name) == val

--- a/tests/diffusion/models/test_base.py
+++ b/tests/diffusion/models/test_base.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fast interface checks for all Diffusion pipelines."""
+
+import pytest
+
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
+from vllm_omni.diffusion.registry import DiffusionModelRegistry
+from vllm_omni.inputs.data import DiffusionParamOverrides, OmniDiffusionSamplingParams
+
+# Pipelines to omit from common tests; this should be done sparingly
+# as the tests are generic, and only added for
+SKIP_PIPELINES = ["DreamIDOmniPipeline"]
+
+# Instance variables that need to be mocked for sampling_param_defaults
+INSTANCE_VAR_MOCKS = {
+    "LTX2Pipeline": {"tokenizer_max_length": 512},
+    "LTX2ImageToVideoPipeline": {"tokenizer_max_length": 512},
+}
+
+TEST_PIPELINES = [pipe for pipe in DiffusionModelRegistry.models.keys() if pipe not in SKIP_PIPELINES]
+
+
+@pytest.mark.parametrize("pipeline_type", TEST_PIPELINES)
+def test_pipelines_are_vllm_diffusion_pipeline(pipeline_type):
+    """Ensure all pipelines are instances of VllmDiffusionPipeline"""
+    pipe_class = DiffusionModelRegistry._try_load_model_cls(pipeline_type)
+    assert pipe_class is not None
+    assert issubclass(pipe_class, VllmDiffusionPipeline)
+
+
+@pytest.mark.parametrize("pipeline_type", TEST_PIPELINES)
+def test_pipeline_sampling_params_are_valid(pipeline_type):
+    """Ensure all pipelines define sampling_param_defaults with valid param kwargs."""
+    pipe_class = DiffusionModelRegistry._try_load_model_cls(pipeline_type)
+    assert pipe_class is not None
+
+    # Create an uninitialized instance; this is easier than going through init/model load
+    # since the vast majority of models do not use instance vars in their default params
+    pipe_instance = object.__new__(pipe_class)
+
+    # Patch instance variables for any pipelines that do need it
+    if pipeline_type in INSTANCE_VAR_MOCKS:
+        for attr_name, attr_value in INSTANCE_VAR_MOCKS[pipeline_type].items():
+            setattr(pipe_instance, attr_name, attr_value)
+
+    # Verify sampling_param_defaults exists and has at least one key, since at a
+    # minimum every class will inherit num_inference_steps from the base class
+    defaults = pipe_instance.sampling_param_defaults
+    assert isinstance(defaults, DiffusionParamOverrides)
+    assert hasattr(defaults, "validated_overrides")
+    assert len(defaults.validated_overrides) > 0
+
+    # Ensure we can create a diffusion sampling params object (i.e., kwargs are valid)
+    params = OmniDiffusionSamplingParams(**defaults.validated_overrides)
+    for attr_name, val in defaults.validated_overrides.items():
+        assert hasattr(params, attr_name)
+        assert getattr(params, attr_name) == val

--- a/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
+++ b/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
@@ -26,6 +26,7 @@ from vllm.transformers_utils.configs.bagel import BagelConfig
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.inputs.data import DiffusionParamOverrides
@@ -149,7 +150,7 @@ class SiglipNaViTWrapper(nn.Module):
         return outputs.last_hidden_state.squeeze(0)
 
 
-class BagelPipeline(nn.Module, DiffusionPipelineProfilerMixin):
+class BagelPipeline(VllmDiffusionPipeline, DiffusionPipelineProfilerMixin):
     """Bagel generation pipeline (MoT) packaged for vllm-omni diffusion engine.
 
     This pipeline is self-contained and uses the ported Bagel core files.

--- a/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
+++ b/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
@@ -28,6 +28,7 @@ from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 
 from .autoencoder import AutoEncoder, AutoEncoderParams
@@ -153,6 +154,12 @@ class BagelPipeline(nn.Module, DiffusionPipelineProfilerMixin):
 
     This pipeline is self-contained and uses the ported Bagel core files.
     """
+
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__()
@@ -334,7 +341,7 @@ class BagelPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         cfg_renorm_min = extra_args.get("cfg_renorm_min", 0.0)
 
         gen_params = BagelGenParams(
-            num_timesteps=int(req.sampling_params.num_inference_steps or 50),
+            num_timesteps=int(req.sampling_params.num_inference_steps),
             timestep_shift=3.0,
             cfg_text_scale=cfg_text_scale,
             cfg_img_scale=cfg_img_scale,

--- a/vllm_omni/diffusion/models/dreamid_omni/pipeline_dreamid_omni.py
+++ b/vllm_omni/diffusion/models/dreamid_omni/pipeline_dreamid_omni.py
@@ -9,15 +9,15 @@ import torch
 import torch.distributed
 from diffusers import FlowMatchEulerDiscreteScheduler
 from PIL import Image, ImageOps
-from torch import nn
 from torchvision.transforms import Compose, Normalize
 from tqdm import tqdm
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
-from vllm_omni.diffusion.models.interface import SupportAudioInput, SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportAudioInput, SupportImageInput, VllmDiffusionPipeline
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import DiffusionParamOverrides
 
 try:
     from dreamid_omni.utils.divisible_crop import DivisibleCrop
@@ -74,8 +74,14 @@ VIDEO_CONFIG = {
 }
 
 
-class DreamIDOmniPipeline(nn.Module, CFGParallelMixin, SupportImageInput, SupportAudioInput):
+class DreamIDOmniPipeline(VllmDiffusionPipeline, CFGParallelMixin, SupportImageInput, SupportAudioInput):
     """DreamID-Omni pipeline for vLLM-Omni."""
+
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
 
     def __init__(
         self,

--- a/vllm_omni/diffusion/models/flux/pipeline_flux.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux.py
@@ -16,7 +16,6 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler,
 )
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import AutoConfig, CLIPTextModel, CLIPTokenizer, T5TokenizerFast
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
@@ -27,6 +26,7 @@ from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.flux import FluxTransformer2DModel
 from vllm_omni.diffusion.models.flux.flux_pipeline_mixin import FluxPipelineMixin
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -65,7 +65,7 @@ def get_flux_post_process_func(
     return post_process_func
 
 
-class FluxPipeline(nn.Module, FluxPipelineMixin, CFGParallelMixin, DiffusionPipelineProfilerMixin):
+class FluxPipeline(VllmDiffusionPipeline, FluxPipelineMixin, CFGParallelMixin, DiffusionPipelineProfilerMixin):
     @property
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(

--- a/vllm_omni/diffusion/models/flux/pipeline_flux.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux.py
@@ -30,6 +30,7 @@ from vllm_omni.diffusion.models.flux.flux_pipeline_mixin import FluxPipelineMixi
 from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,14 @@ def get_flux_post_process_func(
 
 
 class FluxPipeline(nn.Module, FluxPipelineMixin, CFGParallelMixin, DiffusionPipelineProfilerMixin):
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=28,
+            true_cfg_scale=1.0,
+            max_sequence_length=512,
+        )
+
     def __init__(
         self,
         *,
@@ -494,14 +503,11 @@ class FluxPipeline(nn.Module, FluxPipelineMixin, CFGParallelMixin, DiffusionPipe
         prompt_2: str | list[str] | None = None,
         negative_prompt: str | list[str] | None = None,
         negative_prompt_2: str | list[str] | None = None,
-        true_cfg_scale: float = 1.0,
         height: int | None = None,
         width: int | None = None,
-        num_inference_steps: int = 28,
         sigmas: list[float] | None = None,
         guidance_scale: float = 3.5,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.FloatTensor | None = None,
         prompt_embeds: torch.FloatTensor | None = None,
         pooled_prompt_embeds: torch.FloatTensor | None = None,
@@ -511,7 +517,6 @@ class FluxPipeline(nn.Module, FluxPipelineMixin, CFGParallelMixin, DiffusionPipe
         return_dict: bool = True,
         joint_attention_kwargs: dict[str, Any] | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
-        max_sequence_length: int = 512,
     ):
         """Forward pass for flux."""
         # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
@@ -524,13 +529,14 @@ class FluxPipeline(nn.Module, FluxPipelineMixin, CFGParallelMixin, DiffusionPipe
 
         height = req.sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = req.sampling_params.width or self.default_sample_size * self.vae_scale_factor
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
         guidance_scale = (
             req.sampling_params.guidance_scale if req.sampling_params.guidance_scale is not None else guidance_scale
         )
-        generator = req.sampling_params.generator or generator
-        true_cfg_scale = req.sampling_params.true_cfg_scale or true_cfg_scale
+        max_sequence_length = req.sampling_params.max_sequence_length
+        generator = req.sampling_params.generator
+        true_cfg_scale = req.sampling_params.true_cfg_scale
         num_images_per_prompt = (
             req.sampling_params.num_outputs_per_prompt
             if req.sampling_params.num_outputs_per_prompt > 0

--- a/vllm_omni/diffusion/models/flux/pipeline_flux_kontext.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux_kontext.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.logger import init_logger
 
 logger = init_logger(__name__)
@@ -73,6 +74,14 @@ class FluxKontextPipeline(
     nn.Module, FluxPipelineMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin
 ):
     """FLUX.1-Kontext pipeline for image editing with text guidance."""
+
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=28,
+            true_cfg_scale=1.0,
+            max_sequence_length=512,
+        )
 
     support_image_input = True
 
@@ -467,11 +476,8 @@ class FluxKontextPipeline(
         negative_prompt_2: str | list[str] | None = None,
         height: int | None = None,
         width: int | None = None,
-        num_inference_steps: int = 28,
         guidance_scale: float = 3.5,
-        true_cfg_scale: float = 1.0,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.Tensor | None = None,
         prompt_embeds: torch.Tensor | None = None,
         pooled_prompt_embeds: torch.Tensor | None = None,
@@ -482,7 +488,6 @@ class FluxKontextPipeline(
         attention_kwargs: dict[str, Any] | None = None,
         callback_on_step_end: Callable[[int, int, dict], None] | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
-        max_sequence_length: int = 512,
         sigmas: list[float] | None = None,
     ) -> DiffusionOutput:
         # Handle multiple prompts - only take the first one, similar to Flux2KleinPipeline
@@ -514,9 +519,11 @@ class FluxKontextPipeline(
             image = PIL.Image.open(raw_image) if isinstance(raw_image, str) else cast(PIL.Image.Image, raw_image)
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         guidance_scale = req.sampling_params.guidance_scale or guidance_scale
-        generator = req.sampling_params.generator or generator
+        generator = req.sampling_params.generator
+        true_cfg_scale = req.sampling_params.true_cfg_scale
+        max_sequence_length = req.sampling_params.max_sequence_length
         latents = (
             req.sampling_params.extra_args.get("latents")
             if req.sampling_params.extra_args.get("latents") is not None

--- a/vllm_omni/diffusion/models/flux/pipeline_flux_kontext.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux_kontext.py
@@ -29,13 +29,9 @@ from vllm_omni.diffusion.models.flux import (
     FluxKontextTransformer2DModel,
 )
 from vllm_omni.diffusion.models.flux.flux_pipeline_mixin import FluxPipelineMixin
-<<<<<<< HEAD
-from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
-=======
-from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
->>>>>>> 3957749e (first pass at protocol)
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.inputs.data import DiffusionParamOverrides
@@ -73,15 +69,11 @@ def get_flux_kontext_post_process_func(od_config: OmniDiffusionConfig) -> Callab
     return post_process_func
 
 
-<<<<<<< HEAD
 class FluxKontextPipeline(
-    nn.Module, FluxPipelineMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin
+    VllmDiffusionPipeline, FluxPipelineMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin
 ):
     """FLUX.1-Kontext pipeline for image editing with text guidance."""
 
-=======
-class FluxKontextPipeline(VllmDiffusionPipeline, FluxPipelineMixin, SupportImageInput):
->>>>>>> 3957749e (first pass at protocol)
     @property
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(

--- a/vllm_omni/diffusion/models/flux/pipeline_flux_kontext.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux_kontext.py
@@ -14,7 +14,6 @@ from typing import Any, cast
 import numpy as np
 import PIL.Image
 import torch
-import torch.nn as nn
 from diffusers.image_processor import VaeImageProcessor
 from diffusers.loaders import TextualInversionLoaderMixin
 from diffusers.models.autoencoders.autoencoder_kl import AutoencoderKL
@@ -30,9 +29,13 @@ from vllm_omni.diffusion.models.flux import (
     FluxKontextTransformer2DModel,
 )
 from vllm_omni.diffusion.models.flux.flux_pipeline_mixin import FluxPipelineMixin
+<<<<<<< HEAD
 from vllm_omni.diffusion.models.interface import SupportImageInput
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+=======
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
+>>>>>>> 3957749e (first pass at protocol)
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.inputs.data import DiffusionParamOverrides
@@ -70,11 +73,15 @@ def get_flux_kontext_post_process_func(od_config: OmniDiffusionConfig) -> Callab
     return post_process_func
 
 
+<<<<<<< HEAD
 class FluxKontextPipeline(
     nn.Module, FluxPipelineMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin
 ):
     """FLUX.1-Kontext pipeline for image editing with text guidance."""
 
+=======
+class FluxKontextPipeline(VllmDiffusionPipeline, FluxPipelineMixin, SupportImageInput):
+>>>>>>> 3957749e (first pass at protocol)
     @property
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 
 logger = logging.getLogger(__name__)
@@ -341,6 +342,13 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
     _callback_tensor_inputs = ["latents", "prompt_embeds"]
 
     support_image_input = True
+
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+            max_sequence_length=512,
+        )
 
     def __init__(
         self,
@@ -878,11 +886,9 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
         prompt: str | list[str] | None = None,
         height: int | None = None,
         width: int | None = None,
-        num_inference_steps: int = 50,
         sigmas: list[float] | None = None,
         guidance_scale: float | None = 4.0,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.Tensor | None = None,
         prompt_embeds: torch.Tensor | None = None,
         negative_prompt_embeds: torch.Tensor | None = None,
@@ -891,7 +897,6 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
         attention_kwargs: dict[str, Any] | None = None,
         callback_on_step_end: Callable[[int, int, dict], None] | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
-        max_sequence_length: int = 512,
         text_encoder_out_layers: tuple[int, ...] = (10, 20, 30),
         caption_upsample_temperature: float = None,
     ) -> DiffusionOutput:
@@ -916,18 +921,18 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
 
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
         guidance_scale = (
             req.sampling_params.guidance_scale if req.sampling_params.guidance_scale is not None else guidance_scale
         )
-        generator = req.sampling_params.generator or generator
+        generator = req.sampling_params.generator
         num_images_per_prompt = (
             req.sampling_params.num_outputs_per_prompt
             if req.sampling_params.num_outputs_per_prompt > 0
             else num_images_per_prompt
         )
-        max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
+        max_sequence_length = req.sampling_params.max_sequence_length
         text_encoder_out_layers = req.sampling_params.extra_args.get("text_encoder_out_layers", text_encoder_out_layers)
 
         req_prompt_embeds = [p.get("prompt_embeds") if not isinstance(p, str) else None for p in req.prompts]

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -29,13 +29,9 @@ from vllm_omni.diffusion.distributed.parallel_state import get_classifier_free_g
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.flux2 import Flux2Transformer2DModel
-<<<<<<< HEAD
-from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
-=======
-from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
->>>>>>> 3957749e (first pass at protocol)
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.inputs.data import DiffusionParamOverrides
@@ -339,11 +335,9 @@ def retrieve_latents(encoder_output: torch.Tensor, generator: torch.Generator = 
         raise AttributeError("Could not access latents of provided encoder_output")
 
 
-<<<<<<< HEAD
-class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin):
-=======
-class Flux2Pipeline(VllmDiffusionPipeline, SupportImageInput):
->>>>>>> 3957749e (first pass at protocol)
+class Flux2Pipeline(
+    VllmDiffusionPipeline, CFGParallelMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin
+):
     """Flux2 pipeline for text-to-image generation."""
 
     _callback_tensor_inputs = ["latents", "prompt_embeds"]

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -20,7 +20,6 @@ from diffusers.pipelines.flux2.system_messages import (
     SYSTEM_MESSAGE_UPSAMPLING_T2I,
 )
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import AutoProcessor, Mistral3ForConditionalGeneration, PixtralProcessor
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
@@ -30,9 +29,13 @@ from vllm_omni.diffusion.distributed.parallel_state import get_classifier_free_g
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.flux2 import Flux2Transformer2DModel
+<<<<<<< HEAD
 from vllm_omni.diffusion.models.interface import SupportImageInput
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+=======
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
+>>>>>>> 3957749e (first pass at protocol)
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.inputs.data import DiffusionParamOverrides
@@ -336,7 +339,11 @@ def retrieve_latents(encoder_output: torch.Tensor, generator: torch.Generator = 
         raise AttributeError("Could not access latents of provided encoder_output")
 
 
+<<<<<<< HEAD
 class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin):
+=======
+class Flux2Pipeline(VllmDiffusionPipeline, SupportImageInput):
+>>>>>>> 3957749e (first pass at protocol)
     """Flux2 pipeline for text-to-image generation."""
 
     _callback_tensor_inputs = ["latents", "prompt_embeds"]

--- a/vllm_omni/diffusion/models/flux2_klein/pipeline_flux2_klein.py
+++ b/vllm_omni/diffusion/models/flux2_klein/pipeline_flux2_klein.py
@@ -24,7 +24,6 @@ from typing import Any, cast
 import numpy as np
 import PIL.Image
 import torch
-import torch.nn as nn
 from diffusers.image_processor import VaeImageProcessor
 from diffusers.models.autoencoders.autoencoder_kl_flux2 import AutoencoderKLFlux2
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import retrieve_timesteps
@@ -42,7 +41,7 @@ from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineL
 from vllm_omni.diffusion.models.flux2_klein.flux2_klein_transformer import (
     Flux2Transformer2DModel,
 )
-from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
@@ -181,7 +180,7 @@ def compute_empirical_mu(image_seq_len: int, num_steps: int) -> float:
     return float(mu)
 
 
-class Flux2KleinPipeline(nn.Module, CFGParallelMixin, SupportImageInput, DiffusionPipelineProfilerMixin):
+class Flux2KleinPipeline(VllmDiffusionPipeline, CFGParallelMixin, SupportImageInput, DiffusionPipelineProfilerMixin):
     """Flux2 klein pipeline for text-to-image generation."""
 
     support_image_input = True

--- a/vllm_omni/diffusion/models/flux2_klein/pipeline_flux2_klein.py
+++ b/vllm_omni/diffusion/models/flux2_klein/pipeline_flux2_klein.py
@@ -46,6 +46,7 @@ from vllm_omni.diffusion.models.interface import SupportImageInput
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 
 logger = init_logger(__name__)
@@ -184,6 +185,13 @@ class Flux2KleinPipeline(nn.Module, CFGParallelMixin, SupportImageInput, Diffusi
     """Flux2 klein pipeline for text-to-image generation."""
 
     support_image_input = True
+
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+            max_sequence_length=512,
+        )
 
     def __init__(
         self,
@@ -656,11 +664,9 @@ class Flux2KleinPipeline(nn.Module, CFGParallelMixin, SupportImageInput, Diffusi
         prompt: str | list[str] | None = None,
         height: int | None = None,
         width: int | None = None,
-        num_inference_steps: int = 50,
         sigmas: list[float] | None = None,
         guidance_scale: float | None = 4.0,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.Tensor | None = None,
         prompt_embeds: torch.Tensor | None = None,
         negative_prompt_embeds: torch.Tensor | None = None,
@@ -669,7 +675,6 @@ class Flux2KleinPipeline(nn.Module, CFGParallelMixin, SupportImageInput, Diffusi
         attention_kwargs: dict[str, Any] | None = None,
         callback_on_step_end: Callable[[int, int, dict], None] | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
-        max_sequence_length: int = 512,
         text_encoder_out_layers: tuple[int, ...] = (9, 18, 27),
     ) -> DiffusionOutput:
         r"""
@@ -768,18 +773,18 @@ class Flux2KleinPipeline(nn.Module, CFGParallelMixin, SupportImageInput, Diffusi
 
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
         guidance_scale = (
             req.sampling_params.guidance_scale if req.sampling_params.guidance_scale is not None else guidance_scale
         )
-        generator = req.sampling_params.generator or generator
+        generator = req.sampling_params.generator
         num_images_per_prompt = (
             req.sampling_params.num_outputs_per_prompt
             if req.sampling_params.num_outputs_per_prompt > 0
             else num_images_per_prompt
         )
-        max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
+        max_sequence_length = req.sampling_params.max_sequence_length
         text_encoder_out_layers = req.sampling_params.extra_args.get("text_encoder_out_layers", text_encoder_out_layers)
 
         req_prompt_embeds = [p.get("prompt_embeds") if not isinstance(p, str) else None for p in req.prompts]

--- a/vllm_omni/diffusion/models/glm_image/pipeline_glm_image.py
+++ b/vllm_omni/diffusion/models/glm_image/pipeline_glm_image.py
@@ -48,7 +48,7 @@ from vllm_omni.diffusion.models.glm_image.glm_image_transformer import (
 )
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
-from vllm_omni.inputs.data import OmniTextPrompt
+from vllm_omni.inputs.data import DiffusionParamOverrides, OmniTextPrompt
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -254,6 +254,12 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
     3. DiT performs iterative denoising conditioned on prior tokens
     4. VAE decodes final latents to image
     """
+
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
 
     def __init__(
         self,
@@ -722,7 +728,7 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
         # Use image dimensions as default if available
         height = req.sampling_params.height or img_height or self.default_sample_size * self.vae_scale_factor
         width = req.sampling_params.width or img_width or self.default_sample_size * self.vae_scale_factor
-        num_inference_steps = req.sampling_params.num_inference_steps or 50
+        num_inference_steps = req.sampling_params.num_inference_steps
         guidance_scale = req.sampling_params.guidance_scale or 1.5
 
         self.check_inputs(prompt=prompt, height=height, width=width, prompt_embeds=prompt_embeds)

--- a/vllm_omni/diffusion/models/glm_image/pipeline_glm_image.py
+++ b/vllm_omni/diffusion/models/glm_image/pipeline_glm_image.py
@@ -28,7 +28,6 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler,
 )
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import (
     ByT5Tokenizer,
     T5EncoderModel,
@@ -46,6 +45,7 @@ from vllm_omni.diffusion.models.glm_image.glm_image_transformer import (
     GlmImageKVCache,
     GlmImageTransformer2DModel,
 )
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.inputs.data import DiffusionParamOverrides, OmniTextPrompt
@@ -238,7 +238,7 @@ def retrieve_latents(
         raise AttributeError("Could not access latents of provided encoder_output")
 
 
-class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
+class GlmImagePipeline(VllmDiffusionPipeline, DiffusionPipelineProfilerMixin):
     """
     GLM-Image Pipeline for text-to-image and image-to-image generation.
 

--- a/vllm_omni/diffusion/models/helios/pipeline_helios.py
+++ b/vllm_omni/diffusion/models/helios/pipeline_helios.py
@@ -29,6 +29,7 @@ from vllm_omni.diffusion.models.helios.scheduling_helios import HeliosScheduler
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.platforms import current_omni_platform
 
 if TYPE_CHECKING:
@@ -156,6 +157,13 @@ class HeliosPipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPip
     Implements chunked video generation with multi-term memory history context.
     """
 
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+            max_sequence_length=226,
+        )
+
     def __init__(
         self,
         *,
@@ -265,11 +273,9 @@ class HeliosPipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPip
         negative_prompt: str | None = None,
         height: int = 384,
         width: int = 640,
-        num_inference_steps: int = 50,
         guidance_scale: float = 5.0,
         frame_num: int = 132,
         output_type: str | None = "np",
-        generator: torch.Generator | list[torch.Generator] | None = None,
         prompt_embeds: torch.Tensor | None = None,
         negative_prompt_embeds: torch.Tensor | None = None,
         attention_kwargs: dict | None = None,
@@ -342,7 +348,7 @@ class HeliosPipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPip
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
         num_frames = req.sampling_params.num_frames if req.sampling_params.num_frames else frame_num
-        num_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_steps = req.sampling_params.num_inference_steps
 
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale
@@ -356,8 +362,7 @@ class HeliosPipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPip
         device = self.device
         dtype = self.transformer.dtype
 
-        if generator is None:
-            generator = req.sampling_params.generator
+        generator = req.sampling_params.generator
         if generator is None and req.sampling_params.seed is not None:
             generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
 
@@ -368,7 +373,7 @@ class HeliosPipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPip
                 negative_prompt=negative_prompt,
                 do_classifier_free_guidance=self.do_classifier_free_guidance,
                 num_videos_per_prompt=req.sampling_params.num_outputs_per_prompt or 1,
-                max_sequence_length=req.sampling_params.max_sequence_length or 226,
+                max_sequence_length=req.sampling_params.max_sequence_length,
                 device=device,
                 dtype=dtype,
             )

--- a/vllm_omni/diffusion/models/helios/pipeline_helios.py
+++ b/vllm_omni/diffusion/models/helios/pipeline_helios.py
@@ -16,7 +16,6 @@ import torch
 import torch.nn.functional as F
 from diffusers import AutoencoderKLWan
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import AutoConfig, AutoTokenizer, UMT5EncoderModel
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
@@ -26,6 +25,7 @@ from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.helios.helios_transformer import HeliosTransformer3DModel
 from vllm_omni.diffusion.models.helios.scheduling_helios import HeliosScheduler
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -150,7 +150,7 @@ def get_helios_pre_process_func(
     return pre_process_func
 
 
-class HeliosPipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin):
+class HeliosPipeline(VllmDiffusionPipeline, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin):
     """Helios text-to-video / image-to-video / video-to-video pipeline for vllm-omni.
 
     Supports T2V, I2V (with image input), and V2V (with video input).

--- a/vllm_omni/diffusion/models/hunyuan_image_3/pipeline_hunyuan_image_3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image_3/pipeline_hunyuan_image_3.py
@@ -21,7 +21,11 @@ from vllm.transformers_utils.config import get_config
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+<<<<<<< HEAD
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+=======
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
+>>>>>>> 3957749e (first pass at protocol)
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.inputs.data import DiffusionParamOverrides
 
@@ -65,6 +69,7 @@ def to_device(data, device):
         return data
 
 
+<<<<<<< HEAD
 class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, DiffusionPipelineProfilerMixin):
     _PROFILER_TARGETS = [
         "model.forward",
@@ -75,6 +80,9 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
         "vae.decode",
     ]
 
+=======
+class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, VllmDiffusionPipeline, GenerationMixin):
+>>>>>>> 3957749e (first pass at protocol)
     @property
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(

--- a/vllm_omni/diffusion/models/hunyuan_image_3/pipeline_hunyuan_image_3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image_3/pipeline_hunyuan_image_3.py
@@ -23,6 +23,7 @@ from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import DiffusionParamOverrides
 
 from .autoencoder import AutoencoderKLConv3D
 from .hunyuan_image_3_tokenizer import TokenizerWrapper
@@ -73,6 +74,12 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
         "vae.encode",
         "vae.decode",
     ]
+
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
 
     def __init__(self, od_config: OmniDiffusionConfig) -> None:
         self.hf_config = get_config(od_config.model, trust_remote_code=True)
@@ -990,9 +997,8 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
         image_size="auto",
         height: int = 1024,
         width: int = 1024,
-        num_inference_steps: int = 50,
         guidance_scale: float = 5.0,
-        generator: torch.Generator | list[torch.Generator] | None = None,
+        system_prompt: str | None = None,
         **kwargs,
     ) -> DiffusionOutput:
         extra_args = getattr(getattr(req, "sampling_params", None), "extra_args", {}) or {}
@@ -1002,10 +1008,10 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
             system_prompt = get_system_prompt(use_system_prompt, "image", system_prompt)
             system_prompt = system_prompt.strip() if system_prompt is not None else ""
         prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts] or prompt
-        generator = req.sampling_params.generator or generator
+        generator = req.sampling_params.generator
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale
         if guidance_scale <= 1.0:

--- a/vllm_omni/diffusion/models/hunyuan_image_3/pipeline_hunyuan_image_3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image_3/pipeline_hunyuan_image_3.py
@@ -21,11 +21,8 @@ from vllm.transformers_utils.config import get_config
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-<<<<<<< HEAD
-from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
-=======
 from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
->>>>>>> 3957749e (first pass at protocol)
+from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.inputs.data import DiffusionParamOverrides
 
@@ -69,8 +66,9 @@ def to_device(data, device):
         return data
 
 
-<<<<<<< HEAD
-class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, DiffusionPipelineProfilerMixin):
+class HunyuanImage3Pipeline(
+    VllmDiffusionPipeline, HunyuanImage3PreTrainedModel, GenerationMixin, DiffusionPipelineProfilerMixin
+):
     _PROFILER_TARGETS = [
         "model.forward",
         "model.layers[0].forward",
@@ -80,9 +78,6 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
         "vae.decode",
     ]
 
-=======
-class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, VllmDiffusionPipeline, GenerationMixin):
->>>>>>> 3957749e (first pass at protocol)
     @property
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
@@ -15,7 +15,6 @@ from diffusers import AutoencoderKLHunyuanVideo15
 from diffusers.schedulers.scheduling_flow_match_euler_discrete import FlowMatchEulerDiscreteScheduler
 from diffusers.utils.torch_utils import randn_tensor
 from diffusers.video_processor import VideoProcessor
-from torch import nn
 from transformers import AutoConfig, ByT5Tokenizer, Qwen2_5_VLTextModel, Qwen2Tokenizer
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
@@ -25,6 +24,7 @@ from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.hunyuan_video.hunyuan_video_15_transformer import HunyuanVideo15Transformer3DModel
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -84,7 +84,7 @@ def get_hunyuan_video_15_post_process_func(od_config: OmniDiffusionConfig):
     return post_process_func
 
 
-class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin):
+class HunyuanVideo15Pipeline(VllmDiffusionPipeline, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin):
     @property
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
@@ -29,6 +29,7 @@ from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.platforms import current_omni_platform
 
 logger = logging.getLogger(__name__)
@@ -84,6 +85,12 @@ def get_hunyuan_video_15_post_process_func(od_config: OmniDiffusionConfig):
 
 
 class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin):
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
+
     def __init__(
         self,
         *,
@@ -367,7 +374,6 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
     def forward(
         self,
         req: OmniDiffusionRequest,
-        num_inference_steps: int = 50,
         guidance_scale: float = 6.0,
         height: int = 480,
         width: int = 832,
@@ -387,7 +393,7 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
         num_frames_val = req.sampling_params.num_frames if req.sampling_params.num_frames else num_frames
-        num_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_steps = req.sampling_params.num_inference_steps
 
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
@@ -43,6 +43,7 @@ from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.platforms import current_omni_platform
 
 logger = logging.getLogger(__name__)
@@ -105,6 +106,12 @@ class HunyuanVideo15I2VPipeline(
 ):
     support_image_input = True
     color_format = "RGB"
+
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
 
     def __init__(
         self,
@@ -431,7 +438,6 @@ class HunyuanVideo15I2VPipeline(
     def forward(
         self,
         req: OmniDiffusionRequest,
-        num_inference_steps: int = 50,
         guidance_scale: float = 6.0,
         height: int = 480,
         width: int = 832,
@@ -470,7 +476,7 @@ class HunyuanVideo15I2VPipeline(
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
         num_frames_val = req.sampling_params.num_frames if req.sampling_params.num_frames else num_frames
-        num_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_steps = req.sampling_params.num_inference_steps
 
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
@@ -15,7 +15,6 @@ from diffusers import AutoencoderKLHunyuanVideo15
 from diffusers.schedulers.scheduling_flow_match_euler_discrete import FlowMatchEulerDiscreteScheduler
 from diffusers.utils.torch_utils import randn_tensor
 from diffusers.video_processor import VideoProcessor
-from torch import nn
 from transformers import (
     AutoConfig,
     ByT5Tokenizer,
@@ -37,8 +36,12 @@ from vllm_omni.diffusion.models.hunyuan_video.pipeline_hunyuan_video_1_5 import 
     get_hunyuan_video_15_post_process_func,
     retrieve_latents,
 )
+<<<<<<< HEAD
 from vllm_omni.diffusion.models.interface import SupportImageInput
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+=======
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
+>>>>>>> 3957749e (first pass at protocol)
 from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -101,9 +104,13 @@ def get_hunyuan_video_15_i2v_pre_process_func(od_config: OmniDiffusionConfig):
     return pre_process_func
 
 
+<<<<<<< HEAD
 class HunyuanVideo15I2VPipeline(
     nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin
 ):
+=======
+class HunyuanVideo15I2VPipeline(VllmDiffusionPipeline, CFGParallelMixin, SupportImageInput):
+>>>>>>> 3957749e (first pass at protocol)
     support_image_input = True
     color_format = "RGB"
 

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
@@ -36,12 +36,8 @@ from vllm_omni.diffusion.models.hunyuan_video.pipeline_hunyuan_video_1_5 import 
     get_hunyuan_video_15_post_process_func,
     retrieve_latents,
 )
-<<<<<<< HEAD
-from vllm_omni.diffusion.models.interface import SupportImageInput
-from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
-=======
 from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
->>>>>>> 3957749e (first pass at protocol)
+from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -104,13 +100,9 @@ def get_hunyuan_video_15_i2v_pre_process_func(od_config: OmniDiffusionConfig):
     return pre_process_func
 
 
-<<<<<<< HEAD
 class HunyuanVideo15I2VPipeline(
-    nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin
+    VllmDiffusionPipeline, CFGParallelMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin
 ):
-=======
-class HunyuanVideo15I2VPipeline(VllmDiffusionPipeline, CFGParallelMixin, SupportImageInput):
->>>>>>> 3957749e (first pass at protocol)
     support_image_input = True
     color_format = "RGB"
 

--- a/vllm_omni/diffusion/models/interface.py
+++ b/vllm_omni/diffusion/models/interface.py
@@ -10,11 +10,34 @@ from typing import (
     runtime_checkable,
 )
 
+from torch import nn
+
+from vllm_omni.inputs.data import DiffusionParamOverrides
+
 if TYPE_CHECKING:
     import torch
 
     from vllm_omni.diffusion.data import DiffusionOutput
     from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+
+
+class VllmDiffusionPipeline(nn.Module):
+    """Base class for all vLLM Omni diffusion pipelines.
+
+    All registered diffusion pipelines should inherit from this class.
+    Currently, this is only used for ensuring the correct sampling params
+    can be fetched for cache refresh, but additional common capabilities are
+    actively being added here.
+
+    See the following RFC: https://github.com/vllm-project/vllm-omni/issues/2189
+    """
+
+    @property
+    def sampling_param_defaults(self) -> DiffusionParamOverrides:
+        """Pipeline-specific default sampling parameters."""
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
 
 
 @runtime_checkable

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
@@ -18,7 +18,6 @@ from diffusers.models import AutoencoderKL
 from diffusers.pipelines.longcat_image.system_messages import SYSTEM_PROMPT_EN, SYSTEM_PROMPT_ZH
 from diffusers.schedulers import FlowMatchEulerDiscreteScheduler, SchedulerMixin
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import AutoTokenizer, Qwen2_5_VLForConditionalGeneration, Qwen2VLProcessor
 from vllm.logger import init_logger
 from vllm.model_executor.models.utils import AutoWeightsLoader
@@ -27,6 +26,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.models.longcat_image.longcat_image_transformer import LongCatImageTransformer2DModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -201,7 +201,7 @@ def get_prompt_language(prompt):
     return "en"
 
 
-class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMixin):
+class LongCatImagePipeline(VllmDiffusionPipeline, CFGParallelMixin, DiffusionPipelineProfilerMixin):
     @property
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
@@ -30,6 +30,7 @@ from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineL
 from vllm_omni.diffusion.models.longcat_image.longcat_image_transformer import LongCatImageTransformer2DModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -201,6 +202,12 @@ def get_prompt_language(prompt):
 
 
 class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMixin):
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
+
     def __init__(
         self,
         *,
@@ -481,11 +488,9 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
         negative_prompt: str | list[str] | None = None,
         height: int | None = None,
         width: int | None = None,
-        num_inference_steps: int = 50,
         sigmas: list[float] | None = None,
         guidance_scale: float = 4.5,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.FloatTensor | None = None,
         prompt_embeds: torch.Tensor | None = None,
         negative_prompt_embeds: torch.Tensor | None = None,
@@ -506,9 +511,9 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
 
         height = req.sampling_params.height or height or self.default_sample_size * self.vae_scale_factor
         width = req.sampling_params.width or width or self.default_sample_size * self.vae_scale_factor
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
-        generator = req.sampling_params.generator or generator
+        generator = req.sampling_params.generator
         guidance_scale = (
             req.sampling_params.guidance_scale if req.sampling_params.guidance_scale is not None else guidance_scale
         )

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image_edit.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image_edit.py
@@ -16,7 +16,6 @@ from diffusers.models import AutoencoderKL
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import retrieve_timesteps
 from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import (
     AutoTokenizer,
     Qwen2_5_VLForConditionalGeneration,
@@ -29,7 +28,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
 from vllm_omni.diffusion.models.longcat_image.longcat_image_transformer import (
     LongCatImageTransformer2DModel,
 )
@@ -221,7 +220,9 @@ def split_quotation(prompt, quote_pairs=None):
     return result
 
 
-class LongCatImageEditPipeline(nn.Module, CFGParallelMixin, SupportImageInput, DiffusionPipelineProfilerMixin):
+class LongCatImageEditPipeline(
+    VllmDiffusionPipeline, CFGParallelMixin, SupportImageInput, DiffusionPipelineProfilerMixin
+):
     @property
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image_edit.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image_edit.py
@@ -36,7 +36,7 @@ from vllm_omni.diffusion.models.longcat_image.longcat_image_transformer import (
 from vllm_omni.diffusion.models.longcat_image.pipeline_longcat_image import calculate_shift
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
-from vllm_omni.inputs.data import OmniTextPrompt
+from vllm_omni.inputs.data import DiffusionParamOverrides, OmniTextPrompt
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -222,6 +222,12 @@ def split_quotation(prompt, quote_pairs=None):
 
 
 class LongCatImageEditPipeline(nn.Module, CFGParallelMixin, SupportImageInput, DiffusionPipelineProfilerMixin):
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
+
     def __init__(
         self,
         *,
@@ -529,11 +535,9 @@ class LongCatImageEditPipeline(nn.Module, CFGParallelMixin, SupportImageInput, D
         image: PIL.Image.Image | torch.Tensor | None = None,
         prompt: str | list[str] | None = None,
         negative_prompt: str | list[str] | None = None,
-        num_inference_steps: int = 50,
         sigmas: list[float] | None = None,
         guidance_scale: float = 3.5,
         num_images_per_prompt: int | None = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.FloatTensor | None = None,
         prompt_embeds: torch.Tensor | None = None,
         negative_prompt_embeds: torch.Tensor | None = None,
@@ -558,13 +562,13 @@ class LongCatImageEditPipeline(nn.Module, CFGParallelMixin, SupportImageInput, D
         guidance_scale = (
             req.sampling_params.guidance_scale if req.sampling_params.guidance_scale is not None else guidance_scale
         )
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         num_images_per_prompt = (
             req.sampling_params.num_outputs_per_prompt
             if req.sampling_params.num_outputs_per_prompt is not None
             else num_images_per_prompt
         )
-        generator = req.sampling_params.generator or generator
+        generator = req.sampling_params.generator
         height = req.sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = req.sampling_params.width or self.default_sample_size * self.vae_scale_factor
 

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
@@ -20,7 +20,6 @@ from diffusers.pipelines.ltx2.vocoder import LTX2Vocoder
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import rescale_noise_cfg, retrieve_timesteps
 from diffusers.utils.torch_utils import randn_tensor
 from diffusers.video_processor import VideoProcessor
-from torch import nn
 from transformers import AutoTokenizer, Gemma3ForConditionalGeneration
 from vllm.logger import init_logger
 from vllm.model_executor.models.utils import AutoWeightsLoader
@@ -33,7 +32,11 @@ from vllm_omni.diffusion.distributed.parallel_state import (
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.lora.manager import DiffusionLoRAManager
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+<<<<<<< HEAD
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+=======
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
+>>>>>>> 3957749e (first pass at protocol)
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.lora.request import LoRARequest
@@ -121,6 +124,7 @@ def calculate_shift(
     return mu
 
 
+<<<<<<< HEAD
 class _VideoAudioScheduler:
     """Composite scheduler dispatching to video and audio schedulers."""
 
@@ -147,6 +151,9 @@ class _VideoAudioScheduler:
 
 
 class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
+=======
+class LTX2Pipeline(VllmDiffusionPipeline, CFGParallelMixin):
+>>>>>>> 3957749e (first pass at protocol)
     @property
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
@@ -32,11 +32,8 @@ from vllm_omni.diffusion.distributed.parallel_state import (
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.lora.manager import DiffusionLoRAManager
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-<<<<<<< HEAD
-from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
-=======
 from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
->>>>>>> 3957749e (first pass at protocol)
+from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.lora.request import LoRARequest
@@ -124,7 +121,6 @@ def calculate_shift(
     return mu
 
 
-<<<<<<< HEAD
 class _VideoAudioScheduler:
     """Composite scheduler dispatching to video and audio schedulers."""
 
@@ -150,10 +146,7 @@ class _VideoAudioScheduler:
         return ((video_out, audio_out),)
 
 
-class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
-=======
-class LTX2Pipeline(VllmDiffusionPipeline, CFGParallelMixin):
->>>>>>> 3957749e (first pass at protocol)
+class LTX2Pipeline(VllmDiffusionPipeline, CFGParallelMixin, ProgressBarMixin):
     @property
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(
@@ -1162,7 +1155,7 @@ class LTX2Pipeline(VllmDiffusionPipeline, CFGParallelMixin):
         return loader.load_weights(weights)
 
 
-class LTX2TwoStagesPipeline(nn.Module):
+class LTX2TwoStagesPipeline(VllmDiffusionPipeline):
     """LTX2TwoStagesPipeline is for two stages image to video generation"""
 
     def __init__(

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.lora.manager import DiffusionLoRAManager
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.lora.request import LoRARequest
 
 from .ltx2_transformer import LTX2VideoTransformer3DModel
@@ -146,6 +147,13 @@ class _VideoAudioScheduler:
 
 
 class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=40,
+            max_sequence_length=self.tokenizer_max_length,
+        )
+
     def __init__(
         self,
         *,
@@ -755,7 +763,6 @@ class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
         width: int | None = None,
         num_frames: int | None = None,
         frame_rate: float | None = None,
-        num_inference_steps: int | None = None,
         sigmas: list[float] | None = None,
         timesteps: list[int] | None = None,
         guidance_scale: float = 4.0,
@@ -774,7 +781,6 @@ class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
         output_type: str = "np",
         return_dict: bool = True,
         attention_kwargs: dict[str, Any] | None = None,
-        max_sequence_length: int | None = None,
     ) -> DiffusionOutput:
         # Extract prompt/negative_prompt from request.
         # Input format: req.prompts is a list of str or dict with "prompt"/"negative_prompt" keys.
@@ -788,7 +794,7 @@ class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
         width = req.sampling_params.width or width or 768
         num_frames = req.sampling_params.num_frames or num_frames or 121
         frame_rate = req.sampling_params.resolved_frame_rate or frame_rate or 24.0
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps or 40
+        num_inference_steps = req.sampling_params.num_inference_steps
         if timesteps is None:
             num_inference_steps = max(int(num_inference_steps), 2)
         elif len(timesteps) < 2:
@@ -798,9 +804,7 @@ class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
             if req.sampling_params.num_outputs_per_prompt > 0
             else num_videos_per_prompt or 1
         )
-        max_sequence_length = (
-            req.sampling_params.max_sequence_length or max_sequence_length or self.tokenizer_max_length
-        )
+        max_sequence_length = req.sampling_params.max_sequence_length
 
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_image2video.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_image2video.py
@@ -291,7 +291,6 @@ class LTX2ImageToVideoPipeline(LTX2Pipeline):
         width: int | None = None,
         num_frames: int | None = None,
         frame_rate: float | None = None,
-        num_inference_steps: int | None = None,
         sigmas: list[float] | None = None,
         timesteps: list[int] | None = None,
         guidance_scale: float = 4.0,
@@ -310,7 +309,6 @@ class LTX2ImageToVideoPipeline(LTX2Pipeline):
         output_type: str = "np",
         return_dict: bool = True,
         attention_kwargs: dict[str, Any] | None = None,
-        max_sequence_length: int | None = None,
     ) -> DiffusionOutput:
         # Extract prompt/negative_prompt from request.
         # Input format: req.prompts is a list of str or dict with "prompt"/"negative_prompt" keys.
@@ -324,7 +322,7 @@ class LTX2ImageToVideoPipeline(LTX2Pipeline):
         width = req.sampling_params.width or width or 768
         num_frames = req.sampling_params.num_frames or num_frames or 121
         frame_rate = req.sampling_params.resolved_frame_rate or frame_rate or 24.0
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps or 40
+        num_inference_steps = req.sampling_params.num_inference_steps
         if timesteps is None:
             num_inference_steps = max(int(num_inference_steps), 2)
         elif len(timesteps) < 2:
@@ -334,9 +332,7 @@ class LTX2ImageToVideoPipeline(LTX2Pipeline):
             if req.sampling_params.num_outputs_per_prompt > 0
             else num_videos_per_prompt or 1
         )
-        max_sequence_length = (
-            req.sampling_params.max_sequence_length or max_sequence_length or self.tokenizer_max_length
-        )
+        max_sequence_length = req.sampling_params.max_sequence_length
 
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale

--- a/vllm_omni/diffusion/models/nextstep_1_1/pipeline_nextstep_1_1.py
+++ b/vllm_omni/diffusion/models/nextstep_1_1/pipeline_nextstep_1_1.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.models.nextstep_1_1.modeling_nextstep import (
 )
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -139,6 +140,12 @@ class NextStep11Pipeline(nn.Module, DiffusionPipelineProfilerMixin):
     model from StepFun. It uses an LLM backbone with a flow matching head
     to generate images autoregressively.
     """
+
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=28,
+        )
 
     def __init__(
         self,
@@ -558,11 +565,9 @@ class NextStep11Pipeline(nn.Module, DiffusionPipelineProfilerMixin):
         prompt: str | list[str] | None = None,
         height: int | None = None,
         width: int | None = None,
-        num_inference_steps: int = 28,
         guidance_scale: float = 7.5,
         negative_prompt: str | list[str] | None = None,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | None = None,
         seed: int | None = None,
         **kwargs,
     ) -> DiffusionOutput:
@@ -596,7 +601,7 @@ class NextStep11Pipeline(nn.Module, DiffusionPipelineProfilerMixin):
 
         height = req.sampling_params.height or height or 512
         width = req.sampling_params.width or width or 512
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale
         num_images_per_prompt = (
@@ -618,6 +623,7 @@ class NextStep11Pipeline(nn.Module, DiffusionPipelineProfilerMixin):
         positive_prompt = req.sampling_params.extra_args.get("positive_prompt", None)
 
         # Set seed for reproducibility (use generator if provided, else fall back to seed)
+        generator = req.sampling_params.generator
         if generator is None and seed is not None:
             set_seed(seed)
         elif generator is not None:

--- a/vllm_omni/diffusion/models/nextstep_1_1/pipeline_nextstep_1_1.py
+++ b/vllm_omni/diffusion/models/nextstep_1_1/pipeline_nextstep_1_1.py
@@ -13,7 +13,6 @@ import torch.nn.functional as F
 import torchvision.transforms as transforms
 from diffusers.image_processor import VaeImageProcessor
 from PIL import Image
-from torch import nn
 from tqdm.auto import tqdm
 from transformers import AutoTokenizer, PreTrainedTokenizer
 from transformers.cache_utils import StaticCache
@@ -28,6 +27,7 @@ from vllm_omni.diffusion.distributed.parallel_state import (
 )
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.models.nextstep_1_1.modeling_flux_vae import AutoencoderKL
 from vllm_omni.diffusion.models.nextstep_1_1.modeling_nextstep import (
     NextStepConfig,
@@ -132,7 +132,7 @@ def get_nextstep11_post_process_func(od_config: OmniDiffusionConfig):
     return post_process_func
 
 
-class NextStep11Pipeline(nn.Module, DiffusionPipelineProfilerMixin):
+class NextStep11Pipeline(VllmDiffusionPipeline, DiffusionPipelineProfilerMixin):
     """
     NextStep-1.1 Pipeline for text-to-image generation.
 

--- a/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
+++ b/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
@@ -38,7 +38,7 @@ from vllm_omni.diffusion.models.omnigen2.omnigen2_transformer import (
 )
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
-from vllm_omni.inputs.data import OmniTextPrompt
+from vllm_omni.inputs.data import DiffusionParamOverrides, OmniTextPrompt
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -961,6 +961,12 @@ class OmniGen2Pipeline(CFGParallelMixin, nn.Module):
         )
 
     @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=28,
+        )
+
+    @property
     def num_timesteps(self):
         return self._num_timesteps
 
@@ -994,13 +1000,11 @@ class OmniGen2Pipeline(CFGParallelMixin, nn.Module):
         max_pixels: int = 1024 * 1024,
         max_input_image_side_length: int = 1024,
         align_res: bool = True,
-        num_inference_steps: int = 28,
         text_guidance_scale: float = 4.0,
         image_guidance_scale: float = 1.0,
         cfg_range: tuple[float, float] = (0.0, 1.0),
         attention_kwargs: dict[str, Any] | None = None,
         timesteps: list[int] = None,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.FloatTensor | None = None,
         verbose: bool = False,
         step_func=None,
@@ -1026,8 +1030,8 @@ class OmniGen2Pipeline(CFGParallelMixin, nn.Module):
 
         height = req.sampling_params.height or height or self.default_sample_size * self.vae_scale_factor
         width = req.sampling_params.width or width or self.default_sample_size * self.vae_scale_factor
-        generator = req.sampling_params.generator or generator
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        generator = req.sampling_params.generator
+        num_inference_steps = req.sampling_params.num_inference_steps
         if req.sampling_params.guidance_scale_provided:
             text_guidance_scale = req.sampling_params.guidance_scale
         self._text_guidance_scale = text_guidance_scale

--- a/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
+++ b/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
@@ -13,7 +13,6 @@ from typing import Any
 import numpy as np
 import PIL.Image
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.image_processor import (
@@ -32,6 +31,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.models.omnigen2.omnigen2_transformer import (
     OmniGen2RotaryPosEmbed,
     OmniGen2Transformer2DModel,
@@ -620,7 +620,11 @@ def retrieve_timesteps(
     return timesteps, num_inference_steps
 
 
+<<<<<<< HEAD
 class OmniGen2Pipeline(CFGParallelMixin, nn.Module):
+=======
+class OmniGen2Pipeline(VllmDiffusionPipeline):
+>>>>>>> 3957749e (first pass at protocol)
     """
     Pipeline for text-to-image generation using OmniGen2.
 

--- a/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
+++ b/vllm_omni/diffusion/models/omnigen2/pipeline_omnigen2.py
@@ -620,11 +620,7 @@ def retrieve_timesteps(
     return timesteps, num_inference_steps
 
 
-<<<<<<< HEAD
-class OmniGen2Pipeline(CFGParallelMixin, nn.Module):
-=======
-class OmniGen2Pipeline(VllmDiffusionPipeline):
->>>>>>> 3957749e (first pass at protocol)
+class OmniGen2Pipeline(VllmDiffusionPipeline, CFGParallelMixin):
     """
     Pipeline for text-to-image generation using OmniGen2.
 

--- a/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
+++ b/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
@@ -41,6 +41,7 @@ from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineL
 from vllm_omni.diffusion.models.ovis_image.ovis_image_transformer import OvisImageTransformer2DModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 
 logger = init_logger(__name__)
@@ -528,6 +529,13 @@ class OvisImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMi
     def interrupt(self):
         return self._interrupt
 
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+            max_sequence_length=256,
+        )
+
     def forward(
         self,
         req: OmniDiffusionRequest,
@@ -536,10 +544,8 @@ class OvisImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMi
         guidance_scale: float = 5.0,
         height: int | None = None,
         width: int | None = None,
-        num_inference_steps: int = 50,
         sigmas: list[float] | None = None,
         num_images_per_prompt: int | None = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.FloatTensor | None = None,
         prompt_embeds: torch.FloatTensor | None = None,
         negative_prompt_embeds: torch.FloatTensor | None = None,
@@ -548,7 +554,6 @@ class OvisImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMi
         joint_attention_kwargs: dict[str, Any] | None = None,
         callback_on_step_end: Callable[[int, int, dict], None] | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
-        max_sequence_length: int = 256,
     ) -> DiffusionOutput:
         r"""
         Function invoked when calling the pipeline for generation.
@@ -628,12 +633,13 @@ class OvisImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMi
 
         height = req.sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = req.sampling_params.width or self.default_sample_size * self.vae_scale_factor
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
+        max_sequence_length = req.sampling_params.max_sequence_length
         sigmas = req.sampling_params.sigmas or sigmas
         guidance_scale = (
             req.sampling_params.guidance_scale if req.sampling_params.guidance_scale is not None else guidance_scale
         )
-        generator = req.sampling_params.generator or generator
+        generator = req.sampling_params.generator
         num_images_per_prompt = (
             req.sampling_params.num_outputs_per_prompt
             if req.sampling_params.num_outputs_per_prompt > 0

--- a/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
+++ b/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
@@ -29,7 +29,6 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler,
 )
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import Qwen2TokenizerFast, Qwen3Model
 from vllm.logger import init_logger
 from vllm.model_executor.models.utils import AutoWeightsLoader
@@ -38,6 +37,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.models.ovis_image.ovis_image_transformer import OvisImageTransformer2DModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -142,7 +142,7 @@ def retrieve_timesteps(
     return timesteps, num_inference_steps
 
 
-class OvisImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMixin):
+class OvisImagePipeline(VllmDiffusionPipeline, CFGParallelMixin, DiffusionPipelineProfilerMixin):
     def __init__(
         self,
         *,

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -38,6 +38,7 @@ from vllm_omni.diffusion.utils.size_utils import (
     normalize_min_aligned_size,
 )
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.inputs.data import DiffusionParamOverrides
 
 if TYPE_CHECKING:
     from vllm_omni.diffusion.worker.utils import DiffusionRequestState
@@ -246,6 +247,13 @@ def apply_rotary_emb_qwen(
 
 class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin):
     supports_step_execution: ClassVar[bool] = True
+
+    # Overrides for default diffusion sampling params when using this pipeline
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
 
     def __init__(
         self,
@@ -697,7 +705,7 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
             negative_prompt=negative_prompt,
             height=sampling.height or self.default_sample_size * self.vae_scale_factor,
             width=sampling.width or self.default_sample_size * self.vae_scale_factor,
-            num_inference_steps=sampling.num_inference_steps or 50,
+            num_inference_steps=sampling.num_inference_steps,
             sigmas=sampling.sigmas,
             guidance_scale=sampling.guidance_scale if sampling.guidance_scale_provided else 1.0,
             num_images_per_prompt=sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1,
@@ -921,7 +929,6 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         true_cfg_scale: float = 4.0,
         height: int | None = None,
         width: int | None = None,
-        num_inference_steps: int = 50,
         sigmas: list[float] | None = None,
         guidance_scale: float = 1.0,
         num_images_per_prompt: int = 1,
@@ -942,7 +949,7 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         height = req.sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = req.sampling_params.width or self.default_sample_size * self.vae_scale_factor
         height, width = normalize_min_aligned_size(height, width, self.vae_scale_factor * 2)
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
         max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
         generator = req.sampling_params.generator or generator

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -253,6 +253,8 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(
             num_inference_steps=50,
+            true_cfg_scale=4.0,
+            max_sequence_length=512,
         )
 
     def __init__(
@@ -710,8 +712,8 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
             guidance_scale=sampling.guidance_scale if sampling.guidance_scale_provided else 1.0,
             num_images_per_prompt=sampling.num_outputs_per_prompt if sampling.num_outputs_per_prompt > 0 else 1,
             generator=sampling.generator,
-            true_cfg_scale=sampling.true_cfg_scale or 4.0,
-            max_sequence_length=sampling.max_sequence_length or 512,
+            true_cfg_scale=sampling.true_cfg_scale,
+            max_sequence_length=sampling.max_sequence_length,
             attention_kwargs=kwargs.get("attention_kwargs"),
         )
 
@@ -874,15 +876,12 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
             },
         )
 
-        true_cfg_scale = state.sampling.true_cfg_scale or 4.0
-        cfg_normalize = state.sampling.cfg_normalize
-
         return self.predict_noise_maybe_with_cfg(
             state.do_true_cfg,
-            true_cfg_scale,
+            state.sampling.true_cfg_scale,
             positive_kwargs,
             negative_kwargs,
-            cfg_normalize,
+            state.sampling.cfg_normalize,
             output_slice,
         )
 
@@ -926,13 +925,11 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         req: OmniDiffusionRequest,
         prompt: str | list[str] | None = None,
         negative_prompt: str | list[str] | None = None,
-        true_cfg_scale: float = 4.0,
         height: int | None = None,
         width: int | None = None,
         sigmas: list[float] | None = None,
         guidance_scale: float = 1.0,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.Tensor | None = None,
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
@@ -941,7 +938,6 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         output_type: str | None = "pil",
         attention_kwargs: dict[str, Any] | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
-        max_sequence_length: int = 512,
     ) -> DiffusionOutput:
         extracted_prompt, negative_prompt = self._extract_prompts(req.prompts)
         prompt = extracted_prompt or prompt
@@ -951,9 +947,9 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         height, width = normalize_min_aligned_size(height, width, self.vae_scale_factor * 2)
         num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
-        max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
-        generator = req.sampling_params.generator or generator
-        true_cfg_scale = req.sampling_params.true_cfg_scale or true_cfg_scale
+        max_sequence_length = req.sampling_params.max_sequence_length
+        generator = req.sampling_params.generator
+        true_cfg_scale = req.sampling_params.true_cfg_scale
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale
         num_images_per_prompt = (

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -18,7 +18,6 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler,
 )
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import Qwen2_5_VLForConditionalGeneration, Qwen2Tokenizer
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
@@ -26,6 +25,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_qwenimage import DistributedAutoencoderKLQwenImage
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
 )
@@ -245,7 +245,7 @@ def apply_rotary_emb_qwen(
         return x_out.type_as(x)
 
 
-class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin):
+class QwenImagePipeline(VllmDiffusionPipeline, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin):
     supports_step_execution: ClassVar[bool] = True
 
     # Overrides for default diffusion sampling params when using this pipeline

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -223,6 +223,8 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(
             num_inference_steps=50,
+            true_cfg_scale=4.0,
+            max_sequence_length=512,
         )
 
     def __init__(
@@ -615,13 +617,11 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         prompt: str | list[str] | None = None,
         negative_prompt: str | list[str] | None = None,
         image: PIL.Image.Image | torch.Tensor | None = None,
-        true_cfg_scale: float = 4.0,
         height: int | None = None,
         width: int | None = None,
         sigmas: list[float] | None = None,
         guidance_scale: float = 1.0,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.Tensor | None = None,
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
@@ -630,7 +630,6 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         output_type: str | None = "pil",
         attention_kwargs: dict[str, Any] | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
-        max_sequence_length: int = 512,
     ) -> DiffusionOutput:
         """Forward pass for image editing."""
         # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
@@ -678,9 +677,9 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
 
         num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
-        max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
-        generator = req.sampling_params.generator or generator
-        true_cfg_scale = req.sampling_params.true_cfg_scale or true_cfg_scale
+        max_sequence_length = req.sampling_params.max_sequence_length
+        generator = req.sampling_params.generator
+        true_cfg_scale = req.sampling_params.true_cfg_scale
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale
         num_images_per_prompt = (

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -20,14 +20,13 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler,
 )
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import Qwen2_5_VLForConditionalGeneration, Qwen2Tokenizer, Qwen2VLProcessor
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
 from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
 )
@@ -217,7 +216,9 @@ def retrieve_latents(
         raise AttributeError("Could not access latents of provided encoder_output")
 
 
-class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin):
+class QwenImageEditPipeline(
+    VllmDiffusionPipeline, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin
+):
     # Overrides for default diffusion sampling params when using this pipeline
     @property
     def sampling_param_defaults(self):

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -41,7 +41,7 @@ from vllm_omni.diffusion.utils.size_utils import (
     normalize_min_aligned_size,
 )
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
-from vllm_omni.inputs.data import OmniTextPrompt
+from vllm_omni.inputs.data import DiffusionParamOverrides, OmniTextPrompt
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -218,6 +218,13 @@ def retrieve_latents(
 
 
 class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin):
+    # Overrides for default diffusion sampling params when using this pipeline
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
+
     def __init__(
         self,
         *,
@@ -611,7 +618,6 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         true_cfg_scale: float = 4.0,
         height: int | None = None,
         width: int | None = None,
-        num_inference_steps: int = 50,
         sigmas: list[float] | None = None,
         guidance_scale: float = 1.0,
         num_images_per_prompt: int = 1,
@@ -670,7 +676,7 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
                 image = self.image_processor.preprocess(image, calculated_height, calculated_width)
                 image = image.unsqueeze(2)
 
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
         max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
         generator = req.sampling_params.generator or generator

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -18,14 +18,13 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler,
 )
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import Qwen2_5_VLForConditionalGeneration, Qwen2Tokenizer, Qwen2VLProcessor
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
 from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
 )
@@ -169,7 +168,7 @@ def get_qwen_image_edit_plus_post_process_func(
 
 
 class QwenImageEditPlusPipeline(
-    nn.Module, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin
+    VllmDiffusionPipeline, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin
 ):
     # Overrides for default diffusion sampling params when using this pipeline
     @property

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -176,6 +176,8 @@ class QwenImageEditPlusPipeline(
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(
             num_inference_steps=50,
+            true_cfg_scale=4.0,
+            max_sequence_length=512,
         )
 
     def __init__(
@@ -548,13 +550,11 @@ class QwenImageEditPlusPipeline(
         prompt: str | list[str] | None = None,
         negative_prompt: str | list[str] | None = None,
         image: PIL.Image.Image | list[PIL.Image.Image] | torch.Tensor | None = None,
-        true_cfg_scale: float = 4.0,
         height: int | None = None,
         width: int | None = None,
         sigmas: list[float] | None = None,
         guidance_scale: float = 1.0,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.Tensor | None = None,
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
@@ -563,7 +563,6 @@ class QwenImageEditPlusPipeline(
         output_type: str | None = "pil",
         attention_kwargs: dict[str, Any] | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
-        max_sequence_length: int = 512,
     ) -> DiffusionOutput:
         """Forward pass for image editing with support for multiple images."""
         # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
@@ -631,9 +630,9 @@ class QwenImageEditPlusPipeline(
 
         num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
-        max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
-        generator = req.sampling_params.generator or generator
-        true_cfg_scale = req.sampling_params.true_cfg_scale or true_cfg_scale
+        max_sequence_length = req.sampling_params.max_sequence_length
+        generator = req.sampling_params.generator
+        true_cfg_scale = req.sampling_params.true_cfg_scale
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale
         num_images_per_prompt = (

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -44,7 +44,7 @@ from vllm_omni.diffusion.utils.size_utils import (
     normalize_min_aligned_size,
 )
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
-from vllm_omni.inputs.data import OmniTextPrompt
+from vllm_omni.inputs.data import DiffusionParamOverrides, OmniTextPrompt
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -171,6 +171,13 @@ def get_qwen_image_edit_plus_post_process_func(
 class QwenImageEditPlusPipeline(
     nn.Module, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin
 ):
+    # Overrides for default diffusion sampling params when using this pipeline
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
+
     def __init__(
         self,
         *,
@@ -544,7 +551,6 @@ class QwenImageEditPlusPipeline(
         true_cfg_scale: float = 4.0,
         height: int | None = None,
         width: int | None = None,
-        num_inference_steps: int = 50,
         sigmas: list[float] | None = None,
         guidance_scale: float = 1.0,
         num_images_per_prompt: int = 1,
@@ -623,7 +629,7 @@ class QwenImageEditPlusPipeline(
                 condition_images.append(self.image_processor.resize(img, condition_height, condition_width))
                 vae_images.append(self.image_processor.preprocess(img, vae_height, vae_width).unsqueeze(2))
 
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
         max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
         generator = req.sampling_params.generator or generator

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
@@ -206,6 +206,8 @@ class QwenImageLayeredPipeline(nn.Module, SupportImageInput, QwenImageCFGParalle
     def sampling_param_defaults(self):
         return DiffusionParamOverrides(
             num_inference_steps=50,
+            true_cfg_scale=4.0,
+            max_sequence_length=512,
         )
 
     def __init__(
@@ -596,12 +598,10 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         image: PIL.Image.Image | torch.Tensor | None = None,
         prompt: str | list[str] | None = None,
         negative_prompt: str | list[str] | None = None,
-        true_cfg_scale: float = 4.0,
         layers: int | None = 4,
         sigmas: list[float] | None = None,
         guidance_scale: float | None = None,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.Tensor | None = None,
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
@@ -609,7 +609,6 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         negative_prompt_embeds_mask: torch.Tensor | None = None,
         output_type: str | None = "pil",
         attention_kwargs: dict[str, Any] | None = None,
-        max_sequence_length: int = 512,
         resolution: int = 640,
         cfg_normalize: bool = False,
         use_en_prompt: bool = False,
@@ -631,7 +630,7 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
 
         layers = req.sampling_params.layers if req.sampling_params.layers is not None else layers
         resolution = req.sampling_params.resolution if req.sampling_params.resolution is not None else resolution
-        max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
+        max_sequence_length = req.sampling_params.max_sequence_length
         cfg_normalize = (
             req.sampling_params.cfg_normalize if req.sampling_params.cfg_normalize is not None else cfg_normalize
         )
@@ -640,8 +639,8 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         )
         num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
-        generator = req.sampling_params.generator or generator
-        true_cfg_scale = req.sampling_params.true_cfg_scale or true_cfg_scale
+        generator = req.sampling_params.generator
+        true_cfg_scale = req.sampling_params.true_cfg_scale
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale
         num_images_per_prompt = (

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
@@ -40,7 +40,7 @@ from vllm_omni.diffusion.utils.size_utils import (
     normalize_min_aligned_size,
 )
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
-from vllm_omni.inputs.data import OmniTextPrompt
+from vllm_omni.inputs.data import DiffusionParamOverrides, OmniTextPrompt
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -200,6 +200,13 @@ def retrieve_latents(
 
 class QwenImageLayeredPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin):
     color_format = "RGBA"
+
+    # Overrides for default diffusion sampling params when using this pipeline
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+        )
 
     def __init__(
         self,
@@ -591,7 +598,6 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         negative_prompt: str | list[str] | None = None,
         true_cfg_scale: float = 4.0,
         layers: int | None = 4,
-        num_inference_steps: int = 50,
         sigmas: list[float] | None = None,
         guidance_scale: float | None = None,
         num_images_per_prompt: int = 1,
@@ -632,7 +638,7 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         use_en_prompt = (
             req.sampling_params.use_en_prompt if req.sampling_params.use_en_prompt is not None else use_en_prompt
         )
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
         generator = req.sampling_params.generator or generator
         true_cfg_scale = req.sampling_params.true_cfg_scale or true_cfg_scale

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
@@ -17,14 +17,13 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler,
 )
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import Qwen2_5_VLForConditionalGeneration, Qwen2Tokenizer, Qwen2VLProcessor
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
 from vllm_omni.diffusion.models.qwen_image.autoencoder_kl_qwenimage import (
     AutoencoderKLQwenImage,
 )
@@ -198,7 +197,9 @@ def retrieve_latents(
         raise AttributeError("Could not access latents of provided encoder_output")
 
 
-class QwenImageLayeredPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin):
+class QwenImageLayeredPipeline(
+    VllmDiffusionPipeline, SupportImageInput, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin
+):
     color_format = "RGBA"
 
     # Overrides for default diffusion sampling params when using this pipeline

--- a/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
+++ b/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
@@ -24,6 +24,7 @@ from vllm_omni.diffusion.models.sd3.sd3_transformer import (
 )
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -499,6 +500,13 @@ class StableDiffusion3Pipeline(nn.Module, CFGParallelMixin, DiffusionPipelinePro
     def interrupt(self):
         return self._interrupt
 
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=28,
+            max_sequence_length=256,
+        )
+
     def diffuse(
         self,
         latents: torch.Tensor,
@@ -581,16 +589,13 @@ class StableDiffusion3Pipeline(nn.Module, CFGParallelMixin, DiffusionPipelinePro
         negative_prompt_3: str | list[str] = "",
         height: int | None = None,
         width: int | None = None,
-        num_inference_steps: int = 28,
         sigmas: list[float] | None = None,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.Tensor | None = None,
         prompt_embeds: torch.Tensor | None = None,
         negative_prompt_embeds: torch.Tensor | None = None,
         pooled_prompt_embeds: torch.Tensor | None = None,
         negative_pooled_prompt_embeds: torch.Tensor | None = None,
-        max_sequence_length: int = 256,
     ) -> DiffusionOutput:
         # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
         # TODO: May be some data formatting operations on the API side. Hack for now.
@@ -602,9 +607,9 @@ class StableDiffusion3Pipeline(nn.Module, CFGParallelMixin, DiffusionPipelinePro
         height = req.sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = req.sampling_params.width or self.default_sample_size * self.vae_scale_factor
         sigmas = req.sampling_params.sigmas or sigmas
-        max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
-        generator = req.sampling_params.generator or generator
+        max_sequence_length = req.sampling_params.max_sequence_length
+        num_inference_steps = req.sampling_params.num_inference_steps
+        generator = req.sampling_params.generator
         num_images_per_prompt = (
             req.sampling_params.num_outputs_per_prompt
             if req.sampling_params.num_outputs_per_prompt > 0

--- a/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
+++ b/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
@@ -10,7 +10,6 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler,
 )
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import CLIPTextModelWithProjection, CLIPTokenizer, T5EncoderModel, T5Tokenizer
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
@@ -19,6 +18,7 @@ from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl import Distribu
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.models.sd3.sd3_transformer import (
     SD3Transformer2DModel,
 )
@@ -129,7 +129,7 @@ def retrieve_timesteps(
     return timesteps, num_inference_steps
 
 
-class StableDiffusion3Pipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMixin):
+class StableDiffusion3Pipeline(VllmDiffusionPipeline, CFGParallelMixin, DiffusionPipelineProfilerMixin):
     def __init__(
         self,
         *,

--- a/vllm_omni/diffusion/models/stable_audio/pipeline_stable_audio.py
+++ b/vllm_omni/diffusion/models/stable_audio/pipeline_stable_audio.py
@@ -32,6 +32,7 @@ from vllm_omni.diffusion.models.stable_audio.stable_audio_transformer import Sta
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.inputs.data import DiffusionParamOverrides
 
 logger = init_logger(__name__)
 
@@ -71,6 +72,12 @@ class StableAudioPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfil
         od_config: OmniDiffusion configuration object
         prefix: Weight prefix for loading (default: "")
     """
+
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=100,
+        )
 
     def __init__(
         self,
@@ -360,10 +367,8 @@ class StableAudioPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfil
         negative_prompt: str | list[str] | None = None,
         audio_end_in_s: float | None = None,
         audio_start_in_s: float = 0.0,
-        num_inference_steps: int = 100,
         guidance_scale: float = 7.0,
         num_waveforms_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.Tensor | None = None,
         prompt_embeds: torch.Tensor | None = None,
         negative_prompt_embeds: torch.Tensor | None = None,
@@ -399,12 +404,11 @@ class StableAudioPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfil
         elif req.prompts:
             negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in req.prompts]
 
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale
 
-        if generator is None:
-            generator = req.sampling_params.generator
+        generator = req.sampling_params.generator
         if generator is None and req.sampling_params.seed is not None:
             generator = torch.Generator(device=self.device).manual_seed(req.sampling_params.seed)
 

--- a/vllm_omni/diffusion/models/stable_audio/pipeline_stable_audio.py
+++ b/vllm_omni/diffusion/models/stable_audio/pipeline_stable_audio.py
@@ -19,7 +19,6 @@ from diffusers.models.embeddings import get_1d_rotary_pos_embed
 from diffusers.pipelines.stable_audio.modeling_stable_audio import StableAudioProjectionModel
 from diffusers.schedulers import CosineDPMSolverMultistepScheduler
 from diffusers.utils.torch_utils import randn_tensor
-from torch import nn
 from transformers import T5EncoderModel, T5TokenizerFast
 from vllm.logger import init_logger
 from vllm.model_executor.models.utils import AutoWeightsLoader
@@ -27,7 +26,7 @@ from vllm.model_executor.models.utils import AutoWeightsLoader
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import SupportAudioOutput
+from vllm_omni.diffusion.models.interface import SupportAudioOutput, VllmDiffusionPipeline
 from vllm_omni.diffusion.models.stable_audio.stable_audio_transformer import StableAudioDiTModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -61,7 +60,7 @@ def get_stable_audio_post_process_func(
     return post_process_func
 
 
-class StableAudioPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMixin):
+class StableAudioPipeline(VllmDiffusionPipeline, SupportAudioOutput, DiffusionPipelineProfilerMixin):
     """
     Pipeline for text-to-audio generation using Stable Audio Open.
 

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -22,6 +22,7 @@ from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import Dist
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
 from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
 from vllm_omni.diffusion.models.wan2_2.scheduling_wan_euler import WanEulerScheduler
@@ -231,7 +232,7 @@ def get_wan22_pre_process_func(
     return pre_process_func
 
 
-class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin):
+class Wan22Pipeline(VllmDiffusionPipeline, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin):
     def __init__(
         self,
         *,

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -28,7 +28,7 @@ from vllm_omni.diffusion.models.wan2_2.scheduling_wan_euler import WanEulerSched
 from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import WanTransformer3DModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
-from vllm_omni.inputs.data import OmniTextPrompt
+from vllm_omni.inputs.data import DiffusionParamOverrides, OmniTextPrompt
 from vllm_omni.platforms import current_omni_platform
 
 logger = logging.getLogger(__name__)
@@ -358,6 +358,13 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
         return create_transformer_from_config(config)
 
     @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=40,
+            max_sequence_length=512,
+        )
+
+    @property
     def guidance_scale(self):
         return self._guidance_scale
 
@@ -380,11 +387,9 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
         negative_prompt: str | None = None,
         height: int = 480,
         width: int = 832,
-        num_inference_steps: int = 40,
         guidance_scale: float | tuple[float, float] = 4.0,
         frame_num: int = 81,
         output_type: str | None = "np",
-        generator: torch.Generator | list[torch.Generator] | None = None,
         prompt_embeds: torch.Tensor | None = None,
         negative_prompt_embeds: torch.Tensor | None = None,
         attention_kwargs: dict | None = None,
@@ -412,7 +417,7 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
         mod_value = self.vae_scale_factor_spatial * patch_size[1]  # 16*2=32 for TI2V, 8*2=16 for I2V
         height = (height // mod_value) * mod_value
         width = (width // mod_value) * mod_value
-        num_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_steps = req.sampling_params.num_inference_steps
 
         # Respect per-request guidance_scale when explicitly provided.
         if req.sampling_params.guidance_scale_provided:
@@ -467,8 +472,7 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
             dtype = self.text_encoder.dtype
 
         # Seed / generator
-        if generator is None:
-            generator = req.sampling_params.generator
+        generator = req.sampling_params.generator
         if generator is None and req.sampling_params.seed is not None:
             generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
 
@@ -483,7 +487,7 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
                 negative_prompt=negative_prompt,
                 do_classifier_free_guidance=guidance_low > 1.0 or guidance_high > 1.0,
                 num_videos_per_prompt=req.sampling_params.num_outputs_per_prompt or 1,
-                max_sequence_length=req.sampling_params.max_sequence_length or 512,
+                max_sequence_length=req.sampling_params.max_sequence_length,
                 device=device,
                 dtype=dtype,
             )

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -22,7 +22,7 @@ from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import Dist
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
 from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
     build_wan_scheduler,
@@ -145,7 +145,7 @@ def get_wan22_i2v_pre_process_func(
 
 
 class Wan22I2VPipeline(
-    nn.Module, SupportImageInput, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin
+    VllmDiffusionPipeline, SupportImageInput, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin
 ):
     """
     Wan2.2 Image-to-Video Pipeline.

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -34,7 +34,7 @@ from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
 )
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
-from vllm_omni.inputs.data import OmniTextPrompt
+from vllm_omni.inputs.data import DiffusionParamOverrides, OmniTextPrompt
 from vllm_omni.platforms import current_omni_platform
 
 logger = logging.getLogger(__name__)
@@ -255,6 +255,13 @@ class Wan22I2VPipeline(
         )
 
     @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=40,
+            max_sequence_length=512,
+        )
+
+    @property
     def guidance_scale(self):
         return self._guidance_scale
 
@@ -293,11 +300,9 @@ class Wan22I2VPipeline(
         image: PIL.Image.Image | torch.Tensor | None = None,
         height: int = 480,
         width: int = 832,
-        num_inference_steps: int = 40,
         guidance_scale: float | tuple[float, float] = 5.0,
         frame_num: int = 81,
         output_type: str | None = "np",
-        generator: torch.Generator | list[torch.Generator] | None = None,
         prompt_embeds: torch.Tensor | None = None,
         negative_prompt_embeds: torch.Tensor | None = None,
         image_embeds: torch.Tensor | None = None,
@@ -340,7 +345,7 @@ class Wan22I2VPipeline(
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
         num_frames = req.sampling_params.num_frames or frame_num
-        num_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_steps = req.sampling_params.num_inference_steps
 
         # Respect per-request guidance_scale when explicitly provided.
         if req.sampling_params.guidance_scale_provided:
@@ -389,8 +394,7 @@ class Wan22I2VPipeline(
         dtype = self.transformer.dtype
 
         # Generator setup
-        if generator is None:
-            generator = req.sampling_params.generator
+        generator = req.sampling_params.generator
         if generator is None and req.sampling_params.seed is not None:
             generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
 
@@ -406,7 +410,7 @@ class Wan22I2VPipeline(
                 negative_prompt=negative_prompt,
                 do_classifier_free_guidance=guidance_low > 1.0 or guidance_high > 1.0,
                 num_videos_per_prompt=req.sampling_params.num_outputs_per_prompt or 1,
-                max_sequence_length=req.sampling_params.max_sequence_length or 512,
+                max_sequence_length=req.sampling_params.max_sequence_length,
                 device=device,
                 dtype=dtype,
             )

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_ti2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_ti2v.py
@@ -34,7 +34,7 @@ from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import Omni
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportImageInput, VllmDiffusionPipeline
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
     build_wan_scheduler,
@@ -131,7 +131,7 @@ def get_wan22_ti2v_pre_process_func(
     return pre_process_func
 
 
-class Wan22TI2VPipeline(nn.Module, SupportImageInput, CFGParallelMixin, ProgressBarMixin):
+class Wan22TI2VPipeline(VllmDiffusionPipeline, SupportImageInput, CFGParallelMixin, ProgressBarMixin):
     """
     Wan2.2 Text-Image-to-Video (TI2V) Pipeline.
 

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_ti2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_ti2v.py
@@ -45,7 +45,7 @@ from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
     retrieve_latents,
 )
 from vllm_omni.diffusion.request import OmniDiffusionRequest
-from vllm_omni.inputs.data import OmniTextPrompt
+from vllm_omni.inputs.data import DiffusionParamOverrides, OmniTextPrompt
 from vllm_omni.platforms import current_omni_platform
 
 logger = logging.getLogger(__name__)
@@ -201,6 +201,13 @@ class Wan22TI2VPipeline(nn.Module, SupportImageInput, CFGParallelMixin, Progress
         self._current_timestep = None
 
     @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=40,
+            max_sequence_length=512,
+        )
+
+    @property
     def guidance_scale(self):
         return self._guidance_scale
 
@@ -224,11 +231,9 @@ class Wan22TI2VPipeline(nn.Module, SupportImageInput, CFGParallelMixin, Progress
         image: PIL.Image.Image | torch.Tensor | None = None,
         height: int = 704,
         width: int = 1280,
-        num_inference_steps: int = 40,
         guidance_scale: float = 5.0,
         frame_num: int = 81,
         output_type: str | None = "np",
-        generator: torch.Generator | list[torch.Generator] | None = None,
         prompt_embeds: torch.Tensor | None = None,
         negative_prompt_embeds: torch.Tensor | None = None,
         attention_kwargs: dict | None = None,
@@ -270,7 +275,7 @@ class Wan22TI2VPipeline(nn.Module, SupportImageInput, CFGParallelMixin, Progress
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
         num_frames = req.sampling_params.num_frames if req.sampling_params.num_frames else frame_num
-        num_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_steps = req.sampling_params.num_inference_steps
 
         # Respect per-request guidance_scale when explicitly provided.
         if req.sampling_params.guidance_scale_provided:
@@ -298,8 +303,7 @@ class Wan22TI2VPipeline(nn.Module, SupportImageInput, CFGParallelMixin, Progress
         dtype = self.transformer.dtype
 
         # Generator setup
-        if generator is None:
-            generator = req.sampling_params.generator
+        generator = req.sampling_params.generator
         if generator is None and req.sampling_params.seed is not None:
             generator = torch.Generator(device=device).manual_seed(req.sampling_params.seed)
 
@@ -310,7 +314,7 @@ class Wan22TI2VPipeline(nn.Module, SupportImageInput, CFGParallelMixin, Progress
                 negative_prompt=negative_prompt,
                 do_classifier_free_guidance=guidance_scale > 1.0,
                 num_videos_per_prompt=req.sampling_params.num_outputs_per_prompt or 1,
-                max_sequence_length=req.sampling_params.max_sequence_length or 512,
+                max_sequence_length=req.sampling_params.max_sequence_length,
                 device=device,
                 dtype=dtype,
             )

--- a/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
+++ b/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
@@ -23,12 +23,7 @@ from typing import Any
 
 import PIL.Image
 import torch
-<<<<<<< HEAD
-import torch.nn as nn
 from diffusers.image_processor import PipelineImageInput, VaeImageProcessor
-=======
-from diffusers.image_processor import VaeImageProcessor
->>>>>>> 3957749e (first pass at protocol)
 from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
 from diffusers.utils import logging
 from diffusers.utils.torch_utils import randn_tensor

--- a/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
+++ b/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
@@ -23,8 +23,12 @@ from typing import Any
 
 import PIL.Image
 import torch
+<<<<<<< HEAD
 import torch.nn as nn
 from diffusers.image_processor import PipelineImageInput, VaeImageProcessor
+=======
+from diffusers.image_processor import VaeImageProcessor
+>>>>>>> 3957749e (first pass at protocol)
 from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
 from diffusers.utils import logging
 from diffusers.utils.torch_utils import randn_tensor
@@ -35,6 +39,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl import DistributedAutoencoderKL
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline
 from vllm_omni.diffusion.models.z_image.z_image_transformer import (
     ZImageTransformer2DModel,
 )
@@ -159,7 +164,7 @@ def retrieve_timesteps(
     return timesteps, num_inference_steps
 
 
-class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
+class ZImagePipeline(VllmDiffusionPipeline, DiffusionPipelineProfilerMixin):
     def __init__(
         self,
         *,

--- a/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
+++ b/vllm_omni/diffusion/models/z_image/pipeline_z_image.py
@@ -40,6 +40,7 @@ from vllm_omni.diffusion.models.z_image.z_image_transformer import (
 )
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import DiffusionParamOverrides
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -374,6 +375,13 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
     def interrupt(self):
         return self._interrupt
 
+    @property
+    def sampling_param_defaults(self):
+        return DiffusionParamOverrides(
+            num_inference_steps=50,
+            max_sequence_length=512,
+        )
+
     def forward(
         self,
         req: OmniDiffusionRequest,
@@ -382,14 +390,12 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
         strength: float = 0.6,
         height: int = 1024,
         width: int = 1024,
-        num_inference_steps: int = 50,
         sigmas: list[float] | None = None,
         guidance_scale: float = 5.0,
         cfg_normalization: bool = False,
         cfg_truncation: float = 1.0,
         negative_prompt: str | list[str] | None = None,
         num_images_per_prompt: int = 1,
-        generator: torch.Generator | list[torch.Generator] | None = None,
         latents: torch.FloatTensor | None = None,
         prompt_embeds: list[torch.FloatTensor] | None = None,
         negative_prompt_embeds: list[torch.FloatTensor] | None = None,
@@ -398,7 +404,6 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
         joint_attention_kwargs: dict[str, Any] | None = None,
         callback_on_step_end: Callable[[int, int, dict], None] | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
-        max_sequence_length: int = 512,
     ) -> DiffusionOutput:
         r"""
         Function invoked when calling the pipeline for generation.
@@ -520,10 +525,10 @@ class ZImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
 
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        num_inference_steps = req.sampling_params.num_inference_steps
         generator = req.sampling_params.generator
         sigmas = req.sampling_params.sigmas or sigmas
-        max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
+        max_sequence_length = req.sampling_params.max_sequence_length
         guidance_scale = (
             req.sampling_params.guidance_scale if req.sampling_params.guidance_rescale is not None else guidance_scale
         )

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -27,7 +27,7 @@ from vllm_omni.diffusion.compile import regionally_compile
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.forward_context import set_forward_context
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import supports_step_execution
+from vllm_omni.diffusion.models.interface import VllmDiffusionPipeline, supports_step_execution
 from vllm_omni.diffusion.offloader import get_offload_backend
 from vllm_omni.diffusion.registry import _NO_CACHE_ACCELERATION
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -232,10 +232,9 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             sampling_params.generator = torch.Generator(device=gen_device).manual_seed(sampling_params.seed)
 
         # Apply model specific defaults to unset fields
-        def_params = getattr(self.pipeline, "sampling_param_defaults", None)
-        if def_params is not None:
+        if isinstance(self.pipeline, VllmDiffusionPipeline):
             logger.debug("Merging default sampling params into user request")
-            sampling_params.merge_with_def_params(def_params)
+            sampling_params.merge_with_def_params(self.pipeline.sampling_param_defaults)
         return sampling_params
 
     def execute_model(self, req: OmniDiffusionRequest) -> DiffusionOutput:

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -218,6 +218,26 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             pool_overhead_gb / peak_reserved_gb * 100 if peak_reserved_gb > 0 else 0.0,
         )
 
+    def _finalize_sampling_params(self, sampling_params):
+        """Finalizes the sampling params by adding pipeline defaults;
+        NOTE: This is done in place."""
+        # Resolve the sampling params generator first
+        if sampling_params.generator is None and sampling_params.seed is not None:
+            if sampling_params.generator_device is not None:
+                gen_device = sampling_params.generator_device
+            elif self.device.type == "cpu":
+                gen_device = "cpu"
+            else:
+                gen_device = self.device
+            sampling_params.generator = torch.Generator(device=gen_device).manual_seed(sampling_params.seed)
+
+        # Apply model specific defaults to unset fields
+        def_params = getattr(self.pipeline, "sampling_param_defaults", None)
+        if def_params is not None:
+            logger.debug("Merging default sampling params into user request")
+            sampling_params.merge_with_def_params(def_params)
+        return sampling_params
+
     def execute_model(self, req: OmniDiffusionRequest) -> DiffusionOutput:
         """
         Execute a forward pass for the given requests.
@@ -238,6 +258,9 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         if len(req.prompts) == 0:
             raise ValueError("Cannot execute model with empty request list")
 
+        # set the generator and pipeline defaults for sampling params.
+        sampling_params = self._finalize_sampling_params(req.sampling_params)
+
         # Use no_grad() for HSDP compatibility, inference_mode() otherwise for better perf
         use_hsdp = self.od_config.parallel_config.use_hsdp
         grad_context = torch.no_grad() if use_hsdp else torch.inference_mode()
@@ -249,23 +272,14 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                 target_device=getattr(self.pipeline, "device", None),
             )
 
-            if req.sampling_params.generator is None and req.sampling_params.seed is not None:
-                if req.sampling_params.generator_device is not None:
-                    gen_device = req.sampling_params.generator_device
-                elif self.device.type == "cpu":
-                    gen_device = "cpu"
-                else:
-                    gen_device = self.device
-                req.sampling_params.generator = torch.Generator(device=gen_device).manual_seed(req.sampling_params.seed)
-
             # Refresh cache context if needed
             if (
                 not getattr(req, "skip_cache_refresh", False)
                 and self.cache_backend is not None
                 and self.cache_backend.is_enabled()
-                and req.sampling_params.num_inference_steps is not None
+                and sampling_params.num_inference_steps is not None
             ):
-                self.cache_backend.refresh(self.pipeline, req.sampling_params.num_inference_steps)
+                self.cache_backend.refresh(self.pipeline, sampling_params.num_inference_steps)
 
             is_primary = not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
             if is_primary:
@@ -357,16 +371,11 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             state, is_new_request = self._update_states(scheduler_output)
 
             if is_new_request:
-                # TODO: support kv manager recv
-                # TODO: support cache backend
-                if state.sampling.generator is None and state.sampling.seed is not None:
-                    if state.sampling.generator_device is not None:
-                        gen_device = state.sampling.generator_device
-                    elif self.device.type == "cpu":
-                        gen_device = "cpu"
-                    else:
-                        gen_device = self.device
-                    state.sampling.generator = torch.Generator(device=gen_device).manual_seed(state.sampling.seed)
+                # set the generator and pipeline defaults for sampling params.
+                state.sampling = self._finalize_sampling_params(state.sampling)
+
+            # TODO: support kv manager recv
+            # TODO: support cache backend
 
             with set_forward_context(vllm_config=self.vllm_config, omni_diffusion_config=self.od_config):
                 # step0/new request: encode

--- a/vllm_omni/inputs/data.py
+++ b/vllm_omni/inputs/data.py
@@ -1,7 +1,8 @@
 import copy
 import pprint
-from dataclasses import asdict, dataclass, field, fields
-from typing import Any, TypeAlias, TypedDict
+from dataclasses import dataclass, field, fields
+from functools import wraps
+from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, TypeVar
 
 from vllm.inputs import PromptType
 from vllm.sampling_params import SamplingParams
@@ -17,6 +18,23 @@ except ImportError:
 
 import torch
 from vllm.inputs import EmbedsPrompt, TextPrompt, TokensInput, TokensPrompt
+
+_T = TypeVar("_T")
+
+
+def track_init_args(cls: type[_T]) -> type[_T]:
+    """Decorator that wraps __init__ to track which kwargs were explicitly
+    passed by the caller, so that merge_with_def_params can distinguish
+    'caller set this to 0' from 'caller never touched this'."""
+    original_init = cls.__init__
+
+    @wraps(original_init)
+    def new_init(self, **kwargs):
+        self._init_kwargs = set(kwargs.keys())
+        original_init(self, **kwargs)
+
+    cls.__init__ = new_init
+    return cls
 
 
 class OmniTextPrompt(TextPrompt):
@@ -170,6 +188,7 @@ def token_inputs_omni(
     return inputs
 
 
+@track_init_args
 @dataclass
 class OmniDiffusionSamplingParams:
     """
@@ -178,7 +197,14 @@ class OmniDiffusionSamplingParams:
     This dataclass contains all information needed during the diffusion pipeline
     execution, allowing methods to update specific components without needing
     to manage numerous individual parameters.
+
+    The @track_init_args decorator records which kwargs the caller explicitly
+    passed, so merge_with_def_params can fill in pipeline defaults only for
+    fields the caller never touched.
     """
+
+    if TYPE_CHECKING:
+        _init_kwargs: set[str]
 
     # Additional text-related parameters
     max_sequence_length: int | None = None
@@ -234,8 +260,7 @@ class OmniDiffusionSamplingParams:
     step_index: int | None = None
     boundary_ratio: float | None = None
 
-    # Scheduler parameters – ``None`` means "not explicitly set by the caller";
-    # each pipeline's ``forward()`` decides its own model-specific default.
+    # Scheduler parameters
     num_inference_steps: int | None = None
     guidance_scale: float = 0.0
     guidance_scale_provided: bool = False
@@ -247,7 +272,7 @@ class OmniDiffusionSamplingParams:
     eta: float = 0.0
     sigmas: list[float] | None = None
 
-    true_cfg_scale: float | None = None  # qwen-image specific now
+    true_cfg_scale: float | None = None
 
     n_tokens: int | None = None
     extra_step_kwargs: dict[str, Any] = field(default_factory=dict)
@@ -327,20 +352,24 @@ class OmniDiffusionSamplingParams:
         return float(fps)
 
     def __str__(self):
-        return pprint.pformat(asdict(self), indent=2, width=120)
+        return pprint.pformat({f.name: getattr(self, f.name) for f in fields(self)}, indent=2, width=120)
 
     def clone(self) -> "OmniDiffusionSamplingParams":
         return copy.deepcopy(self)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict for IPC / serialization."""
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+
     def merge_with_def_params(self, def_params: "DiffusionParamOverrides"):
-        """Merges an instance of this class with a pipeline's defaults."""
+        """Merges an instance of this class with a pipeline's defaults.
+
+        Only fills in fields that the caller did not explicitly pass to
+        __init__; explicitly-set values (including falsy ones like 0 or
+        False) are preserved.
+        """
         for attr_name, attr_val in def_params.validated_overrides.items():
-            # For now, check if the field is falsy and override it.
-            # TODO: We should handle this better, because this does
-            # not distinguish between the user passing a Falsy value
-            # vs initializing with the default, but it matches the
-            # current pipeline behavior.
-            if not getattr(self, attr_name):
+            if attr_name not in self._init_kwargs:
                 setattr(self, attr_name, attr_val)
 
 

--- a/vllm_omni/inputs/data.py
+++ b/vllm_omni/inputs/data.py
@@ -1,6 +1,6 @@
 import copy
 import pprint
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from typing import Any, TypeAlias, TypedDict
 
 from vllm.inputs import PromptType
@@ -331,6 +331,30 @@ class OmniDiffusionSamplingParams:
 
     def clone(self) -> "OmniDiffusionSamplingParams":
         return copy.deepcopy(self)
+
+    def merge_with_def_params(self, def_params: "DiffusionParamOverrides"):
+        """Merges an instance of this class with a pipeline's defaults."""
+        for attr_name, attr_val in def_params.validated_overrides.items():
+            # For now, check if the field is falsy and override it.
+            # TODO: We should handle this better, because this does
+            # not distinguish between the user passing a Falsy value
+            # vs initializing with the default, but it matches the
+            # current pipeline behavior.
+            if not getattr(self, attr_name):
+                setattr(self, attr_name, attr_val)
+
+
+class DiffusionParamOverrides:
+    """A wrapper around a dict mapping attribute names to sampling params."""
+
+    def __init__(self, **kwargs) -> None:
+        valid_keys = {f.name for f in fields(OmniDiffusionSamplingParams)}
+        for attr_name, attr_val in kwargs.items():
+            if attr_name not in valid_keys:
+                raise AttributeError(f"{attr_name} is not a valid OmniDiffusionSamplingParams field")
+
+        # TODO would be nice to validate types too
+        self.validated_overrides = kwargs
 
 
 OmniSamplingParams: TypeAlias = SamplingParams | OmniDiffusionSamplingParams

--- a/vllm_omni/inputs/data.py
+++ b/vllm_omni/inputs/data.py
@@ -1,8 +1,9 @@
 import copy
 import pprint
+from collections.abc import Callable
 from dataclasses import dataclass, field, fields
 from functools import wraps
-from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, TypeVar
+from typing import Any, TypeAlias, TypedDict, TypeVar
 
 from vllm.inputs import PromptType
 from vllm.sampling_params import SamplingParams
@@ -25,15 +26,22 @@ _T = TypeVar("_T")
 def track_init_args(cls: type[_T]) -> type[_T]:
     """Decorator that wraps __init__ to track which kwargs were explicitly
     passed by the caller, so that merge_with_def_params can distinguish
-    'caller set this to 0' from 'caller never touched this'."""
-    original_init = cls.__init__
+    'caller set this to 0' from 'caller never touched this'.
+
+    NOTE: This decorator preserves the original __init__ signature for
+    type checkers while adding runtime tracking of explicitly-passed kwargs.
+    """
+    original_init: Callable[..., None] = cls.__init__
 
     @wraps(original_init)
-    def new_init(self, **kwargs):
-        self._init_kwargs = set(kwargs.keys())
-        original_init(self, **kwargs)
+    def new_init(self: _T, *args: Any, **kwargs: Any) -> None:
+        # Call the original init first (which sets _init_kwargs to empty set)
+        original_init(self, *args, **kwargs)
+        # Then track which keyword arguments were explicitly passed
+        self._init_kwargs: set[str] = set(kwargs.keys())  # type: ignore[attr-defined]
 
-    cls.__init__ = new_init
+    # Replace __init__ - type: ignore needed due to limitations in typing dynamic method replacement
+    cls.__init__ = new_init  # type: ignore[method-assign]
     return cls
 
 
@@ -203,8 +211,8 @@ class OmniDiffusionSamplingParams:
     fields the caller never touched.
     """
 
-    if TYPE_CHECKING:
-        _init_kwargs: set[str]
+    # Set by the @track_init_args decorator at runtime; excluded from __init__
+    _init_kwargs: set[str] = field(init=False, default_factory=set)
 
     # Additional text-related parameters
     max_sequence_length: int | None = None
@@ -272,7 +280,7 @@ class OmniDiffusionSamplingParams:
     eta: float = 0.0
     sigmas: list[float] | None = None
 
-    true_cfg_scale: float | None = None
+    true_cfg_scale: float | None = None  # qwen-image specific for now
 
     n_tokens: int | None = None
     extra_step_kwargs: dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Purpose
For this RFC: https://github.com/vllm-project/vllm-omni/issues/2189
As a consequence of this refactor, will also fix issues with default params not refreshing properly when `num_inference_steps` isn't set: https://github.com/vllm-project/vllm-omni/issues/2189. If this ends up merged before https://github.com/vllm-project/vllm-omni/pull/2240, we won't need that PR anymore.

### Current State
- every diffusion pipeline inherits from `VllmDiffusionPipeline`
- all `VllmDiffusionPipeline` instances have a `sampling_param_defaults` property which resolves to a `DiffusionParamOverrides` object, setting default values for sampling params on a per pipeline basis
- `DiffusionParamOverrides` can be merged with `OmniDiffusionSamplingParams` with the priority `passed by user > pipeline default (in DiffusionParamOverrides) > OmniDiffusionSamplingParams default`
    - Rather than having a sentinel for every dataclass field, this is accomplished with a `track_init_args` decorator, which just saves the names of the fields that were passed by the user when initializing the dataclass. This is needed for the following case:
         - If the default for `foo` in the `OmniDiffusionSamplingParams` is `0`, but a pipeline sets `foo=1` in its `DiffusionParamOverrides`, resolving should give 1
         - However, if the user actually passes 0, it should override `foo` in the pipeline to set a final value of `0`. I.e., we need to be able to distinguish between when a user passes a default value in `OmniDiffusionSamplingParams` vs when it's set by default.
- When we execute_model, we resolve the sampling params immediately so that when we go to refresh the cache, it behaves correctly

### Things Left
- Take another pass through models and ensure that all params that should be in the params are in the `DiffusionParamOverrides`
- Add additional helpers for getting different components (i.e., should have helpers/proprties for getting the transformer/Vae etc so that we don't have to discover attributes as frequently)
    - We can also add additional properties using those ^ to check for things like support for sequence parallelism etc, e.g `pipe.supports_sequence_parallel` can essentially be boiled down to `hasattr(pipe.get_transformer(), "_sp_plan")`, etc
- Need to ensure behavior is consistent with the online path (mostly have tested with offline so far)


## Test Plan
- Tests have been added for some of the merging utils to ensure the sampling param logic (These are in `tests/diffusion/inputs/test_data.py`)
- We should add fast generic tests for all pipelines where possible. For example, we can be check that all sampling param overrides are resolvable into valid `OmniDiffusionSamplingParams` quickly without loading model weights. (These are in `tests/diffusion/models/test_base.py`)

This is joint work with @vraiti , thanks for the help! 🙂 

Will move this out of draft once it's cleaned up and tested since it's quite messy atm, but opening the draft PR in case people have comments on the direction. FYI @wtomin @SamitHuang @lishunyang12 @asukaqaq-s @hsliuustc0106 @fhfuih 