### PR TITLE
Realtime video support

### DIFF
--- a/tests/test_realtime_e2e_client.py
+++ b/tests/test_realtime_e2e_client.py
@@ -83,10 +83,13 @@ async def run_t2v_interactive(args):
             "width": args.width,
             "num_inference_steps": args.steps,
             "num_frames_per_block": args.frames_per_block,
+            "frame_format": args.frame_format,
+            "frame_quality": args.frame_quality,
         }
         await ws.send(pack_msg(config))
         print(f"Config: prompt='{args.prompt}', "
-              f"{args.width}x{args.height}, steps={args.steps}")
+              f"{args.width}x{args.height}, steps={args.steps}, "
+              f"format={args.frame_format}")
 
         data = await ws.recv()
         msg = unpack_msg(data)
@@ -221,10 +224,13 @@ async def run_t2v_batch(args):
             "width": args.width,
             "num_inference_steps": args.steps,
             "num_frames_per_block": args.frames_per_block,
+            "frame_format": args.frame_format,
+            "frame_quality": args.frame_quality,
         }
         await ws.send(pack_msg(config))
         print(f"Sent config: mode=t2v, prompt='{args.prompt}', "
-              f"{args.width}x{args.height}, steps={args.steps}")
+              f"{args.width}x{args.height}, steps={args.steps}, "
+              f"format={args.frame_format}")
 
         data = await ws.recv()
         msg = unpack_msg(data)
@@ -394,11 +400,14 @@ async def run_v2v_test(args):
             "width": args.width,
             "num_inference_steps": args.steps,
             "num_frames_per_block": args.frames_per_block,
+            "frame_format": args.frame_format,
+            "frame_quality": args.frame_quality,
         }
         if args.strength is not None:
             config["v2v_strength"] = args.strength
         await ws.send(pack_msg(config))
-        print(f"Sent config: mode=v2v, prompt='{args.prompt}'"
+        print(f"Sent config: mode=v2v, prompt='{args.prompt}', "
+              f"format={args.frame_format}"
               f"{f', strength={args.strength}' if args.strength else ''}")
 
         data = await ws.recv()
@@ -551,6 +560,11 @@ def main():
                         help="num_frames_per_block (latent frames per block)")
     parser.add_argument("--strength", type=float, default=None,
                         help="[v2v] V2V strength (0.0-1.0, lower preserves more)")
+    parser.add_argument("--frame-format", choices=["jpeg", "png"],
+                        default="jpeg",
+                        help="Output frame encoding format (default: jpeg)")
+    parser.add_argument("--frame-quality", type=int, default=95,
+                        help="JPEG quality 1-100 (default: 95, ignored for PNG)")
 
     args = parser.parse_args()
 

--- a/tests/test_realtime_e2e_client.py
+++ b/tests/test_realtime_e2e_client.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""End-to-end WebSocket client for testing realtime video streaming.
+
+Usage:
+    # Interactive mode: type prompts while video generates continuously
+    python tests/test_realtime_e2e_client.py -i
+
+    # Batch mode with fixed block count:
+    python tests/test_realtime_e2e_client.py --blocks 5
+
+    # Batch mode with scheduled prompt change:
+    python tests/test_realtime_e2e_client.py --blocks 8 --change-prompt-at 3 \
+        --new-prompt "A rocket launching into space"
+
+    # Save output frames to disk:
+    python tests/test_realtime_e2e_client.py -i --save-dir /tmp/frames
+
+    # V2V mode:
+    python tests/test_realtime_e2e_client.py --mode v2v --blocks 5
+
+Requires: pip install websockets msgpack Pillow
+"""
+
+import argparse
+import asyncio
+import io
+import os
+import sys
+import time
+import threading
+
+try:
+    import msgpack
+except ImportError:
+    msgpack = None
+
+try:
+    import websockets
+except ImportError:
+    websockets = None
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
+
+def pack_msg(msg: dict) -> bytes:
+    if msgpack is not None:
+        return msgpack.packb(msg, use_bin_type=True)
+    import json
+    return json.dumps(msg).encode()
+
+
+def unpack_msg(data: bytes) -> dict:
+    if msgpack is not None:
+        return msgpack.unpackb(data, raw=False)
+    import json
+    return json.loads(data)
+
+
+async def run_t2v_interactive(args):
+    """Interactive T2V: generates continuously, user types prompts to steer."""
+    uri = f"ws://{args.host}:{args.port}/v1/realtime_video/generate"
+    print(f"Connecting to {uri} ...")
+
+    async with websockets.connect(uri, max_size=50 * 1024 * 1024) as ws:
+        config = {
+            "type": "config",
+            "mode": "t2v",
+            "prompt": args.prompt,
+            "height": args.height,
+            "width": args.width,
+            "num_inference_steps": args.steps,
+        }
+        await ws.send(pack_msg(config))
+        print(f"Config: prompt='{args.prompt}', "
+              f"{args.width}x{args.height}, steps={args.steps}")
+
+        data = await ws.recv()
+        msg = unpack_msg(data)
+        if not (msg.get("type") == "status"
+                and msg.get("content") == "session_started"):
+            print(f"Unexpected response: {msg}")
+            return
+        print("Session started!")
+        print("-" * 60)
+        print("Type a new prompt and press Enter to change the scene.")
+        print("Type 'quit' or 'exit' to stop.")
+        print("-" * 60)
+
+        if args.save_dir:
+            os.makedirs(args.save_dir, exist_ok=True)
+
+        # Use a thread to read stdin, push lines into a thread-safe queue
+        input_queue = asyncio.Queue()
+        loop = asyncio.get_running_loop()
+        quit_flag = False
+
+        def _read_stdin():
+            while True:
+                try:
+                    line = input()
+                except EOFError:
+                    break
+                loop.call_soon_threadsafe(input_queue.put_nowait, line.strip())
+
+        stdin_thread = threading.Thread(target=_read_stdin, daemon=True)
+        stdin_thread.start()
+
+        frame_count = 0
+        start_time = time.time()
+        current_prompt = args.prompt
+
+        try:
+            while True:
+                # Check for new prompts (non-blocking)
+                while not input_queue.empty():
+                    line = input_queue.get_nowait()
+                    if not line:
+                        continue
+                    if line.lower() in ("quit", "exit", "q"):
+                        quit_flag = True
+                        break
+
+                    prompt_msg = {"type": "prompt", "content": line}
+                    await ws.send(pack_msg(prompt_msg))
+                    current_prompt = line
+                    print(f">>> Prompt updated: '{line}'")
+
+                if quit_flag:
+                    break
+
+                # Receive next frame
+                try:
+                    data = await asyncio.wait_for(ws.recv(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    continue
+
+                msg = unpack_msg(data)
+                elapsed = time.time() - start_time
+
+                if msg["type"] == "frame":
+                    content = msg["content"]
+                    frame_count += 1
+
+                    parts = [f"Block {frame_count}",
+                             f"{len(content)} bytes",
+                             f"{elapsed:.1f}s"]
+
+                    if Image is not None and isinstance(content, bytes):
+                        try:
+                            img = Image.open(io.BytesIO(content))
+                            parts.append(f"{img.size[0]}x{img.size[1]}")
+
+                            if args.save_dir:
+                                path = os.path.join(
+                                    args.save_dir,
+                                    f"frame_{frame_count:04d}.png",
+                                )
+                                img.save(path)
+                                parts.append(f"saved:{path}")
+                        except Exception as e:
+                            parts.append(f"decode err: {e}")
+
+                    print(f"  {' | '.join(parts)}")
+
+                elif msg["type"] == "error":
+                    print(f"ERROR: {msg['content']}")
+                    break
+
+                elif msg["type"] == "status":
+                    print(f"Status: {msg['content']}")
+
+        except (KeyboardInterrupt,):
+            print("\nInterrupted.")
+        except Exception as e:
+            if "close" not in str(e).lower():
+                print(f"\nConnection error: {e}")
+
+        total = time.time() - start_time
+        if frame_count > 0:
+            print(f"\nDone! {frame_count} blocks in {total:.1f}s "
+                  f"({frame_count / total:.2f} blocks/sec)")
+
+
+async def run_t2v_batch(args):
+    """Batch T2V: generate a fixed number of blocks, optionally change prompt."""
+    uri = f"ws://{args.host}:{args.port}/v1/realtime_video/generate"
+    print(f"Connecting to {uri} ...")
+
+    async with websockets.connect(uri, max_size=50 * 1024 * 1024) as ws:
+        config = {
+            "type": "config",
+            "mode": "t2v",
+            "prompt": args.prompt,
+            "height": args.height,
+            "width": args.width,
+            "num_inference_steps": args.steps,
+        }
+        await ws.send(pack_msg(config))
+        print(f"Sent config: mode=t2v, prompt='{args.prompt}', "
+              f"{args.width}x{args.height}, steps={args.steps}")
+
+        data = await ws.recv()
+        msg = unpack_msg(data)
+        assert msg["type"] == "status" and msg["content"] == "session_started", \
+            f"Expected session_started, got: {msg}"
+        print("Session started!")
+
+        frame_count = 0
+        start_time = time.time()
+
+        if args.save_dir:
+            os.makedirs(args.save_dir, exist_ok=True)
+
+        prompt_changed = False
+
+        while frame_count < args.blocks:
+            if (args.change_prompt_at
+                    and frame_count == args.change_prompt_at
+                    and not prompt_changed):
+                new_prompt = args.new_prompt or \
+                    "A rocket launching into space with flames"
+                prompt_msg = {"type": "prompt", "content": new_prompt}
+                await ws.send(pack_msg(prompt_msg))
+                print(f"\n>>> Prompt changed to: '{new_prompt}'")
+                prompt_changed = True
+
+            data = await ws.recv()
+            msg = unpack_msg(data)
+            elapsed = time.time() - start_time
+
+            if msg["type"] == "frame":
+                content = msg["content"]
+                frame_count += 1
+
+                info = f"Block {frame_count}/{args.blocks} | "
+                info += f"{len(content)} bytes | "
+                info += f"elapsed: {elapsed:.1f}s"
+
+                if Image is not None and isinstance(content, bytes):
+                    try:
+                        img = Image.open(io.BytesIO(content))
+                        info += f" | {img.size[0]}x{img.size[1]} {img.mode}"
+
+                        if args.save_dir:
+                            path = os.path.join(
+                                args.save_dir, f"frame_{frame_count:04d}.png"
+                            )
+                            img.save(path)
+                            info += f" | saved: {path}"
+                    except Exception as e:
+                        info += f" | decode err: {e}"
+
+                print(info)
+
+            elif msg["type"] == "error":
+                print(f"ERROR from server: {msg['content']}")
+                break
+
+            elif msg["type"] == "status":
+                print(f"Status: {msg['content']}")
+
+        total = time.time() - start_time
+        print(f"\nDone! {frame_count} blocks in {total:.1f}s "
+              f"({frame_count / total:.2f} blocks/sec)")
+
+
+async def run_v2v_test(args):
+    """V2V mode: send video frames, receive transformed output."""
+    uri = f"ws://{args.host}:{args.port}/v1/realtime_video/generate"
+    print(f"Connecting to {uri} (V2V mode) ...")
+
+    if Image is None:
+        print("ERROR: Pillow is required for V2V test")
+        return
+
+    async with websockets.connect(uri, max_size=50 * 1024 * 1024) as ws:
+        config = {
+            "type": "config",
+            "mode": "v2v",
+            "prompt": args.prompt,
+            "height": args.height,
+            "width": args.width,
+            "num_inference_steps": args.steps,
+        }
+        await ws.send(pack_msg(config))
+        print(f"Sent config: mode=v2v, prompt='{args.prompt}'")
+
+        data = await ws.recv()
+        msg = unpack_msg(data)
+        assert msg["type"] == "status" and msg["content"] == "session_started"
+        print("Session started!")
+
+        import numpy as np
+        num_input_frames = 12
+        print(f"Sending {num_input_frames} dummy input frames...")
+
+        frames_bytes = []
+        for i in range(num_input_frames):
+            arr = np.random.randint(
+                0, 255, (args.height, args.width, 3), dtype=np.uint8
+            )
+            img = Image.fromarray(arr)
+            buf = io.BytesIO()
+            img.save(buf, format="JPEG", quality=80)
+            frames_bytes.append(buf.getvalue())
+
+        video_msg = {"type": "video", "frames": frames_bytes}
+        await ws.send(pack_msg(video_msg))
+        print(f"Sent {num_input_frames} frames")
+
+        frame_count = 0
+        start = time.time()
+
+        while frame_count < args.blocks:
+            if frame_count > 0:
+                more_frames = []
+                for _ in range(12):
+                    arr = np.random.randint(
+                        0, 255, (args.height, args.width, 3), dtype=np.uint8
+                    )
+                    img = Image.fromarray(arr)
+                    buf = io.BytesIO()
+                    img.save(buf, format="JPEG", quality=80)
+                    more_frames.append(buf.getvalue())
+                await ws.send(
+                    pack_msg({"type": "video", "frames": more_frames})
+                )
+
+            data = await ws.recv()
+            msg = unpack_msg(data)
+
+            if msg["type"] == "frame":
+                frame_count += 1
+                content = msg["content"]
+                elapsed = time.time() - start
+                print(f"V2V Block {frame_count}/{args.blocks} | "
+                      f"{len(content)} bytes | {elapsed:.1f}s")
+
+                if args.save_dir and Image is not None:
+                    try:
+                        img = Image.open(io.BytesIO(content))
+                        path = os.path.join(
+                            args.save_dir, f"v2v_frame_{frame_count:04d}.png"
+                        )
+                        img.save(path)
+                    except Exception:
+                        pass
+
+            elif msg["type"] == "error":
+                print(f"ERROR: {msg['content']}")
+                break
+
+        total = time.time() - start
+        print(f"\nV2V done! {frame_count} blocks in {total:.1f}s")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Realtime video E2E test client"
+    )
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--mode", choices=["t2v", "v2v"], default="t2v")
+    parser.add_argument(
+        "--prompt",
+        default="A beautiful sunset over the ocean, cinematic",
+    )
+    parser.add_argument(
+        "--blocks", type=int, default=None,
+        help="Number of blocks (default: unlimited in interactive, 5 in batch)",
+    )
+    parser.add_argument("--height", type=int, default=480)
+    parser.add_argument("--width", type=int, default=832)
+    parser.add_argument("--steps", type=int, default=4,
+                        help="Denoising steps per block")
+    parser.add_argument(
+        "--interactive", "-i", action="store_true",
+        help="Interactive mode: type prompts while video generates continuously",
+    )
+    parser.add_argument("--change-prompt-at", type=int, default=None,
+                        help="[batch] Change prompt at this block number")
+    parser.add_argument("--new-prompt", default=None,
+                        help="[batch] New prompt for --change-prompt-at")
+    parser.add_argument("--save-dir", default=None,
+                        help="Directory to save output frames as PNG")
+
+    args = parser.parse_args()
+
+    if websockets is None:
+        print("ERROR: pip install websockets")
+        return
+    if msgpack is None:
+        print("WARNING: msgpack not installed, using JSON fallback")
+
+    if args.mode == "v2v":
+        if args.blocks is None:
+            args.blocks = 5
+        asyncio.run(run_v2v_test(args))
+    elif args.interactive:
+        asyncio.run(run_t2v_interactive(args))
+    else:
+        if args.blocks is None:
+            args.blocks = 5
+        asyncio.run(run_t2v_batch(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_realtime_e2e_client.py
+++ b/tests/test_realtime_e2e_client.py
@@ -82,6 +82,7 @@ async def run_t2v_interactive(args):
             "height": args.height,
             "width": args.width,
             "num_inference_steps": args.steps,
+            "num_frames_per_block": args.frames_per_block,
         }
         await ws.send(pack_msg(config))
         print(f"Config: prompt='{args.prompt}', "
@@ -219,6 +220,7 @@ async def run_t2v_batch(args):
             "height": args.height,
             "width": args.width,
             "num_inference_steps": args.steps,
+            "num_frames_per_block": args.frames_per_block,
         }
         await ws.send(pack_msg(config))
         print(f"Sent config: mode=t2v, prompt='{args.prompt}', "
@@ -364,13 +366,18 @@ async def run_v2v_test(args):
         return
 
     # Load frames from video file or generate random ones
+    vae_t = 4  # VAE temporal compression ratio
+    n = args.frames_per_block
+    first_block_frames = (n - 1) * vae_t + 1
+    next_block_frames = n * vae_t
+
     if args.video:
         all_frames = load_video_frames(args.video, args.height, args.width)
         if not all_frames:
             return
     else:
         print("No --video provided, using random dummy frames")
-        total_needed = 9 + 12 * max(args.blocks - 1, 0)
+        total_needed = first_block_frames + next_block_frames * max(args.blocks - 1, 0)
         all_frames = make_random_frames(
             total_needed, args.height, args.width
         )
@@ -383,6 +390,7 @@ async def run_v2v_test(args):
             "height": args.height,
             "width": args.width,
             "num_inference_steps": args.steps,
+            "num_frames_per_block": args.frames_per_block,
         }
         await ws.send(pack_msg(config))
         print(f"Sent config: mode=v2v, prompt='{args.prompt}'")
@@ -395,8 +403,6 @@ async def run_v2v_test(args):
         if args.save_dir:
             os.makedirs(args.save_dir, exist_ok=True)
 
-        first_block_frames = 9
-        next_block_frames = 12
         cursor = 0
 
         block_count = 0
@@ -545,6 +551,8 @@ def main():
                         help="Directory to save output frames as PNG")
     parser.add_argument("--video", default=None,
                         help="[v2v] Path to input video file (mp4/avi/...)")
+    parser.add_argument("--frames-per-block", type=int, default=3,
+                        help="num_frames_per_block (latent frames per block)")
 
     args = parser.parse_args()
 

--- a/tests/test_realtime_e2e_client.py
+++ b/tests/test_realtime_e2e_client.py
@@ -15,10 +15,15 @@ Usage:
     # Save output frames to disk:
     python tests/test_realtime_e2e_client.py -i --save-dir /tmp/frames
 
-    # V2V mode:
+    # V2V mode with local video input:
+    python tests/test_realtime_e2e_client.py --mode v2v --video input.mp4 \
+        --blocks 5 --prompt "anime style" --save-dir /tmp/v2v_out
+
+    # V2V mode with random frames (no video file):
     python tests/test_realtime_e2e_client.py --mode v2v --blocks 5
 
 Requires: pip install websockets msgpack Pillow
+Optional: pip install opencv-python  (for V2V video file input)
 """
 
 import argparse
@@ -43,6 +48,11 @@ try:
     from PIL import Image
 except ImportError:
     Image = None
+
+try:
+    import cv2
+except ImportError:
+    cv2 = None
 
 
 def pack_msg(msg: dict) -> bytes:
@@ -108,9 +118,13 @@ async def run_t2v_interactive(args):
         stdin_thread = threading.Thread(target=_read_stdin, daemon=True)
         stdin_thread.start()
 
+        block_count = 0
         frame_count = 0
+        block_frame_idx = 0
+        last_frame_time = None
         start_time = time.time()
         current_prompt = args.prompt
+        BLOCK_GAP_THRESHOLD = 1.0
 
         try:
             while True:
@@ -138,13 +152,21 @@ async def run_t2v_interactive(args):
                     continue
 
                 msg = unpack_msg(data)
-                elapsed = time.time() - start_time
+                now = time.time()
+                elapsed = now - start_time
 
                 if msg["type"] == "frame":
                     content = msg["content"]
+                    if last_frame_time is not None and (now - last_frame_time) > BLOCK_GAP_THRESHOLD:
+                        block_count += 1
+                        block_frame_idx = 0
+                    elif last_frame_time is None:
+                        pass
+                    last_frame_time = now
                     frame_count += 1
+                    block_frame_idx += 1
 
-                    parts = [f"Block {frame_count}",
+                    parts = [f"Block {block_count} Frame {block_frame_idx}",
                              f"{len(content)} bytes",
                              f"{elapsed:.1f}s"]
 
@@ -208,6 +230,7 @@ async def run_t2v_batch(args):
             f"Expected session_started, got: {msg}"
         print("Session started!")
 
+        block_count = 0
         frame_count = 0
         start_time = time.time()
 
@@ -216,9 +239,9 @@ async def run_t2v_batch(args):
 
         prompt_changed = False
 
-        while frame_count < args.blocks:
+        while block_count < args.blocks:
             if (args.change_prompt_at
-                    and frame_count == args.change_prompt_at
+                    and block_count == args.change_prompt_at
                     and not prompt_changed):
                 new_prompt = args.new_prompt or \
                     "A rocket launching into space with flames"
@@ -229,31 +252,48 @@ async def run_t2v_batch(args):
 
             data = await ws.recv()
             msg = unpack_msg(data)
-            elapsed = time.time() - start_time
 
             if msg["type"] == "frame":
-                content = msg["content"]
-                frame_count += 1
+                block_count += 1
+                block_frames = [msg["content"]]
 
-                info = f"Block {frame_count}/{args.blocks} | "
-                info += f"{len(content)} bytes | "
-                info += f"elapsed: {elapsed:.1f}s"
+                # Collect remaining frames of this block (sent rapidly)
+                try:
+                    while True:
+                        data = await asyncio.wait_for(ws.recv(), timeout=1.0)
+                        msg2 = unpack_msg(data)
+                        if msg2["type"] == "frame":
+                            block_frames.append(msg2["content"])
+                        elif msg2["type"] == "error":
+                            print(f"ERROR from server: {msg2['content']}")
+                            return
+                except asyncio.TimeoutError:
+                    pass
 
-                if Image is not None and isinstance(content, bytes):
-                    try:
-                        img = Image.open(io.BytesIO(content))
-                        info += f" | {img.size[0]}x{img.size[1]} {img.mode}"
+                elapsed = time.time() - start_time
+                for content in block_frames:
+                    frame_count += 1
+                    info = (f"Block {block_count}/{args.blocks} | "
+                            f"frame {frame_count} | "
+                            f"{len(content)} bytes | "
+                            f"elapsed: {elapsed:.1f}s")
 
-                        if args.save_dir:
-                            path = os.path.join(
-                                args.save_dir, f"frame_{frame_count:04d}.png"
-                            )
-                            img.save(path)
-                            info += f" | saved: {path}"
-                    except Exception as e:
-                        info += f" | decode err: {e}"
+                    if Image is not None and isinstance(content, bytes):
+                        try:
+                            img = Image.open(io.BytesIO(content))
+                            info += (f" | {img.size[0]}x{img.size[1]}"
+                                     f" {img.mode}")
+                            if args.save_dir:
+                                path = os.path.join(
+                                    args.save_dir,
+                                    f"frame_{frame_count:04d}.png",
+                                )
+                                img.save(path)
+                                info += f" | saved: {path}"
+                        except Exception as e:
+                            info += f" | decode err: {e}"
 
-                print(info)
+                    print(info)
 
             elif msg["type"] == "error":
                 print(f"ERROR from server: {msg['content']}")
@@ -263,8 +303,55 @@ async def run_t2v_batch(args):
                 print(f"Status: {msg['content']}")
 
         total = time.time() - start_time
-        print(f"\nDone! {frame_count} blocks in {total:.1f}s "
-              f"({frame_count / total:.2f} blocks/sec)")
+        print(f"\nDone! {block_count} blocks, {frame_count} frames "
+              f"in {total:.1f}s "
+              f"({block_count / total:.2f} blocks/sec)")
+
+
+def load_video_frames(video_path: str, height: int, width: int) -> list[bytes]:
+    """Load all frames from a video file as JPEG bytes."""
+    if cv2 is None:
+        print("ERROR: pip install opencv-python")
+        return []
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        print(f"ERROR: Cannot open video: {video_path}")
+        return []
+
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    print(f"Video: {video_path} | {total} frames | {fps:.1f} fps | "
+          f"{int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))}x"
+          f"{int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))}")
+
+    frames = []
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frame = cv2.resize(frame, (width, height))
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        img = Image.fromarray(frame)
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=85)
+        frames.append(buf.getvalue())
+    cap.release()
+    print(f"Loaded {len(frames)} frames, resized to {width}x{height}")
+    return frames
+
+
+def make_random_frames(count: int, height: int, width: int) -> list[bytes]:
+    """Generate random dummy frames as JPEG bytes."""
+    import numpy as np
+    frames = []
+    for _ in range(count):
+        arr = np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
+        img = Image.fromarray(arr)
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=80)
+        frames.append(buf.getvalue())
+    return frames
 
 
 async def run_v2v_test(args):
