### PR TITLE
[Test][OmniVoice] Add offline voice-cloning regression test for #3392

### DIFF
--- a/tests/e2e/offline_inference/test_omnivoice.py
+++ b/tests/e2e/offline_inference/test_omnivoice.py
@@ -17,9 +17,17 @@ import numpy as np
 import pytest
 
 from tests.helpers.mark import hardware_test
+from tests.helpers.media import test_asset_path
 from tests.helpers.runtime import OmniRunner
 
-MODEL = "k2-fsa/OmniVoice"
+MODEL = os.environ.get("VLLM_OMNI_TEST_OMNIVOICE_MODEL", "k2-fsa/OmniVoice")
+
+try:
+    from transformers import HiggsAudioV2TokenizerModel  # noqa: F401
+
+    _HAS_VOICE_CLONE = True
+except ImportError:
+    _HAS_VOICE_CLONE = False
 
 
 def get_stage_config():
@@ -77,3 +85,76 @@ def test_omnivoice_text_to_audio() -> None:
     assert rms > 0.01, f"Audio RMS too low ({rms:.4f}), likely silence"
 
     print(f"Generated audio: {len(audio_np) / 24000:.2f}s, rms={rms:.4f}")
+
+
+@pytest.mark.skipif(not _HAS_VOICE_CLONE, reason="Voice cloning requires transformers>=5.3.0")
+@pytest.mark.advanced_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+def test_omnivoice_offline_voice_clone() -> None:
+    """Regression test for OmniTextPrompt parsing in the offline diffusion path.
+
+    Voice-cloning fields arrive under ``multi_modal_data["audio"]`` and
+    ``mm_processor_kwargs["ref_text"]`` when the prompt is built by
+    ``Omni.generate`` (offline ``end2end.py`` shape) rather than as the
+    top-level ``ref_audio`` / ``ref_text`` keys ``serving_speech.py``
+    populates for ``/v1/audio/speech``. Earlier the diffusion pipeline only
+    read top-level keys and otherwise fell through to ``str(prompt)``,
+    yielding ~30 s of audio reciting the stringified dict for a sub-3 s
+    utterance (#3392). This test asserts the generated audio duration is
+    in the input ballpark — the regression is caught by length alone, no
+    ASR needed.
+
+    The reference clip is the vendored ``tests/assets/qwen3_tts/clone_2.wav``
+    (real human speech) with the matching transcript so the in-context
+    cloning has clean signal — synthetic ref_audio with mismatched
+    ref_text triggers a separate model-level failure mode (the model
+    echoes ref_text fragments) that's unrelated to this prompt-parsing
+    regression.
+    """
+    import soundfile as sf
+
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+    ref_path = test_asset_path("qwen3_tts/clone_2.wav")
+    ref_audio_np, sr = sf.read(str(ref_path), dtype="float32")
+    if ref_audio_np.ndim == 2:
+        ref_audio_np = ref_audio_np.mean(axis=1)
+    ref_text = "Okay. Yeah. I resent you. I love you. I respect you. But you know what? You blew it! And thanks to you."
+    text = "Hello, this is a short test."
+
+    with OmniRunner(
+        MODEL,
+        stage_configs_path=get_stage_config(),
+        trust_remote_code=True,
+        log_stats=True,
+    ) as runner:
+        prompts = {
+            "prompt": text,
+            "multi_modal_data": {"audio": (ref_audio_np, sr)},
+            "mm_processor_kwargs": {"ref_text": ref_text, "sample_rate": sr},
+        }
+        sampling_params_list = [OmniDiffusionSamplingParams()]
+        outputs = list(runner.omni.generate(prompts, sampling_params_list=sampling_params_list))
+
+    assert outputs, "No outputs generated"
+    final_output = outputs[-1]
+    ro = final_output.request_output
+    assert ro is not None, "No request_output"
+
+    mm = getattr(ro, "multimodal_output", None)
+    if not mm and ro.outputs:
+        mm = getattr(ro.outputs[0], "multimodal_output", None)
+    assert mm is not None and "audio" in mm, "No audio in multimodal_output"
+
+    audio = mm["audio"]
+    audio_np = audio if isinstance(audio, np.ndarray) else audio.cpu().numpy().squeeze()
+    duration_s = len(audio_np) / 24000
+    print(f"Voice clone audio: {duration_s:.2f}s for input {text!r}")
+    # Pre-#3392 the dict was stringified and recited end-to-end (~30 s for
+    # a similar prompt). The 10 s upper bound rides through OmniVoice's
+    # stochastic length while still catching the regression.
+    assert duration_s < 10.0, (
+        f"Audio is {duration_s:.2f}s for a short prompt — pipeline is likely "
+        f"reciting the stringified prompt dict instead of just the input."
+    )


### PR DESCRIPTION
## Purpose

Follow-up to #3392 (already merged as `687a44e5`). That fix taught the diffusion pipeline to read voice-cloning fields from `multi_modal_data["audio"]` and `mm_processor_kwargs["ref_text"]` when the prompt arrives in the OmniTextPrompt shape that `Omni.generate` and `examples/.../omnivoice/end2end.py` produce — without that fix the pipeline fell through to `str(prompt)` and the model recited the entire stringified prompt dict (~30 s of audio for a sub-3 s utterance).

The pre-existing offline test only exercises auto-voice mode (`{"prompt": "..."}`) and asserts `audio.size > 0` + `rms > 0.01`, both of which any audio passes. So a re-introduction of the prompt-stringification bug would slip through CI again.

This PR adds `test_omnivoice_offline_voice_clone` that:

- Uses the OmniTextPrompt shape (`multi_modal_data["audio"]` + `mm_processor_kwargs["ref_text"]`), so the prompt-parsing code path is the one under test.
- Reuses the already-vendored `tests/assets/qwen3_tts/clone_2.wav` (real human speech, ~9 s) with its matching transcript so OmniVoice's in-context cloning has clean signal. Synthetic ref_audio with a mismatched ref_text triggers a separate model-level failure mode (the model echoes ref_text fragments) that would make the test fail for the wrong reason.
- Asserts `duration < 10 s` for a sub-3 s prompt — pre-fix the dict was stringified and recited end-to-end (~30 s), so the regression is caught by length alone, no ASR comparison needed.

## Test Plan

```bash
pytest -sv tests/e2e/offline_inference/test_omnivoice.py::test_omnivoice_offline_voice_clone
```

`MODEL` is overridable via `VLLM_OMNI_TEST_OMNIVOICE_MODEL` for local runs against an offline checkout; the default `k2-fsa/OmniVoice` keeps CI behaviour unchanged.

## Test Result

Verified on h20-server-0 against `k2-fsa/OmniVoice`:

| pipeline state | result | log |
| --- | --- | --- |
| upstream `main` (post-#3392) | **PASS** | `Voice clone audio: 1.84s for input 'Hello, this is a short test.'` |
| pipeline reverted to pre-#3392 (`687a44e5^`) | **FAIL** | `AssertionError: Audio is 37.44s for a short prompt — pipeline is likely reciting the stringified prompt dict instead of just the input.` |

The pre-existing `test_omnivoice_text_to_audio` continues to pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results.
- [ ] (Optional) Documentation update.
- [ ] (Optional) Release notes update.
</details>