### PR TITLE
[Feature] HunyuanImage-3.0 AR->DiT KV-cache reuse for image editing (IT2I)

### DIFF
--- a/examples/offline_inference/hunyuan_image3/end2end.py
+++ b/examples/offline_inference/hunyuan_image3/end2end.py
@@ -47,8 +47,23 @@ def build_prompt(
     task: str = "it2i_think",
     sys_type: str | None = None,
     custom_system_prompt: str | None = None,
+    kv_reuse: bool = False,
 ) -> str:
-    """Build a HunyuanImage-3.0 prompt using pretrain template format."""
+    """Build a HunyuanImage-3.0 prompt for the AR stage.
+
+    The HunyuanImage-3.0-Instruct model's generation_config specifies
+    ``sequence_template="instruct"``, so the AR prefill MUST use the
+    Instruct template in both the normal (non-KV-reuse) and the KV-reuse
+    paths.  Otherwise the AR KV cache token layout drifts from the model's
+    training distribution and output quality degrades.
+
+    Format (both kv_reuse=False and kv_reuse=True):
+        <|startoftext|>{sys}\\n\\nUser: [<img>]{user_prompt}\\n\\nAssistant: [trigger_tag]
+
+    The ``kv_reuse`` argument is retained for API compatibility but no
+    longer changes the prompt layout.  The trigger tag is part of the AR
+    prefill; it must NOT be stored separately and re-prepended by the DiT.
+    """
     if task not in _TASK_PRESETS:
         raise ValueError(f"Unknown task {task!r}. Choose from: {sorted(_TASK_PRESETS)}")
 
