### PR TITLE
[Bugfix][Diffusion] Fix QwenImageLayeredPipeline OOM with tensor parallelism

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py
@@ -25,8 +25,8 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.interface import SupportImageInput
-from vllm_omni.diffusion.models.qwen_image.autoencoder_kl_qwenimage import (
-    AutoencoderKLQwenImage,
+from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_qwenimage import (
+    DistributedAutoencoderKLQwenImage,
 )
 from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
@@ -224,9 +224,9 @@ class QwenImageLayeredPipeline(nn.Module, SupportImageInput, QwenImageCFGParalle
         self.text_encoder = Qwen2_5_VLForConditionalGeneration.from_pretrained(
             model, subfolder="text_encoder", local_files_only=local_files_only
         ).to(self.device)
-        self.vae = AutoencoderKLQwenImage.from_pretrained(model, subfolder="vae", local_files_only=local_files_only).to(
-            self.device
-        )
+        self.vae = DistributedAutoencoderKLQwenImage.from_pretrained(
+            model, subfolder="vae", local_files_only=local_files_only
+        ).to(self.device)
         self.tokenizer = Qwen2Tokenizer.from_pretrained(model, subfolder="tokenizer", local_files_only=local_files_only)
         self.processor = Qwen2VLProcessor.from_pretrained(
             model, subfolder="processor", local_files_only=local_files_only
@@ -723,6 +723,11 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
         self._current_timestep = None
         self._interrupt = False
 
+        # Ensure text_encoder is on GPU for prompt encoding
+        # (it may have been offloaded to CPU after a previous forward call)
+        if next(self.text_encoder.parameters()).device.type == "cpu":
+            self.text_encoder.to(self.device)
+
         # 3. encode prompot & negative prompt
         if prompt is None or prompt == "" or prompt == " ":
             prompt = self.get_image_caption(prompt_image, use_en_prompt=use_en_prompt, device=self.device)
@@ -768,6 +773,12 @@ the image\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>as
                 max_sequence_length=max_sequence_length,
                 prompt_name="negative_prompt",
             )
+
+        # Offload text_encoder to CPU to free GPU memory for denoising + VAE decode.
+        # The text_encoder is no longer needed after prompt encoding and typically
+        # dominates GPU memory (>>30 GiB for the Qwen2.5-VL encoder).
+        self.text_encoder.to("cpu")
+        torch.cuda.empty_cache()
 
         # 4. Prepare latent variables
         num_channels_latents = self.transformer.in_channels // 4


### PR DESCRIPTION
## Summary

`QwenImageLayeredPipeline` failed with `CUDA OutOfMemoryError` when running with `--tensor-parallel-size >= 2` on multi-GPU setups (e.g. 4× RTX 5880 48 GB).

## Root Cause

Two issues combined to exhaust GPU memory during VAE decode:

1. **Non-distributed VAE**: The layered pipeline used the local `AutoencoderKLQwenImage` instead of `DistributedAutoencoderKLQwenImage` (which `QwenImagePipeline` already uses). This prevented distributed tiled decoding across TP ranks.

2. **text_encoder not offloaded after encoding**: The Qwen2.5-VL text encoder dominates GPU memory (>>30 GiB). After prompt encoding completes, it sits idle on GPU leaving only ~6 GiB free — insufficient for the denoising loop and VAE decode.

## Fix

- Replace `AutoencoderKLQwenImage` with `DistributedAutoencoderKLQwenImage`, consistent with the non-layered `QwenImagePipeline`.
- After `encode_prompt()`, offload `text_encoder` to CPU and call `torch.cuda.empty_cache()` to reclaim GPU memory.
- At the start of each `forward()` call, move `text_encoder` back to GPU if it was previously offloaded (idempotent for the first call).

## Testing

Tested on a server with 4× NVIDIA RTX 5880-Ada-48Q (48 GB each), CUDA 12.8:
- `--tensor-parallel-size 2`: Previously OOM during VAE decode → now completes successfully.
- Output images generated correctly (`layered_0.png`, `layered_1.png`).

## Changes

| File | Change |
|------|--------|
| `vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_layered.py` | Replace VAE with distributed version; add text_encoder CPU offload after encoding |
