### PR TITLE
[BugFix]: Fix Qwen3-TTS code2wav fails when enforce_eager: false

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py
@@ -324,12 +324,18 @@ class Qwen3TTSCode2Wav(nn.Module):
             multimodal_outputs={"model_outputs": audios, "sr": srs},
         )
 
-    def make_omni_output(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:
+    def make_omni_output(self, model_outputs: torch.Tensor | OmniOutput | tuple, **kwargs: Any) -> OmniOutput:
         if isinstance(model_outputs, OmniOutput):
             return model_outputs
 
+        if isinstance(model_outputs, tuple) and len(model_outputs) == len(OmniOutput._fields):
+            return OmniOutput(*model_outputs)
+
         if not (isinstance(model_outputs, tuple) and len(model_outputs) == 2):
-            raise TypeError(f"Qwen3TTSCode2Wav expected (audio_tensor, sr) outputs, got {type(model_outputs)}")
+            raise TypeError(
+                "Qwen3TTSCode2Wav expected OmniOutput, OmniOutput tuple, "
+                f"or (audio_tensor, sr) outputs, got {type(model_outputs)}"
+            )
 
         audio_tensor, sr = model_outputs
         return OmniOutput(


### PR DESCRIPTION
## Purpose

As described in PR #2866, this PR mainly fixes that issue.  
This is also a review for PR #2328.

## Test Plan
```
python /workspace/vllm-omni/benchmarks/qwen3-tts/vllm_omni/bench_tts_serve.py \
--host 127.0.0.1 --port 8899 \
--task-type Base \
--ref-audio /workspace/resource/clone_2.wav \
--ref-text "Okay. Yeah. I resent you. I love you. I respect you. But you know what? You blew it! And thanks to you." \
--num-prompts 10 \
--config-name base_baseline \
--result-dir benchmarks/qwen3-tts/results/


```

## Test Result
```
Warming up with 3 requests...
  Warmup done.
  Running 10 requests with concurrency=4...
  concurrency=4: 100%|██████████████████████████████████████████████████████████████████████████████| 10/10 [00:15<00:00,  1.56s/it]

==================================================
             Serving Benchmark Result             
==================================================
Successful requests:                    10        
Failed requests:                        0         
Maximum request concurrency:            4         
Benchmark duration (s):                 15.60     
Request throughput (req/s):             0.64      
--------------------------------------------------
                End-to-end Latency                
--------------------------------------------------
Mean E2EL (ms):                         5546.95   
Median E2EL (ms):                       5522.70   
P99 E2EL (ms):                          6739.25   
==================================================
                   Audio Result                   
==================================================
Total audio duration generated (s):     42.24     
Audio throughput (audio duration/s):    2.71      
--------------------------------------------------
               Time to First Packet               
--------------------------------------------------
Mean AUDIO_TTFP (ms):                   768.17    
Median AUDIO_TTFP (ms):                 727.03    
P99 AUDIO_TTFP (ms):                    1049.49   
--------------------------------------------------
                 Real Time Factor                 
--------------------------------------------------
Mean AUDIO_RTF:                         1.330     
Median AUDIO_RTF:                       1.436     
P99 AUDIO_RTF:                          1.457     
==================================================

```

## The accuracy
Test Conclusion: Accuracy is satisfactory, and the content of the two audio segments is consistent.

- When force_eager is false
[output_force_eager_false.wav](https://github.com/user-attachments/files/26878780/output_force_eager_false.wav)

- When force_eager is true
[output_force_eagler_true.wav](https://github.com/user-attachments/files/26878797/output_force_eagler_true.wav)

## Performance (not as good as shown in the chart)
| Concurrency | Metric | `force_eager: false` | `force_eager: true` |
|---:|---|---:|---:|
| 1 | Total duration (s) | 19.36 | 19.07 |
| 1 | Request throughput (req/s) | 0.52 | 0.52 |
| 1 | Audio throughput (audio duration/s) | 2.18 | 2.21 |
| 1 | Mean E2E latency (ms) | 1935.29 | 1906.71 |
| 4 | Total duration (s) | 12.19 | 11.86 |
| 4 | Request throughput (req/s) | 0.82 | 0.84 |
| 4 | Audio throughput (audio duration/s) | 3.41 | 3.44 |
| 4 | Mean E2E latency (ms) | 4321.41 | 4251.28 |
| 10 | Total duration (s) | 10.34 | 10.19 |
| 10 | Request throughput (req/s) | 0.97 | 0.98 |
| 10 | Audio throughput (audio duration/s) | 4.01 | 4.24 |
| 10 | Mean E2E latency (ms) | 9225.24 | 9198.95 |