@@ -275,6 +362,18 @@ async def run_v2v_test(args):
     if Image is None:
         print("ERROR: Pillow is required for V2V test")
         return
+
+    # Load frames from video file or generate random ones
+    if args.video:
+        all_frames = load_video_frames(args.video, args.height, args.width)
+        if not all_frames:
+            return
+    else:
+        print("No --video provided, using random dummy frames")
+        total_needed = 9 + 12 * max(args.blocks - 1, 0)
+        all_frames = make_random_frames(
+            total_needed, args.height, args.width
+        )
 
     async with websockets.connect(uri, max_size=50 * 1024 * 1024) as ws:
         config = {
@@ -293,68 +392,126 @@ async def run_v2v_test(args):
         assert msg["type"] == "status" and msg["content"] == "session_started"
         print("Session started!")
 
-        import numpy as np
-        num_input_frames = 12
-        print(f"Sending {num_input_frames} dummy input frames...")
+        if args.save_dir:
+            os.makedirs(args.save_dir, exist_ok=True)
 
-        frames_bytes = []
-        for i in range(num_input_frames):
-            arr = np.random.randint(
-                0, 255, (args.height, args.width, 3), dtype=np.uint8
-            )
-            img = Image.fromarray(arr)
-            buf = io.BytesIO()
-            img.save(buf, format="JPEG", quality=80)
-            frames_bytes.append(buf.getvalue())
+        first_block_frames = 9
+        next_block_frames = 12
+        cursor = 0
 
-        video_msg = {"type": "video", "frames": frames_bytes}
-        await ws.send(pack_msg(video_msg))
-        print(f"Sent {num_input_frames} frames")
-
-        frame_count = 0
+        block_count = 0
+        output_frame_idx = 0
         start = time.time()
 
-        while frame_count < args.blocks:
-            if frame_count > 0:
-                more_frames = []
-                for _ in range(12):
-                    arr = np.random.randint(
-                        0, 255, (args.height, args.width, 3), dtype=np.uint8
-                    )
-                    img = Image.fromarray(arr)
-                    buf = io.BytesIO()
-                    img.save(buf, format="JPEG", quality=80)
-                    more_frames.append(buf.getvalue())
-                await ws.send(
-                    pack_msg({"type": "video", "frames": more_frames})
-                )
+        while block_count < args.blocks:
+            # Determine how many input frames this block needs
+            needed = first_block_frames if block_count == 0 else next_block_frames
 
-            data = await ws.recv()
-            msg = unpack_msg(data)
+            # Sample frames from the loaded video
+            if cursor + needed <= len(all_frames):
+                batch = all_frames[cursor:cursor + needed]
+                cursor += needed
+            elif cursor < len(all_frames):
+                # Not enough frames left — sample evenly from remaining
+                remaining = all_frames[cursor:]
+                import numpy as np
+                indices = np.round(
+                    np.linspace(0, len(remaining) - 1, needed)
+                ).astype(int)
+                batch = [remaining[i] for i in indices]
+                cursor = len(all_frames)
+            else:
+                # Video exhausted — loop from the beginning
+                cursor = 0
+                batch = all_frames[:needed]
+                cursor = needed
+                print(f"  (video looped)")
 
-            if msg["type"] == "frame":
-                frame_count += 1
-                content = msg["content"]
-                elapsed = time.time() - start
-                print(f"V2V Block {frame_count}/{args.blocks} | "
-                      f"{len(content)} bytes | {elapsed:.1f}s")
+            await ws.send(pack_msg({"type": "video", "frames": batch}))
 
-                if args.save_dir and Image is not None:
+            # Receive output frame(s) for this block
+            block_received = False
+            while not block_received:
+                data = await ws.recv()
+                msg = unpack_msg(data)
+
+                if msg["type"] == "frame":
+                    output_frame_idx += 1
+                    content = msg["content"]
+                    elapsed = time.time() - start
+
+                    parts = [f"Block {block_count + 1}/{args.blocks}",
+                             f"frame {output_frame_idx}",
+                             f"{len(content)} bytes",
+                             f"{elapsed:.1f}s"]
+
+                    if Image is not None and isinstance(content, bytes):
+                        try:
+                            img = Image.open(io.BytesIO(content))
+                            parts.append(f"{img.size[0]}x{img.size[1]}")
+                            if args.save_dir:
+                                path = os.path.join(
+                                    args.save_dir,
+                                    f"v2v_frame_{output_frame_idx:04d}.png",
+                                )
+                                img.save(path)
+                                parts.append(f"saved:{path}")
+                        except Exception as e:
+                            parts.append(f"decode err: {e}")
+
+                    print(f"  {' | '.join(parts)}")
+
+                    # After receiving frames, check if more are pending
+                    # Use a short timeout to collect all frames from this block
                     try:
-                        img = Image.open(io.BytesIO(content))
-                        path = os.path.join(
-                            args.save_dir, f"v2v_frame_{frame_count:04d}.png"
-                        )
-                        img.save(path)
-                    except Exception:
+                        while True:
+                            data = await asyncio.wait_for(
+                                ws.recv(), timeout=0.5
+                            )
+                            msg2 = unpack_msg(data)
+                            if msg2["type"] == "frame":
+                                output_frame_idx += 1
+                                content2 = msg2["content"]
+                                parts2 = [
+                                    f"Block {block_count + 1}/{args.blocks}",
+                                    f"frame {output_frame_idx}",
+                                    f"{len(content2)} bytes",
+                                    f"{time.time() - start:.1f}s",
+                                ]
+                                if args.save_dir and Image is not None:
+                                    try:
+                                        img2 = Image.open(
+                                            io.BytesIO(content2)
+                                        )
+                                        parts2.append(
+                                            f"{img2.size[0]}x{img2.size[1]}"
+                                        )
+                                        path2 = os.path.join(
+                                            args.save_dir,
+                                            f"v2v_frame_{output_frame_idx:04d}"
+                                            ".png",
+                                        )
+                                        img2.save(path2)
+                                        parts2.append(f"saved:{path2}")
+                                    except Exception:
+                                        pass
+                                print(f"  {' | '.join(parts2)}")
+                            elif msg2["type"] == "error":
+                                print(f"ERROR: {msg2['content']}")
+                                return
+                    except asyncio.TimeoutError:
                         pass
 
-            elif msg["type"] == "error":
-                print(f"ERROR: {msg['content']}")
-                break
+                    block_received = True
+                    block_count += 1
+
+                elif msg["type"] == "error":
+                    print(f"ERROR: {msg['content']}")
+                    return
 
         total = time.time() - start
-        print(f"\nV2V done! {frame_count} blocks in {total:.1f}s")
+        print(f"\nV2V done! {block_count} blocks, {output_frame_idx} output "
+              f"frames in {total:.1f}s")
 
 
 def main():
@@ -386,6 +543,8 @@ def main():
                         help="[batch] New prompt for --change-prompt-at")
     parser.add_argument("--save-dir", default=None,
                         help="Directory to save output frames as PNG")
+    parser.add_argument("--video", default=None,
+                        help="[v2v] Path to input video file (mp4/avi/...)")
 
     args = parser.parse_args()
 

--- a/tests/test_realtime_e2e_client.py
+++ b/tests/test_realtime_e2e_client.py
@@ -395,8 +395,11 @@ async def run_v2v_test(args):
             "num_inference_steps": args.steps,
             "num_frames_per_block": args.frames_per_block,
         }
+        if args.strength is not None:
+            config["v2v_strength"] = args.strength
         await ws.send(pack_msg(config))
-        print(f"Sent config: mode=v2v, prompt='{args.prompt}'")
+        print(f"Sent config: mode=v2v, prompt='{args.prompt}'"
+              f"{f', strength={args.strength}' if args.strength else ''}")
 
         data = await ws.recv()
         msg = unpack_msg(data)
@@ -546,6 +549,8 @@ def main():
                         help="[v2v] Path to input video file (mp4/avi/...)")
     parser.add_argument("--frames-per-block", type=int, default=3,
                         help="num_frames_per_block (latent frames per block)")
+    parser.add_argument("--strength", type=float, default=None,
+                        help="[v2v] V2V strength (0.0-1.0, lower preserves more)")
 
     args = parser.parse_args()
 

--- a/tests/test_realtime_e2e_client.py
+++ b/tests/test_realtime_e2e_client.py
@@ -357,7 +357,11 @@ def make_random_frames(count: int, height: int, width: int) -> list[bytes]:
 
 
 async def run_v2v_test(args):
-    """V2V mode: send video frames, receive transformed output."""
+    """V2V mode: send video frames, receive transformed output.
+
+    Sends all input frames upfront to avoid deadlock with the server's
+    pipeline mode (which may return 0 frames for intermediate blocks).
+    """
     uri = f"ws://{args.host}:{args.port}/v1/realtime_video/generate"
     print(f"Connecting to {uri} (V2V mode) ...")
 
@@ -365,7 +369,6 @@ async def run_v2v_test(args):
         print("ERROR: Pillow is required for V2V test")
         return
 
-    # Load frames from video file or generate random ones
     vae_t = 4  # VAE temporal compression ratio
     n = args.frames_per_block
     first_block_frames = (n - 1) * vae_t + 1
@@ -377,7 +380,7 @@ async def run_v2v_test(args):
             return
     else:
         print("No --video provided, using random dummy frames")
-        total_needed = first_block_frames + next_block_frames * max(args.blocks - 1, 0)
+        total_needed = first_block_frames + next_block_frames * max(args.blocks, 1)
         all_frames = make_random_frames(
             total_needed, args.height, args.width
         )
@@ -403,121 +406,111 @@ async def run_v2v_test(args):
         if args.save_dir:
             os.makedirs(args.save_dir, exist_ok=True)
 
+        # Pre-compute frame batches. Pipeline mode needs one extra server
+        # block because each pipeline block returns the *previous* block's
+        # decoded frames (the first pipeline block returns nothing).
+        import numpy as np
+
+        server_blocks = args.blocks + 1
+        batches = []
         cursor = 0
-
-        block_count = 0
-        output_frame_idx = 0
-        start = time.time()
-
-        while block_count < args.blocks:
-            # Determine how many input frames this block needs
-            needed = first_block_frames if block_count == 0 else next_block_frames
-
-            # Sample frames from the loaded video
+        for i in range(server_blocks):
+            needed = first_block_frames if i == 0 else next_block_frames
             if cursor + needed <= len(all_frames):
                 batch = all_frames[cursor:cursor + needed]
                 cursor += needed
             elif cursor < len(all_frames):
-                # Not enough frames left — sample evenly from remaining
                 remaining = all_frames[cursor:]
-                import numpy as np
                 indices = np.round(
                     np.linspace(0, len(remaining) - 1, needed)
                 ).astype(int)
-                batch = [remaining[i] for i in indices]
+                batch = [remaining[int(idx)] for idx in indices]
                 cursor = len(all_frames)
             else:
-                # Video exhausted — loop from the beginning
                 cursor = 0
                 batch = all_frames[:needed]
                 cursor = needed
-                print(f"  (video looped)")
+            batches.append(batch)
 
-            await ws.send(pack_msg({"type": "video", "frames": batch}))
+        print(f"Prepared {len(batches)} input batches "
+              f"({sum(len(b) for b in batches)} total frames)")
 
-            # Receive output frame(s) for this block
-            block_received = False
-            while not block_received:
+        send_error = None
+
+        async def send_all_frames():
+            nonlocal send_error
+            try:
+                for i, batch in enumerate(batches):
+                    await ws.send(pack_msg(
+                        {"type": "video", "frames": batch}
+                    ))
+            except Exception as e:
+                send_error = e
+
+        async def recv_output():
+            block_count = 0
+            output_frame_idx = 0
+            start = time.time()
+
+            while block_count < args.blocks:
                 data = await ws.recv()
                 msg = unpack_msg(data)
 
                 if msg["type"] == "frame":
-                    output_frame_idx += 1
-                    content = msg["content"]
-                    elapsed = time.time() - start
+                    block_count += 1
+                    block_frames = [msg["content"]]
 
-                    parts = [f"Block {block_count + 1}/{args.blocks}",
-                             f"frame {output_frame_idx}",
-                             f"{len(content)} bytes",
-                             f"{elapsed:.1f}s"]
-
-                    if Image is not None and isinstance(content, bytes):
-                        try:
-                            img = Image.open(io.BytesIO(content))
-                            parts.append(f"{img.size[0]}x{img.size[1]}")
-                            if args.save_dir:
-                                path = os.path.join(
-                                    args.save_dir,
-                                    f"v2v_frame_{output_frame_idx:04d}.png",
-                                )
-                                img.save(path)
-                                parts.append(f"saved:{path}")
-                        except Exception as e:
-                            parts.append(f"decode err: {e}")
-
-                    print(f"  {' | '.join(parts)}")
-
-                    # After receiving frames, check if more are pending
-                    # Use a short timeout to collect all frames from this block
                     try:
                         while True:
                             data = await asyncio.wait_for(
-                                ws.recv(), timeout=0.5
+                                ws.recv(), timeout=1.0
                             )
                             msg2 = unpack_msg(data)
                             if msg2["type"] == "frame":
-                                output_frame_idx += 1
-                                content2 = msg2["content"]
-                                parts2 = [
-                                    f"Block {block_count + 1}/{args.blocks}",
-                                    f"frame {output_frame_idx}",
-                                    f"{len(content2)} bytes",
-                                    f"{time.time() - start:.1f}s",
-                                ]
-                                if args.save_dir and Image is not None:
-                                    try:
-                                        img2 = Image.open(
-                                            io.BytesIO(content2)
-                                        )
-                                        parts2.append(
-                                            f"{img2.size[0]}x{img2.size[1]}"
-                                        )
-                                        path2 = os.path.join(
-                                            args.save_dir,
-                                            f"v2v_frame_{output_frame_idx:04d}"
-                                            ".png",
-                                        )
-                                        img2.save(path2)
-                                        parts2.append(f"saved:{path2}")
-                                    except Exception:
-                                        pass
-                                print(f"  {' | '.join(parts2)}")
+                                block_frames.append(msg2["content"])
                             elif msg2["type"] == "error":
                                 print(f"ERROR: {msg2['content']}")
                                 return
                     except asyncio.TimeoutError:
                         pass
 
-                    block_received = True
-                    block_count += 1
+                    elapsed = time.time() - start
+                    for content in block_frames:
+                        output_frame_idx += 1
+                        parts = [
+                            f"Block {block_count}/{args.blocks}",
+                            f"frame {output_frame_idx}",
+                            f"{len(content)} bytes",
+                            f"{elapsed:.1f}s",
+                        ]
+                        if Image is not None and isinstance(content, bytes):
+                            try:
+                                img = Image.open(io.BytesIO(content))
+                                parts.append(f"{img.size[0]}x{img.size[1]}")
+                                if args.save_dir:
+                                    path = os.path.join(
+                                        args.save_dir,
+                                        f"v2v_frame_{output_frame_idx:04d}"
+                                        ".png",
+                                    )
+                                    img.save(path)
+                                    parts.append(f"saved:{path}")
+                            except Exception as e:
+                                parts.append(f"decode err: {e}")
+                        print(f"  {' | '.join(parts)}")
 
                 elif msg["type"] == "error":
                     print(f"ERROR: {msg['content']}")
                     return
 
-        total = time.time() - start
-        print(f"\nV2V done! {block_count} blocks, {output_frame_idx} output "
-              f"frames in {total:.1f}s")
+            total = time.time() - start
+            print(f"\nV2V done! {block_count} blocks, "
+                  f"{output_frame_idx} output frames in {total:.1f}s")
+
+        await asyncio.gather(send_all_frames(), recv_output())
+
+        if send_error:
+            print(f"Frame send error (non-fatal): {send_error}")
 
 
 def main():

--- a/vllm_omni/diffusion/models/wan2_2/__init__.py
+++ b/vllm_omni/diffusion/models/wan2_2/__init__.py
@@ -25,6 +25,12 @@ from .pipeline_wan2_2_vace import (
     get_wan22_vace_pre_process_func,
 )
 from .causal_wan2_2_transformer import CausalWanTransformer3DModel
+from .kv_cache import CrossAttentionKVCache, KVCacheManager, SelfAttentionKVCache
+from .pipeline_wan2_2_realtime import (
+    RealtimeSession,
+    RealtimeVideoMode,
+    Wan22RealtimePipeline,
+)
 from .wan2_2_transformer import WanTransformer3DModel
 from .wan2_2_vace_transformer import VaceWanTransformerBlock, WanVACETransformer3DModel
 
@@ -48,4 +54,10 @@ __all__ = [
     "WanTransformer3DModel",
     "VaceWanTransformerBlock",
     "WanVACETransformer3DModel",
+    "KVCacheManager",
+    "SelfAttentionKVCache",
+    "CrossAttentionKVCache",
+    "RealtimeSession",
+    "RealtimeVideoMode",
+    "Wan22RealtimePipeline",
 ]

--- a/vllm_omni/diffusion/models/wan2_2/__init__.py
+++ b/vllm_omni/diffusion/models/wan2_2/__init__.py
@@ -24,6 +24,7 @@ from .pipeline_wan2_2_vace import (
     get_wan22_vace_post_process_func,
     get_wan22_vace_pre_process_func,
 )
+from .causal_wan2_2_transformer import CausalWanTransformer3DModel
 from .wan2_2_transformer import WanTransformer3DModel
 from .wan2_2_vace_transformer import VaceWanTransformerBlock, WanVACETransformer3DModel
 
@@ -43,6 +44,7 @@ __all__ = [
     "Wan22VACEPipeline",
     "get_wan22_vace_post_process_func",
     "get_wan22_vace_pre_process_func",
+    "CausalWanTransformer3DModel",
     "WanTransformer3DModel",
     "VaceWanTransformerBlock",
     "WanVACETransformer3DModel",

--- a/vllm_omni/diffusion/models/wan2_2/causal_wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/causal_wan2_2_transformer.py
@@ -32,6 +32,10 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.models.wan2_2.kv_cache import (
+    CrossAttentionKVCache,
+    SelfAttentionKVCache,
+)
 from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import (
     AdaLayerNorm,
     DistributedRMSNorm,
@@ -120,7 +124,7 @@ class CausalWanSelfAttention(nn.Module):
         hidden_states: torch.Tensor,
         rotary_emb: tuple[torch.Tensor, torch.Tensor],
         block_mask: BlockMask | None = None,
-        kv_cache: dict | None = None,
+        kv_cache: dict | SelfAttentionKVCache | None = None,
         current_start: int = 0,
         cache_start: int | None = None,
     ) -> torch.Tensor:
@@ -147,19 +151,36 @@ class CausalWanSelfAttention(nn.Module):
         query = apply_rotary_emb_wan(query, freqs_cos, freqs_sin)
         key = apply_rotary_emb_wan(key, freqs_cos, freqs_sin)
 
-        if kv_cache is None:
-            # Training mode: use flex_attention with block-wise causal mask
-            out = self._forward_flex_attention(query, key, value, block_mask)
-        else:
-            # Inference mode: use KV cache with sliding window
+        if isinstance(kv_cache, SelfAttentionKVCache):
+            out = self._forward_sa_kv_cache(
+                query, key, value, kv_cache, current_start
+            )
+        elif kv_cache is not None:
             out = self._forward_kv_cache(
                 query, key, value, kv_cache, current_start, cache_start
             )
+        elif block_mask is not None:
+            out = self._forward_flex_attention(query, key, value, block_mask)
+        else:
+            out = self.attn(query, key, value)
 
         # Output projection
         out = out.flatten(2, 3).type_as(query)
         out = self.to_out(out)
         return out
+
+    def _forward_sa_kv_cache(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: SelfAttentionKVCache,
+        current_start: int,
+    ) -> torch.Tensor:
+        """Inference path using SelfAttentionKVCache with sliding window eviction."""
+        kv_cache.append(key, value, current_start)
+        active_k, active_v = kv_cache.get_active_kv(self.max_attention_size)
+        return self.attn(query, active_k, active_v)
 
     def _forward_flex_attention(
         self,
@@ -316,7 +337,8 @@ class CausalWanTransformerBlock(nn.Module):
         temb: torch.Tensor,
         rotary_emb: tuple[torch.Tensor, torch.Tensor],
         block_mask: BlockMask | None = None,
-        kv_cache: dict | None = None,
+        kv_cache: dict | SelfAttentionKVCache | None = None,
+        crossattn_cache: CrossAttentionKVCache | None = None,
         current_start: int = 0,
         cache_start: int | None = None,
     ) -> torch.Tensor:
@@ -349,9 +371,16 @@ class CausalWanTransformerBlock(nn.Module):
         )
         hidden_states = (hidden_states + attn_output * gate_msa).type_as(hidden_states)
 
-        # 2. Cross-attention
+        # 2. Cross-attention (with optional caching)
         norm_hidden_states = self.norm2(hidden_states).type_as(hidden_states)
-        attn_output = self.attn2(norm_hidden_states, encoder_hidden_states)
+        if crossattn_cache is not None and crossattn_cache.is_initialized:
+            attn_output = self.attn2(norm_hidden_states, encoder_hidden_states)
+        else:
+            attn_output = self.attn2(norm_hidden_states, encoder_hidden_states)
+            if crossattn_cache is not None:
+                crossattn_cache.update(
+                    encoder_hidden_states, encoder_hidden_states
+                )
         hidden_states = hidden_states + attn_output
 
         # 3. Feed-forward
@@ -568,7 +597,8 @@ class CausalWanTransformer3DModel(nn.Module):
         encoder_hidden_states_image: torch.Tensor | None = None,
         return_dict: bool = True,
         attention_kwargs: dict[str, Any] | None = None,
