### PR TITLE
[Config Refactor] sentinel default precedence

### DIFF
--- a/docs/mkdocs/hooks/generate_argparse.py
+++ b/docs/mkdocs/hooks/generate_argparse.py
@@ -121,6 +121,7 @@ def extract_omni_serve_subparser_init():
                         "FlexibleArgumentParser": _FlexibleArgumentParser,
                         "make_arg_parser": lambda parser: parser,  # no-op for doc
                         "_ensure_vllm_platform": lambda: None,  # no-op for doc
+                        "nullify_stage_engine_defaults": lambda parser: None,  # no-op for doc
                         "VLLM_SUBCMD_PARSER_EPILOG": "",
                         "logger": logger,
                         "DummySubparsers": DummySubparsers,

--- a/examples/offline_inference/bagel/end2end.py
+++ b/examples/offline_inference/bagel/end2end.py
@@ -116,6 +116,9 @@ def parse_args():
         help="Temperature for text generation sampling (default: 0.3).",
     )
 
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    nullify_stage_engine_defaults(parser)
     args = parser.parse_args()
     return args
 

--- a/examples/offline_inference/cosyvoice3/verify_e2e_cosyvoice.py
+++ b/examples/offline_inference/cosyvoice3/verify_e2e_cosyvoice.py
@@ -57,7 +57,6 @@ def run_e2e():
     omni = Omni(
         model=args.model,
         deploy_config=args.deploy_config,
-        trust_remote_code=True,
         tokenizer=args.tokenizer,
         log_stats=True,
     )

--- a/examples/offline_inference/custom_pipeline/image_to_image/image_edit.py
+++ b/examples/offline_inference/custom_pipeline/image_to_image/image_edit.py
@@ -118,6 +118,9 @@ def parse_args() -> argparse.Namespace:
         help='JSON profiler config for torch/cuda profiling, e.g. \'{"profiler":"torch","torch_profiler_dir":"./perf"}\'.',
     )
 
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/examples/offline_inference/dynin_omni/end2end.py
+++ b/examples/offline_inference/dynin_omni/end2end.py
@@ -970,6 +970,9 @@ def parse_args(repo_root: Path) -> argparse.Namespace:
     parser.add_argument("--vq-model-audio-local-files-only", action=argparse.BooleanOptionalAction, default=None)
 
     parser.add_argument("--disable-hf-xet", action=argparse.BooleanOptionalAction, default=True)
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/examples/offline_inference/helios/end2end.py
+++ b/examples/offline_inference/helios/end2end.py
@@ -196,6 +196,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--cfg-parallel-size", type=int, default=1, choices=[1, 2], help="CFG parallel size.")
     parser.add_argument("--tensor-parallel-size", type=int, default=1, help="Tensor parallelism size.")
 
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/examples/offline_inference/hunyuan_image3/end2end.py
+++ b/examples/offline_inference/hunyuan_image3/end2end.py
@@ -135,6 +135,9 @@ def parse_args():
     parser.add_argument("--init-timeout", type=int, default=300, help="Initialization timeout in seconds.")
     parser.add_argument("--enforce-eager", action="store_true", help="Disable torch.compile.")
 
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/examples/offline_inference/image_to_image/image_edit.py
+++ b/examples/offline_inference/image_to_image/image_edit.py
@@ -378,6 +378,9 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help='JSON profiler config for torch/cuda profiling, e.g. \'{"profiler":"torch","torch_profiler_dir":"./perf"}\'.',
     )
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/examples/offline_inference/image_to_video/image_to_video.py
+++ b/examples/offline_inference/image_to_video/image_to_video.py
@@ -211,6 +211,9 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help='JSON profiler config for torch/cuda profiling, e.g. \'{"profiler":"torch","torch_profiler_dir":"./perf"}\'.',
     )
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/examples/offline_inference/magi_human/end2end.py
+++ b/examples/offline_inference/magi_human/end2end.py
@@ -24,6 +24,9 @@ def parse_args():
     parser.add_argument("--width", type=int, default=448, help="Video width.")
     parser.add_argument("--num-inference-steps", type=int, default=8, help="Number of denoising steps.")
     parser.add_argument("--seed", type=int, default=52, help="Random seed for generation.")
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/examples/offline_inference/mammothmodal2_preview/run_mammothmoda2_image_summarize.py
+++ b/examples/offline_inference/mammothmodal2_preview/run_mammothmoda2_image_summarize.py
@@ -19,6 +19,7 @@ from vllm import SamplingParams
 from vllm.multimodal.image import convert_image_mode
 
 from vllm_omni import Omni
+from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
 
 DEFAULT_SYSTEM = "You are a helpful assistant."
 DEFAULT_QUESTION = "Please summarize the content of this image."
@@ -48,6 +49,7 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Enable diffusion pipeline profiler to display stage durations.",
     )
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/examples/offline_inference/mammothmodal2_preview/run_mammothmoda2_t2i.py
+++ b/examples/offline_inference/mammothmodal2_preview/run_mammothmoda2_t2i.py
@@ -29,6 +29,7 @@ from PIL import Image
 from vllm.sampling_params import SamplingParams
 
 from vllm_omni import Omni
+from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -117,6 +118,7 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument("--out", type=str, default="output.png", help="Path to save the generated image.")
     p.add_argument("--trust-remote-code", action="store_true", help="Trust remote code when loading the model.")
+    nullify_stage_engine_defaults(p)
     args = p.parse_args()
     if not args.prompt:
         args.prompt = ["A stylish woman with sunglasses riding a motorcycle in NYC."]

--- a/examples/offline_inference/ming_flash_omni_tts/end2end.py
+++ b/examples/offline_inference/ming_flash_omni_tts/end2end.py
@@ -97,7 +97,6 @@ def main():
     omni = Omni(
         model=args.model,
         stage_configs_path=args.stage_configs_path,
-        trust_remote_code=True,
         log_stats=args.log_stats,
         init_timeout=args.init_timeout,
         stage_init_timeout=args.stage_init_timeout,

--- a/examples/offline_inference/omnivoice/end2end.py
+++ b/examples/offline_inference/omnivoice/end2end.py
@@ -89,7 +89,6 @@ def run_e2e():
     omni = Omni(
         model=args.model,
         stage_configs_path=args.stage_config,
-        trust_remote_code=True,
         log_stats=True,
     )
 

--- a/examples/offline_inference/qwen3_omni/end2end.py
+++ b/examples/offline_inference/qwen3_omni/end2end.py
@@ -21,6 +21,7 @@ from vllm.multimodal.image import convert_image_mode
 from vllm.multimodal.media.audio import load_audio
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
+from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
 from vllm_omni.entrypoints.omni import Omni
 
 SEED = 42
@@ -550,6 +551,7 @@ def parse_args():
         help="Model dtype (auto, half, float16, bfloat16, float, float32).",
     )
 
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/examples/offline_inference/text_to_image/text_to_image.py
+++ b/examples/offline_inference/text_to_image/text_to_image.py
@@ -300,6 +300,9 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help=("Custom system prompt. Used when --use-system-prompt is custom. "),
     )
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -226,6 +226,9 @@ def parse_args() -> argparse.Namespace:
         default=1,
         help="Number of HSDP replica groups.",
     )
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/examples/offline_inference/vace/vace_video_generation.py
+++ b/examples/offline_inference/vace/vace_video_generation.py
@@ -71,6 +71,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--ulysses-degree", type=int, default=1, help="Ulysses SP degree.")
     parser.add_argument("--ring-degree", type=int, default=1, help="Ring attention degree.")
     parser.add_argument("--cfg-parallel-size", type=int, default=1, choices=[1, 2], help="CFG parallel size.")
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    nullify_stage_engine_defaults(parser)
     return parser.parse_args()
 
 

--- a/tests/engine/test_single_stage_mode.py
+++ b/tests/engine/test_single_stage_mode.py
@@ -422,6 +422,39 @@ class TestSingleStageModeDetection:
         )
         assert engine._single_stage_id_filter is None
 
+    def test_engine_args_create_only_forwards_explicit_fields(self, mocker: MockerFixture):
+        from vllm_omni.engine.arg_utils import OmniEngineArgs
+
+        captured: dict[str, Any] = {}
+
+        def fake_resolve(self, model: str, kwargs: dict[str, Any]):
+            captured.update(kwargs)
+            return "/fake/path", [_make_stage_cfg(0)]
+
+        mocker.patch.object(AsyncOmniEngine, "_resolve_stage_configs", fake_resolve)
+        mocker.patch.object(AsyncOmniEngine, "_bootstrap_orchestrator")
+        mock_thread_cls = mocker.patch("threading.Thread")
+        mock_future_cls = mocker.patch("concurrent.futures.Future")
+        mock_future = mocker.Mock()
+        mock_future.result.return_value = mocker.Mock()
+        mock_future_cls.return_value = mock_future
+        mock_thread = mocker.Mock()
+        mock_thread.is_alive.return_value = False
+        mock_thread_cls.return_value = mock_thread
+
+        ea = OmniEngineArgs.create(model="ignored", gpu_memory_utilization=0.5)
+        AsyncOmniEngine(model="fake-model", engine_args=ea)
+
+        assert captured["gpu_memory_utilization"] == 0.5
+        assert "model" not in captured
+        assert "max_num_seqs" not in captured
+
+    def test_bare_engine_args_rejected(self, mocker: MockerFixture):
+        from vllm_omni.engine.arg_utils import OmniEngineArgs
+
+        with pytest.raises(TypeError, match="OmniEngineArgs.create"):
+            self._make_engine_no_thread(mocker, engine_args=OmniEngineArgs(model="fake-model"))
+
     def test_master_address_and_port_stored(self, mocker: MockerFixture):
         engine = self._make_engine_no_thread(
             mocker,

--- a/tests/entrypoints/test_omni_entrypoints.py
+++ b/tests/entrypoints/test_omni_entrypoints.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import queue
 from collections.abc import Callable
 from types import SimpleNamespace
@@ -164,6 +165,31 @@ class FakeAsyncOmniEngine:
 def _patch_engine(monkeypatch: pytest.MonkeyPatch, engine: FakeAsyncOmniEngine) -> None:
     monkeypatch.setattr("vllm_omni.entrypoints.omni_base.AsyncOmniEngine", lambda *args, **kwargs: engine)
     monkeypatch.setattr("vllm_omni.entrypoints.omni_base.omni_snapshot_download", lambda model: model)
+
+
+def test_from_cli_args_only_nulls_untyped_override_fields(monkeypatch: pytest.MonkeyPatch):
+    from vllm_omni.entrypoints.omni import Omni
+
+    captured: dict[str, Any] = {}
+
+    def fake_engine(*args: Any, **kwargs: Any) -> FakeAsyncOmniEngine:
+        captured.update(kwargs)
+        return FakeAsyncOmniEngine()
+
+    monkeypatch.setattr("vllm_omni.entrypoints.omni_base.AsyncOmniEngine", fake_engine)
+    monkeypatch.setattr("vllm_omni.entrypoints.omni_base.omni_snapshot_download", lambda model: model)
+    monkeypatch.setattr("sys.argv", ["prog"])
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.9)
+    parser.add_argument("--hsdp-shard-size", type=int, default=-1)
+    args = parser.parse_args([])
+    args.model = "fake-model"
+
+    Omni.from_cli_args(args, parser=parser)
+
+    assert captured["gpu_memory_utilization"] is None
+    assert captured["hsdp_shard_size"] == -1
 
 
 def _make_base():

--- a/tests/test_arg_utils.py
+++ b/tests/test_arg_utils.py
@@ -356,88 +356,73 @@ def test_ambiguous_field_non_strict_routes_to_orchestrator(caplog):
 # Sentinel-default precedence invariants (#3035)
 
 
-def test_nullify_stage_engine_defaults_resets_inherited_defaults():
-    """After nullify, stage-level engine flags have ``default=None`` while
-    server-level flags keep their real defaults."""
-    import argparse
-
+def _build_full_serve_parser():
     from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    try:
+        from vllm.entrypoints.openai.cli_args import make_arg_parser
+    except ImportError:
+        pytest.skip("vllm parser not importable")
+    return make_arg_parser(FlexibleArgumentParser())
+
+
+def test_nullify_stage_engine_defaults_resets_inherited_defaults():
+    import argparse
 
     from vllm_omni.engine.arg_utils import (
         derive_server_dests_from_vllm_parser,
         nullify_stage_engine_defaults,
     )
 
-    try:
-        from vllm.entrypoints.openai.cli_args import make_arg_parser
-    except ImportError:
-        pytest.skip("vllm parser not importable")
-
-    parser = make_arg_parser(FlexibleArgumentParser())
+    parser = _build_full_serve_parser()
     nullify_stage_engine_defaults(parser)
 
     server_dests = derive_server_dests_from_vllm_parser()
-    offenders: list[tuple[str, object]] = []
-    for action in parser._actions:
-        if action.dest in ("help", "version") or not action.option_strings:
-            continue
-        if action.dest in server_dests:
-            continue
-        if action.dest in {f.name for f in fields(_FakeEngineArgs)}:
-            # Engine-level — must be None after nullify.
-            if action.default is not None and action.default is not argparse.SUPPRESS:
-                offenders.append((action.dest, action.default))
-
-    assert not offenders, (
-        f"Stage-level engine flags with non-None defaults after nullify: "
-        f"{offenders}. nullify_stage_engine_defaults should have reset them."
-    )
+    engine_dests = {f.name for f in fields(_FakeEngineArgs)}
+    offenders = [
+        (a.dest, a.default)
+        for a in parser._actions
+        if a.dest not in ("help", "version")
+        and a.option_strings
+        and a.dest not in server_dests
+        and a.dest in engine_dests
+        and a.default is not None
+        and a.default is not argparse.SUPPRESS
+    ]
+    assert not offenders, f"Stage flags with non-None defaults after nullify: {offenders}"
 
 
 def test_server_flags_keep_real_defaults_after_nullify():
-    """Server-level flags (host, port, etc.) must keep their real defaults
-    so uvicorn/FastAPI start cleanly."""
     import argparse
