### PR TITLE
[CI] Update QwenImageEdit2509 to 2511 in CI

### DIFF
--- a/tests/dfx/perf/tests/test_qwen_image_edit_2511_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_edit_2511_vllm_omni.json
@@ -1,10 +1,10 @@
 [
     {
-        "test_name": "test_qwen_image_edit_2509_single_device",
+        "test_name": "test_qwen_image_edit_2511_single_device",
         "description": "Single-device baseline (two input images)",
         "server_type": "vllm-omni",
         "server_params": {
-            "model": "Qwen/Qwen-Image-Edit-2509",
+            "model": "Qwen/Qwen-Image-Edit-2511",
             "serve_args": {
                 "enable-diffusion-pipeline-profiler": true
             }
@@ -49,11 +49,11 @@
         ]
     },
     {
-        "test_name": "test_qwen_image_edit_2509_ulysses2_cfg2_vae_patch4",
+        "test_name": "test_qwen_image_edit_2511_ulysses2_cfg2_vae_patch4",
         "description": "Ulysses SP=2 + CFG=2 + VAE patch parallel=4",
         "server_type": "vllm-omni",
         "server_params": {
-            "model": "Qwen/Qwen-Image-Edit-2509",
+            "model": "Qwen/Qwen-Image-Edit-2511",
             "serve_args": {
                 "ulysses-degree": 2,
                 "cfg-parallel-size": 2,
@@ -102,11 +102,11 @@
         ]
     },
     {
-        "test_name": "test_qwen_image_edit_2509_ulysses2_cfg2_cache_dit",
+        "test_name": "test_qwen_image_edit_2511_ulysses2_cfg2_cache_dit",
         "description": "Ulysses SP=2 + CFG=2 + CacheDiT",
         "server_type": "vllm-omni",
         "server_params": {
-            "model": "Qwen/Qwen-Image-Edit-2509",
+            "model": "Qwen/Qwen-Image-Edit-2511",
             "serve_args": {
                 "ulysses-degree": 2,
                 "cfg-parallel-size": 2,

--- a/tests/e2e/accuracy/test_qwen_image_edit.py
+++ b/tests/e2e/accuracy/test_qwen_image_edit.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.full_model, pytest.mark.diffusion]
 
 
 SINGLE_MODEL = "Qwen/Qwen-Image-Edit"
-MULTIPLE_MODEL = "Qwen/Qwen-Image-Edit-2509"
+MULTIPLE_MODEL = "Qwen/Qwen-Image-Edit-2511"
 WIDTH = 512
 HEIGHT = 512
 NUM_INFERENCE_STEPS = 20

--- a/tests/e2e/online_serving/test_qwen_image_edit_expansion.py
+++ b/tests/e2e/online_serving/test_qwen_image_edit_expansion.py
@@ -2,7 +2,7 @@
 Comprehensive tests of diffusion features that are available in online serving mode
 and are supported by the following models:
 - Qwen-Image-Edit: single image input
-- Qwen-Image-Edit-2509: two image inputs
+- Qwen-Image-Edit-2511: two image inputs
 """
 
 import pytest
@@ -140,11 +140,11 @@ def test_qwen_image_edit(omni_server: OmniServer, openai_client: OpenAIClientHan
 
 @pytest.mark.parametrize(
     "omni_server",
-    _get_diffusion_feature_cases("Qwen/Qwen-Image-Edit-2509"),
+    _get_diffusion_feature_cases("Qwen/Qwen-Image-Edit-2511"),
     indirect=True,
 )
-def test_qwen_image_edit_2509(omni_server: OmniServer, openai_client: OpenAIClientHandler):
-    """Test all diffusion features with Qwen-Image-Edit-2509 in regular end-user scenarios."""
+def test_qwen_image_edit_2511(omni_server: OmniServer, openai_client: OpenAIClientHandler):
+    """Test all diffusion features with Qwen-Image-Edit-2511 in regular end-user scenarios."""
     image_data_url_1 = f"data:image/jpeg;base64,{generate_synthetic_image(512, 512)['base64']}"
     image_data_url_2 = f"data:image/jpeg;base64,{generate_synthetic_image(512, 512)['base64']}"
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Update Qwen Image Edit 2509 to 2511 in CI.

Note that the file `tests/e2e/online_serving/test_image_gen_edit.py` is unchanged.
Because it is scheduled to be deleted in #2556

## Test Plan

Keep intact

## Test Result

Should be the same. This is a hot fix. I think we can directly run it on CI

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

