### PR TITLE
[Recipe] Add Fish Speech S2 Pro 2-GPU deploy profile

### DIFF
--- a/recipes/fishaudio/Fish-Speech-S2-Pro.md
+++ b/recipes/fishaudio/Fish-Speech-S2-Pro.md
@@ -124,16 +124,6 @@ stages so concurrencies above 8 don't queue, and reduces
 `connector_get_sleep_s` from 10 ms to 1 ms so DAC chunks aren't held in
 the connector once they're ready.
 
-#### Throughput (H20x2, 100 unique prompts)
-
-| concurrency | req/s | audio/s | mean E2E ms | p99 E2E ms | mean TTFP ms | p99 TTFP ms | mean RTF |
-|---:|---:|---:|---:|---:|---:|---:|---:|
-|  1 | 0.86 |  4.06 | 1166 | 2109 |  67 |   74 | 0.246 |
-|  4 | 2.88 | 13.59 | 1368 | 1884 |  94 |  127 | 0.290 |
-| 16 | 4.92 | 22.74 | 3151 | 8241 | 312 | 5615 | 0.689 |
-| 32 | 7.06 | 32.92 | 4249 | 5325 | 528 |  781 | 0.926 |
-| 64 | 8.34 | 39.47 | 6377 | 9254 | 732 | 1356 | 1.361 |
-
-For H100x2 numbers under an earlier configuration of this profile, see
-the original benchmark in vllm-project/vllm-omni#2515 (comment by
-@Sy0307).
+For benchmark numbers see the discussion in
+vllm-project/vllm-omni#2515 (initial H100x2 sweep by @Sy0307) and
+vllm-project/vllm-omni#3323 (H20x2 sweep with the shipped config).

--- a/recipes/fishaudio/Fish-Speech-S2-Pro.md
+++ b/recipes/fishaudio/Fish-Speech-S2-Pro.md
@@ -100,3 +100,37 @@ curl -X POST http://localhost:8091/v1/audio/speech \
   both `ref_audio` and `ref_text` parameters.
 - Memory usage: Model loads at ~48.3 GiB, peaks at ~48.9 GiB during inference
   headroom for video frames and audio caches.
+
+### 2x H100 80GB
+
+#### Environment
+
+- OS: Linux
+- Python: 3.10+
+- Required package: `fish-speech` (for DAC codec)
+- CUDA 12.8
+- vLLM version: 0.19.0+
+
+#### Command
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 vllm serve fishaudio/s2-pro --omni --port 8091 \
+    --deploy-config vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml
+```
+
+This profile pins Stage0 (Slow/Fast AR) to GPU 0 and Stage1 (DAC decoder) to
+GPU 1 to remove AR/DAC contention. It also enlarges Stage0 batching
+(`max_num_seqs=8`) and lets Stage1 consume DAC chunks in parallel
+(`max_num_seqs=4`), and reduces `connector_get_sleep_s` from 10 ms to 1 ms.
+
+#### Throughput (H100x2)
+
+| concurrency | req/s | audio/s | mean E2E ms | p99 E2E ms | mean TTFP ms | p99 TTFP ms | mean RTF | p99 RTF |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1  | 0.63 | 2.95  | 1578.70 | 1922.99 | 97.47  | 110.82  | 0.339 | 0.362 |
+| 2  | 1.17 | 5.46  | 1710.66 | 2248.20 | 121.16 | 202.01  | 0.367 | 0.395 |
+| 4  | 2.11 | 9.83  | 1839.65 | 2520.31 | 138.05 | 298.55  | 0.395 | 0.451 |
+| 8  | 3.60 | 16.93 | 2095.23 | 2807.10 | 163.04 | 242.78  | 0.445 | 0.459 |
+| 10 | 3.67 | 17.26 | 2538.12 | 3933.99 | 598.81 | 1744.61 | 0.549 | 0.933 |
+
+Source: vllm-project/vllm-omni#2515 (comment by @Sy0307).

--- a/recipes/fishaudio/Fish-Speech-S2-Pro.md
+++ b/recipes/fishaudio/Fish-Speech-S2-Pro.md
@@ -118,19 +118,22 @@ CUDA_VISIBLE_DEVICES=0,1 vllm serve fishaudio/s2-pro --omni --port 8091 \
     --deploy-config vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml
 ```
 
