### PR TITLE
wan2.2: Optimize VAE stage's blend_v and blend_h

### DIFF
--- a/vllm_omni/diffusion/distributed/autoencoders/autoencoder_kl_wan.py
+++ b/vllm_omni/diffusion/distributed/autoencoders/autoencoder_kl_wan.py
@@ -46,6 +46,38 @@ class OmniAutoencoderKLWan(AutoencoderKLWan):
         with self._execution_context():
             return super().decode(z, return_dict=return_dict)
 
+    def blend_v(self, a: torch.Tensor, b: torch.Tensor, blend_extent: int) -> torch.Tensor:
+        blend_extent = min(a.shape[-2], b.shape[-2], blend_extent)
+        if blend_extent <= 0:
+            return b
+
+        y = torch.arange(blend_extent, device=a.device, dtype=a.dtype)
+        weight_a = 1.0 - y / blend_extent
+        weight_b = y / blend_extent
+
+        a_region = a[..., -blend_extent:, :]
+        b_region = b[..., :blend_extent, :]
+
+        b[..., :blend_extent, :] = a_region * weight_a[None, None, None, :, None] + b_region * weight_b[
+            None, None, None, :, None]
+        return b
+
+    def blend_h(self, a: torch.Tensor, b: torch.Tensor, blend_extent: int) -> torch.Tensor:
+        blend_extent = min(a.shape[-1], b.shape[-1], blend_extent)
+        if blend_extent <= 0:
+            return b
+
+        x = torch.arange(blend_extent, device=a.device, dtype=a.dtype)
+        weight_a = 1.0 - x / blend_extent
+        weight_b = x / blend_extent
+
+        a_region = a[..., -blend_extent:]
+        b_region = b[..., :blend_extent]
+
+        b[..., :blend_extent] = a_region * weight_a[None, None, None, None, :] + b_region * weight_b[
+            None, None, None, None, :]
+        return b
+
 
 class DistributedAutoencoderKLWan(OmniAutoencoderKLWan, DistributedVaeMixin):
     @classmethod

--- a/vllm_omni/diffusion/distributed/autoencoders/autoencoder_kl_wan.py
+++ b/vllm_omni/diffusion/distributed/autoencoders/autoencoder_kl_wan.py
@@ -58,8 +58,9 @@ class OmniAutoencoderKLWan(AutoencoderKLWan):
         a_region = a[..., -blend_extent:, :]
         b_region = b[..., :blend_extent, :]
 
-        b[..., :blend_extent, :] = a_region * weight_a[None, None, None, :, None] + b_region * weight_b[
-            None, None, None, :, None]
+        b[..., :blend_extent, :] = (
+            a_region * weight_a[None, None, None, :, None] + b_region * weight_b[None, None, None, :, None]
+        )
         return b
 
     def blend_h(self, a: torch.Tensor, b: torch.Tensor, blend_extent: int) -> torch.Tensor:
@@ -74,8 +75,9 @@ class OmniAutoencoderKLWan(AutoencoderKLWan):
         a_region = a[..., -blend_extent:]
         b_region = b[..., :blend_extent]
 
-        b[..., :blend_extent] = a_region * weight_a[None, None, None, None, :] + b_region * weight_b[
-            None, None, None, None, :]
+        b[..., :blend_extent] = (
+            a_region * weight_a[None, None, None, None, :] + b_region * weight_b[None, None, None, None, :]
+        )
         return b
 
 


### PR DESCRIPTION
## Purpose
This PR optimizes the wan2.2 VAE blending stage by replacing the original diffusers-style loop-based implementation of `blend_v` and `blend_h` with vectorized tensor computation.
The original implementation performs per-step updates in Python `for` loops, which can introduce host-side overhead and increase host-device synchronization/wait time. This change keeps the same blending semantics while improving execution efficiency.

## Key Changes
1. **Removed Python `for` loops via vectorization**  
   Replaced step-by-step interpolation with batched tensor math to reduce Python-side scheduling overhead.
2. **Replaced element-wise/step-wise indexing with block slicing**  
   Switched to contiguous slice-based computation and assignment to improve memory access and reduce indexing overhead.

## Motivation
- Reduce host-side overhead in the VAE blending path.
- Mitigate unnecessary host-device synchronization caused by loop-driven updates.
- Improve throughput and latency in wan2.2 VAE stage execution.

## Test Plan

- script

```
export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3

export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
export PYTHONPATH=/home/vllm-omni-0.18.0/vllm-omni:$PYTHONPATH

python image_to_video.py \
--model /home/weights/Wan2.2-I2V-A14B-LightX2V-Diffusers \
--image i2v_input.jpg \
--prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside" \
--height 1280 \
--width 720 \
--num-frames 61 \
--guidance-scale 1.0 \
--guidance-scale-high 1.0 \
--num-inference-steps 4 \
--cfg-parallel-size 1 \
--ulysses-degree 4 \
--boundary-ratio 0.875 \
--flow-shift 12.0 \
--fps 16 \
--output i2v_output_origin_weight_1.mp4 \
--vae-patch-parallel-size 4 \
--vae-use-tiling \
```

- result
  before: vae-encoder-1151.82ms, vae-decoder-2078.28ms
  after: vae-encoder-1117.34ms, vae-decoder-1840.72ms    ----- reduce 272.04ms , improve 9.1%