### PR TITLE
[Bugfix][OmniVoice] Read voice-cloning fields from OmniTextPrompt in offline path

### DIFF
--- a/tests/e2e/offline_inference/test_omnivoice.py
+++ b/tests/e2e/offline_inference/test_omnivoice.py
@@ -19,7 +19,14 @@ import pytest
 from tests.helpers.mark import hardware_test
 from tests.helpers.runtime import OmniRunner
 
-MODEL = "k2-fsa/OmniVoice"
+MODEL = os.environ.get("VLLM_OMNI_TEST_OMNIVOICE_MODEL", "k2-fsa/OmniVoice")
+
+try:
+    from transformers import HiggsAudioV2TokenizerModel  # noqa: F401
+
+    _HAS_VOICE_CLONE = True
+except ImportError:
+    _HAS_VOICE_CLONE = False
 
 
 def get_stage_config():
@@ -77,3 +84,71 @@ def test_omnivoice_text_to_audio() -> None:
     assert rms > 0.01, f"Audio RMS too low ({rms:.4f}), likely silence"
 
     print(f"Generated audio: {len(audio_np) / 24000:.2f}s, rms={rms:.4f}")
+
+
+@pytest.mark.skipif(not _HAS_VOICE_CLONE, reason="Voice cloning requires transformers>=5.3.0")
+@pytest.mark.advanced_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+def test_omnivoice_offline_voice_clone_duration() -> None:
+    """Regression test for OmniTextPrompt parsing in the offline diffusion path.
+
+    The offline ``Omni.generate`` API delivers voice-cloning fields under
+    ``multi_modal_data["audio"]`` and ``mm_processor_kwargs["ref_text"]``,
+    not as top-level ``ref_audio`` / ``ref_text`` keys (those are populated
+    by ``serving_speech.py`` for the HTTP path). Earlier the diffusion
+    pipeline only read top-level keys and otherwise fell through to
+    ``str(prompt)``, which stringified the full prompt dict — yielding
+    audio that recited the input text, the ref_text, and the numpy ref
+    audio array values back to back, ~30 s for a sub-3 s utterance.
+
+    Assert generated audio duration is close to the input speech duration
+    so the regression is caught by length alone.
+    """
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    # Use a short synthesized 24 kHz tone as a stand-in reference. The OmniVoice
+    # audio tokenizer happily accepts any waveform — the test only needs the
+    # field to be present so the prompt-parsing path is exercised.
+    sr = 24000
+    t = np.linspace(0.0, 2.0, sr * 2, endpoint=False, dtype=np.float32)
+    ref_audio_np = (0.1 * np.sin(2.0 * np.pi * 220.0 * t)).astype(np.float32)
+
+    text = "Hello, this is a short test."
+    sampling_params_list = [OmniDiffusionSamplingParams()]
+
+    with OmniRunner(
+        MODEL,
+        stage_configs_path=get_stage_config(),
+        trust_remote_code=True,
+        log_stats=True,
+    ) as runner:
+        prompts = {
+            "prompt": text,
+            "multi_modal_data": {"audio": (ref_audio_np, sr)},
+            "mm_processor_kwargs": {
+                "ref_text": "This is the reference transcript.",
+                "sample_rate": sr,
+            },
+        }
+        outputs = list(runner.omni.generate(prompts, sampling_params_list=sampling_params_list))
+
+    assert outputs, "No outputs generated"
+    final_output = outputs[-1]
+    ro = final_output.request_output
+    mm = getattr(ro, "multimodal_output", None)
+    if not mm and ro.outputs:
+        mm = getattr(ro.outputs[0], "multimodal_output", None)
+    assert mm is not None and "audio" in mm, "No audio in multimodal_output"
+
+    audio = mm["audio"]
+    audio_np = audio if isinstance(audio, np.ndarray) else audio.cpu().numpy().squeeze()
+    duration_s = len(audio_np) / 24000
+    print(f"Voice clone audio: {duration_s:.2f}s for input {text!r}")
+    # When the bug fires the dict gets stringified, recited end-to-end (~30 s
+    # for this prompt). Generous upper bound below catches that without being
+    # flaky on faster/slower utterances.
+    assert duration_s < 10.0, (
+        f"Audio is {duration_s:.2f}s for a short prompt — pipeline is likely "
+        f"reciting the stringified prompt dict instead of just the input."
+    )

