### PR TITLE
[XPU] Enable torch inductor for xpu

### DIFF
--- a/vllm_omni/platforms/xpu/platform.py
+++ b/vllm_omni/platforms/xpu/platform.py
@@ -45,8 +45,7 @@ class XPUOmniPlatform(OmniPlatform, XPUPlatform):
 
     @classmethod
     def supports_torch_inductor(cls) -> bool:
-        # TODO: Enable this when torch compile bugs are resolved
-        return False
+        return True
 
     @classmethod
     def get_default_stage_config_path(cls) -> str:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

This PR is aiming for a quick switch on of torch inductor for xpu.

## Test Plan

Tested with wan2.2-S2V from #2751 

 - Output file: /tmp/s2v_singing_480p.mp4                                                                                                                                                                                 
 - E2E generation time: 262.6 seconds (vs 281.8s previously without torch.compile — 6.8% faster)                                                                                                                          
 - Per-step time: ~21.8s (from progress bar; vs ~25.3s previously — 13.8% faster)            

```
wget -O "Five Hundred Miles.png" "https://raw.githubusercontent.com/Wan-Video/Wan2.2/main/examples/Five%20Hundred%20Miles.png"
wget -O "Five Hundred Miles.MP3" "https://raw.githubusercontent.com/Wan-Video/Wan2.2/main/examples/Five%20Hundred%20Miles.MP3"
VLLM_WORKER_MULTIPROC_METHOD=spawn python -u speech_to_video.py \
    --model Wan-AI/Wan2.2-S2V-14B \
    --image "Five Hundred Miles.png" \
    --audio "Five Hundred Miles.MP3" \
    --prompt "A person singing" \
    --height 448 --width 832 \
    --num-inference-steps 10 \
    --tensor-parallel-size 2 \
    --enable-cpu-offloading \
    --vae-use-slicing --vae-use-tiling \
    --output /tmp/s2v_singing_480p.mp4 2>&1 | tee wan-s2v-480p.log
```
output video:

https://github.com/user-attachments/assets/dfb48a2d-c09b-4acd-93ee-b826cd7cc391


         

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
