### PR TITLE
[BugFix] Fix TypeError crash during dummy_run in OmniGPUModelRunner

### DIFF
--- a/vllm_omni/worker_v2/omni_model_runner.py
+++ b/vllm_omni/worker_v2/omni_model_runner.py
@@ -281,7 +281,7 @@ class OmniGPUModelRunner(GPUModelRunner):
                 if hasattr(self.model, "_last_captured_layers"):
                     self.model._last_captured_layers = self._last_aux_output
             else:
-                raise TypeError(f"Unexpected model output type: {type(model_output)}")
+                hidden_states = model_output
 
         # ★ POST-FORWARD: per-request postprocess
         if not dummy_run and isinstance(hidden_states, torch.Tensor):


### PR DESCRIPTION
## Purpose

Fix `TypeError: Unexpected model output type: <class 'torch.Tensor'>` crash during `profile_run` / `dummy_run` in V2 Omni model runner.

PR #2819 introduced a `raise TypeError` in the else branch of the hidden state extraction logic. However, during `dummy_run=True` (called by `profile_run` → `determine_available_memory`), the model forward returns a bare `torch.Tensor` — not `OmniOutput` or a 2-tuple. The `raise` kills engine initialization for all Omni models on V2.

Replaces the `raise TypeError` with a passthrough `hidden_states = model_output`, which correctly handles bare tensors from dummy runs.

## Test Plan

- [ ] CI passes on H100 (Omni V2 tests: Qwen3-Omni, Qwen2.5-Omni, Qwen3-TTS)
- [ ] Verify `profile_run` / `determine_available_memory` completes without crash

## Test Result

Pending CI