-        kv_cache: list[dict] | None = None,
+        kv_cache: list[dict] | list[SelfAttentionKVCache] | None = None,
+        crossattn_cache: list[CrossAttentionKVCache] | None = None,
         current_start: int = 0,
         cache_start: int = 0,
         start_frame: int = 0,
@@ -582,6 +612,7 @@ class CausalWanTransformer3DModel(nn.Module):
                 return_dict,
                 attention_kwargs,
                 kv_cache=kv_cache,
+                crossattn_cache=crossattn_cache,
                 current_start=current_start,
                 cache_start=cache_start,
                 start_frame=start_frame,
@@ -612,10 +643,10 @@ class CausalWanTransformer3DModel(nn.Module):
         post_patch_height = height // p_h
         post_patch_width = width // p_w
 
-        # RoPE (uses start_frame for positional offset in inference)
-        rotary_emb = self.rope(hidden_states)
-        # TODO: if start_frame > 0, need to offset RoPE. For now this matches
-        # the standard WanRotaryPosEmbed which computes from frame 0.
+        # RoPE with start_frame offset for incremental inference
+        rotary_emb = self._compute_rotary_emb(
+            hidden_states, post_patch_num_frames, post_patch_height, post_patch_width, start_frame
+        )
 
         # Patch embedding
         hidden_states = self.patch_embedding(hidden_states)
@@ -656,6 +687,44 @@ class CausalWanTransformer3DModel(nn.Module):
             post_patch_height,
             post_patch_width,
         )
