### PR TITLE
[Redo][Log] Wire stat logging into AsyncOmniEngine matching AsyncLLM

### DIFF
--- a/tests/engine/test_async_omni_engine_do_log_stats.py
+++ b/tests/engine/test_async_omni_engine_do_log_stats.py
@@ -1,0 +1,35 @@
+"""Guard tests for AsyncOmniEngine.do_log_stats edge cases."""
+
+import asyncio
+
+import pytest
+
+from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.asyncio]
+
+
+async def test_do_log_stats_noop_when_manager_missing():
+    """do_log_stats should silently return when logger_manager is None."""
+    engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
+    engine.logger_manager = None
+    engine.orchestrator_loop = None
+    await engine.do_log_stats()  # should not raise
+
+
+async def test_do_log_stats_noop_when_loop_missing():
+    """do_log_stats should silently return when orchestrator_loop is None."""
+    engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
+    engine.logger_manager = object()  # non-None sentinel
+    engine.orchestrator_loop = None
+    await engine.do_log_stats()  # should not raise
+
+
+async def test_do_log_stats_noop_when_loop_closed():
+    """do_log_stats should silently return when orchestrator_loop is closed."""
+    engine = AsyncOmniEngine.__new__(AsyncOmniEngine)
+    engine.logger_manager = object()  # non-None sentinel
+    loop = asyncio.new_event_loop()
+    loop.close()
+    engine.orchestrator_loop = loop
+    await engine.do_log_stats()  # should not raise

--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -374,6 +374,7 @@ def test_attach_llm_stage_uses_omni_input_preprocessor(monkeypatch):
     )
 
     engine = object.__new__(AsyncOmniEngine)
+    engine.log_stats = False
 
     _stage_client, _out_proc, _vllm_cfg, input_processor = engine._attach_llm_stage(started)
 

--- a/tests/engine/test_single_stage_mode.py
+++ b/tests/engine/test_single_stage_mode.py
@@ -467,6 +467,7 @@ class TestInitializeStagesRouting:
     ) -> AsyncOmniEngine:
         """Build a bare AsyncOmniEngine without launching any threads."""
         engine = object.__new__(AsyncOmniEngine)
+        engine.log_stats = False
         engine.model = "fake-model"
         engine.config_path = "/fake"
         engine.stage_configs = stage_cfgs
@@ -1071,6 +1072,7 @@ class TestLaunchDiffusionStage:
 
     def test_registers_stage_with_public_master_properties(self, mocker: MockerFixture):
         engine = object.__new__(AsyncOmniEngine)
+        engine.log_stats = False
         engine.model = "fake-model"
         engine.diffusion_batch_size = 4
 
@@ -1146,6 +1148,7 @@ class TestCreateRemoteLlmStage:
 
     def _engine(self, mocker: MockerFixture) -> AsyncOmniEngine:
         engine = object.__new__(AsyncOmniEngine)
+        engine.log_stats = False
         engine.model = "fake-model"
         engine.single_stage_mode = True
         engine._single_stage_id_filter = 0
@@ -1551,6 +1554,7 @@ class TestLaunchLlmStageSingleStageMode:
 
     def _build_engine_with_oms(self, mocker: MockerFixture) -> AsyncOmniEngine:
         engine = object.__new__(AsyncOmniEngine)
+        engine.log_stats = False
         engine.model = "fake-model"
         engine.single_stage_mode = True
         engine._single_stage_id_filter = 0
@@ -1626,6 +1630,7 @@ class TestLaunchLlmStageSingleStageMode:
     def test_spawn_stage_core_used_in_normal_mode(self, mocker: MockerFixture):
         """~single_stage_mode → spawn_stage_core + complete_stage_handshake."""
         engine = object.__new__(AsyncOmniEngine)
+        engine.log_stats = False
         engine.model = "fake-model"
         engine.single_stage_mode = False
         engine._omni_master_server = None

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -933,10 +933,12 @@ class AsyncOmniEngine:
             self._initialize_stages(stage_init_timeout)
 
             # Build StatLoggerManager after stages are initialized so we
