### PR TITLE
[Core] Integrate HSDP with DiffusersBackend

### DIFF
--- a/tests/diffusion/diffusion_backend/test_diffusers_backend.py
+++ b/tests/diffusion/diffusion_backend/test_diffusers_backend.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from diffusers import DiffusionPipeline  # pyright: ignore[reportPrivateImportUsage]
 from PIL import Image
+from torch import nn
 
 from tests.helpers.mark import hardware_test
 from tests.helpers.runtime import OmniServer, OmniServerParams, OpenAIClientHandler, dummy_messages_from_mix_data
@@ -66,6 +67,16 @@ def _make_request(**overrides) -> OmniDiffusionRequest:
     return OmniDiffusionRequest(**defaults)
 
 
+def _make_adapter(**attrs) -> DiffusersAdapterPipeline:
+    """Create a dummy adapter for testing HSDP validation."""
+    adapter = object.__new__(DiffusersAdapterPipeline)
+    nn.Module.__init__(adapter)
+    adapter.is_initialized = False
+    for k, v in attrs.items():
+        setattr(adapter, k, v)
+    return adapter
+
+
 @pytest.mark.core_model
 @pytest.mark.cpu
 class TestPipelineArgumentsHandling:
@@ -78,6 +89,7 @@ class TestPipelineArgumentsHandling:
         MockPipelineOutput = namedtuple("MockPipelineOutput", ["image"])
         MockPipeline = type("MockPipeline", (DiffusionPipeline,), {})
         adapter._pipeline = MockPipeline()
