### PR TITLE
feat(api): add multi-modal OpenAI API and WebSocket API

### DIFF
--- a/tests/entrypoints/test_multi_modal_api.py
+++ b/tests/entrypoints/test_multi_modal_api.py
@@ -1,0 +1,119 @@
+"""Unit tests for multi-modal API."""
+
+from vllm_omni.entrypoints.openai.multi_modal_api import (
+    ChatCompletionRequest,
+    ChatMessage,
+    ContentType,
+    MultiModalAPIServer,
+    MultiModalContent,
+)
+
+
+class TestMultiModalAPIServer:
+    """Tests for MultiModalAPIServer."""
+
+    def test_parse_image_content(self):
+        """Test parsing image content."""
+        server = MultiModalAPIServer()
+        messages = [
+            ChatMessage(
+                role="user",
+                content=[MultiModalContent(content_type=ContentType.IMAGE_URL, url="https://example.com/image.jpg")],
+            )
+        ]
+
+        result = server.parse_multimodal_content(messages)
+        assert "image" in result
+        assert result["image"] == "https://example.com/image.jpg"
+
+    def test_parse_text_content(self):
+        """Test parsing text content."""
+        server = MultiModalAPIServer()
+        messages = [ChatMessage(role="user", content="Hello world")]
+
+        prompt = server.extract_text_prompt(messages)
+        assert prompt == "Hello world"
+
+    def test_extract_text_from_multimodal(self):
+        """Test extracting text from multi-modal content."""
+        server = MultiModalAPIServer()
+        messages = [
+            ChatMessage(
+                role="user",
+                content=[
+                    MultiModalContent(content_type=ContentType.TEXT, text="Describe this image"),
+                    MultiModalContent(content_type=ContentType.IMAGE_URL, url="https://example.com/img.png"),
+                ],
+            )
+        ]
+
+        prompt = server.extract_text_prompt(messages)
+        assert "Describe this image" in prompt
+
+    def test_build_sampling_params(self):
+        """Test building sampling parameters."""
+        server = MultiModalAPIServer()
+        request = ChatCompletionRequest(
+            model="test",
+            messages=[ChatMessage(role="user", content="test")],
+            temperature=0.8,
+            top_p=0.9,
+            max_tokens=100,
+        )
+
+        params = server.build_sampling_params(request)
+        assert params["temperature"] == 0.8
+        assert params["top_p"] == 0.9
+        assert params["max_tokens"] == 100
+
+    def test_build_sampling_params_with_stop(self):
+        """Test building sampling params with stop."""
+        server = MultiModalAPIServer()
+        request = ChatCompletionRequest(
+            model="test", messages=[ChatMessage(role="user", content="test")], stop=["STOP", "END"]
+        )
+
+        params = server.build_sampling_params(request)
+        assert params["stop"] == ["STOP", "END"]
+
+    def test_list_models(self):
+        """Test listing models."""
+        server = MultiModalAPIServer()
+        models = server.list_models()
+
+        assert len(models) > 0
+        assert "id" in models[0]
+
+
+class TestMultiModalContent:
+    """Tests for MultiModalContent."""
+
+    def test_image_url_content(self):
+        """Test image URL content."""
+        content = MultiModalContent(
+            content_type=ContentType.IMAGE_URL, url="https://example.com/image.jpg", detail="high"
+        )
+
+        assert content.url == "https://example.com/image.jpg"
+        assert content.detail == "high"
+
+    def test_audio_base64_content(self):
+        """Test audio base64 content."""
+        content = MultiModalContent(content_type=ContentType.AUDIO_BASE64, base64_data="dGVzdA==")
+
+        assert content.base64_data == "dGVzdA=="
+
+
+class TestChatMessage:
+    """Tests for ChatMessage."""
+
+    def test_string_content(self):
+        """Test string content."""
+        message = ChatMessage(role="user", content="Hello")
+        assert message.content == "Hello"
+
+    def test_list_content(self):
+        """Test list content."""
+        content = [MultiModalContent(content_type=ContentType.TEXT, text="Hi")]
+        message = ChatMessage(role="user", content=content)
+        assert len(message.content) == 1

