### PR TITLE
[Feature][TeaCache] Add TeaCache support for Wan2.2 T2V and I2V pipelines

### DIFF
--- a/tests/diffusion/cache/test_wan2_2_teacache.py
+++ b/tests/diffusion/cache/test_wan2_2_teacache.py
@@ -1,0 +1,499 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Unit tests for Wan2.2 TeaCache support.
+
+Covers:
+- Polynomial coefficients correctness (WanTransformer3DModel)
+- _teacache_init_loop_state / _teacache_should_compute logic
+- 3D (T2V/I2V) vs 4D (TI2V) timestep handling in extract_wan2_2_context
+- FSDP unshard/reshard path (mocked)
+- Edge cases: rel_l1_thresh exceeded mid-sequence, first-step always-compute
+- TeaCache on vs off consistency (CPU, mock denoising loop)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm_omni.diffusion.cache.teacache.backend import (
+    _teacache_init_loop_state,
+    _teacache_should_compute,
+    enable_wan2_2_teacache,
+)
+from vllm_omni.diffusion.cache.teacache.config import TeaCacheConfig, _MODEL_COEFFICIENTS
+from vllm_omni.diffusion.cache.teacache.extractors import extract_wan2_2_context
+from vllm_omni.diffusion.data import DiffusionCacheConfig
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_pipeline(rel_l1_thresh: float = 0.2) -> MagicMock:
+    pipeline = MagicMock()
+    pipeline._tea_cache_config = TeaCacheConfig(
+        transformer_type="WanTransformer3DModel",
+        rel_l1_thresh=rel_l1_thresh,
+    )
+    return pipeline
+
+
+# ---------------------------------------------------------------------------
+# 1. Polynomial coefficients
+# ---------------------------------------------------------------------------
+
+class TestWan22Coefficients:
+    """Verify WanTransformer3DModel polynomial coefficients are registered and valid."""
+
+    def test_coefficients_registered(self):
+        assert "WanTransformer3DModel" in _MODEL_COEFFICIENTS
+
+    def test_coefficients_length(self):
+        coeffs = _MODEL_COEFFICIENTS["WanTransformer3DModel"]
+        assert len(coeffs) == 5
+
+    def test_coefficients_are_finite(self):
+        coeffs = _MODEL_COEFFICIENTS["WanTransformer3DModel"]
+        for c in coeffs:
+            assert np.isfinite(c), f"Non-finite coefficient: {c}"
+
+    def test_polynomial_monotone_on_typical_range(self):
+        """Polynomial should be roughly monotone on [0.0, 0.5] (at most 3 inflections)."""
+        coeffs = _MODEL_COEFFICIENTS["WanTransformer3DModel"]
+        poly = np.poly1d(coeffs)
+        xs = np.linspace(0.0, 0.5, 50)
+        ys = poly(xs)
+        sign_changes = int(np.sum(np.diff(np.sign(np.diff(ys))) != 0))
+        assert sign_changes <= 3, (
+            f"Polynomial has {sign_changes} inflection points on [0, 0.5]"
+        )
+
+    def test_teacache_config_uses_wan_coefficients(self):
+        cfg = TeaCacheConfig(transformer_type="WanTransformer3DModel")
+        assert cfg.coefficients == _MODEL_COEFFICIENTS["WanTransformer3DModel"]
+
+    def test_teacache_config_custom_coefficients_override(self):
+        custom = [1.0, 2.0, 3.0, 4.0, 5.0]
+        cfg = TeaCacheConfig(transformer_type="WanTransformer3DModel", coefficients=custom)
+        assert cfg.coefficients == custom
+
+    def test_teacache_config_invalid_rel_l1_thresh(self):
+        with pytest.raises(ValueError, match="rel_l1_thresh must be positive"):
+            TeaCacheConfig(transformer_type="WanTransformer3DModel", rel_l1_thresh=0.0)
+
+    def test_teacache_config_wrong_coeff_length(self):
+        with pytest.raises(ValueError, match="coefficients must contain exactly 5"):
+            TeaCacheConfig(
+                transformer_type="WanTransformer3DModel",
+                coefficients=[1.0, 2.0, 3.0],
+            )
+
+
+# ---------------------------------------------------------------------------
+# 2. Loop state init and should_compute logic
+# ---------------------------------------------------------------------------
+
+class TestTeaCacheLoopState:
+    """Unit tests for _teacache_init_loop_state and _teacache_should_compute."""
+
+    def test_init_returns_none_when_no_config(self):
+        pipeline = MagicMock(spec=[])
+        state = _teacache_init_loop_state(pipeline)
+        assert state is None
+
+    def test_init_returns_state_dict(self):
+        state = _teacache_init_loop_state(_make_pipeline())
+        assert state is not None
+        for key in ("config", "rescale", "acc_dist", "prev_modulated_input",
+                    "prev_noise_pred", "cnt"):
+            assert key in state
+
+    def test_init_acc_dist_zero(self):
+        assert _teacache_init_loop_state(_make_pipeline())["acc_dist"] == 0.0
+
+    def test_init_cnt_zero(self):
+        assert _teacache_init_loop_state(_make_pipeline())["cnt"] == 0
+
+    def test_should_compute_none_state(self):
+        assert _teacache_should_compute(None, torch.randn(1, 16, 32)) is True
+
+    def test_should_compute_none_modulated_input(self):
+        state = _teacache_init_loop_state(_make_pipeline())
+        assert _teacache_should_compute(state, None) is True
+
+    def test_first_step_always_computes(self):
+        """cnt=0 must always return True regardless of input similarity."""
+        state = _teacache_init_loop_state(_make_pipeline())
+        result = _teacache_should_compute(state, torch.zeros(1, 16, 32))
+        assert result is True
+
+    def test_prev_modulated_input_stored_after_first_step(self):
+        state = _teacache_init_loop_state(_make_pipeline())
+        mod_input = torch.randn(1, 16, 32)
+        _teacache_should_compute(state, mod_input)
+        assert state["prev_modulated_input"] is not None
+        assert state["prev_modulated_input"].shape == mod_input.shape
+
+    def test_identical_inputs_may_skip_compute(self):
+        """Identical consecutive inputs should eventually trigger cache reuse."""
+        state = _teacache_init_loop_state(_make_pipeline(rel_l1_thresh=0.5))
+        mod_input = torch.ones(1, 16, 32)
+        _teacache_should_compute(state, mod_input)
+        state["cnt"] += 1
+
+        skipped = False
+        for _ in range(20):
+            result = _teacache_should_compute(state, mod_input.clone())
+            if not result:
+                skipped = True
+                break
+            state["cnt"] += 1
+        assert skipped, "Identical inputs should trigger cache reuse within 20 steps"
+
+    def test_large_change_resets_acc_dist(self):
+        """When threshold exceeded, acc_dist resets to 0."""
+        state = _teacache_init_loop_state(_make_pipeline(rel_l1_thresh=0.01))
+        prev = torch.ones(1, 16, 32)
+        _teacache_should_compute(state, prev)
+        state["cnt"] += 1
+
+        very_different = torch.ones(1, 16, 32) * 1000.0
+        result = _teacache_should_compute(state, very_different)
+        assert result is True
+        assert state["acc_dist"] == 0.0
+
+    def test_very_high_threshold_uses_cache(self):
+        """With very high threshold, step 1 should use cache (acc_dist < thresh)."""
+        state = _teacache_init_loop_state(_make_pipeline(rel_l1_thresh=1e6))
+        mod_input = torch.ones(1, 4, 8) * 0.5
+        _teacache_should_compute(state, mod_input)
+        state["cnt"] += 1
+        result = _teacache_should_compute(state, mod_input.clone())
+        assert result is False, "Very high threshold should use cache on step 1"
+
+
+# ---------------------------------------------------------------------------
+# 3. enable_wan2_2_teacache
+# ---------------------------------------------------------------------------
+
+class TestEnableWan22TeaCache:
+
+    def test_attaches_tea_cache_config(self):
+        pipeline = MagicMock()
+        enable_wan2_2_teacache(pipeline, DiffusionCacheConfig(rel_l1_thresh=0.3))
+        assert isinstance(pipeline._tea_cache_config, TeaCacheConfig)
+
+    def test_config_rel_l1_thresh_propagated(self):
+        pipeline = MagicMock()
+        enable_wan2_2_teacache(pipeline, DiffusionCacheConfig(rel_l1_thresh=0.42))
+        assert pipeline._tea_cache_config.rel_l1_thresh == pytest.approx(0.42)
+
+    def test_config_transformer_type(self):
+        pipeline = MagicMock()
+        enable_wan2_2_teacache(pipeline, DiffusionCacheConfig())
+        assert pipeline._tea_cache_config.transformer_type == "WanTransformer3DModel"
+
+    def test_custom_coefficients_propagated(self):
+        pipeline = MagicMock()
+        custom = [1.0, 2.0, 3.0, 4.0, 5.0]
+        enable_wan2_2_teacache(pipeline, DiffusionCacheConfig(coefficients=custom))
+        assert pipeline._tea_cache_config.coefficients == custom
+
+    def test_wan22_pipeline_in_custom_enablers(self):
+        from vllm_omni.diffusion.cache.teacache.backend import CUSTOM_TEACACHE_ENABLERS
+        assert "Wan22Pipeline" in CUSTOM_TEACACHE_ENABLERS
+        assert "Wan22I2VPipeline" in CUSTOM_TEACACHE_ENABLERS
+        assert CUSTOM_TEACACHE_ENABLERS["Wan22Pipeline"] is enable_wan2_2_teacache
+        assert CUSTOM_TEACACHE_ENABLERS["Wan22I2VPipeline"] is enable_wan2_2_teacache
+
+
+# ---------------------------------------------------------------------------
+# 4. extract_wan2_2_context — timestep shape and FSDP
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Minimal CPU-only mock for WanTransformer3DModel
+# ---------------------------------------------------------------------------
+
+class _MockAdaLayerNorm(nn.Module):
+    """CPU-safe AdaLayerNorm substitute: ignores scale/shift, returns input."""
+
+    def forward(self, hidden_states: torch.Tensor, scale=None, shift=None) -> torch.Tensor:
+        return hidden_states
+
+
+class _MockWanBlock(nn.Module):
+    """Minimal WanTransformerBlock for CPU unit tests."""
+
+    def __init__(self, inner_dim: int):
+        super().__init__()
+        self.scale_shift_table = nn.Parameter(torch.zeros(1, 6, inner_dim))
+        self.norm1 = _MockAdaLayerNorm()
+
+
+class _MockPatchEmbedding(nn.Module):
+    """Returns a fixed-shape 5D tensor regardless of input."""
+
+    def __init__(self, inner_dim: int, spatial_out: int = 2):
+        super().__init__()
+        self._inner_dim = inner_dim
+        self._spatial_out = spatial_out
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        B = hidden_states.shape[0]
+        return torch.randn(B, self._inner_dim, 1, self._spatial_out, self._spatial_out)
+
+
+class _MockConditionEmbedder(nn.Module):
+    """Returns (temb, timestep_proj, None, None) with correct shapes."""
+
+    def __init__(self, inner_dim: int):
+        super().__init__()
+        self._inner_dim = inner_dim
+
+    def forward(self, timestep_flat, encoder_hidden_states, encoder_hidden_states_image,
+                timestep_seq_len=None):
+        B = encoder_hidden_states.shape[0]
+        D = self._inner_dim
+        if timestep_seq_len is not None:
+            temb = torch.randn(B, timestep_seq_len, D)
+            ts_proj = torch.randn(B, timestep_seq_len, 6 * D)
+        else:
+            temb = torch.randn(B, D)
+            ts_proj = torch.randn(B, 6 * D)
+        return temb, ts_proj, None, None
+
+
+class _MockTimestepProjPrepare(nn.Module):
+    """Reshapes timestep_proj for block modulation."""
+
+    def __init__(self, inner_dim: int):
+        super().__init__()
+        self._inner_dim = inner_dim
+
+    def forward(self, ts_proj: torch.Tensor, ts_seq_len=None) -> torch.Tensor:
+        D = self._inner_dim
+        B = ts_proj.shape[0]
+        if ts_seq_len is not None:
+            return ts_proj.view(B, ts_seq_len, 6, D)
+        return ts_proj.view(B, 6, D)
+
+
+class _MockWanModule(nn.Module):
+    """
+    CPU-safe mock of WanTransformer3DModel.
+
+    Provides the interface used by extract_wan2_2_context without any NPU ops.
+    """
+
+    def __init__(self, inner_dim: int = 16, num_blocks: int = 2):
+        super().__init__()
+        self.patch_embedding = _MockPatchEmbedding(inner_dim)
+        self.condition_embedder = _MockConditionEmbedder(inner_dim)
+        self.timestep_proj_prepare = _MockTimestepProjPrepare(inner_dim)
+        self.blocks = nn.ModuleList([_MockWanBlock(inner_dim) for _ in range(num_blocks)])
+        self._inner_dim = inner_dim
+
+
+def _make_mock_wan_module(inner_dim: int = 16, image_dim: int | None = None) -> _MockWanModule:
+    """Return a CPU-safe mock WanTransformer3DModel."""
+    return _MockWanModule(inner_dim=inner_dim)
+
+
+class TestExtractWan22Context:
+    """
+    Unit tests for extract_wan2_2_context.
+
+    Uses a mock WanTransformer3DModel that runs on CPU without NPU ops.
+    Tests 3D timestep (T2V/I2V) and 4D timestep (TI2V) paths.
+    """
+
+    INNER_DIM = 16
+
+    @pytest.fixture
+    def tiny_wan_module(self):
+        return _make_mock_wan_module(inner_dim=self.INNER_DIM)
+
+    @pytest.fixture
+    def tiny_wan_i2v_module(self):
+        return _make_mock_wan_module(inner_dim=self.INNER_DIM, image_dim=8)
+
+    def _t2v_inputs(self):
+        return {
+            "hidden_states": torch.randn(1, 4, 1, 4, 4),
+            "timestep": torch.tensor([500]),
+            "encoder_hidden_states": torch.randn(1, 4, 32),
+            "encoder_hidden_states_image": None,
+        }
+
+    def _ti2v_inputs(self):
+        return {
+            "hidden_states": torch.randn(1, 4, 1, 4, 4),
+            "timestep": torch.randint(0, 1000, (1, 4)),
+            "encoder_hidden_states": torch.randn(1, 4, 32),
+            "encoder_hidden_states_image": torch.randn(1, 4, 16),
+        }
+
+    def test_invalid_module_raises(self):
+        bad_module = MagicMock()
+        bad_module.blocks = []
+        with pytest.raises(ValueError, match="Module must have blocks"):
+            extract_wan2_2_context(
+                bad_module,
+                hidden_states=torch.randn(1, 4, 1, 4, 4),
+                timestep=torch.tensor([500]),
+                encoder_hidden_states=torch.randn(1, 4, 32),
+            )
+
+    def test_3d_timestep_modulated_input_shape(self, tiny_wan_module):
+        """3D timestep (T2V): modulated_input is [B, S, inner_dim]."""
+        ctx = extract_wan2_2_context(tiny_wan_module, **self._t2v_inputs())
+        assert ctx.modulated_input.ndim == 3
+        assert ctx.modulated_input.shape[0] == 1
+        assert ctx.modulated_input.shape[2] == self.INNER_DIM
+
+    def test_4d_timestep_modulated_input_shape(self, tiny_wan_i2v_module):
+        """4D timestep (TI2V): modulated_input is [B, S, inner_dim]."""
+        ctx = extract_wan2_2_context(tiny_wan_i2v_module, **self._ti2v_inputs())
+        assert ctx.modulated_input.ndim == 3
+        assert ctx.modulated_input.shape[0] == 1
+        assert ctx.modulated_input.shape[2] == self.INNER_DIM
+
+    def test_modulated_input_no_grad(self, tiny_wan_module):
+        """modulated_input must not require grad (no memory leak across steps)."""
+        ctx = extract_wan2_2_context(tiny_wan_module, **self._t2v_inputs())
+        assert not ctx.modulated_input.requires_grad
+
+    def test_run_transformer_blocks_is_none(self, tiny_wan_module):
+        """Pipeline-level TeaCache: run_transformer_blocks is None."""
+        ctx = extract_wan2_2_context(tiny_wan_module, **self._t2v_inputs())
+        assert ctx.run_transformer_blocks is None
+
+    def test_postprocess_is_none(self, tiny_wan_module):
+        """Pipeline-level TeaCache: postprocess is None."""
+        ctx = extract_wan2_2_context(tiny_wan_module, **self._t2v_inputs())
+        assert ctx.postprocess is None
+
+    def test_temb_is_not_none(self, tiny_wan_module):
+        ctx = extract_wan2_2_context(tiny_wan_module, **self._t2v_inputs())
+        assert ctx.temb is not None
+
+    def test_no_image_encoder_hidden_states_t2v(self, tiny_wan_module):
+        """T2V: encoder_hidden_states_image=None is handled without error."""
+        ctx = extract_wan2_2_context(tiny_wan_module, **self._t2v_inputs())
+        assert ctx is not None
+
+    def test_fsdp_unshard_called_when_fsdp_module(self, tiny_wan_module):
+        """FSDP path: unshard() is called on root module when it is an FSDPModule."""
+        try:
+            from torch.distributed.fsdp._fully_shard._fully_shard import FSDPModule
+        except ImportError:
+            pytest.skip("FSDPModule not available in this PyTorch version")
+
+        # Wrap the real mock module in a MagicMock that looks like FSDPModule
+        mock_module = MagicMock(spec=FSDPModule)
+        mock_module.blocks = tiny_wan_module.blocks
+        mock_module.patch_embedding = tiny_wan_module.patch_embedding
+        mock_module.condition_embedder = tiny_wan_module.condition_embedder
+        mock_module.timestep_proj_prepare = tiny_wan_module.timestep_proj_prepare
+
+        try:
+            extract_wan2_2_context(mock_module, **self._t2v_inputs())
+        except Exception:
+            pass  # May fail due to mock internals; we only verify unshard was called
+        mock_module.unshard.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# 5. TeaCache on vs off consistency (mock denoising loop)
+# ---------------------------------------------------------------------------
+
+class TestTeaCacheConsistency:
+    """
+    Verify TeaCache produces consistent outputs with TeaCache disabled.
+
+    Uses a mock denoising loop that mirrors the pipeline-level caching logic
+    from pipeline_wan2_2.py / pipeline_wan2_2_i2v.py without requiring NPU.
+    """
+
+    def _run_loop(self, noise_fn, num_steps, rel_l1_thresh):
+        pipeline = MagicMock()
+        if rel_l1_thresh is not None:
+            pipeline._tea_cache_config = TeaCacheConfig(
+                transformer_type="WanTransformer3DModel",
+                rel_l1_thresh=rel_l1_thresh,
+            )
+        else:
+            type(pipeline)._tea_cache_config = property(lambda self: None)
+
+        _tc_state = _teacache_init_loop_state(pipeline)
+        results = []
+        for step in range(num_steps):
+            mod_input = torch.ones(1, 16, 32) * (1.0 + step * 0.001)
+            if _teacache_should_compute(_tc_state, mod_input):
+                noise_pred = noise_fn(step)
+                if _tc_state is not None:
+                    _tc_state["prev_noise_pred"] = noise_pred
+            else:
+                noise_pred = _tc_state["prev_noise_pred"]
+            results.append(noise_pred.clone())
+            if _tc_state is not None:
+                _tc_state["cnt"] += 1
+        return results
+
+    def test_disabled_all_steps_computed(self):
+        """With TeaCache disabled, every step calls noise_fn."""
+        calls = [0]
+
+        def noise_fn(step):
+            calls[0] += 1
+            return torch.randn(1, 4, 8)
+
+        self._run_loop(noise_fn, 10, None)
+        assert calls[0] == 10
+
+    def test_enabled_skips_some_steps(self):
+        """With slowly-changing inputs and moderate threshold, some steps are skipped."""
+        calls = [0]
+
+        def noise_fn(step):
+            calls[0] += 1
+            return torch.ones(1, 4, 8) * float(step)
+
+        self._run_loop(noise_fn, 20, 0.3)
+        assert calls[0] < 20, "TeaCache should skip some steps"
+
+    def test_very_low_threshold_matches_no_cache(self):
+        """With very low threshold, acc_dist always exceeds it so cache is never used.
+
+        _teacache_should_compute returns False (use cache) when acc_dist < rel_l1_thresh.
+        With rel_l1_thresh=1e-10, abs(poly(rel_l1)) >> 1e-10 for any non-trivial input,
+        so every step recomputes and outputs match the no-cache run exactly.
+        """
+        # Use a fixed sequence so both runs produce identical noise_pred values
+        noise_seq = [torch.ones(1, 4, 8) * float(i) for i in range(10)]
+
+        def noise_fn(step):
+            return noise_seq[step].clone()
+
+        no_cache = self._run_loop(noise_fn, 10, None)
+        with_cache = self._run_loop(noise_fn, 10, 1e-10)
+
+        for i, (a, b) in enumerate(zip(no_cache, with_cache)):
+            assert torch.allclose(a, b, atol=1e-5), f"Step {i} mismatch"
+
+    def test_first_step_always_matches(self):
+        """Step 0 output must always match no-cache output."""
+        def noise_fn(step):
+            return torch.ones(1, 4, 8) * float(step)
+
+        no_cache = self._run_loop(noise_fn, 5, None)
+        with_cache = self._run_loop(noise_fn, 5, 0.01)
+        assert torch.allclose(no_cache[0], with_cache[0]), "Step 0 must always be computed"

