### PR TITLE
[Bugfix] Fix VAE parallelism dist.gather performance bottleneck on NPU

### DIFF
--- a/vllm_omni/diffusion/distributed/autoencoders/distributed_vae_executor.py
+++ b/vllm_omni/diffusion/distributed/autoencoders/distributed_vae_executor.py
@@ -54,9 +54,9 @@ class DistributedVaeExecutor:
         self.parallel_size = parallel_size
 
     def gather_tensors(self, tensor: torch.Tensor):
-        gather_list = [torch.empty_like(tensor) for _ in range(self.world_size)] if self.rank == 0 else None
-        dist.gather(tensor, gather_list=gather_list, dst=0, group=self.group)
-        return gather_list
+        gather_list = [torch.empty_like(tensor) for _ in range(self.world_size)]
+        dist.all_gather(gather_list, tensor, gather_list, group=self.group)
+        return gather_list if self.rank == 0 else None
 
     def broadcast_tensor(self, tensor: torch.Tensor):
         dist.broadcast(tensor, src=0, group=self.group)

--- a/vllm_omni/diffusion/distributed/autoencoders/distributed_vae_executor.py
+++ b/vllm_omni/diffusion/distributed/autoencoders/distributed_vae_executor.py
@@ -55,7 +55,7 @@ class DistributedVaeExecutor:
 
     def gather_tensors(self, tensor: torch.Tensor):
         gather_list = [torch.empty_like(tensor) for _ in range(self.world_size)]
-        dist.all_gather(gather_list, tensor, gather_list, group=self.group)
+        dist.all_gather(gather_list, tensor, group=self.group)
         return gather_list if self.rank == 0 else None
 
     def broadcast_tensor(self, tensor: torch.Tensor):


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
This PR fixes a resolution-dependent performance bottleneck (480ms ~ 1.5s delay ) in VAE parallelism on NPU devices by replacing dist.gather with dist.all_gather. The root cause is that HCCL emulates the native torch.distributed.gather() using broadcast_object_list + allgather, which forces non-dst ranks to dynamically create gather_list (introducing world_size-sized H2D transfers) even though the standard API only requires gather_list on dst rank. The change maintains the original semantic (only rank 0 returns the gathered result), eliminates the redundant broadcast and H2D overhead on NPU, and has no performance impact on GPU.

## Test Plan
```
export MINDIE_SD_FA_TYPE=ascend_laser_attention
vllm serve wan2.2-i2v-diffusers
--omni
--port 8099
--usp 8
--use-hsdp
--vae-patch-parallel-size 8
--vae-use-tiling
--log-stats
--profiler-config '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile"}'
```

```
curl -X POST http://localhost:8099/v1/videos \
    -F "prompt='一只棕色野兔的正面特写镜头，采用低角度仰拍视角，营造亲密而庄严的视觉冲击。兔子一双圆润漆黑的大眼睛直视镜头深处，眼神中交织着野生动物的警觉与一丝难以言喻的温柔好奇，仿佛在与观者建立跨越物种的静默对话。它毛色呈现层次丰富的棕褐渐变，从浅奶油色腹部过渡到深棕背部，每根毛发纹理清晰可辨，在侧光下泛着丝绸般的光泽。细长洁白的胡须共有三对，随呼吸节奏微微颤动，偶尔因捕捉气流信息而轻轻摇摆。
两只标志性的长耳完全竖立，耳廓外侧覆盖短密棕毛，内侧则露出粉嫩的血管网络，薄如蝉翼的皮肤下血液流动隐约可见，耳朵以细微幅度不时转动，精准定位声源方向。背景是一片澄澈的蔚蓝天空，形态蓬松的白色积云以缓慢速度横向漂移，云影在兔子头顶交替变化，光线随之明暗流转。晴朗天气的明媚阳光从画面左上方45度角倾泻而下，在兔脸右侧形成柔和的伦勃朗式阴影，强化了面部立体感和皮毛质感。
兔子湿润的黑鼻子持续进行每秒三至四次的快速抽动，这是它们感知化学信号的本能动作，粉色三瓣嘴随之轻启，露出正在反刍的洁白门齿，下颌以稳定节奏左右研磨。摄影采用大光圈浅景深，焦点牢牢锁定在兔子双眼连线所在的焦平面，背景天空和远景绿色植被虚化成圆润的彩色光斑，前景几根嫩绿草叶闯入画面边缘，以缓慢弧线随风摇曳，暗示着和煦的春日微风。
整个场景弥漫着宁静致远的田园诗意，色彩温暖饱和，充满生命力。兔子在持续五秒的对视后，以典型 lagomorph 特征完成一次完整的瞬膜眨眼——第三眼睑从内侧横向滑过眼球，继而缓缓歪头向右十五度，这个行为在动物行为学中代表认知加工和好奇心表达，耳朵随之向同一方向倾斜，最终恢复正视姿态，胡须舒展，完成这段短暂而珍贵的自然纪录。'" \
    -F "input_reference=@/home/zf/vllm-omni/rabbit.jpeg" \
    -F "size=1280x720" \
    -F "seconds=5" \
    -F "fps=24" \
    -F "num_frames=121" \
    -F "guidance_scale=1" \
    -F "guidance_scale_2=1" \
    -F "flow_shift=5.0" \
    -F "num_inference_steps=4" \
    -F "seed=42"
```

## Test Result
vae耗时
before: VAE Decoding=2247.04 ms
after:    VAE Decoding=1580.20 ms
diff:      VAE Decoding=-666.84 ms

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [√] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [√] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [√] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
