### PR TITLE
[Refactor] Centralize stage sampling params resolution

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py
@@ -67,6 +67,10 @@ def test_build_multistage_generation_inputs_applies_stage_specific_overrides(ser
     assert len(sampling_params_list) == 3
     assert sampling_params_list[0].temperature == 0.2
     assert sampling_params_list[0].seed == 0
+    assert sampling_params_list[0].extra_args == {"target_h": 768, "target_w": 1024}
+    assert sampling_params_list[1] is not gen_params
+    assert sampling_params_list[2] is not gen_params
+    assert sampling_params_list[1] is not sampling_params_list[2]
     assert sampling_params_list[1].height == 768
     assert sampling_params_list[1].width == 1024
     assert sampling_params_list[1].seed == 0
@@ -75,8 +79,15 @@ def test_build_multistage_generation_inputs_applies_stage_specific_overrides(ser
     assert sampling_params_list[1].num_outputs_per_prompt == 2
     assert sampling_params_list[1].true_cfg_scale == 5.0
     assert sampling_params_list[1].lora_request.name == "adapter-a"
+    assert sampling_params_list[1].lora_scale == 0.6
     assert sampling_params_list[2].height == 768
     assert sampling_params_list[2].width == 1024
+    assert sampling_params_list[2].seed == 0
     assert sampling_params_list[2].num_inference_steps == 28
+    assert sampling_params_list[2].lora_request.name == "adapter-a"
+    assert sampling_params_list[2].lora_scale == 0.6
+    assert gen_params.lora_request is None
     assert engine.default_sampling_params_list[1].height is None
+    assert engine.default_sampling_params_list[1].lora_request is None
     assert engine.default_sampling_params_list[2].resolution == 640
+    assert engine.default_sampling_params_list[2].lora_request is None

--- a/tests/entrypoints/openai_api/test_stage_params.py
+++ b/tests/entrypoints/openai_api/test_stage_params.py
@@ -65,11 +65,16 @@ def test_build_stage_sampling_params_list_can_replace_diffusion_defaults():
 
     assert resolved[0] is not llm_default
     assert resolved[0].temperature == 0.1
-    assert resolved[1] is request_params
-    assert resolved[2] is request_params
+    assert resolved[1] is not request_params
+    assert resolved[2] is not request_params
+    assert resolved[1] is not resolved[2]
+    assert resolved[1].height == 512
+    assert resolved[2].height == 512
+    assert resolved[1].width == 512
+    assert resolved[2].width == 512
 
 
-def test_get_default_sampling_params_list_ignores_missing_or_non_list_defaults():
+def test_get_default_sampling_params_list_reads_engine_defaults_only():
     assert get_default_sampling_params_list(SimpleNamespace()) == []
     assert get_default_sampling_params_list(SimpleNamespace(default_sampling_params_list=None)) == []
 

--- a/tests/entrypoints/openai_api/test_stage_params.py
+++ b/tests/entrypoints/openai_api/test_stage_params.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm import SamplingParams
+
+from vllm_omni.entrypoints.openai.stage_params import (
+    build_stage_sampling_params_list,
+    get_default_sampling_params_list,
+    resolve_stage_sampling_params,
+)
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+
+def test_resolve_stage_sampling_params_clones_stage_default():
+    default = SamplingParams(temperature=0.2, seed=11)
+
+    resolved = resolve_stage_sampling_params(
+        SimpleNamespace(stage_type="llm"),
+        0,
+        [default],
+    )
+
+    assert resolved is not default
+    assert resolved.temperature == 0.2
+    assert resolved.seed == 11
+
+    resolved.seed = 99
+    assert default.seed == 11
+
+
+def test_resolve_stage_sampling_params_uses_diffusion_fallback_when_default_missing():
+    request_params = OmniDiffusionSamplingParams(height=768, width=1024, seed=7)
+
+    resolved = resolve_stage_sampling_params(
+        SimpleNamespace(stage_type="diffusion"),
+        1,
+        [],
+        diffusion_params=request_params,
+    )
+
+    assert resolved is not request_params
+    assert resolved.height == 768
+    assert resolved.width == 1024
+    assert resolved.seed == 7
+
+
+def test_build_stage_sampling_params_list_can_replace_diffusion_defaults():
+    request_params = OmniDiffusionSamplingParams(height=512, width=512)
+    diffusion_default = OmniDiffusionSamplingParams(height=1024, width=1024)
+    llm_default = SamplingParams(temperature=0.1)
+    stages = [
+        SimpleNamespace(stage_type="llm"),
+        SimpleNamespace(stage_type="diffusion"),
+        SimpleNamespace(stage_type="diffusion"),
+    ]
+
+    resolved = build_stage_sampling_params_list(
+        stages,
+        [llm_default, diffusion_default],
+        diffusion_params=request_params,
+        replace_diffusion_params=True,
+    )
+
+    assert resolved[0] is not llm_default
+    assert resolved[0].temperature == 0.1
+    assert resolved[1] is request_params
+    assert resolved[2] is request_params
+
+
+def test_get_default_sampling_params_list_ignores_missing_or_non_list_defaults():
+    assert get_default_sampling_params_list(SimpleNamespace()) == []
+    assert get_default_sampling_params_list(SimpleNamespace(default_sampling_params_list=None)) == []
+
+    defaults = [SamplingParams(max_tokens=8)]
+    resolved = get_default_sampling_params_list(SimpleNamespace(default_sampling_params_list=defaults))
+    assert resolved == defaults
+    assert resolved is not defaults

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -28,7 +28,6 @@ from PIL import Image
 from pydantic import BaseModel, Field
 from starlette.datastructures import State
 from starlette.routing import Route
-from vllm import SamplingParams
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.anthropic.serving import AnthropicServingMessages
 from vllm.entrypoints.chat_utils import load_chat_template
@@ -118,11 +117,15 @@ from vllm_omni.entrypoints.openai.serving_speech import OmniOpenAIServingSpeech
 from vllm_omni.entrypoints.openai.serving_speech_stream import OmniStreamingSpeechHandler
 from vllm_omni.entrypoints.openai.serving_video import OmniOpenAIServingVideo, ReferenceImage
 from vllm_omni.entrypoints.openai.serving_video_stream import OmniStreamingVideoHandler
+from vllm_omni.entrypoints.openai.stage_params import (
+    build_stage_sampling_params_list,
+    get_default_sampling_params_list,
+)
 from vllm_omni.entrypoints.openai.storage import STORAGE_MANAGER
 from vllm_omni.entrypoints.openai.stores import VIDEO_STORE, VIDEO_TASKS
 from vllm_omni.entrypoints.openai.utils import get_stage_type, parse_lora_request
 from vllm_omni.entrypoints.openai.video_api_utils import decode_input_reference
-from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniSamplingParams, OmniTextPrompt
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
 
 logger = init_logger(__name__)
 router = APIRouter()
@@ -2018,34 +2021,12 @@ async def _generate_with_async_omni(
             status_code=HTTPStatus.SERVICE_UNAVAILABLE.value,
             detail="Stage configs not found. Start server with a multi-stage omni model.",
         )
-    default_params_list: list[OmniSamplingParams] | None = getattr(
-        engine_client,
-        "default_sampling_params_list",
-        None,
+    sampling_params_list = build_stage_sampling_params_list(
+        normalized_stage_configs,
+        get_default_sampling_params_list(engine_client),
+        diffusion_params=gen_params,
+        replace_diffusion_params=True,
     )
-    if not isinstance(default_params_list, list):
-        default_params_list = []
-    else:
-        default_params_list = list(default_params_list)
-
-    sampling_params_list: list[OmniSamplingParams] = []
-    for idx, stage_cfg in enumerate(normalized_stage_configs):
-        stage_type = get_stage_type(stage_cfg)
-        if stage_type == "diffusion":
-            sampling_params_list.append(gen_params)
-            continue
-
-        if idx < len(default_params_list):
-            default_stage_params = default_params_list[idx]
-        else:
-            default_stage_params = SamplingParams()
-
-        if hasattr(default_stage_params, "clone"):
-            try:
-                default_stage_params = default_stage_params.clone()
-            except Exception:
-                pass
-        sampling_params_list.append(default_stage_params)
 
     async for output in engine_client.generate(
         sampling_params_list=sampling_params_list,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -87,6 +87,10 @@ from vllm_omni.entrypoints.openai.audio_utils_mixin import AudioMixin
 from vllm_omni.entrypoints.openai.image_api_utils import validate_layered_layers
 from vllm_omni.entrypoints.openai.protocol import OmniChatCompletionStreamResponse
 from vllm_omni.entrypoints.openai.protocol.audio import AudioResponse, CreateAudio
+from vllm_omni.entrypoints.openai.stage_params import (
+    build_stage_sampling_params_list,
+    get_default_sampling_params_list,
+)
 from vllm_omni.entrypoints.openai.utils import (
     get_stage_type,
     get_supported_speakers_from_hf_config,
@@ -2123,7 +2127,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
     ) -> tuple[OmniTextPrompt, list[Any]]:
         """Build the shared multistage generation prompt and stage params."""
         stage_configs = getattr(engine, "stage_configs", None) or []
-        default_params_list = list(getattr(engine, "default_sampling_params_list", []) or [])
+        default_params_list = get_default_sampling_params_list(engine)
 
         height = gen_params.height
         width = gen_params.width
@@ -2173,20 +2177,14 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 comprehension_idx = idx
                 break
 
-        sampling_params_list: list[Any] = []
+        sampling_params_list = build_stage_sampling_params_list(
+            stage_configs,
+            default_params_list,
+            diffusion_params=gen_params,
+        )
         for idx, stage_cfg in enumerate(stage_configs):
             stage_type = get_stage_type(stage_cfg)
-            if idx < len(default_params_list):
-                default_stage_params = default_params_list[idx]
-                if hasattr(default_stage_params, "clone"):
-                    try:
-                        default_stage_params = default_stage_params.clone()
-                    except Exception:
-                        pass
-            elif stage_type == "diffusion":
-                default_stage_params = gen_params.clone()
-            else:
-                default_stage_params = SamplingParams()
+            default_stage_params = sampling_params_list[idx]
 
             if (
                 comprehension_idx is not None
@@ -2233,8 +2231,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                                 default_stage_params.lora_scale = lora_scale
                     except Exception as e:  # pragma: no cover - safeguard
                         logger.warning("Failed to parse LoRA request: %s", e)
-
-            sampling_params_list.append(default_stage_params)
 
         return engine_prompt, sampling_params_list
 
@@ -2523,21 +2519,12 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             # Generate image
             diffusion_engine = cast(AsyncOmni, self._diffusion_engine)
             stage_configs = list(getattr(diffusion_engine, "stage_configs", []) or [])
-            default_params_list = list(getattr(diffusion_engine, "default_sampling_params_list", []) or [])
-
-            sampling_params_list: list[Any] = []
-            for idx, stage_cfg in enumerate(stage_configs):
-                if get_stage_type(stage_cfg) == "diffusion":
-                    sampling_params_list.append(gen_params)
-                    continue
-
-                default_stage_params = default_params_list[idx] if idx < len(default_params_list) else SamplingParams()
-                if hasattr(default_stage_params, "clone"):
-                    try:
-                        default_stage_params = default_stage_params.clone()
-                    except Exception as e:
-                        logger.warning("Failed to clone default params for stage %d: %s", idx, e)
-                sampling_params_list.append(default_stage_params)
+            sampling_params_list = build_stage_sampling_params_list(
+                stage_configs,
+                get_default_sampling_params_list(diffusion_engine),
+                diffusion_params=gen_params,
+                replace_diffusion_params=True,
+            )
 
             if not sampling_params_list:
                 sampling_params_list = [gen_params]

--- a/vllm_omni/entrypoints/openai/serving_video.py
+++ b/vllm_omni/entrypoints/openai/serving_video.py
@@ -20,9 +20,13 @@ from vllm_omni.entrypoints.openai.protocol.videos import (
     VideoGenerationRequest,
     VideoGenerationResponse,
 )
+from vllm_omni.entrypoints.openai.stage_params import (
+    build_stage_sampling_params_list,
+    get_default_sampling_params_list,
+)
 from vllm_omni.entrypoints.openai.utils import get_stage_type, parse_lora_request
 from vllm_omni.entrypoints.openai.video_api_utils import _encode_video_bytes, encode_video_base64
-from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniSamplingParams, OmniTextPrompt
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
 
 logger = init_logger(__name__)
 
@@ -322,7 +326,12 @@ class OmniOpenAIServingVideo:
 
         # Common generation logic for both paths
         engine_client = cast(AsyncOmni, self._engine_client)
-        sampling_params_list: list[OmniSamplingParams] = [gen_params for _ in stage_configs]
+        sampling_params_list = build_stage_sampling_params_list(
+            list(stage_configs),
+            get_default_sampling_params_list(engine_client),
+            diffusion_params=gen_params,
+            replace_diffusion_params=True,
+        )
 
         result = None
         async for output in engine_client.generate(

--- a/vllm_omni/entrypoints/openai/stage_params.py
+++ b/vllm_omni/entrypoints/openai/stage_params.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from vllm import SamplingParams
+
+from vllm_omni.entrypoints.openai.utils import get_stage_type
+from vllm_omni.inputs.data import OmniSamplingParams
+
+
+def clone_sampling_params(params: OmniSamplingParams) -> OmniSamplingParams:
+    """Clone request sampling params without sharing mutable request state."""
+    if hasattr(params, "clone"):
+        try:
+            return params.clone()
+        except Exception:
+            pass
+
+    try:
+        return copy.deepcopy(params)
+    except Exception:
+        return params
+
+
+def get_default_sampling_params_list(source: Any) -> list[OmniSamplingParams]:
+    """Return a mutable copy of an engine/default sampling params list."""
+    default_params = getattr(source, "default_sampling_params_list", source)
+    if isinstance(default_params, list):
+        return list(default_params)
+    return []
+
+
+def resolve_stage_sampling_params(
+    stage_cfg: Any,
+    stage_index: int,
+    default_sampling_params_list: list[OmniSamplingParams],
+    *,
+    diffusion_params: OmniSamplingParams | None = None,
+) -> OmniSamplingParams:
+    """Resolve one stage's effective sampling params from stage defaults."""
+    if stage_index < len(default_sampling_params_list):
+        return clone_sampling_params(default_sampling_params_list[stage_index])
+
+    if get_stage_type(stage_cfg) == "diffusion" and diffusion_params is not None:
+        return clone_sampling_params(diffusion_params)
+
+    return SamplingParams()
+
+
+def build_stage_sampling_params_list(
+    stage_configs: list[Any],
+    default_sampling_params_list: list[OmniSamplingParams],
+    *,
+    diffusion_params: OmniSamplingParams | None = None,
+    replace_diffusion_params: bool = False,
+) -> list[OmniSamplingParams]:
+    """Build effective sampling params for a multi-stage request.
+
+    When ``replace_diffusion_params`` is set, diffusion stages receive the
+    request-level diffusion params directly. That preserves existing image and
+    video endpoint behavior where request params replace diffusion defaults.
+    """
+    sampling_params_list: list[OmniSamplingParams] = []
+    for idx, stage_cfg in enumerate(stage_configs):
+        if replace_diffusion_params and get_stage_type(stage_cfg) == "diffusion" and diffusion_params is not None:
+            sampling_params_list.append(diffusion_params)
+        else:
+            sampling_params_list.append(
+                resolve_stage_sampling_params(
+                    stage_cfg,
+                    idx,
+                    default_sampling_params_list,
+                    diffusion_params=diffusion_params,
+                )
+            )
+    return sampling_params_list

--- a/vllm_omni/entrypoints/openai/stage_params.py
+++ b/vllm_omni/entrypoints/openai/stage_params.py
@@ -7,9 +7,12 @@ import copy
 from typing import Any
 
 from vllm import SamplingParams
+from vllm.logger import init_logger
 
 from vllm_omni.entrypoints.openai.utils import get_stage_type
 from vllm_omni.inputs.data import OmniSamplingParams
+
+logger = init_logger(__name__)
 
 
 def clone_sampling_params(params: OmniSamplingParams) -> OmniSamplingParams:
@@ -17,18 +20,19 @@ def clone_sampling_params(params: OmniSamplingParams) -> OmniSamplingParams:
     if hasattr(params, "clone"):
         try:
             return params.clone()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Failed to clone sampling params with clone(): %s", exc)
 
     try:
         return copy.deepcopy(params)
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to deepcopy sampling params; reusing original object: %s", exc)
         return params
 
 
-def get_default_sampling_params_list(source: Any) -> list[OmniSamplingParams]:
-    """Return a mutable copy of an engine/default sampling params list."""
-    default_params = getattr(source, "default_sampling_params_list", source)
+def get_default_sampling_params_list(engine_client: Any) -> list[OmniSamplingParams]:
+    """Return a mutable copy of an engine client's default sampling params."""
+    default_params = getattr(engine_client, "default_sampling_params_list", None)
     if isinstance(default_params, list):
         return list(default_params)
     return []
@@ -60,14 +64,15 @@ def build_stage_sampling_params_list(
 ) -> list[OmniSamplingParams]:
     """Build effective sampling params for a multi-stage request.
 
-    When ``replace_diffusion_params`` is set, diffusion stages receive the
-    request-level diffusion params directly. That preserves existing image and
-    video endpoint behavior where request params replace diffusion defaults.
+    When ``replace_diffusion_params`` is set, diffusion stages receive cloned
+    request-level diffusion params. That preserves existing image and video
+    endpoint behavior where request params replace diffusion defaults without
+    sharing mutable state across stages.
     """
     sampling_params_list: list[OmniSamplingParams] = []
     for idx, stage_cfg in enumerate(stage_configs):
         if replace_diffusion_params and get_stage_type(stage_cfg) == "diffusion" and diffusion_params is not None:
-            sampling_params_list.append(diffusion_params)
+            sampling_params_list.append(clone_sampling_params(diffusion_params))
         else:
             sampling_params_list.append(
                 resolve_stage_sampling_params(


### PR DESCRIPTION

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

  Centralize repeated stage sampling params resolution logic used by image, chat diffusion, and video generation paths.

  This adds a small shared helper for:
  - cloning stage default sampling params
  - safely reading `default_sampling_params_list`
  - falling back to request-level diffusion params when stage defaults are missing
  - preserving existing endpoint behavior where diffusion request params replace diffusion defaults

## Test Plan

```
  ./.venv/bin/python -m pytest -q \
    tests/entrypoints/openai_api/test_stage_params.py \
    tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py \
    tests/entrypoints/openai_api/test_image_server.py \
    tests/entrypoints/openai_api/test_video_server.py
```

## Test Result

```
$   ./.venv/bin/python -m pytest -q \
>     tests/entrypoints/openai_api/test_stage_params.py \
>     tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py \
>     tests/entrypoints/openai_api/test_image_server.py \
>     tests/entrypoints/openai_api/test_video_server.py

...........................................................................................................                  [100%]
.org/en/stable/how-to/capture-warnings.html
--- Running Summary
107 passed, 19 warnings in 4.09s
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
