### PR TITLE
[WIP][Perf]add adaln fused op in triton

### DIFF
--- a/tests/diffusion/layers/test_adalayernorm.py
+++ b/tests/diffusion/layers/test_adalayernorm.py
@@ -116,6 +116,47 @@ def test_adalayernorm_continuous_forward_shape():
     assert out.shape == (batch, seq_len, dim)
 
 
+def test_adalayernorm_scale_shift_matches_reference():
+    """AdaLayerNorm applies layernorm(x) * (1 + scale) + shift."""
+    from vllm_omni.diffusion.layers.adalayernorm import AdaLayerNorm
+
+    dim = 64
+    torch.manual_seed(42)
+    norm = AdaLayerNorm(dim, elementwise_affine=False, eps=1e-6)
+    x = torch.randn(2, 4, dim)
+    scale = torch.randn(2, 1, dim)
+    shift = torch.randn(2, 1, dim)
+
+    out = norm.forward_native(x, scale, shift)
+    ref = torch.nn.functional.layer_norm(x.float(), (dim,), None, None, 1e-6) * (1 + scale) + shift
+
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_adalayernorm_triton_cuda_matches_native(monkeypatch):
+    """Triton fused CUDA path matches the native implementation."""
+    import vllm_omni.diffusion.layers.adalayernorm as adaln_module
+    from vllm_omni.diffusion.layers.adalayernorm import AdaLayerNorm
+
+    if not adaln_module._HAS_TRITON:
+        pytest.skip("Triton is not available")
+
+    monkeypatch.setenv("VLLM_OMNI_ENABLE_TRITON_ADALN", "1")
+
+    dim = 128
+    torch.manual_seed(42)
+    norm = AdaLayerNorm(dim, elementwise_affine=False, eps=1e-6).cuda()
+    x = torch.randn(2, 8, dim, device="cuda", dtype=torch.bfloat16)
+    emb = torch.randn(2, 6, dim, device="cuda", dtype=torch.bfloat16)
+    shift, scale = emb.chunk(6, dim=1)[:2]
+
+    out = norm.forward_cuda(x, scale, shift)
+    ref = norm.forward_native(x, scale, shift)
+
+    torch.testing.assert_close(out, ref, atol=3e-2, rtol=3e-2)
+
+
 def test_adalayernorm_zero_accepts_quant_config():
     """Constructor accepts quant_config=None and prefix='test' without error."""
     from vllm_omni.diffusion.layers.adalayernorm import (

--- a/vllm_omni/diffusion/layers/adalayernorm.py
+++ b/vllm_omni/diffusion/layers/adalayernorm.py
@@ -1,3 +1,4 @@
+import os
 from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
@@ -15,6 +16,66 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 _HAS_MINDIESD = find_spec("mindiesd") is not None
+_TRITON_ADALN_MAX_BLOCK_SIZE = 8192
+
+try:
+    import triton
+    import triton.language as tl
+
+    _HAS_TRITON = True
+except ImportError:
+    triton = None
+    tl = None
+    _HAS_TRITON = False
+
+
+if _HAS_TRITON:
+
+    @triton.jit
+    def _adalayernorm_scale_shift_kernel(
+        x_ptr,
+        scale_ptr,
+        shift_ptr,
+        out_ptr,
+        n_cols: tl.constexpr,
+        eps: tl.constexpr,
+        scale_mode: tl.constexpr,
+        rows_per_batch: tl.constexpr,
+        scale_stride_batch: tl.constexpr,
+        shift_stride_batch: tl.constexpr,
+        block_size: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        cols = tl.arange(0, block_size)
+        mask = cols < n_cols
+
+        x_offsets = row * n_cols + cols
+        x = tl.load(x_ptr + x_offsets, mask=mask, other=0.0).to(tl.float32)
+        x_masked = tl.where(mask, x, 0.0)
+        mean = tl.sum(x_masked, axis=0) / n_cols
+        centered = tl.where(mask, x - mean, 0.0)
+        var = tl.sum(centered * centered, axis=0) / n_cols
+        normed = centered * tl.rsqrt(var + eps)
+
+        if scale_mode == 0:
+            scale_offsets = row * n_cols + cols
+            shift_offsets = row * n_cols + cols
+        elif scale_mode == 1:
+            batch = row // rows_per_batch
+            scale_offsets = batch * scale_stride_batch + cols
+            shift_offsets = batch * shift_stride_batch + cols
+        else:
+            scale_offsets = cols
+            shift_offsets = cols
+
+        scale = tl.load(scale_ptr + scale_offsets, mask=mask, other=0.0).to(tl.float32)
+        shift = tl.load(shift_ptr + shift_offsets, mask=mask, other=0.0).to(tl.float32)
+        out = normed * (1.0 + scale) + shift
+        tl.store(out_ptr + x_offsets, out, mask=mask)
+
+
+def _next_power_of_2(value: int) -> int:
+    return 1 << (value - 1).bit_length()
 
 
 class AdaLayerNorm(CustomOp):
@@ -36,7 +97,31 @@ class AdaLayerNorm(CustomOp):
         scale: torch.Tensor,
         shift: torch.Tensor,
     ) -> torch.Tensor:
-        return self.forward_native(x, scale, shift)
+        if os.environ.get("VLLM_OMNI_ENABLE_TRITON_ADALN", "1") != "1":
+            return self.forward_native(x, scale, shift)
+
+        triton_args = self._get_triton_args(x, scale, shift)
+        if triton_args is None:
+            return self.forward_native(x, scale, shift)
+
+        scale_mode, rows_per_batch, scale_stride_batch, shift_stride_batch, block_size, num_warps = triton_args
+        out = torch.empty_like(x)
+        rows = x.numel() // self.hidden_size
+        _adalayernorm_scale_shift_kernel[(rows,)](
+            x,
+            scale,
+            shift,
+            out,
+            self.hidden_size,
+            self.eps,
+            scale_mode,
+            rows_per_batch,
+            scale_stride_batch,
+            shift_stride_batch,
+            block_size,
+            num_warps=num_warps,
+        )
+        return out
 
     def forward_hip(
         self,
@@ -85,6 +170,65 @@ class AdaLayerNorm(CustomOp):
         shift: torch.Tensor,
     ) -> torch.Tensor:
         return self.layernorm(x) * (1 + scale) + shift
+
+    def _get_triton_args(
+        self,
+        x: torch.Tensor,
+        scale: torch.Tensor,
+        shift: torch.Tensor,
+    ) -> tuple[int, int, int, int, int, int] | None:
+        if (
+            not _HAS_TRITON
+            or self.elementwise_affine
+            or x.ndim < 2
+            or x.shape[-1] != self.hidden_size
+            or not x.is_cuda
+            or not scale.is_cuda
+            or not shift.is_cuda
+            or x.device != scale.device
+            or x.device != shift.device
+            or x.dtype not in (torch.float16, torch.bfloat16, torch.float32)
+            or scale.dtype != x.dtype
+            or shift.dtype != x.dtype
+            or not x.is_contiguous()
+            or scale.shape[-1] != self.hidden_size
+            or shift.shape[-1] != self.hidden_size
+            or scale.stride(-1) != 1
+            or shift.stride(-1) != 1
+        ):
+            return None
+
+        rows = x.numel() // self.hidden_size
+        block_size = _next_power_of_2(self.hidden_size)
+        if block_size > _TRITON_ADALN_MAX_BLOCK_SIZE:
+            return None
+
+        if scale.shape == x.shape and shift.shape == x.shape and scale.is_contiguous() and shift.is_contiguous():
+            scale_mode = 0
+            rows_per_batch = 1
+            scale_stride_batch = self.hidden_size
+            shift_stride_batch = self.hidden_size
+        elif (
+            scale.shape[0] == x.shape[0]
+            and shift.shape[0] == x.shape[0]
+            and scale.numel() == x.shape[0] * self.hidden_size
+            and shift.numel() == x.shape[0] * self.hidden_size
+            and rows % x.shape[0] == 0
+        ):
+            scale_mode = 1
+            rows_per_batch = rows // x.shape[0]
+            scale_stride_batch = scale.stride(0)
+            shift_stride_batch = shift.stride(0)
+        elif scale.numel() == self.hidden_size and shift.numel() == self.hidden_size:
+            scale_mode = 2
+            rows_per_batch = 1
+            scale_stride_batch = 0
+            shift_stride_batch = 0
+        else:
+            return None
+
+        num_warps = 8 if block_size >= 2048 else 4
+        return scale_mode, rows_per_batch, scale_stride_batch, shift_stride_batch, block_size, num_warps
 
 
 class AdaLayerNormZero(nn.Module):


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

This PR aims to add AdaLayernorm to the GPU platform to improve performance in diffusion models.

## Target
Optimize Wan2.2 transformer block AdaLayerNorm:

```text
out = layernorm(x) * (1 + scale) + shift
```

Relevant source:

```text
vllm_omni/diffusion/layers/adalayernorm.py
vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
```

Wan2.2 uses this path in `norm1`, `norm3`, and `norm_out` with
`elementwise_affine=False`.

## Implementation

CUDA `AdaLayerNorm.forward_cuda()` now uses a fused Triton kernel when the input
matches the safe Wan-style path:

```text
- x is CUDA, contiguous, dtype fp16/bf16/fp32
- scale/shift are CUDA, same dtype/device
- hidden size is the last dimension
- elementwise_affine=False
- hidden size block <= 8192
- scale/shift layout is one of:
  - same shape as x
  - per-batch [B, 1, D] or [B, D]
  - single [D]
```

Fallback behavior:

```text
Any unsupported shape, dtype, stride, or affine case falls back to the existing
native path.
```

Runtime switch:

```text
VLLM_OMNI_ENABLE_TRITON_ADALN=1  # default, enable fused Triton path
VLLM_OMNI_ENABLE_TRITON_ADALN=0  # disable fused path for A/B or rollback
```

## Test Plan

When I tested this fused op to the H20 platform, I ran the command like:
```text
VLLM_OMNI_ENABLE_TRITON_ADALN=1
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
vllm serve ... --use-hsdp --cfg-parallel-size 2 --usp 4
  --vae-patch-parallel-size 8 --vae-use-tiling
  --log-stats --enable-diffusion-pipeline-profiler
```

## Test Result
Comparison against the previous best config A baseline:

| Scenario | Metric | Baseline ms | Triton AdaLN ms | Delta ms | Delta |
|---|---:|---:|---:|---:|---:|
| 832x480 81f | stage_0_gen | 16722.5 | 16677.6 | -44.9 | -0.27% |
| 832x480 81f | text_encoder | 120.7 | 121.2 | +0.5 | +0.39% |
| 832x480 81f | vae.encode | 872.3 | 878.9 | +6.6 | +0.75% |
| 832x480 81f | diffuse | 13705.4 | 13640.4 | -65.0 | -0.47% |
| 832x480 81f | vae.decode | 1327.8 | 1336.0 | +8.2 | +0.62% |
| 1280x720 121f | stage_0_gen | 104760.2 | 104058.5 | -701.7 | -0.67% |
| 1280x720 121f | text_encoder | 120.9 | 121.2 | +0.3 | +0.26% |
| 1280x720 121f | vae.encode | 2631.6 | 2623.2 | -8.4 | -0.32% |
| 1280x720 121f | diffuse | 95803.7 | 95062.6 | -741.1 | -0.77% |
| 1280x720 121f | vae.decode | 4221.1 | 4225.1 | +4.0 | +0.09% |

Memory:

| Scenario | Baseline MB | Triton AdaLN MB | Delta MB | Delta |
|---|---:|---:|---:|---:|
| 832x480 81f | 25524 | 25532 | +8 | +0.03% |
| 1280x720 121f | 31250 | 32134 | +884 | +2.83% |

Conclusion:

```text
The fused Triton AdaLayerNorm path is functional in the full 8-GPU service and
shows a small positive service-level signal, mainly in diffuse:
- 480p: diffuse -65.0 ms, stage_0_gen -44.9 ms
- 720p: diffuse -741.1 ms, stage_0_gen -701.7 ms
```




https://github.com/user-attachments/assets/a74283c8-2951-49ec-b925-9d94188ced29





---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
