### PR TITLE
[Core] Pipeline LLM stage attach during omni startup 

### DIFF
--- a/examples/online_serving/multimodal_data_utils.py
+++ b/examples/online_serving/multimodal_data_utils.py
@@ -1,0 +1,105 @@
+import base64
+import io
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+from PIL import Image
+
+
+def encode_base64_content_from_file(file_path: str) -> str:
+    """Encode a local file as a base64 string."""
+    with open(file_path, "rb") as f:
+        return base64.b64encode(f.read()).decode("utf-8")
+
+
+def _looks_like_url(value: str) -> bool:
+    return value.startswith(("http://", "https://", "data:"))
+
+
+def _detect_mime_type(file_path: str, media_kind: str) -> str:
+    suffix = Path(file_path).suffix.lower()
+    if media_kind == "image":
+        if suffix in (".jpg", ".jpeg"):
+            return "image/jpeg"
+        if suffix == ".png":
+            return "image/png"
+        if suffix == ".gif":
+            return "image/gif"
+        if suffix == ".webp":
+            return "image/webp"
+        return "image/jpeg"
+
+    if media_kind == "audio":
+        if suffix in (".mp3", ".mpeg"):
+            return "audio/mpeg"
+        if suffix == ".wav":
+            return "audio/wav"
+        if suffix == ".ogg":
+            return "audio/ogg"
+        if suffix == ".flac":
+            return "audio/flac"
+        if suffix == ".m4a":
+            return "audio/mp4"
+        return "audio/wav"
+
+    if media_kind == "video":
+        if suffix == ".mp4":
+            return "video/mp4"
+        if suffix == ".webm":
+            return "video/webm"
+        if suffix == ".mov":
+            return "video/quicktime"
+        if suffix == ".avi":
+            return "video/x-msvideo"
+        if suffix == ".mkv":
+            return "video/x-matroska"
+        return "video/mp4"
+
+    raise ValueError(f"Unsupported media kind: {media_kind}")
+
+
+def local_path_to_data_url(file_path: str, media_kind: str) -> str:
+    """Convert a local file path to a base64 data URL."""
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"{media_kind.capitalize()} file not found: {file_path}")
+
+    mime_type = _detect_mime_type(file_path, media_kind)
+    base64_payload = encode_base64_content_from_file(file_path)
+    return f"data:{mime_type};base64,{base64_payload}"
+
+
+def path_or_url_to_url(value: str | None, media_kind: str, default_url: str) -> str:
+    """Resolve a media input into either a remote URL or a data URL."""
+    if not value:
+        return default_url
+    if _looks_like_url(value):
+        return value
+    return local_path_to_data_url(value, media_kind)
+
+
+def pil_image_to_jpeg_data_url(image: Image.Image) -> str:
+    """Convert a PIL image to a JPEG data URL."""
+    buffered = io.BytesIO()
+    if image.mode != "RGB":
+        image = image.convert("RGB")
+    image.save(buffered, format="JPEG")
+    img_b64 = base64.b64encode(buffered.getvalue()).decode("utf-8")
+    return f"data:image/jpeg;base64,{img_b64}"
+
+
+def audio_array_to_wav_data_url(audio_data: tuple[np.ndarray, int]) -> str:
+    """Convert a numpy audio array to a WAV data URL."""
+    audio_np, sample_rate = audio_data
+    if audio_np.dtype != np.int16:
+        if audio_np.dtype in (np.float32, np.float64):
+            audio_np = np.clip(audio_np, -1.0, 1.0)
+            audio_np = (audio_np * 32767).astype(np.int16)
+        else:
+            audio_np = audio_np.astype(np.int16)
+
+    buffered = io.BytesIO()
+    sf.write(buffered, audio_np, sample_rate, format="WAV")
+    wav_b64 = base64.b64encode(buffered.getvalue()).decode("utf-8")
+    return f"data:audio/wav;base64,{wav_b64}"

--- a/examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py
+++ b/examples/online_serving/openai_chat_completion_client_for_multimodal_generation.py
@@ -1,9 +1,8 @@
 import base64
 import concurrent.futures
-import os
 from typing import NamedTuple
 
-import requests
+from examples.online_serving.multimodal_data_utils import path_or_url_to_url
 from openai import OpenAI
 from vllm.assets.audio import AudioAsset
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -24,24 +23,6 @@ def make_audio_output_filename(request_id: str | None, index: int) -> str:
     return f"audio_{safe_request_id}_{index}.wav"
 
 
-def encode_base64_content_from_url(content_url: str) -> str:
-    """Encode a content retrieved from a remote url to base64 format."""
-
-    with requests.get(content_url) as response:
-        response.raise_for_status()
-        result = base64.b64encode(response.content).decode("utf-8")
-
-    return result
-
-
-def encode_base64_content_from_file(file_path: str) -> str:
-    """Encode a local file to base64 format."""
-    with open(file_path, "rb") as f:
-        content = f.read()
-        result = base64.b64encode(content).decode("utf-8")
-    return result
-
-
 def get_video_url_from_path(video_path: str | None) -> str:
     """Convert a video path (local file or URL) to a video URL format for the API.
 
@@ -49,36 +30,11 @@ def get_video_url_from_path(video_path: str | None) -> str:
     If video_path is a local file path, encodes it to base64 data URL.
     If video_path is a URL, returns it as-is.
     """
-    if not video_path:
-        # Default video URL
-        return "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/sample_demo_1.mp4"
-
-    # Check if it's a URL (starts with http:// or https://)
-    if video_path.startswith(("http://", "https://")):
-        return video_path
-
-    # Otherwise, treat it as a local file path
-    if not os.path.exists(video_path):
-        raise FileNotFoundError(f"Video file not found: {video_path}")
-
-    # Detect video MIME type from file extension
-    video_path_lower = video_path.lower()
-    if video_path_lower.endswith(".mp4"):
-        mime_type = "video/mp4"
-    elif video_path_lower.endswith(".webm"):
-        mime_type = "video/webm"
-    elif video_path_lower.endswith(".mov"):
-        mime_type = "video/quicktime"
-    elif video_path_lower.endswith(".avi"):
-        mime_type = "video/x-msvideo"
-    elif video_path_lower.endswith(".mkv"):
-        mime_type = "video/x-matroska"
-    else:
-        # Default to mp4 if extension is unknown
-        mime_type = "video/mp4"
-
-    video_base64 = encode_base64_content_from_file(video_path)
-    return f"data:{mime_type};base64,{video_base64}"
+    return path_or_url_to_url(
+        video_path,
+        media_kind="video",
+        default_url="https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/sample_demo_1.mp4",
+    )
 
 
 def get_image_url_from_path(image_path: str | None) -> str:
@@ -88,34 +44,11 @@ def get_image_url_from_path(image_path: str | None) -> str:
     If image_path is a local file path, encodes it to base64 data URL.
     If image_path is a URL, returns it as-is.
     """
-    if not image_path:
-        # Default image URL
-        return "https://vllm-public-assets.s3.us-west-2.amazonaws.com/vision_model_images/cherry_blossom.jpg"
-
-    # Check if it's a URL (starts with http:// or https://)
-    if image_path.startswith(("http://", "https://")):
-        return image_path
-
-    # Otherwise, treat it as a local file path
-    if not os.path.exists(image_path):
-        raise FileNotFoundError(f"Image file not found: {image_path}")
-
-    # Detect image MIME type from file extension
-    image_path_lower = image_path.lower()
-    if image_path_lower.endswith((".jpg", ".jpeg")):
-        mime_type = "image/jpeg"
-    elif image_path_lower.endswith(".png"):
-        mime_type = "image/png"
-    elif image_path_lower.endswith(".gif"):
-        mime_type = "image/gif"
-    elif image_path_lower.endswith(".webp"):
-        mime_type = "image/webp"
-    else:
-        # Default to jpeg if extension is unknown
-        mime_type = "image/jpeg"
-
-    image_base64 = encode_base64_content_from_file(image_path)
-    return f"data:{mime_type};base64,{image_base64}"
+    return path_or_url_to_url(
+        image_path,
+        media_kind="image",
+        default_url="https://vllm-public-assets.s3.us-west-2.amazonaws.com/vision_model_images/cherry_blossom.jpg",
+    )
 
 
 def get_audio_url_from_path(audio_path: str | None) -> str:
@@ -125,36 +58,11 @@ def get_audio_url_from_path(audio_path: str | None) -> str:
     If audio_path is a local file path, encodes it to base64 data URL.
     If audio_path is a URL, returns it as-is.
     """
-    if not audio_path:
-        # Default audio URL
-        return AudioAsset("mary_had_lamb").url
-
-    # Check if it's a URL (starts with http:// or https://)
-    if audio_path.startswith(("http://", "https://")):
-        return audio_path
-
-    # Otherwise, treat it as a local file path
-    if not os.path.exists(audio_path):
-        raise FileNotFoundError(f"Audio file not found: {audio_path}")
-
-    # Detect audio MIME type from file extension
-    audio_path_lower = audio_path.lower()
-    if audio_path_lower.endswith((".mp3", ".mpeg")):
-        mime_type = "audio/mpeg"
-    elif audio_path_lower.endswith(".wav"):
-        mime_type = "audio/wav"
-    elif audio_path_lower.endswith(".ogg"):
-        mime_type = "audio/ogg"
-    elif audio_path_lower.endswith(".flac"):
-        mime_type = "audio/flac"
-    elif audio_path_lower.endswith(".m4a"):
-        mime_type = "audio/mp4"
-    else:
-        # Default to wav if extension is unknown
-        mime_type = "audio/wav"
-
-    audio_base64 = encode_base64_content_from_file(audio_path)
-    return f"data:{mime_type};base64,{audio_base64}"
+    return path_or_url_to_url(
+        audio_path,
+        media_kind="audio",
+        default_url=AudioAsset("mary_had_lamb").url,
+    )
 
 
 def get_system_prompt():

