### PR TITLE
Fix NPU code predictor device mismatch in concurrent mode

### DIFF
--- a/vllm_omni/platforms/npu/worker/npu_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_model_runner.py
@@ -460,7 +460,6 @@ class OmniNPUModelRunner(OmniGPUModelRunner, NPUModelRunner):
                 **talker_kwargs,
             )
         # update the inputs_embeds and code_predictor_codes
-        code_predictor_codes_cpu = code_predictor_codes.detach().to("cpu").contiguous()
         out_key = getattr(self.model, "talker_mtp_output_key", ("codes", "audio"))
         if not isinstance(out_key, tuple) or len(out_key) != 2:
             raise TypeError(f"talker_mtp_output_key must be a 2-tuple, got {type(out_key).__name__}: {out_key!r}")
@@ -468,5 +467,5 @@ class OmniNPUModelRunner(OmniGPUModelRunner, NPUModelRunner):
             req_index = self.input_batch.req_ids.index(req_id)
             start_offset = int(self.query_start_loc.cpu[req_index])
             inputs_embeds[start_offset : start_offset + 1] = req_embeds[idx : idx + 1]
-            update_dict = {out_key[0]: {out_key[1]: code_predictor_codes_cpu[idx : idx + 1]}}
+            update_dict = {out_key[0]: {out_key[1]: code_predictor_codes[idx : idx + 1]}}
             self._merge_additional_information_update(req_id, update_dict)


### PR DESCRIPTION
# Problem
In concurrent inference mode (max-concurrency > 1), Qwen3-TTS models crash with device mismatch error. Single concurrent tests pass, but 2+ concurrent causes the model to fail.

**Smoke test (max-concurrency=1) passes:**
```bash
vllm bench serve --omni \
    --host 127.0.0.1 --port 8091 \
    --model /root/autodl-tmp/qwen3_tts_VoiceDesign \
    --backend openai-audio-speech \
    --endpoint /v1/audio/speech \
    --dataset-name seed-tts-design \
    --dataset-path /root/autodl-tmp/vllm-omni/benchmarks/build_dataset/seed_tts_design \
    --num-prompts 5 \
    --extra-body '{"task_type":"VoiceDesign","language":"English"}' \
    --max-concurrency 1 \
    --percentile-metrics ttft,e2el,audio_ttfp,audio_rtf,audio_duration \
    --num-warmups 2
```

Concurrent test (max-concurrency=2) crashes:
```
vllm bench serve --omni \
    --host 127.0.0.1 --port 8091 \
    --model /root/autodl-tmp/qwen3TTS \
    --backend openai-audio-speech \
    --endpoint /v1/audio/speech \
    --dataset-name seed-tts-design \
    --dataset-path /root/autodl-tmp/vllm-omni/benchmarks/build_dataset/seed_tts_design \
    --num-prompts 20 \
    --extra-body '{"task_type":"VoiceDesign","language":"English"}' \
    --max-concurrency 2 \
    --percentile-metrics ttft,e2el,audio_ttfp,audio_rtf,audio_duration \
    --num-warmups 2
```

Error log:
```
(StageEngineCoreProc pid=328815) ERROR 05-08 16:12:36 [stage_engine_core_proc.py:106] StageEngineCoreProc encountered a fatal error.
(StageEngineCoreProc pid=328815) ERROR 05-08 16:12:36 [stage_engine_core_proc.py:106] Traceback (most recent call last):
(StageEngineCoreProc pid=328815) ERROR 05-08 16:12:36 [stage_engine_core_proc.py:106]   File "/root/autodl-tmp/vllm-omni/vllm_omni/engine/stage_engine_core_proc.py", line 97, in run_stage_core
(StageEngineCoreProc pid=328815) ERROR 05-08 16:12:36 [stage_engine_core_proc.py:106]     engine_core.run_busy_loop()
(StageEngineCoreProc pid=328815) ERROR 05-08 16:12:36 [stage_engine_core_proc.py:106]   File "/root/autodl-tmp/vllm/vllm/v1/engine/core.py", line 1170, in run_busy_loop
(StageEngineCoreProc pid=328815) ERROR 05-08 16:12:36 [stage_engine_core_proc.py:106]     self._process_engine_step()
...
(StageEngineCoreProc pid=328815) ERROR 05-08 16:12:36 [stage_engine_core_proc.py:106]   File "/root/autodl-tmp/vllm-omni/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py", line 527, in make_omni_output
(StageEngineCoreProc pid=328815) ERROR 05-08 16:12:36 [stage_engine_core_proc.py:106]     audio_codes = torch.cat(audio_codes_list, dim=0)
(StageEngineCoreProc pid=328815) ERROR 05-08 16:12:36 [stage_engine_core_proc.py:106]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc pid=328815) ERROR 05-08 16:12:36 [stage_engine_core_proc.py:106] RuntimeError: Expected all tensors to be on the same device, but got tensors is on npu:0, different from other tensors on cpu (when checking argument in method wrapper_NPU__cat)
```

# Root Cause
NPU model runner (npu_model_runner.py:463) forces code_predictor_codes to CPU:
```
code_predictor_codes_cpu = code_predictor_codes.detach().to("cpu").contiguous()
```
While GPU model runner (gpu_model_runner.py:1442) keeps them on device:
```
update_dict = {out_key[0]: {out_key[1]: code_predictor_codes[idx : idx + 1]}}
```

# Fix
Remove the forced CPU transfer line, matching GPU implementation. The codes will be properly managed through gpu_resident_buffer_keys mechanism which keeps them on NPU.

# Testing
✅ Single concurrent (max-concurrency=1) smoke test passes
✅ 2 concurrent (max-concurrency=2) benchmark test passes (previously crashed)
