### PR TITLE
[Bugfix][CI] fix file name too long error in  Omni · Doc Test with H100

### DIFF
--- a/tests/examples/helpers.py
+++ b/tests/examples/helpers.py
@@ -351,3 +351,33 @@ def strip_trailing_audio_saved_line(text: str) -> str:
     while lines and lines[-1].strip().startswith("Audio saved to"):
         lines.pop()
     return "\n".join(lines).strip()
+
+
+def strip_audio_saved_to_lines(text: str) -> str:
+    """Remove every line starting with ``Audio saved to`` (streaming prints one per chunk).
+
+    Without this, :func:`extract_content_after_keyword` with ``content:`` and ``DOTALL``
+    keeps those lines inside the captured text segment.
+    """
+    lines = [ln for ln in text.splitlines() if not ln.strip().startswith("Audio saved to")]
+    return "\n".join(lines).strip()
+
+
+def extract_last_audio_saved_path(text: str) -> str:
+    """Return the filesystem path from the last ``Audio saved to`` line.
+
+    Non-streaming output has a single line; streaming prints one path per chunk.
+    Do not use :func:`extract_content_after_keyword` with ``Audio saved to`` for
+    streaming: greedy ``.+`` under ``DOTALL`` concatenates every path and body into one
+    invalid string (Linux ``File name too long`` when opening it as a path).
+    """
+    last_path: str | None = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Audio saved to"):
+            rest = stripped[len("Audio saved to") :].strip()
+            if rest:
+                last_path = rest
+    if last_path is None:
+        raise AssertionError("'Audio saved to' line with a path not found in command output")
+    return last_path

--- a/tests/examples/online_serving/test_qwen2_5_omni.py
+++ b/tests/examples/online_serving/test_qwen2_5_omni.py
@@ -10,7 +10,9 @@ import pytest
 
 from tests.examples.helpers import (
     extract_content_after_keyword,
+    extract_last_audio_saved_path,
     run_cmd,
+    strip_audio_saved_to_lines,
     strip_trailing_audio_saved_line,
 )
 from tests.helpers.mark import hardware_test
@@ -55,8 +57,8 @@ def test_send_multimodal_request_001(omni_server) -> None:
     text_content = strip_trailing_audio_saved_line(text_content_tmp)
 
     # Verify text output same as audio output
-    wav_path = extract_content_after_keyword("Audio saved to", result)
-    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path.strip()}")
+    wav_path = extract_last_audio_saved_path(result)
+    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path}")
     print(f"text content is: {text_content}")
     print(f"audio content is: {audio_content}")
 
@@ -91,8 +93,8 @@ def test_send_multimodal_request_002(omni_server) -> None:
     text_content = strip_trailing_audio_saved_line(text_content_tmp)
 
     # Verify text output same as audio output
-    wav_path = extract_content_after_keyword("Audio saved to", result)
-    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path.strip()}")
+    wav_path = extract_last_audio_saved_path(result)
+    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path}")
     print(f"text content is: {text_content}")
     assert all(keyword in text_content for keyword in ["baby", "book"]), (
         "The output does not contain any of the keywords in video description."
@@ -176,8 +178,8 @@ def test_modality_control_002(omni_server) -> None:
 
     result = run_cmd(command)
     # Verify text output same as audio output
-    wav_path = extract_content_after_keyword("Audio saved to", result)
-    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path.strip()}")
+    wav_path = extract_last_audio_saved_path(result)
+    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path}")
     print(f"audio content is: {audio_content}")
     assert all(keyword in audio_content for keyword in ["baby", "book"]), (
         "The output does not contain any of the keywords in video description."
@@ -207,8 +209,8 @@ def test_modality_control_003(omni_server) -> None:
     text_content = strip_trailing_audio_saved_line(text_content_tmp)
 
     # Verify text output same as audio output
-    wav_path = extract_content_after_keyword("Audio saved to", result)
-    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path.strip()}")
+    wav_path = extract_last_audio_saved_path(result)
+    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path}")
     print(f"text content is: {text_content}")
     assert all(keyword in text_content for keyword in ["baby", "book"]), (
         "The output does not contain any of the keywords in video description."
@@ -239,11 +241,11 @@ def test_stream_001(omni_server) -> None:
     result = run_cmd(command)
 
     text_content_tmp = extract_content_after_keyword("content:", result)
-    text_content = strip_trailing_audio_saved_line(text_content_tmp)
+    text_content = strip_audio_saved_to_lines(text_content_tmp)
 
     # Verify text output same as audio output
-    wav_path = extract_content_after_keyword("Audio saved to", result)
-    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path.strip()}")
+    wav_path = extract_last_audio_saved_path(result)
+    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path}")
     print(f"text content is: {text_content}")
     assert all(keyword in text_content for keyword in ["baby", "book"]), (
         "The output does not contain any of the keywords in video description."

--- a/tests/examples/online_serving/test_qwen3_omni.py
+++ b/tests/examples/online_serving/test_qwen3_omni.py
@@ -10,7 +10,9 @@ import pytest
 
 from tests.examples.helpers import (
     extract_content_after_keyword,
+    extract_last_audio_saved_path,
     run_cmd,
+    strip_audio_saved_to_lines,
     strip_trailing_audio_saved_line,
 )
 from tests.helpers.mark import hardware_test
@@ -51,9 +53,9 @@ def test_send_multimodal_request_001(omni_server) -> None:
     result = run_cmd(command)
     text_content_tmp = extract_content_after_keyword("Chat completion output from text:", result)
     text_content = strip_trailing_audio_saved_line(text_content_tmp)
-    wav_path = extract_content_after_keyword("Audio saved to", result)
+    wav_path = extract_last_audio_saved_path(result)
     # Verify text output same as audio output
-    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path.strip()}")
+    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path}")
     print(f"text content is: {text_content}")
     print(f"audio content is: {audio_content}")
 
