### PR TITLE
[Bugfix] enforce prompt length limit for Qwen image edit

### DIFF
--- a/tests/diffusion/models/qwen_image/test_prompt_length_validation.py
+++ b/tests/diffusion/models/qwen_image/test_prompt_length_validation.py
@@ -4,6 +4,7 @@ import pytest
 
 from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
     build_qwen_image_edit_plus_prompt_prefix,
+    tokenize_and_validate_qwen_text_prompt,
     tokenize_and_validate_qwen_vl_prompt,
 )
 
@@ -18,6 +19,18 @@ class FakeProcessor:
         assert padding is True
         assert return_tensors == "pt"
         assert isinstance(text, list)
+        return SimpleNamespace(attention_mask=FakeAttentionMask(self._lengths))
+
+
+class FakeTokenizer:
+    def __init__(self, lengths: list[int]):
+        self._lengths = lengths
+
+    def __call__(self, texts, padding, truncation, return_tensors):
+        assert isinstance(texts, list)
+        assert padding is True
+        assert truncation is False
+        assert return_tensors == "pt"
         return SimpleNamespace(attention_mask=FakeAttentionMask(self._lengths))
 
 
@@ -45,6 +58,33 @@ def test_build_qwen_image_edit_plus_prompt_prefix():
         "Picture 1: <|vision_start|><|image_pad|><|vision_end|>"
         "Picture 2: <|vision_start|><|image_pad|><|vision_end|>"
     )
+
+
+def test_tokenize_and_validate_qwen_text_prompt_accepts_valid_length():
+    tokenizer = FakeTokenizer(lengths=[66])
+
+    result = tokenize_and_validate_qwen_text_prompt(
+        tokenizer,
+        texts=["hello"],
+        drop_idx=34,
+        max_sequence_length=32,
+        field_name="prompt",
+    )
+
+    assert isinstance(result, SimpleNamespace)
+
+
+def test_tokenize_and_validate_qwen_text_prompt_rejects_overlong_prompt():
+    tokenizer = FakeTokenizer(lengths=[1059])
+
+    with pytest.raises(ValueError, match="`prompt` is too long"):
+        tokenize_and_validate_qwen_text_prompt(
+            tokenizer,
+            texts=["hello"],
+            drop_idx=34,
+            max_sequence_length=1024,
+            field_name="prompt",
+        )
 
 
 def test_tokenize_and_validate_qwen_vl_prompt_accepts_valid_length():

--- a/tests/diffusion/models/qwen_image/test_prompt_length_validation.py
+++ b/tests/diffusion/models/qwen_image/test_prompt_length_validation.py
@@ -1,8 +1,8 @@
 import pytest
 
 from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
-    get_effective_qwen_prompt_lengths,
-    validate_qwen_prompt_lengths,
+    get_qwen_text_prompt_lengths,
+    validate_qwen_text_prompt_lengths,
 )
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -25,31 +25,31 @@ class FakeTensor:
         return self._values
 
 
-def test_get_effective_qwen_prompt_lengths():
+def test_get_qwen_text_prompt_lengths():
     attention_mask = FakeAttentionMask([66, 1059, 20])
