### PR TITLE
[Test] Qwen-Image Perf Test with High Concurrency 

### DIFF
--- a/tests/dfx/perf/scripts/run_diffusion_benchmark.py
+++ b/tests/dfx/perf/scripts/run_diffusion_benchmark.py
@@ -719,6 +719,7 @@ def assert_result(
         else:
             assert current <= threshold, f"{metric}: {current:.4f} > baseline {threshold}"
 
+
 def _default_benchmark_endpoint_for_task(task: str) -> str:
     """Return the default client-side benchmark endpoint for a diffusion task."""
     if task in {"t2v", "i2v", "ti2v"}:
@@ -734,6 +735,7 @@ def _resolve_benchmark_endpoint(server_cfg: dict[str, Any], params: dict[str, An
     if configured:
         return normalize_endpoint(cast(str, configured))
     return _default_benchmark_endpoint_for_task(cast(str, params.get("task", "t2i")))
+
 
 def _to_list(value: Any) -> list[Any]:
     if value is None:
@@ -866,20 +868,20 @@ def test_diffusion_performance_benchmark(diffusion_server, benchmark_params, req
     sweep_runs = _iter_sweep_runs(params)
 
     for sweep_run in sweep_runs:
-        backend = _resolve_benchmark_endpoint(server_cfg, sweep_run["params"])
-        endpoint  = run_benchmark(
+        endpoint = _resolve_benchmark_endpoint(server_cfg, sweep_run["params"])
+        endpoint = run_benchmark(
             host=diffusion_server.host,
             port=diffusion_server.port,
             model=diffusion_server.model,
             params=sweep_run["params"],
             test_name=test_name,
-            endpoint =endpoint ,
+            endpoint=endpoint,
             server_cfg=server_cfg,
             source_file=cast(str, CONFIG_FILE_PATH),
         )
 
         print(f"\n{'=' * 60}")
-        print(f"Results for {test_name} (server={diffusion_server.server_type}, backend={backend}):")
+        print(f"Results for {test_name} (server={diffusion_server.server_type}, endpoint={endpoint}):")
         for key in (
             "throughput_qps",
             "latency_mean",
@@ -905,5 +907,5 @@ def test_diffusion_performance_benchmark(diffusion_server, benchmark_params, req
             sweep_index=sweep_run["sweep_index"],
             max_concurrency=sweep_run["max_concurrency"],
             request_rate=sweep_run["request_rate"],
-            assert_baseline=assert_baseline
+            assert_baseline=assert_baseline,
         )

--- a/tests/dfx/perf/scripts/run_diffusion_benchmark.py
+++ b/tests/dfx/perf/scripts/run_diffusion_benchmark.py
@@ -30,6 +30,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
+from unittest import result
 
 import psutil
 import pytest
@@ -654,9 +655,47 @@ def run_benchmark(
 # ---------------------------------------------------------------------------
 
 
-def assert_result(result: dict[str, Any], params: dict[str, Any], *, assert_baseline: bool) -> None:
-    """Assert request completion; optionally assert metrics against ``baseline`` in *params*."""
-    num_prompts = params.get("num-prompts", 10)
+def _resolve_baseline_value(
+    baseline_raw: Any,
+    *,
+    sweep_index: int | None,
+    max_concurrency: Any = None,
+    request_rate: Any = None,
+) -> Any:
+    """Pick the baseline threshold for this sweep step."""
+    if baseline_raw is None:
+        return 100000
+    if isinstance(baseline_raw, dict):
+        if max_concurrency is not None:
+            for key in (max_concurrency, str(max_concurrency)):
+                if key in baseline_raw:
+                    return baseline_raw[key]
+        if request_rate is not None:
+            for key in (request_rate, str(request_rate)):
+                if key in baseline_raw:
+                    return baseline_raw[key]
+        raise KeyError(
+            f"baseline dict has no key for max_concurrency={max_concurrency!r} "
+            f"or request_rate={request_rate!r}; keys={list(baseline_raw.keys())!r}"
+        )
+    if isinstance(baseline_raw, (list, tuple)):
+        if sweep_index is None:
+            raise ValueError("sweep_index is required when baseline is a list or tuple")
+        return baseline_raw[sweep_index]
+    return baseline_raw
+
+
+def assert_result(
+    result: dict[str, Any],
+    params: dict[str, Any],
+    num_prompts: int,
+    *,
+    sweep_index: int | None = None,
+    max_concurrency: Any = None,
+    request_rate: Any = None,
+    assert_baseline: bool = True,
+) -> None:
+    """Assert that benchmark metrics satisfy the configured baselines."""
     completed = result.get("completed_requests", result.get("completed", 0))
     assert completed == num_prompts, f"Expected {num_prompts} completed requests, got {completed}"
 
@@ -666,14 +705,19 @@ def assert_result(result: dict[str, Any], params: dict[str, Any], *, assert_base
         print("Skipping performance assertions.")
         return
 
-    for metric, threshold in params.get("baseline", {}).items():
+    for metric, baseline_raw in params.get("baseline", {}).items():
         current = result.get(metric)
         assert current is not None, f"Metric '{metric}' not found in result: {list(result.keys())}"
+        threshold = _resolve_baseline_value(
+            baseline_raw,
+            sweep_index=sweep_index,
+            max_concurrency=max_concurrency,
+            request_rate=request_rate,
+        )
         if "throughput" in metric:
             assert current >= threshold, f"{metric}: {current:.4f} < baseline {threshold}"
         else:
             assert current <= threshold, f"{metric}: {current:.4f} > baseline {threshold}"
-
 
 def _default_benchmark_endpoint_for_task(task: str) -> str:
     """Return the default client-side benchmark endpoint for a diffusion task."""
@@ -690,6 +734,107 @@ def _resolve_benchmark_endpoint(server_cfg: dict[str, Any], params: dict[str, An
     if configured:
         return normalize_endpoint(cast(str, configured))
     return _default_benchmark_endpoint_for_task(cast(str, params.get("task", "t2i")))
+
+def _to_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    return [value] if not isinstance(value, (list, tuple)) else list(value)
+
+
+def _build_run_params(
+    params: dict[str, Any],
+    *,
+    num_prompts: int,
+    sweep_index: int | None = None,
+    request_rate: Any | None = None,
+    max_concurrency: Any | None = None,
+) -> dict[str, Any]:
+    run_params = {
+        key: value for key, value in params.items() if key not in {"request-rate", "max-concurrency", "num-prompts"}
+    }
+    run_params["num-prompts"] = num_prompts
+    if request_rate is not None:
+        run_params["request-rate"] = request_rate
+    if max_concurrency is not None:
+        run_params["max-concurrency"] = max_concurrency
+    if "baseline" in params:
+        run_params["baseline"] = {
+            metric: _resolve_baseline_value(
+                baseline_raw,
+                sweep_index=sweep_index,
+                max_concurrency=max_concurrency,
+                request_rate=request_rate,
+            )
+            for metric, baseline_raw in params["baseline"].items()
+        }
+    return run_params
+
+
+def _iter_sweep_runs(params: dict[str, Any]) -> list[dict[str, Any]]:
+    request_rate_list = _to_list(params.get("request-rate"))
+    num_prompt_list = _to_list(params.get("num-prompts", 10))
+    max_concurrency_list = _to_list(params.get("max-concurrency"))
+
+    max_len = max(len(request_rate_list), len(max_concurrency_list))
+    if len(num_prompt_list) == 1 and max_len > 1:
+        num_prompt_list = num_prompt_list * max_len
+    elif max_len == 1 and len(num_prompt_list) > 1:
+        if len(request_rate_list) == 1:
+            request_rate_list = request_rate_list * len(num_prompt_list)
+        if len(max_concurrency_list) == 1:
+            max_concurrency_list = max_concurrency_list * len(num_prompt_list)
+        max_len = max(len(request_rate_list), len(max_concurrency_list))
+    elif len(num_prompt_list) != max_len and max_len > 0:
+        raise ValueError("The number of prompts does not match the request-rate or max-concurrency")
+
+    sweep_runs: list[dict[str, Any]] = []
+
+    for i, (request_rate, num_prompts) in enumerate(zip(request_rate_list, num_prompt_list)):
+        sweep_runs.append(
+            {
+                "params": _build_run_params(
+                    params,
+                    request_rate=request_rate,
+                    num_prompts=num_prompts,
+                    sweep_index=i,
+                ),
+                "num_prompts": num_prompts,
+                "sweep_index": i,
+                "request_rate": request_rate,
+                "max_concurrency": None,
+            }
+        )
+
+    for i, (max_concurrency, num_prompts) in enumerate(zip(max_concurrency_list, num_prompt_list)):
+        sweep_runs.append(
+            {
+                "params": _build_run_params(
+                    params,
+                    max_concurrency=max_concurrency,
+                    num_prompts=num_prompts,
+                    request_rate="inf",
+                    sweep_index=i,
+                ),
+                "num_prompts": num_prompts,
+                "sweep_index": i,
+                "request_rate": None,
+                "max_concurrency": max_concurrency,
+            }
+        )
+
+    if not sweep_runs:
+        default_num_prompts = num_prompt_list[0]
+        sweep_runs.append(
+            {
+                "params": _build_run_params(params, num_prompts=default_num_prompts),
+                "num_prompts": default_num_prompts,
+                "sweep_index": None,
+                "request_rate": None,
+                "max_concurrency": None,
+            }
+        )
+
+    return sweep_runs
 
 
 # ---------------------------------------------------------------------------
@@ -715,36 +860,47 @@ def test_diffusion_performance_benchmark(diffusion_server, benchmark_params, req
     test_name = benchmark_params["test_name"]
     params = benchmark_params["params"]
     server_cfg = getattr(diffusion_server, "server_cfg", {})
-    endpoint = _resolve_benchmark_endpoint(server_cfg, params)
+    sweep_runs = _iter_sweep_runs(params)
 
-    result = run_benchmark(
-        host=diffusion_server.host,
-        port=diffusion_server.port,
-        model=diffusion_server.model,
-        params=params,
-        test_name=test_name,
-        endpoint=endpoint,
-        server_cfg=server_cfg,
-        source_file=cast(str, CONFIG_FILE_PATH),
-    )
+    for sweep_run in sweep_runs:
+        backend = _resolve_benchmark_endpoint(server_cfg, sweep_run["params"])
+        endpoint  = run_benchmark(
+            host=diffusion_server.host,
+            port=diffusion_server.port,
+            model=diffusion_server.model,
+            params=sweep_run["params"],
+            test_name=test_name,
+            endpoint =endpoint ,
+            server_cfg=server_cfg,
+            source_file=cast(str, CONFIG_FILE_PATH),
+        )
 
-    print(f"\n{'=' * 60}")
-    print(f"Results for {test_name} (server={diffusion_server.server_type}, endpoint={endpoint}):")
-    for key in (
-        "throughput_qps",
-        "latency_mean",
-        "latency_median",
-        "latency_p50",
-        "latency_p99",
-        "peak_memory_mb_max",
-        "peak_memory_mb_mean",
-        "peak_memory_mb_median",
-    ):
-        if key in result:
-            print(f"  {key}: {result[key]:.4f}")
+        print(f"\n{'=' * 60}")
+        print(f"Results for {test_name} (server={diffusion_server.server_type}, backend={backend}):")
+        for key in (
+            "throughput_qps",
+            "latency_mean",
+            "latency_median",
+            "latency_p50",
+            "latency_p99",
+            "peak_memory_mb_max",
+            "peak_memory_mb_mean",
+            "peak_memory_mb_median",
+        ):
+            if key in result:
+                print(f"  {key}: {result[key]:.4f}")
 
-    print(f"\n  Aggregated results: {AGGREGATED_RESULT_FILE}")
-    print("=" * 60)
+        print(f"\n  Aggregated results: {AGGREGATED_RESULT_FILE}")
+        print("=" * 60)
 
-    assert_baseline = request.config.getoption("--assert-baseline", default=False)
-    assert_result(result, params, assert_baseline=assert_baseline)
+        assert_baseline = request.config.getoption("--assert-baseline", default=False)
+
+        assert_result(
+            result,
+            params,
+            sweep_run["num_prompts"],
+            sweep_index=sweep_run["sweep_index"],
+            max_concurrency=sweep_run["max_concurrency"],
+            request_rate=sweep_run["request_rate"],
+            assert_baseline=assert_baseline
+        )

--- a/tests/dfx/perf/scripts/run_diffusion_benchmark.py
+++ b/tests/dfx/perf/scripts/run_diffusion_benchmark.py
@@ -812,6 +812,7 @@ def _iter_sweep_runs(params: dict[str, Any]) -> list[dict[str, Any]]:
                     params,
                     max_concurrency=max_concurrency,
                     num_prompts=num_prompts,
+                    sweep_index=i,
                     request_rate="inf",
                     sweep_index=i,
                 ),
@@ -826,7 +827,10 @@ def _iter_sweep_runs(params: dict[str, Any]) -> list[dict[str, Any]]:
         default_num_prompts = num_prompt_list[0]
         sweep_runs.append(
             {
-                "params": _build_run_params(params, num_prompts=default_num_prompts),
+                "params": _build_run_params(
+                    params,
+                    num_prompts=default_num_prompts,
+                ),
                 "num_prompts": default_num_prompts,
                 "sweep_index": None,
                 "request_rate": None,

--- a/tests/dfx/perf/scripts/run_diffusion_benchmark.py
+++ b/tests/dfx/perf/scripts/run_diffusion_benchmark.py
@@ -30,7 +30,6 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
-from unittest import result
 
 import psutil
 import pytest
@@ -869,7 +868,7 @@ def test_diffusion_performance_benchmark(diffusion_server, benchmark_params, req
 
     for sweep_run in sweep_runs:
         endpoint = _resolve_benchmark_endpoint(server_cfg, sweep_run["params"])
-        endpoint = run_benchmark(
+        result = run_benchmark(
             host=diffusion_server.host,
             port=diffusion_server.port,
             model=diffusion_server.model,

--- a/tests/dfx/perf/scripts/run_diffusion_benchmark.py
+++ b/tests/dfx/perf/scripts/run_diffusion_benchmark.py
@@ -814,7 +814,6 @@ def _iter_sweep_runs(params: dict[str, Any]) -> list[dict[str, Any]]:
                     num_prompts=num_prompts,
                     sweep_index=i,
                     request_rate="inf",
-                    sweep_index=i,
                 ),
                 "num_prompts": num_prompts,
                 "sweep_index": i,

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -202,16 +202,16 @@
                 "width": 512,
                 "height": 512,
                 "num-inference-steps": 20,
-                "num-prompts": [20, 40, 80, 120, 160],
-                "max-concurrency": [1, 2, 4, 6, 8],
+                "num-prompts": [20, 40, 80,  160],
+                "max-concurrency": [1, 2, 4,  8],
                 "warmup-requests": 8,
                 "warmup-concurrency": 8,
                 "warmup-num-inference-steps": 20,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": [0.30, 0.50, 0.60, 0.70, 0.75],
-                    "latency_mean": [3.50, 4.00, 7.00, 9.00, 12.00],
-                    "peak_memory_mb_mean": [67000, 67000, 67000, 67000, 67000]
+                    "throughput_qps": [0.30, 0.50, 0.60,  0.75],
+                    "latency_mean": [3.50, 4.00, 7.00,  12.00],
+                    "peak_memory_mb_mean": [67000, 67000, 67000, 6 67000]
                 }
             }
         ]

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -211,7 +211,7 @@
                 "baseline": {
                     "throughput_qps": [0.30, 0.50, 0.60,  0.75],
                     "latency_mean": [3.50, 4.00, 7.00,  12.00],
-                    "peak_memory_mb_mean": [67000, 67000, 67000, 6 67000]
+                    "peak_memory_mb_mean": [67000, 67000, 67000, 67000]
                 }
             }
         ]

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -17,8 +17,8 @@
                 "width": 512,
                 "height": 512,
                 "num-inference-steps": 20,
-                "num-prompts": [10, 20, 40],
-                "max-concurrency": [1, 2, 4],
+                "num-prompts": 10,
+                "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
                     "throughput_qps": 0.35,
@@ -63,13 +63,13 @@
                 "width": 512,
                 "height": 512,
                 "num-inference-steps": 20,
-                "num-prompts": 10,
-                "max-concurrency": 1,
+                "num-prompts": [10, 20, 40],
+                "max-concurrency": [1, 2, 4],
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.35,
-                    "latency_mean": 3,
-                    "peak_memory_mb_mean": 56000
+                    "throughput_qps": [0.30, 0.60, 0.90],
+                    "latency_mean": [3.50, 7.00, 14.00],
+                    "peak_memory_mb_mean": [67000, 67000, 67000]
                 }
             },
             {

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -79,13 +79,13 @@
                 "width": 1536,
                 "height": 1536,
                 "num-inference-steps": 35,
-                "num-prompts": 10,
-                "max-concurrency": 1,
+                "num-prompts": [10, 20, 40],
+                "max-concurrency": [1, 2, 4],
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.03,
-                    "latency_mean": 26,
-                    "peak_memory_mb_mean": 65000
+                    "throughput_qps": [0.037, 0.074, 0.111],
+                    "latency_mean": [27.0, 54.0, 108.0],
+                    "peak_memory_mb_mean": [74000, 74000, 74000]
                 }
             }
         ]

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -63,13 +63,13 @@
                 "width": 512,
                 "height": 512,
                 "num-inference-steps": 20,
-                "num-prompts": [10, 20, 40],
-                "max-concurrency": [1, 2, 4],
+                "num-prompts": 10,
+                "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": [0.30, 0.60, 0.90],
-                    "latency_mean": [3.50, 7.00, 14.00],
-                    "peak_memory_mb_mean": [67000, 67000, 67000]
+                    "throughput_qps": 0.30,
+                    "latency_mean": 3.50,
+                    "peak_memory_mb_mean": 67000
                 }
             },
             {
@@ -79,13 +79,13 @@
                 "width": 1536,
                 "height": 1536,
                 "num-inference-steps": 35,
-                "num-prompts": [10, 20, 40],
-                "max-concurrency": [1, 2, 4],
+                "num-prompts": 10,
+                "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": [0.037, 0.074, 0.111],
-                    "latency_mean": [27.0, 54.0, 108.0],
-                    "peak_memory_mb_mean": [74000, 74000, 74000]
+                    "throughput_qps": 0.037,
+                    "latency_mean": 27.0,
+                    "peak_memory_mb_mean": 74000
                 }
             }
         ]
@@ -179,6 +179,36 @@
                     "latency_mean": 6,
                     "peak_memory_mb_mean": 67000
                 }
