### PR TITLE
[Feat][VoxCPM2] Add voice embedding cache for uploaded voices

### DIFF
--- a/benchmarks/voxcpm/vllm_omni/bench_tts_serve.py
+++ b/benchmarks/voxcpm/vllm_omni/bench_tts_serve.py
@@ -38,7 +38,7 @@ import numpy as np
 from tqdm.asyncio import tqdm
 
 DEFAULT_MODEL = "openbmb/VoxCPM2"
-DEFAULT_SAMPLE_RATE = 24000
+DEFAULT_SAMPLE_RATE = 48000
 DEFAULT_REF_AUDIO_URL = "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-TTS-Repo/clone_2.wav"
 DEFAULT_REF_TEXT = (
     "Okay. Yeah. I resent you. I love you. I respect you. "

--- a/benchmarks/voxcpm/vllm_omni/bench_tts_serve.py
+++ b/benchmarks/voxcpm/vllm_omni/bench_tts_serve.py
@@ -1,14 +1,34 @@
 """Benchmark VoxCPM via /v1/audio/speech.
 
 Reports TTFP (time to first packet), E2E latency, and RTF (real-time factor).
+
+By default, runs a voice cache comparison using the Qwen reference audio:
+  A) Inline ref_audio: every request sends base64 audio (re-encoded each time)
+  B) Uploaded voice:   upload once, then use voice name (cache hits after 1st)
+
+Usage:
+    # Voice cache comparison (uses default Qwen reference audio):
+    python bench_tts_serve.py --port 8000
+
+    # Plain TTS only (no voice cloning):
+    python bench_tts_serve.py --port 8000 --no-voice-cache
+
+    # Custom reference audio:
+    python bench_tts_serve.py --port 8000 \
+        --ref-audio /path/to/reference.wav \
+        --ref-text "Transcript of the reference audio."
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import json
+import os
+import tempfile
 import time
+import urllib.request
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -17,8 +37,13 @@ import aiohttp
 import numpy as np
 from tqdm.asyncio import tqdm
 
-DEFAULT_MODEL = "OpenBMB/VoxCPM1.5"
+DEFAULT_MODEL = "openbmb/VoxCPM2"
 DEFAULT_SAMPLE_RATE = 24000
+DEFAULT_REF_AUDIO_URL = "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-TTS-Repo/clone_2.wav"
+DEFAULT_REF_TEXT = (
+    "Okay. Yeah. I resent you. I love you. I respect you. "
+    "But you know what? You blew it! And thanks to you."
+)
 PROMPTS = [
     "Hello, welcome to the VoxCPM speech benchmark.",
     "This is a short benchmark prompt for online text-to-speech generation.",
@@ -43,6 +68,7 @@ class RequestResult:
 
 @dataclass
 class BenchmarkResult:
+    label: str = ""
     concurrency: int = 0
     num_prompts: int = 0
     completed: int = 0
@@ -67,28 +93,84 @@ def pcm_bytes_to_duration(num_bytes: int, sample_rate: int = DEFAULT_SAMPLE_RATE
     return num_samples / sample_rate
 
 
+def encode_audio_to_base64(audio_path: str) -> str:
+    ext = audio_path.lower().rsplit(".", 1)[-1]
+    mime_map = {"wav": "audio/wav", "mp3": "audio/mpeg", "flac": "audio/flac"}
+    mime_type = mime_map.get(ext, "audio/wav")
+    with open(audio_path, "rb") as f:
+        audio_b64 = base64.b64encode(f.read()).decode("utf-8")
+    return f"data:{mime_type};base64,{audio_b64}"
+
+
+def download_ref_audio(url: str, dest_dir: str | None = None) -> str:
+    """Download reference audio to a local temp file, returning the path."""
+    if dest_dir is None:
+        dest_dir = tempfile.gettempdir()
+    filename = url.rsplit("/", 1)[-1]
+    dest = os.path.join(dest_dir, filename)
+    if os.path.exists(dest):
+        print(f"  Using cached ref audio: {dest}")
+        return dest
+    print(f"  Downloading ref audio: {url}")
+    urllib.request.urlretrieve(url, dest)
+    print(f"  Saved to: {dest}")
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Voice registration helpers
+# ---------------------------------------------------------------------------
+
+async def upload_voice(
+    session: aiohttp.ClientSession,
+    host: str,
+    port: int,
+    audio_path: str,
+    ref_text: str | None,
+    voice_name: str = "bench_voice",
+) -> dict:
+    url = f"http://{host}:{port}/v1/audio/voices"
+    data = aiohttp.FormData()
+    data.add_field("name", voice_name)
+    data.add_field("consent", "true")
+    if ref_text:
+        data.add_field("ref_text", ref_text)
+    data.add_field(
+        "audio_sample",
+        open(audio_path, "rb"),
+        filename=os.path.basename(audio_path),
+        content_type="audio/wav",
+    )
+    async with session.post(url, data=data) as resp:
+        result = await resp.json()
+        print(f"  Upload response ({resp.status}): {json.dumps(result, indent=2)}")
+        return result
+
+
+async def delete_voice(
+    session: aiohttp.ClientSession,
+    host: str,
+    port: int,
+    voice_name: str,
+) -> None:
+    url = f"http://{host}:{port}/v1/audio/voices/{voice_name}"
+    async with session.delete(url) as resp:
+        if resp.status == 200:
+            print(f"  Deleted voice '{voice_name}'")
+
+
+# ---------------------------------------------------------------------------
+# Request sender
+# ---------------------------------------------------------------------------
+
 async def send_tts_request(
     session: aiohttp.ClientSession,
     api_url: str,
+    payload: dict[str, object],
     *,
-    model: str,
-    prompt: str,
-    ref_audio: str | None,
-    ref_text: str | None,
     pbar: tqdm | None = None,
 ) -> RequestResult:
-    payload: dict[str, object] = {
-        "model": model,
-        "input": prompt,
-        "stream": True,
-        "response_format": "pcm",
-    }
-    if ref_audio is not None:
-        payload["ref_audio"] = ref_audio
-    if ref_text is not None:
-        payload["ref_text"] = ref_text
-
-    result = RequestResult(prompt=prompt)
+    result = RequestResult(prompt=str(payload.get("input", "")))
     started_at = time.perf_counter()
 
     try:
@@ -122,16 +204,19 @@ async def send_tts_request(
     return result
 
 
+# ---------------------------------------------------------------------------
+# Run one benchmark round
+# ---------------------------------------------------------------------------
+
 async def run_benchmark(
     *,
     host: str,
     port: int,
-    model: str,
     num_prompts: int,
     max_concurrency: int,
     num_warmups: int,
-    ref_audio: str | None,
-    ref_text: str | None,
+    make_payload: callable,
+    label: str,
 ) -> BenchmarkResult:
     api_url = f"http://{host}:{port}/v1/audio/speech"
     connector = aiohttp.TCPConnector(limit=max_concurrency, limit_per_host=max_concurrency, keepalive_timeout=60)
@@ -139,44 +224,33 @@ async def run_benchmark(
 
     async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
         if num_warmups > 0:
-            print(f"  Warming up with {num_warmups} requests...")
+            print(f"  [{label}] Warming up with {num_warmups} requests...")
             warmup_tasks = [
-                send_tts_request(
-                    session,
-                    api_url,
-                    model=model,
-                    prompt=PROMPTS[i % len(PROMPTS)],
-                    ref_audio=ref_audio,
-                    ref_text=ref_text,
-                )
+                send_tts_request(session, api_url, make_payload(PROMPTS[i % len(PROMPTS)]))
                 for i in range(num_warmups)
             ]
-            await asyncio.gather(*warmup_tasks)
+            warmup_results = await asyncio.gather(*warmup_tasks)
+            for i, r in enumerate(warmup_results):
+                status = "OK" if r.success else f"FAIL: {r.error[:80]}"
+                print(f"    warmup {i + 1}: ttfp={r.ttfp * 1000:.0f}ms  {status}")
             print("  Warmup done.")
 
         request_prompts = [PROMPTS[i % len(PROMPTS)] for i in range(num_prompts)]
         semaphore = asyncio.Semaphore(max_concurrency)
-        pbar = tqdm(total=num_prompts, desc=f"  concurrency={max_concurrency}")
+        pbar = tqdm(total=num_prompts, desc=f"  [{label}] c={max_concurrency}")
 
         async def limited_request(prompt: str) -> RequestResult:
             async with semaphore:
-                return await send_tts_request(
-                    session,
-                    api_url,
-                    model=model,
-                    prompt=prompt,
-                    ref_audio=ref_audio,
-                    ref_text=ref_text,
-                    pbar=pbar,
-                )
+                return await send_tts_request(session, api_url, make_payload(prompt), pbar=pbar)
 
         started_at = time.perf_counter()
-        results = await asyncio.gather(*[asyncio.create_task(limited_request(prompt)) for prompt in request_prompts])
+        results = await asyncio.gather(*[asyncio.create_task(limited_request(p)) for p in request_prompts])
         duration = time.perf_counter() - started_at
         pbar.close()
 
-    succeeded = [result for result in results if result.success]
+    succeeded = [r for r in results if r.success]
     bench = BenchmarkResult(
+        label=label,
         concurrency=max_concurrency,
         num_prompts=num_prompts,
         completed=len(succeeded),
@@ -187,10 +261,10 @@ async def run_benchmark(
     if not succeeded:
         return bench
 
-    ttfps = np.array([result.ttfp * 1000 for result in succeeded], dtype=np.float64)
-    e2es = np.array([result.e2e * 1000 for result in succeeded], dtype=np.float64)
-    rtfs = np.array([result.rtf for result in succeeded], dtype=np.float64)
-    audio_durations = np.array([result.audio_duration for result in succeeded], dtype=np.float64)
+    ttfps = np.array([r.ttfp * 1000 for r in succeeded], dtype=np.float64)
+    e2es = np.array([r.e2e * 1000 for r in succeeded], dtype=np.float64)
+    rtfs = np.array([r.rtf for r in succeeded], dtype=np.float64)
+    audio_durations = np.array([r.audio_duration for r in succeeded], dtype=np.float64)
 
     bench.mean_ttfp_ms = float(np.mean(ttfps))
     bench.median_ttfp_ms = float(np.median(ttfps))
@@ -205,76 +279,228 @@ async def run_benchmark(
     bench.request_throughput = len(succeeded) / duration if duration > 0 else 0.0
     bench.per_request = [
         {
-            "prompt": result.prompt,
-            "ttfp_ms": result.ttfp * 1000,
-            "e2e_ms": result.e2e * 1000,
-            "rtf": result.rtf,
-            "audio_duration_s": result.audio_duration,
+            "prompt": r.prompt,
+            "ttfp_ms": r.ttfp * 1000,
+            "e2e_ms": r.e2e * 1000,
+            "rtf": r.rtf,
+            "audio_duration_s": r.audio_duration,
         }
-        for result in succeeded
+        for r in succeeded
     ]
 
     return bench
 
 
+# ---------------------------------------------------------------------------
+# Display
+# ---------------------------------------------------------------------------
+
 def print_summary(result: BenchmarkResult) -> None:
-    width = 54
+    width = 58
+    title = result.label or "VoxCPM Serving Benchmark"
     print("")
     print("=" * width)
-    print(f"{'VoxCPM Serving Benchmark':^{width}}")
+    print(f"{title:^{width}}")
     print("=" * width)
     print(f"concurrency         : {result.concurrency}")
     print(f"requests            : {result.completed}/{result.num_prompts} succeeded")
     print(f"wall time (s)       : {result.duration_s:.3f}")
     print(f"mean TTFP (ms)      : {result.mean_ttfp_ms:.2f}")
+    print(f"median TTFP (ms)    : {result.median_ttfp_ms:.2f}")
     print(f"p95 TTFP (ms)       : {result.p95_ttfp_ms:.2f}")
     print(f"mean E2E (ms)       : {result.mean_e2e_ms:.2f}")
+    print(f"median E2E (ms)     : {result.median_e2e_ms:.2f}")
     print(f"p95 E2E (ms)        : {result.p95_e2e_ms:.2f}")
     print(f"mean RTF            : {result.mean_rtf:.3f}")
+    print(f"median RTF          : {result.median_rtf:.3f}")
     print(f"p95 RTF             : {result.p95_rtf:.3f}")
     print(f"request throughput  : {result.request_throughput:.2f} req/s")
     print("=" * width)
 
+
+def print_comparison(bench_a: BenchmarkResult, bench_b: BenchmarkResult) -> None:
+    width = 70
+    print(f"\n{'=' * width}")
+    print(f"{'COMPARISON: Inline ref_audio vs Uploaded voice (cached)':^{width}}")
+    print(f"{'=' * width}")
+    print(f"{'Metric':<30} {'Inline':>12} {'Cached':>12} {'Speedup':>10}")
+    print(f"{'-' * width}")
+
+    def fmt_speedup(a: float, b: float) -> str:
+        if a > 0 and b > 0:
+            return f"{a / b:.2f}x"
+        return "N/A"
+
+    rows = [
+        ("Mean TTFP (ms)", bench_a.mean_ttfp_ms, bench_b.mean_ttfp_ms),
+        ("Median TTFP (ms)", bench_a.median_ttfp_ms, bench_b.median_ttfp_ms),
+        ("P95 TTFP (ms)", bench_a.p95_ttfp_ms, bench_b.p95_ttfp_ms),
+        ("Mean E2E (ms)", bench_a.mean_e2e_ms, bench_b.mean_e2e_ms),
+        ("Median E2E (ms)", bench_a.median_e2e_ms, bench_b.median_e2e_ms),
+        ("P95 E2E (ms)", bench_a.p95_e2e_ms, bench_b.p95_e2e_ms),
+        ("Mean RTF", bench_a.mean_rtf, bench_b.mean_rtf),
+        ("Throughput (req/s)", bench_a.request_throughput, bench_b.request_throughput),
+    ]
+    for label, a, b in rows:
+        print(f"{label:<30} {a:>12.1f} {b:>12.1f} {fmt_speedup(a, b):>10}")
+
+    print(f"\nNote: Uploaded voice request #1 is a cache MISS (cold start).")
+    print(f"      Requests #2+ are cache HITs (skip audio re-encoding).")
+    print(f"{'=' * width}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
 
 async def main_async(args) -> None:
     result_dir = Path(args.result_dir)
     result_dir.mkdir(parents=True, exist_ok=True)
 
     all_results: list[BenchmarkResult] = []
-    for concurrency in args.max_concurrency:
-        result = await run_benchmark(
-            host=args.host,
-            port=args.port,
-            model=args.model,
-            num_prompts=args.num_prompts,
-            max_concurrency=concurrency,
-            num_warmups=args.num_warmups,
-            ref_audio=args.ref_audio,
-            ref_text=args.ref_text,
-        )
-        print_summary(result)
-        all_results.append(result)
+
+    # Resolve reference audio: explicit path, default URL, or none
+    ref_audio_path = args.ref_audio
+    ref_text = args.ref_text
+    if ref_audio_path is None and not args.no_voice_cache:
+        ref_audio_path = download_ref_audio(DEFAULT_REF_AUDIO_URL)
+        if ref_text is None:
+            ref_text = DEFAULT_REF_TEXT
+
+    if ref_audio_path is not None and not os.path.exists(ref_audio_path):
+        print(f"Error: ref audio file not found: {ref_audio_path}")
+        return
+
+    if ref_audio_path is None:
+        # Plain TTS benchmark (no voice cloning)
+        def make_plain_payload(prompt: str) -> dict:
+            return {
+                "model": args.model,
+                "input": prompt,
+                "stream": True,
+                "response_format": "pcm",
+            }
+
+        for concurrency in args.max_concurrency:
+            result = await run_benchmark(
+                host=args.host,
+                port=args.port,
+                num_prompts=args.num_prompts,
+                max_concurrency=concurrency,
+                num_warmups=args.num_warmups,
+                make_payload=make_plain_payload,
+                label=f"plain_tts (c={concurrency})",
+            )
+            print_summary(result)
+            all_results.append(result)
+    else:
+        ref_audio_b64 = encode_audio_to_base64(ref_audio_path)
+        print(f"Reference audio: {ref_audio_path} ({len(ref_audio_b64) // 1024}KB base64)")
+
+        for concurrency in args.max_concurrency:
+            # ---- Round A: Inline ref_audio (no cache) ----
+            print(f"\n{'=' * 60}")
+            print(f"Round A: INLINE ref_audio (c={concurrency})")
+            print(f"{'=' * 60}")
+
+            def make_inline_payload(prompt: str) -> dict:
+                return {
+                    "model": args.model,
+                    "input": prompt,
+                    "stream": True,
+                    "response_format": "pcm",
+                    "ref_audio": ref_audio_b64,
+                    "ref_text": ref_text,
+                }
+
+            bench_inline = await run_benchmark(
+                host=args.host,
+                port=args.port,
+                num_prompts=args.num_prompts,
+                max_concurrency=concurrency,
+                num_warmups=args.num_warmups,
+                make_payload=make_inline_payload,
+                label=f"inline_ref_audio (c={concurrency})",
+            )
+            print_summary(bench_inline)
+            all_results.append(bench_inline)
+
+            # ---- Upload voice ----
+            print(f"\n{'=' * 60}")
+            print("Uploading voice for cache test...")
+            print(f"{'=' * 60}")
+
+            connector = aiohttp.TCPConnector(limit=1)
+            async with aiohttp.ClientSession(connector=connector, timeout=aiohttp.ClientTimeout(total=60)) as session:
+                await delete_voice(session, args.host, args.port, args.voice_name)
+                await upload_voice(session, args.host, args.port, ref_audio_path, ref_text, args.voice_name)
+
+            # ---- Round B: Uploaded voice (cache hits after 1st request) ----
+            print(f"\n{'=' * 60}")
+            print(f"Round B: UPLOADED VOICE (c={concurrency})")
+            print(f"{'=' * 60}")
+
+            def make_uploaded_payload(prompt: str) -> dict:
+                return {
+                    "model": args.model,
+                    "input": prompt,
+                    "voice": args.voice_name,
+                    "stream": True,
+                    "response_format": "pcm",
+                }
+
+            bench_cached = await run_benchmark(
+                host=args.host,
+                port=args.port,
+                num_prompts=args.num_prompts,
+                max_concurrency=concurrency,
+                num_warmups=args.num_warmups,
+                make_payload=make_uploaded_payload,
+                label=f"uploaded_voice (c={concurrency})",
+            )
+            print_summary(bench_cached)
+            all_results.append(bench_cached)
+
+            print_comparison(bench_inline, bench_cached)
+
+            # Cleanup
+            connector = aiohttp.TCPConnector(limit=1)
+            async with aiohttp.ClientSession(connector=connector, timeout=aiohttp.ClientTimeout(total=60)) as session:
+                await delete_voice(session, args.host, args.port, args.voice_name)
 
     payload = {
         "model": args.model,
         "created_at": datetime.utcnow().isoformat() + "Z",
-        "results": [asdict(result) for result in all_results],
+        "results": [asdict(r) for r in all_results],
     }
     result_path = result_dir / "bench_tts_serve.json"
     result_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    print(f"Saved results to: {result_path}")
+    print(f"\nSaved results to: {result_path}")
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Benchmark VoxCPM via /v1/audio/speech")
+    parser = argparse.ArgumentParser(
+        description="Benchmark VoxCPM via /v1/audio/speech (with voice cache comparison)",
+    )
     parser.add_argument("--host", default="127.0.0.1", help="Server host")
     parser.add_argument("--port", type=int, default=8091, help="Server port")
     parser.add_argument("--model", default=DEFAULT_MODEL, help="Model name or path")
-    parser.add_argument("--num-prompts", type=int, default=20, help="Number of prompts to send")
+    parser.add_argument("--num-prompts", type=int, default=20, help="Number of prompts per round")
     parser.add_argument("--max-concurrency", type=int, nargs="+", default=[1], help="Concurrency levels to benchmark")
-    parser.add_argument("--num-warmups", type=int, default=3, help="Warmup request count")
-    parser.add_argument("--ref-audio", default=None, help="Reference audio URL or data URL for voice cloning")
-    parser.add_argument("--ref-text", default=None, help="Reference audio transcript for voice cloning")
+    parser.add_argument("--num-warmups", type=int, default=3, help="Warmup request count per round")
+    parser.add_argument(
+        "--ref-audio", default=None,
+        help="Path to reference audio file (default: downloads Qwen clone_2.wav)",
+    )
+    parser.add_argument(
+        "--ref-text", default=None,
+        help="Transcript of the reference audio (default: Qwen clone_2 transcript)",
+    )
+    parser.add_argument("--voice-name", default="bench_voice", help="Name for the uploaded voice")
+    parser.add_argument(
+        "--no-voice-cache", action="store_true",
+        help="Skip voice cache comparison; run plain TTS only",
+    )
     parser.add_argument("--result-dir", default="results", help="Directory to save benchmark JSON")
     return parser.parse_args()
 

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -98,6 +98,7 @@ nav:
       - design/feature/disaggregated_inference.md
       - design/feature/ray_based_execution.md
       - design/feature/omni_connectors/
+      - design/feature/prefix_caching.md
       - design/feature/cfg_parallel.md
       - design/feature/expert_parallel.md
       - design/feature/sequence_parallel.md

--- a/docs/design/feature/prefix_caching.md
+++ b/docs/design/feature/prefix_caching.md
@@ -1,0 +1,164 @@
+# Automatic Prefix Caching in Omni Models
+
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [High-Level Approach](#high-level-approach)
+- [Example](#example)
+- [What About Multimodal Inputs?](#what-about-multimodal-inputs)
+
+---
+
+### Overview
+
+Prefix caching in the context of kv-cache management is a useful optimization for avoiding redundant computations. The main idea is that we store portions of the kv-cache from processed requests, so that we can reuse them if incoming requests have the same prefix as previous requests.
+
+vLLM manages the kv-cache as blocks, which represent a span of tokens of a fixed length. Blocks are hashable by the content that they contain, which typically means the tokens within the span, but also could be influenced by other factors, e.g., LoRA and multimodal data.
+
+vLLM implements automatic prefix caching for managing its kv-cache, which is best understood by reading the design document [here](https://docs.vllm.ai/en/latest/design/prefix_caching/). vLLM-Omni builds on top of the prefix caching mechanism in a noninvasive way to allow caching between stages in Omni pipelines. This typically means for a given stage we aim to support caching for the following:
+
+- The last hidden states produced by the stage
+- Model / stage specific multimodal data
+
+!!! note "Note 1"
+    This document describes vLLM-Omni's mechanism for caching tensor outputs that are meant to be passed between stages, when requests have common prefixes, similar to the way in which vLLM has prefix caching for the kv-cache. This works in conjunction with vLLM's multimodal encoder caching, but is distinct. See the final section for a concrete example for how they tie together in practice.
+
+### High-Level Approach
+!!! note "Note 2"
+    Prior to reading this section, it's recommended to take a look at the design documents in vLLM for [Automatic Prefix Caching](https://docs.vllm.ai/en/latest/features/automatic_prefix_caching/), which will make some of the concepts more clear.
+
+The main focus of vLLM-Omni's approach to prefix caching stage outputs is to build on vLLM's prefix caching in the least invasive way possible while minimizing impact for cache misses, and consuming a minimal amount of GPU memory. To understand the implementation, there are a few important things to note:
+
+- Between stages, device tensors are generally moved to CPU; this is important since we're just caching the outputs of stages, so it is okay to keep the entire cache on the CPU.
+
+- For a tensor to be considered cacheable, the first dimension (currently) needs to be the same as the token count, as it allows us to reuse block/slot mappings for our externally maintained tensor caches. This allows us to dynamically discover the tensors to be marked as cacheable outputs in each Omni model without having to explicitly specify cacheable output field names in every model.
+
+With this in mind, consider the set of blocks in a 2D layout, where the row represents the index of blocks being considered, and the columns represent the slots corresponding to tokens within each block. Since we know the `num_blocks` and `block_size` from our kv cache config, if we want to cache a tensor with feature size `D`, we can preallocate a CPU tensor of size `(num_blocks, block_size, D)`, and use the same block index and slot mapping to retrieve the corresponding feature vector.
+
+
+### Example
+!!! note "Note 3"
+    Prefix caching in vLLM-Omni currently is only supported on AutoRegressive stages with one kv-cache group. It can be enabled/disabled per-stage via the `enable_prefix_caching` parameter in the model's stage config.
+
+The way in which vLLM-Omni ties into vLLM's prefix caching is best understood by example. Say that we have the following:
+
+- `num_blocks=8`
+- `block_size=4`
+- `hidden_size=2`
+- A stage specific multimodal output tensor named `mm_feature` with feature dimension `16`
+
+The prefix cache flow is then outlined below.
+
+1. When the model is initialized, we can determine the `hidden_size` from the `ModelConfig`, and allocate a cache of size `(num_blocks, block_size, hidden_size)`.
+
+2. Say we process the request `The quick brown fox was tired and slept beneath the shady tree`, which is 12 tokens and evenly divides into 3 blocks as shown below.
+
+```
+         [  The quick brown fox  ] [  was tired and slept ] [beneath the shady tree ]
+Block 1: |<--- block tokens ---->|
+Block 2: |<------- prefix ------>| |<--- block tokens --->|
+Block 3: |<------------------ prefix -------------------->| |<--- block tokens ---->|
+```
+
+When the request processes, we inspect the multimodal outputs and identify the `mm_feature` tensor, which will be of shape `(seq_len, feature_dim)`, i.e., `(12, 16)` in this example. We note that the first axis is dependent on the `seq_len` and add a new cache_tensor of shape `(num_blocks, block_size, feature_dim)` to our multimodal cache for tensors.
+
+
+3. If we lay out the cache as a 2D tensor of shape (`num_blocks`, `block_size`), we'll have something like the following:
+
+```
+0: [  The quick brown fox  ]
+1: [  was tired and slept  ]
+2: [beneath the shady tree ]
+3: [EMPTY]
+...
+7: [EMPTY]
+```
+
+Or, if we flatten it down to 1D,
+```
+0: The
+1: quick
+2: brown
+3: fox
+...
+11: tree
+12: [EMPTY]
+...
+```
+
+which we can think of as row indices into the hidden states tensor if we view it as the 2D shape `(num_blocks x block_size, feature_dim)`. That is, the analogous flattened (from 3D -> 2D) mapping of the cache for hidden states becomes the following.
+```
+0: <hidden states vector of len 2 corresponding to 'The'>
+1: <hidden states vector of len 2 corresponding to 'quick'>
+2: <hidden states vector of len 2 corresponding to 'brown'>
+3: <hidden states vector of len 2 corresponding to 'fox'>
+...
+11: <hidden states vector of len 2 corresponding to 'tree'>
+12: [EMPTY]
+...
+```
+
+Similarly, for the multimodal outputs cache, the flattened coordinates are the same, but the `mm_feature` maps to vectors of length `16` instead of the hidden size of `2`. Note that in practice, we may have multiple  multimodal output tensors per forward pass, which may have different names and different feature dimensions.
+
+
+4. Now, say that we receive a new request `The quick brown fox jumped over the dog`.
+
+```
+         [  The quick brown fox  ] [  jumped over the dog ]
+Block 1: |<--- block tokens ---->|
+Block 2: |<------- prefix ------>| |<--- block tokens --->|
+```
+
+Here, we will have a cache hit for `Block 1` which will be detected by vLLM based on the hash of the first block when it's handling the prefix caching on the kv-cache. As a result, when we get the output from the scheduler, we will see that `num_computed_tokens=4` (corresponding to the cached first block), and we only need to process the remaining 4 new tokens in the new prefill.
+
+Since we have the block indices / slot mappings from the kv cache manager, we can simply mirror the mappings and leverage the same indices for the cached hidden states and multimodal outputs. This allows us to look up the correct tensors from our externally maintained 3D caches.
+
+```
+0: [  The quick brown fox  ] < already in the cache
+1: [  was tired and slept  ]
+2: [beneath the shady tree ]
+3: [ jumped over the dog  ] < added on the second request
+4: [EMPTY]
+...
+7: [EMPTY]
+...
+```
+
+Finally, to pass the full hidden states and multimodal outputs to the next stage, we simply concatenate the cached contents with the corresponding new tensors computed from the current forward call.
+
+
+### What About Multimodal Inputs?
+It's also useful to consider the case about how Omni prefix caching is handled when we have multimodal inputs that don't cleanly end on block boundaries, as well as how this works with multimodal encoder caching in vLLM. For example:
+
+```
+         [   Im0  Im1  Im2  Im3  ] [ Im4  Im5 foo <empty> ]
+Block 1: |<--- block tokens ---->|
+Block 2: |<------- prefix ------>| |<--- block tokens --->|
+```
+
+In this case, only `Block 1` will have outputs stored in the prefix tensor cache, because vLLM does not store partial blocks. This may appear to be a problem at first glance, because the multimodal input is fragmented across a new block that wasn't cached.
+
+In reality, this isn't a big problem for correctness, because vLLM also maintains an encoder cache for multimodal inputs. In other words, after the first pass, we'll have the following:
+
+- The Block 1 hash, which is used for prefix caching
+- The hash describing the image data starting at position 0 and with length 6
+- In vLLM's encoder cache, a mapping from the image hash above to the encoder output
+
+
+To understand what happens, say we get the following input as a second request:
+```
+         [   Im0  Im1  Im2  Im3  ] [  Im4  Im5 bar  baz  ]
+Block 1: |<--- block tokens ---->|
+Block 2: |<------- prefix ------>| |<--- block tokens --->|
+```
+
+First, the scheduler will check for a prefix cache hit, which we will see on `Block 1`. As a result, we will have 4 tokens marked as precomputed, and only see the remaining 4 tokens in the following prefill.
+
+Because we have multimodal data in a scheduled span that isn't fully precomputed, we still need to call the visual encoder. However, since we have the image hash and encoder cache, we will retrieve the encoder outputs for `Im4` and `Im5` as we create the multimodal embeddings.
+
+When we pass our multimodal tensors to the language model component in the same stage, we'll then expect the same outputs, because the prefix caching behaviors in vLLM-Omni / vLLM match, so the LLM will use vLLM's KV cache manager's prefix caching to correctly handle the attention information for `Block 1` while calculating the outputs for `Block 2`, giving us the correct results for processing `Block 2` with the context of `Block 1`.
+
+Finally, we look up the output hidden states/multimodal tensors corresponding to the prefix cache hit `Block 1` and concatenate it with the forward pass result to get the final result, which is expected to be identical to the full hidden states when prefix caching is disabled.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1850,6 +1850,7 @@ class OmniResponse:
     e2e_latency: float | None = None
     success: bool = False
     error_message: str | None = None
+    cached_tokens: int | None = None
 
 
 @dataclass
@@ -2344,6 +2345,11 @@ class OpenAIClientHandler:
                 # Process text content
                 if hasattr(choice.message, "content") and choice.message.content is not None:
                     text_content = choice.message.content
+
+            # Extract cached_tokens for prefix caching tests
+            usage = getattr(chat_completion, "usage", None)
+            if usage and (details := getattr(usage, "prompt_tokens_details", None)):
+                result.cached_tokens = details.cached_tokens
 
             # Calculate end-to-end latency
             result.e2e_latency = time.perf_counter() - start_time

--- a/tests/core/test_prefix_cache.py
+++ b/tests/core/test_prefix_cache.py
@@ -1,0 +1,347 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from vllm_omni.core.prefix_cache import OmniTensorPrefixCache
+
+DEFAULT_SEQ_LEN = 15
+NUM_BLOCKS = 10
+BLOCK_SIZE = 4
+HIDDEN_SIZE = 2
+DTYPE = torch.float32
+OTHER_DTYPE = torch.float16
+DEFAULT_SHAPE = torch.Size([NUM_BLOCKS, BLOCK_SIZE, HIDDEN_SIZE])
+
+
+class MockInputBatch:
+    def __init__(self, num_computed_tokens_cpu):
+        self.req_ids = ["req1", "req2"]
+        self.req_id_to_index = {req_id: i for i, req_id in enumerate(self.req_ids)}
+        self.num_computed_tokens_cpu = num_computed_tokens_cpu
+        # Block table is only mocked for validation of length;
+        # we don't actually need to add valid values here since
+        # we patch the table when testing.
+        self.block_table = Mock()
+        self.block_table.block_tables = [None]
+
+
+def get_omni_pcache_with_mm_tensors(feat_dims, seq_len) -> OmniTensorPrefixCache:
+    """Build an OmniTensorPrefixCache and init mm tensors."""
+    cache = get_omni_pcache()
+    mm_outputs = get_multimodal_outputs(feat_dims, seq_len)
+    cache.maybe_init_missing_mm_cache_keys(mm_outputs, seq_len)
+    return cache
+
+
+def get_omni_pcache() -> OmniTensorPrefixCache:
+    """Build an OmniTensorPrefixCache, but don't init mm tensors."""
+    cache = OmniTensorPrefixCache(
+        num_blocks=NUM_BLOCKS,
+        block_size=BLOCK_SIZE,
+        hidden_size=HIDDEN_SIZE,
+        hs_dtype=DTYPE,
+    )
+    return cache
+
+
+def get_multimodal_outputs(feat_dims: dict[str, int], seq_len: int) -> dict[str, torch.Tensor]:
+    fake_mm_inputs = {}
+    for mm_key, feat_dim in feat_dims.items():
+        fake_mm_inputs[mm_key] = torch.rand((seq_len, feat_dim), dtype=DTYPE)
+    return fake_mm_inputs
+
+
+### Tests for initialization
+def test_initialization_simple():
+    """Check default initialization only creates the hidden states."""
+    cache = get_omni_pcache()
+    assert isinstance(cache.hidden_states_cache, torch.Tensor)
+    assert cache.hidden_states_cache.shape == DEFAULT_SHAPE
+    assert len(cache.mm_outputs_cache) == 0
+    assert len(cache.mm_cache_keys) == 0
+
+
+def test_initialization_with_multimodal():
+    """Check initialization + registration of multimodal outputs."""
+    cache = get_omni_pcache()
+    feat_dims = {"foo": 100, "bar": 50, "baz": 10}
+    mm_outputs = get_multimodal_outputs(
+        feat_dims,
+        seq_len=DEFAULT_SEQ_LEN,
+    )
+    # Cast one of the keys to a different dtype; the dtype of the tensor
+    # that is used to initialize the cache dictates the cache dtype.
+    mm_outputs["foo"] = mm_outputs["foo"].to(OTHER_DTYPE)
+
+    cache.maybe_init_missing_mm_cache_keys(mm_outputs, DEFAULT_SEQ_LEN)
+    assert len(cache.mm_cache_keys) == 3
+    assert set(cache.mm_cache_keys) == set(feat_dims.keys())
+    for mm_key in cache.mm_cache_keys:
+        cache_tensor = cache.mm_outputs_cache[mm_key]
+        assert isinstance(cache_tensor, torch.Tensor)
+        assert cache_tensor.shape[-1] == feat_dims[mm_key]
+        assert mm_outputs[mm_key].dtype == cache_tensor.dtype
+
+
+def test_init_missing_mm_cache_keys_is_idempotent():
+    """Ensure that the cache doesn't reinitialize old keys."""
+    cache = get_omni_pcache()
+    mm_key = "foo"
+    feat_dims = {mm_key: 100}
+    mm_outputs = get_multimodal_outputs(
+        feat_dims,
+        seq_len=DEFAULT_SEQ_LEN,
+    )
+    cache.maybe_init_missing_mm_cache_keys(mm_outputs, DEFAULT_SEQ_LEN)
+    assert len(cache.mm_cache_keys) == 1
+    assert mm_key in cache.mm_cache_keys
+
+    # Cache is initialized to 0 - fill it with 1s
+    cache.mm_outputs_cache[mm_key].fill_(1)
+
+    # Ensure that running another initialization
+    # doesn't zero out our cache values
+    cache.maybe_init_missing_mm_cache_keys(mm_outputs, DEFAULT_SEQ_LEN)
+    assert len(cache.mm_cache_keys) == 1
+    assert mm_key in cache.mm_cache_keys
+    assert torch.all(cache.mm_outputs_cache[mm_key] == 1)
+
+
+### Tests for Update
+def test_update_no_multimodal():
+    """Test that slot mappings act as row indices hidden states."""
+    cache = get_omni_pcache()
+
+    num_tokens_unpadded = 8
+    slot_offset = 8
+    slot_mapping = torch.arange(slot_offset, slot_offset + num_tokens_unpadded)
+    new_hidden_states = torch.rand((num_tokens_unpadded, HIDDEN_SIZE), dtype=DTYPE)
+
+    cache.update_omni_tensor_prefix_cache(
+        hidden_states=new_hidden_states,
+        multimodal_outputs=None,
+        num_tokens_unpadded=num_tokens_unpadded,
+        slot_mapping=slot_mapping,
+    )
+
+    # Ensure that if we reshape our 3D cache back to 2D, we can use the
+    # indices in our slot mappings to access the hidden states as expected
+    hs_rows = cache.hidden_states_cache.view(NUM_BLOCKS * BLOCK_SIZE, HIDDEN_SIZE)
+    for slot_idx, new_states in zip(slot_mapping, new_hidden_states):
+        slot_states = hs_rows[slot_idx]
+        assert torch.all(slot_states == new_states)
+
+
+@pytest.mark.parametrize(
+    "feat_dims",
+    [
+        {"foo": 100, "bar": 100},
+        {"foo": 100, "bar": 50, "baz": 10},
+    ],
+)
+def test_update_with_multimodal_outputs(feat_dims):
+    """Test that slot mappings are correct for multimodal tensors."""
+    cache = get_omni_pcache_with_mm_tensors(feat_dims, seq_len=DEFAULT_SEQ_LEN)
+
+    num_tokens_unpadded = 8
+    slot_offset = 8
+    slot_mapping = torch.arange(slot_offset, slot_offset + num_tokens_unpadded)
+    feature_dims = {key: val.shape[-1] for key, val in cache.mm_outputs_cache.items()}
+    mm_outputs = {key: torch.rand((num_tokens_unpadded, feature_dims[key]), dtype=DTYPE) for key in cache.mm_cache_keys}
+    cache.update_omni_tensor_prefix_cache(
+        hidden_states=None,
+        multimodal_outputs=mm_outputs,
+        num_tokens_unpadded=num_tokens_unpadded,
+        slot_mapping=slot_mapping,
+    )
+
+    for mm_key in feat_dims.keys():
+        assert mm_key in cache.mm_outputs_cache
+        key_feat_dim = feature_dims[mm_key]
+        mm_state_rows = cache.mm_outputs_cache[mm_key].view(NUM_BLOCKS * BLOCK_SIZE, key_feat_dim)
+
+        # Similar to hidden states, but for each key in the dict;
+        # Different tensors may have different feature dims
+        new_mm_outputs = mm_outputs[mm_key]
+        for slot_idx, new_output in zip(slot_mapping, new_mm_outputs):
+            slot_states = mm_state_rows[slot_idx]
+            assert torch.all(slot_states == new_output)
+
+
+### Tests for Merging
+def fake_get_cached_block_ids(self, req_idx, *args, **kwargs):
+    """Fake block table lookup.
+
+    Assumption:
+        req_idx 0 is a cache hit with slots 8, 9, ..., 15
+        req_idx 1 is a cache miss
+    """
+    assert req_idx < 2
+    if req_idx == 0:
+        # With the slot offset we provided (8), the corresponding
+        # blocks IDs are 2 & 3 because the block size is 4.
+        return torch.tensor([2, 3], dtype=torch.long)
+    return torch.tensor([], dtype=torch.long)
+
+
+@pytest.mark.parametrize("num_tokens_padded", [None, 16])
+def test_get_merged_hidden_states(num_tokens_padded):
+    """Ensure that hidden states are merged correctly."""
+    cache = get_omni_pcache()
+
+    orig_num_tokens_unpadded = 8
+    slot_offset = 8  # We'll put our states in slots 8, 9, 10, ..., 15
+    orig_slot_mapping = torch.arange(slot_offset, slot_offset + orig_num_tokens_unpadded)
+    orig_hidden_states = torch.rand((orig_num_tokens_unpadded, HIDDEN_SIZE), dtype=DTYPE)
+
+    cache.update_omni_tensor_prefix_cache(
+        hidden_states=orig_hidden_states,
+        multimodal_outputs=None,
+        num_tokens_unpadded=orig_num_tokens_unpadded,
+        slot_mapping=orig_slot_mapping,
+        num_tokens_padded=num_tokens_padded,
+    )
+
+    # Say that we have two requests, but only one of them is a cache hit
+    num_new_toks_req1 = 3
+    num_new_toks_req2 = 2
+    cache.add_prefix_cached_new_req_id("req1")
+
+    num_scheduled_tokens = {
+        "req1": num_new_toks_req1,
+        "req2": num_new_toks_req2,
+    }
+    new_hidden_states = torch.rand(
+        (num_new_toks_req1 + num_new_toks_req2, HIDDEN_SIZE),
+        dtype=DTYPE,
+    )
+    req1_new_states = new_hidden_states[:num_new_toks_req1]
+    req2_new_states = new_hidden_states[-num_new_toks_req2:]
+
+    input_batch = MockInputBatch(num_computed_tokens_cpu=torch.Tensor([orig_num_tokens_unpadded, 0]))
+
+    with patch(
+        "vllm_omni.core.prefix_cache.OmniTensorPrefixCache._get_cached_block_ids",
+        new=fake_get_cached_block_ids,
+    ):
+        merged_states = cache.get_merged_hidden_states(
+            query_start_loc=[0, num_new_toks_req1],
+            input_batch=input_batch,
+            hidden_states=new_hidden_states,
+            num_scheduled_tokens=num_scheduled_tokens,
+        )
+
+    assert "req1" in merged_states and "req2" in merged_states
+    req1_merged_states = merged_states["req1"]
+    req2_merged_states = merged_states["req2"]
+
+    # First, check the cache hit case
+    assert req1_merged_states.shape == torch.Size([orig_num_tokens_unpadded + num_new_toks_req1, HIDDEN_SIZE])
+    # Ensure that the req1 merged states are the cached states + the new req1 states
+    assert torch.all(req1_merged_states[:orig_num_tokens_unpadded] == orig_hidden_states)
+    assert torch.all(req1_merged_states[-num_new_toks_req1:] == req1_new_states)
+
+    # Next, ensure that the cache miss case only has the new states
+    assert req2_merged_states.shape == torch.Size([num_new_toks_req2, HIDDEN_SIZE])
+    assert torch.all(req2_merged_states == req2_new_states)
+
+
+@pytest.mark.parametrize("num_tokens_padded", [None, 16])
+@pytest.mark.parametrize(
+    "feat_dims",
+    [
+        {"foo": 100, "bar": 100},
+        {"foo": 100, "bar": 50, "baz": 10},
+    ],
+)
+def test_get_merged_multimodal_outputs(feat_dims, num_tokens_padded):
+    cache = get_omni_pcache_with_mm_tensors(feat_dims, seq_len=DEFAULT_SEQ_LEN)
+
+    orig_num_tokens_unpadded = 8
+    slot_offset = 8  # We'll put our states in slots 8, 9, 10, ..., 15
+    orig_slot_mapping = torch.arange(slot_offset, slot_offset + orig_num_tokens_unpadded)
+    feature_dims = {key: val.shape[-1] for key, val in cache.mm_outputs_cache.items()}
+    orig_mm_outputs = {
+        key: torch.rand((orig_num_tokens_unpadded, feature_dims[key]), dtype=DTYPE) for key in cache.mm_cache_keys
+    }
+
+    cache.update_omni_tensor_prefix_cache(
+        hidden_states=None,
+        multimodal_outputs=orig_mm_outputs,
+        num_tokens_unpadded=orig_num_tokens_unpadded,
+        slot_mapping=orig_slot_mapping,
+        num_tokens_padded=num_tokens_padded,
+    )
+
+    # Similar to hs test- say that we have two requests, but only one of them is a cache hit
+    num_new_toks_req1 = 3
+    num_new_toks_req2 = 2
+    cache.add_prefix_cached_new_req_id("req1")
+
+    num_scheduled_tokens = {
+        "req1": num_new_toks_req1,
+        "req2": num_new_toks_req2,
+    }
+
+    new_mm_outputs = {}
+    for mm_key in cache.mm_cache_keys:
+        new_mm_outputs[mm_key] = torch.rand(
+            (num_new_toks_req1 + num_new_toks_req2, feature_dims[mm_key]),
+            dtype=DTYPE,
+        )
+    # We also want to make sure passthrough data (outside of our keys) isn't dropped
+    new_mm_outputs["passthrough_data"] = "Something else"
+    # Lists are a special case because we can't split them yet if we want to match
+    # the nonprefix cache behavior, because this runs before post process.
+    new_mm_outputs["passthrough_list"] = ["should", "not", "split"]
+
+    input_batch = MockInputBatch(num_computed_tokens_cpu=torch.Tensor([orig_num_tokens_unpadded, 0]))
+
+    with patch(
+        "vllm_omni.core.prefix_cache.OmniTensorPrefixCache._get_cached_block_ids",
+        new=fake_get_cached_block_ids,
+    ):
+        merged_mm_outputs = cache.get_merged_multimodal_states(
+            query_start_loc=[0, num_new_toks_req1],
+            input_batch=input_batch,
+            multimodal_outputs=new_mm_outputs,
+            num_scheduled_tokens=num_scheduled_tokens,
+        )
+
+    # Ensure the passthrough data wasn't dropped
+    assert "passthrough_data" in merged_mm_outputs
+    assert "passthrough_list" in merged_mm_outputs
+
+    for mm_key, mm_output in merged_mm_outputs.items():
+        # Ensure passthrough data is just forwarded normally and not duplicated
+        assert isinstance(mm_output, dict)
+        assert "req1" in mm_output and "req2" in mm_output
+        if mm_key == "passthrough_data":
+            assert mm_key not in cache.mm_cache_keys
+            assert new_mm_outputs[mm_key] == mm_output["req1"]
+            assert new_mm_outputs[mm_key] == mm_output["req2"]
+        elif mm_key == "passthrough_list":
+            assert mm_key not in cache.mm_cache_keys
+            assert new_mm_outputs[mm_key] == mm_output["req1"]
+            assert new_mm_outputs[mm_key] == mm_output["req2"]
+        else:
+            assert mm_key in cache.mm_cache_keys
+            curr_feat_dim = feature_dims[mm_key]
+            # Ensure that req1 (cache hit) merged the mm data
+            req1_merged_mm_outputs = mm_output["req1"]
+            req1_new_mm_outputs = new_mm_outputs[mm_key][:num_new_toks_req1]
+
+            assert req1_merged_mm_outputs.shape == torch.Size(
+                [orig_num_tokens_unpadded + num_new_toks_req1, curr_feat_dim]
+            )
+            # Ensure that the req1 merged mm data are the cached data + the new data
+            assert torch.all(req1_merged_mm_outputs[:orig_num_tokens_unpadded] == orig_mm_outputs[mm_key])
+            assert torch.all(req1_merged_mm_outputs[-num_new_toks_req1:] == req1_new_mm_outputs)
+
+            # Ensure that req2 (cache miss) only has the new mm data
+            req2_merged_mm_outputs = mm_output["req2"]
+            req2_new_mm_outputs = new_mm_outputs[mm_key][-num_new_toks_req2:]
+
+            assert req2_merged_mm_outputs.shape == torch.Size([num_new_toks_req2, curr_feat_dim])
+            assert torch.all(req2_merged_mm_outputs == req2_new_mm_outputs)

--- a/tests/e2e/online_serving/test_qwen3_omni.py
+++ b/tests/e2e/online_serving/test_qwen3_omni.py
@@ -23,11 +23,13 @@ os.environ["VLLM_TEST_CLEAN_GPU_MEMORY"] = "0"
 
 
 models = ["Qwen/Qwen3-Omni-30B-A3B-Instruct"]
+QWEN3_OMNI_CONFIG_PATH = str(Path(__file__).parent.parent / "stage_configs" / "qwen3_omni_ci.yaml")
+QWEN3_OMNI_XPU_CONFIG_PATH = str(Path(__file__).parent.parent / "stage_configs" / "xpu" / "qwen3_omni_ci.yaml")
 
 
-def get_chunk_config():
+def get_chunk_config(config_path: str):
     path = modify_stage_config(
-        str(Path(__file__).parent.parent / "stage_configs" / "qwen3_omni_ci.yaml"),
+        config_path,
         updates={
             "async_chunk": True,
             "stage_args": {
@@ -44,14 +46,40 @@ def get_chunk_config():
     return path
 
 
+def get_prefix_caching_config(config_path: str):
+    """Create a stage config with prefix caching enabled on the thinker (stage 0)."""
+    path = modify_stage_config(
+        config_path,
+        updates={
+            "stage_args": {
+                0: {"engine_args.enable_prefix_caching": True},
+            },
+        },
+    )
+    return path
+
+
 if current_omni_platform.is_xpu():
-    stage_configs = [str(Path(__file__).parent.parent / "stage_configs" / "xpu" / "qwen3_omni_ci.yaml")]
+    stage_configs = [QWEN3_OMNI_XPU_CONFIG_PATH]
+    prefix_caching_stage_configs = [get_prefix_caching_config(QWEN3_OMNI_XPU_CONFIG_PATH)]
 else:  # MI325 GPU should share the same config as H100
-    stage_configs = [get_chunk_config()]
+    stage_configs = [get_chunk_config(QWEN3_OMNI_CONFIG_PATH)]
+    prefix_caching_stage_configs = [get_prefix_caching_config(QWEN3_OMNI_CONFIG_PATH)]
 
 # Create parameter combinations for model and stage config
 test_params = [
     OmniServerParams(model=model, stage_config_path=stage_config) for model in models for stage_config in stage_configs
+]
+# For prefix caching, we need to enable prompt token details so that we
+# can determine if any tokens were cached.
+prefix_test_params = [
+    OmniServerParams(
+        model=model,
+        stage_config_path=stage_config,
+        server_args=["--enable-prompt-tokens-details"],  # Enable prompt tokens details to get cached_tokens
+    )
+    for model in models
+    for stage_config in prefix_caching_stage_configs
 ]
 
 
@@ -75,6 +103,7 @@ def get_prompt(prompt_type="text_only"):
     prompts = {
         "text_only": "What is the capital of China? Answer in 20 words.",
         "mix": "What is recited in the audio? What is in this image? Describe the video briefly.",
+        "text_image": "What color are the squares in this image?",
     }
     return prompts.get(prompt_type, prompts["text_only"])
 
@@ -147,3 +176,41 @@ def test_text_to_text_001(omni_server, openai_client) -> None:
     }
 
     openai_client.send_omni_request(request_config, request_num=get_max_batch_size())
+
+
+@pytest.mark.advanced_model
+@pytest.mark.core_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=2)
+@pytest.mark.parametrize("omni_server", prefix_test_params, indirect=True)
+def test_thinker_prefix_caching(omni_server, openai_client) -> None:
+    """
+    Test thinker prefix caching by sending identical requests with an image (i.e.,
+    a large shared prefix) and verifying that the second request uses cached tokens
+    & produces the same output.
+    """
+    image_data_url = f"data:image/jpeg;base64,{generate_synthetic_image(224, 224)['base64']}"
+    messages = dummy_messages_from_mix_data(
+        system_prompt=get_system_prompt(),
+        image_data_url=image_data_url,
+        content_text=get_prompt("text_image"),
+    )
+
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+        "stream": False,
+        "modalities": ["text"],
+    }
+
+    response_1 = openai_client.send_omni_request(request_config, request_num=1)[0]
+    response_2 = openai_client.send_omni_request(request_config, request_num=1)[0]
+
+    assert response_1.success
+    assert response_2.success
+    assert response_2.cached_tokens is not None
+    # We should cache the vast majority of the prompt (image + up to last full block),
+    # and set seed in the CI config, so the second request should give an identical
+    # response for the generated input image, even if we use dummy weights
+    assert response_2.cached_tokens > 0
+    assert response_1.text_content == response_2.text_content

--- a/tests/entrypoints/openai_api/test_serving_speech_voxcpm.py
+++ b/tests/entrypoints/openai_api/test_serving_speech_voxcpm.py
@@ -60,7 +60,7 @@ class TestVoxCPMServing:
     @pytest.mark.parametrize(
         ("request_kwargs", "expected_substring"),
         [
-            ({"voice": "alice"}, "voice"),
+            ({"voice": "alice"}, "not an uploaded voice"),
             ({"instructions": "whisper"}, "instructions"),
             ({"language": "en"}, "language"),
             ({"task_type": "CustomVoice"}, "plain tts"),
@@ -141,3 +141,46 @@ class TestVoxCPMServing:
             "prompt_token_ids": [1],
             "additional_information": tts_params,
         }
+
+    def test_validate_voxcpm_accepts_uploaded_voice(self, voxcpm_server):
+        voxcpm_server.uploaded_speakers["alice"] = {
+            "ref_text": "hello world",
+            "file_path": "/tmp/alice.wav",
+            "created_at": 1000.0,
+        }
+        request = OpenAICreateSpeechRequest(input="test text", voice="alice")
+        assert voxcpm_server._validate_voxcpm_request(request) is None
+
+    def test_validate_voxcpm_rejects_uploaded_voice_without_ref_text(self, voxcpm_server):
+        voxcpm_server.uploaded_speakers["bob"] = {
+            "file_path": "/tmp/bob.wav",
+            "created_at": 1000.0,
+        }
+        request = OpenAICreateSpeechRequest(input="test text", voice="bob")
+        error = voxcpm_server._validate_voxcpm_request(request)
+        assert error is not None
+        assert "ref_text" in error.lower()
+
+    def test_build_tts_params_voxcpm_uploaded_voice_includes_cache_keys(self, voxcpm_server):
+        voxcpm_server.uploaded_speakers["alice"] = {
+            "ref_text": "hello world",
+            "file_path": "/tmp/alice.wav",
+            "created_at": 1234.5,
+            "embedding_source": "audio",
+        }
+        voxcpm_server._get_uploaded_audio_data = lambda name: "data:audio/wav;base64,QUJD"
+
+        request = OpenAICreateSpeechRequest(input="test text", voice="alice")
+        params = voxcpm_server._build_tts_params(request)
+
+        assert params["voice_name"] == ["alice"]
+        assert params["voice_created_at"] == [1234.5]
+        assert params["ref_audio"] == ["data:audio/wav;base64,QUJD"]
+        assert params["ref_text"] == ["hello world"]
+
+    def test_build_tts_params_voxcpm_no_voice_no_cache_keys(self, voxcpm_server):
+        request = OpenAICreateSpeechRequest(input="test text")
+        params = voxcpm_server._build_tts_params(request)
+
+        assert "voice_name" not in params
+        assert "voice_created_at" not in params

--- a/tests/model_executor/models/test_voxcpm_voice_cache.py
+++ b/tests/model_executor/models/test_voxcpm_voice_cache.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Tests for VoxCPM prompt-cache caching via VoiceEmbeddingCache.
+
+Covers:
+  - Cache miss → build_prompt_cache → store
+  - Cache hit → skip build_prompt_cache, reuse cached artifacts
+  - Inline ref_audio (no voice name) → no caching
+  - Stale-cache protection via created_at
+  - created_at=0 disables caching
+"""
+
+import os
+import tempfile
+
+import pytest
+import torch
+from pytest_mock import MockerFixture
+
+from vllm_omni.model_executor.models.voxcpm.voxcpm_stage_wrappers import (
+    _DirectVoxCPMLatentGenerator,
+)
+from vllm_omni.utils.voice_cache import VoiceEmbeddingCache
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_FAKE_AUDIO_FEAT = torch.randn(5, 2, 64)
+_FAKE_PROMPT_CACHE = {"prompt_text": "hello", "audio_feat": _FAKE_AUDIO_FEAT}
+
+
+def _write_temp_wav() -> str:
+    """Write a trivial temp file to act as a prompt_wav_path."""
+    with tempfile.NamedTemporaryFile(prefix="voxcpm_test_", suffix=".wav", delete=False) as f:
+        f.write(b"\x00" * 44)
+        return f.name
+
+
+@pytest.fixture
+def mock_generator(mocker: MockerFixture) -> _DirectVoxCPMLatentGenerator:
+    """Create a _DirectVoxCPMLatentGenerator with a mocked tts_model."""
+    tts_model = mocker.MagicMock()
+    tts_model.sample_rate = 24000
+    tts_model.build_prompt_cache.return_value = {
+        "prompt_text": "hello",
+        "audio_feat": _FAKE_AUDIO_FEAT.clone(),
+    }
+    gen = _DirectVoxCPMLatentGenerator(tts_model)
+    gen._voice_cache = VoiceEmbeddingCache(max_entries=4)
+    return gen
+
+
+class TestVoxCPMVoiceCacheIntegration:
+    def test_cache_miss_stores_prompt_cache(self, mock_generator):
+        """First request with a named voice should encode and store."""
+        wav_path = _write_temp_wav()
+        try:
+            result = mock_generator._resolve_prompt_cache(
+                wav_path, "hello", voice_name="alice", voice_created_at=1000.0,
+            )
+            assert result is not None
+            assert "audio_feat" in result
+            assert "prompt_text" in result
+
+            mock_generator.tts_model.build_prompt_cache.assert_called_once()
+
+            key = VoiceEmbeddingCache.make_cache_key("alice", xvec_only=False, created_at=1000.0)
+            cached = mock_generator._voice_cache.get(key)
+            assert cached is not None
+            assert torch.equal(cached["audio_feat"], _FAKE_AUDIO_FEAT)
+        finally:
+            os.unlink(wav_path)
+
+    def test_cache_hit_skips_build(self, mock_generator):
+        """Second request with same voice should hit cache and skip build_prompt_cache."""
+        wav_path = _write_temp_wav()
+        try:
+            mock_generator._resolve_prompt_cache(
+                wav_path, "hello", voice_name="alice", voice_created_at=1000.0,
+            )
+            mock_generator.tts_model.build_prompt_cache.reset_mock()
+
+            result = mock_generator._resolve_prompt_cache(
+                wav_path, "hello", voice_name="alice", voice_created_at=1000.0,
+            )
+            assert result is not None
+            mock_generator.tts_model.build_prompt_cache.assert_not_called()
+            assert mock_generator._voice_cache.stats()["hits"] >= 1
+        finally:
+            os.unlink(wav_path)
+
+    def test_no_voice_name_skips_cache(self, mock_generator):
+        """Inline ref_audio without voice_name should not use cache."""
+        wav_path = _write_temp_wav()
+        try:
+            result = mock_generator._resolve_prompt_cache(wav_path, "hello")
+            assert result is not None
+
+            mock_generator.tts_model.build_prompt_cache.assert_called_once()
+            assert mock_generator._voice_cache.stats()["hits"] == 0
+            assert mock_generator._voice_cache.stats()["misses"] == 0
+            assert mock_generator._voice_cache.stats()["entries"] == 0
+        finally:
+            os.unlink(wav_path)
+
+    def test_stale_cache_on_reupload(self, mock_generator):
+        """Re-uploading a voice (new created_at) should not hit old cache."""
+        wav_path = _write_temp_wav()
+        try:
+            mock_generator._resolve_prompt_cache(
+                wav_path, "hello", voice_name="alice", voice_created_at=1000.0,
+            )
+            mock_generator.tts_model.build_prompt_cache.reset_mock()
+
+            result = mock_generator._resolve_prompt_cache(
+                wav_path, "hello", voice_name="alice", voice_created_at=2000.0,
+            )
+            assert result is not None
+            mock_generator.tts_model.build_prompt_cache.assert_called_once()
+        finally:
+            os.unlink(wav_path)
+
+    def test_created_at_zero_disables_cache(self, mock_generator):
+        """created_at=0 should bypass caching entirely."""
+        wav_path = _write_temp_wav()
+        try:
+            mock_generator._resolve_prompt_cache(
+                wav_path, "hello", voice_name="alice", voice_created_at=0.0,
+            )
+            mock_generator._resolve_prompt_cache(
+                wav_path, "hello", voice_name="alice", voice_created_at=0.0,
+            )
+            assert mock_generator.tts_model.build_prompt_cache.call_count == 2
+            assert mock_generator._voice_cache.stats()["entries"] == 0
+        finally:
+            os.unlink(wav_path)
+
+    def test_no_prompt_inputs_returns_none(self, mock_generator):
+        """No prompt_wav_path or prompt_text should return None without caching."""
+        assert mock_generator._resolve_prompt_cache(None, None) is None
+        assert mock_generator._resolve_prompt_cache(None, "text") is None
+        assert mock_generator._resolve_prompt_cache("/path", None) is None
+        mock_generator.tts_model.build_prompt_cache.assert_not_called()

--- a/vllm_omni/core/prefix_cache.py
+++ b/vllm_omni/core/prefix_cache.py
@@ -1,0 +1,264 @@
+"""
+Utilities for Prefix Caching in Omni models.
+"""
+
+import torch
+from vllm.logger import init_logger
+from vllm.v1.worker.gpu_input_batch import InputBatch
+
+from vllm_omni.utils.mm_outputs import build_mm_cpu, to_payload_element
+
+logger = init_logger(__name__)
+
+
+class OmniTensorPrefixCache:
+    """Prefix cache for hidden states (model outputs) and model specific
+    multimodal outputs.
+
+    This class implements prefix caching in a non-invasive way on top of
+    vLLM by leveraging the same slot mappings that the vLLM scheduler uses
+    for the KV Cache.
+
+    Conceptually, this means we are mapping vLLM's cache mapping:
+                        (num_blocks, block_size)
+
+    to 3D tensors of shape:
+                   (num_blocks, block_size, feature_size)
+
+    Note that feature_size may vary across multimodal_outputs.
+    """
+
+    def __init__(
+        self,
+        num_blocks: int,
+        block_size: int,
+        hidden_size: int,
+        hs_dtype: torch.dtype,
+    ):
+        self.num_blocks = num_blocks
+        self.block_size = block_size
+        self.default_hidden_size = hidden_size
+
+        # Initialize the hidden states cache immediately
+        self.hidden_states_cache = self._get_cache_tensor(dtype=hs_dtype)
+
+        # Defer initialization of the mm_outputs_cache until we
+        # actually see mm output tensors dependent on num tokens.
+        self.mm_outputs_cache = {}
+        self.mm_cache_keys = set()
+        self._new_req_cache_hit_ids: set[str] = set()
+
+    def maybe_init_missing_mm_cache_keys(self, multimodal_outputs: dict, seq_len: int):
+        """Given multimodal outputs from executing the model, dynamically
+        determine which multimodal outputs are tensors depending on sequence
+        length and should be cached, and initialize the cache tensors
+        accordingly.
+
+        NOTE: This is done to avoid the need for explicit specification of
+        cache keys for every model/stage and aligns with the current way
+        that we slice the multimodal outputs based on the first dimension.
+
+        This will usually be called by the first forward pass, i.e.,
+        determined by the warmup.
+        """
+        for key, val in multimodal_outputs.items():
+            if isinstance(val, torch.Tensor) and val.shape[0] == seq_len and key not in self.mm_cache_keys:
+                feat_dim = val.shape[-1]
+                self.mm_outputs_cache[key] = self._get_cache_tensor(
+                    dtype=val.dtype,
+                    hidden_size=feat_dim,
+                )
+                self.mm_cache_keys.add(key)
+                new_tensor_shape = self.mm_outputs_cache[key].shape
+                logger.info("Initializing multimodal output cache of size %s for key: %s", list(new_tensor_shape), key)
+
+    def _get_cache_tensor(self, dtype: torch.dtype, hidden_size: int | None = None) -> torch.Tensor:
+        """Allocate a CPU cache tensor for a specific key."""
+        actual_hidden_size = hidden_size if hidden_size is not None else self.default_hidden_size
+        return torch.zeros(
+            (self.num_blocks, self.block_size, actual_hidden_size),
+            dtype=dtype,
+            device="cpu",
+        )
+
+    def add_prefix_cached_new_req_id(self, req_id: str):
+        """Adds a new request ID to the set of prefix cache hits on the batch."""
+        self._new_req_cache_hit_ids.add(req_id)
+
+    def reset_prefix_cached_new_req_ids(self):
+        """Clears the cache hit IDs to prepare for a new engine step."""
+        self._new_req_cache_hit_ids.clear()
+
+    @staticmethod
+    def _coerce_to_cpu_tensor(maybe_gpu_tensor: torch.Tensor) -> torch.Tensor:
+        """Convert GPU tensors -> contiguous CPU tensors if needed."""
+        return maybe_gpu_tensor.detach().cpu().contiguous()
+
+    def update_omni_tensor_prefix_cache(
+        self,
+        hidden_states: torch.Tensor | None,
+        multimodal_outputs: dict[str, torch.Tensor] | None,
+        num_tokens_unpadded: int,
+        slot_mapping: torch.Tensor,
+        num_tokens_padded: int | None = None,
+    ):
+        """Updates the hidden cache state for the provided hidden states and multimodal outputs.
+
+        Args:
+            hidden_states: Hidden states tensor to cache (if any)
+            multimodal_outputs: Multimodal dict whose tensors may be cached
+            num_tokens_unpadded: Number of tokens without padding
+            slot_mapping: Slot mapping for the input sequence
+            num_tokens_padded: Total number of tokens including padding
+        """
+        unpadded_slot_mapping = slot_mapping[:num_tokens_unpadded]
+        if num_tokens_padded is None:
+            num_tokens_padded = num_tokens_unpadded
+
+        if hidden_states is not None:
+            # Slice to unpadded portion before caching
+            hidden_states = hidden_states[:num_tokens_unpadded]
+            # Ensure that hidden states are on the CPU
+            hidden_states = OmniTensorPrefixCache._coerce_to_cpu_tensor(hidden_states)
+            # View the cache as 2D so that we can treat our slots as row indices
+            flat_cache = self.hidden_states_cache.view(-1, self.hidden_states_cache.shape[-1])
+            flat_cache[unpadded_slot_mapping] = hidden_states
+            logger.debug("Writing to hidden states for %s tokens", num_tokens_unpadded)
+
+        # Do the same for the stage's cached multimodal outputs
+        if multimodal_outputs is not None:
+            # If we haven't initialized the keys already, do it now
+            # We check against the padded token count since we haven't sliced yet
+            self.maybe_init_missing_mm_cache_keys(
+                multimodal_outputs,
+                seq_len=num_tokens_padded,
+            )
+
+            for mm_out_key, mm_cache in self.mm_outputs_cache.items():
+                if mm_out_key in multimodal_outputs:
+                    # Slice to unpadded portion before caching
+                    mm_state = multimodal_outputs[mm_out_key][:num_tokens_unpadded]
+                    mm_state = OmniTensorPrefixCache._coerce_to_cpu_tensor(mm_state)
+                    flat_cache = mm_cache.view(-1, mm_cache.shape[-1])
+                    flat_cache[unpadded_slot_mapping] = mm_state
+            logger.debug("Writing to mm output cache for %s tokens", num_tokens_unpadded)
+
+    def _coerce_to_payload_dict(
+        self,
+        element: object,
+        query_start_loc: torch.Tensor,
+        input_batch: InputBatch,
+        num_scheduled_tokens: dict[str, int],
+    ) -> dict[str, object]:
+        """Build the multimodal passthrough data per request for
+        the object under consideration. This is identical to the case
+        for no prefix cache when we tensor does have a first dimension
+        matching the seq len.
+        """
+        elem_dict = {}
+        for req_id in input_batch.req_ids:
+            req_idx = input_batch.req_id_to_index[req_id]
+            start = query_start_loc[req_idx]
+            end = start + num_scheduled_tokens[req_id]
+            elem_dict[req_id] = to_payload_element(
+                element, req_idx, start=start, end=end, pass_lists_through=True, seq_len=None
+            )
+        return elem_dict
+
+    def get_merged_multimodal_states(
+        self,
+        query_start_loc: torch.Tensor,
+        input_batch: InputBatch,
+        multimodal_outputs: dict,
+        num_scheduled_tokens: dict[str, int],
+    ):
+        """Get the merged multimodal states if hidden state prefix caching is enabled."""
+        combined_multimodal_outputs = {}
+        # First get the prefix cached tensors that are present in the mm data
+        for mm_key in self.mm_cache_keys:
+            if mm_key in multimodal_outputs:
+                combined_multimodal_outputs[mm_key] = self._get_merged_tensors(
+                    query_start_loc=query_start_loc,
+                    input_batch=input_batch,
+                    cache=self.mm_outputs_cache[mm_key],
+                    hidden_states=multimodal_outputs[mm_key],
+                    num_scheduled_tokens=num_scheduled_tokens,
+                )
+
+        # Then, get everything else (passthrough data); first, convert to CPU
+        # tensors similarly to the non prefix cached path, and then populate
+        # the subdicts mapping request IDs -> payload objects
+        passthrough_keys = set(multimodal_outputs.keys()) - self.mm_cache_keys
+        passthrough_mm_data = {k: v for k, v in multimodal_outputs.items() if k in passthrough_keys}
+        mm_cpu = build_mm_cpu(multimodal_outputs=passthrough_mm_data)
+
+        for mm_key, mm_val in mm_cpu.items():
+            combined_multimodal_outputs[mm_key] = self._coerce_to_payload_dict(
+                element=mm_val,
+                query_start_loc=query_start_loc,
+                input_batch=input_batch,
+                num_scheduled_tokens=num_scheduled_tokens,
+            )
+        return combined_multimodal_outputs
+
+    def get_merged_hidden_states(self, *args, **kwargs) -> dict[str, torch.Tensor]:
+        """Get the merged hidden states."""
+        return self._get_merged_tensors(
+            *args,
+            **kwargs,
+            cache=self.hidden_states_cache,
+        )
+
+    def _get_merged_tensors(
+        self,
+        query_start_loc: torch.Tensor,
+        input_batch: InputBatch,
+        cache: torch.Tensor,
+        hidden_states: torch.Tensor,
+        num_scheduled_tokens: dict[str, int],
+    ) -> dict[str, torch.Tensor]:
+        """When hidden state caching is enabled, takes the input hidden_states,
+        which only correspond to the scheduled tokens, and returns a mapping
+        from request IDs to their full hidden states. This is accomplished by
+        looking up the block IDs & scheduled token counts to split the
+        hidden_states.
+        """
+        # We do not support hybrid caches at the moment.
+        if len(input_batch.block_table.block_tables) > 1:
+            logger.warning_once(
+                "Omni prefix caching is enabled, but the batch block table appears to"
+                " have multiple kv groups; only the first group will be used!"
+            )
+
+        combined_hidden_states = {}
+        hidden_states = OmniTensorPrefixCache._coerce_to_cpu_tensor(hidden_states)
+        for req_id in input_batch.req_ids:
+            req_idx = input_batch.req_id_to_index[req_id]
+
+            if req_id in self._new_req_cache_hit_ids:
+                block_ids = self._get_cached_block_ids(req_idx, input_batch)
+                cached_hs = cache[block_ids].reshape(-1, cache.shape[-1])
+
+                # Slice the hidden states corresponding to this request;
+                # we do this by using the query start
+                start = query_start_loc[req_idx]
+                new_hs = hidden_states[start : start + num_scheduled_tokens[req_id]]
+                combined_hidden_states[req_id] = torch.cat([cached_hs, new_hs], dim=0)
+            else:
+                # cache miss for this request, pass through normally
+                start = query_start_loc[req_idx]
+                new_hs = hidden_states[start : start + num_scheduled_tokens[req_id]]
+                combined_hidden_states[req_id] = new_hs
+
+        return combined_hidden_states
+
+    def _get_cached_block_ids(self, req_idx: int, input_batch: InputBatch) -> torch.Tensor:
+        """Given an input batch and request index in the batch (not ID), get the
+        block IDs corresponding to the cache hit.
+        """
+        num_computed = input_batch.num_computed_tokens_cpu[req_idx]
+        # NOTE: vLLM only caches full blocks
+        num_cached_blocks = num_computed // self.block_size
+        # Get the block IDs attached to this cache hit and reindex into
+        # the flattened cached hidden states (i.e., 1 row per token).
+        return input_batch.block_table[0].block_table.cpu[req_idx, :num_cached_blocks]

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -1525,8 +1525,20 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         elif self._tts_model_type == "voxcpm2":
             tts_params = {}
             additional: dict[str, Any] = {}
-            if request.ref_audio is not None:
-                wav_list, sr = await self._resolve_ref_audio(request.ref_audio)
+            ref_src = request.ref_audio
+            if ref_src is None and request.voice:
+                voice_lower = request.voice.lower()
+                if voice_lower in self.uploaded_speakers:
+                    ref_src = self._get_uploaded_audio_data(request.voice)
+                    if not ref_src:
+                        raise ValueError(f"Audio file for uploaded voice '{request.voice}' not found")
+                    stored_ref_text = self.uploaded_speakers[voice_lower].get("ref_text")
+                    if stored_ref_text:
+                        additional["prompt_text"] = [stored_ref_text]
+                    additional["voice_name"] = voice_lower
+                    additional["voice_created_at"] = self.uploaded_speakers[voice_lower].get("created_at", 0)
+            if ref_src is not None:
+                wav_list, sr = await self._resolve_ref_audio(ref_src)
                 additional["reference_audio"] = [[wav_list, sr]]
             prompt = {"prompt": request.input}
             if additional:

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -855,7 +855,12 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             return "Input text cannot be empty"
 
         if request.voice is not None:
-            return "'voice' is not supported for VoxCPM"
+            voice_lower = request.voice.lower()
+            if voice_lower not in self.uploaded_speakers:
+                return f"Voice '{request.voice}' is not an uploaded voice; VoxCPM only supports uploaded voices for voice cloning"
+            speaker_info = self.uploaded_speakers[voice_lower]
+            if not speaker_info.get("ref_text"):
+                return f"Uploaded voice '{request.voice}' has no ref_text; VoxCPM voice cloning requires a transcript"
         if request.instructions is not None:
             return "'instructions' is not supported for VoxCPM"
         if request.language is not None:
@@ -1233,6 +1238,21 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             }
             if request.ref_text is not None:
                 params["ref_text"] = [request.ref_text]
+
+            if request.voice is not None and request.ref_audio is None:
+                voice_lower = request.voice.lower()
+                if voice_lower in self.uploaded_speakers:
+                    speaker_info = self.uploaded_speakers[voice_lower]
+                    audio_data = self._get_uploaded_audio_data(request.voice)
+                    if audio_data:
+                        params["ref_audio"] = [audio_data]
+                        stored_ref_text = speaker_info.get("ref_text")
+                        if stored_ref_text:
+                            params["ref_text"] = [stored_ref_text]
+                        params["voice_name"] = [voice_lower]
+                        params["voice_created_at"] = [speaker_info.get("created_at", 0)]
+                        logger.info("VoxCPM: auto-set ref_audio for uploaded voice '%s'", request.voice)
+
             return params
 
         params: dict[str, Any] = {}

--- a/vllm_omni/model_executor/models/voxcpm/voxcpm.py
+++ b/vllm_omni/model_executor/models/voxcpm/voxcpm.py
@@ -700,6 +700,9 @@ class VoxCPMForConditionalGeneration(nn.Module):
             retry_badcase_ratio_threshold = float(self._extract_val(info, "retry_badcase_ratio_threshold", 6.0))
             streaming_prefix_len = int(self._extract_val(info, "streaming_prefix_len", 3))
 
+            voice_name = self._extract_val(info, "voice_name", None)
+            voice_created_at = float(self._extract_val(info, "voice_created_at", 0))
+
             request_key = self._resolve_stream_request_key(info)
             created_temp: str | None = None
 
@@ -734,6 +737,8 @@ class VoxCPMForConditionalGeneration(nn.Module):
                         text=text,
                         prompt_wav_path=prompt_wav_path,
                         prompt_text=prompt_text,
+                        voice_name=voice_name,
+                        voice_created_at=voice_created_at,
                         cfg_value=cfg_value,
                         inference_timesteps=inference_timesteps,
                         min_len=min_len,
@@ -777,6 +782,8 @@ class VoxCPMForConditionalGeneration(nn.Module):
                     text=text,
                     prompt_wav_path=prompt_wav_path,
                     prompt_text=prompt_text,
+                    voice_name=voice_name,
+                    voice_created_at=voice_created_at,
                     cfg_value=cfg_value,
                     inference_timesteps=inference_timesteps,
                     min_len=min_len,

--- a/vllm_omni/model_executor/models/voxcpm/voxcpm_stage_wrappers.py
+++ b/vllm_omni/model_executor/models/voxcpm/voxcpm_stage_wrappers.py
@@ -7,12 +7,51 @@ from typing import Any
 import torch
 import torch.nn as nn
 from einops import rearrange
+from vllm.logger import init_logger
+
+from vllm_omni.utils.voice_cache import VoiceEmbeddingCache
+
+logger = init_logger(__name__)
 
 
 class _DirectVoxCPMLatentGenerator:
     def __init__(self, tts_model: Any):
         self.tts_model = tts_model
         self.sample_rate = int(getattr(tts_model, "sample_rate", 24000))
+        self._voice_cache = VoiceEmbeddingCache()
+
+    def _resolve_prompt_cache(
+        self,
+        prompt_wav_path: str | None,
+        prompt_text: str | None,
+        voice_name: str | None = None,
+        voice_created_at: float = 0.0,
+    ) -> dict[str, Any] | None:
+        """Build or retrieve a cached prompt_cache dict for voice cloning."""
+        if prompt_wav_path is None or prompt_text is None:
+            return None
+
+        cache_key: str | None = None
+        if voice_name and voice_created_at > 0:
+            cache_key = VoiceEmbeddingCache.make_cache_key(voice_name, xvec_only=False, created_at=voice_created_at)
+            cached = self._voice_cache.get(cache_key)
+            if cached is not None:
+                logger.debug("VoxCPM voice cache HIT for '%s'", voice_name)
+                return cached
+
+        prompt_cache = self.tts_model.build_prompt_cache(
+            prompt_text=prompt_text,
+            prompt_wav_path=prompt_wav_path,
+        )
+
+        if cache_key is not None:
+            self._voice_cache.put(cache_key, {
+                "prompt_text": prompt_cache["prompt_text"],
+                "audio_feat": prompt_cache["audio_feat"].detach().cpu(),
+            })
+            logger.debug("VoxCPM voice cache STORE for '%s'", voice_name)
+
+        return prompt_cache
 
     def generate_latents(
         self,
@@ -20,6 +59,8 @@ class _DirectVoxCPMLatentGenerator:
         text: str,
         prompt_wav_path: str | None = None,
         prompt_text: str | None = None,
+        voice_name: str | None = None,
+        voice_created_at: float = 0.0,
         cfg_value: float = 2.0,
         inference_timesteps: int = 10,
         min_len: int = 2,
@@ -35,12 +76,9 @@ class _DirectVoxCPMLatentGenerator:
         if prompt_wav_path is not None and not os.path.exists(prompt_wav_path):
             raise FileNotFoundError(f"prompt_wav_path does not exist: {prompt_wav_path}")
 
-        prompt_cache = None
-        if prompt_wav_path is not None and prompt_text is not None:
-            prompt_cache = self.tts_model.build_prompt_cache(
-                prompt_text=prompt_text,
-                prompt_wav_path=prompt_wav_path,
-            )
+        prompt_cache = self._resolve_prompt_cache(
+            prompt_wav_path, prompt_text, voice_name, voice_created_at,
+        )
 
         gen_kw = dict(
             target_text=" ".join(text.split()),
@@ -72,6 +110,8 @@ class _DirectVoxCPMLatentGenerator:
         text: str,
         prompt_wav_path: str | None = None,
         prompt_text: str | None = None,
+        voice_name: str | None = None,
+        voice_created_at: float = 0.0,
         cfg_value: float = 2.0,
         inference_timesteps: int = 10,
         min_len: int = 2,
@@ -89,12 +129,9 @@ class _DirectVoxCPMLatentGenerator:
         if prompt_wav_path is not None and not os.path.exists(prompt_wav_path):
             raise FileNotFoundError(f"prompt_wav_path does not exist: {prompt_wav_path}")
 
-        prompt_cache = None
-        if prompt_wav_path is not None and prompt_text is not None:
-            prompt_cache = self.tts_model.build_prompt_cache(
-                prompt_text=prompt_text,
-                prompt_wav_path=prompt_wav_path,
-            )
+        prompt_cache = self._resolve_prompt_cache(
+            prompt_wav_path, prompt_text, voice_name, voice_created_at,
+        )
 
         gen_kw = dict(
             target_text=" ".join(text.split()),

--- a/vllm_omni/model_executor/models/voxcpm2/voxcpm2_talker.py
+++ b/vllm_omni/model_executor/models/voxcpm2/voxcpm2_talker.py
@@ -32,6 +32,7 @@ from vllm.model_executor.models.utils import (
 from vllm.sequence import IntermediateTensors
 
 from vllm_omni.model_executor.models.output_templates import OmniOutput
+from vllm_omni.utils.voice_cache import VoiceEmbeddingCache
 
 from .minicpm4_paged import MiniCPM4PagedForVoxCPM2, MiniCPM4PagedResidualLM
 from .voxcpm2_import_utils import import_voxcpm2_core
@@ -360,6 +361,7 @@ class VoxCPM2TalkerForConditionalGeneration(nn.Module):
         self._results_queue: list[tuple[str, torch.Tensor | None]] = []
         self._audio_queue: list[tuple[str, Any]] = []
         self._deferred_cleanup_ids: set[str] = set()
+        self._voice_cache = VoiceEmbeddingCache()
 
     @property
     def tts(self) -> nn.Module:
@@ -1042,13 +1044,36 @@ class VoxCPM2TalkerForConditionalGeneration(nn.Module):
                 prompt_text = prompt_text[0] if prompt_text else None
 
             state.prompt_cache = None
-            if ref_audio or (prompt_audio and prompt_text):
+            voice_name = info_dict.get("voice_name")
+            voice_created_at = float(info_dict.get("voice_created_at", 0))
+            if voice_name and voice_created_at > 0:
+                cache_key = VoiceEmbeddingCache.make_cache_key(
+                    voice_name, xvec_only=False, created_at=voice_created_at,
+                )
+                cached = self._voice_cache.get(cache_key)
+                if cached is not None:
+                    logger.debug("VoxCPM2 voice cache HIT for '%s'", voice_name)
+                    state.prompt_cache = {
+                        k: v.to(self._device) if isinstance(v, torch.Tensor) else v
+                        for k, v in cached.items()
+                    }
+            if state.prompt_cache is None and (ref_audio or (prompt_audio and prompt_text)):
                 try:
                     state.prompt_cache = self._build_prompt_cache(
                         ref_audio=ref_audio,
                         prompt_audio=prompt_audio,
                         prompt_text=prompt_text,
                     )
+                    if voice_name and voice_created_at > 0 and state.prompt_cache:
+                        cache_key = VoiceEmbeddingCache.make_cache_key(
+                            voice_name, xvec_only=False, created_at=voice_created_at,
+                        )
+                        store = {
+                            k: v.detach().cpu() if isinstance(v, torch.Tensor) else v
+                            for k, v in state.prompt_cache.items()
+                        }
+                        self._voice_cache.put(cache_key, store)
+                        logger.debug("VoxCPM2 voice cache STORE for '%s'", voice_name)
                 except Exception as e:
                     logger.warning("build_prompt_cache failed: %s", e)
 

--- a/vllm_omni/utils/mm_outputs.py
+++ b/vllm_omni/utils/mm_outputs.py
@@ -1,0 +1,93 @@
+"""Utilities for handling multimodal outputs / building multimodal output
+payloads, most of which are shared by the prefix cache / no prefix cache path.
+"""
+
+import torch
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def build_mm_cpu(multimodal_outputs: dict) -> dict[str, object]:
+    """Pre-copies multimodal tensor to CPU once (not per-request) to avoid
+    redundant D2H transfers when gpu_resident_buffer_keys keeps them on GPU.
+
+    In the case of prefix caching, the multimodal outputs provided will
+    only contain the passthrough data.
+
+    Args:
+        multimodal_outputs: Multimodal dict mapping strings to objects.
+    """
+    # Pre-copy multimodal tensors to CPU once (not per-request) to avoid
+    # redundant D2H transfers when gpu_resident_buffer_keys keeps them on GPU.
+    mm_cpu: dict[str, object] = {}
+    # Currently there are some cases where this is true at the
+    # moment, which should be fixed.
+    if not isinstance(multimodal_outputs, dict):
+        logger.warning("Multimodal outputs are not a dict and will not be passed")
+
+    if multimodal_outputs:
+        for k, v in multimodal_outputs.items():
+            if isinstance(v, torch.Tensor):
+                mm_cpu[k] = v.detach().to("cpu").contiguous()
+            elif isinstance(v, dict):
+                sub_dict: dict[str, torch.Tensor] = {}
+                for sk, sv in v.items():
+                    if isinstance(sv, torch.Tensor):
+                        sub_dict[str(sk)] = sv.detach().to("cpu").contiguous()
+                if sub_dict:
+                    mm_cpu[k] = sub_dict
+            elif isinstance(v, list) and len(v) > 0:
+                cpu_list = []
+                for elem in v:
+                    if isinstance(elem, torch.Tensor):
+                        cpu_list.append(elem.detach().to("cpu").contiguous())
+                    else:
+                        cpu_list.append(elem)
+                mm_cpu[k] = cpu_list
+            elif v is not None:
+                mm_cpu[k] = v
+    return mm_cpu
+
+
+def to_payload_element(
+    element: object, idx: int, start: int, end: int, pass_lists_through: bool = False, seq_len: int | None = None
+):
+    """Build an mm payload element corresponding to one request index
+    from an element containing 0 or more CPU tensors.
+
+    Args:
+        element: The object to be added to the payload.
+        idx: The index of the request.
+        start: The start index corresponding to the request idx.
+        end: The end index corresponding to the request idx.
+        pass_lists_through: bool Whether or not lists should be treated as
+            passthrough data; this should be False in normal cases, but True
+            if we need to avoid splitting nonempty lists prior to calling
+            postprocess, which is the case for prefix cache.
+        seq_len: Optional sequence length (i.e., dim 0 of hidden states).
+            This should be set to None in the prefix caching case, because
+            the condition that would be executed here is the same as the
+            criteria for being added to the multimodal outputs cache.
+    """
+    # Prefix cache won't hit this case because this is the condition
+    # for being a mm_cache_key in the multimodal outputs tensor.
+    if seq_len is not None and isinstance(element, torch.Tensor) and element.shape[0] == seq_len:
+        return element[start:end].contiguous()
+    # Every other case is shared between prefix cache (passthrough data)
+    # and running a model without prefix caching.
+    elif isinstance(element, dict):
+        return {sk: sv[start:end].contiguous() for sk, sv in element.items()}
+    elif isinstance(element, list):
+        # For lists, clone tensors to avoid cross-request aliasing
+        if pass_lists_through:
+            return [elem.clone() if isinstance(elem, torch.Tensor) else elem for elem in element]
+        element = element[idx] if idx < len(element) else element[0]
+        if isinstance(element, torch.Tensor):
+            element = element.clone()
+        return element
+    elif isinstance(element, torch.Tensor):
+        # List-derived tensor payloads are request-invariant; clone to
+        # avoid accidental cross-request aliasing on downstream mutation.
+        return element.clone()
+    return element

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -39,6 +39,7 @@ from vllm.v1.worker.utils import is_residual_scattered_for_sp
 
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import OmniKVTransferManager
 from vllm_omni.outputs import OmniModelRunnerOutput
+from vllm_omni.utils.mm_outputs import build_mm_cpu, to_payload_element
 from vllm_omni.worker.gpu_model_runner import OmniGPUModelRunner
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
 
@@ -200,6 +201,63 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             ) from e
         finally:
             set_cudagraph_capturing_enabled(False)
+
+    def _maybe_update_prefix_cache(
+        self,
+        hidden_states: torch.Tensor,
+        multimodal_outputs: dict,
+        num_tokens_unpadded: int,
+        num_tokens_padded: int,
+    ):
+        """If prefix caching is enabled and it's the last pipeline parallelism rank,
+        retrieve the hidden states & multimodal outputs from the prefix cache based
+        on our batch slot mappings.
+        """
+        # Cache hidden states if we've enabled hidden state prefix caching
+        # unless this isn't the last pipeline parallelism rank.
+        if self.omni_prefix_cache is not None and get_pp_group().is_last_rank:
+            # If this happens, it generally means the model is not following the correct
+            # interface yet and is therefore currently not compatible with prefix cache.
+            if multimodal_outputs is not None and not isinstance(multimodal_outputs, dict):
+                logger.warning_once(
+                    "prefix caching expects mm outputs to be a dict, but got %s",
+                    type(multimodal_outputs),
+                )
+
+            self.omni_prefix_cache.update_omni_tensor_prefix_cache(
+                hidden_states=hidden_states,
+                multimodal_outputs=multimodal_outputs,
+                num_tokens_unpadded=num_tokens_unpadded,
+                slot_mapping=self.input_batch.block_table[0].slot_mapping.cpu,
+                num_tokens_padded=num_tokens_padded,
+            )
+
+    def _maybe_get_combined_prefix_cache_tensors(
+        self,
+        hidden_states: torch.Tensor,
+        multimodal_outputs: dict,
+        num_scheduled_tokens: dict[str, int],
+    ) -> tuple[dict[str, torch.Tensor] | None, dict | None]:
+        """If prefix caching is enabled, extract the merged hidden states and multimodal outputs for
+        all requests in the batch (including those that aren't a hit on Prefix cache).
+        """
+        # Prior to applying the post-processing func, extract
+        # the prefix cached hidden states and multimodal states.
+        combined_hidden_states, combined_multimodal_outputs = None, None
+        if self.omni_prefix_cache is not None:
+            combined_hidden_states = self.omni_prefix_cache.get_merged_hidden_states(
+                query_start_loc=self.query_start_loc.cpu,
+                input_batch=self.input_batch,
+                hidden_states=hidden_states,
+                num_scheduled_tokens=num_scheduled_tokens,
+            )
+            combined_multimodal_outputs = self.omni_prefix_cache.get_merged_multimodal_states(
+                query_start_loc=self.query_start_loc.cpu,
+                input_batch=self.input_batch,
+                multimodal_outputs=multimodal_outputs,
+                num_scheduled_tokens=num_scheduled_tokens,
+            )
+        return combined_hidden_states, combined_multimodal_outputs
 
     @torch.inference_mode()
     def execute_model(
@@ -476,6 +534,15 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
 
             hidden_states, multimodal_outputs = self.extract_multimodal_outputs(model_output)
 
+            # Cache hidden states & multimodal outputs if we've enabled hidden state
+            # prefix caching unless this isn't the last pipeline parallelism rank.
+            self._maybe_update_prefix_cache(
+                hidden_states=hidden_states,
+                multimodal_outputs=multimodal_outputs,
+                num_tokens_unpadded=num_tokens_unpadded,
+                num_tokens_padded=num_tokens_padded,
+            )
+
             if not self.broadcast_pp_output:
                 # Common case.
                 if not get_pp_group().is_last_rank:
@@ -589,6 +656,23 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
 
         return super()._sample(logits, spec_decode_metadata)
 
+    @staticmethod
+    def _resolve_req_hidden_states(
+        hidden_states_cpu: torch.Tensor,
+        combined_hidden_states: dict[str, torch.Tensor] | None,
+        rid: str,
+        start: int,
+        end: int,
+    ):
+        if combined_hidden_states is not None:
+            # We always have all request IDs for prefix cache, even for
+            # partial cache misses, so this should never happen.
+            if rid not in combined_hidden_states:
+                raise RuntimeError("Request IDs in the batch are missing from the merged states!")
+            return combined_hidden_states[rid]
+        # Prefix caching is disabled
+        return hidden_states_cpu[start:end]
+
     @torch.inference_mode()
     def sample_tokens(
         self,
@@ -596,6 +680,13 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
     ) -> OmniModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
         kv_extracted_req_ids = getattr(self, "kv_extracted_req_ids", None)
         self.kv_extracted_req_ids = None
+
+        # Used for prefix cache
+        combined_hidden_states = None
+        combined_multimodal_outputs = None
+        # Used when we don't use prefix cache; prefix cache builds the payloads
+        # internally since it already needs to do this for the cached tensors
+        mm_cpu = {}
 
         if self.execute_model_state is None:
             kv_connector_output = self.kv_connector_output
@@ -628,6 +719,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             slot_mappings,  # OMNI: unpack slot_mappings for drafter
         ) = self.execute_model_state
         self.execute_model_state = None
+        seq_len = hidden_states.shape[0]
 
         # Apply structured output bitmasks if present.
         if grammar_output is not None:
@@ -749,37 +841,29 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 dtype=np.int32,
             )
 
-        self._process_additional_information_updates(
-            hidden_states, multimodal_outputs, num_scheduled_tokens_np, scheduler_output
-        )
+        # Prior to applying the post-processing func, extract
+        # the prefix cached hidden states and multimodal states.
+        if self.omni_prefix_cache is not None:
+            (
+                combined_hidden_states,
+                combined_multimodal_outputs,
+            ) = self._maybe_get_combined_prefix_cache_tensors(
+                hidden_states,
+                multimodal_outputs,
+                scheduler_output.num_scheduled_tokens,
+            )
+        # Otherwise we don't have the mm CPU data yet, so we still need to build it
+        if self.omni_prefix_cache is None:
+            mm_cpu = build_mm_cpu(multimodal_outputs)
 
-        # Pre-copy multimodal tensors to CPU once (not per-request) to avoid
-        # redundant D2H transfers when gpu_resident_buffer_keys keeps them on GPU.
-        mm_cpu: dict[str, object] = {}
-        if isinstance(multimodal_outputs, dict) and multimodal_outputs:
-            for k, v in multimodal_outputs.items():
-                try:
-                    if isinstance(v, torch.Tensor) and v.shape[0] == hidden_states_cpu.shape[0]:
-                        mm_cpu[k] = v.detach().to("cpu").contiguous()
-                    elif isinstance(v, dict):
-                        sub_dict: dict[str, torch.Tensor] = {}
-                        for sk, sv in v.items():
-                            if isinstance(sv, torch.Tensor) and sv.shape[0] == hidden_states_cpu.shape[0]:
-                                sub_dict[str(sk)] = sv.detach().to("cpu").contiguous()
-                        if sub_dict:
-                            mm_cpu[k] = sub_dict
-                    elif isinstance(v, list):
-                        if len(v) == 0:
-                            continue
-                        cpu_list = []
-                        for elem in v:
-                            if isinstance(elem, torch.Tensor):
-                                cpu_list.append(elem.detach().to("cpu").contiguous())
-                            else:
-                                cpu_list.append(elem)
-                        mm_cpu[k] = cpu_list
-                except Exception as e:
-                    logger.error(f"Error in merge multimodal outputs: {e}")
+        self._process_additional_information_updates(
+            hidden_states,
+            multimodal_outputs,
+            num_scheduled_tokens_np,
+            scheduler_output,
+            combined_hidden_states,
+            combined_multimodal_outputs,
+        )
 
         pooler_output: list[dict[str, object]] = []
         for rid in req_ids_output_copy:
@@ -787,29 +871,43 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             start = int(self.query_start_loc.cpu[idx])
             sched = int(num_scheduled_tokens_np[idx])
             end = start + sched
-            hidden_slice = hidden_states_cpu[start:end]
-            payload: dict[str, object] = {"hidden": hidden_slice}
-            if mm_cpu:
-                mm_payload: dict[str, object] = {}
-                for k, v in mm_cpu.items():
-                    if isinstance(v, torch.Tensor) and v.shape[0] == hidden_states_cpu.shape[0]:
-                        mm_payload[k] = v[start:end].contiguous()
-                    elif isinstance(v, dict):
-                        mm_payload[k] = {sk: sv[start:end].contiguous() for sk, sv in v.items()}
-                    elif isinstance(v, list):
-                        element = v[idx] if idx < len(v) else v[0]
-                        if element is not None:
-                            if isinstance(element, torch.Tensor):
-                                element = element.clone()
-                            mm_payload[k] = element
-                        # Skip None elements: msgspec cannot serialize None
-                        # in dict[str, torch.Tensor] typed fields.
-                    elif isinstance(v, torch.Tensor):
-                        # List-derived tensor payloads are request-invariant; clone to
-                        # avoid accidental cross-request aliasing on downstream mutation.
-                        mm_payload[k] = v.clone()
-                    else:
-                        mm_payload[k] = v
+            # If prefix cache is enabled, we have already split everything
+            # by request and converted the states to CPU tensors
+            req_hidden_states = self._resolve_req_hidden_states(
+                hidden_states_cpu,
+                combined_hidden_states,
+                rid,
+                start,
+                end,
+            )
+            payload: dict[str, object] = {"hidden": req_hidden_states}
+
+            mm_payload: dict[str, object] = {}
+            if combined_multimodal_outputs or mm_cpu:
+                if combined_multimodal_outputs:
+                    # Prefix cache enabled; all items have already been processed
+                    # and split apart for each request as needed, and all tensors
+                    # have already been detached to the CPU. The only exception is
+                    # lists, which we keep as passthrough data for consistent behavior
+                    # in postprocess.
+                    for mm_key in combined_multimodal_outputs.keys():
+                        value = combined_multimodal_outputs[mm_key][rid]
+                        if isinstance(value, list):
+                            mm_payload[mm_key] = value[idx] if idx < len(value) else value[0]
+                        else:
+                            mm_payload[mm_key] = value
+
+                else:
+                    # Prefix cache disabled; we still need to process the data
+                    for mm_key, mm_val in mm_cpu.items():
+                        mm_payload[mm_key] = to_payload_element(
+                            element=mm_val,
+                            idx=idx,
+                            start=start,
+                            end=end,
+                            pass_lists_through=False,
+                            seq_len=seq_len,
+                        )
                 payload.update(mm_payload)
             pooler_output.append(payload)
         with record_function_or_nullcontext("gpu_model_runner: ModelRunnerOutput"):

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -20,6 +20,7 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner, IntermediateTensors, PerLayerAttnMetadata
 from vllm.v1.worker.ubatch_utils import maybe_create_ubatch_slices
 
+from vllm_omni.core.prefix_cache import OmniTensorPrefixCache
 from vllm_omni.engine.serialization import deserialize_additional_information
 from vllm_omni.model_executor.layers.rotary_embedding.mrope import OmniMRotaryEmbedding as MRotaryEmbedding
 from vllm_omni.model_executor.models.output_templates import OmniOutput
@@ -43,6 +44,9 @@ class OmniGPUModelRunner(GPUModelRunner):
         self.model_intermediate_buffer: dict[str, dict[str, Any]] = {}
         self._omni_num_scheduled_tokens_np: np.ndarray | None = None
         self._omni_last_model_output: object | None = None
+        # The Omni tensor prefix cache will be allocated
+        # when we initialize the metadata builders if enabled
+        self.omni_prefix_cache = None
 
     def initialize_metadata_builders(self, kv_cache_config, kernel_block_sizes):
         """Override to fix scheduler_metadata buffer size for FA3 + CUDA graph.
@@ -69,6 +73,16 @@ class OmniGPUModelRunner(GPUModelRunner):
                                 dtype=sm.dtype,
                                 device=sm.device,
                             )
+
+        # Initialize the wrapper for both multimodal output tensors
+        # and for hidden states to be passed between stages
+        if self.cache_config.enable_prefix_caching:
+            self.omni_prefix_cache = OmniTensorPrefixCache(
+                num_blocks=kv_cache_config.num_blocks,
+                block_size=self.cache_config.block_size,
+                hidden_size=self.model_config.get_hidden_size(),
+                hs_dtype=self.dtype,
+            )
 
     @instrument(span_name="Loading (GPU)")
     def load_model(self, *args, **kwargs) -> None:
@@ -234,6 +248,10 @@ class OmniGPUModelRunner(GPUModelRunner):
         The SamplingMetadata is updated and copied to the GPU if there is a
         new/resumed/paused/finished request in the batch.
         """
+        # Used for prefix cache
+        if self.omni_prefix_cache is not None:
+            self.omni_prefix_cache.reset_prefix_cached_new_req_ids()
+
         # Remove finished requests from the cached states.
         for req_id in scheduler_output.finished_req_ids:
             self.requests.pop(req_id, None)
@@ -293,6 +311,13 @@ class OmniGPUModelRunner(GPUModelRunner):
                 req_state = self._update_streaming_request(req_id, new_req_data)
                 reqs_to_add.append(req_state)
                 continue
+
+            # Since this is the first time the request has been scheduled,
+            # num_computed_tokens > 0 means that we have a hit in prefix
+            # caching; mark it so that we can manage the hidden states
+            # later on as needed.
+            if self.omni_prefix_cache is not None and new_req_data.num_computed_tokens > 0:
+                self.omni_prefix_cache.add_prefix_cached_new_req_id(req_id)
 
             sampling_params = new_req_data.sampling_params
             pooling_params = new_req_data.pooling_params
@@ -1010,6 +1035,8 @@ class OmniGPUModelRunner(GPUModelRunner):
         multimodal_outputs: object,
         num_scheduled_tokens_np: np.ndarray,
         scheduler_output: "SchedulerOutput",
+        combined_hidden_states: dict[str, torch.Tensor] | None = None,
+        combined_multimodal_outputs: dict[str, object] | None = None,
     ) -> None:
         """Process model-provided per-request updates and merge into model_intermediate_buffer."""
         try:
@@ -1018,21 +1045,31 @@ class OmniGPUModelRunner(GPUModelRunner):
             if hasattr(self.model, "has_postprocess") and self.model.has_postprocess:
                 for req_index, req_id in enumerate(self.input_batch.req_ids):
                     req_infos = self.model_intermediate_buffer.get(req_id, {})
-                    start_offset = int(self.query_start_loc.cpu[req_index])
-                    sched_tokens = int(num_scheduled_tokens_np[req_index])
-                    s, e = start_offset, start_offset + sched_tokens
-                    # only consider to store data into update dict.
-                    hidden_states_slice = hidden_states[s:e]
+                    if combined_hidden_states:
+                        # Combined hidden states contains all hidden states for every request
+                        hidden_states_slice = combined_hidden_states[req_id]
+                    else:
+                        start_offset = int(self.query_start_loc.cpu[req_index])
+                        sched_tokens = int(num_scheduled_tokens_np[req_index])
+                        s, e = start_offset, start_offset + sched_tokens
+                        # only consider to store data into update dict.
+                        hidden_states_slice = hidden_states[s:e]
+
+                    if combined_multimodal_outputs:
+                        # NOTE this is a bit ugly, but the mm data is structured as a list of
+                        # keys mapping to request IDs, and if enabled, we will always have all
+                        # request IDs in every subdict, including for cache misses.
+                        mm_out = {k: v[req_id] for k, v in combined_multimodal_outputs.items()}
+                    else:
+                        mm_out = multimodal_outputs
                     update_dict = self.model.postprocess(
-                        hidden_states_slice, multimodal_outputs=multimodal_outputs, **req_infos
+                        hidden_states_slice,
+                        multimodal_outputs=mm_out,
+                        **req_infos,
                     )
                     self._update_intermediate_buffer(req_id, update_dict)
         except Exception as e:
-            logger.error(
-                f"Error merging for requests:{self.input_batch.req_ids} "
-                f"additional information update: {e}, with the multimodal_outputs "
-                f"as {multimodal_outputs}"
-            )
+            logger.error(f"Error merging for requests:{self.input_batch.req_ids} additional information update: {e}")
             import traceback
 
             traceback.print_exc()


### PR DESCRIPTION
## Summary
- Wire VoxCPM2 serving path to support uploaded voices (`voice=<name>`) via `POST /v1/audio/voices`, matching the pattern used by VoxCPM v1 and Fish Speech
- Add `VoiceEmbeddingCache` (LRU) to the VoxCPM2 talker so encoded audio features are reused across requests for the same uploaded voice — skipping `_build_prompt_cache` on cache hits
- Update `bench_tts_serve.py` to automatically run a voice cache comparison (inline `ref_audio` vs uploaded voice) using a default Qwen reference audio, with side-by-side TTFP/E2E/RTF reporting

### Changes
1. **`vllm_omni/entrypoints/openai/serving_speech.py`** — VoxCPM2 branch now resolves `request.voice` against `uploaded_speakers` when `ref_audio` is not set, loads stored audio from disk, and passes `voice_name`/`voice_created_at` to the model
2. **`vllm_omni/model_executor/models/voxcpm2/voxcpm2_talker.py`** — Added `VoiceEmbeddingCache` instance; on prefill, checks cache before calling `_build_prompt_cache`, stores result (tensors on CPU) on miss
3. **`benchmarks/voxcpm/vllm_omni/bench_tts_serve.py`** — Two-round benchmark: Round A sends inline base64 ref_audio (re-encoded every request), Round B uploads voice then sends `voice=<name>` (cache hits after 1st request); prints comparison table

### Results
```
======================================================================
       COMPARISON: Inline ref_audio vs Uploaded voice (cached)        
======================================================================
Metric                               Inline       Cached    Speedup
----------------------------------------------------------------------
Mean TTFP (ms)                        108.8         36.2      3.01x
Median TTFP (ms)                      107.9         36.1      2.99x
P95 TTFP (ms)                         130.9         37.6      3.48x
Mean E2E (ms)                       27117.5        449.9     60.28x
Median E2E (ms)                     35320.9        425.1     83.08x
P95 E2E (ms)                        35677.4        581.2     61.38x
Mean RTF                                0.0          0.0      0.96x
Throughput (req/s)                      0.0          2.2      0.02x
```

## Test plan
- [x] Run `python bench_tts_serve.py --port 8000` and verify both rounds complete with comparison table
- [x] Verify uploaded voice produces correct audio (same quality as inline ref_audio)
- [x] Verify `--no-voice-cache` flag still runs plain TTS benchmark