--- a/tests/entrypoints/test_websocket_api.py
+++ b/tests/entrypoints/test_websocket_api.py
@@ -1,0 +1,69 @@
+"""Unit tests for WebSocket API."""
+
+import pytest
+
+from vllm_omni.entrypoints.openai.websocket_api import (
+    ConnectionState,
+    WebSocketAPI,
+    WebSocketConnection,
+)
+
+
+class TestWebSocketAPI:
+    """Tests for WebSocketAPI."""
+
+    @pytest.mark.asyncio
+    async def test_connection_state(self):
+        """Test connection state management."""
+        api = WebSocketAPI()
+
+        assert api.get_active_connections() == 0
+
+    def test_connection_creation(self):
+        """Test WebSocket connection creation."""
+        connection = WebSocketConnection(connection_id="test-123", websocket=None, state=ConnectionState.CONNECTED)
+
+        assert connection.connection_id == "test-123"
+        assert connection.state == ConnectionState.CONNECTED
+        assert connection.metadata is None
+
+    def test_connection_with_metadata(self):
+        """Test connection with metadata."""
+        metadata = {"user": "test_user", "origin": "test"}
+        connection = WebSocketConnection(connection_id="test-456", websocket=None, metadata=metadata)
+
+        assert connection.metadata == metadata
+
+    def test_get_active_connections(self):
+        """Test active connections count."""
+        api = WebSocketAPI()
+
+        api._connections["conn1"] = WebSocketConnection("conn1", None)
+        api._connections["conn2"] = WebSocketConnection("conn2", None)
+
+        assert api.get_active_connections() == 2
+
+
+class TestConnectionState:
+    """Tests for ConnectionState enum."""
+
+    def test_connection_states(self):
+        """Test all connection states."""
+        assert ConnectionState.CONNECTING.value == "connecting"
+        assert ConnectionState.CONNECTED.value == "connected"
+        assert ConnectionState.DISCONNECTING.value == "disconnecting"
+        assert ConnectionState.DISCONNECTED.value == "disconnected"
+
+
+class TestWebSocketConnection:
+    """Tests for WebSocketConnection."""
+
+    def test_default_state(self):
+        """Test default connection state."""
+        conn = WebSocketConnection("id", None)
+        assert conn.state == ConnectionState.CONNECTING
+
+    def test_connected_state(self):
+        """Test connected state."""
+        conn = WebSocketConnection("id", None, state=ConnectionState.CONNECTED)
+        assert conn.state == ConnectionState.CONNECTED

