### PR TITLE
[Bugfix] Fix the issue where the seed parameter does not take effect when using the OpenAI Python client

### DIFF
--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2424,6 +2424,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             cfg_text_scale = extra_body.get("cfg_text_scale")
             cfg_img_scale = extra_body.get("cfg_img_scale")
             seed = extra_body.get("seed")
+            if seed is None:
+                seed = getattr(request, "seed", None)
             negative_prompt = extra_body.get("negative_prompt")
             num_outputs_per_prompt = extra_body.get("num_outputs_per_prompt", 1)
 


### PR DESCRIPTION
…when using the OpenAI Python client

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
When using OpenAI Python client to send a request like [diffusion_chat_api.py](https://github.com/vllm-project/vllm-omni/blob/main/docs/serving/diffusion_chat_api.md), the `seed` parameter does not take effect.
```python
from openai import OpenAI
import base64

client = OpenAI(base_url="http://localhost:8091/v1", api_key="none")

response = client.chat.completions.create(
    model="Qwen/Qwen-Image",
    messages=[{"role": "user", "content": "A beautiful landscape painting"}],
    extra_body={
        "height": 1024,
        "width": 1024,
        "num_inference_steps": 50,
        "true_cfg_scale": 4.0,
        "seed": 42,
    },
)

img_url = response.choices[0].message.content[0]["image_url"]["url"]
_, b64_data = img_url.split(",", 1)
with open("output.png", "wb") as f:
    f.write(base64.b64decode(b64_data))
```

## Test Plan
#### Launch server
```bash
vllm-omni serve Qwen/Qwen-Image --omni \
    --host localhost \
    --port 8091 \
    --tensor-parallel-size 1
```
#### Send requests with the same seed
```python
from openai import OpenAI
import base64

client = OpenAI(base_url="http://localhost:8091/v1", api_key="none")

response = client.chat.completions.create(
    model="Qwen/Qwen-Image",
    messages=[{"role": "user", "content": "A beautiful landscape painting"}],
    extra_body={
        "height": 1024,
        "width": 1024,
        "num_inference_steps": 50,
        "true_cfg_scale": 4.0,
        "seed": 42,
    },
)

img_url = response.choices[0].message.content[0]["image_url"]["url"]
_, b64_data = img_url.split(",", 1)
with open("output.png", "wb") as f:
    f.write(base64.b64decode(b64_data))
```
## Test Result
||Run1 Image|Run2 Image|
|---|---|---|
|w/o this fix|<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/85622584-4e0b-4e37-bcfd-6e3644eb5e02" />|<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/1d5edb37-db83-4e0c-916f-501738a02390" />|
|w/ this fix|<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/f78cbde6-2687-4127-b836-423621cc32ef" />|<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/0f07a2ea-78f4-462c-bcd8-5f25123013bc" />|
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
