### PR TITLE
[BugFix] Modify the splicing method of streaming audio output.

### DIFF
--- a/vllm_omni/benchmarks/patch/patch.py
+++ b/vllm_omni/benchmarks/patch/patch.py
@@ -8,6 +8,7 @@ import ssl
 import sys
 import time
 import traceback
+import wave
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
@@ -374,6 +375,14 @@ async def async_request_openai_chat_omni_completions(
         # outputs or metrics from previous attempts.
         generated_text = ""
         generated_audio = None
+        # For wav responses, accumulate decoded PCM bytes per chunk
+        # to avoid repeated AudioSegment decode/concat.
+        wav_pcm_buffer = bytearray()
+        wav_audio_params: tuple[int, int, int] | None = None
+        wav_inconsistent_chunk_count = 0
+        first_inconsistent_wav_params: tuple[int, int, int] | None = None
+        # For non-wav responses, accumulate encoded bytes then decode once.
+        audio_bytes_buffer = bytearray()
         ttft = 0.0
         st = time.perf_counter()
         output.start_time = st
@@ -440,12 +449,28 @@ async def async_request_openai_chat_omni_completions(
                                         audio_generate_time = timestamp - st
                                         if content:
                                             audio_bytes = base64.b64decode(content)
-                                            seg = AudioSegment.from_file(io.BytesIO(audio_bytes))
-                                            if seg is not None:
-                                                if generated_audio is None:
-                                                    generated_audio = seg
-                                                else:
-                                                    generated_audio = generated_audio + seg
+                                            if response_format == "wav":
+                                                try:
+                                                    with wave.open(io.BytesIO(audio_bytes), "rb") as wav_reader:
+                                                        params = (
+                                                            wav_reader.getnchannels(),
+                                                            wav_reader.getsampwidth(),
+                                                            wav_reader.getframerate(),
+                                                        )
+                                                        if wav_audio_params is None:
+                                                            wav_audio_params = params
+                                                        elif wav_audio_params != params:
+                                                            wav_inconsistent_chunk_count += 1
+                                                            if first_inconsistent_wav_params is None:
+                                                                first_inconsistent_wav_params = params
+                                                            continue
+                                                        wav_pcm_buffer.extend(
+                                                            wav_reader.readframes(wav_reader.getnframes())
+                                                        )
+                                                except Exception as ex:
+                                                    logger.warning("Failed to parse wav audio chunk: %s", ex)
+                                            else:
+                                                audio_bytes_buffer.extend(audio_bytes)
 
                                 if metrics := data.get("metrics"):
                                     output.output_tokens = metrics.get("num_tokens_out", 0)
@@ -454,8 +479,34 @@ async def async_request_openai_chat_omni_completions(
                                     if (pt := usage.get("prompt_tokens")) is not None:
                                         output.prompt_len = pt
 
+                    if wav_inconsistent_chunk_count > 0:
+                        logger.warning(
+                            "Dropped %d wav chunks with inconsistent params during benchmark "
+                            "(expected=%s, first_inconsistent=%s). "
+                            "Audio frames/duration may be undercounted.",
+                            wav_inconsistent_chunk_count,
+                            wav_audio_params,
+                            first_inconsistent_wav_params,
+                        )
+
                     output.latency = timestamp - st
                     output.generated_text = generated_text
+                    if response_format == "wav" and wav_pcm_buffer and wav_audio_params is not None:
+                        channels, sample_width, frame_rate = wav_audio_params
+                        generated_audio = AudioSegment(
+                            data=bytes(wav_pcm_buffer),
+                            sample_width=sample_width,
+                            frame_rate=frame_rate,
+                            channels=channels,
+                        )
+                    elif audio_bytes_buffer:
+                        try:
+                            generated_audio = AudioSegment.from_file(
+                                io.BytesIO(bytes(audio_bytes_buffer)),
+                                format=response_format,
+                            )
+                        except Exception as ex:
+                            logger.warning("Failed to decode accumulated audio bytes: %s", ex)
                     if generated_audio is not None:
                         output.audio_duration = len(generated_audio) / 1000.0
                         frame_width = generated_audio.frame_width


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Modify the splicing method of streaming audio output.
from_file:  ==============costs:163.03753852844238 ms
from_wav: ==============costs:0.07534027099609375 ms

## Test Plan

```
vllm bench serve \
    --omni \
  --dataset-name random \
  --port 28889 \
  --max-concurrency 16 \
  --num-warmups 2 \
  --model /home/models/Qwen3-Omni-30B-A3B-Instruct \
  --endpoint /v1/chat/completions \
  --backend openai-chat-omni \
  --num-prompts 64 \
  --random-input-len 2500 \
  --ignore-eos \
  --percentile-metrics ttft,tpot,itl,e2el,audio_ttfp,audio_rtf \
  --random-output-len 900 \
  --extra_body '{"modalities": ["text", "audio"]}'
```

## Test Result
**Before:**
```
============ Serving Benchmark Result ============
Successful requests:                     64
Failed requests:                         0
Maximum request concurrency:             16
Benchmark duration (s):                  872.39
Request throughput (req/s):              0.07
Peak concurrent requests:                17.00
----------------End-to-end Latency----------------
Mean E2EL (ms):                          198071.08
Median E2EL (ms):                        194534.05
P99 E2EL (ms):                           369676.63
================== Text Result ===================
Total input tokens:                      160896
Total generated tokens:                  35774
Output token throughput (tok/s):         41.01
Peak output token throughput (tok/s):    627.00
Peak concurrent requests:                17.00
Total Token throughput (tok/s):          225.44
---------------Time to First Token----------------
Mean TTFT (ms):                          16451.76
Median TTFT (ms):                        20216.25
P99 TTFT (ms):                           23753.17
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          81.10
Median TPOT (ms):                        53.81
P99 TPOT (ms):                           341.37
---------------Inter-token Latency----------------
Mean ITL (ms):                           32.87
Median ITL (ms):                         0.01
P99 ITL (ms):                            155.51
================== Audio Result ==================
Total audio duration generated(s):       11259.11
Total audio frames generated:            270218595
Audio throughput(audio duration/s):      12.91
---------------Time to First Packet---------------
Mean AUDIO_TTFP (ms):                    19429.70
Median AUDIO_TTFP (ms):                  22007.11
P99 AUDIO_TTFP (ms):                     27807.39
-----------------Real Time Factor-----------------
Mean AUDIO_RTF:                          1.24
Median AUDIO_RTF:                        1.20
P99 AUDIO_RTF:                           2.14
==================================================
```
**After:**
```
============ Serving Benchmark Result ============
Successful requests:                     64
Failed requests:                         0
Maximum request concurrency:             16
Benchmark duration (s):                  500.83
Request throughput (req/s):              0.13
Peak concurrent requests:                17.00
----------------End-to-end Latency----------------
Mean E2EL (ms):                          111891.89
Median E2EL (ms):                        114194.01
P99 E2EL (ms):                           186746.40
================== Text Result ===================
Total input tokens:                      160896
Total generated tokens:                  36493
Output token throughput (tok/s):         72.87
Peak output token throughput (tok/s):    624.00
Peak concurrent requests:                17.00
Total Token throughput (tok/s):          394.12
---------------Time to First Token----------------
Mean TTFT (ms):                          991.00
Median TTFT (ms):                        253.09
P99 TTFT (ms):                           3265.32
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          48.09
Median TPOT (ms):                        29.65
P99 TPOT (ms):                           216.28
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.21
Median ITL (ms):                         16.87
P99 ITL (ms):                            62.08
================== Audio Result ==================
Total audio duration generated(s):       11742.08
Total audio frames generated:            281809770
Audio throughput(audio duration/s):      23.45
---------------Time to First Packet---------------
Mean AUDIO_TTFP (ms):                    3582.23
Median AUDIO_TTFP (ms):                  2536.71
P99 AUDIO_TTFP (ms):                     7089.83
-----------------Real Time Factor-----------------
Mean AUDIO_RTF:                          0.68
Median AUDIO_RTF:                        0.64
P99 AUDIO_RTF:                           1.03
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
