### PR TITLE
[Bugfix] Fix i2v accuracy drop due to flash_attn fallback

### DIFF
--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -140,6 +140,7 @@ class FlashAttentionImpl(AttentionImpl):
         """CUDA/ROCm/MUSA flash attention implementation."""
         from vllm_omni.diffusion.attention.backends.utils.fa import (
             HAS_FLASH_ATTN,
+            flash_attn_func,
         )
 
         if not HAS_FLASH_ATTN:
@@ -159,11 +160,15 @@ class FlashAttentionImpl(AttentionImpl):
                 attention_mask,
             )
 
-        return self._forward_varlen_dense(
+        # Dense case for CUDA – use the dedicated non‑varlen function
+        out = flash_attn_func(
             query,
             key,
             value,
+            causal=self.causal,
+            softmax_scale=self.softmax_scale,
         )
+        return self._unwrap_flash_output(out)
 
     def forward_xpu(
         self,

--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -51,37 +51,38 @@ else:
     # CUDA: try FA3 -> FA2 fallback chain
     # Try FA3 from fa3-fwd PyPI package
     try:
-        from fa3_fwd_interface import flash_attn_varlen_func  # noqa: F401
+        from fa3_fwd_interface import flash_attn_func, flash_attn_varlen_func  # noqa: F401
     except (ImportError, ModuleNotFoundError):
         pass
 
     # Fallback: Try FA3 from flash-attention source build
-    if flash_attn_varlen_func is None:
+    if flash_attn_func is None:
         try:
-            from flash_attn_interface import flash_attn_varlen_func  # noqa: F401
+            from flash_attn_interface import flash_attn_func, flash_attn_varlen_func  # noqa: F401
         except (ImportError, ModuleNotFoundError):
             pass
 
     # Fallback: Try FA2 from flash-attn package (try multiple import paths)
-    if flash_attn_varlen_func is None:
+    if flash_attn_func is None:
         try:
-            from flash_attn import flash_attn_varlen_func  # noqa: F401
+            from flash_attn import flash_attn_func, flash_attn_varlen_func  # noqa: F401
         except (ImportError, ModuleNotFoundError):
             pass
 
-    if flash_attn_varlen_func is None:
+    if flash_attn_func is None:
         try:
             from flash_attn.flash_attn_interface import (  # noqa: F401
+                flash_attn_func,
                 flash_attn_varlen_func,
             )
         except (ImportError, ModuleNotFoundError):
             pass
 
     # Fallback: Try vLLM's encapsulated flash attention dispatcher
-    # TODO discuss priority and remove potentially redundant fallbacks
-    if flash_attn_varlen_func is None:
+    if flash_attn_func is None:
         try:
             from vllm.vllm_flash_attn import (  # noqa: F401
+                flash_attn_func,
                 flash_attn_varlen_func,
             )
         except (ImportError, ModuleNotFoundError):


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fixes #3330 [Bug] [CI failure]: L4 test failure for Video generation models about accuracy

### Problem identification
After #3302 and #3307, the Wan2.2‑I2V model accuracy dropped from 0.94 → 0.7x on L4 tests.

### Root cause
- CUDA `forward_cuda` was changed to always call `_forward_varlen_dense`, which uses `flash_attn_varlen_func` even for dense (mask‑all‑valid) inputs.
- `fa.py` removed imports of `flash_attn_func`, leaving only `flash_attn_varlen_func`.

**Why this breaks accuracy:**
`flash_attn_varlen_func` has **different numerical behaviour** from `flash_attn_func` when used on dense inputs.
- `flash_attn_func` operates on the original padded matrix, preserving the tiling and reduction order as trained.
- `flash_attn_varlen_func` flattens sequences using `cu_seqlens` and skips padding tokens, changing the internal reduction order. 
- Floating‑point addition is non‑associative, so different reduction orders produce different rounding errors. `(a + b) + c` ≠ `a + (b + c)`
**For long‑sequence video models like Wan2.2‑I2V, these tiny per‑token errors accumulate, causing a large metric drop.**

### Fix
- Restore `flash_attn_func` imports in `fa.py` (including `vllm.vllm_flash_attn` fallback).
- Keep `forward_cuda` using `flash_attn_func` for dense inputs; only fall back to `_forward_varlen_masked` when a mask with zeros exists.
- Leave `_forward_varlen_dense` unchanged for XPU and other backends that lack `flash_attn_func`.

### Result
- Accuracy returns to 0.94 for Wan2.2‑I2V.
- The fallback chain now includes `vllm.vllm_flash_attn` as intended.
- No change for XPU/MUSA/NPU backends.

## Test Plan
`pytest -s -v tests/e2e/accuracy/wan22_i2v/test_wan22_i2v_video_similarity.py`
`pytest -sv tests/e2e/online_serving/test_bagel_expansion.py -m "full_model and diffusion and H100" --run-level "full_model"`

Should pass both tests to ensure restoring `test_wan22_i2v_video_similarity.py` accuracy while preserving the idea of flash attention fallback implementation for `test_bagel_expansion.py`
## Test Result
<details>
<summary> Results for test_wan22_i2v_video_similarity.py </summary>

```
...

--- Running test: test_wan22_i2v_serving_matches_diffusers_video_similarity
wan22_i2v_similarity metrics:
  SSIM: value=0.941158, threshold>=0.940000, range=[0, 1], higher_is_better=True, interpretation=structural_similarity
  PSNR: value=33.973948 dB, threshold>=28.000000 dB, range=[0, +inf), higher_is_better=True, interpretation=pixel_error_in_decibels
....
--- Running Summary
================= 16 passed, 17 warnings in 847.31s (0:14:07) ==================
```

</details>

<details>
<summary> Results for test_bagel_expansion.py </summary>
(Soon)
</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
