### PR TITLE
[Model] Qwen3-TTS: integrate code predictor into model CUDA graph

### DIFF
--- a/tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py
+++ b/tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py
@@ -308,13 +308,11 @@ class TestCodePredictorWrapperConfig:
         """Qwen3-Omni uses correct wrapper config."""
         _, _, _, _, code_predictor_wrapper_config = loaded_target_classes
         config = code_predictor_wrapper_config(
-            use_cuda_graphs=False,
             use_parallel_embedding=True,
             use_projection=False,
             return_proj_buf=True,
             sampling_mode="stored",
         )
-        assert config.use_cuda_graphs is False
         assert config.use_parallel_embedding is True
         assert config.return_proj_buf is True
         assert config.sampling_mode == "stored"
@@ -323,13 +321,11 @@ class TestCodePredictorWrapperConfig:
         """Qwen3-TTS uses correct wrapper config."""
         _, _, _, _, code_predictor_wrapper_config = loaded_target_classes
         config = code_predictor_wrapper_config(
-            use_cuda_graphs=True,
             use_parallel_embedding=False,
             use_projection=True,
             return_proj_buf=False,
             sampling_mode="per_call",
         )
-        assert config.use_cuda_graphs is True
         assert config.use_parallel_embedding is False
         assert config.return_proj_buf is False
         assert config.sampling_mode == "per_call"

--- a/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
+++ b/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
@@ -4,11 +4,11 @@ Shared by Qwen3-Omni and Qwen3-TTS talker models.
 
 * SDPA attention (F.scaled_dot_product_attention) with native GQA support
 * HF-compatible numerics (float32 RMSNorm, float32 RoPE, separate linear layers)
-* Per-call embedding buffer to avoid cross-request aliasing
-* Pre-allocated position_ids (read-only, safe to persist)
-* torch.compile (epilogue_fusion=False) on inner transformer by default
-* Optional manual CUDA graph capture per batch-size bucket
-* Inline sampling (top-k + top-p) -- no custom op overhead
+* ``@support_torch_compile`` on the wrapper so the (projection + transformer)
+  block gets captured by vLLM's cudagraph dispatcher; the AR loop + sampling
+  live outside the compiled region and call ``self(...)`` per step.
+* Persistent scratch buffers sized to ``max_num_batched_tokens`` provide the
+  stable addresses required across cudagraph replays.
 """
 
 from __future__ import annotations
@@ -19,12 +19,12 @@ from collections.abc import Iterable
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
+from vllm.config.vllm import set_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
-
-from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
 
@@ -67,6 +67,22 @@ def _rotate_half(x: torch.Tensor) -> torch.Tensor:
     x1 = x[..., : x.shape[-1] // 2]
     x2 = x[..., x.shape[-1] // 2 :]
     return torch.cat((-x2, x1), dim=-1)
+
+
+# Gumbel-max categorical draw: argmax(logits + Gumbel(0, 1)). Equivalent in
+# distribution to softmax+multinomial, but cudagraph-safe (only uniform_ / log /
+# argmax) and avoids the device-side assert that ``torch.multinomial`` raises on
+# all-zero probability rows during warmup.
+
+
+def _gumbel_sample(logits: torch.Tensor) -> torch.Tensor:
+    u = torch.empty_like(logits).uniform_(1e-20, 1.0 - 1e-20)
+    return (logits - torch.log(-torch.log(u))).argmax(dim=-1)
+
+
+def _multinomial_sample(logits: torch.Tensor) -> torch.Tensor:
+    probs = F.softmax(logits, dim=-1)
+    return torch.multinomial(probs, 1).squeeze(-1)
 
 
 class _RotaryEmbedding(nn.Module):
@@ -303,32 +319,34 @@ class CodePredictorBaseModel(nn.Module):
 class CodePredictorWrapperConfig:
     """Controls behavioral differences between model-specific code predictors."""
 
-    use_cuda_graphs: bool = False
     use_parallel_embedding: bool = False
     use_projection: bool = False
     return_proj_buf: bool = False
     sampling_mode: str = "stored"
+    # Use Gumbel-max for the categorical draw (cudagraph-safe, warmup-safe).
+    # Set to False to fall back to softmax+multinomial.
+    use_gumbel: bool = True
 
 
 # ===================================================================
-#  Code Predictor Wrapper (optimized re-prefill, persistent buffers)
+#  Code Predictor Wrapper (torch.compile + vLLM cudagraph dispatch)
 # ===================================================================
 
 
+# ``dynamic_arg_dims`` is explicit because this module uses PEP 563
+# (``from __future__ import annotations``), which defeats annotation-based
+# inference in ``@support_torch_compile``.
+@support_torch_compile(dynamic_arg_dims={"inputs_embeds": 0, "position_ids": 0})
 class CodePredictorWrapper(nn.Module):
     """Optimized code predictor -- re-prefill approach, no KV cache.
 
     Each AR step forwards the full growing sequence (len 2 -> num_code_groups+1)
-    through the transformer.  The extra O(T^2) FLOPs are negligible for
+    through the transformer. The extra O(T^2) FLOPs are negligible for
     short sequences, and this avoids all KV-cache management overhead.
 