--- a/tests/diffusion/cache/test_wan2_2_teacache.py
+++ b/tests/diffusion/cache/test_wan2_2_teacache.py
@@ -13,7 +13,7 @@ Covers:
 - TeaCache on vs off consistency (CPU, mock denoising loop)
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -25,7 +25,7 @@ from vllm_omni.diffusion.cache.teacache.backend import (
     _teacache_should_compute,
     enable_wan2_2_teacache,
 )
-from vllm_omni.diffusion.cache.teacache.config import TeaCacheConfig, _MODEL_COEFFICIENTS
+from vllm_omni.diffusion.cache.teacache.config import _MODEL_COEFFICIENTS, TeaCacheConfig
 from vllm_omni.diffusion.cache.teacache.extractors import extract_wan2_2_context
 from vllm_omni.diffusion.data import DiffusionCacheConfig
 
@@ -35,6 +35,7 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_pipeline(rel_l1_thresh: float = 0.2) -> MagicMock:
     pipeline = MagicMock()
@@ -48,6 +49,7 @@ def _make_pipeline(rel_l1_thresh: float = 0.2) -> MagicMock:
 # ---------------------------------------------------------------------------
 # 1. Polynomial coefficients
 # ---------------------------------------------------------------------------
+
 
 class TestWan22Coefficients:
     """Verify WanTransformer3DModel polynomial coefficients are registered and valid."""
