### PR TITLE
replace the small operator's WanRMS_norm with the fused operator on npu

### DIFF
--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -41,6 +41,41 @@ logger = logging.getLogger(__name__)
 DEBUG_PERF = False
 
 
+def patch_wan_rms_norm():
+    '''Replace small operators with fused operators'''
+
+    if not current_omni_platform.is_npu():
+        return
+
+    import torch_npu
+
+    class WanRMS_norm(nn.Module):
+        def __init__(self, dim: int, channel_first: bool = True, images: bool = True, bias: bool = False) -> None:
+            super().__init__()
+            broadcastable_dims = (1, 1, 1) if not images else (1, 1)
+            shape = (dim, *broadcastable_dims) if channel_first else (dim,)
+            self.channel_first = channel_first
+            self.scale = dim ** 0.5
+            self.gamma = nn.Parameter(torch.ones(shape))
+            self.gamma_new = None
+            self.bias = nn.Parameter(torch.zeros(shape)) if bias else 0.0
+
+        def forward(self, x):
+            x = x.transpose(1, -1)
+            if self.gamma_new is None:
+                self.gamma_new = self.gamma.transpose(0, -1).reshape(-1)
+            x_out = torch_npu.npu_rms_norm(x, self.gamma_new, epsilon=1e-6)
+            x_out = x_out[0].transpose(1, -1)
+            return x_out
+
+    import sys
+    for module_name, module in sys.modules.items():
+        if hasattr(module, 'WanRMS_norm'):
+            setattr(module, 'WanRMS_norm', WanRMS_norm)
+
+
+patch_wan_rms_norm()
+
 def _load_model_index(model: str, local_files_only: bool) -> dict:
     """Load model_index.json from local path or HF Hub."""
     if local_files_only:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
replace the small operator's WanRMS_norm with the fused operator on npu

## Test Plan

- script

```
export ASCEND_RT_VISIBLE_DEVICES=8,9,10,11
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"

python image_to_video.py \
--model /home/l00505491/weights/Wan2.2-I2V-A14B-LightX2V-Diffusers \
--image i2v_input.jpg \
--prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside" \
--height 1280 \
--width 720 \
--num-frames 61 \
--guidance-scale 1.0 \
--guidance-scale-high 1.0 \
--num-inference-steps 4 \
--cfg-parallel-size 1 \
--ulysses-degree 4 \
--boundary-ratio 0.875 \
--flow-shift 12.0 \
--fps 16 \
--output i2v_output_origin_weight_1.mp4 \
--vae-patch-parallel-size 4 \
--vae-use-tiling \
```

## Test Result
- performance
  before: Encoder-2.1s, Decoder-3.4s
  after: Encoder-1.6s, Decoder-2.5s    ----  reduce-1.4s, improve-34%

- Accuracy


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