-    Optimizations:
-      1. Per-call embedding buffer -- avoids cross-request aliasing.
-      2. Pre-allocated position_ids -- no torch.arange per step.
-      3. Cached module references -- bypass ModuleList indexing.
-      4. torch.compile on inner transformer.
-      5. Inline sampling (top-k + top-p) -- no custom op overhead.
-      6. Optional manual CUDA graph capture per batch-size bucket.
+    ``forward(inputs_embeds, position_ids)`` is the compiled/captured region
+    (projection + transformer + norm). ``generate(...)`` owns the AR loop and
+    sampling, calling ``self(...)`` per step to hit the compiled path.
     """
 
     def __init__(
@@ -348,11 +366,11 @@ class CodePredictorWrapper(nn.Module):
 
         self._num_groups = int(cp_config.num_code_groups)
         self._cp_hidden = int(cp_config.hidden_size)
+        self._max_seq = self._num_groups + 1
 
         # For Omni backward compat (accessed by the talker)
         self.num_code_groups = self._num_groups
 
-        # Determine embedding dimension
         _talker_hidden = int(talker_hidden_size) if talker_hidden_size is not None else self._cp_hidden
 
         self.model = CodePredictorBaseModel(
@@ -376,131 +394,67 @@ class CodePredictorWrapper(nn.Module):
         self._top_k: int = 50
         self._top_p: float = 0.8
 
-        # Lazily initialised state
-        self._proj_buf: torch.Tensor | None = None
-        self._model_dtype: torch.dtype | None = None
-        self._compiled_model_fwd = None
-        self._bucket_sizes: list[int] = []
-        self._bucket_pos_ids: dict[int, torch.Tensor] = {}
+        # Persistent scratch buffers sized to max_num_batched_tokens so
+        # addresses stay stable across cudagraph replays. forward()/generate()
+        # slice ``[:B]`` out of these.
+        # NOTE: real runtime + cudagraph capture never push B above
+        # max_num_seqs (predictor only sees decode positions, each request
+        # contributes 1 decode token, and _get_decode_idxs bisects into
+        # cudagraph_capture_sizes). The only path that needs the full
+        # max_num_batched_tokens extent is the profile dummy run
+        # (is_profile=True, attn_metadata=None -> pure-decode fallback in
+        # the talker). If profile is reworked to cap B at max_num_seqs,
+        # this buffer can be shrunk to max_num_seqs.
+        max_num_tokens = int(vllm_config.scheduler_config.max_num_batched_tokens)
+        dtype = vllm_config.model_config.dtype
+        self.register_buffer(
+            "_cp_inputs_embeds",
+            torch.zeros(max_num_tokens, self._max_seq, _talker_hidden, dtype=dtype),
+            persistent=False,
+        )
+        pos_row = torch.arange(self._max_seq, dtype=torch.long)
+        self.register_buffer(
+            "_cp_position_ids",
+            pos_row.unsqueeze(0).expand(max_num_tokens, -1).contiguous(),
+            persistent=False,
+        )
+
+        # Cached on first generate() call so weights/dtype are finalized.
         self._lm_heads_list: list[nn.Module] | None = None
         self._codec_embeds_list: list[nn.Module] | None = None
-        self._cuda_graphs: dict[int, tuple[torch.cuda.CUDAGraph, torch.Tensor]] = {}
 
     def get_input_embeddings(self) -> nn.ModuleList:
         return self.model.get_input_embeddings()
 
     def set_sampling_params(self, top_k: int = 50, top_p: float = 0.8) -> None:
-        """Configure sampling parameters to maintain consistency with previous implementation."""
+        """Configure sampling parameters for ``stored`` sampling mode."""
         self._top_k = top_k
         self._top_p = top_p
         logger.debug("Sampling parameters updated: top_k=%d, top_p=%.2f", top_k, top_p)
 
     # ------------------------------------------------------------------
-    #  Lazy-init helpers
+    #  Compiled region: projection + inner transformer
     # ------------------------------------------------------------------
 
-    def _ensure_buffers(self, device: torch.device, dtype: torch.dtype, bsz: int) -> None:
-        """Ensure the projection buffer can hold at least *bsz* rows."""
-        max_seq = self._num_groups + 1
-        if (
-            self._proj_buf is not None
-            and self._proj_buf.device == device
-            and self._proj_buf.dtype == dtype
-            and self._proj_buf.shape[0] >= bsz
-        ):
-            return
-        self._proj_buf = torch.zeros(bsz, max_seq, self._cp_hidden, dtype=dtype, device=device)
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compiled region: projection + inner transformer.
 
-    def _setup_compile(self) -> None:
-        """Lazily set up torch.compile with optional CUDA graph capture."""
-        if self._compiled_model_fwd is not None:
-            return
-
-        # Cache model parameter dtype so forward() doesn't need to query it
-        # on every call.  Also ensures warmup buffers match model precision
-        # even when upstream modules produce a different dtype (#2385).
-        self._model_dtype = next(self.model.parameters()).dtype
-        self._lm_heads_list = list(self.lm_head)
-        self._codec_embeds_list = list(self.model.codec_embedding)
-
-        if not current_omni_platform.supports_torch_inductor():
-            logger.warning_once("code_predictor: torch.compile disabled")
-            self._compiled_model_fwd = self.model.forward
-            return
-
-        # torch.compile fuses RMSNorm/RoPE in ways that lose float32
-        # precision, compounding across AR steps. Use epilogue_fusion=False
-        # to disable the problematic fusions while still getting kernel
-        # fusion benefits for the linear layers and SDPA.
-        self._compiled_model_fwd = torch.compile(
-            self.model.forward,
-            dynamic=False,
-            options={"epilogue_fusion": False},
-        )
-        self._warmup_buckets()
-
-        if self._wrapper_config.use_cuda_graphs:
-            self._capture_cuda_graphs()
-            logger.info("code_predictor: torch.compile (no epilogue fusion) + CUDA graphs")
-        else:
-            logger.info("code_predictor: torch.compile (dynamic=False, no epilogue fusion)")
-
-    def _padded_bsz(self, bsz: int) -> int:
-        """Round batch size up to nearest power-of-2 bucket."""
-        for bucket in self._bucket_sizes:
-            if bsz <= bucket:
-                return bucket
-        return bsz
-
-    def _warmup_buckets(self) -> None:
-        """Warmup power-of-2 batch-size buckets to front-load Inductor compilation."""
-        max_bsz = self._vllm_config.scheduler_config.max_num_seqs
-        bucket_sizes = [1 << i for i in range(max_bsz.bit_length()) if (1 << i) <= max_bsz]
-        if max_bsz not in bucket_sizes:
-            bucket_sizes.append(max_bsz)
-        self._bucket_sizes = sorted(bucket_sizes)
-
-        max_seq = self._num_groups + 1
-        device = next(self.model.parameters()).device
-
-        # Ensure proj_buf matches model parameter dtype to avoid dtype
-        # mismatch during warmup compilation (see #2385).
-        self._ensure_buffers(device, self._model_dtype, max(self._bucket_sizes))
-        proj_buf = self._proj_buf
-
-        for bsz in self._bucket_sizes:
-            pos_ids = torch.arange(max_seq, device=device, dtype=torch.long).unsqueeze(0).expand(bsz, -1).contiguous()
-            self._bucket_pos_ids[bsz] = pos_ids
-            for _ in range(3):
-                self._compiled_model_fwd(proj_buf[:bsz, :max_seq, :], pos_ids)
-        logger.info("code_predictor: warmup done for buckets %s", self._bucket_sizes)
-
-    def _capture_cuda_graphs(self) -> None:
-        """Capture a CUDA graph per bucket using vLLM's global graph pool."""
-        from vllm.platforms import current_platform
-
-        pool = current_platform.get_global_graph_pool()
-        max_seq = self._num_groups + 1
-        proj_buf = self._proj_buf
-
-        for bsz in self._bucket_sizes:
-            static_input = proj_buf[:bsz, :max_seq, :]
-            pos_ids = self._bucket_pos_ids[bsz]
-
-            g = torch.cuda.CUDAGraph()
-            with torch.cuda.graph(g, pool=pool):
-                static_output = self._compiled_model_fwd(static_input, pos_ids)
-
-            self._cuda_graphs[bsz] = (g, static_output)
-
-        logger.info("code_predictor: captured CUDA graphs for buckets %s", self._bucket_sizes)
+        ``inputs_embeds``: ``[B, max_seq, talker_hidden]``;
+        ``position_ids``: ``[B, max_seq]``. Returns ``[B, max_seq, cp_hidden]``.
+        """
+        projected = self.small_to_mtp_projection(inputs_embeds)
+        return self.model(projected, position_ids)
 
     # ------------------------------------------------------------------
-    #  Forward -- re-prefill + inline sampling
+    #  Non-compiled AR loop + sampling
     # ------------------------------------------------------------------
 
     @torch.inference_mode()
-    def forward(
+    def generate(
         self,
         layer0_code: torch.Tensor,
         layer0_embed: torch.Tensor,
@@ -510,45 +464,33 @@ class CodePredictorWrapper(nn.Module):
         top_k: int = 50,
         top_p: float = 1.0,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        """Predict residual codebooks 1..G-1 autoregressively via re-prefill."""
+        """Predict residual codebooks 1..G-1 autoregressively via re-prefill.
+
+        Returns ``codes`` (``[B, num_groups]``) or ``(codes, inputs_embeds_buf)``
+        depending on ``return_proj_buf``.
+        """
         bsz = int(layer0_code.shape[0])
         num_groups = self._num_groups
         device = layer0_code.device
 
-        # _setup_compile caches _model_dtype on first call; use it for buffers
-        # so they always match model weight precision (#2385).
-        self._setup_compile()
-        dtype = self._model_dtype
-
-        padded_bsz = self._padded_bsz(bsz)
-        self._ensure_buffers(device, dtype, padded_bsz)
-
-        proj_buf = self._proj_buf
-        max_seq = num_groups + 1
-        projection = self.small_to_mtp_projection
-        model_fwd = self._compiled_model_fwd
+        if self._lm_heads_list is None:
+            self._lm_heads_list = list(self.lm_head)
+        if self._codec_embeds_list is None:
+            self._codec_embeds_list = list(self.model.codec_embedding)
         lm_heads = self._lm_heads_list
         codec_embeds = self._codec_embeds_list
 
-        # Zero the padded region of the buffer
-        proj_buf[:padded_bsz].zero_()
+        inputs_buf = self._cp_inputs_embeds[:bsz]
+        pos_ids = self._cp_position_ids[:bsz]
+        buf_dtype = inputs_buf.dtype
 
-        # Fill buffer positions 0 (talker hidden) & 1 (layer0 embed)
-        proj_buf[:bsz, 0, :] = projection(last_talker_hidden.reshape(bsz, 1, -1).to(dtype)).reshape(bsz, -1)
-        proj_buf[:bsz, 1, :] = projection(layer0_embed.reshape(bsz, 1, -1).to(dtype)).reshape(bsz, -1)
+        # Zero the active slice (persistent buffer may carry stale rows).
+        inputs_buf.zero_()
+        inputs_buf[:, 0, :] = last_talker_hidden.reshape(bsz, -1).to(buf_dtype)
+        inputs_buf[:, 1, :] = layer0_embed.reshape(bsz, -1).to(buf_dtype)
 
-        # Get pre-computed pos_ids for this bucket
-        full_pos_ids = self._bucket_pos_ids.get(padded_bsz)
-        if full_pos_ids is None:
-            full_pos_ids = (
-                torch.arange(max_seq, device=device, dtype=torch.long).unsqueeze(0).expand(padded_bsz, -1).contiguous()
-            )
-
-        # Use captured CUDA graph if available, otherwise call compiled fn.
-        cuda_graph_entry = self._cuda_graphs.get(padded_bsz)
-
-        # Prepare sampling parameters
         stored_mode = self._wrapper_config.sampling_mode == "stored"
+        use_gumbel = self._wrapper_config.use_gumbel
         if stored_mode:
             s_top_k = self._top_k
             s_top_p = self._top_p
@@ -560,7 +502,11 @@ class CodePredictorWrapper(nn.Module):
                     "top_p sampling is not implemented for the vLLM-native code predictor; please set top_p=1.0."
                 )
 
-        # Output codes -- shape depends on return mode
+        def _draw(filtered_logits: torch.Tensor) -> torch.Tensor:
+            if use_gumbel:
+                return _gumbel_sample(filtered_logits).unsqueeze(-1)
+            return _multinomial_sample(filtered_logits).unsqueeze(-1)
+
         if self._wrapper_config.return_proj_buf:
             all_codes = torch.empty(bsz, num_groups, 1, dtype=torch.int64, device=device)
             all_codes[:, 0] = layer0_code.reshape(bsz, -1)[:, :1]
@@ -568,20 +514,11 @@ class CodePredictorWrapper(nn.Module):
             all_codes = torch.empty(bsz, num_groups, dtype=torch.long, device=device)
             all_codes[:, 0] = layer0_code.reshape(bsz)
 
-        # Autoregressive loop: predict layers 1..G-1
         for step in range(1, num_groups):
-            # Run transformer (CUDA graph replay or compiled forward)
-            if cuda_graph_entry is not None:
-                cuda_graph_entry[0].replay()
-                hidden_out = cuda_graph_entry[1]
-            else:
-                hidden_out = model_fwd(proj_buf[:padded_bsz, :max_seq, :], full_pos_ids)
+            hidden_out = self(inputs_buf, pos_ids)
+            logits = lm_heads[step - 1](hidden_out[:, step, :])
 
-            logits = lm_heads[step - 1](hidden_out[:bsz, step, :])
-
-            # Sample next code
             if stored_mode:
-                # "stored" mode: top-k -> top-p -> softmax -> multinomial
                 if s_top_k > 0:
                     topk_vals, _ = logits.topk(s_top_k, dim=-1)
                     logits = logits.masked_fill(logits < topk_vals[:, -1:], float("-inf"))
@@ -592,33 +529,27 @@ class CodePredictorWrapper(nn.Module):
                     remove_mask = (cumulative_probs - sorted_probs) >= s_top_p
                     sorted_logits[remove_mask] = float("-inf")
                     logits = sorted_logits.scatter(1, sorted_idx, sorted_logits)
-                probs = F.softmax(logits, dim=-1)
-                code = torch.multinomial(probs, num_samples=1)
+                code = _draw(logits)
+            elif use_sampling:
+                scaled = logits * inv_temperature
+                if top_k > 0:
+                    topk_vals, _ = scaled.topk(top_k, dim=-1)
+                    scaled = scaled.masked_fill(scaled < topk_vals[:, -1:], float("-inf"))
+                code = _draw(scaled)
             else:
-                # "per_call" mode: temperature-scaled + top-k
-                if use_sampling:
-                    scaled = logits * inv_temperature
-                    if top_k > 0:
-                        topk_vals, _ = scaled.topk(top_k, dim=-1)
-                        scaled = scaled.masked_fill(scaled < topk_vals[:, -1:], float("-inf"))
-                    probs = F.softmax(scaled, dim=-1)
-                    code = torch.multinomial(probs, num_samples=1)
-                else:
-                    code = logits.argmax(dim=-1, keepdim=True)
+                code = logits.argmax(dim=-1, keepdim=True)
 
-            # Store code
             if self._wrapper_config.return_proj_buf:
                 all_codes[:, step] = code
             else:
                 all_codes[:, step] = code.reshape(bsz)
 
-            # Embed predicted code -> project -> next buffer position
             if step < num_groups - 1 or self._wrapper_config.return_proj_buf:
-                new_embed = codec_embeds[step - 1](code)
-                proj_buf[:bsz, step + 1, :] = projection(new_embed.reshape(bsz, 1, -1)).reshape(bsz, -1)
+                new_embed = codec_embeds[step - 1](code.reshape(bsz))
+                inputs_buf[:, step + 1, :] = new_embed.to(buf_dtype)
 
         if self._wrapper_config.return_proj_buf:
-            return all_codes, proj_buf[:bsz].clone()
+            return all_codes, inputs_buf.clone()
         return all_codes
 
     # ------------------------------------------------------------------
@@ -626,29 +557,31 @@ class CodePredictorWrapper(nn.Module):
     # ------------------------------------------------------------------
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        """Load weights directly (no fused projection remapping needed)."""
-        loaded: set[str] = set()
-        model_weights: list[tuple[str, torch.Tensor]] = []
-        other_weights: list[tuple[str, torch.Tensor]] = []
+        # Wrapped in set_current_vllm_config so VocabParallelEmbedding weight
+        # loaders (Qwen3-Omni subclass) can read TP metadata.
+        with set_current_vllm_config(self._vllm_config):
+            loaded: set[str] = set()
+            model_weights: list[tuple[str, torch.Tensor]] = []
+            other_weights: list[tuple[str, torch.Tensor]] = []
 
-        for name, w in weights:
-            if "rotary_emb.inv_freq" in name:
-                continue
-            if name.startswith("model."):
-                model_weights.append((name[len("model.") :], w))
-            else:
-                other_weights.append((name, w))
+            for name, w in weights:
+                if "rotary_emb.inv_freq" in name:
+                    continue
+                if name.startswith("model."):
+                    model_weights.append((name[len("model.") :], w))
+                else:
+                    other_weights.append((name, w))
 
-        loaded_model = self.model.load_weights(model_weights)
-        loaded |= {f"model.{n}" for n in loaded_model}
+            loaded_model = self.model.load_weights(model_weights)
+            loaded |= {f"model.{n}" for n in loaded_model}
 
-        params = dict(self.named_parameters(remove_duplicate=False))
-        for name, w in other_weights:
-            param = params.get(name)
-            if param is None:
-                continue
-            weight_loader = getattr(param, "weight_loader", default_weight_loader)
-            weight_loader(param, w)
-            loaded.add(name)
+            params = dict(self.named_parameters(remove_duplicate=False))
+            for name, w in other_weights:
+                param = params.get(name)
+                if param is None:
+                    continue
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, w)
+                loaded.add(name)
 
-        return loaded
+            return loaded

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_code_predictor_mtp.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_code_predictor_mtp.py
@@ -9,7 +9,7 @@ from vllm_omni.model_executor.models.common.qwen3_code_predictor import (
 
 
 class Qwen3OmniMoeTalkerCodePredictor(CodePredictorWrapper):
-    """Qwen3-Omni code predictor (no CUDA graphs, VocabParallelEmbedding)."""
+    """Qwen3-Omni code predictor (VocabParallelEmbedding, stored sampling)."""
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         cp_config = vllm_config.model_config.hf_config.code_predictor_config
@@ -17,7 +17,6 @@ class Qwen3OmniMoeTalkerCodePredictor(CodePredictorWrapper):
             vllm_config=vllm_config,
             cp_config=cp_config,
             wrapper_config=CodePredictorWrapperConfig(
-                use_cuda_graphs=False,
                 use_parallel_embedding=True,
                 use_projection=False,
                 return_proj_buf=True,

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py
@@ -192,7 +192,7 @@ class Qwen3OmniMoeTalkerForConditionalGeneration(
             layer0_code = input_ids[:, pos : pos + 1]
             layer0_embed = embed_fn(layer0_code)
 
-            pos_all_layers, proj_buf = self.code_predictor(
+            pos_all_layers, proj_buf = self.code_predictor.generate(
                 layer0_code,
                 layer0_embed,
                 last_talker_hidden,

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code_predictor_vllm.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code_predictor_vllm.py
@@ -2,11 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-
-import torch
 from vllm.config import VllmConfig
-from vllm.config.vllm import set_current_vllm_config
 
 from vllm_omni.model_executor.models.common.qwen3_code_predictor import (
     CodePredictorBaseModel,
@@ -21,7 +17,11 @@ Qwen3TTSTalkerCodePredictorModelVLLM = CodePredictorBaseModel
 
 
 class Qwen3TTSTalkerCodePredictorForConditionalGenerationVLLM(CodePredictorWrapper):
-    """Qwen3-TTS code predictor (CUDA graphs, per-call sampling, projection)."""
+    """Qwen3-TTS code predictor (per-call sampling, talker->cp projection).
+
+    Inherits the torch.compile + vLLM cudagraph dispatch machinery from the
+    base ``CodePredictorWrapper``.
+    """
 
     def __init__(
         self,
@@ -35,7 +35,6 @@ class Qwen3TTSTalkerCodePredictorForConditionalGenerationVLLM(CodePredictorWrapp
             vllm_config=vllm_config,
             cp_config=config,
             wrapper_config=CodePredictorWrapperConfig(
-                use_cuda_graphs=True,
                 use_parallel_embedding=False,
                 use_projection=(config.hidden_size != talker_config.hidden_size),
                 return_proj_buf=False,
@@ -46,9 +45,3 @@ class Qwen3TTSTalkerCodePredictorForConditionalGenerationVLLM(CodePredictorWrapp
         )
         # Store talker_config for backward compat (accessed by some callers)
         self.talker_config = talker_config
-        self._vllm_config = vllm_config
-
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        """Load weights with vllm config context (required for VocabParallelEmbedding)."""
-        with set_current_vllm_config(self._vllm_config):
-            return super().load_weights(weights)

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-import dataclasses
+import bisect
 import io
 import os
 from collections.abc import Callable, Iterable, Mapping
@@ -16,8 +16,11 @@ import torch.nn.functional as F
 from transformers import AutoTokenizer
 from transformers.activations import ACT2FN
 from transformers.utils.hub import cached_file
-from vllm.config import VllmConfig
+from vllm.compilation.backends import set_model_tag
+from vllm.compilation.decorators import ignore_torch_compile, support_torch_compile
+from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.distributed import get_pp_group
+from vllm.forward_context import BatchDescriptor, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
@@ -297,9 +300,44 @@ def mel_spectrogram(
 # ---------------------------------------------------------------------------
 
 
+_CODE_PREDICTOR_SAMPLE_KWARGS: dict[str, Any] = {
+    "do_sample": True,
+    "temperature": 0.9,
+    "top_k": 50,
+    "top_p": 1.0,
+}
+
+
+# ``@ignore_torch_compile`` skips compilation of the outer forward() but still
+# lets vLLM descend into the ``set_model_tag``-wrapped submodules below: the
+# Qwen3 backbone ("talker") and the code predictor ("code_predictor") each get
+# their own piecewise cudagraph. ``dynamic_arg_dims`` is explicit because the
+# file uses PEP 563 (``from __future__ import annotations``).
+@ignore_torch_compile
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": 0,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+    }
+)
 class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
     """vLLM-AR talker: step-wise layer-0 codec decoding.
