### PR TITLE
[WIP][BugFix]Fix FA3 scheduler_metadata shape mismatch crash in Qwen3-Omni talker

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -268,15 +268,14 @@ class Qwen3OmniMoeForConditionalGeneration(
         attn_metadata = getattr(ctx, "attn_metadata", None)
         if not isinstance(attn_metadata, dict):
             return
-        for layer_name, meta in attn_metadata.items():
-            if not layer_name.startswith("talker."):
-                continue
-            if getattr(meta, "num_actual_tokens", 0) <= self._max_cudagraph_capture_size:
-                return
-            for m in attn_metadata.values():
-                if getattr(m, "scheduler_metadata", None) is not None:
-                    m.scheduler_metadata = None
+        first_meta = next(iter(attn_metadata.values()), None)
+        if first_meta is None:
             return
+        if getattr(first_meta, "num_actual_tokens", 0) <= self._max_cudagraph_capture_size:
+            return
+        for meta in attn_metadata.values():
+            if getattr(meta, "scheduler_metadata", None) is not None:
+                meta.scheduler_metadata = None
 
     # ==================== Device utilities ====================
 

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -252,13 +252,18 @@ class Qwen3OmniMoeForConditionalGeneration(
                 multi_modal_data={"audio": remaining},
             )
 
+    @cached_property
+    def _max_cudagraph_capture_size(self) -> int:
+        return self.vllm_config.compilation_config.max_cudagraph_capture_size or 0
+
     def _nullify_talker_scheduler_metadata(self) -> None:
         """Set FA3 scheduler_metadata to None on talker attention layers.
 
-        Prevents shape mismatch when talker prefill exceeds
-        max_cudagraph_capture_size in the piecewise CUDAGraph path.
-        FA3 falls back to default scheduling (~0.1 ms overhead).
+        Only activates when num_tokens exceeds max_cudagraph_capture_size,
+        where the piecewise CUDAGraph path has a metadata shape mismatch bug.
         """
+        if self._max_cudagraph_capture_size <= 0:
+            return
         ctx = get_forward_context()
         attn_metadata = getattr(ctx, "attn_metadata", None)
         if not isinstance(attn_metadata, dict):
@@ -266,8 +271,12 @@ class Qwen3OmniMoeForConditionalGeneration(
         for layer_name, meta in attn_metadata.items():
             if not layer_name.startswith("talker."):
                 continue
-            if getattr(meta, "scheduler_metadata", None) is not None:
-                meta.scheduler_metadata = None
+            if getattr(meta, "num_actual_tokens", 0) <= self._max_cudagraph_capture_size:
+                return
+            for m in attn_metadata.values():
+                if getattr(m, "scheduler_metadata", None) is not None:
+                    m.scheduler_metadata = None
+            return
 
     # ==================== Device utilities ====================
 

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -18,6 +18,7 @@ from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import (
     Qwen3OmniMoeThinkerConfig,
 )
 from vllm.config import ModelConfig, VllmConfig
+from vllm.forward_context import get_forward_context
 from vllm.inputs import PromptType, TokensPrompt
 from vllm.logger import init_logger
 from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
@@ -251,6 +252,23 @@ class Qwen3OmniMoeForConditionalGeneration(
                 multi_modal_data={"audio": remaining},
             )
 
+    def _nullify_talker_scheduler_metadata(self) -> None:
+        """Set FA3 scheduler_metadata to None on talker attention layers.
+
+        Prevents shape mismatch when talker prefill exceeds
+        max_cudagraph_capture_size in the piecewise CUDAGraph path.
+        FA3 falls back to default scheduling (~0.1 ms overhead).
+        """
+        ctx = get_forward_context()
+        attn_metadata = getattr(ctx, "attn_metadata", None)
+        if not isinstance(attn_metadata, dict):
+            return
+        for layer_name, meta in attn_metadata.items():
+            if not layer_name.startswith("talker."):
+                continue
+            if getattr(meta, "scheduler_metadata", None) is not None:
+                meta.scheduler_metadata = None
+
     # ==================== Device utilities ====================
 
     @staticmethod
@@ -381,6 +399,8 @@ class Qwen3OmniMoeForConditionalGeneration(
             # Ensure we have base embeddings when only ids are provided
             if inputs_embeds is None and input_ids is not None:
                 inputs_embeds = self.talker.embed_input_ids(input_ids)
+
+            self._nullify_talker_scheduler_metadata()
 
             # Run talker forward
             with torch.inference_mode():


### PR DESCRIPTION

## Purpose

Fix Qwen3-Omni talker stage crash: `RuntimeError: scheduler_metadata must have shape (metadata_size)`

When talker prefill tokens exceed `max_cudagraph_capture_size` (128), the piecewise CUDAGraph path uses a pre-allocated FA3 `scheduler_metadata` buffer whose shape mismatches the runtime batch, crashing the entire instance.

Fix: conditionally nullify `scheduler_metadata` on talker attention layers when over threshold, making FA3 fall back to default scheduling. No impact when within CUDAGraph capture range.

## Test Plan


  Reproduce with 40s synthetic audio + concurrent requests. The 40s audio generates ~550 thinker prompt tokens, resulting in talker prompt ~410 tokens which exceeds `max_cudagraph_capture_size` (128) and triggers the piecewise CUDAGraph path.

  ```python
  import aiohttp, asyncio, base64, io, wave, struct, math

  def gen_wav(dur=40.0, sr=16000):
      n = int(sr * dur)
      buf = io.BytesIO()
      with wave.open(buf, "wb") as wf:
          wf.setnchannels(1); wf.setsampwidth(2); wf.setframerate(sr)
          for i in range(n):
              wf.writeframes(struct.pack("<h", int(16000 * math.sin(2 * math.pi * 440 * i / sr))))
      return base64.b64encode(buf.getvalue()).decode()

  audio_b64 = gen_wav(40)
  payload = {
      "model": "/home/admin/model/",
      "messages": [
          {"role": "system", "content": [{"type": "text", "text": "You are Qwen."}]},
          {"role": "user", "content": [
              {"type": "audio_url", "audio_url": {"url": f"data:audio/wav;base64,{audio_b64}"}},
              {"type": "text", "text": "Describe video content."}
          ]}
      ],
      "stream": True, "max_tokens": 1000, "temperature": 0.6, "ignore_eos": True,
  }

  async def send(session, url, rid):
      async with session.post(f"{url}/v1/chat/completions", json=payload,
                              timeout=aiohttp.ClientTimeout(total=180)) as r:
          if r.status != 200:
              return "fail"
          async for _ in r.content:
              pass
          return "ok"

  async def main():
      url = "http://localhost:8188"
      async with aiohttp.ClientSession() as s:
          tasks = []
          for i in range(20):
              tasks.append(asyncio.create_task(send(s, url, i)))
              await asyncio.sleep(0.5)  # 2 req/s, concurrency ~4
          results = await asyncio.gather(*tasks)
          print(f"{sum(1 for r in results if r == 'ok')}/20 ok")

  asyncio.run(main())

  # Deploy config: qwen3_omni_moe_async_chunk.yaml (2x H20, stage 0/1/2, async_chunk: true)
  ```

## Test Result

  Tested on H20 with `qwen3_omni_moe_async_chunk.yaml`, 40s audio, 20 requests at 2 req/s:

  **Before fix:**
  Result: 0/20 ok
  SERVICE CRASHED!

  (Worker pid=346731) RuntimeError: scheduler_metadata must have shape (metadata_size)
  (EngineCore pid=346165) EngineCore encountered a fatal error.

  **After fix:**
    [✓] req=0  ok tok=1111 124.4s
    [✓] req=1  ok tok=1102 119.2s
    ...
    [✓] req=19 ok tok=877  71.9s

  Result: 20/20 ok
  Health: 200

  No `scheduler_metadata` errors in logs. Service remains healthy under sustained load.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