@@ -60,14 +75,18 @@ def build_prompt(
 
     has_image_input = task.startswith("i2t") or task.startswith("it2i")
 
+    # Instruct template (matches the model's generation_config.sequence_template
+    # and the old prompt_utils.build_prompt layout).
     parts = ["<|startoftext|>"]
     if sys_text:
         parts.append(sys_text)
+    parts.append("\n\nUser: ")
     if has_image_input:
         parts.append("<img>")
+    parts.append(user_prompt)
+    parts.append("\n\nAssistant: ")
     if trigger_tag:
         parts.append(trigger_tag)
-    parts.append(user_prompt)
 
     return "".join(parts)
 
@@ -176,12 +195,29 @@ def main():
 
         input_image = Image.open(args.image_path).convert("RGB")
 
+    # Detect KV-reuse stage configs.  Note: the AR prompt layout is now the
+    # same Instruct template in both paths (see build_prompt); the flag is
+    # only used for informational purposes.
+    _kv_reuse_configs = {"hunyuan_image3_it2i_kv_reuse.yaml"}
+    kv_reuse = os.path.basename(stage_configs_path) in _kv_reuse_configs
+
     # Format prompts
     formatted_prompts: list[OmniPromptType] = []
     for p in prompts:
-        formatted_text = build_prompt(p, task=task, sys_type=args.sys_type)
+        formatted_text = build_prompt(p, task=task, sys_type=args.sys_type, kv_reuse=kv_reuse)
+        preset_sys_type, _, _trigger_tag = _TASK_PRESETS[task]
+        effective_sys_type = args.sys_type or preset_sys_type
 
-        prompt_dict: dict = {"prompt": formatted_text}
+        prompt_dict: dict = {
+            "prompt": formatted_text,
+            "user_prompt": p,
+            "use_system_prompt": effective_sys_type,
+        }
+        # Note: under the Instruct template the trigger tag (<think>/<recaption>)
+        # is already included in the AR prefill, so we do NOT pass it separately
+        # to the DiT.  The DiT reconstructs cot_text from the AR-generated text
+        # alone (which begins with the trigger tag's content, terminated by the
+        # matching closing tag like </think>).
 
         if args.modality == "text2img":
             prompt_dict["modalities"] = ["image"]

--- a/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_inject_kv.py
+++ b/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_inject_kv.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for ``ImageKVCacheManager.inject_prompt_kv_cache``.
+
+This is the core interface the KV-reuse PR adds: it takes AR-produced
+text KV tensors and pre-populates the DiT's ``image_kv_cache_map`` so
+subsequent denoising steps can be run with ``first_step=False``
+without recomputing the text KV.
+
+The contract we guard here:
+
+* For a pos-only branch, the cached prefix length equals
+  ``pos_len + num_special_tokens`` and the first ``pos_len`` rows of
+  the cached tensors equal the input positive tensors verbatim.
+* For a pos+neg branch with different lengths, both branches are
+  zero-padded to ``max(pos_len, neg_len)`` so they share a single
+  ``L_text`` slot, and the returned length equals
+  ``max_len + num_special_tokens``.
+* The trailing ``num_special_tokens`` + EOI slots are zero-filled --
+  this is the layout the attention mask in ``_forward_with_kv_reuse``
+  relies on (those positions are masked out of the softmax).
+"""
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import (
+    ImageKVCacheManager,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _mgr() -> ImageKVCacheManager:
+    # ImageKVCacheManager.__init__ queries the SP world-size, which is
+    # only initialised inside a distributed worker. ``inject_prompt_kv_cache``
+    # itself does not touch SP state, so bypass __init__ and stamp the
+    # attributes the method actually reads.
+    mgr = ImageKVCacheManager.__new__(ImageKVCacheManager)
+    mgr.num_heads = 4
+    mgr.num_kv_heads = 2
+    mgr.head_dim = 8
+    mgr.scaling = 1.0
+    mgr.image_token_len = 16
+    mgr.image_kv_cache_map = None
+    return mgr
+
+
+def _rand_kv(length: int, kv_heads: int = 2, head_dim: int = 8):
+    k = torch.randn(length, kv_heads, head_dim)
+    v = torch.randn(length, kv_heads, head_dim)
+    return k, v
+
+
+def test_inject_pos_only_length_and_layout():
+    mgr = _mgr()
+    pos_k, pos_v = _rand_kv(length=17)
+
+    cached_len = mgr.inject_prompt_kv_cache(pos_k, pos_v, num_special_tokens=3)
+
+    # Returned prefix length = text + special tokens (excludes eoi).
+    assert cached_len == 17 + 3
+
+    cached_k, cached_v = mgr.image_kv_cache_map
+    # Full cached layout = pos_text + special + eoi = 17 + 3 + 1 = 21.
+    assert cached_k.shape == (21, 2, 8)
+    assert cached_v.shape == (21, 2, 8)
+    # First pos_len rows preserved verbatim.
+    assert torch.equal(cached_k[:17], pos_k)
+    assert torch.equal(cached_v[:17], pos_v)
+    # The 3 special slots + 1 eoi slot must be zero (they are masked
+    # out of the softmax by the attention mask in _forward_with_kv_reuse).
+    assert torch.equal(cached_k[17:], torch.zeros(4, 2, 8))
+    assert torch.equal(cached_v[17:], torch.zeros(4, 2, 8))
+
+
+def test_inject_pos_and_neg_same_length():
+    mgr = _mgr()
+    pos_k, pos_v = _rand_kv(length=10)
+    neg_k, neg_v = _rand_kv(length=10)
+
+    cached_len = mgr.inject_prompt_kv_cache(pos_k, pos_v, neg_k, neg_v, num_special_tokens=3)
+
+    assert cached_len == 10 + 3
+    cached_k, _ = mgr.image_kv_cache_map
+    # 2 * (text + special + eoi) = 2 * (10 + 3 + 1) = 28.
+    assert cached_k.shape == (28, 2, 8)
+    # Pos branch occupies rows [0:10], neg branch [14:24] (after
+    # 10 text + 3 special + 1 eoi).
+    assert torch.equal(cached_k[:10], pos_k)
+    assert torch.equal(cached_k[14:24], neg_k)
+
+
+def test_inject_pos_and_neg_mismatched_length_pads_shorter_branch():
+    # This is the path that guards against the ``L_pos=6833, L_neg=1``
+    # degeneracy: whichever branch is shorter must be zero-padded up to
+    # ``L_text = max(L_pos, L_neg)`` and the returned length must
+    # reflect the padded max.
+    mgr = _mgr()
+    pos_k, pos_v = _rand_kv(length=12)
+    neg_k, neg_v = _rand_kv(length=7)  # shorter
+
+    cached_len = mgr.inject_prompt_kv_cache(pos_k, pos_v, neg_k, neg_v, num_special_tokens=3)
+
+    assert cached_len == 12 + 3  # max_len + special
+
+    cached_k, cached_v = mgr.image_kv_cache_map
+    # Layout: [pos(12) | special(3) | eoi(1) | neg_padded(12) | special(3) | eoi(1)] = 32
+    assert cached_k.shape == (32, 2, 8)
+    # Positive branch preserved.
+    assert torch.equal(cached_k[:12], pos_k)
+    # Negative branch: first neg_len rows are the original neg_k, the
+    # remaining rows up to L_text=12 must be zero padding.
+    assert torch.equal(cached_k[16:16 + 7], neg_k)
+    assert torch.equal(cached_k[16 + 7:16 + 12], torch.zeros(5, 2, 8))
+    # Values follow the same layout.
+    assert torch.equal(cached_v[:12], pos_v)
+    assert torch.equal(cached_v[16:16 + 7], neg_v)
+
+
+def test_inject_neg_longer_than_pos_also_pads():
+    # Symmetric case: explicit negative prompt longer than the positive
+    # one. Must pad pos, not neg.
+    mgr = _mgr()
+    pos_k, pos_v = _rand_kv(length=5)
+    neg_k, neg_v = _rand_kv(length=9)
+
+    cached_len = mgr.inject_prompt_kv_cache(pos_k, pos_v, neg_k, neg_v, num_special_tokens=3)
+
+    assert cached_len == 9 + 3
+    cached_k, _ = mgr.image_kv_cache_map
+    # 2 * (9 + 3 + 1) = 26
+    assert cached_k.shape == (26, 2, 8)
+    assert torch.equal(cached_k[:5], pos_k)
+    assert torch.equal(cached_k[5:9], torch.zeros(4, 2, 8))  # pos padding
+    assert torch.equal(cached_k[13:13 + 9], neg_k)
+
+
+def test_inject_custom_num_special_tokens():
+    mgr = _mgr()
+    pos_k, pos_v = _rand_kv(length=4)
+
+    cached_len = mgr.inject_prompt_kv_cache(pos_k, pos_v, num_special_tokens=5)
+
+    assert cached_len == 4 + 5
+    cached_k, _ = mgr.image_kv_cache_map
+    assert cached_k.shape == (4 + 5 + 1, 2, 8)
+
+
+def test_inject_preserves_dtype_and_device():
+    mgr = _mgr()
+    pos_k = torch.randn(6, 2, 8, dtype=torch.float16)
+    pos_v = torch.randn(6, 2, 8, dtype=torch.float16)
+
+    mgr.inject_prompt_kv_cache(pos_k, pos_v, num_special_tokens=3)
+
+    cached_k, cached_v = mgr.image_kv_cache_map
+    assert cached_k.dtype == torch.float16
+    assert cached_v.dtype == torch.float16
+    assert cached_k.device == pos_k.device

--- a/tests/model_executor/stage_input_processors/test_hunyuan_image3_kv_reuse.py
+++ b/tests/model_executor/stage_input_processors/test_hunyuan_image3_kv_reuse.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the HunyuanImage3 AR->DiT KV-reuse stage input processor.
+
+Covers the two new public entry points added by the KV-reuse PR:
+
+* ``expand_cfg_prompts`` -- builds the CFG companion request.  Guards the
+  core invariants that prevent the previously-observed ``L_pos=6833,
+  L_neg=1`` degeneracy: (a) the companion must mirror the positive
+  prompt's structure, (b) it must inherit the multi-modal data and
+  image/system-prompt toggles, (c) ``max_tokens`` must be forced to 1 so
+  the companion stops right after prefill, and (d) non-image prompts
+  must NOT trigger an expansion.
+
+* ``collect_cfg_kv_caches`` -- the DiT-side collector that pulls
+  companion KV back via the ``OmniKVTransferManager``.  We test the
+  success path, the "transfer manager returned nothing" path, and the
+  exception-swallowing path (collector must never break the parent
+  request).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.model_executor.stage_input_processors.hunyuan_image3 import (
+    CFG_TEXT_SUFFIX,
+    collect_cfg_kv_caches,
+    expand_cfg_prompts,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+# -----------------------------------------------------------------------------
+# expand_cfg_prompts
+# -----------------------------------------------------------------------------
+
+
+def _image_prompt(**overrides):
+    base = {
+        "prompt": "<|startoftext|>SYS\n\nUser: [<img>]paint a cat\n\nAssistant: <think>",
+        "user_prompt": "paint a cat",
+        "modalities": ["image"],
+        "multi_modal_data": {"image": object()},
+        "height": 1024,
+        "width": 1024,
+        "use_system_prompt": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_expand_cfg_prompts_non_dict_returns_empty():
+    assert expand_cfg_prompts("just a string", SimpleNamespace()) == []
+
+
+def test_expand_cfg_prompts_non_image_returns_empty():
+    # Text-only prompts must not trigger CFG expansion (this is the
+    # short-circuit that keeps t2t / i2t paths cheap).
+    txt = {"prompt": "hi", "modalities": []}
+    assert expand_cfg_prompts(txt, SimpleNamespace()) == []
+
+
+def test_expand_cfg_prompts_substitutes_user_text_with_cfg_token():
+    prompt = _image_prompt()
+
+    result = expand_cfg_prompts(prompt, SimpleNamespace())
+
+    assert len(result) == 1
+    companion = result[0]
+    # Role + suffix are the contract the DiT collector relies on.
+    assert companion.role == "cfg_text"
+    assert companion.request_id_suffix == CFG_TEXT_SUFFIX
+    # max_tokens must be forced to 1 -- otherwise the companion would
+    # decode an entire CoT for the uncond branch.
+    assert companion.sampling_params_override == {"max_tokens": 1}
+
+    neg_dict = companion.prompt
+    # <cfg> must replace ONLY the user-text substring; every other
+    # section (system, image marker, assistant/trigger) is preserved.
+    assert "<cfg>" in neg_dict["prompt"]
+    assert "paint a cat" not in neg_dict["prompt"]
+    assert neg_dict["prompt"].startswith("<|startoftext|>SYS")
+    assert "[<img>]" in neg_dict["prompt"]
+    assert "Assistant: <think>" in neg_dict["prompt"]
+
+
+def test_expand_cfg_prompts_inherits_multimodal_and_meta():
+    mm = {"image": object()}
+    prompt = _image_prompt(multi_modal_data=mm, height=512, width=768, use_system_prompt=False)
+
+    result = expand_cfg_prompts(prompt, SimpleNamespace())
+    neg = result[0].prompt
+
+    assert neg["modalities"] == ["image"]
+    # Must carry the same image payload so the uncond branch prefills the image section too.
+    assert neg["multi_modal_data"] is mm
+    assert neg["height"] == 512
+    assert neg["width"] == 768
+    assert neg["use_system_prompt"] is False
+
+
+def test_expand_cfg_prompts_missing_user_text_falls_back_to_positive():
+    # When user_prompt is absent we cannot locate the user-text substring,
+    # so the fallback keeps the positive prompt verbatim (still structurally
+    # valid, <cfg> is not injected). This branch must not raise.
+    prompt = {
+        "prompt": "<|startoftext|>hi",
+        "modalities": ["image"],
+    }
+    result = expand_cfg_prompts(prompt, SimpleNamespace())
+    assert len(result) == 1
+    assert result[0].prompt["prompt"] == "<|startoftext|>hi"
+
+
+def test_expand_cfg_prompts_respects_explicit_negative_prompt():
+    # If the caller supplied an explicit negative prompt, it wins over
+    # the <cfg>-substitution path.
+    prompt = _image_prompt()
+    sp = SimpleNamespace(extra_args={"negative_prompt": "blurry, low quality"})
+
+    result = expand_cfg_prompts(prompt, sp)
+    assert len(result) == 1
+    neg_text = result[0].prompt["prompt"]
+    assert "blurry, low quality" in neg_text
+
+
+# -----------------------------------------------------------------------------
+# collect_cfg_kv_caches
+# -----------------------------------------------------------------------------
+
+
+class _FakeKVTransferManager:
+    """Minimal stand-in for OmniKVTransferManager."""
+
+    def __init__(self, payload_by_rid):
+        self._payload = payload_by_rid
+        self.calls = []
+
+    def receive_kv_cache_for_request(self, rid, target_device):
+        self.calls.append((rid, target_device))
+        return self._payload.get(rid, (None, 0))
+
+
+def test_collect_cfg_kv_caches_returns_past_kv_and_metadata():
+    rid = "req_0"
+    companion = "req_0__cfg_text"
+    layer_blocks = {"layer_0": object(), "layer_1": object()}
+    metadata = {"shape": [1, 2, 3]}
+    mgr = _FakeKVTransferManager(
+        {companion: ({"layer_blocks": layer_blocks, "metadata": metadata}, 999)}
+    )
+
+    out = collect_cfg_kv_caches(rid, {"cfg_text": companion}, mgr, target_device=None)
+
+    assert "cfg_text_past_key_values" in out
+    kv = out["cfg_text_past_key_values"]
+    # Must be a namespace-like object exposing the layer attributes by name.
+    assert getattr(kv, "layer_0") is layer_blocks["layer_0"]
+    assert getattr(kv, "layer_1") is layer_blocks["layer_1"]
+    assert out["cfg_text_kv_metadata"] == metadata
+    assert mgr.calls == [(companion, None)]
+
+
+def test_collect_cfg_kv_caches_empty_payload_is_silent():
+    # When the transfer manager has nothing, the collector must not raise
+    # and must return an empty dict so the DiT can fall back to the
+    # no-CFG path.
+    mgr = _FakeKVTransferManager({})
+    out = collect_cfg_kv_caches("req_0", {"cfg_text": "req_0__cfg_text"}, mgr)
+    assert out == {}
+
+
+def test_collect_cfg_kv_caches_swallows_transfer_errors():
+    class _BrokenMgr:
+        def receive_kv_cache_for_request(self, rid, target_device):
+            raise RuntimeError("transfer went sideways")
+
+    # Must not propagate -- the parent DiT request should still run.
+    out = collect_cfg_kv_caches("req_0", {"cfg_text": "req_0__cfg_text"}, _BrokenMgr())
+    assert out == {}

--- a/vllm_omni/diffusion/layers/rope.py
+++ b/vllm_omni/diffusion/layers/rope.py
@@ -81,9 +81,12 @@ class RotaryEmbedding(CustomOp):
         self.interleaved = not is_neox_style
         self.apply_rotary_emb_flash_attn = None
         if find_spec("flash_attn") is not None:
-            from flash_attn.ops.triton.rotary import apply_rotary
+            try:
+                from flash_attn.ops.triton.rotary import apply_rotary
 
-            self.apply_rotary_emb_flash_attn = apply_rotary
+                self.apply_rotary_emb_flash_attn = apply_rotary
+            except (ImportError, Exception):
+                pass
 
     def forward_cuda(
         self,

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -746,6 +746,9 @@ class LightProjector(nn.Module):
 
         self.layers = modules
 
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)
+
 
 class HunYuanRotary2DEmbedder:
     r"""
@@ -1000,6 +1003,90 @@ class ImageKVCacheManager:
 
         return joint_text_key.contiguous(), joint_text_value.contiguous()
 
+    def inject_prompt_kv_cache(
+        self,
+        pos_key: torch.Tensor,
+        pos_value: torch.Tensor,
+        neg_key: torch.Tensor | None = None,
+        neg_value: torch.Tensor | None = None,
+        num_special_tokens: int = 3,
+    ) -> int:
+        """Inject pre-computed AR text KV cache into the image KV cache manager.
+
+        This pre-populates ``image_kv_cache_map`` so that subsequent denoising
+        steps can use ``_update_image_kv_caches`` as if the first-step text
+        processing had already occurred.
+
+        The caller (``_forward_with_kv_reuse``) must pass ``kv_injected=True``
+        to the denoising pipeline so that every step is treated as a non-first
+        step (``first_step=False``).  That prevents ``__call__`` from resetting
+        ``image_kv_cache_map`` to ``None`` and recomputing the text KV from the
+        full sequence.  Each denoising step only projects the image-token Q/K/V
+        via the transformer, and the text KV held in ``image_kv_cache_map`` is
+        prepended by ``_update_image_kv_caches`` without being recomputed.
+
+        The ``image_kv_cache_map`` layout must match what ``_save_image_kv_caches``
+        produces on the normal first-step path.  In the normal path the cached
+        prefix length is ``seq_len - image_token_len - 1``, which equals
+        ``L_text + num_special_tokens`` (``<boi>``, ``<img_size>``, ``<img_ratio>``
+        are included in the prefix).  We therefore append ``num_special_tokens``
+        zero-padded slots after the AR-text KV to match that layout exactly.
+
+        Args:
+            pos_key: Positive branch text KV keys ``[pos_len, kv_heads, head_dim]``.
+            pos_value: Positive branch text KV values, same shape as *pos_key*.
+            neg_key: Optional negative/CFG branch text KV keys ``[neg_len, kv_heads, head_dim]``.
+            neg_value: Optional negative/CFG branch text KV values.
+            num_special_tokens: Number of DiT-specific special tokens inserted between
+                the AR text and the image tokens (``<boi>``, ``<img_size>``,
+                ``<img_ratio>``).  Defaults to 3.
+
+        Returns:
+            The (padded) text + special-token prompt length used for the cache
+            (i.e. ``cached_prompt_len`` as seen by ``_update_image_kv_caches``).
+        """
+        kv_heads, head_dim = pos_key.shape[1], pos_key.shape[2]
+        pos_len = pos_key.shape[0]
+        device = pos_key.device
+        dtype = pos_key.dtype
+
+        # Dummy KV slots for DiT-specific special tokens that follow the AR text:
+        # <boi>, <img_size_*>, <img_ratio_*>.  These tokens are not present in the
+        # AR KV cache; we pad with zeros (they are masked in the attention mask).
+        special_k = torch.zeros(num_special_tokens, kv_heads, head_dim, device=device, dtype=dtype)
+        special_v = torch.zeros(num_special_tokens, kv_heads, head_dim, device=device, dtype=dtype)
+
+        # Dummy EOI KV (zeros – masked out by the attention mask)
+        eoi_k = torch.zeros(1, kv_heads, head_dim, device=device, dtype=dtype)
+        eoi_v = torch.zeros(1, kv_heads, head_dim, device=device, dtype=dtype)
+
+        if neg_key is not None:
+            neg_len = neg_key.shape[0]
+            max_len = max(pos_len, neg_len)
+
+            # Pad shorter branch with zeros (masked out by attention)
+            if pos_len < max_len:
+                pad = torch.zeros(max_len - pos_len, kv_heads, head_dim, device=device, dtype=dtype)
+                pos_key = torch.cat([pos_key, pad], dim=0)
+                pos_value = torch.cat([pos_value, pad], dim=0)
+            if neg_len < max_len:
+                pad = torch.zeros(max_len - neg_len, kv_heads, head_dim, device=device, dtype=dtype)
+                neg_key = torch.cat([neg_key, pad], dim=0)
+                neg_value = torch.cat([neg_value, pad], dim=0)
+
+            # Layout: [pos_text, special_pos, eoi_pos, neg_text, special_neg, eoi_neg]
+            # This mirrors _save_image_kv_caches where cached_prompt_len = L_text + num_special_tokens
+            cached_key = torch.cat([pos_key, special_k, eoi_k, neg_key, special_k.clone(), eoi_k.clone()], dim=0)
+            cached_value = torch.cat([pos_value, special_v, eoi_v, neg_value, special_v.clone(), eoi_v.clone()], dim=0)
+            self.image_kv_cache_map = (cached_key, cached_value)
+            return max_len + num_special_tokens
+        else:
+            # Layout: [pos_text, special, eoi]
+            cached_key = torch.cat([pos_key, special_k, eoi_k], dim=0)
+            cached_value = torch.cat([pos_value, special_v, eoi_v], dim=0)
+            self.image_kv_cache_map = (cached_key, cached_value)
+            return pos_len + num_special_tokens
+
     def __call__(
         self,
         query: torch.Tensor,
@@ -1028,6 +1115,11 @@ class ImageKVCacheManager:
         key = key.reshape(bs, q_len, kv_head_num_per_rank, head_dim)
         value = value.reshape(bs, q_len, kv_head_num_per_rank, head_dim)
         if first_step:
+            # NOTE: when AR KV is pre-injected via inject_prompt_kv_cache(),
+            # the pipeline sets first_step=False for every denoising step so
+            # this branch is never entered and the injected cache is preserved.
+            # The else-branch below uses only the image-token K/V (which changes
+            # each step) and prepends the cached text K/V from image_kv_cache_map.
             self.image_kv_cache_map = None
             if self.sp_size <= 1:
                 self._save_image_kv_caches(key, value, seq_len)
@@ -1379,7 +1471,7 @@ class HunyuanImage3ImageProcessor:
                     f"`image_size` should be in the format of 'HxW', 'H:W' or <img_ratio_i>, got {image_size}."
                 )
             assert len(image_size) == 2, f"`image_size` should be in the format of 'HxW', got {image_size}."
-        elif isinstance(image_size, (list, tuple)):
+        elif isinstance(image_size, list | tuple):
             assert len(image_size) == 2 and all(isinstance(s, int) for s in image_size), (
                 f"`image_size` should be a tuple of two integers or a string in the format of 'HxW', got {image_size}."
             )
@@ -2614,6 +2706,7 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
         | None = None,
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
         model_kwargs: dict[str, Any] | None = None,
+        kv_injected: bool = False,
         **kwargs,
     ):
         r"""
@@ -2674,7 +2767,7 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
         callback_steps = kwargs.pop("callback_steps", None)
         pbar_steps = kwargs.pop("pbar_steps", None)
 
-        if isinstance(callback_on_step_end, (PipelineCallback, MultiPipelineCallbacks)):
+        if isinstance(callback_on_step_end, PipelineCallback | MultiPipelineCallbacks):
             callback_on_step_end_tensor_inputs = callback_on_step_end.tensor_inputs
 
         self._guidance_scale = guidance_scale
@@ -2713,11 +2806,15 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
         # (cfg_factor=2) batch before any splitting so that each rank's
         # slice is correct.
         input_ids = model_kwargs.pop("input_ids")
-        attention_mask = self.model._prepare_attention_mask_for_generation(  # noqa
-            input_ids,
-            self.model.generation_config,
-            model_kwargs=model_kwargs,
-        )
+        if kv_injected:
+            # KV reuse path: attention mask is pre-built, skip tokenizer-based mask.
+            attention_mask = model_kwargs.pop("attention_mask")
+        else:
+            attention_mask = self.model._prepare_attention_mask_for_generation(  # noqa
+                input_ids,
+                self.model.generation_config,
+                model_kwargs=model_kwargs,
+            )
 
         # Split inputs for CFG parallel: each rank processes only its branch.
         if cfg_parallel_ready:
@@ -2794,7 +2891,10 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
                     )
 
                     with torch.autocast(device_type=self.device.type, dtype=torch.bfloat16, enabled=True):
-                        model_output = self.model.forward_call(**model_inputs, first_step=(i == 0))
+                        model_output = self.model.forward_call(
+                            **model_inputs,
+                            first_step=(i == 0 and not kv_injected),
+                        )
                         pred = model_output["diffusion_prediction"]
                     pred = pred.to(dtype=torch.float32)
 

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -6,9 +6,13 @@ import os
 from collections.abc import Iterable
 from typing import Any
 
+import numpy as np
 import torch
 import torch.nn as nn
-from diffusers.schedulers.scheduling_flow_match_euler_discrete import FlowMatchEulerDiscreteScheduler
+from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
+    FlowMatchEulerDiscreteScheduler,
+)
+from PIL import Image as PILImage
 from transformers.generation.configuration_utils import GenerationConfig
 from transformers.generation.utils import ALL_CACHE_NAMES, GenerationMixin
 from transformers.models.siglip2 import Siglip2VisionConfig, Siglip2VisionModel
@@ -20,8 +24,12 @@ from vllm.transformers_utils.config import get_config
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import (
+    DiffusionPipelineProfilerMixin,
+)
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import OmniTextPrompt
 
 from .autoencoder import AutoencoderKLConv3D
 from .hunyuan_image3_tokenizer import TokenizerWrapper
@@ -63,7 +71,232 @@ def to_device(data, device):
         return data
 
 
-class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, DiffusionPipelineProfilerMixin):
+def _to_pil_image(image: Any) -> PILImage.Image:
+    if isinstance(image, PILImage.Image):
+        return image
+    if isinstance(image, str):
+        return PILImage.open(image)
+    if isinstance(image, np.ndarray):
+        array = image
+        if array.dtype != np.uint8:
+            if np.issubdtype(array.dtype, np.floating):
+                if float(np.min(array)) < 0.0:
+                    array = (np.clip(array, -1.0, 1.0) + 1.0) / 2.0
+                if float(np.max(array)) <= 1.0:
+                    array = array * 255.0
+            array = np.clip(array, 0, 255).astype(np.uint8)
+        if array.ndim == 3 and array.shape[0] in (1, 3, 4):
+            array = np.transpose(array, (1, 2, 0))
+        return PILImage.fromarray(array)
+    if isinstance(image, torch.Tensor):
+        tensor = image.detach().cpu()
+        if tensor.ndim == 4:
+            if tensor.shape[0] != 1:
+                raise ValueError(f"Only a single image tensor is supported, but got shape {tuple(tensor.shape)}.")
+            tensor = tensor.squeeze(0)
+        if tensor.ndim == 3 and tensor.shape[0] in (1, 3, 4):
+            tensor = tensor.permute(1, 2, 0)
+        if tensor.dtype.is_floating_point:
+            if float(tensor.min()) < 0.0:
+                tensor = (tensor.clamp(-1.0, 1.0) + 1.0) / 2.0
+            if float(tensor.max()) > 1.0:
+                tensor = tensor / 255.0
+            tensor = (tensor.clamp(0.0, 1.0) * 255.0).to(torch.uint8)
+        else:
+            tensor = tensor.to(torch.uint8)
+        return PILImage.fromarray(tensor.numpy())
+    raise TypeError(f"Unsupported image input type: {type(image)}")
+
+
+def _resize_and_crop_center(image: PILImage.Image, target_width: int, target_height: int) -> PILImage.Image:
+    src_width, src_height = image.size
+    scale = max(target_width / src_width, target_height / src_height)
+    resized_width = max(target_width, int(round(src_width * scale)))
+    resized_height = max(target_height, int(round(src_height * scale)))
+    resized = image.resize((resized_width, resized_height), PILImage.Resampling.LANCZOS)
+    left = max((resized_width - target_width) // 2, 0)
+    top = max((resized_height - target_height) // 2, 0)
+    right = left + target_width
+    bottom = top + target_height
+    return resized.crop((left, top, right, bottom))
+
+
+def _to_python_scalar(value: Any) -> Any:
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _image_info_to_payload(image_info: ImageInfo) -> dict[str, Any]:
+    return {
+        "image_type": image_info.image_type,
+        "image_tensor": image_info.image_tensor,
+        "image_width": _to_python_scalar(image_info.image_width),
+        "image_height": _to_python_scalar(image_info.image_height),
+        "token_width": _to_python_scalar(image_info.token_width),
+        "token_height": _to_python_scalar(image_info.token_height),
+        "image_token_length": _to_python_scalar(image_info.image_token_length),
+        "base_size": _to_python_scalar(image_info.base_size),
+        "ratio_index": _to_python_scalar(image_info.ratio_index),
+        "add_timestep_token": image_info.add_timestep_token,
+        "add_guidance_token": image_info.add_guidance_token,
+        "use_front_boi_token": image_info.use_front_boi_token,
+        "add_image_shape_token": image_info.add_image_shape_token,
+    }
+
+
+def _to_tensor_if_needed(value: Any) -> Any:
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, list):
+        return torch.tensor(value)
+    return value
+
+
+def _image_info_from_payload(payload: dict[str, Any]) -> ImageInfo:
+    return ImageInfo(
+        image_type=payload.get("image_type"),
+        image_tensor=_to_tensor_if_needed(payload.get("image_tensor")),
+        image_width=payload.get("image_width"),
+        image_height=payload.get("image_height"),
+        token_width=payload.get("token_width"),
+        token_height=payload.get("token_height"),
+        image_token_length=payload.get("image_token_length"),
+        base_size=payload.get("base_size"),
+        ratio_index=payload.get("ratio_index"),
+        add_timestep_token=payload.get("add_timestep_token", True),
+        add_guidance_token=payload.get("add_guidance_token", False),
+        use_front_boi_token=payload.get("use_front_boi_token", True),
+        add_image_shape_token=payload.get("add_image_shape_token", True),
+    )
+
+
+def _joint_image_info_to_payload(joint_image_info: JointImageInfo) -> dict[str, Any]:
+    return {
+        "type": "joint_image_info",
+        "vae_image_info": _image_info_to_payload(joint_image_info.vae_image_info),
+        "vision_image_info": _image_info_to_payload(joint_image_info.vision_image_info),
+        "vision_encoder_kwargs": joint_image_info.vision_encoder_kwargs,
+    }
+
+
+def _joint_image_info_from_payload(payload: Any) -> JointImageInfo:
+    if isinstance(payload, JointImageInfo):
+        return payload
+    if not isinstance(payload, dict):
+        raise TypeError(f"Expected dict or JointImageInfo for conditional image payload, got {type(payload)}.")
+
+    vae_image_info = _image_info_from_payload(payload["vae_image_info"])
+    vision_image_info = _image_info_from_payload(payload["vision_image_info"])
+    vision_encoder_kwargs = payload.get("vision_encoder_kwargs") or {}
+    if isinstance(vision_encoder_kwargs, dict):
+        vision_encoder_kwargs = {key: _to_tensor_if_needed(value) for key, value in vision_encoder_kwargs.items()}
+    return JointImageInfo(
+        vae_image_info=vae_image_info,
+        vision_image_info=vision_image_info,
+        vision_encoder_kwargs=vision_encoder_kwargs,
+    )
+
+
+def get_hunyuan_image_3_pre_process_func(od_config: OmniDiffusionConfig):
+    hf_config = get_config(od_config.model, trust_remote_code=True)
+    image_processor = HunyuanImage3ImageProcessor(hf_config)
+    vae_h_factor = hf_config.vae_downsample_factor[0] * hf_config.patch_size
+    vae_w_factor = hf_config.vae_downsample_factor[1] * hf_config.patch_size
+    vit_patch_size = getattr(image_processor.vision_encoder_processor, "patch_size", 1)
+    if isinstance(vit_patch_size, tuple | list):
+        vit_patch_size = int(vit_patch_size[0])
+
+    def _build_cond_joint_image(raw_image: Any) -> dict[str, Any]:
+        pil_image = _to_pil_image(raw_image).convert("RGB")
+        orig_width, orig_height = pil_image.size
+
+        target_width, target_height = image_processor.reso_group.get_target_size(orig_width, orig_height)
+        target_width = int(target_width)
+        target_height = int(target_height)
+        vae_input = _resize_and_crop_center(pil_image, target_width, target_height)
+        vae_tensor = image_processor.vae_processor(vae_input)
+        base_size, ratio_idx = image_processor.reso_group.get_base_size_and_ratio_index(orig_width, orig_height)
+        base_size = int(base_size)
+        ratio_idx = int(ratio_idx)
+
+        vae_info = ImageInfo(
+            image_type="vae",
+            image_tensor=vae_tensor,
+            image_width=target_width,
+            image_height=target_height,
+            token_width=target_width // vae_w_factor,
+            token_height=target_height // vae_h_factor,
+            base_size=base_size,
+            ratio_index=ratio_idx,
+        )
+
+        vit_inputs = image_processor.vision_encoder_processor(pil_image, return_tensors="pt")
+        vit_tensor = vit_inputs["pixel_values"]
+        spatial_shapes = vit_inputs["spatial_shapes"].squeeze(0)
+        pixel_attention_mask = vit_inputs["pixel_attention_mask"].squeeze(0)
+        vit_token_h = int(spatial_shapes[0].item())
+        vit_token_w = int(spatial_shapes[1].item())
+
+        vit_info = ImageInfo(
+            image_type="siglip2",
+            image_tensor=vit_tensor,
+            image_width=vit_token_w * vit_patch_size,
+            image_height=vit_token_h * vit_patch_size,
+            token_width=vit_token_w,
+            token_height=vit_token_h,
+            image_token_length=int(vit_tensor.shape[1]),
+        )
+
+        return _joint_image_info_to_payload(
+            JointImageInfo(
+                vae_image_info=vae_info,
+                vision_image_info=vit_info,
+                vision_encoder_kwargs={
+                    "spatial_shapes": spatial_shapes,
+                    "pixel_attention_mask": pixel_attention_mask,
+                },
+            )
+        )
+
+    def pre_process_func(request: OmniDiffusionRequest):
+        for i, prompt in enumerate(request.prompts):
+            if isinstance(prompt, str):
+                prompt = OmniTextPrompt(prompt=prompt)
+
+            if "additional_information" not in prompt:
+                prompt["additional_information"] = {}
+
+            multi_modal_data = prompt.get("multi_modal_data") or {}
+            raw_images = multi_modal_data.get("image")
+            if raw_images is None:
+                raw_images = prompt.get("pil_image")
+            has_images = raw_images is not None and (not isinstance(raw_images, list) or len(raw_images) > 0)
+            if has_images:
+                image_list = raw_images if isinstance(raw_images, list) else [raw_images]
+                cond_image_infos = [_build_cond_joint_image(image) for image in image_list]
+                prompt["additional_information"]["batch_cond_image_info"] = cond_image_infos
+
+                first_image_w, first_image_h = _to_pil_image(image_list[0]).size
+                if request.sampling_params.width is None:
+                    request.sampling_params.width = int(first_image_w)
+                if request.sampling_params.height is None:
+                    request.sampling_params.height = int(first_image_h)
+
+            request.prompts[i] = prompt
+
+        return request
+
+    return pre_process_func
+
+
+class HunyuanImage3Pipeline(
+    HunyuanImage3PreTrainedModel,
+    GenerationMixin,
+    SupportImageInput,
+    DiffusionPipelineProfilerMixin,
+):
+    support_image_input = True
     _PROFILER_TARGETS = [
         "model.forward",
         "model.layers[0].forward",
@@ -371,6 +604,13 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
     def vae_encode(self, image, cfg_factor=1):
         config = self.vae.config
 
+        if image.ndim == 3:
+            image = image.unsqueeze(0)
+        if image.ndim == 4:
+            image = image.unsqueeze(2)
+        if image.ndim != 5:
+            raise ValueError(f"Expected image tensor with 3/4/5 dims, got shape {tuple(image.shape)}.")
+
         with torch.autocast(device_type=self.model.device.type, dtype=torch.float16, enabled=True):
             vae_encode_result = self.vae.encode(image)
             if isinstance(vae_encode_result, torch.Tensor):
@@ -490,8 +730,7 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
         batch_cot_text = cot_text
         batch_system_prompt = system_prompt
         batch_gen_image_info = None
-        # TODO: construct with user input images
-        batch_cond_image_info = None
+        batch_cond_image_info = kwargs.pop("batch_cond_image_info", None)
 
         #   -- 2.1 message_list
         if batch_message_list is not None:
@@ -536,6 +775,12 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
             if mode == "gen_image":
                 batch_gen_image_info = [self.image_processor.build_image_info(image_size) for _ in range(batch_size)]
 
+            if batch_cond_image_info is not None:
+                assert isinstance(batch_cond_image_info, list) and len(batch_cond_image_info) == batch_size, (
+                    "`batch_cond_image_info` should be a list with the same batch size as `prompt`."
+                )
+                batch_cond_image_info = [cond if isinstance(cond, list) else [cond] for cond in batch_cond_image_info]
+
         #   -- 2.3 seed
         generator = kwargs.get("generator", None)
         if generator is None:
@@ -547,6 +792,11 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
         bot_task = kwargs.pop("bot_task", "auto")
         # If `drop_think` enabled, always drop <think> parts in the context.
         drop_think = kwargs.get("drop_think", self.generation_config.drop_think)
+        # Pull sequence_template from the model's generation_config so the DiT
+        # text prefix matches how the model was trained (Instruct for the
+        # HunyuanImage-3.0-Instruct checkpoint).  Falling back to "pretrain"
+        # only if the config does not specify it.
+        sequence_template = getattr(self.generation_config, "sequence_template", "pretrain")
         # Apply batched prompt or batched message_list to build input sequence with associated info.
         out = self._tkwrapper.apply_chat_template(
             batch_prompt=batch_prompt,
@@ -559,7 +809,7 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
             max_length=kwargs.get("max_length"),
             bot_task=bot_task,
             image_base_size=self.config.image_base_size,
-            sequence_template="pretrain",
+            sequence_template=sequence_template,
             cfg_factor=cfg_factor[mode],
             drop_think=drop_think,
         )
@@ -618,8 +868,16 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
         stop_token_id = dict(
             auto=[tkw.eos_token_id] + extra_auto_stops,
             image=[tkw.eos_token_id],
-            recaption=[tkw.end_recaption_token_id, tkw.end_answer_token_id, tkw.eos_token_id],
-            think=[tkw.end_recaption_token_id, tkw.end_answer_token_id, tkw.eos_token_id],
+            recaption=[
+                tkw.end_recaption_token_id,
+                tkw.end_answer_token_id,
+                tkw.eos_token_id,
+            ],
+            think=[
+                tkw.end_recaption_token_id,
+                tkw.end_answer_token_id,
+                tkw.eos_token_id,
+            ],
             img_ratio=extra_auto_stops,
         )
         model_input_kwargs = dict(
@@ -809,7 +1067,10 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
             # 50 and 5.0 hard code
             results = self.pipeline(
                 batch_size=len(batch_gen_image_info),
-                image_size=[batch_gen_image_info[0].image_height, batch_gen_image_info[0].image_width],
+                image_size=[
+                    batch_gen_image_info[0].image_height,
+                    batch_gen_image_info[0].image_width,
+                ],
                 num_inference_steps=kwargs.get("num_inference_steps", 50),
                 guidance_scale=kwargs.get("guidance_scale", 5.0),
                 generator=generator,
@@ -997,10 +1258,51 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
         extra_args = getattr(getattr(req, "sampling_params", None), "extra_args", {}) or {}
         use_system_prompt = extra_args.get("use_system_prompt")
         system_prompt = extra_args.get("system_prompt")
+        # Fall back to per-prompt use_system_prompt forwarded by ar2diffusion
+        if use_system_prompt is None and req.prompts:
+            first_prompt = req.prompts[0]
+            if isinstance(first_prompt, dict):
+                use_system_prompt = first_prompt.get("use_system_prompt")
         if use_system_prompt is not None:
             system_prompt = get_system_prompt(use_system_prompt, "image", system_prompt)
             system_prompt = system_prompt.strip() if system_prompt is not None else ""
         prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts] or prompt
+
+        # Extract AR-generated CoT/recaption text from each prompt's extra dict.
+        # The AR-side stage input processor (``ar2diffusion``) already prepends
+        # the trigger tag (e.g. ``<think>``) when the AR used the KV-reuse
+        # pretrain format, so ``ar_generated_text`` is a self-contained string
+        # and ``get_cot_sections()`` can parse the think/recaption structure
+        # directly.
+        cot_text_list = []
+        for p in req.prompts:
+            extra = p.get("extra", {}) if isinstance(p, dict) else {}
+            cot_text_list.append(extra.get("ar_generated_text") or None)
+        cot_text = cot_text_list if any(t is not None for t in cot_text_list) else None
+
+        batch_cond_image_info: list[list[JointImageInfo]] | None = None
+        if any(not isinstance(p, str) for p in req.prompts):
+            batch_cond_image_info = []
+            for prompt_item in req.prompts:
+                if isinstance(prompt_item, str):
+                    batch_cond_image_info.append([])
+                    continue
+                prompt_additional_information = prompt_item.get("additional_information") or {}
+                prompt_cond_infos = prompt_additional_information.get("batch_cond_image_info", [])
+                if isinstance(prompt_cond_infos, JointImageInfo | dict):
+                    prompt_cond_infos = [prompt_cond_infos]
+                if prompt_cond_infos is None:
+                    prompt_cond_infos = []
+                batch_cond_image_info.append([_joint_image_info_from_payload(item) for item in prompt_cond_infos])
+
+            has_cond_image = [len(cond_infos) > 0 for cond_infos in batch_cond_image_info]
+            if any(has_cond_image) and not all(has_cond_image):
+                raise ValueError(
+                    "When batching Hunyuan image editing requests, every prompt must include input image(s)."
+                )
+            if not any(has_cond_image):
+                batch_cond_image_info = None
+
         generator = req.sampling_params.generator or generator
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
@@ -1010,17 +1312,293 @@ class HunyuanImage3Pipeline(HunyuanImage3PreTrainedModel, GenerationMixin, Diffu
         if guidance_scale <= 1.0:
             logger.info("HunyuanImage3.0 runs without classifier-free guidance when guidance_scale <= 1.0.")
         image_size = (height, width)
+
+        # Check for injected KV cache from AR stage
+        past_kv = getattr(getattr(req, "sampling_params", None), "past_key_values", None)
+        if past_kv is not None:
+            return self._forward_with_kv_reuse(
+                req=req,
+                past_kv=past_kv,
+                image_size=image_size,
+                num_inference_steps=num_inference_steps,
+                guidance_scale=guidance_scale,
+                generator=generator,
+                batch_cond_image_info=batch_cond_image_info,
+                **kwargs,
+            )
+
         model_inputs = self.prepare_model_inputs(
             prompt=prompt,
-            cot_text=None,
+            cot_text=cot_text,
             system_prompt=system_prompt,
             mode="gen_image",
             generator=generator,
             image_size=image_size,
             num_inference_steps=num_inference_steps,
             guidance_scale=guidance_scale,
+            batch_cond_image_info=batch_cond_image_info,
         )
         outputs = self._generate(**model_inputs, **kwargs)
         return DiffusionOutput(
-            output=outputs[0], stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None
+            output=outputs[0],
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
+
+    def _forward_with_kv_reuse(
+        self,
+        req: OmniDiffusionRequest,
+        past_kv: Any,
+        image_size: tuple[int, int],
+        num_inference_steps: int = 50,
+        guidance_scale: float = 5.0,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        batch_cond_image_info: list[list[JointImageInfo]] | None = None,
+        **kwargs,
+    ) -> DiffusionOutput:
+        """Generate image using injected AR text KV cache.
+
+        Instead of processing text tokens through the model, this method
+        injects pre-computed text KV from the AR stage into each layer's
+        ``ImageKVCacheManager`` and runs the denoising loop with all steps
+        as non-first steps.
+
+        ``batch_cond_image_info`` carries the source-image conditioning for
+        IT2I (image editing). If provided it is VAE+ViT-encoded here, mirroring
+        the non-reuse ``__call__`` path so the denoiser still sees the source
+        image via ``cond_vae_images`` / ``cond_vit_images``.
+        """
+        height, width = image_size
+        device = self.device
+
+        # 1. Build image info
+        image_info = self.image_processor.build_image_info(image_size)
+        batch_gen_image_info = [image_info]
+        token_h = image_info.token_height
+        token_w = image_info.token_width
+        num_patches = token_h * token_w
+        num_image_tokens = (
+            num_patches + (1 if image_info.add_timestep_token else 0) + (1 if image_info.add_guidance_token else 0)
+        )
+
+        # 2. Get AR KV lengths
+        pos_key_cache = past_kv.key_cache
+        pos_value_cache = past_kv.value_cache
+        L_pos = next(k.shape[0] for k in pos_key_cache if k is not None)
+
+        # cfg_text_past_key_values is populated by collect_cfg_kv_caches()
+        # (hunyuan_image3 stage input processor), which is invoked by the
+        # diffusion model runner after receiving the primary KV cache from
+        # the AR stage.  It collects the companion negative-branch KV cache
+        # (generated by the expand_cfg_prompts companion request) and attaches
+        # it to sampling_params so the DiT can use it here for CFG.
+        neg_kv = getattr(req.sampling_params, "cfg_text_past_key_values", None)
+        use_cfg = neg_kv is not None and guidance_scale > 1.0
+
+        if use_cfg:
+            neg_key_cache = neg_kv.key_cache
+            neg_value_cache = neg_kv.value_cache
+            L_neg = next(k.shape[0] for k in neg_key_cache if k is not None)
+            L_text = max(L_pos, L_neg)
+            bsz = 2  # cfg_factor = 2
+        else:
+            L_neg = 0
+            L_text = L_pos
+            bsz = 1
+
+        # The normal (non-KV-reuse) token sequence layout is:
+        #   [BOS][sys][user][cot]  [<boi>][<img_size_*>][<img_ratio_*>]  [<timestep>][img×N]  [<eoi>]
+        #   ←─────── L_text ────────────────── NUM_SPECIAL_TOKENS=3 ──→  ←── num_image_tokens ──→  1
+        #
+        # The 3 DiT-specific special tokens (<boi>, <img_size>, <img_ratio>) are NOT
+        # produced by the AR model; they are inserted by encode_sequence() and therefore
+        # absent from the AR KV cache.  We must account for them in every position-
+        # sensitive calculation: total_seq_len, position_ids, gen_image_start, and
+        # inject_prompt_kv_cache (zero-padded slots).
+        NUM_SPECIAL_TOKENS = 3  # <boi>, <img_size_*>, <img_ratio_*>
+        total_seq_len = L_text + NUM_SPECIAL_TOKENS + num_image_tokens + 1  # text + special + image + eoi
+
+        logger.info(
+            "[KV Reuse] L_pos=%d, L_neg=%d, L_text=%d, num_special=%d, "
+            "num_image_tokens=%d, total_seq_len=%d, use_cfg=%s",
+            L_pos,
+            L_neg,
+            L_text,
+            NUM_SPECIAL_TOKENS,
+            num_image_tokens,
+            total_seq_len,
+            use_cfg,
+        )
+        # 3. Inject KV into each layer's ImageKVCacheManager
+        num_layers = len(self.model.layers)
+        last_pos_k, last_pos_v = None, None
+        last_neg_k, last_neg_v = None, None
+
+        for layer_idx in range(num_layers):
+            pos_k = pos_key_cache[layer_idx]
+            pos_v = pos_value_cache[layer_idx]
+
+            # Handle CLA: copy from previous non-None layer
+            if pos_k is None:
+                pos_k, pos_v = last_pos_k, last_pos_v
+            else:
+                last_pos_k, last_pos_v = pos_k, pos_v
+
+            neg_k, neg_v = None, None
+            if use_cfg:
+                neg_k = neg_key_cache[layer_idx]
+                neg_v = neg_value_cache[layer_idx]
+                if neg_k is None:
+                    neg_k, neg_v = last_neg_k, last_neg_v
+                else:
+                    last_neg_k, last_neg_v = neg_k, neg_v
+
+            kv_mgr = self.model.layers[layer_idx].self_attn.image_attn
+            kv_mgr.inject_prompt_kv_cache(
+                pos_k.to(device),
+                pos_v.to(device),
+                neg_k.to(device) if neg_k is not None else None,
+                neg_v.to(device) if neg_v is not None else None,
+                num_special_tokens=NUM_SPECIAL_TOKENS,
+            )
+            # Reset RoPE cache: normally cleared by first_step=True, which we skip.
+            self.model.layers[layer_idx].self_attn.image_rope2d_emb.custom_pos_emb = None
+
+        # 4. Build custom_pos_emb (2D RoPE)
+        # Image sequence after text: [<boi>][<img_size>][<img_ratio>][<timestep>][img×N]
+        # Patches start at L_text + NUM_SPECIAL_TOKENS + 1 (after special tokens + timestep)
+        gen_image_start = L_text + NUM_SPECIAL_TOKENS + 1
+        gen_image_slice = slice(gen_image_start, gen_image_start + num_patches)
+        rope_image_info = [[(gen_image_slice, (token_h, token_w))]] * bsz
+
+        cos, sin = build_batch_2d_rope(
+            image_infos=rope_image_info,
+            seq_len=total_seq_len,
+            n_elem=self.config.attention_head_dim,
+            device=device,
+            base=self.config.rope_theta,
+        )
+        custom_pos_emb = (cos, sin)
+
+        # 5. Build position_ids for image-only queries
+        # Queries are: [<timestep>, img_patch_0, ..., img_patch_N-1]
+        # Their absolute positions in the full sequence start at L_text + NUM_SPECIAL_TOKENS
+        position_ids = (
+            torch.arange(
+                L_text + NUM_SPECIAL_TOKENS,
+                L_text + NUM_SPECIAL_TOKENS + num_image_tokens,
+                device=device,
+                dtype=torch.long,
+            )
+            .unsqueeze(0)
+            .expand(bsz, -1)
+        )
+
+        # 6. Build attention mask [bsz, 1, num_image_tokens, total_seq_len]
+        # Image tokens attend to all text + all special + all image tokens, but not eoi
+        attention_mask = torch.ones(
+            bsz,
+            1,
+            num_image_tokens,
+            total_seq_len,
+            dtype=torch.bool,
+            device=device,
+        )
+        attention_mask[:, :, :, -1] = False  # don't attend to dummy eoi
+
+        # Mask zero-padded DiT-specific special tokens for both branches.
+        # inject_prompt_kv_cache fills positions [L_text : L_text+NUM_SPECIAL_TOKENS]
+        # with zeros; without this mask the image queries waste attention weight on
+        # zero KV vectors, producing different softmax normalisation than the normal path.
+        attention_mask[:, :, :, L_text : L_text + NUM_SPECIAL_TOKENS] = False
+
+        # Mask padded text positions independently for each branch.
+        # ``inject_prompt_kv_cache`` pads whichever branch is shorter up to
+        # ``L_text = max(L_pos, L_neg)`` with zeros; if we only mask one side,
+        # the other (longer-padded) branch attends to its own zero-padded
+        # region and the softmax normalisation is wrong, which degrades CFG
+        # quality. Handle both L_neg < L_pos (the common path) and L_pos < L_neg
+        # (explicit long negative prompt) symmetrically.
+        if use_cfg:
+            if L_pos < L_text:
+                attention_mask[0, :, :, L_pos:L_text] = False
+            if L_neg < L_text:
+                attention_mask[1, :, :, L_neg:L_text] = False
+
+        # 7. Build dummy input_ids (not used for non-first steps, but needed for shape)
+        # These zeros never reach the transformer layers: the pipeline passes
+        # ``kv_injected=True`` so every step runs with ``first_step=False``, and
+        # in that branch ``prepare_inputs_embeds`` rebuilds ``inputs_embeds``
+        # from scratch as ``torch.cat([timestep_emb, image_emb])`` -- the
+        # ``embed_tokens(input_ids)`` output is overwritten before it is used.
+        # ``input_ids`` is kept only because the model signature requires it
+        # for shape inference and attention-mask bookkeeping.
+        input_ids = torch.zeros(bsz, num_image_tokens, dtype=torch.long, device=device)
+
+        # 8. Prepare generator
+        if generator is None:
+            seeds = self.prepare_seed(seed=None, batch_size=1)
+            generator = [torch.Generator(device).manual_seed(seed) for seed in seeds]
+
+        # 9. Assemble model_kwargs for the denoising pipeline.
+        # NOTE: on the KV-reuse path the source-image conditioning (VAE + ViT
+        # features of the input image for IT2I) has already been consumed by
+        # the AR stage and is encoded in the injected text/image KV. Passing
+        # ``cond_vae_images``/``cond_vit_images`` again here would require the
+        # matching ``cond_*_image_mask`` / scatter indices, which only exist
+        # on the non-reuse ``encode_sequence`` output. Threading them through
+        # is a separate design discussion (see review thread); for now leave
+        # these as ``None`` on the KV-reuse path -- the AR KV carries the
+        # image conditioning.
+        #    images and timestep are provided per-step by __call__, but
+        #    gen_timestep_scatter_index must be present (forward_call asserts
+        #    it's not None in gen_image mode, even though it's only used at
+        #    the first step).
+        gen_timestep_scatter_index = torch.zeros(
+            bsz,
+            1,
+            dtype=torch.long,
+            device=device,
+        )
+        model_kwargs: dict[str, Any] = {
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "attention_mask": attention_mask,
+            "custom_pos_emb": custom_pos_emb,
+            "mode": "gen_image",
+            "num_image_tokens": num_image_tokens,
+            "batch_gen_image_info": batch_gen_image_info,
+            "query_lens": [num_image_tokens] * bsz,
+            "seq_lens": [total_seq_len] * bsz,
+            "gen_timestep_scatter_index": gen_timestep_scatter_index,
+            # Not needed for non-first steps but must not conflict with
+            # __call__'s per-step images/timestep kwargs.
+            "past_key_values": None,
+            "image_mask": None,
+            "cond_vae_images": None,
+            "cond_timestep": None,
+            "cond_vae_image_mask": None,
+            "cond_vit_images": None,
+            "cond_vit_image_mask": None,
+            "vit_kwargs": None,
+            "cond_timestep_scatter_index": None,
+        }
+
+        # 10. Call the denoising pipeline with kv_injected=True
+        # Use the snapped resolution from image_info to ensure latent dimensions
+        # match the num_image_tokens computed above (build_image_info snaps to
+        # the nearest resolution in reso_group; passing raw height/width would
+        # produce latents with a different spatial size → patch count mismatch).
+        results = self.pipeline(
+            batch_size=1,
+            image_size=[image_info.image_height, image_info.image_width],
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+            generator=generator,
+            model_kwargs=model_kwargs,
+            kv_injected=True,
+        )
+        samples = results[0]
+        return DiffusionOutput(
+            output=samples,
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
         )

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -425,6 +425,7 @@ _DIFFUSION_PRE_PROCESS_FUNCS = {
     "HeliosPipeline": "get_helios_pre_process_func",
     "HeliosPyramidPipeline": "get_helios_pre_process_func",
     "HunyuanVideo15ImageToVideoPipeline": "get_hunyuan_video_15_i2v_pre_process_func",
+    "HunyuanImage3ForCausalMM": "get_hunyuan_image_3_pre_process_func",
     "MagiHumanPipeline": "get_magi_human_pre_process_func",
 }
 

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -96,6 +96,7 @@ class DiffusionWorker:
 
     def init_device(self) -> None:
         """Initialize the device and distributed environment."""
+        torch.backends.cudnn.enabled = False
         world_size = self.od_config.num_gpus
         rank = self.rank
 

--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -576,7 +576,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
 
             # Use 'if' (not 'elif') so the ManagedBuffer fallback above can
             # convert to Tensor and flow into this branch seamlessly.
-            if isinstance(data, (torch.Tensor, bytes)):
+            if isinstance(data, torch.Tensor | bytes):
                 # Copy Path
                 # 1. Determine size
                 if isinstance(data, torch.Tensor):
@@ -793,9 +793,9 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             # Path 3: no metadata at all — query default sender
             if not self.sender_host or not self.sender_zmq_port or str(self.sender_host).lower() == "auto":
                 raise RuntimeError(
-                    f"get(metadata=None) requires sender info to be resolved, "
-                    f"but sender_host={self.sender_host!r}, sender_zmq_port={self.sender_zmq_port!r}. "
-                    f"Call update_sender_info(host, port) before using get() without metadata."
+                    f"get({get_key}): sender info not yet resolved "
+                    f"(sender_host={self.sender_host!r}, sender_zmq_port={self.sender_zmq_port!r}). "
+                    "Caller must call update_sender_info() before issuing a get with no metadata."
                 )
             metadata = self._query_metadata_from_sender(get_key)
             if not metadata:

--- a/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
+++ b/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
@@ -995,6 +995,11 @@ class OmniKVTransferManager:
             logger.info(f"Skip receiving KV cache for {request_id} (need_recv_cache=False)")
             return None, 0
 
+        # Skip during warmup dummy run — no sender is available.
+        if request_id == "dummy_req_id":
+            logger.info("Skip receiving KV cache for dummy warmup request")
+            return None, 0
+
         timeout = self.config.recv_timeout
         start_time = time.time()
         poll_interval = 0.01
@@ -1060,7 +1065,7 @@ class OmniKVTransferManager:
                             if managed_buffer is not None:
                                 raw_data.release()
                             return None, 0
-                    elif isinstance(raw_data, (bytes, bytearray)):
+                    elif isinstance(raw_data, bytes | bytearray):
                         data = KVCacheTransferData.from_bytes(raw_data)
                     elif isinstance(raw_data, torch.Tensor) and raw_data.dtype == torch.uint8 and raw_data.dim() == 1:
                         data = KVCacheTransferData.from_bytes(raw_data.cpu().numpy().tobytes())

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -1589,8 +1589,6 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
 
         min_score = torch.finfo(logits.dtype).min
 
-        assert logits.shape[0] == 1, f"HunyuanImage3 sampler requires max_num_seqs=1, got batch size {logits.shape[0]}"
-
         for req_idx in range(logits.shape[0]):
             decoded_tokens: list[int] = (
                 sampling_metadata.output_token_ids[req_idx] if req_idx < len(sampling_metadata.output_token_ids) else []

--- a/vllm_omni/model_executor/stage_configs/hunyuan_image3_i2t.yaml
+++ b/vllm_omni/model_executor/stage_configs/hunyuan_image3_i2t.yaml
@@ -39,3 +39,6 @@ stage_args:
 
 runtime:
   enabled: true
+  defaults:
+    window_size: -1
+    max_inflight: 1

--- a/vllm_omni/model_executor/stage_configs/hunyuan_image3_it2i_kv_reuse.yaml
+++ b/vllm_omni/model_executor/stage_configs/hunyuan_image3_it2i_kv_reuse.yaml
@@ -1,25 +1,33 @@
-# Stage config for HunyuanImage-3.0 Image+Text-to-Image (image editing).
-# Stage 0: AR (HunyuanImage3ForConditionalGeneration) — reads (image, text), emits latent tokens
-# Stage 1: Diffusion (HunyuanImage3Pipeline / DiT + VAE) — denoise + decode latents → image
+# Stage config for HunyuanImage-3.0 Image+Text-to-Image with AR->DiT KV reuse.
+#
+# Compared to hunyuan_image3_it2i.yaml, this config:
+#   1. Adds omni_kv_config.need_send_cache=true on stage-0 (AR)
+#   2. Adds prompt_expand_func for CFG companion AR request (negative branch)
+#   3. Adds cfg_kv_collect_func on stage-1 (DiT)
+#   4. Keeps requires_multimodal_data=true so the original image is forwarded
+#      to DiT for conditional VAE encoding (image editing conditioning)
+#   5. No kv_transfer_criteria: full KV (think + recaption) is transferred
+#      after AR decodes to EOS
 
 stage_args:
-  # Stage 0: AR Model
   - stage_id: 0
     stage_type: llm
+    prompt_expand_func: vllm_omni.model_executor.stage_input_processors.hunyuan_image3.expand_cfg_prompts
     runtime:
       process: true
       devices: "0,1,2,3"
       max_batch_size: 1
-      requires_multimodal_data: true  # AR needs the original image
+      requires_multimodal_data: true
     engine_args:
       model_stage: AR
+      max_num_seqs: 2
       model_arch: HunyuanImage3ForCausalMM
       worker_cls: vllm_omni.worker.gpu_ar_worker.GPUARWorker
       scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
       gpu_memory_utilization: 0.95
       enforce_eager: true
       trust_remote_code: true
-      engine_output_type: latent  # AR outputs latent for DiT
+      engine_output_type: latent
       enable_prefix_caching: false
       max_num_batched_tokens: 32768
       tensor_parallel_size: 4
@@ -28,25 +36,26 @@ stage_args:
         rope_parameters:
           mrope_section: [0, 32, 32]
           rope_type: default
-    is_comprehension: false  # Generation task, not comprehension
-    final_output: false  # AR is not the final output
+      omni_kv_config:
+        need_send_cache: true
+    is_comprehension: false
+    final_output: false
     default_sampling_params:
       temperature: 0.6
       top_p: 0.95
       top_k: 1024
       max_tokens: 4096
-      stop_token_ids: [127957]  # <|endoftext|>
+      stop_token_ids: [127957]
       detokenize: false
 
-  # Stage 1: Diffusion (DiT + VAE)
-  # Receives latents from AR stage, performs denoising + VAE decode
   - stage_id: 1
     stage_type: diffusion
+    cfg_kv_collect_func: vllm_omni.model_executor.stage_input_processors.hunyuan_image3.collect_cfg_kv_caches
     runtime:
       process: true
       devices: "4,5,6,7"
       max_batch_size: 1
-      requires_multimodal_data: true  # May need condition images
+      requires_multimodal_data: true
     engine_args:
       model_stage: dit
       model_arch: HunyuanImage3ForCausalMM
@@ -58,7 +67,7 @@ stage_args:
         enable_expert_parallel: true
       omni_kv_config:
         need_recv_cache: true
-    engine_input_source: [0]  # Input from AR stage
+    engine_input_source: [0]
     custom_process_input_func: vllm_omni.model_executor.stage_input_processors.hunyuan_image3.ar2diffusion
     final_output: true
     final_output_type: image
@@ -66,13 +75,12 @@ stage_args:
       num_inference_steps: 50
       guidance_scale: 2.5
 
-# Top-level runtime config
 runtime:
   enabled: true
   defaults:
-    window_size: -1  # Trigger downstream only after full upstream completion
-    max_inflight: 1  # Process serially within each stage
+    window_size: -1
+    max_inflight: 1
   edges:
-    - from: 0  # AR → Diffusion
+    - from: 0
       to: 1
       window_size: -1

--- a/vllm_omni/model_executor/stage_configs/hunyuan_image3_moe.yaml
+++ b/vllm_omni/model_executor/stage_configs/hunyuan_image3_moe.yaml
@@ -8,17 +8,21 @@
 # Compared to hunyuan_image3_t2i.yaml, this config:
 #   1. Enables both stages [0, 1] for text-to-image (AR prefill + DiT denoising)
 #   2. Adds omni_kv_config to send/receive KV cache between stages
+#   3. Uses prompt_expand_func for CFG companion AR requests
+#   4. Removes kv_transfer_criteria so AR decodes until EOS, then transfers
+#      full KV cache (including think + recaption tokens) to DiT.
 
 # The following config has been verified on 8x L40S-48G GPU (4 for AR + 4 for DiT).
 stage_args:
   - stage_id: 0
     stage_type: llm  # Use llm stage type for AR stages
+    prompt_expand_func: vllm_omni.model_executor.stage_input_processors.hunyuan_image3.expand_cfg_prompts
     runtime:
       process: true  # Run this stage in a separate process
       devices: "0,1,2,3"  # AR stage uses GPU 0-3
     engine_args:
       model_stage: AR
-      max_num_seqs: 1
+      max_num_seqs: 2  # main request + CFG companion
       model_arch: HunyuanImage3ForCausalMM
       worker_cls: vllm_omni.worker.gpu_ar_worker.GPUARWorker
       scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
@@ -36,8 +40,8 @@ stage_args:
           rope_type: default
       omni_kv_config:
         need_send_cache: true
-        kv_transfer_criteria:
-          type: prefill_finished  # Send KV cache after AR prefill completes
+        # No kv_transfer_criteria: AR decodes until EOS, then transfers full
+        # KV cache (including think + recaption tokens) via _free_request path.
     is_comprehension: true
     final_output: true
     final_output_type: text
@@ -51,6 +55,7 @@ stage_args:
       repetition_penalty: 1.1
   - stage_id: 1
     stage_type: diffusion
+    cfg_kv_collect_func: vllm_omni.model_executor.stage_input_processors.hunyuan_image3.collect_cfg_kv_caches
     runtime:
       process: true
       devices: "4,5,6,7"  # DiT stage uses GPU 4-7

--- a/vllm_omni/model_executor/stage_configs/hunyuan_image3_t2t.yaml
+++ b/vllm_omni/model_executor/stage_configs/hunyuan_image3_t2t.yaml
@@ -40,3 +40,6 @@ stage_args:
 
 runtime:
   enabled: true
+  defaults:
+    window_size: -1
+    max_inflight: 1

--- a/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
+++ b/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
@@ -6,10 +6,19 @@ In IT2I (image editing) mode:
   - Stage 0 (AR) receives (image + edit instruction), generates CoT/latent tokens
   - Stage 1 (DiT) receives the AR output + original image, denoises → edited image
 
+For inter-stage KV cache reuse (text-to-image):
+  - Stage 0 (AR) prefills text tokens and sends KV cache to Stage 1
+  - expand_cfg_prompts creates a CFG companion request for the negative branch
+  - collect_cfg_kv_caches collects the companion KV cache for the DiT
+
 The ar2diffusion function bridges these two stages, following the same
 signature pattern as glm_image.ar2diffusion.
 """
 
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
 from typing import Any
 
 import torch