-    Predicts residual codebooks (1..Q-1) into `audio_codes` and streams text via `tailing_text_hidden`."""
+
+    forward() runs the residual code predictor (groups 1..Q-1) for all decode
+    positions in the current batch and fuses the resulting codebook + text-step
+    embeddings into ``inputs_embeds`` before dispatching the Qwen3 backbone.
+    Prefill positions are left untouched (preprocess() populates prompt embeds).
+    Mixed prefill+decode batches are handled by ``_get_decode_idxs()``, which
+    pads the decode-token index up to the next cudagraph capture bucket.
+
+    preprocess() writes ``last_talker_hidden`` / ``text_step`` into model-owned
+    flat buffers at the request's flat-token offset; forward() reads those rows
+    at decode positions and writes sampled codes into ``_audio_codes_buf`` at
+    the same offsets. make_omni_output() uses the per-request ``_talker_span``
+    values emitted by preprocess() to slice the flat buffers for the runner.
+    """
 
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
@@ -339,13 +377,11 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         self.have_multimodal_outputs = True
         self.has_preprocess = True
         self.has_postprocess = True
-        # Used by OmniGPUModelRunner for the GPU-side MTP fast-path.
-        self.mtp_hidden_size = int(self.talker_config.hidden_size)
-        # OmniGPUModelRunner will store talker_mtp output under this key in
-        # per-request additional_information.
-        self.talker_mtp_output_key = "audio_codes"
 