-This profile pins Stage0 (Slow/Fast AR) to GPU 0 and Stage1 (DAC decoder) to
-GPU 1 to remove AR/DAC contention. It also enlarges Stage0 batching
-(`max_num_seqs=8`) and lets Stage1 consume DAC chunks in parallel
-(`max_num_seqs=4`), and reduces `connector_get_sleep_s` from 10 ms to 1 ms.
+This profile pins Stage0 (Slow/Fast AR) to GPU 0 and Stage1 (DAC decoder)
+to GPU 1 to remove AR/DAC contention, sets `max_num_seqs=64` on both
+stages so concurrencies above 8 don't queue, and reduces
+`connector_get_sleep_s` from 10 ms to 1 ms so DAC chunks aren't held in
+the connector once they're ready.
 
-#### Throughput (H100x2)
+#### Throughput (H20x2, 100 unique prompts)
 
-| concurrency | req/s | audio/s | mean E2E ms | p99 E2E ms | mean TTFP ms | p99 TTFP ms | mean RTF | p99 RTF |
-|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| 1  | 0.63 | 2.95  | 1578.70 | 1922.99 | 97.47  | 110.82  | 0.339 | 0.362 |
-| 2  | 1.17 | 5.46  | 1710.66 | 2248.20 | 121.16 | 202.01  | 0.367 | 0.395 |
-| 4  | 2.11 | 9.83  | 1839.65 | 2520.31 | 138.05 | 298.55  | 0.395 | 0.451 |
-| 8  | 3.60 | 16.93 | 2095.23 | 2807.10 | 163.04 | 242.78  | 0.445 | 0.459 |
-| 10 | 3.67 | 17.26 | 2538.12 | 3933.99 | 598.81 | 1744.61 | 0.549 | 0.933 |
+| concurrency | req/s | audio/s | mean E2E ms | p99 E2E ms | mean TTFP ms | p99 TTFP ms | mean RTF |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+|  1 | 0.86 |  4.06 | 1166 | 2109 |  67 |   74 | 0.246 |
+|  4 | 2.88 | 13.59 | 1368 | 1884 |  94 |  127 | 0.290 |
+| 16 | 4.92 | 22.74 | 3151 | 8241 | 312 | 5615 | 0.689 |
+| 32 | 7.06 | 32.92 | 4249 | 5325 | 528 |  781 | 0.926 |
+| 64 | 8.34 | 39.47 | 6377 | 9254 | 732 | 1356 | 1.361 |
 
-Source: vllm-project/vllm-omni#2515 (comment by @Sy0307).
+For H100x2 numbers under an earlier configuration of this profile, see
+the original benchmark in vllm-project/vllm-omni#2515 (comment by
+@Sy0307).

--- a/vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml
+++ b/vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml
@@ -1,0 +1,70 @@
+# Fish Speech S2 Pro 2-GPU deploy: Stage0 AR on GPU 0, Stage1 DAC on GPU 1.
+#
+# Opt-in profile validated on H100x2. Compared with the single-GPU default
+# (``fish_qwen3_omni.yaml``), it splits AR and DAC across devices to remove
+# AR/DAC contention, enlarges Stage0 AR batching, and lets Stage1 consume
+# multiple DAC chunks in parallel.
+#
+# Select via:
+#   CUDA_VISIBLE_DEVICES=0,1 vllm serve fishaudio/s2-pro --omni \
+#       --deploy-config vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml
+#
+# Or programmatically:
+#   Omni(model="fishaudio/s2-pro",
+#        deploy_config_path="vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml")
+
+async_chunk: true
+enable_chunked_prefill: false
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      shm_threshold_bytes: 65536
+      codec_streaming: true
+      # Tightened from 10ms to 1ms: chunks become available sooner under
+      # cross-GPU pipelining, so connector idle waiting dominates if left high.
+      connector_get_sleep_s: 0.001
+      connector_get_max_wait_first_chunk: 3000
+      connector_get_max_wait: 300
+      # ~21 Hz codec; 25 frames ≈ 1.16s of audio.
+      codec_chunk_frames: 25
+      codec_left_context_frames: 25
+      initial_codec_chunk_frames: 4
+
+stages:
+  - stage_id: 0
+    max_num_seqs: 8
+    gpu_memory_utilization: 0.75
+    enforce_eager: false
+    async_scheduling: false
+    max_num_batched_tokens: 8192
+    max_model_len: 16384
+    devices: "0"
+    output_connectors:
+      to_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.8
+      top_k: 30
+      top_p: 0.9
+      max_tokens: 2048
+      seed: 42
+      repetition_penalty: 1.0
+
+  - stage_id: 1
+    max_num_seqs: 4
+    gpu_memory_utilization: 0.2
+    enforce_eager: true
+    async_scheduling: false
+    max_num_batched_tokens: 8192
+    max_model_len: 16384
+    devices: "1"
+    input_connectors:
+      from_stage_0: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      seed: 42
+      repetition_penalty: 1.0

