### PR TITLE
Fix links in glm_image.md

### DIFF
--- a/docs/user_guide/examples/online_serving/glm_image.md
+++ b/docs/user_guide/examples/online_serving/glm_image.md
@@ -104,9 +104,9 @@ guides.
 
 When using `/v1/chat/completions`, pass these inside `extra_body` in the curl
 JSON, or via the `extra_body` keyword argument in the OpenAI Python SDK (see the
-[Diffusion Chat API guide](../../../../serving/diffusion_chat_api.md)).
-When using the dedicated [`/v1/images/generations`](../../../../serving/image_generation_api.md)
-or [`/v1/images/edits`](../../../../serving/image_edit_api.md) endpoints, pass
+[Diffusion Chat API guide](../../../serving/diffusion_chat_api.md)).
+When using the dedicated [`/v1/images/generations`](../../../serving/image_generation_api.md)
+or [`/v1/images/edits`](../../../serving/image_edit_api.md) endpoints, pass
 the supported generation controls as top-level fields directly. For image
 dimensions and count, use `size` and `n` rather than `height` or `width`.
 


### PR DESCRIPTION
## Purpose

Fix 3 broken relative links in `docs/user_guide/examples/online_serving/glm_image.md` that cause the ReadTheDocs build to fail in strict mode.

The links use `../../../../serving/` (4 levels up) when they should use `../../../serving/` (3 levels up). The file is at `docs/user_guide/examples/online_serving/glm_image.md`, so reaching `docs/user_guide/serving/` requires going up 3 directories, not 4.

Introduced in PR #2051 (`[Doc] Improve diffusion generation parameter docs for online serving`, commit `d96d63cb`).

```
WARNING - Doc file 'user_guide/examples/online_serving/glm_image.md' contains a link
  '../../../../serving/diffusion_chat_api.md', but the target '../serving/diffusion_chat_api.md'
  is not found among documentation files. Did you mean '../../../serving/diffusion_chat_api.md'?
```

This currently blocks the ReadTheDocs CI for all open PRs.

## Test Plan

```bash
python -m mkdocs build --clean --site-dir /tmp/mkdocs-output --config-file mkdocs.yml --strict
```

No additional test scripts needed -- this is a documentation-only fix.

## Test Result

Before: `Aborted with 3 warnings in strict mode!`

After: 0 warnings from `glm_image.md`. Build completes successfully.

---
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands.
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update.
- [ ] (Optional) Release notes update.