--- a/vllm_omni/entrypoints/openai/multi_modal_api.py
+++ b/vllm_omni/entrypoints/openai/multi_modal_api.py
@@ -1,0 +1,139 @@
+"""OpenAI-compatible multi-modal API."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class ContentType(Enum):
+    """Content types for multi-modal input."""
+
+    TEXT = "text"
+    IMAGE_URL = "image_url"
+    IMAGE_BASE64 = "image_base64"
+    AUDIO_URL = "audio_url"
+    AUDIO_BASE64 = "audio_base64"
+    VIDEO_URL = "video_url"
+    VIDEO_BASE64 = "video_base64"
+
+
+@dataclass
+class MultiModalContent:
+    """Multi-modal content item."""
+
+    content_type: ContentType
+    text: str | None = None
+    url: str | None = None
+    base64_data: str | None = None
+    detail: str = "auto"
+
+
+@dataclass
+class ChatMessage:
+    """Chat message."""
+
+    role: str
+    content: str | list[MultiModalContent]
+
+
+@dataclass
+class ChatCompletionRequest:
+    """Chat completion request."""
+
+    model: str
+    messages: list[ChatMessage]
+    temperature: float = 0.7
+    top_p: float = 1.0
+    max_tokens: int | None = None
+    stream: bool = False
+    stop: str | list[str] | None = None
+
+
+class MultiModalAPIServer:
+    """Extended OpenAI-compatible API server."""
+
+    def __init__(self, omni_engine=None):
+        self._engine = omni_engine
+
+    def parse_multimodal_content(self, messages: list[ChatMessage]) -> dict[str, Any]:
+        """Parse multi-modal content from messages."""
+        multi_modal_data: dict[str, Any] = {}
+
+        for message in messages:
+            if isinstance(message.content, list):
+                for content in message.content:
+                    if content.content_type == ContentType.IMAGE_URL:
+                        multi_modal_data["image"] = content.url
+                    elif content.content_type == ContentType.IMAGE_BASE64:
+                        multi_modal_data["image"] = content.base64_data
+                    elif content.content_type == ContentType.AUDIO_URL:
+                        multi_modal_data["audio"] = content.url
+                    elif content.content_type == ContentType.AUDIO_BASE64:
+                        multi_modal_data["audio"] = content.base64_data
+                    elif content.content_type == ContentType.VIDEO_URL:
+                        multi_modal_data["video"] = content.url
+                    elif content.content_type == ContentType.VIDEO_BASE64:
+                        multi_modal_data["video"] = content.base64_data
+
+        return multi_modal_data
+
+    def extract_text_prompt(self, messages: list[ChatMessage]) -> str:
+        """Extract text prompt from messages."""
+        prompts = []
+
+        for message in messages:
+            if isinstance(message.content, str):
+                prompts.append(message.content)
+            elif isinstance(message.content, list):
+                for content in message.content:
+                    if content.text:
+                        prompts.append(content.text)
+
+        return "\n".join(prompts)
+
+    def build_sampling_params(self, request: ChatCompletionRequest) -> dict[str, Any]:
+        """Build sampling parameters from request."""
+        params = {
+            "temperature": request.temperature,
+            "top_p": request.top_p,
+            "max_tokens": request.max_tokens,
+        }
+
+        if request.stop:
+            params["stop"] = [request.stop] if isinstance(request.stop, str) else request.stop
+
+        return params
+
+    def format_completion(self, outputs: Any) -> dict[str, Any]:
+        """Format completion response."""
+        return {
+            "id": f"chatcmpl-{id(outputs)}",
+            "object": "chat.completion",
+            "created": 0,
+            "model": outputs.model_name if hasattr(outputs, "model_name") else "unknown",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": outputs.text if hasattr(outputs, "text") else str(outputs),
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": getattr(outputs, "prompt_tokens", 0),
+                "completion_tokens": getattr(outputs, "completion_tokens", 0),
+                "total_tokens": getattr(outputs, "total_tokens", 0),
+            },
+        }
+
+    def list_models(self) -> list[dict[str, Any]]:
+        """List available models."""
+        return [
+            {"id": "qwen-omni", "object": "model", "created": 0, "permission": [], "root": "qwen-omni"},
+        ]

--- a/vllm_omni/entrypoints/openai/websocket_api.py
+++ b/vllm_omni/entrypoints/openai/websocket_api.py
@@ -1,0 +1,146 @@
+"""WebSocket API for real-time streaming inference."""
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class ConnectionState(Enum):
+    """WebSocket connection states."""
+
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    DISCONNECTING = "disconnecting"
+    DISCONNECTED = "disconnected"
+
+
+@dataclass
+class WebSocketConnection:
+    """WebSocket connection."""
+
+    connection_id: str
+    websocket: Any
+    state: ConnectionState = ConnectionState.CONNECTING
+    metadata: dict[str, Any] = None  # type: ignore[assignment]
+
+
+class WebSocketAPI:
+    """WebSocket API for real-time inference."""
+
+    def __init__(self, omni_engine=None):
+        self._engine = omni_engine
+        self._connections: dict[str, WebSocketConnection] = {}
+        self._connection_tasks: dict[str, asyncio.Task] = {}
+
+    async def handle_connection(self, websocket) -> str:
+        """Handle new WebSocket connection."""
+        connection_id = str(uuid.uuid4())
+
+        connection = WebSocketConnection(
+            connection_id=connection_id, websocket=websocket, state=ConnectionState.CONNECTED
+        )
+        self._connections[connection_id] = connection
+
+        task = asyncio.create_task(self._connection_loop(connection_id, websocket))
+        self._connection_tasks[connection_id] = task
+
+        await websocket.send_json({"type": "connection", "connection_id": connection_id, "status": "connected"})
+
+        logger.info(f"WebSocket connection established: {connection_id}")
+        return connection_id
+
+    async def _connection_loop(self, connection_id: str, websocket) -> None:
+        """Main connection loop."""
+        try:
+            while connection_id in self._connections:
+                message = await websocket.receive_json()
+                await self._handle_message(connection_id, message)
+
+        except asyncio.CancelledError:
+            logger.info(f"Connection {connection_id} cancelled")
+        except Exception as e:
+            logger.error(f"Connection error: {e}")
+        finally:
+            await self._cleanup_connection(connection_id)
+
+    async def _handle_message(self, connection_id: str, message: dict[str, Any]) -> None:
+        """Handle incoming message."""
+        message_type = message.get("type")
+
+        if message_type == "infer":
+            await self._handle_inference(connection_id, message)
+        elif message_type == "cancel":
+            await self._handle_cancel(connection_id, message)
+        elif message_type == "ping":
+            await self._handle_ping(connection_id)
+        elif message_type == "status":
+            await self._handle_status(connection_id)
+
+    async def _handle_inference(self, connection_id: str, message: dict[str, Any]) -> None:
+        """Handle inference request."""
+        connection = self._connections.get(connection_id)
+        if not connection:
+            return
+
+        prompt = message.get("prompt", "")
+        multi_modal_data = message.get("multi_modal_data", {})
+        sampling_params = message.get("sampling_params", {})
+        stream = message.get("stream", True)
+
+        if stream and self._engine:
+            async for output in self._engine.stream_generate(
+                prompt=prompt, multi_modal_data=multi_modal_data, sampling_params=sampling_params
+            ):
+                await connection.websocket.send_json(
+                    {
+                        "type": "chunk",
+                        "content": output.text if hasattr(output, "text") else str(output),
+                        "final": getattr(output, "is_final", False),
+                    }
+                )
+        else:
+            await connection.websocket.send_json({"type": "error", "message": "Non-streaming not implemented"})
+
+    async def _handle_cancel(self, connection_id: str, message: dict[str, Any]) -> None:
+        """Handle cancellation request."""
+        request_id = message.get("request_id")
+        if request_id and self._engine:
+            await self._engine.cancel(request_id)
+
+    async def _handle_ping(self, connection_id: str) -> None:
+        """Handle ping."""
+        connection = self._connections.get(connection_id)
+        if connection:
+            await connection.websocket.send_json({"type": "pong"})
+
+    async def _handle_status(self, connection_id: str) -> None:
+        """Handle status request."""
+        connection = self._connections.get(connection_id)
+        if connection:
+            await connection.websocket.send_json(
+                {
+                    "type": "status",
+                    "connection_id": connection_id,
+                    "state": connection.state.value,
+                    "active_connections": len(self._connections),
+                }
+            )
+
+    async def _cleanup_connection(self, connection_id: str) -> None:
+        """Clean up connection resources."""
+        self._connections.pop(connection_id, None)
+        task = self._connection_tasks.pop(connection_id, None)
+        if task and not task.done():
+            task.cancel()
+
+        logger.info(f"WebSocket connection closed: {connection_id}")
+
+    def get_active_connections(self) -> int:
+        """Get number of active connections."""
+        return len(self._connections)


### PR DESCRIPTION
## Purpose
Add two API features:

1. **MultiModalAPIServer** - OpenAI-compatible multi-modal API
   - Support for text, image, audio, video content types
   - Chat completion format with multi-modal content
   - Model listing endpoint

2. **WebSocketAPI** - Real-time streaming inference
   - Connection management with states
   - Streaming inference via WebSocket
   - Ping/pong and status endpoints

## Test Plan
```bash
pytest tests/entrypoints/test_multi_modal_api.py tests/entrypoints/test_websocket_api.py -v

Test Result
All tests passing ✅

- [x] Purpose: Add MultiModalAPIServer and WebSocketAPI
- [x] Test Plan: Unit tests provided
- [x] Test Result: All passing
- [ ] Documentation: Not required
- [ ] Release notes: Will be included in API section