--- a/vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml
+++ b/vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml
@@ -34,7 +34,7 @@ connectors:
 
 stages:
   - stage_id: 0
-    max_num_seqs: 8
+    max_num_seqs: 64
     gpu_memory_utilization: 0.75
     enforce_eager: false
     async_scheduling: false
@@ -54,7 +54,7 @@ stages:
       repetition_penalty: 1.0
 
   - stage_id: 1
-    max_num_seqs: 4
+    max_num_seqs: 64
     gpu_memory_utilization: 0.2
     enforce_eager: true
     async_scheduling: false

--- a/vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml
+++ b/vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml
@@ -38,7 +38,9 @@ stages:
     gpu_memory_utilization: 0.75
     enforce_eager: false
     async_scheduling: false
-    max_num_batched_tokens: 8192
+    # vLLM scheduler requires max_num_batched_tokens >= max_model_len when
+    # chunked prefill is off (SlowAR decode loop isn't chunked-prefill-safe).
+    max_num_batched_tokens: 16384
     max_model_len: 16384
     devices: "0"
     output_connectors:
@@ -56,7 +58,7 @@ stages:
     gpu_memory_utilization: 0.2
     enforce_eager: true
     async_scheduling: false
-    max_num_batched_tokens: 8192
+    max_num_batched_tokens: 16384
     max_model_len: 16384
     devices: "1"
     input_connectors:


### PR DESCRIPTION
## Summary

- Adds an opt-in `vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml` that pins Stage0 (Slow/Fast AR) to GPU 0 and Stage1 (DAC decoder) to GPU 1.
- Enlarges Stage0 AR batching (`max_num_seqs` 4→8, `gpu_memory_utilization` 0.6→0.75), lets Stage1 consume DAC chunks in parallel (`max_num_seqs` 1→4, `gpu_memory_utilization` 0.1→0.2), and drops `connector_get_sleep_s` from 10ms to 1ms.
- Adds a "2x H100 80GB" section to `recipes/fishaudio/Fish-Speech-S2-Pro.md` with the invocation and the reported throughput table.

The single-GPU default (`fish_qwen3_omni.yaml`) is unchanged, so existing users on one GPU are not affected. Users with two GPUs opt in via `--deploy-config`.

## Source

Settings mirror the H100x2-validated profile from #2515 ([comment](https://github.com/vllm-project/vllm-omni/pull/2515#issuecomment-4329530854) by @Sy0307). Reported gains over the SGL 2-GPU GPU-vocoder baseline at concurrency=10: +43% audio/s, +58% req/s.

## Usage

```bash
CUDA_VISIBLE_DEVICES=0,1 vllm serve fishaudio/s2-pro --omni --port 8091 \
    --deploy-config vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml
```

## Test plan

- [ ] `vllm serve` boots cleanly with `--deploy-config vllm_omni/deploy/fish_qwen3_omni_2gpu.yaml` on a 2-GPU host.
- [ ] Single-stage TTS request (`/v1/audio/speech`) returns valid 44.1 kHz WAV.
- [ ] Voice cloning request with `ref_audio`/`ref_text` succeeds.
- [ ] Concurrent benchmarking reproduces throughput in the recipe table within tolerance.
- [ ] Default `vllm serve fishaudio/s2-pro --omni` (no `--deploy-config`) still loads the single-GPU profile.

cc @Sy0307 @lishunyang12