### PR TITLE
[Bugfix][CI] Enhance get_open_port function to handle port binding more robustly

### DIFF
--- a/tests/helpers/runtime.py
+++ b/tests/helpers/runtime.py
@@ -2,6 +2,7 @@
 
 import base64
 import concurrent.futures
+import errno
 import io
 import json
 import os
@@ -56,10 +57,37 @@ except Exception:  # pragma: no cover
         return None
 
 
-def get_open_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return int(s.getsockname()[1])
+def get_open_port(host: str = "127.0.0.1", *, max_attempts: int = 128) -> int:
+    """Return a local TCP port that is suitable for binding a new listener.
+
+    A single ``bind(host, 0)`` / close cycle leaves a race where another process can
+    take the same port number before PyTorch/vLLM bind it, yielding
+    ``EADDRINUSE`` / ``DistNetworkError``. We therefore:
+
+    #. Allocate an ephemeral port on *host*.
+    #. Immediately attempt ``bind(host, port)`` again. If that fails with
+       ``errno.EADDRINUSE``, retry from step 1.
+
+    Raises ``RuntimeError`` if no free port is found after *max_attempts* (e.g. port
+    exhaustion under heavy parallel tests).
+    """
+    last_exc: OSError | None = None
+    for _ in range(max_attempts):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((host, 0))
+            port = int(s.getsockname()[1])
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+                probe.bind((host, port))
+        except OSError as exc:
+            last_exc = exc
+            if exc.errno == errno.EADDRINUSE:
+                continue
+            raise
+        return port
+    raise RuntimeError(
+        f"Could not obtain a free TCP port on {host!r} after {max_attempts} attempts (last error: {last_exc!r})"
+    ) from last_exc
 
 
 def dummy_messages_from_mix_data(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
fix #2619 
Harden `tests/helpers/runtime.py::get_open_port()` so test harnesses (`OmniServer`, `OmniServerStageCli`, `OpenAIClientHandler`, etc.) are less likely to hit `EADDRINUSE` or `torch.distributed.DistNetworkError: address already in use`.
Previously the helper used `bind(host, 0)`, read the assigned port, then closed the socket before the child process bound the same port—another process could take that port in between. The new logic performs a second `bind(host, port)` (“probe”) immediately after; on `errno.EADDRINUSE` it retries with a fresh ephemeral allocation (default up to **`max_attempts=128`**). Other `OSError`s from the probe bind are re-raised. New signature: **`get_open_port(host="127.0.0.1", *, max_attempts=128)`**; existing callers using `get_open_port()` with no args remain valid.
## Test Plan
**Smoke** 
```bash
python -c "from tests.helpers.runtime import get_open_port; import socket; assert len({get_open_port() for _ in range(32)}) == 32; p = get_open_port(); s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.bind(('127.0.0.1', p)); s.close(); print('ok')"
```
**Indirect regression**
run in ci
## Test Result
<img width="2330" height="480" alt="ef59f699-f20d-428a-b607-5baad34f78e5" src="https://github.com/user-attachments/assets/768d5eda-505c-492b-9cfa-8b55a33d6d31" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