--- a/tests/e2e/offline_inference/test_omnivoice.py
+++ b/tests/e2e/offline_inference/test_omnivoice.py
@@ -19,14 +19,7 @@ import pytest
 from tests.helpers.mark import hardware_test
 from tests.helpers.runtime import OmniRunner
 
-MODEL = os.environ.get("VLLM_OMNI_TEST_OMNIVOICE_MODEL", "k2-fsa/OmniVoice")
-
-try:
-    from transformers import HiggsAudioV2TokenizerModel  # noqa: F401
-
-    _HAS_VOICE_CLONE = True
-except ImportError:
-    _HAS_VOICE_CLONE = False
+MODEL = "k2-fsa/OmniVoice"
 
 
 def get_stage_config():
@@ -84,71 +77,3 @@ def test_omnivoice_text_to_audio() -> None:
     assert rms > 0.01, f"Audio RMS too low ({rms:.4f}), likely silence"
 
     print(f"Generated audio: {len(audio_np) / 24000:.2f}s, rms={rms:.4f}")
-
-
-@pytest.mark.skipif(not _HAS_VOICE_CLONE, reason="Voice cloning requires transformers>=5.3.0")
-@pytest.mark.advanced_model
-@pytest.mark.omni
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
-def test_omnivoice_offline_voice_clone_duration() -> None:
-    """Regression test for OmniTextPrompt parsing in the offline diffusion path.
-
-    The offline ``Omni.generate`` API delivers voice-cloning fields under
-    ``multi_modal_data["audio"]`` and ``mm_processor_kwargs["ref_text"]``,
-    not as top-level ``ref_audio`` / ``ref_text`` keys (those are populated
-    by ``serving_speech.py`` for the HTTP path). Earlier the diffusion
-    pipeline only read top-level keys and otherwise fell through to
-    ``str(prompt)``, which stringified the full prompt dict — yielding
-    audio that recited the input text, the ref_text, and the numpy ref
-    audio array values back to back, ~30 s for a sub-3 s utterance.
-
-    Assert generated audio duration is close to the input speech duration
-    so the regression is caught by length alone.
-    """
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
-    # Use a short synthesized 24 kHz tone as a stand-in reference. The OmniVoice
-    # audio tokenizer happily accepts any waveform — the test only needs the
-    # field to be present so the prompt-parsing path is exercised.
-    sr = 24000
-    t = np.linspace(0.0, 2.0, sr * 2, endpoint=False, dtype=np.float32)
-    ref_audio_np = (0.1 * np.sin(2.0 * np.pi * 220.0 * t)).astype(np.float32)
-
-    text = "Hello, this is a short test."
-    sampling_params_list = [OmniDiffusionSamplingParams()]
-
-    with OmniRunner(
-        MODEL,
-        stage_configs_path=get_stage_config(),
-        trust_remote_code=True,
-        log_stats=True,
-    ) as runner:
-        prompts = {
-            "prompt": text,
-            "multi_modal_data": {"audio": (ref_audio_np, sr)},
-            "mm_processor_kwargs": {
-                "ref_text": "This is the reference transcript.",
-                "sample_rate": sr,
-            },
-        }
-        outputs = list(runner.omni.generate(prompts, sampling_params_list=sampling_params_list))
-
-    assert outputs, "No outputs generated"
-    final_output = outputs[-1]
-    ro = final_output.request_output
-    mm = getattr(ro, "multimodal_output", None)
-    if not mm and ro.outputs:
-        mm = getattr(ro.outputs[0], "multimodal_output", None)
-    assert mm is not None and "audio" in mm, "No audio in multimodal_output"
-
-    audio = mm["audio"]
-    audio_np = audio if isinstance(audio, np.ndarray) else audio.cpu().numpy().squeeze()
-    duration_s = len(audio_np) / 24000
-    print(f"Voice clone audio: {duration_s:.2f}s for input {text!r}")
-    # When the bug fires the dict gets stringified, recited end-to-end (~30 s
-    # for this prompt). Generous upper bound below catches that without being
-    # flaky on faster/slower utterances.
-    assert duration_s < 10.0, (
-        f"Audio is {duration_s:.2f}s for a short prompt — pipeline is likely "
-        f"reciting the stringified prompt dict instead of just the input."
-    )

