### PR TITLE
add check_health in inline client

### DIFF
--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -385,9 +385,9 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             raise
 
     def check_health(self) -> None:
-        self._ensure_open()
         if self.is_failed:
             raise EngineDeadError()
+        self._ensure_open()
         for p in self._processes:
             if not p.is_alive():
                 self.is_failed = True

--- a/vllm_omni/diffusion/inline_stage_diffusion_client.py
+++ b/vllm_omni/diffusion/inline_stage_diffusion_client.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 from PIL import Image
 from vllm.logger import init_logger
+from vllm.v1.engine.exceptions import EngineDeadError
 
 from vllm_omni.diffusion.data import DiffusionRequestAbortedError
 from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
@@ -332,7 +333,7 @@ class InlineStageDiffusionClient:
     def check_health(self) -> None:
         """Check if the inline diffusion engine and its workers are healthy."""
         if self._shutting_down:
-            raise RuntimeError("InlineStageDiffusionClient is shutting down")
+            raise EngineDeadError("InlineStageDiffusionClient is shutting down")
         self._engine.executor.check_health()
 
     def shutdown(self) -> None:

--- a/vllm_omni/diffusion/inline_stage_diffusion_client.py
+++ b/vllm_omni/diffusion/inline_stage_diffusion_client.py
@@ -328,7 +328,7 @@ class InlineStageDiffusionClient:
             kwargs,
             None,
         )
-    
+
     def check_health(self) -> None:
         """Check if the inline diffusion engine and its workers are healthy."""
         if self._shutting_down:

--- a/vllm_omni/diffusion/inline_stage_diffusion_client.py
+++ b/vllm_omni/diffusion/inline_stage_diffusion_client.py
@@ -328,6 +328,12 @@ class InlineStageDiffusionClient:
             kwargs,
             None,
         )
+    
+    def check_health(self) -> None:
+        """Check if the inline diffusion engine and its workers are healthy."""
+        if self._shutting_down:
+            raise RuntimeError("InlineStageDiffusionClient is shutting down")
+        self._engine.executor.check_health()
 
     def shutdown(self) -> None:
         self._shutting_down = True


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix: https://github.com/vllm-project/vllm-omni/issues/3050

Because when use inline diffusion client, but in this client not `check_health` method, so need add this method, to check if the inline diffusion engine and its workers are healthy.

## Test Plan

1. Start serve
```
$ vllm serve /home/jovyan/Wan2.2-T2V-A14B-Diffusers/ --omni --port 8091 
```

2. kill work process, we can look this log
```
ERROR 04-23 03:02:52 [multiproc_executor.py:220] Diffusion worker(s) died unexpectedly: ['DiffusionWorker-0']
```

3. Send health reqeust
```
$ curl -i http://localhost:8091/health
HTTP/1.1 503 Service Unavailable
date: Thu, 23 Apr 2026 03:02:58 GMT
server: uvicorn
content-length: 0
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
