### PR TITLE
[Bugfix] Qwen-Image use teachche serve will crash

### DIFF
--- a/tests/e2e/online_serving/test_qwen_image_edit_expansion.py
+++ b/tests/e2e/online_serving/test_qwen_image_edit_expansion.py
@@ -2,7 +2,7 @@
 Comprehensive tests of diffusion features that are available in online serving mode
 and are supported by the following models:
 - Qwen-Image-Edit: single image input
-- Qwen-Image-Edit-2509: two image inputs
+- Qwen-Image-Edit-2509: single image input and two image inputs
 """
 
 import pytest
@@ -14,6 +14,7 @@ from tests.helpers.runtime import OmniServer, OmniServerParams, OpenAIClientHand
 pytestmark = [pytest.mark.diffusion, pytest.mark.full_model]
 
 EDIT_PROMPT = "Transform this modern, geometrist image into a Vincent van Gogh style impressionist painting."
+SINGLE_EDIT_PROMPT_2509 = "Restyle this image into a Vincent van Gogh style impressionist painting."
 MULTI_EDIT_PROMPT = (
     "Transform the first image into a Dadaism collage art. "
     "Transform the second image into a Vincent van Gogh style painting. "
@@ -143,8 +144,43 @@ def test_qwen_image_edit(omni_server: OmniServer, openai_client: OpenAIClientHan
     _get_diffusion_feature_cases("Qwen/Qwen-Image-Edit-2509"),
     indirect=True,
 )
-def test_qwen_image_edit_2509(omni_server: OmniServer, openai_client: OpenAIClientHandler):
-    """Test all diffusion features with Qwen-Image-Edit-2509 in regular end-user scenarios."""
+def test_qwen_image_edit_2509_single_image(omni_server: OmniServer, openai_client: OpenAIClientHandler):
+    """Test Qwen-Image-Edit-2509 with a single image input.
+
+    Regression: with tea_cache enabled and zero_cond_t=True, the TeaCache
+    postprocess closure used the doubled temb (shape 2*batch) without halving
+    it, causing norm_out to broadcast and return noise_pred with shape
+    (2*batch, seq, ch). The scheduler step then silently expanded latents via
+    broadcasting, so at step 2 torch.cat([latents, image_latents], dim=1)
+    crashed with a batch size mismatch. Fixed in extractors.py.
+    """
+    image_data_url = f"data:image/jpeg;base64,{generate_synthetic_image(512, 512)['base64']}"
+
+    messages = dummy_messages_from_mix_data(image_data_url=image_data_url, content_text=SINGLE_EDIT_PROMPT_2509)
+
+    request_config = {
+        "model": omni_server.model,
+        "messages": messages,
+        "extra_body": {
+            "height": 512,
+            "width": 512,
+            "num_inference_steps": 2,
+            "negative_prompt": NEGATIVE_PROMPT,
+            "true_cfg_scale": 4.0,
+            "seed": 42,
+        },
+    }
+
+    openai_client.send_diffusion_request(request_config)
+
+
+@pytest.mark.parametrize(
+    "omni_server",
+    _get_diffusion_feature_cases("Qwen/Qwen-Image-Edit-2509"),
+    indirect=True,
+)
+def test_qwen_image_edit_2509_two_images(omni_server: OmniServer, openai_client: OpenAIClientHandler):
+    """Test Qwen-Image-Edit-2509 with two image inputs."""
     image_data_url_1 = f"data:image/jpeg;base64,{generate_synthetic_image(512, 512)['base64']}"
     image_data_url_2 = f"data:image/jpeg;base64,{generate_synthetic_image(512, 512)['base64']}"
 

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -277,7 +277,8 @@ def extract_qwen_context(
 
     def postprocess(h):
         """Apply Qwen-specific output postprocessing."""
-        h = module.norm_out(h, temb)
+        t = temb.chunk(2, dim=0)[0] if module.zero_cond_t else temb
+        h = module.norm_out(h, t)
         output = module.proj_out(h)
         if not return_dict:
             return (output,)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix when run `Qwen/Qwen-Image-Edit-2511` this model in `tea_cache` cache backend.

## Test Plan

```
$ python -m vllm_omni.entrypoints.cli.main serve /model/Qwen-Image-Edit-2511/ --omni --cache-backend tea_cache 
```

Start after call image edit api:
```
curl -s -D >(grep -i x-request-id >&2) \
  -o >(jq -r '.data[0].b64_json' | base64 --decode > edit_out_http.jpeg) \
  -X POST "http://localhost:8000/v1/images/edits" \
  -F "model=/model/Qwen-Image-Edit-2511/" \
  -F "image=@/home/jovyan/code/vllm-omni/tmp/qwen-bear.png" \
  -F "prompt='Change the bears in the two input images into walking together.'" \
  -F "negative_prompt=blurry, distorted, low quality" \
  -F "size=512x512" \
  -F "num_inference_steps=50" \
  -F "guidance_scale=1" \
  -F "seed=777" \
  -F "output_format=jpeg"
```

then serve will crash, it throw a RuntimeError:
```
ERROR 05-08 01:36:56 [diffusion_worker.py:926] Error executing method 'execute_model'. This might cause issues in distributed execution.
ERROR 05-08 01:36:56 [diffusion_worker.py:926] Traceback (most recent call last):
ERROR 05-08 01:36:56 [diffusion_worker.py:926]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 922, in execute_method
ERROR 05-08 01:36:56 [diffusion_worker.py:926]     return func(*args, **kwargs)
ERROR 05-08 01:36:56 [diffusion_worker.py:926]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:926]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 266, in execute_model
ERROR 05-08 01:36:56 [diffusion_worker.py:926]     output = self.model_runner.execute_model(req)
ERROR 05-08 01:36:56 [diffusion_worker.py:926]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:926]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_model_runner.py", line 278, in execute_model
ERROR 05-08 01:36:56 [diffusion_worker.py:926]     output = self.pipeline.forward(req)
ERROR 05-08 01:36:56 [diffusion_worker.py:926]              ^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:926]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py", line 804, in forward
ERROR 05-08 01:36:56 [diffusion_worker.py:926]     latents = self.diffuse(
ERROR 05-08 01:36:56 [diffusion_worker.py:926]               ^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:926]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/models/qwen_image/cfg_parallel.py", line 85, in diffuse
ERROR 05-08 01:36:56 [diffusion_worker.py:926]     latent_model_input = torch.cat([latents, image_latents], dim=1)
ERROR 05-08 01:36:56 [diffusion_worker.py:926]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:926] RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 2 but got size 1 for tensor number 1 in the list.
ERROR 05-08 01:36:56 [diffusion_worker.py:614] Error executing RPC: Sizes of tensors must match except in dimension 1. Expected size 2 but got size 1 for tensor number 1 in the list.
ERROR 05-08 01:36:56 [diffusion_worker.py:614] Traceback (most recent call last):
ERROR 05-08 01:36:56 [diffusion_worker.py:614]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 611, in execute_rpc
ERROR 05-08 01:36:56 [diffusion_worker.py:614]     result = self.worker.execute_method(method, *args, **kwargs)
ERROR 05-08 01:36:56 [diffusion_worker.py:614]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:614]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 927, in execute_method
ERROR 05-08 01:36:56 [diffusion_worker.py:614]     raise e
ERROR 05-08 01:36:56 [diffusion_worker.py:614]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 922, in execute_method
ERROR 05-08 01:36:56 [diffusion_worker.py:614]     return func(*args, **kwargs)
ERROR 05-08 01:36:56 [diffusion_worker.py:614]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:614]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 266, in execute_model
ERROR 05-08 01:36:56 [diffusion_worker.py:614]     output = self.model_runner.execute_model(req)
ERROR 05-08 01:36:56 [diffusion_worker.py:614]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:614]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_model_runner.py", line 278, in execute_model
ERROR 05-08 01:36:56 [diffusion_worker.py:614]     output = self.pipeline.forward(req)
ERROR 05-08 01:36:56 [diffusion_worker.py:614]              ^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:614]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py", line 804, in forward
ERROR 05-08 01:36:56 [diffusion_worker.py:614]     latents = self.diffuse(
ERROR 05-08 01:36:56 [diffusion_worker.py:614]               ^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:614]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/models/qwen_image/cfg_parallel.py", line 85, in diffuse
ERROR 05-08 01:36:56 [diffusion_worker.py:614]     latent_model_input = torch.cat([latents, image_latents], dim=1)
ERROR 05-08 01:36:56 [diffusion_worker.py:614]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:614] RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 2 but got size 1 for tensor number 1 in the list.
ERROR 05-08 01:36:56 [diffusion_worker.py:654] Error processing RPC: Sizes of tensors must match except in dimension 1. Expected size 2 but got size 1 for tensor number 1 in the list.
ERROR 05-08 01:36:56 [diffusion_worker.py:654] Traceback (most recent call last):
ERROR 05-08 01:36:56 [diffusion_worker.py:654]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 650, in worker_busy_loop
ERROR 05-08 01:36:56 [diffusion_worker.py:654]     result, should_reply = self.execute_rpc(msg)
ERROR 05-08 01:36:56 [diffusion_worker.py:654]                            ^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:654]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 615, in execute_rpc
ERROR 05-08 01:36:56 [diffusion_worker.py:654]     raise e
ERROR 05-08 01:36:56 [diffusion_worker.py:654]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 611, in execute_rpc
ERROR 05-08 01:36:56 [diffusion_worker.py:654]     result = self.worker.execute_method(method, *args, **kwargs)
ERROR 05-08 01:36:56 [diffusion_worker.py:654]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:654]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 927, in execute_method
ERROR 05-08 01:36:56 [diffusion_worker.py:654]     raise e
ERROR 05-08 01:36:56 [diffusion_worker.py:654]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 922, in execute_method
ERROR 05-08 01:36:56 [diffusion_worker.py:654]     return func(*args, **kwargs)
ERROR 05-08 01:36:56 [diffusion_worker.py:654]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:654]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_worker.py", line 266, in execute_model
ERROR 05-08 01:36:56 [diffusion_worker.py:654]     output = self.model_runner.execute_model(req)
ERROR 05-08 01:36:56 [diffusion_worker.py:654]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:654]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/worker/diffusion_model_runner.py", line 278, in execute_model
ERROR 05-08 01:36:56 [diffusion_worker.py:654]     output = self.pipeline.forward(req)
ERROR 05-08 01:36:56 [diffusion_worker.py:654]              ^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:654]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py", line 804, in forward
ERROR 05-08 01:36:56 [diffusion_worker.py:654]     latents = self.diffuse(
ERROR 05-08 01:36:56 [diffusion_worker.py:654]               ^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:654]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/models/qwen_image/cfg_parallel.py", line 85, in diffuse
ERROR 05-08 01:36:56 [diffusion_worker.py:654]     latent_model_input = torch.cat([latents, image_latents], dim=1)
ERROR 05-08 01:36:56 [diffusion_worker.py:654]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [diffusion_worker.py:654] RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 2 but got size 1 for tensor number 1 in the list.
ERROR 05-08 01:36:56 [inline_stage_diffusion_client.py:130] Diffusion request 0_a5e00938-b621-434f-ad14-97931dfd3557 failed: Sizes of tensors must match except in dimension 1. Expected size 2 but got size 1 for tensor number 1 in the list.
ERROR 05-08 01:36:56 [inline_stage_diffusion_client.py:130] Traceback (most recent call last):
ERROR 05-08 01:36:56 [inline_stage_diffusion_client.py:130]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/inline_stage_diffusion_client.py", line 121, in _dispatch_request
ERROR 05-08 01:36:56 [inline_stage_diffusion_client.py:130]     results = await self._engine.step(request)
ERROR 05-08 01:36:56 [inline_stage_diffusion_client.py:130]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [inline_stage_diffusion_client.py:130]   File "/home/jovyan/code/vllm-omni/vllm_omni/diffusion/diffusion_engine.py", line 159, in step
ERROR 05-08 01:36:56 [inline_stage_diffusion_client.py:130]     raise RuntimeError(output.error)
ERROR 05-08 01:36:56 [inline_stage_diffusion_client.py:130] RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 2 but got size 1 for tensor number 1 in the list.
Processed prompts:   0%|                                                                                                                                                 | 0/1 [00:00<?, ?it/s]
ERROR 05-08 01:36:56 [omni.py:82] [Omni] Failed to run generation: Sizes of tensors must match except in dimension 1. Expected size 2 but got size 1 for tensor number 1 in the list.
ERROR 05-08 01:36:56 [omni.py:82] Traceback (most recent call last):
ERROR 05-08 01:36:56 [omni.py:82]   File "/home/jovyan/code/vllm-omni/vllm_omni/entrypoints/omni.py", line 80, in generate
ERROR 05-08 01:36:56 [omni.py:82]     return list(self._run_generation(prompts, sampling_params_list, use_tqdm))
ERROR 05-08 01:36:56 [omni.py:82]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [omni.py:82]   File "/home/jovyan/code/vllm-omni/vllm_omni/entrypoints/omni.py", line 161, in _run_generation
ERROR 05-08 01:36:56 [omni.py:82]     should_continue, req_id, stage_id, req_state = self._handle_output_message(msg)
ERROR 05-08 01:36:56 [omni.py:82]                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 05-08 01:36:56 [omni.py:82]   File "/home/jovyan/code/vllm-omni/vllm_omni/entrypoints/omni_base.py", line 329, in _handle_output_message
ERROR 05-08 01:36:56 [omni.py:82]     raise RuntimeError(error_text)
ERROR 05-08 01:36:56 [omni.py:82] RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 2 but got size 1 for tensor number 1 in the list.
INFO 05-08 01:36:56 [orchestrator.py:348] [Orchestrator] Aborted request(s) ['0_a5e00938-b621-434f-ad14-97931dfd3557']
INFO 05-08 01:36:56 [omni_base.py:470] [Omni] Shutting down
INFO 05-08 01:36:56 [async_omni_engine.py:1904] [AsyncOmniEngine] Shutting down Orchestrator
INFO 05-08 01:36:56 [orchestrator.py:212] [Orchestrator] Received shutdown signal
INFO 05-08 01:36:56 [orchestrator.py:1089] [Orchestrator] Shutting down all 1 client(s)
INFO 05-08 01:36:56 [diffusion_worker.py:659] Worker 0: Received shutdown message
INFO 05-08 01:36:56 [diffusion_worker.py:680] event loop terminated.
INFO 05-08 01:36:56 [diffusion_worker.py:717] Worker 0: Shutdown complete.
INFO 05-08 01:36:58 [stage_pool.py:392] [StagePool] Stage 0 replica 0 shut down
Traceback (most recent call last):
  File "/home/jovyan/code/vllm-omni/examples/offline_inference/image_to_image/image_edit.py", line 566, in <module>
    main()
  File "/home/jovyan/code/vllm-omni/examples/offline_inference/image_to_image/image_edit.py", line 476, in main
    outputs = omni.generate(
              ^^^^^^^^^^^^^^
  File "/home/jovyan/code/vllm-omni/vllm_omni/entrypoints/omni.py", line 80, in generate
    return list(self._run_generation(prompts, sampling_params_list, use_tqdm))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/code/vllm-omni/vllm_omni/entrypoints/omni.py", line 161, in _run_generation
    should_continue, req_id, stage_id, req_state = self._handle_output_message(msg)
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jovyan/code/vllm-omni/vllm_omni/entrypoints/omni_base.py", line 329, in _handle_output_message
    raise RuntimeError(error_text)
RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 2 but got size 1 for tensor number 1 in the list.
```

Current pr will fix this bug, because, when `zero_cond_t=True`, the original Transformer `forward` method (lines 1148–1149) slices `temb` from shape `(2*batch, d)` down to `(batch, d)` *before* calling `norm_out`. Since the TeaCache extractor bypasses the Transformer's `forward` method, this step is omitted.

## Test Result

The test passes successfully using the method currently under testing.

<img width="512" height="512" alt="edit_out_http" src="https://github.com/user-attachments/assets/7d5418e9-d5bc-484f-bef6-fcf5270614b7" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