+
+    def _compute_rotary_emb(
+        self,
+        hidden_states: torch.Tensor,
+        ppf: int,
+        pph: int,
+        ppw: int,
+        start_frame: int = 0,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute RoPE with optional frame offset for incremental inference."""
+        if start_frame == 0:
+            return self.rope(hidden_states)
+
+        head_dim = self.attention_head_dim
+        h_dim = w_dim = 2 * (head_dim // 6)
+        t_dim = head_dim - h_dim - w_dim
+
+        split_sizes = [
+            head_dim - 2 * (head_dim // 3),
+            head_dim // 3,
+            head_dim // 3,
+        ]
+        freqs_cos = self.rope.freqs_cos.split(split_sizes, dim=1)
+        freqs_sin = self.rope.freqs_sin.split(split_sizes, dim=1)
+
+        end_frame = start_frame + ppf
+        freqs_cos_f = freqs_cos[0][start_frame:end_frame].view(ppf, 1, 1, -1).expand(ppf, pph, ppw, -1)
+        freqs_cos_h = freqs_cos[1][:pph].view(1, pph, 1, -1).expand(ppf, pph, ppw, -1)
+        freqs_cos_w = freqs_cos[2][:ppw].view(1, 1, ppw, -1).expand(ppf, pph, ppw, -1)
+
+        freqs_sin_f = freqs_sin[0][start_frame:end_frame].view(ppf, 1, 1, -1).expand(ppf, pph, ppw, -1)
+        freqs_sin_h = freqs_sin[1][:pph].view(1, pph, 1, -1).expand(ppf, pph, ppw, -1)
+        freqs_sin_w = freqs_sin[2][:ppw].view(1, 1, ppw, -1).expand(ppf, pph, ppw, -1)
+
+        cos_emb = torch.cat([freqs_cos_f, freqs_cos_h, freqs_cos_w], dim=-1).reshape(1, ppf * pph * ppw, 1, -1)
+        sin_emb = torch.cat([freqs_sin_f, freqs_sin_h, freqs_sin_w], dim=-1).reshape(1, ppf * pph * ppw, 1, -1)
+
+        return cos_emb.to(hidden_states.device), sin_emb.to(hidden_states.device)
 
     def _forward_train(
         self,
@@ -712,7 +781,8 @@ class CausalWanTransformer3DModel(nn.Module):
         encoder_hidden_states_image: torch.Tensor | None = None,
         return_dict: bool = True,
         attention_kwargs: dict[str, Any] | None = None,
-        kv_cache: list[dict] | None = None,
+        kv_cache: list[dict] | list[SelfAttentionKVCache] | None = None,
+        crossattn_cache: list[CrossAttentionKVCache] | None = None,
         current_start: int = 0,
         cache_start: int = 0,
         start_frame: int = 0,
@@ -730,6 +800,7 @@ class CausalWanTransformer3DModel(nn.Module):
         # Transformer blocks with KV cache
         for block_index, block in enumerate(self.blocks):
             block_kv_cache = kv_cache[block_index] if kv_cache is not None else None
+            block_crossattn_cache = crossattn_cache[block_index] if crossattn_cache is not None else None
             hidden_states = block(
                 hidden_states,
                 encoder_hidden_states,
@@ -737,6 +808,7 @@ class CausalWanTransformer3DModel(nn.Module):
                 rotary_emb,
                 block_mask=self.block_mask,
                 kv_cache=block_kv_cache,
+                crossattn_cache=block_crossattn_cache,
                 current_start=current_start,
                 cache_start=cache_start,
             )
@@ -759,7 +831,17 @@ class CausalWanTransformer3DModel(nn.Module):
     ) -> torch.Tensor | Transformer2DModelOutput:
         p_t, p_h, p_w = self.config.patch_size
 
-        shift, scale = (self.scale_shift_table.to(hidden_states.device) + temb.unsqueeze(1)).chunk(2, dim=1)
+        if temb.ndim == 3:
+            shift, scale = (
+                self.scale_shift_table.unsqueeze(0).to(hidden_states.device)
+                + temb.unsqueeze(2)
+            ).chunk(2, dim=2)
+            shift = shift.squeeze(2)
+            scale = scale.squeeze(2)
+        else:
+            shift, scale = (
+                self.scale_shift_table.to(hidden_states.device) + temb.unsqueeze(1)
+            ).chunk(2, dim=1)
         hidden_states = self.norm_out(hidden_states, scale, shift).type_as(hidden_states)
         hidden_states = self.proj_out(hidden_states)
 

--- a/vllm_omni/diffusion/models/wan2_2/causal_wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/causal_wan2_2_transformer.py
@@ -1,0 +1,847 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Causal WanVideo Transformer with block-wise causal attention and KV cache.
+# Based on CausVid (arXiv:2412.07772) and adapted from sglang's implementation.
+
+import math
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+from diffusers.models.normalization import FP32LayerNorm
+from torch.nn.attention.flex_attention import (
+    BlockMask,
+    create_block_mask,
+    flex_attention,
+)
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import (
+    AdaLayerNorm,
+    DistributedRMSNorm,
+    WanCrossAttention,
+    WanFeedForward,
+    WanRotaryPosEmbed,
+    WanTimeTextImageEmbedding,
+    apply_rotary_emb_wan,
+)
+from vllm_omni.platforms import current_omni_platform
+
+logger = init_logger(__name__)
+
+# Compile flex_attention with max-autotune for Wan 1.3B compatibility
+# See https://github.com/pytorch/pytorch/issues/133254
+_compiled_flex_attention = torch.compile(
+    flex_attention, dynamic=False, mode="max-autotune-no-cudagraphs"
+)
+
+
+class CausalWanSelfAttention(nn.Module):
+    """
+    Block-wise causal self-attention with TP support.
+
+    Training: uses flex_attention with BlockMask for block-wise causal masking.
+    Inference: uses sliding-window KV cache with sink tokens.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        head_dim: int,
+        local_attn_size: int = -1,
+        sink_size: int = 0,
+        eps: float = 1e-6,
+    ):
+        super().__init__()
+        assert dim % num_heads == 0
+
+        self.dim = dim
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.local_attn_size = local_attn_size
+        self.sink_size = sink_size
+        self.max_attention_size = (
+            32760 if local_attn_size == -1 else local_attn_size * 1560
+        )
+
+        # Fused QKV projection with TP
+        self.to_qkv = QKVParallelLinear(
+            hidden_size=dim,
+            head_size=head_dim,
+            total_num_heads=num_heads,
+            bias=True,
+        )
+        self.local_num_heads = self.to_qkv.num_heads
+        self.local_num_kv_heads = self.to_qkv.num_kv_heads
+        self.tp_inner_dim = self.local_num_heads * head_dim
+
+        # QK normalization (TP-aware)
+        self.norm_q = DistributedRMSNorm(self.tp_inner_dim, eps=eps)
+        self.norm_k = DistributedRMSNorm(self.tp_inner_dim, eps=eps)
+
+        # Output projection with TP
+        self.to_out = RowParallelLinear(
+            num_heads * head_dim,
+            dim,
+            bias=True,
+            input_is_parallel=True,
+            return_bias=False,
+        )
+
+        # Local attention for inference mode (no SP)
+        self.attn = Attention(
+            num_heads=self.local_num_heads,
+            head_size=head_dim,
+            num_kv_heads=self.local_num_kv_heads,
+            softmax_scale=1.0 / (head_dim**0.5),
+            causal=False,
+            skip_sequence_parallel=True,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_emb: tuple[torch.Tensor, torch.Tensor],
+        block_mask: BlockMask | None = None,
+        kv_cache: dict | None = None,
+        current_start: int = 0,
+        cache_start: int | None = None,
+    ) -> torch.Tensor:
+        if cache_start is None:
+            cache_start = current_start
+
+        # Fused QKV projection
+        qkv, _ = self.to_qkv(hidden_states)
+        q_size = self.local_num_heads * self.head_dim
+        kv_size = self.local_num_kv_heads * self.head_dim
+        query, key, value = qkv.split([q_size, kv_size, kv_size], dim=-1)
+
+        # QK normalization
+        query = self.norm_q(query)
+        key = self.norm_k(key)
+
+        # Reshape: [B, S, local_heads * head_dim] -> [B, S, local_heads, head_dim]
+        query = query.unflatten(2, (self.local_num_heads, self.head_dim))
+        key = key.unflatten(2, (self.local_num_kv_heads, self.head_dim))
+        value = value.unflatten(2, (self.local_num_kv_heads, self.head_dim))
+
+        # Apply rotary embeddings
+        freqs_cos, freqs_sin = rotary_emb
+        query = apply_rotary_emb_wan(query, freqs_cos, freqs_sin)
+        key = apply_rotary_emb_wan(key, freqs_cos, freqs_sin)
+
+        if kv_cache is None:
+            # Training mode: use flex_attention with block-wise causal mask
+            out = self._forward_flex_attention(query, key, value, block_mask)
+        else:
+            # Inference mode: use KV cache with sliding window
+            out = self._forward_kv_cache(
+                query, key, value, kv_cache, current_start, cache_start
+            )
+
+        # Output projection
+        out = out.flatten(2, 3).type_as(query)
+        out = self.to_out(out)
+        return out
+
+    def _forward_flex_attention(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        block_mask: BlockMask | None,
+    ) -> torch.Tensor:
+        """Training path: flex_attention with block-wise causal mask."""
+        seq_len = query.shape[1]
+        padded_length = math.ceil(seq_len / 128) * 128 - seq_len
+
+        if padded_length > 0:
+            pad_shape_q = [query.shape[0], padded_length, query.shape[2], query.shape[3]]
+            pad_shape_kv = [key.shape[0], padded_length, key.shape[2], key.shape[3]]
+            query = torch.cat([query, query.new_zeros(pad_shape_q)], dim=1)
+            key = torch.cat([key, key.new_zeros(pad_shape_kv)], dim=1)
+            value = torch.cat([value, value.new_zeros(pad_shape_kv)], dim=1)
+
+        # flex_attention expects [B, H, S, D]
+        out = _compiled_flex_attention(
+            query=query.transpose(1, 2),
+            key=key.transpose(1, 2),
+            value=value.transpose(1, 2),
+            block_mask=block_mask,
+        ).transpose(1, 2)
+
+        if padded_length > 0:
+            out = out[:, :seq_len]
+
+        return out
+
+    def _forward_kv_cache(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: dict,
+        current_start: int,
+        cache_start: int,
+    ) -> torch.Tensor:
+        """Inference path: sliding-window KV cache with sink tokens."""
+        frame_seqlen = query.shape[1]
+        current_end = current_start + query.shape[1]
+        sink_tokens = self.sink_size * frame_seqlen
+        kv_cache_size = kv_cache["k"].shape[1]
+        num_new_tokens = query.shape[1]
+
+        if (
+            self.local_attn_size != -1
+            and (current_end > kv_cache["global_end_index"].item())
+            and (num_new_tokens + kv_cache["local_end_index"].item() > kv_cache_size)
+        ):
+            # Evict old tokens, preserving sink tokens
+            num_evicted_tokens = (
+                num_new_tokens + kv_cache["local_end_index"].item() - kv_cache_size
+            )
+            num_rolled_tokens = (
+                kv_cache["local_end_index"].item() - num_evicted_tokens - sink_tokens
+            )
+            src_start = sink_tokens + num_evicted_tokens
+            src_end = src_start + num_rolled_tokens
+            dst_start = sink_tokens
+            dst_end = dst_start + num_rolled_tokens
+            kv_cache["k"][:, dst_start:dst_end] = kv_cache["k"][:, src_start:src_end].clone()
+            kv_cache["v"][:, dst_start:dst_end] = kv_cache["v"][:, src_start:src_end].clone()
+
+            local_end_index = (
+                kv_cache["local_end_index"].item()
+                + current_end
+                - kv_cache["global_end_index"].item()
+                - num_evicted_tokens
+            )
+            local_start_index = local_end_index - num_new_tokens
+            kv_cache["k"][:, local_start_index:local_end_index] = key
+            kv_cache["v"][:, local_start_index:local_end_index] = value
+        else:
+            # Direct assignment without eviction
+            local_end_index = (
+                kv_cache["local_end_index"].item()
+                + current_end
+                - kv_cache["global_end_index"].item()
+            )
+            local_start_index = local_end_index - num_new_tokens
+            kv_cache["k"] = kv_cache["k"].detach()
+            kv_cache["v"] = kv_cache["v"].detach()
+            kv_cache["k"][:, local_start_index:local_end_index] = key
+            kv_cache["v"][:, local_start_index:local_end_index] = value
+
+        # Attend to recent window only
+        attn_start = max(0, local_end_index - self.max_attention_size)
+        cached_k = kv_cache["k"][:, attn_start:local_end_index]
+        cached_v = kv_cache["v"][:, attn_start:local_end_index]
+
+        out = self.attn(query, cached_k, cached_v)
+
+        kv_cache["global_end_index"].fill_(current_end)
+        kv_cache["local_end_index"].fill_(local_end_index)
+
+        return out
+
+
+class CausalWanTransformerBlock(nn.Module):
+    """
+    Transformer block with block-wise causal self-attention, cross-attention, and FFN.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        ffn_dim: int,
+        num_heads: int,
+        head_dim: int,
+        local_attn_size: int = -1,
+        sink_size: int = 0,
+        eps: float = 1e-6,
+        added_kv_proj_dim: int | None = None,
+        cross_attn_norm: bool = False,
+    ):
+        super().__init__()
+
+        # 1. Self-attention with causal masking
+        self.norm1 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)
+        self.attn1 = CausalWanSelfAttention(
+            dim=dim,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            local_attn_size=local_attn_size,
+            sink_size=sink_size,
+            eps=eps,
+        )
+
+        # 2. Cross-attention (reuse existing TP-enabled implementation)
+        self.attn2 = WanCrossAttention(
+            dim=dim,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            eps=eps,
+            added_kv_proj_dim=added_kv_proj_dim,
+        )
+        self.norm2 = FP32LayerNorm(dim, eps, elementwise_affine=True) if cross_attn_norm else nn.Identity()
+
+        # 3. Feed-forward (reuse existing TP-enabled implementation)
+        self.ffn = WanFeedForward(dim=dim, inner_dim=ffn_dim, dim_out=dim)
+        self.norm3 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)
+
+        # Scale-shift table for modulation
+        self.scale_shift_table = nn.Parameter(torch.randn(1, 6, dim) / dim**0.5)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        rotary_emb: tuple[torch.Tensor, torch.Tensor],
+        block_mask: BlockMask | None = None,
+        kv_cache: dict | None = None,
+        current_start: int = 0,
+        cache_start: int | None = None,
+    ) -> torch.Tensor:
+        if temb.ndim == 4:
+            # TI2V mode: [batch, seq_len, 6, inner_dim]
+            shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (
+                self.scale_shift_table.unsqueeze(0) + temb
+            ).chunk(6, dim=2)
+            shift_msa = shift_msa.squeeze(2)
+            scale_msa = scale_msa.squeeze(2)
+            gate_msa = gate_msa.squeeze(2)
+            c_shift_msa = c_shift_msa.squeeze(2)
+            c_scale_msa = c_scale_msa.squeeze(2)
+            c_gate_msa = c_gate_msa.squeeze(2)
+        else:
+            # Standard mode: [batch, 6, inner_dim]
+            shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (
+                self.scale_shift_table + temb
+            ).chunk(6, dim=1)
+
+        # 1. Self-attention
+        norm_hidden_states = self.norm1(hidden_states, scale_msa, shift_msa).type_as(hidden_states)
+        attn_output = self.attn1(
+            norm_hidden_states,
+            rotary_emb,
+            block_mask=block_mask,
+            kv_cache=kv_cache,
+            current_start=current_start,
+            cache_start=cache_start,
+        )
+        hidden_states = (hidden_states + attn_output * gate_msa).type_as(hidden_states)
+
+        # 2. Cross-attention
+        norm_hidden_states = self.norm2(hidden_states).type_as(hidden_states)
+        attn_output = self.attn2(norm_hidden_states, encoder_hidden_states)
+        hidden_states = hidden_states + attn_output
+
+        # 3. Feed-forward
+        norm_hidden_states = self.norm3(hidden_states, c_scale_msa, c_shift_msa).type_as(hidden_states)
+        ff_output = self.ffn(norm_hidden_states)
+        hidden_states = (hidden_states + ff_output * c_gate_msa).type_as(hidden_states)
+
+        return hidden_states
+
+
+class CausalWanTransformer3DModel(nn.Module):
+    """
+    Causal WanVideo Transformer with block-wise causal attention and KV cache.
+    Supports TP via vLLM parallel layers.
+
+    Compared to WanTransformer3DModel:
+    - Uses block-wise causal attention instead of bidirectional
+    - Supports KV cache for frame-by-frame autoregressive inference
+    - Supports sliding-window attention with sink tokens
+    - Does NOT support Sequence Parallelism (TP only)
+    """
+
+    _repeated_blocks = ["CausalWanTransformerBlock"]
+    _layerwise_offload_blocks_attrs = ["blocks"]
+    packed_modules_mapping = {
+        "to_qkv": ["to_q", "to_k", "to_v"],
+    }
+
+    @staticmethod
+    def _is_transformer_block(name: str, module) -> bool:
+        return "blocks" in name and name.split(".")[-1].isdigit()
+
+    _hsdp_shard_conditions = [_is_transformer_block]
+
+    def __init__(
+        self,
+        patch_size: tuple[int, int, int] = (1, 2, 2),
+        num_attention_heads: int = 40,
+        attention_head_dim: int = 128,
+        in_channels: int = 16,
+        out_channels: int = 16,
+        text_dim: int = 4096,
+        freq_dim: int = 256,
+        ffn_dim: int = 13824,
+        num_layers: int = 40,
+        cross_attn_norm: bool = True,
+        eps: float = 1e-6,
+        image_dim: int | None = None,
+        added_kv_proj_dim: int | None = None,
+        rope_max_seq_len: int = 1024,
+        pos_embed_seq_len: int | None = None,
+        # Causal-specific parameters
+        local_attn_size: int = -1,
+        sink_size: int = 0,
+        num_frame_per_block: int = 1,
+    ):
+        super().__init__()
+
+        inner_dim = num_attention_heads * attention_head_dim
+        out_channels = out_channels or in_channels
+        head_dim = attention_head_dim
+
+        self.config = type(
+            "Config",
+            (),
+            {
+                "patch_size": patch_size,
+                "num_attention_heads": num_attention_heads,
+                "attention_head_dim": attention_head_dim,
+                "in_channels": in_channels,
+                "out_channels": out_channels,
+                "text_dim": text_dim,
+                "freq_dim": freq_dim,
+                "ffn_dim": ffn_dim,
+                "num_layers": num_layers,
+                "cross_attn_norm": cross_attn_norm,
+                "eps": eps,
+                "image_dim": image_dim,
+                "added_kv_proj_dim": added_kv_proj_dim,
+                "rope_max_seq_len": rope_max_seq_len,
+                "pos_embed_seq_len": pos_embed_seq_len,
+                "local_attn_size": local_attn_size,
+                "sink_size": sink_size,
+                "num_frame_per_block": num_frame_per_block,
+            },
+        )()
+
+        self.inner_dim = inner_dim
+        self.num_attention_heads = num_attention_heads
+        self.attention_head_dim = attention_head_dim
+        self.local_attn_size = local_attn_size
+        self.num_frame_per_block = num_frame_per_block
+        assert num_frame_per_block <= 3
+
+        # 1. Patch & position embedding
+        from vllm.model_executor.layers.conv import Conv3dLayer
+
+        self.rope = WanRotaryPosEmbed(attention_head_dim, patch_size, rope_max_seq_len)
+        self.patch_embedding = Conv3dLayer(
+            in_channels=in_channels,
+            out_channels=inner_dim,
+            kernel_size=patch_size,
+            stride=patch_size,
+        )
+
+        # 2. Condition embeddings
+        self.condition_embedder = WanTimeTextImageEmbedding(
+            dim=inner_dim,
+            time_freq_dim=freq_dim,
+            time_proj_dim=inner_dim * 6,
+            text_embed_dim=text_dim,
+            image_embed_dim=image_dim,
+            pos_embed_seq_len=pos_embed_seq_len,
+        )
+
+        # 3. Transformer blocks
+        self.blocks = nn.ModuleList(
+            [
+                CausalWanTransformerBlock(
+                    dim=inner_dim,
+                    ffn_dim=ffn_dim,
+                    num_heads=num_attention_heads,
+                    head_dim=head_dim,
+                    local_attn_size=local_attn_size,
+                    sink_size=sink_size,
+                    eps=eps,
+                    added_kv_proj_dim=added_kv_proj_dim,
+                    cross_attn_norm=cross_attn_norm,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+        # 4. Output norm & projection
+        self.norm_out = AdaLayerNorm(inner_dim, elementwise_affine=False, eps=eps)
+        self.proj_out = nn.Linear(inner_dim, out_channels * math.prod(patch_size))
+        self.scale_shift_table = nn.Parameter(
+            torch.randn(1, 2, inner_dim) / inner_dim**0.5
+        )
+
+        # Causal state
+        self.block_mask: BlockMask | None = None
+        self.gradient_checkpointing = False
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(self.parameters()).dtype
+
+    @staticmethod
+    def _prepare_blockwise_causal_attn_mask(
+        device: torch.device | str,
+        num_frames: int = 21,
+        frame_seqlen: int = 1560,
+        num_frame_per_block: int = 1,
+        local_attn_size: int = -1,
+    ) -> BlockMask:
+        """
+        Build a block-wise causal attention mask for flex_attention.
+
+        Divides the token sequence into blocks of `num_frame_per_block` frames.
+        Each block can attend to itself and all prior blocks.
+        """
+        total_length = num_frames * frame_seqlen
+        padded_length = math.ceil(total_length / 128) * 128 - total_length
+
+        ends = torch.zeros(
+            total_length + padded_length, device=device, dtype=torch.long
+        )
+
+        frame_indices = torch.arange(
+            start=0,
+            end=total_length,
+            step=frame_seqlen * num_frame_per_block,
+            device=device,
+        )
+        for tmp in frame_indices:
+            ends[tmp : tmp + frame_seqlen * num_frame_per_block] = (
+                tmp + frame_seqlen * num_frame_per_block
+            )
+
+        def attention_mask(b, h, q_idx, kv_idx):
+            if local_attn_size == -1:
+                return (kv_idx < ends[q_idx]) | (q_idx == kv_idx)
+            else:
+                return (
+                    (kv_idx < ends[q_idx])
+                    & (kv_idx >= (ends[q_idx] - local_attn_size * frame_seqlen))
+                ) | (q_idx == kv_idx)
+
+        block_mask = create_block_mask(
+            attention_mask,
+            B=None,
+            H=None,
+            Q_LEN=total_length + padded_length,
+            KV_LEN=total_length + padded_length,
+            _compile=False,
+            device=device,
+        )
+
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            logger.info(
+                "Cached block-wise causal mask: block_size=%d frames, shape=%s",
+                num_frame_per_block,
+                block_mask,
+            )
+
+        return block_mask
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.LongTensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states_image: torch.Tensor | None = None,
+        return_dict: bool = True,
+        attention_kwargs: dict[str, Any] | None = None,
+        kv_cache: list[dict] | None = None,
+        current_start: int = 0,
+        cache_start: int = 0,
+        start_frame: int = 0,
+    ) -> torch.Tensor | Transformer2DModelOutput:
+        if kv_cache is not None:
+            return self._forward_inference(
+                hidden_states,
+                timestep,
+                encoder_hidden_states,
+                encoder_hidden_states_image,
+                return_dict,
+                attention_kwargs,
+                kv_cache=kv_cache,
+                current_start=current_start,
+                cache_start=cache_start,
+                start_frame=start_frame,
+            )
+        else:
+            return self._forward_train(
+                hidden_states,
+                timestep,
+                encoder_hidden_states,
+                encoder_hidden_states_image,
+                return_dict,
+                attention_kwargs,
+                start_frame=start_frame,
+            )
+
+    def _forward_common_prepare(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.LongTensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states_image: torch.Tensor | None,
+        start_frame: int = 0,
+    ) -> tuple:
+        """Shared preparation logic for both train and inference paths."""
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        p_t, p_h, p_w = self.config.patch_size
+        post_patch_num_frames = num_frames // p_t
+        post_patch_height = height // p_h
+        post_patch_width = width // p_w
+
+        # RoPE (uses start_frame for positional offset in inference)
+        rotary_emb = self.rope(hidden_states)
+        # TODO: if start_frame > 0, need to offset RoPE. For now this matches
+        # the standard WanRotaryPosEmbed which computes from frame 0.
+
+        # Patch embedding
+        hidden_states = self.patch_embedding(hidden_states)
+        hidden_states = hidden_states.flatten(2).transpose(1, 2)
+
+        # Timestep handling
+        if timestep.ndim == 2:
+            ts_seq_len = timestep.shape[1]
+            timestep = timestep.flatten()
+        else:
+            ts_seq_len = None
+
+        temb, timestep_proj, encoder_hidden_states, encoder_hidden_states_image = (
+            self.condition_embedder(
+                timestep, encoder_hidden_states, encoder_hidden_states_image,
+                timestep_seq_len=ts_seq_len,
+            )
+        )
+
+        if ts_seq_len is not None:
+            timestep_proj = timestep_proj.unflatten(2, (6, -1))
+        else:
+            timestep_proj = timestep_proj.unflatten(1, (6, -1))
+
+        if encoder_hidden_states_image is not None:
+            encoder_hidden_states = torch.concat(
+                [encoder_hidden_states_image, encoder_hidden_states], dim=1
+            )
+
+        return (
+            hidden_states,
+            encoder_hidden_states,
+            temb,
+            timestep_proj,
+            rotary_emb,
+            batch_size,
+            post_patch_num_frames,
+            post_patch_height,
+            post_patch_width,
+        )
+
+    def _forward_train(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.LongTensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states_image: torch.Tensor | None = None,
+        return_dict: bool = True,
+        attention_kwargs: dict[str, Any] | None = None,
+        start_frame: int = 0,
+    ) -> torch.Tensor | Transformer2DModelOutput:
+        (
+            hidden_states, encoder_hidden_states, temb, timestep_proj,
+            rotary_emb, batch_size,
+            post_patch_num_frames, post_patch_height, post_patch_width,
+        ) = self._forward_common_prepare(
+            hidden_states, timestep, encoder_hidden_states,
+            encoder_hidden_states_image, start_frame,
+        )
+        p_t, p_h, p_w = self.config.patch_size
+
+        # Build block mask (lazily cached)
+        if self.block_mask is None:
+            num_frames = hidden_states.shape[1] // (post_patch_height * post_patch_width)
+            self.block_mask = self._prepare_blockwise_causal_attn_mask(
+                device=hidden_states.device,
+                num_frames=num_frames,
+                frame_seqlen=post_patch_height * post_patch_width,
+                num_frame_per_block=self.num_frame_per_block,
+                local_attn_size=self.local_attn_size,
+            )
+
+        # Transformer blocks
+        for block in self.blocks:
+            hidden_states = block(
+                hidden_states,
+                encoder_hidden_states,
+                timestep_proj,
+                rotary_emb,
+                block_mask=self.block_mask,
+            )
+
+        # Output
+        return self._forward_output(
+            hidden_states, temb, batch_size,
+            post_patch_num_frames, post_patch_height, post_patch_width, return_dict,
+        )
+
+    def _forward_inference(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.LongTensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states_image: torch.Tensor | None = None,
+        return_dict: bool = True,
+        attention_kwargs: dict[str, Any] | None = None,
+        kv_cache: list[dict] | None = None,
+        current_start: int = 0,
+        cache_start: int = 0,
+        start_frame: int = 0,
+    ) -> torch.Tensor | Transformer2DModelOutput:
+        (
+            hidden_states, encoder_hidden_states, temb, timestep_proj,
+            rotary_emb, batch_size,
+            post_patch_num_frames, post_patch_height, post_patch_width,
+        ) = self._forward_common_prepare(
+            hidden_states, timestep, encoder_hidden_states,
+            encoder_hidden_states_image, start_frame,
+        )
+        p_t, p_h, p_w = self.config.patch_size
+
+        # Transformer blocks with KV cache
+        for block_index, block in enumerate(self.blocks):
+            block_kv_cache = kv_cache[block_index] if kv_cache is not None else None
+            hidden_states = block(
+                hidden_states,
+                encoder_hidden_states,
+                timestep_proj,
+                rotary_emb,
+                block_mask=self.block_mask,
+                kv_cache=block_kv_cache,
+                current_start=current_start,
+                cache_start=cache_start,
+            )
+
+        # Output
+        return self._forward_output(
+            hidden_states, temb, batch_size,
+            post_patch_num_frames, post_patch_height, post_patch_width, return_dict,
+        )
+
+    def _forward_output(
+        self,
+        hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        batch_size: int,
+        post_patch_num_frames: int,
+        post_patch_height: int,
+        post_patch_width: int,
+        return_dict: bool,
+    ) -> torch.Tensor | Transformer2DModelOutput:
+        p_t, p_h, p_w = self.config.patch_size
+
+        shift, scale = (self.scale_shift_table.to(hidden_states.device) + temb.unsqueeze(1)).chunk(2, dim=1)
+        hidden_states = self.norm_out(hidden_states, scale, shift).type_as(hidden_states)
+        hidden_states = self.proj_out(hidden_states)
+
+        hidden_states = hidden_states.reshape(
+            batch_size, post_patch_num_frames, post_patch_height, post_patch_width,
+            p_t, p_h, p_w, -1,
+        )
+        hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
+        output = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+        if not return_dict:
+            return (output,)
+        return Transformer2DModelOutput(sample=output)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """
+        Load weights, handling Q/K/V fusion for self-attention (same as WanTransformer3DModel).
+        """
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
+
+        stacked_params_mapping = [
+            (".attn1.to_qkv", ".attn1.to_q", "q"),
+            (".attn1.to_qkv", ".attn1.to_k", "k"),
+            (".attn1.to_qkv", ".attn1.to_v", "v"),
+        ]
+        self.stacked_params_mapping = stacked_params_mapping
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            original_name = name
+            lookup_name = name
+
+            # Handle QKV fusion
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in original_name:
+                    continue
+                lookup_name = original_name.replace(weight_name, param_name)
+                param = params_dict[lookup_name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if ".ffn.net.0." in lookup_name:
+                    lookup_name = lookup_name.replace(".ffn.net.0.", ".ffn.net_0.")
+                elif ".ffn.net.2." in lookup_name:
+                    lookup_name = lookup_name.replace(".ffn.net.2.", ".ffn.net_2.")
+
+                if ".to_out.0." in lookup_name:
+                    lookup_name = lookup_name.replace(".to_out.0.", ".to_out.")
+
+                if lookup_name.endswith(".modulation"):
+                    modulation_alias = lookup_name[: -len(".modulation")] + ".scale_shift_table"
+                    if modulation_alias in params_dict:
+                        lookup_name = modulation_alias
+
+                if lookup_name not in params_dict:
+                    logger.warning("Skipping weight %s -> %s", original_name, lookup_name)
+                    continue
+
+                param = params_dict[lookup_name]
+
+                # Shard RMSNorm weights for TP
+                if tp_size > 1 and any(
+                    norm_name in lookup_name
+                    for norm_name in [
+                        ".attn1.norm_q.",
+                        ".attn1.norm_k.",
+                        ".attn2.norm_q.",
+                        ".attn2.norm_k.",
+                        ".attn2.norm_added_k.",
+                    ]
+                ):
+                    shard_size = loaded_weight.shape[0] // tp_size
+                    loaded_weight = loaded_weight[tp_rank * shard_size : (tp_rank + 1) * shard_size]
+
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+
+            loaded_params.add(original_name)
+            loaded_params.add(lookup_name)
+
+        return loaded_params

--- a/vllm_omni/diffusion/models/wan2_2/kv_cache.py
+++ b/vllm_omni/diffusion/models/wan2_2/kv_cache.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# KV cache abstractions for causal video diffusion inference.
+# Ported from sglang's pipelines_core/kv_cache.py.
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+class SelfAttentionKVCache:
+    """Per-layer self-attention KV buffer with sliding window eviction."""
+
+    __slots__ = (
+        "k",
+        "v",
+        "_global_end",
+        "_local_end",
+        "_sink_size",
+        "_frame_seq_length",
+        "_batch_size",
+        "_max_size",
+        "_num_heads",
+        "_head_dim",
+        "_dtype",
+        "_device",
+    )
+
+    def __init__(
+        self,
+        batch_size: int,
+        max_size: int,
+        num_heads: int,
+        head_dim: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        sink_size: int = 0,
+        frame_seq_length: int = 1,
+    ):
+        self._batch_size: int = batch_size
+        self._max_size: int = max_size
+        self._num_heads: int = num_heads
+        self._head_dim: int = head_dim
+        self._dtype: torch.dtype = dtype
+        self._device: torch.device = device
+        self._global_end: int = 0
+        self._local_end: int = 0
+        self._sink_size: int = sink_size
+        self._frame_seq_length: int = frame_seq_length
+        self.k: Tensor | None = None
+        self.v: Tensor | None = None
+        self._allocate_buffers()
+
+    def _allocate_buffers(self) -> None:
+        self.k = torch.zeros(
+            self._batch_size,
+            self._max_size,
+            self._num_heads,
+            self._head_dim,
+            dtype=self._dtype,
+            device=self._device,
+        ).contiguous()
+        self.v = torch.zeros(
+            self._batch_size,
+            self._max_size,
+            self._num_heads,
+            self._head_dim,
+            dtype=self._dtype,
+            device=self._device,
+        ).contiguous()
+
+    def _ensure_allocated(self) -> None:
+        if self.k is None or self.v is None:
+            self._allocate_buffers()
+
+    @property
+    def max_size(self) -> int:
+        return self._max_size
+
+    def reset(self) -> None:
+        self._global_end = 0
+        self._local_end = 0
+
+    def release(self) -> None:
+        self.k = None
+        self.v = None
+        self._global_end = 0
+        self._local_end = 0
+
+    def bulk_write(self, key: Tensor, value: Tensor) -> None:
+        """Overwrite from position 0 (recompute phase with block_mask)."""
+        self._ensure_allocated()
+        seq_len = key.shape[1]
+        if seq_len > self.max_size:
+            raise ValueError(
+                f"bulk_write seq_len ({seq_len}) exceeds buffer capacity ({self.max_size})"
+            )
+        self.k[:, :seq_len] = key
+        self.v[:, :seq_len] = value
+        self._global_end = seq_len
+        self._local_end = seq_len
+
+    def append(
+        self,
+        key: Tensor,
+        value: Tensor,
+        current_start: int,
+    ) -> None:
+        """Append new KV; evicts old tokens (preserving sink) when buffer is full."""
+        self._ensure_allocated()
+        current_end = current_start + key.shape[1]
+        num_new = key.shape[1]
+        buf_size = self.max_size
+        sink_tokens = self._sink_size * self._frame_seq_length
+
+        if num_new > buf_size:
+            raise ValueError(
+                f"append num_new ({num_new}) exceeds buffer capacity ({buf_size})"
+            )
+
+        needs_eviction = (
+            current_end > self._global_end and num_new + self._local_end > buf_size
+        )
+
+        if needs_eviction:
+            num_evicted = num_new + self._local_end - buf_size
+            num_rolled = self._local_end - num_evicted - sink_tokens
+            if num_rolled < 0:
+                raise ValueError(
+                    f"sink_tokens ({sink_tokens}) too large for eviction: "
+                    f"local_end={self._local_end}, num_evicted={num_evicted}, "
+                    f"num_rolled={num_rolled}"
+                )
+            self.k[:, sink_tokens : sink_tokens + num_rolled] = self.k[
+                :,
+                sink_tokens + num_evicted : sink_tokens + num_evicted + num_rolled,
+            ].clone()
+            self.v[:, sink_tokens : sink_tokens + num_rolled] = self.v[
+                :,
+                sink_tokens + num_evicted : sink_tokens + num_evicted + num_rolled,
+            ].clone()
+            local_end = self._local_end + current_end - self._global_end - num_evicted
+        else:
+            self.k = self.k.detach()
+            self.v = self.v.detach()
+            local_end = self._local_end + current_end - self._global_end
+
+        local_start = local_end - num_new
+        self.k[:, local_start:local_end] = key
+        self.v[:, local_start:local_end] = value
+        self._global_end = current_end
+        self._local_end = local_end
+
+    def get_active_kv(self, max_attention_size: int) -> tuple[Tensor, Tensor]:
+        """Return (k, v) sliced to at most ``max_attention_size`` from the end."""
+        self._ensure_allocated()
+        start = max(0, self._local_end - max_attention_size)
+        return (
+            self.k[:, start : self._local_end],
+            self.v[:, start : self._local_end],
+        )
+
+
+class CrossAttentionKVCache:
+    """Per-layer cross-attention KV cache with compute-once semantics."""
+
+    __slots__ = ("k", "v")
+
+    def __init__(self):
+        self.k: Tensor | None = None
+        self.v: Tensor | None = None
+
+    @property
+    def is_initialized(self) -> bool:
+        return self.k is not None
+
+    def reset(self) -> None:
+        self.k = None
+        self.v = None
+
+    def release(self) -> None:
+        self.reset()
+
+    def update(self, k: Tensor, v: Tensor) -> None:
+        self.k = k
+        self.v = v
+
+    def get(self) -> tuple[Tensor, Tensor]:
+        return self.k, self.v
+
+
+class KVCacheManager:
+    """Per-layer KV cache container for all transformer blocks."""
+
+    def __init__(
+        self,
+        num_blocks: int,
+        sa_batch_size: int | None = None,
+        sa_max_size: int | None = None,
+        sa_num_heads: int | None = None,
+        sa_head_dim: int | None = None,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        sink_size: int = 0,
+        frame_seq_length: int = 1,
+        create_cross_attn: bool = True,
+    ):
+        sa_params = (
+            sa_batch_size,
+            sa_max_size,
+            sa_num_heads,
+            sa_head_dim,
+            dtype,
+            device,
+        )
+        sa_any_set = any(p is not None for p in sa_params)
+        sa_all_set = all(p is not None for p in sa_params)
+        if sa_any_set and not sa_all_set:
+            missing = [
+                name
+                for name, val in zip(
+                    (
+                        "sa_batch_size",
+                        "sa_max_size",
+                        "sa_num_heads",
+                        "sa_head_dim",
+                        "dtype",
+                        "device",
+                    ),
+                    sa_params,
+                )
+                if val is None
+            ]
+            raise ValueError(
+                f"Self-attention cache requires all parameters; missing: {missing}"
+            )
+
+        if sa_all_set:
+            self.self_attn_caches: list[SelfAttentionKVCache] | None = [
+                SelfAttentionKVCache(
+                    sa_batch_size,
+                    sa_max_size,
+                    sa_num_heads,
+                    sa_head_dim,
+                    dtype,
+                    device,
+                    sink_size=sink_size,
+                    frame_seq_length=frame_seq_length,
+                )
+                for _ in range(num_blocks)
+            ]
+        else:
+            self.self_attn_caches = None
+
+        if create_cross_attn:
+            self.cross_attn_caches: list[CrossAttentionKVCache] | None = [
+                CrossAttentionKVCache() for _ in range(num_blocks)
+            ]
+        else:
+            self.cross_attn_caches = None
+
+    def reset_self_attn(self) -> None:
+        if self.self_attn_caches is not None:
+            for cache in self.self_attn_caches:
+                cache.reset()
+
+    def reset_cross_attn(self) -> None:
+        if self.cross_attn_caches is not None:
+            for cache in self.cross_attn_caches:
+                cache.reset()
+
+    def release(self) -> None:
+        if self.self_attn_caches is not None:
+            for cache in self.self_attn_caches:
+                cache.release()
+        if self.cross_attn_caches is not None:
+            for cache in self.cross_attn_caches:
+                cache.release()

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -115,40 +115,39 @@ def load_transformer_config(model_path: str, subfolder: str = "transformer", loc
     return {}
 
 
-def create_transformer_from_config(config: dict) -> WanTransformer3DModel:
-    """Create WanTransformer3DModel from config dict."""
-    kwargs = {}
+def _is_causal_config(config: dict) -> bool:
+    """Detect if config describes a causal WanVideo model."""
+    return config.get("causal", False) or "local_attn_size" in config or "num_frame_per_block" in config
 
+
+def _extract_common_kwargs(config: dict) -> dict:
+    """Extract kwargs shared by both standard and causal transformers."""
+    kwargs = {}
+    _COMMON_KEYS = [
+        "num_attention_heads", "attention_head_dim", "in_channels", "out_channels",
+        "text_dim", "freq_dim", "ffn_dim", "num_layers", "cross_attn_norm", "eps",
+        "image_dim", "added_kv_proj_dim", "rope_max_seq_len", "pos_embed_seq_len",
+    ]
+    for key in _COMMON_KEYS:
+        if key in config:
+            kwargs[key] = config[key]
     if "patch_size" in config:
         kwargs["patch_size"] = tuple(config["patch_size"])
-    if "num_attention_heads" in config:
-        kwargs["num_attention_heads"] = config["num_attention_heads"]
-    if "attention_head_dim" in config:
-        kwargs["attention_head_dim"] = config["attention_head_dim"]
-    if "in_channels" in config:
-        kwargs["in_channels"] = config["in_channels"]
-    if "out_channels" in config:
-        kwargs["out_channels"] = config["out_channels"]
-    if "text_dim" in config:
-        kwargs["text_dim"] = config["text_dim"]
-    if "freq_dim" in config:
-        kwargs["freq_dim"] = config["freq_dim"]
-    if "ffn_dim" in config:
-        kwargs["ffn_dim"] = config["ffn_dim"]
-    if "num_layers" in config:
-        kwargs["num_layers"] = config["num_layers"]
-    if "cross_attn_norm" in config:
-        kwargs["cross_attn_norm"] = config["cross_attn_norm"]
-    if "eps" in config:
-        kwargs["eps"] = config["eps"]
-    if "image_dim" in config:
-        kwargs["image_dim"] = config["image_dim"]
-    if "added_kv_proj_dim" in config:
-        kwargs["added_kv_proj_dim"] = config["added_kv_proj_dim"]
-    if "rope_max_seq_len" in config:
-        kwargs["rope_max_seq_len"] = config["rope_max_seq_len"]
-    if "pos_embed_seq_len" in config:
-        kwargs["pos_embed_seq_len"] = config["pos_embed_seq_len"]
+    return kwargs
+
+
+def create_transformer_from_config(config: dict) -> WanTransformer3DModel:
+    """Create WanTransformer3DModel (or CausalWanTransformer3DModel) from config dict."""
+    kwargs = _extract_common_kwargs(config)
+
+    if _is_causal_config(config):
+        from vllm_omni.diffusion.models.wan2_2.causal_wan2_2_transformer import CausalWanTransformer3DModel
+
+        _CAUSAL_KEYS = ["local_attn_size", "sink_size", "num_frame_per_block"]
+        for key in _CAUSAL_KEYS:
+            if key in config:
+                kwargs[key] = config[key]
+        return CausalWanTransformer3DModel(**kwargs)
 
     return WanTransformer3DModel(**kwargs)
 

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -117,6 +117,9 @@ def load_transformer_config(model_path: str, subfolder: str = "transformer", loc
 
 def _is_causal_config(config: dict) -> bool:
     """Detect if config describes a causal WanVideo model."""
+    cls_name = config.get("_class_name", "")
+    if "Causal" in cls_name or "causal" in cls_name.lower():
+        return True
     return config.get("causal", False) or "local_attn_size" in config or "num_frame_per_block" in config
 
 

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
@@ -133,6 +133,22 @@ class Wan22RealtimePipeline:
     def device(self) -> torch.device:
         return next(self.transformer.parameters()).device
 
+    _MIN_PROMPT_TOKENS = 40
+
+    def _pad_short_prompt(self, prompt: str) -> str:
+        """Repeat short prompts to fill more cross-attention positions.
+
+        Short prompts produce few non-zero positions in the 512-length embedding,
+        so cross-attention signal gets diluted by zero-padded bias-only keys.
+        Repeating the prompt text gives the model more real-token positions to
+        attend to, making prompt changes more visible during streaming.
+        """
+        tokens = self.tokenizer(prompt, add_special_tokens=False).input_ids
+        if len(tokens) >= self._MIN_PROMPT_TOKENS:
+            return prompt
+        reps = (self._MIN_PROMPT_TOKENS // max(len(tokens), 1)) + 1
+        return ". ".join([prompt] * reps)
+
     def encode_prompt(
         self,
         prompt: str | list[str],
@@ -143,7 +159,9 @@ class Wan22RealtimePipeline:
         dtype = self.text_encoder.dtype
 
         if isinstance(prompt, str):
-            prompt = [prompt]
+            prompt = [self._pad_short_prompt(prompt)]
+        else:
+            prompt = [self._pad_short_prompt(p) for p in prompt]
 
         text_inputs = self.tokenizer(
             prompt,

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
@@ -126,8 +126,12 @@ class Wan22RealtimePipeline:
             dtype=vae_dtype,
         ).view(1, self.vae.config.z_dim, 1, 1, 1)
 
-        p_t, p_h, p_w = transformer.config.patch_size
-        self.frame_seq_length = (480 // p_h // 8) * (832 // p_w // 8)
+        self._patch_size = transformer.config.patch_size
+        self.frame_seq_length = self._compute_frame_seq_length(480, 832)
+
+    def _compute_frame_seq_length(self, height: int, width: int) -> int:
+        _, p_h, p_w = self._patch_size
+        return (height // p_h // 8) * (width // p_w // 8)
 
     @property
     def device(self) -> torch.device:
@@ -456,6 +460,13 @@ class Wan22RealtimePipeline:
         """
         if num_inference_steps is None:
             num_inference_steps = self.DEFAULT_NUM_INFERENCE_STEPS