@@ -60,6 +69,27 @@ def ar2diffusion(
         generated_token_ids = output.token_ids
         generated_text = getattr(output, "text", "") or ""
 
+        # When the AR stage is configured with `detokenize: false` (the default
+        # for the HunyuanImage-3 IT2I configs, which avoids the cost of streaming
+        # text during generation), ``output.text`` is empty even though tokens
+        # were produced.  The DiT needs the decoded CoT text to rebuild the
+        # joint sequence via ``apply_chat_template``, so decode the tokens here
+        # on the fly as a fallback.  Without this fallback the DiT receives an
+        # empty ``ar_generated_text`` and silently drops the image conditioning
+        # — this is the "text length=0 / model ignores the input image" symptom
+        # reported in https://github.com/vllm-project/vllm-omni/pull/2590.
+        if not generated_text and generated_token_ids:
+            tokenizer = _resolve_ar_tokenizer(stage_list[source_stage_id])
+            if tokenizer is not None:
+                try:
+                    generated_text = tokenizer.decode(list(generated_token_ids), skip_special_tokens=False)
+                except Exception as exc:
+                    logger.warning(
+                        "[ar2diffusion] Failed to decode AR tokens for request %d: %s",
+                        i,
+                        exc,
+                    )
+
         # Get original prompt info
         original_prompt = prompt[i] if i < len(prompt) else {}
         if isinstance(original_prompt, dict):
@@ -73,7 +103,11 @@ def ar2diffusion(
 
         height = original_prompt.get("height", 1024)
         width = original_prompt.get("width", 1024)
-        text_prompt = original_prompt.get("prompt", "")
+        # Prefer clean user_prompt over the full baked AR string so the DiT
+        # can reconstruct the sequence with the same template as at training time.
+        # Fall back to "prompt" for callers that do not populate "user_prompt".
+        text_prompt = original_prompt.get("user_prompt") or original_prompt.get("prompt", "")
+        use_system_prompt = original_prompt.get("use_system_prompt")
 
         logger.info(
             "[ar2diffusion] Request %d: AR generated %d tokens, text length=%d, target size=%dx%d",
@@ -83,6 +117,18 @@ def ar2diffusion(
             height,
             width,
         )
+
+        # If the AR stage used a pretrain-format input (KV-reuse path) the
+        # trigger tag (e.g. "<think>") was NOT part of the AR prefill and is
+        # provided separately via ``original_prompt["trigger_tag"]``.  Concatenate
+        # it here (mirroring the official HunyuanImage-3 reference:
+        # https://github.com/Tencent-Hunyuan/HunyuanImage-3.0/blob/main/hunyuan_image_3/modeling_hunyuan_image_3.py#L3355)
+        # so the DiT just sees a single ``ar_generated_text`` field without
+        # needing to know about the trigger tag.  Guard against double-prepend
+        # when the AR model has already emitted the trigger as its first token.
+        trigger_tag = original_prompt.get("trigger_tag")
+        if trigger_tag and generated_text and not generated_text.startswith(trigger_tag):
+            generated_text = trigger_tag + generated_text
 
         token_tensor = torch.tensor(generated_token_ids, dtype=torch.long)
 
@@ -96,16 +142,19 @@ def ar2diffusion(
             },
         }
 
+        # Forward use_system_prompt so the DiT can build the same system prefix
+        if use_system_prompt is not None:
+            diffusion_input["use_system_prompt"] = use_system_prompt
+
         # Forward multimodal data (original image for IT2I conditioning)
         mm_data = original_prompt.get("multi_modal_data")
         if mm_data:
-            pil_image = mm_data.get("image")
-            if pil_image is None:
-                images = mm_data.get("images")
-                if images:
-                    pil_image = images[0] if isinstance(images, list) else images
-            if pil_image is not None:
-                diffusion_input["pil_image"] = pil_image
+            prompt_images = mm_data.get("image")
+            if prompt_images is None:
+                prompt_images = mm_data.get("images")
+            if prompt_images is not None:
+                diffusion_input["pil_image"] = prompt_images
+                diffusion_input["multi_modal_data"] = {"image": prompt_images}
 
         # Forward multimodal output from AR (if any)
         if hasattr(ar_output, "multimodal_output") and ar_output.multimodal_output:
@@ -121,3 +170,223 @@ def ar2diffusion(
         diffusion_inputs.append(diffusion_input)
 
     return diffusion_inputs
+
+
+# ---------------------------------------------------------------------------
+# CFG prompt expansion & KV cache collection for inter-stage KV reuse
+# ---------------------------------------------------------------------------
+
+logger = logging.getLogger(__name__)
+
+CFG_TEXT_SUFFIX = "__cfg_text"
+
+
+_AR_TOKENIZER_CACHE: dict[str, Any] = {}
+
+
+def _resolve_ar_tokenizer(stage_client: Any) -> Any:
+    """Best-effort resolution of the AR stage's tokenizer.
+
+    The stage client exposes the resolved ``vllm_config``; we use its
+    ``model_config.model`` path to load an ``AutoTokenizer`` lazily and cache
+    the result so we don't pay the init cost on every request.
+    """
+    model_path = None
+    vllm_config = getattr(stage_client, "vllm_config", None)
+    if vllm_config is not None:
+        model_cfg = getattr(vllm_config, "model_config", None)
+        if model_cfg is not None:
+            model_path = getattr(model_cfg, "tokenizer", None) or getattr(model_cfg, "model", None)
+    if model_path is None:
+        model_path = getattr(stage_client, "model", None) or getattr(stage_client, "model_name", None)
+    if not model_path:
+        return None
+    if model_path in _AR_TOKENIZER_CACHE:
+        return _AR_TOKENIZER_CACHE[model_path]
+    try:
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    except Exception as exc:
+        logger.warning("[ar2diffusion] Could not load tokenizer from %r: %s", model_path, exc)
+        _AR_TOKENIZER_CACHE[model_path] = None
+        return None
+    _AR_TOKENIZER_CACHE[model_path] = tokenizer
+    return tokenizer
+
+
+def expand_cfg_prompts(
+    prompt: dict[str, Any] | str,
+    sampling_params: Any,
+) -> list:
+    """Expand user prompt into companion prompts for HunyuanImage3 CFG.
+
+    Creates a negative/unconditional companion request that the AR stage
+    prefills to produce the CFG text KV cache.  The companion request gets
+    ``max_tokens=1`` so it stops immediately after prefill – only the text
+    KV cache is needed, no decoding.
+
+    The companion must mirror the **structure** of the positive prompt so
+    that the positive and negative KV caches have matching layouts
+    (same system-prompt section, same image section when present, same
+    assistant/trigger prefix).  Otherwise the injected ``L_pos`` and
+    ``L_neg`` diverge in both length and per-section semantics, and the
+    DiT's CFG becomes mathematically degenerate – the exact failure mode
+    we observed as ``L_pos=6833, L_neg=1`` in the logs.
+
+    Official Hunyuan reference behaviour (``tokenization_hunyuan_image_3.py``):
+
+        if uncond_flag and do_uncond_drop:
+            text_token = [self.cfg_token_id] * len(text_token)
+
+    i.e. every user-text token is replaced with the ``<cfg>`` token, but
+    every other section (system, image, trigger) is preserved.  We
+    approximate that here by reusing the positive prompt dict and
+    replacing only the user-facing text fields with the ``<cfg>`` token.
+
+    Args:
+        prompt: The original user prompt (dict or string).
+        sampling_params: Stage-0 sampling params.
+
+    Returns:
+        List of ``ExpandedPrompt``.  Empty if no expansion needed.
+    """
+    from vllm_omni.model_executor.stage_input_processors.bagel import ExpandedPrompt
+
+    if not isinstance(prompt, dict):
+        return []
+
+    modalities = prompt.get("modalities", [])
+    if "image" not in modalities:
+        return []
+
+    CFG_TOKEN = "<cfg>"
+
+    # 1. Build the negative prompt string from the positive prompt string.
+    # Substitute the user's text with a single <cfg> token so the companion
+    # traverses the exact same sections (BOS, system, image marker,
+    # assistant/trigger) as the positive branch.  The small length delta
+    # vs the "one <cfg> per user-text token" official behaviour is zero-
+    # padded and masked in inject_prompt_kv_cache, which is benign because
+    # the padding sits at the end of the user-text section — all the
+    # model-critical sections remain aligned.
+    pos_prompt_text = prompt.get("prompt")
+    user_text = prompt.get("user_prompt")
+    explicit_neg = _get_negative_prompt(prompt, sampling_params)
+
+    if explicit_neg:
+        neg_prompt = explicit_neg
+    elif pos_prompt_text and user_text and user_text in pos_prompt_text:
+        # Replace the exact user-text substring with the <cfg> token.
+        neg_prompt = pos_prompt_text.replace(user_text, CFG_TOKEN, 1)
+    elif pos_prompt_text:
+        # Cannot locate user_text; append <cfg> before the assistant
+        # marker if present, else fall back to the pos prompt verbatim.
+        neg_prompt = pos_prompt_text
+    else:
+        # Final fallback — at least non-empty.
+        neg_prompt = "<|startoftext|>"
+
+    # 2. Build the companion dict, inheriting modalities + multimodal data
+    # so the image section is prefilled for the uncond branch too.
+    neg_prompt_dict: dict[str, Any] = {
+        "prompt": neg_prompt,
+        "modalities": prompt.get("modalities", []),
+    }
+    if "multi_modal_data" in prompt:
+        neg_prompt_dict["multi_modal_data"] = prompt["multi_modal_data"]
+    if "height" in prompt:
+        neg_prompt_dict["height"] = prompt["height"]
+    if "width" in prompt:
+        neg_prompt_dict["width"] = prompt["width"]
+    if "use_system_prompt" in prompt:
+        neg_prompt_dict["use_system_prompt"] = prompt["use_system_prompt"]
+
+    # Companion only needs prefill KV – stop after 1 token.
+    companion_params = {"max_tokens": 1}
+
+    return [
+        ExpandedPrompt(
+            prompt=neg_prompt_dict,
+            role="cfg_text",
+            request_id_suffix=CFG_TEXT_SUFFIX,
+            sampling_params_override=companion_params,
+        ),
+    ]
+
+
+def collect_cfg_kv_caches(
+    request_id: str,
+    cfg_request_ids: dict[str, str],
+    kv_transfer_manager: Any,
+    target_device: Any | None = None,
+) -> dict[str, Any]:
+    """Collect KV caches for CFG companion requests.
+
+    Called by the diffusion model runner after receiving the primary KV
+    cache.  Uses the kv_transfer_manager to fetch companion KV caches by
+    their request IDs.
+
+    Args:
+        request_id: The original (parent) request ID.
+        cfg_request_ids: Mapping of role → companion request ID,
+            e.g. ``{"cfg_text": "req_0__cfg_text"}``.
+        kv_transfer_manager: The ``OmniKVTransferManager`` instance.
+        target_device: Device to move tensors to.
+
+    Returns:
+        Dict with keys like ``"cfg_text_past_key_values"``,
+        ``"cfg_text_kv_metadata"``, etc.
+    """
+    result: dict[str, Any] = {}
+
+    for role, companion_rid in cfg_request_ids.items():
+        try:
+            data, size = kv_transfer_manager.receive_kv_cache_for_request(
+                companion_rid,
+                target_device,
+            )
+            if data and "layer_blocks" in data:
+                layer_blocks = data["layer_blocks"]
+                kv_obj = SimpleNamespace(**layer_blocks)
+                result[f"{role}_past_key_values"] = kv_obj
+                if "metadata" in data:
+                    result[f"{role}_kv_metadata"] = data["metadata"]
+                logger.info(
+                    "Collected CFG KV cache for role=%s, rid=%s, size=%d bytes",
+                    role,
+                    companion_rid,
+                    size,
+                )
+            else:
+                logger.warning(
+                    "Failed to collect CFG KV cache for role=%s, rid=%s",
+                    role,
+                    companion_rid,
+                )
+        except Exception as e:
+            logger.exception(
+                "Error collecting CFG KV cache for role=%s, rid=%s: %s",
+                role,
+                companion_rid,
+                e,
+            )
+
+    return result
+
+
+def _get_negative_prompt(
+    prompt: dict[str, Any],
+    sampling_params: Any,
+) -> str:
+    """Resolve the negative prompt from prompt dict or sampling params."""
+    neg = prompt.get("negative_prompt")
+    if neg:
+        return neg
+
+    if hasattr(sampling_params, "extra_args") and sampling_params.extra_args:
+        neg = sampling_params.extra_args.get("negative_prompt")
+        if neg:
+            return neg
+
+    return ""


### PR DESCRIPTION
## Summary

Enables the AR (language) stage to share its prefilled text KV cache with the
DiT (diffusion) stage on HunyuanImage-3.0-Instruct so the DiT no longer has to
re-encode the prompt from scratch. End-to-end denoise time for a 1216x832 IT2I
request drops from ~57 s to ~27 s on 4xL20X (TP=2 for both stages) with
visually indistinguishable output from the non-reuse baseline.

## What this change does

### Diffusion pipeline (`pipeline_hunyuan_image3.py`)

- New `_forward_with_kv_reuse()` path that injects AR-produced K/V into each
  layer's `ImageKVCacheManager` and runs every denoising step as a non-first
  step (`kv_injected=True` / `first_step=False`).
- Builds the correct `[BOS|sys|user|cot] + [<boi>|<img_size>|<img_ratio>] +
  [<timestep>|img*N] + [<eoi>]` token layout; zero-pads the three DiT special
  tokens the AR doesn't emit and masks them in attention.
- Reads `sequence_template` from `generation_config` (defaults to `"instruct"`
  for HunyuanImage-3.0-Instruct) instead of hard-coding `"pretrain"`, so the
  DiT text prefix matches the checkpoint's training distribution.

### Transformer (`hunyuan_image3_transformer.py`)

- `ImageKVCacheManager.inject_prompt_kv_cache()` prepares `image_kv_cache_map`
  in the exact layout `_save_image_kv_caches()` produces (pos/neg branches,
  special-token pad, eoi slot), so `_update_image_kv_caches()` works unchanged
  on every subsequent step.
- `forward(..., kv_injected=...)` propagates the flag to every layer's
  attention call so the AR-produced text K/V is preserved across steps.

### CFG companion (`stage_input_processors/hunyuan_image3.py`)

- `expand_cfg_prompts()` now mirrors the positive prompt's structure (same
  system prompt, same image, same assistant/trigger) with only the user-text
  tokens replaced by `<cfg>`. This fixes the `L_pos=6833 / L_neg=1`
  degeneracy that produced visibly degraded images before (PSNR 6.5 dB;
  after fix PSNR ~10 dB and visually matching).
- `collect_cfg_kv_caches()` retrieves the companion KV via
  `OmniKVTransferManager` and attaches it as
  `sampling_params.cfg_text_past_key_values`.
- `ar2diffusion()` forwards `ar_generated_text` plus user metadata (system
  prompt, height/width, multi-modal data) to the DiT, and lazily decodes AR
  tokens via `AutoTokenizer` when `detokenize: false` on the AR stage leaves
  `output.text` empty -- this fixes the `text length=0 / image ignored`
  symptom reported on #2590.

### Entry point (`examples/offline_inference/hunyuan_image3/end2end.py`)

- Unified `build_prompt()` across all modalities using the Instruct chat
  template `<|startoftext|>{sys}\n\nUser: [<img>]{q}\n\nAssistant:
  [trigger]`; removes the earlier pretrain-vs-instruct split that silently
  drifted from the model's training distribution.
- New `img2img` / `img2text` branches plumb multi-modal data and
  `use_system_prompt` through to both stages.

### Stage configs

- Adds `hunyuan_image3_it2i_kv_reuse.yaml` (the KV-reuse entry config) with
  `need_send_cache` on stage 0 (AR), `need_recv_cache` on stage 1 (DiT), the
  CFG companion expand/collect hooks, and `requires_multimodal_data=true` so
  the source image is forwarded to the DiT for VAE conditioning.
- Updates `hunyuan_image3_{i2t,it2i,t2t,moe}.yaml` to declare the new
  `need_send_cache / need_recv_cache` fields so the non-reuse paths stay
  consistent with the transport-layer changes.

### Transport

- `kv_transfer_manager.py` exposes the per-request receive call used by
  `collect_cfg_kv_caches`.
- `mooncake_transfer_engine_connector.py` small adjustments for the
  cross-node KV-reuse path.

### Worker / misc

- `diffusion_worker.py`: disable cuDNN at device-init time to work around
  `CUDNN_STATUS_NOT_INITIALIZED` on certain driver / cuDNN combinations;
  VAE 3D convolutions fall back to the PyTorch native implementation.
- `rope.py`: guard the optional `flash_attn.ops.triton.rotary` import so an
  ABI-incompatible flash-attn install does not break startup.

## Performance

Hardware: 4xNVIDIA L20X (143 GB), driver 570.133.20, TP=2 per stage.
Prompt / image: official `assets/demo_instruct_imgs/input_0_0.png` + the
"新年宠物海报" prompt from `run_demo_instruct.sh`; seed 42, 50 inference
steps, guidance 5.0, 1216x832 output.

| path | AR generate | DiT denoise | end-to-end |
|---|---:|---:|---:|
| non-reuse baseline | 424 tokens | 57.3 s | 195 s |
| **KV-reuse** | **443-481 tokens** | **26.5-27.7 s (2.05-2.16x)** | **169-174 s** |

KV transfer (single request, shared-memory connector):
- primary KV: ~420 MB at ~1000 MB/s (~0.4 s)
- CFG companion KV: ~70 MB at ~270 MB/s (<0.01 s)

## Precision analysis

A full precision breakdown is in the threaded comments (see
[initial breakdown](https://github.com/vllm-project/vllm-omni/pull/2949#issuecomment-4295301318),
[greedy decoding experiment](https://github.com/vllm-project/vllm-omni/pull/2949#issuecomment-4296361635),
[follow-up diagnosis](https://github.com/vllm-project/vllm-omni/pull/2949#issuecomment-4296677684),
and [final apples-to-apples measurement](https://github.com/vllm-project/vllm-omni/pull/2949#issuecomment-4296854534)).
Short version:

| measurement | PSNR | interpretation |
|---|---:|---|
| greedy KV-reuse, run 1 vs run 2 | **inf dB** | KV-reuse path is 100% bitwise reproducible |
| greedy non-reuse, run 1 vs run 2 | 26.70 dB | non-reuse DiT non-determinism floor (MoE / NCCL ordering) |
| greedy non-reuse (with CFG expansion) vs KV-reuse | **10.22 dB** | **pure KV-reuse algorithmic drift** |
| non-reuse vs KV-reuse (same AR seed, sampling) | 10.45 dB | total observed gap |
| non-reuse at seed=42 vs seed=123 | 12.40 dB | pure AR sampling diversity (reference) |

Key findings:

1. **KV-reuse is bitwise reproducible** end-to-end, whereas the non-reuse
   path has a ~26 dB determinism floor coming from the DiT MoE dispatch.
   The KV-reuse code is therefore **more** numerically stable than the
   baseline, not less.
2. **Residual 10.2 dB gap is fp16 drift, not a bug.** When both paths are
   fed bitwise-identical AR tokens the DiT outputs differ by 10.22 dB, with
   the diff heatmap being spatially smooth and diffuse -- the signature of
   fp16 noise propagated through 50 denoising steps. Visually the two
   images are the same scene with the same composition, typography, and
   colour palette. See the [heatmap and side-by-side](https://github.com/vllm-project/vllm-omni/pull/2949#issuecomment-4296854534).
3. **Originally-suspected `L_pos/L_neg=6833/1` CFG bug is fixed**: with
   the companion rewrite `L_neg` is now ~L_pos (6214/6793), bringing image
   quality up to parity with the non-reuse path.

## Validation scope

- Single-node 4xL20X (TP=2 per stage): covered by the measurements above.
- `it2i_inference.py` regression from #2590 (`text length=0`, image
  ignored): validated as fixed; AR now produces `text length=749` and the
  DiT correctly conditions on both the input image and the edit prompt.
- 8-GPU layout (`hunyuan_image3_it2i_kv_reuse.yaml` with `devices: "0,1,2,3"`
  for AR and `devices: "4,5,6,7"` for DiT): end2end.py path exercised, not
  re-benchmarked in this PR.
- Cross-node via `mooncake_transfer_engine_connector.py`: code paths
  touched but not functionally benchmarked here.

## Addresses

- Feature request / main KV-reuse path: this PR
- Bug report on #2590 "IT2I model ignores image": fixed by the
  `AutoTokenizer` fallback in `ar2diffusion()`
