### PR TITLE
[CI][Bugfix] Switch accuracy judge to Gemma AWQ 4-bit with parser to fix #3257

### DIFF
--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -392,7 +392,7 @@ steps:
       - label: ":full_moon: Diffusion X2I(&A&T) · GEBench Accuracy Test"
         timeout_in_minutes: 60
         commands:
-          - pytest -s -v tests/e2e/accuracy/test_gebench_h100_smoke.py --run-level full_model --gebench-model Qwen/Qwen-Image-2512 --accuracy-judge-model QuantTrio/Qwen3.5-35B-A3B-AWQ --accuracy-gpu 0 --gebench-port 8093 --accuracy-workers 1
+          - pytest -s -v tests/e2e/accuracy/test_gebench_h100_smoke.py --run-level full_model --gebench-model Qwen/Qwen-Image-2512 --accuracy-judge-model Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 --accuracy-gpu 0 --gebench-port 8093 --accuracy-workers 1
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gebench_qwen-image-2512/summary*.json"
         agents:
           queue: "mithril-h100-pool"
@@ -431,7 +431,7 @@ steps:
       - label: ":full_moon: Diffusion X2I(&A&T) · GEdit-Bench Accuracy Test"
         timeout_in_minutes: 60
         commands:
-          - pytest -s -v tests/e2e/accuracy/test_gedit_bench_h100_smoke.py --run-level full_model --gedit-model Qwen/Qwen-Image-Edit --accuracy-judge-model QuantTrio/Qwen3.5-35B-A3B-AWQ --accuracy-gpu 0 --gedit-port 8093 --gedit-samples-per-group 20 --accuracy-workers 1
+          - pytest -s -v tests/e2e/accuracy/test_gedit_bench_h100_smoke.py --run-level full_model --gedit-model Qwen/Qwen-Image-Edit --accuracy-judge-model Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 --accuracy-gpu 0 --gedit-port 8093 --gedit-samples-per-group 20 --accuracy-workers 1
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gedit_scores_qwen-image-edit/qwen-image-edit_all_all_vie_score_*.csv"
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gedit_scores_qwen-image-edit/qwen-image-edit_all_all_summary_*.json"
         agents:

--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -392,7 +392,7 @@ steps:
       - label: ":full_moon: Diffusion X2I(&A&T) · GEBench Accuracy Test"
         timeout_in_minutes: 60
         commands:
-          - pytest -s -v tests/e2e/accuracy/test_gebench_h100_smoke.py --run-level full_model --gebench-model Qwen/Qwen-Image-2512 --accuracy-judge-model QuantTrio/Qwen3-VL-30B-A3B-Instruct-AWQ --accuracy-gpu 0 --gebench-port 8093 --accuracy-workers 1
+          - pytest -s -v tests/e2e/accuracy/test_gebench_h100_smoke.py --run-level full_model --gebench-model Qwen/Qwen-Image-2512 --accuracy-judge-model Qwen/Qwen3.6-35B-A3B-FP8 --accuracy-gpu 0 --gebench-port 8093 --accuracy-workers 1
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gebench_qwen-image-2512/summary*.json"
         agents:
           queue: "mithril-h100-pool"
@@ -431,7 +431,7 @@ steps:
       - label: ":full_moon: Diffusion X2I(&A&T) · GEdit-Bench Accuracy Test"
         timeout_in_minutes: 60
         commands:
-          - pytest -s -v tests/e2e/accuracy/test_gedit_bench_h100_smoke.py --run-level full_model --gedit-model Qwen/Qwen-Image-Edit --accuracy-judge-model QuantTrio/Qwen3-VL-30B-A3B-Instruct-AWQ --accuracy-gpu 0 --gedit-port 8093 --gedit-samples-per-group 20 --accuracy-workers 1
+          - pytest -s -v tests/e2e/accuracy/test_gedit_bench_h100_smoke.py --run-level full_model --gedit-model Qwen/Qwen-Image-Edit --accuracy-judge-model Qwen/Qwen3.6-35B-A3B-FP8 --accuracy-gpu 0 --gedit-port 8093 --gedit-samples-per-group 20 --accuracy-workers 1
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gedit_scores_qwen-image-edit/qwen-image-edit_all_all_vie_score_*.csv"
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gedit_scores_qwen-image-edit/qwen-image-edit_all_all_summary_*.json"
         agents:

