### PR TITLE
[Fix][Fish Speech] Remove redundant get_vocab() in control token encoding

### DIFF
--- a/vllm_omni/model_executor/models/fish_speech/prompt_utils.py
+++ b/vllm_omni/model_executor/models/fish_speech/prompt_utils.py
@@ -38,10 +38,7 @@ def _encode_plain_text(tokenizer: Any, text: str) -> list[int]:
 
 
 def _encode_control_token(tokenizer: Any, token: str) -> list[int]:
-    vocab = tokenizer.get_vocab() if hasattr(tokenizer, "get_vocab") else {}
-    token_id = vocab.get(token)
-    if token_id is None:
-        token_id = tokenizer.convert_tokens_to_ids(token)
+    token_id = tokenizer.convert_tokens_to_ids(token)
     if token_id is None or token_id == getattr(tokenizer, "unk_token_id", None):
         raise ValueError(f"Fish Speech tokenizer is missing required control token: {token}")
     return [int(token_id)]


### PR DESCRIPTION
## Purpose

`_encode_control_token()` in `prompt_utils.py` called `tokenizer.get_vocab()` on every invocation, which rebuilds the full 155K-entry vocabulary dictionary each time (~68ms on H20 GPU). Since this function is called 6 times per prompt (for `<|im_start|>`, `<|im_end|>`, `<|voice|>`), it adds **~408ms of pure Python overhead** to every Fish Speech S2 Pro TTS request.

Replace with `tokenizer.convert_tokens_to_ids()` which performs the same single-token lookup in <1ms.

## Test Plan

- [x] A/B benchmark: run baseline (origin/main) and fix on the same H20 GPU with identical config (`enforce_eager=false`, CUDA graph enabled), same model, same text
- [x] Verify audio output is valid WAV with correct content
- [x] Ruff lint/format pass

## Test Result

**Setup:**  `enforce_eager=false` (torch.compile + CUDA graph), text = "The quick brown fox jumps over the lazy dog." (~3s audio)

| | Median Total | Median RTF | Improvement |
|---|---|---|---|
| **Baseline** (origin/main) | 1.205s | 0.399 | — |
| **This PR** | 0.908s | 0.292 | **-25%** |

Long text (~14s audio):

| | Median Total | Median RTF | Improvement |
|---|---|---|---|
| **Baseline** (origin/main) | 3.830s | 0.269 | — |
| **This PR** | 3.649s | 0.248 | **-8%** |

Root cause profiling: `build_prompt` dropped from ~400ms to ~1ms per request.

cc @linyueqian @zwhzzz0821