### PR TITLE
[Quant] Wire quant_config through HunyuanVideo-1.5 and Wan2.2 DiT for online FP8

### DIFF
--- a/benchmarks/diffusion/bench_video_fp8.py
+++ b/benchmarks/diffusion/bench_video_fp8.py
@@ -77,7 +77,9 @@ def _extract_video(outputs) -> np.ndarray:
 
     if isinstance(frames, torch.Tensor):
         v = frames.detach().cpu()
-        if v.dim() == 5:
+        # Strip extra leading dims (batch, num_videos_per_prompt, etc.) until 4D.
+        # Wan2.2 returns 6D ([B, N, C, T, H, W]); HV-1.5 returns 5D.
+        while v.dim() > 4:
             v = v[0]
         if v.dim() == 4 and v.shape[0] in (3, 4):
             v = v.permute(1, 2, 3, 0)
@@ -213,20 +215,27 @@ def main() -> None:
         print(f"  peak {mem_fp8:.2f} GiB, {t_fp8:.2f}s -> {fp8_path}", flush=True)
 
         print("\n  computing LPIPS/PSNR/SSIM...", flush=True)
-        m = compute_metrics(v_bf16, v_fp8)
-        print(
-            f"  LPIPS={m['lpips']:.4f}  PSNR={m['psnr']:.2f}dB  SSIM={m['ssim']:.4f}",
-            flush=True,
-        )
+        try:
+            m = compute_metrics(v_bf16, v_fp8)
+            print(
+                f"  LPIPS={m['lpips']:.4f}  PSNR={m['psnr']:.2f}dB  SSIM={m['ssim']:.4f}",
+                flush=True,
+            )
+            quality_cols = f"{m['lpips']:.4f} | {m['psnr']:.2f} | {m['ssim']:.4f}"
+        except Exception as e:
+            print(f"  metric computation failed: {e}", flush=True)
+            quality_cols = "n/a | n/a | n/a"
 
         mem_red = (1 - mem_fp8 / mem_bf16) if mem_bf16 > 0 else 0.0
         speedup = (1 - t_fp8 / t_bf16) if t_bf16 > 0 else 0.0
