### PR TITLE
[Test][HunyuanImage3] Add e2e offline I2T smoke test

### DIFF
--- a/tests/e2e/offline_inference/test_hunyuanimage3_i2t_expansion.py
+++ b/tests/e2e/offline_inference/test_hunyuanimage3_i2t_expansion.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 from PIL import Image
 
+from tests.helpers.runtime import OmniRunner
 from vllm_omni import Omni
 from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import build_prompt
 
@@ -49,16 +50,11 @@ pytestmark = [pytest.mark.full_model, pytest.mark.diffusion]
 
 @pytest.fixture(scope="module")
 def omni() -> Generator[Omni, None, None]:
-    engine = Omni(
-        model=MODEL_NAME,
+    with OmniRunner(
+        MODEL_NAME,
         stage_configs_path=str(STAGE_CONFIG_PATH),
-        stage_init_timeout=600,
-        init_timeout=900,
-    )
-    try:
-        yield engine
-    finally:
-        engine.close()
+    ) as runner:
+        yield runner.omni
 
 
 @pytest.mark.skipif(torch.accelerator.device_count() < 4, reason="Need at least 4 CUDA GPUs.")

--- a/tests/e2e/offline_inference/test_hunyuanimage3_i2t_expansion.py
+++ b/tests/e2e/offline_inference/test_hunyuanimage3_i2t_expansion.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 import torch
+from PIL import Image
 
 from vllm_omni import Omni
 from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import build_prompt
@@ -15,11 +16,9 @@ MODEL_NAME = "tencent/HunyuanImage-3.0-Instruct"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 STAGE_CONFIG_PATH = REPO_ROOT / "vllm_omni" / "model_executor" / "stage_configs" / "hunyuan_image3_i2t.yaml"
 
