### PR TITLE
[UX][Metrics] improving vllm-omni metrics

### DIFF
--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -175,12 +175,12 @@ class DiffusionEngine:
 
         step_total_ms = (time.perf_counter() - diffusion_engine_start_time) * 1000
         logger.info(
-            "DiffusionEngine.step breakdown: preprocess=%.2f ms, "
-            "add_req_and_wait=%.2f ms, postprocess=%.2f ms, total=%.2f ms",
+            "[StageTiming stage=%s diffusion] total=%.2fs preprocess=%.2fms exec=%.2fs postprocess=%.2fms",
+            self.od_config.stage_id,
+            step_total_ms / 1000.0,
             preprocess_time * 1000,
-            exec_total_time * 1000,
+            exec_total_time,
             postprocess_time * 1000,
-            step_total_ms,
         )
 
         # Convert to OmniRequestOutput format

--- a/vllm_omni/diffusion/stage_diffusion_client.py
+++ b/vllm_omni/diffusion/stage_diffusion_client.py
@@ -117,6 +117,7 @@ class StageDiffusionClient:
         self.default_sampling_params = metadata.default_sampling_params
         self.custom_process_input_func = metadata.custom_process_input_func
         self.engine_input_source = metadata.engine_input_source
+        self.model_stage = metadata.model_stage
         self._proc = proc
         self._owns_process = proc is not None
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1009,6 +1009,7 @@ class AsyncOmniEngine:
         message_type: str = "add_request",
     ) -> dict[str, Any]:
         """Build an add_request message after stage-0 preprocessing."""
+        build_add_request_message_start = time.perf_counter()
         effective_sampling_params_list = (
             list(sampling_params_list) if sampling_params_list is not None else list(self.default_sampling_params_list)
         )
@@ -1074,6 +1075,7 @@ class AsyncOmniEngine:
             )
             prompt = request
 
+        build_add_request_message_time_ms = (time.perf_counter() - build_add_request_message_start) * 1000.0
         return {
             "type": message_type,
             "request_id": request_id,
@@ -1081,6 +1083,8 @@ class AsyncOmniEngine:
             "original_prompt": original_prompt,
             "sampling_params_list": effective_sampling_params_list,
             "final_stage_id": final_stage_id,
+            "input_preprocess_time_ms": build_add_request_message_time_ms,
+            "build_add_request_message_time_ms": build_add_request_message_time_ms,
         }
 
     def _enqueue_cfg_companions(

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1010,6 +1010,7 @@ class AsyncOmniEngine:
     ) -> dict[str, Any]:
         """Build an add_request message after stage-0 preprocessing."""
         build_add_request_message_start = time.perf_counter()
+        input_preprocess_time_ms = 0.0
         effective_sampling_params_list = (
             list(sampling_params_list) if sampling_params_list is not None else list(self.default_sampling_params_list)
         )
@@ -1033,6 +1034,7 @@ class AsyncOmniEngine:
                     _inject_global_id(item, request_id)
 
             # Full input processing (tokenization, multimodal, etc.)
+            input_preprocess_start = time.perf_counter()
             request = self.input_processor.process_inputs(
                 request_id=request_id,
                 prompt=prompt,
@@ -1046,6 +1048,7 @@ class AsyncOmniEngine:
                 data_parallel_rank=data_parallel_rank,
                 resumable=resumable,
             )
+            input_preprocess_time_ms = (time.perf_counter() - input_preprocess_start) * 1000.0
             # TODO (Peiqi): add this for Qwen3-TTS only. Other models don't have
             # additional_information field in the prompt.
             request = _upgrade_to_omni_request(request, prompt)
@@ -1083,7 +1086,7 @@ class AsyncOmniEngine:
             "original_prompt": original_prompt,
             "sampling_params_list": effective_sampling_params_list,
             "final_stage_id": final_stage_id,
-            "input_preprocess_time_ms": build_add_request_message_time_ms,
+            "input_preprocess_time_ms": input_preprocess_time_ms,
             "build_add_request_message_time_ms": build_add_request_message_time_ms,
         }
 

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -108,6 +108,8 @@ class OrchestratorRequestState:
 
     # Metrics: timestamp when request was submitted to each stage
     stage_submit_ts: dict[int, float] = field(default_factory=dict)