+
+        # 0. Update frame_seq_length for actual resolution
+        new_seq_len = self._compute_frame_seq_length(height, width)
+        if new_seq_len != self.frame_seq_length:
+            self.frame_seq_length = new_seq_len
+            if session.kv_cache_manager is not None:
+                session.kv_cache_manager = None
 
         block_idx = session.block_idx
         has_video = input_video_frames is not None

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
@@ -1,0 +1,615 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Realtime video streaming pipeline for Causal WanVideo models.
+# Supports both T2V (text-to-video) and V2V (video-to-video) streaming.
+# Ported from sglang's Krea realtime video implementation.
+
+from __future__ import annotations
+
+import logging
+import math
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import numpy as np
+import torch
+from diffusers.utils.torch_utils import randn_tensor
+from diffusers.video_processor import VideoProcessor
+
+from vllm_omni.diffusion.models.wan2_2.causal_wan2_2_transformer import (
+    CausalWanTransformer3DModel,
+)
+from vllm_omni.diffusion.models.wan2_2.kv_cache import KVCacheManager
+from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import retrieve_latents
+
+logger = logging.getLogger(__name__)
+
+
+class RealtimeVideoMode(str, Enum):
+    T2V = "t2v"
+    V2V = "v2v"
+
+
+@dataclass
+class RealtimeSession:
+    """Persistent state across video blocks within a streaming session."""
+
+    last_prompts: str | list[str] | None = None
+    last_embeds: list[torch.Tensor] = field(default_factory=list)
+    interpolated_embeds: list[list[torch.Tensor]] = field(default_factory=list)
+    kv_cache_manager: KVCacheManager | None = None
+    current_denoised_latents: torch.Tensor | None = None
+    frame_cache_context: deque | None = None
+    decoder_cache: Any = None
+    block_idx: int = 0
+
+    def is_prompt_changed(self, prompts: str | list[str]) -> bool:
+        return prompts != self.last_prompts
+
+    def save_prompt_changed(
+        self,
+        prompts: str | list[str],
+        prompt_embeds: list[torch.Tensor],
+        interpolated: list[list[torch.Tensor]] | None = None,
+    ) -> None:
+        self.last_prompts = prompts
+        self.last_embeds = prompt_embeds
+        if interpolated is not None:
+            self.interpolated_embeds.extend(interpolated)
+
+    def get_current_embeds(self) -> list[torch.Tensor]:
+        if self.interpolated_embeds:
+            step_embeds = self.interpolated_embeds.pop(0)
+            return step_embeds
+        return self.last_embeds
+
+    @property
+    def update_prompt_embeds(self) -> bool:
+        return len(self.interpolated_embeds) > 0
+
+    def dispose(self) -> None:
+        if self.kv_cache_manager is not None:
+            self.kv_cache_manager.release()
+            self.kv_cache_manager = None
+        self.current_denoised_latents = None
+        self.frame_cache_context = None
+        self.decoder_cache = None
+        self.last_embeds.clear()
+        self.interpolated_embeds.clear()
+        torch.cuda.empty_cache()
+
+
+class Wan22RealtimePipeline:
+    """Realtime video streaming pipeline using Causal WanVideo with KV cache.
+
+    Generates video one block at a time, maintaining state across blocks
+    via RealtimeSession. Supports both T2V and V2V modes.
+    """
+
+    INTERPOLATION_STEPS = 4
+    DEFAULT_NUM_INFERENCE_STEPS = 4
+    DEFAULT_FLOW_SHIFT = 5.0
+
+    def __init__(
+        self,
+        transformer: CausalWanTransformer3DModel,
+        vae,
+        tokenizer,
+        text_encoder,
+        *,
+        num_frames_per_block: int = 1,
+        kv_cache_num_frames: int = 12,
+        vae_dtype: torch.dtype = torch.bfloat16,
+        transformer_dtype: torch.dtype = torch.bfloat16,
+    ):
+        self.transformer = transformer
+        self.vae = vae
+        self.tokenizer = tokenizer
+        self.text_encoder = text_encoder
+        self.num_frames_per_block = num_frames_per_block
+        self.kv_cache_num_frames = kv_cache_num_frames
+        self.vae_dtype = vae_dtype
+        self.transformer_dtype = transformer_dtype
+        self.video_processor = VideoProcessor(vae_scale_factor=8)
+
+        self._vae_latents_mean = torch.tensor(
+            self.vae.config.latents_mean,
+            device=self.vae.device,
+            dtype=vae_dtype,
+        ).view(1, self.vae.config.z_dim, 1, 1, 1)
+        self._vae_latents_std = 1.0 / torch.tensor(
+            self.vae.config.latents_std,
+            device=self.vae.device,
+            dtype=vae_dtype,
+        ).view(1, self.vae.config.z_dim, 1, 1, 1)
+
+        p_t, p_h, p_w = transformer.config.patch_size
+        self.frame_seq_length = (480 // p_h // 8) * (832 // p_w // 8)
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.transformer.parameters()).device
+
+    def encode_prompt(
+        self,
+        prompt: str | list[str],
+        max_sequence_length: int = 512,
+    ) -> torch.Tensor:
+        """Encode text prompt to embeddings."""
+        device = self.device
+        dtype = self.text_encoder.dtype
+
+        if isinstance(prompt, str):
+            prompt = [prompt]
+
+        text_inputs = self.tokenizer(
+            prompt,
+            padding="max_length",
+            max_length=max_sequence_length,
+            truncation=True,
+            add_special_tokens=True,
+            return_attention_mask=True,
+            return_tensors="pt",
+        )
+        ids, mask = text_inputs.input_ids, text_inputs.attention_mask
+        seq_lens = mask.gt(0).sum(dim=1).long()
+
+        prompt_embeds = self.text_encoder(
+            ids.to(device), mask.to(device)
+        ).last_hidden_state
+        prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
+        prompt_embeds = [u[:v] for u, v in zip(prompt_embeds, seq_lens)]
+        prompt_embeds = torch.stack(
+            [
+                torch.cat(
+                    [u, u.new_zeros(max_sequence_length - u.size(0), u.size(1))]
+                )
+                for u in prompt_embeds
+            ],
+            dim=0,
+        )
+        return prompt_embeds
+
+    def interpolate_embeds(
+        self,
+        prev_embeds: list[torch.Tensor],
+        curr_embeds: list[torch.Tensor],
+    ) -> list[list[torch.Tensor]]:
+        """Interpolate between previous and current prompt embeddings.
+
+        Skips weight=0 (which equals the previous embed) so the first block
+        after a prompt change already shows new-prompt influence.
+        """
+        steps = self.INTERPOLATION_STEPS
+        result = []
+        # Weights: [1/steps, 2/steps, ..., 1.0] e.g. [0.25, 0.5, 0.75, 1.0]
+        weights = torch.linspace(1.0 / steps, 1.0, steps=steps)
+
+        for step_idx in range(steps):
+            w = weights[step_idx]
+            step_embeds = []
+            for prev, curr in zip(prev_embeds, curr_embeds):
+                interp = torch.lerp(prev, curr, w.to(prev))
+                step_embeds.append(interp)
+            result.append(step_embeds)
+        return result
+
+    def prepare_timesteps(
+        self,
+        shift: float,
+        strength: float,
+        num_inference_steps: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Prepare timestep schedule for flow matching."""
+        device = self.device
+        sigmas = torch.linspace(1.0, 0.0, 1001, device=device)[:-1]
+        sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)
+        all_timesteps = sigmas * 1000.0
+        zero_padded = torch.cat(
+            [all_timesteps, torch.tensor([0], device=device, dtype=all_timesteps.dtype)]
+        )
+        denoising_steps = torch.linspace(
+            strength * 1000, 0, num_inference_steps, dtype=torch.float32
+        ).to(torch.long)
+        timesteps = zero_padded[1000 - denoising_steps]
+        return timesteps, all_timesteps, sigmas
+
+    def _reset_vae_encode_cache(self) -> None:
+        if hasattr(self.vae, "_original_clear_cache"):
+            self.vae._original_clear_cache()
+        else:
+            self.vae.clear_cache()
+
+        if not hasattr(self.vae, "_enc_conv_idx"):
+            self.vae._enc_conv_idx = 0
+        if hasattr(self.vae, "_enc_conv_num"):
+            self.vae._enc_feat_map = [None] * self.vae._enc_conv_num
+        elif hasattr(self.vae, "_enc_feat_map"):
+            self.vae._enc_feat_map = [None] * len(self.vae._enc_feat_map)
+        else:
+            self.vae._enc_feat_map = [None] * 55
+
+    def _encode_video_frames(
+        self,
+        video: torch.Tensor,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Encode video frames to latent space via VAE."""
+        self._reset_vae_encode_cache()
+        init_latents = [
+            retrieve_latents(
+                self.vae.encode(
+                    vid.unsqueeze(0)
+                    .transpose(2, 1)
+                    .to(device=self.vae.device, dtype=dtype)
+                    .contiguous()
+                ),
+                sample_mode="argmax",
+            )
+            for vid in video
+        ]
+        init_latents = torch.cat(init_latents, dim=0).to(dtype)
+        init_latents = (init_latents - self._vae_latents_mean) * self._vae_latents_std
+        return init_latents
+
+    def _prepare_frame_latents(
+        self,
+        frames: torch.Tensor,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Encode single frame(s) to latents for context recomputation."""
+        self._reset_vae_encode_cache()
+        frames = frames.to(device=self.vae.device, dtype=dtype).contiguous()
+        latents = retrieve_latents(self.vae.encode(frames), sample_mode="argmax")
+        latents = (latents - self._vae_latents_mean) * self._vae_latents_std
+        return latents
+
+    def _get_context_frames(
+        self,
+        session: RealtimeSession,
+    ) -> torch.Tensor:
+        """Get context frames for KV cache recomputation."""
+        total_frames_generated = (session.block_idx - 1) * self.num_frames_per_block
+
+        if total_frames_generated < self.kv_cache_num_frames:
+            return session.current_denoised_latents[
+                :, :, : self.kv_cache_num_frames
+            ]
+
+        context = session.current_denoised_latents
+        context = context[:, :, 1:][:, :, -self.kv_cache_num_frames + 1 :]
+        first_frame_latent = self._prepare_frame_latents(
+            frames=session.frame_cache_context[0],
+            dtype=self.vae_dtype,
+        )
+        first_frame_latent = first_frame_latent.to(context)
+        return torch.cat((first_frame_latent, context), dim=2)
+
+    def _setup_kv_cache(
+        self,
+        session: RealtimeSession,
+    ) -> KVCacheManager:
+        """Create or reset KV cache manager."""
+        from vllm.distributed import get_tensor_model_parallel_world_size
+
+        tp_size = get_tensor_model_parallel_world_size()
+        num_heads = self.transformer.num_attention_heads // tp_size
+        head_dim = self.transformer.attention_head_dim
+        num_blocks = len(self.transformer.blocks)
+        sa_max_size = (
+            (self.kv_cache_num_frames + self.num_frames_per_block)
+            * self.frame_seq_length
+        )
+
+        if session.kv_cache_manager is None:
+            sink_size = self.transformer.blocks[0].attn1.sink_size
+            session.kv_cache_manager = KVCacheManager(
+                num_blocks=num_blocks,
+                sa_batch_size=1,
+                sa_max_size=sa_max_size,
+                sa_num_heads=num_heads,
+                sa_head_dim=head_dim,
+                dtype=self.transformer_dtype,
+                device=self.device,
+                sink_size=sink_size,
+                frame_seq_length=self.frame_seq_length,
+            )
+        else:
+            session.kv_cache_manager.reset_self_attn()
+            if session.update_prompt_embeds:
+                session.kv_cache_manager.reset_cross_attn()
+
+        return session.kv_cache_manager
+
+    def _recompute_context(
+        self,
+        session: RealtimeSession,
+        prompt_embeds: torch.Tensor,
+        manager: KVCacheManager,
+    ) -> None:
+        """Recompute KV cache from context frames for temporal coherence."""
+        context_frames = self._get_context_frames(session)
+        block_mask = CausalWanTransformer3DModel._prepare_blockwise_causal_attn_mask(
+            self.device,
+            num_frames=context_frames.shape[2],
+            frame_seqlen=self.frame_seq_length,
+            num_frame_per_block=self.num_frames_per_block,
+            local_attn_size=-1,
+        )
+        self.transformer.block_mask = block_mask
+        context_timestep = torch.zeros(
+            (context_frames.shape[0],),
+            device=self.device,
+            dtype=torch.int64,
+        )
+        self.transformer(
+            hidden_states=context_frames.to(self.transformer_dtype),
+            timestep=context_timestep,
+            encoder_hidden_states=prompt_embeds.to(self.transformer_dtype),
+            kv_cache=manager.self_attn_caches,
+            crossattn_cache=manager.cross_attn_caches,
+            current_start=0,
+            cache_start=None,
+        )
+        self.transformer.block_mask = None
+
+    @staticmethod
+    def _add_noise(
+        sample: torch.Tensor,
+        noise: torch.Tensor,
+        sigma_t: torch.Tensor,
+    ) -> torch.Tensor:
+        sigma = sigma_t.to(device=sample.device).reshape(1, 1, 1, 1)
+        return (
+            (1 - sigma.double()) * sample.double() + sigma.double() * noise.double()
+        ).type_as(noise)
+
+    @staticmethod
+    def _update_latents(
+        latents: torch.Tensor,
+        noise_pred: torch.Tensor,
+        sigma_t: torch.Tensor,
+    ) -> torch.Tensor:
+        latents_dtype = latents.dtype
+        sigma_t = sigma_t.to(device=latents.device)
+        return (latents.double() - sigma_t.double() * noise_pred.double()).to(
+            latents_dtype
+        )
+
+    def _predict_noise(
+        self,
+        latents: torch.Tensor,
+        timestep: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        kv_cache: list,
+        crossattn_cache: list,
+        current_start_frame: int,
+    ) -> torch.Tensor:
+        start_frame = min(current_start_frame, self.kv_cache_num_frames)
+        noise_pred = self.transformer(
+            hidden_states=latents,
+            timestep=timestep.expand(latents.shape[0]),
+            encoder_hidden_states=prompt_embeds.to(self.transformer_dtype),
+            kv_cache=kv_cache,
+            crossattn_cache=crossattn_cache,
+            current_start=start_frame * self.frame_seq_length,
+            start_frame=start_frame,
+            cache_start=None,
+            return_dict=False,
+        )
+        if isinstance(noise_pred, tuple):
+            noise_pred = noise_pred[0]
+        return noise_pred
+
+    @torch.no_grad()
+    def generate_block(
+        self,
+        session: RealtimeSession,
+        prompt: str,
+        height: int = 480,
+        width: int = 832,
+        num_inference_steps: int | None = None,
+        input_video_frames: list | None = None,
+        generator: torch.Generator | None = None,
+    ) -> np.ndarray:
+        """Generate one video block.
+
+        Args:
+            session: Persistent session state across blocks.
+            prompt: Text prompt for generation.
+            height: Video height in pixels.
+            width: Video width in pixels.
+            num_inference_steps: Denoising steps (default 4).
+            input_video_frames: PIL images for V2V mode (None for T2V).
+            generator: Optional random generator for reproducibility.
+
+        Returns:
+            Video frames as numpy array (postprocessed by VideoProcessor).
+        """
+        if num_inference_steps is None:
+            num_inference_steps = self.DEFAULT_NUM_INFERENCE_STEPS
+
+        block_idx = session.block_idx
+        has_video = input_video_frames is not None
+        strength = 0.7 if has_video else 1.0
+
+        # 1. Text encoding with prompt interpolation
+        prompt_embeds = self._encode_with_interpolation(session, prompt)
+
+        # 2. Prepare timesteps
+        timesteps, all_timesteps, sigmas = self.prepare_timesteps(
+            self.DEFAULT_FLOW_SHIFT, strength, num_inference_steps
+        )
+
+        # 3. Prepare latents
+        if has_video:
+            latents = self._prepare_v2v_latents(
+                input_video_frames, height, width, timesteps, generator
+            )
+        else:
+            latents = self._prepare_t2v_latents(
+                block_idx, height, width, generator
+            )
+
+        current_start_frame = block_idx * self.num_frames_per_block
+
+        # 4. Setup KV cache
+        manager = self._setup_kv_cache(session)
+
+        # 5. Context recomputation (for blocks after the first)
+        if block_idx > 0:
+            self._recompute_context(session, prompt_embeds, manager)
+
+        # 6. Denoising loop
+        step_timestep_ids = torch.argmin(
+            (all_timesteps.unsqueeze(0) - timesteps.unsqueeze(1)).abs(), dim=1
+        )
+        step_sigmas = sigmas[step_timestep_ids]
+
+        for i, t in enumerate(timesteps):
+            noise_pred = self._predict_noise(
+                latents=latents,
+                timestep=t,
+                prompt_embeds=prompt_embeds,
+                kv_cache=manager.self_attn_caches,
+                crossattn_cache=manager.cross_attn_caches,
+                current_start_frame=current_start_frame,
+            )
+
+            latents = self._update_latents(latents, noise_pred, step_sigmas[i])
+
+            if i < num_inference_steps - 1:
+                sample = latents.transpose(1, 2).squeeze(0)
+                noise = randn_tensor(
+                    sample.shape,
+                    device=latents.device,
+                    dtype=latents.dtype,
+                    generator=generator,
+                )
+                latents = (
+                    self._add_noise(sample, noise, step_sigmas[i + 1])
+                    .unsqueeze(0)
+                    .transpose(1, 2)
+                )
+
+        # 7. Save denoised latents
+        session.current_denoised_latents = latents
+
+        # 8. VAE decode
+        videos = self._decode_latents(session, block_idx, latents)
+
+        # 9. Update session
+        session.block_idx += 1
+
+        return videos
+
+    def _encode_with_interpolation(
+        self,
+        session: RealtimeSession,
+        prompt: str,
+    ) -> torch.Tensor:
+        """Encode prompt with interpolation on change."""
+        if session.is_prompt_changed(prompt):
+            new_embeds = self.encode_prompt(prompt)
+            interpolated = None
+            if session.last_embeds:
+                interpolated = self.interpolate_embeds(
+                    session.last_embeds, [new_embeds]
+                )
+            session.save_prompt_changed(prompt, [new_embeds], interpolated)
+
+        embeds = session.get_current_embeds()
+        return embeds[0] if isinstance(embeds, list) else embeds
+
+    def _prepare_v2v_latents(
+        self,
+        frames: list,
+        height: int,
+        width: int,
+        timesteps: torch.Tensor,
+        generator: torch.Generator | None,
+    ) -> torch.Tensor:
+        """Prepare latents for V2V mode by encoding input frames."""
+        if len(frames) < self.num_frames_per_block:
+            frames = frames + [frames[-1]] * (self.num_frames_per_block - len(frames))
+
+        video = (
+            self.video_processor.preprocess(frames, height, width)
+            .unsqueeze(0)
+            .to(self.vae_dtype)
+        )
+        init_latents = self._encode_video_frames(video, self.vae_dtype)
+        init_latents = init_latents[:, :, -self.num_frames_per_block :]
+
+        strength = timesteps[0].item() / 1000.0
+        noise = randn_tensor(
+            init_latents.shape,
+            device=self.device,
+            dtype=self.transformer_dtype,
+            generator=generator,
+        )
+        init_latents = init_latents * (1.0 - strength) + noise * strength
+        return init_latents.to(self.transformer_dtype).contiguous()
+
+    def _prepare_t2v_latents(
+        self,
+        block_idx: int,
+        height: int,
+        width: int,
+        generator: torch.Generator | None,
+    ) -> torch.Tensor:
+        """Prepare random latents for T2V mode."""
+        num_channels = self.transformer.config.in_channels
+        vae_sf = 8
+        effective_blocks = max(1, block_idx + 1)
+        num_latent_frames = effective_blocks * self.num_frames_per_block
+        shape = (
+            1,
+            num_channels,
+            num_latent_frames,
+            height // vae_sf,
+            width // vae_sf,
+        )
+        all_latents = randn_tensor(
+            shape,
+            generator=generator,
+            device=self.device,
+            dtype=self.transformer_dtype,
+        )
+        start = block_idx * self.num_frames_per_block
+        end = start + self.num_frames_per_block
+        return all_latents[:, :, start:end].contiguous()
+
+    def _decode_latents(
+        self,
+        session: RealtimeSession,
+        block_idx: int,
+        latents: torch.Tensor,
+    ) -> np.ndarray:
+        """Decode latents to video frames via VAE."""
+        if session.frame_cache_context is None:
+            frame_cache_len = 1 + (self.kv_cache_num_frames - 1) * 4
+            session.frame_cache_context = deque(maxlen=frame_cache_len)
+
+        if block_idx == 0:
+            if not hasattr(self.vae, "_original_clear_cache"):
+                self.vae._original_clear_cache = self.vae.clear_cache
+            self.vae._original_clear_cache()
+            self.vae.clear_cache = lambda: None
+            decoder_cache_len = getattr(self.vae, "_conv_num", 55)
+            self.vae._feat_map = [None] * decoder_cache_len
+        else:
+            self.vae._feat_map = session.decoder_cache
+
+        decode_latents = latents.to(device=self.vae.device, dtype=self.vae_dtype)
+        decode_latents = decode_latents / self._vae_latents_std + self._vae_latents_mean
+
+        decode_out = self.vae.decode(decode_latents)
+        videos = decode_out.sample if hasattr(decode_out, "sample") else decode_out
+        session.decoder_cache = self.vae._feat_map
+        session.frame_cache_context.extend(videos.split(1, dim=2))
+
+        return self.video_processor.postprocess_video(videos, output_type="np")

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
@@ -45,6 +45,7 @@ class RealtimeSession:
     frame_cache_context: deque | None = None
     decoder_cache: Any = None
     v2v_strength: float | None = None
+    first_frame_latent: torch.Tensor | None = None
     block_idx: int = 0
 
     def is_prompt_changed(self, prompts: str | list[str]) -> bool:
@@ -78,6 +79,7 @@ class RealtimeSession:
         self.current_denoised_latents = None
         self.frame_cache_context = None
         self.decoder_cache = None
+        self.first_frame_latent = None
         self.last_embeds.clear()
         self.interpolated_embeds.clear()
         torch.cuda.empty_cache()
@@ -311,11 +313,12 @@ class Wan22RealtimePipeline:
 
         context = session.current_denoised_latents
         context = context[:, :, 1:][:, :, -self.kv_cache_num_frames + 1 :]
-        first_frame_latent = self._prepare_frame_latents(
-            frames=session.frame_cache_context[0],
-            dtype=self.vae_dtype,
-        )
-        first_frame_latent = first_frame_latent.to(context)
+        if session.first_frame_latent is None:
+            session.first_frame_latent = self._prepare_frame_latents(
+                frames=session.frame_cache_context[0],
+                dtype=self.vae_dtype,
+            )
+        first_frame_latent = session.first_frame_latent.to(context)
         return torch.cat((first_frame_latent, context), dim=2)
 
     def _setup_kv_cache(

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
@@ -100,8 +100,8 @@ class Wan22RealtimePipeline:
         tokenizer,
         text_encoder,
         *,
-        num_frames_per_block: int = 1,
-        kv_cache_num_frames: int = 12,
+        num_frames_per_block: int = 3,
+        kv_cache_num_frames: int = 3,
         vae_dtype: torch.dtype = torch.bfloat16,
         transformer_dtype: torch.dtype = torch.bfloat16,
     ):
@@ -198,21 +198,28 @@ class Wan22RealtimePipeline:
     ) -> list[list[torch.Tensor]]:
         """Interpolate between previous and current prompt embeddings.
 
-        Skips weight=0 (which equals the previous embed) so the first block
-        after a prompt change already shows new-prompt influence.
+        Weights start at 1/steps (not 0) so the first block after a prompt
+        change already shows new-prompt influence.  All steps are computed
+        in a single vectorised ``torch.lerp`` call per embedding layer.
         """
         steps = self.INTERPOLATION_STEPS
-        result = []
-        # Weights: [1/steps, 2/steps, ..., 1.0] e.g. [0.25, 0.5, 0.75, 1.0]
-        weights = torch.linspace(1.0 / steps, 1.0, steps=steps)
+        assert len(prev_embeds) == len(curr_embeds)
 
+        weights = (
+            torch.linspace(1.0 / steps, 1.0, steps=steps)
+            .unsqueeze(1)
+            .unsqueeze(2)
+        )
+
+        per_layer_chunks: list[list[torch.Tensor]] = []
+        for prev, curr in zip(prev_embeds, curr_embeds):
+            assert prev.shape == curr.shape
+            x = torch.lerp(prev, curr, weights.to(prev))
+            per_layer_chunks.append(list(x.chunk(steps, dim=0)))
+
+        result: list[list[torch.Tensor]] = []
         for step_idx in range(steps):
-            w = weights[step_idx]
-            step_embeds = []
-            for prev, curr in zip(prev_embeds, curr_embeds):
-                interp = torch.lerp(prev, curr, w.to(prev))
-                step_embeds.append(interp)
-            result.append(step_embeds)
+            result.append([chunks[step_idx] for chunks in per_layer_chunks])
         return result
 
     def prepare_timesteps(
@@ -607,7 +614,14 @@ class Wan22RealtimePipeline:
         block_idx: int,
         latents: torch.Tensor,
     ) -> np.ndarray:
-        """Decode latents to video frames via VAE."""
+        """Decode latents to video frames via VAE.
+
+        Performs frame-by-frame decoding directly instead of going through
+        vae.decode(), which always passes first_chunk=True for frame 0.
+        In realtime streaming, only block 0 frame 0 is the true first chunk;
+        subsequent blocks must use first_chunk=False to keep temporal
+        upsampling consistent with the cached decoder state.
+        """
         if session.frame_cache_context is None:
             frame_cache_len = 1 + (self.kv_cache_num_frames - 1) * 4
             session.frame_cache_context = deque(maxlen=frame_cache_len)
@@ -625,8 +639,42 @@ class Wan22RealtimePipeline:
         decode_latents = latents.to(device=self.vae.device, dtype=self.vae_dtype)
         decode_latents = decode_latents / self._vae_latents_std + self._vae_latents_mean
 
-        decode_out = self.vae.decode(decode_latents)
-        videos = decode_out.sample if hasattr(decode_out, "sample") else decode_out
+        from contextlib import nullcontext
+
+        ctx = (
+            self.vae._execution_context()
+            if hasattr(self.vae, "_execution_context")
+            else nullcontext()
+        )
+        with ctx:
+            x = self.vae.post_quant_conv(decode_latents)
+            num_frames = x.shape[2]
+
+            for i in range(num_frames):
+                self.vae._conv_idx = [0]
+                is_first_chunk = block_idx == 0 and i == 0
+                frame = x[:, :, i : i + 1, :, :]
+                decoded = self.vae.decoder(
+                    frame,
+                    feat_cache=self.vae._feat_map,
+                    feat_idx=self.vae._conv_idx,
+                    first_chunk=is_first_chunk,
+                )
+                if i == 0:
+                    videos = decoded
+                else:
+                    videos = torch.cat([videos, decoded], dim=2)
+
+            patch_size = getattr(self.vae.config, "patch_size", None)
+            if patch_size is not None:
+                from diffusers.models.autoencoders.autoencoder_kl_wan import (
+                    unpatchify,
+                )
+
+                videos = unpatchify(videos, patch_size=patch_size)
+
+            videos = torch.clamp(videos, min=-1.0, max=1.0)
+
         session.decoder_cache = self.vae._feat_map
         session.frame_cache_context.extend(videos.split(1, dim=2))
 

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
@@ -434,7 +434,7 @@ class Wan22RealtimePipeline:
         return noise_pred
 
     @torch.no_grad()
-    def generate_block(
+    def denoise_block(
         self,
         session: RealtimeSession,
         prompt: str,
@@ -443,32 +443,21 @@ class Wan22RealtimePipeline:
         num_inference_steps: int | None = None,
         input_video_frames: list | None = None,
         generator: torch.Generator | None = None,
-    ) -> np.ndarray:
-        """Generate one video block.
+    ) -> torch.Tensor:
+        """Run text encoding, latent prep, context recomputation, and denoising.
 
-        Args:
-            session: Persistent session state across blocks.
-            prompt: Text prompt for generation.
-            height: Video height in pixels.
-            width: Video width in pixels.
-            num_inference_steps: Denoising steps (default 4).
-            input_video_frames: PIL images for V2V mode (None for T2V).
-            generator: Optional random generator for reproducibility.
-
-        Returns:
-            Video frames as numpy array (postprocessed by VideoProcessor).
+        Returns denoised latents. Updates session.current_denoised_latents
+        and increments session.block_idx.
         """
         if num_inference_steps is None:
             num_inference_steps = self.DEFAULT_NUM_INFERENCE_STEPS
 
-        # 0. Align resolution to required factor (VAE 8x × patch 2x = 16)
         _, p_h, p_w = self._patch_size
         align_h = 8 * p_h
         align_w = 8 * p_w
         height = (height // align_h) * align_h
         width = (width // align_w) * align_w
 
-        # Update frame_seq_length for actual resolution
         new_seq_len = self._compute_frame_seq_length(height, width)
         if new_seq_len != self.frame_seq_length:
             self.frame_seq_length = new_seq_len
@@ -479,15 +468,12 @@ class Wan22RealtimePipeline:
         has_video = input_video_frames is not None
         strength = 0.7 if has_video else 1.0
 
-        # 1. Text encoding with prompt interpolation
         prompt_embeds = self._encode_with_interpolation(session, prompt)
 
-        # 2. Prepare timesteps
         timesteps, all_timesteps, sigmas = self.prepare_timesteps(
             self.DEFAULT_FLOW_SHIFT, strength, num_inference_steps
         )
 
-        # 3. Prepare latents
         if has_video:
             latents = self._prepare_v2v_latents(
                 input_video_frames, height, width, timesteps, generator
@@ -498,15 +484,11 @@ class Wan22RealtimePipeline:
             )
 
         current_start_frame = block_idx * self.num_frames_per_block
-
-        # 4. Setup KV cache
         manager = self._setup_kv_cache(session)
 
-        # 5. Context recomputation (for blocks after the first)
         if block_idx > 0:
             self._recompute_context(session, prompt_embeds, manager)
 
-        # 6. Denoising loop
         step_timestep_ids = torch.argmin(
             (all_timesteps.unsqueeze(0) - timesteps.unsqueeze(1)).abs(), dim=1
         )
@@ -521,9 +503,7 @@ class Wan22RealtimePipeline:
                 crossattn_cache=manager.cross_attn_caches,
                 current_start_frame=current_start_frame,
             )
-
             latents = self._update_latents(latents, noise_pred, step_sigmas[i])
-
             if i < num_inference_steps - 1:
                 sample = latents.transpose(1, 2).squeeze(0)
                 noise = randn_tensor(
@@ -538,16 +518,113 @@ class Wan22RealtimePipeline:
                     .transpose(1, 2)
                 )
 
-        # 7. Save denoised latents
         session.current_denoised_latents = latents
-
-        # 8. VAE decode
-        videos = self._decode_latents(session, block_idx, latents)
-
-        # 9. Update session
         session.block_idx += 1
+        return latents
 
+    def decode_block(
+        self,
+        session: RealtimeSession,
+        block_idx: int,
+        latents: torch.Tensor,
+    ) -> torch.Tensor:
+        """VAE decode latents to video tensor. Updates session caches.
+
+        Returns clamped video tensor on GPU. Call postprocess_decoded()
+        to convert to numpy.
+        """
+        if session.frame_cache_context is None:
+            frame_cache_len = 1 + (self.kv_cache_num_frames - 1) * 4
+            session.frame_cache_context = deque(maxlen=frame_cache_len)
+
+        if block_idx == 0:
+            if not hasattr(self.vae, "_original_clear_cache"):
+                self.vae._original_clear_cache = self.vae.clear_cache
+            self.vae._original_clear_cache()
+            self.vae.clear_cache = lambda: None
+            decoder_cache_len = getattr(self.vae, "_conv_num", 55)
+            self.vae._feat_map = [None] * decoder_cache_len
+        else:
+            self.vae._feat_map = session.decoder_cache
+
+        decode_latents = latents.to(device=self.vae.device, dtype=self.vae_dtype)
+        decode_latents = (
+            decode_latents / self._vae_latents_std + self._vae_latents_mean
+        )
+
+        from contextlib import nullcontext
+
+        ctx = (
+            self.vae._execution_context()
+            if hasattr(self.vae, "_execution_context")
+            else nullcontext()
+        )
+
+        with ctx:
+            x = self.vae.post_quant_conv(decode_latents)
+            num_frames = x.shape[2]
+
+            for i in range(num_frames):
+                self.vae._conv_idx = [0]
+                is_first_chunk = block_idx == 0 and i == 0
+                frame = x[:, :, i : i + 1, :, :]
+                decoded = self.vae.decoder(
+                    frame,
+                    feat_cache=self.vae._feat_map,
+                    feat_idx=self.vae._conv_idx,
+                    first_chunk=is_first_chunk,
+                )
+                if i == 0:
+                    videos = decoded
+                else:
+                    videos = torch.cat([videos, decoded], dim=2)
+
+            patch_size = getattr(self.vae.config, "patch_size", None)
+            if patch_size is not None:
+                from diffusers.models.autoencoders.autoencoder_kl_wan import (
+                    unpatchify,
+                )
+
+                videos = unpatchify(videos, patch_size=patch_size)
+
+            videos = torch.clamp(videos, min=-1.0, max=1.0)
+
+        session.decoder_cache = self.vae._feat_map
+        session.frame_cache_context.extend(videos.split(1, dim=2))
         return videos
+
+    def postprocess_decoded(self, video_tensor: torch.Tensor) -> np.ndarray:
+        """Convert decoded video tensor to numpy array."""
+        return self.video_processor.postprocess_video(
+            video_tensor, output_type="np"
+        )
+
+    @torch.no_grad()
+    def generate_block(
+        self,
+        session: RealtimeSession,
+        prompt: str,
+        height: int = 480,
+        width: int = 832,
+        num_inference_steps: int | None = None,
+        input_video_frames: list | None = None,
+        generator: torch.Generator | None = None,
+    ) -> np.ndarray:
+        """Generate one video block (synchronous).
+
+        For async pipeline use denoise_block() + decode_block() +
+        postprocess_decoded() separately.
+        """
+        block_idx = session.block_idx
+
+        latents = self.denoise_block(
+            session, prompt, height, width,
+            num_inference_steps, input_video_frames, generator,
+        )
+
+        videos = self.decode_block(session, block_idx, latents)
+
+        return self.postprocess_decoded(videos)
 
     def _encode_with_interpolation(
         self,
@@ -626,74 +703,3 @@ class Wan22RealtimePipeline:
         end = start + self.num_frames_per_block
         return all_latents[:, :, start:end].contiguous()
 
-    def _decode_latents(
-        self,
-        session: RealtimeSession,
-        block_idx: int,
-        latents: torch.Tensor,
-    ) -> np.ndarray:
-        """Decode latents to video frames via VAE.
-
-        Performs frame-by-frame decoding directly instead of going through
-        vae.decode(), which always passes first_chunk=True for frame 0.
-        In realtime streaming, only block 0 frame 0 is the true first chunk;
-        subsequent blocks must use first_chunk=False to keep temporal
-        upsampling consistent with the cached decoder state.
-        """
-        if session.frame_cache_context is None:
-            frame_cache_len = 1 + (self.kv_cache_num_frames - 1) * 4
-            session.frame_cache_context = deque(maxlen=frame_cache_len)
-
-        if block_idx == 0:
-            if not hasattr(self.vae, "_original_clear_cache"):
-                self.vae._original_clear_cache = self.vae.clear_cache
-            self.vae._original_clear_cache()
-            self.vae.clear_cache = lambda: None
-            decoder_cache_len = getattr(self.vae, "_conv_num", 55)
-            self.vae._feat_map = [None] * decoder_cache_len
-        else:
-            self.vae._feat_map = session.decoder_cache
-
-        decode_latents = latents.to(device=self.vae.device, dtype=self.vae_dtype)
-        decode_latents = decode_latents / self._vae_latents_std + self._vae_latents_mean
-
-        from contextlib import nullcontext
-
-        ctx = (
-            self.vae._execution_context()
-            if hasattr(self.vae, "_execution_context")
-            else nullcontext()
-        )
-        with ctx:
-            x = self.vae.post_quant_conv(decode_latents)
-            num_frames = x.shape[2]
-
-            for i in range(num_frames):
-                self.vae._conv_idx = [0]
-                is_first_chunk = block_idx == 0 and i == 0
-                frame = x[:, :, i : i + 1, :, :]
-                decoded = self.vae.decoder(
-                    frame,
-                    feat_cache=self.vae._feat_map,
-                    feat_idx=self.vae._conv_idx,
-                    first_chunk=is_first_chunk,
-                )
-                if i == 0:
-                    videos = decoded
-                else:
-                    videos = torch.cat([videos, decoded], dim=2)
-
-            patch_size = getattr(self.vae.config, "patch_size", None)
-            if patch_size is not None:
-                from diffusers.models.autoencoders.autoencoder_kl_wan import (
-                    unpatchify,
-                )
-
-                videos = unpatchify(videos, patch_size=patch_size)
-
-            videos = torch.clamp(videos, min=-1.0, max=1.0)
-
-        session.decoder_cache = self.vae._feat_map
-        session.frame_cache_context.extend(videos.split(1, dim=2))
-
-        return self.video_processor.postprocess_video(videos, output_type="np")

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
@@ -461,7 +461,14 @@ class Wan22RealtimePipeline:
         if num_inference_steps is None:
             num_inference_steps = self.DEFAULT_NUM_INFERENCE_STEPS
 
-        # 0. Update frame_seq_length for actual resolution
+        # 0. Align resolution to required factor (VAE 8x × patch 2x = 16)
+        _, p_h, p_w = self._patch_size
+        align_h = 8 * p_h
+        align_w = 8 * p_w
+        height = (height // align_h) * align_h
+        width = (width // align_w) * align_w
+
+        # Update frame_seq_length for actual resolution
         new_seq_len = self._compute_frame_seq_length(height, width)
         if new_seq_len != self.frame_seq_length:
             self.frame_seq_length = new_seq_len

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_realtime.py
@@ -44,6 +44,7 @@ class RealtimeSession:
     current_denoised_latents: torch.Tensor | None = None
     frame_cache_context: deque | None = None
     decoder_cache: Any = None
+    v2v_strength: float | None = None
     block_idx: int = 0
 
     def is_prompt_changed(self, prompts: str | list[str]) -> bool:
@@ -466,7 +467,7 @@ class Wan22RealtimePipeline:
 
         block_idx = session.block_idx
         has_video = input_video_frames is not None
-        strength = 0.7 if has_video else 1.0
+        strength = (session.v2v_strength or 0.7) if has_video else 1.0
 
         prompt_embeds = self._encode_with_interpolation(session, prompt)
 

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -58,6 +58,11 @@ _DIFFUSION_MODELS = {
         "pipeline_wan2_2",
         "Wan22Pipeline",
     ),
+    "KreaWanCausalPipeline": (
+        "wan2_2",
+        "pipeline_wan2_2",
+        "Wan22Pipeline",
+    ),
     "WanVACEPipeline": (
         "wan2_2",
         "pipeline_wan2_2_vace",
@@ -352,6 +357,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "ZImagePipeline": "get_post_process_func",
     "OvisImagePipeline": "get_ovis_image_post_process_func",
     "WanPipeline": "get_wan22_post_process_func",
+    "KreaWanCausalPipeline": "get_wan22_post_process_func",
     "WanVACEPipeline": "get_wan22_vace_post_process_func",
     "LTX2Pipeline": "get_ltx2_post_process_func",
     "LTX2TwoStagesPipeline": "get_ltx2_post_process_func",
@@ -388,6 +394,7 @@ _DIFFUSION_PRE_PROCESS_FUNCS = {
     "LongCatImageEditPipeline": "get_longcat_image_edit_pre_process_func",
     "QwenImageLayeredPipeline": "get_qwen_image_layered_pre_process_func",
     "WanPipeline": "get_wan22_pre_process_func",
+    "KreaWanCausalPipeline": "get_wan22_pre_process_func",
     "WanVACEPipeline": "get_wan22_vace_pre_process_func",
     "WanImageToVideoPipeline": "get_wan22_i2v_pre_process_func",
     "OmniGen2Pipeline": "get_omnigen2_pre_process_func",

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -319,7 +319,13 @@ class DiffusionWorker:
         num_inference_steps: int | None = None,
         video_frames_bytes: list[bytes] | None = None,
     ) -> list[bytes]:
-        """Generate one video block, return list of PNG frame bytes."""
+        """Generate one video block, return list of PNG frame bytes.
+
+        All TP ranks execute the transformer forward pass (which requires
+        collective communication).  VAE decode runs on every rank (it is
+        not sharded) but PNG encoding is only performed on rank 0 — the
+        only rank whose result is returned to the API server.
+        """
         if not hasattr(self, "_realtime_sessions"):
             raise RuntimeError(f"No realtime sessions; session {session_id} not found")
         if session_id not in self._realtime_sessions:
@@ -338,16 +344,22 @@ class DiffusionWorker:
                 for b in video_frames_bytes
             ]
 
-        video_np = rt_pipeline.generate_block(
-            session=session,
-            prompt=prompt,
-            height=height,
-            width=width,
-            num_inference_steps=num_inference_steps,
-            input_video_frames=input_frames,
-        )
+        with (
+            set_forward_context(vllm_config=self.vllm_config, omni_diffusion_config=self.od_config),
+            set_current_vllm_config(self.vllm_config),
+        ):
+            video_np = rt_pipeline.generate_block(
+                session=session,
+                prompt=prompt,
+                height=height,
+                width=width,
+                num_inference_steps=num_inference_steps,
+                input_video_frames=input_frames,
+            )
 
-        return self._encode_all_frames_png(video_np)
+        if self.rank == 0:
+            return self._encode_all_frames_png(video_np)
+        return []
 
     def realtime_dispose_session(self, session_id: str) -> bool:
         """Dispose a realtime session and free GPU resources."""

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -385,10 +385,9 @@ class DiffusionWorker:
                 generator=generator,
             )
 
-            if self.rank == 0:
-                self._launch_async_vae(
-                    session_id, rt_pipeline, session, block_idx, latents
-                )
+            self._launch_async_vae(
+                session_id, rt_pipeline, session, block_idx, latents
+            )
 
             return self._collect_encoded_frames(session_id)
 

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -321,15 +321,17 @@ class DiffusionWorker:
         num_inference_steps: int | None = None,
         video_frames_bytes: list[bytes] | None = None,
     ) -> list[bytes]:
-        """Generate one video block, return list of PNG frame bytes.
+        """Generate one video block with VAE-denoise overlap.
 
-        All TP ranks execute the transformer forward pass (which requires
-        collective communication).  VAE decode runs on every rank (it is
-        not sharded) but PNG encoding is only performed on rank 0 — the
-        only rank whose result is returned to the API server.
+        First block runs synchronously for fast initial output.
+        Subsequent blocks pipeline: denoise(N) on default stream overlaps
+        with VAE decode(N-1) on a separate CUDA stream.
+        Non-rank-0 workers skip VAE entirely (it's replicated, not sharded).
         """
         if not hasattr(self, "_realtime_sessions"):
-            raise RuntimeError(f"No realtime sessions; session {session_id} not found")
+            raise RuntimeError(
+                f"No realtime sessions; session {session_id} not found"
+            )
         if session_id not in self._realtime_sessions:
             raise RuntimeError(f"Realtime session {session_id} not found")
 
@@ -346,11 +348,34 @@ class DiffusionWorker:
                 for b in video_frames_bytes
             ]
 
+        block_idx = session.block_idx
+        is_first_block = block_idx == 0
+
         with (
-            set_forward_context(vllm_config=self.vllm_config, omni_diffusion_config=self.od_config),
+            set_forward_context(
+                vllm_config=self.vllm_config,
+                omni_diffusion_config=self.od_config,
+            ),
             set_current_vllm_config(self.vllm_config),
         ):
-            video_np = rt_pipeline.generate_block(
+            if is_first_block:
+                # Synchronous first block for fast initial output
+                video_np = rt_pipeline.generate_block(
+                    session=session,
+                    prompt=prompt,
+                    height=height,
+                    width=width,
+                    num_inference_steps=num_inference_steps,
+                    input_video_frames=input_frames,
+                    generator=generator,
+                )
+                if self.rank == 0:
+                    return self._encode_all_frames_png(video_np)
+                return []
+
+            prev_frames = self._sync_pending_vae(session_id, rt_pipeline)
+
+            latents = rt_pipeline.denoise_block(
                 session=session,
                 prompt=prompt,
                 height=height,
@@ -360,19 +385,86 @@ class DiffusionWorker:
                 generator=generator,
             )
 
+            if self.rank == 0:
+                self._launch_async_vae(
+                    session_id, rt_pipeline, session, block_idx, latents
+                )
+
+            return prev_frames
+
+    def _sync_pending_vae(
+        self, session_id: str, rt_pipeline
+    ) -> list[bytes]:
+        """Sync pending async VAE decode and return encoded frames."""
+        if not hasattr(self, "_pending_vae_decode"):
+            return []
+        pending = self._pending_vae_decode.pop(session_id, None)
+        if pending is None:
+            return []
+
+        pending["stream"].synchronize()
         if self.rank == 0:
+            video_np = rt_pipeline.postprocess_decoded(pending["video_tensor"])
             return self._encode_all_frames_png(video_np)
         return []
+
+    def _launch_async_vae(
+        self,
+        session_id: str,
+        rt_pipeline,
+        session,
+        block_idx: int,
+        latents: torch.Tensor,
+    ) -> None:
+        """Launch VAE decode on a separate CUDA stream (non-blocking)."""
+        if not hasattr(self, "_pending_vae_decode"):
+            self._pending_vae_decode: dict[str, dict] = {}
+        if not hasattr(self, "_vae_streams"):
+            self._vae_streams: dict[str, torch.cuda.Stream] = {}
+
+        vae_stream = self._vae_streams.get(session_id)
+        if vae_stream is None:
+            vae_stream = torch.cuda.Stream()
+            self._vae_streams[session_id] = vae_stream
+
+        # Ensure denoise results on default stream are visible to vae_stream
+        vae_stream.wait_stream(torch.cuda.current_stream())
+
+        with torch.cuda.stream(vae_stream):
+            video_tensor = rt_pipeline.decode_block(session, block_idx, latents)
+
+        self._pending_vae_decode[session_id] = {
+            "stream": vae_stream,
+            "video_tensor": video_tensor,
+        }
+
+    def realtime_flush_decode(self, session_id: str) -> list[bytes]:
+        """Flush pending VAE decode and return last block's frames."""
+        if not hasattr(self, "_realtime_sessions"):
+            return []
+        entry = self._realtime_sessions.get(session_id)
+        if entry is None:
+            return []
+        rt_pipeline = entry[0]
+        return self._sync_pending_vae(session_id, rt_pipeline)
 
     def realtime_dispose_session(self, session_id: str) -> bool:
         """Dispose a realtime session and free GPU resources."""
         if not hasattr(self, "_realtime_sessions"):
             return True
+        # Flush any pending async VAE decode
+        self.realtime_flush_decode(session_id)
+        if hasattr(self, "_vae_streams"):
+            self._vae_streams.pop(session_id, None)
         entry = self._realtime_sessions.pop(session_id, None)
         if entry is not None:
             _, session, _ = entry
             session.dispose()
-            logger.info("Worker %d: Disposed realtime session %s", self.rank, session_id)
+            logger.info(
+                "Worker %d: Disposed realtime session %s",
+                self.rank,
+                session_id,
+            )
         return True
 
     @staticmethod

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -304,7 +304,9 @@ class DiffusionWorker:
             vae_dtype=torch.float32,
             transformer_dtype=next(pipeline.transformer.parameters()).dtype,
         )
-        session = RealtimeSession()
+        session = RealtimeSession(
+            v2v_strength=config.get("v2v_strength"),
+        )
         seed = config.get("seed", 42)
         generator = torch.Generator(device=self.device).manual_seed(seed)
         self._realtime_sessions[session_id] = (rt_pipeline, session, generator)

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -275,6 +275,112 @@ class DiffusionWorker:
     def pin_lora(self, adapter_id: int) -> bool:
         return self.lora_manager.pin_adapter(adapter_id)
 
+    # ==================== Realtime Video ====================
+
+    def realtime_create_session(self, session_id: str, config: dict) -> bool:
+        """Create a realtime video pipeline + session on this worker."""
+        if not hasattr(self, "_realtime_sessions"):
+            self._realtime_sessions: dict[str, tuple] = {}
+
+        if session_id in self._realtime_sessions:
+            return True
+
+        pipeline = self.model_runner.pipeline
+        if pipeline is None:
+            raise RuntimeError("No pipeline loaded on worker")
+
+        from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2_realtime import (
+            RealtimeSession,
+            Wan22RealtimePipeline,
+        )
+
+        rt_pipeline = Wan22RealtimePipeline(
+            transformer=pipeline.transformer,
+            vae=pipeline.vae,
+            tokenizer=pipeline.tokenizer,
+            text_encoder=pipeline.text_encoder,
+            num_frames_per_block=config.get("num_frames_per_block", 1),
+            kv_cache_num_frames=config.get("kv_cache_num_frames", 12),
+            vae_dtype=torch.float32,
+            transformer_dtype=next(pipeline.transformer.parameters()).dtype,
+        )
+        session = RealtimeSession()
+        self._realtime_sessions[session_id] = (rt_pipeline, session)
+        logger.info("Worker %d: Created realtime session %s", self.rank, session_id)
+        return True
+
+    @torch.no_grad()
+    def realtime_generate_block(
+        self,
+        session_id: str,
+        prompt: str,
+        height: int = 480,
+        width: int = 832,
+        num_inference_steps: int | None = None,
+        video_frames_bytes: list[bytes] | None = None,
+    ) -> bytes:
+        """Generate one video block, return PNG frame bytes."""
+        if not hasattr(self, "_realtime_sessions"):
+            raise RuntimeError(f"No realtime sessions; session {session_id} not found")
+        if session_id not in self._realtime_sessions:
+            raise RuntimeError(f"Realtime session {session_id} not found")
+
+        rt_pipeline, session = self._realtime_sessions[session_id]
+
+        input_frames = None
+        if video_frames_bytes:
+            import io as _io
+
+            from PIL import Image
+
+            input_frames = [
+                Image.open(_io.BytesIO(b)).convert("RGB")
+                for b in video_frames_bytes
+            ]
+
+        video_np = rt_pipeline.generate_block(
+            session=session,
+            prompt=prompt,
+            height=height,
+            width=width,
+            num_inference_steps=num_inference_steps,
+            input_video_frames=input_frames,
+        )
+
+        return self._encode_frame_png(video_np)
+
+    def realtime_dispose_session(self, session_id: str) -> bool:
+        """Dispose a realtime session and free GPU resources."""
+        if not hasattr(self, "_realtime_sessions"):
+            return True
+        entry = self._realtime_sessions.pop(session_id, None)
+        if entry is not None:
+            _, session = entry
+            session.dispose()
+            logger.info("Worker %d: Disposed realtime session %s", self.rank, session_id)
+        return True
+
+    @staticmethod
+    def _encode_frame_png(video_np) -> bytes:
+        """Encode video numpy array's first frame to PNG bytes."""
+        import io as _io
+
+        import numpy as np
+        from PIL import Image
+
+        if video_np.ndim == 5:
+            video_np = video_np[0]
+        if video_np.ndim == 4:
+            frame = video_np[0]
+        else:
+            frame = video_np
+        if frame.dtype in (np.float32, np.float64):
+            frame = (frame * 255).clip(0, 255).astype(np.uint8)
+        img = Image.fromarray(frame)
+        buf = _io.BytesIO()
+        img.save(buf, format="PNG")
+        return buf.getvalue()
+
     def sleep(self, level: int = 1) -> bool:
         """
         Put the worker to sleep, offloading model weights.
@@ -395,11 +501,13 @@ class WorkerProc:
         od_config: OmniDiffusionConfig,
         gpu_id: int,
         broadcast_handle,
+        wake_event: mp.Event = None,
         worker_extension_cls: str | None = None,
         custom_pipeline_args: dict[str, Any] | None = None,
     ):
         self.od_config = od_config
         self.gpu_id = gpu_id
+        self.wake_event = wake_event
 
         # Inter-process Communication
         self.context = zmq.Context(io_threads=2)
@@ -414,7 +522,13 @@ class WorkerProc:
         if gpu_id == 0:
             self.result_mq = MessageQueue(n_reader=1, n_local_reader=1, local_reader_ranks=[0])
             self.result_mq_handle = self.result_mq.export_handle()
+            WorkerProc._shared_result_handle = self.result_mq_handle
             logger.info(f"Worker {gpu_id} created result MessageQueue")
+        else:
+            handle = getattr(WorkerProc, "_shared_result_handle", None)
+            if handle:
+                self.result_mq = MessageQueue.create_from_handle(handle, gpu_id)
+                logger.info(f"Worker {gpu_id} attached to shared result MessageQueue")
 
         assert od_config.master_port is not None
 
@@ -538,6 +652,7 @@ class WorkerProc:
         od_config: OmniDiffusionConfig,
         pipe_writer: mp.connection.Connection,
         broadcast_handle,
+        wake_event: mp.Event = None,
         worker_extension_cls: str | None = None,
         custom_pipeline_args: dict[str, Any] | None = None,
     ) -> None:
@@ -549,6 +664,7 @@ class WorkerProc:
             od_config,
             gpu_id=rank,
             broadcast_handle=broadcast_handle,
+            wake_event=wake_event,
             worker_extension_cls=worker_extension_cls,
             custom_pipeline_args=custom_pipeline_args,
         )

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -373,7 +373,7 @@ class DiffusionWorker:
                     return self._encode_all_frames_png(video_np)
                 return []
 
-            prev_frames = self._sync_pending_vae(session_id, rt_pipeline)
+            self._sync_and_start_encode(session_id, rt_pipeline)
 
             latents = rt_pipeline.denoise_block(
                 session=session,
@@ -390,23 +390,57 @@ class DiffusionWorker:
                     session_id, rt_pipeline, session, block_idx, latents
                 )
 
-            return prev_frames
+            return self._collect_encoded_frames(session_id)
 
-    def _sync_pending_vae(
+    def _sync_and_start_encode(
         self, session_id: str, rt_pipeline
-    ) -> list[bytes]:
-        """Sync pending async VAE decode and return encoded frames."""
+    ) -> None:
+        """Sync VAE stream and submit CPU encode work to a background thread.
+
+        Must be called before denoise_block so that session state written
+        by decode_block on the VAE stream is visible. The heavy CPU work
+        (postprocess + PNG encode) runs in a thread that overlaps with
+        the subsequent GPU denoise.
+        """
         if not hasattr(self, "_pending_vae_decode"):
-            return []
+            return
         pending = self._pending_vae_decode.pop(session_id, None)
         if pending is None:
-            return []
+            return
 
         pending["stream"].synchronize()
+
         if self.rank == 0:
-            video_np = rt_pipeline.postprocess_decoded(pending["video_tensor"])
-            return self._encode_all_frames_png(video_np)
-        return []
+            video_tensor_cpu = pending["video_tensor"].cpu()
+
+            if not hasattr(self, "_encode_executor"):
+                from concurrent.futures import ThreadPoolExecutor
+
+                self._encode_executor = ThreadPoolExecutor(max_workers=1)
+            if not hasattr(self, "_pending_png_future"):
+                self._pending_png_future: dict = {}
+
+            self._pending_png_future[session_id] = (
+                self._encode_executor.submit(
+                    self._postprocess_and_encode,
+                    rt_pipeline,
+                    video_tensor_cpu,
+                )
+            )
+
+    def _collect_encoded_frames(self, session_id: str) -> list[bytes]:
+        """Collect PNG bytes from the background encode thread."""
+        if not hasattr(self, "_pending_png_future"):
+            return []
+        future = self._pending_png_future.pop(session_id, None)
+        if future is None:
+            return []
+        return future.result()
+
+    @staticmethod
+    def _postprocess_and_encode(rt_pipeline, video_tensor_cpu) -> list[bytes]:
+        video_np = rt_pipeline.postprocess_decoded(video_tensor_cpu)
+        return DiffusionWorker._encode_all_frames_png(video_np)
 
     def _launch_async_vae(
         self,
@@ -440,13 +474,25 @@ class DiffusionWorker:
 
     def realtime_flush_decode(self, session_id: str) -> list[bytes]:
         """Flush pending VAE decode and return last block's frames."""
+        frames = self._collect_encoded_frames(session_id)
         if not hasattr(self, "_realtime_sessions"):
-            return []
+            return frames
         entry = self._realtime_sessions.get(session_id)
         if entry is None:
-            return []
-        rt_pipeline = entry[0]
-        return self._sync_pending_vae(session_id, rt_pipeline)
+            return frames
+        if not hasattr(self, "_pending_vae_decode"):
+            return frames
+        pending = self._pending_vae_decode.pop(session_id, None)
+        if pending is None:
+            return frames
+        pending["stream"].synchronize()
+        if self.rank == 0:
+            rt_pipeline = entry[0]
+            video_np = rt_pipeline.postprocess_decoded(
+                pending["video_tensor"]
+            )
+            frames.extend(self._encode_all_frames_png(video_np))
+        return frames
 
     def realtime_dispose_session(self, session_id: str) -> bool:
         """Dispose a realtime session and free GPU resources."""

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -325,10 +325,9 @@ class DiffusionWorker:
     ) -> list[bytes]:
         """Generate one video block with VAE-denoise overlap.
 
-        First block runs synchronously for fast initial output.
-        Subsequent blocks pipeline: denoise(N) on default stream overlaps
-        with VAE decode(N-1) on a separate CUDA stream.
-        Non-rank-0 workers skip VAE entirely (it's replicated, not sharded).
+        Block 0 runs synchronously for fast initial output.
+        Block 1 seeds the pipeline (denoise + async VAE, returns []).
+        Block 2+ pipelines: collect VAE(N-1) while denoise(N) runs.
         """
         if not hasattr(self, "_realtime_sessions"):
             raise RuntimeError(
@@ -351,10 +350,7 @@ class DiffusionWorker:
             ]
 
         block_idx = session.block_idx
-        has_pending_pipeline = (
-            hasattr(self, "_pending_vae_decode")
-            and session_id in self._pending_vae_decode
-        )
+        is_first_block = block_idx == 0
 
         with (
             set_forward_context(
@@ -363,7 +359,7 @@ class DiffusionWorker:
             ),
             set_current_vllm_config(self.vllm_config),
         ):
-            if not has_pending_pipeline:
+            if is_first_block:
                 video_np = rt_pipeline.generate_block(
                     session=session,
                     prompt=prompt,

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -299,8 +299,8 @@ class DiffusionWorker:
             vae=pipeline.vae,
             tokenizer=pipeline.tokenizer,
             text_encoder=pipeline.text_encoder,
-            num_frames_per_block=config.get("num_frames_per_block", 1),
-            kv_cache_num_frames=config.get("kv_cache_num_frames", 12),
+            num_frames_per_block=config.get("num_frames_per_block", 3),
+            kv_cache_num_frames=config.get("kv_cache_num_frames", 3),
             vae_dtype=torch.float32,
             transformer_dtype=next(pipeline.transformer.parameters()).dtype,
         )
@@ -318,8 +318,8 @@ class DiffusionWorker:
         width: int = 832,
         num_inference_steps: int | None = None,
         video_frames_bytes: list[bytes] | None = None,
-    ) -> bytes:
-        """Generate one video block, return PNG frame bytes."""
+    ) -> list[bytes]:
+        """Generate one video block, return list of PNG frame bytes."""
         if not hasattr(self, "_realtime_sessions"):
             raise RuntimeError(f"No realtime sessions; session {session_id} not found")
         if session_id not in self._realtime_sessions:
