### PR TITLE
[WIP][Refactor] Replace TTS/omni audio encoder dependency on `flash-attn` with `vllm.vllm_flash_attn`

### DIFF
--- a/vllm_omni/diffusion/attention/backends/utils/fa.py
+++ b/vllm_omni/diffusion/attention/backends/utils/fa.py
@@ -48,21 +48,34 @@ elif current_omni_platform.is_musa():
     except (ImportError, ModuleNotFoundError):
         pass
 else:
-    # CUDA: try FA3 -> FA2 fallback chain
-    # Try FA3 from fa3-fwd PyPI package
+    # CUDA: prefer vllm.vllm_flash_attn (always present, dispatches FA3/FA2 by
+    # device capability), then fall back to upstream FA3 / FA2 packages if a
+    # user has explicitly installed them. Earlier versions of this file put
+    # fa3-fwd / flash_attn_interface first; the import-time ordering of those
+    # is unsafe because they import cleanly even on devices whose prebuilt
+    # kernel images don't run there (e.g. Blackwell with fa3-fwd's Hopper
+    # wheel), and the failure surfaces only at first kernel call.
+    # See PR #3302 (the TODO note) and the discussion thread for context.
     try:
-        from fa3_fwd_interface import flash_attn_varlen_func  # noqa: F401
+        from vllm.vllm_flash_attn import flash_attn_varlen_func  # noqa: F401
     except (ImportError, ModuleNotFoundError):
         pass
 
-    # Fallback: Try FA3 from flash-attention source build
+    # Opt-in fast path: FA3 from fa3-fwd PyPI prebuilt wheel.
+    if flash_attn_varlen_func is None:
+        try:
+            from fa3_fwd_interface import flash_attn_varlen_func  # noqa: F401
+        except (ImportError, ModuleNotFoundError):
+            pass
+
+    # Opt-in fast path: FA3 from flash-attention upstream source build.
     if flash_attn_varlen_func is None:
         try:
             from flash_attn_interface import flash_attn_varlen_func  # noqa: F401
         except (ImportError, ModuleNotFoundError):
             pass
 
-    # Fallback: Try FA2 from flash-attn package (try multiple import paths)
+    # Fallback: FA2 from flash-attn package (try multiple import paths).
     if flash_attn_varlen_func is None:
         try:
             from flash_attn import flash_attn_varlen_func  # noqa: F401
@@ -72,16 +85,6 @@ else:
     if flash_attn_varlen_func is None:
         try:
             from flash_attn.flash_attn_interface import (  # noqa: F401
-                flash_attn_varlen_func,
-            )
-        except (ImportError, ModuleNotFoundError):
-            pass
-
-    # Fallback: Try vLLM's encapsulated flash attention dispatcher
-    # TODO discuss priority and remove potentially redundant fallbacks
-    if flash_attn_varlen_func is None:
-        try:
-            from vllm.vllm_flash_attn import (  # noqa: F401
                 flash_attn_varlen_func,
             )
         except (ImportError, ModuleNotFoundError):

--- a/vllm_omni/model_executor/models/mimo_audio/modeling_audio_tokenizer.py
+++ b/vllm_omni/model_executor/models/mimo_audio/modeling_audio_tokenizer.py
@@ -9,22 +9,17 @@ from transformers.activations import ACT2FN
 from transformers.modeling_utils import PreTrainedModel
 from vllm.logger import init_logger
 
+from vllm_omni.diffusion.attention.backends.utils.fa import HAS_FLASH_ATTN, flash_attn_varlen_func
+
 from .config_mimo_audio import MiMoAudioTokenizerConfig
 from .modeling_rope_utils import ROPE_INIT_FUNCTIONS, apply_rotary_pos_emb, dynamic_rope_update
 from .quantization import ResidualVectorQuantizer
 
 logger = init_logger(__name__)
-is_flash_atth_available = False
-try:
-    from flash_attn import flash_attn_varlen_func
-
-    is_flash_atth_available = True
-except Exception:
-    logger.warning("flash_attn not installed")
 
 
 def _should_use_flash_attn(hidden_states: torch.Tensor) -> bool:
