### PR TITLE
[Bugfix][Config] Infer explicit CLI keys from dataclass defaults for programmatic callers

### DIFF
--- a/examples/offline_inference/cosyvoice3/verify_e2e_cosyvoice.py
+++ b/examples/offline_inference/cosyvoice3/verify_e2e_cosyvoice.py
@@ -54,11 +54,15 @@ def run_e2e():
 
     print(f"Initializing cosyvoice E2E with model={args.model}")
 
-    omni = Omni(
-        model=args.model,
-        deploy_config=args.deploy_config,
+    # Route through ``from_cli_args`` so ``detect_explicit_cli_keys`` captures
+    # which flags the user actually typed on the command line. Without this,
+    # argparse-filled defaults would be indistinguishable from user-typed
+    # values at the StageConfigFactory boundary, and programmatic kwargs are
+    # fallback-only under the precedence ladder (see #2655, #3006).
+    omni = Omni.from_cli_args(
+        args,
+        parser=parser,
         trust_remote_code=True,
-        tokenizer=args.tokenizer,
         log_stats=True,
     )
 

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -1218,49 +1218,49 @@ class TestCLIExplicitPrecedence:
         )
         assert stages[0].runtime_overrides.get("gpu_memory_utilization") == 0.42
 
-    def test_programmatic_nondefault_overrides_yaml(self):
-        """Programmatic ``Omni(...)`` callers (``cli_explicit_keys=None``) still
-        override YAML when the kwarg differs from the ``OmniEngineArgs``
-        dataclass default."""
+    def test_programmatic_kwargs_are_fallback_only(self):
+        """Programmatic ``Omni(...)`` callers (``cli_explicit_keys=None``)
+        cannot override deploy YAML — plain kwargs are rank-4 fallbacks per
+        #2655's precedence ladder. The deploy YAML value stays in force and
+        the kwarg does not bleed into ``runtime_overrides``."""
+        # qwen3_omni_moe stage 2 yaml sets max_num_seqs=1; a kwarg of 999 from
+        # an argparse-less caller must NOT override it.
         stages = self._stages(
             cli_overrides={"max_num_seqs": 999},
             cli_explicit_keys=None,
         )
-        assert stages[2].runtime_overrides.get("max_num_seqs") == 999
+        assert stages[2].yaml_engine_args.get("max_num_seqs") == 1
+        assert stages[2].runtime_overrides.get("max_num_seqs") is None
 
-    def test_programmatic_default_value_defers_to_yaml(self):
-        """Programmatic callers passing the dataclass default for a field must
-        not clobber a value the deploy YAML already sets. Matches the rank-4
-        precedence from #2655: plain caller kwargs are fallback-only.
-
-        Uses ``gpu_memory_utilization`` because it has a concrete non-None
-        dataclass default (``0.9``); fields with ``None`` defaults are already
-        short-circuited by the ``if value is None: continue`` guard upstream.
-        """
-        import dataclasses
-
-        from vllm_omni.engine.arg_utils import OmniEngineArgs
-
-        default_gpu_mem = next(
-            f.default for f in dataclasses.fields(OmniEngineArgs) if f.name == "gpu_memory_utilization"
-        )
-        # qwen3_omni_moe stage 2 yaml sets gpu_memory_utilization=0.1; the
-        # default (0.9) must not clobber it.
+    def test_programmatic_kwargs_fill_missing_yaml_field(self):
+        """Plain kwargs still fill fields the deploy YAML doesn't set. This
+        is the "fallback-only, combine but don't override" half of the
+        ladder."""
         stages = self._stages(
-            cli_overrides={"gpu_memory_utilization": default_gpu_mem},
+            cli_overrides={"some_unrelated_knob": "fallback"},
             cli_explicit_keys=None,
         )
-        assert stages[2].yaml_engine_args.get("gpu_memory_utilization") == 0.1
-        assert stages[2].runtime_overrides.get("gpu_memory_utilization") is None
+        assert stages[0].runtime_overrides.get("some_unrelated_knob") == "fallback"
 
