### PR TITLE
[BugFix] Fix V2 model runner profile_run crash for Omni Talker stages

### DIFF
--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
@@ -380,6 +380,29 @@ class Qwen2_5OmniForConditionalGeneration(
         self,
         input_tokens: list[int],
         mm_features: list[MultiModalFeatureSpec] | None = None,
+        # V1 runner passes these explicitly; thinker extracts them
+        # from mm_features via gather_kwargs, so they're unused here.
+        hf_config: PretrainedConfig | None = None,
+        image_grid_thw: list[list[int]] | torch.Tensor | None = None,
+        video_grid_thw: list[list[int]] | torch.Tensor | None = None,
+        second_per_grid_ts: list[float] | None = None,
+        context_len: int = 0,
+        seq_len: int | None = None,
+        audio_feature_lengths: torch.Tensor | None = None,
+        use_audio_in_video: bool = False,
+    ) -> tuple[torch.Tensor, int]:
+        if self.model_stage == "thinker":
+            if mm_features is None:
+                mm_features = []
+            return self.thinker.get_mrope_input_positions(input_tokens, mm_features)
+        seq_len_ = len(input_tokens)
+        positions = torch.arange(seq_len_).unsqueeze(0).expand(3, -1)
+        return positions, 0
+
+    def _get_mrope_input_positions_v1(
+        self,
+        input_tokens: list[int],
+        mm_features: list[MultiModalFeatureSpec] | None = None,
         *,
         hf_config: PretrainedConfig,
         image_grid_thw: list[list[int]] | torch.Tensor,

--- a/vllm_omni/worker_v2/model_states/__init__.py
+++ b/vllm_omni/worker_v2/model_states/__init__.py
@@ -19,6 +19,7 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 # AND update the corresponding test in tests/worker_v2/test_init_model_state.py.
 _OMNI_ARCHITECTURES: set[str] = {
     "Qwen3OmniMoeForConditionalGeneration",
+    "Qwen2_5OmniForConditionalGeneration",
     "MammothModa2ForConditionalGeneration",
     "MiMoAudioForConditionalGeneration",
     "MammothModa2ARForConditionalGeneration",

--- a/vllm_omni/worker_v2/omni_model_runner.py
+++ b/vllm_omni/worker_v2/omni_model_runner.py
@@ -273,22 +273,15 @@ class OmniGPUModelRunner(GPUModelRunner):
                 model_output = self.model(**model_inputs)
 
             # Extract hidden_states from model output.
+            self._last_aux_output = None
             if isinstance(model_output, OmniOutput):
-                self._last_aux_output = None
                 hidden_states = model_output.text_hidden_states
             elif isinstance(model_output, tuple) and len(model_output) == 2:
-                first, second = model_output
-                if isinstance(first, torch.Tensor):
-                    self._last_aux_output = second
-                    if hasattr(self.model, "_last_captured_layers"):
-                        self.model._last_captured_layers = second
-                    hidden_states = first
-                else:
-                    self._last_aux_output = None
-                    hidden_states = model_output
+                hidden_states, self._last_aux_output = model_output
+                if hasattr(self.model, "_last_captured_layers"):
+                    self.model._last_captured_layers = self._last_aux_output
             else:
-                self._last_aux_output = None
-                hidden_states = model_output
+                raise TypeError(f"Unexpected model output type: {type(model_output)}")
 
         # ★ POST-FORWARD: per-request postprocess
         if not dummy_run and isinstance(hidden_states, torch.Tensor):

--- a/vllm_omni/worker_v2/omni_model_runner.py
+++ b/vllm_omni/worker_v2/omni_model_runner.py
@@ -30,6 +30,7 @@ from vllm.v1.worker.gpu.model_runner import (
     get_uniform_token_count,
 )
 
+from vllm_omni.model_executor.models.output_templates import OmniOutput
 from vllm_omni.worker_v2.model_states import init_omni_model_state
 from vllm_omni.worker_v2.model_states.omni_model_state import OmniModelState
 
@@ -65,6 +66,12 @@ class OmniGPUModelRunner(GPUModelRunner):
         # FULL graph replay bypasses Python entirely — only PIECEWISE
         # is safe for these models.
         self._exclude_full_graph = self._model_returns_tuple or hasattr(self.model, "_last_captured_layers")
+
+        # Preprocess models get embeddings via run_preprocess(), not
+        # encoder_runner (whose buffer size would mismatch).
+        if getattr(self.model, "has_preprocess", False) and self.supports_mm_inputs:
+            self.supports_mm_inputs = False
+            self.encoder_cache = None
 
     # ------------------------------------------------------------------
     # CUDA Graph: conditionally exclude FULL mode
@@ -265,17 +272,14 @@ class OmniGPUModelRunner(GPUModelRunner):
                 self.kv_connector.pre_forward(scheduler_output)
                 model_output = self.model(**model_inputs)
 
-            # ★ TUPLE INTERCEPT: handle models that return (hidden, aux_dict).
-            # torch.compile may prevent in-model side-effects like
-            # self._last_captured_layers = ... from taking effect,
-            # so the tuple may surface here even when the model tries to
-            # store captured layers internally.
-            if isinstance(model_output, tuple) and len(model_output) == 2:
+            # Extract hidden_states from model output.
+            if isinstance(model_output, OmniOutput):
+                self._last_aux_output = None
+                hidden_states = model_output.text_hidden_states
+            elif isinstance(model_output, tuple) and len(model_output) == 2:
                 first, second = model_output
                 if isinstance(first, torch.Tensor):
                     self._last_aux_output = second
-                    # Store captured layers on the model so
-                    # make_omni_output can retrieve them.
                     if hasattr(self.model, "_last_captured_layers"):
                         self.model._last_captured_layers = second
                     hidden_states = first


### PR DESCRIPTION
## Purpose

Fix three V2 model runner bugs that crash during `profile_run` for Omni Talker stages (Qwen3-Omni and Qwen2.5-Omni). These bugs block V2 runner adoption for all Omni models with Talker stages.

Reproduces CI failures in buildkite builds [#6704 (H100)](https://buildkite.com/vllm/vllm-omni/builds/6704) and [#6691 (L4)](https://buildkite.com/vllm/vllm-omni/builds/6691).

**Root causes and fixes:**

1. **encoder_runner buffer shape mismatch** — Talker shares `Qwen3OmniMoeForConditionalGeneration` architecture with Thinker, so multimodal registry marks `supports_mm_inputs=True`. encoder_runner allocates `inputs_embeds` buffer using `hf_text_config.hidden_size` (2048) but Talker's actual embedding dim is 1024 → `RuntimeError: expanded size (2048) must match existing size (1024)`. Fix: disable MM path for models with `has_preprocess` (embeddings injected via `run_preprocess()`, not encoder_runner).

2. **OmniOutput not handled in execute_model** — `OmniOutput` is a NamedTuple (len=4), but the tuple intercept only checks `len==2`, leaving `hidden_states` as a non-tensor → `AssertionError`. Fix: check `isinstance(OmniOutput)` first and extract `text_hidden_states`.

3. **Qwen2.5-Omni M-RoPE signature mismatch** — V2 `RopeState` calls `get_mrope_input_positions(input_tokens, mm_features)` but the old signature required keyword-only args (`hf_config`, `image_grid_thw`, etc.) → `TypeError`. Fix: new signature accepts all params as optional, delegates to `thinker.get_mrope_input_positions()` which extracts grid data from `mm_features` via `gather_kwargs`. Old implementation preserved as `_get_mrope_input_positions_v1`.

4. **Qwen2.5-Omni not in `_OMNI_ARCHITECTURES`** — V2 fell back to `DefaultModelState` (no `run_preprocess`) → `AttributeError`. Fix: register `Qwen2_5OmniForConditionalGeneration`.


## Test Plan

- [x] Qwen3-Omni 30B V1 text-only (H20 2xGPU) — pass
- [x] Qwen3-Omni 30B V2 text-only (H20 2xGPU) — pass
- [x] Qwen2.5-Omni 7B V2 text-only (H20 2xGPU) — pass
- [x] Qwen3-TTS V1 end2end Base (H20) — pass
- [x] Qwen3-TTS V2 end2end Base (H20) — pass

## Test Result

All 5 test configurations pass with `returncode=0` and `Processed prompts: 100%`.

V2 runner previously crashed at `profile_run` for all Omni Talker stages; after fix all stages initialize and run inference successfully.

cc @Fattysand @tzhouam 