-            # know how many engine indices to register.
-            if self.log_stats and self.stage_vllm_configs:
+            # know how many engine indices to register.  Use the first
+            # non-None vllm_config (diffusion stages have None).
+            stats_vllm_config = next((c for c in self.stage_vllm_configs if c is not None), None)
+            if self.log_stats and stats_vllm_config is not None:
                 self.logger_manager = StatLoggerManager(
-                    vllm_config=self.stage_vllm_configs[0],
+                    vllm_config=stats_vllm_config,
                     engine_idxs=list(range(self.num_stages)),
                 )
                 self.logger_manager.log_engine_initialized()

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -32,6 +32,7 @@ from vllm.logger import init_logger
 from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.input_processor import InputProcessor
+from vllm.v1.metrics.loggers import StatLoggerManager
 
 from vllm_omni.config.stage_config import strip_parent_engine_args
 from vllm_omni.diffusion.data import DiffusionParallelConfig
@@ -312,6 +313,9 @@ class AsyncOmniEngine:
         self.num_stages = len(self.stage_configs)
         stage0_args = getattr(self.stage_configs[0], "engine_args", None) if self.num_stages > 0 else None
         self.async_chunk = bool(getattr(stage0_args, "async_chunk", False))
+        self.log_stats = not bool(getattr(stage0_args, "disable_log_stats", False))
+        self.logger_manager: StatLoggerManager | None = None
+        self.orchestrator_loop: asyncio.AbstractEventLoop | None = None
         self.stage_clients: list[Any] = []
         self.stage_vllm_configs: list[Any] = []
         self.output_processors: list[MultimodalOutputProcessor | None] = []
