### PR TITLE
[Bugfix][Perf] Fix compile-compatible hidden state capture for Qwen3-Omni

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -368,8 +368,12 @@ class Qwen3OmniMoeForConditionalGeneration(
             captured_layer_dict = None
             if accept_layer is not None and aux_hidden_states is not None:
                 captured_layer_dict = {
-                    str(layer_idx): hidden_state
-                    for layer_idx, hidden_state in zip((0, int(accept_layer)), aux_hidden_states)
+                    "hidden_states": {
+                        "layers": {
+                            layer_idx: hidden_state
+                            for layer_idx, hidden_state in zip((0, int(accept_layer)), aux_hidden_states)
+                        }
+                    }
                 }
             return text_hidden_states, captured_layer_dict
 

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -141,6 +141,9 @@ class Qwen3OmniMoeForConditionalGeneration(
                 architectures=["Qwen3OmniMoeThinkerForConditionalGeneration"],
             )
             self.model = self.thinker
+            accept_layer = getattr(talker_config, "accept_hidden_layer", None)
+            if accept_layer is not None:
+                self.thinker.language_model.model._set_aux_hidden_state_layers((0, int(accept_layer)))
             self.talker = None
             self.code2wav = None
             self.tts_tokens = torch.tensor(
@@ -352,25 +355,22 @@ class Qwen3OmniMoeForConditionalGeneration(
             if inputs_embeds is not None and inputs_embeds.device != thinker_dev:
                 inputs_embeds = inputs_embeds.to(thinker_dev)
 
-            # Run thinker forward
-            # If talker expects a specific intermediate layer, capture it here
             accept_layer = getattr(self.talker_config, "accept_hidden_layer", None)
-            capture_kwargs = {}
-            if accept_layer is not None:
-                capture_kwargs = {
-                    "capture_layer_indices": [0, int(accept_layer)],
-                    "return_hidden_states": True,
-                }
 
             # Run thinker
-            text_hidden_states, captured_layer_dict = self.thinker(
+            text_hidden_states, aux_hidden_states = self.thinker(
                 input_ids=input_ids,
                 positions=positions,
                 intermediate_tensors=intermediate_tensors,
                 inputs_embeds=inputs_embeds,
-                **capture_kwargs,
                 **kwargs,
             )
+            captured_layer_dict = None
+            if accept_layer is not None and aux_hidden_states is not None:
+                captured_layer_dict = {
+                    str(layer_idx): hidden_state
+                    for layer_idx, hidden_state in zip((0, int(accept_layer)), aux_hidden_states)
+                }
             return text_hidden_states, captured_layer_dict
 
         # ========== Stage 2.1: Talker ==========

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py
@@ -305,13 +305,17 @@ class Qwen3OmniMoeTalkerForConditionalGeneration(
         **kwargs: object,
     ) -> torch.Tensor | IntermediateTensors:
         """Forward pass through the talker model."""
-        talker_hidden_states, _ = self.language_model.model(
+        model_output = self.language_model.model(
             input_ids,
             positions,
             intermediate_tensors,
             inputs_embeds=inputs_embeds,
             **kwargs,
         )
+        if isinstance(model_output, tuple):
+            talker_hidden_states = model_output[0]
+        else:
+            talker_hidden_states = model_output
 
         return talker_hidden_states
 

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -523,10 +523,8 @@ class Qwen3MoeLLMModel(_Qwen3MoeLLMModel):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-        capture_layer_indices: Sequence[int] | None = None,
-        return_hidden_states: bool = False,
         deepstack_input_embeds: IntermediateTensors | None = None,
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -537,17 +535,11 @@ class Qwen3MoeLLMModel(_Qwen3MoeLLMModel):
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
-        capture_set = set(capture_layer_indices) if capture_layer_indices else None
-        captured_hidden_states: dict[str, torch.Tensor] | None = {} if return_hidden_states else None
+
+        aux_hidden_states = self._maybe_add_hidden_state([], self.start_layer, hidden_states, residual)
 
         for layer_idx, layer in enumerate(self.layers[self.start_layer : self.end_layer]):
             layer_idx = layer_idx + self.start_layer
-
-            if captured_hidden_states is not None and capture_set is not None:
-                if layer_idx in capture_set:
-                    hs = captured_hidden_states.setdefault("hidden_states", {})
-                    layers = hs.setdefault("layers", {})
-                    layers[layer_idx] = hidden_states.clone().view(-1, hidden_states.shape[-1])
 
             hidden_states, residual = layer(
                 positions,
@@ -558,13 +550,14 @@ class Qwen3MoeLLMModel(_Qwen3MoeLLMModel):
             if deepstack_input_embeds is not None and layer_idx in range(0, len(deepstack_input_embeds)):
                 hidden_states = hidden_states + deepstack_input_embeds[f"deepstack_input_embeds_{layer_idx}"]
 
+            self._maybe_add_hidden_state(aux_hidden_states, layer_idx + 1, hidden_states, residual)
+
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
         hidden_states, _ = self.norm(hidden_states, residual)
-        if captured_hidden_states is not None:
-            return hidden_states, captured_hidden_states
-        else:
-            return hidden_states, None
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
+        return hidden_states
 
 
 class Qwen3MoeLLMForCausalLM(Qwen3MoeForCausalLM):
@@ -1393,10 +1386,8 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-        capture_layer_indices: Sequence[int] | None = None,
-        return_hidden_states: bool = False,
         **kwargs: object,
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor] | None]:
         if intermediate_tensors is not None:
             inputs_embeds = None
 
@@ -1405,13 +1396,11 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
         else:
             deepstack_input_embeds = None
 
-        hidden_states, captured_hidden_states = self.language_model.model(
+        model_output = self.language_model.model(
             input_ids,
             positions,
             intermediate_tensors,
             inputs_embeds=inputs_embeds,
-            capture_layer_indices=capture_layer_indices,
-            return_hidden_states=return_hidden_states,
             # args for deepstack
             deepstack_input_embeds=deepstack_input_embeds,
         )
@@ -1419,7 +1408,13 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
         if inputs_embeds is not None and get_pp_group().is_first_rank:
             self._clear_deepstack_input_embeds(inputs_embeds.size(0))
 
-        return hidden_states, captured_hidden_states
+        if isinstance(model_output, tuple):
+            hidden_states, aux_hidden_states = model_output
+        else:
+            hidden_states = model_output
+            aux_hidden_states = None
+
+        return hidden_states, aux_hidden_states
 
     def compute_logits(
         self,

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
@@ -23,9 +23,9 @@ from vllm_omni.model_executor.stage_input_processors.tts_utils import (
 
 logger = logging.getLogger(__name__)
 
-# Pooling output layer keys: "0" = word embedding, "24" = accept_hidden_layer
-_EMBED_LAYER_KEY = "0"
-_HIDDEN_LAYER_KEY = "24"
+# Pooling output layer keys: 0 = word embedding, 24 = accept_hidden_layer
+_EMBED_LAYER_KEY = 0
+_HIDDEN_LAYER_KEY = 24
 
 
 def _compute_talker_prompt_ids_length(info: OmniPayload, device: torch.device | str = "cuda") -> int:
@@ -130,8 +130,8 @@ def _merge_pd_embeddings(
     """
     try:
         p_layers = prefill_mm.get("hidden_states", {}).get("layers", {})
-        p_emb = p_layers[int(_EMBED_LAYER_KEY)].detach().to(device=device, dtype=torch.float)
-        p_hid = p_layers[int(_HIDDEN_LAYER_KEY)].detach().to(device=device, dtype=torch.float)
+        p_emb = p_layers[_EMBED_LAYER_KEY].detach().to(device=device, dtype=torch.float)
+        p_hid = p_layers[_HIDDEN_LAYER_KEY].detach().to(device=device, dtype=torch.float)
     except (KeyError, AttributeError, TypeError) as exc:
         available_keys = list(prefill_mm.keys()) if isinstance(prefill_mm, dict) else type(prefill_mm).__name__
         logger.error(
@@ -312,13 +312,13 @@ def thinker2talker_async_chunk(
         prompt_token_ids = _ensure_list(prompt_token_ids)
         payload: OmniPayload = {
             "embed": {
-                "prefill": thinker_layers[int(_EMBED_LAYER_KEY)].detach().cpu(),
+                "prefill": thinker_layers[_EMBED_LAYER_KEY].detach().cpu(),
                 # Provide thinker-side TTS token embeddings for talker projection
                 "tts_bos": thinker_embed["tts_bos"].detach().cpu(),
                 "tts_eos": thinker_embed["tts_eos"].detach().cpu(),
                 "tts_pad": thinker_embed["tts_pad"].detach().cpu(),
             },
-            "hidden_states": {"output": thinker_layers[int(_HIDDEN_LAYER_KEY)].detach().cpu()},
+            "hidden_states": {"output": thinker_layers[_HIDDEN_LAYER_KEY].detach().cpu()},
             "ids": {"all": all_token_ids, "prompt": prompt_token_ids},
             "meta": {"finished": torch.tensor(is_finished, dtype=torch.bool)},
         }
@@ -366,12 +366,12 @@ def thinker2talker_async_chunk(
 
         if output_token_ids:
             talker_additional_info["meta"]["override_keys"] = [("embed", "decode"), ("ids", "output")]
-            talker_additional_info["embed"] = {"decode": thinker_layers[int(_EMBED_LAYER_KEY)].detach().cpu()}
+            talker_additional_info["embed"] = {"decode": thinker_layers[_EMBED_LAYER_KEY].detach().cpu()}
             talker_additional_info["ids"] = {"output": output_token_ids}
         else:
             # When prefilling a chunked thinker, thinker_hidden_states needs to be updated.
-            talker_additional_info["embed"] = {"prefill": thinker_layers[0].detach().cpu()}
-            talker_additional_info["hidden_states"] = {"output": thinker_layers[24].detach().cpu()}
+            talker_additional_info["embed"] = {"prefill": thinker_layers[_EMBED_LAYER_KEY].detach().cpu()}
+            talker_additional_info["hidden_states"] = {"output": thinker_layers[_HIDDEN_LAYER_KEY].detach().cpu()}
     return talker_additional_info
 
 
@@ -434,8 +434,8 @@ def thinker2talker(
         thinker_mm: OmniPayload = output.multimodal_output
         mm_hs = thinker_mm.get("hidden_states", {})
         mm_layers = mm_hs.get("layers", {})
-        thinker_emb = mm_layers[int(_EMBED_LAYER_KEY)].detach().to(device=device, dtype=torch.float)[-new_seq_length:]
-        thinker_hid = mm_layers[int(_HIDDEN_LAYER_KEY)].detach().to(device=device, dtype=torch.float)[-new_seq_length:]
+        thinker_emb = mm_layers[_EMBED_LAYER_KEY].detach().to(device=device, dtype=torch.float)[-new_seq_length:]
+        thinker_hid = mm_layers[_HIDDEN_LAYER_KEY].detach().to(device=device, dtype=torch.float)[-new_seq_length:]
 
         prefill_mm: dict[str, Any] | None = None
         if prefill_stage is not None:


### PR DESCRIPTION
## Summary

- Restore compile-compatible auxiliary hidden state capture in Qwen3 Omni thinker using `EagleModelMixin._maybe_add_hidden_state`.
- Remove the ad hoc `capture_layer_indices` / `return_hidden_states` path from Qwen3 Omni model execution.
- Configure thinker hidden-state capture from `talker_config.accept_hidden_layer`.
- Preserve the existing downstream `captured_layer_dict` format outside the compiled model path.
- Make Qwen3 Omni talker tolerate both tensor and tuple returns from `language_model.model()`.

## Verification

- Ran `python -m py_compile` on the updated Qwen3 Omni model files.
- Confirmed the old capture parameters are no longer present under `vllm_omni/model_executor/models/qwen3_omni`.

Before:

<img width="1491" height="831" alt="image" src="https://github.com/user-attachments/assets/973e8730-49de-42bf-a4fc-ab0776b4e18b" />

After:

<img width="664" height="516" alt="image" src="https://github.com/user-attachments/assets/33f209f9-3dc9-455e-89bb-5091b7287156" />