-    assert get_effective_qwen_prompt_lengths(attention_mask, drop_idx=34) == [32, 1025, 0]
+    assert get_qwen_text_prompt_lengths(attention_mask) == [66, 1059, 20]
 
 
-def test_validate_qwen_prompt_lengths_accepts_valid_length():
-    validate_qwen_prompt_lengths(
+def test_validate_qwen_text_prompt_lengths_accepts_valid_length():
+    validate_qwen_text_prompt_lengths(
         [32],
         max_sequence_length=32,
         field_name="prompt",
     )
 
 
-def test_validate_qwen_prompt_lengths_rejects_overlong_prompt():
+def test_validate_qwen_text_prompt_lengths_rejects_overlong_prompt():
     with pytest.raises(ValueError, match="`prompt` is too long"):
-        validate_qwen_prompt_lengths(
+        validate_qwen_text_prompt_lengths(
             [1025],
             max_sequence_length=1024,
             field_name="prompt",
         )
 
 
-def test_validate_qwen_prompt_lengths_mentions_negative_prompt():
+def test_validate_qwen_text_prompt_lengths_mentions_negative_prompt():
     with pytest.raises(ValueError, match="`negative_prompt` is too long"):
-        validate_qwen_prompt_lengths(
+        validate_qwen_text_prompt_lengths(
             [26, 1101],
             max_sequence_length=1024,
             field_name="negative_prompt",

--- a/tests/diffusion/models/qwen_image/test_prompt_length_validation.py
+++ b/tests/diffusion/models/qwen_image/test_prompt_length_validation.py
@@ -1,7 +1,6 @@
 import pytest
 
 from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
-    build_qwen_image_edit_plus_prompt_prefix,
     get_effective_qwen_prompt_lengths,
     validate_qwen_prompt_lengths,
 )
@@ -24,15 +23,6 @@ class FakeTensor:
 
     def tolist(self):
         return self._values
-
-
-def test_build_qwen_image_edit_plus_prompt_prefix():
-    assert build_qwen_image_edit_plus_prompt_prefix(0) == ""
-    assert build_qwen_image_edit_plus_prompt_prefix(1) == "Picture 1: <|vision_start|><|image_pad|><|vision_end|>"
-    assert build_qwen_image_edit_plus_prompt_prefix(2) == (
-        "Picture 1: <|vision_start|><|image_pad|><|vision_end|>"
-        "Picture 2: <|vision_start|><|image_pad|><|vision_end|>"
-    )
 
 
 def test_get_effective_qwen_prompt_lengths():

--- a/tests/diffusion/models/qwen_image/test_prompt_length_validation.py
+++ b/tests/diffusion/models/qwen_image/test_prompt_length_validation.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
+    build_qwen_image_edit_plus_prompt_prefix,
+    tokenize_and_validate_qwen_vl_prompt,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class FakeProcessor:
+    def __init__(self, lengths: list[int]):
+        self._lengths = lengths
+
+    def __call__(self, *, text, images, padding, return_tensors):
+        assert padding is True
+        assert return_tensors == "pt"
+        assert isinstance(text, list)
+        return SimpleNamespace(attention_mask=FakeAttentionMask(self._lengths))
+
+
+class FakeAttentionMask:
+    def __init__(self, lengths: list[int]):
+        self._lengths = lengths
+
+    def sum(self, dim: int):
+        assert dim == 1
+        return FakeTensor(self._lengths)
+
+
+class FakeTensor:
+    def __init__(self, values: list[int]):
+        self._values = values
+
+    def tolist(self):
+        return self._values
+
+
+def test_build_qwen_image_edit_plus_prompt_prefix():
+    assert build_qwen_image_edit_plus_prompt_prefix(0) == ""
+    assert build_qwen_image_edit_plus_prompt_prefix(1) == "Picture 1: <|vision_start|><|image_pad|><|vision_end|>"
+    assert build_qwen_image_edit_plus_prompt_prefix(2) == (
+        "Picture 1: <|vision_start|><|image_pad|><|vision_end|>"
+        "Picture 2: <|vision_start|><|image_pad|><|vision_end|>"
+    )
+
+
+def test_tokenize_and_validate_qwen_vl_prompt_accepts_valid_length():
+    processor = FakeProcessor(lengths=[96])
+
+    result = tokenize_and_validate_qwen_vl_prompt(
+        processor,
+        texts=["hello"],
+        images=None,
+        drop_idx=64,
+        max_sequence_length=32,
+        field_name="prompt",
+    )
+
+    assert isinstance(result, SimpleNamespace)
+
+
+def test_tokenize_and_validate_qwen_vl_prompt_rejects_overlong_prompt():
+    processor = FakeProcessor(lengths=[1164])
+
+    with pytest.raises(ValueError, match="`prompt` is too long"):
+        tokenize_and_validate_qwen_vl_prompt(
+            processor,
+            texts=["hello"],
+            images=None,
+            drop_idx=64,
+            max_sequence_length=1024,
+            field_name="prompt",
+        )
+
+
+def test_tokenize_and_validate_qwen_vl_prompt_mentions_negative_prompt():
+    processor = FakeProcessor(lengths=[90, 1165])
+
+    with pytest.raises(ValueError, match="`negative_prompt` is too long"):
+        tokenize_and_validate_qwen_vl_prompt(
+            processor,
+            texts=["a", "b"],
+            images=None,
+            drop_idx=64,
+            max_sequence_length=1024,
+            field_name="negative_prompt",
+        )

--- a/tests/diffusion/models/qwen_image/test_prompt_length_validation.py
+++ b/tests/diffusion/models/qwen_image/test_prompt_length_validation.py
@@ -1,37 +1,12 @@
-from types import SimpleNamespace
-
 import pytest
 
 from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
     build_qwen_image_edit_plus_prompt_prefix,
-    tokenize_and_validate_qwen_text_prompt,
-    tokenize_and_validate_qwen_vl_prompt,
+    get_effective_qwen_prompt_lengths,
+    validate_qwen_prompt_lengths,
 )
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
-
-
-class FakeProcessor:
-    def __init__(self, lengths: list[int]):
-        self._lengths = lengths
-
-    def __call__(self, *, text, images, padding, return_tensors):
-        assert padding is True
-        assert return_tensors == "pt"
-        assert isinstance(text, list)
-        return SimpleNamespace(attention_mask=FakeAttentionMask(self._lengths))
-
-
-class FakeTokenizer:
-    def __init__(self, lengths: list[int]):
-        self._lengths = lengths
-
-    def __call__(self, texts, padding, truncation, return_tensors):
-        assert isinstance(texts, list)
-        assert padding is True
-        assert truncation is False
-        assert return_tensors == "pt"
-        return SimpleNamespace(attention_mask=FakeAttentionMask(self._lengths))
 
 
 class FakeAttentionMask:
@@ -60,71 +35,32 @@ def test_build_qwen_image_edit_plus_prompt_prefix():
     )
 
 
-def test_tokenize_and_validate_qwen_text_prompt_accepts_valid_length():
-    tokenizer = FakeTokenizer(lengths=[66])
+def test_get_effective_qwen_prompt_lengths():
+    attention_mask = FakeAttentionMask([66, 1059, 20])
+    assert get_effective_qwen_prompt_lengths(attention_mask, drop_idx=34) == [32, 1025, 0]
 
-    result = tokenize_and_validate_qwen_text_prompt(
-        tokenizer,
-        texts=["hello"],
-        drop_idx=34,
+
+def test_validate_qwen_prompt_lengths_accepts_valid_length():
+    validate_qwen_prompt_lengths(
+        [32],
         max_sequence_length=32,
         field_name="prompt",
     )
 
-    assert isinstance(result, SimpleNamespace)
 
-
-def test_tokenize_and_validate_qwen_text_prompt_rejects_overlong_prompt():
-    tokenizer = FakeTokenizer(lengths=[1059])
-
+def test_validate_qwen_prompt_lengths_rejects_overlong_prompt():
     with pytest.raises(ValueError, match="`prompt` is too long"):
-        tokenize_and_validate_qwen_text_prompt(
-            tokenizer,
-            texts=["hello"],
-            drop_idx=34,
+        validate_qwen_prompt_lengths(
+            [1025],
             max_sequence_length=1024,
             field_name="prompt",
         )
 
 
-def test_tokenize_and_validate_qwen_vl_prompt_accepts_valid_length():
-    processor = FakeProcessor(lengths=[96])
-
-    result = tokenize_and_validate_qwen_vl_prompt(
-        processor,
-        texts=["hello"],
-        images=None,
-        drop_idx=64,
-        max_sequence_length=32,
-        field_name="prompt",
-    )
-
-    assert isinstance(result, SimpleNamespace)
-
-
-def test_tokenize_and_validate_qwen_vl_prompt_rejects_overlong_prompt():
-    processor = FakeProcessor(lengths=[1164])
-
-    with pytest.raises(ValueError, match="`prompt` is too long"):
-        tokenize_and_validate_qwen_vl_prompt(
-            processor,
-            texts=["hello"],
-            images=None,
-            drop_idx=64,
-            max_sequence_length=1024,
-            field_name="prompt",
-        )
-
-
-def test_tokenize_and_validate_qwen_vl_prompt_mentions_negative_prompt():
-    processor = FakeProcessor(lengths=[90, 1165])
-
+def test_validate_qwen_prompt_lengths_mentions_negative_prompt():
     with pytest.raises(ValueError, match="`negative_prompt` is too long"):
-        tokenize_and_validate_qwen_vl_prompt(
-            processor,
-            texts=["a", "b"],
-            images=None,
-            drop_idx=64,
+        validate_qwen_prompt_lengths(
+            [26, 1101],
             max_sequence_length=1024,
             field_name="negative_prompt",
         )

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -618,6 +618,7 @@ def test_parameter_validation():
     assert req.size is None  # Engine will use model defaults
     assert req.num_inference_steps is None  # Engine will use model defaults
     assert req.true_cfg_scale is None  # Engine will use model defaults
+    assert req.max_sequence_length is None
 
     # Invalid num_inference_steps (out of range)
     with pytest.raises(ValueError):
@@ -653,6 +654,7 @@ def test_parameters_passed_through(test_client, mock_async_diffusion):
             "num_inference_steps": 100,
             "guidance_scale": 7.5,
             "true_cfg_scale": 3.0,
+            "max_sequence_length": 1024,
             "seed": 42,
         },
     )
@@ -663,6 +665,7 @@ def test_parameters_passed_through(test_client, mock_async_diffusion):
     assert captured.num_inference_steps == 100
     assert captured.guidance_scale == 7.5
     assert captured.true_cfg_scale == 3.0
+    assert captured.max_sequence_length == 1024
     assert captured.seed == 42
 
 
@@ -795,6 +798,7 @@ def test_image_edit_parameter_pass(async_omni_test_client):
             "output_format": "jpeg",
             "num_inference_steps": 20,
             "guidance_scale": 8.0,
+            "max_sequence_length": 1024,
             "seed": 1234,
             "negative_prompt": "negative",
             "n": 2,
@@ -809,6 +813,7 @@ def test_image_edit_parameter_pass(async_omni_test_client):
     assert captured_prompt["negative_prompt"] == "negative"
     assert captured_sampling_params.num_inference_steps == 20
     assert captured_sampling_params.guidance_scale == 8.0
+    assert captured_sampling_params.max_sequence_length == 1024
     assert captured_sampling_params.seed == 1234
     assert captured_sampling_params.num_outputs_per_prompt == 2
     assert captured_sampling_params.width == 16

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -367,6 +367,24 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
                 "that was used to generate `negative_prompt_embeds`."
             )
 
+        for field_name, field_value in (("prompt", prompt), ("negative_prompt", negative_prompt)):
+            if field_value is None:
+                continue
+
+            text_inputs = [field_value] if isinstance(field_value, str) else field_value
+            tokenized_inputs = self.tokenizer(
+                text_inputs,
+                padding=True,
+                truncation=False,
+                return_tensors="pt",
+            )
+            prompt_lengths = get_qwen_text_prompt_lengths(tokenized_inputs.attention_mask)
+            validate_qwen_text_prompt_lengths(
+                prompt_lengths,
+                max_sequence_length=max_sequence_length,
+                field_name=field_name,
+            )
+
         if max_sequence_length is not None and max_sequence_length > 1024:
             raise ValueError(f"`max_sequence_length` cannot be greater than 1024 but is {max_sequence_length}")
 
@@ -382,24 +400,10 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         self,
         prompt: str | list[str] = None,
         dtype: torch.dtype | None = None,
-        max_sequence_length: int | None = None,
-        field_name: str = "prompt",
     ):
         dtype = dtype or self.text_encoder.dtype
 
         prompt = [prompt] if isinstance(prompt, str) else prompt
