### PR TITLE
[CI][Bugfix] Relax stable-audio layerwise offload determinism tolerance to 1e-2

### DIFF
--- a/tests/e2e/offline_inference/test_diffusion_layerwise_offload.py
+++ b/tests/e2e/offline_inference/test_diffusion_layerwise_offload.py
@@ -98,7 +98,10 @@ def test_layerwise_offload_diffusion_model(model_name: str):
     if model_name == "stabilityai/stable-audio-open-1.0":
         audio_offload = output_offload[0].request_output.multimodal_output.get("audio")
         audio_no_offload = output_no_offload[0].request_output.multimodal_output.get("audio")
-        check_audio_determinism(audio_offload, audio_no_offload, atol=1e-3)
+        # Match the sibling cpu-offload test's tolerance: layerwise offload moves
+        # blocks across the PCIe bus on a side stream, which can perturb cuBLAS
+        # algorithm selection and produce ~ULP-level drift larger than 1e-3.
+        check_audio_determinism(audio_offload, audio_no_offload, atol=1e-2)
 
     is_rocm = torch.version.hip is not None
     platform = "rocm" if is_rocm else "cuda"


### PR DESCRIPTION
## Purpose

Fix the `Diffusion Model CPU offloading Test` failure on the `merge-test` lane that has been failing on every PR carrying that label since #2909 was merged. Surfaced via #3290 and confirmed in [build 8939](https://buildkite.com/vllm/vllm-omni/builds/8939).

The `merge-test` label was not active on #2909 itself, so this lane never gated that change.

## Diagnosis

`tests/e2e/offline_inference/test_diffusion_layerwise_offload.py::test_layerwise_offload_diffusion_model[stabilityai/stable-audio-open-1.0]` fails with:

```
Max difference: 0.0012287553399801254
Mean difference: 1.1917034498765133e-05
AssertionError: Audio outputs differ beyond tolerance atol=0.001
```

- Mean diff is three orders of magnitude under the threshold, so this is FP reduction-order drift, not a wrapper or RNG bug.
- Layerwise offload prefetches transformer blocks one at a time on a side CUDA stream (`vllm_omni/diffusion/offloader/layerwise_backend.py`), which changes the GPU memory footprint and lets cuBLAS pick a different algorithm than the resident-weights baseline. That algorithm difference is enough to push max-elementwise drift past 1e-3 on L4.
- The sibling `tests/e2e/offline_inference/test_diffusion_cpu_offload.py` (added in the same #2909) uses `atol=1e-2` for the same audio comparison. The observed 1.23e-3 sits comfortably under that.

## Change

One-line tolerance bump from 1e-3 to 1e-2 in `test_diffusion_layerwise_offload.py`.

## Test plan

- Buildkite `merge-test` lane on this PR, specifically the `Diffusion Model CPU offloading Test` job, should go green.
- `test_diffusion_cpu_offload.py::test_cpu_offload_diffusion_model[stabilityai/stable-audio-open-1.0]` continues to pass at `atol=1e-2`.