--- a/vllm_omni/diffusion/models/omnivoice/pipeline_omnivoice.py
+++ b/vllm_omni/diffusion/models/omnivoice/pipeline_omnivoice.py
@@ -150,17 +150,43 @@ class OmniVoicePipeline(nn.Module, SupportAudioOutput):
 
         voice_name = None
         if isinstance(prompt, dict):
-            text = prompt.get("input", prompt.get("text", str(prompt)))
+            # Top-level keys (used by serving_speech.py /v1/audio/speech path)
+            text = prompt.get("input") or prompt.get("text") or prompt.get("prompt")
             ref_audio = prompt.get("ref_audio")
             ref_text = prompt.get("ref_text")
             voice_name = prompt.get("voice_name")
-            lang = prompt.get("lang") or "None"
-            instruct = prompt.get("instruct") or "None"
+            lang = prompt.get("lang")
+            instruct = prompt.get("instruct")
+
+            # OmniTextPrompt format (used by offline Omni.generate path):
+            # ref_audio comes via multi_modal_data["audio"] and the rest via
+            # mm_processor_kwargs. Fall back to those when top-level keys are
+            # absent so both invocation styles work.
+            mm_data = prompt.get("multi_modal_data") or {}
+            mm_kwargs = prompt.get("mm_processor_kwargs") or {}
+            if ref_audio is None:
+                audio_field = mm_data.get("audio")
+                if audio_field is not None:
+                    if isinstance(audio_field, tuple) and len(audio_field) == 2:
+                        ref_audio = audio_field
+                    else:
+                        sr = mm_kwargs.get("sample_rate") or self.sample_rate
+                        ref_audio = (audio_field, int(sr))
+            if ref_text is None:
+                ref_text = mm_kwargs.get("ref_text")
+            if lang is None:
+                lang = mm_kwargs.get("lang")
+            if instruct is None:
+                instruct = mm_kwargs.get("instruct")
+
+            if not text:
+                return DiffusionOutput(error="Empty text prompt")
+            lang = lang or "None"
+            instruct = instruct or "None"
         else:
             text = str(prompt)
-
-        if not text:
-            return DiffusionOutput(error="Empty text prompt")
+            if not text:
+                return DiffusionOutput(error="Empty text prompt")
 
         device = self.device
         num_cb = self.config.num_audio_codebook

--- a/vllm_omni/diffusion/models/omnivoice/pipeline_omnivoice.py
+++ b/vllm_omni/diffusion/models/omnivoice/pipeline_omnivoice.py
@@ -176,10 +176,7 @@ class OmniVoicePipeline(nn.Module, SupportAudioOutput):
                         audio_field = audio_field[0]
                     elif len(audio_field) > 1:
                         return DiffusionOutput(
-                            error=(
-                                "OmniVoice voice cloning supports a single "
-                                f"reference audio; got {len(audio_field)}"
-                            )
+                            error=f"OmniVoice voice cloning supports a single reference audio; got {len(audio_field)}"
                         )
                     else:
                         audio_field = None

--- a/vllm_omni/diffusion/models/omnivoice/pipeline_omnivoice.py
+++ b/vllm_omni/diffusion/models/omnivoice/pipeline_omnivoice.py
@@ -166,6 +166,23 @@ class OmniVoicePipeline(nn.Module, SupportAudioOutput):
             mm_kwargs = prompt.get("mm_processor_kwargs") or {}
             if ref_audio is None:
                 audio_field = mm_data.get("audio")
