### PR TITLE
Update streaming_speech_client.py to solve Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice voice problem

### DIFF
--- a/examples/online_serving/text_to_speech/qwen3_tts/streaming_speech_client.py
+++ b/examples/online_serving/text_to_speech/qwen3_tts/streaming_speech_client.py
@@ -7,8 +7,9 @@ Usage:
     # Send full text at once
     python streaming_speech_client.py --text "Hello world. How are you? I am fine."
 
-    # TTS with certain speaker
-    python streaming_speech_client_ori.py --text "Hello world. How are you? I am fine." \
+    # Pick a built-in speaker for CustomVoice models
+    python streaming_speech_client.py \
+        --text "打开电子枪，关闭扫描，切换到低倍模式。" \
         --speaker "Serena" \
         --language "Chinese"
 
@@ -216,11 +217,13 @@ def main():
 
     args = parser.parse_args()
 
-    # Build session config (only include non-None values)
+    # Build session config (only include non-None values).
+    # Server canonical field is `voice`; `speaker` is accepted as an alias
+    # (see StreamingSpeechSessionConfig.voice in protocol/audio.py).
     config = {}
     for key in [
         "model",
-        # "speaker",
+        "speaker",
         "task_type",
         "language",
         "instructions",
@@ -233,9 +236,6 @@ def main():
         val = getattr(args, key.replace("-", "_"), None)
         if val is not None:
             config[key] = val
-    # Server receive voice instead of speaker to control
-    if args.speaker:
-        config["voice"] = args.speaker.lower().strip()
     if args.stream_audio:
         config["stream_audio"] = True
     if args.x_vector_only_mode:

--- a/examples/online_serving/text_to_speech/qwen3_tts/streaming_speech_client.py
+++ b/examples/online_serving/text_to_speech/qwen3_tts/streaming_speech_client.py
@@ -7,6 +7,11 @@ Usage:
     # Send full text at once
     python streaming_speech_client.py --text "Hello world. How are you? I am fine."
 
+    # TTS with certain speaker
+    python streaming_speech_client_ori.py --text "Hello world. How are you? I am fine." \
+        --speaker "Serena" \
+        --language "Chinese"
+
     # Simulate STT: send text word-by-word with delay
     python streaming_speech_client.py \
         --text "Hello world. How are you? I am fine." \
@@ -215,7 +220,7 @@ def main():
     config = {}
     for key in [
         "model",
-        "speaker",
+        # "speaker",
         "task_type",
         "language",
         "instructions",
@@ -228,6 +233,9 @@ def main():
         val = getattr(args, key.replace("-", "_"), None)
         if val is not None:
             config[key] = val
+    # Server receive voice instead of speaker to control
+    if args.speaker:
+        config["voice"] = args.speaker.lower().strip()
     if args.stream_audio:
         config["stream_audio"] = True
     if args.x_vector_only_mode:

--- a/vllm_omni/entrypoints/openai/protocol/audio.py
+++ b/vllm_omni/entrypoints/openai/protocol/audio.py
@@ -196,7 +196,7 @@ class SpeechBatchItem(BaseModel):
     all other fields override the batch-level defaults when set."""
 
     input: str
-    voice: str | None = None
+    voice: str | None = Field(default=None, validation_alias=AliasChoices("voice", "speaker"))
     instructions: str | None = None
     response_format: Literal["wav", "pcm", "flac", "mp3", "aac", "opus"] | None = None
     speed: float | None = Field(default=None, ge=0.25, le=4.0)
@@ -215,7 +215,7 @@ class BatchSpeechRequest(BaseModel):
 
     model: str | None = None
     items: list[SpeechBatchItem] = Field(..., min_length=1)
-    voice: str | None = None
+    voice: str | None = Field(default=None, validation_alias=AliasChoices("voice", "speaker"))
     instructions: str | None = None
     response_format: Literal["wav", "pcm", "flac", "mp3", "aac", "opus"] = "wav"
     speed: float | None = Field(default=1.0, ge=0.25, le=4.0)
@@ -248,7 +248,7 @@ class StreamingSpeechSessionConfig(BaseModel):
     """Configuration sent as the first WebSocket message for streaming TTS."""
 
     model: str | None = None
-    voice: str | None = None
+    voice: str | None = Field(default=None, validation_alias=AliasChoices("voice", "speaker"))
     task_type: Literal["CustomVoice", "VoiceDesign", "Base"] | None = None
     language: str | None = None
     instructions: str | None = None


### PR DESCRIPTION
## Purpose
Fix Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice speaker useless problem

## Test Plan
Compare with transormers output and debug why changed speaker but output not change.

## Test Result
Server recieve `voice` instaed of `speaker`

---
# Backgroud
I have deploy Qwen3 TTS with command as followed

```bash
CUDA_VISIBLE_DEVICES=0 vllm serve Qwen3-TTS-12Hz-0.6B-CustomVoice \
  --deploy-config vllm-omni-main/vllm_omni/deploy/qwen3_tts.yaml \
  --omni \
  --host 0.0.0.0 \
  --port 8091 \
  --trust-remote-code \
  --enforce-eager
```

Then I use `vllm-omni-main/examples/online_serving/qwen3_tts/streaming_speech_client.py` script to call TTS service which command is 

```bash
python streaming_speech_client.py --text "打开电子枪，关闭扫描，切换到低倍模式。" \
        --speaker "Serena" \
        --language "Chinese"
```

It is different with transformer output and voice do not change whatever I changed speaker as followed:

```bash
"aiden",
"dylan",
"eric",
"ono_anna",
"ryan",
"serena",
"sohee",
"uncle_fu",
"vivian"
```
so I debuged it and I find that StreamingSpeechSessionConfig in `vllm-omni-main/vllm_omni/entrypoints/openai/protocol/audio.py` only have voice instead of speaker, so I change speaker to voice and problem solved. 

# Baseline Transformers code 
The transformers code `transformers_qwen3tts.py` as followed: 
```python
import torch import soundfile as sf
from qwen_tts import Qwen3TTSModel

# Load the model
model = Qwen3TTSModel.from_pretrained(
    "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice",
    device_map="cuda:0",
    dtype=torch.bfloat16,
    attn_implementation="flash_attention_2",
)

# Generate speech with specific instructions
wavs, sr = model.generate_custom_voice(
    text="打开电子枪，关闭扫描，切换到低倍模式。",
    language="Chinese", 
    speaker="Serena"
)

# Save the generated audio
sf.write("output_custom_voice.wav", wavs[0], sr)
```

<!-- markdownlint-disable -->
## baseline output
```bash
python transformers_qwen3tts.py
```
[transformers Qwen3-TTS-12Hz-0.6B-CustomVoice](https://github.com/user-attachments/files/27432015/output_custom_voice_transformer.wav)

## original output
```bash
python streaming_speech_client.py
```
[sentence_000_ori.wav](https://github.com/user-attachments/files/27432060/sentence_000_ori.wav)

## after fix bug output
```bash
python streaming_speech_client.py
```
[sentence_000_change_speaker2voice.wav](https://github.com/user-attachments/files/27432070/sentence_000_change_speaker2voice.wav)
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