@@ -347,7 +347,7 @@ class DiffusionWorker:
             input_video_frames=input_frames,
         )
 
-        return self._encode_frame_png(video_np)
+        return self._encode_all_frames_png(video_np)
 
     def realtime_dispose_session(self, session_id: str) -> bool:
         """Dispose a realtime session and free GPU resources."""
@@ -361,8 +361,8 @@ class DiffusionWorker:
         return True
 
     @staticmethod
-    def _encode_frame_png(video_np) -> bytes:
-        """Encode video numpy array's first frame to PNG bytes."""
+    def _encode_all_frames_png(video_np) -> list[bytes]:
+        """Encode all video frames to a list of PNG bytes."""
         import io as _io
 
         import numpy as np
@@ -370,16 +370,18 @@ class DiffusionWorker:
 
         if video_np.ndim == 5:
             video_np = video_np[0]
-        if video_np.ndim == 4:
-            frame = video_np[0]
-        else:
-            frame = video_np
-        if frame.dtype in (np.float32, np.float64):
-            frame = (frame * 255).clip(0, 255).astype(np.uint8)
-        img = Image.fromarray(frame)
-        buf = _io.BytesIO()
-        img.save(buf, format="PNG")
-        return buf.getvalue()
+        if video_np.ndim == 3:
+            video_np = video_np[np.newaxis]
+
+        result = []
+        for frame in video_np:
+            if frame.dtype in (np.float32, np.float64):
+                frame = (frame * 255).clip(0, 255).astype(np.uint8)
+            img = Image.fromarray(frame)
+            buf = _io.BytesIO()
+            img.save(buf, format="PNG")
+            result.append(buf.getvalue())
+        return result
 
     def sleep(self, level: int = 1) -> bool:
         """

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -305,7 +305,9 @@ class DiffusionWorker:
             transformer_dtype=next(pipeline.transformer.parameters()).dtype,
         )
         session = RealtimeSession()
-        self._realtime_sessions[session_id] = (rt_pipeline, session)
+        seed = config.get("seed", 42)
+        generator = torch.Generator(device=self.device).manual_seed(seed)
+        self._realtime_sessions[session_id] = (rt_pipeline, session, generator)
         logger.info("Worker %d: Created realtime session %s", self.rank, session_id)
         return True
 
@@ -331,7 +333,7 @@ class DiffusionWorker:
         if session_id not in self._realtime_sessions:
             raise RuntimeError(f"Realtime session {session_id} not found")
 
-        rt_pipeline, session = self._realtime_sessions[session_id]
+        rt_pipeline, session, generator = self._realtime_sessions[session_id]
 
         input_frames = None
         if video_frames_bytes:
@@ -355,6 +357,7 @@ class DiffusionWorker:
                 width=width,
                 num_inference_steps=num_inference_steps,
                 input_video_frames=input_frames,
+                generator=generator,
             )
 
         if self.rank == 0:
@@ -367,7 +370,7 @@ class DiffusionWorker:
             return True
         entry = self._realtime_sessions.pop(session_id, None)
         if entry is not None:
-            _, session = entry
+            _, session, _ = entry
             session.dispose()
             logger.info("Worker %d: Disposed realtime session %s", self.rank, session_id)
         return True

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -349,7 +349,10 @@ class DiffusionWorker:
             ]
 
         block_idx = session.block_idx
-        is_first_block = block_idx == 0
+        has_pending_pipeline = (
+            hasattr(self, "_pending_vae_decode")
+            and session_id in self._pending_vae_decode
+        )
 
         with (
             set_forward_context(
@@ -358,8 +361,7 @@ class DiffusionWorker:
             ),
             set_current_vllm_config(self.vllm_config),
         ):
-            if is_first_block:
-                # Synchronous first block for fast initial output
+            if not has_pending_pipeline:
                 video_np = rt_pipeline.generate_block(
                     session=session,
                     prompt=prompt,

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -310,6 +310,12 @@ class DiffusionWorker:
         seed = config.get("seed", 42)
         generator = torch.Generator(device=self.device).manual_seed(seed)
         self._realtime_sessions[session_id] = (rt_pipeline, session, generator)
+        if not hasattr(self, "_realtime_session_config"):
+            self._realtime_session_config: dict[str, dict] = {}
+        self._realtime_session_config[session_id] = {
+            "frame_format": config.get("frame_format", "jpeg"),
+            "frame_quality": config.get("frame_quality", 95),
+        }
         logger.info("Worker %d: Created realtime session %s", self.rank, session_id)
         return True
 
@@ -370,7 +376,10 @@ class DiffusionWorker:
                     generator=generator,
                 )
                 if self.rank == 0:
-                    return self._encode_all_frames_png(video_np)
+                    cfg = self._get_session_encode_config(session_id)
+                    return self._encode_all_frames(
+                        video_np, **cfg
+                    )
                 return []
 
             self._sync_and_start_encode(session_id, rt_pipeline)
@@ -391,6 +400,15 @@ class DiffusionWorker:
 
             return self._collect_encoded_frames(session_id)
 
+    def _get_session_encode_config(self, session_id: str) -> dict:
+        if hasattr(self, "_realtime_session_config"):
+            cfg = self._realtime_session_config.get(session_id, {})
+            return {
+                "fmt": cfg.get("frame_format", "jpeg"),
+                "quality": cfg.get("frame_quality", 95),
+            }
+        return {}
+
     def _sync_and_start_encode(
         self, session_id: str, rt_pipeline
     ) -> None:
@@ -398,7 +416,7 @@ class DiffusionWorker:
 
         Must be called before denoise_block so that session state written
         by decode_block on the VAE stream is visible. The heavy CPU work
-        (postprocess + PNG encode) runs in a thread that overlaps with
+        (postprocess + image encode) runs in a thread that overlaps with
         the subsequent GPU denoise.
         """
         if not hasattr(self, "_pending_vae_decode"):