-    return hidden_states.is_cuda and is_flash_atth_available
+    return hidden_states.is_cuda and HAS_FLASH_ATTN
 
 
 def _build_varlen_attn_mask(
@@ -422,12 +417,12 @@ class Attention(nn.Module):
                 query_states,
                 key_states,
                 value_states,
-                cu_len,
-                cu_len,
-                max_seqlen,
-                max_seqlen,
+                cu_seqlens_q=cu_len,
+                cu_seqlens_k=cu_len,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
                 causal=self.causal,
-                window_size=self.window_size,
+                window_size=list(self.window_size),
             )
             attn_output = attn_output.reshape(total_seq_len, self.embed_dim)
 

--- a/vllm_omni/model_executor/models/ming_flash_omni/audio_encoder.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/audio_encoder.py
@@ -62,7 +62,15 @@ class MultiHeadAttention(nn.Module):
         # Try flash attention varlen
         if self.use_flash_attn and cu_seqlens is not None and q.dtype in [torch.float16, torch.bfloat16]:
             max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
-            attn_output = flash_attn_varlen_func(q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen)
+            attn_output = flash_attn_varlen_func(
+                q,
+                k,
+                v,
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+            )
         else:
             attn_output = self._manual_attention(q, k, v, cu_seqlens)
 

--- a/vllm_omni/model_executor/models/qwen2_5_omni/audio_flash_attn.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/audio_flash_attn.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Override HF audio-encoder attention to use the project's FA dispatcher.
+
+HF's ``Qwen*OmniAudioAttention.forward`` routes through ``_attn_implementation``
+and only takes the FA path when the upstream ``flash_attn`` package is
+installed. To drop that source-build dependency we class-swap each attention
+instance to a subclass whose ``forward`` calls ``flash_attn_varlen_func`` from
+``vllm_omni.diffusion.attention.backends.utils.fa`` directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm_omni.diffusion.attention.backends.utils.fa import flash_attn_varlen_func
+
+
+def _fa_audio_forward(
+    self: nn.Module,
+    hidden_states: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
+    attention_mask: torch.Tensor | None = None,  # unused; kept for signature compat
+    **_: Any,
+) -> torch.Tensor:
+    seq_length, _ = hidden_states.size()
+    q = self.q_proj(hidden_states).reshape(seq_length, self.num_heads, -1)
+    k = self.k_proj(hidden_states).reshape(seq_length, self.num_heads, -1)
+    v = self.v_proj(hidden_states).reshape(seq_length, self.num_heads, -1)
+
+    cu_seqlens = cu_seqlens.to(torch.int32)
+    max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().to(torch.int32)
+
+    attn_output = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_k=max_seqlen,
+        softmax_scale=self.scaling,
+        causal=False,
+    )
+
+    attn_output = attn_output.reshape(seq_length, -1).contiguous()
+    return self.out_proj(attn_output)
+
+
+def patch_audio_tower_attention(audio_tower: nn.Module, target_class: type) -> None:
+    """Class-swap every ``target_class`` instance under ``audio_tower`` so its
+    ``forward`` calls ``flash_attn_varlen_func``. Loaded weights and submodules
+    are preserved — only the bound ``forward`` changes."""
+    new_class = type(
+        f"FA{target_class.__name__}",
+        (target_class,),
+        {"forward": _fa_audio_forward},
+    )
+    for module in audio_tower.modules():
+        if type(module) is target_class:
+            module.__class__ = new_class

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
@@ -9,6 +9,7 @@ from transformers.models.qwen2_5_omni.configuration_qwen2_5_omni import (
     Qwen2_5OmniThinkerConfig,
 )
 from transformers.models.qwen2_5_omni.modeling_qwen2_5_omni import (
+    Qwen2_5OmniAudioAttention,
     Qwen2_5OmniAudioEncoder,
 )
 from vllm.config import VllmConfig
@@ -64,14 +65,13 @@ from vllm.multimodal.processing.processor import (
 )
 from vllm.sequence import IntermediateTensors
 
+from vllm_omni.model_executor.models.qwen2_5_omni.audio_flash_attn import (
+    patch_audio_tower_attention,
+)
 from vllm_omni.quantization.component_config import (
     resolve_encoder_quant_config,
 )
 
-try:
-    import flash_attn
-except (ImportError, ModuleNotFoundError):
-    flash_attn = None
 logger = init_logger(__name__)
 
 
@@ -346,19 +346,6 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
         self.config = thinker_config
         self.multimodal_config = multimodal_config
 
