### PR TITLE
[Bugfix] Use get_open_ports_list for stage ports in OmniMasterServer

### DIFF
--- a/vllm_omni/engine/stage_engine_startup.py
+++ b/vllm_omni/engine/stage_engine_startup.py
@@ -14,7 +14,7 @@ import zmq
 from omegaconf import OmegaConf
 from vllm.config import CacheConfig, VllmConfig
 from vllm.logger import init_logger
-from vllm.utils.network_utils import get_open_port, zmq_socket_ctx
+from vllm.utils.network_utils import get_open_ports_list, zmq_socket_ctx
 from vllm.v1.engine.coordinator import DPCoordinator
 from vllm.v1.engine.utils import (
     STARTUP_POLL_PERIOD_MS,
@@ -120,9 +120,7 @@ class OmniMasterServer:
         for sid in stage_ids:
             self._stage_config_events[sid] = threading.Event()
             self._stage_coordinator_addresses[sid] = StageCoordinatorAddresses()
-            hs_port = get_open_port()
-            inp_port = get_open_port()
-            out_port = get_open_port()
+            hs_port, inp_port, out_port = get_open_ports_list(count=3)
             self._allocations[sid] = StageAllocation(
                 handshake_bind_address=f"tcp://{master_address}:{hs_port}",
                 handshake_connect_address=f"tcp://{master_address}:{hs_port}",


### PR DESCRIPTION
## Purpose
Fix https://github.com/vllm-project/vllm-omni/issues/3317

Currently, we use `get_open_port` 3 times to get open ports to use for setting up the stage, but these can collide with each other if we're unlucky. E.g., the vllm check to get an open port [here](https://github.com/vllm-project/vllm/blob/67058ca326ac566db1aac6fc20ff0c43510422f8/vllm/utils/network_utils.py#L190) is doing this:

```
        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
            s.bind(("", 0))
            return s.getsockname()[1]
```

This doesn't actually reserver the port. For example:
```python
import socket
from vllm.utils.network_utils import get_open_port

port_no = get_open_port()

with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
    s.bind(("", port_no))

```
Does not throw `OSError: [Errno 98] Address already in use`.

instead, we should use `get_open_ports_list`, which underneath calls the same thing ([here](https://github.com/vllm-project/vllm/blob/67058ca326ac566db1aac6fc20ff0c43510422f8/vllm/utils/network_utils.py#L185)), but builds a unique set of ports of a specified count, so we won't randomly hit collisions.

@Gaohan123 @yenuo26 