### PR TITLE
hotfix #3257 GEdit-Bench judge (Qwen3-VL-30B-A3B-Instruct-AWQ) crashes 

### DIFF
--- a/benchmarks/accuracy/image_to_image/gedit_bench.py
+++ b/benchmarks/accuracy/image_to_image/gedit_bench.py
@@ -477,6 +477,7 @@ class GEditBenchRunner:
             height=self.height,
             num_inference_steps=self.num_inference_steps,
             guidance_scale=self.guidance_scale,
+            negative_prompt=" ",
             seed=self.seed,
         )
         edited_image.save(output_path)

--- a/benchmarks/accuracy/text_to_image/gbench.py
+++ b/benchmarks/accuracy/text_to_image/gbench.py
@@ -572,6 +572,7 @@ class GEBenchRunner:
                 num_inference_steps=self.num_inference_steps,
                 output_compression=self.output_compression,
                 guidance_scale=self.guidance_scale,
+                negative_prompt=" ",
                 seed=self.seed,
             )
             save_image(output_path, generated)
@@ -606,6 +607,7 @@ class GEBenchRunner:
                     num_inference_steps=self.num_inference_steps,
                     output_compression=self.output_compression,
                     guidance_scale=self.guidance_scale,
+                    negative_prompt=" ",
                     seed=self.seed,
                 )
                 save_image(frame_path, generated)
@@ -650,6 +652,7 @@ class GEBenchRunner:
                     num_inference_steps=self.num_inference_steps,
                     output_compression=self.output_compression,
                     guidance_scale=self.guidance_scale,
+                    negative_prompt=" ",
                     seed=self.seed,
                 )
                 save_image(frame_path, generated)
@@ -683,6 +686,7 @@ class GEBenchRunner:
                 num_inference_steps=self.num_inference_steps,
                 output_compression=self.output_compression,
                 guidance_scale=self.guidance_scale,
+                negative_prompt=" ",
                 seed=self.seed,
             )
             save_image(output_path, generated)

--- a/vllm_omni/patch.py
+++ b/vllm_omni/patch.py
@@ -96,6 +96,86 @@ except ImportError:
     # GlmImageTextConfig not available, skip patching
     pass
 