@@ -428,7 +432,7 @@ class AsyncOmniEngine:
                                 launch_omni_core_engines(
                                     vllm_config=vllm_config,
                                     executor_class=executor_class,
-                                    log_stats=False,
+                                    log_stats=self.log_stats,
                                     omni_master_server=self._omni_master_server,
                                     stage_id=metadata.stage_id,
                                     stage_config=stage_cfg,
@@ -447,7 +451,7 @@ class AsyncOmniEngine:
                             addresses, proc, handshake_address = spawn_stage_core(
                                 vllm_config=vllm_config,
                                 executor_class=executor_class,
-                                log_stats=False,
+                                log_stats=self.log_stats,
                             )
                             started_stage = StartedLlmStage(
                                 stage_id=metadata.stage_id,
@@ -650,7 +654,7 @@ class AsyncOmniEngine:
                 )
             output_processor = MultimodalOutputProcessor(
                 tokenizer=tokenizer,
-                log_stats=False,
+                log_stats=self.log_stats,
                 engine_core_output_type=started.metadata.engine_output_type,
             )
             input_processor = None
@@ -921,11 +925,22 @@ class AsyncOmniEngine:
 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
+        self.orchestrator_loop = loop
 
         async def _run_orchestrator() -> None:
             self._initialize_janus_queues()
 
             self._initialize_stages(stage_init_timeout)
+
+            # Build StatLoggerManager after stages are initialized so we
+            # know how many engine indices to register.
+            if self.log_stats and self.stage_vllm_configs:
+                self.logger_manager = StatLoggerManager(
+                    vllm_config=self.stage_vllm_configs[0],
+                    engine_idxs=list(range(self.num_stages)),
+                )
+                self.logger_manager.log_engine_initialized()
+
             pd_config = self._detect_pd_config()
             orchestrator = Orchestrator(
                 request_async_queue=self.request_queue.async_q,
@@ -935,6 +950,7 @@ class AsyncOmniEngine:
                 stage_clients=self.stage_clients,
                 output_processors=self.output_processors,
                 stage_vllm_configs=self.stage_vllm_configs,
+                logger_manager=self.logger_manager,
                 pd_config=pd_config,
             )
             if not startup_future.done():
@@ -970,6 +986,25 @@ class AsyncOmniEngine:
             finally:
                 asyncio.set_event_loop(None)
                 loop.close()
+
+    # ---- stat logging ----
+
+    async def do_log_stats(self) -> None:
+        """Schedule StatLoggerManager.log() on the orchestrator loop.
+
+        Fire-and-forget: the log() call is dispatched to the orchestrator
+        thread without blocking the caller, so it never stalls the API
+        server's request-handling loop.  Both record() and log() execute
+        on the same (orchestrator) thread, avoiding data races.
+        """
+        manager = self.logger_manager
+        if manager is None:
+            return
+        loop = self.orchestrator_loop
+        if loop is None or loop.is_closed():
+            return
+
+        loop.call_soon_threadsafe(manager.log)
 
     # ---- request helpers ----
 

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -22,6 +22,7 @@ from vllm.outputs import RequestOutput
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.v1.engine import EngineCoreOutputs
+from vllm.v1.metrics.stats import IterationStats
 
 from vllm_omni.distributed.omni_connectors.adapter import compute_talker_prompt_ids_length
 from vllm_omni.engine import (
@@ -142,6 +143,7 @@ class Orchestrator:
         stage_vllm_configs: list[Any],
         *,
         async_chunk: bool = False,
+        logger_manager: Any | None = None,
         pd_config: dict[str, Any] | None = None,
     ) -> None:
         self.request_async_queue = request_async_queue
@@ -154,6 +156,10 @@ class Orchestrator:
         self.stage_clients: list[Any] = stage_clients
         self.output_processors: list[Any] = output_processors
         self.stage_vllm_configs: list[Any] = stage_vllm_configs
+
+        # Stat logging (shared with AsyncOmniEngine, accessed only on this loop).
+        self.logger_manager = logger_manager
+        self.log_stats = logger_manager is not None
 
         # PD disaggregation state
         self._pd_pair: tuple[int, int] | None = None
@@ -771,10 +777,13 @@ class Orchestrator:
         """
         processor = self.output_processors[stage_id]
 
+        num_outputs = len(raw_outputs.outputs)
+        iteration_stats = IterationStats() if (self.log_stats and num_outputs) else None
+
         processed = processor.process_outputs(
             raw_outputs.outputs,
             raw_outputs.timestamp,
-            None,
+            iteration_stats,
         )
         for eco in raw_outputs.outputs:
             if not hasattr(eco, "request_id"):
@@ -789,6 +798,13 @@ class Orchestrator:
 
         if raw_outputs.scheduler_stats is not None:
             processor.update_scheduler_stats(raw_outputs.scheduler_stats)
+
+        if self.logger_manager is not None:
+            self.logger_manager.record(
+                engine_idx=stage_id,
+                scheduler_stats=raw_outputs.scheduler_stats,
+                iteration_stats=iteration_stats,
+            )
 
         return processed.request_outputs
 

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -800,11 +800,21 @@ class Orchestrator:
             processor.update_scheduler_stats(raw_outputs.scheduler_stats)
 
         if self.logger_manager is not None:
-            self.logger_manager.record(
-                engine_idx=stage_id,
-                scheduler_stats=raw_outputs.scheduler_stats,
-                iteration_stats=iteration_stats,
-            )
+            # Fire-and-forget: offload Prometheus / logger work so it
+            # doesn't block the output-processing hot path.  Runs on the
+            # same orchestrator loop (single-threaded, no lock needed).
+            manager = self.logger_manager
+            sched_stats = raw_outputs.scheduler_stats
+            iter_stats = iteration_stats
+
+            async def _record() -> None:
+                manager.record(
+                    engine_idx=stage_id,
+                    scheduler_stats=sched_stats,
+                    iteration_stats=iter_stats,
+                )
+
+            asyncio.create_task(_record())
 
         return processed.request_outputs
 

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -755,11 +755,13 @@ class AsyncOmni(EngineClient, OmniBase):
         return False
 
     async def do_log_stats(self) -> None:
-        """Log statistics.
+        """Delegate stat logging to AsyncOmniEngine.
 
-        TODO: Forward to Orchestrator process via message.
+        The actual StatLoggerManager.log() call is scheduled on the
+        orchestrator thread's event loop so that record() and log()
+        never race on the same accumulators.
         """
-        pass
+        await self.engine.do_log_stats()
 
     async def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         """Return the task set exposed by the orchestrator-backed engine."""


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Redo https://github.com/vllm-project/vllm-omni/pull/2551, which made  Qwen3-Omni performance regression before. This PR is fixing the performance issue.

- Derive log_stats from stage0 engine_args.disable_log_stats instead of hardcoding False; thread it through spawn_stage_core and MultimodalOutputProcessor.
- Build a single StatLoggerManager in _bootstrap_orchestrator with one engine_idx per stage; pass it to Orchestrator.
- Orchestrator: accept logger_manager, derive log_stats from it; create IterationStats and call manager.record() in _process_stage_outputs.
- AsyncOmniEngine.do_log_stats: fire-and-forget via loop.call_soon_threadsafe(manager.log) to avoid blocking the API server thread while keeping all StatLoggerManager access on the orchestrator loop (no data race).
- AsyncOmni.do_log_stats: delegate to self.engine.do_log_stats().
- Add guard tests for do_log_stats no-op branches.


## Test Plan

Run Omni Test.

```
vllm bench serve \
    --omni \
  --dataset-name random \
  --port 8000 \
  --max-concurrency 10 \
  --model Qwen/Qwen3-Omni-30B-A3B-Instruct \
  --endpoint /v1/chat/completions \
  --backend openai-chat-omni \
  --num-prompts 100 \
  --random-input-len 100 \
  --ignore-eos \
  --percentile-metrics ttft,tpot,itl,e2el,audio_ttfp,audio_rtf \
  --random-output-len 100 \
  --extra_body '{"modalities": ["text", "audio"]}'
```

## Test Result

https://buildkite.com/vllm/vllm-omni/builds/7245/steps/canvas

```
(APIServer pid=367) INFO 04-19 14:07:00 [stage_engine_core_client.py:172] [StageEngineCoreClient] Stage-0 adding request: chatcmpl-bench-75e3fce4-13
(APIServer pid=367) INFO 04-19 14:07:00 [stage_engine_core_client.py:172] [StageEngineCoreClient] Stage-1 adding request: chatcmpl-bench-75e3fce4-13
(APIServer pid=367) INFO 04-19 14:07:00 [stage_engine_core_client.py:172] [StageEngineCoreClient] Stage-2 adding request: chatcmpl-bench-75e3fce4-13
(APIServer pid=367) INFO 04-19 14:07:09 [loggers.py:259] Engine 000: Avg prompt throughput: 250.8 tokens/s, Avg generation throughput: 90.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=367) INFO 04-19 14:07:09 [loggers.py:259] Engine 001: Avg prompt throughput: 251.4 tokens/s, Avg generation throughput: 66.9 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.2%, Prefix cache hit rate: 0.0%
(APIServer pid=367) INFO 04-19 14:07:09 [loggers.py:259] Engine 002: Avg prompt throughput: 251.4 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=367) INFO 04-19 14:07:19 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=367) INFO 04-19 14:07:19 [loggers.py:259] Engine 001: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 74.8 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.2%, Prefix cache hit rate: 0.0%
(APIServer pid=367) INFO 04-19 14:07:19 [loggers.py:259] Engine 002: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=367) INFO 04-19 14:07:29 [loggers.py:259] Engine 001: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 74.8 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.2%, Prefix cache hit rate: 0.0%
(APIServer pid=367) INFO 04-19 14:07:39 [loggers.py:259] Engine 001: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 46.6 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=367) INFO 04-19 14:07:49 [loggers.py:259] Engine 001: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=367) INFO 04-19 14:08:09 [loggers.py:259] Engine 002: Avg prompt throughput: 251.4 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 2 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=367) INFO 04-19 14:08:19 [loggers.py:259] Engine 002: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 2 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
