### PR TITLE
[BugFix][CI] Change max_tokens from 150 to 2048

### DIFF
--- a/tests/e2e/online_serving/test_qwen3_omni_expansion.py
+++ b/tests/e2e/online_serving/test_qwen3_omni_expansion.py
@@ -49,7 +49,7 @@ def get_batch_token_config(default_path):
     )
 
 
-def get_async_chunk_config(default_path):
+def get_default_config(default_path):
     """Flip async_chunk on and bump stage 0 thinker output to 2048 tokens.
 
     Pipeline registry (qwen3_omni/pipeline.py) already wires
@@ -75,14 +75,17 @@ default_path = get_deploy_config_path("ci/qwen3_omni_moe.yaml")
 test_params = [
     pytest.param(
         OmniServerParams(
-            model=model, stage_config_path=default_path, use_stage_cli=True, server_args=["--no-async-chunk"]
+            model=model,
+            stage_config_path=get_default_config(default_path),
+            use_stage_cli=True,
+            server_args=["--no-async-chunk"],
         ),
         id="default",
     ),
     pytest.param(
         OmniServerParams(
             model=model,
-            stage_config_path=get_async_chunk_config(default_path),
+            stage_config_path=get_default_config(default_path),
             use_stage_cli=True,
             server_args=["--async-chunk"],
         ),


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix https://github.com/vllm-project/vllm-omni/issues/3264

If `max_tokens` is too small, the thinker's response will be truncated, thus failing to include keywords describing the video.
<img width="1365" height="531" alt="ed80512d-57b1-482f-ada5-5f0f09134554" src="https://github.com/user-attachments/assets/36cb861f-8969-482c-a352-963734fd3523" />

<img width="1626" height="633" alt="image" src="https://github.com/user-attachments/assets/4f18e065-5bdd-428d-a650-414093ee06c4" />


## Test Plan

`pytest -sv tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_audio_in_video_002 -m "full_model" --run-level "full_model" --count=100`

## Test Result

There will be no more error messages indicating that keyword assertions have failed.
```
>                   assert similarity > 0.9, "The audio content is not same as the text"
                           ^^^^^^^^^^^^^^^^
E                   AssertionError: The audio content is not same as the text

tests/helpers/assertions.py:474: AssertionError
=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../../usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: 14 warnings
  /usr/local/lib/python3.12/dist-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_audio_in_video_002[default-1-100]
  /usr/local/lib/python3.12/dist-packages/pydub/utils.py:14: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
    import audioop

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
=========================== short test summary info ============================
FAILED tests/e2e/online_serving/test_qwen3_omni_expansion.py::test_audio_in_video_002[default-37-100]
============ 1 failed, 99 passed, 17 warnings in 4664.06s (1:17:44) ============
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
