### PR TITLE
[WIP] Add HTTP 400 error propegation to diffusion pipelines via OmniInputVa…

### DIFF
--- a/tests/diffusion/models/qwen_image/test_qwen_image_edit_plus.py
+++ b/tests/diffusion/models/qwen_image/test_qwen_image_edit_plus.py
@@ -11,18 +11,21 @@ from PIL import Image
 from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit_plus import (
     get_qwen_image_edit_plus_pre_process_func,
 )
+from vllm_omni.exceptions import OmniInputValidationError
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
 
-def test_qwen_image_edit_plus_rejects_too_many_input_images(tmp_path: Path):
+def _make_od_config(tmp_path: Path, *, max_multimodal_image_inputs=None):
     vae_dir = tmp_path / "vae"
-    vae_dir.mkdir()
-    # Keep the mock config intentionally minimal: this test only needs the
-    # fields touched during pre-process initialization.
+    vae_dir.mkdir(exist_ok=True)
     (vae_dir / "config.json").write_text(json.dumps({"z_dim": 16}))
+    return SimpleNamespace(model=str(tmp_path), max_multimodal_image_inputs=max_multimodal_image_inputs)
 
-    pre_process = get_qwen_image_edit_plus_pre_process_func(SimpleNamespace(model=str(tmp_path)))
+
+def test_qwen_image_edit_plus_rejects_too_many_input_images(tmp_path: Path):
+    od_config = _make_od_config(tmp_path)
+    pre_process = get_qwen_image_edit_plus_pre_process_func(od_config)
     image = Image.fromarray(np.zeros((32, 32, 3), dtype=np.uint8))
     request = SimpleNamespace(
         prompts=[
@@ -34,5 +37,23 @@ def test_qwen_image_edit_plus_rejects_too_many_input_images(tmp_path: Path):
         sampling_params=SimpleNamespace(height=None, width=None),
     )
 
-    with pytest.raises(ValueError, match=r"At most 4 images are supported by this model"):
+    with pytest.raises(OmniInputValidationError, match=r"At most 4 images are supported"):
+        pre_process(request)
+
+
+def test_qwen_image_edit_plus_rejects_images_exceeding_config_limit(tmp_path: Path):
+    od_config = _make_od_config(tmp_path, max_multimodal_image_inputs=2)
+    pre_process = get_qwen_image_edit_plus_pre_process_func(od_config)
+    image = Image.fromarray(np.zeros((32, 32, 3), dtype=np.uint8))
+    request = SimpleNamespace(
+        prompts=[
+            {
+                "prompt": "combine",
+                "multi_modal_data": {"image": [image, image, image]},
+            }
+        ],
+        sampling_params=SimpleNamespace(height=None, width=None),
+    )
+
+    with pytest.raises(OmniInputValidationError, match=r"At most 2 images are supported"):
         pre_process(request)

--- a/tests/diffusion/models/qwen_image/test_qwen_image_max_sequence_length.py
+++ b/tests/diffusion/models/qwen_image/test_qwen_image_max_sequence_length.py
@@ -17,6 +17,7 @@ from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit_plus import 
 from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_layered import (
     QwenImageLayeredPipeline,
 )
+from vllm_omni.exceptions import OmniInputValidationError
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -258,3 +259,49 @@ def test_qwen_edit_validator_excludes_image_placeholders_from_budget(pipeline_cl
 )
 def test_forward_max_sequence_length_default_is_1024(pipeline_class: type):
     assert inspect.signature(pipeline_class.forward).parameters["max_sequence_length"].default == 1024
+
+
+def test_forward_caps_max_sequence_length_with_max_multimodal_text_tokens():
+    pipeline = object.__new__(QwenImageEditPlusPipeline)
+    nn.Module.__init__(pipeline)
+    pipeline.device = torch.device("cpu")
+    pipeline.text_encoder = _RejectingTextEncoder()
+    pipeline.tokenizer_max_length = 1024
+    pipeline.prompt_template_encode = "{}"
+    pipeline.prompt_template_encode_start_idx = 64
+    pipeline.tokenizer = _FakeTokenizer([17, 0])
+    pipeline.processor = _FakeProcessor(17)
+    pipeline.vae_scale_factor = 8
+    pipeline.od_config = SimpleNamespace(max_multimodal_text_tokens=16, max_multimodal_image_inputs=None)
+    pipeline.check_cfg_parallel_validity = lambda *_args: True
+
+    req = SimpleNamespace(
+        prompts=[
+            {
+                "prompt": "a long prompt",
+                "additional_information": {
+                    "condition_images": [],
+                    "vae_images": [],
+                    "condition_image_sizes": [],
+                    "vae_image_sizes": [],
+                    "calculated_height": 1024,
+                    "calculated_width": 1024,
+                },
+            }
+        ],
+        sampling_params=SimpleNamespace(
+            height=1024,
+            width=1024,
+            num_inference_steps=1,
+            sigmas=None,
+            max_sequence_length=None,
+            generator=None,
+            true_cfg_scale=1.0,
+            guidance_scale_provided=False,
+            guidance_scale=1.0,
+            num_outputs_per_prompt=0,
+        ),
+    )
+
+    with pytest.raises(OmniInputValidationError, match=r"got 17 tokens"):
+        pipeline.forward(req)

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -496,6 +496,8 @@ class OmniDiffusionConfig:
     supports_multimodal_inputs: bool = False
     max_multimodal_image_inputs: int | None = None
 
+    max_multimodal_text_tokens: int | None = None
+
     log_level: str = "info"
 
     # Omni configuration (injected from stage config)
@@ -686,9 +688,14 @@ class OmniDiffusionConfig:
     def update_multimodal_support(self) -> None:
         # Resolve serving-visible multimodal behavior from shared metadata
         # instead of importing concrete pipeline modules into the config layer.
+        # User-supplied values (from stage config) take precedence over
+        # model defaults.
         metadata = get_diffusion_model_metadata(self.model_class_name)
         self.supports_multimodal_inputs = metadata.supports_multimodal_inputs
-        self.max_multimodal_image_inputs = metadata.max_multimodal_image_inputs
+        if self.max_multimodal_image_inputs is None:
+            self.max_multimodal_image_inputs = metadata.max_multimodal_image_inputs
+        if self.max_multimodal_text_tokens is None:
+            self.max_multimodal_text_tokens = metadata.max_multimodal_text_tokens
 
     def enrich_config(self) -> None:
         """Load model metadata from HuggingFace and populate config fields.
@@ -796,6 +803,7 @@ class DiffusionOutput:
     trajectory_log_probs: torch.Tensor | dict | None = None
     trajectory_decoded: list[Image.Image] | None = None
     error: str | None = None
+    error_type: str | None = None
     aborted: bool = False
     abort_message: str | None = None
 

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -367,7 +367,7 @@ class DiffusionEngine:
                         req_id=sched_req_id,
                         step_index=None,
                         finished=True,
-                        result=DiffusionOutput(error=str(exc)),
+                        result=DiffusionOutput(error=str(exc), error_type=type(exc).__name__),
                     )
 
                 self._process_aborts_queue()

--- a/vllm_omni/diffusion/inline_stage_diffusion_client.py
+++ b/vllm_omni/diffusion/inline_stage_diffusion_client.py
@@ -123,6 +123,7 @@ class InlineStageDiffusionClient:
                 images=[],
             )
             error_output.error = str(e)
+            error_output.error_type = type(e).__name__
             self._output_queue.put_nowait(error_output)
         finally:
             self._tasks.pop(request_id, None)
@@ -223,6 +224,7 @@ class InlineStageDiffusionClient:
                 images=[],
             )
             error_output.error = str(e)
+            error_output.error_type = type(e).__name__
             self._output_queue.put_nowait(error_output)
         finally:
             self._tasks.pop(request_id, None)

--- a/vllm_omni/diffusion/model_metadata.py
+++ b/vllm_omni/diffusion/model_metadata.py
@@ -10,15 +10,33 @@ class DiffusionModelMetadata:
     # config/model plumbing can read it without importing concrete pipelines.
     supports_multimodal_inputs: bool = False
     max_multimodal_image_inputs: int | None = None
+    max_multimodal_text_tokens: int | None = None
 
 
 QWEN_IMAGE_EDIT_PLUS_MAX_INPUT_IMAGES = 4
 
 
 _DIFFUSION_MODEL_METADATA: dict[str, DiffusionModelMetadata] = {
+    "Flux2Pipeline": DiffusionModelMetadata(
+        max_multimodal_text_tokens=512,
+    ),
+    "QwenImagePipeline": DiffusionModelMetadata(
+        max_multimodal_text_tokens=1024,
+    ),
+    "QwenImageLayeredPipeline": DiffusionModelMetadata(
+        supports_multimodal_inputs=True,
+        max_multimodal_image_inputs=1,
+        max_multimodal_text_tokens=1024,
+    ),
+    "QwenImageEditPipeline": DiffusionModelMetadata(
+        supports_multimodal_inputs=True,
+        max_multimodal_image_inputs=1,
+        max_multimodal_text_tokens=1024,
+    ),
     "QwenImageEditPlusPipeline": DiffusionModelMetadata(
         supports_multimodal_inputs=True,
         max_multimodal_image_inputs=QWEN_IMAGE_EDIT_PLUS_MAX_INPUT_IMAGES,
+        max_multimodal_text_tokens=1024,
     ),
 }
 

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+from vllm_omni.exceptions import OmniInputValidationError
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 
 logger = logging.getLogger(__name__)
@@ -67,15 +68,17 @@ class Flux2ImageProcessor(VaeImageProcessor):
         max_area: int = 1024 * 1024,
     ) -> PIL.Image.Image:
         if not isinstance(image, PIL.Image.Image):
-            raise ValueError(f"Image must be a PIL.Image.Image, got {type(image)}")
+            raise OmniInputValidationError(f"Image must be a PIL.Image.Image, got {type(image)}")
 
         width, height = image.size
         if width < min_side_length or height < min_side_length:
-            raise ValueError(f"Image too small: {width}x{height}. Both dimensions must be at least {min_side_length}px")
+            raise OmniInputValidationError(
+                f"Image too small: {width}x{height}. Both dimensions must be at least {min_side_length}px"
+            )
 
         aspect_ratio = max(width / height, height / width)
         if aspect_ratio > max_aspect_ratio:
-            raise ValueError(
+            raise OmniInputValidationError(
                 f"Aspect ratio too extreme: {width}x{height} (ratio: {aspect_ratio:.1f}:1). "
                 f"Maximum allowed ratio is {max_aspect_ratio}:1"
             )

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -40,6 +40,7 @@ from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import (
     validate_prompt_sequence_lengths,
 )
+from vllm_omni.exceptions import OmniInputValidationError
 from vllm_omni.diffusion.utils.size_utils import (
     normalize_min_aligned_size,
 )
@@ -83,11 +84,11 @@ def get_qwen_image_edit_pre_process_func(
 
             # Only handles single image
             if not raw_image:  # None or empty list
-                raise ValueError("""Received no input image. This model requires one input image to run.""")
+                raise OmniInputValidationError("Received no input image. This model requires one input image to run.")
             elif isinstance(raw_image, list):
                 if len(raw_image) > 1:
-                    raise ValueError(
-                        """Received multiple input images. Only a single image is supported by this model."""
+                    raise OmniInputValidationError(
+                        "Received multiple input images. Only a single image is supported by this model."
                     )
                 else:
                     raw_image = raw_image[0]

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -44,6 +44,7 @@ from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import (
     validate_prompt_sequence_lengths,
 )
+from vllm_omni.exceptions import OmniInputValidationError
 from vllm_omni.diffusion.utils.size_utils import (
     normalize_min_aligned_size,
 )
@@ -100,10 +101,11 @@ def get_qwen_image_edit_plus_pre_process_func(
 
             if not isinstance(raw_image, list):
                 raw_image = [raw_image]
-            if len(raw_image) > MAX_QWEN_IMAGE_EDIT_PLUS_INPUT_IMAGES:
-                raise ValueError(
+            max_images = od_config.max_multimodal_image_inputs if od_config.max_multimodal_image_inputs is not None else MAX_QWEN_IMAGE_EDIT_PLUS_INPUT_IMAGES
+            if len(raw_image) > max_images:
+                raise OmniInputValidationError(
                     f"Received {len(raw_image)} input images. "
-                    f"At most {MAX_QWEN_IMAGE_EDIT_PLUS_INPUT_IMAGES} images are supported by this model."
+                    f"At most {max_images} images are supported by this model."
                 )
             image = [
                 PIL.Image.open(im) if isinstance(im, str) else cast(PIL.Image.Image | np.ndarray | torch.Tensor, im)
@@ -677,6 +679,8 @@ class QwenImageEditPlusPipeline(
         num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
         sigmas = req.sampling_params.sigmas or sigmas
         max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
+        if self.od_config.max_multimodal_text_tokens is not None:
+            max_sequence_length = min(max_sequence_length, self.od_config.max_multimodal_text_tokens)
         generator = req.sampling_params.generator or generator
         true_cfg_scale = req.sampling_params.true_cfg_scale or true_cfg_scale
         if req.sampling_params.guidance_scale_provided:
@@ -726,25 +730,31 @@ class QwenImageEditPlusPipeline(
         do_true_cfg = true_cfg_scale > 1 and has_neg_prompt
         self.check_cfg_parallel_validity(true_cfg_scale, has_neg_prompt)
 
-        prompt_embeds, prompt_embeds_mask = self.encode_prompt(
-            prompt=prompt,
-            image=condition_images,  # Use condition images for prompt encoding
-            prompt_embeds=prompt_embeds,
-            prompt_embeds_mask=prompt_embeds_mask,
-            num_images_per_prompt=num_images_per_prompt,
-            max_sequence_length=max_sequence_length,
-        )
-
-        if do_true_cfg:
-            negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
-                prompt=negative_prompt,
-                image=condition_images,  # Use same condition images for negative prompt encoding
-                prompt_embeds=negative_prompt_embeds,
-                prompt_embeds_mask=negative_prompt_embeds_mask,
+        try:
+            prompt_embeds, prompt_embeds_mask = self.encode_prompt(
+                prompt=prompt,
+                image=condition_images,  # Use condition images for prompt encoding
+                prompt_embeds=prompt_embeds,
+                prompt_embeds_mask=prompt_embeds_mask,
                 num_images_per_prompt=num_images_per_prompt,
                 max_sequence_length=max_sequence_length,
-                prompt_name="negative_prompt",
             )
+        except ValueError as exc:
+            raise OmniInputValidationError(str(exc)) from exc
+
+        if do_true_cfg:
+            try:
+                negative_prompt_embeds, negative_prompt_embeds_mask = self.encode_prompt(
+                    prompt=negative_prompt,
+                    image=condition_images,  # Use same condition images for negative prompt encoding
+                    prompt_embeds=negative_prompt_embeds,
+                    prompt_embeds_mask=negative_prompt_embeds_mask,
+                    num_images_per_prompt=num_images_per_prompt,
+                    max_sequence_length=max_sequence_length,
+                    prompt_name="negative_prompt",
+                )
+            except ValueError as exc:
+                raise OmniInputValidationError(str(exc)) from exc
 
         num_channels_latents = self.transformer.in_channels // 4
         # random noise latents, and image latents encoded by vae

--- a/vllm_omni/diffusion/stage_diffusion_client.py
+++ b/vllm_omni/diffusion/stage_diffusion_client.py
@@ -226,7 +226,9 @@ class StageDiffusionClient:
                 # Route request errors as error outputs so the Orchestrator
                 # sees the request complete (instead of hanging forever).
                 if req_id is not None:
-                    self._output_queue.put_nowait(OmniRequestOutput.from_error(req_id, error_msg))
+                    self._output_queue.put_nowait(OmniRequestOutput.from_error(
+                        req_id, error_msg, error_type=msg.get("error_type"),
+                    ))
 
     # Fields that are subprocess-local and cannot be serialized across
     # process boundaries.  They are recreated in the subprocess with

--- a/vllm_omni/diffusion/stage_diffusion_proc.py
+++ b/vllm_omni/diffusion/stage_diffusion_proc.py
@@ -341,6 +341,7 @@ class StageDiffusionProc:
                             "type": "error",
                             "request_id": request_id,
                             "error": str(e),
+                            "error_type": type(e).__name__,
                         }
                     )
                 )
@@ -396,6 +397,7 @@ class StageDiffusionProc:
                                         "type": "error",
                                         "request_id": rid,
                                         "error": str(e),
+                                        "error_type": type(e).__name__,
                                     }
                                 )
                             )

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -631,7 +631,10 @@ class WorkerProc:
                 except Exception as e:
                     logger.error(f"Error processing RPC: {e}", exc_info=True)
                     if self.result_mq is not None:
-                        self.return_result(DiffusionOutput(error=str(e)))
+                        self.return_result(DiffusionOutput(
+                            error=str(e),
+                            error_type=type(e).__name__,
+                        ))
 
             elif isinstance(msg, dict) and msg.get("type") == "shutdown":
                 logger.info("Worker %s: Received shutdown message", self.gpu_id)
@@ -647,7 +650,7 @@ class WorkerProc:
                         f"Error executing forward in event loop: {e}",
                         exc_info=True,
                     )
-                    output = DiffusionOutput(error=str(e))
+                    output = DiffusionOutput(error=str(e), error_type=type(e).__name__)
 
                 try:
                     self.return_result(output)

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+from vllm_omni.exceptions import OmniInputValidationError  # noqa: F401
+
+
 class OmniEngineDeadError(EngineDeadError):
     _DEFAULT_MESSAGE = EngineDeadError().args[0]
     error_stage_id: int | None
@@ -356,14 +359,17 @@ class OmniBase(PDDisaggregationMixin):
     ) -> None:
         """Raise if ``engine_outputs`` carries an error field.
 
-        Raises :class:`EngineDeadError` when ``self.errored`` indicates the
-        engine is unrecoverable, otherwise raises :class:`EngineGenerateError`
-        (recoverable, single-request failure).
+        Raises :class:`OmniEngineDeadError` when the engine is
+        unrecoverable, :class:`OmniInputValidationError` when the
+        original exception was explicitly marked as an input-validation
+        error (so the API layer can return 400), and
+        :class:`EngineGenerateError` otherwise.
         """
         engine_outputs = result.get("engine_outputs")
         error_text = getattr(engine_outputs, "error", None)
         if error_text is None:
             return
+        error_type = getattr(engine_outputs, "error_type", None)
         logger.error(
             "[%s] Stage error for req=%s stage-%s: %s",
             self.__class__.__name__,
@@ -377,6 +383,8 @@ class OmniBase(PDDisaggregationMixin):
                 error_text,
                 error_stage_id=stage_id,
             )
+        if error_type == "OmniInputValidationError":
+            raise OmniInputValidationError(error_text)
         raise EngineGenerateError(error_text)
 
     def _process_single_result(

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -88,6 +88,8 @@ from vllm.utils import random_uuid
 from vllm.utils.system_utils import decorate_logs
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
 
+from vllm_omni.entrypoints.omni_base import OmniInputValidationError
+
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.entrypoints.openai.errors import InvalidInputReferenceError
 from vllm_omni.entrypoints.openai.image_api_utils import (
@@ -1557,6 +1559,8 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
         return _create_engine_error_json_response(raw_request, exc)
     except HTTPException:
         raise
+    except OmniInputValidationError as e:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST.value, detail=str(e))
     except ValueError as e:
         logger.error(f"Validation error: {e}")
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST.value, detail=str(e))
@@ -1794,6 +1798,8 @@ async def edit_images(
         return _create_engine_error_json_response(raw_request, exc)
     except HTTPException:
         raise
+    except OmniInputValidationError as e:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST.value, detail=str(e))
     except ValueError as e:
         logger.error(f"Validation error: {e}")
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST.value, detail=str(e))
@@ -1851,6 +1857,17 @@ def _get_diffusion_od_config(raw_request: Request, engine_client: Any) -> Any:
     )
 
 
+def _get_int_limit(od_config: Any, attr: str) -> int | None:
+    value = getattr(od_config, attr, None)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        return None
+    if value < 1:
+        return None
+    return int(value)
+
+
 def _get_max_edit_input_images(raw_request: Request, engine_client: Any) -> int | None:
     od_config = _get_diffusion_od_config(raw_request, engine_client)
     if od_config is None:
@@ -1868,14 +1885,14 @@ def _get_max_edit_input_images(raw_request: Request, engine_client: Any) -> int 
     if not supports_multimodal_inputs:
         return 1
 
-    max_input_images = getattr(od_config, "max_multimodal_image_inputs", None)
-    if max_input_images is None:
+    return _get_int_limit(od_config, "max_multimodal_image_inputs")
+
+
+def _get_max_multimodal_text_tokens(raw_request: Request, engine_client: Any) -> int | None:
+    od_config = _get_diffusion_od_config(raw_request, engine_client)
+    if od_config is None:
         return None
-    if isinstance(max_input_images, bool) or not isinstance(max_input_images, Integral):
-        return None
-    if max_input_images < 1:
-        return None
-    return int(max_input_images)
+    return _get_int_limit(od_config, "max_multimodal_text_tokens")
 
 
 def _get_lora_from_json_str(lora_body):

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -15,6 +15,7 @@ from PIL import Image
 from pydantic import TypeAdapter
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni
+from vllm_omni.entrypoints.omni_base import OmniInputValidationError
 from vllm_omni.entrypoints.openai.protocol.chat_completion import OmniChatCompletionResponse
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
 
@@ -451,6 +452,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 request_metadata,
                 reasoning_parser,
             )
+        except OmniInputValidationError as e:
+            return self.create_error_response(e)
         except ValueError as e:
             return self.create_error_response(e)
 

--- a/vllm_omni/exceptions.py
+++ b/vllm_omni/exceptions.py
@@ -1,0 +1,5 @@
+class OmniInputValidationError(Exception):
+    """Raised when a pipeline worker rejects a request due to invalid input.
+
+    Caught explicitly by API-layer handlers to return HTTP 400.
+    """

--- a/vllm_omni/outputs.py
+++ b/vllm_omni/outputs.py
@@ -102,18 +102,21 @@ class OmniRequestOutput:
 
     # Error information -- set when the output represents a failed request.
     error: str | None = None
+    error_type: str | None = None
 
     @classmethod
     def from_error(
         cls,
         request_id: str,
         error: str,
+        error_type: str | None = None,
     ) -> "OmniRequestOutput":
         """Create an error output for a request that failed during generation."""
         return cls(
             request_id=request_id,
             finished=True,
             error=error,
+            error_type=error_type,
         )
 
     @classmethod


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Diffusion pipeline input-validation errors (oversized prompts, too many images, malformed input) currently raise `ValueError`, which surfaces as HTTP 500 in the API server. https://github.com/vllm-project/vllm-omni/pull/2840 adds the ability for QwenImageEditPlusPipeline to return a 400 error when too many images are passed as input to prevent OOM. This PR generalizes this feature to all diffusion models for any input validation with `OmniInputValidation` 

Also adds `max_multimodal_text_tokens` for text input size validation.

**Changes:**

1. **`vllm_omni/exceptions.py`** (new) — Defines `OmniInputValidationError(Exception)` in a zero-dependency module so pipeline code can import it without pulling in entrypoints.

2. **`vllm_omni/entrypoints/omni_base.py`** — Re-exports `OmniInputValidationError` for backward compatibility. `_check_engine_output_error` inspects `error_type == "OmniInputValidationError"` and re-raises accordingly. Adds `OmniEngineDeadError` with `error_stage_id` for richer diagnostics.

3. **`vllm_omni/entrypoints/openai/api_server.py`** — Image generation, image editing, chat completion, speech, and video endpoints catch `OmniInputValidationError` and return HTTP 400. Engine error handling refactored into `_create_engine_error_json_response` / `_build_engine_error_payload` with `error_stage_id` and `request_id` in the response body. Adds `_get_int_limit` helper and `_get_max_multimodal_text_tokens` accessor.

4. **`vllm_omni/entrypoints/openai/serving_chat.py`** — Catches `OmniInputValidationError` in chat completion and returns error response instead of 500.

5. **`vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py`** — Pre-process uses `od_config.max_multimodal_image_inputs` (falls back to hardcoded 4) and raises `OmniInputValidationError`. `forward()` caps `max_sequence_length` with `od_config.max_multimodal_text_tokens` and wraps `encode_prompt` calls to convert `ValueError` to `OmniInputValidationError`.

6. **`vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py`** — Pre-process raises `OmniInputValidationError` for missing or multiple images.

7. **`vllm_omni/diffusion/models/flux2/pipeline_flux2.py`** — `Flux2ImageProcessor.check_image_input()` raises `OmniInputValidationError` for wrong type, too small, or extreme aspect ratio.

8. **`vllm_omni/diffusion/model_metadata.py`** — Adds `max_multimodal_text_tokens` field to `DiffusionModelMetadata`. Registers defaults for Flux2Pipeline (512), QwenImagePipeline (1024), QwenImageLayeredPipeline (1024, 1 image), QwenImageEditPipeline (1024, 1 image), QwenImageEditPlusPipeline (1024, 4 images).

9. **`vllm_omni/diffusion/data.py`** — Adds `max_multimodal_text_tokens` and `error_type` fields to `OmniDiffusionConfig` / `DiffusionOutput`. `update_multimodal_support()` respects user-supplied stage config values for both `max_multimodal_image_inputs` and `max_multimodal_text_tokens` (metadata defaults only fill `None`).

## Test Plan

```bash
# Unit tests — input validation and max_sequence_length enforcement
pytest tests/diffusion/models/qwen_image/test_qwen_image_edit_plus.py -v
pytest tests/diffusion/models/qwen_image/test_qwen_image_max_sequence_length.py -v
```

- `test_qwen_image_edit_plus_rejects_too_many_input_images` — verifies `OmniInputValidationError` raised at default limit (4 images)
- `test_qwen_image_edit_plus_rejects_images_exceeding_config_limit` — verifies config-driven limit (`max_multimodal_image_inputs=2`)
- `test_forward_caps_max_sequence_length_with_max_multimodal_text_tokens` — verifies `od_config.max_multimodal_text_tokens` caps token count and raises `OmniInputValidationError` through `forward()`
- Existing `test_qwen_image_max_sequence_length.py` tests continue to pass (prompt-length validation unchanged)

## Test Result

22/22 relevant tests passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
