### PR TITLE
[Bugfix] Fix CUBLAS_STATUS_EXECUTION_FAILED when native Flash Attention is available (Wan2.2)

### DIFF
--- a/tests/diffusion/attention/test_flash_attn.py
+++ b/tests/diffusion/attention/test_flash_attn.py
@@ -15,9 +15,12 @@ import torch
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.backends.flash_attn import FlashAttentionImpl
 from vllm_omni.diffusion.attention.backends.sdpa import SDPAImpl
+from vllm_omni.diffusion.attention.backends.utils import fa  # noqa: E402
 from vllm_omni.platforms import current_omni_platform
 
 is_gpu = current_omni_platform.is_cuda_alike() or current_omni_platform.is_xpu()
+HAS_FLASH_ATTN = fa.HAS_FLASH_ATTN
+flash_attn_func = fa.flash_attn_func  # noqa: N813
 
 
 def create_attention_mask(batch_size: int, seq_len: int, valid_len: int, device: torch.device) -> torch.Tensor:
@@ -262,6 +265,36 @@ def test_fa_vs_sdpa():
     assert mean_diff < 0.001, f"Mean difference {mean_diff} exceeds threshold 0.001"
 
     print("✓ Case 2 PASSED: FA and SDPA outputs are very close!")
+
+
+@pytest.mark.skipif(not is_gpu, reason="FlashAttention requires CUDA or XPU")
+def test_flash_attn_func_preferred_over_varlen():
+    """Test flash_attn_func availability and basic forward call."""
+    if not HAS_FLASH_ATTN:
+        pytest.skip("No Flash Attention available")
+
+    if flash_attn_func is None:
+        pytest.skip("flash_attn_func not available, will use varlen fallback")
+
+    device = torch.device(current_omni_platform.device_type)
+    dtype = torch.bfloat16
+
+    num_heads, head_dim = 8, 64
+    fa_impl = FlashAttentionImpl(
+        num_heads=num_heads, head_size=head_dim, softmax_scale=1.0 / (head_dim**0.5), causal=False
+    )
+
+    torch.manual_seed(42)
+    q = torch.randn(1, 32, num_heads, head_dim, device=device, dtype=dtype)
+    k = q.clone()
+    v = q.clone()
+
+    attn_metadata = AttentionMetadata(attn_mask=None)
+    output = fa_impl.forward(q, k, v, attn_metadata)
+
+    assert output.shape == q.shape
+    assert not torch.isnan(output).any()
+    print("✓ flash_attn_func forward works correctly!")
 
 
 if __name__ == "__main__":

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -140,6 +140,7 @@ class FlashAttentionImpl(AttentionImpl):
         """CUDA/ROCm/MUSA flash attention implementation."""
         from vllm_omni.diffusion.attention.backends.utils.fa import (
             HAS_FLASH_ATTN,
+            flash_attn_func,
         )
 
         if not HAS_FLASH_ATTN:
@@ -158,6 +159,16 @@ class FlashAttentionImpl(AttentionImpl):
                 value,
                 attention_mask,
             )
+
+        if flash_attn_func is not None:
+            out = flash_attn_func(
+                query,
+                key,
+                value,
+                causal=self.causal,
+                softmax_scale=self.softmax_scale,
+            )
+            return self._unwrap_flash_output(out)
 
         return self._forward_varlen_dense(
             query,

--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -51,27 +51,28 @@ else:
     # CUDA: try FA3 -> FA2 fallback chain
     # Try FA3 from fa3-fwd PyPI package
     try:
-        from fa3_fwd_interface import flash_attn_varlen_func  # noqa: F401
+        from fa3_fwd_interface import flash_attn_func, flash_attn_varlen_func  # noqa: F401
     except (ImportError, ModuleNotFoundError):
         pass
 
     # Fallback: Try FA3 from flash-attention source build
-    if flash_attn_varlen_func is None:
+    if flash_attn_func is None:
         try:
-            from flash_attn_interface import flash_attn_varlen_func  # noqa: F401
+            from flash_attn_interface import flash_attn_func, flash_attn_varlen_func  # noqa: F401
         except (ImportError, ModuleNotFoundError):
             pass
 
     # Fallback: Try FA2 from flash-attn package (try multiple import paths)
-    if flash_attn_varlen_func is None:
+    if flash_attn_func is None:
         try:
-            from flash_attn import flash_attn_varlen_func  # noqa: F401
+            from flash_attn import flash_attn_func, flash_attn_varlen_func  # noqa: F401
         except (ImportError, ModuleNotFoundError):
             pass
 
-    if flash_attn_varlen_func is None:
+    if flash_attn_func is None:
         try:
             from flash_attn.flash_attn_interface import (  # noqa: F401
+                flash_attn_func,
                 flash_attn_varlen_func,
             )
         except (ImportError, ModuleNotFoundError):


### PR DESCRIPTION

## Purpose

```
CUDA_LAUNCH_BLOCKING=1 CUDA_VISIBLE_DEVICES=2,3 python examples/offline_inference/text_to_video/text_to_video.py  --model Wan-AI/Wan2.2-TI2V-5B-Diffusers  --prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."   --negative-prompt "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发
灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"   --height 480   --width 832   --num-frames 33   --guidance-scale 4.0   --guidance-scale-high 4.0   --boundary-ratio 0.875   --num-inference-steps 40   --flow-shift 12.0   --fps 16  --enable-cpu-offload --tensor-parallel-size 2  --output t2v_out.mp4
```

```
ERROR 05-04 07:59:21 [diffusion_worker.py:608]   File "/tmp/torchinductor_root/qs/cqs7gsnpjnfkg5aamv3y5ou7js3mdincduqtectbqvkhcckrquqq.py", line 942, in call
ERROR 05-04 07:59:21 [diffusion_worker.py:608]     extern_kernels.mm(reinterpret_tensor(buf22, (s67, 1536), (1536, 1), 0), reinterpret_tensor(arg22_1, (1536, 3072), (1, 1536), 0), out=buf26)
ERROR 05-04 07:59:21 [diffusion_worker.py:608] RuntimeError: CUDA error: CUBLAS_STATUS_EXECUTION_FAILED when calling `cublasGemmEx( handle, opa, opb, m, n, k, &falpha, a, CUDA_R_16BF, lda, b, CUDA_R_16BF, ldb, &fbeta, c, std::is_same_v<C_Dtype, float> ? CUDA_R_32F : CUDA_
R_16BF, ldc, compute_type, CUBLAS_GEMM_DEFAULT_TENSOR_OP)`
```

**Root cause:**

The recent commit removed `flash_attn_func` from the native FA import chain, leaving only `flash_attn_varlen_func` . This caused `forward_cuda` to always use the varlen path ( `_forward_varlen_dense` ) even when native `flash_attn_func` was available, leading to `CUBLAS_STATUS_EXECUTION_FAILED` in certain environments.


## Test Plan

## Test Result


https://github.com/user-attachments/assets/d9554483-b1ff-48e3-894b-7a95c44a6d5c



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