-        # force "use_flash_attention_2=True" to audio tower to align
-        # the results.
-        if flash_attn is not None:
-            audio_config = thinker_config.audio_config
-            audio_config._attn_implementation_autoset = True
-            audio_config._attn_implementation = "flash_attention_2"
-        else:
-            logger.warning(
-                "flash_attn is not available, the model may not yield the "
-                "exactly same result as the transformers implementation "
-                "in the audio tower part."
-            )
-
         self.quant_config = quant_config
 
         # Pre-quantized checkpoints (modelopt NVFP4/FP8/MXFP8) only quantize
@@ -370,6 +357,7 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
         with self._mark_tower_model(vllm_config, "audio"):
             if multimodal_config.get_limit_per_prompt("audio"):
                 self.audio_tower = Qwen2_5OmniAudioEncoder(thinker_config.audio_config)
+                patch_audio_tower_attention(self.audio_tower, Qwen2_5OmniAudioAttention)
             else:
                 self.audio_tower = None
 

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py
@@ -7,6 +7,7 @@ from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import (
     Qwen3OmniMoeTalkerConfig,
 )
 from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+    Qwen3OmniMoeAudioAttention,
     Qwen3OmniMoeAudioEncoder,
 )
 from vllm.config import VllmConfig
@@ -27,6 +28,9 @@ from vllm.model_executor.models.utils import (
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.sequence import IntermediateTensors
 
+from vllm_omni.model_executor.models.qwen2_5_omni.audio_flash_attn import (
+    patch_audio_tower_attention,
+)
 from vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_moe_code_predictor_mtp import (
     Qwen3OmniMoeTalkerCodePredictor,
 )
@@ -38,12 +42,6 @@ from vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_moe_thinker import (
     Qwen3OmniMoeThinkerProcessingInfo,
 )
 from vllm_omni.quantization.component_config import ComponentQuantizationConfig
-
-try:
-    import flash_attn
-except (ImportError, ModuleNotFoundError):
-    flash_attn = None
-
 
 logger = init_logger(__name__)
 
@@ -233,6 +231,7 @@ class Qwen3OmniMoeTalkerForConditionalGeneration(
             thinker_config: Configuration from the thinker model (for reference only)
         """
         self.audio_tower = Qwen3OmniMoeAudioEncoder(thinker_config.audio_config)
+        patch_audio_tower_attention(self.audio_tower, Qwen3OmniMoeAudioAttention)
         self.visual = Qwen3Omni_VisionTransformer(
             vision_config=thinker_config.vision_config,
             norm_eps=getattr(thinker_config.text_config, "rms_norm_eps", 1e-6),

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -125,11 +125,6 @@ from vllm_omni.quantization.component_config import (
     ComponentQuantizationConfig,
 )
 
-try:
-    import flash_attn
-except (ImportError, ModuleNotFoundError):
-    flash_attn = None
-
 logger = init_logger(__name__)
 
 

--- a/vllm_omni/model_executor/models/qwen3_tts/tokenizer_25hz/vq/whisper_encoder.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/tokenizer_25hz/vq/whisper_encoder.py
@@ -148,7 +148,6 @@ class MultiHeadAttention(nn.Module):
             cu_seqlens_k=cu_seqlens,
             max_seqlen_q=max_seqlen,
             max_seqlen_k=max_seqlen,
-            dropout_p=0.0,
         )
         x = x.reshape(n_ctx, n_state)
         return x

--- a/vllm_omni/model_executor/models/qwen3_tts/tokenizer_25hz/vq/whisper_encoder.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/tokenizer_25hz/vq/whisper_encoder.py
@@ -140,7 +140,16 @@ class MultiHeadAttention(nn.Module):
 
         max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
 
-        x = flash_attn_varlen_func(q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen, dropout_p=0.0)
+        x = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_k=max_seqlen,
+            dropout_p=0.0,
+        )
         x = x.reshape(n_ctx, n_state)
         return x
 

--- a/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_tokenizer.py
+++ b/vllm_omni/model_executor/models/voxtral_tts/voxtral_tts_audio_tokenizer.py
@@ -11,6 +11,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 from vllm.config import VllmConfig
 
+from vllm_omni.diffusion.attention.backends.utils.fa import (
+    HAS_FLASH_ATTN,
+    flash_attn_func,
+    flash_attn_varlen_func,
+)
 from vllm_omni.model_executor.models.voxtral_tts.voxtral_tts_audio_generation import (
     AudioSpecialTokens,
     FeedForward,
@@ -18,14 +23,6 @@ from vllm_omni.model_executor.models.voxtral_tts.voxtral_tts_audio_generation im
     from_nested_dict,
 )
 from vllm_omni.platforms import current_omni_platform
-
-try:
-    from flash_attn import flash_attn_func
-
-    HAS_FLASH_ATTN = True
-except ImportError:
-    flash_attn_func = None
-    HAS_FLASH_ATTN = False
 
 try:
     from apex.normalization import FusedRMSNorm
@@ -585,17 +582,39 @@ class Attention(nn.Module):
 
         if HAS_FLASH_ATTN:
             alibi_slopes = self.alibi_slopes.to(torch.float32)
-            output = flash_attn_func(
-                xq,
-                xk,
-                xv,
-                causal=self.args.causal,
-                window_size=(
-                    self.sliding_window,
-                    0 if self.args.causal else self.sliding_window,
-                ),
-                alibi_slopes=alibi_slopes,
-            )
+            window_size = [
+                self.sliding_window,
+                0 if self.args.causal else self.sliding_window,
+            ]
+            if flash_attn_func is not None:
+                output = flash_attn_func(
+                    xq,
+                    xk,
+                    xv,
+                    causal=self.args.causal,
+                    window_size=window_size,
+                    alibi_slopes=alibi_slopes,
+                )
+            else:
+                # Fall back to varlen (vllm.vllm_flash_attn only exposes that)
+                # by flattening the uniform-length batch into one varlen call.
+                q_flat = xq.reshape(bsz * seqlen, self.n_local_heads, self.args.head_dim)
+                k_flat = xk.reshape(bsz * seqlen, self.n_local_kv_heads, self.args.head_dim)
+                v_flat = xv.reshape(bsz * seqlen, self.n_local_kv_heads, self.args.head_dim)
+                cu_seqlens = torch.arange(0, (bsz + 1) * seqlen, step=seqlen, dtype=torch.int32, device=xq.device)
+                output = flash_attn_varlen_func(
+                    q_flat,
+                    k_flat,
+                    v_flat,
+                    cu_seqlens_q=cu_seqlens,
+                    cu_seqlens_k=cu_seqlens,
+                    max_seqlen_q=seqlen,
+                    max_seqlen_k=seqlen,
+                    causal=self.args.causal,
+                    window_size=window_size,
+                    alibi_slopes=alibi_slopes,
+                )
+                output = output.reshape(bsz, seqlen, self.n_local_heads, self.args.head_dim)
         else:
             output = self._native_attention(xq, xk, xv)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Latest Status [8 May ]
Will mark as ready for review by this week after finish testing the last 3 models, also write a more detailed PR description 

## Purpose
Closes https://github.com/vllm-project/vllm-omni/issues/3131. 

Currently, there are 6 TTS/omni models' audio encoder that chose their own attention instead of relying on our existing flash attention backend in `vllm_omni/diffusion/attention/backends/utils/fa.py`. Also the order in `fa` is a bit messy as pointed out by a [code comment](https://github.com/vllm-project/vllm-omni/pull/3302/changes#diff-5639abe628477d9b25f523f26c39d6900fdd028d3d9e645f7150282f97925d31R81) in https://github.com/vllm-project/vllm-omni/pull/3302. 

This PR updated the priority order for attention in `fa.py` to be as follows:
1. use `vllm.vllm_flash_attn`. This method will run FA3 on Hopper, and FA2 on other GPU architecture. 
2. prebuilt FA3 wheel (`fa3_fwd_interface`)
3. source build FA3 (`flash_attn_interface`), 
4. source build FA2 (`flash_attn`). 

For each model, we followed the `Ming-flash-omni-2.0` refactor in https://github.com/vllm-project/vllm-omni/pull/3146, and route attention selection via `fa.py` dispatch. We mainly updated function signatures to match with `fa.py`. The following models are affected: `mimo_audio`, `voxtral_tts`, `ming_flash_omni`, `qwen2_5_omni`, `qwen3_omni` and `qwen3_tts`. We tested each model and show the accuracy stays the same on this branch.  

Also, voxtral tts hit the same https://github.com/vllm-project/vllm-omni/pull/3327 error. It was using a method (`flash_attn_func`) available in ROCm and MUSA but not on CUDA, so we added the same fix by adding an if-else branch that uses `flash_attn_varlen_func` (available on CUDA) when architecture is CUDA. 


## Test Plan

We firstly ran pytests for each of the 6 models, and then tested their accuracy. 

<details><summary>Env configs</summary>

All runs were executed against the top of this branch, on 2 RTX PRO 6000 Blackwell (sm_120, 96 GB)

```bash
# Run with flash-attn UNINSTALLED so fa.py exercises vllm.vllm_flash_attn
pip uninstall -y flash-attn flash_attn_interface fa3_fwd_interface || true

python -c "
from vllm_omni.diffusion.attention.backends.utils.fa import HAS_FLASH_ATTN, flash_attn_varlen_func
print('HAS_FLASH_ATTN=', HAS_FLASH_ATTN, 'fn=', flash_attn_varlen_func.__module__)
"
# Expected: HAS_FLASH_ATTN=True, fn=vllm.vllm_flash_attn.flash_attn_interface

# Env required for the runs to reach the model under test
export VLLM_USE_FLASHINFER_SAMPLER=0       # flashinfer JIT path mis-detects Blackwell
export TORCH_CUDA_ARCH_LIST="12.0+PTX"     # so JIT compiles target sm_120
export LD_LIBRARY_PATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/lib:$LD_LIBRARY_PATH"
                                            # libnvrtc-builtins.so.13.0 lives in the nvidia/cu13 wheel
                                            # (driver is CUDA 13, system toolkit is 12.8)
```

</details>


<details><summary>e2e commands to run each model</summary>

### mimo_audio
Default model: `XiaomiMiMo/MiMo-Audio-7B-Instruct`. 
```bash
export MIMO_AUDIO_TOKENIZER_PATH="XiaomiMiMo/MiMo-Audio-Tokenizer"
OUT="$FA_TEST_ROOT/migrated/mimo_audio"; mkdir -p "$OUT"
python3 -u examples/offline_inference/mimo_audio/end2end.py \
  --model-name XiaomiMiMo/MiMo-Audio-7B-Instruct \
  --query-type tts_sft --output-dir "$OUT/tts_sft" 2>&1 | tee "$OUT/tts_sft.log"
python3 -u examples/offline_inference/mimo_audio/end2end.py \
  --model-name XiaomiMiMo/MiMo-Audio-7B-Instruct \
  --query-type audio_understanding_sft \
  --text "Summarize the audio." \
  --audio-path examples/offline_inference/mimo_audio/spoken_dialogue_assistant_turn_1.wav \
  --output-dir "$OUT/audio_understanding" 2>&1 | tee "$OUT/audio_understanding.log"
```

### voxtral_tts
Default model: `mistralai/Voxtral-4B-TTS-2603`. 
```bash
OUT="$FA_TEST_ROOT/migrated/voxtral_tts"; mkdir -p "$OUT"
python3 examples/offline_inference/voxtral_tts/end2end.py \
  --write-audio --voice cheerful_female \
  --model mistralai/Voxtral-4B-TTS-2603 \
  --text "That eerie silence after the first storm was just the calm before another round of chaos, wasn't it?" \
  --output-dir "$OUT/blocking_single" 2>&1 | tee "$OUT/blocking_single.log"
python3 examples/offline_inference/voxtral_tts/end2end.py \
  --streaming --write-audio --voice neutral_female \
  --model mistralai/Voxtral-4B-TTS-2603 \
  --text "That eerie silence after the first storm was just the calm before another round of chaos, wasn't it?" \
  --output-dir "$OUT/streaming_single" 2>&1 | tee "$OUT/streaming_single.log"
```

### qwen2_5_omni
Default model: `Qwen/Qwen2.5-Omni-7B`. 
```bash
OUT="$FA_TEST_ROOT/migrated/qwen2_5_omni"; mkdir -p "$OUT"
python examples/offline_inference/qwen2_5_omni/end2end.py \
  --output-wav "$OUT/use_audio" --query-type use_audio 2>&1 | tee "$OUT/use_audio.log"
python examples/offline_inference/qwen2_5_omni/end2end.py \
  --output-wav "$OUT/use_mixed_modalities" --query-type use_mixed_modalities 2>&1 | tee "$OUT/mix.log"
```

### qwen3_omni
Default model: `Qwen/Qwen3-Omni-30B-A3B-Instruct`. 
```bash
OUT="$FA_TEST_ROOT/migrated/qwen3_omni"; mkdir -p "$OUT"
python examples/offline_inference/qwen3_omni/end2end.py \
  --output-wav "$OUT/use_audio" --query-type use_audio 2>&1 | tee "$OUT/use_audio.log"
python examples/offline_inference/qwen3_omni/end2end_async_chunk.py \
  --output-wav "$OUT/async_chunk" --query-type use_audio 2>&1 | tee "$OUT/async_chunk.log"
```

### ming_flash_omni
Default model: `Jonathan1909/Ming-flash-omni-2.0`. 
```bash
OUT="$FA_TEST_ROOT/migrated/ming_flash_omni"; mkdir -p "$OUT"
python examples/offline_inference/ming_flash_omni/end2end.py \
  --deploy-config vllm_omni/deploy/ming_flash_omni_thinker_only.yaml \
  --query-type use_audio 2>&1 | tee "$OUT/thinker_use_audio.log"
python examples/offline_inference/ming_flash_omni/end2end.py \
  --query-type use_audio 2>&1 | tee "$OUT/omni_speech_use_audio.log"
```

### qwen3_tts
Default model: `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` (and -VoiceDesign / -Base variants). 
```bash
OUT="$FA_TEST_ROOT/migrated/qwen3_tts"; mkdir -p "$OUT"
cd examples/offline_inference/qwen3_tts
python end2end.py --query-type CustomVoice  --output-dir "$OUT/CustomVoice"  2>&1 | tee "$OUT/CustomVoice.log"
python end2end.py --query-type VoiceDesign  --output-dir "$OUT/VoiceDesign"  2>&1 | tee "$OUT/VoiceDesign.log"
python end2end.py --query-type Base         --output-dir "$OUT/Base"         2>&1 | tee "$OUT/Base.log"
```


</details>

## Test Result

All pytests for the 6 models still pass. 
<details>

### qwen3_tts — `Qwen/Qwen3-TTS-12Hz-0.6B-Base` and `-1.7B-CustomVoice`

```text
$ pytest tests/e2e/offline_inference/test_qwen3_tts_base.py -v
tests/e2e/offline_inference/test_qwen3_tts_base.py::test_text_to_audio_001[no_cuda_graph] PASSED [100%]
================== 1 passed, 20 warnings in 131.07s (0:02:11) ==================

$ pytest tests/e2e/offline_inference/test_qwen3_tts_customvoice.py -v
tests/e2e/offline_inference/test_qwen3_tts_customvoice.py::test_text_to_audio_001[no_cuda_graph] PASSED [100%]
======================= 1 passed, 22 warnings in 48.32s ========================
```

### voxtral_tts — `mistralai/Voxtral-4B-TTS-2603`

```text
$ pytest tests/e2e/offline_inference/test_voxtral_tts.py -v
tests/e2e/offline_inference/test_voxtral_tts.py::test_voxtral_tts_offline_basic PASSED [ 50%]
tests/e2e/offline_inference/test_voxtral_tts.py::test_voxtral_tts_offline_streaming PASSED [100%]
================== 2 passed, 38 warnings in 115.46s (0:01:55) ==================

$ pytest tests/e2e/online_serving/test_voxtral_tts.py -v
tests/e2e/online_serving/test_voxtral_tts.py::TestVoxtralTTSFixedVoice::test_speech_english_basic[omni_server0]               PASSED [ 14%]
tests/e2e/online_serving/test_voxtral_tts.py::TestVoxtralTTSFixedVoice::test_speech_english_streaming[omni_server0]           PASSED [ 28%]
tests/e2e/online_serving/test_voxtral_tts.py::TestVoxtralTTSFixedVoice::test_speech_different_voices[omni_server0]            PASSED [ 42%]
tests/e2e/online_serving/test_voxtral_tts.py::TestVoxtralTTSFixedVoice::test_speech_invalid_voice_rejected[omni_server0]      PASSED [ 57%]
tests/e2e/online_serving/test_voxtral_tts.py::TestVoxtralTTSFixedVoice::test_speech_binary_response_not_utf8_error[omni_server0] PASSED [ 71%]
tests/e2e/online_serving/test_voxtral_tts.py::TestVoxtralTTSAPIEndpoints::test_list_voices_endpoint[omni_server0]              PASSED [ 85%]
tests/e2e/online_serving/test_voxtral_tts.py::TestVoxtralTTSAPIEndpoints::test_models_endpoint[omni_server0]                   PASSED [100%]
================== 7 passed, 16 warnings in 85.18s (0:01:25) ===================
```

### mimo_audio — `XiaomiMiMo/MiMo-Audio-7B-Instruct`

```text
$ pytest tests/e2e/online_serving/test_mimo_audio.py -v
tests/e2e/online_serving/test_mimo_audio.py::test_text_to_text_001[omni_server0] PASSED [100%]
============= 1 passed, 1 skipped, 16 warnings in 94.36s (0:01:34) =============
```

### qwen2_5_omni — `Qwen/Qwen2.5-Omni-7B`

still pending 

### ming_flash_omni — `Jonathan1909/Ming-flash-omni-2.0`

still pending

### qwen3_omni — `Qwen/Qwen3-Omni-30B-A3B-Instruct`

still pending

</details>

The end 2 end test for each model still works, and we attach the generated audio files. 

| Model | config | Input prompt | Main Branch's Output|This PR's Output | Whisper-medium transcript | WER / CER |
|---|---|---|---|---|---|---|
| **qwen3_tts** | `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice`, `--query-type CustomVoice` | `其实我真的有发现，我是一个特别善于观察别人情绪的人。` (`examples/offline_inference/qwen3_tts/end2end.py:get_customvoice_query`) | [qwen3_tts_main.wav](https://github.com/user-attachments/files/27518908/qwen3_tts_main.wav) |[qwen3_tts_branch.wav](https://github.com/user-attachments/files/27518266/qwen3_tts_branch.wav)  | `其实我真的有发现我是一个特别善于观察别人情绪的人`  | **CER 0.0000** ✅ |
| **voxtral_tts** | `mistralai/Voxtral-4B-TTS-2603`, `--voice cheerful_female`, blocking path | `That eerie silence after the first storm was just the calm before another round of chaos, wasn't it?` (`examples/offline_inference/voxtral_tts/end2end.py`) | [voxtral_tts_main.wav](https://github.com/user-attachments/files/27518909/voxtral_tts_main.wav) | [voxtral_branch.wav](https://github.com/user-attachments/files/27518269/voxtral_branch.wav)  | `That eerie silence after the first storm was just the calm before another round of chaos, wasn't it?` | **WER 0.0000** ✅ |
| **mimo_audio** | `XiaomiMiMo/MiMo-Audio-7B-Instruct`, `--query-type tts_sft --text "The weather is so nice today."` | `Please convert this text to speech: The weather is so nice today.` | [mimo_main.wav](https://github.com/user-attachments/files/27518905/mimo_main.wav)| [mimo_branch.wav](https://github.com/user-attachments/files/27518274/mimo_branch.wav)  | `The weather is S O O D` | WER 0.6667, the main branch model also does not work as reported in https://github.com/vllm-project/vllm-omni/issues/3452. |
| qwen2_5_omni | `Qwen/Qwen2.5-Omni-7B`, `--query-type use_audio` | n/a — **deferred** | n/a | n/a | n/a | n/a — CI deploy YAML hard-codes 3 GPUs (`stage 0→cuda:0, 1→cuda:1, 2→cuda:2`); to be run on rental hardware per §8.7 |
| ming_flash_omni | `Jonathan1909/Ming-flash-omni-2.0`, `--query-type use_audio` | n/a — **deferred** | n/a | n/a | n/a | n/a — weights ~64 GB, will not fit on 80 GB system disk alongside other test models |
| qwen3_omni | `Qwen/Qwen3-Omni-30B-A3B-Instruct`, `--query-type use_audio` | n/a — **deferred** | n/a | n/a | n/a | n/a — 30B params (~60 GB bf16), multi-GPU per deploy YAML |





<details>

For mimo-audio, the main branch does not work, 

</details>

The accuracy for each model compared to the main branch remains the same. 

<details>

</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
