### PR TITLE
[CI][Perf] Add high-load stress phase for Qwen3-TTS daily perf

### DIFF
--- a/tests/dfx/perf/tests/test_tts.json
+++ b/tests/dfx/perf/tests/test_tts.json
@@ -116,6 +116,24 @@
         }
       },
       {
+        "task": "default_voice",
+        "eval_phase": "stress",
+        "dataset_name": "seed-tts-text",
+        "backend": "openai-audio-speech",
+        "endpoint": "/v1/audio/speech",
+        "dataset_path": "benchmarks/build_dataset/seed_tts_smoke",
+        "num_prompts": [100],
+        "request_rate": [2.0],
+        "seed_tts_locale": "en",
+        "extra_body": {"voice": "Vivian", "language": "English", "task_type": "CustomVoice"},
+        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
+        "baseline": {
+          "median_audio_ttfp_ms": [3000],
+          "median_audio_rtf": [0.25],
+          "audio_throughput": [4.0]
+        }
+      },
+      {
         "task": "voice_design",
         "eval_phase": "latency",
         "dataset_name": "seed-tts-design",
@@ -148,6 +166,24 @@
           "median_audio_ttfp_ms": [1500],
           "median_audio_rtf": [0.35],
           "audio_throughput": [25.0]
+        }
+      },
+      {
+        "task": "voice_design",
+        "eval_phase": "stress",
+        "dataset_name": "seed-tts-design",
+        "backend": "openai-audio-speech",
+        "endpoint": "/v1/audio/speech",
+        "dataset_path": "benchmarks/build_dataset/seed_tts_design",
+        "num_prompts": [100],
+        "request_rate": [2.0],
+        "seed_tts_locale": "en",
+        "extra_body": {"task_type": "VoiceDesign", "language": "English"},
+        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
+        "baseline": {
+          "median_audio_ttfp_ms": [3500],
+          "median_audio_rtf": [0.30],
+          "audio_throughput": [4.0]
         }
       }
     ]


### PR DESCRIPTION
## Summary

Daily DFX TTS perf currently caps at `max_concurrency=8` in the throughput regime, so high-load TTFA tail regressions (e.g. the cross-request Code2Wav batching gap that #3163 proposes to fix and that #3221's Triton stack already demonstrates a fix for) are invisible to nightly CI.

This PR adds a `stress` phase to `test_qwen3_tts_customvoice` for both `default_voice` and `voice_design`, mirroring the open-loop pattern already used by `test_qwen_omni.json`:

- `num_prompts: [100]`, `request_rate: [2.0]` (open-loop, ~2 req/s offered for ~50 s of wall time)
- Same prompt source as the existing throughput phase, so no new dataset deps
- Baselines intentionally loose (median TTFA 3.0–3.5 s, median RTF 0.25–0.30, `audio_throughput` floor 4.0 audio-s/wall-s) so it alarms only on real regressions and can be tightened once we have a few nightly runs

`eval_phase: \"stress\"` is metadata only — `run_benchmark.py` already lists `eval_phase` in `exclude_keys`, so no script change is needed.

## Why this matters

On H20 (single H20-3e), the gap between current `main` and a stack with cross-request codec batching shows up exactly in this load region:

| Concurrency | main req/s | main TTFA p95 | PR #3221 req/s | PR #3221 TTFA p95 |
| ----------: | ---------: | ------------: | -------------: | ----------------: |
| 8           | 2.29       | 386 ms        | 4.41           | 397 ms            |
| 16          | 2.44       | **4437 ms**   | 4.52           | 258 ms            |
| 32          | 2.47       | **8626 ms**   | 6.73           | 463 ms            |

`main` saturates at ~2.47 req/s starting at c=8, so any offered load above that queues hard. The new entry sits at offered `rate=2.0` (~80 % of `main`'s sustainable rate, ~30 % of #3221's) — that's the regime where regressions in scheduler / codec batching are loudest.

## Test plan

- [ ] `python3 -c \"import json; json.load(open('tests/dfx/perf/tests/test_tts.json'))\"` parses cleanly
- [ ] `tests/dfx/perf/tests/test_runner_metadata.py` (already excludes `eval_phase`) still passes
- [ ] First nightly run produces baseline metrics for the new stress entries; tighten the floors in a follow-up PR
- [ ] After #3163 lands, re-check the median TTFA / RTF on the stress entries to confirm the win is captured by daily

cc @ischencheng (re #3163), @vklimkov-nvidia (re #3221), @hsliuustc0106