+            }
+        ]
+    },
+    {
+        "test_name": "test_qwen_image_single_device_step_execution_high_concurrency",
+        "description": "Single-device Qwen-Image step-level execution benchmark at 512x512, 20 steps, concurrency sweep",
+        "server_type": "vllm-omni",
+        "server_params": {
+            "model": "Qwen/Qwen-Image",
+            "serve_args": {
+                "enable-diffusion-pipeline-profiler": true,
+                "step-execution": true,
+                "max-num-seqs": 8
+            }
+        },
+        "benchmark_params": [
+            {
+                "name": "512x512_steps20_high_concurrency",
+                "dataset": "random",
+                "task": "t2i",
+                "width": 512,
+                "height": 512,
+                "num-inference-steps": 20,
+                "num-prompts": [20, 40, 60, 80],
+                "max-concurrency": [2, 4, 6, 8],
+                "warmup-requests": 8,
+                "warmup-concurrency": 8,
+                "warmup-num-inference-steps": 20,
+                "enable-negative-prompt": true,
+                "skip-performance-assertion": true
             }
         ]
     }

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -209,7 +209,7 @@
                 "warmup-num-inference-steps": 20,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": [0.30, 0.50, 0.60, 0.75],
+                    "throughput_qps": [0.30, 0.50, 0.60, 0.70],
                     "latency_mean": [3.50, 4.00, 7.00, 12.00],
                     "peak_memory_mb_mean": [67000, 67000, 67000, 67000]
                 }

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -202,13 +202,17 @@
                 "width": 512,
                 "height": 512,
                 "num-inference-steps": 20,
