### PR TITLE
[Perf][Wan2.2] Add fused RMSNorm replace WanRMS_norm on npu

### DIFF
--- a/vllm_omni/diffusion/layers/norm.py
+++ b/vllm_omni/diffusion/layers/norm.py
@@ -108,3 +108,80 @@ class RMSNorm(CustomOp):
         out = x * torch.rsqrt(variance + self.variance_epsilon)
         out = self.weight.to(torch.float32) * out
         return out.to(input_dtype)
+
+class RMSNormVAE(CustomOp):
+    """Root Mean Square Layer Normalization for Channel-First or Last"""
+
+    def __init__(
+        self,
+        dim: int,
+        channel_first: bool = True,
+        images: bool = True,
+        bias: bool = False,
+        epsilon: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        broadcastable_dims = (1, 1, 1) if not images else (1, 1)
+        shape = (dim, *broadcastable_dims) if channel_first else (dim,)
+
+        self.channel_first = channel_first
+        self.scale = dim**0.5
+        self.gamma = nn.Parameter(torch.ones(shape))
+        self.bias = nn.Parameter(torch.zeros(shape)) if bias else None
+        self.epsilon = epsilon
+
+        self.gamma_rmsnorm = None
+
+    def forward_cuda(
+        self,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.forward_native(x)
+
+    def forward_hip(
+        self,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.forward_native(x)
+
+    def forward_npu(
+        self,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        import torch_npu
+
+        if self.gamma_rmsnorm is None:
+            self.gamma_rmsnorm = self.gamma.reshape(-1)
+
+        if self.channel_first:
+            x = x.transpose(1, -1)
+            out = torch_npu.npu_rms_norm(x, self.gamma_rmsnorm, epsilon=self.epsilon)[0].transpose(1, -1)
+        else:
+            out = torch_npu.npu_rms_norm(x, self.gamma_rmsnorm, epsilon=self.epsilon)[0]
+
+        if self.bias is not None:
+            out = out + self.bias
+        return out
+
+    def forward_xpu(
+        self,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.forward_native(x)
+
+    def forward_native(
+        self,
+        x: torch.Tensor,
+    ) -> torch.Tensor:
+        out = (
+            F.normalize(
+                x,
+                dim=(1 if self.channel_first else -1),
+                eps=self.epsilon,
+            )
+            * self.scale
+            * self.gamma
+        )
+        if self.bias is not None:
+            out = out + self.bias
+        return out

--- a/vllm_omni/diffusion/layers/norm.py
+++ b/vllm_omni/diffusion/layers/norm.py
@@ -109,6 +109,7 @@ class RMSNorm(CustomOp):
         out = self.weight.to(torch.float32) * out
         return out.to(input_dtype)
 
+
 class RMSNormVAE(CustomOp):
     """Root Mean Square Layer Normalization for Channel-First or Last"""
 

--- a/vllm_omni/diffusion/models/wan2_2/__init__.py
+++ b/vllm_omni/diffusion/models/wan2_2/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from .patch_diffusers import patch_wan_rms_norm
 from .pipeline_wan2_2 import (
     Wan22Pipeline,
     WanT2VDMD2Pipeline,
@@ -51,3 +52,5 @@ __all__ = [
     "VaceWanTransformerBlock",
     "WanVACETransformer3DModel",
 ]
+
+patch_wan_rms_norm()

--- a/vllm_omni/diffusion/models/wan2_2/patch_diffusers.py
+++ b/vllm_omni/diffusion/models/wan2_2/patch_diffusers.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+
+from vllm_omni.diffusion.layers.norm import RMSNormVAE
+
+
+def patch_wan_rms_norm():
+    """Patch diffusers Wan RMSNorm implementation with RMSNormVAE."""
+
+    for module_name, module in sys.modules.items():
+        if hasattr(module, "WanRMS_norm"):
+            setattr(module, "WanRMS_norm", RMSNormVAE)


### PR DESCRIPTION
## Purpose
replace the small operator's WanRMS_norm with the fused operator on npu.

In the VAE of Wan2.2 and hyvideo1.5, the implementation of RMSNorm is different from the traditional RMSNorm implementation. Additionally, it uses small operators and has a relatively high time cost, so it is considered to use fused operators as a replacement. Moreover, vllm-omni directly calls the VAE in diffusers without rewriting the VAE model, so this PR uses a patch to replace RMSNorm.

## Test Plan

- script

```
export ASCEND_RT_VISIBLE_DEVICES=8,9,10,11
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"

python image_to_video.py \
--model /weights/Wan2.2-I2V-A14B-LightX2V-Diffusers \
--image i2v_input.jpg \
--prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside" \
--height 1280 \
--width 720 \
--num-frames 61 \
--guidance-scale 1.0 \
--guidance-scale-high 1.0 \
--num-inference-steps 4 \
--cfg-parallel-size 1 \
--ulysses-degree 4 \
--boundary-ratio 0.875 \
--flow-shift 12.0 \
--fps 16 \
--output i2v_output_origin_weight_1.mp4 \
--vae-patch-parallel-size 4 \
--vae-use-tiling \
```

## Test Result
- performance
  before: Encoder-2.1s, Decoder-3.4s
  after: Encoder-1.6s, Decoder-2.5s    ----  reduce-1.4s, improve-34%

- Accuracy

  berfore
https://github.com/user-attachments/assets/683596fe-7e83-4272-ba16-0475c464cf73
  after
https://github.com/user-attachments/assets/4597a909-27a8-4930-95eb-2f9c1913f0ae
