### PR TITLE
[BugFix]: Fix async scheduer transfer exceed KV cache

### DIFF
--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -82,22 +82,12 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         self._new_prompt_len_snapshot: dict[str, int] = {}
 
     def _get_confirmed_num_computed_tokens(self, request: Request) -> int:
-        """Return the number of tokens confirmed computed (excluding async placeholders).
-
-        In async scheduling mode, num_computed_tokens is optimistically advanced
-        to include scheduled-but-not-yet-executed tokens. The confirmed count
-        (actual KV data on GPU) is obtained by subtracting the outstanding
-        output placeholders.
-        """
+        """num_computed_tokens minus async placeholders (KV actually on GPU)."""
         return request.num_computed_tokens - request.num_output_placeholders
 
     def _update_request_with_output(self, request: Request, new_token_ids: list[int]) -> tuple[list[int], bool]:
-        """Handle output tokens with proper async scheduling protocol.
-
-        Uses the sync Scheduler's token-appending logic (no cache_blocks call),
-        then manages num_output_placeholders ourselves. This avoids the
-        AsyncScheduler's eager cache_blocks call which can interfere with KV
-        transfer block management in omni pipelines.
+        """Append output tokens, then cache blocks up to the confirmed count
+        so KV transfer never sees blocks whose data has not been computed yet.
         """
         if request.discard_latest_async_tokens:
             request.discard_latest_async_tokens = False
@@ -105,17 +95,11 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
         status_before_update = request.status
 
-        # Use the base sync Scheduler logic: append tokens, check stop.
         new_token_ids, stopped = SyncScheduler._update_request_with_output(self, request, new_token_ids)
 
-        # Maintain the async placeholder bookkeeping.
         request.num_output_placeholders -= len(new_token_ids)
         assert request.num_output_placeholders >= 0
 
-        # Cache blocks up to the confirmed computed tokens. We do this
-        # explicitly (same as AsyncScheduler) so prefix caching still works
-        # when enabled, but using the confirmed count to avoid caching blocks
-        # whose KV has not yet been computed on GPU.
         if status_before_update == RequestStatus.RUNNING:
             confirmed = self._get_confirmed_num_computed_tokens(request)
             self.kv_cache_manager.cache_blocks(request, confirmed)
@@ -188,8 +172,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 return True
             return False
 
-        # Use confirmed computed tokens (excludes async placeholders) to get
-        # the actual seq_len of KV data present on GPU.
+        # seq_len for KV transfer must exclude async placeholders.
         confirmed_computed = self._get_confirmed_num_computed_tokens(request)
 
         if criteria_type == "prefill_finished":

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -11,6 +11,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStat
 from vllm.logger import init_logger
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler as VLLMScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.scheduler import Scheduler as SyncScheduler
 from vllm.v1.core.sched.utils import remove_all
 from vllm.v1.engine import EngineCoreOutput, EngineCoreOutputs
 from vllm.v1.metrics.perf import PerfStats
@@ -80,6 +81,47 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # Snapshot prompt length for each streaming input update
         self._new_prompt_len_snapshot: dict[str, int] = {}
 
+    def _get_confirmed_num_computed_tokens(self, request: Request) -> int:
+        """Return the number of tokens confirmed computed (excluding async placeholders).
+
+        In async scheduling mode, num_computed_tokens is optimistically advanced
+        to include scheduled-but-not-yet-executed tokens. The confirmed count
+        (actual KV data on GPU) is obtained by subtracting the outstanding
+        output placeholders.
+        """
+        return request.num_computed_tokens - request.num_output_placeholders
+
+    def _update_request_with_output(self, request: Request, new_token_ids: list[int]) -> tuple[list[int], bool]:
+        """Handle output tokens with proper async scheduling protocol.
+
+        Uses the sync Scheduler's token-appending logic (no cache_blocks call),
+        then manages num_output_placeholders ourselves. This avoids the
+        AsyncScheduler's eager cache_blocks call which can interfere with KV
+        transfer block management in omni pipelines.
+        """
+        if request.discard_latest_async_tokens:
+            request.discard_latest_async_tokens = False
+            return [], False
+
+        status_before_update = request.status
+
+        # Use the base sync Scheduler logic: append tokens, check stop.
+        new_token_ids, stopped = SyncScheduler._update_request_with_output(self, request, new_token_ids)
+
+        # Maintain the async placeholder bookkeeping.
+        request.num_output_placeholders -= len(new_token_ids)
+        assert request.num_output_placeholders >= 0
+
+        # Cache blocks up to the confirmed computed tokens. We do this
+        # explicitly (same as AsyncScheduler) so prefix caching still works
+        # when enabled, but using the confirmed count to avoid caching blocks
+        # whose KV has not yet been computed on GPU.
+        if status_before_update == RequestStatus.RUNNING:
+            confirmed = self._get_confirmed_num_computed_tokens(request)
+            self.kv_cache_manager.cache_blocks(request, confirmed)
+
+        return new_token_ids, stopped
+
     def _get_kv_transfer_criteria(self) -> dict | None:
         # Note: vllm_config is available in Scheduler after super().__init__
         if not hasattr(self, "vllm_config"):
@@ -146,10 +188,14 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 return True
             return False
 
+        # Use confirmed computed tokens (excludes async placeholders) to get
+        # the actual seq_len of KV data present on GPU.
+        confirmed_computed = self._get_confirmed_num_computed_tokens(request)
+
         if criteria_type == "prefill_finished":
-            if request.num_computed_tokens >= request.num_prompt_tokens:
+            if confirmed_computed >= request.num_prompt_tokens:
                 self.transfer_triggered_requests.add(request.request_id)
-                self._mark_request_for_kv_transfer(request.request_id, request.num_computed_tokens)
+                self._mark_request_for_kv_transfer(request.request_id, confirmed_computed)
                 actually_queued = request.request_id in self.requests_needing_kv_transfer
 
                 if stop_decode_on_trigger and actually_queued:
@@ -169,9 +215,9 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 try:
                     idx = new_token_ids.index(target_token_id)
                     tokens_to_exclude = len(new_token_ids) - (idx + 1)
-                    snapshot_len = request.num_computed_tokens - tokens_to_exclude
+                    snapshot_len = confirmed_computed - tokens_to_exclude
                 except ValueError:
-                    snapshot_len = request.num_computed_tokens
+                    snapshot_len = confirmed_computed
 
                 self._mark_request_for_kv_transfer(request.request_id, snapshot_len)
                 actually_queued = request.request_id in self.requests_needing_kv_transfer
@@ -622,7 +668,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                     )
             else:
                 self.waiting_for_transfer_free.add(request_id)
-                self._mark_request_for_kv_transfer(request_id, request.num_computed_tokens)
+                confirmed_computed = self._get_confirmed_num_computed_tokens(request)
+                self._mark_request_for_kv_transfer(request_id, confirmed_computed)
                 # Return KV transfer metadata so it propagates to RequestOutput
                 if request_id in self.requests_needing_kv_transfer:
                     transfer_data = self.requests_needing_kv_transfer[request_id]

--- a/vllm_omni/model_executor/models/bagel/bagel.py
+++ b/vllm_omni/model_executor/models/bagel/bagel.py
@@ -567,7 +567,12 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
             return None
         if num_computed_tokens is not None and "image_shape" in meta:
             prefill_rope = meta["ropes"][0] if meta.get("ropes") else 0
-            if num_computed_tokens > prefill_rope:
+            prefill_position_count = meta.get("prefill_position_count")
+            if prefill_position_count is not None:
+                num_decoded = num_computed_tokens - prefill_position_count
+                if num_decoded > 0:
+                    meta["ropes"] = [prefill_rope + num_decoded]
+            elif num_computed_tokens > prefill_rope:
                 meta["ropes"] = [num_computed_tokens]
         return meta
 
@@ -849,6 +854,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                         {
                             "ropes": [rope],
                             "image_shape": [img_H, img_W],
+                            "prefill_position_count": int(end - start),
                         }
                     )
                     img2img_idx += 1


### PR DESCRIPTION
## Purpose

`AsyncScheduler._update_after_schedule()` optimistically advances `request.num_computed_tokens` with output placeholders before GPU execution confirms the tokens. The KV transfer logic was using this inflated `num_computed_tokens` as `seq_len`, causing the DiT stage to read uninitialized KV data for placeholder positions — resulting in wrong conditioning and different generated pixels.

**Fix**: Override `_update_request_with_output` in `OmniARScheduler` to explicitly manage the async placeholder protocol, and use `num_computed_tokens - num_output_placeholders` (confirmed computed tokens) for all KV transfer `seq_len` values.

## Test Plan

```bash
pytest -v tests/e2e/offline_inference/test_bagel_text2img.py -m "advanced_model" --run-level "advanced_model"
```

## Result

```
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python3.12
cachedir: .pytest_cache
rootdir: /proj-tango-pvc/users/zhipeng.wang/workspace/vllm-omni
configfile: pyproject.toml
plugins: forked-1.6.0, timeout-2.4.0, hydra-core-1.3.2, asyncio-1.3.0, rerunfailures-16.1, mock-3.15.1, shard-0.1.2, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 2 items                                                                                                                                                         
Running 2 items in this shard: tests/e2e/offline_inference/test_bagel_text2img.py::test_bagel_text2img_shared_memory_connector, tests/e2e/offline_inference/test_bagel_text2img.py::test_bagel_text2img_mooncake_connector

tests/e2e/offline_inference/test_bagel_text2img.py::test_bagel_text2img_shared_memory_connector PASSED                                                              [ 50%]
tests/e2e/offline_inference/test_bagel_text2img.py::test_bagel_text2img_mooncake_connector PASSED                                                                   [100%]

============================================================================ warnings summary =============================================================================
vllm_omni/version.py:55
  /proj-tango-pvc/users/zhipeng.wang/workspace/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
   --> vLLM-Omni version 0.18.1.dev411+gd49356e4c.d20260503
   --> vLLM version 0.20.0
  This will likely cause compatibility issues.
    warn_if_misaligned_vllm_version()

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../../../../usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: 14 warnings
  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
=============================================================== 2 passed, 17 warnings in 180.57s (0:03:00) ================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```