-                "num-prompts": [20, 40, 60, 80],
-                "max-concurrency": [2, 4, 6, 8],
+                "num-prompts": [15, 20, 40, 60, 80],
+                "max-concurrency": [1, 2, 4, 6, 8],
                 "warmup-requests": 8,
                 "warmup-concurrency": 8,
                 "warmup-num-inference-steps": 20,
                 "enable-negative-prompt": true,
-                "skip-performance-assertion": true
+                "baseline": {
+                    "throughput_qps": [0.30, 0.50, 0.60, 0.70, 0.80],
+                    "latency_mean": [3.50, 4.00, 7.00, 9.00, 12.00],
+                    "peak_memory_mb_mean": [67000, 67000, 67000, 67000, 67000]
+                }
             }
         ]
     }

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -21,9 +21,9 @@
                 "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.30,
-                    "latency_mean": 3.50,
-                    "peak_memory_mb_mean": 67000
+                    "throughput_qps": 0.35,
+                    "latency_mean": 3,
+                    "peak_memory_mb_mean": 56000
                 }
             },
             {
@@ -37,9 +37,9 @@
                 "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.037,
-                    "latency_mean": 27.0,
-                    "peak_memory_mb_mean": 74000
+                    "throughput_qps": 0.03,
+                    "latency_mean": 26,
+                    "peak_memory_mb_mean": 65000
                 }
             }
         ]