@@ -71,9 +73,7 @@ class TestWan22Coefficients:
         xs = np.linspace(0.0, 0.5, 50)
         ys = poly(xs)
         sign_changes = int(np.sum(np.diff(np.sign(np.diff(ys))) != 0))
-        assert sign_changes <= 3, (
-            f"Polynomial has {sign_changes} inflection points on [0, 0.5]"
-        )
+        assert sign_changes <= 3, f"Polynomial has {sign_changes} inflection points on [0, 0.5]"
 
     def test_teacache_config_uses_wan_coefficients(self):
         cfg = TeaCacheConfig(transformer_type="WanTransformer3DModel")
@@ -100,6 +100,7 @@ class TestWan22Coefficients:
 # 2. Loop state init and should_compute logic
 # ---------------------------------------------------------------------------
 
+
 class TestTeaCacheLoopState:
     """Unit tests for _teacache_init_loop_state and _teacache_should_compute."""
 
@@ -111,8 +112,7 @@ class TestTeaCacheLoopState:
     def test_init_returns_state_dict(self):
         state = _teacache_init_loop_state(_make_pipeline())
         assert state is not None
-        for key in ("config", "rescale", "acc_dist", "prev_modulated_input",
-                    "prev_noise_pred", "cnt"):
+        for key in ("config", "rescale", "acc_dist", "prev_modulated_input", "prev_noise_pred", "cnt"):
             assert key in state
 
     def test_init_acc_dist_zero(self):
