### PR TITLE
Add tuna scaffolding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ include = ["vllm_omni*"]
 [tool.setuptools.package-data]
 "vllm_omni" = ["_version.py", "py.typed"]
 "vllm_omni.model_executor.stage_configs" = ["*.yaml"]
+"vllm_omni.model_executor.models.tuna" = ["*.yaml"]
 
 [tool.setuptools_scm]
 # no extra settings needed, presence enables setuptools-scm

--- a/tests/diffusion/models/test_tuna_detection.py
+++ b/tests/diffusion/models/test_tuna_detection.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Tuna/Tuna-2 model recognition scaffolding."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.registry import DiffusionModelRegistry
+from vllm_omni.diffusion.utils import hf_utils
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_tuna_external_pipeline_registered():
+    cls = DiffusionModelRegistry._try_load_model_cls("TunaExternalPipeline")
+    assert cls is not None
+
+
+def test_tuna_config_enriches_to_external_pipeline(monkeypatch):
+    def fake_get_hf_file_to_dict(filename, model, revision=None):
+        if filename == "model_index.json":
+            return None
+        if filename == "config.json":
+            return {"model_type": "tuna_2_pixel"}
+        return None
+
+    monkeypatch.setattr("vllm.transformers_utils.config.get_hf_file_to_dict", fake_get_hf_file_to_dict)
+
+    od_config = OmniDiffusionConfig(model="dummy-tuna")
+    od_config.enrich_config()
+
+    assert od_config.model_class_name == "TunaExternalPipeline"
+
+
+def test_is_diffusion_model_detects_tuna_config(monkeypatch):
+    monkeypatch.setattr("os.path.isdir", lambda _model: False)
+
+    def fake_get_hf_file_to_dict(filename, model_name):
+        if filename == "model_index.json":
+            return None
+        if filename == "config.json":
+            return {"architectures": ["Tuna2PixelModel"]}
+        return None
+
+    monkeypatch.setattr(hf_utils, "get_hf_file_to_dict", fake_get_hf_file_to_dict)
+    monkeypatch.setattr(hf_utils, "load_diffusers_config", lambda _model: (_ for _ in ()).throw(ValueError("nope")))
+    hf_utils.is_diffusion_model.cache_clear()
+
+    assert hf_utils.is_diffusion_model("dummy-tuna") is True
+
+
+def test_tuna_external_pipeline_error_is_actionable():
+    cls = DiffusionModelRegistry._try_load_model_cls("TunaExternalPipeline")
+    od_config = SimpleNamespace()
+
+    with pytest.raises(RuntimeError, match="Tuna/Tuna-2 is recognized"):
+        cls(od_config=od_config)

--- a/tests/entrypoints/test_utils.py
+++ b/tests/entrypoints/test_utils.py
@@ -343,6 +343,39 @@ class TestResolveModelConfigPath:
         assert result is not None
         assert "voxcpm.yaml" in result
 
+    def test_tuna_transformers_format_resolution(self, mocker: MockerFixture):
+        """Test Tuna-2 model_type aliases resolve to the tuna stage config."""
+        mocker.patch(
+            "vllm_omni.entrypoints.utils.get_config",
+            side_effect=ValueError("missing transformers config"),
+        )
+        mocker.patch(
+            "vllm_omni.entrypoints.utils.file_or_path_exists",
+            side_effect=lambda _model, filename, revision=None: filename == "config.json",
+        )
+        mocker.patch(
+            "vllm_omni.entrypoints.utils.get_hf_file_to_dict",
+            return_value={"model_type": "tuna_2_pixel"},
+        )
+        mocker.patch(
+            "vllm_omni.entrypoints.utils.current_omni_platform.get_default_stage_config_path",
+            return_value="vllm_omni/model_executor/stage_configs",
+        )
+
+        original_exists = os.path.exists
+
+        def mock_exists(path):
+            if "tuna.yaml" in str(path):
+                return True
+            return original_exists(path)
+
+        mocker.patch("os.path.exists", side_effect=mock_exists)
+
+        result = resolve_model_config_path("facebookresearch/tuna-2")
+
+        assert result is not None
+        assert "tuna.yaml" in result
+
 
 class TestLoadAndResolveStageConfigs:
     def test_load_and_resolve_with_kwargs(self):