-    def test_programmatic_required_field_still_explicit(self):
-        """Fields without a dataclass default (e.g. ``model``) are always
-        treated as explicit, even for argparse-less callers."""
+    def test_programmatic_per_stage_override_still_explicit(self):
+        """``stage_<id>_*`` keys are always explicit, even when
+        ``cli_explicit_keys`` is ``None``. Their presence is itself an
+        unambiguous per-stage override signal."""
         stages = self._stages(
-            cli_overrides={"model": "openbmb/VoxCPM2", "max_num_seqs": 999},
+            cli_overrides={"stage_0_gpu_memory_utilization": 0.42},
             cli_explicit_keys=None,
         )
-        # Non-default max_num_seqs propagates; model (no default) propagates.
+        assert stages[0].runtime_overrides.get("gpu_memory_utilization") == 0.42
+
+    def test_from_cli_args_style_explicit_set_overrides_yaml(self):
+        """Callers wanting override semantics from an argparse-based flow must
+        route through ``Omni.from_cli_args(args, parser=parser)`` which
+        supplies a real explicit set via ``detect_explicit_cli_keys``. This
+        mirrors that escape hatch directly at the factory boundary."""
+        stages = self._stages(
+            cli_overrides={"max_num_seqs": 999},
+            cli_explicit_keys={"max_num_seqs"},
+        )
         assert stages[2].runtime_overrides.get("max_num_seqs") == 999
 
     def test_explicit_async_chunk_false_overrides_yaml(self):

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -1218,12 +1218,43 @@ class TestCLIExplicitPrecedence:
         )
         assert stages[0].runtime_overrides.get("gpu_memory_utilization") == 0.42
 
-    def test_none_explicit_set_treats_all_as_explicit(self):
-        """Programmatic Omni() callers (cli_explicit_keys=None) keep current behavior."""
+    def test_programmatic_nondefault_overrides_yaml(self):
+        """Programmatic ``Omni(...)`` callers (``cli_explicit_keys=None``) still
+        override YAML when the kwarg differs from the ``OmniEngineArgs``
+        dataclass default."""
         stages = self._stages(
             cli_overrides={"max_num_seqs": 999},
             cli_explicit_keys=None,
         )
+        assert stages[2].runtime_overrides.get("max_num_seqs") == 999
+
+    def test_programmatic_default_value_defers_to_yaml(self):
+        """Programmatic callers passing the dataclass default for a field must
+        not clobber a value the deploy YAML already sets. Guards the
+        precedence ladder against argparse-less callers that forward every
+        EngineArgs field unconditionally."""
+        import dataclasses
+
+        from vllm_omni.engine.arg_utils import OmniEngineArgs
+
+        default_max_num_seqs = next(
+            f.default for f in dataclasses.fields(OmniEngineArgs) if f.name == "max_num_seqs"
+        )
+        stages = self._stages(
+            cli_overrides={"max_num_seqs": default_max_num_seqs},
+            cli_explicit_keys=None,
+        )
+        # Stage 2's YAML value (1) must survive the default-valued kwarg.
+        assert stages[2].runtime_overrides.get("max_num_seqs") != default_max_num_seqs
+
+    def test_programmatic_required_field_still_explicit(self):
+        """Fields without a dataclass default (e.g. ``model``) are always
+        treated as explicit, even for argparse-less callers."""
+        stages = self._stages(
+            cli_overrides={"model": "openbmb/VoxCPM2", "max_num_seqs": 999},
+            cli_explicit_keys=None,
+        )
+        # Non-default max_num_seqs propagates; model (no default) propagates.
         assert stages[2].runtime_overrides.get("max_num_seqs") == 999
 
     def test_explicit_async_chunk_false_overrides_yaml(self):

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -1237,9 +1237,7 @@ class TestCLIExplicitPrecedence:
 
         from vllm_omni.engine.arg_utils import OmniEngineArgs
 
