### PR TITLE
[Bugfix] Use float32 softmax in code predictor sampling loop

### DIFF
--- a/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
+++ b/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
@@ -686,12 +686,12 @@ class CodePredictorWrapper(nn.Module):
                     logits = logits.masked_fill(logits < topk_vals[:, -1:], float("-inf"))
                 if s_top_p < 1.0:
                     sorted_logits, sorted_idx = logits.sort(dim=-1, descending=True)
-                    sorted_probs = F.softmax(sorted_logits, dim=-1)
+                    sorted_probs = F.softmax(sorted_logits, dim=-1, dtype=torch.float32)
                     cumulative_probs = sorted_probs.cumsum(dim=-1)
                     remove_mask = (cumulative_probs - sorted_probs) >= s_top_p
                     sorted_logits[remove_mask] = float("-inf")
                     logits = sorted_logits.scatter(1, sorted_idx, sorted_logits)
-                probs = F.softmax(logits, dim=-1)
+                probs = F.softmax(logits, dim=-1, dtype=torch.float32)
                 code = torch.multinomial(probs, num_samples=1)
             else:
                 # "per_call" mode: temperature-scaled + top-k
@@ -700,7 +700,7 @@ class CodePredictorWrapper(nn.Module):
                     if top_k > 0:
                         topk_vals, _ = scaled.topk(top_k, dim=-1)
                         scaled = scaled.masked_fill(scaled < topk_vals[:, -1:], float("-inf"))
-                    probs = F.softmax(scaled, dim=-1)
+                    probs = F.softmax(scaled, dim=-1, dtype=torch.float32)
                     code = torch.multinomial(probs, num_samples=1)
                 else:
                     code = logits.argmax(dim=-1, keepdim=True)

--- a/vllm_omni/model_executor/models/fish_speech/fish_speech_fast_ar.py
+++ b/vllm_omni/model_executor/models/fish_speech/fish_speech_fast_ar.py
@@ -476,11 +476,13 @@ class FishSpeechFastAR(nn.Module):
                     scaled = scaled.masked_fill(scaled < topk_vals[:, -1:], float("-inf"))
                 if top_p < 1.0:
                     sorted_logits, sorted_indices = torch.sort(scaled, descending=True)
-                    cumulative_probs = torch.cumsum(F.softmax(sorted_logits, dim=-1), dim=-1)
-                    sorted_indices_to_remove = cumulative_probs - F.softmax(sorted_logits, dim=-1) >= top_p
+                    cumulative_probs = torch.cumsum(F.softmax(sorted_logits, dim=-1, dtype=torch.float32), dim=-1)
+                    sorted_indices_to_remove = (
+                        cumulative_probs - F.softmax(sorted_logits, dim=-1, dtype=torch.float32) >= top_p
+                    )
                     sorted_logits[sorted_indices_to_remove] = float("-inf")
                     scaled = sorted_logits.scatter(1, sorted_indices, sorted_logits)
-                probs = F.softmax(scaled, dim=-1)
+                probs = F.softmax(scaled, dim=-1, dtype=torch.float32)
                 next_ids = torch.multinomial(probs, num_samples=1, generator=generator)
             else:
                 next_ids = logits.argmax(dim=-1, keepdim=True)

--- a/vllm_omni/model_executor/models/mimo_audio/mimo_audio_llm.py
+++ b/vllm_omni/model_executor/models/mimo_audio/mimo_audio_llm.py
@@ -83,7 +83,7 @@ class MiMoSampler:
         if self.top_p is not None and 0.0 < self.top_p <= 1.0:
             top_p = self.top_p if 0.0 < self.top_p <= 1.0 else 1.0
             sorted_logits, sorted_indices = torch.sort(scores)
-            cumulative_probs = sorted_logits.softmax(dim=-1).cumsum(dim=-1)
+            cumulative_probs = sorted_logits.softmax(dim=-1, dtype=torch.float32).cumsum(dim=-1)
             sorted_indices_to_remove = cumulative_probs <= (1 - top_p)
             sorted_indices_to_remove[:, -1] = 0
             indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)
@@ -97,7 +97,7 @@ class MiMoSampler:
             scores[:, t] = float("-inf")
 
         if self.do_sample:
-            probs = scores.softmax(dim=-1)
+            probs = scores.softmax(dim=-1, dtype=torch.float32)
             return torch.multinomial(probs, num_samples=1).squeeze(-1)
 
         return torch.argmax(scores, dim=-1)
@@ -125,7 +125,7 @@ class MiMoLocalSamplerTensor:
 
         if self.top_p is not None:
             sorted_logits, sorted_indices = torch.sort(scores)
-            cumulative_probs = sorted_logits.softmax(dim=-1).cumsum(dim=-1)
+            cumulative_probs = sorted_logits.softmax(dim=-1, dtype=torch.float32).cumsum(dim=-1)
             sorted_indices_to_remove = cumulative_probs <= torch.sub(1, self.top_p[:, None])
             sorted_indices_to_remove[:, -1] = 0
             indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)


### PR DESCRIPTION
## Purpose

The code predictor runs F.softmax in the model native dtype (bf16/fp16), which can produce NaN probabilities from large logit values, crashing torch.multinomial with a CUDA device-side assert. This is the same class of issue that vLLM main sampler already handles by upcasting to float32 before softmax, like in [1].

Add dtype=torch.float32 to all three F.softmax calls in the autoregressive sampling loop to match the established convention.

[1] https://github.com/vllm-project/vllm/blob/5b39b268f506150dbab38f6f6c04b7c843e37c07/vllm/v1/sample/sampler.py#L91

This bug is triggered prominently on certain hardware, as in https://github.com/vllm-project/vllm-omni/issues/3250

bf16 isn't natively supported, so PyTorch casts bf16 weights to fp16 for compute. fp16 max is ~65504. Any logit > 65504 becomes inf, softmax(inf) produces NaN, and torch.multinomial immediately hits the CUDA assert.

## Test Plan

TBD

## Test Result

TBD

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