-        prompt_tokens = self.tokenizer(
-            prompt,
-            padding=True,
-            truncation=False,
-            return_tensors="pt",
-        )
-        prompt_lengths = get_qwen_text_prompt_lengths(prompt_tokens.attention_mask)
-        validate_qwen_text_prompt_lengths(
-            prompt_lengths,
-            max_sequence_length=max_sequence_length,
-            field_name=field_name,
-        )
 
         template = self.prompt_template_encode
         drop_idx = self.prompt_template_encode_start_idx
@@ -438,8 +442,7 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         num_images_per_prompt: int = 1,
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
-        max_sequence_length: int = 1024,
-        field_name: str = "prompt",
+        max_sequence_length: int = 512,
     ):
         r"""
 
@@ -457,11 +460,7 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         batch_size = len(prompt) if prompt_embeds is None else prompt_embeds.shape[0]
 
         if prompt_embeds is None:
-            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(
-                prompt,
-                max_sequence_length=max_sequence_length,
-                field_name=field_name,
-            )
+            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(prompt)
 
         prompt_embeds = prompt_embeds[:, :max_sequence_length]
         prompt_embeds_mask = prompt_embeds_mask[:, :max_sequence_length]
@@ -646,7 +645,6 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
             prompt_embeds_mask=prompt_embeds_mask,
             num_images_per_prompt=num_images_per_prompt,
             max_sequence_length=max_sequence_length,
-            field_name="prompt",
         )
         if do_true_cfg:
             negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
@@ -655,7 +653,6 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
                 prompt_embeds_mask=negative_prompt_embeds_mask,
                 num_images_per_prompt=num_images_per_prompt,
                 max_sequence_length=max_sequence_length,
-                field_name="negative_prompt",
             )
         else:
             negative_prompt_embeds = None

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -29,6 +29,9 @@ from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineL
 from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
 )
+from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
+    tokenize_and_validate_qwen_text_prompt,
+)
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
@@ -378,6 +381,8 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         self,
         prompt: str | list[str] = None,
         dtype: torch.dtype | None = None,
+        max_sequence_length: int | None = None,
+        field_name: str = "prompt",
     ):
         dtype = dtype or self.text_encoder.dtype
 
@@ -386,12 +391,12 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         template = self.prompt_template_encode
         drop_idx = self.prompt_template_encode_start_idx
         txt = [template.format(e) for e in prompt]
-        txt_tokens = self.tokenizer(
-            txt,
-            max_length=self.tokenizer_max_length + drop_idx,
-            padding=True,
-            truncation=True,
-            return_tensors="pt",
+        txt_tokens = tokenize_and_validate_qwen_text_prompt(
+            self.tokenizer,
+            texts=txt,
+            drop_idx=drop_idx,
+            max_sequence_length=max_sequence_length,
+            field_name=field_name,
         ).to(self.device)
         # print(f"attention mask: {txt_tokens.attention_mask}")
         encoder_hidden_states = self.text_encoder(
@@ -422,6 +427,7 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
         max_sequence_length: int = 1024,
+        field_name: str = "prompt",
     ):
         r"""
 
@@ -439,7 +445,11 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         batch_size = len(prompt) if prompt_embeds is None else prompt_embeds.shape[0]
 
         if prompt_embeds is None:
-            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(prompt)
+            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(
+                prompt,
+                max_sequence_length=max_sequence_length,
+                field_name=field_name,
+            )
 
         prompt_embeds = prompt_embeds[:, :max_sequence_length]
         prompt_embeds_mask = prompt_embeds_mask[:, :max_sequence_length]
@@ -624,6 +634,7 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
             prompt_embeds_mask=prompt_embeds_mask,
             num_images_per_prompt=num_images_per_prompt,
             max_sequence_length=max_sequence_length,
+            field_name="prompt",
         )
         if do_true_cfg:
             negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
@@ -632,6 +643,7 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
                 prompt_embeds_mask=negative_prompt_embeds_mask,
                 num_images_per_prompt=num_images_per_prompt,
                 max_sequence_length=max_sequence_length,
+                field_name="negative_prompt",
             )
         else:
             negative_prompt_embeds = None

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -30,8 +30,8 @@ from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
 )
 from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
-    get_effective_qwen_prompt_lengths,
-    validate_qwen_prompt_lengths,
+    get_qwen_text_prompt_lengths,
+    validate_qwen_text_prompt_lengths,
 )
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
@@ -388,6 +388,18 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         dtype = dtype or self.text_encoder.dtype
 
         prompt = [prompt] if isinstance(prompt, str) else prompt
+        prompt_tokens = self.tokenizer(
+            prompt,
+            padding=True,
+            truncation=False,
+            return_tensors="pt",
+        )
+        prompt_lengths = get_qwen_text_prompt_lengths(prompt_tokens.attention_mask)
+        validate_qwen_text_prompt_lengths(
+            prompt_lengths,
+            max_sequence_length=max_sequence_length,
+            field_name=field_name,
+        )
 
         template = self.prompt_template_encode
         drop_idx = self.prompt_template_encode_start_idx
@@ -398,15 +410,6 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
             truncation=False,
             return_tensors="pt",
         ).to(self.device)