@@ -67,9 +67,9 @@
                 "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.30,
-                    "latency_mean": 3.50,
-                    "peak_memory_mb_mean": 67000
+                    "throughput_qps": 0.35,
+                    "latency_mean": 3,
+                    "peak_memory_mb_mean": 56000
                 }
             },
             {
@@ -83,9 +83,9 @@
                 "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.037,
-                    "latency_mean": 27.0,
-                    "peak_memory_mb_mean": 74000
+                    "throughput_qps": 0.03,
+                    "latency_mean": 26,
+                    "peak_memory_mb_mean": 65000
                 }
             }
         ]

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -21,9 +21,9 @@
                 "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.35,
-                    "latency_mean": 3,
-                    "peak_memory_mb_mean": 56000
+                    "throughput_qps": 0.30,
+                    "latency_mean": 3.50,
+                    "peak_memory_mb_mean": 67000
                 }
             },
             {
@@ -37,9 +37,9 @@
                 "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.03,
-                    "latency_mean": 26,
-                    "peak_memory_mb_mean": 65000
+                    "throughput_qps": 0.037,
+                    "latency_mean": 27.0,
+                    "peak_memory_mb_mean": 74000
                 }
             }
         ]

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -202,15 +202,15 @@
                 "width": 512,
                 "height": 512,
                 "num-inference-steps": 20,
