### PR TITLE
fix(api): add output_format and size to /v1/images/generations response

### DIFF
--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1463,7 +1463,12 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
                 )
             flat_images, _, _ = generation_result
             image_data = [ImageData(b64_json=encode_image_base64(img), revised_prompt=None) for img in flat_images]
-            return ImageGenerationResponse(created=int(time.time()), data=image_data)
+            return ImageGenerationResponse(
+                created=int(time.time()),
+                data=image_data,
+                output_format="png",
+                size=request.size or "model default",
+            )
 
         # Build params - pass through user values directly
         prompt: OmniTextPrompt = {"prompt": request.prompt}
@@ -1551,6 +1556,8 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
         return ImageGenerationResponse(
             created=int(time.time()),
             data=image_data,
+            output_format="png",
+            size=size_str,
         )
 
     except (EngineGenerateError, EngineDeadError) as exc:


### PR DESCRIPTION

Summary

Purpose

Fix issue #3092 where /v1/images/generations response was missing output_format and size fields, causing them to be null in the response. The /v1/images/edits endpoint already populates these fields correctly, breaking OpenAI API spec compatibility.

Changes Made
- Added output_format="png" to both multi-stage and single-stage response paths in api_server.py
- Added size=request.size or "model default" for multi-stage path
- Added size=size_str for single-stage path

Test Plan
No additional test scripts required - this is an API response structure fix. The existing tests in tests/entrypoints/openai_api/test_image_server.py cover the /v1/images/generations endpoint and will verify the response structure.

Test Result
The fix ensures the response now includes:
{
  "created": 1234567890,
  "data": [...],
  "output_format": "png",
  "size": "1024x1024"  // or whatever was requested
}
Instead of:
{
  "created": 1234567890,
  "data": [...],
  "output_format": null,
  "size": null
}


**Links**
- Fixes #3092