### PR TITLE
[Bugfix] Fix Flux2klein Text Input Processing

### DIFF
--- a/tests/e2e/offline_inference/test_flux2_klein.py
+++ b/tests/e2e/offline_inference/test_flux2_klein.py
@@ -65,6 +65,7 @@ def _extract_images_from_output(outputs: list) -> list[Image.Image]:
     return images
 
 
+# Regression test for https://github.com/vllm-project/vllm-omni/issues/3097
 @pytest.mark.core_model
 @pytest.mark.diffusion
 def test_flux2_klein_can_accept_text_inputs():

--- a/tests/e2e/offline_inference/test_flux2_klein.py
+++ b/tests/e2e/offline_inference/test_flux2_klein.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 from PIL import Image, ImageDraw
 
+from vllm_omni.entrypoints.omni import Omni
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.platforms import current_omni_platform
@@ -23,8 +24,6 @@ from vllm_omni.platforms import current_omni_platform
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
-
-from vllm_omni import Omni
 
 os.environ["VLLM_TEST_CLEAN_GPU_MEMORY"] = "1"
 
@@ -64,6 +63,17 @@ def _extract_images_from_output(outputs: list) -> list[Image.Image]:
                     if hasattr(s, "images") and s.images:
                         images.extend(s.images)
     return images
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+def test_flux2_klein_can_accept_text_inputs():
+    model = Omni(model=MODEL)
+    outputs = model.generate(
+        "a cup of coffee on the table",
+        OmniDiffusionSamplingParams(num_inference_steps=2, seed=42),
+    )
+    assert len(outputs[0].images) == 1
 
 
 @pytest.mark.core_model

--- a/vllm_omni/diffusion/models/flux2_klein/pipeline_flux2_klein.py
+++ b/vllm_omni/diffusion/models/flux2_klein/pipeline_flux2_klein.py
@@ -829,15 +829,20 @@ class Flux2KleinPipeline(nn.Module, CFGParallelMixin, SupportImageInput, Diffusi
                 """Taking only the first image for now.""",
             )
         first_prompt = req.prompts[0]
-        prompt = first_prompt if isinstance(first_prompt, str) else (first_prompt.get("prompt") or "")
+        if isinstance(first_prompt, str):
+            multi_modal_data = {}
+            prompt = first_prompt
+            raw_image = None
+            mask_image = None
+            reference_image = None
+        else:
+            multi_modal_data = first_prompt.get("multi_modal_data", {})
+            prompt = first_prompt.get("prompt", "")
+            raw_image = multi_modal_data.get("image")
+            mask_image = multi_modal_data.get("mask_image")
+            reference_image = multi_modal_data.get("reference_image")
 
-        if (
-            raw_image := None
-            if isinstance(first_prompt, str)
-            else first_prompt.get("multi_modal_data", {}).get("image")
-        ) is None:
-            pass  # use image from param list
-        elif isinstance(raw_image, list):
+        if isinstance(raw_image, list):
             image = [PIL.Image.open(im) if isinstance(im, str) else cast(PIL.Image.Image, im) for im in raw_image]
         else:
             image = PIL.Image.open(raw_image) if isinstance(raw_image, str) else cast(PIL.Image.Image, raw_image)
@@ -955,11 +960,6 @@ class Flux2KleinPipeline(nn.Module, CFGParallelMixin, SupportImageInput, Diffusi
 
         height = height or self.default_sample_size * self.vae_scale_factor
         width = width or self.default_sample_size * self.vae_scale_factor
-
-        # Get mask_image and reference_image
-        multi_modal_data = req.prompts[0].get("multi_modal_data", {}) if req.prompts else {}
-        mask_image = multi_modal_data.get("mask_image")
-        reference_image = multi_modal_data.get("reference_image")
 
         if mask_image is not None and (image is None or (isinstance(image, list) and len(image) == 0)):
             raise ValueError("image must be provided when using mask_image for inpainting")

--- a/vllm_omni/diffusion/models/flux2_klein/pipeline_flux2_klein.py
+++ b/vllm_omni/diffusion/models/flux2_klein/pipeline_flux2_klein.py
@@ -837,12 +837,14 @@ class Flux2KleinPipeline(nn.Module, CFGParallelMixin, SupportImageInput, Diffusi
             reference_image = None
         else:
             multi_modal_data = first_prompt.get("multi_modal_data", {})
-            prompt = first_prompt.get("prompt", "")
+            prompt = first_prompt.get("prompt") or ""
             raw_image = multi_modal_data.get("image")
             mask_image = multi_modal_data.get("mask_image")
             reference_image = multi_modal_data.get("reference_image")
 
-        if isinstance(raw_image, list):
+        if raw_image is None:
+            image = None
+        elif isinstance(raw_image, list):
             image = [PIL.Image.open(im) if isinstance(im, str) else cast(PIL.Image.Image, im) for im in raw_image]
         else:
             image = PIL.Image.open(raw_image) if isinstance(raw_image, str) else cast(PIL.Image.Image, raw_image)


### PR DESCRIPTION
## Purpose
Fix: https://github.com/vllm-project/vllm-omni/issues/3097 - recent changes around inpainting seem to have broken support for text prompts in Flux2Klein.

## Test Plan
```python
from vllm_omni.entrypoints.omni import Omni
from vllm_omni.inputs.data import OmniDiffusionSamplingParams

if __name__ == "__main__":
    omni = Omni(model="black-forest-labs/FLUX.2-klein-4B")

    outputs = omni.generate(
        "a cup of coffee on the table",
        OmniDiffusionSamplingParams(num_inference_steps=50, seed=42),
    )
```

Crashes:
```
ERROR 04-24 06:02:42 [diffusion_worker.py:632]     return func(*args, **kwargs)
ERROR 04-24 06:02:42 [diffusion_worker.py:632]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 06:02:42 [diffusion_worker.py:632]   File "/home/alex-jw-brooks/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 244, in execute_model
ERROR 04-24 06:02:42 [diffusion_worker.py:632]     output = self.model_runner.execute_model(req)
ERROR 04-24 06:02:42 [diffusion_worker.py:632]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 06:02:42 [diffusion_worker.py:632]   File "/home/alex-jw-brooks/vllm-omni/vllm_omni/diffusion/worker/diffusion_model_runner.py", line 276, in execute_model
ERROR 04-24 06:02:42 [diffusion_worker.py:632]     output = self.pipeline.forward(req)
ERROR 04-24 06:02:42 [diffusion_worker.py:632]              ^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-24 06:02:42 [diffusion_worker.py:632]   File "/home/alex-jw-brooks/vllm-omni/vllm_omni/diffusion/models/flux2_klein/pipeline_flux2_klein.py", line 960, in forward
ERROR 04-24 06:02:42 [diffusion_worker.py:632]     multi_modal_data = req.prompts[0].get("multi_modal_data", {}) if req.prompts else {}
ERROR 04-24 06:02:42 [diffusion_worker.py:632]                        ^^^^^^^^^^^^^^^^^^
ERROR 04-24 06:02:42 [diffusion_worker.py:632] AttributeError: 'str' object has no attribute 'get'
```

## Test Result
Above works as expected, regression test added.