--- a/examples/online_serving/qwen2_5_omni/gradio_demo.py
+++ b/examples/online_serving/qwen2_5_omni/gradio_demo.py
@@ -13,6 +13,11 @@ except ImportError:
 import numpy as np
 import soundfile as sf
 import torch
+from examples.online_serving.multimodal_data_utils import (
+    audio_array_to_wav_data_url,
+    local_path_to_data_url,
+    pil_image_to_jpeg_data_url,
+)
 from openai import OpenAI
 from PIL import Image
 
@@ -104,65 +109,6 @@ def build_sampling_params_dict(seed: int, model_key: str) -> list[dict]:
         params["seed"] = seed
         sampling_params.append(params)
     return sampling_params
-
-
-def image_to_base64_data_url(image: Image.Image) -> str:
-    """Convert PIL Image to base64 data URL."""
-    buffered = io.BytesIO()
-    # Convert to RGB if needed
-    if image.mode != "RGB":
-        image = image.convert("RGB")
-    image.save(buffered, format="JPEG")
-    img_bytes = buffered.getvalue()
-    img_b64 = base64.b64encode(img_bytes).decode("utf-8")
-    return f"data:image/jpeg;base64,{img_b64}"
-
-
-def audio_to_base64_data_url(audio_data: tuple[np.ndarray, int]) -> str:
-    """Convert audio (numpy array, sample_rate) to base64 data URL."""
-    audio_np, sample_rate = audio_data
-    # Convert to int16 format for WAV
-    if audio_np.dtype != np.int16:
-        # Normalize to [-1, 1] range if needed
-        if audio_np.dtype == np.float32 or audio_np.dtype == np.float64:
-            audio_np = np.clip(audio_np, -1.0, 1.0)
-            audio_np = (audio_np * 32767).astype(np.int16)
-        else:
-            audio_np = audio_np.astype(np.int16)
-
-    # Write to WAV bytes
-    buffered = io.BytesIO()
-    sf.write(buffered, audio_np, sample_rate, format="WAV")
-    wav_bytes = buffered.getvalue()
-    wav_b64 = base64.b64encode(wav_bytes).decode("utf-8")
-    return f"data:audio/wav;base64,{wav_b64}"
-
-
-def video_to_base64_data_url(video_file: str) -> str:
-    """Convert video file to base64 data URL."""
-    video_path = Path(video_file)
-    if not video_path.exists():
-        raise FileNotFoundError(f"Video file not found: {video_file}")
-
-    # Detect MIME type from extension
-    video_path_lower = str(video_path).lower()
-    if video_path_lower.endswith(".mp4"):
-        mime_type = "video/mp4"
-    elif video_path_lower.endswith(".webm"):
-        mime_type = "video/webm"
-    elif video_path_lower.endswith(".mov"):
-        mime_type = "video/quicktime"
-    elif video_path_lower.endswith(".avi"):
-        mime_type = "video/x-msvideo"
-    elif video_path_lower.endswith(".mkv"):
-        mime_type = "video/x-matroska"
-    else:
-        mime_type = "video/mp4"
-
-    with open(video_path, "rb") as f:
-        video_bytes = f.read()
-    video_b64 = base64.b64encode(video_bytes).decode("utf-8")
-    return f"data:{mime_type};base64,{video_b64}"
 
 
 def process_audio_file(
@@ -266,7 +212,7 @@ def run_inference_api(
         # Process audio
         audio_data = process_audio_file(audio_file)
         if audio_data is not None:
-            audio_url = audio_to_base64_data_url(audio_data)
+            audio_url = audio_array_to_wav_data_url(audio_data)
             content_list.append(
                 {
                     "type": "audio_url",
@@ -278,7 +224,7 @@ def run_inference_api(
         if image_file is not None:
             image_data = process_image_file(image_file)
             if image_data is not None:
-                image_url = image_to_base64_data_url(image_data)
+                image_url = pil_image_to_jpeg_data_url(image_data)
                 content_list.append(
                     {
                         "type": "image_url",
@@ -289,7 +235,7 @@ def run_inference_api(
         # Process video
         mm_processor_kwargs = {}
         if video_file is not None:
-            video_url = video_to_base64_data_url(video_file)
+            video_url = local_path_to_data_url(video_file, media_kind="video")
             video_content = {
                 "type": "video_url",
                 "video_url": {"url": video_url},

--- a/examples/online_serving/qwen3_omni/README.md
+++ b/examples/online_serving/qwen3_omni/README.md
@@ -479,6 +479,14 @@ The convenience script launches both the vLLM server and Gradio demo together:
 ./run_gradio_demo.sh --model Qwen/Qwen3-Omni-30B-A3B-Instruct --server-port 8091 --gradio-port 7861
 ```
 
+If your server was launched from a local checkpoint path, you can pass that
+same local path to the script. The demo now auto-detects the built-in
+Qwen3-Omni sampling config from the model basename:
+
+```bash
+./run_gradio_demo.sh --model /path/to/Qwen3-Omni-30B-A3B-Instruct --server-port 8091 --gradio-port 7861
+```
+
 This script will:
 1. Start the vLLM server in the background
 2. Wait for the server to be ready
@@ -515,11 +523,16 @@ In a separate terminal:
 python gradio_demo.py --model Qwen/Qwen3-Omni-30B-A3B-Instruct --api-base http://localhost:8091/v1 --port 7861
 ```
 
+This also works when `--model` is a local checkpoint path as long as the path
+basename matches a supported model family, for example
+`/path/to/Qwen3-Omni-30B-A3B-Instruct`.
+
 Then open `http://localhost:7861/` on your local browser to interact with the web UI.
 
 The gradio script supports the following arguments:
 
 - `--model`: Model name/path (should match the server model)
+- `--model-config-key`: Optional built-in config key for demo-side sampling defaults. Useful when `--model` is a custom alias or local path that cannot be auto-detected.
 - `--api-base`: Base URL for the vLLM API server (default: http://localhost:8091/v1)
 - `--ip`: Host/IP for Gradio server (default: 127.0.0.1)
 - `--port`: Port for Gradio server (default: 7861)

--- a/examples/online_serving/qwen3_omni/gradio_demo.py
+++ b/examples/online_serving/qwen3_omni/gradio_demo.py
@@ -13,6 +13,11 @@ except ImportError:
 import numpy as np
 import soundfile as sf
 import torch
+from examples.online_serving.multimodal_data_utils import (
+    audio_array_to_wav_data_url,
+    local_path_to_data_url,
+    pil_image_to_jpeg_data_url,
+)
 from openai import OpenAI
 from PIL import Image
 
@@ -69,7 +74,15 @@ def parse_args():
     parser.add_argument(
         "--model",
         default="Qwen/Qwen3-Omni-30B-A3B-Instruct",
-        help="Model name/path (should match the server model).",
+        help="Model name/path sent to the server for inference.",
+    )
+    parser.add_argument(
+        "--model-config-key",
+        default=None,
+        help=(
+            "Optional key used to select demo-side sampling defaults. "
+            "Defaults to auto-detecting a supported config from --model."
+        ),
     )
     parser.add_argument(
         "--api-base",
@@ -101,63 +114,50 @@ def build_sampling_params_dict(seed: int, model_key: str) -> list[dict]:
     return sampling_params
 
 
-def image_to_base64_data_url(image: Image.Image) -> str:
-    """Convert PIL Image to base64 data URL."""
-    buffered = io.BytesIO()
-    # Convert to RGB if needed
-    if image.mode != "RGB":
-        image = image.convert("RGB")
-    image.save(buffered, format="JPEG")
-    img_bytes = buffered.getvalue()
-    img_b64 = base64.b64encode(img_bytes).decode("utf-8")
-    return f"data:image/jpeg;base64,{img_b64}"
+def resolve_model_config_key(model_arg: str, explicit_key: str | None = None) -> str:
+    """Resolve which built-in sampling config should back the demo.
 
+    The API server may be launched with either a Hugging Face model name or a
+    local path. The demo only needs a stable config key to choose stage-wise
+    sampling defaults, so we infer that key from the provided model string.
+    """
+    if explicit_key is not None:
+        if explicit_key not in SUPPORTED_MODELS:
+            raise ValueError(
+                f"Unsupported --model-config-key '{explicit_key}'. "
+                f"Supported keys: {tuple(SUPPORTED_MODELS)}"
+            )
+        return explicit_key
 
-def audio_to_base64_data_url(audio_data: tuple[np.ndarray, int]) -> str:
-    """Convert audio (numpy array, sample_rate) to base64 data URL."""
-    audio_np, sample_rate = audio_data
-    # Convert to int16 format for WAV
-    if audio_np.dtype != np.int16:
-        # Normalize to [-1, 1] range if needed
-        if audio_np.dtype == np.float32 or audio_np.dtype == np.float64:
-            audio_np = np.clip(audio_np, -1.0, 1.0)
-            audio_np = (audio_np * 32767).astype(np.int16)
-        else:
-            audio_np = audio_np.astype(np.int16)
+    candidates: list[str] = []
 
-    # Write to WAV bytes
-    buffered = io.BytesIO()
-    sf.write(buffered, audio_np, sample_rate, format="WAV")
-    wav_bytes = buffered.getvalue()
-    wav_b64 = base64.b64encode(wav_bytes).decode("utf-8")
-    return f"data:audio/wav;base64,{wav_b64}"
+    if model_arg in SUPPORTED_MODELS:
+        candidates.append(model_arg)
 
+    last_two_segments = "/".join(Path(model_arg).parts[-2:])
+    if last_two_segments in SUPPORTED_MODELS and last_two_segments not in candidates:
+        candidates.append(last_two_segments)
 
-def video_to_base64_data_url(video_file: str) -> str:
-    """Convert video file to base64 data URL."""
-    video_path = Path(video_file)
-    if not video_path.exists():
-        raise FileNotFoundError(f"Video file not found: {video_file}")
+    model_basename = Path(model_arg).name
+    basename_matches = [key for key in SUPPORTED_MODELS if Path(key).name == model_basename]
+    for key in basename_matches:
+        if key not in candidates:
+            candidates.append(key)
 
-    # Detect MIME type from extension
-    video_path_lower = str(video_path).lower()
-    if video_path_lower.endswith(".mp4"):
-        mime_type = "video/mp4"
-    elif video_path_lower.endswith(".webm"):
-        mime_type = "video/webm"
-    elif video_path_lower.endswith(".mov"):
-        mime_type = "video/quicktime"
-    elif video_path_lower.endswith(".avi"):
-        mime_type = "video/x-msvideo"
-    elif video_path_lower.endswith(".mkv"):
-        mime_type = "video/x-matroska"
-    else:
-        mime_type = "video/mp4"
+    if len(candidates) == 1:
+        return candidates[0]
 
-    with open(video_path, "rb") as f:
-        video_bytes = f.read()
-    video_b64 = base64.b64encode(video_bytes).decode("utf-8")
-    return f"data:{mime_type};base64,{video_b64}"
+    if not candidates:
+        raise ValueError(
+            f"Could not infer a supported model config for '{model_arg}'. "
+            f"Supported keys: {tuple(SUPPORTED_MODELS)}. "
+            "If you are serving a local path, pass --model-config-key explicitly."
+        )
+
+    raise ValueError(
+        f"Ambiguous model config for '{model_arg}': {candidates}. "
+        "Pass --model-config-key explicitly."
+    )
 
 
 def process_audio_file(
@@ -260,7 +260,7 @@ def run_inference_api(
         # Process audio
         audio_data = process_audio_file(audio_file)
         if audio_data is not None:
-            audio_url = audio_to_base64_data_url(audio_data)
+            audio_url = audio_array_to_wav_data_url(audio_data)
             content_list.append(
                 {
                     "type": "audio_url",
@@ -272,7 +272,7 @@ def run_inference_api(
         if image_file is not None:
             image_data = process_image_file(image_file)
             if image_data is not None:
-                image_url = image_to_base64_data_url(image_data)
+                image_url = pil_image_to_jpeg_data_url(image_data)
                 content_list.append(
                     {
                         "type": "image_url",
@@ -283,7 +283,7 @@ def run_inference_api(
         # Process video
         mm_processor_kwargs = {}
         if video_file is not None:
-            video_url = video_to_base64_data_url(video_file)
+            video_url = local_path_to_data_url(video_file, media_kind="video")
             video_content = {
                 "type": "video_url",
                 "video_url": {"url": video_url},
@@ -550,11 +550,7 @@ def build_interface(
 
 def main():
     args = parse_args()
-
-    model_name = "/".join(args.model.split("/")[-2:])
-    assert model_name in SUPPORTED_MODELS, (
-        f"Unsupported model '{model_name}'. Supported models: {SUPPORTED_MODELS.keys()}"
-    )
+    model_config_key = resolve_model_config_key(args.model, args.model_config_key)
 
     # Initialize OpenAI client
     print(f"Connecting to API server at: {args.api_base}")
@@ -563,9 +559,10 @@ def main():
         base_url=args.api_base,
     )
     print("✓ Connected to API server")
+    print(f"Using sampling config: {model_config_key}")
 
     # Build sampling params
-    sampling_params_dict = build_sampling_params_dict(SEED, model_name)
+    sampling_params_dict = build_sampling_params_dict(SEED, model_config_key)
 
     demo = build_interface(
         client,

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -361,3 +361,21 @@ def test_apply_stage_startup_policy_shared_device_eager():
     assert not hasattr(stage_configs[0].engine_args, "enforce_eager")
     assert stage_configs[1].engine_args.enforce_eager is True
     assert stage_configs[2].engine_args.enforce_eager is True
+
+
+def test_apply_stage_startup_policy_balanced_eager():
+    stage_configs = [
+        _stage_cfg(0, devices=["cuda:0"], is_comprehension=True),
+        _stage_cfg(1, devices=["cuda:1"]),
+        _stage_cfg(2, devices=["cuda:1"]),
+    ]
+
+    policy, plan = AsyncOmniEngine._apply_stage_startup_policy(stage_configs, "balanced-eager")
+
+    assert policy == "balanced-eager"
+    assert plan == {
+        1: "shared-device-upstream:cuda:1",
+    }
+    assert not hasattr(stage_configs[0].engine_args, "enforce_eager")
+    assert stage_configs[1].engine_args.enforce_eager is True
+    assert not hasattr(stage_configs[2].engine_args, "enforce_eager")

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+from omegaconf import OmegaConf
 from pydantic import ValidationError
 from transformers import PretrainedConfig
 from vllm.engine.arg_utils import EngineArgs
@@ -311,3 +312,52 @@ def test_strip_single_engine_args_model_does_not_trigger_warning(mocker):
     warned_args = mock_warn.call_args[0][-1]  # the formatted arg list
     assert "tensor_parallel_size" in warned_args
     assert "model" not in warned_args
+
+
+def _stage_cfg(stage_id: int, *, devices: list[str], is_comprehension: bool = False):
+    return SimpleNamespace(
+        stage_id=stage_id,
+        stage_type="llm",
+        runtime=OmegaConf.create({"devices": devices}),
+        engine_args=OmegaConf.create({}),
+        default_sampling_params=OmegaConf.create({}),
+        is_comprehension=is_comprehension,
+        final_output=False,
+        final_output_type=None,
+        engine_input_source=[],
+    )
+
+
+def test_apply_stage_startup_policy_comprehension_eager():
+    stage_configs = [
+        _stage_cfg(0, devices=["cuda:0"], is_comprehension=True),
+        _stage_cfg(1, devices=["cuda:1"]),
+        _stage_cfg(2, devices=["cuda:2"]),
+    ]
+
+    policy, plan = AsyncOmniEngine._apply_stage_startup_policy(stage_configs, "comprehension-eager")
+
+    assert policy == "comprehension-eager"
+    assert plan == {0: "comprehension-stage"}
+    assert stage_configs[0].engine_args.enforce_eager is True
+    assert not hasattr(stage_configs[1].engine_args, "enforce_eager")
+    assert not hasattr(stage_configs[2].engine_args, "enforce_eager")
+
+
+def test_apply_stage_startup_policy_shared_device_eager():
+    stage_configs = [
+        _stage_cfg(0, devices=["cuda:0"], is_comprehension=True),
+        _stage_cfg(1, devices=["cuda:1"]),
+        _stage_cfg(2, devices=["cuda:1"]),
+    ]
+
+    policy, plan = AsyncOmniEngine._apply_stage_startup_policy(stage_configs, "shared-device-eager")
+
+    assert policy == "shared-device-eager"
+    assert plan == {
+        1: "shared-device:cuda:1",
+        2: "shared-device:cuda:1",
+    }
+    assert not hasattr(stage_configs[0].engine_args, "enforce_eager")
+    assert stage_configs[1].engine_args.enforce_eager is True
+    assert stage_configs[2].engine_args.enforce_eager is True

--- a/tests/entrypoints/test_omni_entrypoints.py
+++ b/tests/entrypoints/test_omni_entrypoints.py
@@ -201,6 +201,17 @@ def _make_base():
     return obj
 
 
+def test_log_summary_and_cleanup_builds_summary_and_clears_state() -> None:
+    app = _make_base()
+    metrics = MagicMock()
+    app.request_states["req-1"] = SimpleNamespace(metrics=metrics)
+
+    app._log_summary_and_cleanup("req-1")
+
+    metrics.build_and_log_summary.assert_called_once_with()
+    assert "req-1" not in app.request_states
+
+
 def _stage_spec(
     stage_id: int,
     *,

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -123,6 +123,10 @@ class OmniEngineArgs(EngineArgs):
         output_modalities: Optional list of output modality names to enable
             (e.g. ["text", "audio"]). If None, all modalities supported by
             the model are used.
+        startup_policy: Optional cold-start policy that can rewrite
+            per-stage startup behavior (for example, setting
+            ``enforce_eager`` only on selected stages). ``None`` keeps the
+            deploy config unchanged.
         log_stats: Whether to log engine statistics. Defaults to False.
         custom_pipeline_args: Dictionary of arguments for custom pipeline
             initialization (e.g., ``{"pipeline_class": "my.Module"}``).
@@ -164,6 +168,7 @@ class OmniEngineArgs(EngineArgs):
     omni_master_port: int | None = None
     stage_configs_path: str | None = None
     output_modalities: list[str] | None = None
+    startup_policy: str | None = None
     log_stats: bool = False
     custom_pipeline_args: dict[str, Any] | None = None
     has_sampling_extra_args: bool = False
@@ -430,6 +435,7 @@ class OrchestratorArgs:
 
     # === Observability ===
     log_stats: bool = False
+    startup_policy: str | None = None
 
     # === Headless Mode (also forwarded to engine — see SHARED_FIELDS) ===
     stage_id: int | None = None
@@ -452,6 +458,7 @@ SHARED_FIELDS: frozenset[str] = frozenset(
         "model",  # orch: detect model_type; engine: load weights
         "stage_id",  # orch: route (headless); engine: identity
         "log_stats",  # both want the flag
+        "startup_policy",  # orch: stage-aware startup rewrite; engine: consume in AsyncOmniEngine
         "stage_configs_path",  # orch: load legacy YAML; engine: may reference for validation
     }
 )

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -95,6 +95,16 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 _STARTUP_POLL_INTERVAL_S = 1.0
+_DEFAULT_STARTUP_POLICY = "default"
+_SUPPORTED_STARTUP_POLICIES: frozenset[str] = frozenset(
+    {
+        _DEFAULT_STARTUP_POLICY,
+        "all-eager",
+        "comprehension-eager",
+        "shared-device-eager",
+        "critical-path-eager",
+    }
+)
 
 
 # ============================================================================
@@ -279,6 +289,8 @@ class AsyncOmniEngine:
         startup_timeout = int(init_timeout)
 
         logger.info(f"[AsyncOmniEngine] Initializing with model {model}")
+        self._startup_policy = _DEFAULT_STARTUP_POLICY
+        self._startup_policy_stage_plan: dict[int, str] = {}
 
         # Merge tracked engine_args fields into kwargs; explicit kwargs take priority.
         if engine_args is not None:
@@ -342,6 +354,7 @@ class AsyncOmniEngine:
             "model": model,
             "num_stages": self.num_stages,
             "async_chunk": self.async_chunk,
+            "startup_policy": self._startup_policy,
             "single_stage_mode": self.single_stage_mode,
             "stages": {},
         }
@@ -377,9 +390,9 @@ class AsyncOmniEngine:
         self._log_startup_summary()
         logger.info(f"[AsyncOmniEngine] Orchestrator ready with {self.num_stages} stages")
 
-    def _record_startup_metric(self, name: str, value_ms: float) -> None:
+    def _record_startup_metric(self, name: str, value: Any) -> None:
         with self._startup_metrics_lock:
-            self._startup_metrics[name] = round(value_ms, 3)
+            self._startup_metrics[name] = round(value, 3) if isinstance(value, float) else value
 
     def _record_stage_startup_metric(self, stage_id: int, name: str, value: Any) -> None:
         with self._startup_metrics_lock:
@@ -389,6 +402,77 @@ class AsyncOmniEngine:
     def get_startup_metrics(self) -> dict[str, Any]:
         with self._startup_metrics_lock:
             return json.loads(json.dumps(self._startup_metrics))
+
+    @staticmethod
+    def _normalize_startup_policy(startup_policy: str | None) -> str:
+        if startup_policy is None:
+            return _DEFAULT_STARTUP_POLICY
+        normalized = str(startup_policy).strip().lower()
+        if normalized not in _SUPPORTED_STARTUP_POLICIES:
+            raise ValueError(
+                f"Unsupported startup_policy={startup_policy!r}. "
+                f"Expected one of: {sorted(_SUPPORTED_STARTUP_POLICIES)}"
+            )
+        return normalized
+
+    @staticmethod
+    def _stage_runtime_devices(stage_cfg: Any) -> tuple[str, ...]:
+        runtime_cfg = getattr(stage_cfg, "runtime", None)
+        devices = getattr(runtime_cfg, "devices", None)
+        if devices is None and hasattr(runtime_cfg, "get"):
+            devices = runtime_cfg.get("devices")
+        if devices is None:
+            return ()
+        if isinstance(devices, str):
+            return (devices,)
+        return tuple(str(device) for device in devices)
+
+    @classmethod
+    def _apply_stage_startup_policy(
+        cls,
+        stage_configs: Sequence[Any],
+        startup_policy: str | None,
+    ) -> tuple[str, dict[int, str]]:
+        normalized_policy = cls._normalize_startup_policy(startup_policy)
+        if normalized_policy == _DEFAULT_STARTUP_POLICY:
+            return normalized_policy, {}
+
+        device_refcounts: dict[str, int] = {}
+        for stage_cfg in stage_configs:
+            for device in cls._stage_runtime_devices(stage_cfg):
+                device_refcounts[device] = device_refcounts.get(device, 0) + 1
+
+        applied_stage_plan: dict[int, str] = {}
+        for stage_cfg in stage_configs:
+            metadata = extract_stage_metadata(stage_cfg)
+            stage_id = metadata.stage_id
+            is_comprehension = bool(metadata.is_comprehension or stage_id == 0)
+            shared_devices = tuple(
+                device for device in cls._stage_runtime_devices(stage_cfg) if device_refcounts.get(device, 0) > 1
+            )
+
+            reason: str | None = None
+            if normalized_policy == "all-eager":
+                reason = "all-eager"
+            elif normalized_policy == "comprehension-eager" and is_comprehension:
+                reason = "comprehension-stage"
+            elif normalized_policy == "shared-device-eager" and shared_devices:
+                reason = f"shared-device:{','.join(shared_devices)}"
+            elif normalized_policy == "critical-path-eager":
+                if is_comprehension:
+                    reason = "comprehension-stage"
+                elif shared_devices:
+                    reason = f"shared-device:{','.join(shared_devices)}"
+
+            if reason is None:
+                continue
+
+            if not hasattr(stage_cfg, "engine_args") or stage_cfg.engine_args is None:
+                stage_cfg.engine_args = OmegaConf.create({})
+            stage_cfg.engine_args.enforce_eager = True
+            applied_stage_plan[stage_id] = reason
+
+        return normalized_policy, applied_stage_plan
 
     def _log_startup_summary(self) -> None:
         startup_summary = self.get_startup_metrics()
@@ -799,6 +883,18 @@ class AsyncOmniEngine:
                     configured_stage_id = metadata.stage_id
                     stage_start_times[stage_idx] = time.monotonic()
                     self._record_stage_startup_metric(configured_stage_id, "stage_type", metadata.stage_type)
+                    self._record_stage_startup_metric(
+                        configured_stage_id,
+                        "effective_enforce_eager",
+                        bool(getattr(stage_cfg.engine_args, "enforce_eager", False)),
+                    )
+                    stage_policy_reason = self._startup_policy_stage_plan.get(configured_stage_id)
+                    if stage_policy_reason is not None:
+                        self._record_stage_startup_metric(
+                            configured_stage_id,
+                            "startup_policy_reason",
+                            stage_policy_reason,
+                        )
                     logger.info("[AsyncOmniEngine] Initializing stage %s", configured_stage_id)
                     if metadata.prompt_expand_func is not None:
                         prompt_expand_func = metadata.prompt_expand_func
@@ -1507,6 +1603,19 @@ class AsyncOmniEngine:
             deploy_config_path=deploy_config_path,
             stage_overrides=stage_overrides,
         )
+
+        startup_policy, stage_plan = self._apply_stage_startup_policy(
+            stage_configs,
+            kwargs.get("startup_policy"),
+        )
+        self._startup_policy = startup_policy
+        self._startup_policy_stage_plan = stage_plan
+        if startup_policy != _DEFAULT_STARTUP_POLICY:
+            logger.info(
+                "[AsyncOmniEngine] Applied startup policy %s to stage(s): %s",
+                startup_policy,
+                {stage_id: stage_plan[stage_id] for stage_id in sorted(stage_plan)},
+            )
 
         # Inject diffusion LoRA-related knobs from kwargs if not present in the stage config.
         for cfg in stage_configs:

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -273,6 +273,7 @@ class AsyncOmniEngine:
         single_stage_mode: bool = False,
         **kwargs: Any,
     ) -> None:
+        init_start_time = time.monotonic()
         self.model = model
         self.diffusion_batch_size = diffusion_batch_size
         startup_timeout = int(init_timeout)
@@ -336,6 +337,14 @@ class AsyncOmniEngine:
         self._shutdown_called = False
         self._weak_finalizer: weakref.finalize | None = None
         self._rpc_lock = threading.Lock()
+        self._startup_metrics_lock = threading.Lock()
+        self._startup_metrics: dict[str, Any] = {
+            "model": model,
+            "num_stages": self.num_stages,
+            "async_chunk": self.async_chunk,
+            "single_stage_mode": self.single_stage_mode,
+            "stages": {},
+        }
 
         logger.info(f"[AsyncOmniEngine] Launching Orchestrator thread with {self.num_stages} stages")
 
@@ -364,7 +373,26 @@ class AsyncOmniEngine:
             self.rpc_output_queue,
         )
 
+        self._record_startup_metric("engine_init_total_ms", (time.monotonic() - init_start_time) * 1000.0)
+        self._log_startup_summary()
         logger.info(f"[AsyncOmniEngine] Orchestrator ready with {self.num_stages} stages")
+
+    def _record_startup_metric(self, name: str, value_ms: float) -> None:
+        with self._startup_metrics_lock:
+            self._startup_metrics[name] = round(value_ms, 3)
+
+    def _record_stage_startup_metric(self, stage_id: int, name: str, value: Any) -> None:
+        with self._startup_metrics_lock:
+            stage_metrics = self._startup_metrics.setdefault("stages", {}).setdefault(str(stage_id), {})
+            stage_metrics[name] = round(value, 3) if isinstance(value, float) else value
+
+    def get_startup_metrics(self) -> dict[str, Any]:
+        with self._startup_metrics_lock:
+            return json.loads(json.dumps(self._startup_metrics))
+
+    def _log_startup_summary(self) -> None:
+        startup_summary = self.get_startup_metrics()
+        logger.info("[AsyncOmniEngine][StartupSummary] %s", json.dumps(startup_summary, sort_keys=True))
 
     def _launch_llm_stage(
         self,
@@ -376,6 +404,7 @@ class AsyncOmniEngine:
         omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None] = (None, None, None),
     ) -> StartedLlmStage:
         """Launch one LLM stage to READY state in a helper thread."""
+        launch_start_time = time.monotonic()
         started_stage: StartedLlmStage | None = None
         lock_fds: list[int] = []
         device_control_env = current_omni_platform.device_control_env_var
@@ -471,6 +500,11 @@ class AsyncOmniEngine:
                     assert handshake_address is not None
                     complete_stage_handshake(proc, handshake_address, addresses, vllm_config, stage_init_timeout)
                 logger.info("[AsyncOmniEngine] Stage %s engine startup completed", metadata.stage_id)
+                self._record_stage_startup_metric(
+                    metadata.stage_id,
+                    "engine_startup_ms",
+                    (time.monotonic() - launch_start_time) * 1000.0,
+                )
 
             assert started_stage is not None
             return started_stage
@@ -491,6 +525,7 @@ class AsyncOmniEngine:
         omni_master_server: OmniMasterServer,
     ) -> StartedLlmStage:
         """Attach to a remote engine core and wait for its startup handshake."""
+        launch_start_time = time.monotonic()
         started_stage: StartedLlmStage | None = None
         try:
             raw_stage_cfg = omni_master_server.get_stage_config(
@@ -529,6 +564,11 @@ class AsyncOmniEngine:
                     addresses=addresses,
                 )
             logger.info("[AsyncOmniEngine] Stage %s remote engine startup completed", metadata.stage_id)
+            self._record_stage_startup_metric(
+                metadata.stage_id,
+                "remote_engine_startup_ms",
+                (time.monotonic() - launch_start_time) * 1000.0,
+            )
             assert started_stage is not None
             return started_stage
         except Exception:
@@ -543,6 +583,7 @@ class AsyncOmniEngine:
         omni_master_server: OmniMasterServer,
     ) -> StageDiffusionClient:
         """Launch a local diffusion stage on OmniMasterServer-allocated sockets."""
+        launch_start_time = time.monotonic()
         proc = None
         try:
             od_config = build_diffusion_config(self.model, stage_cfg, metadata)
@@ -569,6 +610,11 @@ class AsyncOmniEngine:
                 "[AsyncOmniEngine] Stage %s diffusion startup completed",
                 metadata.stage_id,
             )
+            self._record_stage_startup_metric(
+                metadata.stage_id,
+                "diffusion_startup_ms",
+                (time.monotonic() - launch_start_time) * 1000.0,
+            )
             return StageDiffusionClient.from_addresses(
                 metadata,
                 request_address=request_address,
@@ -588,6 +634,7 @@ class AsyncOmniEngine:
         omni_master_server: OmniMasterServer,
     ) -> StageDiffusionClient:
         """Attach to a remote diffusion stage registered with OmniMasterServer."""
+        launch_start_time = time.monotonic()
         remote_stage_cfg = OmegaConf.create(
             omni_master_server.get_stage_config(
                 metadata.stage_id,
@@ -599,6 +646,11 @@ class AsyncOmniEngine:
         logger.info(
             "[AsyncOmniEngine] Stage %s remote diffusion startup completed",
             metadata.stage_id,
+        )
+        self._record_stage_startup_metric(
+            metadata.stage_id,
+            "remote_diffusion_startup_ms",
+            (time.monotonic() - launch_start_time) * 1000.0,
         )
         return StageDiffusionClient.from_addresses(
             remote_metadata,
@@ -612,6 +664,7 @@ class AsyncOmniEngine:
         started: StartedLlmStage,
     ) -> tuple[Any, Any, Any, InputProcessor | None]:
         """Attach a READY LLM stage to the orchestrator event loop."""
+        attach_start_time = time.monotonic()
 
         client_addresses: dict[str, str] = {
             "input_address": started.addresses.inputs[0],
@@ -677,10 +730,12 @@ class AsyncOmniEngine:
             raise
 
         logger.info("[AsyncOmniEngine] Stage %s initialized", started.stage_id)
+        self._record_stage_startup_metric(started.stage_id, "attach_ms", (time.monotonic() - attach_start_time) * 1000.0)
         return stage_client, output_processor, started.vllm_config, input_processor
 
     def _initialize_stages(self, stage_init_timeout: int) -> None:
         """Initialize stage clients/processors in orchestrator thread and assign to self."""
+        init_start_time = time.monotonic()
         device_control_env = current_omni_platform.device_control_env_var
 
         num_stages = self.num_stages
@@ -692,6 +747,7 @@ class AsyncOmniEngine:
         llm_launch_futures: dict[int, concurrent.futures.Future[StartedLlmStage]] = {}
         started_llm_stages: dict[int, StartedLlmStage] = {}
         llm_stage_launch_lock = threading.Lock()
+        stage_start_times: dict[int, float] = {}
 
         async_chunk = self.async_chunk
         prompt_expand_func = None
@@ -741,6 +797,8 @@ class AsyncOmniEngine:
                 for stage_idx, stage_cfg in enumerate(self.stage_configs):
                     metadata = extract_stage_metadata(stage_cfg)
                     configured_stage_id = metadata.stage_id
+                    stage_start_times[stage_idx] = time.monotonic()
+                    self._record_stage_startup_metric(configured_stage_id, "stage_type", metadata.stage_type)
                     logger.info("[AsyncOmniEngine] Initializing stage %s", configured_stage_id)
                     if metadata.prompt_expand_func is not None:
                         prompt_expand_func = metadata.prompt_expand_func
@@ -802,6 +860,11 @@ class AsyncOmniEngine:
                                     configured_stage_id,
                                     self.diffusion_batch_size,
                                 )
+                                self._record_stage_startup_metric(
+                                    configured_stage_id,
+                                    "total_init_ms",
+                                    (time.monotonic() - stage_start_times[stage_idx]) * 1000.0,
+                                )
                             finally:
                                 if previous_visible_devices is None:
                                     current_omni_platform.unset_device_control_env_var()
@@ -861,6 +924,12 @@ class AsyncOmniEngine:
                     stage_vllm_configs[stage_idx] = vllm_config
                     if stage0_input_processor is not None:
                         input_processor = stage0_input_processor
+                    stage_id = started_llm_stages[stage_idx].stage_id
+                    self._record_stage_startup_metric(
+                        stage_id,
+                        "total_init_ms",
+                        (time.monotonic() - stage_start_times[stage_idx]) * 1000.0,
+                    )
 
             initialized_stage_clients, default_sampling_params_list, stage_metadata = finalize_initialized_stages(
                 stage_clients,
@@ -901,12 +970,15 @@ class AsyncOmniEngine:
 
         self.default_sampling_params_list = default_sampling_params_list
         self.stage_metadata = stage_metadata
+        self._record_startup_metric("stage_init_total_ms", (time.monotonic() - init_start_time) * 1000.0)
 
     def _initialize_janus_queues(self) -> None:
         """Initialize janus queues inside orchestrator thread loop context."""
+        queue_init_start_time = time.monotonic()
         self.request_queue = janus.Queue()
         self.output_queue = janus.Queue()
         self.rpc_output_queue = janus.Queue()
+        self._record_startup_metric("janus_queue_init_ms", (time.monotonic() - queue_init_start_time) * 1000.0)
         logger.debug("[AsyncOmniEngine] janus queues initialized in orchestrator thread loop")
 
     def _bootstrap_orchestrator(
@@ -915,6 +987,7 @@ class AsyncOmniEngine:
         startup_future: concurrent.futures.Future,
     ) -> None:
         """Create loop, initialize stages, then run Orchestrator."""
+        bootstrap_start_time = time.monotonic()
 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -934,6 +1007,7 @@ class AsyncOmniEngine:
                 stage_vllm_configs=self.stage_vllm_configs,
                 pd_config=pd_config,
             )
+            self._record_startup_metric("orchestrator_bootstrap_ms", (time.monotonic() - bootstrap_start_time) * 1000.0)
             if not startup_future.done():
                 startup_future.set_result(asyncio.get_running_loop())
             await orchestrator.run()

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -285,6 +285,8 @@ class AsyncOmniEngine:
         **kwargs: Any,
     ) -> None:
         init_start_time = time.monotonic()
+        self._engine_wall_clock_start = init_start_time
+        self._engine_wall_clock_end: float | None = None
         self.model = model
         self.diffusion_batch_size = diffusion_batch_size
         startup_timeout = int(init_timeout)
@@ -387,7 +389,12 @@ class AsyncOmniEngine:
             self.rpc_output_queue,
         )
 
-        self._record_startup_metric("engine_init_total_ms", (time.monotonic() - init_start_time) * 1000.0)
+        self._engine_wall_clock_end = time.monotonic()
+        self._record_startup_metric(
+            "engine_wall_clock_ms",
+            (self._engine_wall_clock_end - self._engine_wall_clock_start) * 1000.0,
+        )
+        self._record_startup_metric("engine_init_total_ms", (self._engine_wall_clock_end - init_start_time) * 1000.0)
         self._log_startup_summary()
         logger.info(f"[AsyncOmniEngine] Orchestrator ready with {self.num_stages} stages")
 
@@ -967,7 +974,12 @@ class AsyncOmniEngine:
             with concurrent.futures.ThreadPoolExecutor(
                 max_workers=max(1, llm_stage_count),
                 thread_name_prefix="llm-stage-launch",
-            ) as launch_executor:
+            ) as launch_executor, concurrent.futures.ThreadPoolExecutor(
+                max_workers=max(1, llm_stage_count),
+                thread_name_prefix="llm-stage-attach",
+            ) as attach_executor:
+                attach_futures: dict[concurrent.futures.Future[tuple[Any, Any, Any, InputProcessor | None]], int] = {}
+
                 for stage_idx, stage_cfg in enumerate(self.stage_configs):
                     metadata = extract_stage_metadata(stage_cfg)
                     configured_stage_id = metadata.stage_id
@@ -1087,20 +1099,12 @@ class AsyncOmniEngine:
                             omni_kv_connector,
                         )
 
-                concurrent.futures.wait(list(llm_launch_futures.values()))
-
-                for stage_idx in llm_stage_positions:
-                    started_llm_stages[stage_idx] = llm_launch_futures[stage_idx].result()
-
-            attach_futures: dict[concurrent.futures.Future[tuple[Any, Any, Any, InputProcessor | None]], int] = {}
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=max(1, len(llm_stage_positions)),
-                thread_name_prefix="llm-stage-attach",
-            ) as attach_executor:
-                for stage_idx in llm_stage_positions:
-                    attach_futures[attach_executor.submit(self._attach_llm_stage, started_llm_stages[stage_idx])] = (
-                        stage_idx
-                    )
+                launch_future_to_stage_idx = {future: stage_idx for stage_idx, future in llm_launch_futures.items()}
+                for future in concurrent.futures.as_completed(launch_future_to_stage_idx):
+                    stage_idx = launch_future_to_stage_idx[future]
+                    started_stage = future.result()
+                    started_llm_stages[stage_idx] = started_stage
+                    attach_futures[attach_executor.submit(self._attach_llm_stage, started_stage)] = stage_idx
 
                 for future in concurrent.futures.as_completed(attach_futures):
                     stage_idx = attach_futures[future]

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -102,6 +102,7 @@ _SUPPORTED_STARTUP_POLICIES: frozenset[str] = frozenset(
         "all-eager",
         "comprehension-eager",
         "shared-device-eager",
+        "balanced-eager",
         "critical-path-eager",
     }
 )
@@ -442,14 +443,35 @@ class AsyncOmniEngine:
             for device in cls._stage_runtime_devices(stage_cfg):
                 device_refcounts[device] = device_refcounts.get(device, 0) + 1
 
+        shared_devices_by_stage: dict[int, tuple[str, ...]] = {}
+        for stage_cfg in stage_configs:
+            metadata = extract_stage_metadata(stage_cfg)
+            shared_devices_by_stage[metadata.stage_id] = tuple(
+                device for device in cls._stage_runtime_devices(stage_cfg) if device_refcounts.get(device, 0) > 1
+            )
+
+        upstream_shared_devices_by_stage: dict[int, tuple[str, ...]] = {}
+        for idx, stage_cfg in enumerate(stage_configs):
+            metadata = extract_stage_metadata(stage_cfg)
+            stage_id = metadata.stage_id
+            shared_devices = shared_devices_by_stage[stage_id]
+            upstream_shared_devices = tuple(
+                device
+                for device in shared_devices
+                if any(
+                    device in shared_devices_by_stage.get(extract_stage_metadata(later_stage_cfg).stage_id, ())
+                    for later_stage_cfg in stage_configs[idx + 1 :]
+                )
+            )
+            upstream_shared_devices_by_stage[stage_id] = upstream_shared_devices
+
         applied_stage_plan: dict[int, str] = {}
         for stage_cfg in stage_configs:
             metadata = extract_stage_metadata(stage_cfg)
             stage_id = metadata.stage_id
             is_comprehension = bool(metadata.is_comprehension or stage_id == 0)
-            shared_devices = tuple(
-                device for device in cls._stage_runtime_devices(stage_cfg) if device_refcounts.get(device, 0) > 1
-            )
+            shared_devices = shared_devices_by_stage[stage_id]
+            upstream_shared_devices = upstream_shared_devices_by_stage[stage_id]
 
             reason: str | None = None
             if normalized_policy == "all-eager":
@@ -458,6 +480,8 @@ class AsyncOmniEngine:
                 reason = "comprehension-stage"
             elif normalized_policy == "shared-device-eager" and shared_devices:
                 reason = f"shared-device:{','.join(shared_devices)}"
+            elif normalized_policy == "balanced-eager" and upstream_shared_devices:
+                reason = f"shared-device-upstream:{','.join(upstream_shared_devices)}"
             elif normalized_policy == "critical-path-eager":
                 if is_comprehension:
                     reason = "comprehension-stage"

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -496,14 +496,32 @@ class AsyncOmniEngine:
             proc = None
             handshake_address = None
             with ExitStack() as launch_stack:
+                launch_lock_wait_start = time.monotonic()
                 with llm_stage_launch_lock:
+                    self._record_stage_startup_metric(
+                        metadata.stage_id,
+                        "launch_lock_wait_ms",
+                        (time.monotonic() - launch_lock_wait_start) * 1000.0,
+                    )
                     previous_visible_devices = os.environ.get(device_control_env)
                     try:
+                        device_setup_start = time.monotonic()
                         setup_stage_devices(metadata.stage_id, metadata.runtime_cfg)
+                        self._record_stage_startup_metric(
+                            metadata.stage_id,
+                            "device_setup_ms",
+                            (time.monotonic() - device_setup_start) * 1000.0,
+                        )
+                        engine_args_build_start = time.monotonic()
                         engine_args_dict = build_engine_args_dict(
                             stage_cfg,
                             self.model,
                             stage_connector_spec=stage_connector_spec,
+                        )
+                        self._record_stage_startup_metric(
+                            metadata.stage_id,
+                            "engine_args_build_ms",
+                            (time.monotonic() - engine_args_build_start) * 1000.0,
                         )
                         omni_conn_cfg, omni_from, omni_to = omni_kv_connector
                         if omni_conn_cfg:
@@ -521,17 +539,30 @@ class AsyncOmniEngine:
                                 metadata.stage_id,
                                 self.stage_configs,
                             )
+                        config_build_start = time.monotonic()
                         vllm_config, executor_class = build_vllm_config(
                             stage_cfg,
                             self.model,
                             stage_connector_spec=stage_connector_spec,
                             engine_args_dict=engine_args_dict,
                         )
+                        self._record_stage_startup_metric(
+                            metadata.stage_id,
+                            "vllm_config_build_ms",
+                            (time.monotonic() - config_build_start) * 1000.0,
+                        )
+                        device_lock_wait_start = time.monotonic()
                         lock_fds = acquire_device_locks(
                             metadata.stage_id,
                             engine_args_dict,
                             stage_init_timeout,
                         )
+                        self._record_stage_startup_metric(
+                            metadata.stage_id,
+                            "device_lock_wait_ms",
+                            (time.monotonic() - device_lock_wait_start) * 1000.0,
+                        )
+                        spawn_start = time.monotonic()
                         if self.single_stage_mode and self._omni_master_server is not None:
                             engine_manager, coordinator, addresses = launch_stack.enter_context(
                                 launch_omni_core_engines(
@@ -566,6 +597,11 @@ class AsyncOmniEngine:
                                 addresses=addresses,
                                 proc=proc,
                             )
+                        self._record_stage_startup_metric(
+                            metadata.stage_id,
+                            "proc_spawn_ms",
+                            (time.monotonic() - spawn_start) * 1000.0,
+                        )
                         logger.info("[AsyncOmniEngine] Stage %s engine launch started", metadata.stage_id)
                     finally:
                         if previous_visible_devices is None:
@@ -582,7 +618,13 @@ class AsyncOmniEngine:
                 else:
                     assert proc is not None
                     assert handshake_address is not None
+                    handshake_start = time.monotonic()
                     complete_stage_handshake(proc, handshake_address, addresses, vllm_config, stage_init_timeout)
+                    self._record_stage_startup_metric(
+                        metadata.stage_id,
+                        "handshake_ms",
+                        (time.monotonic() - handshake_start) * 1000.0,
+                    )
                 logger.info("[AsyncOmniEngine] Stage %s engine startup completed", metadata.stage_id)
                 self._record_stage_startup_metric(
                     metadata.stage_id,
@@ -758,6 +800,7 @@ class AsyncOmniEngine:
             client_addresses["stats_update_address"] = started.addresses.frontend_stats_publish_address
 
         try:
+            client_attach_start = time.monotonic()
             stage_client = StageEngineCoreClientBase.make_async_mp_client(
                 vllm_config=started.vllm_config,
                 executor_class=started.executor_class,
@@ -770,21 +813,38 @@ class AsyncOmniEngine:
             started.proc = None
             started.engine_manager = None
             started.coordinator = None
+            self._record_stage_startup_metric(
+                started.stage_id,
+                "client_attach_ms",
+                (time.monotonic() - client_attach_start) * 1000.0,
+            )
         except Exception:
             close_started_llm_stage(started)
             raise
 
         try:
+            tokenizer_load_start = time.monotonic()
             if started.vllm_config.model_config.skip_tokenizer_init:
                 tokenizer = None
             else:
                 tokenizer = cached_tokenizer_from_config(
                     model_config=started.vllm_config.model_config,
                 )
+            self._record_stage_startup_metric(
+                started.stage_id,
+                "tokenizer_load_ms",
+                (time.monotonic() - tokenizer_load_start) * 1000.0,
+            )
+            output_processor_start = time.monotonic()
             output_processor = MultimodalOutputProcessor(
                 tokenizer=tokenizer,
                 log_stats=False,
                 engine_core_output_type=started.metadata.engine_output_type,
+            )
+            self._record_stage_startup_metric(
+                started.stage_id,
+                "output_processor_init_ms",
+                (time.monotonic() - output_processor_start) * 1000.0,
             )
             input_processor = None
             if started.stage_id == 0:
@@ -794,6 +854,7 @@ class AsyncOmniEngine:
                 # to raise ValueError. Patch it to return None so
                 # InputProcessor doesn't crash.
                 _patch_generation_config_if_needed(started.vllm_config.model_config)
+                input_processor_start = time.monotonic()
                 input_processor = InputProcessor(vllm_config=started.vllm_config)
                 # Use omni preprocessor so text-only prompts with
                 # mm_processor_kwargs (e.g. GLM-Image t2i target_h/target_w)
@@ -801,6 +862,11 @@ class AsyncOmniEngine:
                 input_processor.input_preprocessor = OmniInputPreprocessor(
                     vllm_config=started.vllm_config,
                     renderer=input_processor.renderer,
+                )
+                self._record_stage_startup_metric(
+                    started.stage_id,
+                    "input_processor_init_ms",
+                    (time.monotonic() - input_processor_start) * 1000.0,
                 )
         except Exception:
             try:

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -109,6 +109,9 @@ class OrchestratorRequestState:
 
     # Metrics: timestamp when request was submitted to each stage
     stage_submit_ts: dict[int, float] = field(default_factory=dict)
+    stage_first_output_ts: dict[int, float] = field(default_factory=dict)
+    stage_finished_ts: dict[int, float] = field(default_factory=dict)
+    stage_output_counts: dict[int, int] = field(default_factory=dict)
     mm_processor_kwargs: dict | None = None
     mm_features: list | None = None
 
@@ -186,6 +189,28 @@ class Orchestrator:
         self._stages_shutdown = False
         self._fatal_error: str | None = None
         self._fatal_error_stage_id: int | None = None
+
+    @staticmethod
+    def _accumulate_pipeline_timing(req_state: OrchestratorRequestState, key: str, delta_ms: float) -> None:
+        if delta_ms <= 0:
+            return
+        req_state.pipeline_timings[key] = req_state.pipeline_timings.get(key, 0.0) + float(delta_ms)
+
+    def _record_stage_first_output(self, req_state: OrchestratorRequestState, stage_id: int) -> None:
+        now = _time.time()
+        req_state.stage_output_counts[stage_id] = req_state.stage_output_counts.get(stage_id, 0) + 1
+        req_state.pipeline_timings[f"stage_{stage_id}_output_count"] = float(req_state.stage_output_counts[stage_id])
+        if stage_id in req_state.stage_first_output_ts:
+            return
+        req_state.stage_first_output_ts[stage_id] = now
+        submit_ts = req_state.stage_submit_ts.get(stage_id)
+        if submit_ts is None:
+            return
+        self._accumulate_pipeline_timing(
+            req_state,
+            f"stage_{stage_id}_ttfo_ms",
+            (now - submit_ts) * 1000.0,
+        )
 
     async def run(self) -> None:
         """Main entry point for the Orchestrator event loop."""
@@ -368,7 +393,9 @@ class Orchestrator:
                 await self._handle_kv_ready_raw_outputs(stage_id, raw_outputs)
 
                 # 2) Process raw outputs through the output processor
+                process_outputs_start = _time.perf_counter()
                 request_outputs = await self._process_stage_outputs(stage_id, raw_outputs)
+                process_outputs_ms = (_time.perf_counter() - process_outputs_start) * 1000.0
 
                 # 3) Route each processed output
                 for output in request_outputs:
@@ -381,8 +408,16 @@ class Orchestrator:
                             list(self.request_states.keys()),
                         )
                         continue
+                    self._record_stage_first_output(req_state, stage_id)
+                    if request_outputs:
+                        self._accumulate_pipeline_timing(
+                            req_state,
+                            f"stage_{stage_id}_output_process_ms",
+                            process_outputs_ms / len(request_outputs),
+                        )
                     stage_metrics = None
                     if output.finished:
+                        req_state.stage_finished_ts[stage_id] = _time.time()
                         stage_metrics = self._build_stage_metrics(
                             stage_id,
                             output.request_id,
@@ -404,6 +439,7 @@ class Orchestrator:
         stage_metrics: Any,
     ) -> None:
         """Route a processed output: send to main thread and/or forward to next stage."""
+        route_start = _time.perf_counter()
         req_id = output.request_id
         finished = output.finished
         submit_ts = req_state.stage_submit_ts.get(stage_id)
@@ -412,6 +448,11 @@ class Orchestrator:
         # CFG companion handling: companions don't produce user-visible output
         # and don't forward to the next stage directly.
         if finished and self._cfg_tracker.is_companion(req_id):
+            self._accumulate_pipeline_timing(
+                req_state,
+                f"stage_{stage_id}_route_ms",
+                (_time.perf_counter() - route_start) * 1000.0,
+            )
             await self._handle_cfg_companion_ready(req_id)
             self.request_states.pop(req_id, None)
             return
@@ -489,10 +530,26 @@ class Orchestrator:
                     )
 
         if finished and stage_id == req_state.final_stage_id:
+            self._accumulate_pipeline_timing(
+                req_state,
+                f"stage_{stage_id}_route_ms",
+                (_time.perf_counter() - route_start) * 1000.0,
+            )
+            if stage_metrics is not None:
+                stage_metrics.pipeline_timings = dict(req_state.pipeline_timings)
             # PD: clean up any lingering KV params for this request
             self._pd_kv_params.pop(req_id, None)
             self._cfg_tracker.cleanup_parent(req_id)
             self.request_states.pop(req_id, None)
+            return
+
+        self._accumulate_pipeline_timing(
+            req_state,
+            f"stage_{stage_id}_route_ms",
+            (_time.perf_counter() - route_start) * 1000.0,
+        )
+        if stage_metrics is not None:
+            stage_metrics.pipeline_timings = dict(req_state.pipeline_timings)
 
     def _next_stage_already_submitted(self, stage_id: int, req_state: OrchestratorRequestState) -> bool:
         return (stage_id + 1) in req_state.stage_submit_ts
@@ -671,6 +728,9 @@ class Orchestrator:
         next-stage inputs, build lightweight requests, and submit them.
         """
         next_stage_id = stage_id + 1
+        forward_start = _time.perf_counter()
+        source_stage_finish_ts = _time.time()
+        req_state.stage_finished_ts[stage_id] = source_stage_finish_ts
         next_client = self.stage_clients[next_stage_id]
         params = req_state.sampling_params_list[next_stage_id]
         next_stage_resumable = is_streaming_session and not is_final_update
@@ -744,6 +804,16 @@ class Orchestrator:
                     kv_sender_info=kv_sender_info,
                 )
             req_state.stage_submit_ts[next_stage_id] = _time.time()
+            self._accumulate_pipeline_timing(
+                req_state,
+                f"stage_{stage_id}_forward_ms",
+                (_time.perf_counter() - forward_start) * 1000.0,
+            )
+            self._accumulate_pipeline_timing(
+                req_state,
+                f"stage_{stage_id}_to_stage_{next_stage_id}_handoff_ms",
+                (req_state.stage_submit_ts[next_stage_id] - source_stage_finish_ts) * 1000.0,
+            )
             return
 
         # PD disaggregation: prefill → decode routing uses original prompt + KV transfer params
@@ -790,6 +860,16 @@ class Orchestrator:
                 await next_client.add_request_async(request)
 
             req_state.stage_submit_ts[next_stage_id] = _time.time()
+            self._accumulate_pipeline_timing(
+                req_state,
+                f"stage_{stage_id}_forward_ms",
+                (_time.perf_counter() - forward_start) * 1000.0,
+            )
+            self._accumulate_pipeline_timing(
+                req_state,
+                f"stage_{stage_id}_to_stage_{next_stage_id}_handoff_ms",
+                (req_state.stage_submit_ts[next_stage_id] - source_stage_finish_ts) * 1000.0,
+            )
             return
 
         self.stage_clients[stage_id].set_engine_outputs([output])
@@ -839,6 +919,16 @@ class Orchestrator:
 
         # Record submit timestamp for the next stage
         req_state.stage_submit_ts[next_stage_id] = _time.time()
+        self._accumulate_pipeline_timing(
+            req_state,
+            f"stage_{stage_id}_forward_ms",
+            (_time.perf_counter() - forward_start) * 1000.0,
+        )
+        self._accumulate_pipeline_timing(
+            req_state,
+            f"stage_{stage_id}_to_stage_{next_stage_id}_handoff_ms",
+            (req_state.stage_submit_ts[next_stage_id] - source_stage_finish_ts) * 1000.0,
+        )
 
     async def _poll_stage_raw(self, stage_id: int) -> EngineCoreOutputs | None:
         """Pull raw EngineCoreOutputs from a stage client without processing.

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -182,6 +182,20 @@ class OmniServeCommand(CLISubcommand):
             help="Override the deploy YAML's ``async_chunk:`` bool. Unset leaves the YAML value in force.",
         )
         omni_config_group.add_argument(
+            "--startup-policy",
+            type=str,
+            default=None,
+            choices=[
+                "default",
+                "all-eager",
+                "comprehension-eager",
+                "shared-device-eager",
+                "critical-path-eager",
+            ],
+            help="Apply a stage-aware cold-start policy. This rewrites selected "
+            "stages to `enforce_eager=true` without editing the deploy YAML.",
+        )
+        omni_config_group.add_argument(
             "--stage-id",
             type=int,
             default=None,

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -190,10 +190,14 @@ class OmniServeCommand(CLISubcommand):
                 "all-eager",
                 "comprehension-eager",
                 "shared-device-eager",
+                "balanced-eager",
                 "critical-path-eager",
             ],
             help="Apply a stage-aware cold-start policy. This rewrites selected "
-            "stages to `enforce_eager=true` without editing the deploy YAML.",
+            "stages to `enforce_eager=true` without editing the deploy YAML. "
+            "`balanced-eager` only rewrites upstream shared-device stages, which "
+            "helps cold start while avoiding unnecessary runtime regressions on "
+            "text-only stage-0 workloads.",
         )
         omni_config_group.add_argument(
             "--stage-id",

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -255,6 +255,7 @@ class OmniBase(PDDisaggregationMixin):
         try:
             if req_state is None or req_state.metrics is None:
                 return
+            req_state.metrics.build_and_log_summary()
         except Exception:
             logger.exception(
                 "[%s] Failed to build/log summary for req=%s",

--- a/vllm_omni/metrics/stats.py
+++ b/vllm_omni/metrics/stats.py
@@ -498,6 +498,17 @@ class OrchestratorAggregator:
                     break  # only once per request
         if preprocess_times:
             overall_summary["input_preprocess_time_ms"] = sum(preprocess_times) / len(preprocess_times)
+        pipeline_metric_values: defaultdict[str, list[float]] = defaultdict(list)
+        for req_id, evts in self.stage_events.items():
+            if not evts:
+                continue
+            pipeline_timings = evts[-1].pipeline_timings or {}
+            for key, value in pipeline_timings.items():
+                if isinstance(value, (int, float)):
+                    pipeline_metric_values[key].append(float(value))
+        for key, values in sorted(pipeline_metric_values.items()):
+            if values:
+                overall_summary[f"avg_{key}"] = sum(values) / len(values)
         # Add stage_wall_time_ms as separate fields for each stage
         for idx, wall_time in enumerate(stage_wall_time_ms):
             overall_summary[f"e2e_stage_{idx}_wall_time_ms"] = wall_time
@@ -557,6 +568,8 @@ class OrchestratorAggregator:
                 parts = [f"req={rid}"]
                 if e2e_evt:
                     parts.append(f"total={e2e_evt.e2e_total_ms / 1000.0:.2f}s")
+                if "queue_wait_ms" in pt:
+                    parts.append(f"queue={pt['queue_wait_ms']:.2f}ms")
                 if "preprocess_ms" in pt:
                     parts.append(f"preprocess={pt['preprocess_ms'] / 1000.0:.2f}s")
                 if e2e_evt:
@@ -577,6 +590,16 @@ class OrchestratorAggregator:
                     parts.append(f"transfers=[{','.join(transfer_parts)}]")
                 if "ar2diffusion_ms" in pt:
                     parts.append(f"ar2diffusion={pt['ar2diffusion_ms']:.2f}ms")
+                runtime_parts = []
+                for key in sorted(pt):
+                    if key in {"queue_wait_ms", "preprocess_ms", "ar2diffusion_ms"}:
+                        continue
+                    value = pt[key]
+                    if value in (0, 0.0):
+                        continue
+                    runtime_parts.append(f"{key}={value:.2f}")
+                if runtime_parts:
+                    parts.append(f"runtime=[{','.join(runtime_parts)}]")
                 logger.info("[OmniTiming] %s", " ".join(parts))
 
             # === Stage table (columns = stage_id) ===


### PR DESCRIPTION
## Summary

This PR pipelines LLM stage attachment during omni startup.

Previously, `AsyncOmniEngine` waited for all LLM stages to finish launch/handshake
before starting the attach phase. This made stage attachment fully serialized
after the slowest stage became ready.

With this change, each stage is attached as soon as its launch future completes,
allowing attach work to overlap with the remaining startup work of other stages.

This PR also adds a minimal `engine_wall_clock_ms` startup metric so the startup
effect can be measured with an explicit wall-clock anchor.

## What this PR claims

- **Primary claim**: ~8s cold-start reduction on the `default` policy,
  measured by `engine_wall_clock_ms`, attributed to overlapping stage
  attach with the remaining launch work.
- **Secondary check**: text-only steady-state runtime is unchanged
  based on single-request curl checks and a 128-prompt sanity benchmark.

This PR is not making a runtime performance claim.

## Motivation

For multi-stage omni deployments such as Qwen3-Omni, startup is dominated by
stage initialization and cross-stage orchestration. In the previous flow, stage
attachment was delayed until all stages had completed launch, which introduced
avoidable serialization in the startup critical path.

The goal of this PR is to reduce cold-start wall-clock time without changing
steady-state request behavior.

## Change

In `AsyncOmniEngine`:

- keep launching stage processes in parallel as before
- as each stage launch future completes, immediately submit `_attach_llm_stage`
- stop waiting for all stages to finish launch before beginning attach
- record `engine_wall_clock_ms` from engine init start to orchestrator ready

## Validation

### Test environment

- Model: `Qwen3-Omni-30B-A3B-Instruct`
- Hardware: `4× RTX PRO 6000 (96GB each)`
- Runtime: `vLLM 0.19.0 + vLLM-Omni`

### Cold-start results

| Version | Startup policy | Startup wall-clock |
|---|---|---:|
| `763b7ae4` | `default` | `54.37s` |
| `19766d17` | `default` | `46.18s` |
| `763b7ae4` | `balanced-eager` | `45.47s` |
| `19766d17` | `balanced-eager` | `45.42s` |

This shows the improvement comes from overlapping attach with startup work in
the default path. In this setup, the `default` policy improves by `8.20s`,
while `balanced-eager` remains effectively unchanged, which is consistent with
`balanced-eager` already being close to the lower bound.

Note: the `54.37s` baseline comes from `engine_init_total_ms` on `763b7ae4`,
which does not yet expose `engine_wall_clock_ms`. In the new branch,
`engine_wall_clock_ms` and `engine_init_total_ms` are populated from the same
startup anchor and match exactly in validation runs.

### Runtime sanity check

Single-request text-only curl on both commits remained in the same ~0.6s range:

- `763b7ae4 default`: `0.638s / 0.561s`
- `19766d17 default`: `0.629s / 0.548s`
- `19766d17 balanced-eager`: `0.612s / 0.526s`

A larger text-only sanity benchmark on this PR branch:

- workload: text-only
- `max_concurrency=4`
- `num_prompts=128`
- `input_len=512`
- `output_len=128`

Observed on `19766d17`:

- `Request throughput: 1.17 req/s`
- `Mean TTFT: 136.92 ms`
- `Mean TPOT: 26.87 ms`
- `Mean E2EL: 3418.81 ms`

Shorter runs (`--num-prompts 16`) showed warmup variance; the sanity numbers
above use 128 prompts to stabilize after warmup.

## Scope

This PR intentionally stays narrow.

Included:

- stage attach pipelining during startup
- minimal startup wall-clock metric

Not included:

- deeper startup profiling fields
- workload tagging
- multimodal runtime instrumentation
- startup policy changes
- CUDA graph capture experiments

Those are better handled separately.

## Follow-up

Follow-up work planned separately:

- deeper startup critical-path profiling
- stage-level CUDA graph capture costs in startup
- multimodal runtime profiling and workload-aware metrics