-        rows.append(
+        row = (
             f"| {c['id']} | {c['task']} "
             f"| {mem_bf16:.2f} GiB | {mem_fp8:.2f} GiB | {mem_red:.0%} "
             f"| {t_bf16:.2f}s | {t_fp8:.2f}s | {speedup:.0%} "
-            f"| {m['lpips']:.4f} | {m['psnr']:.2f} | {m['ssim']:.4f} |"
+            f"| {quality_cols} |"
         )
+        print(f"\n  row: {row}", flush=True)
+        rows.append(row)
 
     print("\n\n## Benchmark (H100 80GB × 1)\n")
     print(

--- a/benchmarks/diffusion/bench_video_fp8.py
+++ b/benchmarks/diffusion/bench_video_fp8.py
@@ -10,18 +10,19 @@ Target: 1×H100 80GB. Wan2.2 uses the TI2V-5B dense checkpoint (fits in 80GB
 BF16); for A14B MoE you need 2×H100 + TP=2 or CPU offload.
 
 Deps:
-    pip install lpips scikit-image pynvml
+    pip install lpips scikit-image pynvml imageio[ffmpeg]
 
 Usage:
-    python benchmarks/diffusion/bench_video_fp8.py              # both models
-    python benchmarks/diffusion/bench_video_fp8.py --only hv15  # HV-1.5 only
-    python benchmarks/diffusion/bench_video_fp8.py --only wan22 # Wan2.2 only
+    python benchmarks/diffusion/bench_video_fp8.py                           # both models
+    python benchmarks/diffusion/bench_video_fp8.py --only hv15               # HV-1.5 only
+    python benchmarks/diffusion/bench_video_fp8.py --output-dir ./my_videos  # custom dir
 """
 
 from __future__ import annotations
 
 import argparse
 import gc
+import os
 import threading
 import time
 
@@ -154,6 +155,15 @@ def run(model: str, quantization: str | None, kwargs: dict) -> tuple[float, floa
         torch.cuda.synchronize()
 
 
+def save_video(video: np.ndarray, path: str, fps: int = 24) -> None:
+    """Save [T, H, W, 3] float video in [0, 1] as MP4."""
+    import imageio.v2 as imageio
+
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    frames_uint8 = (np.clip(video, 0.0, 1.0) * 255).astype(np.uint8)
+    imageio.mimsave(path, list(frames_uint8), fps=fps, codec="libx264", quality=8)
+
+
 def compute_metrics(bf16: np.ndarray, fp8: np.ndarray) -> dict[str, float]:
     """Frame-averaged LPIPS (lower better), PSNR (higher better), SSIM (higher better)."""
     import lpips
@@ -182,18 +192,25 @@ def compute_metrics(bf16: np.ndarray, fp8: np.ndarray) -> dict[str, float]:
 def main() -> None:
     p = argparse.ArgumentParser()
     p.add_argument("--only", choices=list(CASES), default=None)
+    p.add_argument("--output-dir", default="./bench_output", help="Where to save MP4s.")
+    p.add_argument("--fps", type=int, default=24)
     args = p.parse_args()
-    cases = [CASES[args.only]] if args.only else list(CASES.values())
 
+    keys = [args.only] if args.only else list(CASES)
     rows: list[str] = []
-    for c in cases:
+    for case_key in keys:
+        c = CASES[case_key]
         print(f"\n=== {c['id']} BF16 ===", flush=True)
         mem_bf16, t_bf16, v_bf16 = run(c["model"], None, c["kwargs"])
-        print(f"  peak {mem_bf16:.2f} GiB, {t_bf16:.2f}s", flush=True)
+        bf16_path = os.path.join(args.output_dir, f"{case_key}_bf16_seed{SEED}.mp4")
+        save_video(v_bf16, bf16_path, fps=args.fps)
+        print(f"  peak {mem_bf16:.2f} GiB, {t_bf16:.2f}s -> {bf16_path}", flush=True)
 
         print(f"\n=== {c['id']} FP8 ===", flush=True)
         mem_fp8, t_fp8, v_fp8 = run(c["model"], "fp8", c["kwargs"])
-        print(f"  peak {mem_fp8:.2f} GiB, {t_fp8:.2f}s", flush=True)
+        fp8_path = os.path.join(args.output_dir, f"{case_key}_fp8_seed{SEED}.mp4")
+        save_video(v_fp8, fp8_path, fps=args.fps)
+        print(f"  peak {mem_fp8:.2f} GiB, {t_fp8:.2f}s -> {fp8_path}", flush=True)
 
         print("\n  computing LPIPS/PSNR/SSIM...", flush=True)
         m = compute_metrics(v_bf16, v_fp8)

--- a/benchmarks/diffusion/bench_video_fp8.py
+++ b/benchmarks/diffusion/bench_video_fp8.py
@@ -13,9 +13,11 @@ Deps:
     pip install lpips scikit-image pynvml imageio[ffmpeg]
 
 Usage:
-    python benchmarks/diffusion/bench_video_fp8.py                           # both models
-    python benchmarks/diffusion/bench_video_fp8.py --only hv15               # HV-1.5 only
-    python benchmarks/diffusion/bench_video_fp8.py --output-dir ./my_videos  # custom dir
+    python benchmarks/diffusion/bench_video_fp8.py                           # both models, defaults
+    python benchmarks/diffusion/bench_video_fp8.py --only wan22              # one model
+    python benchmarks/diffusion/bench_video_fp8.py --only wan22 \\
+        --prompt "An astronaut riding a horse on Mars" \\
+        --num-frames 121 --steps 40 --tag long
 """
 
 from __future__ import annotations
@@ -150,7 +152,7 @@ class _PeakPoller:
             self._thread.join(timeout=2.0)
 
 
-def run(model: str, quantization: str | None, kwargs: dict) -> tuple[float, float, np.ndarray]:
+def run(model: str, quantization: str | None, kwargs: dict, prompt: str = PROMPT) -> tuple[float, float, np.ndarray]:
     """One (model, precision) pair: warmup + timed run. Returns (peak_gib, seconds, video).
 
     Uses integer `seed=` via sampling params (pickles to the worker subprocess correctly —
@@ -163,12 +165,12 @@ def run(model: str, quantization: str | None, kwargs: dict) -> tuple[float, floa
     omni = Omni(**omni_kw)
     try:
         # warmup
-        omni.generate(PROMPT, OmniDiffusionSamplingParams(**kwargs, seed=0))
+        omni.generate(prompt, OmniDiffusionSamplingParams(**kwargs, seed=0))
         torch.cuda.synchronize()
 
         with _PeakPoller() as poll:
             t0 = time.perf_counter()
-            outputs = omni.generate(PROMPT, OmniDiffusionSamplingParams(**kwargs, seed=SEED))
+            outputs = omni.generate(prompt, OmniDiffusionSamplingParams(**kwargs, seed=SEED))
             torch.cuda.synchronize()
             elapsed = time.perf_counter() - t0
         peak = poll.peak
@@ -220,21 +222,38 @@ def main() -> None:
     p.add_argument("--only", choices=list(CASES), default=None)
     p.add_argument("--output-dir", default="./bench_output", help="Where to save MP4s.")
     p.add_argument("--fps", type=int, default=24)
+    p.add_argument("--prompt", type=str, default=None, help="Override the default prompt.")
+    p.add_argument("--num-frames", type=int, default=None, help="Override num_frames.")
+    p.add_argument("--steps", type=int, default=None, help="Override num_inference_steps.")
+    p.add_argument("--tag", type=str, default="", help="Suffix for output filenames (e.g. 'long').")
     args = p.parse_args()
+
+    prompt = args.prompt or PROMPT
+    print(f"Prompt: {prompt}", flush=True)
 
     keys = [args.only] if args.only else list(CASES)
     rows: list[str] = []
     for case_key in keys:
-        c = CASES[case_key]
+        c = dict(CASES[case_key])  # shallow copy so we don't mutate the module-level dict
+        c["kwargs"] = dict(c["kwargs"])
+        if args.num_frames is not None:
+            c["kwargs"]["num_frames"] = args.num_frames
+        if args.steps is not None:
+            c["kwargs"]["num_inference_steps"] = args.steps
+        c["task"] = (
+            f"T2V {c['kwargs']['height']}x{c['kwargs']['width']}, "
+            f"{c['kwargs']['num_frames']} frames, {c['kwargs']['num_inference_steps']} steps"
+        )
+        suffix = f"_{args.tag}" if args.tag else ""
         print(f"\n=== {c['id']} BF16 ===", flush=True)
-        mem_bf16, t_bf16, v_bf16 = run(c["model"], None, c["kwargs"])
-        bf16_path = os.path.join(args.output_dir, f"{case_key}_bf16_seed{SEED}.mp4")
+        mem_bf16, t_bf16, v_bf16 = run(c["model"], None, c["kwargs"], prompt=prompt)
+        bf16_path = os.path.join(args.output_dir, f"{case_key}_bf16_seed{SEED}{suffix}.mp4")
         save_video(v_bf16, bf16_path, fps=args.fps)
         print(f"  peak {mem_bf16:.2f} GiB, {t_bf16:.2f}s -> {bf16_path}", flush=True)
 
         print(f"\n=== {c['id']} FP8 ===", flush=True)
-        mem_fp8, t_fp8, v_fp8 = run(c["model"], "fp8", c["kwargs"])
-        fp8_path = os.path.join(args.output_dir, f"{case_key}_fp8_seed{SEED}.mp4")
+        mem_fp8, t_fp8, v_fp8 = run(c["model"], "fp8", c["kwargs"], prompt=prompt)
+        fp8_path = os.path.join(args.output_dir, f"{case_key}_fp8_seed{SEED}{suffix}.mp4")
         save_video(v_fp8, fp8_path, fps=args.fps)
         print(f"  peak {mem_fp8:.2f} GiB, {t_fp8:.2f}s -> {fp8_path}", flush=True)
 

--- a/benchmarks/diffusion/bench_video_fp8.py
+++ b/benchmarks/diffusion/bench_video_fp8.py
@@ -22,6 +22,11 @@ Usage:
     python benchmarks/diffusion/bench_video_fp8.py --only hv15 \\
         --presets S1,S2,S3,S4 --frames-list 33,121 --steps 30 --tag sweep
 
+    # Winning preset + block-wise FP8 (per-tile scales, closer to BF16 quality).
+    # Block size [128, 128] is the standard; try [1, 128] for per-output-row precision.
+    python benchmarks/diffusion/bench_video_fp8.py --only hv15 \\
+        --presets S4 --weight-block-size 128,128 --num-frames 33 --tag bs128
+
     # Custom prompt + long-only run
     python benchmarks/diffusion/bench_video_fp8.py --only hv15 \\
         --prompt "An astronaut riding a horse on Mars" \\
@@ -160,8 +165,16 @@ class _PeakPoller:
             self._thread.join(timeout=2.0)
 
 
-def run(model: str, quantization: str | None, kwargs: dict, prompt: str = PROMPT) -> tuple[float, float, np.ndarray]:
+def run(
+    model: str,
+    quantization: str | dict | None,
+    kwargs: dict,
+    prompt: str = PROMPT,
+) -> tuple[float, float, np.ndarray]:
     """One (model, precision) pair: warmup + timed run. Returns (peak_gib, seconds, video).
+
+    `quantization` may be None (BF16), a string like "fp8", or a dict like
+    `{"method": "fp8", "weight_block_size": [128, 128]}` for finer-grained FP8 config.
 
     Uses integer `seed=` via sampling params (pickles to the worker subprocess correctly —
     `torch.Generator` handles do not propagate across processes). Peak VRAM is captured via
@@ -246,7 +259,22 @@ def main() -> None:
         default=None,
         help="Comma-separated list of num_frames to sweep (e.g. '33,121'). Overrides --num-frames.",
     )
+    p.add_argument(
+        "--weight-block-size",
+        type=str,
+        default=None,
+        help="FP8 weight quantization block size as 'M,N' (e.g. '128,128' for block-wise scales). "
+        "Default: per-tensor (one scale per linear). Requires activation_scheme=dynamic (default).",
+    )
     args = p.parse_args()
+
+    weight_block_size: list[int] | None = None
+    if args.weight_block_size:
+        parts = [int(x) for x in args.weight_block_size.split(",") if x.strip()]
+        if len(parts) != 2:
+            raise SystemExit(f"--weight-block-size must be 'M,N' (2 ints), got {args.weight_block_size!r}")
+        weight_block_size = parts
+        print(f"FP8 weight_block_size: {weight_block_size}", flush=True)
 
     prompt = args.prompt or PROMPT
     print(f"Prompt: {prompt}", flush=True)
@@ -297,9 +325,18 @@ def main() -> None:
                     continue
                 print(f"\n=== {base['id']} FP8 preset={preset} frames={frames} ===", flush=True)
                 os.environ["HV15_FP8_PRESET"] = preset
-                mem_fp8, t_fp8, v_fp8 = run(base["model"], "fp8", kwargs_f, prompt=prompt)
+
+                # Per-tensor (string "fp8") vs block-wise (dict with weight_block_size).
+                quant_spec: str | dict = "fp8"
+                bs_tag = ""
+                if weight_block_size is not None:
+                    quant_spec = {"method": "fp8", "weight_block_size": weight_block_size}
+                    bs_tag = f"_bs{weight_block_size[0]}x{weight_block_size[1]}"
+
+                mem_fp8, t_fp8, v_fp8 = run(base["model"], quant_spec, kwargs_f, prompt=prompt)
                 fp8_path = os.path.join(
-                    args.output_dir, f"{case_key}_fp8_{preset}_seed{SEED}{frame_suffix}{suffix_tag}.mp4"
+                    args.output_dir,
+                    f"{case_key}_fp8_{preset}{bs_tag}_seed{SEED}{frame_suffix}{suffix_tag}.mp4",
                 )
                 save_video(v_fp8, fp8_path, fps=args.fps)
                 print(f"  peak {mem_fp8:.2f} GiB, {t_fp8:.2f}s -> {fp8_path}", flush=True)
@@ -318,8 +355,11 @@ def main() -> None:
 
                 mem_red = (1 - mem_fp8 / mem_bf16) if mem_bf16 > 0 else 0.0
                 speedup = (1 - t_fp8 / t_bf16) if t_bf16 > 0 else 0.0
+                preset_label = (
+                    f"{preset}+bs{weight_block_size[0]}x{weight_block_size[1]}" if weight_block_size else preset
+                )
                 row = (
-                    f"| {base['id']} | {task} | **{preset}** "
+                    f"| {base['id']} | {task} | **{preset_label}** "
                     f"| {mem_bf16:.2f} GiB | {mem_fp8:.2f} GiB | {mem_red:.0%} "
                     f"| {t_bf16:.2f}s | {t_fp8:.2f}s | {speedup:.0%} "
                     f"| {quality_cols} |"

--- a/benchmarks/diffusion/bench_video_fp8.py
+++ b/benchmarks/diffusion/bench_video_fp8.py
@@ -10,7 +10,7 @@ Target: 1×H100 80GB. Wan2.2 uses the TI2V-5B dense checkpoint (fits in 80GB
 BF16); for A14B MoE you need 2×H100 + TP=2 or CPU offload.
 
 Deps:
-    pip install lpips scikit-image
+    pip install lpips scikit-image pynvml
 
 Usage:
     python benchmarks/diffusion/bench_video_fp8.py              # both models
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import gc
+import threading
 import time
 
 import numpy as np
@@ -85,29 +86,65 @@ def _extract_video(outputs) -> np.ndarray:
     return np.asarray(frames).astype(np.float32) / 255.0
 
 
+def _nvml_used_gib() -> float:
+    """Process-wide GPU-0 used memory in GiB. Captures the worker subprocess too."""
+    import pynvml
+
+    pynvml.nvmlInit()
+    try:
+        h = pynvml.nvmlDeviceGetHandleByIndex(0)
+        return pynvml.nvmlDeviceGetMemoryInfo(h).used / (1024**3)
+    finally:
+        pynvml.nvmlShutdown()
+
+
+class _PeakPoller:
+    """Polls process-wide NVML 'used' memory every 100ms, tracks peak."""
+
+    def __init__(self, interval_s: float = 0.1) -> None:
+        self.interval_s = interval_s
+        self.peak = 0.0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> _PeakPoller:
+        def loop() -> None:
+            while not self._stop.is_set():
+                self.peak = max(self.peak, _nvml_used_gib())
+                self._stop.wait(self.interval_s)
+
+        self._thread = threading.Thread(target=loop, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+
+
 def run(model: str, quantization: str | None, kwargs: dict) -> tuple[float, float, np.ndarray]:
-    """One (model, precision) pair: warmup + timed run. Returns (peak_gib, seconds, video)."""
+    """One (model, precision) pair: warmup + timed run. Returns (peak_gib, seconds, video).
+
+    Uses integer `seed=` via sampling params (pickles to the worker subprocess correctly —
+    `torch.Generator` handles do not propagate across processes). Peak VRAM is captured via
+    pynvml polling so the worker's memory counts.
+    """
     omni_kw: dict = {"model": model}
     if quantization:
         omni_kw["quantization"] = quantization
     omni = Omni(**omni_kw)
     try:
         # warmup
-        omni.generate(
-            PROMPT,
-            OmniDiffusionSamplingParams(**kwargs, generator=torch.Generator("cuda").manual_seed(0)),
-        )
+        omni.generate(PROMPT, OmniDiffusionSamplingParams(**kwargs, seed=0))
         torch.cuda.synchronize()
-        torch.cuda.reset_peak_memory_stats()
 
-        t0 = time.perf_counter()
-        outputs = omni.generate(
-            PROMPT,
-            OmniDiffusionSamplingParams(**kwargs, generator=torch.Generator("cuda").manual_seed(SEED)),
-        )
-        torch.cuda.synchronize()
-        elapsed = time.perf_counter() - t0
-        peak = torch.cuda.max_memory_allocated() / (1024**3)
+        with _PeakPoller() as poll:
+            t0 = time.perf_counter()
+            outputs = omni.generate(PROMPT, OmniDiffusionSamplingParams(**kwargs, seed=SEED))
+            torch.cuda.synchronize()
+            elapsed = time.perf_counter() - t0
+        peak = poll.peak
         video = _extract_video(outputs)
         return peak, elapsed, video
     finally:
@@ -165,8 +202,8 @@ def main() -> None:
             flush=True,
         )
 
-        mem_red = 1 - mem_fp8 / mem_bf16
-        speedup = 1 - t_fp8 / t_bf16
+        mem_red = (1 - mem_fp8 / mem_bf16) if mem_bf16 > 0 else 0.0
+        speedup = (1 - t_fp8 / t_bf16) if t_bf16 > 0 else 0.0
         rows.append(
             f"| {c['id']} | {c['task']} "
             f"| {mem_bf16:.2f} GiB | {mem_fp8:.2f} GiB | {mem_red:.0%} "

--- a/benchmarks/diffusion/bench_video_fp8.py
+++ b/benchmarks/diffusion/bench_video_fp8.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""BF16 vs FP8 perf/mem/quality bench for HunyuanVideo-1.5 and Wan2.2.
+
+Runs each (model, precision) pair with the same seed, records peak VRAM and
+wall time, then computes frame-averaged LPIPS / PSNR / SSIM between the BF16
+and FP8 outputs. Emits a markdown table suitable for pasting into a PR.
+
+Target: 1×H100 80GB. Wan2.2 uses the TI2V-5B dense checkpoint (fits in 80GB
+BF16); for A14B MoE you need 2×H100 + TP=2 or CPU offload.
+
+Deps:
+    pip install lpips scikit-image
+
+Usage:
+    python benchmarks/diffusion/bench_video_fp8.py              # both models
+    python benchmarks/diffusion/bench_video_fp8.py --only hv15  # HV-1.5 only
+    python benchmarks/diffusion/bench_video_fp8.py --only wan22 # Wan2.2 only
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import time
+
+import numpy as np
+import torch
+
+from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+CASES = {
+    "hv15": dict(
+        id="HunyuanVideo-1.5",
+        model="hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v",
+        task="T2V 480x832, 33 frames, 30 steps",
+        kwargs=dict(
+            height=480,
+            width=832,
+            num_inference_steps=30,
+            num_frames=33,
+            guidance_scale=6.0,
+        ),
+    ),
+    "wan22": dict(
+        id="Wan2.2 (TI2V 5B)",
+        model="Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+        task="T2V 704x1280, 49 frames, 30 steps",
+        kwargs=dict(
+            height=704,
+            width=1280,
+            num_inference_steps=30,
+            num_frames=49,
+            guidance_scale=5.0,
+        ),
+    ),
+}
+PROMPT = "A dog running across a field of golden wheat."
+SEED = 42
+
+
+def _extract_video(outputs) -> np.ndarray:
+    """Return [T, H, W, 3] float in [0, 1]."""
+    from vllm_omni.outputs import OmniRequestOutput
+
+    first = outputs[0]
+    if hasattr(first, "request_output") and isinstance(first.request_output, list):
+        inner = first.request_output[0]
+        frames = inner.images[0] if isinstance(inner, OmniRequestOutput) and inner.images else inner
+    elif hasattr(first, "images") and first.images:
+        frames = first.images
+    else:
+        raise ValueError("Cannot extract frames from output.")
+
+    if isinstance(frames, torch.Tensor):
+        v = frames.detach().cpu()
+        if v.dim() == 5:
+            v = v[0]
+        if v.dim() == 4 and v.shape[0] in (3, 4):
+            v = v.permute(1, 2, 3, 0)
+        if v.is_floating_point():
+            v = v.clamp(-1, 1) * 0.5 + 0.5
+        return v.float().numpy()
+    return np.asarray(frames).astype(np.float32) / 255.0
+
+
+def run(model: str, quantization: str | None, kwargs: dict) -> tuple[float, float, np.ndarray]:
+    """One (model, precision) pair: warmup + timed run. Returns (peak_gib, seconds, video)."""
+    omni_kw: dict = {"model": model}
+    if quantization:
+        omni_kw["quantization"] = quantization
+    omni = Omni(**omni_kw)
+    try:
+        # warmup
+        omni.generate(
+            PROMPT,
+            OmniDiffusionSamplingParams(**kwargs, generator=torch.Generator("cuda").manual_seed(0)),
+        )
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+
+        t0 = time.perf_counter()
+        outputs = omni.generate(
+            PROMPT,
+            OmniDiffusionSamplingParams(**kwargs, generator=torch.Generator("cuda").manual_seed(SEED)),
+        )
+        torch.cuda.synchronize()
+        elapsed = time.perf_counter() - t0
+        peak = torch.cuda.max_memory_allocated() / (1024**3)
+        video = _extract_video(outputs)
+        return peak, elapsed, video
+    finally:
+        del omni
+        gc.collect()
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+
+
+def compute_metrics(bf16: np.ndarray, fp8: np.ndarray) -> dict[str, float]:
+    """Frame-averaged LPIPS (lower better), PSNR (higher better), SSIM (higher better)."""
+    import lpips
+    from skimage.metrics import peak_signal_noise_ratio, structural_similarity
+
+    t = min(bf16.shape[0], fp8.shape[0])
+    bf16, fp8 = bf16[:t], fp8[:t]
+
+    # LPIPS expects [B, 3, H, W] in [-1, 1]
+    lp = lpips.LPIPS(net="alex").cuda().eval()
+
+    def to_lp(x: np.ndarray) -> torch.Tensor:
+        return (torch.from_numpy(x).permute(0, 3, 1, 2).cuda() * 2 - 1).float()
+
+    with torch.no_grad():
+        lpips_scores = lp(to_lp(bf16), to_lp(fp8)).squeeze().cpu().numpy()
+    mean_lpips = float(np.mean(lpips_scores))
+
+    psnrs, ssims = [], []
+    for a, b in zip(bf16, fp8, strict=False):
+        psnrs.append(peak_signal_noise_ratio(a, b, data_range=1.0))
+        ssims.append(structural_similarity(a, b, data_range=1.0, channel_axis=-1))
+    return dict(lpips=mean_lpips, psnr=float(np.mean(psnrs)), ssim=float(np.mean(ssims)))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--only", choices=list(CASES), default=None)
+    args = p.parse_args()
+    cases = [CASES[args.only]] if args.only else list(CASES.values())
+
+    rows: list[str] = []
+    for c in cases:
+        print(f"\n=== {c['id']} BF16 ===", flush=True)
+        mem_bf16, t_bf16, v_bf16 = run(c["model"], None, c["kwargs"])
+        print(f"  peak {mem_bf16:.2f} GiB, {t_bf16:.2f}s", flush=True)
+
+        print(f"\n=== {c['id']} FP8 ===", flush=True)
+        mem_fp8, t_fp8, v_fp8 = run(c["model"], "fp8", c["kwargs"])
+        print(f"  peak {mem_fp8:.2f} GiB, {t_fp8:.2f}s", flush=True)
+
+        print("\n  computing LPIPS/PSNR/SSIM...", flush=True)
+        m = compute_metrics(v_bf16, v_fp8)
+        print(
+            f"  LPIPS={m['lpips']:.4f}  PSNR={m['psnr']:.2f}dB  SSIM={m['ssim']:.4f}",
+            flush=True,
+        )
+
+        mem_red = 1 - mem_fp8 / mem_bf16
+        speedup = 1 - t_fp8 / t_bf16
+        rows.append(
+            f"| {c['id']} | {c['task']} "
+            f"| {mem_bf16:.2f} GiB | {mem_fp8:.2f} GiB | {mem_red:.0%} "
+            f"| {t_bf16:.2f}s | {t_fp8:.2f}s | {speedup:.0%} "
+            f"| {m['lpips']:.4f} | {m['psnr']:.2f} | {m['ssim']:.4f} |"
+        )
+
+    print("\n\n## Benchmark (H100 80GB × 1)\n")
+    print(
+        "| Model | Task | Mem BF16 | Mem FP8 | Mem Red | Time BF16 | Time FP8 | Speedup | LPIPS ↓ | PSNR ↑ | SSIM ↑ |"
+    )
+    print(
+        "|-------|------|----------|---------|---------|-----------|----------|---------|---------|--------|--------|"
+    )
+    print("\n".join(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/diffusion/bench_video_fp8.py
+++ b/benchmarks/diffusion/bench_video_fp8.py
@@ -63,7 +63,7 @@ SEED = 42
 
 
 def _extract_video(outputs) -> np.ndarray:
-    """Return [T, H, W, 3] float in [0, 1]."""
+    """Return [T, H, W, 3] float in [0, 1]. Handles any dim order / batch wrappers."""
     from vllm_omni.outputs import OmniRequestOutput
 
     first = outputs[0]
@@ -76,17 +76,41 @@ def _extract_video(outputs) -> np.ndarray:
         raise ValueError("Cannot extract frames from output.")
 
     if isinstance(frames, torch.Tensor):
-        v = frames.detach().cpu()
-        # Strip extra leading dims (batch, num_videos_per_prompt, etc.) until 4D.
-        # Wan2.2 returns 6D ([B, N, C, T, H, W]); HV-1.5 returns 5D.
-        while v.dim() > 4:
-            v = v[0]
-        if v.dim() == 4 and v.shape[0] in (3, 4):
-            v = v.permute(1, 2, 3, 0)
-        if v.is_floating_point():
-            v = v.clamp(-1, 1) * 0.5 + 0.5
-        return v.float().numpy()
-    return np.asarray(frames).astype(np.float32) / 255.0
+        v = frames.detach().cpu().float().numpy()
+    else:
+        v = np.asarray(frames)
+        if v.dtype == np.uint8:
+            v = v.astype(np.float32) / 255.0
+        else:
+            v = v.astype(np.float32)
+
+    print(f"    _extract_video raw shape: {v.shape}, dtype: {v.dtype}", flush=True)
+
+    # Clamp [-1, 1] → [0, 1] if signed
+    if v.dtype.kind == "f" and v.min() < -1e-3:
+        v = np.clip(v, -1.0, 1.0) * 0.5 + 0.5
+
+    # Strip leading size-1 dims, then any extra leading dims (take first)
+    while v.ndim > 4 and v.shape[0] == 1:
+        v = v[0]
+    while v.ndim > 4:
+        v = v[0]
+
+    if v.ndim != 4:
+        raise ValueError(f"Expected 4D video after reduction, got {v.shape}")
+
+    # Permute to [T, H, W, C]. Try in order: already-correct, [C, T, H, W], [T, C, H, W].
+    if v.shape[-1] in (1, 3, 4):
+        pass  # already [T, H, W, C]
+    elif v.shape[0] in (1, 3, 4):
+        v = np.transpose(v, (1, 2, 3, 0))  # [C, T, H, W] -> [T, H, W, C]
+    elif v.shape[1] in (1, 3, 4):
+        v = np.transpose(v, (0, 2, 3, 1))  # [T, C, H, W] -> [T, H, W, C]
+    else:
+        raise ValueError(f"Cannot identify channel axis in shape {v.shape}")
+
+    print(f"    _extract_video normalized shape: {v.shape}", flush=True)
+    return v
 
 
 def _nvml_used_gib() -> float:

--- a/benchmarks/diffusion/bench_video_fp8.py
+++ b/benchmarks/diffusion/bench_video_fp8.py
@@ -13,11 +13,19 @@ Deps:
     pip install lpips scikit-image pynvml imageio[ffmpeg]
 
 Usage:
-    python benchmarks/diffusion/bench_video_fp8.py                           # both models, defaults
-    python benchmarks/diffusion/bench_video_fp8.py --only wan22              # one model
-    python benchmarks/diffusion/bench_video_fp8.py --only wan22 \\
+    # single model, default config
+    python benchmarks/diffusion/bench_video_fp8.py --only hv15
+
+    # HV-1.5 sweep: 4 FP8 presets × 2 frame counts (short + long).
+    # S1 = FFN only, S2 = video stream only, S3 = all FP8 except encoder cross-attn,
+    # S4 = everything FP8. BF16 is captured once per frame count and reused.
+    python benchmarks/diffusion/bench_video_fp8.py --only hv15 \\
+        --presets S1,S2,S3,S4 --frames-list 33,121 --steps 30 --tag sweep
+
+    # Custom prompt + long-only run
+    python benchmarks/diffusion/bench_video_fp8.py --only hv15 \\
         --prompt "An astronaut riding a horse on Mars" \\
-        --num-frames 121 --steps 40 --tag long
+        --num-frames 121 --steps 40 --tag astronaut
 """
 
 from __future__ import annotations
@@ -223,71 +231,117 @@ def main() -> None:
     p.add_argument("--output-dir", default="./bench_output", help="Where to save MP4s.")
     p.add_argument("--fps", type=int, default=24)
     p.add_argument("--prompt", type=str, default=None, help="Override the default prompt.")
-    p.add_argument("--num-frames", type=int, default=None, help="Override num_frames.")
+    p.add_argument("--num-frames", type=int, default=None, help="Override num_frames (single value).")
     p.add_argument("--steps", type=int, default=None, help="Override num_inference_steps.")
-    p.add_argument("--tag", type=str, default="", help="Suffix for output filenames (e.g. 'long').")
+    p.add_argument("--tag", type=str, default="", help="Suffix for output filenames.")
+    p.add_argument(
+        "--presets",
+        type=str,
+        default="S4",
+        help="Comma-separated FP8 presets for HV-1.5 sweep (BF16,S1,S2,S3,S4). Ignored for other models.",
+    )
+    p.add_argument(
+        "--frames-list",
+        type=str,
+        default=None,
+        help="Comma-separated list of num_frames to sweep (e.g. '33,121'). Overrides --num-frames.",
+    )
     args = p.parse_args()
 
     prompt = args.prompt or PROMPT
     print(f"Prompt: {prompt}", flush=True)
 
+    presets = [s.strip().upper() for s in args.presets.split(",") if s.strip()]
+    valid_presets = {"BF16", "S1", "S2", "S3", "S4"}
+    for pr in presets:
+        if pr not in valid_presets:
+            raise SystemExit(f"Invalid preset {pr!r}. Expected one of {sorted(valid_presets)}")
+
     keys = [args.only] if args.only else list(CASES)
+    suffix_tag = f"_{args.tag}" if args.tag else ""
+
     rows: list[str] = []
     for case_key in keys:
-        c = dict(CASES[case_key])  # shallow copy so we don't mutate the module-level dict
-        c["kwargs"] = dict(c["kwargs"])
+        base = CASES[case_key]
+        base_kwargs = dict(base["kwargs"])
         if args.num_frames is not None:
-            c["kwargs"]["num_frames"] = args.num_frames
+            base_kwargs["num_frames"] = args.num_frames
         if args.steps is not None:
-            c["kwargs"]["num_inference_steps"] = args.steps
-        c["task"] = (
-            f"T2V {c['kwargs']['height']}x{c['kwargs']['width']}, "
-            f"{c['kwargs']['num_frames']} frames, {c['kwargs']['num_inference_steps']} steps"
+            base_kwargs["num_inference_steps"] = args.steps
+        frames_values = (
+            [int(x) for x in args.frames_list.split(",") if x.strip()]
+            if args.frames_list
+            else [base_kwargs["num_frames"]]
         )
-        suffix = f"_{args.tag}" if args.tag else ""
-        print(f"\n=== {c['id']} BF16 ===", flush=True)
-        mem_bf16, t_bf16, v_bf16 = run(c["model"], None, c["kwargs"], prompt=prompt)
-        bf16_path = os.path.join(args.output_dir, f"{case_key}_bf16_seed{SEED}{suffix}.mp4")
-        save_video(v_bf16, bf16_path, fps=args.fps)
-        print(f"  peak {mem_bf16:.2f} GiB, {t_bf16:.2f}s -> {bf16_path}", flush=True)
 
-        print(f"\n=== {c['id']} FP8 ===", flush=True)
-        mem_fp8, t_fp8, v_fp8 = run(c["model"], "fp8", c["kwargs"], prompt=prompt)
-        fp8_path = os.path.join(args.output_dir, f"{case_key}_fp8_seed{SEED}{suffix}.mp4")
-        save_video(v_fp8, fp8_path, fps=args.fps)
-        print(f"  peak {mem_fp8:.2f} GiB, {t_fp8:.2f}s -> {fp8_path}", flush=True)
-
-        print("\n  computing LPIPS/PSNR/SSIM...", flush=True)
-        try:
-            m = compute_metrics(v_bf16, v_fp8)
-            print(
-                f"  LPIPS={m['lpips']:.4f}  PSNR={m['psnr']:.2f}dB  SSIM={m['ssim']:.4f}",
-                flush=True,
+        for frames in frames_values:
+            kwargs_f = dict(base_kwargs)
+            kwargs_f["num_frames"] = frames
+            task = (
+                f"T2V {kwargs_f['height']}x{kwargs_f['width']}, "
+                f"{kwargs_f['num_frames']} frames, {kwargs_f['num_inference_steps']} steps"
             )
-            quality_cols = f"{m['lpips']:.4f} | {m['psnr']:.2f} | {m['ssim']:.4f}"
-        except Exception as e:
-            print(f"  metric computation failed: {e}", flush=True)
-            quality_cols = "n/a | n/a | n/a"
+            frame_suffix = f"_f{frames}"
 
-        mem_red = (1 - mem_fp8 / mem_bf16) if mem_bf16 > 0 else 0.0
-        speedup = (1 - t_fp8 / t_bf16) if t_bf16 > 0 else 0.0
-        row = (
-            f"| {c['id']} | {c['task']} "
-            f"| {mem_bf16:.2f} GiB | {mem_fp8:.2f} GiB | {mem_red:.0%} "
-            f"| {t_bf16:.2f}s | {t_fp8:.2f}s | {speedup:.0%} "
-            f"| {quality_cols} |"
-        )
-        print(f"\n  row: {row}", flush=True)
-        rows.append(row)
+            # BF16 baseline once per frame count.
+            print(f"\n=== {base['id']} BF16 frames={frames} ===", flush=True)
+            os.environ["HV15_FP8_PRESET"] = "BF16"  # harmless on other models
+            mem_bf16, t_bf16, v_bf16 = run(base["model"], None, kwargs_f, prompt=prompt)
+            bf16_path = os.path.join(args.output_dir, f"{case_key}_bf16_seed{SEED}{frame_suffix}{suffix_tag}.mp4")
+            save_video(v_bf16, bf16_path, fps=args.fps)
+            print(f"  peak {mem_bf16:.2f} GiB, {t_bf16:.2f}s -> {bf16_path}", flush=True)
 
-    print("\n\n## Benchmark (H100 80GB × 1)\n")
-    print(
-        "| Model | Task | Mem BF16 | Mem FP8 | Mem Red | Time BF16 | Time FP8 | Speedup | LPIPS ↓ | PSNR ↑ | SSIM ↑ |"
-    )
-    print(
-        "|-------|------|----------|---------|---------|-----------|----------|---------|---------|--------|--------|"
-    )
-    print("\n".join(rows))
+            # Sweep FP8 presets against the cached BF16 video.
+            for preset in presets:
+                if preset == "BF16":
+                    continue
+                print(f"\n=== {base['id']} FP8 preset={preset} frames={frames} ===", flush=True)
+                os.environ["HV15_FP8_PRESET"] = preset
+                mem_fp8, t_fp8, v_fp8 = run(base["model"], "fp8", kwargs_f, prompt=prompt)
+                fp8_path = os.path.join(
+                    args.output_dir, f"{case_key}_fp8_{preset}_seed{SEED}{frame_suffix}{suffix_tag}.mp4"
+                )
+                save_video(v_fp8, fp8_path, fps=args.fps)
+                print(f"  peak {mem_fp8:.2f} GiB, {t_fp8:.2f}s -> {fp8_path}", flush=True)
+
+                print("\n  computing LPIPS/PSNR/SSIM...", flush=True)
+                try:
+                    m = compute_metrics(v_bf16, v_fp8)
+                    print(
+                        f"  LPIPS={m['lpips']:.4f}  PSNR={m['psnr']:.2f}dB  SSIM={m['ssim']:.4f}",
+                        flush=True,
+                    )
+                    quality_cols = f"{m['lpips']:.4f} | {m['psnr']:.2f} | {m['ssim']:.4f}"
+                except Exception as e:
+                    print(f"  metric computation failed: {e}", flush=True)
+                    quality_cols = "n/a | n/a | n/a"
+
+                mem_red = (1 - mem_fp8 / mem_bf16) if mem_bf16 > 0 else 0.0
+                speedup = (1 - t_fp8 / t_bf16) if t_bf16 > 0 else 0.0
+                row = (
+                    f"| {base['id']} | {task} | **{preset}** "
+                    f"| {mem_bf16:.2f} GiB | {mem_fp8:.2f} GiB | {mem_red:.0%} "
+                    f"| {t_bf16:.2f}s | {t_fp8:.2f}s | {speedup:.0%} "
+                    f"| {quality_cols} |"
+                )
+                print(f"\n  row: {row}", flush=True)
+                rows.append(row)
+
+    header = [
+        "\n## Benchmark (H100 80GB × 1)\n",
+        f"Prompt: `{prompt}`\n",
+        "| Model | Task | Preset | Mem BF16 | Mem FP8 | Mem Red | Time BF16 | Time FP8 | Speedup | LPIPS ↓ | PSNR ↑ | SSIM ↑ |",
+        "|-------|------|--------|----------|---------|---------|-----------|----------|---------|---------|--------|--------|",
+        *rows,
+    ]
+    md = "\n".join(header)
+    print("\n" + md)
+
+    results_path = os.path.join(args.output_dir, "results.md")
+    os.makedirs(args.output_dir, exist_ok=True)
+    with open(results_path, "w", encoding="utf-8") as f:
+        f.write(md + "\n")
+    print(f"\nResults saved to {results_path}", flush=True)
 
 
 if __name__ == "__main__":

--- a/vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
@@ -31,6 +32,31 @@ if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
 logger = init_logger(__name__)
+
+
+# FP8 preset mechanism for sweep experiments (see benchmarks/diffusion/bench_video_fp8.py).
+# Env var HV15_FP8_PRESET selects which per-block linears get FP8:
+#   BF16 - nothing (same as --quantization none)
+#   S1   - FFN only (video + encoder)
+#   S2   - video stream only (self-attn QKV/out + video FFN)
+#   S3   - all FP8 except encoder cross-attn (keeps add_kv_proj, to_add_out BF16)
+#   S4   - everything FP8 (default, matches pre-sweep behavior)
+_HV15_FP8_PRESET_ROLES: dict[str, set[str]] = {
+    "BF16": set(),
+    "S1": {"video_ffn", "encoder_ffn"},
+    "S2": {"video_attn", "video_ffn"},
+    "S3": {"video_attn", "video_ffn", "encoder_ffn"},
+    "S4": {"video_attn", "encoder_attn", "video_ffn", "encoder_ffn"},
+}
+
+
+def _hv15_quant_for_role(base_quant_config, role: str):
+    """Resolve preset: return `base_quant_config` if `role` is FP8 under current preset, else None."""
+    if base_quant_config is None:
+        return None
+    preset = os.environ.get("HV15_FP8_PRESET", "S4").upper()
+    allowed = _HV15_FP8_PRESET_ROLES.get(preset, _HV15_FP8_PRESET_ROLES["S4"])
+    return base_quant_config if role in allowed else None
 
 
 class HunyuanVideo15PatchEmbed(nn.Module):
@@ -351,7 +377,7 @@ class HunyuanVideo15Attention(nn.Module):
             head_size=self.head_dim,
             total_num_heads=self.heads,
             bias=bias,
-            quant_config=quant_config,
+            quant_config=_hv15_quant_for_role(quant_config, "video_attn"),
             prefix=f"{prefix}.to_qkv",
         )
 
@@ -363,7 +389,7 @@ class HunyuanVideo15Attention(nn.Module):
                     bias=out_bias,
                     input_is_parallel=True,
                     return_bias=False,
-                    quant_config=quant_config,
+                    quant_config=_hv15_quant_for_role(quant_config, "video_attn"),
                     prefix=f"{prefix}.to_out.0",
                 ),
                 nn.Identity(),  # placeholder for dropout (none used)
@@ -379,7 +405,7 @@ class HunyuanVideo15Attention(nn.Module):
                 head_size=self.head_dim,
                 total_num_heads=self.heads,
                 bias=added_proj_bias,
-                quant_config=quant_config,
+                quant_config=_hv15_quant_for_role(quant_config, "encoder_attn"),
                 prefix=f"{prefix}.add_kv_proj",
             )
 
@@ -389,7 +415,7 @@ class HunyuanVideo15Attention(nn.Module):
                 bias=out_bias,
                 input_is_parallel=True,
                 return_bias=False,
-                quant_config=quant_config,
+                quant_config=_hv15_quant_for_role(quant_config, "encoder_attn"),
                 prefix=f"{prefix}.to_add_out",
             )
 
@@ -508,7 +534,11 @@ class HunyuanVideo15TransformerBlock(nn.Module):
 
         self.norm2 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
         self.ff = FeedForward(
-            dim=hidden_size, dim_out=hidden_size, mult=mlp_ratio, quant_config=quant_config, prefix=f"{prefix}.ff"
+            dim=hidden_size,
+            dim_out=hidden_size,
+            mult=mlp_ratio,
+            quant_config=_hv15_quant_for_role(quant_config, "video_ffn"),
+            prefix=f"{prefix}.ff",
         )
 
         self.norm2_context = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
@@ -516,7 +546,7 @@ class HunyuanVideo15TransformerBlock(nn.Module):
             dim=hidden_size,
             dim_out=hidden_size,
             mult=mlp_ratio,
-            quant_config=quant_config,
+            quant_config=_hv15_quant_for_role(quant_config, "encoder_ffn"),
             prefix=f"{prefix}.ff_context",
         )
 

--- a/vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/hunyuan_video_15_transformer.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn.functional as F
@@ -26,6 +26,9 @@ from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.hsdp_utils import is_transformer_block_module
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
 from vllm_omni.diffusion.models.flux.flux_transformer import FeedForward
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
 logger = init_logger(__name__)
 
@@ -328,6 +331,8 @@ class HunyuanVideo15Attention(nn.Module):
         out_bias: bool = True,
         eps: float = 1e-6,
         out_dim: int | None = None,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ):
         super().__init__()
 
@@ -346,6 +351,8 @@ class HunyuanVideo15Attention(nn.Module):
             head_size=self.head_dim,
             total_num_heads=self.heads,
             bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_qkv",
         )
 
         self.to_out = nn.ModuleList(
@@ -356,6 +363,8 @@ class HunyuanVideo15Attention(nn.Module):
                     bias=out_bias,
                     input_is_parallel=True,
                     return_bias=False,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.to_out.0",
                 ),
                 nn.Identity(),  # placeholder for dropout (none used)
             ]
@@ -370,6 +379,8 @@ class HunyuanVideo15Attention(nn.Module):
                 head_size=self.head_dim,
                 total_num_heads=self.heads,
                 bias=added_proj_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.add_kv_proj",
             )
 
             self.to_add_out = RowParallelLinear(
@@ -378,6 +389,8 @@ class HunyuanVideo15Attention(nn.Module):
                 bias=out_bias,
                 input_is_parallel=True,
                 return_bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.to_add_out",
             )
 
         self.rope = RotaryEmbedding(is_neox_style=False)
@@ -396,6 +409,8 @@ class HunyuanVideo15Attention(nn.Module):
         attention_mask: torch.Tensor | None = None,
         image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Ensure contiguous for FP8 quantized linear layers
+        hidden_states = hidden_states.contiguous()
         qkv, _ = self.to_qkv(hidden_states)
         q_size = self.to_qkv.num_heads * self.head_dim
         kv_size = self.to_qkv.num_kv_heads * self.head_dim
@@ -416,6 +431,7 @@ class HunyuanVideo15Attention(nn.Module):
             key = self.rope(key, cos, sin)
 
         if encoder_hidden_states is not None:
+            encoder_hidden_states = encoder_hidden_states.contiguous()
             encoder_qkv, _ = self.add_kv_proj(encoder_hidden_states)
             add_q_size = self.add_kv_proj.num_heads * self.head_dim
             add_kv_size = self.add_kv_proj.num_kv_heads * self.head_dim
@@ -469,6 +485,8 @@ class HunyuanVideo15TransformerBlock(nn.Module):
         attention_head_dim: int,
         mlp_ratio: float = 4.0,
         qk_norm: str = "rms_norm",
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         hidden_size = num_attention_heads * attention_head_dim
@@ -484,13 +502,23 @@ class HunyuanVideo15TransformerBlock(nn.Module):
             out_dim=hidden_size,
             bias=True,
             eps=1e-6,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
         )
 
         self.norm2 = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
-        self.ff = FeedForward(dim=hidden_size, dim_out=hidden_size, mult=mlp_ratio)
+        self.ff = FeedForward(
+            dim=hidden_size, dim_out=hidden_size, mult=mlp_ratio, quant_config=quant_config, prefix=f"{prefix}.ff"
+        )
 
         self.norm2_context = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
-        self.ff_context = FeedForward(dim=hidden_size, dim_out=hidden_size, mult=mlp_ratio)
+        self.ff_context = FeedForward(
+            dim=hidden_size,
+            dim_out=hidden_size,
+            mult=mlp_ratio,
+            quant_config=quant_config,
+            prefix=f"{prefix}.ff_context",
+        )
 
     def forward(
         self,
@@ -568,6 +596,7 @@ class HunyuanVideo15Transformer3DModel(nn.Module):
         target_size: int = 640,
         task_type: str = "i2v",
         use_meanflow: bool = False,
+        quant_config: "QuantizationConfig | None" = None,
     ):
         super().__init__()
 
@@ -599,9 +628,14 @@ class HunyuanVideo15Transformer3DModel(nn.Module):
         self.transformer_blocks = nn.ModuleList(
             [
                 HunyuanVideo15TransformerBlock(
-                    num_attention_heads, attention_head_dim, mlp_ratio=mlp_ratio, qk_norm=qk_norm
+                    num_attention_heads,
+                    attention_head_dim,
+                    mlp_ratio=mlp_ratio,
+                    qk_norm=qk_norm,
+                    quant_config=quant_config,
+                    prefix=f"transformer_blocks.{i}",
                 )
-                for _ in range(num_layers)
+                for i in range(num_layers)
             ]
         )
 

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
@@ -124,7 +124,9 @@ class HunyuanVideo15Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, Diff
             self.scheduler._shift = od_config.flow_shift
 
         transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, HunyuanVideo15Transformer3DModel)
-        self.transformer = HunyuanVideo15Transformer3DModel(od_config=od_config, **transformer_kwargs)
+        self.transformer = HunyuanVideo15Transformer3DModel(
+            od_config=od_config, quant_config=od_config.quantization_config, **transformer_kwargs
+        )
 
         # Check if model uses meanflow (distilled variants)
         self.use_meanflow = getattr(od_config.tf_model_config, "use_meanflow", False)

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5_i2v.py
@@ -153,7 +153,9 @@ class HunyuanVideo15I2VPipeline(
             self.scheduler._shift = od_config.flow_shift
 
         transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, HunyuanVideo15Transformer3DModel)
-        self.transformer = HunyuanVideo15Transformer3DModel(od_config=od_config, **transformer_kwargs)
+        self.transformer = HunyuanVideo15Transformer3DModel(
+            od_config=od_config, quant_config=od_config.quantization_config, **transformer_kwargs
+        )
 
         self.use_meanflow = getattr(od_config.tf_model_config, "use_meanflow", False)
 

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -119,9 +119,11 @@ def load_transformer_config(model_path: str, subfolder: str = "transformer", loc
     return {}
 
 
-def create_transformer_from_config(config: dict) -> WanTransformer3DModel:
+def create_transformer_from_config(config: dict, quant_config=None) -> WanTransformer3DModel:
     """Create WanTransformer3DModel from config dict."""
     kwargs = {}
+    if quant_config is not None:
+        kwargs["quant_config"] = quant_config
 
     if "patch_size" in config:
         kwargs["patch_size"] = tuple(config["patch_size"])
@@ -374,7 +376,7 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
 
     def _create_transformer(self, config: dict) -> WanTransformer3DModel:
         """Create a transformer from a config dict. Subclasses may override."""
-        return create_transformer_from_config(config)
+        return create_transformer_from_config(config, quant_config=self.od_config.quantization_config)
 
     @property
     def guidance_scale(self):

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -244,10 +244,14 @@ class Wan22I2VPipeline(
         # Transformers (weights loaded via load_weights)
         # Load config from model directory or HF Hub to get correct in_channels for I2V models
         transformer_config = load_transformer_config(model, "transformer", local_files_only)
-        self.transformer = create_transformer_from_config(transformer_config)
+        self.transformer = create_transformer_from_config(
+            transformer_config, quant_config=od_config.quantization_config
+        )
         if self.has_transformer_2:
             transformer_2_config = load_transformer_config(model, "transformer_2", local_files_only)
-            self.transformer_2 = create_transformer_from_config(transformer_2_config)
+            self.transformer_2 = create_transformer_from_config(
+                transformer_2_config, quant_config=od_config.quantization_config
+            )
         else:
             self.transformer_2 = None
 

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_ti2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_ti2v.py
@@ -202,7 +202,9 @@ class Wan22TI2VPipeline(nn.Module, SupportImageInput, CFGParallelMixin, Progress
         # Single transformer (TI2V uses dense 5B model, not MoE)
         # Load config from model to get correct dimensions
         transformer_config = load_transformer_config(model, "transformer", local_files_only)
-        self.transformer = create_transformer_from_config(transformer_config)
+        self.transformer = create_transformer_from_config(
+            transformer_config, quant_config=od_config.quantization_config
+        )
 
         self._sample_solver = "unipc"
         self._flow_shift = od_config.flow_shift if od_config.flow_shift is not None else 5.0

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_vace.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_vace.py
@@ -40,9 +40,11 @@ from vllm_omni.platforms import current_omni_platform
 logger = init_logger(__name__)
 
 
-def create_vace_transformer_from_config(config: dict) -> WanVACETransformer3DModel:
+def create_vace_transformer_from_config(config: dict, quant_config=None) -> WanVACETransformer3DModel:
     """Create WanVACETransformer3DModel from config dict."""
     kwargs = {}
+    if quant_config is not None:
+        kwargs["quant_config"] = quant_config
     if "patch_size" in config:
         kwargs["patch_size"] = tuple(config["patch_size"])
     if "num_attention_heads" in config:
@@ -174,7 +176,7 @@ class Wan22VACEPipeline(Wan22Pipeline, SupportImageInput):
 
     def _create_transformer(self, config: dict) -> WanVACETransformer3DModel:
         """Build VACE transformer directly from config dict."""
-        return create_vace_transformer_from_config(config)
+        return create_vace_transformer_from_config(config, quant_config=self.od_config.quantization_config)
 
     def diffuse(
         self,

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -3,7 +3,7 @@
 
 import math
 from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
@@ -31,6 +31,9 @@ from vllm_omni.diffusion.forward_context import get_forward_context
 from vllm_omni.diffusion.layers.adalayernorm import AdaLayerNorm
 from vllm_omni.diffusion.layers.norm import LayerNorm, RMSNorm
 from vllm_omni.platforms import current_omni_platform
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
 logger = init_logger(__name__)
 
@@ -100,7 +103,16 @@ class DistributedRMSNorm(nn.Module):
 class ColumnParallelGELU(nn.Module):
     """Column parallel linear with GELU activation."""
 
-    def __init__(self, dim_in: int, dim_out: int, *, approximate: str = "tanh", bias: bool = True):
+    def __init__(
+        self,
+        dim_in: int,
+        dim_out: int,
+        *,
+        approximate: str = "tanh",
+        bias: bool = True,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.proj = ColumnParallelLinear(
             dim_in,
@@ -108,6 +120,8 @@ class ColumnParallelGELU(nn.Module):
             bias=bias,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.proj",
         )
         self.approximate = approximate
 
@@ -128,12 +142,16 @@ class WanFeedForward(nn.Module):
         inner_dim: int,
         dim_out: int | None = None,
         bias: bool = True,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         dim_out = dim_out or dim
 
         # ColumnParallel: scatter to each tp_rank
-        self.net_0 = ColumnParallelGELU(dim, inner_dim, approximate="tanh", bias=bias)
+        self.net_0 = ColumnParallelGELU(
+            dim, inner_dim, approximate="tanh", bias=bias, quant_config=quant_config, prefix=f"{prefix}.net_0"
+        )
         # Placeholder for weight loading compatibility
         self.net_1 = nn.Identity()
         # RowParallel: gather from each tp_rank
@@ -143,6 +161,8 @@ class WanFeedForward(nn.Module):
             bias=bias,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.net_2",
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -357,6 +377,8 @@ class WanSelfAttention(nn.Module):
         head_dim: int,
         eps: float = 1e-5,
         dropout: float = 0.0,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ):
         super().__init__()
 
@@ -371,6 +393,8 @@ class WanSelfAttention(nn.Module):
             head_size=head_dim,
             total_num_heads=num_heads,
             bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_qkv",
         )
 
         self.num_heads = self.to_qkv.num_heads
@@ -391,6 +415,8 @@ class WanSelfAttention(nn.Module):
             bias=True,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_out",
         )
         self.dropout = nn.Dropout(dropout)
 
@@ -409,6 +435,8 @@ class WanSelfAttention(nn.Module):
         rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
         attn_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        # Ensure contiguous for FP8 quantized linear layers
+        hidden_states = hidden_states.contiguous()
         # Fused QKV projection
         qkv, _ = self.to_qkv(hidden_states)
 
@@ -462,6 +490,8 @@ class WanCrossAttention(nn.Module):
         eps: float = 1e-5,
         dropout: float = 0.0,
         added_kv_proj_dim: int | None = None,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ):
         super().__init__()
 
@@ -478,6 +508,8 @@ class WanCrossAttention(nn.Module):
             bias=True,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_q",
         )
 
         # Separate K and V projections for cross-attention
@@ -487,6 +519,8 @@ class WanCrossAttention(nn.Module):
             bias=True,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_k",
         )
 
         self.to_v = ColumnParallelLinear(
@@ -495,6 +529,8 @@ class WanCrossAttention(nn.Module):
             bias=True,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_v",
         )
 
         tp_size = get_tensor_model_parallel_world_size()
@@ -518,6 +554,8 @@ class WanCrossAttention(nn.Module):
                 bias=True,
                 gather_output=False,
                 return_bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.add_k_proj",
             )
             self.add_v_proj = ColumnParallelLinear(
                 added_kv_proj_dim,
@@ -525,6 +563,8 @@ class WanCrossAttention(nn.Module):
                 bias=True,
                 gather_output=False,
                 return_bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.add_v_proj",
             )
             if get_tensor_model_parallel_world_size() > 1:
                 self.norm_added_k = DistributedRMSNorm(self.tp_inner_dim, eps=eps)
@@ -542,6 +582,8 @@ class WanCrossAttention(nn.Module):
             bias=True,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_out",
         )
         self.dropout = nn.Dropout(dropout)
 
@@ -560,6 +602,9 @@ class WanCrossAttention(nn.Module):
         hidden_states: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
     ) -> torch.Tensor:
+        # Ensure contiguous for FP8 quantized linear layers
+        hidden_states = hidden_states.contiguous()
+        encoder_hidden_states = encoder_hidden_states.contiguous()
         # Handle I2V case where encoder_hidden_states contains both image and text
         encoder_hidden_states_img = None
         if self.add_k_proj is not None:
@@ -626,6 +671,8 @@ class WanTransformerBlock(nn.Module):
         eps: float = 1e-6,
         added_kv_proj_dim: int | None = None,
         cross_attn_norm: bool = False,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ):
         super().__init__()
 
@@ -638,6 +685,8 @@ class WanTransformerBlock(nn.Module):
             num_heads=num_heads,
             head_dim=head_dim,
             eps=eps,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn1",
         )
 
         # 2. Cross-attention
@@ -647,11 +696,15 @@ class WanTransformerBlock(nn.Module):
             head_dim=head_dim,
             eps=eps,
             added_kv_proj_dim=added_kv_proj_dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn2",
         )
         self.norm2 = LayerNorm(dim, eps, elementwise_affine=True) if cross_attn_norm else nn.Identity()
 
         # 3. Feed-forward
-        self.ffn = WanFeedForward(dim=dim, inner_dim=ffn_dim, dim_out=dim)
+        self.ffn = WanFeedForward(
+            dim=dim, inner_dim=ffn_dim, dim_out=dim, quant_config=quant_config, prefix=f"{prefix}.ffn"
+        )
         self.norm3 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)
 
         # Scale-shift table for modulation
@@ -807,6 +860,7 @@ class WanTransformer3DModel(nn.Module):
         added_kv_proj_dim: int | None = None,
         rope_max_seq_len: int = 1024,
         pos_embed_seq_len: int | None = None,
+        quant_config: "QuantizationConfig | None" = None,
     ):
         super().__init__()
 
@@ -858,8 +912,17 @@ class WanTransformer3DModel(nn.Module):
         # 3. Transformer blocks
         self.blocks = nn.ModuleList(
             [
-                WanTransformerBlock(inner_dim, ffn_dim, num_attention_heads, eps, added_kv_proj_dim, cross_attn_norm)
-                for _ in range(num_layers)
+                WanTransformerBlock(
+                    inner_dim,
+                    ffn_dim,
+                    num_attention_heads,
+                    eps,
+                    added_kv_proj_dim,
+                    cross_attn_norm,
+                    quant_config=quant_config,
+                    prefix=f"blocks.{i}",
+                )
+                for i in range(num_layers)
             ]
         )
 

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -680,12 +680,18 @@ class WanTransformerBlock(nn.Module):
 
         # 1. Self-attention
         self.norm1 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)
+        # Self-attention also kept full precision. Video DiT attention runs over
+        # very long sequences (87K+ tokens at 704×1280×121) and FP8 on Q/K/V
+        # accumulates enough score drift to visibly degrade composition
+        # (astronaut-on-Mars test on Wan2.2 showed detail loss). Keeping attn
+        # BF16 and quantizing only FFN mirrors the FLUX single-stream-only
+        # pattern (see #2728).
         self.attn1 = WanSelfAttention(
             dim=dim,
             num_heads=num_heads,
             head_dim=head_dim,
             eps=eps,
-            quant_config=quant_config,
+            quant_config=None,
             prefix=f"{prefix}.attn1",
         )
 

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -689,14 +689,16 @@ class WanTransformerBlock(nn.Module):
             prefix=f"{prefix}.attn1",
         )
 
-        # 2. Cross-attention
+        # 2. Cross-attention — kept full precision. FP8 on the text-conditioning
+        # joint attention path collapses output quality (same pattern as FLUX
+        # dual-stream blocks, see #2728).
         self.attn2 = WanCrossAttention(
             dim=dim,
             num_heads=num_heads,
             head_dim=head_dim,
             eps=eps,
             added_kv_proj_dim=added_kv_proj_dim,
-            quant_config=quant_config,
+            quant_config=None,
             prefix=f"{prefix}.attn2",
         )
         self.norm2 = LayerNorm(dim, eps, elementwise_affine=True) if cross_attn_norm else nn.Identity()

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_vace_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_vace_transformer.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
@@ -20,6 +20,9 @@ from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import (
     WanTransformerBlock,
 )
 
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
 
 class VaceWanTransformerBlock(WanTransformerBlock):
     """VACE variant of WanTransformerBlock with proj_in/proj_out for skip connections."""
@@ -33,8 +36,19 @@ class VaceWanTransformerBlock(WanTransformerBlock):
         added_kv_proj_dim: int | None = None,
         cross_attn_norm: bool = False,
         block_id: int = 0,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
     ):
-        super().__init__(dim, ffn_dim, num_heads, eps, added_kv_proj_dim, cross_attn_norm)
+        super().__init__(
+            dim,
+            ffn_dim,
+            num_heads,
+            eps,
+            added_kv_proj_dim,
+            cross_attn_norm,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
         self.proj_in = nn.Linear(dim, dim) if block_id == 0 else None
         self.proj_out = nn.Linear(dim, dim)
 
@@ -83,9 +97,10 @@ class WanVACETransformer3DModel(WanTransformer3DModel):
         *,
         vace_layers: list[int] | None = None,
         vace_in_channels: int | None = None,
+        quant_config: QuantizationConfig | None = None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(quant_config=quant_config, **kwargs)
 
         self.vace_blocks = None
         self.vace_patch_embedding = None
@@ -118,6 +133,8 @@ class WanVACETransformer3DModel(WanTransformer3DModel):
                         self.config.added_kv_proj_dim,
                         self.config.cross_attn_norm,
                         block_id=i,
+                        quant_config=quant_config,
+                        prefix=f"vace_blocks.{i}",
                     )
                     for i in range(len(vace_layers))
                 ]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Thread `quant_config` through the HunyuanVideo-1.5 and Wan2.2 DiT transformers so that `--quantization fp8` actually activates the FP8 kernel. Before this PR the flag populated `od_config.quantization_config` but never reached the transformer's `QKVParallelLinear` / `RowParallelLinear` / `FeedForward` constructors — every linear picked up `UnquantizedLinearMethod` and the loader's `_process_weights_after_loading` had nothing to quantize.

**Proof the original #1516 FP8 claim was a silent no-op:** FP8 vs BF16 rows in that PR's latency table are within 0.1 s of each other; model-load memory was identical. After this PR the engine log shows `Selected CutlassFP8ScaledMMLinearKernel for Fp8OnlineLinearMethod` on FP8 runs, and model-load memory drops measurably.

Pattern follows the #2728 / #2795 fix for Z-Image / Qwen-Image / FLUX.1-dev:
- Main attention and FFN get `quant_config=` + `prefix=`
- Modulation / AdaLayerNorm / entry / output-projection linears stay full precision
- Cross-attention kept full precision (mirror of FLUX dual-stream)
- `.contiguous()` guard at attention entry (FP8 kernels require it)

Fixes #2912.

## Benchmark (1×H100 80GB)

### HunyuanVideo-1.5 (480p T2V, 33 frames, 30 steps)

| Config | Weights (load) | Time | Kernel log |
|---|---|---|---|
| BF16 | 33.81 GiB | 25.4 s | — |
| **FP8 (this PR)** | **28.74 GiB (−15%)** | **23.5 s (−8%)** | `Selected CutlassFP8ScaledMMLinearKernel` ✅ |

### Wan2.2 (TI2V-5B, 704×1280 T2V)

| Config | Frames | Peak VRAM | Time |
|---|---|---|---|
| BF16 | 49 | 44.89 GiB | 21.5 s |
| **FP8 (this PR)** | 49 | **41.46 GiB (−8%)** | **19.6 s (−8%)** |
| BF16 | 121 | 47.19 GiB | 66.2 s |
| **FP8 (this PR)** | 121 | **43.31 GiB (−8%)** | **59.6 s (−10%)** |

Seed 42, guidance 6.0 (HV-1.5) / 5.0 (Wan2.2). Tested with TI2V-5B (fits in 80 GiB BF16); A14B MoE wiring is identical but needs TP=2 and is out of scope here.

## HunyuanVideo-1.5 FP8 preset ablation

Visual comparison of BF16 baseline against four per-layer FP8 presets (same prompt, same seed, 480×832, 33 frames, 30 steps). All FP8 configs reduce model-load memory; quality differences are primarily in fine detail / atmospheric texture.

| Preset | FP8 layers | BF16 layers (kept full precision) |
|---|---|---|
| **S1** | `ff` + `ff_context` | all attention + modulation |
| **S2** | `to_qkv`, `to_out[0]`, `ff` (video stream only) | encoder-stream attn + `ff_context` + modulation |
| **S3** | All except encoder cross-attn (`add_kv_proj`, `to_add_out` BF16) | encoder cross-attn + modulation |
| **S4** | Everything in attention + FFN | modulation, patch embed, proj_out, VAE, text encoders |

### BF16 baseline

https://github.com/user-attachments/assets/a6858965-01b2-4999-a7ab-806340125e4e

### S1 — FFN only

https://github.com/user-attachments/assets/7e9bef81-fdf5-4306-8ac7-c55a6ea27bbb

### S2 — video stream only

https://github.com/user-attachments/assets/67ece7cb-8160-49f7-bfbc-30ed6039fa4e

### S3 — all FP8 except encoder cross-attn

https://github.com/user-attachments/assets/f272b968-b67d-4477-9cd6-9f4cfd48981d

### S4 — everything FP8

https://github.com/user-attachments/assets/5a98a84f-b4e5-4318-a4e1-fae745ac5df7

<!-- Unlabeled — reclassify if needed: https://github.com/user-attachments/assets/380b1aad-d73a-4457-aa8a-d57203485596 -->

**Observation:** All four presets (S1 → S4) show similar quality reduction relative to BF16, with no visually decisive winner. This suggests the FFN path (common to every preset) is the primary source of FP8 drift — not attention. The shipped default is **S4** (maximum memory savings, no measurable quality penalty over S1).

## Known limitations

**Online FP8 has visible quality reduction on video DiTs.** Output stays coherent but fine detail — atmospheric depth, high-frequency texture, distant ridges — softens vs BF16. Same profile as #2795 shipped for Qwen-Image (LPIPS 0.32, threshold 0.35).

**Block-wise FP8 is not available for online quantization.** `Fp8Config.__init__` in upstream vLLM (`fp8.py:120-125`) currently requires `is_checkpoint_fp8_serialized=True` for any `weight_block_size`. Block-wise would recover most of the quality gap but needs pre-quantized checkpoints. Tracked as follow-up.

**Recommended use:** memory-constrained workflows where the ~15% memory / ~10% speed tradeoff is worth the detail softening. For quality-critical rendering, leave `--quantization none`.

## Model layers that remain FP8 (shipped config)

<details>
<summary><b>HunyuanVideo-1.5</b></summary>

| Layer | Role |
|---|---|
| `HunyuanVideo15Attention.to_qkv` · `to_out[0]` · `add_kv_proj` · `to_add_out` | joint attention Q/K/V/output (video + encoder streams) |
| `FeedForward.net[0].proj` (GELU) · `net[2]` — both `ff` and `ff_context` | per-block FFN on both streams |

**Kept full precision:** modulation (raw `nn.Linear`), `AdaLayerNormZero`, patch embed, `proj_out`, VAE, text encoders (Qwen2.5-VL + ByT5 + SigLIP), token refiner path.

Matches Qwen-Image pattern from #2795. An env-var preset mechanism (`HV15_FP8_PRESET`) is also added for research sweeps (see ablation above); default `S4` matches the behavior above.
</details>

<details>
<summary><b>Wan2.2 (T2V / I2V / TI2V / VACE)</b></summary>

| Layer | Role |
|---|---|
| `WanFeedForward.net_0` (GELU via `ColumnParallelGELU`) · `net_2` | per-block FFN |

**Kept full precision:**
- `WanSelfAttention.to_qkv` · `to_out` — self-attention over long video tokens (87K+ at 704×1280×121) accumulates visible FP8 drift
- `WanCrossAttention.to_q` · `to_k` · `to_v` · `to_out` · `add_k_proj` · `add_v_proj` — text/image joint attention; mirrors FLUX dual-stream (#2728)
- Modulation, patch embed, time/text/image embedding, `proj_out`, VAE, text encoder (UMT5)

**Why FFN-only for Wan2.2:** with full attention+FFN FP8, long-sequence outputs collapsed to noise (LPIPS 0.93). Cross-attn skip alone reduced it but left composition drift (LPIPS 0.52). FFN-only is the most aggressive setting that produced stable output on long videos.
</details>

## Changes

**HunyuanVideo-1.5**
- `hunyuan_video_15_transformer.py` — `HunyuanVideo15Attention`, `HunyuanVideo15TransformerBlock`, `HunyuanVideo15Transformer3DModel` thread `quant_config` / `prefix` to all attention + FFN linears; modulation layers stay raw `nn.Linear`.
- `pipeline_hunyuan_video_1_5.py` + `pipeline_hunyuan_video_1_5_i2v.py` — pass `quant_config=od_config.quantization_config` to transformer.

**Wan2.2 (all four pipelines)**
- `wan2_2_transformer.py` — `WanFeedForward` (+ `ColumnParallelGELU`) receives `quant_config`; `WanSelfAttention` and `WanCrossAttention` get `quant_config=None` (documented with #2728 reference).
- `wan2_2_vace_transformer.py` — threading inherited via `super().__init__`.
- `create_transformer_from_config` (`pipeline_wan2_2.py`) and `create_vace_transformer_from_config` (`pipeline_wan2_2_vace.py`) accept optional `quant_config`.
- All pipelines (`pipeline_wan2_2.py`, `..._i2v.py`, `..._ti2v.py`, `..._vace.py`) pass `od_config.quantization_config`.

**Bench infrastructure**
- `benchmarks/diffusion/bench_video_fp8.py` — new; BF16 vs FP8 perf / peak-VRAM / LPIPS / PSNR / SSIM with `--presets`, `--frames-list`, `--weight-block-size`, MP4 output. Used to produce the tables and ablation above.

## Test plan

- [x] HV-1.5 T2V 480p FP8 — kernel selects, weight memory drops 15%, output coherent
- [x] HV-1.5 FP8 preset ablation (S1 / S2 / S3 / S4) at 480p — all presets produce valid video, no decisive quality winner, S4 shipped as default
- [x] Wan2.2 TI2V-5B T2V FP8 — 49 frames and 121 frames both produce valid video
- [x] Visual inspection BF16 vs FP8 on both models at multiple frame counts
- [x] Pre-commit (ruff, format, typos) — passing
- [x] `Selected CutlassFP8ScaledMMLinearKernel` confirmed in engine log on FP8 runs
- [ ] HV-1.5 I2V FP8 — wiring identical to T2V (untested)
- [ ] Wan2.2 T2V-A14B MoE FP8 — needs 2×H100
- [ ] Wan2.2 VACE FP8 — wiring threaded, not yet end-to-end tested
- [ ] TP=2 across both models — wiring is TP-aware via existing parallel primitives

## Follow-ups

1. **Static FP8 checkpoints** for HV-1.5 and Wan2.2 via NVIDIA ModelOpt — unlocks block-wise FP8 (closer to BF16 quality). Tracked under "Static" column in #1854.
2. **HV-1.5 seed propagation** — `OmniDiffusionSamplingParams.seed` doesn't propagate to HV-1.5's noise generator across the worker subprocess boundary, which blocks reliable LPIPS measurement. Separate bugfix PR.
3. **SageAttention FP8 backend** — FP8 on the attention kernel itself (not just projections). Would close most of the remaining quality gap and deliver a more significant speedup. Separate design PR.
4. **Text encoder + VAE FP8** (#1338) — larger memory savings on HV-1.5's Qwen2.5-VL; VAE FP8 remains a research question (Conv3d kernel support).

cc @ArtificialRay @DarkLight1337