@@ -183,8 +183,8 @@ class TestTeaCacheLoopState:
 # 3. enable_wan2_2_teacache
 # ---------------------------------------------------------------------------
 
-class TestEnableWan22TeaCache:
 
+class TestEnableWan22TeaCache:
     def test_attaches_tea_cache_config(self):
         pipeline = MagicMock()
         enable_wan2_2_teacache(pipeline, DiffusionCacheConfig(rel_l1_thresh=0.3))
@@ -208,6 +208,7 @@ class TestEnableWan22TeaCache:
 
     def test_wan22_pipeline_in_custom_enablers(self):
         from vllm_omni.diffusion.cache.teacache.backend import CUSTOM_TEACACHE_ENABLERS
+
         assert "Wan22Pipeline" in CUSTOM_TEACACHE_ENABLERS
         assert "Wan22I2VPipeline" in CUSTOM_TEACACHE_ENABLERS
         assert CUSTOM_TEACACHE_ENABLERS["Wan22Pipeline"] is enable_wan2_2_teacache
@@ -221,6 +222,7 @@ class TestEnableWan22TeaCache:
 # ---------------------------------------------------------------------------
 # Minimal CPU-only mock for WanTransformer3DModel
 # ---------------------------------------------------------------------------
+
 
 class _MockAdaLayerNorm(nn.Module):
     """CPU-safe AdaLayerNorm substitute: ignores scale/shift, returns input."""
@@ -258,8 +260,7 @@ class _MockConditionEmbedder(nn.Module):
         super().__init__()
         self._inner_dim = inner_dim
 
-    def forward(self, timestep_flat, encoder_hidden_states, encoder_hidden_states_image,
-                timestep_seq_len=None):
+    def forward(self, timestep_flat, encoder_hidden_states, encoder_hidden_states_image, timestep_seq_len=None):
         B = encoder_hidden_states.shape[0]
         D = self._inner_dim
         if timestep_seq_len is not None:
@@ -415,6 +416,7 @@ class TestExtractWan22Context:
 # 5. TeaCache on vs off consistency (mock denoising loop)
 # ---------------------------------------------------------------------------
 