-        effective_lengths = get_effective_qwen_prompt_lengths(
-            txt_tokens.attention_mask,
-            drop_idx=drop_idx,
-        )
-        validate_qwen_prompt_lengths(
-            effective_lengths,
-            max_sequence_length=max_sequence_length,
-            field_name=field_name,
-        )
         # print(f"attention mask: {txt_tokens.attention_mask}")
         encoder_hidden_states = self.text_encoder(
             input_ids=txt_tokens.input_ids,

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -30,7 +30,8 @@ from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
 )
 from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
-    tokenize_and_validate_qwen_text_prompt,
+    get_effective_qwen_prompt_lengths,
+    validate_qwen_prompt_lengths,
 )
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
@@ -391,13 +392,21 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         template = self.prompt_template_encode
         drop_idx = self.prompt_template_encode_start_idx
         txt = [template.format(e) for e in prompt]
-        txt_tokens = tokenize_and_validate_qwen_text_prompt(
-            self.tokenizer,
-            texts=txt,
+        txt_tokens = self.tokenizer(
+            txt,
+            padding=True,
+            truncation=False,
+            return_tensors="pt",
+        ).to(self.device)
+        effective_lengths = get_effective_qwen_prompt_lengths(
+            txt_tokens.attention_mask,
             drop_idx=drop_idx,
+        )
+        validate_qwen_prompt_lengths(
+            effective_lengths,
             max_sequence_length=max_sequence_length,
             field_name=field_name,
-        ).to(self.device)
+        )
         # print(f"attention mask: {txt_tokens.attention_mask}")
         encoder_hidden_states = self.text_encoder(
             input_ids=txt_tokens.input_ids,

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -327,6 +327,24 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
                 "that was used to generate `negative_prompt_embeds`."
             )
 
+        for field_name, field_value in (("prompt", prompt), ("negative_prompt", negative_prompt)):
+            if field_value is None:
+                continue
+
+            text_inputs = [field_value] if isinstance(field_value, str) else field_value
+            tokenized_inputs = self.tokenizer(
+                text_inputs,
+                padding=True,
+                truncation=False,
+                return_tensors="pt",
+            )
+            prompt_lengths = get_qwen_text_prompt_lengths(tokenized_inputs.attention_mask)
+            validate_qwen_text_prompt_lengths(
+                prompt_lengths,
+                max_sequence_length=max_sequence_length,
+                field_name=field_name,
+            )
+
         if max_sequence_length is not None and max_sequence_length > 1024:
             raise ValueError(f"`max_sequence_length` cannot be greater than 1024 but is {max_sequence_length}")
 
@@ -388,25 +406,11 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         prompt: str | list[str] = None,
         image: PIL.Image.Image | torch.Tensor | None = None,
         dtype: torch.dtype | None = None,
-        max_sequence_length: int | None = None,
-        field_name: str = "prompt",
     ):
         """Get prompt embeddings with image support for editing."""
         dtype = dtype or self.text_encoder.dtype
 
         prompt = [prompt] if isinstance(prompt, str) else prompt
-        prompt_tokens = self.tokenizer(
-            prompt,
-            padding=True,
-            truncation=False,
-            return_tensors="pt",
-        )
-        prompt_lengths = get_qwen_text_prompt_lengths(prompt_tokens.attention_mask)
-        validate_qwen_text_prompt_lengths(
-            prompt_lengths,
-            max_sequence_length=max_sequence_length,
-            field_name=field_name,
-        )
 
         template = self.prompt_template_encode
         drop_idx = self.prompt_template_encode_start_idx
@@ -451,8 +455,7 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         num_images_per_prompt: int = 1,
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
-        max_sequence_length: int = 1024,
-        field_name: str = "prompt",
+        max_sequence_length: int = 512,
     ):
         r"""
 
@@ -472,12 +475,7 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         batch_size = len(prompt) if prompt_embeds is None else prompt_embeds.shape[0]
 
         if prompt_embeds is None:
-            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(
-                prompt,
-                image,
-                max_sequence_length=max_sequence_length,
-                field_name=field_name,
-            )
+            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(prompt, image)
 
         prompt_embeds = prompt_embeds[:, :max_sequence_length]
         prompt_embeds_mask = prompt_embeds_mask[:, :max_sequence_length]
@@ -756,7 +754,6 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
             prompt_embeds_mask=prompt_embeds_mask,
             num_images_per_prompt=num_images_per_prompt,
             max_sequence_length=max_sequence_length,
-            field_name="prompt",
         )
 
         if do_true_cfg:
@@ -767,7 +764,6 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
                 prompt_embeds_mask=negative_prompt_embeds_mask,
                 num_images_per_prompt=num_images_per_prompt,
                 max_sequence_length=max_sequence_length,
-                field_name="negative_prompt",
             )
 
         num_channels_latents = self.transformer.in_channels // 4

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -416,6 +416,8 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         model_inputs = self.processor(
             text=txt,
             images=image,
+            padding=True,
+            return_tensors="pt",
         ).to(self.device)
 
         outputs = self.text_encoder(

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -33,7 +33,8 @@ from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
 )
 from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import calculate_shift
 from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
-    tokenize_and_validate_qwen_vl_prompt,
+    get_effective_qwen_prompt_lengths,
+    validate_qwen_prompt_lengths,
 )
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
@@ -400,14 +401,19 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         txt = [template.format(e) for e in prompt]
 
         # Use processor to handle both text and image inputs
-        model_inputs = tokenize_and_validate_qwen_vl_prompt(
-            self.processor,
-            texts=txt,
+        model_inputs = self.processor(
+            text=txt,
             images=image,
+        ).to(self.device)
+        effective_lengths = get_effective_qwen_prompt_lengths(
+            model_inputs.attention_mask,
             drop_idx=drop_idx,
+        )
+        validate_qwen_prompt_lengths(
+            effective_lengths,
             max_sequence_length=max_sequence_length,
             field_name=field_name,
-        ).to(self.device)
+        )
 
         outputs = self.text_encoder(
             input_ids=model_inputs.input_ids,

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -33,8 +33,8 @@ from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
 )
 from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import calculate_shift
 from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
-    get_effective_qwen_prompt_lengths,
-    validate_qwen_prompt_lengths,
+    get_qwen_text_prompt_lengths,
+    validate_qwen_text_prompt_lengths,
 )
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
@@ -395,6 +395,18 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         dtype = dtype or self.text_encoder.dtype
 
         prompt = [prompt] if isinstance(prompt, str) else prompt
+        prompt_tokens = self.tokenizer(
+            prompt,
+            padding=True,
+            truncation=False,
+            return_tensors="pt",
+        )
+        prompt_lengths = get_qwen_text_prompt_lengths(prompt_tokens.attention_mask)
+        validate_qwen_text_prompt_lengths(
+            prompt_lengths,
+            max_sequence_length=max_sequence_length,
+            field_name=field_name,
+        )
 
         template = self.prompt_template_encode
         drop_idx = self.prompt_template_encode_start_idx
@@ -405,15 +417,6 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
             text=txt,
             images=image,
         ).to(self.device)
-        effective_lengths = get_effective_qwen_prompt_lengths(
-            model_inputs.attention_mask,
-            drop_idx=drop_idx,
-        )
-        validate_qwen_prompt_lengths(
-            effective_lengths,
-            max_sequence_length=max_sequence_length,
-            field_name=field_name,
-        )
 
         outputs = self.text_encoder(
             input_ids=model_inputs.input_ids,

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -32,6 +32,9 @@ from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
 )
 from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import calculate_shift
+from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
+    tokenize_and_validate_qwen_vl_prompt,
+)
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
@@ -384,6 +387,8 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         prompt: str | list[str] = None,
         image: PIL.Image.Image | torch.Tensor | None = None,
         dtype: torch.dtype | None = None,
+        max_sequence_length: int | None = None,
+        field_name: str = "prompt",
     ):
         """Get prompt embeddings with image support for editing."""
         dtype = dtype or self.text_encoder.dtype
@@ -395,11 +400,13 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         txt = [template.format(e) for e in prompt]
 
         # Use processor to handle both text and image inputs
-        model_inputs = self.processor(
-            text=txt,
+        model_inputs = tokenize_and_validate_qwen_vl_prompt(
+            self.processor,
+            texts=txt,
             images=image,
-            padding=True,
-            return_tensors="pt",
+            drop_idx=drop_idx,
+            max_sequence_length=max_sequence_length,
+            field_name=field_name,
         ).to(self.device)
 
         outputs = self.text_encoder(
@@ -434,6 +441,7 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
         max_sequence_length: int = 1024,
+        field_name: str = "prompt",
     ):
         r"""
 