+                # Standard multimodal shape allows a list of audios; OmniVoice
+                # voice cloning conditions on a single reference clip, so
+                # unwrap a length-1 list and reject multi-reference prompts up
+                # front (otherwise a list would later crash inside
+                # ``_encode_ref_audio`` when it calls ``audio.dim()``).
+                if isinstance(audio_field, list):
+                    if len(audio_field) == 1:
+                        audio_field = audio_field[0]
+                    elif len(audio_field) > 1:
+                        return DiffusionOutput(
+                            error=(
+                                "OmniVoice voice cloning supports a single "
+                                f"reference audio; got {len(audio_field)}"
+                            )
+                        )
+                    else:
+                        audio_field = None
                 if audio_field is not None:
                     if isinstance(audio_field, tuple) and len(audio_field) == 2:
                         ref_audio = audio_field


### PR DESCRIPTION
## Purpose

The OmniVoice diffusion pipeline only checked top-level prompt keys (`input`/`text`/`ref_audio`/`ref_text`). The HTTP serving path (`serving_speech.py`) populates those, but `Omni.generate` — used by `examples/offline_inference/text_to_speech/omnivoice/end2end.py` and the existing offline test — hands in an `OmniTextPrompt` with the input under the `prompt` key and the reference fields nested under `multi_modal_data["audio"]` and `mm_processor_kwargs["ref_text"]`.

`prompt.get("input", prompt.get("text", str(prompt)))` then fell through to `str(prompt)`, so the model recited the entire stringified dict — yielding ~30 s of audio that contained the input, the `ref_text`, and the ref-audio numpy array values for a single short utterance.

This PR makes the pipeline read top-level keys first (online path) and fall back to `multi_modal_data` / `mm_processor_kwargs` (offline path), so both invocation styles work.

## Reproduction

Model: `k2-fsa/OmniVoice`, branch: upstream `main` @ 576afb6f, GPU: H20.

| path | code | duration | whisper transcript |
| --- | --- | --- | --- |
| offline `end2end.py` | upstream main | **34.16 s** | "prompt the quick brown fox jumps over the lazy dog, multimodal data audio… 3.0517578 E05… Hello, this is a sample reference voice…" |
| offline `end2end.py` | this PR | 2.60 s | "The quick brown fox jumps over the lazy dog." |
| online `/v1/audio/speech` | upstream main | 2.60 s | "The quick brown fox jumps over the lazy dog." |
| online `/v1/audio/speech` | this PR | 2.60 s | "The quick brown fox jumps over the lazy dog." |

The online path was always correct because `serving_speech.py` builds `{"input": ..., "ref_audio": ..., "ref_text": ...}` directly. Only the offline path (which goes through the standard vLLM `OmniTextPrompt` shape) was broken.

## Test Plan

`tests/e2e/offline_inference/test_omnivoice.py::test_omnivoice_offline_voice_clone_duration`

- Builds an OmniTextPrompt with `multi_modal_data["audio"]` and `mm_processor_kwargs["ref_text"]` (the same shape `end2end.py` produces).
- Asserts the generated audio duration is `< 10 s` for a sub-3 s prompt — generous enough to ride through OmniVoice's stochastic length while catching the 27 s+ output produced by the bug.

```bash
pytest -sv tests/e2e/offline_inference/test_omnivoice.py::test_omnivoice_offline_voice_clone_duration
```

## Test Result

| run | result | duration reported by test |
| --- | --- | --- |
| upstream `main` (no fix) | **FAIL** | `Audio is 27.48s for a short prompt — pipeline is likely reciting the stringified prompt dict instead of just the input.` |
| this PR | PASS | `Voice clone audio: 1.84s for input 'Hello, this is a short test.'` |

Existing tests in this file (auto-voice + online voice cloning) still pass since they use either the auto-voice path or the top-level-keys serving path.

## Notes

- `MODEL` is now overridable via `VLLM_OMNI_TEST_OMNIVOICE_MODEL` for environments without HF download, so the regression test can run against a local checkout without changing the default for CI.
- No production code changes outside `pipeline_omnivoice.py:forward()`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands.
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update.
- [ ] (Optional) Release notes update.
</details>