### PR TITLE
[Test-only][Qwen3-TTS] AsyncOmniARScheduler isolation — code from #3221, please merge #3221 instead

### DIFF
--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -15,6 +15,7 @@ from typing import Any
 from vllm.logger import init_logger
 
 from vllm_omni.config.yaml_util import create_config, load_yaml_config, to_dict
+from vllm_omni.core.sched.async_omni_ar_scheduler import AsyncOmniARScheduler
 from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
 from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
 
@@ -152,6 +153,20 @@ def _scheduler_path(cls: type | None) -> str | None:
     if cls is None:
         return None
     return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _resolve_scheduler_cls(execution_type: StageExecutionType, async_scheduling: bool | None) -> type | None:
+    """Pick the scheduler class for a stage, switching the LLM_AR mapping to
+    ``AsyncOmniARScheduler`` when ``async_scheduling=True`` so the scheduler's
+    ``num_output_placeholders`` bookkeeping aligns with vLLM's
+    ``step_with_batch_queue`` and the alternating empty-step pattern is
+    avoided. ``async_scheduling=None``/False keeps the synchronous
+    ``OmniARScheduler``.
+    """
+    base = _EXECUTION_TYPE_TO_SCHEDULER.get(execution_type)
+    if execution_type is StageExecutionType.LLM_AR and async_scheduling:
+        return AsyncOmniARScheduler
+    return base
 
 
 @dataclass(frozen=True)
