### PR TITLE
[XPU][BUGFIX] vae distribution

### DIFF
--- a/vllm_omni/diffusion/distributed/autoencoders/distributed_vae_executor.py
+++ b/vllm_omni/diffusion/distributed/autoencoders/distributed_vae_executor.py
@@ -10,6 +10,7 @@ import torch.distributed as dist
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.distributed.parallel_state import get_dit_group
+from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
 
@@ -49,6 +50,7 @@ class DistributedVaeExecutor:
         self.world_size = dist.get_world_size(self.group)
         self.rank = dist.get_rank(self.group)
         self.parallel_size = 1
+        self._meta_dtype = torch.int32 if current_omni_platform.is_xpu() else torch.int64
 
     def set_parallel_size(self, parallel_size: int):
         self.parallel_size = parallel_size
@@ -78,7 +80,7 @@ class DistributedVaeExecutor:
     def _pack_local_tiles(self, local_results, global_padding_shape, grid_spec, device, dtype):
         tile_tensor = torch.zeros(global_padding_shape, device=device, dtype=dtype)
         meta_tensor = torch.full(
-            (global_padding_shape[0], len(grid_spec.split_dims) + 1), -1, device=device, dtype=torch.int64
+            (global_padding_shape[0], len(grid_spec.split_dims) + 1), -1, device=device, dtype=self._meta_dtype
         )
         for idx, (tid, t_tensor) in enumerate(local_results):
             meta_tensor[idx, 0] = tid


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

The output was looking weird with VAE tiling on XPU platform
Main issue is the dist.gather behaviour is not same as CUDA.

Solution:
Since tile IDs and dimension sizes will never exceed int32 range (max ~2 billion). Even the largest video tiles are nowhere close. Using int32 would be fine, so fix VAE tiling issue by using int32 as meta_dtype for XPU.

## Test Plan

Use wan2.2-t2v to test
```
cd examples/offline_inference/text_to_video
python -u text_to_video.py \                                                                                                                                    
    --model Wan-AI/Wan2.2-T2V-A14B-Diffusers \                                                                                                                                             
    --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage." \                                                                   
    --height 480 --width 832 --num-frames 32 \                                                                                                                                             
    --guidance-scale 4.0 --guidance-scale-high 3.0 \                                                                                                                                       
    --flow-shift 12.0 --fps 16 \                                                                                                                                                           
    --num-inference-steps 40 \                                                                                                                                                             
    --output /tmp/t2v_output_tp4_32f_profiled.mp4 \                                                                                                                                        
    --tensor-parallel-size 4 \                                                                                                                                                             
    --vae-use-slicing --vae-use-tiling --vae-patch-parallel-size 4 \                                                                                                                       
    --cache-backend cache_dit \                                                                                                                                                            
    --enable-diffusion-pipeline-profiler 2>&1 | tee wan-t2v-480p.log 
```

## Test Result

https://github.com/user-attachments/assets/6cf3edce-925a-4e12-88c5-40e7ec83c2c6



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