-                "num-prompts": [20, 40, 80,  160],
-                "max-concurrency": [1, 2, 4,  8],
+                "num-prompts": [20, 40, 80, 160],
+                "max-concurrency": [1, 2, 4, 8],
                 "warmup-requests": 8,
                 "warmup-concurrency": 8,
                 "warmup-num-inference-steps": 20,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": [0.30, 0.50, 0.60,  0.75],
-                    "latency_mean": [3.50, 4.00, 7.00,  12.00],
+                    "throughput_qps": [0.30, 0.50, 0.60, 0.75],
+                    "latency_mean": [3.50, 4.00, 7.00, 12.00],
                     "peak_memory_mb_mean": [67000, 67000, 67000, 67000]
                 }
             }

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -17,8 +17,8 @@
                 "width": 512,
                 "height": 512,
                 "num-inference-steps": 20,
-                "num-prompts": 10,
-                "max-concurrency": 1,
+                "num-prompts": [10, 20, 40],
+                "max-concurrency": [1, 2, 4],
                 "enable-negative-prompt": true,
                 "baseline": {
                     "throughput_qps": 0.35,

--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -202,14 +202,14 @@
                 "width": 512,
                 "height": 512,
                 "num-inference-steps": 20,
-                "num-prompts": [15, 20, 40, 60, 80],
+                "num-prompts": [20, 40, 80, 120, 160],
                 "max-concurrency": [1, 2, 4, 6, 8],
                 "warmup-requests": 8,
                 "warmup-concurrency": 8,
                 "warmup-num-inference-steps": 20,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": [0.30, 0.50, 0.60, 0.70, 0.80],
+                    "throughput_qps": [0.30, 0.50, 0.60, 0.70, 0.75],
                     "latency_mean": [3.50, 4.00, 7.00, 9.00, 12.00],
                     "peak_memory_mb_mean": [67000, 67000, 67000, 67000, 67000]
                 }


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

