### PR TITLE
ci: move VoxCPM E2E test from L2 ready to L4 nightly

### DIFF
--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -70,6 +70,32 @@ steps:
               volumes:
                 - "/fsx/hf_cache:/fsx/hf_cache"
 
+      - label: ":full_moon: Omni · VoxCPM E2E Test with L4"
+        timeout_in_minutes: 30
+        depends_on: upload-nightly-pipeline
+        if: *nightly_or_pr_label
+        commands:
+          - |
+            timeout 30m bash -c '
+              pip install voxcpm
+              export VLLM_LOGGING_LEVEL=DEBUG
+              export VLLM_WORKER_MULTIPROC_METHOD=spawn
+              pytest -s -v tests/e2e/offline_inference/test_voxcpm.py -m "advanced_model" --run-level "advanced_model"
+            '
+        agents:
+          queue: "gpu_4_queue" # g6.12xlarge instance on AWS, has 4 L4 GPU
+        plugins:
+          - docker#v5.2.0:
+              image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
+              always-pull: true
+              propagate-environment: true
+              shm-size: "8gb"
+              environment:
+                - "HF_HOME=/fsx/hf_cache"
+                - "HF_TOKEN"
+              volumes:
+                - "/fsx/hf_cache:/fsx/hf_cache"
+
       - label: ":full_moon: Omni · Doc Test with L4"
         timeout_in_minutes: 90
         depends_on: upload-nightly-pipeline

--- a/.buildkite/test-ready.yml
+++ b/.buildkite/test-ready.yml
@@ -295,31 +295,6 @@ steps:
           volumes:
             - "/fsx/hf_cache:/fsx/hf_cache"
 
-  - label: "VoxCPM E2E Test"
-    timeout_in_minutes: 20
-    depends_on: upload-ready-pipeline
-    commands:
-      - |
-        timeout 20m bash -c '
-          pip install voxcpm
-          export VLLM_LOGGING_LEVEL=DEBUG
-          export VLLM_WORKER_MULTIPROC_METHOD=spawn
-          pytest -s -v tests/e2e/offline_inference/test_voxcpm.py -m "core_model" --run-level "core_model"
-        '
-    agents:
-      queue: "gpu_1_queue"
-    plugins:
-      - docker#v5.2.0:
-          image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
-          always-pull: true
-          propagate-environment: true
-          shm-size: "8gb"
-          environment:
-            - "HF_HOME=/fsx/hf_cache"
-            - "HF_TOKEN"
-          volumes:
-            - "/fsx/hf_cache:/fsx/hf_cache"
-
   - label: "VoxCPM2 Native AR E2E Test"
     timeout_in_minutes: 20
     depends_on: upload-ready-pipeline

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -52,6 +52,7 @@ th {
 | `Qwen3TTSForConditionalGeneration` | Qwen3-TTS-12Hz-1.7B-CustomVoice | `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `Qwen3TTSForConditionalGeneration` | Qwen3-TTS-12Hz-1.7B-VoiceDesign | `Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `Qwen3TTSForConditionalGeneration` | Qwen3-TTS-12Hz-1.7B-Base | `Qwen/Qwen3-TTS-12Hz-0.6B-Base` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
+| `VoxCPMForConditionalGeneration` | VoxCPM1.5 | `OpenBMB/VoxCPM1.5` | ✅︎ | | ✅︎ | |
 | `NextStep11Pipeline` | NextStep-1.1 | `stepfun-ai/NextStep-1.1` | ✅︎ | ✅︎ | | ✅︎ |
 | `MiMoAudioForConditionalGeneration` | MiMo-Audio-7B-Instruct | `XiaomiMiMo/MiMo-Audio-7B-Instruct` | ✅︎ | ✅︎ | | |
 | `Flux2Pipeline` | FLUX.2-dev | `black-forest-labs/FLUX.2-dev` | ✅︎ | ✅︎ | | |

--- a/tests/e2e/offline_inference/test_voxcpm.py
+++ b/tests/e2e/offline_inference/test_voxcpm.py
@@ -132,7 +132,7 @@ def test_resolve_voxcpm_model_dir_local_path(tmp_path: Path):
     assert resolve_voxcpm_model_dir(str(model_dir)) == model_dir
 
 
-@pytest.mark.core_model
+@pytest.mark.advanced_model
 @pytest.mark.omni
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 def test_voxcpm_zero_shot_001(voxcpm_model_path: str):


### PR DESCRIPTION
## Summary

This PR moves the VoxCPM offline E2E test out of PR/L2 and runs it in L4 nightly instead.

Changes:
- remove the `VoxCPM E2E Test` job from `.buildkite/test-ready.yml`
- add a dedicated L4 nightly job for `tests/e2e/offline_inference/test_voxcpm.py`
- change `test_voxcpm_zero_shot_001` from `core_model` to `advanced_model`
- update `docs/models/supported_models.md` to list `OpenBMB/VoxCPM1.5`

## Motivation

The VoxCPM offline real-model E2E path is too heavy for L2/ready CI. This keeps coverage in nightly while reducing PR-time cost.
