### PR TITLE
[Feat] Enable VAE parallel in HunyuanImage3

### DIFF
--- a/tests/diffusion/distributed/test_autoencoder_kl_hunyuan.py
+++ b/tests/diffusion/distributed/test_autoencoder_kl_hunyuan.py
@@ -16,7 +16,7 @@ class _DummyDistributedAutoencoderKLHunyuan(DistributedAutoencoderKLHunyuan):
         torch.nn.Module.__init__(self)
         self.tile_latent_min_size = 2
         self.tile_sample_min_size = 2
-        self.tile_overlap_factor = 0.0
+        self.tile_overlap_factor = 0.25
         self.use_spatial_tiling = False
 
     @property

--- a/tests/diffusion/distributed/test_autoencoder_kl_hunyuan.py
+++ b/tests/diffusion/distributed/test_autoencoder_kl_hunyuan.py
@@ -37,6 +37,7 @@ class _DummyDistributedAutoencoderKLHunyuan(DistributedAutoencoderKLHunyuan):
 
 
 def test_hunyuan_vae_use_tiling_aliases_spatial_tiling():
+    # Verify use_tiling property maps to use_spatial_tiling.
     vae = _DummyDistributedAutoencoderKLHunyuan()
 
     assert not vae.use_tiling
@@ -47,6 +48,7 @@ def test_hunyuan_vae_use_tiling_aliases_spatial_tiling():
 
 
 def test_hunyuan_vae_decode_tiles_round_trip():
+    # Validate decode tile split/exec/merge returns expected reconstructed tensor.
     vae = _DummyDistributedAutoencoderKLHunyuan()
     z = torch.arange(16, dtype=torch.float32).reshape(1, 1, 1, 4, 4)
 
@@ -62,6 +64,7 @@ def test_hunyuan_vae_decode_tiles_round_trip():
 
 
 def test_hunyuan_vae_encode_tiles_round_trip():
+    # Validate encode tile split/exec/merge returns expected latent tensor.
     vae = _DummyDistributedAutoencoderKLHunyuan()
     x = torch.arange(16, dtype=torch.float32).reshape(1, 1, 1, 4, 4)
 

