### PR TITLE
[Bugfix] fix when diffusion model not set sleeping_stages

### DIFF
--- a/tests/entrypoints/openai_api/test_omni_sleep_wakeup.py
+++ b/tests/entrypoints/openai_api/test_omni_sleep_wakeup.py
@@ -2,11 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import dataclasses
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from unittest.mock import AsyncMock, MagicMock
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -25,7 +25,6 @@ def _make_app(engine_client):
     app.state.engine_client = engine_client
     app.state.sleeping_stages = set()
     return app
-
 
 
 @pytest.fixture
@@ -241,4 +240,3 @@ def test_pure_diffusion_wakeup_skipped(pure_diffusion_app, pure_diffusion_engine
     assert response.status_code == 200
     assert response.json()["status"] == "SKIPPED"
     pure_diffusion_engine.wake_up.assert_not_awaited()
-

--- a/tests/entrypoints/openai_api/test_omni_sleep_wakeup.py
+++ b/tests/entrypoints/openai_api/test_omni_sleep_wakeup.py
@@ -55,7 +55,7 @@ def test_sleep_success(sleep_capable_engine):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "SUCCESS"
-    assert len(data["acks"]) == 2
+    assert [ack["stage_id"] for ack in data["acks"]] == [0, 1]
     # sleeping_stages should be updated
     assert app.state.sleeping_stages == {0, 1}
     sleep_capable_engine.sleep.assert_awaited_once_with(stage_ids=[0, 1], level=2)
@@ -71,6 +71,22 @@ def test_sleep_default_level(sleep_capable_engine):
     sleep_capable_engine.sleep.assert_awaited_once_with(stage_ids=[0], level=2)
 
 
+def test_sleep_empty_stage_ids(sleep_capable_engine):
+    """Empty stage_ids: engine is still called and returns SUCCESS with no acks."""
+    sleep_capable_engine.sleep = AsyncMock(return_value=[])
+    app = _make_app(sleep_capable_engine)
+    client = TestClient(app)
+
+    response = client.post("/v1/omni/sleep", json={"stage_ids": [], "level": 2})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "SUCCESS"
+    assert data["acks"] == []
+    assert app.state.sleeping_stages == set()
+    sleep_capable_engine.sleep.assert_awaited_once_with(stage_ids=[], level=2)
+
+
 def test_sleep_updates_sleeping_set(sleep_capable_engine):
     app = _make_app(sleep_capable_engine)
     app.state.sleeping_stages = {5}  # pre-existing entry
@@ -79,6 +95,16 @@ def test_sleep_updates_sleeping_set(sleep_capable_engine):
     client.post("/v1/omni/sleep", json={"stage_ids": [0, 1], "level": 2})
 
     assert app.state.sleeping_stages == {5, 0, 1}
+
+
+def test_sleep_engine_not_support(sleep_incapable_engine):
+    app = _make_app(sleep_incapable_engine)
+    client = TestClient(app)
+
+    response = client.post("/v1/omni/sleep", json={"stage_ids": [0], "level": 1})
+
+    assert response.status_code == 501
+    assert "sleep" in response.json()["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -96,7 +122,7 @@ def test_wakeup_success(sleep_capable_engine):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "SUCCESS"
-    assert len(data["acks"]) == 2
+    assert [ack["stage_id"] for ack in data["acks"]] == [0, 1]
     assert app.state.sleeping_stages == set()
     sleep_capable_engine.wake_up.assert_awaited_once_with(stage_ids=[0, 1])
 
@@ -127,6 +153,30 @@ def test_wakeup_partial_sleeping(sleep_capable_engine):
     assert data["status"] == "SUCCESS"
     # Only stage 0 was in sleeping_stages so only it gets removed
     assert 0 not in app.state.sleeping_stages
+
+
+def test_wakeup_empty_stage_ids(sleep_capable_engine):
+    """Empty stage_ids: any() on empty iterable is False → SKIPPED, engine not called."""
+    app = _make_app(sleep_capable_engine)
+    app.state.sleeping_stages = {0, 1}  # stages are sleeping, but request asks for none
+    client = TestClient(app)
+
+    response = client.post("/v1/omni/wakeup", json={"stage_ids": []})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "SKIPPED"
+    sleep_capable_engine.wake_up.assert_not_awaited()
+
+
+def test_wakeup_engine_not_support(sleep_incapable_engine):
+    app = _make_app(sleep_incapable_engine)
+    app.state.sleeping_stages = {0}
+    client = TestClient(app)
+
+    response = client.post("/v1/omni/wakeup", json={"stage_ids": [0]})
+
+    assert response.status_code == 501
+    assert "wake_up" in response.json()["detail"]
 
 
 def test_wakeup_removes_only_requested_stages(sleep_capable_engine):

--- a/tests/entrypoints/openai_api/test_omni_sleep_wakeup.py
+++ b/tests/entrypoints/openai_api/test_omni_sleep_wakeup.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import dataclasses
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@dataclasses.dataclass
+class FakeAck:
+    stage_id: int
+    result: str = "ok"
+
+
+def _make_app(engine_client):
+    from vllm_omni.entrypoints.openai.api_server import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.state.engine_client = engine_client
+    app.state.sleeping_stages = set()
+    return app
+
+
+
+@pytest.fixture
+def sleep_capable_engine():
+    engine = MagicMock()
+    engine.sleep = AsyncMock(return_value=[FakeAck(stage_id=0), FakeAck(stage_id=1)])
+    engine.wake_up = AsyncMock(return_value=[FakeAck(stage_id=0), FakeAck(stage_id=1)])
+    return engine
+
+
+@pytest.fixture
+def sleep_incapable_engine():
+    engine = MagicMock(spec=[])  # no 'sleep' or 'wake_up' attributes
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# /v1/omni/sleep
+# ---------------------------------------------------------------------------
+
+
+def test_sleep_success(sleep_capable_engine):
+    app = _make_app(sleep_capable_engine)
+    client = TestClient(app)
+
+    response = client.post("/v1/omni/sleep", json={"stage_ids": [0, 1], "level": 2})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "SUCCESS"
+    assert len(data["acks"]) == 2
+    # sleeping_stages should be updated
+    assert app.state.sleeping_stages == {0, 1}
+    sleep_capable_engine.sleep.assert_awaited_once_with(stage_ids=[0, 1], level=2)
+
+
+def test_sleep_default_level(sleep_capable_engine):
+    app = _make_app(sleep_capable_engine)
+    client = TestClient(app)
+
+    response = client.post("/v1/omni/sleep", json={"stage_ids": [0]})
+
+    assert response.status_code == 200
+    sleep_capable_engine.sleep.assert_awaited_once_with(stage_ids=[0], level=2)
+
+
+def test_sleep_updates_sleeping_set(sleep_capable_engine):
+    app = _make_app(sleep_capable_engine)
+    app.state.sleeping_stages = {5}  # pre-existing entry
+    client = TestClient(app)
+
+    client.post("/v1/omni/sleep", json={"stage_ids": [0, 1], "level": 2})
+
+    assert app.state.sleeping_stages == {5, 0, 1}
+
+
+# ---------------------------------------------------------------------------
+# /v1/omni/wakeup
+# ---------------------------------------------------------------------------
+
+
+def test_wakeup_success(sleep_capable_engine):
+    app = _make_app(sleep_capable_engine)
+    app.state.sleeping_stages = {0, 1}
+    client = TestClient(app)
+
+    response = client.post("/v1/omni/wakeup", json={"stage_ids": [0, 1]})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "SUCCESS"
+    assert len(data["acks"]) == 2
+    assert app.state.sleeping_stages == set()
+    sleep_capable_engine.wake_up.assert_awaited_once_with(stage_ids=[0, 1])
+
+
+def test_wakeup_skipped_when_not_sleeping(sleep_capable_engine):
+    app = _make_app(sleep_capable_engine)
+    app.state.sleeping_stages = set()  # nothing sleeping
+    client = TestClient(app)
+
+    response = client.post("/v1/omni/wakeup", json={"stage_ids": [0, 1]})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "SKIPPED"
+    sleep_capable_engine.wake_up.assert_not_awaited()
+
+
+def test_wakeup_partial_sleeping(sleep_capable_engine):
+    """Only stage 0 is sleeping; stage 1 is not. Should still proceed (partial match)."""
+    app = _make_app(sleep_capable_engine)
+    app.state.sleeping_stages = {0}
+    client = TestClient(app)
+
+    response = client.post("/v1/omni/wakeup", json={"stage_ids": [0, 1]})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "SUCCESS"
+    # Only stage 0 was in sleeping_stages so only it gets removed
+    assert 0 not in app.state.sleeping_stages
+
+
+def test_wakeup_removes_only_requested_stages(sleep_capable_engine):
+    app = _make_app(sleep_capable_engine)
+    app.state.sleeping_stages = {0, 1, 2}
+    client = TestClient(app)
+
+    client.post("/v1/omni/wakeup", json={"stage_ids": [0]})
+
+    # stage 1 and 2 remain sleeping
+    assert app.state.sleeping_stages == {1, 2}
+
+
+def _make_pure_diffusion_engine(sleep_capable: bool = True):
+    """Return a mock engine that omni_init_app_state recognises as pure-diffusion.
+
+    Requirements checked by omni_init_app_state:
+      - has stage_configs with exactly one entry whose stage_type == "diffusion"
+      - has no vllm_config / get_vllm_config  (so _get_vllm_config returns None)
+    """
+    engine = MagicMock()
+    engine.stage_configs = [{"stage_type": "diffusion"}]
+    # Remove attributes that would make _get_vllm_config return a config
+    del engine.get_vllm_config
+    del engine.vllm_config
+    if sleep_capable:
+        engine.sleep = AsyncMock(return_value=[FakeAck(stage_id=0)])
+        engine.wake_up = AsyncMock(return_value=[FakeAck(stage_id=0)])
+    else:
+        # Remove sleep/wake_up so hasattr returns False
+        engine_no_sleep = MagicMock(spec=["stage_configs"])
+        engine_no_sleep.stage_configs = [{"stage_type": "diffusion"}]
+        return engine_no_sleep
+    return engine
+
+
+def _make_pure_diffusion_args():
+    from argparse import Namespace
+
+    return Namespace(
+        served_model_name=None,
+        model="fake-diffusion-model",
+        enable_log_requests=False,
+        disable_log_stats=True,
+        max_log_len=0,
+        enable_server_load_tracking=False,
+    )
+
+
+@pytest.fixture
+def pure_diffusion_engine():
+    return _make_pure_diffusion_engine(sleep_capable=True)
+
+
+@pytest.fixture
+def pure_diffusion_incapable_engine():
+    return _make_pure_diffusion_engine(sleep_capable=False)
+
+
+@pytest.fixture
+def pure_diffusion_args():
+    return _make_pure_diffusion_args()
+
+
+@pytest.fixture
+def pure_diffusion_app(pure_diffusion_engine, pure_diffusion_args):
+    """App whose state was initialised via omni_init_app_state (pure diffusion path)."""
+    import asyncio
+    from unittest.mock import patch
+
+    from fastapi import FastAPI
+
+    from vllm_omni.entrypoints.openai.api_server import omni_init_app_state, router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    with (
+        patch("vllm_omni.entrypoints.openai.api_server.OmniOpenAIServingChat") as mock_chat,
+        patch("vllm_omni.entrypoints.openai.api_server.OmniOpenAIServingVideo") as mock_video,
+        patch("vllm_omni.entrypoints.openai.api_server.OmniOpenAIServingSpeech") as mock_speech,
+        patch("vllm_omni.entrypoints.openai.api_server._DiffusionServingModels"),
+    ):
+        mock_chat.for_diffusion.return_value = MagicMock()
+        mock_video.for_diffusion.return_value = MagicMock()
+        mock_speech.for_diffusion.return_value = MagicMock()
+        asyncio.get_event_loop().run_until_complete(
+            omni_init_app_state(pure_diffusion_engine, app.state, pure_diffusion_args)
+        )
+
+    return app
+
+
+def test_pure_diffusion_sleep_success(pure_diffusion_app, pure_diffusion_engine):
+    client = TestClient(pure_diffusion_app)
+
+    response = client.post("/v1/omni/sleep", json={"stage_ids": [0], "level": 2})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "SUCCESS"
+    assert pure_diffusion_app.state.sleeping_stages == {0}
+    pure_diffusion_engine.sleep.assert_awaited_once_with(stage_ids=[0], level=2)
+
+
+def test_pure_diffusion_wakeup_skipped(pure_diffusion_app, pure_diffusion_engine):
+    # sleeping_stages is empty after init — nothing is sleeping
+    client = TestClient(pure_diffusion_app)
+
+    response = client.post("/v1/omni/wakeup", json={"stage_ids": [0]})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "SKIPPED"
+    pure_diffusion_engine.wake_up.assert_not_awaited()
+

--- a/tests/entrypoints/openai_api/test_omni_sleep_wakeup.py
+++ b/tests/entrypoints/openai_api/test_omni_sleep_wakeup.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import dataclasses
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -28,17 +27,16 @@ def _make_app(engine_client):
 
 
 @pytest.fixture
-def sleep_capable_engine():
-    engine = MagicMock()
-    engine.sleep = AsyncMock(return_value=[FakeAck(stage_id=0), FakeAck(stage_id=1)])
-    engine.wake_up = AsyncMock(return_value=[FakeAck(stage_id=0), FakeAck(stage_id=1)])
+def sleep_capable_engine(mocker):
+    engine = mocker.MagicMock()
+    engine.sleep = mocker.AsyncMock(return_value=[FakeAck(stage_id=0), FakeAck(stage_id=1)])
+    engine.wake_up = mocker.AsyncMock(return_value=[FakeAck(stage_id=0), FakeAck(stage_id=1)])
     return engine
 
 
 @pytest.fixture
-def sleep_incapable_engine():
-    engine = MagicMock(spec=[])  # no 'sleep' or 'wake_up' attributes
-    return engine
+def sleep_incapable_engine(mocker):
+    return mocker.MagicMock(spec=[])  # no 'sleep' or 'wake_up' attributes
 
 
 # ---------------------------------------------------------------------------
@@ -56,7 +54,6 @@ def test_sleep_success(sleep_capable_engine):
     data = response.json()
     assert data["status"] == "SUCCESS"
     assert [ack["stage_id"] for ack in data["acks"]] == [0, 1]
-    # sleeping_stages should be updated
     assert app.state.sleeping_stages == {0, 1}
     sleep_capable_engine.sleep.assert_awaited_once_with(stage_ids=[0, 1], level=2)
 
@@ -71,9 +68,9 @@ def test_sleep_default_level(sleep_capable_engine):
     sleep_capable_engine.sleep.assert_awaited_once_with(stage_ids=[0], level=2)
 
 
-def test_sleep_empty_stage_ids(sleep_capable_engine):
+def test_sleep_empty_stage_ids(sleep_capable_engine, mocker):
     """Empty stage_ids: engine is still called and returns SUCCESS with no acks."""
-    sleep_capable_engine.sleep = AsyncMock(return_value=[])
+    sleep_capable_engine.sleep = mocker.AsyncMock(return_value=[])
     app = _make_app(sleep_capable_engine)
     client = TestClient(app)
 
@@ -151,14 +148,13 @@ def test_wakeup_partial_sleeping(sleep_capable_engine):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "SUCCESS"
-    # Only stage 0 was in sleeping_stages so only it gets removed
     assert 0 not in app.state.sleeping_stages
 
 
 def test_wakeup_empty_stage_ids(sleep_capable_engine):
     """Empty stage_ids: any() on empty iterable is False → SKIPPED, engine not called."""
     app = _make_app(sleep_capable_engine)
-    app.state.sleeping_stages = {0, 1}  # stages are sleeping, but request asks for none
+    app.state.sleeping_stages = {0, 1}
     client = TestClient(app)
 
     response = client.post("/v1/omni/wakeup", json={"stage_ids": []})
@@ -186,37 +182,48 @@ def test_wakeup_removes_only_requested_stages(sleep_capable_engine):
 
     client.post("/v1/omni/wakeup", json={"stage_ids": [0]})
 
-    # stage 1 and 2 remain sleeping
     assert app.state.sleeping_stages == {1, 2}
 
 
-def _make_pure_diffusion_engine(sleep_capable: bool = True):
-    """Return a mock engine that omni_init_app_state recognises as pure-diffusion.
+def test_sleep_then_wakeup_roundtrip(sleep_capable_engine):
+    app = _make_app(sleep_capable_engine)
+    client = TestClient(app)
 
-    Requirements checked by omni_init_app_state:
-      - has stage_configs with exactly one entry whose stage_type == "diffusion"
-      - has no vllm_config / get_vllm_config  (so _get_vllm_config returns None)
-    """
-    engine = MagicMock()
+    sleep_resp = client.post("/v1/omni/sleep", json={"stage_ids": [0, 1], "level": 2})
+    assert sleep_resp.status_code == 200
+    assert app.state.sleeping_stages == {0, 1}
+
+    wakeup_resp = client.post("/v1/omni/wakeup", json={"stage_ids": [0, 1]})
+    assert wakeup_resp.status_code == 200
+    assert app.state.sleeping_stages == set()
+
+
+# ---------------------------------------------------------------------------
+# pure-diffusion branch: omni_init_app_state initialises sleeping_stages
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pure_diffusion_engine(mocker):
+    engine = mocker.MagicMock()
     engine.stage_configs = [{"stage_type": "diffusion"}]
+    engine.sleep = mocker.AsyncMock(return_value=[FakeAck(stage_id=0)])
+    engine.wake_up = mocker.AsyncMock(return_value=[FakeAck(stage_id=0)])
     # Remove attributes that would make _get_vllm_config return a config
     del engine.get_vllm_config
     del engine.vllm_config
-    if sleep_capable:
-        engine.sleep = AsyncMock(return_value=[FakeAck(stage_id=0)])
-        engine.wake_up = AsyncMock(return_value=[FakeAck(stage_id=0)])
-    else:
-        # Remove sleep/wake_up so hasattr returns False
-        engine_no_sleep = MagicMock(spec=["stage_configs"])
-        engine_no_sleep.stage_configs = [{"stage_type": "diffusion"}]
-        return engine_no_sleep
     return engine
 
 
-def _make_pure_diffusion_args():
+@pytest.fixture
+def pure_diffusion_app(pure_diffusion_engine, mocker):
+    """App whose state was initialised via omni_init_app_state (pure diffusion path)."""
+    import asyncio
     from argparse import Namespace
 
-    return Namespace(
+    from vllm_omni.entrypoints.openai.api_server import omni_init_app_state, router
+
+    args = Namespace(
         served_model_name=None,
         model="fake-diffusion-model",
         enable_log_requests=False,
@@ -225,47 +232,21 @@ def _make_pure_diffusion_args():
         enable_server_load_tracking=False,
     )
 
-
-@pytest.fixture
-def pure_diffusion_engine():
-    return _make_pure_diffusion_engine(sleep_capable=True)
-
-
-@pytest.fixture
-def pure_diffusion_incapable_engine():
-    return _make_pure_diffusion_engine(sleep_capable=False)
-
-
-@pytest.fixture
-def pure_diffusion_args():
-    return _make_pure_diffusion_args()
-
-
-@pytest.fixture
-def pure_diffusion_app(pure_diffusion_engine, pure_diffusion_args):
-    """App whose state was initialised via omni_init_app_state (pure diffusion path)."""
-    import asyncio
-    from unittest.mock import patch
-
-    from fastapi import FastAPI
-
-    from vllm_omni.entrypoints.openai.api_server import omni_init_app_state, router
-
     app = FastAPI()
     app.include_router(router)
 
-    with (
-        patch("vllm_omni.entrypoints.openai.api_server.OmniOpenAIServingChat") as mock_chat,
-        patch("vllm_omni.entrypoints.openai.api_server.OmniOpenAIServingVideo") as mock_video,
-        patch("vllm_omni.entrypoints.openai.api_server.OmniOpenAIServingSpeech") as mock_speech,
-        patch("vllm_omni.entrypoints.openai.api_server._DiffusionServingModels"),
-    ):
-        mock_chat.for_diffusion.return_value = MagicMock()
-        mock_video.for_diffusion.return_value = MagicMock()
-        mock_speech.for_diffusion.return_value = MagicMock()
-        asyncio.get_event_loop().run_until_complete(
-            omni_init_app_state(pure_diffusion_engine, app.state, pure_diffusion_args)
-        )
+    mocker.patch(
+        "vllm_omni.entrypoints.openai.api_server.OmniOpenAIServingChat"
+    ).for_diffusion.return_value = mocker.MagicMock()
+    mocker.patch(
+        "vllm_omni.entrypoints.openai.api_server.OmniOpenAIServingVideo"
+    ).for_diffusion.return_value = mocker.MagicMock()
+    mocker.patch(
+        "vllm_omni.entrypoints.openai.api_server.OmniOpenAIServingSpeech"
+    ).for_diffusion.return_value = mocker.MagicMock()
+    mocker.patch("vllm_omni.entrypoints.openai.api_server._DiffusionServingModels")
+
+    asyncio.get_event_loop().run_until_complete(omni_init_app_state(pure_diffusion_engine, app.state, args))
 
     return app
 
@@ -290,3 +271,15 @@ def test_pure_diffusion_wakeup_skipped(pure_diffusion_app, pure_diffusion_engine
     assert response.status_code == 200
     assert response.json()["status"] == "SKIPPED"
     pure_diffusion_engine.wake_up.assert_not_awaited()
+
+
+def test_pure_diffusion_sleep_then_wakeup(pure_diffusion_app, pure_diffusion_engine):
+    client = TestClient(pure_diffusion_app)
+
+    sleep_resp = client.post("/v1/omni/sleep", json={"stage_ids": [0], "level": 2})
+    assert sleep_resp.status_code == 200
+    assert pure_diffusion_app.state.sleeping_stages == {0}
+
+    wakeup_resp = client.post("/v1/omni/wakeup", json={"stage_ids": [0]})
+    assert wakeup_resp.status_code == 200
+    assert pure_diffusion_app.state.sleeping_stages == set()

--- a/tests/entrypoints/openai_api/test_omni_sleep_wakeup.py
+++ b/tests/entrypoints/openai_api/test_omni_sleep_wakeup.py
@@ -246,7 +246,11 @@ def pure_diffusion_app(pure_diffusion_engine, mocker):
     ).for_diffusion.return_value = mocker.MagicMock()
     mocker.patch("vllm_omni.entrypoints.openai.api_server._DiffusionServingModels")
 
-    asyncio.get_event_loop().run_until_complete(omni_init_app_state(pure_diffusion_engine, app.state, args))
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(omni_init_app_state(pure_diffusion_engine, app.state, args))
+    finally:
+        loop.close()
 
     return app
 

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -632,6 +632,7 @@ async def omni_init_app_state(
 
         state.enable_server_load_tracking = getattr(args, "enable_server_load_tracking", False)
         state.server_load_metrics = 0
+        state.sleeping_stages = set()
         logger.info("Pure diffusion API server initialized for model: %s", model_name)
         return
 

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -586,6 +586,7 @@ async def omni_init_app_state(
     state.engine_client = engine_client
     state.log_stats = not args.disable_log_stats
     state.args = args
+    state.sleeping_stages = set()
 
     # For omni models
     state.stage_configs = engine_client.stage_configs if hasattr(engine_client, "stage_configs") else None
@@ -632,7 +633,6 @@ async def omni_init_app_state(
 
         state.enable_server_load_tracking = getattr(args, "enable_server_load_tracking", False)
         state.server_load_metrics = 0
-        state.sleeping_stages = set()
         logger.info("Pure diffusion API server initialized for model: %s", model_name)
         return
 
@@ -950,7 +950,6 @@ async def omni_init_app_state(
 
     state.enable_server_load_tracking = args.enable_server_load_tracking
     state.server_load_metrics = 0
-    state.sleeping_stages = set()
 
 
 def Omnivideo(request: Request) -> OmniOpenAIServingVideo | None:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix in use diffusion model not set this var sleeping_stages.

## Test Plan

```
$ vllm serve /home/jovyan/Wan2.2-T2V-A14B-Diffusers/ --omni --use-hsdp --usp 4 --use-hsdp --vae-patch-parallel-size 4 --vae-use-tiling --log-stats --enable-sleep-mode --port 8091
```

- Test 
```
$ curl -X POST http://localhost:8091/v1/omni/sleep      -H "Content-Type: application/json"      -d '{"stage_ids": [0], "level": 2}'
{"status":"SUCCESS","acks":[{"task_id":"da6ef70b-bea8-43e3-baec-bcb0a0c7b8ad","status":"SUCCESS","stage_id":0,"rank":0,"freed_bytes":0,"metadata":{"source":"Platform_NVIDIA H100 80GB HBM3","total_freed_gib":"0.00","rank_residual_gib":"24.26"},"error_msg":null}]}
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