@@ -453,7 +461,15 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         batch_size = len(prompt) if prompt_embeds is None else prompt_embeds.shape[0]
 
         if prompt_embeds is None:
-            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(prompt, image)
+            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(
+                prompt,
+                image,
+                max_sequence_length=max_sequence_length,
+                field_name=field_name,
+            )
+
+        prompt_embeds = prompt_embeds[:, :max_sequence_length]
+        prompt_embeds_mask = prompt_embeds_mask[:, :max_sequence_length]
 
         _, seq_len, _ = prompt_embeds.shape
         prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
@@ -729,6 +745,7 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
             prompt_embeds_mask=prompt_embeds_mask,
             num_images_per_prompt=num_images_per_prompt,
             max_sequence_length=max_sequence_length,
+            field_name="prompt",
         )
 
         if do_true_cfg:
@@ -739,6 +756,7 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
                 prompt_embeds_mask=negative_prompt_embeds_mask,
                 num_images_per_prompt=num_images_per_prompt,
                 max_sequence_length=max_sequence_length,
+                field_name="negative_prompt",
             )
 
         num_channels_latents = self.transformer.in_channels // 4

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -338,6 +338,8 @@ class QwenImageEditPlusPipeline(
         model_inputs = self.processor(
             text=txt,
             images=image,
+            padding=True,
+            return_tensors="pt",
         ).to(self.device)
 
         outputs = self.text_encoder(

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -36,8 +36,8 @@ from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit import (
     retrieve_timesteps,
 )
 from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
-    get_effective_qwen_prompt_lengths,
-    validate_qwen_prompt_lengths,
+    get_qwen_text_prompt_lengths,
+    validate_qwen_text_prompt_lengths,
 )
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
@@ -310,6 +310,18 @@ class QwenImageEditPlusPipeline(
         dtype = dtype or self.text_encoder.dtype
 
         prompt = [prompt] if isinstance(prompt, str) else prompt
+        prompt_tokens = self.tokenizer(
+            prompt,
+            padding=True,
+            truncation=False,
+            return_tensors="pt",
+        )
+        prompt_lengths = get_qwen_text_prompt_lengths(prompt_tokens.attention_mask)
+        validate_qwen_text_prompt_lengths(
+            prompt_lengths,
+            max_sequence_length=max_sequence_length,
+            field_name=field_name,
+        )
 
         img_prompt_template = "Picture {}: <|vision_start|><|image_pad|><|vision_end|>"
         if isinstance(image, list):
@@ -327,15 +339,6 @@ class QwenImageEditPlusPipeline(
             text=txt,
             images=image,
         ).to(self.device)
-        effective_lengths = get_effective_qwen_prompt_lengths(
-            model_inputs.attention_mask,
-            drop_idx=drop_idx,
-        )
-        validate_qwen_prompt_lengths(
-            effective_lengths,
-            max_sequence_length=max_sequence_length,
-            field_name=field_name,
-        )
 
         outputs = self.text_encoder(
             input_ids=model_inputs.input_ids,

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -37,7 +37,8 @@ from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit import (
 )
 from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
     build_qwen_image_edit_plus_prompt_prefix,
-    tokenize_and_validate_qwen_vl_prompt,
+    get_effective_qwen_prompt_lengths,
+    validate_qwen_prompt_lengths,
 )
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
@@ -322,14 +323,19 @@ class QwenImageEditPlusPipeline(
         drop_idx = self.prompt_template_encode_start_idx
         txt = [template.format(base_img_prompt + e) for e in prompt]
 
-        model_inputs = tokenize_and_validate_qwen_vl_prompt(
-            self.processor,
-            texts=txt,
+        model_inputs = self.processor(
+            text=txt,
             images=image,
+        ).to(self.device)
+        effective_lengths = get_effective_qwen_prompt_lengths(
+            model_inputs.attention_mask,
             drop_idx=drop_idx,
+        )
+        validate_qwen_prompt_lengths(
+            effective_lengths,
             max_sequence_length=max_sequence_length,
             field_name=field_name,
-        ).to(self.device)
+        )
 
         outputs = self.text_encoder(
             input_ids=model_inputs.input_ids,

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -36,7 +36,6 @@ from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit import (
     retrieve_timesteps,
 )
 from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
-    build_qwen_image_edit_plus_prompt_prefix,
     get_effective_qwen_prompt_lengths,
     validate_qwen_prompt_lengths,
 )
@@ -312,10 +311,11 @@ class QwenImageEditPlusPipeline(
 
         prompt = [prompt] if isinstance(prompt, str) else prompt
 
+        img_prompt_template = "Picture {}: <|vision_start|><|image_pad|><|vision_end|>"
         if isinstance(image, list):
-            base_img_prompt = build_qwen_image_edit_plus_prompt_prefix(len(image))
+            base_img_prompt = "".join(img_prompt_template.format(i + 1) for i in range(len(image)))
         elif image is not None:
-            base_img_prompt = build_qwen_image_edit_plus_prompt_prefix(1)
+            base_img_prompt = img_prompt_template.format(1)
         else:
             base_img_prompt = ""
 

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -287,6 +287,24 @@ class QwenImageEditPlusPipeline(
                 "that was used to generate `negative_prompt_embeds`."
             )
 
+        for field_name, field_value in (("prompt", prompt), ("negative_prompt", negative_prompt)):
+            if field_value is None:
+                continue
+
+            text_inputs = [field_value] if isinstance(field_value, str) else field_value
+            tokenized_inputs = self.tokenizer(
+                text_inputs,
+                padding=True,
+                truncation=False,
+                return_tensors="pt",
+            )
+            prompt_lengths = get_qwen_text_prompt_lengths(tokenized_inputs.attention_mask)
+            validate_qwen_text_prompt_lengths(
+                prompt_lengths,
+                max_sequence_length=max_sequence_length,
+                field_name=field_name,
+            )
+
         if max_sequence_length is not None and max_sequence_length > 1024:
             raise ValueError(f"`max_sequence_length` cannot be greater than 1024 but is {max_sequence_length}")
 
@@ -303,25 +321,11 @@ class QwenImageEditPlusPipeline(
         prompt: str | list[str],
         image: list[torch.Tensor] | torch.Tensor | None = None,
         dtype: torch.dtype | None = None,
-        max_sequence_length: int | None = None,
-        field_name: str = "prompt",
     ):
         """Get prompt embeddings with support for multiple images."""
         dtype = dtype or self.text_encoder.dtype
 
         prompt = [prompt] if isinstance(prompt, str) else prompt
-        prompt_tokens = self.tokenizer(
-            prompt,
-            padding=True,
-            truncation=False,
-            return_tensors="pt",
-        )
-        prompt_lengths = get_qwen_text_prompt_lengths(prompt_tokens.attention_mask)
-        validate_qwen_text_prompt_lengths(
-            prompt_lengths,
-            max_sequence_length=max_sequence_length,
-            field_name=field_name,
-        )
 
         img_prompt_template = "Picture {}: <|vision_start|><|image_pad|><|vision_end|>"
         if isinstance(image, list):
@@ -373,8 +377,7 @@ class QwenImageEditPlusPipeline(
         num_images_per_prompt: int = 1,
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
-        max_sequence_length: int = 1024,
-        field_name: str = "prompt",
+        max_sequence_length: int = 512,
     ):
         r"""
 
@@ -394,12 +397,7 @@ class QwenImageEditPlusPipeline(
         batch_size = len(prompt) if prompt_embeds is None else prompt_embeds.shape[0]
 
         if prompt_embeds is None:
-            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(
-                prompt,
-                image,
-                max_sequence_length=max_sequence_length,
-                field_name=field_name,
-            )
+            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(prompt, image)
 
         prompt_embeds = prompt_embeds[:, :max_sequence_length]
         prompt_embeds_mask = prompt_embeds_mask[:, :max_sequence_length]
@@ -705,7 +703,6 @@ class QwenImageEditPlusPipeline(
             prompt_embeds_mask=prompt_embeds_mask,
             num_images_per_prompt=num_images_per_prompt,
             max_sequence_length=max_sequence_length,
-            field_name="prompt",
         )
 
         if do_true_cfg:
@@ -716,7 +713,6 @@ class QwenImageEditPlusPipeline(
                 prompt_embeds_mask=negative_prompt_embeds_mask,
                 num_images_per_prompt=num_images_per_prompt,
                 max_sequence_length=max_sequence_length,
-                field_name="negative_prompt",
             )
 
         num_channels_latents = self.transformer.in_channels // 4

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -35,6 +35,10 @@ from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit import (
     retrieve_latents,
     retrieve_timesteps,
 )
+from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
+    build_qwen_image_edit_plus_prompt_prefix,
+    tokenize_and_validate_qwen_vl_prompt,
+)
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
@@ -299,20 +303,18 @@ class QwenImageEditPlusPipeline(
         prompt: str | list[str],
         image: list[torch.Tensor] | torch.Tensor | None = None,
         dtype: torch.dtype | None = None,
+        max_sequence_length: int | None = None,
+        field_name: str = "prompt",
     ):
         """Get prompt embeddings with support for multiple images."""
         dtype = dtype or self.text_encoder.dtype
 
         prompt = [prompt] if isinstance(prompt, str) else prompt
 
-        # Build image prompt template for multiple images
-        img_prompt_template = "Picture {}: <|vision_start|><|image_pad|><|vision_end|>"
         if isinstance(image, list):
-            base_img_prompt = ""
-            for i, img in enumerate(image):
-                base_img_prompt += img_prompt_template.format(i + 1)
+            base_img_prompt = build_qwen_image_edit_plus_prompt_prefix(len(image))
         elif image is not None:
-            base_img_prompt = img_prompt_template.format(1)
+            base_img_prompt = build_qwen_image_edit_plus_prompt_prefix(1)
         else:
             base_img_prompt = ""
 
@@ -320,12 +322,13 @@ class QwenImageEditPlusPipeline(
         drop_idx = self.prompt_template_encode_start_idx
         txt = [template.format(base_img_prompt + e) for e in prompt]
 
-        # Use processor to handle both text and image inputs
-        model_inputs = self.processor(
-            text=txt,
+        model_inputs = tokenize_and_validate_qwen_vl_prompt(
+            self.processor,
+            texts=txt,
             images=image,
-            padding=True,
-            return_tensors="pt",
+            drop_idx=drop_idx,
+            max_sequence_length=max_sequence_length,
+            field_name=field_name,
         ).to(self.device)
 
         outputs = self.text_encoder(
@@ -360,6 +363,7 @@ class QwenImageEditPlusPipeline(
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
         max_sequence_length: int = 1024,
+        field_name: str = "prompt",
     ):
         r"""
 
@@ -379,7 +383,15 @@ class QwenImageEditPlusPipeline(
         batch_size = len(prompt) if prompt_embeds is None else prompt_embeds.shape[0]
 
         if prompt_embeds is None:
-            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(prompt, image)
+            prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(
+                prompt,
+                image,
+                max_sequence_length=max_sequence_length,
+                field_name=field_name,
+            )
+
+        prompt_embeds = prompt_embeds[:, :max_sequence_length]
+        prompt_embeds_mask = prompt_embeds_mask[:, :max_sequence_length]
 
         _, seq_len, _ = prompt_embeds.shape
         prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
@@ -682,6 +694,7 @@ class QwenImageEditPlusPipeline(
             prompt_embeds_mask=prompt_embeds_mask,
             num_images_per_prompt=num_images_per_prompt,
             max_sequence_length=max_sequence_length,
+            field_name="prompt",
         )
 
         if do_true_cfg:
@@ -692,6 +705,7 @@ class QwenImageEditPlusPipeline(
                 prompt_embeds_mask=negative_prompt_embeds_mask,
                 num_images_per_prompt=num_images_per_prompt,
                 max_sequence_length=max_sequence_length,
+                field_name="negative_prompt",
             )
 
         num_channels_latents = self.transformer.in_channels // 4

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
@@ -31,6 +31,10 @@ from vllm_omni.diffusion.models.qwen_image.autoencoder_kl_qwenimage import (
 from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
 )
+from vllm_omni.diffusion.models.qwen_image.prompt_length_validation import (
+    get_qwen_text_prompt_lengths,
+    validate_qwen_text_prompt_lengths,
+)
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
@@ -340,6 +344,24 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
                 "generate `negative_prompt_embeds`."
             )
 
+        for field_name, field_value in (("prompt", prompt), ("negative_prompt", negative_prompt)):
+            if field_value is None:
+                continue
+
+            text_inputs = [field_value] if isinstance(field_value, str) else field_value
+            tokenized_inputs = self.tokenizer(
+                text_inputs,
+                padding=True,
+                truncation=False,
+                return_tensors="pt",
+            )
+            prompt_lengths = get_qwen_text_prompt_lengths(tokenized_inputs.attention_mask)
+            validate_qwen_text_prompt_lengths(
+                prompt_lengths,
+                max_sequence_length=max_sequence_length,
+                field_name=field_name,
+            )
+
         if max_sequence_length is not None and max_sequence_length > 1024:
             raise ValueError(f"`max_sequence_length` cannot be greater than 1024 but is {max_sequence_length}")
 
@@ -398,7 +420,7 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         num_images_per_prompt: int = 1,
         prompt_embeds: torch.Tensor | None = None,
         prompt_embeds_mask: torch.Tensor | None = None,
-        max_sequence_length: int = 1024,
+        max_sequence_length: int = 512,
     ):
         r"""
 
@@ -696,6 +718,19 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         # 3. encode prompot & negative prompt
         if prompt is None or prompt == "" or prompt == " ":
             prompt = self.get_image_caption(prompt_image, use_en_prompt=use_en_prompt, device=self.device)
+            prompt_lengths = get_qwen_text_prompt_lengths(
+                self.tokenizer(
+                    [prompt],
+                    padding=True,
+                    truncation=False,
+                    return_tensors="pt",
+                ).attention_mask
+            )
+            validate_qwen_text_prompt_lengths(
+                prompt_lengths,
+                max_sequence_length=max_sequence_length,
+                field_name="prompt",
+            )
         if prompt is not None and isinstance(prompt, str):
             batch_size = 1
         elif prompt is not None and isinstance(prompt, list):

--- a/vllm_omni/diffusion/models/qwen_image/prompt_length_validation.py
+++ b/vllm_omni/diffusion/models/qwen_image/prompt_length_validation.py
@@ -10,64 +10,25 @@ def build_qwen_image_edit_plus_prompt_prefix(image_count: int) -> str:
     return "".join(img_prompt_template.format(i + 1) for i in range(image_count))
 
 
-def tokenize_and_validate_qwen_text_prompt(
-    tokenizer: Any,
+def get_effective_qwen_prompt_lengths(attention_mask: Any, *, drop_idx: int) -> list[int]:
+    """Return prompt lengths after removing the fixed system/template prefix."""
+    token_lengths = attention_mask.sum(dim=1).tolist()
+    return [max(int(length) - drop_idx, 0) for length in token_lengths]
+
+
+def validate_qwen_prompt_lengths(
+    effective_lengths: list[int],
     *,
-    texts: list[str],
-    drop_idx: int,
     max_sequence_length: int | None,
     field_name: str,
-):
-    """Tokenize a text-only Qwen prompt and fail fast if it exceeds the limit."""
-    tokenized = tokenizer(
-        texts,
-        padding=True,
-        truncation=False,
-        return_tensors="pt",
-    )
-
+) -> None:
+    """Raise when any prompt length exceeds the configured maximum."""
     if max_sequence_length is None:
-        return tokenized
+        return
 
-    token_lengths = tokenized.attention_mask.sum(dim=1).tolist()
-    effective_lengths = [max(int(length) - drop_idx, 0) for length in token_lengths]
     for effective_length in effective_lengths:
         if effective_length > max_sequence_length:
             raise ValueError(
                 f"`{field_name}` is too long after Qwen image prompt expansion: "
                 f"{effective_length} tokens exceeds max_sequence_length={max_sequence_length}."
             )
-
-    return tokenized
-
-
-def tokenize_and_validate_qwen_vl_prompt(
-    processor: Any,
-    *,
-    texts: list[str],
-    images: Any,
-    drop_idx: int,
-    max_sequence_length: int | None,
-    field_name: str,
-):
-    """Tokenize a Qwen VL prompt and fail fast if it exceeds the requested limit."""
-    model_inputs = processor(
-        text=texts,
-        images=images,
-        padding=True,
-        return_tensors="pt",
-    )
-
-    if max_sequence_length is None:
-        return model_inputs
-
-    token_lengths = model_inputs.attention_mask.sum(dim=1).tolist()
-    effective_lengths = [max(int(length) - drop_idx, 0) for length in token_lengths]
-    for effective_length in effective_lengths:
-        if effective_length > max_sequence_length:
-            raise ValueError(
-                f"`{field_name}` is too long after Qwen image prompt expansion: "
-                f"{effective_length} tokens exceeds max_sequence_length={max_sequence_length}."
-            )
-
-    return model_inputs

--- a/vllm_omni/diffusion/models/qwen_image/prompt_length_validation.py
+++ b/vllm_omni/diffusion/models/qwen_image/prompt_length_validation.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+
+def build_qwen_image_edit_plus_prompt_prefix(image_count: int) -> str:
+    """Build the text prefix used by Qwen image edit-plus for image placeholders."""
+    if image_count <= 0:
+        return ""
+
+    img_prompt_template = "Picture {}: <|vision_start|><|image_pad|><|vision_end|>"
+    return "".join(img_prompt_template.format(i + 1) for i in range(image_count))
+
+
+def tokenize_and_validate_qwen_vl_prompt(
+    processor: Any,
+    *,
+    texts: list[str],
+    images: Any,
+    drop_idx: int,
+    max_sequence_length: int | None,
+    field_name: str,
+):
+    """Tokenize a Qwen VL prompt and fail fast if it exceeds the requested limit."""
+    model_inputs = processor(
+        text=texts,
+        images=images,
+        padding=True,
+        return_tensors="pt",
+    )
+
+    if max_sequence_length is None:
+        return model_inputs
+
+    token_lengths = model_inputs.attention_mask.sum(dim=1).tolist()
+    effective_lengths = [max(int(length) - drop_idx, 0) for length in token_lengths]
+    for effective_length in effective_lengths:
+        if effective_length > max_sequence_length:
+            raise ValueError(
+                f"`{field_name}` is too long after Qwen image prompt expansion: "
+                f"{effective_length} tokens exceeds max_sequence_length={max_sequence_length}."
+            )
+
+    return model_inputs

--- a/vllm_omni/diffusion/models/qwen_image/prompt_length_validation.py
+++ b/vllm_omni/diffusion/models/qwen_image/prompt_length_validation.py
@@ -10,6 +10,37 @@ def build_qwen_image_edit_plus_prompt_prefix(image_count: int) -> str:
     return "".join(img_prompt_template.format(i + 1) for i in range(image_count))
 
 
+def tokenize_and_validate_qwen_text_prompt(
+    tokenizer: Any,
+    *,
+    texts: list[str],
+    drop_idx: int,
+    max_sequence_length: int | None,
+    field_name: str,
+):
+    """Tokenize a text-only Qwen prompt and fail fast if it exceeds the limit."""
+    tokenized = tokenizer(
+        texts,
+        padding=True,
+        truncation=False,
+        return_tensors="pt",
+    )
+
+    if max_sequence_length is None:
+        return tokenized
+
+    token_lengths = tokenized.attention_mask.sum(dim=1).tolist()
+    effective_lengths = [max(int(length) - drop_idx, 0) for length in token_lengths]
+    for effective_length in effective_lengths:
+        if effective_length > max_sequence_length:
+            raise ValueError(
+                f"`{field_name}` is too long after Qwen image prompt expansion: "
+                f"{effective_length} tokens exceeds max_sequence_length={max_sequence_length}."
+            )
+
+    return tokenized
+
+
 def tokenize_and_validate_qwen_vl_prompt(
     processor: Any,
     *,

--- a/vllm_omni/diffusion/models/qwen_image/prompt_length_validation.py
+++ b/vllm_omni/diffusion/models/qwen_image/prompt_length_validation.py
@@ -1,25 +1,23 @@
 from typing import Any
 
 
-def get_effective_qwen_prompt_lengths(attention_mask: Any, *, drop_idx: int) -> list[int]:
-    """Return prompt lengths after removing the fixed system/template prefix."""
-    token_lengths = attention_mask.sum(dim=1).tolist()
-    return [max(int(length) - drop_idx, 0) for length in token_lengths]
+def get_qwen_text_prompt_lengths(attention_mask: Any) -> list[int]:
+    """Return token lengths for user-provided text prompts."""
+    return [int(length) for length in attention_mask.sum(dim=1).tolist()]
 
 
-def validate_qwen_prompt_lengths(
-    effective_lengths: list[int],
+def validate_qwen_text_prompt_lengths(
+    lengths: list[int],
     *,
     max_sequence_length: int | None,
     field_name: str,
 ) -> None:
-    """Raise when any prompt length exceeds the configured maximum."""
+    """Raise when any user-provided text prompt exceeds the configured maximum."""
     if max_sequence_length is None:
         return
 
-    for effective_length in effective_lengths:
-        if effective_length > max_sequence_length:
+    for length in lengths:
+        if length > max_sequence_length:
             raise ValueError(
-                f"`{field_name}` is too long after Qwen image prompt expansion: "
-                f"{effective_length} tokens exceeds max_sequence_length={max_sequence_length}."
+                f"`{field_name}` is too long: {length} tokens exceeds max_sequence_length={max_sequence_length}."
             )

--- a/vllm_omni/diffusion/models/qwen_image/prompt_length_validation.py
+++ b/vllm_omni/diffusion/models/qwen_image/prompt_length_validation.py
@@ -1,15 +1,6 @@
 from typing import Any
 
 
-def build_qwen_image_edit_plus_prompt_prefix(image_count: int) -> str:
-    """Build the text prefix used by Qwen image edit-plus for image placeholders."""
-    if image_count <= 0:
-        return ""
-
-    img_prompt_template = "Picture {}: <|vision_start|><|image_pad|><|vision_end|>"
-    return "".join(img_prompt_template.format(i + 1) for i in range(image_count))
-
-
 def get_effective_qwen_prompt_lengths(attention_mask: Any, *, drop_idx: int) -> list[int]:
     """Return prompt lengths after removing the fixed system/template prefix."""
     token_lengths = attention_mask.sum(dim=1).tolist()

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -423,12 +423,15 @@ class AsyncOmni(EngineClient, OmniBase):
 
             # Check for errors
             if "error" in result:
+                error_message = result["error"]
                 logger.error(
                     "[AsyncOmni] Orchestrator error for req=%s stage-%s: %s",
                     request_id,
                     stage_id,
-                    result["error"],
+                    error_message,
                 )
+                if isinstance(error_message, str) and "exceeds max_sequence_length=" in error_message:
+                    raise ValueError(error_message)
                 raise RuntimeError(result)
 
             # Process the result (constructs OmniRequestOutput)

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1347,6 +1347,7 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
         _update_if_not_none(gen_params, "num_inference_steps", request.num_inference_steps)
         _update_if_not_none(gen_params, "guidance_scale", request.guidance_scale)
         _update_if_not_none(gen_params, "true_cfg_scale", request.true_cfg_scale)
+        _update_if_not_none(gen_params, "max_sequence_length", request.max_sequence_length)
         # If seed is not provided, generate a random one to ensure
         # a proper generator is initialized in the backend.
         # This fixes issues where using the default global generator
@@ -1432,6 +1433,7 @@ async def edit_images(
     guidance_scale: float | None = Form(None),
     strength: float | None = Form(None),
     true_cfg_scale: float | None = Form(None),
+    max_sequence_length: Annotated[int | None, Form(ge=1)] = None,
     seed: int | None = Form(None),
     generator_device: str | None = Form(None),
     # vllm-omni extension for per-request LoRA.
@@ -1546,6 +1548,7 @@ async def edit_images(
         _update_if_not_none(gen_params, "guidance_scale", guidance_scale)
         _update_if_not_none(gen_params, "strength", strength)
         _update_if_not_none(gen_params, "true_cfg_scale", true_cfg_scale)
+        _update_if_not_none(gen_params, "max_sequence_length", max_sequence_length)
         # If seed is not provided, generate a random one to ensure
         # a proper generator is initialized in the backend.
         # This fixes issues where using the default global generator

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -122,6 +122,11 @@ class ImageGenerationRequest(BaseModel):
         default=None,
         description="Device for the seeded torch.Generator (e.g. 'cpu', 'cuda'). Defaults to the runner's device.",
     )
+    max_sequence_length: int | None = Field(
+        default=None,
+        ge=1,
+        description="Optional prompt token limit for models that support configurable maximum sequence lengths.",
+    )
 
     # vllm-omni extension for per-request LoRA.
     # This mirrors the `extra_body.lora` convention in /v1/chat/completions.


### PR DESCRIPTION
## Summary

This PR fixes the Qwen image prompt length handling for issue #2794.

## Root Cause

The regression had two parts:

1. `max_sequence_length` existed in diffusion sampling params, but the OpenAI image endpoints did not pass the request value through for image edit requests.
2. Very long user text prompts could still reach the Qwen text encoder path and trigger OOM instead of failing fast with a request error.

## What Changed

- Added `max_sequence_length` to the OpenAI image request surface and passed it through to diffusion sampling params.
- Added a lightweight text prompt length validation helper for Qwen image pipelines.
- Enforced prompt length checks on the user-provided `prompt` / `negative_prompt` text before encoder execution for:
  - `QwenImagePipeline`
  - `QwenImageEditPipeline`
  - `QwenImageEditPlusPipeline`
- Restored the required `processor(..., padding=True, return_tensors="pt")` path for Qwen image edit pipelines.
- Converted the overlong-prompt error path back into `400 Bad Request` at the API surface instead of leaking as `500` through async orchestration.
- Added unit tests for request passthrough and text prompt length validation.

## User Impact

Overlong text prompts now fail fast with a clear validation error and return `400 Bad Request` instead of reaching the Qwen encoder path and causing an OOM.

## Validation

- `pytest -q tests/diffusion/models/qwen_image/test_prompt_length_validation.py tests/entrypoints/openai_api/test_image_server.py -q`
- E2E with local `serve` + `curl` on cached `Qwen/Qwen-Image-Edit`:
  - normal request returned `200 OK`
  - overlong prompt with `max_sequence_length=1024` returned `400 Bad Request`

Fixes #2794