--- a/tests/diffusion/distributed/test_autoencoder_kl_hunyuan.py
+++ b/tests/diffusion/distributed/test_autoencoder_kl_hunyuan.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_hunyuan import (
+    DistributedAutoencoderKLHunyuan,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _DummyDistributedAutoencoderKLHunyuan(DistributedAutoencoderKLHunyuan):
+    def __init__(self):
+        torch.nn.Module.__init__(self)
+        self.tile_latent_min_size = 2
+        self.tile_sample_min_size = 2
+        self.tile_overlap_factor = 0.0
+        self.use_spatial_tiling = False
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return torch.float32
+
+    def decoder(self, x: torch.Tensor) -> torch.Tensor:
+        return x + 10
+
+    def encoder(self, x: torch.Tensor) -> torch.Tensor:
+        return x + 20
+
+    def blend_v(self, _a: torch.Tensor, b: torch.Tensor, _blend_extent: int) -> torch.Tensor:
+        return b
+
+    def blend_h(self, _a: torch.Tensor, b: torch.Tensor, _blend_extent: int) -> torch.Tensor:
+        return b
+
+
+def test_hunyuan_vae_use_tiling_aliases_spatial_tiling():
+    vae = _DummyDistributedAutoencoderKLHunyuan()
+
+    assert not vae.use_tiling
+
+    vae.use_tiling = True
+
+    assert vae.use_spatial_tiling
+
+
+def test_hunyuan_vae_decode_tiles_round_trip():
+    vae = _DummyDistributedAutoencoderKLHunyuan()
+    z = torch.arange(16, dtype=torch.float32).reshape(1, 1, 1, 4, 4)
+
+    tile_tasks, grid_spec = vae.tile_split(z)
+    decoded_tiles = {task.grid_coord: vae.tile_exec(task) for task in tile_tasks}
+    output = vae.tile_merge(decoded_tiles, grid_spec)
+
+    assert grid_spec.split_dims == (3, 4)
+    assert grid_spec.grid_shape == (2, 2)
+    assert grid_spec.tile_spec == {"blend_extent": 0, "row_limit": 2}
+    assert [task.grid_coord for task in tile_tasks] == [(0, 0), (0, 1), (1, 0), (1, 1)]
+    assert torch.equal(output, z + 10)
+
+
+def test_hunyuan_vae_encode_tiles_round_trip():
+    vae = _DummyDistributedAutoencoderKLHunyuan()
+    x = torch.arange(16, dtype=torch.float32).reshape(1, 1, 1, 4, 4)
+
+    tile_tasks, grid_spec = vae.encode_tile_split(x)
+    encoded_tiles = {task.grid_coord: vae.encode_tile_exec(task) for task in tile_tasks}
+    output = vae.encode_tile_merge(encoded_tiles, grid_spec)
+
+    assert grid_spec.split_dims == (3, 4)
+    assert grid_spec.grid_shape == (2, 2)
+    assert grid_spec.tile_spec == {"blend_extent": 0, "row_limit": 2}
+    assert [task.grid_coord for task in tile_tasks] == [(0, 0), (0, 1), (1, 0), (1, 1)]
+    assert torch.equal(output, x + 20)

--- a/tests/diffusion/distributed/test_autoencoder_kl_hunyuan.py
+++ b/tests/diffusion/distributed/test_autoencoder_kl_hunyuan.py
@@ -14,8 +14,8 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 class _DummyDistributedAutoencoderKLHunyuan(DistributedAutoencoderKLHunyuan):
     def __init__(self):
         torch.nn.Module.__init__(self)
-        self.tile_latent_min_size = 2
-        self.tile_sample_min_size = 2
+        self.tile_latent_min_size = 8
+        self.tile_sample_min_size = 8
         self.tile_overlap_factor = 0.25
         self.use_spatial_tiling = False
 
@@ -50,30 +50,30 @@ def test_hunyuan_vae_use_tiling_aliases_spatial_tiling():
 def test_hunyuan_vae_decode_tiles_round_trip():
     # Validate decode tile split/exec/merge returns expected reconstructed tensor.
     vae = _DummyDistributedAutoencoderKLHunyuan()
-    z = torch.arange(16, dtype=torch.float32).reshape(1, 1, 1, 4, 4)
+    z = torch.arange(144, dtype=torch.float32).reshape(1, 1, 1, 12, 12)
 
     tile_tasks, grid_spec = vae.tile_split(z)
     decoded_tiles = {task.grid_coord: vae.tile_exec(task) for task in tile_tasks}
     output = vae.tile_merge(decoded_tiles, grid_spec)
 
     assert grid_spec.split_dims == (3, 4)
-    assert grid_spec.grid_shape == (4, 4)
-    assert grid_spec.tile_spec == {"blend_extent": 0, "row_limit": 2}
-    assert len(tile_tasks) == 16
+    assert grid_spec.grid_shape == (2, 2)
+    assert grid_spec.tile_spec == {"blend_extent": 2, "row_limit": 6}
+    assert len(tile_tasks) == 4
     assert torch.equal(output, z + 10)
 
 
 def test_hunyuan_vae_encode_tiles_round_trip():
     # Validate encode tile split/exec/merge returns expected latent tensor.
     vae = _DummyDistributedAutoencoderKLHunyuan()
-    x = torch.arange(16, dtype=torch.float32).reshape(1, 1, 1, 4, 4)
+    x = torch.arange(144, dtype=torch.float32).reshape(1, 1, 1, 12, 12)
 
     tile_tasks, grid_spec = vae.encode_tile_split(x)
     encoded_tiles = {task.grid_coord: vae.encode_tile_exec(task) for task in tile_tasks}
     output = vae.encode_tile_merge(encoded_tiles, grid_spec)
 
     assert grid_spec.split_dims == (3, 4)
-    assert grid_spec.grid_shape == (4, 4)
-    assert grid_spec.tile_spec == {"blend_extent": 0, "row_limit": 2}
-    assert len(tile_tasks) == 16
+    assert grid_spec.grid_shape == (2, 2)
+    assert grid_spec.tile_spec == {"blend_extent": 2, "row_limit": 6}
+    assert len(tile_tasks) == 4
     assert torch.equal(output, x + 20)

--- a/tests/diffusion/distributed/test_autoencoder_kl_hunyuan.py
+++ b/tests/diffusion/distributed/test_autoencoder_kl_hunyuan.py
@@ -57,9 +57,9 @@ def test_hunyuan_vae_decode_tiles_round_trip():
     output = vae.tile_merge(decoded_tiles, grid_spec)
 
     assert grid_spec.split_dims == (3, 4)
-    assert grid_spec.grid_shape == (2, 2)
+    assert grid_spec.grid_shape == (4, 4)
     assert grid_spec.tile_spec == {"blend_extent": 0, "row_limit": 2}
-    assert [task.grid_coord for task in tile_tasks] == [(0, 0), (0, 1), (1, 0), (1, 1)]
+    assert len(tile_tasks) == 16
     assert torch.equal(output, z + 10)
 
 
@@ -73,7 +73,7 @@ def test_hunyuan_vae_encode_tiles_round_trip():
     output = vae.encode_tile_merge(encoded_tiles, grid_spec)
 
     assert grid_spec.split_dims == (3, 4)
-    assert grid_spec.grid_shape == (2, 2)
+    assert grid_spec.grid_shape == (4, 4)
     assert grid_spec.tile_spec == {"blend_extent": 0, "row_limit": 2}
-    assert [task.grid_coord for task in tile_tasks] == [(0, 0), (0, 1), (1, 0), (1, 1)]
+    assert len(tile_tasks) == 16
     assert torch.equal(output, x + 20)

--- a/vllm_omni/diffusion/distributed/autoencoders/autoencoder_kl_hunyuan.py
+++ b/vllm_omni/diffusion/distributed/autoencoders/autoencoder_kl_hunyuan.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import torch
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.distributed.autoencoders.distributed_vae_executor import (
+    DistributedOperator,
+    DistributedVaeMixin,
+    GridSpec,
+    TileTask,
+)
+from vllm_omni.diffusion.models.hunyuan_image3.autoencoder import AutoencoderKLConv3D
+
+logger = init_logger(__name__)
+
+
+class DistributedAutoencoderKLHunyuan(AutoencoderKLConv3D, DistributedVaeMixin):
+    @classmethod
+    def from_config(cls, config: Any, **kwargs: Any):
+        model = super().from_config(config, **kwargs)
+        model.init_distributed()
+        return model
+
+    @property
+    def use_tiling(self) -> bool:
+        return self.use_spatial_tiling
+
+    @use_tiling.setter
+    def use_tiling(self, use_tiling: bool) -> None:
+        self.use_spatial_tiling = use_tiling
+
+    def tile_split(self, z: torch.Tensor) -> tuple[list[TileTask], GridSpec]:
+        _, _, _, height, width = z.shape
+        overlap_size = int(self.tile_latent_min_size * (1 - self.tile_overlap_factor))
+        blend_extent = int(self.tile_sample_min_size * self.tile_overlap_factor)
+        row_limit = int(self.tile_sample_min_size - blend_extent)
+
+        tiletask_list = []
+        for i in range(0, height, overlap_size):
+            for j in range(0, width, overlap_size):
+                tile = z[:, :, :, i : i + self.tile_latent_min_size, j : j + self.tile_latent_min_size]
+                tiletask_list.append(
+                    TileTask(
+                        len(tiletask_list),
+                        (i // overlap_size, j // overlap_size),
+                        tile,
+                        workload=tile.shape[3] * tile.shape[4],
+                    )
+                )
+
+        grid_spec = GridSpec(
+            split_dims=(3, 4),
+            grid_shape=(tiletask_list[-1].grid_coord[0] + 1, tiletask_list[-1].grid_coord[1] + 1),
+            tile_spec={"blend_extent": blend_extent, "row_limit": row_limit},
+            output_dtype=self.dtype,
+        )
+        return tiletask_list, grid_spec
+
+    def tile_exec(self, task: TileTask) -> torch.Tensor:
+        return self.decoder(task.tensor)
+
+    def tile_merge(self, coord_tensor_map: dict[tuple[int, ...], torch.Tensor], grid_spec: GridSpec) -> torch.Tensor:
+        grid_h, grid_w = grid_spec.grid_shape
+        result_rows = []
+        for i in range(grid_h):
+            result_row = []
+            for j in range(grid_w):
+                tile = coord_tensor_map[(i, j)]
+                if i > 0:
+                    tile = self.blend_v(coord_tensor_map[(i - 1, j)], tile, grid_spec.tile_spec["blend_extent"])
+                if j > 0:
+                    tile = self.blend_h(coord_tensor_map[(i, j - 1)], tile, grid_spec.tile_spec["blend_extent"])
+                result_row.append(tile[:, :, :, : grid_spec.tile_spec["row_limit"], : grid_spec.tile_spec["row_limit"]])
+            result_rows.append(torch.cat(result_row, dim=-1))
+        return torch.cat(result_rows, dim=-2)
+
+    def encode_tile_split(self, x: torch.Tensor) -> tuple[list[TileTask], GridSpec]:
+        _, _, _, height, width = x.shape
+        overlap_size = int(self.tile_sample_min_size * (1 - self.tile_overlap_factor))
+        blend_extent = int(self.tile_latent_min_size * self.tile_overlap_factor)
+        row_limit = int(self.tile_latent_min_size - blend_extent)
+
+        tiletask_list = []
+        for i in range(0, height, overlap_size):
+            for j in range(0, width, overlap_size):
+                tile = x[:, :, :, i : i + self.tile_sample_min_size, j : j + self.tile_sample_min_size]
+                tiletask_list.append(
+                    TileTask(
+                        len(tiletask_list),
+                        (i // overlap_size, j // overlap_size),
+                        tile,
+                        workload=tile.shape[3] * tile.shape[4],
+                    )
+                )
+
+        grid_spec = GridSpec(
+            split_dims=(3, 4),
+            grid_shape=(tiletask_list[-1].grid_coord[0] + 1, tiletask_list[-1].grid_coord[1] + 1),
+            tile_spec={"blend_extent": blend_extent, "row_limit": row_limit},
+            output_dtype=self.dtype,
+        )
+        return tiletask_list, grid_spec
+
+    def encode_tile_exec(self, task: TileTask) -> torch.Tensor:
+        return self.encoder(task.tensor)
+
+    def encode_tile_merge(
+        self, coord_tensor_map: dict[tuple[int, ...], torch.Tensor], grid_spec: GridSpec
+    ) -> torch.Tensor:
+        grid_h, grid_w = grid_spec.grid_shape
+        result_rows = []
+        for i in range(grid_h):
+            result_row = []
+            for j in range(grid_w):
+                tile = coord_tensor_map[(i, j)]
+                if i > 0:
+                    tile = self.blend_v(coord_tensor_map[(i - 1, j)], tile, grid_spec.tile_spec["blend_extent"])
+                if j > 0:
+                    tile = self.blend_h(coord_tensor_map[(i, j - 1)], tile, grid_spec.tile_spec["blend_extent"])
+                result_row.append(tile[:, :, :, : grid_spec.tile_spec["row_limit"], : grid_spec.tile_spec["row_limit"]])
+            result_rows.append(torch.cat(result_row, dim=-1))
+        return torch.cat(result_rows, dim=-2)
+
+    def spatial_tiled_encode(self, x: torch.Tensor):
+        if not self.is_distributed_enabled():
+            return super().spatial_tiled_encode(x)
+
+        logger.debug("Encode running with distributed executor")
+        return self.distributed_executor.execute(
+            x,
+            DistributedOperator(
+                split=self.encode_tile_split,
+                exec=self.encode_tile_exec,
+                merge=self.encode_tile_merge,
+            ),
+            broadcast_result=True,
+        )
+
+    def spatial_tiled_decode(self, z: torch.Tensor):
+        if not self.is_distributed_enabled():
+            return super().spatial_tiled_decode(z)
+
+        logger.debug("Decode running with distributed executor")
+        return self.distributed_executor.execute(
+            z,
+            DistributedOperator(split=self.tile_split, exec=self.tile_exec, merge=self.tile_merge),
+            broadcast_result=True,
+        )

--- a/vllm_omni/diffusion/distributed/autoencoders/autoencoder_kl_hunyuan.py
+++ b/vllm_omni/diffusion/distributed/autoencoders/autoencoder_kl_hunyuan.py
@@ -24,6 +24,12 @@ class DistributedAutoencoderKLHunyuan(AutoencoderKLConv3D, DistributedVaeMixin):
         model.init_distributed()
         return model
 
+    @classmethod
+    def from_pretrained(cls, *args: Any, **kwargs: Any):
+        model = super().from_pretrained(*args, **kwargs)
+        model.init_distributed()
+        return model
+
     @property
     def use_tiling(self) -> bool:
         return self.use_spatial_tiling
@@ -110,19 +116,7 @@ class DistributedAutoencoderKLHunyuan(AutoencoderKLConv3D, DistributedVaeMixin):
     def encode_tile_merge(
         self, coord_tensor_map: dict[tuple[int, ...], torch.Tensor], grid_spec: GridSpec
     ) -> torch.Tensor:
-        grid_h, grid_w = grid_spec.grid_shape
-        result_rows = []
-        for i in range(grid_h):
-            result_row = []
-            for j in range(grid_w):
-                tile = coord_tensor_map[(i, j)]
-                if i > 0:
-                    tile = self.blend_v(coord_tensor_map[(i - 1, j)], tile, grid_spec.tile_spec["blend_extent"])
-                if j > 0:
-                    tile = self.blend_h(coord_tensor_map[(i, j - 1)], tile, grid_spec.tile_spec["blend_extent"])
-                result_row.append(tile[:, :, :, : grid_spec.tile_spec["row_limit"], : grid_spec.tile_spec["row_limit"]])
-            result_rows.append(torch.cat(result_row, dim=-1))
-        return torch.cat(result_rows, dim=-2)
+        return self.tile_merge(coord_tensor_map, grid_spec)
 
     def spatial_tiled_encode(self, x: torch.Tensor):
         if not self.is_distributed_enabled():

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -20,9 +20,6 @@ from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
 from vllm.transformers_utils.config import get_config
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
-from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_hunyuan import (
-    DistributedAutoencoderKLHunyuan,
-)
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.interface import SupportImageInput
@@ -345,6 +342,11 @@ class HunyuanImage3Pipeline(
         quant_config = od_config.quantization_config
         self.model = HunyuanImage3Model(self.hf_config, quant_config=quant_config)
         self.transformer = self.model
+        # Lazy import to break circular dependency:
+        # autoencoder_kl_hunyuan -> hunyuan_image3/__init__ -> pipeline_hunyuan_image3 -> autoencoder_kl_hunyuan
+        from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_hunyuan import (  # noqa: PLC0415
+            DistributedAutoencoderKLHunyuan,
+        )
         self.vae = DistributedAutoencoderKLHunyuan.from_config(self.hf_config.vae)
         self.vae.use_spatial_tiling = self.od_config.vae_use_tiling
         self._pipeline = None

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -347,6 +347,7 @@ class HunyuanImage3Pipeline(
         from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_hunyuan import (  # noqa: PLC0415
             DistributedAutoencoderKLHunyuan,
         )
+
         self.vae = DistributedAutoencoderKLHunyuan.from_config(self.hf_config.vae)
         self.vae.use_spatial_tiling = self.od_config.vae_use_tiling
         self._pipeline = None

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -20,6 +20,9 @@ from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
 from vllm.transformers_utils.config import get_config
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_hunyuan import (
+    DistributedAutoencoderKLHunyuan,
+)
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.interface import SupportImageInput
@@ -30,7 +33,6 @@ from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.inputs.data import OmniTextPrompt
 from vllm_omni.model_executor.models.hunyuan_image3.siglip2 import Siglip2VisionTransformer
 
-from .autoencoder import AutoencoderKLConv3D
 from .hunyuan_image3_tokenizer import TokenizerWrapper
 from .hunyuan_image3_transformer import (
     CausalMMOutputWithPast,
@@ -343,7 +345,7 @@ class HunyuanImage3Pipeline(
         quant_config = od_config.quantization_config
         self.model = HunyuanImage3Model(self.hf_config, quant_config=quant_config)
         self.transformer = self.model
-        self.vae = AutoencoderKLConv3D.from_config(self.hf_config.vae)
+        self.vae = DistributedAutoencoderKLHunyuan.from_config(self.hf_config.vae)
         self.vae.use_spatial_tiling = self.od_config.vae_use_tiling
         self._pipeline = None
         self._tkwrapper = TokenizerWrapper(od_config.model)


### PR DESCRIPTION
## Summary

Enable VAE parallel support in HunyuanImage3.

Current changes:
- add a distributed Hunyuan VAE wrapper at `vllm_omni/diffusion/distributed/autoencoders/autoencoder_kl_hunyuan.py`
- wire `HunyuanImage3Pipeline` to use the distributed autoencoder wrapper
- remove the NPU fused MoE init hook in `vllm_omni/platforms/npu/models/hunyuan_fused_moe.py`

unified deploy yaml in https://github.com/vllm-project/vllm-omni/pull/3172

## Validation

- static checks only so far (`py_compile`, diff checks)
- runtime validation is still pending

## Test Plan
Tested on 4xAscend NPU

server
```
vllm serve $model --omni --port "8031" \
    --log-stats \
    --stage-configs-path "vllm_omni/platforms/npu/stage_configs/hunyuan_image3_t2i.yaml" 
```
vae_patch_parallel_size is set to 4

client
```
curl -X POST http://localhost:8031/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{
    "prompt": 
    "A cinematic medium shot captures a single Asian woman seated on a chair within a dimly lit room, creating an intimate and theatrical atmosphere. The composition is focused on the subject, rendered with rich colors and intricate textures that evoke a nostalgic and moody feeling.\n\nThe primary subject is a young Asian woman with a thoughtful and expressive countenance, her gaze directed slightly away from the camera. She is seated in a relaxed yet elegant posture on an ornate, vintage armchair. The chair is upholstered in a deep red velvet, its fabric showing detailed, intricate textures and slight signs of wear. She wears a simple, elegant dress in a dark teal hue, the material catching the light in a way that reveals its fine-woven texture. Her skin has a soft, matte quality, and the light delicately models the contours of her face and arms.\n\nThe surrounding room is characterized by its vintage decor, which contributes to the historic and evocative mood. In the immediate background, partially blurred due to a shallow depth of field consistent with a f/2.8 aperture, the wall is covered with wallpaper featuring a subtle, damask pattern. The overall color palette is a carefully balanced interplay of deep teal and rich red hues, creating a visually compelling and cohesive environment. The entire scene is detailed, from the fibers of the upholstery to the subtle patterns on the wall.\n\nThe lighting is highly dramatic and artistic, defined by high contrast and pronounced shadow play. A single key light source, positioned off-camera, projects gobo lighting patterns onto the scene, casting intricate shapes of light and shadow across the woman and the back wall. These dramatic shadows create a strong scense of depth and a theatrical quality. While some shadows are deep and defined, others remain soft, gently wrapping around the subject and preventing the loss of detail in darker areas. The soft focus on the background enhances the intimate feeling, drawing all attention to the expressive subject. The overall image presents a cinematic, photorealistic photography style.",
    "num_inference_steps": 2,
    "guidance_scale": "1.0",
    "n": 1,
    "size": "1024x1024",
    "seed": 42
  }' | jq -r '.data[0].b64_json' | base64 -d > output.png
```

## Test Result
output

<img width="1024" height="1024" alt="output" src="https://github.com/user-attachments/assets/75f2a3e6-74da-47d0-960b-0e943e4c97af" />


VAE decode time  625.7ms -> 355ms

w/o vae parallel
<img width="514" height="202" alt="wo-vae" src="https://github.com/user-attachments/assets/0aa16e09-2a22-4ee5-aa3a-95e27e58ba7e" />

w vae parallel
<img width="515" height="293" alt="w vae" src="https://github.com/user-attachments/assets/be33a5b6-51c0-4672-8e4d-c83aa20da2b1" />