To test the performance of Qwen-Image under high concurrency requests, this PR:
- Add sweep support in `run_diffusion_benchmark.py` for both `request-rate` and `max-concurrency`.
- Support per-sweep baseline thresholds using scalar/list/dict formats.
- Execute and validate each sweep point independently, with per-run parameter materialization.
- Update `test_qwen_image_vllm_omni.json` to run a max-concurrency sweep (`[1, 2, 4, 6, 8]`) with matching prompt counts and baselines.

## Test Plan

In nightly CI, run:
```bash
pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py  --test-config-file  tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
```
## Test Result

After test it locally, I spent an extra **12 mins** to pass the high-concurrency test cases. I list the obtained results here.

| max_concurrency | num_prompts | latency_mean (s) | throughput_qps |
|-----------------|---------------|------------------|----------------|
| 1 | 20 | 2.403181 | 0.416081 |
| 2 | 40 | 2.967411 | 0.672986 |
| 4 | 80 | 5.827227 | 0.677064 |
| 6 | 120 | 7.833425 | 0.755917 |
| 8 | 160 | 10.161401 | 0.778160 |

An image visualization of the test results are shown here:
<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/edbc5747-04cc-4994-a885-217c59673a4d" />


Code to obtaint the plot:
<details>
<summary>collapse</summary>