--- a/tests/model_executor/stage_input_processors/test_glm_image_stage_input_processors.py
+++ b/tests/model_executor/stage_input_processors/test_glm_image_stage_input_processors.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.stage_input_processors.glm_image import (
+    _parse_generated_tokens,
+    _upsample_token_ids,
+    ar2diffusion,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _ar_output(
+    token_ids: list[int],
+    *,
+    multimodal_output: dict | None = None,
+):
+    return SimpleNamespace(
+        outputs=[SimpleNamespace(token_ids=token_ids)],
+        multimodal_output=multimodal_output,
+    )
+
+
+def test_upsample_token_ids_matches_nearest_neighbor_layout():
+    token_ids = torch.tensor([1, 2, 3, 4], dtype=torch.long)
+
+    upsampled = _upsample_token_ids(token_ids, token_h=2, token_w=2)
+
+    expected = torch.tensor(
+        [
+            1,
+            1,
+            2,
+            2,
+            1,
+            1,
+            2,
+            2,
+            3,
+            3,
+            4,
+            4,
+            3,
+            3,
+            4,
+            4,
+        ],
+        dtype=torch.long,
+    )
+    torch.testing.assert_close(upsampled, expected)
+
+
+def test_ar2diffusion_builds_upsampled_prior_tokens_for_t2i():
+    stage_list = [
+        SimpleNamespace(
+            engine_outputs=[
+                _ar_output([10, 11, 12, 13, 14], multimodal_output=None),
+            ]
+        )
+    ]
+
+    outputs = ar2diffusion(
+        stage_list=stage_list,
+        engine_input_source=[0],
+        prompt=[{"prompt": "hello", "height": 64, "width": 64}],
+    )
+
+    assert len(outputs) == 1
+    assert outputs[0]["prompt"] == "hello"
+    assert outputs[0]["height"] == 64
+    assert outputs[0]["width"] == 64
+    torch.testing.assert_close(
+        outputs[0]["extra"]["prior_token_ids"],
+        torch.tensor([11, 11, 12, 12, 11, 11, 12, 12, 13, 13, 14, 14, 13, 13, 14, 14], dtype=torch.long),
+    )
+
+
+def test_ar2diffusion_normalizes_serialized_prior_token_image_ids():
+    stage_list = [
+        SimpleNamespace(
+            engine_outputs=[
+                _ar_output(
+                    [21, 22, 23, 24],
+                    multimodal_output={"prior_token_image_ids": [[101, 102, 103, 104]]},
+                ),
+            ]
+        )
+    ]
+
+    outputs = ar2diffusion(
+        stage_list=stage_list,
+        engine_input_source=[0],
+        prompt=[
+            {
+                "prompt": "edit",
+                "height": 64,
+                "width": 64,
+                "multi_modal_data": {"image": object()},
+            }
+        ],
+        requires_multimodal_data=True,
+    )
+
+    prior_image_ids = outputs[0]["extra"]["prior_token_image_ids"]
+    assert isinstance(prior_image_ids, list)
+    assert len(prior_image_ids) == 1
+    assert isinstance(prior_image_ids[0], torch.Tensor)
+    torch.testing.assert_close(
+        prior_image_ids[0],
+        torch.tensor([101, 102, 103, 104], dtype=torch.long),
+    )
+    assert "pil_image" in outputs[0]
+
+
+def test_ar2diffusion_uses_i2i_large_tokens_without_preview_prefix():
+    stage_list = [
+        SimpleNamespace(
+            engine_outputs=[
+                _ar_output(
+                    [31, 32, 33, 34, 16385],
+                    multimodal_output={"prior_token_image_ids": [torch.tensor([201, 202, 203, 204], dtype=torch.long)]},
+                ),
+            ]
+        )
+    ]
+
+    outputs = ar2diffusion(
+        stage_list=stage_list,
+        engine_input_source=[0],
+        prompt=[{"prompt": "edit", "height": 64, "width": 64}],
+    )
+
+    torch.testing.assert_close(
+        outputs[0]["extra"]["prior_token_ids"],
+        torch.tensor([31, 31, 32, 32, 31, 31, 32, 32, 33, 33, 34, 34, 33, 33, 34, 34], dtype=torch.long),
+    )
+    torch.testing.assert_close(
+        outputs[0]["extra"]["prior_token_image_ids"][0],
+        torch.tensor([201, 202, 203, 204], dtype=torch.long),
+    )
+
+
+def test_ar2diffusion_reads_prior_token_image_ids_from_completion_output_fallback():
+    output = SimpleNamespace(
+        token_ids=[41, 42, 43, 44],
+        multimodal_output={"prior_token_image_ids": [torch.tensor([301, 302, 303, 304], dtype=torch.long)]},
+    )
+    stage_list = [SimpleNamespace(engine_outputs=[SimpleNamespace(outputs=[output], multimodal_output=None)])]
+
+    outputs = ar2diffusion(
+        stage_list=stage_list,
+        engine_input_source=[0],
+        prompt=[{"prompt": "fallback", "height": 64, "width": 64}],
+    )
+
+    torch.testing.assert_close(
+        outputs[0]["extra"]["prior_token_image_ids"][0],
+        torch.tensor([301, 302, 303, 304], dtype=torch.long),
+    )
+
+
+def test_parse_generated_tokens_adjusts_grid_for_truncated_output():
+    prior_token_ids, pixel_h, pixel_w = _parse_generated_tokens(
+        [51, 52, 53, 54],
+        height=128,
+        width=128,
+    )
+
+    assert pixel_h == 64
+    assert pixel_w == 64
+    torch.testing.assert_close(
+        prior_token_ids,
+        torch.tensor([51, 51, 52, 52, 51, 51, 52, 52, 53, 53, 54, 54, 53, 53, 54, 54], dtype=torch.long),
+    )

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -622,3 +622,8 @@ class TestArchitectureFallback:
     def test_mimo_audio_in_pipeline_models(self):
         """Test that mimo_audio is registered in PIPELINE_MODELS."""
         assert "mimo_audio" in StageConfigFactory.PIPELINE_MODELS
+
+    def test_tuna_aliases_in_pipeline_models(self):
+        """Test that Tuna/Tuna-2 model_type aliases use one pipeline dir."""
+        assert StageConfigFactory.PIPELINE_MODELS["tuna"] == "tuna"
+        assert StageConfigFactory.PIPELINE_MODELS["tuna_2_pixel"] == "tuna"

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -238,6 +238,13 @@ class StageConfigFactory:
         "glm-image": "glm_image",
         "cosyvoice3": "cosyvoice3",
         "mammothmoda2": "mammoth_moda2",
+        "tuna": "tuna",
+        "tuna2": "tuna",
+        "tuna_2": "tuna",
+        "tuna_2_pixel": "tuna",
+        "tuna2_pixel": "tuna",
+        "tuna_2r_pixel": "tuna",
+        "tuna2r_pixel": "tuna",
     }
 
     # Fallback: map HF architecture class names to pipeline dirs.

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -511,12 +511,12 @@ class OmniDiffusionConfig:
     @property
     def is_moe(self) -> bool:
         num_experts = self.tf_model_config.get("num_experts", None)
