### PR TITLE
[Example] Add online serving setup for HunyuanImage-3.0-Instruct

### DIFF
--- a/examples/online_serving/hunyuan_image3/README.md
+++ b/examples/online_serving/hunyuan_image3/README.md
@@ -1,0 +1,186 @@
+# HunyuanImage-3.0-Instruct (Online Serving)
+
+OpenAI-compatible online serving for HunyuanImage-3.0-Instruct via `vllm serve --omni`.
+For offline (Python `Omni()`) usage, see [`examples/offline_inference/hunyuan_image3/`](../../offline_inference/hunyuan_image3/).
+
+## Architecture
+
+HunyuanImage-3.0-Instruct is a two-stage AR + DiT model:
+
+| Stage | Role | Topology choices |
+| :---- | :--- | :--------------- |
+| Stage 0 (AR / Thinker) | Text + image understanding, emits CoT and latent tokens | TP=2 / 4 |
+| Stage 1 (DiT) | Denoising loop + VAE decode | TP=2 / 4 |
+
+Stage 0 sends KV cache to Stage 1 via the SharedMemoryConnector (single-node) so the DiT
+conditions on the AR's prefill state without re-encoding. Both stages support all four
+modalities: `text2img`, `img2img`, `img2text`, `text2text` (the latter two skip stage 1).
+
+## GPU Topology Configs
+
+| Config YAML | Stages | GPUs | Notes |
+| :---------- | :----- | :--- | :---- |
+| `hunyuan_image3_t2i.yaml` | DiT only | 4 | Pairs with external AR for development |
+| `hunyuan_image3_moe.yaml` | AR + DiT | 8 (4+4) | Default; verified on 8x L40S 48GB |
+| `hunyuan_image3_t2i_4gpu.yaml` | AR + DiT | 4 (2+2) | Verified on 4x L20X 144GB |
+| `hunyuan_image3_t2i_2gpu.yaml` | AR only | 2 | For comprehension benchmarks (not full t2i) |
+| `hunyuan_image3_moe_dit_2gpu_fp8.yaml` | DiT only | 2 (FP8) | DiT-side, requires external AR; for 2x H200 |
+
+All YAMLs live under `vllm_omni/model_executor/stage_configs/`.
+
+## Launch the Server
+
+### Quick start (8-GPU default)
+
+```bash
+cd examples/online_serving/hunyuan_image3
+bash run_server.sh
+```
+
+### 4-GPU layout (2 AR + 2 DiT)
+
+```bash
+STAGE_CONFIG=$(python -c "import vllm_omni, os; print(os.path.join(os.path.dirname(vllm_omni.__file__), 'model_executor/stage_configs/hunyuan_image3_t2i_4gpu.yaml'))") \
+bash run_server.sh
+```
+
+### Ada-class GPUs (sm89: L20 / L40 / L40S / RTX 6000 Ada)
+
+vLLM's auto MoE backend picks `flashinfer_cutlass`, which JIT-compiles a sm90-only kernel
+and fails on sm89. Force triton:
+
+```bash
+MOE_BACKEND=triton bash run_server.sh
+```
+
+If you hit `FileNotFoundError: ninja` during model load, install `ninja` in the active
+environment (`pip install ninja`) — flashinfer's JIT path needs it even when ultimately
+unused. With `MOE_BACKEND=triton` set early enough the JIT path is bypassed entirely.
+
+### Stage-level timing breakdown
+
+Set `ENABLE_PROFILER=1` to enable both `--enable-diffusion-pipeline-profiler` and
+`--enable-ar-profiler`. The server then attaches `stage_durations` to each chat
+completion response, including `HunyuanImage3Pipeline.model.forward` (DiT total),
+`HunyuanImage3Pipeline.vae.decode`, `ar_stage_0`, `stage_0_gen_ms`, `stage_1_gen_ms`,
+`queue_wait_ms`, and `preprocess_ms`. Use this with
+[`benchmarks/diffusion/diffusion_benchmark_serving.py`](../../../benchmarks/diffusion/diffusion_benchmark_serving.py).
+
+```bash
+ENABLE_PROFILER=1 bash run_server.sh
+```
+
+### Manual `vllm serve` invocation
+
+```bash
+vllm serve tencent/HunyuanImage-3.0-Instruct --omni \
+    --port 8091 \
+    --stage-configs-path vllm_omni/model_executor/stage_configs/hunyuan_image3_moe.yaml \
+    --chat-template examples/online_serving/hunyuan_image3/chat_template.jinja \
+    --moe-backend triton    # only on Ada-class GPUs
+```
+
+## Why a custom `chat_template.jinja`?
+
+HunyuanImage-3.0-Instruct's HF tokenizer does not ship a `chat_template`. Without one,
+`/v1/chat/completions` returns `400 ChatTemplateResolutionError`. The shipped
+[`chat_template.jinja`](chat_template.jinja) is a minimal template that emits the
+`<|startoftext|>... User: ... Assistant: <think>` sequence expected by the
+text-to-image-with-CoT path (`t2i_think` task in `prompt_utils.py`).
+
+It does **not** embed the official `unified_system_prompt_en` literal — that 6 KB
+string belongs to the model repo, not vllm-omni. For non-benchmark / quality-sensitive
+runs, pass it via a `system` role message (the `--system-prompt-file` flag in
+[`openai_chat_client.py`](openai_chat_client.py) wires this up).
+
+For pure-text comprehension (`i2t` / `t2t`) where the `<think>` trigger is wrong,
+prefer the offline `end2end.py` path — it builds prompts via
+`build_prompt_tokens()` and selects the right trigger per task.
+
+## Send Requests
+
+### Text → Image (text2img)
+
+```bash
+python openai_chat_client.py \
+    --prompt "A cute cat sitting on a windowsill watching the sunset" \
+    --output cat.png \
+    --steps 50 \
+    --height 1024 --width 1024
+```
+
+curl:
+
+```bash
+curl http://localhost:8091/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "messages": [{"role": "user", "content": "A cute cat sitting on a windowsill"}],
+        "modalities": ["image"],
+        "height": 1024, "width": 1024,
+        "num_inference_steps": 50, "seed": 42
+    }' | jq -r '.choices[0].message.content[0].image_url.url' \
+       | sed 's/^data:image\/[^;]*;base64,//' | base64 -d > cat.png
+```
+
+> **Resolution buckets**: HunyuanImage-3.0 has `image_base_size=1024` hard-coded; any
+> request resolution is rounded to the nearest aspect-ratio bucket with area ≈ 1024².
+> Sending `width=496, height=496` produces a 1024×1024 image — sub-1024 generations are
+> not supported by the model. `width=1280, height=720` rounds to 1280×768.
+
+### Image → Image (img2img)
+
+```bash
+python openai_chat_client.py \
+    --prompt "Make the petals neon pink" \
+    --image-url input.png \
+    --output edited.png \
+    --modality img2img --steps 50
+```
+
+### Image → Text (img2text) and Text → Text (text2text)
+
+For comprehension tasks the `<think>` trigger emitted by the default chat template is
+wrong (it forces the AR into chain-of-thought mode). Two options:
+
+1. Use the offline path: `python examples/offline_inference/hunyuan_image3/end2end.py --modality img2text ...`
+2. Pass a different chat template to `vllm serve` via `--chat-template` that omits the
+   trigger (out of scope for this example).
+
+## Client Arguments
+
+| Argument | Default | Description |
+| :------- | :------ | :---------- |
+| `--prompt` / `-p` | `A cute cat ...` | Text prompt |
+| `--output` / `-o` | `hyimage3_output.png` | Output path (image only) |
+| `--server` / `-s` | `http://localhost:8091` | Server URL |
+| `--image-url` / `-i` | None | Input image URL or local path (img2img / img2text) |
+| `--modality` / `-m` | `text2img` | `text2img` / `img2img` / `img2text` / `text2text` |
+| `--height` / `--width` | 1024 | Output image size (rounded to model's aspect-ratio bucket) |
+| `--steps` | 50 | Inference steps |
+| `--guidance-scale` | 5.0 | CFG scale |
+| `--seed` | 42 | Random seed |
+| `--negative` | None | Negative prompt |
+| `--system-prompt-file` | None | Optional file containing the unified_system_prompt_en text |
+
+## VRAM Footprint
+
+Approximate per-stage VRAM (bf16, no quantization):
+
+| Stage | VRAM (4-GPU 2+2) | VRAM (8-GPU 4+4) |
+| :---- | :--------------- | :--------------- |
+| Stage 0 (AR) | ~84 GiB / GPU | ~30 GiB / GPU |
+| Stage 1 (DiT) | ~83 GiB / GPU | ~30 GiB / GPU |
+
+For 48 GB cards (L40S / RTX 6000 Ada) the 4-GPU layout overflows; use the 8-GPU layout
+or enable `--vae-use-tiling`.
+
+## FAQ
+
+- **`ChatTemplateResolutionError`**: pass `--chat-template chat_template.jinja`.
+- **`FileNotFoundError: ninja`** during load: `pip install ninja` in the env.
+- **`flashinfer cutlass MoE` build failure**: set `MOE_BACKEND=triton` (Ada-class GPUs).
+- **OOM on stage 1**: pass `--vae-use-tiling`, lower `gpu_memory_utilization` in the
+  stage YAML, or move to a topology with more DiT GPUs.
+- **Stage 0 hangs at startup**: in two-process layouts, Stage 0 waits for Stage 1's
+  worker to connect — this is expected.

--- a/examples/online_serving/hunyuan_image3/chat_template.jinja
+++ b/examples/online_serving/hunyuan_image3/chat_template.jinja
@@ -1,0 +1,61 @@
+{#-
+  HunyuanImage-3.0-Instruct chat template for /v1/chat/completions.
+
+  HunyuanImage3's HF tokenizer ships without a default chat_template, so
+  /v1/chat/completions requests fail with ChatTemplateResolutionError unless
+  one is supplied explicitly via --chat-template.
+
+  This template targets the **text-to-image with chain-of-thought** path
+  (the `t2i_think` task in `vllm_omni.diffusion.models.hunyuan_image3.prompt_utils`).
+  It emits the `<think>` trigger after `Assistant: `, which is the format the
+  AR/DiT pipeline expects for image generation. For pure-text comprehension
+  (i2t / t2t), prefer the offline `examples/offline_inference/hunyuan_image3/`
+  flow which builds prompts via `build_prompt_tokens()` and skips the trigger.
+
+  The official `unified_system_prompt_en` (see system_prompt.py) is *not*
+  embedded here — pass it explicitly as a `system` role message when output
+  quality matters (e.g. demos / non-benchmark runs). Without a system message
+  the AR will still produce a latent, but quality is degraded vs. the offline
+  end2end.py path.
+
+  Reference format (from prompt_utils.py):
+    <|startoftext|>{system?}\n\nUser: {<img>?}{user_prompt}\n\nAssistant: {<think>?}
+-#}
+{{- '<|startoftext|>' -}}
+{%- for message in messages -%}
+  {%- if message.role == 'system' -%}
+    {%- if message.content is string -%}
+      {{- message.content -}}
+    {%- else -%}
+      {%- for c in message.content -%}
+        {%- if c.type == 'text' -%}{{- c.text -}}{%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+    {{- '\n\n' -}}
+  {%- endif -%}
+{%- endfor -%}
+{%- for message in messages -%}
+  {%- if message.role == 'user' -%}
+    {{- 'User: ' -}}
+    {%- if message.content is string -%}
+      {{- message.content -}}
+    {%- else -%}
+      {%- for c in message.content -%}
+        {%- if c.type == 'image_url' -%}{{- '<img>' -}}{%- endif -%}
+        {%- if c.type == 'text' -%}{{- c.text -}}{%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+    {{- '\n\nAssistant: ' -}}
+  {%- elif message.role == 'assistant' -%}
+    {%- if message.content is string -%}
+      {{- message.content -}}
+    {%- else -%}
+      {%- for c in message.content -%}
+        {%- if c.type == 'text' -%}{{- c.text -}}{%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+  {{- '<think>' -}}
+{%- endif -%}

--- a/examples/online_serving/hunyuan_image3/openai_chat_client.py
+++ b/examples/online_serving/hunyuan_image3/openai_chat_client.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+HunyuanImage-3.0-Instruct OpenAI-compatible chat client.
+
+Targets the t2i-with-`<think>` path served by `run_server.sh` + `chat_template.jinja`.
+For higher-quality runs, pass the official `unified_system_prompt_en` (from
+`vllm_omni.diffusion.models.hunyuan_image3.system_prompt`) via --system-prompt-file.
+
+Usage:
+    python openai_chat_client.py --prompt "A cute cat sitting on a windowsill" \
+        --output cat.png --steps 50 --height 1024 --width 1024
+
+    python openai_chat_client.py --prompt "Make the petals neon pink" \
+        --image-url input.png --output edited.png --steps 50
+"""
+
+import argparse
+import base64
+from pathlib import Path
+
+import requests
+
+
+def generate(
+    prompt: str,
+    server_url: str = "http://localhost:8091",
+    image_url: str | None = None,
+    height: int | None = None,
+    width: int | None = None,
+    steps: int | None = None,
+    seed: int | None = None,
+    guidance_scale: float | None = None,
+    negative_prompt: str | None = None,
+    system_prompt: str | None = None,
+    modality: str = "text2img",
+    timeout: int = 600,
+) -> bytes | str | None:
+    """Generate an image (or text) via /v1/chat/completions.
+
+    Note: vllm-omni's chat endpoint reads generation params from the JSON
+    payload top-level — NOT from `extra_body`. The OpenAI Python SDK packs
+    unknown kwargs into `extra_body` by default, which would be silently
+    dropped. This client posts raw JSON with params at top-level to avoid
+    that footgun.
+    """
+    content: list[dict] = []
+    if image_url:
+        if Path(image_url).exists():
+            with open(image_url, "rb") as f:
+                b64 = base64.b64encode(f.read()).decode("utf-8")
+            url = f"data:image/jpeg;base64,{b64}"
+        else:
+            url = image_url
+        content.append({"type": "image_url", "image_url": {"url": url}})
+    content.append({"type": "text", "text": prompt})
+
+    messages: list[dict] = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": content})
+
+    payload: dict = {"messages": messages}
+    if modality in ("text2img", "img2img"):
+        payload["modalities"] = ["image"]
+    elif modality in ("img2text", "text2text"):
+        payload["modalities"] = ["text"]
+    if height is not None:
+        payload["height"] = height
+    if width is not None:
+        payload["width"] = width
+    if steps is not None:
+        payload["num_inference_steps"] = steps
+    if seed is not None:
+        payload["seed"] = seed
+    if guidance_scale is not None:
+        payload["guidance_scale"] = guidance_scale
+    if negative_prompt:
+        payload["negative_prompt"] = negative_prompt
+
+    print(f"Sending request to {server_url} (modality={modality})...")
+    resp = requests.post(
+        f"{server_url}/v1/chat/completions",
+        headers={"Content-Type": "application/json"},
+        json=payload,
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    choices = data.get("choices", [])
+
+    for choice in choices:
+        c = choice.get("message", {}).get("content")
+        if isinstance(c, list) and c and isinstance(c[0], dict) and "image_url" in c[0]:
+            url = c[0]["image_url"].get("url", "")
+            if url.startswith("data:image"):
+                return base64.b64decode(url.split(",", 1)[1])
+    for choice in choices:
+        c = choice.get("message", {}).get("content")
+        if isinstance(c, str) and c:
+            return c
+
+    print(f"Unexpected response: {data}")
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="HunyuanImage-3.0-Instruct chat client")
+    parser.add_argument("--prompt", "-p", default="A cute cat sitting on a windowsill")
+    parser.add_argument("--output", "-o", default="hyimage3_output.png")
+    parser.add_argument("--server", "-s", default="http://localhost:8091")
+    parser.add_argument("--image-url", "-i", help="Input image URL or local path")
+    parser.add_argument(
+        "--modality",
+        "-m",
+        default="text2img",
+        choices=["text2img", "img2img", "img2text", "text2text"],
+    )
+    parser.add_argument("--height", type=int, default=1024)
+    parser.add_argument("--width", type=int, default=1024)
+    parser.add_argument("--steps", type=int, default=50)
+    parser.add_argument("--guidance-scale", type=float, default=5.0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--negative")
+    parser.add_argument(
+        "--system-prompt-file",
+        help="Optional path to a system prompt file (e.g. unified_system_prompt_en.txt). "
+        "Without this, image quality is degraded vs the offline end2end.py path.",
+    )
+    args = parser.parse_args()
+
+    system_prompt = None
+    if args.system_prompt_file:
+        system_prompt = Path(args.system_prompt_file).read_text(encoding="utf-8").strip()
+
+    result = generate(
+        prompt=args.prompt,
+        server_url=args.server,
+        image_url=args.image_url,
+        height=args.height,
+        width=args.width,
+        steps=args.steps,
+        seed=args.seed,
+        guidance_scale=args.guidance_scale,
+        negative_prompt=args.negative,
+        system_prompt=system_prompt,
+        modality=args.modality,
+    )
+    if result is None:
+        print("Generation failed")
+        raise SystemExit(1)
+    if isinstance(result, bytes):
+        Path(args.output).write_bytes(result)
+        print(f"Image saved to {args.output} ({len(result) / 1024:.1f} KB)")
+    else:
+        print("Response:")
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/online_serving/hunyuan_image3/run_server.sh
+++ b/examples/online_serving/hunyuan_image3/run_server.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# HunyuanImage-3.0-Instruct online serving startup script.
+#
+# Defaults to the 8-GPU two-stage config (4 AR + 4 DiT). Override via env vars:
+#
+#   STAGE_CONFIG=path/to/yaml      # Custom stage config (e.g. hunyuan_image3_t2i_4gpu.yaml)
+#   PORT=8091                      # Server port
+#   MODEL=tencent/HunyuanImage-3.0-Instruct
+#
+# On Ada-class (sm89) GPUs (L20 / L40 / L40S / RTX 6000 Ada), set:
+#
+#   MOE_BACKEND=triton             # Avoids flashinfer cutlass MoE auto-pick
+#                                  # (flashinfer's MoE path targets sm90+ only)
+#
+# Examples:
+#
+#   # 4-GPU (2 AR + 2 DiT) on L20X / L40S
+#   STAGE_CONFIG=$(python -c "import vllm_omni, os; print(os.path.join(os.path.dirname(vllm_omni.__file__), 'model_executor/stage_configs/hunyuan_image3_t2i_4gpu.yaml'))") \
+#   MOE_BACKEND=triton bash run_server.sh
+#
+#   # 8-GPU MoE default
+#   bash run_server.sh
+#
+#   # 2-GPU FP8 DiT-only (AR runs externally; for development only)
+#   STAGE_CONFIG=$(python -c "...moe_dit_2gpu_fp8.yaml...") bash run_server.sh
+
+set -euo pipefail
+
+MODEL="${MODEL:-tencent/HunyuanImage-3.0-Instruct}"
+PORT="${PORT:-8091}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHAT_TEMPLATE="${CHAT_TEMPLATE:-$SCRIPT_DIR/chat_template.jinja}"
+
+# Resolve default stage config from the installed vllm_omni package so the
+# script works no matter where the user runs it from.
+DEFAULT_STAGE_CONFIG=$(python -c "import vllm_omni, os; print(os.path.join(os.path.dirname(vllm_omni.__file__), 'model_executor/stage_configs/hunyuan_image3_moe.yaml'))")
+STAGE_CONFIG="${STAGE_CONFIG:-$DEFAULT_STAGE_CONFIG}"
+
+EXTRA_ARGS=()
+if [[ -n "${MOE_BACKEND:-}" ]]; then
+    EXTRA_ARGS+=(--moe-backend "$MOE_BACKEND")
+fi
+if [[ "${ENABLE_PROFILER:-0}" == "1" ]]; then
+    EXTRA_ARGS+=(--enable-diffusion-pipeline-profiler --enable-ar-profiler)
+fi
+
+echo "Starting HunyuanImage-3.0-Instruct server..."
+echo "  Model:         $MODEL"
+echo "  Port:          $PORT"
+echo "  Stage config:  $STAGE_CONFIG"
+echo "  Chat template: $CHAT_TEMPLATE"
+if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
+    echo "  Extra args:    ${EXTRA_ARGS[*]}"
+fi
+
+vllm serve "$MODEL" --omni \
+    --port "$PORT" \
+    --stage-configs-path "$STAGE_CONFIG" \
+    --chat-template "$CHAT_TEMPLATE" \
+    "${EXTRA_ARGS[@]}"

--- a/vllm_omni/model_executor/stage_configs/hunyuan_image3_t2i_4gpu.yaml
+++ b/vllm_omni/model_executor/stage_configs/hunyuan_image3_t2i_4gpu.yaml
@@ -1,0 +1,90 @@
+# Stage config for running Hunyuan-Image3.0 t2i on 4 GPUs (2 AR + 2 DiT).
+# Adapted from hunyuan_image3_moe.yaml (8 GPU 4+4) by halving TP on each stage.
+#
+# Verified on 4x NVIDIA L20X 144GB. Should also fit on 4x L40S 48GB / 4x A100 80GB
+# but VAE tiling may be required on the smaller-VRAM cards (pass --vae-use-tiling).
+#
+# Devices layout: AR on GPU 0,1 (TP=2); DiT on GPU 2,3 (TP=2).
+
+stage_args:
+  - stage_id: 0
+    stage_type: llm
+    runtime:
+      process: true
+      devices: "0,1"
+    engine_args:
+      model_stage: AR
+      max_num_seqs: 1
+      model_arch: HunyuanImage3ForCausalMM
+      worker_cls: vllm_omni.worker.gpu_ar_worker.GPUARWorker
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      gpu_memory_utilization: 0.9
+      enforce_eager: true
+      trust_remote_code: true
+      engine_output_type: latent
+      enable_prefix_caching: false
+      max_num_batched_tokens: 32768
+      tensor_parallel_size: 2
+      pipeline_parallel_size: 1
+      hf_overrides:
+        rope_parameters:
+          mrope_section: [0, 32, 32]
+          rope_type: default
+      omni_kv_config:
+        need_send_cache: true
+        kv_transfer_criteria:
+          type: prefill_finished
+    is_comprehension: true
+    final_output: true
+    final_output_type: text
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 2048
+      seed: 42
+      detokenize: True
+      repetition_penalty: 1.1
+  - stage_id: 1
+    stage_type: diffusion
+    runtime:
+      process: true
+      devices: "2,3"
+      max_batch_size: 1
+    engine_args:
+      model_stage: diffusion
+      enforce_eager: true
+      distributed_executor_backend: "mp"
+      vae_use_slicing: false
+      vae_use_tiling: false
+      cache_backend: null
+      cache_config: null
+      enable_cache_dit_summary: false
+      omni_kv_config:
+        need_recv_cache: true
+      parallel_config:
+        pipeline_parallel_size: 1
+        data_parallel_size: 1
+        tensor_parallel_size: 2
+        enable_expert_parallel: false
+        sequence_parallel_size: 1
+        ulysses_degree: 1
+        ring_degree: 1
+        cfg_parallel_size: 1
+        vae_patch_parallel_size: 1
+        use_hsdp: false
+        hsdp_shard_size: -1
+        hsdp_replicate_size: 1
+    engine_input_source: [0]
+    final_output: true
+    final_output_type: image
+
+runtime:
+  enabled: true
+  defaults:
+    window_size: -1
+    max_inflight: 1
+  edges:
+    - from: 0
+      to: 1
+      window_size: -1


### PR DESCRIPTION
 ## Summary

  Adds an online-serving example for HunyuanImage-3.0-Instruct, mirroring the
  existing `examples/online_serving/bagel/` layout, plus a missing 4-GPU stage
  config.

  HunyuanImage3 already serves via `vllm serve --omni`, but the path is
  underdocumented and several assets are missing — anyone trying to spin up an
  online server today walks into the same three blockers I did:

  1. **Tokenizer ships without `chat_template`**, so `/v1/chat/completions`
     returns `400 ChatTemplateResolutionError` until you supply one.
  2. **No 4-GPU stage config** — existing options are 8-GPU MoE 4+4 / 2-GPU
     AR-only / 2-GPU FP8 DiT-only. Anyone with 4× L20 / L40S / A100 has to
     hand-derive the YAML from `hunyuan_image3_moe.yaml`.
  3. **No turn-key example** with a `run_server.sh` + chat client, despite
     bagel and text_to_image both shipping one.

  ## Changes

  **New files (5)**
  - `examples/online_serving/hunyuan_image3/README.md` — topology table
    (2/4/8-GPU variants), Ada-class (sm89) gotchas, request examples, FAQ.
  - `examples/online_serving/hunyuan_image3/chat_template.jinja` — minimal
    template for the `t2i_think` path. Does *not* embed
    `unified_system_prompt_en` (that 6 KB literal belongs to the model repo,
    not vllm-omni); callers pass it via `system` role for quality-sensitive
    runs.
  - `examples/online_serving/hunyuan_image3/openai_chat_client.py` — adapted
    from `examples/online_serving/bagel/openai_chat_client.py`. Adds
    `--system-prompt-file` for the unified system prompt.
  - `examples/online_serving/hunyuan_image3/run_server.sh` — env-driven,
    defaults to 8-GPU MoE config; exposes `STAGE_CONFIG`, `MOE_BACKEND`,
    `ENABLE_PROFILER` knobs.
  - `vllm_omni/model_executor/stage_configs/hunyuan_image3_t2i_4gpu.yaml` —
    TP=2 AR (GPU 0,1) + TP=2 DiT (GPU 2,3), derived from `_moe.yaml` by
    halving each stage's TP.

  **Ada-class (sm89) note in README**

  vLLM's auto MoE backend picks `flashinfer_cutlass` and JIT-compiles a
  sm90-only kernel — fails on L20 / L40 / L40S / RTX 6000 Ada. The README
  documents `MOE_BACKEND=triton` and the `ninja` requirement.

  ## Validation

  - Chat template rendered against the HF tokenizer for three cases (t2i no
    system / t2i with system / it2i list-form content) — output matches
    `vllm_omni.diffusion.models.hunyuan_image3.prompt_utils.build_prompt`
    byte-for-byte.
  - 4-GPU YAML verified end-to-end on 4× L20X 144 GB: server loads in ~5 min,
    serves t2i requests at 1024×1024, returns `stage_durations` payload with
    DiT / VAE / AR / queue / preprocess timings.


  ## Test plan

  - [x] `bash examples/online_serving/hunyuan_image3/run_server.sh` on 8× L40S
    48 GB (default config)
  - [x] `STAGE_CONFIG=...t2i_4gpu.yaml MOE_BACKEND=triton bash run_server.sh`
    on 4× L40S 48 GB (or equivalent sm89 platform)
  - [x] `python openai_chat_client.py --prompt "..." --output cat.png` returns
    a valid 1024×1024 PNG
  - [x] `ENABLE_PROFILER=1 bash run_server.sh` then
    `benchmarks/diffusion/diffusion_benchmark_serving.py --backend vllm-omni`
    populates `stage_durations` in the output JSON

  ## Out of scope (separate follow-ups)

  - A separate chat template for `i2t` / `t2t` (omits `<think>` trigger).
    The README points users to the offline `end2end.py` flow for now.
  - Whether `/v1/chat/completions` should unpack `extra_body` (the OpenAI
    Python SDK's default convention). The benchmark's `vllm-omni` backend
    currently posts top-level params, matching this example. Will open a
    separate issue to confirm intended convention.