--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -430,7 +430,7 @@ steps:
       - label: ":full_moon: Diffusion X2I(&A&T) · GEBench Accuracy Test"
         timeout_in_minutes: 60
         commands:
-          - pytest -s -v tests/e2e/accuracy/test_gebench_h100_smoke.py --run-level full_model --gebench-model Qwen/Qwen-Image-2512 --accuracy-judge-model Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 --accuracy-gpu 0 --gebench-port 8093 --accuracy-workers 1
+          - pytest -s -v tests/e2e/accuracy/test_gebench_h100_smoke.py --run-level full_model --gebench-model Qwen/Qwen-Image-2512 --accuracy-judge-model cyankiwi/gemma-4-31B-it-AWQ-4bit --accuracy-gpu 0 --gebench-port 8093 --accuracy-workers 1
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gebench_qwen-image-2512/summary*.json"
         agents:
           queue: "mithril-h100-pool"
@@ -469,7 +469,7 @@ steps:
       - label: ":full_moon: Diffusion X2I(&A&T) · GEdit-Bench Accuracy Test"
         timeout_in_minutes: 60
         commands:
-          - pytest -s -v tests/e2e/accuracy/test_gedit_bench_h100_smoke.py --run-level full_model --gedit-model Qwen/Qwen-Image-Edit --accuracy-judge-model Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 --accuracy-gpu 0 --gedit-port 8093 --gedit-samples-per-group 20 --accuracy-workers 1
+          - pytest -s -v tests/e2e/accuracy/test_gedit_bench_h100_smoke.py --run-level full_model --gedit-model Qwen/Qwen-Image-Edit --accuracy-judge-model cyankiwi/gemma-4-31B-it-AWQ-4bit --accuracy-gpu 0 --gedit-port 8093 --gedit-samples-per-group 20 --accuracy-workers 1
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gedit_scores_qwen-image-edit/qwen-image-edit_all_all_vie_score_*.csv"
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gedit_scores_qwen-image-edit/qwen-image-edit_all_all_summary_*.json"
         agents:

--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -392,7 +392,7 @@ steps:
       - label: ":full_moon: Diffusion X2I(&A&T) · GEBench Accuracy Test"
         timeout_in_minutes: 60
         commands:
-          - pytest -s -v tests/e2e/accuracy/test_gebench_h100_smoke.py --run-level full_model --gebench-model Qwen/Qwen-Image-2512 --accuracy-judge-model Qwen/Qwen3.6-35B-A3B-FP8 --accuracy-gpu 0 --gebench-port 8093 --accuracy-workers 1
+          - pytest -s -v tests/e2e/accuracy/test_gebench_h100_smoke.py --run-level full_model --gebench-model Qwen/Qwen-Image-2512 --accuracy-judge-model QuantTrio/Qwen3.5-35B-A3B-AWQ --accuracy-gpu 0 --gebench-port 8093 --accuracy-workers 1
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gebench_qwen-image-2512/summary*.json"
         agents:
           queue: "mithril-h100-pool"
@@ -431,7 +431,7 @@ steps:
       - label: ":full_moon: Diffusion X2I(&A&T) · GEdit-Bench Accuracy Test"
         timeout_in_minutes: 60
         commands:
-          - pytest -s -v tests/e2e/accuracy/test_gedit_bench_h100_smoke.py --run-level full_model --gedit-model Qwen/Qwen-Image-Edit --accuracy-judge-model Qwen/Qwen3.6-35B-A3B-FP8 --accuracy-gpu 0 --gedit-port 8093 --gedit-samples-per-group 20 --accuracy-workers 1
+          - pytest -s -v tests/e2e/accuracy/test_gedit_bench_h100_smoke.py --run-level full_model --gedit-model Qwen/Qwen-Image-Edit --accuracy-judge-model QuantTrio/Qwen3.5-35B-A3B-AWQ --accuracy-gpu 0 --gedit-port 8093 --gedit-samples-per-group 20 --accuracy-workers 1
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gedit_scores_qwen-image-edit/qwen-image-edit_all_all_vie_score_*.csv"
           - buildkite-agent artifact upload "tests/e2e/accuracy/artifacts/gedit_scores_qwen-image-edit/qwen-image-edit_all_all_summary_*.json"
         agents:

--- a/tests/e2e/accuracy/conftest.py
+++ b/tests/e2e/accuracy/conftest.py
@@ -28,7 +28,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--accuracy-judge-model",
         action="store",
