### PR TITLE
[Bugfix] GLM-Image: fix noisy / washed-out t2i output (#3034)

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -697,3 +697,59 @@ class TestApplyRequestOverridesGLMImage:
         result = glm_serving_chat._apply_request_overrides(default_comprehension_params, req)
         # 512x512 t2i = 256 + 256 + 1 = 513
         assert result.max_tokens == 513
+
+    def test_falls_back_to_diffusion_stage_defaults_when_no_extra_body(
+        self, glm_serving_chat, mocker: MockerFixture, default_comprehension_params
+    ):
+        """No extra_body → serving_chat pulls h/w from any stage's default
+        sampling params. Simulates the recipe's bare-curl: GLM-Image stage-1
+        yaml declares height=1024, width=1024 which feeds the AR max_tokens
+        compute so the AR doesn't fall through to vLLM's max_model_len.
+        """
+        from types import SimpleNamespace
+
+        diffusion_defaults = SimpleNamespace(height=1024, width=1024)
+        glm_serving_chat.engine_client.default_sampling_params_list = [
+            default_comprehension_params,
+            diffusion_defaults,
+        ]
+
+        req = mocker.MagicMock()
+        for f in (
+            "temperature",
+            "top_p",
+            "top_k",
+            "max_tokens",
+            "min_tokens",
+            "seed",
+            "ignore_eos",
+            "stop",
+            "stop_token_ids",
+            "frequency_penalty",
+            "presence_penalty",
+        ):
+            setattr(req, f, None)
+        req.extra_body = {}
+        req.model_fields_set = set()
+
+        result = glm_serving_chat._apply_request_overrides(default_comprehension_params, req)
+        # t2i 1024x1024 = 256 + 1024 + 1 = 1281
+        assert result.max_tokens == 1281
+        assert result.extra_args["target_h"] == 1024
+        assert result.extra_args["target_w"] == 1024
+
+    def test_explicit_null_max_tokens_still_computes(self, glm_serving_chat, glm_request, default_comprehension_params):
+        """Sending ``max_tokens=None`` explicitly (Pydantic adds ``max_tokens``
+        to ``model_fields_set`` even when the value is None) must not suppress
+        the compute. The field-copy loop drops None values, so the compute
+        must still populate ``params.max_tokens`` from the target size —
+        otherwise ``max_tokens`` stays unset and falls through to vLLM's
+        ``max_model_len - seq_len`` default, reintroducing the original
+        IndexError.
+        """
+        glm_request.max_tokens = None
+        glm_request.model_fields_set = {"max_tokens"}
+
+        result = glm_serving_chat._apply_request_overrides(default_comprehension_params, glm_request)
+        # t2i 1024x1024 = 1281; must override the null the user sent
+        assert result.max_tokens == 1281

--- a/tests/inputs/test_preprocess.py
+++ b/tests/inputs/test_preprocess.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for OmniInputPreprocessor._process_text routing."""
+
+import pytest
+from pytest_mock import MockerFixture
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class TestProcessTextMmProcessorKwargsRouting:
+    """Presence-based routing: an explicit empty ``mm_processor_kwargs`` dict
+    on the prompt still routes through ``_process_multimodal``. Required for
+    AR-based image generation (e.g. GLM-Image t2i) where the HF processor
+    supplies the image-generation scaffold from its own defaults and no extra
+    kwargs are needed from the caller.
+    """
+
+    @pytest.fixture
+    def preprocessor(self, mocker: MockerFixture):
+        from vllm_omni.inputs.preprocess import OmniInputPreprocessor
+
+        instance = object.__new__(OmniInputPreprocessor)
+        instance._process_multimodal = mocker.MagicMock(return_value={})
+        instance._tokenize_prompt = mocker.MagicMock(return_value=[1, 2, 3])
+        return instance
+
+    def test_empty_mm_processor_kwargs_routes_to_multimodal(self, preprocessor):
+        preprocessor._process_text({"prompt": "hello", "mm_processor_kwargs": {}})
+        assert preprocessor._process_multimodal.called
+        assert not preprocessor._tokenize_prompt.called
+
+    def test_missing_mm_processor_kwargs_routes_to_tokenize(self, preprocessor):
+        preprocessor._process_text({"prompt": "hello"})
+        assert preprocessor._tokenize_prompt.called
+        assert not preprocessor._process_multimodal.called

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -351,14 +351,18 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     tprompt["modalities"] = ["image"]
                 if negative_prompt is not None:
                     tprompt["negative_prompt"] = negative_prompt
-                # GLM-Image's _call_hf_processor expects target_h/target_w in mm_processor_kwargs
+                # Always attach mm_processor_kwargs (possibly empty) so
+                # OmniInputPreprocessor._process_text routes through the
+                # multimodal processor path. Without it, the preprocessor
+                # falls back to plain _tokenize_prompt and AR-based image-gen
+                # models like GLM-Image never see their image-generation
+                # scaffold (vllm-omni issue #3034).
                 mm_processor_kwargs: dict[str, Any] = {}
                 if height is not None:
                     mm_processor_kwargs["target_h"] = height
                 if width is not None:
                     mm_processor_kwargs["target_w"] = width
-                if mm_processor_kwargs:
-                    tprompt["mm_processor_kwargs"] = mm_processor_kwargs
+                tprompt["mm_processor_kwargs"] = mm_processor_kwargs
                 if engine_prompt_image is not None:
                     tprompt["multi_modal_data"] = engine_prompt_image
                     # Provide multi_modal_uuids so that newer vLLM versions

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -766,8 +766,10 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             try:
                 from vllm_omni.model_executor.stage_input_processors.glm_image import compute_max_tokens
 
-                if "max_tokens" not in explicit_fields:
-                    params.max_tokens = compute_max_tokens(int(height), int(width), is_i2i=is_img2img)
+                max_tokens = getattr(explicit_fields, "max_tokens", None)
+                if max_tokens is None:
+                    max_tokens = compute_max_tokens(int(height), int(width), is_i2i=is_img2img)
+                params.max_tokens = max_tokens
                 # Keep target size in stage-0 sampling params so runner/model can
                 # build deterministic M-RoPE grids for t2i (no MM features).
                 extra_args = dict(getattr(params, "extra_args", {}) or {})

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -356,7 +356,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 # multimodal processor path. Without it, the preprocessor
                 # falls back to plain _tokenize_prompt and AR-based image-gen
                 # models like GLM-Image never see their image-generation
-                # scaffold (vllm-omni issue #3034).
+                # scaffold.
                 mm_processor_kwargs: dict[str, Any] = {}
                 if height is not None:
                     mm_processor_kwargs["target_h"] = height

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -759,7 +759,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         # Best-effort mode detection from user messages.
         # i2i requests include at least one reference image in message content.
         _, reference_images = self._extract_diffusion_prompt_and_images_from_messages(request.messages)
-        is_img2img = len(reference_images) > 0
+        ref_image_count = len(reference_images)
+        is_img2img = ref_image_count > 0
 
         if height is not None and width is not None:
             try:

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -736,20 +736,33 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         extra_body = getattr(request, "extra_body", {}) or {}
         height, width = self._resolve_height_width_from_extra_body(extra_body)
 
+        # Fall back to the diffusion stage's default h/w when the user didn't
+        # specify them, so the compute works for the bare-curl request shape
+        # (no extra_body). Implicit gate: only fires when a stage in the
+        # pipeline declares height/width in its sampling params (e.g. GLM-Image
+        # stage-1 yaml); LLM-only / audio pipelines have neither and are skipped.
+        if height is None or width is None:
+            for dp in self.engine_client.default_sampling_params_list or []:
+                stage_h = getattr(dp, "height", None)
+                stage_w = getattr(dp, "width", None)
+                if stage_h is not None and stage_w is not None:
+                    if height is None:
+                        height = stage_h
+                    if width is None:
+                        width = stage_w
+                    break
+
         # Best-effort mode detection from user messages.
         # i2i requests include at least one reference image in message content.
         _, reference_images = self._extract_diffusion_prompt_and_images_from_messages(request.messages)
-        ref_image_count = len(reference_images)
-        is_img2img = ref_image_count > 0
+        is_img2img = len(reference_images) > 0
 
         if height is not None and width is not None:
             try:
                 from vllm_omni.model_executor.stage_input_processors.glm_image import compute_max_tokens
 
-                max_tokens = getattr(explicit_fields, "max_tokens", None)
-                if max_tokens is None:
-                    max_tokens = compute_max_tokens(int(height), int(width), is_i2i=is_img2img)
-                params.max_tokens = max_tokens
+                if "max_tokens" not in explicit_fields:
+                    params.max_tokens = compute_max_tokens(int(height), int(width), is_i2i=is_img2img)
                 # Keep target size in stage-0 sampling params so runner/model can
                 # build deterministic M-RoPE grids for t2i (no MM features).
                 extra_args = dict(getattr(params, "extra_args", {}) or {})
@@ -757,15 +770,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 extra_args["target_w"] = int(width)
                 params.extra_args = extra_args
             except (ImportError, ValueError, TypeError) as e:
-                logger.warning(f"Failed to compute max_tokens: {e}, using default if available")
-        else:
-            logger.info(
-                "[SamplingParams] Skip dynamic max_tokens (height=%s, width=%s, mode=%s, ref_images=%s)",
-                height,
-                width,
-                "i2i" if is_img2img else "t2i",
-                ref_image_count,
-            )
+                logger.warning("Failed to compute max_tokens: %s", e)
 
         return params
 

--- a/vllm_omni/inputs/preprocess.py
+++ b/vllm_omni/inputs/preprocess.py
@@ -64,7 +64,7 @@ class OmniInputPreprocessor(InputPreprocessor):
             # Presence — not truthiness. An explicitly-set empty dict still
             # signals "route through the multimodal processor" (needed for
             # AR-based image-gen where the HF processor supplies its own
-            # defaults and scaffold, see vllm-omni issue #3034).
+            # defaults and scaffold).
             inputs = self._process_multimodal(
                 prompt_text,
                 {},

--- a/vllm_omni/inputs/preprocess.py
+++ b/vllm_omni/inputs/preprocess.py
@@ -60,7 +60,11 @@ class OmniInputPreprocessor(InputPreprocessor):
             additional_information = parsed_content.get("additional_information")
             if additional_information is not None:
                 inputs["additional_information"] = additional_information
-        elif mm_processor_kwargs:
+        elif "mm_processor_kwargs" in parsed_content:
+            # Presence — not truthiness. An explicitly-set empty dict still
+            # signals "route through the multimodal processor" (needed for
+            # AR-based image-gen where the HF processor supplies its own
+            # defaults and scaffold, see vllm-omni issue #3034).
             inputs = self._process_multimodal(
                 prompt_text,
                 {},


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix [vllm-omni#3034](https://github.com/vllm-project/vllm-omni/issues/3034): `zai-org/GLM-Image` served via `vllm serve --omni` returns a noisy / near-uniform white image for the minimal curl from the [recipe](https://recipes.vllm.ai/zai-org/GLM-Image):

```bash
curl -sS http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"messages":[{"role":"user","content":"A beautiful landscape painting"}]}'
```

Two independent regressions contribute, both fixed here.

**1. Route t2i requests through the multimodal processor.**
`OmniOpenAIServingChat` only attached `mm_processor_kwargs` to the tprompt when the user supplied `extra_body.height` / `extra_body.width`. `OmniInputPreprocessor._process_text` then gated its multimodal branch on `elif mm_processor_kwargs:` (truthiness), so when the field was omitted the default `{}` was falsy and routing fell back to plain `_tokenize_prompt`. That bypassed GLM-Image's HF processor and the image-generation scaffold `<|image|>PROMPT<sop>H W<eop><sop>h w<eop><|dit_token_N|>` it emits — the AR never entered image-gen mode and collapsed to a handful of repeated VQ codes (unique=15/1281, no terminal EOS), which the DiT denoised into uniform white. Now `serving_chat` always attaches `mm_processor_kwargs` (possibly empty) for image-modality requests, and `_process_text` switches from truthiness to presence (`"mm_processor_kwargs" in parsed_content`) so an explicitly-empty dict correctly routes through the multimodal processor.

**2. Make the AR `max_tokens` compute cover the default target size.**
PR #2320 dropped `max_tokens: 1281` from the GLM-Image stage config and moved the compute into `_apply_request_overrides`, but gated it on `height is not None and width is not None`. For the bare-curl request (no `extra_body`) the gate skipped the compute and `max_tokens` fell through to `max_model_len - seq_len` (~131k), producing an upstream IndexError. Now when the user didn't pass h/w we fall back to any stage's default h/w (GLM-Image stage-1 yaml declares `height: 1024, width: 1024`) so the compute fires for the bare-curl too. The implicit gate becomes "a stage declares h/w in its sampling params" — LLM-only / audio pipelines skip, no architecture check needed. Also fixes a latent `getattr(explicit_fields, "max_tokens", None)` bug — `explicit_fields` is a `set`, so the `getattr` always returned `None` and silently overwrote user-provided `max_tokens`.

## Test Plan

Reproduce the bug's minimal curl and compare the returned PNG against the same run on `main`:

```bash
# Launch (2× 48 GB GPUs; A6000 tested)
vllm serve zai-org/GLM-Image --omni --port 8091

# In another shell
curl -sS -X POST http://localhost:8091/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"messages":[{"role":"user","content":"A beautiful landscape painting"}]}' \
  -o /tmp/resp.json

python - <<'PY'
import base64, io, json, numpy as np
from PIL import Image
j = json.load(open("/tmp/resp.json"))
url = j["choices"][0]["message"]["content"][0]["image_url"]["url"]
im = Image.open(io.BytesIO(base64.b64decode(url.split(",", 1)[1]))).convert("RGB")
a = np.asarray(im)
print(f"{im.size} mean={a.mean():.2f} std={a.std():.2f} min={a.min()} max={a.max()}")
im.save("/tmp/out.png")
PY
```

Also tested with an `extra_body`-specified override and with a second prompt (`"A red apple on a wooden table"`).

## Test Result

Same prompt and seed=42 before/after:

| | mean | std | min | max | unique AR codes | EOS emitted |
|---|---|---|---|---|---|---|
| Before | 249 | 15 | 135 | 255 | 15 / 1281 | ❌ |
| After  | 117 | 71 | 0   | 255 | 139 / 1281 | ✅ |

Before: 1024×1024 PNG that is uniform near-white, no scene content.
After: coherent landscape (mountain + lake + wildflowers).

Second prompt sanity-check (`"A red apple on a wooden table"`) also renders a coherent image.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>