-
-    from vllm.utils.argparse_utils import FlexibleArgumentParser
 
     from vllm_omni.engine.arg_utils import (
         derive_server_dests_from_vllm_parser,
         nullify_stage_engine_defaults,
     )
 
-    try:
-        from vllm.entrypoints.openai.cli_args import make_arg_parser
-    except ImportError:
-        pytest.skip("vllm parser not importable")
-
-    parser = make_arg_parser(FlexibleArgumentParser())
+    parser = _build_full_serve_parser()
     nullify_stage_engine_defaults(parser)
 
     server_dests = derive_server_dests_from_vllm_parser()
     if not server_dests:
         pytest.skip("server dest derivation returned empty set")
 
-    # At least one server-level dest should have a non-None default still.
-    server_actions_with_defaults = [
+    kept = [
         a
         for a in parser._actions
         if a.dest in server_dests and a.default is not None and a.default is not argparse.SUPPRESS
     ]
-    assert server_actions_with_defaults, "All server-level flags lost their defaults — nullify is over-reaching."
+    assert kept, "Server flags lost their defaults — nullify over-reach"
 
 
 def test_help_text_preserves_default_after_nullify():
-    """Real defaults stay visible in --help text via ``(default: X)`` suffix
-    even though parser stores None."""
+    # Real defaults must stay visible in --help even though parser stores None.
     import argparse
 
     from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--example-flag", type=int, default=42, help="Example knob.")
-
-    # Use a dummy "engine" by leaving server dests empty.
     nullify_stage_engine_defaults(parser)
 
     action = next(a for a in parser._actions if a.dest == "example_flag")
@@ -445,18 +430,8 @@ def test_help_text_preserves_default_after_nullify():
     assert "(default: 42)" in action.help
 
 
-def test_omniengineargs_user_input_fields_default_to_none():
-    """User-input fields default to None so ``OmniEngineArgs.create()`` can
-    distinguish set from unset. Internal flags are exempt."""
-    try:
-        from vllm_omni.engine.arg_utils import OmniEngineArgs
-    except Exception as exc:
-        pytest.skip(f"OmniEngineArgs not importable: {exc}")
-
-    INTERNAL = {"omni", "has_sampling_extra_args", "stage_id"}
-    # default_factory fields (e.g. dict) and inherited EngineArgs fields
-    # are out of scope for this invariant.
-    OWN_FIELDS = {
+_OMNIENGINEARGS_USER_INPUT_FIELDS = frozenset(
+    {
         "model_stage",
         "model_arch",
         "engine_output_type",
@@ -477,23 +452,26 @@ def test_omniengineargs_user_input_fields_default_to_none():
         "log_stats",
         "custom_pipeline_args",
     }
-
-    offenders: list[tuple[str, object]] = []
-    for f in fields(OmniEngineArgs):
-        if f.name not in OWN_FIELDS:
-            continue
-        if f.default is not dataclasses.MISSING and f.default is not None:
-            offenders.append((f.name, f.default))
-
-    assert not offenders, (
-        f"OmniEngineArgs fields with non-None defaults: {offenders}. "
-        f"User-input fields must default to None for explicit-vs-unset tracking."
-    )
+)
 
 
-def test_omniengineargs_create_factory_tracks_explicit_fields():
-    """``OmniEngineArgs.create(**explicit)`` records which fields the caller
-    set in ``_explicit_fields``; ``explicit_kwargs()`` returns only those."""
+def test_omniengineargs_user_input_fields_default_to_none():
+    try:
+        from vllm_omni.engine.arg_utils import OmniEngineArgs
+    except Exception as exc:
+        pytest.skip(f"OmniEngineArgs not importable: {exc}")
+
+    offenders = [
+        (f.name, f.default)
+        for f in fields(OmniEngineArgs)
+        if f.name in _OMNIENGINEARGS_USER_INPUT_FIELDS
+        and f.default is not dataclasses.MISSING
+        and f.default is not None
+    ]
+    assert not offenders, f"User-input fields with non-None defaults: {offenders}"
+
+
+def test_omniengineargs_create_tracks_explicit_fields():
     try:
         from vllm_omni.engine.arg_utils import OmniEngineArgs
     except Exception as exc:
@@ -501,26 +479,18 @@ def test_omniengineargs_create_factory_tracks_explicit_fields():
 
     ea = OmniEngineArgs.create(model="x", gpu_memory_utilization=0.5)
     assert ea._explicit_fields == frozenset({"model", "gpu_memory_utilization"})
-    explicit = ea.explicit_kwargs()
-    assert explicit == {"model": "x", "gpu_memory_utilization": 0.5}
+    assert ea.explicit_kwargs() == {"model": "x", "gpu_memory_utilization": 0.5}
 
 
-def test_omniengineargs_bare_constructor_warns_when_passed_to_omnibase():
-    """Bare ``OmniEngineArgs(...)`` cannot distinguish caller-set from
-    dataclass-default. Passing such an instance via ``engine_args=`` triggers
-    a DeprecationWarning."""
+def test_omniengineargs_bare_constructor_has_no_explicit_tracking():
     try:
         from vllm_omni.engine.arg_utils import OmniEngineArgs
     except Exception as exc:
         pytest.skip(f"OmniEngineArgs not importable: {exc}")
 
     ea = OmniEngineArgs(model="x")
-    # Bare constructor doesn't set _explicit_fields
     assert not hasattr(ea, "_explicit_fields")
-
-    # explicit_kwargs() falls back to all-non-None for legacy
-    explicit = ea.explicit_kwargs()
-    assert "model" in explicit
+    assert "model" in ea.explicit_kwargs()
 
 
 # dataclasses already imported via ``from dataclasses import dataclass, fields``

--- a/tests/test_arg_utils.py
+++ b/tests/test_arg_utils.py
@@ -353,9 +353,7 @@ def test_ambiguous_field_non_strict_routes_to_orchestrator(caplog):
     assert any("both OrchestratorArgs" in r.message for r in caplog.records)
 
 
-# ============================================================================
-# RFC #3035 — sentinel-default precedence invariants
-# ============================================================================
+# Sentinel-default precedence invariants (#3035)
 
 
 def test_nullify_stage_engine_defaults_resets_inherited_defaults():
@@ -448,10 +446,8 @@ def test_help_text_preserves_default_after_nullify():
 
 
 def test_omniengineargs_user_input_fields_default_to_none():
-    """RFC #3035: user-input fields on ``OmniEngineArgs`` default to ``None``
-    so callers using ``OmniEngineArgs.create(**explicit)`` can distinguish
-    set from unset. Internal flags (``omni``, ``has_sampling_extra_args``)
-    are exempt — they're not user-facing config."""
+    """User-input fields default to None so ``OmniEngineArgs.create()`` can
+    distinguish set from unset. Internal flags are exempt."""
     try:
         from vllm_omni.engine.arg_utils import OmniEngineArgs
     except Exception as exc:
@@ -491,8 +487,7 @@ def test_omniengineargs_user_input_fields_default_to_none():
 
     assert not offenders, (
         f"OmniEngineArgs fields with non-None defaults: {offenders}. "
-        f"User-input fields must default to None per RFC #3035 so "
-        f"OmniEngineArgs.create() can track explicit-vs-unset."
+        f"User-input fields must default to None for explicit-vs-unset tracking."
     )
 
 

--- a/tests/test_arg_utils.py
+++ b/tests/test_arg_utils.py
@@ -351,3 +351,97 @@ def test_ambiguous_field_non_strict_routes_to_orchestrator(caplog):
     assert orch.deploy_config == "x"
     assert "deploy_config" not in engine
     assert any("both OrchestratorArgs" in r.message for r in caplog.records)
+
+
+# ============================================================================
+# RFC #3035 — sentinel-default precedence invariants
+# ============================================================================
+
+
+def test_nullify_stage_engine_defaults_resets_inherited_defaults():
+    """After nullify, stage-level engine flags have ``default=None`` while
+    server-level flags keep their real defaults."""
+    import argparse
+
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    from vllm_omni.engine.arg_utils import (
+        derive_server_dests_from_vllm_parser,
+        nullify_stage_engine_defaults,
+    )
+
+    try:
+        from vllm.entrypoints.openai.cli_args import make_arg_parser
+    except ImportError:
+        pytest.skip("vllm parser not importable")
+
+    parser = make_arg_parser(FlexibleArgumentParser())
+    nullify_stage_engine_defaults(parser)
+
+    server_dests = derive_server_dests_from_vllm_parser()
+    offenders: list[tuple[str, object]] = []
+    for action in parser._actions:
+        if action.dest in ("help", "version") or not action.option_strings:
+            continue
+        if action.dest in server_dests:
+            continue
+        if action.dest in {f.name for f in fields(_FakeEngineArgs)}:
+            # Engine-level — must be None after nullify.
+            if action.default is not None and action.default is not argparse.SUPPRESS:
+                offenders.append((action.dest, action.default))
+
+    assert not offenders, (
+        f"Stage-level engine flags with non-None defaults after nullify: "
+        f"{offenders}. nullify_stage_engine_defaults should have reset them."
+    )
+
+
+def test_server_flags_keep_real_defaults_after_nullify():
+    """Server-level flags (host, port, etc.) must keep their real defaults
+    so uvicorn/FastAPI start cleanly."""
+    import argparse
+
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+    from vllm_omni.engine.arg_utils import (
+        derive_server_dests_from_vllm_parser,
+        nullify_stage_engine_defaults,
+    )
+
+    try:
+        from vllm.entrypoints.openai.cli_args import make_arg_parser
+    except ImportError:
+        pytest.skip("vllm parser not importable")
+
+    parser = make_arg_parser(FlexibleArgumentParser())
+    nullify_stage_engine_defaults(parser)
+
+    server_dests = derive_server_dests_from_vllm_parser()
+    if not server_dests:
+        pytest.skip("server dest derivation returned empty set")
+
+    # At least one server-level dest should have a non-None default still.
+    server_actions_with_defaults = [
+        a
+        for a in parser._actions
+        if a.dest in server_dests and a.default is not None and a.default is not argparse.SUPPRESS
+    ]
+    assert server_actions_with_defaults, "All server-level flags lost their defaults — nullify is over-reaching."
+
+
+def test_help_text_preserves_default_after_nullify():
+    """Real defaults stay visible in --help text via ``(default: X)`` suffix
+    even though parser stores None."""
+    import argparse
+
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--example-flag", type=int, default=42, help="Example knob.")
+
+    # Use a dummy "engine" by leaving server dests empty.
+    nullify_stage_engine_defaults(parser)
+
+    action = next(a for a in parser._actions if a.dest == "example_flag")
+    assert action.default is None
+    assert "(default: 42)" in action.help

--- a/tests/test_arg_utils.py
+++ b/tests/test_arg_utils.py
@@ -445,3 +445,88 @@ def test_help_text_preserves_default_after_nullify():
     action = next(a for a in parser._actions if a.dest == "example_flag")
     assert action.default is None
     assert "(default: 42)" in action.help
+
+
+def test_omniengineargs_user_input_fields_default_to_none():
+    """RFC #3035: user-input fields on ``OmniEngineArgs`` default to ``None``
+    so callers using ``OmniEngineArgs.create(**explicit)`` can distinguish
+    set from unset. Internal flags (``omni``, ``has_sampling_extra_args``)
+    are exempt — they're not user-facing config."""
+    try:
+        from vllm_omni.engine.arg_utils import OmniEngineArgs
+    except Exception as exc:
+        pytest.skip(f"OmniEngineArgs not importable: {exc}")
+
+    INTERNAL = {"omni", "has_sampling_extra_args", "stage_id"}
+    # default_factory fields (e.g. dict) and inherited EngineArgs fields
+    # are out of scope for this invariant.
+    OWN_FIELDS = {
+        "model_stage",
+        "model_arch",
+        "engine_output_type",
+        "hf_config_name",
+        "custom_process_next_stage_input_func",
+        "subtalker_sampling_params",
+        "async_chunk",
+        "omni_kv_config",
+        "quantization_config",
+        "worker_type",
+        "task_type",
+        "worker_cls",
+        "enable_sleep_mode",
+        "omni_master_address",
+        "omni_master_port",
+        "stage_configs_path",
+        "output_modalities",
+        "log_stats",
+        "custom_pipeline_args",
+    }
+
+    offenders: list[tuple[str, object]] = []
+    for f in fields(OmniEngineArgs):
+        if f.name not in OWN_FIELDS:
+            continue
+        if f.default is not dataclasses.MISSING and f.default is not None:
+            offenders.append((f.name, f.default))
+
+    assert not offenders, (
+        f"OmniEngineArgs fields with non-None defaults: {offenders}. "
+        f"User-input fields must default to None per RFC #3035 so "
+        f"OmniEngineArgs.create() can track explicit-vs-unset."
+    )
+
+
+def test_omniengineargs_create_factory_tracks_explicit_fields():
+    """``OmniEngineArgs.create(**explicit)`` records which fields the caller
+    set in ``_explicit_fields``; ``explicit_kwargs()`` returns only those."""
+    try:
+        from vllm_omni.engine.arg_utils import OmniEngineArgs
+    except Exception as exc:
+        pytest.skip(f"OmniEngineArgs not importable: {exc}")
+
+    ea = OmniEngineArgs.create(model="x", gpu_memory_utilization=0.5)
+    assert ea._explicit_fields == frozenset({"model", "gpu_memory_utilization"})
+    explicit = ea.explicit_kwargs()
+    assert explicit == {"model": "x", "gpu_memory_utilization": 0.5}
+
+
+def test_omniengineargs_bare_constructor_warns_when_passed_to_omnibase():
+    """Bare ``OmniEngineArgs(...)`` cannot distinguish caller-set from
+    dataclass-default. Passing such an instance via ``engine_args=`` triggers
+    a DeprecationWarning."""
+    try:
+        from vllm_omni.engine.arg_utils import OmniEngineArgs
+    except Exception as exc:
+        pytest.skip(f"OmniEngineArgs not importable: {exc}")
+
+    ea = OmniEngineArgs(model="x")
+    # Bare constructor doesn't set _explicit_fields
+    assert not hasattr(ea, "_explicit_fields")
+
+    # explicit_kwargs() falls back to all-non-None for legacy
+    explicit = ea.explicit_kwargs()
+    assert "model" in explicit
+
+
+# dataclasses already imported via ``from dataclasses import dataclass, fields``
+import dataclasses  # noqa: E402  -- needed for MISSING sentinel above

--- a/tests/test_arg_utils.py
+++ b/tests/test_arg_utils.py
@@ -370,49 +370,40 @@ def test_nullify_stage_engine_defaults_resets_inherited_defaults():
     import argparse
 
     from vllm_omni.engine.arg_utils import (
-        derive_server_dests_from_vllm_parser,
+        deploy_override_field_names,
         nullify_stage_engine_defaults,
     )
 
     parser = _build_full_serve_parser()
     nullify_stage_engine_defaults(parser)
 
-    server_dests = derive_server_dests_from_vllm_parser()
-    engine_dests = {f.name for f in fields(_FakeEngineArgs)}
+    override_dests = deploy_override_field_names()
     offenders = [
         (a.dest, a.default)
         for a in parser._actions
         if a.dest not in ("help", "version")
         and a.option_strings
-        and a.dest not in server_dests
-        and a.dest in engine_dests
+        and a.dest in override_dests
         and a.default is not None
         and a.default is not argparse.SUPPRESS
     ]
     assert not offenders, f"Stage flags with non-None defaults after nullify: {offenders}"
 
 
-def test_server_flags_keep_real_defaults_after_nullify():
+def test_non_override_flags_keep_real_defaults_after_nullify():
     import argparse
 
-    from vllm_omni.engine.arg_utils import (
-        derive_server_dests_from_vllm_parser,
-        nullify_stage_engine_defaults,
-    )
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
 
-    parser = _build_full_serve_parser()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hsdp-shard-size", type=int, default=-1, help="HSDP shard size.")
+    parser.add_argument("--max-num-seqs", type=int, default=64, help="Max num seqs.")
     nullify_stage_engine_defaults(parser)
 
-    server_dests = derive_server_dests_from_vllm_parser()
-    if not server_dests:
-        pytest.skip("server dest derivation returned empty set")
-
-    kept = [
-        a
-        for a in parser._actions
-        if a.dest in server_dests and a.default is not None and a.default is not argparse.SUPPRESS
-    ]
-    assert kept, "Server flags lost their defaults — nullify over-reach"
+    hsdp = next(a for a in parser._actions if a.dest == "hsdp_shard_size")
+    max_num_seqs = next(a for a in parser._actions if a.dest == "max_num_seqs")
+    assert hsdp.default == -1
+    assert max_num_seqs.default is None
 
 
 def test_help_text_preserves_default_after_nullify():
@@ -422,10 +413,10 @@ def test_help_text_preserves_default_after_nullify():
     from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--example-flag", type=int, default=42, help="Example knob.")
+    parser.add_argument("--max-num-seqs", type=int, default=42, help="Example knob.")
     nullify_stage_engine_defaults(parser)
 
-    action = next(a for a in parser._actions if a.dest == "example_flag")
+    action = next(a for a in parser._actions if a.dest == "max_num_seqs")
     assert action.default is None
     assert "(default: 42)" in action.help
 

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -4,6 +4,7 @@
 Unit tests for StageConfigFactory and related classes.
 """
 
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -1196,98 +1197,109 @@ class TestCLIOverrideFlow:
             assert s.runtime_overrides["enforce_eager"] is True
 
 
-class TestCLIExplicitPrecedence:
-    """Verify YAML > argparse defaults; explicit CLI args > YAML."""
+class TestSentinelDefaultPrecedence:
+    """RFC #3035: parser nullifies un-typed flags → merge layer's None-guard
+    is the entire precedence rule. Caller-typed (non-None) values win over
+    YAML; None values fall through to YAML / dataclass defaults."""
 
-    def _stages(self, cli_overrides, cli_explicit_keys):
+    def _stages(self, cli_overrides):
         import vllm_omni.model_executor.models.qwen3_omni.pipeline  # noqa: F401
 
         return StageConfigFactory._create_from_registry(
             "qwen3_omni_moe",
             cli_overrides=cli_overrides,
-            cli_explicit_keys=cli_explicit_keys,
         )
 
-    def test_explicit_cli_overrides_yaml(self):
-        """User-typed --max-num-seqs wins over the deploy YAML value."""
-        stages = self._stages(
-            cli_overrides={"max_num_seqs": 999},
-            cli_explicit_keys={"max_num_seqs"},
-        )
-        # Stage 2 yaml has max_num_seqs=1; explicit CLI must beat it.
+    def test_typed_kwarg_overrides_yaml(self):
+        """A non-None caller value wins over the deploy YAML."""
+        stages = self._stages({"max_num_seqs": 999})
+        # Stage 2 yaml has max_num_seqs=1; caller value must beat it.
         assert stages[2].runtime_overrides.get("max_num_seqs") == 999
 
-    def test_default_cli_does_not_override_yaml(self):
-        """Argparse defaults must NOT clobber values that are present in YAML."""
-        stages = self._stages(
-            cli_overrides={"max_num_seqs": 256},
-            cli_explicit_keys=set(),  # user typed nothing
-        )
-        # Stage 2's YAML value (1) should win because the user didn't type --max-num-seqs.
-        assert stages[2].runtime_overrides.get("max_num_seqs") != 256
+    def test_none_value_skipped_yaml_wins(self):
+        """A None value (un-typed flag, post-nullification) falls through to YAML."""
+        stages = self._stages({"max_num_seqs": None})
+        # YAML's value (1 for stage 2) must survive.
+        assert stages[2].runtime_overrides.get("max_num_seqs") is None
+        assert stages[2].yaml_engine_args.get("max_num_seqs") == 1
 
-    def test_default_cli_fills_missing_yaml_field(self):
-        """Argparse defaults still fill fields the YAML doesn't set."""
-        stages = self._stages(
-            cli_overrides={"some_unrelated_knob": "fallback"},
-            cli_explicit_keys=set(),
-        )
-        # Field absent from YAML → CLI default flows through as a fallback.
-        assert stages[0].runtime_overrides.get("some_unrelated_knob") == "fallback"
+    def test_empty_kwargs_yaml_only(self):
+        """No caller overrides → YAML wins for declared keys."""
+        stages = self._stages({})
+        for stage in stages:
+            assert stage.runtime_overrides == {}
 
-    def test_per_stage_overrides_always_explicit(self):
-        """``stage_<id>_*`` keys are always treated as explicit."""
-        stages = self._stages(
-            cli_overrides={"stage_0_gpu_memory_utilization": 0.42},
-            cli_explicit_keys=set(),  # not in the explicit set, but per-stage
-        )
+    def test_typed_kwarg_equal_to_dataclass_default_still_overrides(self):
+        """Caller intent is honored regardless of value coincidence — no
+        dataclass-default heuristic. (Row 3 of the #3035 precedence table.)"""
+        # gpu_memory_utilization yaml=0.1 for stage 2; caller types 0.9
+        # (which equals dataclass default) — still wins over yaml.
+        stages = self._stages({"gpu_memory_utilization": 0.9})
+        assert stages[2].runtime_overrides.get("gpu_memory_utilization") == 0.9
+
+    def test_per_stage_kwarg_routed_to_correct_stage(self):
+        """``stage_N_*`` prefix routes to stage N only."""
+        stages = self._stages({"stage_0_gpu_memory_utilization": 0.42})
         assert stages[0].runtime_overrides.get("gpu_memory_utilization") == 0.42
+        # Other stages keep their YAML value.
+        assert stages[2].runtime_overrides.get("gpu_memory_utilization") is None
 
-    def test_none_explicit_set_treats_all_as_explicit(self):
-        """Programmatic Omni() callers (cli_explicit_keys=None) keep current behavior."""
-        stages = self._stages(
-            cli_overrides={"max_num_seqs": 999},
-            cli_explicit_keys=None,
-        )
-        assert stages[2].runtime_overrides.get("max_num_seqs") == 999
-
-    def test_explicit_async_chunk_false_overrides_yaml(self):
-        """``--no-async-chunk`` flips the deploy-level async_chunk to False even
-        when the YAML sets it to True. Verifies that the per-stage
-        ``async_chunk: True`` injection in ``merge_pipeline_deploy`` is skipped
-        and that ``async_chunk`` does not leak through ``_merge_cli_overrides``.
-        """
-        stages = self._stages(
-            cli_overrides={"async_chunk": False},
-            cli_explicit_keys={"async_chunk"},
-        )
-        # qwen3_omni_moe.yaml has `async_chunk: true`, so by default every
-        # stage's engine_args would carry it. With the explicit override, it
-        # must NOT show up.
+    def test_async_chunk_false_overrides_yaml_true(self):
+        """``--no-async-chunk`` (caller=False) flips deploy.async_chunk regardless
+        of the YAML default. None means caller didn't type."""
+        stages = self._stages({"async_chunk": False})
         for stage in stages:
             assert stage.yaml_engine_args.get("async_chunk") is not True
-            assert stage.runtime_overrides.get("async_chunk") is None
 
-    def test_default_async_chunk_leaves_yaml_alone(self):
-        """An unset ``--async-chunk`` (default None) must leave the YAML's True
-        in force on every stage."""
-        stages = self._stages(
-            cli_overrides={"async_chunk": None},
-            cli_explicit_keys=set(),
-        )
-        # qwen3_omni_moe.yaml: `async_chunk: true` → injected on every stage.
+    def test_async_chunk_none_keeps_yaml_true(self):
+        """Un-typed --async-chunk arrives as None → YAML's true survives."""
+        stages = self._stages({"async_chunk": None})
         for stage in stages:
             assert stage.yaml_engine_args.get("async_chunk") is True
 
-    def test_explicit_enable_prefix_caching_overrides_yaml(self):
-        """``--enable-prefix-caching`` (global) flips every stage's
-        ``enable_prefix_caching`` to True regardless of the YAML default."""
-        stages = self._stages(
-            cli_overrides={"enable_prefix_caching": True},
-            cli_explicit_keys={"enable_prefix_caching"},
-        )
+    def test_enable_prefix_caching_typed_overrides_yaml(self):
+        """``--enable-prefix-caching`` (caller=True) reaches every stage."""
+        stages = self._stages({"enable_prefix_caching": True})
         for stage in stages:
             assert stage.runtime_overrides.get("enable_prefix_caching") is True
+
+    def test_omni_with_vars_args_anti_pattern_is_safe(self):
+        """``Omni(**vars(args))`` with mostly-None namespace (post-nullification)
+        must not clobber YAML. The anti-pattern works because of the None-guard."""
+        simulated_vars_args = {
+            "gpu_memory_utilization": None,
+            "max_num_seqs": None,
+            "async_chunk": None,
+            "enable_prefix_caching": None,
+            "dtype": None,
+        }
+        stages = self._stages(simulated_vars_args)
+        for stage in stages:
+            assert stage.runtime_overrides == {}
+
+    def test_create_from_registry_no_cli_explicit_keys_param(self):
+        """RFC #3035: cli_explicit_keys parameter must be removed (or accepted-
+        and-deprecated). Catches accidental re-introduction."""
+        import inspect
+
+        sig = inspect.signature(StageConfigFactory._create_from_registry)
+        # Either fully removed, or only present as **deprecated_kwargs.
+        named = [p for p in sig.parameters.values() if p.kind != p.VAR_KEYWORD]
+        named_names = {p.name for p in named}
+        assert "cli_explicit_keys" not in named_names
+
+    def test_cli_explicit_keys_kwarg_emits_deprecation(self):
+        """Pre-RFC callers passing ``cli_explicit_keys=`` get a DeprecationWarning."""
+        import vllm_omni.model_executor.models.qwen3_omni.pipeline  # noqa: F401
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            StageConfigFactory._create_from_registry(
+                "qwen3_omni_moe",
+                cli_overrides={},
+                cli_explicit_keys={"max_num_seqs"},
+            )
+            assert any(issubclass(x.category, DeprecationWarning) for x in w)
 
     def test_async_chunk_dispatches_processors(self):
         """A single ``qwen3_tts`` pipeline picks per-chunk vs end-to-end

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -1198,9 +1198,8 @@ class TestCLIOverrideFlow:
 
 
 class TestSentinelDefaultPrecedence:
-    """RFC #3035: parser nullifies un-typed flags → merge layer's None-guard
-    is the entire precedence rule. Caller-typed (non-None) values win over
-    YAML; None values fall through to YAML / dataclass defaults."""
+    """Caller-typed (non-None) values win over YAML; None values fall through
+    to YAML / dataclass defaults (#3035)."""
 
     def _stages(self, cli_overrides):
         import vllm_omni.model_executor.models.qwen3_omni.pipeline  # noqa: F401
@@ -1211,61 +1210,46 @@ class TestSentinelDefaultPrecedence:
         )
 
     def test_typed_kwarg_overrides_yaml(self):
-        """A non-None caller value wins over the deploy YAML."""
         stages = self._stages({"max_num_seqs": 999})
-        # Stage 2 yaml has max_num_seqs=1; caller value must beat it.
         assert stages[2].runtime_overrides.get("max_num_seqs") == 999
 
     def test_none_value_skipped_yaml_wins(self):
-        """A None value (un-typed flag, post-nullification) falls through to YAML."""
         stages = self._stages({"max_num_seqs": None})
-        # YAML's value (1 for stage 2) must survive.
         assert stages[2].runtime_overrides.get("max_num_seqs") is None
         assert stages[2].yaml_engine_args.get("max_num_seqs") == 1
 
     def test_empty_kwargs_yaml_only(self):
-        """No caller overrides → YAML wins for declared keys."""
         stages = self._stages({})
         for stage in stages:
             assert stage.runtime_overrides == {}
 
     def test_typed_kwarg_equal_to_dataclass_default_still_overrides(self):
-        """Caller intent is honored regardless of value coincidence — no
-        dataclass-default heuristic. (Row 3 of the #3035 precedence table.)"""
-        # gpu_memory_utilization yaml=0.1 for stage 2; caller types 0.9
-        # (which equals dataclass default) — still wins over yaml.
+        # Caller intent honored regardless of value coincidence (no heuristic).
         stages = self._stages({"gpu_memory_utilization": 0.9})
         assert stages[2].runtime_overrides.get("gpu_memory_utilization") == 0.9
 
     def test_per_stage_kwarg_routed_to_correct_stage(self):
-        """``stage_N_*`` prefix routes to stage N only."""
         stages = self._stages({"stage_0_gpu_memory_utilization": 0.42})
         assert stages[0].runtime_overrides.get("gpu_memory_utilization") == 0.42
-        # Other stages keep their YAML value.
         assert stages[2].runtime_overrides.get("gpu_memory_utilization") is None
 
     def test_async_chunk_false_overrides_yaml_true(self):
-        """``--no-async-chunk`` (caller=False) flips deploy.async_chunk regardless
-        of the YAML default. None means caller didn't type."""
         stages = self._stages({"async_chunk": False})
         for stage in stages:
             assert stage.yaml_engine_args.get("async_chunk") is not True
 
     def test_async_chunk_none_keeps_yaml_true(self):
-        """Un-typed --async-chunk arrives as None → YAML's true survives."""
         stages = self._stages({"async_chunk": None})
         for stage in stages:
             assert stage.yaml_engine_args.get("async_chunk") is True
 
     def test_enable_prefix_caching_typed_overrides_yaml(self):
-        """``--enable-prefix-caching`` (caller=True) reaches every stage."""
         stages = self._stages({"enable_prefix_caching": True})
         for stage in stages:
             assert stage.runtime_overrides.get("enable_prefix_caching") is True
 
     def test_omni_with_vars_args_anti_pattern_is_safe(self):
-        """``Omni(**vars(args))`` with mostly-None namespace (post-nullification)
-        must not clobber YAML. The anti-pattern works because of the None-guard."""
+        # Omni(**vars(args)) with mostly-None namespace must not clobber YAML.
         simulated_vars_args = {
             "gpu_memory_utilization": None,
             "max_num_seqs": None,
@@ -1278,18 +1262,13 @@ class TestSentinelDefaultPrecedence:
             assert stage.runtime_overrides == {}
 
     def test_create_from_registry_no_cli_explicit_keys_param(self):
-        """RFC #3035: cli_explicit_keys parameter must be removed (or accepted-
-        and-deprecated). Catches accidental re-introduction."""
         import inspect
 
         sig = inspect.signature(StageConfigFactory._create_from_registry)
-        # Either fully removed, or only present as **deprecated_kwargs.
         named = [p for p in sig.parameters.values() if p.kind != p.VAR_KEYWORD]
-        named_names = {p.name for p in named}
-        assert "cli_explicit_keys" not in named_names
+        assert "cli_explicit_keys" not in {p.name for p in named}
 
     def test_cli_explicit_keys_kwarg_emits_deprecation(self):
-        """Pre-RFC callers passing ``cli_explicit_keys=`` get a DeprecationWarning."""
         import vllm_omni.model_executor.models.qwen3_omni.pipeline  # noqa: F401
 
         with warnings.catch_warnings(record=True) as w:

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -996,17 +996,26 @@ class StageConfigFactory:
         model: str,
         cli_overrides: dict[str, Any] | None = None,
         deploy_config_path: str | None = None,
-        cli_explicit_keys: set[str] | None = None,
+        **deprecated_kwargs: Any,
     ) -> list[StageConfig] | None:
         """Load pipeline + deploy config, merge with CLI overrides.
 
         Checks _PIPELINE_REGISTRY first (new path), falls back to legacy YAML.
 
-        ``cli_explicit_keys`` is the set of CLI keys the user actually typed
-        (captured at the parser layer in ``vllm serve``). When ``None`` —
-        which is the case for programmatic ``Omni()`` callers — every kwarg
-        in ``cli_overrides`` is treated as explicit.
+        Per RFC #3035, the CLI/parser layer nullifies un-typed flags so the
+        merge layer's ``if value is None: continue`` guard is the entire
+        precedence rule. Pre-RFC callers passed a ``cli_explicit_keys=`` set
+        explicitly; that parameter is now accepted-and-ignored for one
+        version with a ``DeprecationWarning``.
         """
+        if "cli_explicit_keys" in deprecated_kwargs:
+            warnings.warn(
+                "cli_explicit_keys= is deprecated and ignored — RFC #3035 "
+                "moved precedence to the parser layer. Remove the kwarg.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if cli_overrides is None:
             cli_overrides = {}
 
@@ -1015,7 +1024,7 @@ class StageConfigFactory:
         # --- New path: check pipeline registry by model_type first ---
         model_type, hf_config = cls._auto_detect_model_type(model, trust_remote_code=trust_remote_code)
         if model_type and model_type in _PIPELINE_REGISTRY:
-            return cls._create_from_registry(model_type, cli_overrides, deploy_config_path, cli_explicit_keys)
+            return cls._create_from_registry(model_type, cli_overrides, deploy_config_path)
 
         # --- HF architecture fallback: some models report a generic
         # model_type that collides with another model. Match by the
@@ -1025,9 +1034,7 @@ class StageConfigFactory:
             if hf_archs:
                 for registered in _PIPELINE_REGISTRY.values():
                     if hf_archs.intersection(registered.hf_architectures):
-                        return cls._create_from_registry(
-                            registered.model_type, cli_overrides, deploy_config_path, cli_explicit_keys
-                        )
+                        return cls._create_from_registry(registered.model_type, cli_overrides, deploy_config_path)
 
         # --- Legacy path: load from pipeline YAML ---
         pipeline = cls._load_pipeline(model, trust_remote_code=trust_remote_code)
@@ -1063,20 +1070,30 @@ class StageConfigFactory:
         model_type: str,
         cli_overrides: dict[str, Any],
         deploy_config_path: str | None = None,
-        cli_explicit_keys: set[str] | None = None,
+        **deprecated_kwargs: Any,
     ) -> list[StageConfig]:
         """Create StageConfigs from pipeline registry + deploy YAML.
 
         Precedence (high → low):
-            explicit CLI args  >  deploy YAML  >  parser default CLI values
+            caller-typed value  >  deploy YAML  >  StageDeployConfig dataclass
 
-        ``cli_explicit_keys`` carries the set of long-option attribute names
-        the user actually typed (captured in ``OmniServeCommand.cmd``). Any
-        kwarg whose key is not in that set is treated as a parser default
-        and is only used to fill fields YAML doesn't already cover. When the
-        set is ``None`` (programmatic ``Omni()`` callers, which have no
-        argparse layer), every kwarg is treated as explicit.
+        Per RFC #3035, the CLI/parser layer nullifies un-typed flags before
+        kwargs reach this layer. Every key in ``cli_overrides`` with a
+        non-None value is treated as caller intent. Per-stage keys
+        (``stage_N_*``) are routed to their respective stage by
+        ``build_stage_runtime_overrides``.
+
+        ``cli_explicit_keys=`` is accepted-and-ignored for one version with
+        a ``DeprecationWarning``.
         """
+        if "cli_explicit_keys" in deprecated_kwargs:
+            warnings.warn(
+                "cli_explicit_keys= is deprecated and ignored — RFC #3035 "
+                "moved precedence to the parser layer. Remove the kwarg.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         # Resolve deploy config path
         if deploy_config_path is None:
             deploy_path = _DEPLOY_DIR / f"{model_type}.yaml"
@@ -1093,7 +1110,7 @@ class StageConfigFactory:
             deploy_cfg = load_deploy_config(deploy_path)
 
         cli_async_chunk = cli_overrides.get("async_chunk")
-        if cli_async_chunk is not None and (cli_explicit_keys is None or "async_chunk" in cli_explicit_keys):
+        if cli_async_chunk is not None:
             deploy_cfg.async_chunk = bool(cli_async_chunk)
 
         pipeline_key = deploy_cfg.pipeline or model_type
@@ -1107,25 +1124,14 @@ class StageConfigFactory:
 
         stages = merge_pipeline_deploy(pipeline_cfg, deploy_cfg, cli_overrides)
 
-        # Precedence: explicit CLI > yaml > parser-default CLI.
-        # Per-stage (``stage_N_*``) keys are always treated as explicit.
-        explicit_overrides: dict[str, Any] = {}
-        default_overrides: dict[str, Any] = {}
-        for key, value in cli_overrides.items():
-            if value is None:
-                continue
-            is_per_stage = bool(re.match(r"stage_\d+_", key))
-            is_explicit = cli_explicit_keys is None or key in cli_explicit_keys or is_per_stage
-            if is_explicit:
-                explicit_overrides[key] = value
-            else:
-                default_overrides[key] = value
+        # Single-rule precedence (RFC #3035): every kwarg with a non-None
+        # value wins over YAML for its key. Un-typed CLI flags arrive as
+        # None thanks to ``nullify_stage_engine_defaults`` and are filtered
+        # by the loop below.
+        explicit_overrides = {k: v for k, v in cli_overrides.items() if v is not None}
 
         for stage in stages:
-            yaml_keys = set(stage.yaml_engine_args)
-            fallback = {k: v for k, v in default_overrides.items() if k not in yaml_keys}
-            merged = {**fallback, **explicit_overrides}
-            stage.runtime_overrides = cls._merge_cli_overrides(stage, merged)
+            stage.runtime_overrides = cls._merge_cli_overrides(stage, explicit_overrides)
 
         return stages
 

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -28,6 +28,15 @@ def get_pipeline_path(model_dir: str, filename: str) -> Path:
 logger = init_logger(__name__)
 
 
+def _warn_deprecated_kwargs(kwargs: dict[str, Any]) -> None:
+    if "cli_explicit_keys" in kwargs:
+        warnings.warn(
+            "cli_explicit_keys= is deprecated and ignored. Remove the kwarg.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+
 _STAGE_OVERRIDE_PATTERN = re.compile(r"^stage_(\d+)_(.+)$")
 
 
@@ -1002,12 +1011,7 @@ class StageConfigFactory:
 
         Checks _PIPELINE_REGISTRY first (new path), falls back to legacy YAML.
         """
-        if "cli_explicit_keys" in deprecated_kwargs:
-            warnings.warn(
-                "cli_explicit_keys= is deprecated and ignored. Remove the kwarg.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        _warn_deprecated_kwargs(deprecated_kwargs)
 
         if cli_overrides is None:
             cli_overrides = {}
@@ -1070,12 +1074,7 @@ class StageConfigFactory:
         Precedence: caller-typed (non-None) value > deploy YAML >
         StageDeployConfig dataclass default.
         """
-        if "cli_explicit_keys" in deprecated_kwargs:
-            warnings.warn(
-                "cli_explicit_keys= is deprecated and ignored. Remove the kwarg.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        _warn_deprecated_kwargs(deprecated_kwargs)
 
         # Resolve deploy config path
         if deploy_config_path is None:

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -1001,17 +1001,10 @@ class StageConfigFactory:
         """Load pipeline + deploy config, merge with CLI overrides.
 
         Checks _PIPELINE_REGISTRY first (new path), falls back to legacy YAML.
-
-        Per RFC #3035, the CLI/parser layer nullifies un-typed flags so the
-        merge layer's ``if value is None: continue`` guard is the entire
-        precedence rule. Pre-RFC callers passed a ``cli_explicit_keys=`` set
-        explicitly; that parameter is now accepted-and-ignored for one
-        version with a ``DeprecationWarning``.
         """
         if "cli_explicit_keys" in deprecated_kwargs:
             warnings.warn(
-                "cli_explicit_keys= is deprecated and ignored — RFC #3035 "
-                "moved precedence to the parser layer. Remove the kwarg.",
+                "cli_explicit_keys= is deprecated and ignored. Remove the kwarg.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -1074,22 +1067,12 @@ class StageConfigFactory:
     ) -> list[StageConfig]:
         """Create StageConfigs from pipeline registry + deploy YAML.
 
-        Precedence (high → low):
-            caller-typed value  >  deploy YAML  >  StageDeployConfig dataclass
-
-        Per RFC #3035, the CLI/parser layer nullifies un-typed flags before
-        kwargs reach this layer. Every key in ``cli_overrides`` with a
-        non-None value is treated as caller intent. Per-stage keys
-        (``stage_N_*``) are routed to their respective stage by
-        ``build_stage_runtime_overrides``.
-
-        ``cli_explicit_keys=`` is accepted-and-ignored for one version with
-        a ``DeprecationWarning``.
+        Precedence: caller-typed (non-None) value > deploy YAML >
+        StageDeployConfig dataclass default.
         """
         if "cli_explicit_keys" in deprecated_kwargs:
             warnings.warn(
-                "cli_explicit_keys= is deprecated and ignored — RFC #3035 "
-                "moved precedence to the parser layer. Remove the kwarg.",
+                "cli_explicit_keys= is deprecated and ignored. Remove the kwarg.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -1124,10 +1107,6 @@ class StageConfigFactory:
 
         stages = merge_pipeline_deploy(pipeline_cfg, deploy_cfg, cli_overrides)
 
-        # Single-rule precedence (RFC #3035): every kwarg with a non-None
-        # value wins over YAML for its key. Un-typed CLI flags arrive as
-        # None thanks to ``nullify_stage_engine_defaults`` and are filtered
-        # by the loop below.
         explicit_overrides = {k: v for k, v in cli_overrides.items() if v is not None}
 
         for stage in stages:

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -743,8 +743,9 @@ def _build_engine_args(
                 continue
             engine_args[k] = v
         engine_args.update(ds.engine_extras)
-    if deploy.async_chunk:
-        engine_args["async_chunk"] = True
+    # Materialize the resolved pipeline-wide async_chunk value into every
+    # stage so explicit False overrides do not get lost downstream.
+    engine_args["async_chunk"] = bool(deploy.async_chunk)
     return engine_args
 
 
@@ -1043,14 +1044,14 @@ class StageConfigFactory:
         if errors:
             logger.warning(f"Pipeline validation warnings for {model}: {errors}")
 
-        # Inject pipeline-wide async_chunk into ALL stages' engine_args.
-        # The legacy loader (load_stage_configs_from_yaml) sets async_chunk
-        # on every stage so that build_engine_args_dict() can inject the
-        # stage_connector_spec.  AsyncOmniEngine.__init__ also reads it
-        # from stage_configs[0].engine_args.async_chunk.
-        if pipeline.async_chunk:
-            for stage in pipeline.stages:
-                stage.yaml_engine_args.setdefault("async_chunk", True)
+        # Materialize the resolved pipeline-wide async_chunk value into every
+        # stage so build_engine_args_dict() can inject the stage connector
+        # spec and explicit False overrides are preserved.
+        resolved_async_chunk = cli_overrides.get("async_chunk")
+        if resolved_async_chunk is None:
+            resolved_async_chunk = bool(pipeline.async_chunk)
+        for stage in pipeline.stages:
+            stage.yaml_engine_args["async_chunk"] = bool(resolved_async_chunk)
 
         # Apply CLI overrides
         result: list[StageConfig] = []

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -192,19 +192,12 @@ class OmniEngineArgs(EngineArgs):
 
     @classmethod
     def create(cls, **explicit: Any) -> "OmniEngineArgs":
-        """Constructor that records caller-set fields.
-
-        Prefer this over the bare constructor when passing via
-        ``Omni(..., engine_args=ea)`` — only recorded fields reach the merge
-        layer as caller-explicit.
-        """
+        """Tracks caller-set fields for ``Omni(..., engine_args=ea)``."""
         ea = cls(**explicit)
         ea._explicit_fields = frozenset(explicit.keys())
         return ea
 
     def explicit_kwargs(self) -> dict[str, Any]:
-        """Caller-set fields, or all non-None fields for bare-constructor
-        instances (legacy fallback)."""
         explicit = getattr(self, "_explicit_fields", None)
         if explicit is None:
             return {
@@ -623,13 +616,9 @@ def orchestrator_args_from_argparse(args: Any) -> OrchestratorArgs:
 
 
 def nullify_stage_engine_defaults(parser: argparse.ArgumentParser) -> None:
-    """Reset stage-level engine flag defaults to ``None`` so un-typed flags
-    arrive at the merge layer as ``None``. Real defaults are appended to
-    each action's help as ``(default: X)``. Idempotent.
-
-    Server-level flags (host, port, api_key, ssl_*) and orchestrator-only
-    fields are exempt — they bypass the stage merge layer.
-    """
+    """Reset stage-level engine flag defaults to ``None``; preserve real
+    default in help text. Server- and orchestrator-only flags are exempt.
+    Idempotent."""
     server_dests = derive_server_dests_from_vllm_parser()
     orch_only = orchestrator_field_names() - SHARED_FIELDS
 

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -133,22 +133,26 @@ class OmniEngineArgs(EngineArgs):
             Passed through to the diffusion stage engine.
     """
 
-    stage_id: int = 0
-    model_stage: str = "thinker"
+    # RFC #3035: user-input fields default to ``None`` so ``OmniEngineArgs.create()``
+    # / ``from_cli_args()`` callers can distinguish "caller set this" from
+    # "caller didn't touch it". Internal flags (``omni``, ``has_sampling_extra_args``)
+    # keep concrete defaults because they're not user-input.
+    stage_id: int = 0  # per-stage identifier; 0 is meaningful for single-stage
+    model_stage: str | None = None  # was "thinker"; per-model default set by pipeline.py
     model_arch: str | None = None
     engine_output_type: str | None = None
     hf_config_name: str | None = None
     custom_process_next_stage_input_func: str | None = None
     stage_connector_spec: dict[str, Any] = field(default_factory=dict)
     subtalker_sampling_params: dict[str, Any] | None = None
-    async_chunk: bool = False
+    async_chunk: bool | None = None  # was False; merge layer handles None ⇒ yaml/dataclass
     omni_kv_config: dict | None = None
     quantization_config: Any | None = None
     worker_type: str | None = None
     task_type: str | None = None
-    worker_cls: str = None
-    enable_sleep_mode: bool = False
-    omni: bool = False
+    worker_cls: str | None = None  # was bare None — type hint corrected
+    enable_sleep_mode: bool | None = None  # was False
+    omni: bool = False  # internal: "is this an Omni invocation?" — keep concrete
 
     @classmethod
     def _add_omni_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -168,9 +172,9 @@ class OmniEngineArgs(EngineArgs):
     omni_master_port: int | None = None
     stage_configs_path: str | None = None
     output_modalities: list[str] | None = None
-    log_stats: bool = False
+    log_stats: bool | None = None  # was False; consumers handle None ⇒ off
     custom_pipeline_args: dict[str, Any] | None = None
-    has_sampling_extra_args: bool = False
+    has_sampling_extra_args: bool = False  # internal — keep concrete
 
     def __post_init__(self) -> None:
         if self.worker_cls is None:
@@ -185,7 +189,54 @@ class OmniEngineArgs(EngineArgs):
     def from_cli_args(cls, args: argparse.Namespace) -> "OmniEngineArgs":
         attrs = [attr.name for attr in dataclasses.fields(cls)]
         engine_args = cls(**{attr: getattr(args, attr) for attr in attrs if hasattr(args, attr)})
+        # Track which fields the namespace explicitly set (post-nullification,
+        # un-typed flags arrive as None on ``args`` and we record only
+        # the typed ones). Callers passing this instance via ``engine_args=``
+        # benefit from the same RFC #3035 None-guard semantics.
+        engine_args._explicit_fields = frozenset(
+            attr for attr in attrs if hasattr(args, attr) and getattr(args, attr) is not None
+        )
         return engine_args
+
+    @classmethod
+    def create(cls, **explicit: Any) -> "OmniEngineArgs":
+        """Construct an ``OmniEngineArgs`` recording which fields the caller set.
+
+        Use this instead of the bare constructor when you intend to pass the
+        instance via ``Omni(..., engine_args=ea)``. Fields not passed to
+        ``create`` stay at their dataclass default but are not recorded as
+        explicit, so the merge layer treats them as fall-through (matching
+        RFC #3035 sentinel-default semantics).
+
+        Example::
+
+            ea = OmniEngineArgs.create(model="x", gpu_memory_utilization=0.5)
+            omni = Omni(model="x", engine_args=ea)
+            # → only gpu_memory_utilization=0.5 reaches the merge layer as
+            #   caller-explicit; everything else is treated as None.
+        """
+        ea = cls(**explicit)
+        ea._explicit_fields = frozenset(explicit.keys())
+        return ea
+
+    def explicit_kwargs(self) -> dict[str, Any]:
+        """Return the dict of fields the caller explicitly set.
+
+        For instances built via ``OmniEngineArgs.create(...)`` or
+        ``OmniEngineArgs.from_cli_args(args)`` (with nullified parser),
+        this returns only the explicit subset. For instances built via the
+        bare constructor (legacy), returns every non-None field — matches
+        pre-RFC behavior.
+        """
+        explicit = getattr(self, "_explicit_fields", None)
+        if explicit is None:
+            # Legacy constructor — no tracking. Surface every non-None field
+            # to preserve pre-RFC behavior. Callers wanting RFC #3035
+            # semantics should switch to ``OmniEngineArgs.create(...)``.
+            return {
+                f.name: getattr(self, f.name) for f in dataclasses.fields(self) if getattr(self, f.name) is not None
+            }
+        return {k: getattr(self, k) for k in explicit}
 
     def _ensure_omni_models_registered(self):
         if hasattr(self, "_omni_models_registered"):
@@ -658,3 +709,7 @@ def nullify_stage_engine_defaults(parser: argparse.ArgumentParser) -> None:
             action.help = f"{action.help} (default: {real_default})"
 
         action.default = None
+
+    # Mark so ``Omni.from_cli_args`` doesn't re-nullify (idempotent anyway,
+    # but skips a typed-key derivation pass).
+    parser._omni_nullified = True  # type: ignore[attr-defined]

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -133,26 +133,22 @@ class OmniEngineArgs(EngineArgs):
             Passed through to the diffusion stage engine.
     """
 
-    # RFC #3035: user-input fields default to ``None`` so ``OmniEngineArgs.create()``
-    # / ``from_cli_args()`` callers can distinguish "caller set this" from
-    # "caller didn't touch it". Internal flags (``omni``, ``has_sampling_extra_args``)
-    # keep concrete defaults because they're not user-input.
-    stage_id: int = 0  # per-stage identifier; 0 is meaningful for single-stage
-    model_stage: str | None = None  # was "thinker"; per-model default set by pipeline.py
+    stage_id: int = 0
+    model_stage: str | None = None
     model_arch: str | None = None
     engine_output_type: str | None = None
     hf_config_name: str | None = None
     custom_process_next_stage_input_func: str | None = None
     stage_connector_spec: dict[str, Any] = field(default_factory=dict)
     subtalker_sampling_params: dict[str, Any] | None = None
-    async_chunk: bool | None = None  # was False; merge layer handles None ⇒ yaml/dataclass
+    async_chunk: bool | None = None
     omni_kv_config: dict | None = None
     quantization_config: Any | None = None
     worker_type: str | None = None
     task_type: str | None = None
-    worker_cls: str | None = None  # was bare None — type hint corrected
-    enable_sleep_mode: bool | None = None  # was False
-    omni: bool = False  # internal: "is this an Omni invocation?" — keep concrete
+    worker_cls: str | None = None
+    enable_sleep_mode: bool | None = None
+    omni: bool = False
 
     @classmethod
     def _add_omni_specific_args(cls, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -172,9 +168,9 @@ class OmniEngineArgs(EngineArgs):
     omni_master_port: int | None = None
     stage_configs_path: str | None = None
     output_modalities: list[str] | None = None
-    log_stats: bool | None = None  # was False; consumers handle None ⇒ off
+    log_stats: bool | None = None
     custom_pipeline_args: dict[str, Any] | None = None
-    has_sampling_extra_args: bool = False  # internal — keep concrete
+    has_sampling_extra_args: bool = False
 
     def __post_init__(self) -> None:
         if self.worker_cls is None:
@@ -189,10 +185,6 @@ class OmniEngineArgs(EngineArgs):
     def from_cli_args(cls, args: argparse.Namespace) -> "OmniEngineArgs":
         attrs = [attr.name for attr in dataclasses.fields(cls)]
         engine_args = cls(**{attr: getattr(args, attr) for attr in attrs if hasattr(args, attr)})
-        # Track which fields the namespace explicitly set (post-nullification,
-        # un-typed flags arrive as None on ``args`` and we record only
-        # the typed ones). Callers passing this instance via ``engine_args=``
-        # benefit from the same RFC #3035 None-guard semantics.
         engine_args._explicit_fields = frozenset(
             attr for attr in attrs if hasattr(args, attr) and getattr(args, attr) is not None
         )
@@ -200,39 +192,21 @@ class OmniEngineArgs(EngineArgs):
 
     @classmethod
     def create(cls, **explicit: Any) -> "OmniEngineArgs":
-        """Construct an ``OmniEngineArgs`` recording which fields the caller set.
+        """Constructor that records caller-set fields.
 
-        Use this instead of the bare constructor when you intend to pass the
-        instance via ``Omni(..., engine_args=ea)``. Fields not passed to
-        ``create`` stay at their dataclass default but are not recorded as
-        explicit, so the merge layer treats them as fall-through (matching
-        RFC #3035 sentinel-default semantics).
-
-        Example::
-
-            ea = OmniEngineArgs.create(model="x", gpu_memory_utilization=0.5)
-            omni = Omni(model="x", engine_args=ea)
-            # → only gpu_memory_utilization=0.5 reaches the merge layer as
-            #   caller-explicit; everything else is treated as None.
+        Prefer this over the bare constructor when passing via
+        ``Omni(..., engine_args=ea)`` — only recorded fields reach the merge
+        layer as caller-explicit.
         """
         ea = cls(**explicit)
         ea._explicit_fields = frozenset(explicit.keys())
         return ea
 
     def explicit_kwargs(self) -> dict[str, Any]:
-        """Return the dict of fields the caller explicitly set.
-
-        For instances built via ``OmniEngineArgs.create(...)`` or
-        ``OmniEngineArgs.from_cli_args(args)`` (with nullified parser),
-        this returns only the explicit subset. For instances built via the
-        bare constructor (legacy), returns every non-None field — matches
-        pre-RFC behavior.
-        """
+        """Caller-set fields, or all non-None fields for bare-constructor
+        instances (legacy fallback)."""
         explicit = getattr(self, "_explicit_fields", None)
         if explicit is None:
-            # Legacy constructor — no tracking. Surface every non-None field
-            # to preserve pre-RFC behavior. Callers wanting RFC #3035
-            # semantics should switch to ``OmniEngineArgs.create(...)``.
             return {
                 f.name: getattr(self, f.name) for f in dataclasses.fields(self) if getattr(self, f.name) is not None
             }
@@ -648,68 +622,26 @@ def orchestrator_args_from_argparse(args: Any) -> OrchestratorArgs:
     return OrchestratorArgs(**kwargs)
 
 
-# ============================================================================
-# Sentinel-default precedence (RFC #3035)
-# ============================================================================
-#
-# Stage-level engine flags (gpu_memory_utilization, max_num_seqs, dtype, ...)
-# must default to ``None`` after the parser is built. The merge layer's
-# existing ``if value is None: continue`` guard then becomes the entire
-# precedence rule:
-#
-#     caller-typed value  >  deploy YAML  >  StageDeployConfig dataclass
-#
-# vLLM's ``make_arg_parser`` ships real parser defaults for inherited
-# EngineArgs fields. ``nullify_stage_engine_defaults`` walks the built
-# parser and resets ``action.default = None`` for every action that isn't
-# server-level, preserving the visible default in the help text.
-#
-# Server-level flags (--host, --port, --api-key, ssl_*, ...) bypass the
-# stage merge layer and need real defaults so uvicorn/FastAPI start cleanly.
-
-
 def nullify_stage_engine_defaults(parser: argparse.ArgumentParser) -> None:
-    """Set ``action.default = None`` for every stage-level engine flag.
+    """Reset stage-level engine flag defaults to ``None`` so un-typed flags
+    arrive at the merge layer as ``None``. Real defaults are appended to
+    each action's help as ``(default: X)``. Idempotent.
 
-    Call this AFTER ``make_arg_parser`` has populated the parser with
-    inherited vLLM defaults and AFTER any vllm-omni-specific flags are
-    added. Idempotent.
-
-    Server-level flags (host, port, api_key, ssl_*, etc.) keep their real
-    defaults because they bypass the stage merge layer.
-
-    Real default values are appended to ``action.help`` as ``(default: X)``
-    so ``--help`` output stays informative even though the parser stores
-    ``None``.
-
-    Boolean flags using ``store_true`` / ``store_false`` actions are also
-    nullified — the parser still recognizes the flag and sets True/False
-    when typed, but absent flags become ``None`` instead of False/True.
+    Server-level flags (host, port, api_key, ssl_*) and orchestrator-only
+    fields are exempt — they bypass the stage merge layer.
     """
     server_dests = derive_server_dests_from_vllm_parser()
+    orch_only = orchestrator_field_names() - SHARED_FIELDS
 
     for action in parser._actions:
-        # Skip help, positionals, server-level flags, and the version action
         if action.dest in ("help", "version") or not action.option_strings:
             continue
-        if action.dest in server_dests:
+        if action.dest in server_dests or action.dest in orch_only:
             continue
-        # Skip orchestrator-only fields that argparse_args_from_argparse
-        # consumes directly — they don't go through the stage merge layer.
-        if action.dest in orchestrator_field_names() and action.dest not in SHARED_FIELDS:
-            continue
-
-        # Don't double-process if already None
         if action.default is None or action.default is argparse.SUPPRESS:
             continue
-
-        # Preserve real default in help text for visibility
-        real_default = action.default
         if action.help and "(default:" not in action.help and "%(default)" not in action.help:
-            action.help = f"{action.help} (default: {real_default})"
-
+            action.help = f"{action.help} (default: {action.default})"
         action.default = None
 
-    # Mark so ``Omni.from_cli_args`` doesn't re-nullify (idempotent anyway,
-    # but skips a typed-key derivation pass).
     parser._omni_nullified = True  # type: ignore[attr-defined]

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -595,3 +595,66 @@ def orchestrator_args_from_argparse(args: Any) -> OrchestratorArgs:
             if value is not None or f.default is None:
                 kwargs[f.name] = value
     return OrchestratorArgs(**kwargs)
+
+
+# ============================================================================
+# Sentinel-default precedence (RFC #3035)
+# ============================================================================
+#
+# Stage-level engine flags (gpu_memory_utilization, max_num_seqs, dtype, ...)
+# must default to ``None`` after the parser is built. The merge layer's
+# existing ``if value is None: continue`` guard then becomes the entire
+# precedence rule:
+#
+#     caller-typed value  >  deploy YAML  >  StageDeployConfig dataclass
+#
+# vLLM's ``make_arg_parser`` ships real parser defaults for inherited
+# EngineArgs fields. ``nullify_stage_engine_defaults`` walks the built
+# parser and resets ``action.default = None`` for every action that isn't
+# server-level, preserving the visible default in the help text.
+#
+# Server-level flags (--host, --port, --api-key, ssl_*, ...) bypass the
+# stage merge layer and need real defaults so uvicorn/FastAPI start cleanly.
+
+
+def nullify_stage_engine_defaults(parser: argparse.ArgumentParser) -> None:
+    """Set ``action.default = None`` for every stage-level engine flag.
+
+    Call this AFTER ``make_arg_parser`` has populated the parser with
+    inherited vLLM defaults and AFTER any vllm-omni-specific flags are
+    added. Idempotent.
+
+    Server-level flags (host, port, api_key, ssl_*, etc.) keep their real
+    defaults because they bypass the stage merge layer.
+
+    Real default values are appended to ``action.help`` as ``(default: X)``
+    so ``--help`` output stays informative even though the parser stores
+    ``None``.
+
+    Boolean flags using ``store_true`` / ``store_false`` actions are also
+    nullified — the parser still recognizes the flag and sets True/False
+    when typed, but absent flags become ``None`` instead of False/True.
+    """
+    server_dests = derive_server_dests_from_vllm_parser()
+
+    for action in parser._actions:
+        # Skip help, positionals, server-level flags, and the version action
+        if action.dest in ("help", "version") or not action.option_strings:
+            continue
+        if action.dest in server_dests:
+            continue
+        # Skip orchestrator-only fields that argparse_args_from_argparse
+        # consumes directly — they don't go through the stage merge layer.
+        if action.dest in orchestrator_field_names() and action.dest not in SHARED_FIELDS:
+            continue
+
+        # Don't double-process if already None
+        if action.default is None or action.default is argparse.SUPPRESS:
+            continue
+
+        # Preserve real default in help text for visibility
+        real_default = action.default
+        if action.help and "(default:" not in action.help and "%(default)" not in action.help:
+            action.help = f"{action.help} (default: {real_default})"
+
+        action.default = None

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -460,10 +460,48 @@ SHARED_FIELDS: frozenset[str] = frozenset(
     }
 )
 
+_DEPLOY_ENGINE_ARG_OVERRIDE_FIELDS: frozenset[str] = frozenset(
+    {
+        # Capacity / scheduling.
+        "async_scheduling",
+        "max_model_len",
+        "max_num_batched_tokens",
+        "max_num_seqs",
+        # Memory / parallelism.
+        "data_parallel_size",
+        "gpu_memory_utilization",
+        "pipeline_parallel_size",
+        "tensor_parallel_size",
+        # Execution / loading.
+        "enforce_eager",
+        "distributed_executor_backend",
+        "dtype",
+        "quantization",
+        "trust_remote_code",
+        # Caching / chunking.
+        "async_chunk",
+        "enable_prefix_caching",
+        "enable_chunked_prefill",
+        # Model-specific engine extras.
+        "subtalker_sampling_params",
+    }
+)
+
+_DEPLOY_RUNTIME_OVERRIDE_FIELDS: frozenset[str] = frozenset(
+    {
+        "devices",
+    }
+)
+
 
 def orchestrator_field_names() -> frozenset[str]:
     """Return the names of every field on OrchestratorArgs."""
     return frozenset(f.name for f in fields(OrchestratorArgs))
+
+
+def deploy_override_field_names() -> frozenset[str]:
+    """Return kwargs whose parser defaults must not override deploy YAML."""
+    return _DEPLOY_ENGINE_ARG_OVERRIDE_FIELDS | _DEPLOY_RUNTIME_OVERRIDE_FIELDS
 
 
 def internal_blacklist_keys() -> frozenset[str]:
@@ -617,15 +655,14 @@ def orchestrator_args_from_argparse(args: Any) -> OrchestratorArgs:
 
 def nullify_stage_engine_defaults(parser: argparse.ArgumentParser) -> None:
     """Reset stage-level engine flag defaults to ``None``; preserve real
-    default in help text. Server- and orchestrator-only flags are exempt.
+    default in help text. Only deploy-YAML override fields are touched.
     Idempotent."""
-    server_dests = derive_server_dests_from_vllm_parser()
-    orch_only = orchestrator_field_names() - SHARED_FIELDS
+    override_dests = deploy_override_field_names()
 
     for action in parser._actions:
         if action.dest in ("help", "version") or not action.option_strings:
             continue
-        if action.dest in server_dests or action.dest in orch_only:
+        if action.dest not in override_dests:
             continue
         if action.default is None or action.default is argparse.SUPPRESS:
             continue

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -134,20 +134,20 @@ class OmniEngineArgs(EngineArgs):
     """
 
     stage_id: int = 0
-    model_stage: str | None = None
+    model_stage: str = "thinker"
     model_arch: str | None = None
     engine_output_type: str | None = None
     hf_config_name: str | None = None
     custom_process_next_stage_input_func: str | None = None
     stage_connector_spec: dict[str, Any] = field(default_factory=dict)
     subtalker_sampling_params: dict[str, Any] | None = None
-    async_chunk: bool | None = None
+    async_chunk: bool = False
     omni_kv_config: dict | None = None
     quantization_config: Any | None = None
     worker_type: str | None = None
     task_type: str | None = None
-    worker_cls: str | None = None
-    enable_sleep_mode: bool | None = None
+    worker_cls: str = None
+    enable_sleep_mode: bool = False
     omni: bool = False
 
     @classmethod
@@ -168,7 +168,7 @@ class OmniEngineArgs(EngineArgs):
     omni_master_port: int | None = None
     stage_configs_path: str | None = None
     output_modalities: list[str] | None = None
-    log_stats: bool | None = None
+    log_stats: bool = False
     custom_pipeline_args: dict[str, Any] | None = None
     has_sampling_extra_args: bool = False
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1388,10 +1388,6 @@ class AsyncOmniEngine:
         stage_configs_path = kwargs.get("stage_configs_path", None)
         deploy_config_path = kwargs.pop("deploy_config", None)
         stage_overrides_json = kwargs.pop("stage_overrides", None)
-        # RFC #3035: parser-level nullification means un-typed flags arrive
-        # as None; the merge layer's None-guard is now the entire precedence
-        # rule. Discard any legacy ``_cli_explicit_keys`` kwarg from
-        # pre-RFC callers.
         kwargs.pop("_cli_explicit_keys", None)
         explicit_stage_configs = kwargs.pop("stage_configs", None)
         if explicit_stage_configs is not None:

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1388,10 +1388,11 @@ class AsyncOmniEngine:
         stage_configs_path = kwargs.get("stage_configs_path", None)
         deploy_config_path = kwargs.pop("deploy_config", None)
         stage_overrides_json = kwargs.pop("stage_overrides", None)
-        # Set of CLI keys the user actually typed; ``None`` means we have no
-        # parser-level info (e.g. programmatic Omni() call) and the lower
-        # layers should treat all kwargs as explicit.
-        cli_explicit_keys = kwargs.pop("_cli_explicit_keys", None)
+        # RFC #3035: parser-level nullification means un-typed flags arrive
+        # as None; the merge layer's None-guard is now the entire precedence
+        # rule. Discard any legacy ``_cli_explicit_keys`` kwarg from
+        # pre-RFC callers.
+        kwargs.pop("_cli_explicit_keys", None)
         explicit_stage_configs = kwargs.pop("stage_configs", None)
         if explicit_stage_configs is not None:
             logger.warning(
@@ -1424,7 +1425,6 @@ class AsyncOmniEngine:
             default_stage_cfg_factory=lambda: self._create_default_diffusion_stage_cfg(kwargs),
             deploy_config_path=deploy_config_path,
             stage_overrides=stage_overrides,
-            cli_explicit_keys=cli_explicit_keys,
         )
 
         # Inject diffusion LoRA-related knobs from kwargs if not present in the stage config.

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -279,13 +279,16 @@ class AsyncOmniEngine:
 
         logger.info(f"[AsyncOmniEngine] Initializing with model {model}")
 
-        # Merge typed engine_args fields into kwargs; explicit kwargs take priority.
+        # Merge tracked engine_args fields into kwargs; explicit kwargs take priority.
         if engine_args is not None:
-            ea_dict = {
-                f.name: getattr(engine_args, f.name)
-                for f in dataclasses.fields(engine_args)
-                if not f.name.startswith("_")
-            }
+            if not hasattr(engine_args, "_explicit_fields"):
+                raise TypeError(
+                    "engine_args=OmniEngineArgs(...) is ambiguous under "
+                    "sentinel-default precedence. Use "
+                    "OmniEngineArgs.create(**explicit) or pass explicit kwargs "
+                    "directly."
+                )
+            ea_dict = engine_args.explicit_kwargs()
             # Remove model since it is passed as a positional arg already.
             ea_dict.pop("model", None)
             kwargs = {**ea_dict, **kwargs}

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1241,6 +1241,8 @@ class AsyncOmniEngine:
         if not isinstance(default_sampling_params, dict):
             default_sampling_params = None
         stage_default_sampling_params = default_sampling_params.get("0", {}) if default_sampling_params else {}
+        if normalized_kwargs.get("dtype") is None:
+            normalized_kwargs["dtype"] = "auto"
 
         # TODO: hack, convert dtype to string to avoid non-premitive omegaconf create error.
         if "dtype" in normalized_kwargs and not isinstance(normalized_kwargs["dtype"], str):

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -9,7 +9,6 @@ import argparse
 import json
 import os
 import signal
-import sys
 from types import FrameType
 from typing import Any
 
@@ -22,7 +21,6 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 from vllm_omni.entrypoints.cli.logo import log_logo
 from vllm_omni.entrypoints.openai.api_server import omni_run_server
-from vllm_omni.entrypoints.utils import detect_explicit_cli_keys
 
 logger = init_logger(__name__)
 
@@ -95,9 +93,9 @@ class OmniServeCommand(CLISubcommand):
         if hasattr(args, "model_tag") and args.model_tag is not None:
             args.model = args.model_tag
 
-        # Stash the set of long-option keys the user actually typed so the
-        # stage-config factory can give YAML precedence over argparse defaults.
-        args._cli_explicit_keys = detect_explicit_cli_keys(sys.argv[1:], OmniServeCommand._parser)
+        # RFC #3035: parser defaults are nullified for stage-level flags in
+        # subparser_init, so un-typed flags reach the merge layer as None.
+        # No need to compute an explicit-key set anymore.
 
         if args.headless:
             run_headless(args)
@@ -485,6 +483,12 @@ class OmniServeCommand(CLISubcommand):
         # Stash via type(self) so the docs hook (which execs this function in a
         # sandboxed globals dict via ``DummySelf``) doesn't fail on a NameError.
         type(self)._parser = serve_parser
+        # RFC #3035: nullify stage-level engine flag defaults so un-typed CLI
+        # values arrive as None and the merge layer's None-guard becomes the
+        # entire precedence rule. Real defaults stay visible in --help.
+        from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
+        nullify_stage_engine_defaults(serve_parser)
         return serve_parser
 
 
@@ -540,15 +544,14 @@ def run_headless(args: argparse.Namespace) -> None:
         raise ValueError("headless mode requires worker_backend=multi_process")
 
     args_dict = vars(args).copy()
-    # Preserve the explicit-keys set captured at parse time so per-stage yaml
-    # values (e.g. stage 1's ``gpu_memory_utilization: 0.5``) are not
-    # overwritten by argparse defaults for flags the user didn't type.
-    cli_explicit_keys = args_dict.pop("_cli_explicit_keys", None)
+    # RFC #3035: parser defaults are nullified for stage-level flags, so
+    # un-typed flags arrive as None and get filtered by the merge layer's
+    # None-guard. No more explicit-key set required.
+    args_dict.pop("_cli_explicit_keys", None)
     config_path, stage_configs = load_and_resolve_stage_configs(
         model,
         args_dict.get("stage_configs_path"),
         args_dict,
-        cli_explicit_keys=cli_explicit_keys,
     )
 
     # Locate the stage config that matches stage_id.

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -93,10 +93,6 @@ class OmniServeCommand(CLISubcommand):
         if hasattr(args, "model_tag") and args.model_tag is not None:
             args.model = args.model_tag
 
-        # RFC #3035: parser defaults are nullified for stage-level flags in
-        # subparser_init, so un-typed flags reach the merge layer as None.
-        # No need to compute an explicit-key set anymore.
-
         if args.headless:
             run_headless(args)
         else:
@@ -483,9 +479,6 @@ class OmniServeCommand(CLISubcommand):
         # Stash via type(self) so the docs hook (which execs this function in a
         # sandboxed globals dict via ``DummySelf``) doesn't fail on a NameError.
         type(self)._parser = serve_parser
-        # RFC #3035: nullify stage-level engine flag defaults so un-typed CLI
-        # values arrive as None and the merge layer's None-guard becomes the
-        # entire precedence rule. Real defaults stay visible in --help.
         from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
 
         nullify_stage_engine_defaults(serve_parser)
@@ -544,9 +537,6 @@ def run_headless(args: argparse.Namespace) -> None:
         raise ValueError("headless mode requires worker_backend=multi_process")
 
     args_dict = vars(args).copy()
-    # RFC #3035: parser defaults are nullified for stage-level flags, so
-    # un-typed flags arrive as None and get filtered by the merge layer's
-    # None-guard. No more explicit-key set required.
     args_dict.pop("_cli_explicit_keys", None)
     config_path, stage_configs = load_and_resolve_stage_configs(
         model,

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -19,6 +19,7 @@ from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
+from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
 from vllm_omni.entrypoints.cli.logo import log_logo
 from vllm_omni.entrypoints.openai.api_server import omni_run_server
 
@@ -479,7 +480,6 @@ class OmniServeCommand(CLISubcommand):
         # Stash via type(self) so the docs hook (which execs this function in a
         # sandboxed globals dict via ``DummySelf``) doesn't fail on a NameError.
         type(self)._parser = serve_parser
-        from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
 
         nullify_stage_engine_defaults(serve_parser)
         return serve_parser

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -96,31 +96,12 @@ class OmniBase(PDDisaggregationMixin):
         parser: argparse.ArgumentParser | None = None,
         **overrides: Any,
     ) -> OmniBase:
-        """Construct an ``Omni`` / ``AsyncOmni`` from an ``argparse.Namespace``.
-
-        Per RFC #3035, un-typed CLI flags should arrive at the merge layer as
-        ``None`` so the None-guard becomes the entire precedence rule. The
-        ``vllm serve`` path nullifies stage-level parser defaults via
-        ``nullify_stage_engine_defaults`` before parsing, so ``vars(args)``
-        already carries None for un-typed flags.
-
-        For non-vllm-serve callers (offline scripts that build their own
-        argparse parser), pass ``parser=`` and we detect typed keys via
-        ``sys.argv`` and null out everything else — same end-state as
-        pre-parse nullification, achieved post-parse.
-
-        Example::
-
-            parser = FlexibleArgumentParser()
-            OmniEngineArgs.add_cli_args(parser)
-            args = parser.parse_args()
-            omni = Omni.from_cli_args(args, parser=parser)   # auto-nullifies
+        """Build from an argparse namespace. If ``parser`` is passed and not
+        already nullified, un-typed engine fields are reset to ``None`` so the
+        merge layer's None-guard handles precedence.
         """
         kwargs: dict[str, Any] = {k: v for k, v in vars(args).items() if not k.startswith("_")}
 
-        # Auto-nullify un-typed engine fields when the caller passes a parser
-        # they built themselves (not via vllm serve). Skipped if the parser
-        # has been pre-nullified via ``nullify_stage_engine_defaults``.
         if parser is not None and not getattr(parser, "_omni_nullified", False):
             from vllm_omni.engine.arg_utils import (
                 derive_server_dests_from_vllm_parser,
@@ -129,14 +110,11 @@ class OmniBase(PDDisaggregationMixin):
             from vllm_omni.entrypoints.utils import detect_explicit_cli_keys
 
             typed = detect_explicit_cli_keys(sys.argv[1:], parser) or set()
-            shared = orchestrator_field_names() & {"model", "stage_id", "log_stats", "stage_configs_path"}
+            orch = orchestrator_field_names()
             server_dests = derive_server_dests_from_vllm_parser()
+            shared = orch & {"model", "stage_id", "log_stats", "stage_configs_path"}
             for key in list(kwargs.keys()):
-                if key in typed or key in server_dests or key in shared:
-                    continue
-                # Orchestrator-only fields keep their values; merge layer
-                # consumes them through OrchestratorArgs, not the None-guard.
-                if key in orchestrator_field_names():
+                if key in typed or key in server_dests or key in shared or key in orch:
                     continue
                 kwargs[key] = None
 
@@ -150,23 +128,15 @@ class OmniBase(PDDisaggregationMixin):
     ) -> None:
         engine_args: OmniEngineArgs | None = kwargs.pop("engine_args", None)
 
-        # RFC #3035: when ``engine_args=`` is passed, fold only the caller-
-        # explicit fields into kwargs so the merge layer's None-guard treats
-        # un-set fields as fall-through. Built via ``OmniEngineArgs.create()``
-        # or ``from_cli_args()`` ⇒ explicit set is real. Bare constructor
-        # legacy callers fall through to all-non-None semantics (warned).
         if engine_args is not None:
-            explicit = engine_args.explicit_kwargs()
-            for key, value in explicit.items():
+            for key, value in engine_args.explicit_kwargs().items():
                 kwargs.setdefault(key, value)
             if not hasattr(engine_args, "_explicit_fields"):
                 import warnings as _warnings
 
                 _warnings.warn(
-                    "Passing engine_args=OmniEngineArgs(...) built via the bare "
-                    "constructor cannot distinguish caller-set fields from dataclass "
-                    "defaults. Use OmniEngineArgs.create(**explicit) instead "
-                    "(RFC #3035).",
+                    "Bare OmniEngineArgs(...) cannot distinguish caller-set from "
+                    "dataclass defaults. Use OmniEngineArgs.create(**explicit).",
                     DeprecationWarning,
                     stacklevel=2,
                 )

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -96,10 +96,8 @@ class OmniBase(PDDisaggregationMixin):
         parser: argparse.ArgumentParser | None = None,
         **overrides: Any,
     ) -> OmniBase:
-        """Build from an argparse namespace. If ``parser`` is passed and not
-        already nullified, un-typed engine fields are reset to ``None`` so the
-        merge layer's None-guard handles precedence.
-        """
+        """Build from argparse. If ``parser`` is passed and not yet nullified,
+        un-typed engine fields are reset to ``None``."""
         kwargs: dict[str, Any] = {k: v for k, v in vars(args).items() if not k.startswith("_")}
 
         if parser is not None and not getattr(parser, "_omni_nullified", False):
@@ -109,14 +107,14 @@ class OmniBase(PDDisaggregationMixin):
             )
             from vllm_omni.entrypoints.utils import detect_explicit_cli_keys
 
-            typed = detect_explicit_cli_keys(sys.argv[1:], parser) or set()
-            orch = orchestrator_field_names()
-            server_dests = derive_server_dests_from_vllm_parser()
-            shared = orch & {"model", "stage_id", "log_stats", "stage_configs_path"}
-            for key in list(kwargs.keys()):
-                if key in typed or key in server_dests or key in shared or key in orch:
-                    continue
-                kwargs[key] = None
+            keep = (
+                (detect_explicit_cli_keys(sys.argv[1:], parser) or set())
+                | derive_server_dests_from_vllm_parser()
+                | orchestrator_field_names()
+            )
+            for key in list(kwargs):
+                if key not in keep:
+                    kwargs[key] = None
 
         kwargs.update(overrides)
         return cls(**kwargs)

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
 import time
 import types
 import weakref
@@ -17,7 +16,7 @@ from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.entrypoints.client_request_state import ClientRequestState
 from vllm_omni.entrypoints.pd_utils import PDDisaggregationMixin
-from vllm_omni.entrypoints.utils import detect_explicit_cli_keys, get_final_stage_id_for_e2e
+from vllm_omni.entrypoints.utils import get_final_stage_id_for_e2e
 from vllm_omni.metrics.stats import OrchestratorAggregator as OrchestratorMetrics
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 from vllm_omni.outputs import OmniRequestOutput
@@ -98,36 +97,25 @@ class OmniBase(PDDisaggregationMixin):
     ) -> OmniBase:
         """Construct an ``Omni`` / ``AsyncOmni`` from an ``argparse.Namespace``.
 
-        Mirrors the ``EngineArgs.from_cli_args`` pattern used upstream and in
-        ``OmniEngineArgs.from_cli_args``. This is the recommended entry point
-        for any argparse-based caller (offline scripts, tests, CI): it
-        expands ``vars(args)`` into kwargs and automatically captures which
-        flags the user typed on the command line so that argparse defaults
-        do not silently override deploy YAML values.
+        Per RFC #3035, the CLI parser nullifies stage-level engine flag
+        defaults via ``nullify_stage_engine_defaults`` so un-typed flags
+        arrive as ``None``. The merge layer's None-guard then handles
+        precedence — no need to capture an explicit-key set.
 
-        Passing ``parser`` is strongly recommended: without it, flag-to-dest
-        resolution falls back to a name-based heuristic that misidentifies
-        flags with ``dest=`` overrides, alias flags, and ``--disable-X`` /
-        ``store_false`` pairs. See :func:`detect_explicit_cli_keys`.
-
-        Args:
-            args: Parsed argparse namespace from ``parser.parse_args()``.
-            parser: The argparse parser used to produce ``args``. When
-                provided, each user-typed flag is resolved to its real
-                ``dest`` via the parser's action table.
-            **overrides: Extra keyword arguments that take precedence over
-                attributes on ``args``.
+        ``parser`` is kept as a parameter for backward compatibility but is
+        no longer required.
 
         Example::
 
             parser = FlexibleArgumentParser()
-            parser.add_argument("--model", required=True)
+            OmniEngineArgs.add_cli_args(parser)
+            nullify_stage_engine_defaults(parser)   # only needed for non-vllm-serve callers
             args = parser.parse_args()
-            omni = Omni.from_cli_args(args, parser=parser)          # preferred
-            omni = Omni.from_cli_args(args, parser=parser, model="other")
+            omni = Omni.from_cli_args(args)
         """
-        kwargs: dict[str, Any] = {**vars(args), **overrides}
-        kwargs["_cli_explicit_keys"] = detect_explicit_cli_keys(sys.argv[1:], parser)
+        del parser  # No longer load-bearing for precedence; kept for compat.
+        kwargs: dict[str, Any] = {k: v for k, v in vars(args).items() if not k.startswith("_")}
+        kwargs.update(overrides)
         return cls(**kwargs)
 
     def __init__(

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -102,18 +102,14 @@ class OmniBase(PDDisaggregationMixin):
 
         if parser is not None and not getattr(parser, "_omni_nullified", False):
             from vllm_omni.engine.arg_utils import (
-                derive_server_dests_from_vllm_parser,
-                orchestrator_field_names,
+                deploy_override_field_names,
             )
             from vllm_omni.entrypoints.utils import detect_explicit_cli_keys
 
-            keep = (
-                (detect_explicit_cli_keys(sys.argv[1:], parser) or set())
-                | derive_server_dests_from_vllm_parser()
-                | orchestrator_field_names()
-            )
+            explicit = detect_explicit_cli_keys(sys.argv[1:], parser) or set()
+            override_dests = deploy_override_field_names()
             for key in list(kwargs):
-                if key not in keep:
+                if key in override_dests and key not in explicit:
                     kwargs[key] = None
 
         kwargs.update(overrides)
@@ -125,19 +121,6 @@ class OmniBase(PDDisaggregationMixin):
         **kwargs: Any,
     ) -> None:
         engine_args: OmniEngineArgs | None = kwargs.pop("engine_args", None)
-
-        if engine_args is not None:
-            for key, value in engine_args.explicit_kwargs().items():
-                kwargs.setdefault(key, value)
-            if not hasattr(engine_args, "_explicit_fields"):
-                import warnings as _warnings
-
-                _warnings.warn(
-                    "Bare OmniEngineArgs(...) cannot distinguish caller-set from "
-                    "dataclass defaults. Use OmniEngineArgs.create(**explicit).",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
 
         stage_init_timeout = kwargs.pop("stage_init_timeout", 300)
         init_timeout = kwargs.pop("init_timeout", 600)

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 import time
 import types
 import weakref
@@ -97,24 +98,48 @@ class OmniBase(PDDisaggregationMixin):
     ) -> OmniBase:
         """Construct an ``Omni`` / ``AsyncOmni`` from an ``argparse.Namespace``.
 
-        Per RFC #3035, the CLI parser nullifies stage-level engine flag
-        defaults via ``nullify_stage_engine_defaults`` so un-typed flags
-        arrive as ``None``. The merge layer's None-guard then handles
-        precedence — no need to capture an explicit-key set.
+        Per RFC #3035, un-typed CLI flags should arrive at the merge layer as
+        ``None`` so the None-guard becomes the entire precedence rule. The
+        ``vllm serve`` path nullifies stage-level parser defaults via
+        ``nullify_stage_engine_defaults`` before parsing, so ``vars(args)``
+        already carries None for un-typed flags.
 
-        ``parser`` is kept as a parameter for backward compatibility but is
-        no longer required.
+        For non-vllm-serve callers (offline scripts that build their own
+        argparse parser), pass ``parser=`` and we detect typed keys via
+        ``sys.argv`` and null out everything else — same end-state as
+        pre-parse nullification, achieved post-parse.
 
         Example::
 
             parser = FlexibleArgumentParser()
             OmniEngineArgs.add_cli_args(parser)
-            nullify_stage_engine_defaults(parser)   # only needed for non-vllm-serve callers
             args = parser.parse_args()
-            omni = Omni.from_cli_args(args)
+            omni = Omni.from_cli_args(args, parser=parser)   # auto-nullifies
         """
-        del parser  # No longer load-bearing for precedence; kept for compat.
         kwargs: dict[str, Any] = {k: v for k, v in vars(args).items() if not k.startswith("_")}
+
+        # Auto-nullify un-typed engine fields when the caller passes a parser
+        # they built themselves (not via vllm serve). Skipped if the parser
+        # has been pre-nullified via ``nullify_stage_engine_defaults``.
+        if parser is not None and not getattr(parser, "_omni_nullified", False):
+            from vllm_omni.engine.arg_utils import (
+                derive_server_dests_from_vllm_parser,
+                orchestrator_field_names,
+            )
+            from vllm_omni.entrypoints.utils import detect_explicit_cli_keys
+
+            typed = detect_explicit_cli_keys(sys.argv[1:], parser) or set()
+            shared = orchestrator_field_names() & {"model", "stage_id", "log_stats", "stage_configs_path"}
+            server_dests = derive_server_dests_from_vllm_parser()
+            for key in list(kwargs.keys()):
+                if key in typed or key in server_dests or key in shared:
+                    continue
+                # Orchestrator-only fields keep their values; merge layer
+                # consumes them through OrchestratorArgs, not the None-guard.
+                if key in orchestrator_field_names():
+                    continue
+                kwargs[key] = None
+
         kwargs.update(overrides)
         return cls(**kwargs)
 
@@ -124,6 +149,28 @@ class OmniBase(PDDisaggregationMixin):
         **kwargs: Any,
     ) -> None:
         engine_args: OmniEngineArgs | None = kwargs.pop("engine_args", None)
+
+        # RFC #3035: when ``engine_args=`` is passed, fold only the caller-
+        # explicit fields into kwargs so the merge layer's None-guard treats
+        # un-set fields as fall-through. Built via ``OmniEngineArgs.create()``
+        # or ``from_cli_args()`` ⇒ explicit set is real. Bare constructor
+        # legacy callers fall through to all-non-None semantics (warned).
+        if engine_args is not None:
+            explicit = engine_args.explicit_kwargs()
+            for key, value in explicit.items():
+                kwargs.setdefault(key, value)
+            if not hasattr(engine_args, "_explicit_fields"):
+                import warnings as _warnings
+
+                _warnings.warn(
+                    "Passing engine_args=OmniEngineArgs(...) built via the bare "
+                    "constructor cannot distinguish caller-set fields from dataclass "
+                    "defaults. Use OmniEngineArgs.create(**explicit) instead "
+                    "(RFC #3035).",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
         stage_init_timeout = kwargs.pop("stage_init_timeout", 300)
         init_timeout = kwargs.pop("init_timeout", 600)
         log_stats = kwargs.pop("log_stats", False)

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -2779,6 +2779,8 @@ if __name__ == "__main__":
 
     from vllm.entrypoints.openai.cli_args import make_arg_parser
 
+    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+
     parser = argparse.ArgumentParser(description="vLLM-Omni OpenAI-Compatible REST API server")
     parser = make_arg_parser(parser)
     registered_flags = set()
@@ -2790,6 +2792,7 @@ if __name__ == "__main__":
         parser.add_argument(
             "--enable-sleep-mode", action="store_true", default=False, help="Enable GPU memory pool for sleep mode."
         )
+    nullify_stage_engine_defaults(parser)
     args = parser.parse_args()
     if not hasattr(args, "model_tag"):
         setattr(args, "model_tag", args.model)

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -353,10 +353,6 @@ def load_stage_configs_from_model(
 
     For other models (legacy path), loads stage configs from YAML.
 
-    Per RFC #3035, the parser layer nullifies un-typed flags so the merge
-    layer's None-guard is the entire precedence rule. ``cli_explicit_keys=``
-    is accepted-and-ignored for one version with a ``DeprecationWarning``.
-
     Args:
         model: Model name or path (used to determine model_type)
         base_engine_args: Base engine args to merge as CLI overrides.
@@ -370,8 +366,7 @@ def load_stage_configs_from_model(
         import warnings
 
         warnings.warn(
-            "cli_explicit_keys= is deprecated and ignored — RFC #3035 moved "
-            "precedence to the parser layer. Remove the kwarg.",
+            "cli_explicit_keys= is deprecated and ignored. Remove the kwarg.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -597,8 +592,7 @@ def load_and_resolve_stage_configs(
         import warnings
 
         warnings.warn(
-            "cli_explicit_keys= is deprecated and ignored — RFC #3035 moved "
-            "precedence to the parser layer. Remove the kwarg.",
+            "cli_explicit_keys= is deprecated and ignored. Remove the kwarg.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -21,6 +21,18 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent
 
 logger = init_logger(__name__)
 
+
+def _warn_deprecated_explicit_keys(kwargs: dict[str, Any]) -> None:
+    if "cli_explicit_keys" in kwargs:
+        import warnings
+
+        warnings.warn(
+            "cli_explicit_keys= is deprecated and ignored. Remove the kwarg.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+
 _DIFFUSERS_CLASS_TO_CONFIG: dict[str, str] = {
     "GlmImagePipeline": "glm_image",
 }
@@ -362,14 +374,7 @@ def load_stage_configs_from_model(
     Returns:
         List of stage configuration dictionaries
     """
-    if "cli_explicit_keys" in deprecated_kwargs:
-        import warnings
-
-        warnings.warn(
-            "cli_explicit_keys= is deprecated and ignored. Remove the kwarg.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    _warn_deprecated_explicit_keys(deprecated_kwargs)
 
     if base_engine_args is None:
         base_engine_args = {}
@@ -588,14 +593,7 @@ def load_and_resolve_stage_configs(
                 stage_configs_path,
             )
 
-    if "cli_explicit_keys" in deprecated_kwargs:
-        import warnings
-
-        warnings.warn(
-            "cli_explicit_keys= is deprecated and ignored. Remove the kwarg.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    _warn_deprecated_explicit_keys(deprecated_kwargs)
 
     if deploy_config_path is not None:
         config_path = deploy_config_path

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -343,7 +343,7 @@ def load_stage_configs_from_model(
     base_engine_args: dict | None = None,
     deploy_config_path: str | None = None,
     stage_overrides: dict[str, dict[str, Any]] | None = None,
-    cli_explicit_keys: set[str] | None = None,
+    **deprecated_kwargs: Any,
 ) -> list:
     """Load stage configurations from model's default config file.
 
@@ -353,38 +353,42 @@ def load_stage_configs_from_model(
 
     For other models (legacy path), loads stage configs from YAML.
 
+    Per RFC #3035, the parser layer nullifies un-typed flags so the merge
+    layer's None-guard is the entire precedence rule. ``cli_explicit_keys=``
+    is accepted-and-ignored for one version with a ``DeprecationWarning``.
+
     Args:
         model: Model name or path (used to determine model_type)
         base_engine_args: Base engine args to merge as CLI overrides.
         deploy_config_path: Optional explicit deploy config path.
         stage_overrides: Per-stage overrides from --stage-overrides.
-        cli_explicit_keys: Set of CLI keys the user actually typed. When
-            provided, only these keys override deploy YAML; argparse defaults
-            stay subordinate to YAML. ``None`` means treat every kwarg as
-            explicit (programmatic ``Omni()`` calls).
 
     Returns:
         List of stage configuration dictionaries
     """
+    if "cli_explicit_keys" in deprecated_kwargs:
+        import warnings
+
+        warnings.warn(
+            "cli_explicit_keys= is deprecated and ignored — RFC #3035 moved "
+            "precedence to the parser layer. Remove the kwarg.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if base_engine_args is None:
         base_engine_args = {}
 
     cli_overrides = _convert_dataclasses_to_dict(dict(base_engine_args))
-    # Per-stage JSON overrides are always explicit (the user typed --stage-overrides).
-    explicit = set(cli_explicit_keys) if cli_explicit_keys is not None else None
     if stage_overrides:
         for stage_id_str, overrides in stage_overrides.items():
             for key, val in overrides.items():
-                stage_key = f"stage_{stage_id_str}_{key}"
-                cli_overrides[stage_key] = val
-                if explicit is not None:
-                    explicit.add(stage_key)
+                cli_overrides[f"stage_{stage_id_str}_{key}"] = val
 
     stages = StageConfigFactory.create_from_model(
         model,
         cli_overrides=cli_overrides,
         deploy_config_path=deploy_config_path,
-        cli_explicit_keys=explicit,
     )
     if stages is not None:
         # Convert StageConfig objects to OmegaConf for backward compat
@@ -545,7 +549,7 @@ def load_and_resolve_stage_configs(
     default_stage_cfg_factory: Any = None,
     deploy_config_path: str | None = None,
     stage_overrides: dict[str, dict[str, Any]] | None = None,
-    cli_explicit_keys: set[str] | None = None,
+    **deprecated_kwargs: Any,
 ) -> tuple[str, list]:
     """Load stage configurations from model or YAML file with fallback to defaults.
 
@@ -589,6 +593,16 @@ def load_and_resolve_stage_configs(
                 stage_configs_path,
             )
 
+    if "cli_explicit_keys" in deprecated_kwargs:
+        import warnings
+
+        warnings.warn(
+            "cli_explicit_keys= is deprecated and ignored — RFC #3035 moved "
+            "precedence to the parser layer. Remove the kwarg.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if deploy_config_path is not None:
         config_path = deploy_config_path
         stage_configs = load_stage_configs_from_model(
@@ -596,7 +610,6 @@ def load_and_resolve_stage_configs(
             base_engine_args=kwargs,
             deploy_config_path=deploy_config_path,
             stage_overrides=stage_overrides,
-            cli_explicit_keys=cli_explicit_keys,
         )
         if not stage_configs:
             if default_stage_cfg_factory is not None:
@@ -610,7 +623,6 @@ def load_and_resolve_stage_configs(
             model,
             base_engine_args=kwargs,
             stage_overrides=stage_overrides,
-            cli_explicit_keys=cli_explicit_keys,
         )
         if not stage_configs:
             if default_stage_cfg_factory is not None:


### PR DESCRIPTION
<!-- markdownlint-disable -->


## **Background**

This PR continues the work in #3035 / RFC-3035 around deploy override precedence.

The core problem is: when a model has a `deploy.yaml`, users may still want to override some of its fields at runtime. These override-intent fields can come from three entry paths:

1. `Omni(..., engine_args=...)`
2. parser / CLI-based paths
3. direct `Omni(**kwargs)` paths

In the previous implementation, override-intent fields were mainly inferred from `argv`. That only works reliably for parser-driven flows. It does not cover the `engine_args` path or direct `kwargs` path well, because those paths do not naturally expose which values were explicitly provided by the user versus inherited from defaults.

This PR follows the RFC direction and switches the model to sentinel-default precedence: non-explicit default values are normalized to `None`, so only user-explicit values participate in override semantics.

## **Design**

According to the RFC, effective fallback defaults should come from `deploy config`, rather than from upper-layer implicit defaults leaking down as if they were overrides.

However, the pure diffusion path is different: it does not rely on `deploy.yaml`, and instead builds stage config directly from `kwargs` via the default diffusion creator. Because of that, we cannot blindly nullify every non-explicit field. Otherwise, diffusion-only required inputs would be erased.

To address this, this PR introduces an override whitelist:
only fields with deploy-override semantics participate in sentinel-default handling. This preserves the intended precedence behavior for deploy-backed models, while avoiding regressions for pure diffusion flows.

**EngineArgs Path**

A second issue is that `OmniEngineArgs` inherits from upstream vLLM `EngineArgs`, so its inherited defaults cannot simply all be rewritten to `None`.

To make explicitness trackable on this path, this PR adds `OmniEngineArgs.create(...)` and tightens the contract for `engine_args` consumption:
only explicitly provided fields are treated as override-intent fields when passed into `Omni`.

This makes the `engine_args` path align with the new precedence model without depending on upstream inherited defaults.

**Parser / CLI Path**

For parser-based flows, older code relied on `from_cli_args(...)` to recover override-intent fields from `argv`.

But the repo still contains many parser-driven entrypoints that either:

- construct `Omni(...)` directly, or
- call `from_cli_args(...)` without passing the parser explicitly

Both cases are risky under sentinel-default precedence, because parser defaults may still leak in as fake overrides.

To handle this with minimal churn, this PR introduces / applies `nullify_stage_engine_defaults(parser)`.
This keeps the fix localized to parser setup: whenever a parser contains whitelist fields, nullifying those defaults is enough to preserve correctness, even if the downstream code path still uses direct `Omni(...)` construction or incomplete `from_cli_args(...)` usage.

This is intentionally lower-touch than rewriting all call sites.

## **Result**

After these changes, all three entry paths can consistently identify override-intent fields as user-explicit inputs only:

1. `engine_args` path: explicit fields tracked via `OmniEngineArgs.create(...)`
2. parser path: non-explicit whitelist defaults nullified
3. direct `kwargs` path: passed values are already explicit by construction

After these changes, all three entry paths can consistently identify override-intent fields as user-explicit inputs only. These fields now come strictly from user-provided values rather than inherited upper-layer defaults, and pure diffusion-only execution remains outside this override-normalization path.

Once the stage configs are resolved under this rule, they are passed downstream as finalized configs for stage initialization and engine launch. From that point on, lower layers only consume the resolved stage_config / vllm_config; precedence is no longer re-evaluated downstream.

## Validation

Focused smoke checks passed for the behavior touched here:

- `tests/test_arg_utils.py -k 'nullify_stage_engine_defaults or help_text_preserves_default or non_override_flags'`
- `tests/entrypoints/test_omni_entrypoints.py -k from_cli_args_only_nulls_untyped_override_fields`
- `tests/engine/test_single_stage_mode.py -k 'engine_args_create_only_forwards_explicit_fields or bare_engine_args_rejected'`




---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
