### PR TITLE
[BugFix] Qwen2.5-Omni streaming code2wav input handling

### DIFF
--- a/vllm_omni/model_executor/models/qwen2_5_omni/pipeline.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/pipeline.py
@@ -51,6 +51,7 @@ QWEN2_5_OMNI_PIPELINE = PipelineConfig(
             final_output=True,
             final_output_type="audio",
             engine_output_type="audio",
+            custom_process_input_func=f"{_PROC}.talker2code2wav",
             sampling_constraints={"detokenize": True},
         ),
     ),

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
@@ -356,11 +356,7 @@ class Qwen2_5OmniForConditionalGeneration(
             if code.numel() and code[0] == TALKER_CODEC_BOS_TOKEN_ID:
                 code = code[1:]
 
-            audio_tensor = (
-                self.generate_audio(code, voice_type)
-                if code.numel()
-                else torch.zeros(0, device=code.device)
-            )
+            audio_tensor = self.generate_audio(code, voice_type) if code.numel() else torch.zeros(0, device=code.device)
             return OmniOutput(text_hidden_states=None, multimodal_outputs={"model_outputs": audio_tensor})
 
         return OmniOutput(

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
@@ -351,10 +351,16 @@ class Qwen2_5OmniForConditionalGeneration(
                 )
             )
 
-            code = code[:-1] if code[-1] == TALKER_CODEC_EOS_TOKEN_ID else code
-            code = code[1:] if code[0] == TALKER_CODEC_BOS_TOKEN_ID else code
+            if code.numel() and code[-1] == TALKER_CODEC_EOS_TOKEN_ID:
+                code = code[:-1]
+            if code.numel() and code[0] == TALKER_CODEC_BOS_TOKEN_ID:
+                code = code[1:]
 
-            audio_tensor = self.generate_audio(code, voice_type)
+            audio_tensor = (
+                self.generate_audio(code, voice_type)
+                if code.numel()
+                else torch.zeros(0, device=code.device)
+            )
             return OmniOutput(text_hidden_states=None, multimodal_outputs={"model_outputs": audio_tensor})
 
         return OmniOutput(

--- a/vllm_omni/model_executor/stage_input_processors/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen2_5_omni.py
@@ -56,3 +56,28 @@ def thinker2talker(
             )
         )
     return talker_inputs
+
+
+def talker2code2wav(
+    source_outputs,
+    _prompt: OmniTokensPrompt | TextPrompt = None,
+    _requires_multimodal_data: bool = False,
+):
+    code2wav_inputs = []
+    for talker_output in source_outputs:
+        output = talker_output.outputs[0]
+        token_ids = list(output.cumulative_token_ids)
+        if token_ids and token_ids[0] == TALKER_CODEC_START_TOKEN_ID:
+            token_ids = token_ids[1:]
+        if token_ids and token_ids[-1] == TALKER_CODEC_END_TOKEN_ID:
+            token_ids = token_ids[:-1]
+        if not token_ids:
+            continue
+        code2wav_inputs.append(
+            OmniTokensPrompt(
+                prompt_token_ids=token_ids,
+                multi_modal_data=None,
+                mm_processor_kwargs=None,
+            )
+        )
+    return code2wav_inputs


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
This PR fixes a Qwen2.5-Omni streaming failure where the talker-to-code2wav stage could receive delta or special-only codec tokens during streamed chat completions. In that case, code2wav could be invoked with an empty codec sequence and crash while indexing the first token.

The fix adds an explicit Qwen2.5 talker-to-code2wav input processor that uses cumulative talker token ids, strips codec BOS/EOS tokens, and skips empty updates. The code2wav model path also now handles empty codec input defensively without crashing.

## Test Result

```
  python -m pytest -q tests/examples/online_serving/test_qwen2_5_omni.py::test_stream_001 -s --run-level full_model
  # 1 passed, 17 warnings in 224.57s
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