@@ -83,8 +85,8 @@ def test_send_multimodal_request_002(omni_server) -> None:
     text_content = strip_trailing_audio_saved_line(text_content_tmp)
 
     # Verify text output same as audio output
-    wav_path = extract_content_after_keyword("Audio saved to", result)
-    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path.strip()}")
+    wav_path = extract_last_audio_saved_path(result)
+    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path}")
     print(f"text content is: {text_content}")
     print(f"audio content is: {audio_content}")
     assert all(keyword in text_content for keyword in ["baby", "book"]), (
@@ -148,8 +150,8 @@ def test_modality_control_002(omni_server) -> None:
 
     result = run_cmd(command)
     # Verify text output same as audio output
-    wav_path = extract_content_after_keyword("Audio saved to", result)
-    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path.strip()}")
+    wav_path = extract_last_audio_saved_path(result)
+    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path}")
     print(f"audio content is: {audio_content}")
     assert "cherry blossom" in audio_content, "The output does not contain any of the keywords."
 
@@ -174,8 +176,8 @@ def test_modality_control_003(omni_server) -> None:
     text_content = strip_trailing_audio_saved_line(text_content_tmp)
 
     # Verify text output same as audio output
-    wav_path = extract_content_after_keyword("Audio saved to", result)
-    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path.strip()}")
+    wav_path = extract_last_audio_saved_path(result)
+    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path}")
     print(f"text content is: {text_content}")
     assert "cherry blossom" in audio_content, "The output does not contain any of the keywords."
     print(f"audio content is: {audio_content}")
@@ -200,11 +202,11 @@ def test_stream_001(omni_server) -> None:
     result = run_cmd(command)
 
     text_content_tmp = extract_content_after_keyword("content:", result)
-    text_content = strip_trailing_audio_saved_line(text_content_tmp)
+    text_content = strip_audio_saved_to_lines(text_content_tmp)
 
     # Verify text output same as audio output
-    wav_path = extract_content_after_keyword("Audio saved to", result)
-    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path.strip()}")
+    wav_path = extract_last_audio_saved_path(result)
+    audio_content = convert_audio_file_to_text(output_path=f"./{wav_path}")
     print(f"text content is: {text_content}")
     assert "cherry blossom" in audio_content, "The output does not contain any of the keywords."
     print(f"audio content is: {audio_content}")


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
fix error in  [nightly ci-Omni · Doc Test with  H100](https://buildkite.com/vllm/vllm-omni/builds/8199/canvas?sid=019dd1cc-1d79-4c88-9235-1c06a49867df&tab=output)
- Introduced `strip_audio_saved_to_lines` to remove lines starting with "Audio saved to".
- Added `extract_last_audio_saved_path` to retrieve the last path from "Audio saved to" lines.
- Updated tests in `test_qwen2_5_omni.py` and `test_qwen3_omni.py` to utilize the new functions for improved handling of audio output.
## Test Plan
### run local
1.`pytest -sv tests/examples/online_serving/test_qwen2_5_omni.py -m full_model --run-level full_model`
2.`pytest -sv tests/examples/online_serving/test_qwen3_omni.py -m full_model --run-level full_model`

### run in ci
run omni-test
## Test Result
### local
<img width="2322" height="186" alt="009b6451ad2b85b6378c8440c0555e4d" src="https://github.com/user-attachments/assets/8ece0be8-83aa-4423-8c6d-795f74e36670" />
<img width="2328" height="80" alt="b59e0d39-2d29-4265-aa0d-858bd1013ee4" src="https://github.com/user-attachments/assets/36bc5b6a-3c9f-4ab5-a798-855572fd87d7" />

### ci
<img width="876" height="118" alt="afedc2a3-fc42-47fe-9453-8fb9d7fcf53f" src="https://github.com/user-attachments/assets/dbb457a6-3fad-44fb-a7f1-95fdaa6fa93a" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