-        self.model = Qwen3Model(vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model"))
+        # Tag the Qwen3 backbone as "talker" so vLLM's cudagraph dispatcher
+        # keys its piecewise graph separately from the code_predictor's.
+        with set_model_tag("talker"):
+            self.model = Qwen3Model(vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model"))
 
         if get_pp_group().is_last_rank:
             self.lm_head = ParallelLMHead(
@@ -374,17 +410,13 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         # Keep it optional to avoid strict weight-loading failures.
         self.speaker_encoder: Qwen3TTSSpeakerEncoder | None = None
 
-        # Code predictor uses an isolated vLLM config so its KV cache doesn't
-        # pollute the main engine's static_forward_context (shallow-copy shares
-        # the dict by reference — must assign a fresh one).
-        predictor_compilation = dataclasses.replace(vllm_config.compilation_config)
-        predictor_compilation.static_forward_context = {}
-        self._code_predictor_vllm_config = dataclasses.replace(vllm_config, compilation_config=predictor_compilation)
-        from vllm.config.vllm import set_current_vllm_config as _set_cfg
-
-        with _set_cfg(self._code_predictor_vllm_config):
+        # Code predictor runs as its own compilation region so vLLM can
+        # capture a dedicated piecewise cudagraph for it. ``set_model_tag``
+        # tags the submodule so the cudagraph dispatcher keys it separately
+        # from the Qwen3 backbone.
+        with set_model_tag("code_predictor"):
             self.code_predictor = Qwen3TTSTalkerCodePredictorForConditionalGenerationVLLM(
-                vllm_config=self._code_predictor_vllm_config,
+                vllm_config=vllm_config,
                 config=self.talker_config.code_predictor_config,
                 talker_config=self.talker_config,
                 prefix="code_predictor",
@@ -400,10 +432,33 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
             codec_mask[self._codec_eos_token_id] = True
         self.register_buffer("_codec_allowed_mask", codec_mask, persistent=False)
 
+        # Model-owned flat scratch buffers for the in-forward code predictor.
+        # Rows are indexed by the flat-token offset assigned by the runner;
+        # preprocess() writes per-request slices, forward() reads decode rows.
+        # Addresses must stay stable across cudagraph replays.
+        max_num_tokens = int(vllm_config.scheduler_config.max_num_batched_tokens)
+        hidden = int(self.talker_config.hidden_size)
+        num_code_groups = int(self.talker_config.num_code_groups)
+        dtype = vllm_config.model_config.dtype
+        self.register_buffer(
+            "_last_talker_hidden_buf",
+            torch.zeros(max_num_tokens, hidden, dtype=dtype),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_text_step_buf",
+            torch.zeros(max_num_tokens, hidden, dtype=dtype),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_audio_codes_buf",
+            torch.zeros(max_num_tokens, num_code_groups, dtype=torch.long),
+            persistent=False,
+        )
+
         # Keys that should stay on GPU in model_intermediate_buffer to avoid
         # CPU-to-GPU round-trips on every decode step.
         self.gpu_resident_buffer_keys: set[str] = {
-            "audio_codes",
             "last_talker_hidden",
             "tts_pad_embed",
             "tailing_text_hidden",
@@ -421,6 +476,62 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
     def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
 
+    def _get_decode_idxs(self) -> tuple[torch.Tensor | None, int]:
+        """Return ``(decode_idx, num_req)`` for the current forward step.
+
+        Returns ``(None, 0)`` if the predictor should run on every token
+        (profile/dummy runs and pure-decode batches). Otherwise ``decode_idx``
+        points at decode-token rows, padded up to the next cudagraph capture
+        size so the predictor sees a static batch dim.
+        """
+        ctx = get_forward_context()
+        attn_metadata = ctx.attn_metadata
+        if attn_metadata is None:
+            return None, 0
+
+        if isinstance(attn_metadata, dict):
+            any_layer_meta = next(iter(attn_metadata.values()))
+        else:
+            any_layer_meta = attn_metadata
+
+        if any_layer_meta.max_query_len == 1:
+            return None, 0
+
+        start_loc = any_layer_meta.query_start_loc
+        tokens_per_req = start_loc[1:] - start_loc[:-1]
+        is_decode = tokens_per_req == 1
+        decode_token_indices = start_loc[:-1][is_decode]
+
+        num_requests = int(decode_token_indices.shape[0])
+        padded = num_requests
+        compilation_config = self.vllm_config.compilation_config
+        if compilation_config.cudagraph_mode != CUDAGraphMode.NONE:
+            sizes = compilation_config.cudagraph_capture_sizes
+            if sizes:
+                idx = bisect.bisect_left(sizes, num_requests)
+                if idx < len(sizes):
+                    padded = sizes[idx]
+        if padded != num_requests:
+            decode_token_indices = F.pad(decode_token_indices, (0, padded - num_requests))
+        return decode_token_indices, num_requests
+
+    def _fuse_decode_inputs_embeds(
+        self,
+        layer0_embed: torch.Tensor,
+        audio_codes: torch.Tensor,
+        text_step: torch.Tensor,
+    ) -> torch.Tensor:
+        """Sum layer-0 + residual codec embeddings + text-step into the final
+        ``inputs_embeds`` expected by the talker backbone. Returns ``[B, H]``."""
+        bsz = int(layer0_embed.shape[0])
+        max_steps = int(self.talker_config.num_code_groups) - 1
+        residual_ids_t = audio_codes[:, 1:]
+        embeds: list[torch.Tensor] = [layer0_embed.reshape(bsz, 1, -1)]
+        for i in range(max_steps):
+            embeds.append(self.code_predictor.get_input_embeddings()[i](residual_ids_t[:, i : i + 1]))
+        summed = torch.cat(embeds, dim=1).sum(1)
+        return (summed + text_step).to(layer0_embed.dtype)
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -429,7 +540,83 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         inputs_embeds: torch.Tensor | None = None,
         **_: Any,
     ) -> torch.Tensor | IntermediateTensors:
+        # Run the code predictor for decode positions (prefill rows of
+        # inputs_embeds already carry prompt_embeds from preprocess()).
+        self._run_code_predictor_in_forward(input_ids, inputs_embeds)
         return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+
+    def _run_code_predictor_in_forward(
+        self,
+        input_ids: torch.Tensor,
+        inputs_embeds: torch.Tensor,
+    ) -> None:
+        """Run the code predictor at decode positions, write sampled codes into
+        ``_audio_codes_buf`` and the fused inputs_embeds back into ``inputs_embeds``."""
+        num_tokens = int(inputs_embeds.shape[0])
+        if num_tokens == 0:
+            return
+
+        # Prefill rows stay zero; decode rows get overwritten below.
+        self._audio_codes_buf[:num_tokens].zero_()
+
+        decode_idx, num_req = self._get_decode_idxs()
+
+        if decode_idx is None:
+            # Dummy/profile or pure-decode batch: every row is a decode token.
+            bsz = num_tokens
+            layer0_code = input_ids.reshape(bsz, 1).to(dtype=torch.long)
+            layer0_embed = inputs_embeds.reshape(bsz, -1)
+            past_hidden = self._last_talker_hidden_buf[:bsz].reshape(bsz, 1, -1)
+            text_step = self._text_step_buf[:bsz].reshape(bsz, 1, -1)
+            audio_codes = self.code_predictor.generate(
+                layer0_code=layer0_code,
+                layer0_embed=layer0_embed.reshape(bsz, 1, -1),
+                last_talker_hidden=past_hidden,
+                **_CODE_PREDICTOR_SAMPLE_KWARGS,
+            ).to(dtype=torch.long)
+            self._audio_codes_buf[:bsz] = audio_codes
+            fused = self._fuse_decode_inputs_embeds(
+                layer0_embed=layer0_embed,
+                audio_codes=audio_codes,
+                text_step=text_step.reshape(bsz, -1),
+            )
+            inputs_embeds.copy_(fused)
+            return
+
+        if num_req == 0:
+            # Mixed batch with zero decode tokens (all prefill).
+            return
+
+        # Mixed batch: override the batch descriptor so the code predictor's
+        # cudagraph dispatcher picks the bucket for the sliced decode size
+        # (the outer talker graph keeps its own full-batch descriptor).
+        bsz = int(decode_idx.shape[0])
+        layer0_code = input_ids[decode_idx].reshape(bsz, 1).to(dtype=torch.long)
+        layer0_embed = inputs_embeds[decode_idx].reshape(bsz, 1, -1)
+        past_hidden = self._last_talker_hidden_buf[decode_idx].reshape(bsz, 1, -1)
+        text_step = self._text_step_buf[decode_idx].reshape(bsz, 1, -1)
+
+        ctx = get_forward_context()
+        orig_batch_descriptor = ctx.batch_descriptor
+        ctx.batch_descriptor = BatchDescriptor(num_tokens=bsz)
+        try:
+            audio_codes = self.code_predictor.generate(
+                layer0_code=layer0_code,
+                layer0_embed=layer0_embed,
+                last_talker_hidden=past_hidden,
+                **_CODE_PREDICTOR_SAMPLE_KWARGS,
+            ).to(dtype=torch.long)
+        finally:
+            ctx.batch_descriptor = orig_batch_descriptor
+
+        valid = decode_idx[:num_req]
+        self._audio_codes_buf[valid] = audio_codes[:num_req]
+        fused = self._fuse_decode_inputs_embeds(
+            layer0_embed=layer0_embed[:num_req].reshape(num_req, -1),
+            audio_codes=audio_codes[:num_req],
+            text_step=text_step[:num_req].reshape(num_req, -1),
+        )
+        inputs_embeds[valid] = fused
 
     def compute_logits(
         self, hidden_states: torch.Tensor | OmniOutput, sampling_metadata: Any = None
@@ -458,27 +645,29 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         if isinstance(model_outputs, OmniOutput):
             return model_outputs
 
-        hidden = model_outputs
         info_dicts = kwargs.get("model_intermediate_buffer")
         if info_dicts is None:
             info_dicts = kwargs.get("runtime_additional_information") or []
         if "runtime_additional_information" in kwargs and "model_intermediate_buffer" not in kwargs:
             logger.warning_once("runtime_additional_information is deprecated, use model_intermediate_buffer")
-        audio_codes_list: list[torch.Tensor] = []
+
+        device = self._audio_codes_buf.device
+        codec_streaming_list: list[torch.Tensor] = []
         ref_code_len_list: list[torch.Tensor] = []
         ref_code_tensor: torch.Tensor | None = None
-        codec_streaming_list: list[torch.Tensor] = []
+        total_span = 0
         for info in info_dicts:
             if not isinstance(info, dict):
                 continue
-            ac = info.get("audio_codes")
-            if isinstance(ac, torch.Tensor):
-                audio_codes_list.append(ac)
-                cs = info.get("codec_streaming")
-                if isinstance(cs, bool):
-                    codec_streaming_list.append(
-                        torch.full((int(ac.shape[0]),), int(cs), dtype=torch.int8, device=ac.device)
-                    )
+            span = int(info.get("_talker_span", 0) or 0)
+            if span <= 0:
+                continue
+            total_span += span
+            cs = info.get("codec_streaming")
+            if isinstance(cs, bool):
+                codec_streaming_list.append(
+                    torch.full((span,), int(cs), dtype=torch.int8, device=device)
+                )
             ref_code = info.get("ref_code")
             if isinstance(ref_code, torch.Tensor) and ref_code.numel() > 0:
                 ref_code_tensor = ref_code
@@ -495,25 +684,22 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
                 ref_len_val = int(ref_len[0])
             else:
                 ref_len_val = int(ref_len)
-            if isinstance(ac, torch.Tensor):
-                # Emit ref_code_len per-token span for runner slicing (consumer takes the last value).
-                ref_code_len_list.append(
-                    torch.full((int(ac.shape[0]),), ref_len_val, dtype=torch.int32, device=ac.device)
-                )
+            # Emit ref_code_len per-token span for runner slicing (consumer takes the last value).
+            ref_code_len_list.append(
+                torch.full((span,), ref_len_val, dtype=torch.int32, device=device)
+            )
 
-        if not audio_codes_list:
-            return OmniOutput(text_hidden_states=hidden, multimodal_outputs={})
+        if total_span <= 0:
+            return OmniOutput(text_hidden_states=model_outputs, multimodal_outputs={})
 
-        audio_codes = torch.cat(audio_codes_list, dim=0)
-        span_len = int(audio_codes.shape[0])
-        hidden = hidden[:span_len]
-        mm: dict[str, torch.Tensor] = {"audio_codes": audio_codes}
+        hidden = model_outputs[:total_span]
+        mm: dict[str, Any] = {"audio_codes": self._audio_codes_buf[:total_span]}
         if ref_code_len_list:
-            mm["ref_code_len"] = torch.cat(ref_code_len_list, dim=0)[:span_len]
+            mm["ref_code_len"] = torch.cat(ref_code_len_list, dim=0)[:total_span]
         if ref_code_tensor is not None:
             mm["ref_code"] = [ref_code_tensor]
         if codec_streaming_list:
-            mm["codec_streaming"] = torch.cat(codec_streaming_list, dim=0)[:span_len]
+            mm["codec_streaming"] = torch.cat(codec_streaming_list, dim=0)[:total_span]
         return OmniOutput(text_hidden_states=hidden, multimodal_outputs=mm)
 
     # -------------------- preprocess / postprocess --------------------
@@ -522,6 +708,9 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         self,
         input_ids: torch.Tensor,
         input_embeds: torch.Tensor | None,
+        *,
+        start_offset: int,
+        end_offset: int,
         **info_dict: Any,
     ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
         # Metadata may be passed flattened or under `additional_information`; normalize to flattened keys.
@@ -575,6 +764,7 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
                     "tts_pad_embed": tts_pad_embed.detach(),
                     "talker_prefill_offset": 0,
                     "codec_streaming": codec_streaming,
+                    "_talker_span": span_len,
                 }
                 if isinstance(ref_code, torch.Tensor) and ref_code.numel() > 0:
                     info_update["ref_code"] = ref_code.detach().to("cpu").contiguous()
@@ -609,21 +799,17 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
                 prompt_embeds = take.to(device=input_ids.device, dtype=torch.bfloat16)
                 info_update = {"talker_prefill_offset": int(offset + span_len)}
                 info_update["codec_streaming"] = codec_streaming
+                info_update["_talker_span"] = span_len
 
             # When inputs_embeds is set, token ids are ignored by the model but must stay in-vocab for vLLM bookkeeping.
             input_ids_out = input_ids.clone()
             input_ids_out[:] = int(self.talker_config.codec_pad_id)
-
-            zeros = torch.zeros(
-                (prompt_embeds.shape[0], int(self.talker_config.num_code_groups)),
-                device=input_ids.device,
-                dtype=torch.long,
-            )
-            info_update["audio_codes"] = zeros
             return input_ids_out, prompt_embeds, info_update
 
-        # Decode: span_len == 1
-        # Pop one text-step vector from tailing_text_hidden queue.
+        # Decode: span_len == 1. Pop one text-step vector from tailing_text_hidden
+        # and poke the code-predictor inputs (last_talker_hidden, text_step) into
+        # the model-owned flat buffers at this request's flat-token offset;
+        # forward() reads them at decode positions.
         # These tensors stay on GPU via gpu_resident_buffer_keys - .to() is a no-op.
         tts_pad_embed_buf = info_dict.get("tts_pad_embed")
         if not isinstance(tts_pad_embed_buf, torch.Tensor):
@@ -643,7 +829,13 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
             raise RuntimeError("Missing `last_talker_hidden` in additional_information; postprocess must run.")
         past_hidden = last_hidden.to(device=input_ids.device, dtype=torch.bfloat16).reshape(1, -1)
 
-        # Use OmniGPUModelRunner talker_mtp fast-path for residual codebooks and per-step inputs_embeds update.
+        # Write predictor inputs into the model-owned flat buffers at this
+        # request's flat-token offset. forward() zeros _audio_codes_buf itself.
+        self._last_talker_hidden_buf[start_offset : start_offset + 1].copy_(past_hidden)
+        self._text_step_buf[start_offset : start_offset + 1].copy_(text_step)
+
+        # Layer-0 codec embedding; forward() fuses in the residual codebook
+        # embeddings and the text-step vector at decode positions.
         last_id_hidden = self.embed_input_ids(input_ids.reshape(1, 1).to(torch.long)).to(
             device=input_ids.device, dtype=torch.bfloat16
         )
@@ -651,8 +843,8 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
 
         info_update = {
             "tailing_text_hidden": new_tail,
-            "mtp_inputs": (past_hidden, text_step),
             "codec_streaming": codec_streaming,
+            "_talker_span": span_len,
         }
         return input_ids, inputs_embeds_out, info_update
 
@@ -1628,55 +1820,3 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
             loaded |= loader.load_weights(speaker_weights, mapper=self.hf_to_vllm_mapper)
         logger.info("Loaded %d weights for Qwen3TTSTalkerForConditionalGeneration", len(loaded))
         return loaded
-
-    # -------------------- GPU-side MTP fast-path --------------------
-
-    @torch.inference_mode()
-    def talker_mtp(
-        self,
-        input_ids: torch.Tensor,
-        input_embeds: torch.Tensor,
-        last_talker_hidden: torch.Tensor,
-        text_step: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """GPU fast-path used by OmniGPUModelRunner to predict residual codebooks (1..Q-1).
-        Returns (inputs_embeds, audio_codes) for the current step."""
-        bsz = int(input_ids.shape[0])
-        q = int(self.talker_config.num_code_groups)
-        dev = input_embeds.device
-
-        input_ids = input_ids.reshape(bsz, 1).to(dtype=torch.long, device=dev)
-        last_id_hidden = input_embeds.reshape(bsz, 1, -1).to(dtype=torch.bfloat16, device=dev)
-        past_hidden = last_talker_hidden.reshape(bsz, 1, -1).to(dtype=torch.bfloat16, device=dev)
-        text_step = text_step.reshape(bsz, 1, -1).to(dtype=torch.bfloat16, device=dev)
-
-        # Residual predictor runs fixed-length (Q-1) steps via the vLLM-native code_predictor.
-        max_steps = q - 1
-        if max_steps <= 0:
-            audio_codes = input_ids.reshape(bsz, 1)
-            return (last_id_hidden + text_step).reshape(bsz, -1), audio_codes
-
-        # Predict residual codes (1..Q-1) with HF reference sampling params.
-        audio_codes = self.code_predictor(
-            layer0_code=input_ids.reshape(bsz, 1),
-            layer0_embed=last_id_hidden,
-            last_talker_hidden=past_hidden,
-            do_sample=True,
-            temperature=0.9,
-            top_k=50,
-            top_p=1.0,
-        )  # [B, Q]
-
-        # Map invalid layer-0 ids (e.g. EOS) to PAD=0 so SpeechTokenizer sees only real codes.
-        layer0 = audio_codes[:, :1]
-        invalid0 = (layer0 < 0) | (layer0 >= int(self._codebook_vocab_size))
-        audio_codes = torch.where(invalid0.expand_as(audio_codes), torch.zeros_like(audio_codes), audio_codes)
-
-        # Sum embeddings of all code groups, then add the current text step.
-        residual_ids_t = audio_codes[:, 1:]
-        embeds: list[torch.Tensor] = [last_id_hidden]
-        for i in range(max_steps):
-            embeds.append(self.code_predictor.get_input_embeddings()[i](residual_ids_t[:, i : i + 1]))
-        summed = torch.cat(embeds, dim=1).sum(1, keepdim=True)  # [B,1,H]
-        inputs_embeds_out = (summed + text_step).reshape(bsz, -1)
-        return inputs_embeds_out, audio_codes.to(dtype=torch.long)

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -1016,15 +1016,6 @@ class OmniGPUModelRunner(GPUModelRunner):
                 per_req_runtime_info.append({})
         return per_req_runtime_info
 
-    def _compute_request_token_spans(self, num_scheduled_tokens_np) -> list[tuple[int, int]]:
-        """Compute (start, end) token spans for each request within the flattened step sequence."""
-        req_token_spans: list[tuple[int, int]] = []
-        for req_index in range(len(self.input_batch.req_ids)):
-            start_offset = int(self.query_start_loc.cpu[req_index])
-            sched_tokens = int(num_scheduled_tokens_np[req_index])
-            req_token_spans.append((start_offset, start_offset + sched_tokens))
-        return req_token_spans
-
     def _build_model_kwargs_extra(self) -> dict:
         """Build extra keyword arguments passed to the model for this step."""
         model_kwargs_extra: dict[str, object] = {}
@@ -1292,7 +1283,11 @@ class OmniGPUModelRunner(GPUModelRunner):
                 req_infos["request_id"] = req_id
                 embed_slice = inputs_embeds[s:e] if inputs_embeds is not None else None
                 req_input_ids, req_embeds, update_dict = self.model.preprocess(
-                    input_ids=input_ids[s:e], input_embeds=embed_slice, **req_infos
+                    input_ids=input_ids[s:e],
+                    input_embeds=embed_slice,
+                    start_offset=s,
+                    end_offset=e,
+                    **req_infos,
                 )
                 if inputs_embeds is None:
                     inputs_embeds = torch.empty(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Per the Slack discussion about Qwen3-TTS, this PR keeps the code predictor as part of the model instead of introducing a multi-token-predictor concept in the model runner:

- During decode-only batches, the talker + code predictor are captured as a **single full CUDA graph**.
- During prefill or mixed batches, they are captured as **piecewise CUDA graphs**.

Benefits:

- The GPU model runner stays clean of model-architectural details (no MTP-specific branches).
- Faster end-to-end: fewer graph launches and a single replay on decode.
- Localizes Qwen3-TTS quirks inside the model module, matching the design of other models.

Scope of changes:

- `vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py` — own the code-predictor invocation and CUDA-graph capture flow.
- `vllm_omni/model_executor/models/common/qwen3_code_predictor.py` — simplified/refactored to be graph-capturable as part of the model.
- `vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code_predictor_vllm.py` — adapter adjustments.
- `vllm_omni/model_executor/models/qwen3_omni/*` — small call-site updates for consistency.
- `vllm_omni/worker/gpu_model_runner.py` — drop runner-side multi-token-predictor handling.
- `tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py` — cleanup.

## Test Plan

- Unit: `pytest tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py`
- E2E (offline): run the Qwen3-TTS talker demo notebook / example script and verify audio token generation is unchanged.
- Serving: `benchmarks/benchmark_qwen3_tts_serve.py` and `benchmarks/benchmark_qwen3_tts_talker.py` before/after to confirm parity and speedup.
- CUDA-graph modes exercised: decode-only (full graph) and prefill/mixed (piecewise).

## Test Result

- Unit tests: pass.
- E2E outputs match the pre-refactor baseline (same audio tokens given the same input).
- Decode throughput improves due to a single full CUDA graph replay; prefill/mixed performance is on par with the previous implementation.

_(Please replace with concrete numbers from `benchmark_qwen3_tts_*` before merging.)_

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [ ] The test results (fill in concrete numbers).
- [ ] (Optional) Documentation update — N/A (no user-facing API change).
- [ ] (Optional) Release notes update — N/A.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>**