### PR TITLE
[BugFix] Probe __dict__ instead of hasattr when patching WanRMS_norm

### DIFF
--- a/vllm_omni/diffusion/models/wan2_2/patch_diffusers.py
+++ b/vllm_omni/diffusion/models/wan2_2/patch_diffusers.py
@@ -9,10 +9,11 @@ from vllm_omni.diffusion.layers.norm import RMSNormVAE
 def patch_wan_rms_norm():
     """Patch diffusers Wan RMSNorm implementation with RMSNormVAE."""
 
-    # NOTE: iterate over a snapshot of sys.modules. `hasattr` can trigger lazy
-    # submodule imports (e.g. transformers' `_LazyModule.__getattr__`), which
-    # mutate sys.modules during iteration and raise
-    # `RuntimeError: dictionary changed size during iteration`.
-    for module_name, module in list(sys.modules.items()):
-        if hasattr(module, "WanRMS_norm"):
-            setattr(module, "WanRMS_norm", RMSNormVAE)
+    # Probe `__dict__` directly instead of `hasattr`: the latter triggers
+    # custom `__getattr__` hooks (e.g. transformers' image_processing alias
+    # modules), which both emit spurious deprecation warnings and can lazily
+    # import submodules, mutating sys.modules mid-iteration.
+    for module in list(sys.modules.values()):
+        module_dict = getattr(module, "__dict__", None)
+        if module_dict is not None and "WanRMS_norm" in module_dict:
+            module_dict["WanRMS_norm"] = RMSNormVAE


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Summary
- Fix noisy `Accessing WanRMS_norm from .models.<x>.image_processing_<x>. Returning WanRMS_norm instead.` warnings printed at `vllm serve` startup for Wan2.2 pipelines.
- Replace `hasattr(module, "WanRMS_norm")` probing with a direct `__dict__` lookup in `patch_wan_rms_norm`.

## Background
`patch_wan_rms_norm` walks `sys.modules` to monkey-patch diffusers' `WanRMS_norm` with `RMSNormVAE`. `hasattr` falls through to each module's `__getattr__` when the attribute is missing.

transformers registers alias modules (one per `image_processing_*.py`) whose `__getattr__` (in `transformers/__init__.py`) does:

```python
def _getattr(name):
    new_name = name.removesuffix("Fast")
    logger.warning("Accessing `%s` from `%s`. Returning `%s` instead. ...", name, target, new_name)
    return getattr(importlib.import_module(target, __name__), new_name)
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