+    input_preprocess_time_ms: float = 0.0
+    build_add_request_message_time_ms: float = 0.0
     mm_processor_kwargs: dict | None = None
     mm_features: list | None = None
 
@@ -419,6 +421,8 @@ class Orchestrator:
                     "metrics": stage_metrics,
                     "finished": finished and stage_id == req_state.final_stage_id,
                     "stage_submit_ts": submit_ts,
+                    "input_preprocess_time_ms": req_state.input_preprocess_time_ms,
+                    "build_add_request_message_time_ms": req_state.build_add_request_message_time_ms,
                 }
             )
         elif stage_metrics is not None:
@@ -877,6 +881,8 @@ class Orchestrator:
             prompt=original_prompt,
             sampling_params_list=sampling_params_list,
             final_stage_id=final_stage_id,
+            input_preprocess_time_ms=float(msg.get("input_preprocess_time_ms", 0.0)),
+            build_add_request_message_time_ms=float(msg.get("build_add_request_message_time_ms", 0.0)),
             mm_features=getattr(prompt, "mm_features", None),  # Save mm_features for PD
         )
         req_state.streaming.enabled = is_streaming

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -280,6 +280,7 @@ def extract_stage_metadata(stage_config: Any) -> StageMetadata:
     stage_id: int = stage_config.stage_id
     stage_type: Literal["llm", "diffusion"] = getattr(stage_config, "stage_type", "llm")
     engine_args = stage_config.engine_args
+    model_stage = getattr(engine_args, "model_stage", None)
 
     if current_omni_platform.is_rocm():
         if engine_args.get("attention_backend") is None:
@@ -333,12 +334,11 @@ def extract_stage_metadata(stage_config: Any) -> StageMetadata:
             final_output_type=final_output_type,
             default_sampling_params=default_sampling_params,
             custom_process_input_func=custom_process_input_func,
-            model_stage=None,
+            model_stage=model_stage,
             runtime_cfg=runtime_cfg,
             cfg_kv_collect_func=cfg_kv_collect_func,
         )
 
-    model_stage = getattr(engine_args, "model_stage", None)
     engine_output_type = getattr(engine_args, "engine_output_type", None)
     is_comprehension = getattr(stage_config, "is_comprehension", False)
     requires_multimodal_data = getattr(runtime_cfg, "requires_multimodal_data", False)
@@ -755,6 +755,7 @@ def finalize_initialized_stages(
             "final_output": stage_client.final_output,
             "final_output_type": stage_client.final_output_type,
             "stage_type": stage_client.stage_type,
+            "model_stage": getattr(stage_client, "model_stage", None),
         }
         for stage_client in initialized_stage_clients
     ]

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -305,7 +305,7 @@ class AsyncOmni(EngineClient, OmniBase):
             # Add request(s) to stage 0. For streaming inputs, submit
             # chunks incrementally through streaming_update.
             if isinstance(prompt, AsyncGenerator):