-        default="Qwen/Qwen3.6-35B-A3B-FP8",
+        default="QuantTrio/Qwen3.5-35B-A3B-AWQ",
         help="Judge model path",
     )
     group.addoption("--accuracy-gpu", action="store", default="0", help="Single GPU id used sequentially")

--- a/tests/e2e/accuracy/conftest.py
+++ b/tests/e2e/accuracy/conftest.py
@@ -15,6 +15,9 @@ from PIL import Image
 from tests.helpers.runtime import OmniServer, OmniServerParams
 
 
+GEMMA_ACCURACY_JUDGE_MODEL = "cyankiwi/gemma-4-31B-it-AWQ-4bit"
+
+
 def pytest_addoption(parser):
     group = parser.getgroup("accuracy-e2e")
     group.addoption("--gebench-root", action="store", default=None, help="Local GEBench dataset root")
@@ -28,7 +31,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--accuracy-judge-model",
         action="store",
-        default="cyankiwi/gemma-4-31B-it-AWQ-4bit",
+        default=GEMMA_ACCURACY_JUDGE_MODEL,
         help="Judge model path",
     )
     group.addoption("--accuracy-gpu", action="store", default="0", help="Single GPU id used sequentially")
@@ -228,6 +231,8 @@ def _build_accuracy_server_config(
         "--gpu-memory-utilization",
         "0.8",
     ]
+    if judge_model == GEMMA_ACCURACY_JUDGE_MODEL:
+        judge_server_args.extend(["--reasoning-parser", "gemma4"])
 
     judge_env = {"CUDA_VISIBLE_DEVICES": shared_gpu}
 

--- a/tests/e2e/accuracy/conftest.py
+++ b/tests/e2e/accuracy/conftest.py
@@ -28,7 +28,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--accuracy-judge-model",
         action="store",
-        default="Qwen/Qwen3-VL-30B-A3B-Instruct-FP8",
+        default="cyankiwi/gemma-4-31B-it-AWQ-4bit",
         help="Judge model path",
     )
     group.addoption("--accuracy-gpu", action="store", default="0", help="Single GPU id used sequentially")

--- a/tests/e2e/accuracy/conftest.py
+++ b/tests/e2e/accuracy/conftest.py
@@ -28,7 +28,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--accuracy-judge-model",
         action="store",
-        default="QuantTrio/Qwen3.5-35B-A3B-AWQ",
+        default="Qwen/Qwen3-VL-30B-A3B-Instruct-FP8",
         help="Judge model path",
     )
     group.addoption("--accuracy-gpu", action="store", default="0", help="Single GPU id used sequentially")

--- a/tests/e2e/accuracy/conftest.py
+++ b/tests/e2e/accuracy/conftest.py
@@ -28,7 +28,7 @@ def pytest_addoption(parser):
     group.addoption(
         "--accuracy-judge-model",
         action="store",
-        default="QuantTrio/Qwen3-VL-30B-A3B-Instruct-AWQ",
+        default="Qwen/Qwen3.6-35B-A3B-FP8",
         help="Judge model path",
     )
     group.addoption("--accuracy-gpu", action="store", default="0", help="Single GPU id used sequentially")


### PR DESCRIPTION
## Summary
- Replace the GEBench and GEdit-Bench accuracy judge model from `QuantTrio/Qwen3-VL-30B-A3B-Instruct-AWQ` to `cyankiwi/gemma-4-31B-it-AWQ-4bit`.
- Update the shared `--accuracy-judge-model` default to match the Buildkite nightly jobs.
- Start the Gemma judge server with `--reasoning-parser gemma4`.

## Why
The previous Qwen3-VL AWQ judge can crash during GEdit-Bench judging with a deepstack token buffer overflow, as tracked in #3257. Switching the judge model avoids that failing path for the nightly accuracy jobs, and the Gemma judge needs the matching reasoning parser during serving.

Fixes #3257.

## Validation
- `git grep -n "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"` returns no matches.
- `git grep -n "cyankiwi/gemma-4-31B-it-AWQ-4bit"` shows the expected 3 references.
- `git grep -n "reasoning-parser\|GEMMA_ACCURACY_JUDGE_MODEL" tests/e2e/accuracy/conftest.py`
- `git diff --check`
- `python -m py_compile tests/e2e/accuracy/conftest.py`

Full GPU accuracy jobs were not run locally. Direct fixture import could not be run locally because `torch` is not installed in this environment.