+# =============================================================================
+# Patch Qwen3-VL / Qwen3-Omni-Thinker deepstack checks for CUDA-graph padding
+# =============================================================================
+# WHY: vllm's gpu_model_runner._preprocess calls embed_input_ids on the
+# unpadded scheduled-token length, then runs forward on the CUDA-graph padded
+# length. embed_input_ids → _set_deepstack_input_embeds stores
+# `deepstack_input_embeds_num_tokens = unpadded`, but forward calls
+# _get_deepstack_input_embeds(padded). The original strict check
+# `num_tokens > self.deepstack_input_embeds_num_tokens` raises ValueError
+# whenever scheduled tokens don't already sit on a CUDA-graph bucket boundary
+# (e.g. judge model with 309 scheduled tokens padded to 320). The buffer
+# itself (allocated to max_num_batched_tokens) has plenty of capacity; the
+# guard is just over-strict. Tail rows are zero-initialised and the per-
+# position add of zero is a no-op, so dropping the guard is safe.
+#
+# WHY NOT model-level: judge processes (e.g. Qwen3-VL-30B-A3B-Instruct-AWQ
+# in GEdit-Bench) launch via `vllm_omni.entrypoints.cli.main` without the
+# `--omni` flag and therefore never resolve through OmniModelRegistry, so
+# a vllm-omni-side subclass + registry override would not be reachable.
+#
+# SCOPE: Replaces _get_deepstack_input_embeds and _clear_deepstack_input_embeds
+# on:
+#   - Qwen3VLForConditionalGeneration (Qwen3VLMoeForConditionalGeneration
+#     inherits without overriding, so it picks up the patch automatically)
+#   - Qwen3OmniMoeThinkerForConditionalGeneration (independent class, ships
+#     its own duplicate copies of these methods upstream)
+# vllm-omni's own qwen3_omni_moe_thinker.py override (used on the --omni
+# path) already implements the fix; this patch covers the upstream-CLI path.
+#
+# FRAGILITY: If upstream rewrites these methods (e.g. dynamic buffer
+# allocation) or renames the class, this patch becomes either redundant or
+# inert. The replacement is semantically equivalent to upstream PR #40932,
+# so re-applying on an already-fixed vllm is harmless.
+#
+# TODO: Remove once vllm pin is past commit 22631f80a (PR #40932, v0.20.2rc0).
+# https://github.com/vllm-project/vllm/pull/40932
+try:
+    from vllm.sequence import IntermediateTensors as _IntermediateTensors
+
+    def _patched_get_deepstack_input_embeds(self, num_tokens):
+        if not getattr(self, "deepstack_input_embeds", None):
+            return None
+        if getattr(self, "deepstack_input_embeds_num_tokens", 0) == 0:
+            return None
+        return _IntermediateTensors(
+            {
+                f"deepstack_input_embeds_{idx}": self.deepstack_input_embeds[idx][:num_tokens]
+                for idx in range(self.deepstack_num_level)
+            }
+        )
+
+    def _patched_clear_deepstack_input_embeds(self, num_tokens):
+        if not getattr(self, "deepstack_input_embeds", None):
+            return
+        if getattr(self, "deepstack_input_embeds_num_tokens", 0) == 0:
+            return
+        if num_tokens > 0:
+            for idx in range(self.deepstack_num_level):
+                self.deepstack_input_embeds[idx][:num_tokens].zero_()
+            self.deepstack_input_embeds_num_tokens = 0
+
+    for _module_path, _class_name in (
+        ("vllm.model_executor.models.qwen3_vl", "Qwen3VLForConditionalGeneration"),
+        (
+            "vllm.model_executor.models.qwen3_omni_moe_thinker",
+            "Qwen3OmniMoeThinkerForConditionalGeneration",
+        ),
+    ):
+        try:
+            _mod = __import__(_module_path, fromlist=[_class_name])
+            _cls = getattr(_mod, _class_name)
+        except (ImportError, AttributeError):
+            # Class not available in this vllm version — skip.
+            continue
+        _cls._get_deepstack_input_embeds = _patched_get_deepstack_input_embeds
+        _cls._clear_deepstack_input_embeds = _patched_clear_deepstack_input_embeds
+except ImportError:
+    # vllm.sequence.IntermediateTensors missing — skip patching entirely.
+    pass
+
 # Extend RequestStatus enum with omni-specific statuses
 if not hasattr(RequestStatus, "WAITING_FOR_CHUNK"):
     # The value - 1 is intentionally chosen to ensure it is treated


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

hotfix issue #3257 by:

adding monkey patch for vllm that from https://github.com/vllm-project/vllm/pull/40932 

**This hotfix is going to be removed after the pin vllm being v0.20.2rc0 (commit 22631f80a) or above, it is expected to be vllm-omni v0.20.2 or above**

```
# WHY: vllm's gpu_model_runner._preprocess calls embed_input_ids on the
# unpadded scheduled-token length, then runs forward on the CUDA-graph padded
# length. embed_input_ids → _set_deepstack_input_embeds stores
# `deepstack_input_embeds_num_tokens = unpadded`, but forward calls
# _get_deepstack_input_embeds(padded). The original strict check
# `num_tokens > self.deepstack_input_embeds_num_tokens` raises ValueError
# whenever scheduled tokens don't already sit on a CUDA-graph bucket boundary
# (e.g. judge model with 309 scheduled tokens padded to 320). The buffer
# itself (allocated to max_num_batched_tokens) has plenty of capacity; the
# guard is just over-strict. Tail rows are zero-initialised and the per-
# position add of zero is a no-op, so dropping the guard is safe.
#
# WHY NOT model-level: judge processes (e.g. Qwen3-VL-30B-A3B-Instruct-AWQ
# in GEdit-Bench) launch via `vllm_omni.entrypoints.cli.main` without the
# `--omni` flag and therefore never resolve through OmniModelRegistry, so
# a vllm-omni-side subclass + registry override would not be reachable.
```



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
