### PR TITLE
[Bugfix] Fix stage device mapping failure when logical IDs exceed visible device count

### DIFF
--- a/tests/entrypoints/test_stage_utils.py
+++ b/tests/entrypoints/test_stage_utils.py
@@ -98,6 +98,32 @@ def test_set_stage_devices_handles_not_enough_devices(mocker: MockerFixture, mon
     assert os.environ["CUDA_VISIBLE_DEVICES"] == "6,7"
 
 
+@pytest.mark.core_model
+@pytest.mark.cpu
+@pytest.mark.usefixtures("clean_gpu_memory_between_tests")
+def test_set_stage_devices_value_based_fallback(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch):
+    # When a process is spawned with CUDA_VISIBLE_DEVICES="2,3" (e.g. for a
+    # second stage in multi-process mode) and the YAML specifies absolute device
+    # IDs that match those values (devices="2,3"), the index-based path fails
+    # because logical IDs [2,3] exceed the visible list length (2).  The
+    # value-based fallback should recognise that "2" and "3" are present in the
+    # visible set and map them directly.
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
+    call_log: list[int] = []
+    dummy_torch = _make_dummy_torch(call_log)
+    monkeypatch.setitem(sys.modules, "torch", dummy_torch)
+
+    mock_platform = _make_mock_platform(mocker, device_type="cuda", env_var="CUDA_VISIBLE_DEVICES")
+    monkeypatch.setattr(
+        "vllm_omni.platforms.current_omni_platform",
+        mock_platform,
+    )
+
+    set_stage_devices(stage_id=1, devices="2,3")
+
+    mock_platform.set_device_control_env_var.assert_called_once_with("2,3")
+
+
 @pytest.mark.usefixtures("clean_gpu_memory_between_tests")
 def test_set_stage_devices_npu_platform(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch):
     """Test that set_stage_devices works correctly for NPU platform."""

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -96,6 +96,14 @@ logger = init_logger(__name__)
 
 _STARTUP_POLL_INTERVAL_S = 1.0
 
+# Process-global lock serialising the CUDA_VISIBLE_DEVICES save/set/spawn/restore
+# critical section across ALL AsyncOmniEngine instances in this process.  A per-
+# instance lock (the previous design) allowed concurrent engine inits (e.g. DP
+# replicas) to race on os.environ, causing one instance to save a value already
+# mutated by another and then restore it incorrectly, leading to the
+# "Stage N has logical IDs … none of which map to visible devices" crash.
+_STAGE_LAUNCH_LOCK = threading.Lock()
+
 
 # ============================================================================
 # Parent-EngineArgs field-routing contracts (consumed by
@@ -691,7 +699,7 @@ class AsyncOmniEngine:
         llm_stage_positions: list[int] = []
         llm_launch_futures: dict[int, concurrent.futures.Future[StartedLlmStage]] = {}
         started_llm_stages: dict[int, StartedLlmStage] = {}
-        llm_stage_launch_lock = threading.Lock()
+        llm_stage_launch_lock = _STAGE_LAUNCH_LOCK
 
         async_chunk = self.async_chunk
         prompt_expand_func = None

--- a/vllm_omni/entrypoints/stage_utils.py
+++ b/vllm_omni/entrypoints/stage_utils.py
@@ -118,7 +118,10 @@ def _map_device_list(stage_id: int, device_list: list[str], visible_device_list:
             logger.debug(
                 "Stage %s: logical IDs %s all exceed visible device count (%d); "
                 "falling back to direct physical-ID matching against %s",
-                stage_id, device_list, num_visible, visible_device_list,
+                stage_id,
+                device_list,
+                num_visible,
+                visible_device_list,
             )
     if not mapped_devices:
         raise ValueError(

--- a/vllm_omni/entrypoints/stage_utils.py
+++ b/vllm_omni/entrypoints/stage_utils.py
@@ -96,10 +96,30 @@ def _map_device_list(stage_id: int, device_list: list[str], visible_device_list:
         raise ValueError("Logical devices must be non-negative integers")
 
     logical_ids = [int(device) for device in device_list]
-    mapped_devices = [visible_device_list[idx] for idx in logical_ids if idx < num_visible]
-    mapping_pairs = [
-        f"{logical_id}->{visible_device_list[logical_id]}" for logical_id in logical_ids if logical_id < num_visible
-    ]
+
+    # Primary path: index-based mapping (logical ID is an index into visible_device_list).
+    index_mapped = [(lid, visible_device_list[lid]) for lid in logical_ids if lid < num_visible]
+
+    if index_mapped:
+        mapped_devices = [phys for _, phys in index_mapped]
+        mapping_pairs = [f"{lid}->{phys}" for lid, phys in index_mapped]
+    else:
+        # Fallback: value-based matching.  Handles deploy configs that use absolute
+        # physical device IDs when the process CUDA_VISIBLE_DEVICES is already
+        # restricted to the target subset (e.g. stage process spawned with
+        # CUDA_VISIBLE_DEVICES="2,3" and YAML specifies devices="2,3").
+        # Only activated when *no* ID fits as an index, avoiding mixed-mode
+        # interpretation that could silently map two IDs to the same GPU.
+        visible_set = set(visible_device_list)
+        value_mapped = [(lid, str(lid)) for lid in logical_ids if str(lid) in visible_set]
+        mapped_devices = [phys for _, phys in value_mapped]
+        mapping_pairs = [f"{lid}->{phys}(direct)" for lid, phys in value_mapped]
+        if mapped_devices:
+            logger.debug(
+                "Stage %s: logical IDs %s all exceed visible device count (%d); "
+                "falling back to direct physical-ID matching against %s",
+                stage_id, device_list, num_visible, visible_device_list,
+            )
     if not mapped_devices:
         raise ValueError(
             f"Stage {stage_id} has logical IDs {device_list}, none of which map to the visible devices "


### PR DESCRIPTION
  ## Summary

  Fix a `ValueError` in stage device initialisation that occurs when multiple
  `AsyncOmniEngine` instances start concurrently (e.g. data-parallel replicas),
  and as a defence-in-depth also handle deploy configs that specify absolute
  device IDs when `CUDA_VISIBLE_DEVICES` is already restricted to that subset.

  ## Root Cause

  **Primary — race condition on `CUDA_VISIBLE_DEVICES`**

  `_initialize_stages` created `llm_stage_launch_lock = threading.Lock()` as a
  local variable, so each engine instance held its own independent lock.  The
  save/set/spawn/restore sequence on `os.environ["CUDA_VISIBLE_DEVICES"]` was
  not serialised across concurrent engines:

  1. Engine A stage 1 saves `"0,1,2,3"`, sets `"2,3"`, spawns (in progress)
  2. Engine B stage 0 saves `"2,3"` ← polluted by Engine A → maps `[0,1]`
     against `["2","3"]` → `0→2, 1→3` → spawns → restores to `"2,3"` (wrong)
  3. Engine A stage 1 restores `"0,1,2,3"`
  4. Engine B stage 1: `visible=["2","3"]`, `logical=["2","3"]`, both indices
     OOB → raises:

  ValueError: Stage 1 has logical IDs ['2', '3'], none of which map to
  the visible devices ['2', '3']

  **Secondary — `_map_device_list` index-only mapping**

  Even without the race, when a stage process is spawned with
  `CUDA_VISIBLE_DEVICES=2,3` and the deploy config specifies `devices: "2,3"`,
  logical IDs `[2, 3]` are used as indices into a 2-element list — both exceed
  the list length — so `mapped_devices` is empty and the same error is raised.

  ## Fix

  **Primary:** Promote the lock to a module-level singleton `_STAGE_LAUNCH_LOCK`
  in `async_omni_engine.py`.  All engine instances in the same process share one
  lock, serialising the critical section and eliminating the race.  The slow
  HELLO/READY handshake already runs outside the lock, so the cost is limited to
  the brief fork window only.

  **Secondary:** Add a value-based fallback in `_map_device_list`: when no
  logical ID fits as an index (`all lids >= num_visible`), check whether their
  string representations exist as values in `visible_device_list` and map them
  directly.  The index-based path is always tried first, preserving backward
  compatibility.

  ## Test

  `test_set_stage_devices_value_based_fallback` in
  `tests/entrypoints/test_stage_utils.py` covers the exact failure scenario:
  `CUDA_VISIBLE_DEVICES=2,3` with `devices="2,3"`.