@@ -424,11 +442,12 @@ class DiffusionWorker:
                     self._postprocess_and_encode,
                     rt_pipeline,
                     video_tensor_cpu,
+                    self._get_session_encode_config(session_id),
                 )
             )
 
     def _collect_encoded_frames(self, session_id: str) -> list[bytes]:
-        """Collect PNG bytes from the background encode thread."""
+        """Collect encoded bytes from the background encode thread."""
         if not hasattr(self, "_pending_png_future"):
             return []
         future = self._pending_png_future.pop(session_id, None)
@@ -437,9 +456,13 @@ class DiffusionWorker:
         return future.result()
 
     @staticmethod
-    def _postprocess_and_encode(rt_pipeline, video_tensor_cpu) -> list[bytes]:
+    def _postprocess_and_encode(
+        rt_pipeline, video_tensor_cpu, encode_cfg: dict | None = None
+    ) -> list[bytes]:
         video_np = rt_pipeline.postprocess_decoded(video_tensor_cpu)
-        return DiffusionWorker._encode_all_frames_png(video_np)
+        return DiffusionWorker._encode_all_frames(
+            video_np, **(encode_cfg or {})
+        )
 
     def _launch_async_vae(
         self,
@@ -490,7 +513,8 @@ class DiffusionWorker:
             video_np = rt_pipeline.postprocess_decoded(
                 pending["video_tensor"]
             )
-            frames.extend(self._encode_all_frames_png(video_np))
+            cfg = self._get_session_encode_config(session_id)
+            frames.extend(self._encode_all_frames(video_np, **cfg))
         return frames
 
     def realtime_dispose_session(self, session_id: str) -> bool:
@@ -501,6 +525,8 @@ class DiffusionWorker:
         self.realtime_flush_decode(session_id)
         if hasattr(self, "_vae_streams"):
             self._vae_streams.pop(session_id, None)
+        if hasattr(self, "_realtime_session_config"):
+            self._realtime_session_config.pop(session_id, None)
         entry = self._realtime_sessions.pop(session_id, None)
         if entry is not None:
             _, session, _ = entry
@@ -513,8 +539,10 @@ class DiffusionWorker:
         return True
 
     @staticmethod
-    def _encode_all_frames_png(video_np) -> list[bytes]:
-        """Encode all video frames to a list of PNG bytes."""
+    def _encode_all_frames(
+        video_np, fmt: str = "jpeg", quality: int = 95
+    ) -> list[bytes]:
+        """Encode all video frames to a list of image bytes."""
         import io as _io
 
         import numpy as np
@@ -525,13 +553,20 @@ class DiffusionWorker:
         if video_np.ndim == 3:
             video_np = video_np[np.newaxis]
 
+        fmt_upper = fmt.upper()
+        if fmt_upper == "JPG":
+            fmt_upper = "JPEG"
+        save_kwargs: dict = {"format": fmt_upper}
+        if fmt_upper == "JPEG":
+            save_kwargs["quality"] = quality
+
         result = []
         for frame in video_np:
             if frame.dtype in (np.float32, np.float64):
                 frame = (frame * 255).clip(0, 255).astype(np.uint8)
             img = Image.fromarray(frame)
             buf = _io.BytesIO()
-            img.save(buf, format="PNG")
+            img.save(buf, **save_kwargs)
             result.append(buf.getvalue())
         return result
 

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -522,6 +522,12 @@ async def omni_init_app_state(
         )
         state.openai_streaming_speech = None
 
+        from vllm_omni.entrypoints.openai.serving_realtime_video import (
+            RealtimeVideoHandler,
+        )
+
+        state.realtime_video_handler = RealtimeVideoHandler(engine_client)
+
         state.enable_server_load_tracking = getattr(args, "enable_server_load_tracking", False)
         state.server_load_metrics = 0
         logger.info("Pure diffusion API server initialized for model: %s", model_name)
@@ -1211,6 +1217,28 @@ async def realtime_websocket(websocket: WebSocket):
         return
     connection = RealtimeConnection(websocket, serving)
     await connection.handle_connection()
+
+
+@router.websocket("/v1/realtime_video/generate")
+async def realtime_video_generate(websocket: WebSocket):
+    """WebSocket endpoint for realtime video streaming (T2V + V2V).
+
+    Uses MessagePack protocol. See serving_realtime_video.py for details.
+    """
+    handler = getattr(websocket.app.state, "realtime_video_handler", None)
+    if handler is None:
+        await websocket.accept()
+        try:
+            from msgpack import packb as _packb
+            await websocket.send_bytes(
+                _packb({"type": "error", "content": "Realtime video is not available"}, use_bin_type=True)
+            )
+        except ImportError:
+            import json
+            await websocket.send_text(json.dumps({"type": "error", "content": "Realtime video is not available"}))
+        await websocket.close()
+        return
+    await handler.handle_session(websocket)
 
 
 # Health and Model endpoints for diffusion mode

--- a/vllm_omni/entrypoints/openai/serving_realtime_video.py
+++ b/vllm_omni/entrypoints/openai/serving_realtime_video.py
@@ -171,6 +171,8 @@ class RealtimeVideoHandler:
                     "num_frames_per_block": config.get("num_frames_per_block", 3),
                     "kv_cache_num_frames": config.get("kv_cache_num_frames", 3),
                     "v2v_strength": config.get("v2v_strength"),
+                    "frame_format": config.get("frame_format", "jpeg"),
+                    "frame_quality": config.get("frame_quality", 95),
                 },
             )
             worker_session_created = True