-                input_stream_task = await self.add_streaming_input_request(
+                input_stream_task = await self._add_streaming_input_request(
                     request_id=request_id,
                     input_stream=prompt,
                     sampling_params_list=req_sp_list,
@@ -319,9 +319,9 @@ class AsyncOmni(EngineClient, OmniBase):
                     sampling_params_list=req_sp_list,
                     final_stage_id=final_stage_id_for_e2e,
                 )
-                submit_ts = time.time()
-                req_state.metrics.stage_first_ts[0] = submit_ts
-                req_start_ts[request_id] = submit_ts
+            submit_ts = time.time()
+            req_state.metrics.stage_first_ts[0] = submit_ts
+            req_start_ts[request_id] = submit_ts
 
             # Process results based on mode
             # Both sequential and async_chunk modes read the same message stream
@@ -351,7 +351,7 @@ class AsyncOmni(EngineClient, OmniBase):
             logger.info(f"[AsyncOmni] Request {request_id} failed (input error): {e}")
             raise
 
-    async def add_streaming_input_request(
+    async def _add_streaming_input_request(
         self,
         *,
         request_id: str,
@@ -365,7 +365,7 @@ class AsyncOmni(EngineClient, OmniBase):
             raise ValueError("sampling_params_list cannot be empty for streaming input")
         # only check thinker's sampling params now
         stage0_params = sampling_params_list[0]
-        self.validate_streaming_input_sampling_params(stage0_params)
+        self._validate_streaming_input_sampling_params(stage0_params)
 
         req_state = self.request_states[request_id]
 
@@ -386,7 +386,7 @@ class AsyncOmni(EngineClient, OmniBase):
             try:
                 async for chunk in input_stream:
                     chunk_params = getattr(chunk, "sampling_params", None) or stage0_params
-                    self.validate_streaming_input_sampling_params(chunk_params)
+                    self._validate_streaming_input_sampling_params(chunk_params)
                     chunk_sampling_params_list = list(sampling_params_list)
                     chunk_sampling_params_list[0] = chunk_params
                     chunk_prompt = chunk.prompt
@@ -449,7 +449,7 @@ class AsyncOmni(EngineClient, OmniBase):
         return input_stream_task
 
     @staticmethod
-    def validate_streaming_input_sampling_params(params: OmniSamplingParams) -> None:
+    def _validate_streaming_input_sampling_params(params: OmniSamplingParams) -> None:
         if (
             not isinstance(params, SamplingParams)
             or params.n > 1

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -290,6 +290,7 @@ class AsyncOmni(EngineClient, OmniBase):
                 wall_start_ts,
                 final_stage_id_for_e2e,
             )
+            metrics.stage_labels = dict(self._stage_labels)
             req_state = ClientRequestState(request_id)
             req_state.metrics = metrics
             self.request_states[request_id] = req_state
@@ -304,11 +305,12 @@ class AsyncOmni(EngineClient, OmniBase):
             # Add request(s) to stage 0. For streaming inputs, submit
             # chunks incrementally through streaming_update.
             if isinstance(prompt, AsyncGenerator):
-                input_stream_task = await self._add_streaming_input_request(
+                input_stream_task = await self.add_streaming_input_request(
                     request_id=request_id,
                     input_stream=prompt,
                     sampling_params_list=req_sp_list,
                     final_stage_id=final_stage_id_for_e2e,
+                    req_start_ts=req_start_ts,
                 )
             else:
                 await self.engine.add_request_async(
@@ -317,9 +319,9 @@ class AsyncOmni(EngineClient, OmniBase):
                     sampling_params_list=req_sp_list,
                     final_stage_id=final_stage_id_for_e2e,
                 )
-            submit_ts = time.time()
-            req_state.metrics.stage_first_ts[0] = submit_ts
-            req_start_ts[request_id] = submit_ts
+                submit_ts = time.time()
+                req_state.metrics.stage_first_ts[0] = submit_ts
+                req_start_ts[request_id] = submit_ts
 
             # Process results based on mode
             # Both sequential and async_chunk modes read the same message stream
@@ -349,20 +351,21 @@ class AsyncOmni(EngineClient, OmniBase):
             logger.info(f"[AsyncOmni] Request {request_id} failed (input error): {e}")
             raise
 
-    async def _add_streaming_input_request(
+    async def add_streaming_input_request(
         self,
         *,
         request_id: str,
         input_stream: AsyncGenerator[StreamingInput, None],
         sampling_params_list: Sequence[OmniSamplingParams],
         final_stage_id: int,
+        req_start_ts: dict[str, float],
     ) -> asyncio.Task:
         """Submit a streaming input generator as incremental stage-0 updates."""
         if not sampling_params_list:
             raise ValueError("sampling_params_list cannot be empty for streaming input")
         # only check thinker's sampling params now
         stage0_params = sampling_params_list[0]
-        self._validate_streaming_input_sampling_params(stage0_params)
+        self.validate_streaming_input_sampling_params(stage0_params)
 
         req_state = self.request_states[request_id]
 
@@ -372,13 +375,18 @@ class AsyncOmni(EngineClient, OmniBase):
 
         has_submitted_first_chunk = False
 
+        def mark_stage0_submit() -> None:
+            submit_ts = time.time()
+            req_state.metrics.stage_first_ts[0] = submit_ts
+            req_start_ts[request_id] = submit_ts
+
         async def handle_inputs() -> None:
             nonlocal has_submitted_first_chunk
             cancelled = False
             try:
                 async for chunk in input_stream:
                     chunk_params = getattr(chunk, "sampling_params", None) or stage0_params
-                    self._validate_streaming_input_sampling_params(chunk_params)
+                    self.validate_streaming_input_sampling_params(chunk_params)
                     chunk_sampling_params_list = list(sampling_params_list)
                     chunk_sampling_params_list[0] = chunk_params
                     chunk_prompt = chunk.prompt
@@ -393,6 +401,7 @@ class AsyncOmni(EngineClient, OmniBase):
                             final_stage_id=final_stage_id,
                             resumable=True,
                         )
+                        mark_stage0_submit()
                         has_submitted_first_chunk = True
                     else:
                         await self.engine.add_streaming_update_async(
@@ -433,13 +442,14 @@ class AsyncOmni(EngineClient, OmniBase):
                             final_stage_id=final_stage_id,
                             resumable=False,
                         )
+                        mark_stage0_submit()
 
         input_stream_task = asyncio.create_task(handle_inputs())
         req_state.input_stream_task = input_stream_task
         return input_stream_task
 
     @staticmethod
-    def _validate_streaming_input_sampling_params(params: OmniSamplingParams) -> None:
+    def validate_streaming_input_sampling_params(params: OmniSamplingParams) -> None:
         if (
             not isinstance(params, SamplingParams)
             or params.n > 1

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -128,6 +128,7 @@ class Omni(OmniBase):
                     wall_start_ts,
                     final_stage_id,
                 )
+                metrics.stage_labels = dict(self._stage_labels)
                 req_state = ClientRequestState(req_id)
                 req_state.metrics = metrics
                 self.request_states[req_id] = req_state

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -174,6 +174,7 @@ class OmniBase(PDDisaggregationMixin):
         self._stage_meta_list = [
             types.SimpleNamespace(**self.engine.get_stage_metadata(i)) for i in range(self.engine.num_stages)
         ]
+        self._stage_labels = self.build_stage_labels()
 
         logger.info(
             "[%s] Initialized with %s stages for model %s",
@@ -247,8 +248,12 @@ class OmniBase(PDDisaggregationMixin):
         try:
             if req_state is None or req_state.metrics is None:
                 return
+            timing_line = req_state.metrics.format_request_timing_line(request_id)
+            if timing_line is not None and self.num_stages > 1:
+                logger.info("%s", timing_line)
             summary = req_state.metrics.build_and_log_summary()
-            logger.info("[Summary] %s", pformat(summary, sort_dicts=False))
+            if summary:
+                logger.info("[Summary] %s", pformat(summary, sort_dicts=False))
         except Exception:
             logger.exception(
                 "[%s] Failed to build/log summary for req=%s",
@@ -264,6 +269,18 @@ class OmniBase(PDDisaggregationMixin):
             self.output_modalities,
             self._stage_meta_list,
         )
+
+    def build_stage_labels(self) -> dict[int, str]:
+        stage_labels: dict[int, str] = {}
+        for idx, stage_meta in enumerate(self._stage_meta_list):
+            stage_type = getattr(stage_meta, "stage_type", None)
+            model_stage = getattr(stage_meta, "model_stage", None)
+            if stage_type == "diffusion":
+                stage_name = "diffusion"
+            else:
+                stage_name = model_stage or stage_type or f"stage_{idx}"
+            stage_labels[idx] = f"{idx}:{stage_name}"
+        return stage_labels
 
     def _process_stage_metrics_message(self, msg: dict[str, Any]) -> None:
         req_id = msg.get("request_id")
@@ -377,6 +394,12 @@ class OmniBase(PDDisaggregationMixin):
         metrics.stage_last_ts[stage_id] = max(metrics.stage_last_ts[stage_id] or 0.0, now)
 
         _m = result.get("metrics")
+        input_preprocess_time_ms = result.get("input_preprocess_time_ms")
+        if input_preprocess_time_ms is not None:
+            metrics.input_preprocess_time_ms = float(input_preprocess_time_ms)
+        build_add_request_message_time_ms = result.get("build_add_request_message_time_ms")
+        if build_add_request_message_time_ms is not None:
+            metrics.build_add_request_message_time_ms = float(build_add_request_message_time_ms)
         if finished and _m is not None:
             metrics.on_stage_metrics(stage_id, req_id, _m)
 

--- a/vllm_omni/metrics/stats.py
+++ b/vllm_omni/metrics/stats.py
@@ -199,6 +199,30 @@ class OrchestratorAggregator:
             f"stages=[{stages}]{transfers_fragment}"
         )
 
+    def build_timing_composition(self, summary: dict[str, Any]) -> list[dict[str, Any]]:
+        return [
+            {
+                "step": "input_preprocess",
+                "time_ms": summary["input_preprocess_time_ms"],
+                "scope": "InputProcessor.process_inputs",
+            },
+            {
+                "step": "engine_pipeline",
+                "time_ms": summary["engine_pipeline_time_ms"],
+                "scope": "stage pipeline",
+            },
+            {
+                "step": "request_wall",
+                "time_ms": summary["request_wall_time_ms"],
+                "scope": "input_preprocess + engine_pipeline",
+            },
+            {
+                "step": "request_message_build",
+                "time_ms": summary["build_add_request_message_time_ms"],
+                "scope": "full _build_add_request_message",
+            },
+        ]
+
     def _get_or_create_transfer_event(
         self,
         from_stage: int,
@@ -557,6 +581,15 @@ class OrchestratorAggregator:
             logger.info(
                 "\n%s",
                 _format_table("Overall Summary", overall_summary, overall_fields),
+            )
+            logger.info(
+                "\n%s",
+                _format_table(
+                    "Omni Timing Composition",
+                    self.build_timing_composition(overall_summary),
+                    value_fields=["time_ms", "scope"],
+                    column_key="step",
+                ),
             )
 
         all_request_ids = sorted(set(self.stage_events.keys()) | {e.request_id for e in self.e2e_events})

--- a/vllm_omni/metrics/stats.py
+++ b/vllm_omni/metrics/stats.py
@@ -570,12 +570,19 @@ class OrchestratorAggregator:
         for idx, wall_time in enumerate(stage_wall_time_ms):
             overall_summary[f"e2e_stage_{idx}_wall_time_ms"] = wall_time
 
+        timing_summary_fields = {
+            "request_wall_time_ms",
+            "input_preprocess_time_ms",
+            "build_add_request_message_time_ms",
+            "engine_pipeline_time_ms",
+        }
+
         # Print overall summary
         # filter out all-zero fields for logging
         overall_fields = []
         for k in OVERALL_FIELDS or list(overall_summary.keys()):
             v = overall_summary.get(k, None)
-            if v not in (0, 0.0, 0.000, None, ""):
+            if k in timing_summary_fields or v not in (0, 0.0, 0.000, None, ""):
                 overall_fields.append(k)
         if overall_fields:
             logger.info(

--- a/vllm_omni/metrics/stats.py
+++ b/vllm_omni/metrics/stats.py
@@ -164,12 +164,8 @@ class OrchestratorAggregator:
             return None
         engine_pipeline_time_ms = float(e2e_evt.e2e_total_ms)
         input_preprocess_time_ms = float(self.input_preprocess_time_ms)
-        return (
-            rid,
-            engine_pipeline_time_ms,
-            input_preprocess_time_ms,
-            engine_pipeline_time_ms + input_preprocess_time_ms,
-        )
+        request_wall_time_ms = engine_pipeline_time_ms + input_preprocess_time_ms
+        return rid, engine_pipeline_time_ms, input_preprocess_time_ms, request_wall_time_ms
 
     def format_request_timing_line(self, request_id: str) -> str | None:
         timing_fields = self.get_request_timing_fields(request_id)

--- a/vllm_omni/metrics/stats.py
+++ b/vllm_omni/metrics/stats.py
@@ -119,10 +119,14 @@ class OrchestratorAggregator:
         log_stats: bool,
         wall_start_ts: float,
         final_stage_id_for_e2e: dict[str, int] | int,
+        stage_labels: dict[int, str] | None = None,
     ) -> None:
         self.num_stages = int(num_stages)
         self.log_stats = bool(log_stats)
         self.final_stage_id_for_e2e = final_stage_id_for_e2e
+        self.stage_labels = dict(stage_labels or {})
+        self.input_preprocess_time_ms = 0.0
+        self.build_add_request_message_time_ms = 0.0
         self.init_run_state(wall_start_ts)
         self.stage_events: dict[str, list[StageRequestStats]] = {}
         self.transfer_events: dict[
@@ -147,6 +151,57 @@ class OrchestratorAggregator:
         self.diffusion_metrics: defaultdict[str, defaultdict[str, float]] = defaultdict(
             lambda: defaultdict(float)
         )  # {request_id: {diffusion_metrics_key: accumulated_metrics_data}}
+
+    def format_stage_label(self, stage_id: int | None) -> str:
+        if stage_id is None:
+            return "?"
+        return self.stage_labels.get(stage_id, str(stage_id))
+
+    def get_request_timing_fields(self, request_id: str) -> tuple[str, float, float, float] | None:
+        rid = str(request_id)
+        e2e_evt = next((evt for evt in self.e2e_events if evt.request_id == rid), None)
+        if e2e_evt is None:
+            return None
+        engine_pipeline_time_ms = float(e2e_evt.e2e_total_ms)
+        input_preprocess_time_ms = float(self.input_preprocess_time_ms)
+        return (
+            rid,
+            engine_pipeline_time_ms,
+            input_preprocess_time_ms,
+            engine_pipeline_time_ms + input_preprocess_time_ms,
+        )
+
+    def format_request_timing_line(self, request_id: str) -> str | None:
+        timing_fields = self.get_request_timing_fields(request_id)
+        if timing_fields is None:
+            return None
+        rid, engine_pipeline_time_ms, input_preprocess_time_ms, request_wall_time_ms = timing_fields
+
+        def format_seconds(time_ms: float) -> str:
+            return f"{time_ms / 1000.0:.2f}s"
+
+        stages = ",".join(
+            f"{self.format_stage_label(evt.stage_id)}={format_seconds(float(evt.stage_gen_time_ms))}"
+            for evt in sorted(
+                self.stage_events.get(rid, []),
+                key=lambda evt: evt.stage_id if evt.stage_id is not None else -1,
+            )
+        )
+        transfers = ",".join(
+            f"{evt.from_stage}->{evt.to_stage}={evt.total_time_ms:.2f}ms"
+            for evt in sorted(
+                (evt for evt in self.transfer_events.values() if evt.request_id == rid and evt.total_time_ms > 0.0),
+                key=lambda evt: (evt.from_stage, evt.to_stage),
+            )
+        )
+        transfers_fragment = f" transfers=[{transfers}]" if transfers else ""
+        return (
+            f"[OmniTiming] req={rid} "
+            f"total={format_seconds(request_wall_time_ms)} "
+            f"preprocess={format_seconds(input_preprocess_time_ms)} "
+            f"engine={format_seconds(engine_pipeline_time_ms)} "
+            f"stages=[{stages}]{transfers_fragment}"
+        )
 
     def _get_or_create_transfer_event(
         self,
@@ -482,6 +537,10 @@ class OrchestratorAggregator:
 
         overall_summary = {
             "e2e_requests": int(self.e2e_count),
+            "request_wall_time_ms": float(self.e2e_total_ms + self.input_preprocess_time_ms),
+            "input_preprocess_time_ms": float(self.input_preprocess_time_ms),
+            "build_add_request_message_time_ms": float(self.build_add_request_message_time_ms),
+            "engine_pipeline_time_ms": float(self.e2e_total_ms),
             "e2e_wall_time_ms": float(wall_time_ms),
             "e2e_total_tokens": int(self.e2e_total_tokens),
             "e2e_avg_time_per_request_ms": float(e2e_avg_req),
@@ -515,6 +574,17 @@ class OrchestratorAggregator:
             e2e_evt = next((e for e in self.e2e_events if e.request_id == rid), None)
             if e2e_evt:
                 e2e_data = _build_row(e2e_evt, E2E_FIELDS)
+                timing_fields = self.get_request_timing_fields(rid)
+                if timing_fields is not None:
+                    _, engine_pipeline_time_ms, input_preprocess_time_ms, request_wall_time_ms = timing_fields
+                    e2e_data.update(
+                        {
+                            "engine_pipeline_time_ms": engine_pipeline_time_ms,
+                            "input_preprocess_time_ms": input_preprocess_time_ms,
+                            "build_add_request_message_time_ms": float(self.build_add_request_message_time_ms),
+                            "request_wall_time_ms": request_wall_time_ms,
+                        }
+                    )
                 result_e2e_table.append({"request_id": rid, **e2e_data})
 
                 # filter out all-zero fields for logging
@@ -551,7 +621,11 @@ class OrchestratorAggregator:
             # then remove diffusion_metrics from the table
             stage_rows = []
             for evt in stage_evts:
-                row = {"stage_id": evt.stage_id, **_build_row(evt, local_stage_fields)}
+                row = {
+                    "stage_id": evt.stage_id,
+                    "stage": self.format_stage_label(evt.stage_id),
+                    **_build_row(evt, local_stage_fields),
+                }
                 if evt.diffusion_metrics:
                     row.update(evt.diffusion_metrics)
                 row.pop("diffusion_metrics", None)  # Remove the dict itself
@@ -564,7 +638,7 @@ class OrchestratorAggregator:
                 all_value_fields = set()
                 for row in stage_rows:
                     for k in row.keys():
-                        if k != "stage_id":
+                        if k not in {"stage_id", "stage"}:
                             all_value_fields.add(k)
                 value_fields_list = []
                 for field in sorted(all_value_fields):
@@ -583,7 +657,7 @@ class OrchestratorAggregator:
                         _format_table(
                             f"StageRequestStats [request_id={rid}]",
                             stage_rows,
-                            column_key="stage_id",
+                            column_key="stage",
                             value_fields=value_fields_list,
                         ),
                     )


### PR DESCRIPTION
## Motivation

https://github.com/vllm-project/vllm-omni/issues/3039 proposed changes for omni metrics based on pain points discovered in https://github.com/vllm-project/vllm-omni/issues/2834

### Changes

Changes are based off of the proposal in https://github.com/vllm-project/vllm-omni/issues/3039 

### Testing
<details><summary>ut passed</summary>
<p>

```

from __future__ import annotations

import importlib.util
import logging
import sys
import types
from pathlib import Path

import pytest

pytestmark = [pytest.mark.core_model, pytest.mark.cpu]

REPO_ROOT = Path(__file__).resolve().parents[2]
UTILS_PATH = REPO_ROOT / "vllm_omni/metrics/utils.py"
STATS_PATH = REPO_ROOT / "vllm_omni/metrics/stats.py"


def load_stats_module():
    if "vllm_omni.metrics.stats" in sys.modules:
        return sys.modules["vllm_omni.metrics.stats"]

    prettytable_module = types.ModuleType("prettytable")

    class PrettyTable:
        def __init__(self) -> None:
            self.field_names: list[str] = []
            self.align: dict[str, str] = {}
            self.rows: list[list[str]] = []

        def add_row(self, row: list[str]) -> None:
            self.rows.append(row)

        def get_string(self) -> str:
            table_lines = [" | ".join(map(str, self.field_names))]
            table_lines.extend(" | ".join(map(str, row)) for row in self.rows)
            return "\n".join(table_lines)

    prettytable_module.PrettyTable = PrettyTable
    sys.modules.setdefault("prettytable", prettytable_module)

    vllm_module = types.ModuleType("vllm")
    logger_module = types.ModuleType("vllm.logger")
    logger_module.init_logger = logging.getLogger
    vllm_module.logger = logger_module
    sys.modules.setdefault("vllm", vllm_module)
    sys.modules["vllm.logger"] = logger_module

    vllm_omni_pkg = sys.modules.setdefault("vllm_omni", types.ModuleType("vllm_omni"))
    vllm_omni_pkg.__path__ = [str(REPO_ROOT / "vllm_omni")]
    metrics_pkg = sys.modules.setdefault("vllm_omni.metrics", types.ModuleType("vllm_omni.metrics"))
    metrics_pkg.__path__ = [str(REPO_ROOT / "vllm_omni/metrics")]

    utils_spec = importlib.util.spec_from_file_location("vllm_omni.metrics.utils", UTILS_PATH)
    assert utils_spec is not None and utils_spec.loader is not None
    utils_module = importlib.util.module_from_spec(utils_spec)
    sys.modules["vllm_omni.metrics.utils"] = utils_module
    utils_spec.loader.exec_module(utils_module)

    stats_spec = importlib.util.spec_from_file_location("vllm_omni.metrics.stats", STATS_PATH)
    assert stats_spec is not None and stats_spec.loader is not None
    stats_module = importlib.util.module_from_spec(stats_spec)
    sys.modules["vllm_omni.metrics.stats"] = stats_module
    stats_spec.loader.exec_module(stats_module)
    return stats_module


def get_request_entry(table: list[dict], request_id: str) -> dict:
    for entry in table:
        if entry.get("request_id") == request_id:
            return entry
    raise AssertionError(f"request_id={request_id} not found")


def test_orchestrator_aggregator_reports_omni_timing_fields_and_line() -> None:
    stats_module = load_stats_module()
    OrchestratorAggregator = stats_module.OrchestratorAggregator
    RequestE2EStats = stats_module.RequestE2EStats
    StageRequestStats = stats_module.StageRequestStats
    StageStats = stats_module.StageStats

    agg = OrchestratorAggregator(
        num_stages=2,
        log_stats=True,
        wall_start_ts=0.0,
        final_stage_id_for_e2e=1,
        stage_labels={0: "0:ar", 1: "1:diffusion"},
    )
    agg.input_preprocess_time_ms = 2796.015
    agg.build_add_request_message_time_ms = 3010.125
    agg.e2e_total_ms = 30189.544
    agg.e2e_total_tokens = 1281
    agg.e2e_count = 1
    agg.last_finish_ts = 32.985559
    agg.stage_first_ts[0] = 0.0
    agg.stage_last_ts[0] = 16.227201
    agg.stage_first_ts[1] = 16.227201
    agg.stage_last_ts[1] = 30.187782

    agg.on_stage_metrics(
        0,
        "r1",
        StageRequestStats(
            batch_id=1,
            batch_size=1,
            num_tokens_in=1281,
            num_tokens_out=1281,
            stage_gen_time_ms=16227.201,
            rx_transfer_bytes=0,
            rx_decode_time_ms=0.0,
            rx_in_flight_time_ms=0.0,
            stage_stats=StageStats(),
        ),
    )
    agg.on_stage_metrics(
        1,
        "r1",
        StageRequestStats(
            batch_id=1,
            batch_size=1,
            num_tokens_in=0,
            num_tokens_out=0,
            stage_gen_time_ms=13960.581,
            rx_transfer_bytes=0,
            rx_decode_time_ms=0.0,
            rx_in_flight_time_ms=0.0,
            stage_stats=StageStats(),
        ),
    )
    agg.on_forward(0, 1, "r1", size_bytes=1024, tx_ms=0.78, used_shm=False)
    agg.e2e_events.append(
        RequestE2EStats(
            request_id="r1",
            e2e_total_ms=30189.544,
            e2e_total_tokens=1281,
            transfers_total_time_ms=0.78,
            transfers_total_bytes=1024,
        )
    )

    summary = agg.build_and_log_summary()
    overall = summary["overall_summary"]
    assert overall["request_wall_time_ms"] == pytest.approx(32985.559)
    assert overall["input_preprocess_time_ms"] == pytest.approx(2796.015)
    assert overall["build_add_request_message_time_ms"] == pytest.approx(3010.125)
    assert overall["engine_pipeline_time_ms"] == pytest.approx(30189.544)

    e2e_entry = get_request_entry(summary["e2e_table"], "r1")
    assert e2e_entry["request_wall_time_ms"] == pytest.approx(32985.559)
    assert e2e_entry["input_preprocess_time_ms"] == pytest.approx(2796.015)
    assert e2e_entry["build_add_request_message_time_ms"] == pytest.approx(3010.125)
    assert e2e_entry["engine_pipeline_time_ms"] == pytest.approx(30189.544)

    assert agg.format_request_timing_line("r1") == (
        "[OmniTiming] req=r1 total=32.99s preprocess=2.80s engine=30.19s "
        "stages=[0:ar=16.23s,1:diffusion=13.96s] transfers=[0->1=0.78ms]"
    )



```

</p>
</details> 