### PR TITLE
CI: publish Omni images to a separate Docker Hub repository

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -64,12 +64,13 @@ while true; do
 done
 
 echo "--- Pulling container"
-## Temporary change to use AMD Docker Hub to store the vllm-ci image
+## Temporary change to use AMD Docker Hub to store the vllm-omni image
 # to bypass the rate limit issue with ECR Public Gallery.
+# Images are now stored in a separate repository for vllm-omni, instead of vllm-ci.
 # TODO: @tjtanaa point back to ECR Public Gallery
 # once the amd agents are configured to use ECR Public Gallery.
 # image_name="public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:${BUILDKITE_COMMIT}-rocm-omni"
-image_name="rocm/vllm-ci:${BUILDKITE_COMMIT}-rocm-omni"
+image_name="rocm/vllm-omni:${BUILDKITE_COMMIT}"
 container_name="rocm_${BUILDKITE_COMMIT}_$(tr -dc A-Za-z0-9 < /dev/urandom | head -c 10; echo)"
 
 # TODO: @tjtanaa uncomment this once the amd agents are configured to use ECR Public Gallery.

--- a/.buildkite/test-template-amd-omni.j2
+++ b/.buildkite/test-template-amd-omni.j2
@@ -3,7 +3,7 @@
    Last synced: 2025-12-15
    Modifications: Removed unused CUDA/NVIDIA logic, keeping only AMD tests
 #}
-{% set docker_image_amd = "rocm/vllm-ci:$BUILDKITE_COMMIT-rocm-omni" %}
+{% set docker_image_amd = "rocm/vllm-omni:$BUILDKITE_COMMIT" %}
 {% set default_working_dir = "/app/vllm-omni" %}
 
   - group: "AMD Tests"


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Point vLLM-Omni AMD hardware CI at a dedicated Docker Hub repository so Omni ROCm CI images are no longer published alongside core vLLM images under `rocm/vllm-ci`.

- **Build/push:** `.buildkite/test-template-amd-omni.j2`: tag and push `rocm/vllm-omni:$BUILDKITE_COMMIT`.
- **Pull:** `.buildkite/scripts/hardware_ci/run-amd-test.sh`: pull `rocm/vllm-omni:${BUILDKITE_COMMIT}` so test steps use the same image as the AMD build step.

The image tag is the commit SHA only (no `-rocm-omni` suffix), since the repository name already scopes Omni.

## Test Plan

- **CI:** After merge, confirm a build that runs the AMD Buildkite path: the `amd-build` step builds and pushes to `rocm/vllm-omni:<commit>`, and subsequent AMD GPU steps successfully `docker pull` that image and run tests.

## Test Result

- [x] Run/observe AMD CI: build push + test pull both succeed against `rocm/vllm-omni`. (https://buildkite.com/vllm/vllm-omni-amd-ci/builds/5417/steps/canvas and https://hub.docker.com/repository/docker/rocm/vllm-omni/tags/3688ef1a6be0cb0b30f4edbb10092970195cb113/sha256-bc25394e7ccc453324febe5429306cfce3404bd4f16d25c0147c298e847b6566)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.