### PR TITLE
[CI] update Qwen Image perf baseline for CUDA 13.0

### DIFF
--- a/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
@@ -21,8 +21,8 @@
                 "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.30,
-                    "latency_mean": 3.50,
+                    "throughput_qps": 0.25,
+                    "latency_mean": 4.5,
                     "peak_memory_mb_mean": 67000
                 }
             },
@@ -37,8 +37,8 @@
                 "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.037,
-                    "latency_mean": 27.0,
+                    "throughput_qps": 0.032,
+                    "latency_mean": 32.0,
                     "peak_memory_mb_mean": 74000
                 }
             }
@@ -67,8 +67,8 @@
                 "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.30,
-                    "latency_mean": 3.50,
+                    "throughput_qps": 0.25,
+                    "latency_mean": 4.5,
                     "peak_memory_mb_mean": 67000
                 }
             },
@@ -83,8 +83,8 @@
                 "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.037,
-                    "latency_mean": 27.0,
+                    "throughput_qps": 0.032,
+                    "latency_mean": 32.0,
                     "peak_memory_mb_mean": 74000
                 }
             }
@@ -116,8 +116,8 @@
                 "max-concurrency": 1,
                 "enable-negative-prompt": true,
                 "baseline": {
-                    "throughput_qps": 0.1,
-                    "latency_mean": 9.1,
+                    "throughput_qps": 0.085,
+                    "latency_mean": 11.5,
                     "peak_memory_mb_mean": 61000
                 }
             }


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Resolve #3266

## Test Plan

The same L4 performance test, but with loosened threshold.

The new thresholds are set based on the most recent 4 nightly results:

Test Name | Input Param | Build (vLLM-Omni) | Throughput (QPS) | Latency Mean (s) | Latency Median (s) | Latency P99 (s)
-- | -- | -- | -- | -- | -- | --
single_device | 512x512_steps20 | 8772 | 0.2601 | 3.8446 | 3.8535 | 4.0220
  |   | 8697 | 0.2683 | 3.7272 | 3.6800 | 4.0268
  |   | 8612 | 0.3132 | 3.1925 | 3.1916 | 3.3228
  |   | 8590 | 0.2725 | 3.6700 | 3.6250 | 3.9171
  | 1536x1536_steps35 | 8772 | 0.0357 | 28.0334 | 28.0572 | 28.2480
  |   | 8697 | 0.0361 | 27.6644 | 27.6936 | 27.8867
  |   | 8612 | 0.0356 | 28.0741 | 28.0450 | 28.2155
  |   | 8590 | 0.0359 | 27.8930 | 27.9067 | 28.0832
single_device_step_execution | 512x512_steps20 | 8772 | 0.2712 | 3.6871 | 3.6840 | 3.7028
  |   | 8697 | 0.2675 | 3.7382 | 3.7463 | 3.8329
  |   | 8612 | 0.3190 | 3.1348 | 3.1272 | 3.2686
  |   | 8590 | 0.2837 | 3.5245 | 3.5207 | 3.5963
  | 1536x1536_steps35 | 8772 | 0.0358 | 27.9408 | 27.9786 | 28.1068
  |   | 8697 | 0.0360 | 27.7840 | 27.8019 | 28.0677
  |   | 8612 | 0.0356 | 28.0748 | 28.0757 | 28.1965
  |   | 8590 | 0.0359 | 27.8435 | 27.9086 | 28.0079
ulysses2_cfg2_vae_patch4 | 1536x1536_steps35 | 8772 | 0.1048 | 9.5419 | 9.5075 | 9.8178
  |   | 8697 | 0.1040 | 9.5790 | 9.5345 | 10.0783
  |   | 8612 | 0.1094 | 9.1426 | 9.1494 | 9.3254
  |   | 8590 | 0.1052 | 9.5032 | 9.4638 | 9.7812


## Test Result

These thresholds are CI specific. Need to test them on CI machine

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
