### PR TITLE
[Bugfix] Fix Wan RMSNorm patch module iteration

### DIFF
--- a/vllm_omni/diffusion/models/wan2_2/patch_diffusers.py
+++ b/vllm_omni/diffusion/models/wan2_2/patch_diffusers.py
@@ -9,6 +9,7 @@ from vllm_omni.diffusion.layers.norm import RMSNormVAE
 def patch_wan_rms_norm():
     """Patch diffusers Wan RMSNorm implementation with RMSNormVAE."""
 
-    for module_name, module in sys.modules.items():
-        if hasattr(module, "WanRMS_norm"):
+    for module_name, module in list(sys.modules.items()):
+        module_dict = getattr(module, "__dict__", None)
+        if module_dict is not None and "WanRMS_norm" in module_dict:
             setattr(module, "WanRMS_norm", RMSNormVAE)


### PR DESCRIPTION
## Summary

- Snapshot `sys.modules.items()` before patching Wan RMSNorm implementations.

## Root Cause

In file `patch_diffusers.py`. It occured an error when starting the Wan2.2 model.

```
   File "/xxx/vllm-omni-profiling/vllm_omni/diffusion/models/wan2_2/__init__.py", line 56, in <module>
     patch_wan_rms_norm()
   File "/xxx/vllm-omni-profiling/vllm_omni/diffusion/models/wan2_2/patch_diffusers.py", line 12, in patch_wan_rms_norm
     for module_name, module in sys.modules.items():
 RuntimeError: dictionary changed size during iteration
```

`patch_wan_rms_norm()` iterates over `sys.modules` while checking each module for `WanRMS_norm`. Some modules can lazily import additional modules during attribute lookup, which mutates `sys.modules` and can raise `RuntimeError: dictionary changed size during iteration`.

## Impact

This keeps Wan2.2 startup patching stable when lazy imports occur during the diffusers patch scan.

## Validation

- `python -m py_compile vllm_omni/diffusion/models/wan2_2/patch_diffusers.py`

Note: pytest was not run because the current environment is missing `torch`, which prevents pytest plugin initialization.