### PR TITLE
[Perf] Optimize RMSNorm in Z-Image

### DIFF
--- a/tests/diffusion/layers/test_norm.py
+++ b/tests/diffusion/layers/test_norm.py
@@ -451,3 +451,97 @@ def test_rmsnorm_with_single_element_batch():
     out = norm(x)
 
     assert out.shape == (1, 1, hidden_size)
+
+
+# ── Fused vs Native correctness tests ──
+
+
+def test_rmsnorm_fused_native_parity_cuda():
+    """Verify fused and native RMSNorm produce identical results on CUDA.
+
+    The fused kernel uses vllm._custom_ops.rms_norm while native uses pure PyTorch.
+    Both should produce numerically equivalent results.
+    """
+    from vllm_omni.diffusion.layers.norm import RMSNorm
+
+    hidden_size = 128
+    eps = 1e-6
+    torch.manual_seed(42)
+
+    for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+        torch.manual_seed(42)
+        norm = RMSNorm(hidden_size, eps=eps).cuda()
+        norm.weight.data = norm.weight.data.to(dtype)
+
+        x = torch.randn(4, 8, hidden_size, dtype=dtype, device="cuda")
+
+        out_fused = norm._forward_fused(x)
+        out_native = norm.forward_native(x)
+
+        torch.testing.assert_close(out_fused, out_native, atol=1e-3, rtol=1e-3)
+
+
+def test_rmsnorm_fused_native_parity_large_tensor():
+    """Verify fused and native RMSNorm parity with large tensors.
+
+    Tests realistic tensor sizes used in diffusion models.
+    """
+    from vllm_omni.diffusion.layers.norm import RMSNorm
+
+    hidden_size = 4096
+    batch_size = 16
+    seq_len = 1024
+    eps = 1e-6
+
+    for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+        torch.manual_seed(123)
+        norm = RMSNorm(hidden_size, eps=eps).cuda()
+        norm.weight.data = norm.weight.data.to(dtype)
+
+        x = torch.randn(batch_size, seq_len, hidden_size, dtype=dtype, device="cuda")
+
+        out_fused = norm._forward_fused(x)
+        out_native = norm.forward_native(x)
+
+        torch.testing.assert_close(out_fused, out_native, atol=1e-2, rtol=1e-2)
+
+
+def test_rmsnorm_fused_native_parity_2d_input():
+    """Verify fused and native RMSNorm parity with 2D input tensors."""
+    from vllm_omni.diffusion.layers.norm import RMSNorm
+
+    hidden_size = 256
+    batch_size = 32
+    eps = 1e-6
+
+    for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+        torch.manual_seed(456)
+        norm = RMSNorm(hidden_size, eps=eps).cuda()
+        norm.weight.data = norm.weight.data.to(dtype)
+
+        x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+
+        out_fused = norm._forward_fused(x)
+        out_native = norm.forward_native(x)
+
+        torch.testing.assert_close(out_fused, out_native, atol=1e-3, rtol=1e-3)
+
+
+def test_rmsnorm_fused_native_parity_custom_weight():
+    """Verify fused and native RMSNorm parity with non-default weights."""
+    from vllm_omni.diffusion.layers.norm import RMSNorm
+
+    hidden_size = 64
+    eps = 1e-6
+
+    for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+        torch.manual_seed(789)
+        norm = RMSNorm(hidden_size, eps=eps).cuda()
+        norm.weight.data = torch.randn(hidden_size, dtype=dtype, device="cuda")
+
+        x = torch.randn(2, 4, hidden_size, dtype=dtype, device="cuda")
+
+        out_fused = norm._forward_fused(x)
+        out_native = norm.forward_native(x)
+
+        torch.testing.assert_close(out_fused, out_native, atol=1e-3, rtol=1e-3)

--- a/vllm_omni/diffusion/layers/norm.py
+++ b/vllm_omni/diffusion/layers/norm.py
@@ -70,17 +70,33 @@ class RMSNorm(CustomOp):
         self.weight = nn.Parameter(torch.ones(hidden_size))
         self.variance_epsilon = eps
 
+    def _forward_fused(self, x: torch.Tensor) -> torch.Tensor:
+        from vllm._custom_ops import rms_norm as fused_rms_norm
+
+        orig_shape = x.shape
+        hidden_size = orig_shape[-1]
+        x_2d = x.reshape(-1, hidden_size)
+        out = torch.empty_like(x_2d)
+        fused_rms_norm(out, x_2d, self.weight.data, self.variance_epsilon)
+        return out.reshape(orig_shape)
+
     def forward_cuda(
         self,
         x: torch.Tensor,
     ) -> torch.Tensor:
-        return self.forward_native(x)
+        try:
+            return self._forward_fused(x)
+        except Exception:
+            return self.forward_native(x)
 
     def forward_hip(
         self,
         x: torch.Tensor,
     ) -> torch.Tensor:
-        return self.forward_native(x)
+        try:
+            return self._forward_fused(x)
+        except Exception:
+            return self.forward_native(x)
 
     def forward_npu(
         self,

--- a/vllm_omni/diffusion/models/z_image/z_image_transformer.py
+++ b/vllm_omni/diffusion/models/z_image/z_image_transformer.py
@@ -25,7 +25,6 @@ import torch.nn as nn
 from torch.nn.utils.rnn import pad_sequence
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul
-from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
     QKVParallelLinear,
@@ -33,6 +32,8 @@ from vllm.model_executor.layers.linear import (
     RowParallelLinear,
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+from vllm_omni.diffusion.layers.norm import RMSNorm
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization.base_config import (


### PR DESCRIPTION
## Purpose
1 * NVIDIA 4090(24G)

```
curl -X POST http://localhost:8004/v1/images/generations   -H "Content-Type: application/json"   -d '{
          "prompt": "A beautiful sunset over the ocean with sailing boats",
         "size": "1024x1024",
         "num_inference_steps": 50,
         "guidance_scale": 4.0,
         "seed": 42
       }' | jq -r '.data[0].b64_json' | base64 -d > output.png
```


<img width="1423" height="115" alt="截屏2026-05-03 07 12 16" src="https://github.com/user-attachments/assets/56736636-4858-4725-8c40-e502211e9431" />


Reduces kernel launch overhead for the residual=None path, which is the hot path in diffusion models (~102 calls/step in ZImage).

## Test Plan

## Test Result

| Configuration | Baseline | OPT | Improvement |
| :--- | :---: | :---: | :---: |
| Time | 47426.02 ms | 38267.76 ms | 19.31% |

**NOTE:**
Some models may also benefit from similar optimizations.

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