@@ -811,7 +826,9 @@ def merge_pipeline_deploy(
                 final_output=ps.final_output,
                 final_output_type=ps.final_output_type,
                 worker_type=worker_type,
-                scheduler_cls=_scheduler_path(_EXECUTION_TYPE_TO_SCHEDULER.get(ps.execution_type)),
+                scheduler_cls=_scheduler_path(
+                    _resolve_scheduler_cls(ps.execution_type, engine_args.get("async_scheduling"))
+                ),
                 hf_config_name=ps.hf_config_name,
                 is_comprehension=ps.owns_tokenizer,
                 yaml_engine_args=engine_args,

--- a/vllm_omni/core/sched/__init__.py
+++ b/vllm_omni/core/sched/__init__.py
@@ -2,11 +2,13 @@
 Scheduling components for vLLM-Omni.
 """
 
+from .async_omni_ar_scheduler import AsyncOmniARScheduler
 from .omni_ar_scheduler import OmniARScheduler
 from .omni_generation_scheduler import OmniGenerationScheduler
 from .output import OmniNewRequestData
 
 __all__ = [
+    "AsyncOmniARScheduler",
     "OmniARScheduler",
     "OmniGenerationScheduler",
     "OmniNewRequestData",

--- a/vllm_omni/core/sched/async_omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/async_omni_ar_scheduler.py
@@ -1,0 +1,76 @@
+"""
+AsyncOmniARScheduler: ``OmniARScheduler`` variant that activates the
+async-scheduling bookkeeping from ``vllm.v1.core.sched.async_scheduler``.
+
+When ``async_scheduling=True``, vLLM's ``EngineCoreProc`` drives
+``step_with_batch_queue``, which speculatively schedules the *next* batch
+while the current one is still on the GPU. For that to actually keep the
+queue full, the scheduler must increment ``request.num_output_placeholders``
+after every scheduled step (so the next call to ``schedule()`` knows it can
+launch one more decode token even though the previous step's output has
+not been merged in yet) and decrement it again when the output arrives.
+
+The base ``OmniARScheduler`` inherits from ``vllm.v1.core.sched.Scheduler``
+and does **not** do this bookkeeping. As a result, with
+``async_scheduling=True`` the scheduler returns 0 scheduled tokens on every
+other engine step. The engine then sees ``model_executed=False`` and falls
+through ``EngineCoreProc._process_engine_step`` 's
+``time.sleep(0.001)`` guard, producing the alternating empty-step pattern
+seen in profiles.
+
+``AsyncOmniARScheduler`` injects ``AsyncScheduler`` into the MRO so the
+``_update_after_schedule`` / ``_update_request_with_output`` overrides take
+effect, while keeping every Omni-specific behaviour (OmniNewRequestData
+wrapping, KV-transfer metadata, chunk-transfer adapter, streaming-session
+hooks, etc.) provided by ``OmniARScheduler`` and ``OmniSchedulerMixin``.
+
+Use this class instead of ``OmniARScheduler`` for any stage that sets
+``async_scheduling: true``. Stages with ``async_scheduling: false`` should
+keep using ``OmniARScheduler`` to preserve their current behaviour.
+"""
+
+from __future__ import annotations
+
+from vllm.logger import init_logger
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+
+from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
+
+logger = init_logger(__name__)
+
+
+class AsyncOmniARScheduler(OmniARScheduler, AsyncScheduler):
+    """OmniARScheduler with async-scheduling placeholder bookkeeping.
+
+    MRO:
+        AsyncOmniARScheduler
+        -> OmniARScheduler
+        -> OmniSchedulerMixin
+        -> AsyncScheduler
+        -> vllm.v1.core.sched.Scheduler
+        -> object
+
+    With this MRO:
+
+    * ``OmniARScheduler.schedule()`` runs as before (calls
+      ``super().schedule()`` which ends in ``Scheduler.schedule()``); inside,
+      ``self._update_after_schedule(...)`` resolves to
+      ``AsyncScheduler._update_after_schedule``, which calls back into
+      ``Scheduler._update_after_schedule`` via ``super()`` and then bumps
+      ``num_output_placeholders``.
+    * ``OmniARScheduler.update_from_output()`` runs as before (Omni-specific
+      KV-transfer / OmniModelRunnerOutput handling); inside, the call to
+      ``self._update_request_with_output(...)`` resolves to
+      ``AsyncScheduler._update_request_with_output``, which decrements
+      ``num_output_placeholders`` and caches blocks at the correct offset
+      for prefix caching.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if not self.scheduler_config.async_scheduling:
+            logger.warning(
+                "AsyncOmniARScheduler is in use but async_scheduling=False. "
+                "Use OmniARScheduler for sync stages; AsyncOmniARScheduler "
+                "is only meaningful when async_scheduling=True."
+            )


### PR DESCRIPTION
## Purpose

**Not for merge.** This PR isolates the `AsyncOmniARScheduler` portion of #3221 for benchmarking purposes only. The code is taken verbatim from #3221.

The original PR #3221 should be the one that lands this scheduler change. This PR exists only to:

1. Test the AsyncOmniARScheduler in isolation (without the rest of #3221's NV-talker / Triton recipe changes).
2. Provide a clean diff for measuring scheduler-only impact on H100.

## Test Plan

- E2E: `tests/e2e/online_serving/test_qwen3_tts_base.py -m core_model` on H100 — confirms audio output correctness.
- Concurrent benchmark on H100, single GPU, `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice`, default deploy yaml, 96-req warmup + 30/60/80/128 reqs at c=1/4/8/32.

## Test Result

E2E `test_qwen3_tts_base.py` core_model PASSES on H100.

Concurrent bench (H100, `Qwen3-TTS-12Hz-1.7B-CustomVoice`, default mns config = 10 / 10):

| Concurrency | TTFA mean (main) | TTFA mean (+Async) | rps main | rps +Async |
| ----------: | ---------------: | -----------------: | -------: | ---------: |
|           1 |          68 ms   |            68 ms   |    1.49  |     1.49   |
|           4 |         135 ms   |           135 ms   |    4.06  |     4.06   |
|           8 |         250 ms   |           240 ms   |    6.71  |     6.80   |
|          32 |        2834 ms   |          2300 ms   |    7.45  |     8.50   |

c=32 sees the largest improvement: TTFA mean -19% and rps +14% vs main on the same workload. Lower concurrency is unchanged (codec-not-bound, no async-scheduling gap to recover).

## Action

Please review and merge **#3221** (the original PR) for the actual change. This PR will be closed once #3221 lands or as soon as the maintainers indicate.

## CC List
@linyueqian  @Sy0307 