--- a/vllm_omni/entrypoints/openai/serving_realtime_video.py
+++ b/vllm_omni/entrypoints/openai/serving_realtime_video.py
@@ -167,8 +167,8 @@ class RealtimeVideoHandler:
                 "realtime_create_session",
                 session.id,
                 {
-                    "num_frames_per_block": config.get("num_frames_per_block", 1),
-                    "kv_cache_num_frames": config.get("kv_cache_num_frames", 12),
+                    "num_frames_per_block": config.get("num_frames_per_block", 3),
+                    "kv_cache_num_frames": config.get("kv_cache_num_frames", 3),
                 },
             )
             worker_session_created = True
@@ -263,7 +263,7 @@ class RealtimeVideoHandler:
                     continue
 
             try:
-                frame_bytes = await self._rpc(
+                result = await self._rpc(
                     "realtime_generate_block",
                     session.id,
                     prompt,
@@ -273,7 +273,11 @@ class RealtimeVideoHandler:
                     video_frames_bytes,
                 )
 
-                await self._send_frame(websocket, frame_bytes)
+                if isinstance(result, list):
+                    for frame_bytes in result:
+                        await self._send_frame(websocket, frame_bytes)
+                else:
+                    await self._send_frame(websocket, result)
                 session.generate_chunk_completed()
 
             except Exception as e:

--- a/vllm_omni/entrypoints/openai/serving_realtime_video.py
+++ b/vllm_omni/entrypoints/openai/serving_realtime_video.py
@@ -79,22 +79,20 @@ class GenerateSession:
         return len(self.video_frame_queue) >= self.required_video_frames
 
     def sample_video_frames_bytes(self) -> list[bytes] | None:
-        """Sample and encode frames from the queue as JPEG bytes for RPC."""
-        pending = list(self.video_frame_queue)
-        self.video_frame_queue.clear()
-        required = self.required_video_frames
+        """Pop exactly the required number of frames from the queue.
 
-        if len(pending) < required:
+        Only consumes `required_video_frames` frames, leaving the rest
+        for subsequent blocks. This avoids discarding buffered frames
+        when the client sends ahead.
+        """
+        required = self.required_video_frames
+        if len(self.video_frame_queue) < required:
             return None
 
-        if len(pending) > required:
-            indices = np.round(
-                np.linspace(0, len(pending) - 1, required)
-            ).astype(int)
-            pending = [pending[i] for i in indices]
+        frames = [self.video_frame_queue.popleft() for _ in range(required)]
 
         result = []
-        for frame_bytes in pending:
+        for frame_bytes in frames:
             if isinstance(frame_bytes, bytes):
                 result.append(frame_bytes)
             elif Image is not None:

--- a/vllm_omni/entrypoints/openai/serving_realtime_video.py
+++ b/vllm_omni/entrypoints/openai/serving_realtime_video.py
@@ -45,8 +45,7 @@ logger = logging.getLogger(__name__)
 
 _CONFIG_TIMEOUT = 30.0
 _FRAME_WAIT_INTERVAL = 0.01
-_FIRST_BLOCK_ENCODE_FRAMES = 9
-_NEXT_BLOCK_ENCODE_FRAMES = 12
+_VAE_TEMPORAL_COMPRESSION = 4
 
 
 class GenerateSession:
@@ -63,15 +62,18 @@ class GenerateSession:
         self.height: int = 480
         self.width: int = 832
         self.num_inference_steps: int | None = None
+        self.num_frames_per_block: int = 3
         self.action_queue: deque = deque(maxlen=1)
         self.video_frame_queue: deque = deque(maxlen=256)
         self.generate_chunk_cnt: int = 0
 
     @property
     def required_video_frames(self) -> int:
+        n = self.num_frames_per_block
+        r = _VAE_TEMPORAL_COMPRESSION
         if self.generate_chunk_cnt == 0:
-            return _FIRST_BLOCK_ENCODE_FRAMES
-        return _NEXT_BLOCK_ENCODE_FRAMES
+            return (n - 1) * r + 1
+        return n * r
 
     def has_pending_video_frames(self) -> bool:
         return len(self.video_frame_queue) >= self.required_video_frames
@@ -156,6 +158,7 @@ class RealtimeVideoHandler:
             session.height = config.get("height", 480)
             session.width = config.get("width", 832)
             session.num_inference_steps = config.get("num_inference_steps")
+            session.num_frames_per_block = config.get("num_frames_per_block", 3)
 
             if session.mode == "t2v" and config.get("first_frame"):
                 await self._send_error(

--- a/vllm_omni/entrypoints/openai/serving_realtime_video.py
+++ b/vllm_omni/entrypoints/openai/serving_realtime_video.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""WebSocket handler for realtime video streaming.
+
+Supports both text-to-video (T2V) and video-to-video (V2V) streaming.
+Uses MessagePack binary protocol for efficient frame transfer.
+GPU work is delegated to DiffusionWorker via collective_rpc.
+
+Protocol:
+    Client -> Server:
+        {"type": "config", "mode": "t2v"|"v2v", "prompt": "...", ...}
+        {"type": "prompt", "content": "new prompt"}
+        {"type": "video", "frames": [bytes, ...]}
+
+    Server -> Client:
+        {"type": "frame", "content": bytes}
+        {"type": "status", "content": "..."}
+        {"type": "error", "content": "..."}
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+from collections import deque
+from typing import Any
+from uuid import uuid4
+
+import numpy as np
+from fastapi import WebSocket, WebSocketDisconnect
+
+try:
+    from msgpack import packb, unpackb
+except ImportError:
+    packb = None
+    unpackb = None
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_TIMEOUT = 30.0
+_FRAME_WAIT_INTERVAL = 0.01
+_FIRST_BLOCK_ENCODE_FRAMES = 9
+_NEXT_BLOCK_ENCODE_FRAMES = 12
+
+
+class GenerateSession:
+    """Session state for a single WebSocket realtime video connection.
+
+    Only holds API-layer state. GPU-side state (KV caches, latents,
+    decoder cache) is managed by the worker via session_id.
+    """
+
+    def __init__(self) -> None:
+        self.id: str = uuid4().hex
+        self.mode: str | None = None
+        self.prompt: str | None = None
+        self.height: int = 480
+        self.width: int = 832
+        self.num_inference_steps: int | None = None
+        self.action_queue: deque = deque(maxlen=1)
+        self.video_frame_queue: deque = deque(maxlen=256)
+        self.generate_chunk_cnt: int = 0
+
+    @property
+    def required_video_frames(self) -> int:
+        if self.generate_chunk_cnt == 0:
+            return _FIRST_BLOCK_ENCODE_FRAMES
+        return _NEXT_BLOCK_ENCODE_FRAMES
+
+    def has_pending_video_frames(self) -> bool:
+        return len(self.video_frame_queue) >= self.required_video_frames
+
+    def sample_video_frames_bytes(self) -> list[bytes] | None:
+        """Sample and encode frames from the queue as JPEG bytes for RPC."""
+        pending = list(self.video_frame_queue)
+        self.video_frame_queue.clear()
+        required = self.required_video_frames
+
+        if len(pending) < required:
+            return None
+
+        if len(pending) > required:
+            indices = np.round(
+                np.linspace(0, len(pending) - 1, required)
+            ).astype(int)
+            pending = [pending[i] for i in indices]
+
+        result = []
+        for frame_bytes in pending:
+            if isinstance(frame_bytes, bytes):
+                result.append(frame_bytes)
+            elif Image is not None:
+                buf = io.BytesIO()
+                frame_bytes.save(buf, format="JPEG", quality=90)
+                result.append(buf.getvalue())
+        return result
+
+    def get_current_prompt(self) -> str:
+        if self.action_queue:
+            action = self.action_queue.popleft()
+            self.prompt = action
+        return self.prompt
+
+    def generate_chunk_completed(self) -> None:
+        self.generate_chunk_cnt += 1
+
+    def dispose(self) -> None:
+        self.action_queue.clear()
+        self.video_frame_queue.clear()
+
+
+class RealtimeVideoHandler:
+    """Handles WebSocket sessions for realtime video generation.
+
+    Delegates GPU work to DiffusionWorker via engine_client.collective_rpc().
+    """
+
+    def __init__(self, engine_client: Any) -> None:
+        self._engine = engine_client
+
+    async def _rpc(self, method: str, *args: Any) -> Any:
+        """Call a worker method via collective_rpc, return rank-0 result.
+
+        The result goes through multiple wrapping layers:
+          worker result → executor [result] → stage_client [result] →
+          orchestrator [[result]] → AsyncOmni [[result]]
+        We unwrap until we reach a non-list scalar.
+        """
+        results = await self._engine.collective_rpc(
+            method=method, args=args
+        )
+        # Unwrap nested list layers: [[value]] → [value] → value
+        while isinstance(results, list) and len(results) == 1:
+            results = results[0]
+        return results
+
+    async def handle_session(self, websocket: WebSocket) -> None:
+        """Main session handler for a WebSocket connection."""
+        await websocket.accept()
+        session = GenerateSession()
+        worker_session_created = False
+
+        try:
+            config = await self._receive_config(websocket)
+            if config is None:
+                return
+
+            session.mode = config.get("mode", "t2v")
+            session.prompt = config.get("prompt", "")
+            session.height = config.get("height", 480)
+            session.width = config.get("width", 832)
+            session.num_inference_steps = config.get("num_inference_steps")
+
+            if session.mode == "t2v" and config.get("first_frame"):
+                await self._send_error(
+                    websocket, "first_frame not allowed in T2V mode"
+                )
+                return
+
+            await self._rpc(
+                "realtime_create_session",
+                session.id,
+                {
+                    "num_frames_per_block": config.get("num_frames_per_block", 1),
+                    "kv_cache_num_frames": config.get("kv_cache_num_frames", 12),
+                },
+            )
+            worker_session_created = True
+
+            await self._send_status(websocket, "session_started")
+
+            gen_task = asyncio.create_task(
+                self._generate_loop(websocket, session)
+            )
+            listen_task = asyncio.create_task(
+                self._listen_actions(websocket, session)
+            )
+
+            done, pending = await asyncio.wait(
+                {gen_task, listen_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in pending:
+                task.cancel()
+            for task in done:
+                if task.exception():
+                    logger.error(
+                        "Session %s task error: %s",
+                        session.id,
+                        task.exception(),
+                    )
+
+        except WebSocketDisconnect:
+            logger.info("Session %s disconnected", session.id)
+        except Exception as e:
+            logger.error("Session %s error: %s", session.id, e)
+            try:
+                await self._send_error(websocket, str(e))
+            except Exception:
+                pass
+        finally:
+            if worker_session_created:
+                try:
+                    await self._rpc("realtime_dispose_session", session.id)
+                except Exception:
+                    logger.warning(
+                        "Session %s: failed to dispose worker session",
+                        session.id,
+                    )
+            session.dispose()
+
+    async def _receive_config(self, websocket: WebSocket) -> dict | None:
+        """Wait for initial config message."""
+        try:
+            data = await asyncio.wait_for(
+                websocket.receive_bytes(), timeout=_CONFIG_TIMEOUT
+            )
+            if unpackb is not None:
+                msg = unpackb(data, raw=False)
+            else:
+                import json
+
+                msg = json.loads(data)
+
+            if not isinstance(msg, dict) or msg.get("type") != "config":
+                await self._send_error(
+                    websocket,
+                    'Expected {"type": "config", ...} as first message',
+                )
+                return None
+            return msg
+        except asyncio.TimeoutError:
+            await self._send_error(websocket, "Config timeout")
+            return None
+        except Exception as e:
+            await self._send_error(websocket, f"Config parse error: {e}")
+            return None
+
+    async def _generate_loop(
+        self,
+        websocket: WebSocket,
+        session: GenerateSession,
+    ) -> None:
+        """Main generation loop: produces video blocks continuously."""
+        while True:
+            is_v2v = session.mode == "v2v"
+
+            if is_v2v:
+                while not session.has_pending_video_frames():
+                    await asyncio.sleep(_FRAME_WAIT_INTERVAL)
+
+            prompt = session.get_current_prompt()
+
+            video_frames_bytes = None
+            if is_v2v:
+                video_frames_bytes = session.sample_video_frames_bytes()
+                if video_frames_bytes is None:
+                    continue
+
+            try:
+                frame_bytes = await self._rpc(
+                    "realtime_generate_block",
+                    session.id,
+                    prompt,
+                    session.height,
+                    session.width,
+                    session.num_inference_steps,
+                    video_frames_bytes,
+                )
+
+                await self._send_frame(websocket, frame_bytes)
+                session.generate_chunk_completed()
+
+            except Exception as e:
+                logger.error(
+                    "Session %s generation error at block %d: %s",
+                    session.id,
+                    session.generate_chunk_cnt,
+                    e,
+                )
+                await self._send_error(websocket, f"Generation error: {e}")
+                break
+
+    async def _listen_actions(
+        self,
+        websocket: WebSocket,
+        session: GenerateSession,
+    ) -> None:
+        """Listen for prompt/video updates from client."""
+        async for data in websocket.iter_bytes():
+            try:
+                if unpackb is not None:
+                    msg = unpackb(data, raw=False)
+                else:
+                    import json
+
+                    msg = json.loads(data)
+
+                if not isinstance(msg, dict):
+                    continue
+
+                msg_type = msg.get("type")
+
+                if msg_type == "prompt":
+                    content = msg.get("content", "")
+                    if isinstance(content, str) and content.strip():
+                        session.action_queue.append(content.strip())
+
+                elif msg_type == "video":
+                    if session.mode != "v2v":
+                        await self._send_error(
+                            websocket,
+                            "Video frames only accepted in V2V mode",
+                        )
+                        continue
+                    frames_data = msg.get("frames", [])
+                    if frames_data:
+                        session.video_frame_queue.extend(frames_data)
+
+            except Exception as e:
+                logger.warning(
+                    "Session %s action parse error: %s", session.id, e
+                )
+
+    async def _send_frame(
+        self, websocket: WebSocket, content: bytes
+    ) -> None:
+        msg = {"type": "frame", "content": content}
+        if packb is not None:
+            await websocket.send_bytes(packb(msg, use_bin_type=True))
+        else:
+            await websocket.send_bytes(content)
+
+    async def _send_status(
+        self, websocket: WebSocket, status: str
+    ) -> None:
+        msg = {"type": "status", "content": status}
+        if packb is not None:
+            await websocket.send_bytes(packb(msg, use_bin_type=True))
+        else:
+            import json
+
+            await websocket.send_text(json.dumps(msg))
+
+    async def _send_error(
+        self, websocket: WebSocket, error: str
+    ) -> None:
+        msg = {"type": "error", "content": error}
+        try:
+            if packb is not None:
+                await websocket.send_bytes(packb(msg, use_bin_type=True))
+            else:
+                import json
+
+                await websocket.send_text(json.dumps(msg))
+        except Exception:
+            pass

--- a/vllm_omni/entrypoints/openai/serving_realtime_video.py
+++ b/vllm_omni/entrypoints/openai/serving_realtime_video.py
@@ -170,6 +170,7 @@ class RealtimeVideoHandler:
                 {
                     "num_frames_per_block": config.get("num_frames_per_block", 3),
                     "kv_cache_num_frames": config.get("kv_cache_num_frames", 3),
+                    "v2v_strength": config.get("v2v_strength"),
                 },
             )
             worker_session_created = True


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
To support realtime video input/output generation, we decide to support realtime API in vllm-omni
like models: krea-realtime-video
https://www.modelscope.cn/models/IPostYellow/krea-realtime-video-diffusers/summary
 
## Test Plan
start vllm-omni:
vllm serve /vllm-workspace/models/krea-realtime-video-diffusers/ --omni --port 8000 --tensor_parallel_size 2

V2V:
orig video:

https://github.com/user-attachments/assets/73b22c99-20f0-44ae-9640-c1469e953509

`python tests/test_realtime_e2e_client.py --mode v2v --video car.mp4 --blocks  11 --prompt "Same car as the original video, keep the car completely unchanged (exact body shape, paint color, logos, wheels, windows, reflections, proportions). Keep the original camera motion and framing. Transform only the road and surroundings into a snowy mountain highway: snow-covered asphalt, icy texture, snowbanks/guardrails, distant snowy mountains, cold winter color palette. Photorealistic, match the original lighting direction and shadows, stable details, no flicker." --save-dir /tmp/v2v_out --strength 0.6`

output:
use below scripts to encode jpgs to mp4:
`import cv2
import os
import glob
# 配置参数
#image_folder = "/tmp/realtime_prompt_change/"  # 图片文件夹路径
#image_folder = "/tmp/realtime_frames/"  # 图片文件夹路径
image_folder = "/tmp/v2v_out/"  # 图片文件夹路径

video_name = "output.mp4"        # 输出视频文件名
fps = 24                        # 帧率（根据需求调整）
frame_size = (832, 480)       # 视频分辨率（需与图片一致）
# 获取所有 JPEG 图片（按文件名排序）
images = sorted(glob.glob(os.path.join(image_folder, "*.png")))  # 或 *.jpeg
print(f"{images=}")
if not images:
    raise ValueError("未找到 JPEG 图片！")
# 创建视频写入对象
fourcc = cv2.VideoWriter_fourcc(*'mp4v')  # 编码格式：'mp4v' 或 'avc1'
video_writer = cv2.VideoWriter(video_name, fourcc, fps, frame_size)
# 逐帧写入
for img_path in images:
    frame = cv2.imread(img_path)
    if frame is None:
        continue
    # 若图片尺寸不统一，需调整大小
    if (frame.shape[1], frame.shape[0]) != frame_size:
        frame = cv2.resize(frame, frame_size)
    video_writer.write(frame)
video_writer.release()
print(f"视频已保存至: {os.path.abspath(video_name)}")`

T2V：
python /vllm-workspace/vllm-omni/tests/test_realtime_e2e_client.py  --prompt "A serene ocean with gentle waves" --blocks 33 --change-prompt-at 3 --new-prompt "A rocket launching from the water serface into the sky with flames then only could see the rocket and the sky" --save-dir /tmp/realtime_frames


## Test Result
V2V：
输出视频

https://github.com/user-attachments/assets/44954841-7090-4af3-8c38-c977c2228312

T2V：
输出视频：

https://github.com/user-attachments/assets/293044f1-6858-4dea-bb7b-6278fb6cfb83




---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>
API:
Realtime Video Streaming API                                       
  Endpoint                                                                                                                                                                                                                                                                   
  ws://{host}:{port}/v1/realtime_video/generate                                                                                                                                                                                                                              
  传输协议:                               
- 编码格式：MessagePack 二进制（推荐），或 JSON fallback
- 所有消息均通过 websocket.send_bytes() / websocket.receive_bytes() 传输

Porformence:
Test in 2*H20-3e:
Block 12/12 | frame 141 | 111825 bytes | elapsed: 53.1s | 832x480 RGB | saved: /tmp/realtime_frames/frame_0141.png

Next: optimize the performance, and TP-size 


</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