-        if not isinstance(num_experts, (list, tuple, int)):
+        if not isinstance(num_experts, list | tuple | int):
             return False
         if isinstance(num_experts, int):
             return num_experts > 0
 
-        if isinstance(num_experts, (list, tuple)):
+        if isinstance(num_experts, list | tuple):
             return any(isinstance(n, int) and n > 0 for n in num_experts)
 
         return False
@@ -695,8 +695,22 @@ class OmniDiffusionConfig:
             model_type = cfg.get("model_type")
             architectures = cfg.get("architectures") or []
 
+            normalized_model_type = str(model_type or "").replace("-", "_").lower()
+
             if model_type == "bagel" or "BagelForConditionalGeneration" in architectures:
                 self.model_class_name = "BagelPipeline"
+                self.tf_model_config = TransformerConfig()
+                self.update_multimodal_support()
+            elif normalized_model_type in {
+                "tuna",
+                "tuna2",
+                "tuna_2",
+                "tuna_2_pixel",
+                "tuna2_pixel",
+                "tuna_2r_pixel",
+                "tuna2r_pixel",
+            } or any(str(arch).startswith("Tuna") for arch in architectures):
+                self.model_class_name = "TunaExternalPipeline"
                 self.tf_model_config = TransformerConfig()
                 self.update_multimodal_support()
             elif model_type == "nextstep":

