### PR TITLE
[Bugfix][Fish Speech] Flatten Fast AR RoPE positions

### DIFF
--- a/vllm_omni/model_executor/models/fish_speech/fish_speech_fast_ar.py
+++ b/vllm_omni/model_executor/models/fish_speech/fish_speech_fast_ar.py
@@ -106,7 +106,7 @@ class _FastARAttention(nn.Module):
             q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view(q.shape)
             k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view(k.shape)
 
-        q, k = self.rotary_emb(position_ids, q, k)
+        q, k = self.rotary_emb(position_ids.reshape(-1), q, k)
 
         q = q.view(bsz, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
         k = k.view(bsz, seq_len, self.num_kv_heads, self.head_dim).transpose(1, 2)


### PR DESCRIPTION
## Purpose

Fix https://github.com/vllm-project/vllm-omni/issues/3237

Fix Fish Speech S2 Pro voice cloning failure in Fast AR residual code prediction.

Fish Fast AR flattens Q/K to token-major shape `[batch_size * seq_len, hidden]`, but passed RoPE positions as `[batch_size, seq_len]`. The vLLM rotary embedding custom op treats 2D positions as a batched layout and requires Q/K to have matching `[batch_size, seq_len, ...]` dimensions, so voice clone requests can fail with:

```text
RuntimeError: query, key and positions must have the same batch_size and seq_len
```

This PR flattens `position_ids` before applying RoPE so the positions layout matches the already-flattened Q/K tensors.

## Test Plan

- [x] Ran Ruff lint check:
  ```bash
  ruff check .
  ```
- [x] Reproduced the failure with real Fish Speech S2 Pro online voice clone serving before the fix.
- [x] Verified the fix with real Fish Speech S2 Pro online voice clone serving after the fix.

## Test Result

Before the fix, the real online voice clone request failed after reference audio encoding reached Fast AR:

```text
Encoded reference audio codes: 202978 samples @ 24000Hz -> frames=100 codebooks=10
Fish Speech Fast AR torch.compile fallback to eager after runtime failure: query, key and positions must have the same batch_size and seq_len
RuntimeError: query, key and positions must have the same batch_size and seq_len
POST /v1/audio/speech HTTP/1.1 500 Internal Server Error
```

After the fix, the same real online voice clone path completed successfully:

```text
Encoded reference audio codes: 202978 samples @ 24000Hz -> frames=100 codebooks=10
DAC decoder: frames=4 q=10 uniq=37 range=[20,3673] batch=1
POST /v1/audio/speech HTTP/1.1 200 OK
Audio saved to: /tmp/fish_3237_fixed_online_client.wav
size: 585772 bytes
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
