### PR TITLE
[CI] Remove small resolution test in Qwen-Image Perf test when vae patch parallel is enabled

### DIFF
--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -106,22 +106,6 @@
         },
         "benchmark_params": [
             {
-                "name": "512x512_steps20",
-                "dataset": "random",
-                "task": "t2i",
-                "width": 512,
-                "height": 512,
-                "num-inference-steps": 20,
-                "num-prompts": 10,
-                "max-concurrency": 1,
-                "enable-negative-prompt": true,
-                "baseline": {
-                    "throughput_qps": 0.1,
-                    "latency_mean": 2.7,
-                    "peak_memory_mb_mean": 61000
-                }
-            },
-            {
                 "name": "1536x1536_steps35",
                 "dataset": "random",
                 "task": "t2i",


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Solving #2863.

Vae patch parallelism is enabled to reduce the peak memory of long sequence decoding. It may increase the latency when the resolution is too small, because the communication overhead is larger than the parallel computation gains.

Therefore, this PR removes the "512x512_steps20" test in the `Ulysses SP=2 + CFG-parallel=2 + VAE Patch Parallel=4` test case. This actually helps to stablize the nightly CI performance, preventing it from failure.

##  Previous  CI results

| resolution | num_steps | buildkite url | latency_mean | test case CI success |
| ---| ---|---| ---|---|
| 512x512 | 20 | [6979](https://buildkite.com/vllm/vllm-omni/builds/6979/steps/canvas) |  3.1746 | ❌ |
| 512x512 | 20 | [6662](https://buildkite.com/vllm/vllm-omni/builds/6662/steps/canvas) |  1.92344  | ✅  |
| 1536x1536 | 35 | [6979](https://buildkite.com/vllm/vllm-omni/builds/6979/steps/canvas) |  8.44113 | ✅ |
| 1536x1536 | 35 | [6662](https://buildkite.com/vllm/vllm-omni/builds/6662/steps/canvas) |  8.34948 | ✅  |

The table above indicates that larger resolution yields more stable performance results.

## Test Plan
```bash
pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
```
## Test Result

Wait for Nightly-CI results.

cc @yenuo26 @Gaohan123 @hsliuustc0106 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