+        adapter.is_initialized = True
 
         mocker.patch.object(
             MockPipeline,
@@ -92,7 +104,7 @@ class TestPipelineArgumentsHandling:
 
     @pytest.mark.parametrize(
         "feature_id",
-        ["cfg_parallel", "ulysses", "ring", "teacache", "cache_dit", "enforce_eager", "quantization"],
+        ["cfg_parallel", "ulysses", "ring", "teacache", "cache_dit", "quantization"],
     )
     def test_adapter_guard_unsupported_feature(self, feature_id):
         if feature_id == "cfg_parallel":
@@ -139,6 +151,7 @@ class TestPipelineArgumentsHandling:
 
         MockPipeline = type("MockPipeline", (DiffusionPipeline,), {})
         adapter._pipeline = MockPipeline()
+        adapter.is_initialized = True
 
         mocker.patch.object(
             MockPipeline,
@@ -404,6 +417,45 @@ class TestPipelineArgumentsHandling:
         )
         with pytest.raises(ValueError):
             pipeline.forward(problematic_request)
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+class TestDiffusersAdapterHSDP:
+    def test_hsdp_matches_only_direct_modulelist_names(self):
+        """Ensure we match only names that are direct child Modulelist-like."""
+        condition = DiffusersAdapterPipeline._build_hsdp_condition({"blocks", "layers"})
+        stub = nn.Module()
+        assert condition("blocks.0", stub) is True
+        assert condition("layers.2", stub) is True
+        assert condition("other.0", stub) is False
+        assert condition("blocks.0.sublayer.1", stub) is False
+        assert condition("blocks.name", stub) is False
+
+    def test_set_dit_hsdp_conditions_sets_shard_conditions_on_transformer(self):
+        """Ensure set DiT hsdp conditions matches direct child module lists."""
+        transformer = nn.Module()
+        transformer.blocks = nn.ModuleList([nn.Linear(4, 4) for _ in range(3)])
+
+        adapter = _make_adapter(is_initialized=True, _transformer=transformer)
+        adapter._set_dit_hsdp_conditions()
+
+        conditions = transformer._hsdp_shard_conditions
+        matched = [name for name, mod in transformer.named_modules() if any(c(name, mod) for c in conditions)]
+        assert matched == ["blocks.0", "blocks.1", "blocks.2"]
+
+    def test_set_dit_hsdp_conditions_raises_without_transformer(self):
+        """Ensure set DiT hsdp conditions needs a DiT."""
+        adapter = _make_adapter(is_initialized=True, _transformer=None)
+        with pytest.raises(RuntimeError, match="HSDP requires an encapsulated DiT"):
+            adapter._set_dit_hsdp_conditions()
+
+    @pytest.mark.parametrize("attr_name", ["pipeline", "transformer"])
+    def test_pipeline_property_guards_before_load_weights(self, attr_name):
+        """Ensure that attributes that require loading raise if accessed too early."""
+        adapter = _make_adapter()
+        with pytest.raises(RuntimeError):
+            getattr(adapter, attr_name)
 
 
 @pytest.mark.advanced_model

--- a/tests/diffusion/diffusion_backend/test_diffusers_backend.py
+++ b/tests/diffusion/diffusion_backend/test_diffusers_backend.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 from diffusers import DiffusionPipeline  # pyright: ignore[reportPrivateImportUsage]
+from diffusers.models.modeling_utils import ModelMixin
 from PIL import Image
 from torch import nn
 
@@ -437,16 +438,40 @@ class TestDiffusersAdapterHSDP:
         transformer = nn.Module()
         transformer.blocks = nn.ModuleList([nn.Linear(4, 4) for _ in range(3)])
 
-        adapter = _make_adapter(is_initialized=True, _transformer=transformer)
+        adapter = _make_adapter(is_initialized=True, _transformer=transformer, _transformer_2=None)
         adapter._set_dit_hsdp_conditions()
 
         conditions = transformer._hsdp_shard_conditions
         matched = [name for name, mod in transformer.named_modules() if any(c(name, mod) for c in conditions)]
         assert matched == ["blocks.0", "blocks.1", "blocks.2"]
 
+    def test_hsdp_conditions_with_dual_transformers(self):
+        """Ensure set DiT hsdp conditions matches direct child module lists correctly
+        if we have 2 DiTs with potentially different architectures."""
+        transformer = nn.Module()
+        transformer.blocks = nn.ModuleList([nn.Linear(4, 4) for _ in range(3)])
+        # Name dual transformer block something else, since the conditions are set at the DiT level
+        other_transformer = nn.Module()
+        other_transformer.t_blocks = nn.ModuleList([nn.Linear(4, 4) for _ in range(3)])
+
+        adapter = _make_adapter(is_initialized=True, _transformer=transformer, _transformer_2=other_transformer)
+        adapter._set_dit_hsdp_conditions()
+
+        # The first DiT will match blocks.<x>
+        conditions = transformer._hsdp_shard_conditions
+        matched = [name for name, mod in transformer.named_modules() if any(c(name, mod) for c in conditions)]
+        assert matched == ["blocks.0", "blocks.1", "blocks.2"]
+
+        # The secondary DiT will match t_blocks.<x>
+        other_conditions = other_transformer._hsdp_shard_conditions
+        matched = [
+            name for name, mod in other_transformer.named_modules() if any(c(name, mod) for c in other_conditions)
+        ]
+        assert matched == ["t_blocks.0", "t_blocks.1", "t_blocks.2"]
+
     def test_set_dit_hsdp_conditions_raises_without_transformer(self):
         """Ensure set DiT hsdp conditions needs a DiT."""
-        adapter = _make_adapter(is_initialized=True, _transformer=None)
+        adapter = _make_adapter(is_initialized=True, _transformer=None, _transformer_2=None)
         with pytest.raises(RuntimeError, match="HSDP requires an encapsulated DiT"):
             adapter._set_dit_hsdp_conditions()
 
@@ -456,6 +481,51 @@ class TestDiffusersAdapterHSDP:
         adapter = _make_adapter()
         with pytest.raises(RuntimeError):
             getattr(adapter, attr_name)
+
+
+class TestDiffusersAttentionInitialization:
+    @pytest.mark.parametrize(
+        "transformer_attrs",
+        (["transformer"], ["transformer", "transformer_2"]),
+    )
+    def test_attn_backend(self, transformer_attrs, mocker):
+        adapter = DiffusersAdapterPipeline(od_config=_make_od_config())
+
+        class MockTransformer(ModelMixin):
+            def __init__(self, name):
+                self.name = name
+
+            def __eq__(self, other):
+                # This is just added for readability to ensure we are passing the right DiT
+                return self is other
+
+        class MockPipeline:
+            def __init__(self):
+                for attr_name in transformer_attrs:
+                    fake_transformer = MockTransformer(name=attr_name)
+                    setattr(self, attr_name, fake_transformer)
+
+            def __call__(self, *args, **kwargs):
+                return None
+
+            def to(self, *args, **kwargs):
+                return self
+
+        mock_from_pretrained = mocker.patch(
+            "vllm_omni.diffusion.models.diffusers_adapter.pipeline_diffusers_adapter.DiffusionPipeline.from_pretrained",
+            return_value=MockPipeline(),
+        )
+        mock_set_attn = mocker.patch(
+            "vllm_omni.diffusion.models.diffusers_adapter.pipeline_diffusers_adapter.DiffusersAdapterPipeline._set_attention_backend",
+        )
+
+        adapter.load_weights()
+        mock_from_pretrained.assert_called_once()
+        assert adapter.is_initialized
+        for attr_name in transformer_attrs:
+            # Ensure that we tried to set the attention backend for each defined DiT
+            fake_dit = getattr(adapter.pipeline, attr_name)
+            mock_set_attn.assert_any_call(fake_dit)
 
 
 @pytest.mark.advanced_model

--- a/tests/e2e/accuracy/test_diffusers_backend_similarity.py
+++ b/tests/e2e/accuracy/test_diffusers_backend_similarity.py
@@ -179,6 +179,7 @@ def _run_vllm_omni_qwen_image(*, model: str, output_path: Path) -> tuple[Image.I
         "--diffusion-load-format",
         "diffusers",
         # "--enable-diffusion-pipeline-profiler",
+        "--enforce-eager",
     ]
     with OmniServer(model, server_args, use_omni=True) as omni_server:
         start_time = time.perf_counter()

--- a/vllm_omni/diffusion/compile.py
+++ b/vllm_omni/diffusion/compile.py
@@ -21,6 +21,9 @@ def regionally_compile(model: nn.Module, *compile_args: Any, **compile_kwargs: A
         The same model instance (modified in-place)
     """
     # Get the list of repeated blocks from the model
+    # NOTE: _repeated_blocks is also the attribute name used for repeating blocks
+    # in Diffusers for the purpose of regional compile, so no special handling is
+    # needed for the Diffusers Backend case once we have the transformer.
     repeated_blocks = getattr(model, "_repeated_blocks", None)
 
     if not repeated_blocks:

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -641,8 +641,6 @@ class DiffusersPipelineLoader:
         # directly on GPU, HSDP needs weights on CPU first so they can be redistributed
         # across GPUs by apply_hsdp_to_model. The model's load_weights handles weight
         # mapping (QKV fusion, etc.).
-        if load_format == "diffusers":
-            raise ValueError("HSDP is not supported with the diffusers adapter load format")
         model = self._init_from_load_format(load_format, target_device, custom_pipeline_name, is_hsdp=True)
         self.load_weights(model)
 
@@ -663,9 +661,15 @@ class DiffusersPipelineLoader:
             logger.debug("Applying HSDP to %s", name)
             apply_hsdp_to_model(trans, hsdp_config)
 
-        # # HSDP only shards transformer modules. All other runtime modules must
-        # # be placed on the execution device explicitly after sharding.
-        discovered_modules = ModuleDiscovery.discover(model)
+        # If we are trying to run HSDP on a DiffusersAdapterPipeline,
+        # then we need to unwrap it to run module discovery, since the
+        # internal Diffusers pipeline is what will have the modules,
+        # not the wrapper
+        pipeline = model.pipeline if isinstance(model, DiffusersAdapterPipeline) else model
+
+        # HSDP only shards transformer modules. All other runtime modules must
+        # be placed on the execution device explicitly after sharding.
+        discovered_modules = ModuleDiscovery.discover(pipeline)
         modules_to_move: list[nn.Module] = []
         if discovered_modules.vaes is not None:
             modules_to_move.extend(discovered_modules.vaes)

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -339,7 +339,7 @@ class DiffusersPipelineLoader:
         with set_default_torch_dtype(self.od_config.dtype):
             if self.parallel_config.use_hsdp:
                 model = self._load_model_with_hsdp(
-                    target_device=target_device, load_format=load_format, custom_pipeline_name=custom_pipeline_name
+                    target_device=device, load_format=load_format, custom_pipeline_name=custom_pipeline_name
                 )
             else:
                 model = self._init_from_load_format(load_format, target_device, custom_pipeline_name, is_hsdp=False)

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -646,6 +646,9 @@ class DiffusersPipelineLoader:
 
         # Collect all transformers to shard (some models have transformer_2 for MoE)
         transformers_to_shard = []
+
+        # NOTE: In the case of DiffusersAdapterPipeline, this .transformer unwraps
+        # the transformer attribute on the encapsulated pipeline for now.
         transformer = getattr(model, "transformer", None)
         if transformer is None:
             raise ValueError("Model has no transformer attribute for HSDP")
@@ -661,10 +664,8 @@ class DiffusersPipelineLoader:
             logger.debug("Applying HSDP to %s", name)
             apply_hsdp_to_model(trans, hsdp_config)
 
-        # If we are trying to run HSDP on a DiffusersAdapterPipeline,
-        # then we need to unwrap it to run module discovery, since the
-        # internal Diffusers pipeline is what will have the modules,
-        # not the wrapper
+        # If we are trying to run HSDP on a DiffusersAdapterPipeline, unwrap the
+        # adapter prior to module discovery, since we want to run it on the pipeline module
         pipeline = model.pipeline if isinstance(model, DiffusersAdapterPipeline) else model
 
         # HSDP only shards transformer modules. All other runtime modules must

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -339,7 +339,7 @@ class DiffusersPipelineLoader:
         with set_default_torch_dtype(self.od_config.dtype):
             if self.parallel_config.use_hsdp:
                 model = self._load_model_with_hsdp(
-                    target_device=device, load_format=load_format, custom_pipeline_name=custom_pipeline_name
+                    target_device=target_device, load_format=load_format, custom_pipeline_name=custom_pipeline_name
                 )
             else:
                 model = self._init_from_load_format(load_format, target_device, custom_pipeline_name, is_hsdp=False)

--- a/vllm_omni/diffusion/models/diffusers_adapter/pipeline_diffusers_adapter.py
+++ b/vllm_omni/diffusion/models/diffusers_adapter/pipeline_diffusers_adapter.py
@@ -54,6 +54,7 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         self.is_initialized = False
         self._pipeline: DiffusionPipeline
         self._transformer: ModelMixin | None
+        self._transformer_2: ModelMixin | None
         self._accept_call_kwargs: set[str] | None = None  # None to accept all kwargs
         self.od_config = od_config
         self.device = device
@@ -85,6 +86,12 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
             raise RuntimeError("transformer can't be accessed before .load_weights()")
         return self._transformer
 
+    @property
+    def transformer_2(self) -> ModelMixin | None:
+        if not self.is_initialized:
+            raise RuntimeError("transformer_2 can't be accessed before .load_weights()")
+        return self._transformer_2
+
     @staticmethod
     def _build_hsdp_condition(modulelist_names: set[str]):
         """Best effort check for determining HSDP shardable modules;
@@ -99,14 +106,25 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
 
         return should_shard
 
-    def _set_dit_hsdp_conditions(self):
+    @staticmethod
+    def _maybe_set_module_hsdp_conditions(maybe_module: nn.Module | None):
         """Best effort check for determining HSDP shardable modules."""
-        if self.transformer is None:
-            raise RuntimeError("HSDP requires an encapsulated DiT, but one was not found")
-
-        modulelist_names = {name for name, m in self.transformer.named_children() if isinstance(m, nn.ModuleList)}
+        if maybe_module is None:
+            return
+        modulelist_names = {name for name, m in maybe_module.named_children() if isinstance(m, nn.ModuleList)}
         condition = DiffusersAdapterPipeline._build_hsdp_condition(modulelist_names)
-        setattr(self.transformer, "_hsdp_shard_conditions", [condition])
+        setattr(maybe_module, "_hsdp_shard_conditions", [condition])
+
+    def _set_dit_hsdp_conditions(self):
+        """Set the HSDP conditions for all encapsulated components currently supported for HSDP.
+
+        NOTE: Currently this only checks DiT related components. We should also support components
+        like U-net as we add HSDP support outside the Diffusers backend.
+        """
+        if self.transformer is None and self.transformer_2 is None:
+            raise RuntimeError("HSDP requires an encapsulated DiT, but one was not found")
+        self._maybe_set_module_hsdp_conditions(self.transformer)
+        self._maybe_set_module_hsdp_conditions(self.transformer_2)
 
     # ------------------------------------------------------------------
     # Weight loading
@@ -162,11 +180,13 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
 
         # Mark as initialized so that we can access component properties
         self._transformer = getattr(pipe, "transformer", None)
+        self._transformer_2 = getattr(pipe, "transformer_2", None)
         self._pipeline = pipe
         self.is_initialized = True
 
         # Handle attention backend after we've set the .transformer if we have one
-        self._set_attention_backend()
+        self._set_attention_backend(self.transformer)
+        self._set_attention_backend(self.transformer_2)
         if self.od_config.parallel_config.use_hsdp:
             self._set_dit_hsdp_conditions()
 
@@ -244,15 +264,14 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
     # Wrap settings, inputs, and outputs
     # ------------------------------------------------------------------
 
-    def _set_attention_backend(self) -> None:
+    def _set_attention_backend(self, maybe_transformer: ModelMixin | None) -> None:
         """Set the attention backend.
 
         Roughly follow the logic in vllm_omni/diffusion/attention/backends/utils/fa.py,
         But also consider the available attention backends in diffusers.
         (See: https://huggingface.co/docs/diffusers/optimization/attention_backends)
         """
-        if self.transformer is None:
-            logging.info("No transformer found in diffusers pipeline. Skipping attention backend setting.")
+        if maybe_transformer is None:
             return
 
         default_spec = self.od_config.diffusion_attention_config.default
@@ -297,7 +316,7 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         set_backend: str | None = None
         for backend in attention_backend_attempts:
             try:
-                self.transformer.set_attention_backend(backend)
+                maybe_transformer.set_attention_backend(backend)
                 set_backend = backend
                 break
             except Exception as e:
@@ -305,7 +324,7 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
 
         # If all attempts fail, fallback to SDPA and warn the user about the failures
         if len(attempt_errors) == len(attention_backend_attempts):
-            self.transformer.set_attention_backend("native")
+            maybe_transformer.set_attention_backend("native")
             logger.warning(
                 f"Failed to set attention backend '{attention_backend_config}' for "
                 f"diffusers pipeline {self._pipeline.__class__.__name__}. "

--- a/vllm_omni/diffusion/models/diffusers_adapter/pipeline_diffusers_adapter.py
+++ b/vllm_omni/diffusion/models/diffusers_adapter/pipeline_diffusers_adapter.py
@@ -19,6 +19,7 @@ import re
 from typing import Any, cast
 
 import torch
+from diffusers.configuration_utils import ConfigMixin
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from torch import nn
 
@@ -50,10 +51,13 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
 
     def __init__(self, *, od_config: OmniDiffusionConfig, device: torch.device | None = None):
         super().__init__()
+        self.is_initialized = False
         self._pipeline: DiffusionPipeline
+        self._transformer: ConfigMixin | None
         self._accept_call_kwargs: set[str] | None = None  # None to accept all kwargs
         self.od_config = od_config
         self.device = device
+
         self._capabilities: dict[str, Any] = {}
         self._pipeline_utils: BasePipelineUtils = BasePipelineUtils()
         self._raise_unsupported_features()
@@ -66,10 +70,49 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
             logger.info("Profiling enabled for DiffusersAdapterPipeline. Only 'forward' is supported.")
 
     # ------------------------------------------------------------------
+    # Common components that can be leveraged after loading
+    # ------------------------------------------------------------------
+
+    @property
+    def pipeline(self) -> DiffusionPipeline:
+        if not self.is_initialized:
+            raise RuntimeError("pipeline can't be accessed before .load_weights()")
+        return self._pipeline
+
+    @property
+    def transformer(self) -> ConfigMixin | None:
+        if not self.is_initialized:
+            raise RuntimeError("transformer can't be accessed before .load_weights()")
+        return self._transformer
+
+    @staticmethod
+    def _build_hsdp_condition(modulelist_names: set[str]):
+        """Best effort check for determining HSDP shardable modules;
+        Currently we say that something is HSDP shardable if its a ModuleList
+        with depth 2, since most cases are things like transformer.blocks.<int>
+        etc.
+        """
+
+        def should_shard(name: str, module: nn.Module):
+            parts = name.split(".")
+            return len(parts) == 2 and parts[0] in modulelist_names and parts[-1].isdigit()
+
+        return should_shard
+
+    def _set_dit_hsdp_conditions(self):
+        """Best effort check for determining HSDP shardable modules."""
+        if self.transformer is None:
+            raise RuntimeError("HSDP requires an encapsulated DiT, but one was not found")
+
+        modulelist_names = {name for name, m in self.transformer.named_children() if isinstance(m, nn.ModuleList)}
+        condition = DiffusersAdapterPipeline._build_hsdp_condition(modulelist_names)
+        setattr(self.transformer, "_hsdp_shard_conditions", [condition])
+
+    # ------------------------------------------------------------------
     # Weight loading
     # ------------------------------------------------------------------
 
-    def load_weights(self) -> None:
+    def load_weights(self, *args, **kwargs) -> None:
         """Load the diffusers pipeline via ``DiffusionPipeline.from_pretrained()``."""
 
         model_id = self.od_config.model
@@ -86,38 +129,40 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         self._pipeline_utils = get_pipeline_utils(pipeline_class_name)
         self._pipeline_utils.update_load_kwargs(self.od_config, load_kwargs)
 
-        self._pipeline = DiffusionPipeline.from_pretrained(model_id, **load_kwargs)
-        self._pipeline_utils.apply_post_load_updates(self._pipeline, self.od_config)
-
-        self._pipeline.to(self.device)
+        pipe = DiffusionPipeline.from_pretrained(model_id, **load_kwargs)
+        self._pipeline_utils.apply_post_load_updates(pipe, self.od_config)
+        pipe.to(self.device)
 
         # Cache __call__kwargs signature introspection for later input validation
-        self._accept_call_kwargs = set(inspect.signature(self._pipeline.__call__).parameters.keys())
+        self._accept_call_kwargs = set(inspect.signature(pipe.__call__).parameters.keys())
 
         # CPU offloading
         if self.od_config.enable_layerwise_offload:
-            self._pipeline.enable_sequential_cpu_offload()
+            pipe.enable_sequential_cpu_offload()
         elif self.od_config.enable_cpu_offload:
-            self._pipeline.enable_model_cpu_offload()
+            pipe.enable_model_cpu_offload()
 
         # VAE slicing and tiling: try-catch because not all models have VAE
         if self.od_config.vae_use_slicing:
             try:
-                self._pipeline.enable_vae_slicing()
+                pipe.enable_vae_slicing()
             except Exception as e:
-                logger.warning(
-                    f"Failed to enable VAE slicing for diffusers pipeline {self._pipeline.__class__.__name__}: {e}"
-                )
+                logger.warning(f"Failed to enable VAE slicing for diffusers pipeline {pipe.__class__.__name__}: {e}")
         if self.od_config.vae_use_tiling:
             try:
-                self._pipeline.enable_vae_tiling()
+                pipe.enable_vae_tiling()
             except Exception as e:
-                logger.warning(
-                    f"Failed to enable VAE tiling for diffusers pipeline {self._pipeline.__class__.__name__}: {e}"
-                )
+                logger.warning(f"Failed to enable VAE tiling for diffusers pipeline {pipe.__class__.__name__}: {e}")
 
-        # Attention backend
+        # Mark as initialized so that we can access component properties
+        self._transformer = getattr(pipe, "transformer", None)
+        self._pipeline = pipe
+        self.is_initialized = True
+
+        # Handle attention backend after we've set the .transformer if we have one
         self._set_attention_backend()
+        if self.od_config.parallel_config.use_hsdp:
+            self._set_dit_hsdp_conditions()
 
     # ------------------------------------------------------------------
     # Step-wise execution — explicitly rejected
@@ -158,7 +203,7 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         logger.debug(f"Calling diffusers pipeline with kwargs: {kwargs}")
 
         with torch.inference_mode():
-            output = self._pipeline(**kwargs)  # pyright: ignore[reportCallIssue]
+            output = self.pipeline(**kwargs)  # pyright: ignore[reportCallIssue]
 
         return self._wrap_output(output)
 
@@ -185,11 +230,6 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
                 "with the diffusers backend. TeaCache/Cache-DiT require hooking "
                 "into individual transformer blocks."
             )
-        if self.od_config.enforce_eager:
-            raise NotImplementedError(
-                "Eager execution is not supported with the diffusers backend. "
-                "Use a native pipeline for continuous batching mode."
-            )
         if self.od_config.quantization_config is not None:
             raise NotImplementedError(
                 "Quantization is not supported with the diffusers backend. Use a native pipeline for quantization."
@@ -206,7 +246,7 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         But also consider the available attention backends in diffusers.
         (See: https://huggingface.co/docs/diffusers/optimization/attention_backends)
         """
-        if not hasattr(self._pipeline, "transformer"):
+        if self.transformer is None:
             logging.info("No transformer found in diffusers pipeline. Skipping attention backend setting.")
             return
 
@@ -252,7 +292,7 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         set_backend: str | None = None
         for backend in attention_backend_attempts:
             try:
-                self._pipeline.transformer.set_attention_backend(backend)
+                self.transformer.set_attention_backend(backend)
                 set_backend = backend
                 break
             except Exception as e:
@@ -260,7 +300,7 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
 
         # If all attempts fail, fallback to SDPA and warn the user about the failures
         if len(attempt_errors) == len(attention_backend_attempts):
-            self._pipeline.transformer.set_attention_backend("native")
+            self.transformer.set_attention_backend("native")
             logger.warning(
                 f"Failed to set attention backend '{attention_backend_config}' for "
                 f"diffusers pipeline {self._pipeline.__class__.__name__}. "

--- a/vllm_omni/diffusion/models/diffusers_adapter/pipeline_diffusers_adapter.py
+++ b/vllm_omni/diffusion/models/diffusers_adapter/pipeline_diffusers_adapter.py
@@ -19,7 +19,7 @@ import re
 from typing import Any, cast
 
 import torch
-from diffusers.configuration_utils import ConfigMixin
+from diffusers.models.modeling_utils import ModelMixin
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from torch import nn
 
@@ -53,7 +53,7 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         super().__init__()
         self.is_initialized = False
         self._pipeline: DiffusionPipeline
-        self._transformer: ConfigMixin | None
+        self._transformer: ModelMixin | None
         self._accept_call_kwargs: set[str] | None = None  # None to accept all kwargs
         self.od_config = od_config
         self.device = device
@@ -80,7 +80,7 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         return self._pipeline
 
     @property
-    def transformer(self) -> ConfigMixin | None:
+    def transformer(self) -> ModelMixin | None:
         if not self.is_initialized:
             raise RuntimeError("transformer can't be accessed before .load_weights()")
         return self._transformer
@@ -137,6 +137,10 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         self._accept_call_kwargs = set(inspect.signature(pipe.__call__).parameters.keys())
 
         # CPU offloading
+        # NOTE: Currently group offload in Diffusers isn't supported because vLLM Omni
+        # does not have an analogous setting, and it can't be enabled through kwargs in
+        # from_pretrained and .__call__(); when/if we add a similar mechanism in vLLM
+        # Omni, we should also expose it here.
         if self.od_config.enable_layerwise_offload:
             pipe.enable_sequential_cpu_offload()
         elif self.od_config.enable_cpu_offload:
@@ -202,8 +206,7 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
         kwargs = self._build_call_kwargs(req)
         logger.debug(f"Calling diffusers pipeline with kwargs: {kwargs}")
 
-        with torch.inference_mode():
-            output = self.pipeline(**kwargs)  # pyright: ignore[reportCallIssue]
+        output = self.pipeline(**kwargs)  # pyright: ignore[reportCallIssue]
 
         return self._wrap_output(output)
 

--- a/vllm_omni/diffusion/models/diffusers_adapter/pipeline_diffusers_adapter.py
+++ b/vllm_omni/diffusion/models/diffusers_adapter/pipeline_diffusers_adapter.py
@@ -131,7 +131,6 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
 
         pipe = DiffusionPipeline.from_pretrained(model_id, **load_kwargs)
         self._pipeline_utils.apply_post_load_updates(pipe, self.od_config)
-        pipe.to(self.device)
 
         # Cache __call__kwargs signature introspection for later input validation
         self._accept_call_kwargs = set(inspect.signature(pipe.__call__).parameters.keys())
@@ -145,6 +144,9 @@ class DiffusersAdapterPipeline(nn.Module, DiffusionPipelineProfilerMixin):
             pipe.enable_sequential_cpu_offload()
         elif self.od_config.enable_cpu_offload:
             pipe.enable_model_cpu_offload()
+        else:
+            # Only move to device if we don't enable offloading
+            pipe.to(self.device)
 
         # VAE slicing and tiling: try-catch because not all models have VAE
         if self.od_config.vae_use_slicing:


### PR DESCRIPTION
## Purpose
While rebasing https://github.com/vllm-project/vllm-omni/pull/1932, I noticed that the DiffusersBackend crashes with an unhandled error when you enable HSDP.

E.g.,
```bash
vllm serve stabilityai/stable-diffusion-3-medium-diffusers \
    --omni \
    --diffusion-load-format diffusers \
    --diffusers-load-kwargs '{"use_safetensors": true}' \
    --diffusers-call-kwargs '{"num_inference_steps": 30, "guidance_scale": 7.5}' \
    --use-hsdp --hsdp-replicate-size 2 --hsdp-shard-size  2
```

Will hit:
```
...
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex-jw-brooks/vllm-omni/vllm_omni/diffusion/model_loader/diffusers_loader.py", line 565, in _load_model_with_hsdp
    self.load_weights(model)
                      ^^^^^
UnboundLocalError: cannot access local variable 'model' where it is not associated with a value
```

This PR takes a pass at generic HSDP integration for compatibility with most DiTs in Diffusers; where the condition for splitting is that it's a direct child ModuleList, since this is what we tend to split in our models most of the time (i.e., things like  `model.blocks.<int>`).

it also makes some small cleanup changes:
- Removes the unsupported guard for `enforce_eager=True`, since this doesn't make sense 
- Adds properties for `pipeline` and `transformer` and explodes if they are accessed too early, since we need to load first, and the loader needs to get the `.transformer` for HSDP

## Test Plan
```bash
vllm serve stabilityai/stable-diffusion-3-medium-diffusers \
    --omni \
    --diffusion-load-format diffusers \
    --diffusers-load-kwargs '{"use_safetensors": true}' \
    --diffusers-call-kwargs '{"num_inference_steps": 30, "guidance_scale": 7.5}' \
    --use-hsdp --hsdp-replicate-size 2 --hsdp-shard-size  2
```
Should now start ok and shard the 24 transformer blocks:
```
INFO 05-08 22:01:33 [hsdp.py:128] HSDP Inference: replicate_size=2, shard_size=2, world_size=4, rank=0, fs_world_size=2, fs_rank=0
INFO 05-08 22:01:33 [hsdp.py:202] Sharded 24 modules + root
```

example output:
```bash
curl -s http://localhost:8000/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{
    "model": "stabilityai/stable-diffusion-3-medium-diffusers",
    "prompt": "a photo of a cat sitting on a windowsill",
    "size": "1024x1024",
    "seed": 42
  }' | python -c "
import sys, json, base64
data = json.load(sys.stdin)
img = base64.b64decode(data['data'][0]['b64_json'])
with open('/tmp/test_output.png', 'wb') as f:
    f.write(img)
print('Saved to /tmp/test_output.png')
"
```

<img width="240" height="240" alt="hsdp" src="https://github.com/user-attachments/assets/3ea3d7e4-02ab-48aa-8e27-101351f9b3ea" />
(output should be identical with/without hsdp).

Also added some unit tests for checking the parsing directly.

CC @fhfuih, could you PTAL?