```python
import json
import matplotlib.pyplot as plt
with open("tests/dfx/perf/results/xxx.json", "r", encoding="utf-8") as f:
    data = json.load(f)

x = [d["max_concurrency"] for d in data]
latency_ms = [d["latency_mean"] * 1000 for d in data]
throughput = [d["throughput_qps"] for d in data]
fig, ax1 = plt.subplots()
ax1.plot(x, latency_ms, "-o", color="tab:blue", label="latency_mean")
ax1.set_xlabel("max-concurrency")
ax1.set_ylabel("latency_mean (ms)", color="tab:blue")
ax1.set_ylim(0, 18000)
ax1.tick_params(axis="y", labelcolor="tab:blue")
ax2 = ax1.twinx()
ax2.plot(x, throughput, "--o", color="tab:orange", label="throughput_qps")
ax2.set_ylabel("throughput (req/s)", color="tab:orange")
ax2.set_ylim(0, 1.5)
ax2.tick_params(axis="y", labelcolor="tab:orange")
fig.legend(loc="upper center", ncol=2)
fig.text(0.5, 0.01, "server max-num-seqs is fixed at 8",
         ha="center", fontsize=8)
plt.grid(True)
plt.tight_layout(rect=[0, 0.04, 1, 1])
plt.savefig("qwen_image_perf.png", dpi=200)
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