+
 class TestTeaCacheConsistency:
     """
     Verify TeaCache produces consistent outputs with TeaCache disabled.
@@ -491,6 +493,7 @@ class TestTeaCacheConsistency:
 
     def test_first_step_always_matches(self):
         """Step 0 output must always match no-cache output."""
+
         def noise_fn(step):
             return torch.ones(1, 4, 8) * float(step)
 

--- a/vllm_omni/diffusion/cache/teacache/backend.py
+++ b/vllm_omni/diffusion/cache/teacache/backend.py
@@ -11,7 +11,6 @@ interface using the hooks-based TeaCache system.
 from typing import Any
 
 import torch
-
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.cache.base import CacheBackend

--- a/vllm_omni/diffusion/cache/teacache/backend.py
+++ b/vllm_omni/diffusion/cache/teacache/backend.py
@@ -94,10 +94,7 @@ def enable_wan2_2_teacache(pipeline: Any, config: DiffusionCacheConfig) -> None:
         coefficients=config.coefficients,
     )
     pipeline._tea_cache_config = teacache_config
-    logger.info(
-        f"TeaCache enabled for {type(pipeline).__name__} "
-        f"with rel_l1_thresh={teacache_config.rel_l1_thresh}"
-    )
+    logger.info(f"TeaCache enabled for {type(pipeline).__name__} with rel_l1_thresh={teacache_config.rel_l1_thresh}")
 
 
 def _teacache_init_loop_state(pipeline: Any) -> dict | None:

--- a/vllm_omni/diffusion/cache/teacache/backend.py
+++ b/vllm_omni/diffusion/cache/teacache/backend.py
@@ -10,6 +10,8 @@ interface using the hooks-based TeaCache system.
 
 from typing import Any
 
+import torch
+
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.cache.base import CacheBackend
@@ -76,10 +78,83 @@ def enable_flux2_klein_teacache(pipeline: Any, config: DiffusionCacheConfig) -> 
     )
 
 
+def enable_wan2_2_teacache(pipeline: Any, config: DiffusionCacheConfig) -> None:
+    """
+    Enable TeaCache for Wan22Pipeline (T2V) and Wan22I2VPipeline (I2V).
+
+    Both pipelines share WanTransformer3DModel and use the same pipeline-level
+    TeaCache approach.  Hook-based TeaCache cannot be used here because _sp_plan
+    splits hidden_states at blocks.0 input before the hook would fire, causing a
+    shape mismatch between rotary_emb (computed on unsharded hidden_states) and
+    the sharded hidden_states seen by transformer blocks.
+    """
+    teacache_config = TeaCacheConfig(
+        transformer_type="WanTransformer3DModel",
+        rel_l1_thresh=config.rel_l1_thresh,
+        coefficients=config.coefficients,
+    )
+    pipeline._tea_cache_config = teacache_config
+    logger.info(
+        f"TeaCache enabled for {type(pipeline).__name__} "
+        f"with rel_l1_thresh={teacache_config.rel_l1_thresh}"
+    )
+
+
+def _teacache_init_loop_state(pipeline: Any) -> dict | None:
+    """
+    Initialize TeaCache loop state from pipeline config.
+
+    Returns a state dict if TeaCache is configured on the pipeline, else None.
+    The state dict tracks: rescale polynomial, accumulated distance, previous
+    modulated input, previous noise prediction, and step counter.
+    """
+    import numpy as np
+
+    config = getattr(pipeline, "_tea_cache_config", None)
+    if config is None:
+        return None
+    return {
+        "config": config,
+        "rescale": np.poly1d(config.coefficients),
+        "acc_dist": 0.0,
+        "prev_modulated_input": None,
+        "prev_noise_pred": None,
+        "cnt": 0,
+    }
+
+
+def _teacache_should_compute(state: dict | None, modulated_input: torch.Tensor | None) -> bool:
+    """
+    Decide whether to compute noise_pred or reuse the cached value.
+
+    Computes rel_l1 on the modulated first-block norm output (content-aware signal)
+    rather than a raw timestep delta.  Updates state["prev_modulated_input"] in-place.
+
+    Returns True if noise_pred must be computed, False if cached value can be reused.
+    If state is None or modulated_input is None, always returns True (no caching).
+    """
+    if state is None or modulated_input is None:
+        return True
+    should_compute = True
+    if state["cnt"] > 0 and state["prev_modulated_input"] is not None:
+        prev = state["prev_modulated_input"]
+        rel_l1 = (modulated_input - prev).abs().mean() / (prev.abs().mean() + 1e-8)
+        rescaled = float(state["rescale"](rel_l1.item()))
+        state["acc_dist"] += abs(rescaled)
+        if state["acc_dist"] < state["config"].rel_l1_thresh:
+            should_compute = False
+        else:
+            state["acc_dist"] = 0.0
+    state["prev_modulated_input"] = modulated_input.detach().clone()
+    return should_compute
+
+
 CUSTOM_TEACACHE_ENABLERS = {
     "BagelPipeline": enable_bagel_teacache,
     "Flux2KleinPipeline": enable_flux2_klein_teacache,
     "HunyuanImage3Pipeline": enable_hunyuan_image3_teacache,
+    "Wan22Pipeline": enable_wan2_2_teacache,
+    "Wan22I2VPipeline": enable_wan2_2_teacache,
 }
 
 
@@ -167,15 +242,19 @@ class TeaCacheBackend(CacheBackend):
                                 Currently not used by TeaCache but accepted for interface consistency.
             verbose: Whether to log refresh operations (default: True)
         """
-        # HunyuanImage3: tea cache state is managed inside the denoising loop,
+        # Pipeline-level TeaCache: state is managed inside the denoising loop,
         # so refresh is a no-op (state is re-initialized every __call__).
+        _pipeline_level_types = ("HunyuanImage3Pipeline", "Wan22Pipeline", "Wan22I2VPipeline")
         if (
             hasattr(pipeline, "_tea_cache_config")
             and isinstance(pipeline._tea_cache_config, TeaCacheConfig)
-            and pipeline.__class__.__name__ == "HunyuanImage3Pipeline"
+            and pipeline.__class__.__name__ in _pipeline_level_types
         ):
             if verbose:
-                logger.debug(f"TeaCache state refreshed for HunyuanImage3 (num_inference_steps={num_inference_steps})")
+                logger.debug(
+                    f"TeaCache state refreshed for {pipeline.__class__.__name__} "
+                    f"(num_inference_steps={num_inference_steps})"
+                )
             return
 
         # Extract transformer from pipeline

