### PR TITLE
[Bugfix] Use vllm.utils.system_utils.get_mp_context treewide

### DIFF
--- a/tests/e2e/features/comfyui/test_comfyui_integration.py
+++ b/tests/e2e/features/comfyui/test_comfyui_integration.py
@@ -8,7 +8,6 @@ It ensures that
 
 from __future__ import annotations
 
-import multiprocessing
 import time
 import traceback
 from collections.abc import Iterable, Sequence
@@ -38,6 +37,7 @@ from PIL import Image
 from pytest_mock import MockerFixture
 from vllm import SamplingParams
 from vllm.outputs import CompletionOutput, RequestOutput
+from vllm.utils.system_utils import get_mp_context
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni as RealAsyncOmni
 from vllm_omni.entrypoints.cli.serve import OmniServeCommand
@@ -542,7 +542,7 @@ def api_server(unused_tcp_port_factory, server_case: ServerCase, mock_async_omni
         except Exception:
             traceback.print_exc()
 
-    server_process = multiprocessing.Process(target=run_server)
+    server_process = get_mp_context().Process(target=run_server)
     server_process.start()
 
     # Wait for the server to be ready by polling the health endpoint.

--- a/tests/helpers/process.py
+++ b/tests/helpers/process.py
@@ -99,11 +99,6 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
         if os.environ.get("RUNNING_IN_SUBPROCESS") == "1":
             return f(*args, **kwargs)
 
-        import torch.multiprocessing as mp
-
-        with suppress(RuntimeError):
-            mp.set_start_method("spawn")
-
         module_name = f.__module__
         env = os.environ.copy()
         env["RUNNING_IN_SUBPROCESS"] = "1"

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, cast
 import zmq
 from vllm.distributed.device_communicators.shm_broadcast import Handle, MessageQueue
 from vllm.logger import init_logger
+from vllm.utils.system_utils import get_mp_context
 from vllm.v1.engine.exceptions import EngineDeadError
 from vllm.v1.executor.multiproc_executor import set_multiprocessing_worker_envs
 
@@ -104,7 +105,8 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         self._rpc_wave_id: int = 0
 
         num_workers = cast(int, self.od_config.num_gpus)
-        self.wake_events = [mp.Event() for _ in range(num_workers)]
+        ctx = get_mp_context()
+        self.wake_events = [ctx.Event() for _ in range(num_workers)]
 
         self._broadcast_mq = self._init_broadcast_queue(num_workers)
         broadcast_handle = self._broadcast_mq.export_handle()
@@ -300,7 +302,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         # N-GPU run oversubscribes the host by N x core_count. Honours a
         # user-provided OMP_NUM_THREADS.
         set_multiprocessing_worker_envs()
-        mp.set_start_method("spawn", force=True)
+        ctx = get_mp_context()
         processes = []
 
         # Extract worker_extension_cls and custom_pipeline_args from od_config
@@ -312,9 +314,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         scheduler_pipe_writers = []
 
         for i in range(num_gpus):
-            reader, writer = mp.Pipe(duplex=False)
+            reader, writer = ctx.Pipe(duplex=False)
             scheduler_pipe_writers.append(writer)
-            process = mp.Process(
+            process = ctx.Process(
                 target=WorkerProc.worker_main,
                 args=(
                     i,  # rank

--- a/vllm_omni/distributed/omni_coordinator/runtime.py
+++ b/vllm_omni/distributed/omni_coordinator/runtime.py
@@ -18,12 +18,12 @@ from __future__ import annotations
 import logging
 import multiprocessing
 import multiprocessing.connection
-import os
 import signal
 import weakref
 from typing import Any
 
 from vllm.utils.network_utils import get_open_ports_list
+from vllm.utils.system_utils import get_mp_context
 
 from vllm_omni.distributed.omni_coordinator.omni_coordinator import OmniCoordinator
 
@@ -49,26 +49,6 @@ def run_omni_coordinator_proc(
     ready_pipe.close()
 
     coordinator.wait_for_shutdown()
-
-
-def _get_coordinator_mp_context() -> multiprocessing.context.BaseContext:
-    """Return the multiprocessing context used for OmniCoordinator.
-
-    For the current vllm-omni startup path, ``spawn`` is too expensive: the
-    child re-imports a heavy CLI / model stack before it can acknowledge the
-    ready pipe, which can exceed the coordinator startup timeout. Prefer
-    ``fork`` on platforms that support it.
-
-    ``fork`` must happen before the parent initializes CUDA or owns long-lived
-    ZMQ sockets; otherwise the child inherits unsafe state. If coordinator
-    startup moves later, switch this to ``spawn``/``forkserver``.
-
-    TODO: make the coordinator child entry cheap and spawn-safe, then revisit
-    whether ``spawn`` is still needed here.
-    """
-    if os.name != "nt" and "fork" in multiprocessing.get_all_start_methods():
-        return multiprocessing.get_context("fork")
-    return multiprocessing.get_context("spawn")
 
 
 def _shutdown_proc(proc: multiprocessing.Process) -> None:
@@ -107,7 +87,7 @@ class OmniCoordinatorRuntime:
 
         self._closed = False
 
-        ctx = _get_coordinator_mp_context()
+        ctx = get_mp_context()
         parent_conn, child_conn = ctx.Pipe(duplex=False)
 
         self._proc: multiprocessing.Process = ctx.Process(

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import copy
 import fcntl
 import importlib
-import multiprocessing as mp
 import os
 import time
 from collections.abc import Callable, Generator, Sequence
@@ -535,14 +534,6 @@ def prepare_engine_environment() -> None:
     from vllm_omni.plugins import load_omni_general_plugins
 
     load_omni_general_plugins()
-
-    if os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") != "spawn":
-        os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
-        logger.info("[stage_init] Set VLLM_WORKER_MULTIPROC_METHOD=spawn")
-    try:
-        mp.set_start_method("spawn", force=True)
-    except RuntimeError:
-        pass
 
 
 def _maybe_set_qwen3_omni_moe_env(engine_args_dict: dict[str, Any]) -> None:

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -5,8 +5,6 @@ import base64
 import dataclasses
 import io
 import json
-import multiprocessing
-import multiprocessing.forkserver as forkserver
 import os
 
 # Image generation API imports
@@ -629,8 +627,7 @@ async def build_async_omni(
     """Build an AsyncOmni instance from command-line arguments.
 
     Creates an async context manager that yields an AsyncOmni instance
-    configured from the provided arguments. Handles forkserver setup if
-    needed and ensures proper cleanup on exit.
+    configured from the provided arguments.
 
     Args:
         args: Parsed command-line arguments containing model and configuration
@@ -641,15 +638,6 @@ async def build_async_omni(
     Yields:
         EngineClient instance (AsyncOmni) ready for use
     """
-    if os.getenv("VLLM_WORKER_MULTIPROC_METHOD") == "forkserver":
-        # The executor is expected to be mp.
-        # Pre-import heavy modules in the forkserver process
-        logger.debug("Setup forkserver with pre-imports")
-        multiprocessing.set_start_method("forkserver")
-        multiprocessing.set_forkserver_preload(["vllm.v1.engine.async_llm"])
-        forkserver.ensure_running()
-        logger.debug("Forkserver setup complete!")
-
     # Context manager to handle async_omni lifecycle
     # Ensures everything is shutdown and cleaned up on error/exit
     async with build_async_omni_from_stage_config(


### PR DESCRIPTION
## Purpose

Replace hardcoded mp.set_start_method("spawn", force=True) with get_mp_context() helper from vllm.

This ensures the diffusion executor respects VLLM_WORKER_MULTIPROC_METHOD consistently with the rest of the codebase, and avoids calling set_start_method after processes have already been spawned.

## Test Plan

```shell
pytest tests/e2e/offline_inference/test_t2i_model.py
```

## Test Result

Wait for CI.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
