### PR TITLE
[Perf][Qwen3-TTS] Restore Code2Wav cross-request batching (RFC #3163 P0)

### DIFF
--- a/docs/user_guide/examples/online_serving/text_to_speech.md
+++ b/docs/user_guide/examples/online_serving/text_to_speech.md
@@ -201,6 +201,16 @@ Stage configs ship with the chunked-streaming default. To use the uniproc execut
 
 To opt out of chunked streaming, pass `--no-async-chunk` instead — the pipeline auto-dispatches to the end-to-end codec processor.
 
+### Tuning stage 1 `max_num_seqs` per task type
+The bundled `qwen3_tts.yaml` ships stage 1 (Code2Wav) at `max_num_seqs: 10`, tuned for Base voice cloning: stage-1 lifetimes are long (~3 s/req), so admitting up to 10 concurrent codec sequences lets requests progress in parallel in the scheduler — ~2× TTFA p95 at c=4 / c=8 (1× H100, 1.7B-Base, seed-tts) at an 8–12 % audio-throughput cost.
+
+CustomVoice / VoiceDesign have much shorter stage-1 lifetimes (~50–200 ms) and are TTFA-optimal at `max_num_seqs: 1`. Override the default when serving those task types:
+
+```bash
+vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-Base --omni \
+    --stage-overrides '{"1": {"max_num_seqs": 1}}'
+```
+
 ### Sending requests
 ```bash
 # CustomVoice with a predefined speaker

--- a/vllm_omni/deploy/qwen3_tts.yaml
+++ b/vllm_omni/deploy/qwen3_tts.yaml
@@ -52,6 +52,7 @@ stages:
       top_p: 1.0
 
   - stage_id: 1
+    # Tuned for Base voice clone; CustomVoice / VoiceDesign are TTFA-optimal at 1.
     max_num_seqs: 10
     gpu_memory_utilization: 0.3
     enforce_eager: true


### PR DESCRIPTION
## Purpose

Resolves #3163.

PR #1617 introduced ``CUDAGraphDecoderWrapper`` for the Qwen3-TTS Code2Wav stage, which captured CUDA graphs at ``bs=1`` only. To keep the wrapper hit rate high it also enforced ``bs=1`` in ``Qwen3TTSCode2Wav.forward()`` via a per-request for-loop, undoing the cross-request batching landed in PR #1426.

Combined with the ``max_num_seqs: 1`` setting in ``qwen3_tts.yaml``, this means the Code2Wav stage decodes one request's chunk per scheduler step even when the scheduler has multiple ready streams in flight. On RTX 4090 + 1.7B-Base + voice cloning (the setup reported in #3163), this surfaces as 11.7× TTFB scaling between QPS=1 and QPS=4.

This PR:

1. **Restores the batched forward path**: replaces the per-request for-loop with a single padded ``[B, Q, F_max]`` ``chunked_decode`` call. Includes a ``B==1`` fast path (no padding cost) so the existing single-request behaviour is preserved.
2. **Extends ``CUDAGraphDecoderWrapper``** to capture ``(batch_size, seq_len)`` pairs instead of ``seq_len`` only. Default capture set keeps all existing ``bs=1`` buckets and adds ``(bs ∈ {2,4,8}, seq=streaming_hot)`` so the new bs>1 hot path stays on the graph; uncaptured (bs, seq) falls back to eager.
3. **Raises Stage 1 ``max_num_seqs: 1 → 10``** (matches Stage 0) so the scheduler can actually deliver bs>1 to the codec.
4. **Adds a YAML override** ``code2wav_capture_pairs`` for operators on memory-rich GPUs to opt into a wider capture set.

## Test Plan

- New ``tests/model_executor/models/qwen3_tts/test_code2wav_batching.py`` (7 cases): bs=1 baseline parity, bs>1 per-request parity, padding-no-bleed, per-request ``left_context_size`` honoring, malformed-mixed batches.
- Updated ``tests/model_executor/models/qwen3_tts/test_cuda_graph_decoder.py`` to exercise the new ``(bs, seq)`` capture API: multi-bs replay, uncaptured-bs fallback, ``compute_capture_pairs`` parametrize.
- New ``tests/e2e/online_serving/test_qwen3_tts_concurrent_ttfb.py`` mirrors the bench shape of PR #3221's ``benchmark_service.py`` and asserts sub-linear TTFA scaling per the RFC target (``scaling_4 ≤ 4.0×``).
- Existing ``tests/e2e/online_serving/test_qwen3_tts_base.py -m core_model`` to verify audio output correctness (HNR + format checks).

## Test Result

Unit tests: ``test_code2wav_batching.py`` 7/7 PASS, ``test_cuda_graph_decoder.py`` 38/38 PASS, ``test_qwen3_tts_code2wav.py`` 2/2 PASS.

E2E ``test_qwen3_tts_base.py`` core_model PASSES on H100.

Concurrent bench (the issue #3163 setup is RTX 4090; we measured H100 + ``Qwen3-TTS-12Hz-0.6B-Base`` + voice cloning as the closest reproducible scenario on our hardware):

| Concurrency | main TTFA mean / rps | branch TTFA mean / rps | speedup |
| ----------: | -------------------: | ---------------------: | ------: |
|           1 |          255 / 0.94  |           259 / 0.93   |  ≈ 1×   |
|           4 |         1731 / 1.26  |           761 / 1.26   |  2.3×   |
|           8 |         4949 / 1.22  |          1220 / 1.75   |  4.1×   |
|          32 |         8047 / 3.51  |          7286 / 3.24   |  1.1×   |

c=4 / c=8 are large wins (TTFA -56% / -75%, rps at c=8 +43%) for the Base-mode + voice-cloning scenario, addressing the RFC #3163 reproducer.

### Known scope limitation

On H100 + ``Qwen3-TTS-12Hz-1.7B-CustomVoice`` (CustomVoice voice mode, no voice cloning), ``main`` is already saturated and this PR is approximately break-even or slightly slower (within ~5-30% TTFA / rps depending on concurrency). The codec-bs=1 enforcement was masking voice-cloning's audio-encoder latency on slower GPUs / Base mode; it is not a bottleneck on H100 + CustomVoice.

We measured the same model on H100:

| Concurrency | main TTFA / rps | this PR TTFA / rps |
| ----------: | --------------: | -----------------: |
|           1 |     68 / 1.49   |       57 / 1.50    |
|           4 |    135 / 4.06   |      175 / 2.65    |
|           8 |    250 / 6.71   |      346 / 4.19    |
|          32 |   2834 / 7.45   |     4047 / 5.22    |

We have not yet pinned down the per-call cost (per-call codec decode time itself is identical at ~12ms via profiling; the regression is in inter-forward idle time which we suspect comes from the wrapper's ``dict`` key change or some IPC interaction we haven't traced). Reviewers familiar with the chunk_transfer_adapter / async pipeline interaction may have better intuition.

If this trade-off is unacceptable, options are:

1. Land only the YAML knob (``code2wav_capture_pairs``) without the forward-path change.
2. Gate the batched path behind a config flag (``code2wav_force_bs1``).
3. Hold this PR until we trace the CustomVoice slowdown.

Happy to iterate based on review.

## CC List
@linyueqian @Sy0307 