### PR TITLE
[Bugfix] ComfyUI image-to-image DALL-E endpoint cases #2886

### DIFF
--- a/tests/comfyui/test_comfyui_integration.py
+++ b/tests/comfyui/test_comfyui_integration.py
@@ -523,7 +523,6 @@ def api_server(unused_tcp_port_factory, server_case: ServerCase, mock_async_omni
             "Qwen/Qwen-Image-Edit",
             True,
             id="image-to-image-dalle-endpoint",
-            marks=pytest.mark.skip(reason="Temporarily disabled due to failure."),
         ),
         pytest.param(
             ServerCase(

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -1061,6 +1061,27 @@ def test_image_edit_rejects_too_many_images_for_qwen_image_edit_2511_before_load
     assert engine.captured_prompt is None
 
 
+def test_image_edit_ignores_mock_like_multimodal_limit(async_omni_test_client):
+    engine = async_omni_test_client.app.state.engine_client
+    engine.get_diffusion_od_config = lambda: SimpleNamespace(
+        supports_multimodal_inputs=SimpleNamespace(),
+        max_multimodal_image_inputs=SimpleNamespace(),
+    )
+
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[("image", make_test_image_bytes((16, 16)))],
+        data={"prompt": "hello world."},
+    )
+
+    assert response.status_code == 200
+    captured_prompt = engine.captured_prompt
+    assert captured_prompt is not None
+    processed_images = captured_prompt["multi_modal_data"]["image"]
+    assert len(processed_images) == 1
+    assert processed_images[0].size == (16, 16)
+
+
 def test_image_edit_parameter_pass(async_omni_test_client):
     img_bytes_1 = make_test_image_bytes((16, 16))
 

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -16,6 +16,7 @@ from argparse import Namespace
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from http import HTTPStatus
+from numbers import Integral
 from typing import Annotated, Any, Literal, cast
 
 import httpx
@@ -1826,10 +1827,24 @@ def _get_max_edit_input_images(raw_request: Request, engine_client: Any) -> int 
         # config is not exposed on the serving surface.
         return None
 
-    if not bool(getattr(od_config, "supports_multimodal_inputs", False)):
+    supports_multimodal_inputs = getattr(od_config, "supports_multimodal_inputs", None)
+    if not isinstance(supports_multimodal_inputs, bool):
+        # Older serving surfaces and mocked engines may expose a placeholder
+        # object instead of a real diffusion config. Treat that as "unknown"
+        # so existing single-image flows keep working.
+        return None
+
+    if not supports_multimodal_inputs:
         return 1
 
-    return getattr(od_config, "max_multimodal_image_inputs", None)
+    max_input_images = getattr(od_config, "max_multimodal_image_inputs", None)
+    if max_input_images is None:
+        return None
+    if isinstance(max_input_images, bool) or not isinstance(max_input_images, Integral):
+        return None
+    if max_input_images < 1:
+        return None
+    return int(max_input_images)
 
 
 def _get_lora_from_json_str(lora_body):


### PR DESCRIPTION
## Summary
- fix the `/v1/images/edits` input-limit helper so it ignores mock-like or invalid diffusion config values instead of raising a server-side `500`
- restore the ComfyUI image-to-image DALL-E integration cases that were temporarily skipped in `#2884`
- add a regression test covering mocked diffusion config objects on the serving path

## Root Cause
`#2840` added early input-count validation for image edit requests. That logic assumed `get_diffusion_od_config()` would always return a real diffusion config with concrete `bool` and `int` fields.

In the ComfyUI integration tests, the mocked `AsyncOmni` surface exposed placeholder objects instead. The serving layer then evaluated:

`len(input_images_list) > max_input_images`

with `max_input_images` being a `MagicMock`, which raised `TypeError` and got wrapped into an HTTP `500`.

So `#2886` is a serving compatibility regression introduced by the new validation path, not a bad test expectation.

## Fix
- treat non-`bool` `supports_multimodal_inputs` values as unknown compatibility state
- accept `max_multimodal_image_inputs` only when it is a real positive integer
- fall back to the existing compatibility path when the serving surface exposes mocked or incomplete config objects

This keeps the `#2840` behavior for real model configs, including the desired `400` response for over-limit edit requests, while avoiding false `500`s in mocked or partially populated environments.

## Validation
- `pytest -q tests/entrypoints/openai_api/test_image_server.py`
- `pytest -q tests/comfyui/test_comfyui_integration.py`
- `pre-commit run --all-files`

## E2E
- served local `Qwen-Image-Edit-2511` from `/mnt/data1/huggingface/hub/models--Qwen--Qwen-Image-Edit-2511/snapshots/6f3ccc0b56e431dc6a0c2b2039706d7d26f22cb9`
- sent a real `/v1/images/edits` request with 5 input images
- verified the server returns `HTTP 400` with:
  - `Received 5 input images. At most 4 images are supported by this model.`

Fixes #2886.