-# First 20 generated token IDs from the HF greedy reference on this input
-# (verified 2026-05-04 via scripts/bench/hf_i2t_pr2986_baseline.py;
-# baseline JSON: scripts/bench/baselines/hf_i2t_pr2986.json). vllm-omni AR
-# output matches this prefix bitwise; the two implementations diverge past
-# this point — see memory/hf/hf_omni_alignment_method.md.
+# First 20 generated token IDs from the HF greedy reference on this input.
+# vllm-omni AR output matches this prefix bitwise; the two implementations
+# diverge past this point.
 EXPECTED_PREFIX_TOKEN_IDS: list[int] = [
     791,
     2217,
@@ -66,8 +65,6 @@ def omni() -> Generator[Omni, None, None]:
 def test_i2t_generates_text(omni: Omni) -> None:
     """Verify I2T output's first 20 token IDs match the HF greedy baseline."""
     # Solid-color image keeps the input self-contained and reproducible.
-    from PIL import Image
-
     input_image = Image.new("RGB", (256, 256), color=(128, 200, 100))
 
     prompt = build_prompt("Describe the content of the picture.", task="i2t")
@@ -80,8 +77,7 @@ def test_i2t_generates_text(omni: Omni) -> None:
     outputs = omni.generate(prompts=[prompt_dict])
     assert outputs, "No outputs returned from Omni.generate()"
 
-    first_output = outputs[0]
-    request_output = getattr(first_output, "request_output", first_output)
+    request_output = outputs[0].request_output
     assert request_output.outputs, "No completion outputs"
 
     completion = request_output.outputs[0]

--- a/tests/e2e/offline_inference/test_hunyuanimage3_i2t_expansion.py
+++ b/tests/e2e/offline_inference/test_hunyuanimage3_i2t_expansion.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Smoke test for HunyuanImage-3.0 Image-to-Text (I2T) pipeline."""
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+import torch
+
+from vllm_omni import Omni
+from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import build_prompt
+
+MODEL_NAME = "tencent/HunyuanImage-3.0-Instruct"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+STAGE_CONFIG_PATH = REPO_ROOT / "vllm_omni" / "model_executor" / "stage_configs" / "hunyuan_image3_i2t.yaml"
+
+# First 20 generated token IDs from the HF greedy reference on this input
+# (verified 2026-05-04 via scripts/bench/hf_i2t_pr2986_baseline.py;
+# baseline JSON: scripts/bench/baselines/hf_i2t_pr2986.json). vllm-omni AR
+# output matches this prefix bitwise; the two implementations diverge past
+# this point — see memory/hf/hf_omni_alignment_method.md.
+EXPECTED_PREFIX_TOKEN_IDS: list[int] = [
+    791,
+    2217,
+    374,
+    264,
+    6573,
+    11,
+    14113,
+    6307,
+    1933,
+    449,
+    912,
+    27339,
+    11,
+    6302,
+    11,
+    477,
+    3649,
+    3118,
+    13,
+    1102,
+]
+# Decoded form, kept only for human-readable assertion messages.
+EXPECTED_PREFIX_TEXT = "The image is a solid, uniform green color with no variations, objects, or details present. It"
+
+pytestmark = [pytest.mark.full_model, pytest.mark.diffusion]
+
+
+@pytest.fixture(scope="module")
+def omni() -> Generator[Omni, None, None]:
+    engine = Omni(
+        model=MODEL_NAME,
+        stage_configs_path=str(STAGE_CONFIG_PATH),
+        stage_init_timeout=600,
+        init_timeout=900,
+    )
+    try:
+        yield engine
+    finally:
+        engine.close()
+
+
+@pytest.mark.skipif(torch.accelerator.device_count() < 4, reason="Need at least 4 CUDA GPUs.")
+def test_i2t_generates_text(omni: Omni) -> None:
+    """Verify I2T output's first 20 token IDs match the HF greedy baseline."""
+    # Solid-color image keeps the input self-contained and reproducible.
+    from PIL import Image
+
+    input_image = Image.new("RGB", (256, 256), color=(128, 200, 100))
+
+    prompt = build_prompt("Describe the content of the picture.", task="i2t")
+    prompt_dict = {
+        "prompt": prompt,
+        "modalities": ["text"],
+        "multi_modal_data": {"image": input_image},
+    }
+
+    outputs = omni.generate(prompts=[prompt_dict])
+    assert outputs, "No outputs returned from Omni.generate()"
+
+    first_output = outputs[0]
+    request_output = getattr(first_output, "request_output", first_output)
+    assert request_output.outputs, "No completion outputs"
+
+    completion = request_output.outputs[0]
+    finish_reason = getattr(completion, "finish_reason", None)
+    assert finish_reason is not None, "AR generation did not finish (finish_reason is None)"
+    assert str(finish_reason) != "abort", f"AR generation aborted: finish_reason={finish_reason!r}"
+
+    token_ids = list(getattr(completion, "token_ids", []) or [])
+    n = len(EXPECTED_PREFIX_TOKEN_IDS)
+    assert len(token_ids) >= n, (
+        f"AR output shorter than {n} tokens (got {len(token_ids)}): token_ids={token_ids!r} text={completion.text!r}"
+    )
+    assert token_ids[:n] == EXPECTED_PREFIX_TOKEN_IDS, (
+        f"AR prefix drift vs HF reference\n"
+        f"  expected ids : {EXPECTED_PREFIX_TOKEN_IDS!r}\n"
+        f"  actual ids   : {token_ids[:n]!r}\n"
+        f"  expected text: {EXPECTED_PREFIX_TEXT!r}\n"
+        f"  actual text  : {completion.text!r}"
+    )


### PR DESCRIPTION
 ## Summary

  Adds a single offline e2e smoke test for HunyuanImage-3.0-Instruct's I2T
  (image-to-text) pipeline:
  `tests/e2e/offline_inference/test_hunyuanimage3_i2t_expansion.py`.

  The test feeds a fixed solid-color image + prompt into `Omni.generate()`
  under the `hunyuan_image3_i2t.yaml` stage config, and asserts that the
  first 20 generated token IDs match the HF greedy baseline bit-exact.
  Token-ID match is what we actually care about (text decoding can mask
  divergence); the decoded reference text is kept only for human-readable
  assertion messages.

  ## Why

  We need a small, deterministic regression hook for HunyuanImage-3.0 AR
  output that runs without an HF reference model in-process. Solid-color
  input + greedy decoding + first-20-token prefix give us a stable signal
  that catches MoE routing / RoPE / kernel regressions in vllm-omni's AR
  path without the noise of full free-form generation.

  The expected token IDs were captured 2026-05-04 from the official HF
  implementation on the same input — see
  `scripts/bench/hf_i2t_pr2986_baseline.py` and the alignment notes in
  `memory/hf/hf_omni_alignment_method.md`. vllm-omni AR matches this
  prefix bitwise; the two implementations diverge past this point.

  ## Scope

  - 1 file, +103 lines, no production code changes.
  - Marker: `full_model + diffusion`, gated on
    `torch.accelerator.device_count() >= 4` (same gate other Hunyuan tests
    use).
  - **Not wired into nightly CI in this PR.** Earlier revisions wired a
    dedicated buildkite step on `mithril-h100-pool` (4× H100 SXM), but the
    job's pod scheduling has been unstable (0-byte log on build 9142 →
    almost certainly never scheduled). I want to keep this PR small and
    green, and follow up with CI wiring in a separate PR once the
    scheduling story is sorted.

  ## Test plan

  - [x] `pytest -s -v tests/e2e/offline_inference/test_hunyuanimage3_i2t_expansion.py`
        locally on a 4×H100 box → passes (token IDs match baseline).
  - [x] Pre-commit: ruff-check, ruff-format, typos, banned-API guard all
        green.
  - [x] No CI wiring in this PR; will follow up.