### PR TITLE
Bump diffusers minimum version to >=0.38.0

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,7 +1,8 @@
 # Common dependencies for all platforms
 av>=14.0.0
 omegaconf>=2.3.0
-diffusers>=0.36.0
+diffusers==0.38.0
+safetensors>=0.8.0rc0
 accelerate==1.12.0
 soundfile>=0.13.1
 cache-dit==1.3.0


### PR DESCRIPTION
Aligns the global dependency pin with the LTX-2.3 model requirement and the latest stable diffusers release (v0.38.0).

Closes #3347

## Purpose
Bump the diffusers minimum version from >=0.36.0 to >=0.38.0 in requirements/common.txt.
Motivation:
- diffusers v0.38.0 (https://github.com/huggingface/diffusers/releases/tag/v0.38.0) is now the latest stable release (May 1, 2025).
- The LTX-2.3 model already requires diffusers>=0.38.0 (documented in recipes/LTX/LTX-2.3.md), but the global pin was still at 0.36.0. This caused a mismatch where the test code in tests/e2e/accuracy/test_ltx2_3_video_similarity.py needed a runtime version guard (_DIFFUSERS_038) to work around it.
- Aligning the global pin ensures models that depend on 0.38.0 features fail at install time rather than at runtime.
Fixes https://github.com/vllm-project/vllm-omni/issues/3347

## Test Plan
This is a single-line dependency version bump in requirements/common.txt (diffusers>=0.36.0 -> diffusers>=0.38.0). All platform-specific requirements inherit from it via -r common.txt.
No new test scripts are needed. Relying on CI to validate there are no regressions:
- ready — PR-level L1/L2 core model tests
- diffusion-x2iat-test — x2image, x2audio, x2text diffusion model tests
- diffusion-x2v-test — x2video diffusion model tests

## Test Result
Pending CI results.