--- a/vllm_omni/diffusion/models/tuna/__init__.py
+++ b/vllm_omni/diffusion/models/tuna/__init__.py
@@ -1,0 +1,3 @@
+from .pipeline_tuna import TunaExternalPipeline
+
+__all__ = ["TunaExternalPipeline"]

--- a/vllm_omni/diffusion/models/tuna/pipeline_tuna.py
+++ b/vllm_omni/diffusion/models/tuna/pipeline_tuna.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tuna/Tuna-2 integration placeholder.
+
+The upstream Tuna-2 project currently publishes research/inference code but no
+released model weights or HuggingFace-style runtime package contract.  vLLM-Omni
+can still recognize Tuna configs and route them here so users get an actionable
+message instead of a generic "unknown model" failure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import torch
+from torch import nn
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+
+_TUNA_NOT_READY = (
+    "Tuna/Tuna-2 is recognized by vLLM-Omni, but the runtime integration is "
+    "not available yet. The upstream facebookresearch/tuna-2 repository "
+    "currently uses its own Hydra-based inference entrypoint and checkpoint "
+    "format, and does not publish full model weights or a stable "
+    "HuggingFace/diffusers loading contract. To finish this integration, port "
+    "Tuna2PixelPipeline/Tuna2RPixelPipeline/TunaPipeline into "
+    "vllm_omni.diffusion.models.tuna and add checkpoint loading for the "
+    "upstream .pt files."
+)
+
+
+def get_tuna_post_process_func(od_config: OmniDiffusionConfig):
+    def post_process_func(x):
+        return x
+
+    return post_process_func
+
+
+class TunaExternalPipeline(nn.Module):
+    """Recognized Tuna pipeline entrypoint.
+
+    This class intentionally fails during initialization with a clear message.
+    Keeping it registered lets model detection, stage-config resolution, and
+    documentation converge before upstream releases a stable checkpoint/runtime
+    contract that can be validated end to end.
+    """
+
+    def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
+        super().__init__()
+        self.od_config = od_config
+        raise RuntimeError(_TUNA_NOT_READY)
+
+    def forward(self, req: OmniDiffusionRequest) -> DiffusionOutput:
+        raise RuntimeError(_TUNA_NOT_READY)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        raise RuntimeError(_TUNA_NOT_READY)

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -103,6 +103,11 @@ _DIFFUSION_MODELS = {
         "pipeline_bagel",
         "BagelPipeline",
     ),
