### PR TITLE
[feature] [MXFP4] Add MXFP4 (W4A16) Online Quantization for Wan2.2 Diffusion Models

### DIFF
--- a/tests/diffusion/quantization/test_mxfp4_config.py
+++ b/tests/diffusion/quantization/test_mxfp4_config.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for MXFP4 quantization config."""
+
+import pytest
+import torch
+
+from vllm_omni.quantization import build_quant_config
+from vllm_omni.quantization.factory import SUPPORTED_QUANTIZATION_METHODS
+from vllm_omni.quantization.mxfp4_config import (
+    DiffusionMXFP4Config,
+    DiffusionMXFP4LinearMethod,
+    _quantize_bf16_to_mxfp4,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion]
+
+
+def test_mxfp4_config_creation():
+    """Test that MXFP4 config can be created."""
+    config = build_quant_config("mxfp4")
+    assert config is not None
+    assert config.get_name() == "mxfp4"
+
+
+def test_mxfp4_config_custom_params():
+    """Test MXFP4 config with custom parameters."""
+    config = build_quant_config(
+        "mxfp4",
+        ignored_layers=["proj_out"],
+        weight_block_size=32,
+    )
+    assert config is not None
+    assert "proj_out" in config.ignored_layers
+    assert config.weight_block_size == [32, 32]  # Converted to list internally
+
+
+def test_mxfp4_config_weight_block_size_list():
+    """Test MXFP4 config with list weight_block_size."""
+    config = DiffusionMXFP4Config(weight_block_size=[64, 64])
+    assert config.weight_block_size == [64, 64]
+    assert config._block_size_scalar == 64
+
+
+def test_supported_methods():
+    """Test that mxfp4 is in supported methods list."""
+    assert "mxfp4" in SUPPORTED_QUANTIZATION_METHODS
+
+
+def test_quantize_bf16_to_mxfp4_basic():
+    """Test basic BF16 to MXFP4 quantization."""
+    out_features, in_features = 64, 128
+    weight = torch.randn(out_features, in_features, dtype=torch.bfloat16)
+
+    qweight, weight_scale = _quantize_bf16_to_mxfp4(weight, block_size=32)
+
+    assert qweight.dtype == torch.uint8
+    assert qweight.shape == (out_features, in_features // 2)
+    assert weight_scale.dtype == torch.uint8
+    assert weight_scale.shape == (out_features, in_features // 32)
+
+
+def test_quantize_bf16_to_mxfp4_fp16():
+    """Test FP16 to MXFP4 quantization."""
+    out_features, in_features = 64, 128
+    weight = torch.randn(out_features, in_features, dtype=torch.float16)
+
+    qweight, weight_scale = _quantize_bf16_to_mxfp4(weight, block_size=32)
+
+    assert qweight.dtype == torch.uint8
+    assert qweight.shape == (out_features, in_features // 2)
+
+
+def test_quantize_bf16_to_mxfp4_block_size():
+    """Test quantization with different block sizes."""
+    weight = torch.randn(64, 256, dtype=torch.bfloat16)
+
+    qweight, weight_scale = _quantize_bf16_to_mxfp4(weight, block_size=16)
+    assert weight_scale.shape == (64, 256 // 16)
+
+    qweight, weight_scale = _quantize_bf16_to_mxfp4(weight, block_size=64)
+    assert weight_scale.shape == (64, 256 // 64)
+
+
+def test_quantize_bf16_to_mxfp4_zero_weights():
+    """Test quantization with zero weights."""
+    weight = torch.zeros(32, 64, dtype=torch.bfloat16)
+
+    qweight, weight_scale = _quantize_bf16_to_mxfp4(weight, block_size=32)
+
+    assert qweight.dtype == torch.uint8
+    assert weight_scale.dtype == torch.uint8
+
+
+def test_quantize_bf16_to_mxfp4_large_tensor():
+    """Test quantization with large tensor (simulating real model size)."""
+    out_features, in_features = 5120, 5120
+    weight = torch.randn(out_features, in_features, dtype=torch.bfloat16)
+
+    qweight, weight_scale = _quantize_bf16_to_mxfp4(weight, block_size=32)
+
+    assert qweight.shape == (out_features, in_features // 2)
+    assert weight_scale.shape == (out_features, in_features // 32)
+
+
+def test_mxfp4_linear_method_creation():
+    """Test MXFP4 Linear Method creation."""
+    config = DiffusionMXFP4Config()
+    method = DiffusionMXFP4LinearMethod(config)
+    assert method.quant_config == config
+
+
+def test_mxfp4_config_get_quant_method_cuda():
+    """Test get_quant_method returns LinearMethod on CUDA."""
+    from unittest.mock import patch
+
+    config = DiffusionMXFP4Config()
+
+    with patch("vllm_omni.quantization.mxfp4_config.current_omni_platform") as mock_platform:
+        mock_platform.is_cuda.return_value = True
+        mock_platform._omni_enum.value = "cuda"
+
+        from vllm.model_executor.layers.linear import LinearBase
+
+        class MockLinear(LinearBase):
+            def __init__(self):
+                pass
+
+        method = config.get_quant_method(MockLinear(), "test_layer")
+        assert isinstance(method, DiffusionMXFP4LinearMethod)
+
+
+def test_mxfp4_config_ignored_layers():
+    """Test that ignored layers return UnquantizedLinearMethod."""
+    from unittest.mock import patch
+
+    config = DiffusionMXFP4Config(ignored_layers=["proj_out"])
+
+    with patch("vllm_omni.quantization.mxfp4_config.current_omni_platform") as mock_platform:
+        mock_platform.is_cuda.return_value = True
+        mock_platform._omni_enum.value = "cuda"
+
+        from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+
+        class MockLinear(LinearBase):
+            def __init__(self):
+                pass
+
+        # Should return UnquantizedLinearMethod for ignored layer
+        method = config.get_quant_method(MockLinear(), "proj_out")
+        assert isinstance(method, UnquantizedLinearMethod)
+
+        # Should return MXFP4 method for non-ignored layer
+        method = config.get_quant_method(MockLinear(), "blocks.0.attn1.to_qkv")
+        assert isinstance(method, DiffusionMXFP4LinearMethod)
+
+
+def test_mxfp4_config_not_implemented_on_non_cuda():
+    """Test that MXFP4 raises NotImplementedError on non-CUDA platforms."""
+    from unittest.mock import patch
+
+    config = DiffusionMXFP4Config()
+
+    with patch("vllm_omni.quantization.mxfp4_config.current_omni_platform") as mock_platform:
+        mock_platform.is_cuda.return_value = False
+        mock_platform._omni_enum.value = "npu"
+
+        from vllm.model_executor.layers.linear import LinearBase
+
+        class MockLinear(LinearBase):
+            def __init__(self):
+                pass
+
+        with pytest.raises(NotImplementedError, match="MXFP4 is not supported"):
+            config.get_quant_method(MockLinear(), "test_layer")
+
+
+def test_mxfp4_config_from_config():
+    """Test config creation from dict."""
+    config = DiffusionMXFP4Config.from_config(
+        {"ignored_layers": ["proj_out"], "weight_block_size": 64}
+    )
+    assert "proj_out" in config.ignored_layers
+    assert config.weight_block_size == [64, 64]
+
+
+def test_mxfp4_config_from_config_defaults():
+    """Test config creation with defaults."""
+    config = DiffusionMXFP4Config.from_config({})
+    assert config.ignored_layers == []
+    assert config.weight_block_size == [32, 32]
+
+
+def test_mxfp4_config_get_min_capability():
+    """Test min capability is 75 (Turing)."""
+    assert DiffusionMXFP4Config.get_min_capability() == 75
+
+
+def test_mxfp4_config_get_supported_act_dtypes():
+    """Test supported activation dtypes."""
+    dtypes = DiffusionMXFP4Config.get_supported_act_dtypes()
+    assert torch.bfloat16 in dtypes
+    assert torch.float16 in dtypes

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -116,7 +116,10 @@ def load_transformer_config(model_path: str, subfolder: str = "transformer", loc
     return {}
 
 
-def create_transformer_from_config(config: dict) -> WanTransformer3DModel:
+def create_transformer_from_config(
+    config: dict,
+    quant_config=None,
+) -> WanTransformer3DModel:
     """Create WanTransformer3DModel from config dict."""
     kwargs = {}
 
@@ -150,6 +153,9 @@ def create_transformer_from_config(config: dict) -> WanTransformer3DModel:
         kwargs["rope_max_seq_len"] = config["rope_max_seq_len"]
     if "pos_embed_seq_len" in config:
         kwargs["pos_embed_seq_len"] = config["pos_embed_seq_len"]
+
+    if quant_config is not None:
+        kwargs["quant_config"] = quant_config
 
     return WanTransformer3DModel(**kwargs)
 
@@ -324,16 +330,19 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
             model, subfolder="vae", torch_dtype=dtype, local_files_only=local_files_only
         ).to(self.device)
 
+        # Build quantization config from OmniDiffusionConfig
+        quant_config = self._build_quant_config()
+
         # Initialize transformers with correct config (weights loaded via load_weights)
         if load_transformer:
             transformer_config = load_transformer_config(model, "transformer", local_files_only)
-            self.transformer = self._create_transformer(transformer_config)
+            self.transformer = self._create_transformer(transformer_config, quant_config)
         else:
             self.transformer = None
 
         if load_transformer_2:
             transformer_2_config = load_transformer_config(model, "transformer_2", local_files_only)
-            self.transformer_2 = self._create_transformer(transformer_2_config)
+            self.transformer_2 = self._create_transformer(transformer_2_config, quant_config)
         else:
             self.transformer_2 = None
 
@@ -360,6 +369,20 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
         self.setup_diffusion_pipeline_profiler(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
+
+    def _build_quant_config(self):
+        """Build quantization config from OmniDiffusionConfig."""
+        from vllm_omni.quantization import build_quant_config
+
+        return build_quant_config(self.od_config.quantization_config)
+
+    def _create_transformer(
+        self,
+        config: dict,
+        quant_config=None,
+    ) -> WanTransformer3DModel:
+        """Create a transformer from a config dict. Subclasses may override."""
+        return create_transformer_from_config(config, quant_config)
 
     def _create_transformer(self, config: dict) -> WanTransformer3DModel:
         """Create a transformer from a config dict. Subclasses may override."""

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -384,10 +384,6 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
         """Create a transformer from a config dict. Subclasses may override."""
         return create_transformer_from_config(config, quant_config)
 
-    def _create_transformer(self, config: dict) -> WanTransformer3DModel:
-        """Create a transformer from a config dict. Subclasses may override."""
-        return create_transformer_from_config(config)
-
     @property
     def guidance_scale(self):
         return self._guidance_scale

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -212,13 +212,16 @@ class Wan22I2VPipeline(
             model, subfolder="vae", torch_dtype=dtype, local_files_only=local_files_only
         ).to(self.device)
 
+        # Build quantization config
+        quant_config = self._build_quant_config()
+
         # Transformers (weights loaded via load_weights)
         # Load config from model directory or HF Hub to get correct in_channels for I2V models
         transformer_config = load_transformer_config(model, "transformer", local_files_only)
-        self.transformer = create_transformer_from_config(transformer_config)
+        self.transformer = create_transformer_from_config(transformer_config, quant_config)
         if self.has_transformer_2:
             transformer_2_config = load_transformer_config(model, "transformer_2", local_files_only)
-            self.transformer_2 = create_transformer_from_config(transformer_2_config)
+            self.transformer_2 = create_transformer_from_config(transformer_2_config, quant_config)
         else:
             self.transformer_2 = None
 
@@ -243,6 +246,12 @@ class Wan22I2VPipeline(
         self.setup_diffusion_pipeline_profiler(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
+
+    def _build_quant_config(self):
+        """Build quantization config from OmniDiffusionConfig."""
+        from vllm_omni.quantization import build_quant_config
+
+        return build_quant_config(self.od_config.quantization_config)
 
     @property
     def guidance_scale(self):

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_ti2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_ti2v.py
@@ -187,10 +187,13 @@ class Wan22TI2VPipeline(nn.Module, SupportImageInput, CFGParallelMixin, Progress
             model, subfolder="vae", torch_dtype=dtype, local_files_only=local_files_only
         ).to(self.device)
 
+        # Build quantization config
+        quant_config = self._build_quant_config()
+
         # Single transformer (TI2V uses dense 5B model, not MoE)
         # Load config from model to get correct dimensions
         transformer_config = load_transformer_config(model, "transformer", local_files_only)
-        self.transformer = create_transformer_from_config(transformer_config)
+        self.transformer = create_transformer_from_config(transformer_config, quant_config)
 
         self._sample_solver = "unipc"
         self._flow_shift = od_config.flow_shift if od_config.flow_shift is not None else 5.0
@@ -206,6 +209,12 @@ class Wan22TI2VPipeline(nn.Module, SupportImageInput, CFGParallelMixin, Progress
         self._guidance_scale = None
         self._num_timesteps = None
         self._current_timestep = None
+
+    def _build_quant_config(self):
+        """Build quantization config from OmniDiffusionConfig."""
+        from vllm_omni.quantization import build_quant_config
+
+        return build_quant_config(self.od_config.quantization_config)
 
     @property
     def guidance_scale(self):

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -3,7 +3,7 @@
 
 import math
 from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
@@ -31,6 +31,9 @@ from vllm_omni.diffusion.forward_context import get_forward_context
 from vllm_omni.diffusion.layers.adalayernorm import AdaLayerNorm
 from vllm_omni.diffusion.layers.norm import LayerNorm, RMSNorm
 from vllm_omni.platforms import current_omni_platform
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 
 logger = init_logger(__name__)
 
@@ -100,7 +103,16 @@ class DistributedRMSNorm(nn.Module):
 class ColumnParallelGELU(nn.Module):
     """Column parallel linear with GELU activation."""
 
-    def __init__(self, dim_in: int, dim_out: int, *, approximate: str = "tanh", bias: bool = True):
+    def __init__(
+        self,
+        dim_in: int,
+        dim_out: int,
+        *,
+        approximate: str = "tanh",
+        bias: bool = True,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.proj = ColumnParallelLinear(
             dim_in,
@@ -108,6 +120,8 @@ class ColumnParallelGELU(nn.Module):
             bias=bias,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.proj",
         )
         self.approximate = approximate
 
@@ -128,12 +142,17 @@ class WanFeedForward(nn.Module):
         inner_dim: int,
         dim_out: int | None = None,
         bias: bool = True,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         dim_out = dim_out or dim
 
         # ColumnParallel: scatter to each tp_rank
-        self.net_0 = ColumnParallelGELU(dim, inner_dim, approximate="tanh", bias=bias)
+        self.net_0 = ColumnParallelGELU(
+            dim, inner_dim, approximate="tanh", bias=bias,
+            quant_config=quant_config, prefix=f"{prefix}.net_0",
+        )
         # Placeholder for weight loading compatibility
         self.net_1 = nn.Identity()
         # RowParallel: gather from each tp_rank
@@ -143,6 +162,8 @@ class WanFeedForward(nn.Module):
             bias=bias,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.net_2",
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -357,6 +378,8 @@ class WanSelfAttention(nn.Module):
         head_dim: int,
         eps: float = 1e-5,
         dropout: float = 0.0,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ):
         super().__init__()
 
@@ -371,6 +394,8 @@ class WanSelfAttention(nn.Module):
             head_size=head_dim,
             total_num_heads=num_heads,
             bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_qkv",
         )
 
         self.num_heads = self.to_qkv.num_heads
@@ -391,6 +416,8 @@ class WanSelfAttention(nn.Module):
             bias=True,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_out",
         )
         self.dropout = nn.Dropout(dropout)
 
@@ -462,6 +489,8 @@ class WanCrossAttention(nn.Module):
         eps: float = 1e-5,
         dropout: float = 0.0,
         added_kv_proj_dim: int | None = None,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ):
         super().__init__()
 
@@ -478,6 +507,8 @@ class WanCrossAttention(nn.Module):
             bias=True,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_q",
         )
 
         # Separate K and V projections for cross-attention
@@ -487,6 +518,8 @@ class WanCrossAttention(nn.Module):
             bias=True,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_k",
         )
 
         self.to_v = ColumnParallelLinear(
@@ -495,6 +528,8 @@ class WanCrossAttention(nn.Module):
             bias=True,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_v",
         )
 
         tp_size = get_tensor_model_parallel_world_size()
@@ -518,6 +553,8 @@ class WanCrossAttention(nn.Module):
                 bias=True,
                 gather_output=False,
                 return_bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.add_k_proj",
             )
             self.add_v_proj = ColumnParallelLinear(
                 added_kv_proj_dim,
@@ -525,6 +562,8 @@ class WanCrossAttention(nn.Module):
                 bias=True,
                 gather_output=False,
                 return_bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.add_v_proj",
             )
             if get_tensor_model_parallel_world_size() > 1:
                 self.norm_added_k = DistributedRMSNorm(self.tp_inner_dim, eps=eps)
@@ -542,6 +581,8 @@ class WanCrossAttention(nn.Module):
             bias=True,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_out",
         )
         self.dropout = nn.Dropout(dropout)
 
@@ -626,6 +667,8 @@ class WanTransformerBlock(nn.Module):
         eps: float = 1e-6,
         added_kv_proj_dim: int | None = None,
         cross_attn_norm: bool = False,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ):
         super().__init__()
 
@@ -638,6 +681,8 @@ class WanTransformerBlock(nn.Module):
             num_heads=num_heads,
             head_dim=head_dim,
             eps=eps,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn1",
         )
 
         # 2. Cross-attention
@@ -647,11 +692,17 @@ class WanTransformerBlock(nn.Module):
             head_dim=head_dim,
             eps=eps,
             added_kv_proj_dim=added_kv_proj_dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn2",
         )
         self.norm2 = LayerNorm(dim, eps, elementwise_affine=True) if cross_attn_norm else nn.Identity()
 
         # 3. Feed-forward
-        self.ffn = WanFeedForward(dim=dim, inner_dim=ffn_dim, dim_out=dim)
+        self.ffn = WanFeedForward(
+            dim=dim, inner_dim=ffn_dim, dim_out=dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.ffn",
+        )
         self.norm3 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)
 
         # Scale-shift table for modulation
@@ -807,8 +858,11 @@ class WanTransformer3DModel(nn.Module):
         added_kv_proj_dim: int | None = None,
         rope_max_seq_len: int = 1024,
         pos_embed_seq_len: int | None = None,
+        quant_config: "QuantizationConfig | None" = None,
     ):
         super().__init__()
+
+        self.quant_config = quant_config
 
         # Store config for compatibility
         self.config = type(
@@ -858,8 +912,12 @@ class WanTransformer3DModel(nn.Module):
         # 3. Transformer blocks
         self.blocks = nn.ModuleList(
             [
-                WanTransformerBlock(inner_dim, ffn_dim, num_attention_heads, eps, added_kv_proj_dim, cross_attn_norm)
-                for _ in range(num_layers)
+                WanTransformerBlock(
+                    inner_dim, ffn_dim, num_attention_heads, eps, added_kv_proj_dim, cross_attn_norm,
+                    quant_config=quant_config,
+                    prefix=f"blocks.{i}",
+                )
+                for i in range(num_layers)
             ]
         )
 

--- a/vllm_omni/quantization/factory.py
+++ b/vllm_omni/quantization/factory.py
@@ -55,11 +55,19 @@ def _build_inc(**kw: Any) -> QuantizationConfig:
     return OmniINCConfig(**filtered)
 
 
+def _build_mxfp4(**kw: Any) -> QuantizationConfig:
+    """Lazy import for MXFP4 diffusion config (W4A16, Marlin kernel)."""
+    from .mxfp4_config import DiffusionMXFP4Config
+
+    return DiffusionMXFP4Config(**kw)
+
+
 _OVERRIDES: dict[str, Callable[..., QuantizationConfig]] = {
     "gguf": _build_gguf,
     "int8": _build_int8,
     "inc": _build_inc,
     "auto-round": _build_inc,
+    "mxfp4": _build_mxfp4,
 }
 
 SUPPORTED_QUANTIZATION_METHODS: list[str] = list(dict.fromkeys(QUANTIZATION_METHODS + list(_OVERRIDES.keys())))

--- a/vllm_omni/quantization/mxfp4_config.py
+++ b/vllm_omni/quantization/mxfp4_config.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MXFP4 quantization config for diffusion transformers (W4A16).
+
+Implements MXFP4 (Microscaling FP4) weight-only quantization for diffusion
+models like Wan2.2. Reuses vLLM's Marlin kernel for efficient FP4 GEMM.
+
+MXFP4 format:
+- 4-bit float weights (E2M1) packed into uint8 (2 values per byte)
+- Per-group E8M0 scales with group_size=32
+- No global scale (unlike NVFP4)
+- W4A16: 4-bit weights, 16-bit (BF16) activations
+
+Online quantization flow:
+1. create_weights() registers BF16 weight parameters
+2. Weight loader loads BF16 checkpoints into these parameters
+3. process_weights_after_loading() quantizes BF16 -> MXFP4 and repacks for Marlin
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import TYPE_CHECKING, Any, Optional
+
+import torch
+from torch.nn import Module
+from torch.nn.parameter import Parameter
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization import QuantizationMethods
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+    apply_fp4_marlin_linear,
+    prepare_fp4_layer_for_marlin,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
+from vllm.model_executor.parameter import (
+    GroupQuantScaleParameter,
+    ModelWeightParameter,
+)
+from vllm.model_executor.utils import replace_parameter
+
+from vllm_omni.platforms import current_omni_platform
+
+if TYPE_CHECKING:
+    from vllm.model_executor.models.utils import WeightsMapper
+
+logger = init_logger(__name__)
+
+# MXFP4 block size (OCP standard: 32 elements share one E8M0 scale)
+MXFP4_BLOCK_SIZE = 32
+
+# FP4 E2M1 representable values (absolute)
+FP4_E2M1_VALUES = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
+FP4_E2M1_MAX = 6.0
+
+# FP4 E2M1 encoding table: value -> 3-bit code
+# 0.0=000, 0.5=001, 1.0=010, 1.5=011, 2.0=100, 3.0=101, 4.0=110, 6.0=111
+FP4_ENCODE_LUT = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.uint8)
+
+
+def _quantize_bf16_to_mxfp4(
+    weight: torch.Tensor,
+    block_size: int = MXFP4_BLOCK_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize BF16/FP16 weight tensor to MXFP4 format.
+
+    Args:
+        weight: Input weight tensor of shape [out, in] with dtype bf16/fp16.
+        block_size: Number of elements sharing one scale factor (default 32).
+
+    Returns:
+        qweight: Packed FP4 weights, shape [out, in//2], dtype uint8.
+        weight_scale: Per-group E8M0 scales, shape [out, in//block_size], dtype uint8.
+    """
+    assert weight.ndim == 2, f"Expected 2D weight, got {weight.ndim}D"
+    assert weight.dtype in (torch.bfloat16, torch.float16), f"Unsupported dtype: {weight.dtype}"
+
+    out_features, in_features = weight.shape
+    assert in_features % block_size == 0, (
+        f"Input features ({in_features}) must be divisible by block_size ({block_size})"
+    )
+
+    device = weight.device
+    # Reshape to [out, num_groups, block_size]
+    weight_f32 = weight.to(torch.float32)
+    weight_grouped = weight_f32.view(out_features, -1, block_size)
+
+    # Compute per-group max absolute value
+    abs_max = torch.max(torch.abs(weight_grouped), dim=-1, keepdim=True)[0]  # [out, num_groups, 1]
+
+    # Compute E8M0 scale: scale = 2^round(log2(abs_max / FP4_MAX))
+    # E8M0 is exponent-only: value = 2^(exp - 127), stored as uint8 exp
+    # We clamp to avoid log(0)
+    abs_max_clamped = torch.clamp(abs_max, min=1e-12)
+    log2_scale = torch.log2(abs_max_clamped / FP4_E2M1_MAX)
+    exp = torch.round(log2_scale + 127).clamp(0, 255).to(torch.uint8)  # E8M0 exponent
+
+    # Decode E8M0 scale back to float for quantization
+    scale_f32 = torch.pow(2.0, exp.to(torch.float32) - 127.0)  # [out, num_groups, 1]
+
+    # Normalize and quantize to FP4
+    normalized = weight_grouped / scale_f32  # [out, num_groups, block_size]
+    normalized = torch.clamp(normalized, -FP4_E2M1_MAX, FP4_E2M1_MAX)
+
+    # Round to nearest FP4 value using lookup
+    abs_normalized = torch.abs(normalized)
+    # Find nearest FP4 value index
+    diffs = torch.abs(abs_normalized.unsqueeze(-1) - FP4_E2M1_VALUES.to(device))
+    indices = torch.argmin(diffs, dim=-1).to(torch.uint8)  # [out, num_groups, block_size]
+
+    # Apply sign
+    signs = (normalized < 0).to(torch.uint8)
+    fp4_codes = indices | (signs << 3)  # 4-bit code: [sign(1bit) | magnitude(3bit)]
+
+    # Pack 2 FP4 values into 1 uint8 byte: [high_nibble | low_nibble]
+    fp4_flat = fp4_codes.view(out_features, -1)  # [out, num_groups * block_size] = [out, in]
+    low = fp4_flat[:, 0::2]  # [out, in//2]
+    high = fp4_flat[:, 1::2]  # [out, in//2]
+    qweight = (high << 4) | low  # Pack: high nibble | low nibble
+
+    # Scales: remove the keepdim dimension -> [out, num_groups]
+    weight_scale = exp.view(out_features, -1)  # [out, in//block_size]
+
+    return qweight, weight_scale
+
+
+class DiffusionMXFP4Config(QuantizationConfig):
+    """MXFP4 quantization config for diffusion transformers.
+
+    Supports W4A16 (4-bit weights, 16-bit activations) using Marlin kernel
+    on CUDA GPUs (SM 75+).
+
+    Args:
+        ignored_layers: Layer name patterns to skip quantization.
+        weight_block_size: Group size for per-group scaling (default 32).
+    """
+
+    def __init__(
+        self,
+        ignored_layers: list[str] | None = None,
+        weight_block_size: list[int] | int = MXFP4_BLOCK_SIZE,
+    ) -> None:
+        super().__init__()
+        self.ignored_layers = ignored_layers or []
+        # vLLM expects weight_block_size to be a list (e.g., [32, 32])
+        if isinstance(weight_block_size, int):
+            self.weight_block_size = [weight_block_size, weight_block_size]
+        else:
+            self.weight_block_size = weight_block_size
+        # Store scalar for internal quantization logic
+        self._block_size_scalar = self.weight_block_size[0]
+
+    @classmethod
+    def get_name(cls) -> QuantizationMethods:
+        return "mxfp4"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> list[torch.dtype]:
+        return [torch.bfloat16, torch.float16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        # Marlin requires SM 75+ (Turing or newer)
+        return 75
+
+    @classmethod
+    def get_config_filenames(cls) -> list[str]:
+        return []
+
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
+        if self.ignored_layers is not None:
+            self.ignored_layers = hf_to_vllm_mapper.apply_list(self.ignored_layers)
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "DiffusionMXFP4Config":
+        ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
+        if not ignored_layers:
+            ignored_layers = cls.get_from_keys_or(config, ["modules_to_not_convert"], None)
+        weight_block_size = cls.get_from_keys_or(config, ["weight_block_size"], MXFP4_BLOCK_SIZE)
+        return cls(
+            ignored_layers=ignored_layers,
+            weight_block_size=weight_block_size,
+        )
+
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+    ) -> Optional["QuantizeMethodBase"]:
+        if isinstance(layer, LinearBase):
+            if is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=self.ignored_layers,
+                fused_mapping=self.packed_modules_mapping,
+            ):
+                logger.info(f"[MXFP4] Skipping layer {prefix} (ignored)")
+                return UnquantizedLinearMethod()
+
+            if current_omni_platform.is_cuda():
+                logger.info(f"[MXFP4] Applying quantization to layer: {prefix}")
+                return DiffusionMXFP4LinearMethod(self)
+            else:
+                raise NotImplementedError(
+                    f"MXFP4 is not supported on {current_omni_platform._omni_enum.value}. "
+                    "Currently only CUDA (SM 75+) is supported."
+                )
+        return None
+
+
+class DiffusionMXFP4LinearMethod(LinearMethodBase):
+    """MXFP4 Linear method for diffusion models using Marlin kernel.
+
+    This method implements online quantization:
+    1. create_weights() registers BF16 weight parameters
+    2. Weight loader loads BF16 checkpoints into these parameters
+    3. process_weights_after_loading() quantizes BF16 -> MXFP4 and repacks for Marlin
+
+    Applicable to:
+    - ColumnParallelLinear
+    - RowParallelLinear
+    - QKVParallelLinear
+    - Standard nn.Linear (via vLLM wrapper)
+    """
+
+    def __init__(self, quant_config: DiffusionMXFP4Config):
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        """Create BF16 weight parameters for online MXFP4 quantization.
+
+        The weight loader will load BF16 weights from the checkpoint into
+        these parameters. Quantization happens in process_weights_after_loading().
+        """
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.params_dtype = params_dtype
+
+        # Register BF16 weight parameter (will be quantized after loading)
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition,
+                dtype=params_dtype,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        """Quantize BF16 weights to MXFP4 and repack for Marlin kernel."""
+        layer_name = getattr(layer, "prefix", "unknown_layer")
+        logger.info(f"[MXFP4] Starting online quantization for: {layer_name}")
+        
+        device = layer.weight.device
+        torch.cuda.synchronize(device)
+        mem_before = torch.cuda.memory_allocated(device)
+
+        # Step 1: Quantize BF16 -> MXFP4
+        qweight, weight_scale = _quantize_bf16_to_mxfp4(
+            layer.weight.data,
+            block_size=self.quant_config._block_size_scalar,
+        )
+        logger.info(f"[MXFP4] Quantized {layer_name}: weight shape={qweight.shape}, dtype={qweight.dtype}")
+
+        # Step 2: Replace parameters with quantized versions
+        replace_parameter(layer, "weight", Parameter(qweight, requires_grad=False))
+        replace_parameter(layer, "weight_scale", Parameter(weight_scale, requires_grad=False))
+
+        # Step 3: Repack for Marlin kernel
+        prepare_fp4_layer_for_marlin(layer)
+
+        # Force release old BF16 weights from PyTorch cache for accurate measurement
+        gc.collect()
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize(device)
+        mem_after = torch.cuda.memory_allocated(device)
+        
+        saved_mb = (mem_before - mem_after) / (1024 * 1024)
+        logger.info(f"[MXFP4] Quantization complete for {layer_name}. Memory saved: {saved_mb:.2f} MB")
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Execute MXFP4 W4A16 GEMM using Marlin kernel."""
+        return apply_fp4_marlin_linear(
+            input=x,
+            weight=layer.weight,
+            weight_scale=layer.weight_scale,
+            weight_global_scale=None,  # MXFP4 has no global scale
+            workspace=layer.workspace,
+            size_n=layer.output_size_per_partition,
+            size_k=layer.input_size_per_partition,
+            bias=bias,
+        )


### PR DESCRIPTION

## Summary

Add MXFP4 (W4A16) online quantization support for Wan2.2 diffusion models in vLLM-Omni. This feature enables 4-bit weight quantization using the Marlin kernel, significantly reducing GPU memory usage while maintaining video generation quality.

## Key Changes

- **New quantization config**: `vllm_omni/quantization/mxfp4_config.py` implements `DiffusionMXFP4Config` and `DiffusionMXFP4LinearMethod` for online BF16→MXFP4 quantization
- **Transformer integration**: Updated `WanTransformer3DModel` and all parallel Linear layers (`ColumnParallelLinear`, `RowParallelLinear`, `QKVParallelLinear`) to accept and propagate `quant_config`
- **Pipeline support**: Added `_build_quant_config()` to `Wan22Pipeline`, `Wan22I2VPipeline`, and `Wan22TI2VPipeline`
- **Factory registration**: Registered `mxfp4` in `vllm_omni/quantization/factory.py` overrides

## Quantization Flow

1. `create_weights()` registers BF16 weight parameters
2. Weight loader loads BF16 checkpoint weights
3. `process_weights_after_loading()` triggers online quantization:
   - Quantize BF16 → MXFP4 (FP4 packed + E8M0 scales)
   - Replace parameters with quantized versions
   - Repack weights for Marlin kernel format


## Quantitative Strategy

| Layer Type | Parameter Quantization Proportion | Quantization Benefits | Accuracy Risk | Decision |
| :--- | :--- | :--- | :--- | :--- |
| **Attention / FFN Linear** | **~95%** | **Very High** (Memory ↓ 75%) | **Low** (Tolerable Error) | **✅ Quantization** |
| **Output Projection (`proj_out`)** | ~1% | Low | **Very High** (Image Distortion) | Skip |
| **Input Conv (`patch_embedding`)** | ~1% | Low | **High** (Error Accumulation) | Skip |
| **Norm / Embedding** | <1% | Very Low | Medium | Skip |


## Benchmark Results (Wan2.2-I2V-A14B) (A100 8GPUs)
| Metric | BF16 | MXFP4 (W4A16) | Improvement |
|--------|------|---------------|-------------|
| **Model Loading Memory** | 64.47 GiB | 25.90 GiB | **↓ 60%** |
| **Worker GPU Memory** | 64.97 GiB | 27.50 GiB | **↓ 58%** |
| **Inference Peak Memory** | 65.18 GB | 30.42 GB | **↓ 53%** |
| **Generation Time (40 steps)** | ~410s | ~480s | Baseline |
| **Video Output** | ✅ Normal | ✅ Normal | Quality maintained |

## Generated video
### bf16

https://github.com/user-attachments/assets/36bdd1c7-f557-43ef-8b3a-d6e75469a39f

### mxfp4

https://github.com/user-attachments/assets/0b166b2e-b8e1-4da1-807a-6274764fc1fc




## Usage

### CLI
```bash
vllm serve Wan-AI/Wan2.2-I2V-A14B-Diffusers --omni --quantization mxfp4
```

### Python API
```python
from vllm_omni import Omni

omni = Omni(
    model="Wan-AI/Wan2.2-I2V-A14B-Diffusers",
    quantization="mxfp4",
)

outputs = omni.generate(
    "A cat sitting on a windowsill",
    OmniDiffusionSamplingParams(num_inference_steps=40),
)
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
