### PR TITLE
[BugFix] Fixed the issue where --no-async-chunk was not working.

### DIFF
--- a/tests/dfx/perf/tests/test_qwen_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_omni.json
@@ -2,7 +2,8 @@
     {
         "test_name": "test_qwen3_omni",
         "server_params": {
-            "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+            "model": "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+            "extra_cli_args": ["--no-async-chunk"]
         },
         "benchmark_params": [
             {

--- a/tests/e2e/online_serving/test_qwen3_omni_expansion.py
+++ b/tests/e2e/online_serving/test_qwen3_omni_expansion.py
@@ -64,7 +64,6 @@ def get_async_chunk_config(default_path):
     return modify_stage_config(
         default_path,
         updates={
-            "async_chunk": True,
             "stages": {0: {"default_sampling_params.max_tokens": 2048}},
         },
     )
@@ -78,7 +77,9 @@ default_path = get_deploy_config_path("ci/qwen3_omni_moe.yaml")
 
 test_params = [
     pytest.param(
-        OmniServerParams(model=model, stage_config_path=default_path, use_stage_cli=True),
+        OmniServerParams(
+            model=model, stage_config_path=default_path, use_stage_cli=True, server_args=["--no-async-chunk"]
+        ),
         id="default",
     ),
     pytest.param(

--- a/tests/entrypoints/test_serve.py
+++ b/tests/entrypoints/test_serve.py
@@ -7,9 +7,31 @@ import argparse
 import pytest
 from pytest_mock import MockerFixture
 
-from vllm_omni.entrypoints.cli.serve import run_headless
+from vllm_omni.entrypoints.cli.serve import OmniServeCommand, run_headless
+from vllm_omni.entrypoints.utils import detect_explicit_cli_keys
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_serve_parser_accepts_no_async_chunk_and_marks_it_explicit() -> None:
+    """``--no-async-chunk`` should parse to ``async_chunk=False`` and mark the
+    shared deploy-level dest as explicitly provided by the user."""
+    try:
+        from vllm.utils.argparse_utils import FlexibleArgumentParser
+    except Exception as exc:
+        pytest.skip(f"Cannot build parser in this environment: {exc}")
+
+    root = FlexibleArgumentParser()
+    subparsers = root.add_subparsers(dest="subcommand")
+    cmd = OmniServeCommand()
+    serve_parser = cmd.subparser_init(subparsers)
+
+    argv = ["serve", "fake-model", "--omni", "--no-async-chunk"]
+    args = root.parse_args(argv)
+
+    assert args.async_chunk is False
+    explicit = detect_explicit_cli_keys(argv, serve_parser)
+    assert "async_chunk" in explicit
 
 
 def _make_headless_args() -> argparse.Namespace:

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -122,7 +122,11 @@ class OmniBase(PDDisaggregationMixin):
         stage_init_timeout = kwargs.pop("stage_init_timeout", 300)
         init_timeout = kwargs.pop("init_timeout", 600)
         log_stats = kwargs.pop("log_stats", False)
-        async_chunk = kwargs.pop("async_chunk", False)
+        # NOTE: read-only lookup — must NOT pop. Popping here drops the key
+        # before it reaches ``StageConfigFactory._create_from_registry``, so
+        # ``--no-async-chunk`` (``async_chunk=False``) silently fails to
+        # override the deploy YAML's ``async_chunk: true`` default.
+        async_chunk = kwargs.get("async_chunk")
         output_modalities = kwargs.pop("output_modalities", None)
         diffusion_batch_size: int = kwargs.pop("diffusion_batch_size", 1)
 
@@ -132,7 +136,10 @@ class OmniBase(PDDisaggregationMixin):
         self._name = self.__class__.__name__
         self.model = model
         self.log_stats = log_stats
-        self.async_chunk = async_chunk
+        # Provisional value (mirrors the CLI/caller kwarg); the engine resolves
+        # pipeline + deploy YAML + CLI precedence below and the final value is
+        # re-assigned from ``self.engine.async_chunk`` after init.
+        self.async_chunk = bool(async_chunk) if async_chunk is not None else False
         self.output_modalities = output_modalities or []
         self.tts_batch_max_items: int = kwargs.pop("tts_batch_max_items", 32)
 
@@ -150,7 +157,11 @@ class OmniBase(PDDisaggregationMixin):
         self._weak_finalizer = weakref.finalize(self, _weak_shutdown_engine, self.engine)
         et = time.time()
         logger.info("[%s] AsyncOmniEngine initialized in %.2f seconds", self.__class__.__name__, et - st)
-        self.async_chunk = bool(self.async_chunk or getattr(self.engine, "async_chunk", False))
+        # Authoritative: ``AsyncOmniEngine`` resolves (pipeline + deploy YAML +
+        # CLI overrides) through ``StageConfigFactory`` and stores the final
+        # value on ``engine.async_chunk``; mirror it here so ``--no-async-chunk``
+        # (explicit ``False``) is not fallen-back-through by ``or``.
+        self.async_chunk = bool(getattr(self.engine, "async_chunk", False))
 
         self.request_states: dict[str, ClientRequestState] = {}
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
fix https://github.com/vllm-project/vllm-omni/issues/2933
## Test Plan
`vllm serve /home/models/Qwen3-Omni-30B-A3B-Instruct --omni --port 28889 --no-async-chunk`
## Test Result
```
(Worker pid=3867183) INFO 04-20 04:03:12 [qwen3_omni.py:1006] ============self.vllm_config.model_config.async_chunk:False
(APIServer pid=3866749) INFO 04-20 04:03:12 [stage_engine_core_client.py:172] [StageEngineCoreClient] Stage-2 adding request: chatcmpl-84dfae6f31fc3eb1
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502]
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] [Overall Summary]
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] +-----------------------------+------------+
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] | Field                       |      Value |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] +-----------------------------+------------+
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] | e2e_requests                |          1 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] | e2e_wall_time_ms            | 11,939.418 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] | e2e_total_tokens            |        301 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] | e2e_avg_time_per_request_ms | 11,939.418 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] | e2e_avg_tokens_per_s        |     25.211 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] | e2e_stage_0_wall_time_ms    |  1,953.011 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] | e2e_stage_1_wall_time_ms    |  3,227.079 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] | e2e_stage_2_wall_time_ms    |  1,626.541 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:502] +-----------------------------+------------+
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:528]
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:528] [RequestE2EStats [request_id=chatcmpl-84dfae6f31fc3eb1]]
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:528] +------------------+------------+
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:528] | Field            |      Value |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:528] +------------------+------------+
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:528] | e2e_total_ms     | 11,875.375 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:528] | e2e_total_tokens |        301 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:528] +------------------+------------+
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:581]
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:581] [StageRequestStats [request_id=chatcmpl-84dfae6f31fc3eb1]]
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:581] +-------------------+-----------+-----------+-----------+
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:581] | Field             |         0 |         1 |         2 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:581] +-------------------+-----------+-----------+-----------+
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:581] | batch_id          |         1 |         1 |         1 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:581] | batch_size        |         1 |         1 |         1 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:581] | num_tokens_in     |        67 |         0 |         0 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:581] | num_tokens_out    |        30 |       204 |         0 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:581] | stage_gen_time_ms | 1,951.266 | 3,226.583 | 1,625.796 |
(APIServer pid=3866749) INFO 04-20 04:03:14 [stats.py:581] +-------------------+-----------+-----------+-----------+

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