--- a/vllm_omni/diffusion/cache/teacache/config.py
+++ b/vllm_omni/diffusion/cache/teacache/config.py
@@ -50,10 +50,10 @@ _MODEL_COEFFICIENTS = {
     # Source: TeaCache official repo (ali-vilab/TeaCache), empirically validated on Wan2.1.
     # Wan2.2 shares the same WanTransformer3DModel architecture; coefficients are reused.
     "WanTransformer3DModel": [
-        -5.21862437e+04,
-         9.23041404e+03,
-        -5.28275948e+02,
-         1.36987616e+01,
+        -5.21862437e04,
+        9.23041404e03,
+        -5.28275948e02,
+        1.36987616e01,
         -4.99875664e-02,
     ],
     # Estimated TeaCache polynomial coefficients for StableAudioDiTModel.

--- a/vllm_omni/diffusion/cache/teacache/config.py
+++ b/vllm_omni/diffusion/cache/teacache/config.py
@@ -46,6 +46,16 @@ _MODEL_COEFFICIENTS = {
         3.20000000e00,
         -2.00000000e-02,
     ],
+    # Wan2.2 transformer coefficients
+    # Source: TeaCache official repo (ali-vilab/TeaCache), empirically validated on Wan2.1.
+    # Wan2.2 shares the same WanTransformer3DModel architecture; coefficients are reused.
+    "WanTransformer3DModel": [
+        -5.21862437e+04,
+         9.23041404e+03,
+        -5.28275948e+02,
+         1.36987616e+01,
+        -4.99875664e-02,
+    ],
     # Estimated TeaCache polynomial coefficients for StableAudioDiTModel.
     "StableAudioDiTModel": [
         121.77490545701518,

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -94,8 +94,8 @@ class CacheContext:
     hidden_states: torch.Tensor
     encoder_hidden_states: torch.Tensor | None
     temb: torch.Tensor
-    run_transformer_blocks: Callable[[], tuple[torch.Tensor, ...]]
-    postprocess: Callable[[torch.Tensor], Any]
+    run_transformer_blocks: Callable[[], tuple[torch.Tensor, ...]] | None = None
+    postprocess: Callable[[torch.Tensor], Any] | None = None
     extra_states: dict[str, Any] | None = None
 
     def validate(self) -> None:
@@ -125,11 +125,11 @@ class CacheContext:
         if not isinstance(self.temb, torch.Tensor):
             raise TypeError(f"temb must be torch.Tensor, got {type(self.temb)}")
 
-        # Validate callables
-        if not callable(self.run_transformer_blocks):
+        # Validate callables (optional for pipeline-level TeaCache models)
+        if self.run_transformer_blocks is not None and not callable(self.run_transformer_blocks):
             raise TypeError(f"run_transformer_blocks must be callable, got {type(self.run_transformer_blocks)}")
 
-        if not callable(self.postprocess):
+        if self.postprocess is not None and not callable(self.postprocess):
             raise TypeError(f"postprocess must be callable, got {type(self.postprocess)}")
 
         # Validate tensor shapes are compatible

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -1199,6 +1199,99 @@ def extract_flux_context(
 #
 # Note: Use the transformer class name as specified in pipelines as TeaCache hooks operate
 # on the transformer module and multiple pipelines can share the same transformer.
+def extract_wan2_2_context(
+    module: nn.Module,
+    hidden_states: torch.Tensor,
+    timestep: torch.LongTensor,
+    encoder_hidden_states: torch.Tensor,
+    encoder_hidden_states_image: torch.Tensor | None = None,
+    **kwargs: Any,
+) -> CacheContext:
+    """
+    Extract cache context for WanTransformer3DModel (Wan2.2 T2V / I2V).
+
+    Wan2.2 uses a single-stream transformer with AdaLayerNorm modulation.
+    The modulated input is extracted from the first transformer block's norm1
+    output on hidden_states, conditioned on timestep_proj.  This is the same
+    signal the block uses to modulate self-attention, making it a reliable
+    cache-decision indicator.
+
+    Pipeline-level approach is required (same reason as HunyuanVideo-1.5):
+    _sp_plan splits hidden_states at blocks.0 input, so hook-based interception
+    before the SP-split would cause a shape mismatch in rotary_emb.
+    """
+    if not hasattr(module, "blocks") or len(module.blocks) == 0:
+        raise ValueError("Module must have blocks")
+
+    block0 = module.blocks[0]
+
+    try:
+        from torch.distributed.fsdp._fully_shard._fully_shard import FSDPModule as _FSDPModule
+    except ImportError:
+        _FSDPModule = None
+
+    _root_is_fsdp = _FSDPModule is not None and isinstance(module, _FSDPModule)
+    _block0_is_fsdp = _FSDPModule is not None and isinstance(block0, _FSDPModule)
+
+    try:
+        if _root_is_fsdp:
+            module.unshard()
+        if _block0_is_fsdp:
+            block0.unshard()
+
+        # Mirror transformer forward preprocessing
+        # Handle timestep shape (TI2V uses 2D timestep)
+        if timestep.ndim == 2:
+            ts_seq_len = timestep.shape[1]
+            timestep_flat = timestep.flatten()
+        else:
+            ts_seq_len = None
+            timestep_flat = timestep
+
+        # Patch embedding: [B, C, T, H, W] -> [B, S, D]
+        hidden_states_emb = module.patch_embedding(hidden_states)
+        hidden_states_emb = hidden_states_emb.flatten(2).transpose(1, 2)
+
+        # Condition embedding: get temb and timestep_proj
+        temb, timestep_proj, _, _ = module.condition_embedder(
+            timestep_flat, encoder_hidden_states, encoder_hidden_states_image,
+            timestep_seq_len=ts_seq_len,
+        )
+        timestep_proj = module.timestep_proj_prepare(timestep_proj, ts_seq_len)
+
+        # Extract modulated input from block0.norm1
+        # WanTransformerBlock: scale_shift_table + timestep_proj -> shift/scale/gate
+        if timestep_proj.ndim == 4:
+            # TI2V mode: [B, seq, 6, dim]
+            shift_msa, scale_msa, *_ = (
+                block0.scale_shift_table.unsqueeze(0) + timestep_proj
+            ).chunk(6, dim=2)
+            shift_msa = shift_msa.squeeze(2)
+            scale_msa = scale_msa.squeeze(2)
+        else:
+            # T2V / I2V mode: [B, 6, dim]
+            shift_msa, scale_msa, *_ = (
+                block0.scale_shift_table + timestep_proj
+            ).chunk(6, dim=1)
+
+        norm_hidden_states = block0.norm1(
+            hidden_states_emb, scale_msa, shift_msa
+        ).type_as(hidden_states_emb)
+
+    finally:
+        if _block0_is_fsdp:
+            block0.reshard()
+        if _root_is_fsdp:
+            module.reshard()
+
+    return CacheContext(
+        modulated_input=norm_hidden_states,
+        hidden_states=hidden_states_emb,
+        encoder_hidden_states=encoder_hidden_states,
+        temb=temb,
+    )
+
+
 EXTRACTOR_REGISTRY: dict[str, Callable] = {
     "QwenImageTransformer2DModel": extract_qwen_context,
     "Bagel": extract_bagel_context,
@@ -1208,6 +1301,7 @@ EXTRACTOR_REGISTRY: dict[str, Callable] = {
     "Flux2Transformer2DModel": extract_flux2_context,
     "LongCatImageTransformer2DModel": extract_longcat_context,
     "FluxTransformer2DModel": extract_flux_context,
+    "WanTransformer3DModel": extract_wan2_2_context,
     # Future models:
     # "CogVideoXTransformer3DModel": extract_cogvideox_context,
 }

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -1254,7 +1254,9 @@ def extract_wan2_2_context(
 
         # Condition embedding: get temb and timestep_proj
         temb, timestep_proj, _, _ = module.condition_embedder(
-            timestep_flat, encoder_hidden_states, encoder_hidden_states_image,
+            timestep_flat,
+            encoder_hidden_states,
+            encoder_hidden_states_image,
             timestep_seq_len=ts_seq_len,
         )
         timestep_proj = module.timestep_proj_prepare(timestep_proj, ts_seq_len)
@@ -1263,20 +1265,14 @@ def extract_wan2_2_context(
         # WanTransformerBlock: scale_shift_table + timestep_proj -> shift/scale/gate
         if timestep_proj.ndim == 4:
             # TI2V mode: [B, seq, 6, dim]
-            shift_msa, scale_msa, *_ = (
-                block0.scale_shift_table.unsqueeze(0) + timestep_proj
-            ).chunk(6, dim=2)
+            shift_msa, scale_msa, *_ = (block0.scale_shift_table.unsqueeze(0) + timestep_proj).chunk(6, dim=2)
             shift_msa = shift_msa.squeeze(2)
             scale_msa = scale_msa.squeeze(2)
         else:
             # T2V / I2V mode: [B, 6, dim]
-            shift_msa, scale_msa, *_ = (
-                block0.scale_shift_table + timestep_proj
-            ).chunk(6, dim=1)
+            shift_msa, scale_msa, *_ = (block0.scale_shift_table + timestep_proj).chunk(6, dim=1)
 
-        norm_hidden_states = block0.norm1(
-            hidden_states_emb, scale_msa, shift_msa
-        ).type_as(hidden_states_emb)
+        norm_hidden_states = block0.norm1(hidden_states_emb, scale_msa, shift_msa).type_as(hidden_states_emb)
 
     finally:
         if _block0_is_fsdp:

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -17,6 +17,8 @@ from torch import nn
 from transformers import AutoTokenizer, UMT5EncoderModel
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
+from vllm_omni.diffusion.cache.teacache.backend import _teacache_init_loop_state, _teacache_should_compute
+from vllm_omni.diffusion.cache.teacache.extractors import extract_wan2_2_context as _wan2_2_extractor
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import DistributedAutoencoderKLWan
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
@@ -403,6 +405,9 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
         latent_condition: torch.Tensor | None = None,
         first_frame_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        # ---- TeaCache initialization ----
+        _tc_state = _teacache_init_loop_state(self)
+
         with self.progress_bar(total=len(timesteps)) as pbar:
             for t in timesteps:
                 self._current_timestep = t
@@ -472,15 +477,37 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
                 else:
                     negative_kwargs = None
 
-                noise_pred = self.predict_noise_maybe_with_cfg(
-                    do_true_cfg=do_true_cfg,
-                    true_cfg_scale=current_guidance_scale,
-                    positive_kwargs=positive_kwargs,
-                    negative_kwargs=negative_kwargs,
-                    cfg_normalize=False,
-                )
+                # ---- TeaCache: decide whether to compute or reuse ----
+                # Only cache on self.transformer (stage-1); skip caching for transformer_2
+                # (stage-2 MoE model) to avoid cross-model residual reuse.
+                _mod_input = None
+                if _tc_state is not None and current_model is self.transformer:
+                    _cache_ctx = _wan2_2_extractor(
+                        current_model,
+                        hidden_states=positive_kwargs["hidden_states"],
+                        timestep=positive_kwargs["timestep"],
+                        encoder_hidden_states=positive_kwargs["encoder_hidden_states"],
+                        encoder_hidden_states_image=positive_kwargs.get("encoder_hidden_states_image"),
+                    )
+                    _mod_input = _cache_ctx.modulated_input
+
+                if _teacache_should_compute(_tc_state, _mod_input):
+                    noise_pred = self.predict_noise_maybe_with_cfg(
+                        do_true_cfg=do_true_cfg,
+                        true_cfg_scale=current_guidance_scale,
+                        positive_kwargs=positive_kwargs,
+                        negative_kwargs=negative_kwargs,
+                        cfg_normalize=False,
+                    )
+                    if _tc_state is not None:
+                        _tc_state["prev_noise_pred"] = noise_pred
+                else:
+                    noise_pred = _tc_state["prev_noise_pred"]
 
                 latents = self.scheduler_step_maybe_with_cfg(noise_pred, t, latents, do_true_cfg)
+
+                if _tc_state is not None:
+                    _tc_state["cnt"] += 1
                 pbar.update()
 
         return latents

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -18,6 +18,8 @@ from torch import nn
 from transformers import AutoTokenizer, CLIPImageProcessor, CLIPVisionModel, UMT5EncoderModel
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
+from vllm_omni.diffusion.cache.teacache.backend import _teacache_init_loop_state, _teacache_should_compute
+from vllm_omni.diffusion.cache.teacache.extractors import extract_wan2_2_context as _wan2_2_extractor
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import DistributedAutoencoderKLWan
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
@@ -282,6 +284,9 @@ class Wan22I2VPipeline(
         condition: torch.Tensor,
         first_frame_mask: torch.Tensor,
     ) -> torch.Tensor:
+        # ---- TeaCache initialization ----
+        _tc_state = _teacache_init_loop_state(self)
+
         with self.progress_bar(total=len(timesteps)) as pbar:
             for t in timesteps:
                 self._current_timestep = t
@@ -330,15 +335,37 @@ class Wan22I2VPipeline(
                 else:
                     negative_kwargs = None
 
-                noise_pred = self.predict_noise_maybe_with_cfg(
-                    do_true_cfg=do_true_cfg,
-                    true_cfg_scale=current_guidance_scale,
-                    positive_kwargs=positive_kwargs,
-                    negative_kwargs=negative_kwargs,
-                    cfg_normalize=False,
-                )
+                # ---- TeaCache: decide whether to compute or reuse ----
+                # Only cache on self.transformer (stage-1); skip caching for transformer_2
+                # (stage-2 MoE model) to avoid cross-model residual reuse.
+                _mod_input = None
+                if _tc_state is not None and current_model is self.transformer:
+                    _cache_ctx = _wan2_2_extractor(
+                        current_model,
+                        hidden_states=positive_kwargs["hidden_states"],
+                        timestep=positive_kwargs["timestep"],
+                        encoder_hidden_states=positive_kwargs["encoder_hidden_states"],
+                        encoder_hidden_states_image=positive_kwargs.get("encoder_hidden_states_image"),
+                    )
+                    _mod_input = _cache_ctx.modulated_input
+
+                if _teacache_should_compute(_tc_state, _mod_input):
+                    noise_pred = self.predict_noise_maybe_with_cfg(
+                        do_true_cfg=do_true_cfg,
+                        true_cfg_scale=current_guidance_scale,
+                        positive_kwargs=positive_kwargs,
+                        negative_kwargs=negative_kwargs,
+                        cfg_normalize=False,
+                    )
+                    if _tc_state is not None:
+                        _tc_state["prev_noise_pred"] = noise_pred
+                else:
+                    noise_pred = _tc_state["prev_noise_pred"]
 
                 latents = self.scheduler_step_maybe_with_cfg(noise_pred, t, latents, do_true_cfg)
+
+                if _tc_state is not None:
+                    _tc_state["cnt"] += 1
                 pbar.update()
 
         return latents


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
 TeaCache (Timestep Embedding Aware Cache) speeds up diffusion inference by reusing transformer block outputs when consecutive timestep embeddings are sufficiently
  similar, as measured by a polynomial-rescaled relative L1 distance on the first block's modulated norm output.

  Why pipeline-level (not hook-based)

  WanTransformer3DModel uses _sp_plan to shard hidden_states at the input of blocks[0] for sequence parallelism. Hook-based TeaCache intercepts before this split, so it
  would see unsharded hidden_states while rotary_emb is already computed on the sharded shape — causing a shape mismatch. Pipeline-level extraction avoids this by running
   before the transformer forward pass entirely.

  Changes

  vllm_omni/diffusion/cache/teacache/config.py
  - Add polynomial coefficients for WanTransformer3DModel (sourced from https://github.com/ali-vilab/TeaCache; validated on Wan2.1, same architecture as Wan2.2)

  vllm_omni/diffusion/cache/teacache/extractors.py
  - Add extract_wan2_2_context(): mirrors the transformer forward preprocessing to extract modulated_input from block0.norm1(hidden_states, scale_msa, shift_msa) without
  running the full forward pass
  - Handles both TI2V (4D timestep) and T2V/I2V (3D timestep) modes
  - FSDP unshard/reshard in try/finally for distributed inference compatibility
  - Register as "WanTransformer3DModel" in EXTRACTOR_REGISTRY
  - Make CacheContext.run_transformer_blocks and postprocess optional (| None = None), consistent with the pipeline-level pattern where the pipeline manages execution
  directly

  vllm_omni/diffusion/cache/teacache/backend.py
  - Add enable_wan2_2_teacache(): stores TeaCacheConfig on pipeline._tea_cache_config
  - Add _teacache_init_loop_state() and _teacache_should_compute() shared helpers (same helpers used by HunyuanVideo-1.5)
  - Register "Wan22Pipeline" and "Wan22I2VPipeline" in CUSTOM_TEACACHE_ENABLERS
  - Extend refresh() no-op to cover both pipelines

  vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
  - Integrate TeaCache into diffuse(): initialize state with _teacache_init_loop_state, extract modulated_input per step, call _teacache_should_compute to decide
  compute-or-reuse
  - TeaCache only applies to self.transformer (stage-1, high-noise); transformer_2 (stage-2 MoE, low-noise) always computes to avoid cross-model residual reuse

  vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
  - Same pattern as I2V pipeline
  
## Test Plan
Hardware: Ascend NPU (4 * 910B3)
Software: vLLM-Omni, vllm, vllm-ascend, MindIE-SD 
Model: Wan2.2
cpu: aarch64 
cann: 8.3.RC1
Model checkpoint path/weights location:  [Wan2.2-T2V-A14B-Diffusers](https://www.modelscope.cn/models/Wan-AI/Wan2.2-T2V-A14B-Diffusers)  [Wan2.2-I2V-A14B-Diffusers](https://www.modelscope.cn/models/Wan-AI/Wan2.2-I2V-A14B-Diffusers)


I2V baseline:
```
#!/bin/bash
# Wan2.2 image-to-video server start script

PORT="${PORT:-8011}"
CACHE_BACKEND="${CACHE_BACKEND:-none}"
ENABLE_CACHE_DIT_SUMMARY="${ENABLE_CACHE_DIT_SUMMARY:-0}"

echo "Starting Wan2.2 I2V server..."
echo "Port: $PORT"
echo "Cache backend: $CACHE_BACKEND"
if [ "$ENABLE_CACHE_DIT_SUMMARY" != "0" ]; then
    echo "Cache-DiT summary: enabled"
fi

CACHE_BACKEND_FLAG=""
if [ "$CACHE_BACKEND" != "none" ]; then
    CACHE_BACKEND_FLAG="--cache-backend $CACHE_BACKEND"
fi


export ASCEND_RT_VISIBLE_DEVICES=4,5,6,7
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
export DIFFUSION_ATTENTION_BACKEND="FLASH_ATTN"
/usr/local/python3.11.14/bin/vllm-omni serve /weights/Wan2.2-I2V-A14B-Diffusers --omni \
    --port "$PORT" \
    --seed 1024 \
    --allowed-local-media-path / \
    --trust-remote-code \
    --cfg-parallel-size 1 \
    --ulysses-degree 4 \
    --use-hsdp

```

I2V with TeaCache: 
```
#!/bin/bash
# Wan2.2 image-to-video server start script

PORT="${PORT:-8011}"
CACHE_BACKEND="${CACHE_BACKEND:-none}"
ENABLE_CACHE_DIT_SUMMARY="${ENABLE_CACHE_DIT_SUMMARY:-0}"

echo "Starting Wan2.2 I2V server..."
echo "Port: $PORT"
echo "Cache backend: $CACHE_BACKEND"
if [ "$ENABLE_CACHE_DIT_SUMMARY" != "0" ]; then
    echo "Cache-DiT summary: enabled"
fi

CACHE_BACKEND_FLAG=""
if [ "$CACHE_BACKEND" != "none" ]; then
    CACHE_BACKEND_FLAG="--cache-backend $CACHE_BACKEND"
fi


export ASCEND_RT_VISIBLE_DEVICES=4,5,6,7
export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
export DIFFUSION_ATTENTION_BACKEND="FLASH_ATTN"
/usr/local/python3.11.14/bin/vllm-omni serve /weights/Wan2.2-I2V-A14B-Diffusers --omni \
    --port "$PORT" \
    --seed 1024 \
    --allowed-local-media-path / \
    --trust-remote-code \
    --cfg-parallel-size 1 \
    --ulysses-degree 4 \
    --cache-backend tea_cache \
    --use-hsdp
```

Test:
```
#!/bin/bash
# Wan2.2 image-to-video curl example using the async video job API.

set -euo pipefail

INPUT_IMAGE="${INPUT_IMAGE:-./i2v_input.jpg}"
BASE_URL="${BASE_URL:-http://localhost:8011}"
OUTPUT_PATH="${OUTPUT_PATH:-wan22_i2v_output.mp4}"
NEGATIVE_PROMPT="${NEGATIVE_PROMPT:-}"
POLL_INTERVAL="${POLL_INTERVAL:-2}"

if [ ! -f "$INPUT_IMAGE" ]; then
    echo "Input image not found: $INPUT_IMAGE"
    exit 1
fi

create_cmd=(
  curl -sS -X POST "${BASE_URL}/v1/videos"
  -H "Accept: application/json" \
  -F "prompt=Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside" \
  -F "negative_prompt=low quality, blurry, static" \
  -F "input_reference=@${INPUT_IMAGE}" \
  -F "width=1280" \
  -F "height=720" \
  -F "num_frames=61" \
  -F "fps=16" \
  -F "num_inference_steps=40" \
  -F "guidance_scale=1.0" \
  -F "guidance_scale_2=1.0" \
  -F "boundary_ratio=0.875" \
  -F "flow_shift=12.0" \
  -F "seed=42"
)

if [ -n "${NEGATIVE_PROMPT}" ]; then
  create_cmd+=(-F "negative_prompt=${NEGATIVE_PROMPT}")
fi

create_response="$("${create_cmd[@]}")"
video_id="$(echo "${create_response}" | jq -r '.id')"
if [ -z "${video_id}" ] || [ "${video_id}" = "null" ]; then
  echo "Failed to create video job:"
  echo "${create_response}" | jq .
  exit 1
fi

echo "Created video job ${video_id}"
echo "${create_response}" | jq .

while true; do
  status_response="$(curl -sS "${BASE_URL}/v1/videos/${video_id}")"
  status="$(echo "${status_response}" | jq -r '.status')"

  case "${status}" in
    queued|in_progress)
      echo "Video job ${video_id} status: ${status}"
      sleep "${POLL_INTERVAL}"
      ;;
    completed)
      echo "${status_response}" | jq .
      break
      ;;
    failed)
      echo "Video generation failed:"
      echo "${status_response}" | jq .
      exit 1
      ;;
    *)
      echo "Unexpected status response:"
      echo "${status_response}" | jq .
      exit 1
      ;;
  esac
done

curl -sS -L "${BASE_URL}/v1/videos/${video_id}/content" -o "${OUTPUT_PATH}"
echo "Saved video to ${OUTPUT_PATH}"

```

## Test Result
| model | width * height | fps | frames | interface_steps | E2E time (no teacache) | E2E time (with teacache) |
| --- | --- | --- | --- | --- | --- | --- | 
| Wan2.2-I2V-A14B-Diffusers | 1280*720 | 16 | 61 | 40 | 378.25s | 205.07s |
| Wan2.2-T2V-A14B-Diffusers | 1280*720 | 16 | 61 | 40 | 347.18s | 199.37s |

Generated video with teacache:
https://github.com/vasede/vllm-omni/blob/demo/wan2.2-teacache-output/wan22_i2v_output.mp4


## Unit test results:
[TeaCache] Add unit tests for Wan2.2 TeaCache support

    Covers:
    - Polynomial coefficients correctness (WanTransformer3DModel)
    - _teacache_init_loop_state / _teacache_should_compute logic
    - 3D (T2V/I2V) vs 4D (TI2V) timestep handling in extract_wan2_2_context
    - FSDP unshard/reshard path (mocked)
    - Edge cases: rel_l1_thresh exceeded mid-sequence, first-step always-compute
    - TeaCache on vs off consistency (CPU, mock denoising loop)

```
root@syn-114:/vllm-workspace/vllm-omni# python -m pytest tests/diffusion/cache/test_wan2_2_teacache.py
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.11.14, pytest-9.0.3, pluggy-1.6.0
rootdir: /vllm-workspace/vllm-omni
configfile: pyproject.toml
plugins: timeout-2.4.0, anyio-4.12.1
collected 37 items

tests/diffusion/cache/test_wan2_2_teacache.py .....................................                                                                                                    [100%]

====================================================================================== warnings summary ======================================================================================
../../usr/local/python3.11.14/lib/python3.11/site-packages/_pytest/config/__init__.py:1434
  /usr/local/python3.11.14/lib/python3.11/site-packages/_pytest/config/__init__.py:1434: PytestConfigWarning: Unknown config option: asyncio_mode

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

vllm_omni/__init__.py:19
  /vllm-workspace/vllm-omni/vllm_omni/__init__.py:19: RuntimeWarning: Failed to import version from _version.py: No module named 'vllm_omni._version'
  This typically happens in development mode before building.
  Using fallback version 'dev'.
    from .version import __version__, __version_tuple__  # isort:skip # noqa: F401

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
=============================================================================== 37 passed, 4 warnings in 8.04s ===============================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