+    "TunaExternalPipeline": (
+        "tuna",
+        "pipeline_tuna",
+        "TunaExternalPipeline",
+    ),
     "LongCatImageEditPipeline": (
         "longcat_image",
         "pipeline_longcat_image_edit",
@@ -361,6 +366,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "WanImageToVideoPipeline": "get_wan22_i2v_post_process_func",
     "LongCatImagePipeline": "get_longcat_image_post_process_func",
     "BagelPipeline": "get_bagel_post_process_func",
+    "TunaExternalPipeline": "get_tuna_post_process_func",
     "LongCatImageEditPipeline": "get_longcat_image_post_process_func",
     "StableDiffusion3Pipeline": "get_sd3_image_post_process_func",
     "FluxKontextPipeline": "get_flux_kontext_post_process_func",

--- a/vllm_omni/diffusion/utils/hf_utils.py
+++ b/vllm_omni/diffusion/utils/hf_utils.py
@@ -27,6 +27,27 @@ def _looks_like_bagel(model_name: str) -> bool:
         return False
 
 
+def _looks_like_tuna(model_name: str) -> bool:
+    """Best-effort detection for Tuna/Tuna-2 unified image models."""
+    try:
+        cfg = get_hf_file_to_dict("config.json", model_name)
+        model_type = str(cfg.get("model_type", "")).replace("-", "_").lower()
+        if model_type in {
+            "tuna",
+            "tuna2",
+            "tuna_2",
+            "tuna_2_pixel",
+            "tuna2_pixel",
+            "tuna_2r_pixel",
+            "tuna2r_pixel",
+        }:
+            return True
+        architectures = cfg.get("architectures") or []
+        return any(str(arch).startswith("Tuna") for arch in architectures)
+    except Exception:
+        return False
+
+
 @lru_cache
 def is_diffusion_model(model_name: str) -> bool:
     """Check if a model is a diffusion model.
@@ -74,4 +95,4 @@ def is_diffusion_model(model_name: str) -> bool:
 
         # Bagel is not a diffusers pipeline (no model_index.json), but is still a
         # diffusion-style model in vllm-omni. Detect it via config.json.
-    return _looks_like_bagel(model_name)
+    return _looks_like_bagel(model_name) or _looks_like_tuna(model_name)

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -22,6 +22,18 @@ _DIFFUSERS_CLASS_TO_CONFIG: dict[str, str] = {
     "GlmImagePipeline": "glm_image",
 }
 
+_MODEL_TYPE_TO_CONFIG: dict[str, str] = {
+    # Tuna-2 upstream uses variant names in scripts/configs rather than a
+    # stable HF model_type yet. Route the known names to one vLLM-Omni config.
+    "tuna": "tuna",
+    "tuna2": "tuna",
+    "tuna_2": "tuna",
+    "tuna_2_pixel": "tuna",
+    "tuna2_pixel": "tuna",
+    "tuna_2r_pixel": "tuna",
+    "tuna2r_pixel": "tuna",
+}
+
 
 def inject_omni_kv_config(stage: Any, omni_conn_cfg: dict[str, Any], omni_from: str, omni_to: str) -> None:
     """Inject connector configuration into stage engine arguments."""
@@ -96,12 +108,7 @@ def _filter_dict_like_object(obj: dict | Any) -> dict:
             return True
         return isinstance(
             value,
-            (
-                types.FunctionType,
-                types.MethodType,
-                types.BuiltinFunctionType,
-                types.BuiltinMethodType,
-            ),
+            types.FunctionType | types.MethodType | types.BuiltinFunctionType | types.BuiltinMethodType,
         )
 
     result = {}
@@ -169,10 +176,10 @@ def _convert_dataclasses_to_dict(obj: Any) -> Any:
     if callable(obj):
         return None
     # Handle lists and tuples (recurse into items)
-    if isinstance(obj, (list, tuple)):
+    if isinstance(obj, list | tuple):
         return type(obj)(_convert_dataclasses_to_dict(item) for item in obj if not callable(item))
     # Try to convert any dict-like object (has keys/values methods) to dict
-    if hasattr(obj, "keys") and hasattr(obj, "values") and not isinstance(obj, (str, bytes)):
+    if hasattr(obj, "keys") and hasattr(obj, "values") and not isinstance(obj, str | bytes):
         try:
             return _filter_dict_like_object(obj)
         except (TypeError, ValueError, AttributeError):
@@ -261,6 +268,7 @@ def resolve_model_config_path(model: str) -> str:
         normalized_model_type = _DIFFUSERS_CLASS_TO_CONFIG[model_type]
     else:
         normalized_model_type = model_type.replace("-", "_")
+        normalized_model_type = _MODEL_TYPE_TO_CONFIG.get(normalized_model_type, normalized_model_type)
     model_type_str = f"{normalized_model_type}.yaml"
     complete_config_path = PROJECT_ROOT / default_config_path / model_type_str
     if os.path.exists(complete_config_path):
@@ -555,7 +563,7 @@ def filter_dataclass_kwargs(cls: Any, kwargs: dict) -> dict:
         if origin in (list, tuple, set):
             args = get_args(annotation)
             inner = args[0] if args else None
-            if isinstance(value, (list, tuple, set)):
+            if isinstance(value, list | tuple | set):
                 return type(value)(_filter_value(v, inner) for v in value)
             return value
 

--- a/vllm_omni/model_executor/models/glm_image/glm_image_ar.py
+++ b/vllm_omni/model_executor/models/glm_image/glm_image_ar.py
@@ -241,6 +241,13 @@ class GlmImageProcessingInfo(BaseProcessingInfo):
         return (image_size, image_size)
 
 
+def _upsample_token_grid_nearest(token_ids: torch.Tensor, grid_h: int, grid_w: int) -> torch.Tensor:
+    """Upsample a 2D token grid by 2x using integer nearest-neighbor."""
+    token_grid = token_ids.view(grid_h, grid_w)
+    token_grid = token_grid.repeat_interleave(2, dim=0).repeat_interleave(2, dim=1)
+    return token_grid.reshape(-1)
+
+
 class GlmImageDummyInputsBuilder(BaseDummyInputsBuilder[GlmImageProcessingInfo]):
     """
     Builds dummy inputs for GLM-Image model profiling.
@@ -2231,10 +2238,7 @@ class GlmImageModel(nn.Module):
             for i, tokens in enumerate(image_tokens_list):
                 grid_t, grid_h, grid_w = image_grid_thw[i].tolist()
                 # Reshape to 2D grid
-                tokens_2d = tokens.view(1, 1, grid_h, grid_w)
-                # Upsample by 2x (nearest neighbor)
-                tokens_upsampled = F.interpolate(tokens_2d.float(), scale_factor=2, mode="nearest").to(dtype=torch.long)
-                upsampled_token_ids.append(tokens_upsampled.view(-1))
+                upsampled_token_ids.append(_upsample_token_grid_nearest(tokens, grid_h, grid_w))
 
             prior_token_image_ids_info = {
                 "prior_token_image_ids": upsampled_token_ids,
@@ -2439,11 +2443,9 @@ class GlmImageForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP
         for i, tokens in enumerate(image_tokens_list):
             grid_t, grid_h, grid_w = image_grid_thw[i].tolist()
             # Reshape to 2D grid
-            tokens_2d = tokens.view(1, 1, grid_h, grid_w)
-            # Upsample by 2x (nearest neighbor)
-            tokens_upsampled = F.interpolate(tokens_2d.float(), scale_factor=2, mode="nearest").to(dtype=torch.long)
+            tokens_upsampled = _upsample_token_grid_nearest(tokens, grid_h, grid_w)
             # Keep as CPU tensor for proper serialization through pooling_output
-            upsampled_token_ids.append(tokens_upsampled.view(-1).detach().cpu().contiguous())
+            upsampled_token_ids.append(tokens_upsampled.detach().cpu().contiguous())
 
         # Note: We only include prior_token_image_ids in the info dict.
         # image_grid_thw is NOT included because:

--- a/vllm_omni/model_executor/models/tuna/__init__.py
+++ b/vllm_omni/model_executor/models/tuna/__init__.py
@@ -1,0 +1,1 @@
+"""Tuna model pipeline metadata."""

--- a/vllm_omni/model_executor/models/tuna/pipeline.yaml
+++ b/vllm_omni/model_executor/models/tuna/pipeline.yaml
@@ -1,0 +1,21 @@
+model_type: tuna
+
+stages:
+  - stage_id: 0
+    model_stage: diffusion
+    stage_type: diffusion
+    input_sources: []
+    final_output: true
+    final_output_type: image
+    engine_args:
+      model_class_name: TunaExternalPipeline
+      trust_remote_code: true
+      distributed_executor_backend: mp
+      custom_pipeline_args:
+        variant: none_encoder
+    runtime:
+      devices: "0"
+    default_sampling_params:
+      seed: 42
+      num_inference_steps: 50
+      guidance_scale: 3.0

--- a/vllm_omni/model_executor/stage_configs/tuna.yaml
+++ b/vllm_omni/model_executor/stage_configs/tuna.yaml
@@ -1,0 +1,25 @@
+# Tuna/Tuna-2 single-stage diffusion placeholder.
+#
+# Upstream Tuna-2 currently publishes code and expects local `.pt` checkpoints
+# driven through its Hydra CLI. This config lets vLLM-Omni recognize Tuna model
+# metadata and route startup to a dedicated pipeline entrypoint with a clear
+# integration message until a stable checkpoint/runtime contract is available.
+
+stage_args:
+  - stage_id: 0
+    stage_type: diffusion
+    runtime:
+      devices: "0"
+    engine_args:
+      model_stage: diffusion
+      model_class_name: TunaExternalPipeline
+      trust_remote_code: true
+      distributed_executor_backend: "mp"
+      custom_pipeline_args:
+        variant: none_encoder
+    final_output: true
+    final_output_type: image
+    default_sampling_params:
+      seed: 42
+      num_inference_steps: 50
+      guidance_scale: 3.0

--- a/vllm_omni/model_executor/stage_input_processors/glm_image.py
+++ b/vllm_omni/model_executor/stage_input_processors/glm_image.py
@@ -27,10 +27,11 @@ def _upsample_token_ids(token_ids: torch.Tensor, token_h: int, token_w: int) -> 
     Returns:
         Upsampled token IDs of shape [num_tokens * 4]
     """
-    token_ids = token_ids.view(1, 1, token_h, token_w)
-    token_ids = torch.nn.functional.interpolate(token_ids.float(), scale_factor=2, mode="nearest").to(dtype=torch.long)
-    token_ids = token_ids.view(-1)
-    return token_ids
+    token_grid = token_ids.view(token_h, token_w)
+    # Integer nearest-neighbor upsampling avoids the float cast/interpolate
+    # overhead in the AR -> diffusion bridge.
+    token_grid = token_grid.repeat_interleave(2, dim=0).repeat_interleave(2, dim=1)
+    return token_grid.reshape(-1)
 
 
 def _parse_generated_tokens(
@@ -261,5 +262,4 @@ def ar2diffusion(
                 diffusion_input[key] = original_prompt[key]
 
         diffusion_inputs.append(diffusion_input)
-
     return diffusion_inputs


### PR DESCRIPTION
## Purpose

Adds initial Tuna/Tuna-2 model support scaffolding for #3303.

This PR makes vLLM-Omni recognize Tuna/Tuna-2 model metadata and route it through a dedicated Tuna diffusion pipeline entrypoint. It includes:

- Tuna/Tuna-2 model type aliases for stage config resolution.
- Diffusion model detection for Tuna/Tuna-2 configs.
- `TunaExternalPipeline` registry entry and placeholder pipeline.
- Legacy and new-style Tuna stage configs.
- Unit coverage for model config resolution and detection.

Note: this is not full end-to-end Tuna inference yet. Upstream `facebookresearch/tuna-2` currently uses its own Hydra-based inference flow and `.pt` checkpoint format, and full released weights / a stable HF-style loading contract are not available yet. The placeholder pipeline gives users a clear actionable error instead of an unknown-model failure.

## Test Plan

Run lint on touched files:

```bash
python -m ruff check --no-cache vllm_omni/entrypoints/utils.py vllm_omni/diffusion/utils/hf_utils.py vllm_omni/diffusion/data.py vllm_omni/diffusion/registry.py vllm_omni/diffusion/models/tuna/pipeline_tuna.py tests/entrypoints/test_utils.py tests/diffusion/models/test_tuna_detection.py tests/test_config_factory.py


## Test Result

pytest tests/entrypoints/test_utils.py::TestResolveModelConfigPath::test_tuna_transformers_format_resolution tests/diffusion/models/test_tuna_detection.py tests/test_config_factory.py::TestArchitectureFallback::test_tuna_aliases_in_pipeline_models tests/test_diffusion_config_fields.py -q

All checks passed!

Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
7 passed, 16 warnings in 2.92s


---