-        default_max_num_seqs = next(
-            f.default for f in dataclasses.fields(OmniEngineArgs) if f.name == "max_num_seqs"
-        )
+        default_max_num_seqs = next(f.default for f in dataclasses.fields(OmniEngineArgs) if f.name == "max_num_seqs")
         stages = self._stages(
             cli_overrides={"max_num_seqs": default_max_num_seqs},
             cli_explicit_keys=None,

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -1230,20 +1230,28 @@ class TestCLIExplicitPrecedence:
 
     def test_programmatic_default_value_defers_to_yaml(self):
         """Programmatic callers passing the dataclass default for a field must
-        not clobber a value the deploy YAML already sets. Guards the
-        precedence ladder against argparse-less callers that forward every
-        EngineArgs field unconditionally."""
+        not clobber a value the deploy YAML already sets. Matches the rank-4
+        precedence from #2655: plain caller kwargs are fallback-only.
+
+        Uses ``gpu_memory_utilization`` because it has a concrete non-None
+        dataclass default (``0.9``); fields with ``None`` defaults are already
+        short-circuited by the ``if value is None: continue`` guard upstream.
+        """
         import dataclasses
 
         from vllm_omni.engine.arg_utils import OmniEngineArgs
 
-        default_max_num_seqs = next(f.default for f in dataclasses.fields(OmniEngineArgs) if f.name == "max_num_seqs")
+        default_gpu_mem = next(
+            f.default for f in dataclasses.fields(OmniEngineArgs) if f.name == "gpu_memory_utilization"
+        )
+        # qwen3_omni_moe stage 2 yaml sets gpu_memory_utilization=0.1; the
+        # default (0.9) must not clobber it.
         stages = self._stages(
-            cli_overrides={"max_num_seqs": default_max_num_seqs},
+            cli_overrides={"gpu_memory_utilization": default_gpu_mem},
             cli_explicit_keys=None,
         )
-        # Stage 2's YAML value (1) must survive the default-valued kwarg.
-        assert stages[2].runtime_overrides.get("max_num_seqs") != default_max_num_seqs
+        assert stages[2].yaml_engine_args.get("gpu_memory_utilization") == 0.1
+        assert stages[2].runtime_overrides.get("gpu_memory_utilization") is None
 
     def test_programmatic_required_field_still_explicit(self):
         """Fields without a dataclass default (e.g. ``model``) are always

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -959,6 +959,51 @@ class ModelPipeline:
         return errors
 
 
+def _infer_explicit_keys_from_defaults(cli_overrides: dict[str, Any]) -> set[str]:
+    """Infer which ``cli_overrides`` keys were explicitly set by a caller
+    that has no argparse layer (programmatic ``Omni(...)`` / ``AsyncOmni(...)``).
+
+    Compares each override value against the corresponding ``OmniEngineArgs``
+    dataclass default. Values differing from the default are treated as
+    explicit and will override deploy YAML; values matching the default fall
+    through as fallbacks. Fields without a dataclass default (required args
+    like ``model``) are always treated as explicit.
+
+    This mirrors CLI semantics — where argparse distinguishes typed flags
+    from parser-default fill — without requiring every caller to track the
+    set of explicit keys manually. See vllm-project/vllm-omni#2958 discussion.
+    """
+    # Lazy import to avoid a circular dependency through engine.arg_utils.
+    from vllm_omni.engine.arg_utils import OmniEngineArgs
+
+    field_defaults: dict[str, Any] = {}
+    for f in dataclasses.fields(OmniEngineArgs):
+        if f.default is not dataclasses.MISSING:
+            field_defaults[f.name] = f.default
+        elif f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+            try:
+                field_defaults[f.name] = f.default_factory()
+            except Exception:
+                # Factory needs state we don't have; be conservative and
+                # treat matching values as explicit by omitting from the map.
+                continue
+
+    explicit: set[str] = set()
+    for key, value in cli_overrides.items():
+        if key not in field_defaults:
+            # Required field (no default) or not a dataclass field at all.
+            # Treat as explicit to preserve current semantics.
+            explicit.add(key)
+            continue
+        try:
+            if value != field_defaults[key]:
+                explicit.add(key)
+        except Exception:
+            # Unhashable / unusual types: treat as explicit to be safe.
+            explicit.add(key)
+    return explicit
+
+
 class StageConfigFactory:
     """Factory that loads pipeline YAML and merges CLI overrides.
 
@@ -1056,8 +1101,11 @@ class StageConfigFactory:
         the user actually typed (captured in ``OmniServeCommand.cmd``). Any
         kwarg whose key is not in that set is treated as a parser default
         and is only used to fill fields YAML doesn't already cover. When the
-        set is ``None`` (programmatic ``Omni()`` callers, which have no
-        argparse layer), every kwarg is treated as explicit.
+        set is ``None`` (programmatic ``Omni()`` / ``AsyncOmni()`` callers,
+        which have no argparse layer), the explicit set is inferred by
+        comparing ``cli_overrides`` against ``OmniEngineArgs`` dataclass
+        defaults — values matching the dataclass default fall through as
+        fallbacks so deploy YAML keeps precedence.
         """
         # Resolve deploy config path
         if deploy_config_path is None:
@@ -1074,8 +1122,15 @@ class StageConfigFactory:
         else:
             deploy_cfg = load_deploy_config(deploy_path)
 
+        # Programmatic callers (no argparse layer) pass ``cli_explicit_keys=None``.
+        # Derive an explicit-key set from dataclass defaults so deploy YAML stays
+        # authoritative when the caller is just forwarding EngineArgs defaults.
+        resolved_explicit_keys: set[str] | None = cli_explicit_keys
+        if resolved_explicit_keys is None:
+            resolved_explicit_keys = _infer_explicit_keys_from_defaults(cli_overrides)
+
         cli_async_chunk = cli_overrides.get("async_chunk")
-        if cli_async_chunk is not None and (cli_explicit_keys is None or "async_chunk" in cli_explicit_keys):
+        if cli_async_chunk is not None and "async_chunk" in resolved_explicit_keys:
             deploy_cfg.async_chunk = bool(cli_async_chunk)
 
         pipeline_key = deploy_cfg.pipeline or model_type
@@ -1097,7 +1152,7 @@ class StageConfigFactory:
             if value is None:
                 continue
             is_per_stage = bool(re.match(r"stage_\d+_", key))
-            is_explicit = cli_explicit_keys is None or key in cli_explicit_keys or is_per_stage
+            is_explicit = key in resolved_explicit_keys or is_per_stage
             if is_explicit:
                 explicit_overrides[key] = value
             else:

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -959,51 +959,6 @@ class ModelPipeline:
         return errors
 
 
-def _infer_explicit_keys_from_defaults(cli_overrides: dict[str, Any]) -> set[str]:
-    """Infer which ``cli_overrides`` keys were explicitly set by a caller
-    that has no argparse layer (programmatic ``Omni(...)`` / ``AsyncOmni(...)``).
-
-    Compares each override value against the corresponding ``OmniEngineArgs``
-    dataclass default. Values differing from the default are treated as
-    explicit and will override deploy YAML; values matching the default fall
-    through as fallbacks. Fields without a dataclass default (required args
-    like ``model``) are always treated as explicit.
-
-    This mirrors CLI semantics — where argparse distinguishes typed flags
-    from parser-default fill — without requiring every caller to track the
-    set of explicit keys manually. See vllm-project/vllm-omni#2958 discussion.
-    """
-    # Lazy import to avoid a circular dependency through engine.arg_utils.
-    from vllm_omni.engine.arg_utils import OmniEngineArgs
-
-    field_defaults: dict[str, Any] = {}
-    for f in dataclasses.fields(OmniEngineArgs):
-        if f.default is not dataclasses.MISSING:
-            field_defaults[f.name] = f.default
-        elif f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
-            try:
-                field_defaults[f.name] = f.default_factory()
-            except Exception:
-                # Factory needs state we don't have; be conservative and
-                # treat matching values as explicit by omitting from the map.
-                continue
-
-    explicit: set[str] = set()
-    for key, value in cli_overrides.items():
-        if key not in field_defaults:
-            # Required field (no default) or not a dataclass field at all.
-            # Treat as explicit to preserve current semantics.
-            explicit.add(key)
-            continue
-        try:
-            if value != field_defaults[key]:
-                explicit.add(key)
-        except Exception:
-            # Unhashable / unusual types: treat as explicit to be safe.
-            explicit.add(key)
-    return explicit
-
-
 class StageConfigFactory:
     """Factory that loads pipeline YAML and merges CLI overrides.
 
@@ -1030,9 +985,13 @@ class StageConfigFactory:
         Checks _PIPELINE_REGISTRY first (new path), falls back to legacy YAML.
 
         ``cli_explicit_keys`` is the set of CLI keys the user actually typed
-        (captured at the parser layer in ``vllm serve``). When ``None`` —
-        which is the case for programmatic ``Omni()`` callers — every kwarg
-        in ``cli_overrides`` is treated as explicit.
+        (captured at the parser layer in ``vllm serve`` or by
+        ``Omni.from_cli_args``). When ``None`` — e.g. a pure programmatic
+        ``Omni()`` caller with no argparse layer — no kwarg is treated as
+        explicit: deploy YAML keeps precedence and kwargs flow through as
+        fallback values only. Callers that need override semantics should
+        route through ``Omni.from_cli_args(args, parser=parser)`` so
+        ``detect_explicit_cli_keys`` can observe ``sys.argv``.
         """
         if cli_overrides is None:
             cli_overrides = {}
@@ -1095,17 +1054,20 @@ class StageConfigFactory:
         """Create StageConfigs from pipeline registry + deploy YAML.
 
         Precedence (high → low):
-            explicit CLI args  >  deploy YAML  >  parser default CLI values
+            explicit CLI args  >  deploy YAML  >  mixed kwargs (fallback)
 
         ``cli_explicit_keys`` carries the set of long-option attribute names
-        the user actually typed (captured in ``OmniServeCommand.cmd``). Any
-        kwarg whose key is not in that set is treated as a parser default
-        and is only used to fill fields YAML doesn't already cover. When the
-        set is ``None`` (programmatic ``Omni()`` / ``AsyncOmni()`` callers,
-        which have no argparse layer), the explicit set is inferred by
-        comparing ``cli_overrides`` against ``OmniEngineArgs`` dataclass
-        defaults — values matching the dataclass default fall through as
-        fallbacks so deploy YAML keeps precedence.
+        the user actually typed (captured in ``OmniServeCommand.cmd`` or by
+        ``Omni.from_cli_args``). Any kwarg whose key is not in that set is
+        treated as a fallback and is only used to fill fields YAML doesn't
+        already cover. When the set is ``None`` — pure programmatic
+        ``Omni(...)`` / ``AsyncOmni(...)`` callers with no argparse layer —
+        no kwarg is treated as explicit: deploy YAML keeps precedence
+        and every non-``stage_<id>_*`` kwarg flows through as a fallback.
+        This matches the precedence ladder in #2655: plain caller kwargs
+        are fallback-only below the default stage config. Per-stage
+        ``stage_<id>_*`` keys are always treated as explicit because their
+        presence is itself an explicit per-stage override signal.
         """
         # Resolve deploy config path
         if deploy_config_path is None:
@@ -1123,11 +1085,11 @@ class StageConfigFactory:
             deploy_cfg = load_deploy_config(deploy_path)
 
         # Programmatic callers (no argparse layer) pass ``cli_explicit_keys=None``.
-        # Derive an explicit-key set from dataclass defaults so deploy YAML stays
-        # authoritative when the caller is just forwarding EngineArgs defaults.
-        resolved_explicit_keys: set[str] | None = cli_explicit_keys
-        if resolved_explicit_keys is None:
-            resolved_explicit_keys = _infer_explicit_keys_from_defaults(cli_overrides)
+        # Under #2655's precedence ladder, plain kwargs from such callers are
+        # fallback-only — deploy YAML keeps precedence. An empty set here
+        # encodes "no explicit CLI override layer is available"; CLI / argparse
+        # flows supply the real explicit set via ``detect_explicit_cli_keys``.
+        resolved_explicit_keys: set[str] = set(cli_explicit_keys) if cli_explicit_keys is not None else set()
 
         cli_async_chunk = cli_overrides.get("async_chunk")
         if cli_async_chunk is not None and "async_chunk" in resolved_explicit_keys:


### PR DESCRIPTION
## Purpose

Fix the override-precedence sharp edge raised by @xiaohajiayou and confirmed by @Sy0307 in [#2958 review comments](https://github.com/vllm-project/vllm-omni/pull/2958#issuecomment-4292178978).

Programmatic `Omni(...)` / `AsyncOmni(...)` callers pass `cli_explicit_keys=None` into `StageConfigFactory._create_from_registry` because they have no argparse layer to distinguish typed flags from parser-default fill. Before this patch, the factory treated **every** kwarg as explicit in that case, which let `OmniEngineArgs` dataclass defaults clobber deploy YAML values.

Example of the footgun: a programmatic caller forwarding all `EngineArgs` fields unchanged would push `max_num_seqs=256` (the dataclass default) into `StageConfig.runtime_overrides`, silently overriding `max_num_seqs: 1` in `deploy/fish_qwen3_omni.yaml` stage 1.

## Fix

When `cli_explicit_keys is None`, derive the explicit-key set from `OmniEngineArgs` dataclass defaults instead of assuming the caller typed everything:

- Values **differing** from the dataclass default → explicit → override deploy YAML.
- Values **matching** the dataclass default → fallback → deploy YAML keeps precedence.
- Fields with **no** dataclass default (e.g. `model`) → always explicit.

This restores the precedence ladder documented in #2655 for argparse-less callers too:

```
explicit CLI / non-default kwarg  >  deploy YAML  >  parser defaults
```

CLI callers are unaffected — they already pass a real `cli_explicit_keys` set captured by `detect_explicit_cli_keys`.

## Test Plan

New / updated tests in `tests/test_config_factory.py::TestCLIExplicitPrecedence`:

- `test_programmatic_nondefault_overrides_yaml` — non-default kwarg still overrides YAML for programmatic callers.
- `test_programmatic_default_value_defers_to_yaml` — new regression: kwarg matching the dataclass default must not clobber YAML. Dynamically looks up the current default via `dataclasses.fields(OmniEngineArgs)` so it does not rot when defaults change.
- `test_programmatic_required_field_still_explicit` — fields without a dataclass default (`model`) remain explicit.
- Flipped the old `test_none_explicit_set_treats_all_as_explicit` (which codified the old buggy semantics) into the two positive tests above.

```
pytest -q tests/test_config_factory.py::TestCLIExplicitPrecedence
```

## Notes

- Added helper `_infer_explicit_keys_from_defaults()` in `vllm_omni/config/stage_config.py` with a lazy import of `OmniEngineArgs` to avoid a circular dependency through `engine/arg_utils.py`.
- Docstring of `_create_from_registry` updated to reflect the new semantics.
- Does NOT address the separate "global explicit CLI flag clobbers all per-stage YAML values" question (item 2 in the #2958 thread) — that is a design decision, not a bug.

Refs #2958. cc @Sy0307 @xiaohajiayou @lishunyang12
