### PR TITLE
[Fix] Fix RMSNorm inductor KeyError under HSDP + torch.compile

### DIFF
--- a/tests/diffusion/layers/test_norm.py
+++ b/tests/diffusion/layers/test_norm.py
@@ -320,8 +320,10 @@ def test_rmsnorm_forward_cuda_does_not_call_fused_during_compile():
     norm = RMSNorm(hidden_size=64)
     x = torch.randn(2, 4, 64)
 
-    with patch.object(norm, "_forward_fused", wraps=norm._forward_fused) as mock_fused, \
-         patch("torch.compiler.is_compiling", return_value=True):
+    with (
+        patch.object(norm, "_forward_fused", wraps=norm._forward_fused) as mock_fused,
+        patch("torch.compiler.is_compiling", return_value=True),
+    ):
         out = norm.forward_cuda(x)
 
     mock_fused.assert_not_called()
@@ -341,8 +343,10 @@ def test_rmsnorm_forward_hip_does_not_call_fused_during_compile():
     norm = RMSNorm(hidden_size=64)
     x = torch.randn(2, 4, 64)
 
-    with patch.object(norm, "_forward_fused", wraps=norm._forward_fused) as mock_fused, \
-         patch("torch.compiler.is_compiling", return_value=True):
+    with (
+        patch.object(norm, "_forward_fused", wraps=norm._forward_fused) as mock_fused,
+        patch("torch.compiler.is_compiling", return_value=True),
+    ):
         out = norm.forward_hip(x)
 
     mock_fused.assert_not_called()

--- a/tests/diffusion/layers/test_norm.py
+++ b/tests/diffusion/layers/test_norm.py
@@ -4,6 +4,7 @@
 
 import pytest
 import torch
+from pytest_mock import MockerFixture
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
@@ -301,7 +302,7 @@ def test_rmsnorm_numerical_correctness():
 # ── RMSNorm compile-path regression tests ──
 
 
-def test_rmsnorm_forward_cuda_does_not_call_fused_during_compile():
+def test_rmsnorm_forward_cuda_does_not_call_fused_during_compile(mocker: MockerFixture) -> None:
     """Regression: _forward_fused must not be called during torch.compile tracing.
 
     Under HSDP, RMSNorm.weight is a DTensor. Accessing .data on a DTensor inside
@@ -313,41 +314,35 @@ def test_rmsnorm_forward_cuda_does_not_call_fused_during_compile():
     If someone removes the guard, this test will catch the regression by asserting
     that _forward_fused was not called while is_compiling() returns True.
     """
-    from unittest.mock import patch
-
     from vllm_omni.diffusion.layers.norm import RMSNorm
 
     norm = RMSNorm(hidden_size=64)
     x = torch.randn(2, 4, 64)
 
-    with (
-        patch.object(norm, "_forward_fused", wraps=norm._forward_fused) as mock_fused,
-        patch("torch.compiler.is_compiling", return_value=True),
-    ):
-        out = norm.forward_cuda(x)
+    mock_fused = mocker.patch.object(norm, "_forward_fused", wraps=norm._forward_fused)
+    mocker.patch("torch.compiler.is_compiling", return_value=True)
+
+    out = norm.forward_cuda(x)
 
     mock_fused.assert_not_called()
     assert out.shape == x.shape
 
 
-def test_rmsnorm_forward_hip_does_not_call_fused_during_compile():
+def test_rmsnorm_forward_hip_does_not_call_fused_during_compile(mocker: MockerFixture) -> None:
     """Regression: same guard must be present in forward_hip.
 
     forward_hip is the entry point on ROCm (AMD GPU). It must behave identically
     to forward_cuda with respect to the is_compiling() guard.
     """
-    from unittest.mock import patch
-
     from vllm_omni.diffusion.layers.norm import RMSNorm
 
     norm = RMSNorm(hidden_size=64)
     x = torch.randn(2, 4, 64)
 
-    with (
-        patch.object(norm, "_forward_fused", wraps=norm._forward_fused) as mock_fused,
-        patch("torch.compiler.is_compiling", return_value=True),
-    ):
-        out = norm.forward_hip(x)
+    mock_fused = mocker.patch.object(norm, "_forward_fused", wraps=norm._forward_fused)
+    mocker.patch("torch.compiler.is_compiling", return_value=True)
+
+    out = norm.forward_hip(x)
 
     mock_fused.assert_not_called()
     assert out.shape == x.shape

--- a/tests/diffusion/layers/test_norm.py
+++ b/tests/diffusion/layers/test_norm.py
@@ -298,6 +298,57 @@ def test_rmsnorm_numerical_correctness():
     torch.testing.assert_close(out, expected, atol=1e-5, rtol=1e-5)
 
 
+# ── RMSNorm compile-path regression tests ──
+
+
+def test_rmsnorm_forward_cuda_does_not_call_fused_during_compile():
+    """Regression: _forward_fused must not be called during torch.compile tracing.
+
+    Under HSDP, RMSNorm.weight is a DTensor. Accessing .data on a DTensor inside
+    _forward_fused during tracing produces an orphan all-gather node outside the
+    compile boundary, causing inductor's compute_ancestors to raise KeyError.
+    The is_compiling() guard in forward_cuda/forward_hip prevents this by routing
+    to forward_native during tracing.
+
+    If someone removes the guard, this test will catch the regression by asserting
+    that _forward_fused was not called while is_compiling() returns True.
+    """
+    from unittest.mock import patch
+
+    from vllm_omni.diffusion.layers.norm import RMSNorm
+
+    norm = RMSNorm(hidden_size=64)
+    x = torch.randn(2, 4, 64)
+
+    with patch.object(norm, "_forward_fused", wraps=norm._forward_fused) as mock_fused, \
+         patch("torch.compiler.is_compiling", return_value=True):
+        out = norm.forward_cuda(x)
+
+    mock_fused.assert_not_called()
+    assert out.shape == x.shape
+
+
+def test_rmsnorm_forward_hip_does_not_call_fused_during_compile():
+    """Regression: same guard must be present in forward_hip.
+
+    forward_hip is the entry point on ROCm (AMD GPU). It must behave identically
+    to forward_cuda with respect to the is_compiling() guard.
+    """
+    from unittest.mock import patch
+
+    from vllm_omni.diffusion.layers.norm import RMSNorm
+
+    norm = RMSNorm(hidden_size=64)
+    x = torch.randn(2, 4, 64)
+
+    with patch.object(norm, "_forward_fused", wraps=norm._forward_fused) as mock_fused, \
+         patch("torch.compiler.is_compiling", return_value=True):
+        out = norm.forward_hip(x)
+
+    mock_fused.assert_not_called()
+    assert out.shape == x.shape
+
+
 def test_rmsnorm_matches_reference_implementation():
     """Verify RMSNorm matches a reference implementation."""
     from vllm_omni.diffusion.layers.norm import RMSNorm

--- a/vllm_omni/diffusion/layers/norm.py
+++ b/vllm_omni/diffusion/layers/norm.py
@@ -88,7 +88,7 @@ class RMSNorm(CustomOp):
         # (returns None) and accesses self.weight.data, which is a DTensor under
         # HSDP. Both patterns confuse inductor's compute_ancestors scheduler.
         # Fall back to forward_native so inductor can fuse the pure-PyTorch ops
-        # itself. In eager mode (including HSDP inference) use the fused kernel.
+        # itself.
         if torch.compiler.is_compiling():
             return self.forward_native(x)
         try:

--- a/vllm_omni/diffusion/layers/norm.py
+++ b/vllm_omni/diffusion/layers/norm.py
@@ -84,6 +84,13 @@ class RMSNorm(CustomOp):
         self,
         x: torch.Tensor,
     ) -> torch.Tensor:
+        # During torch.compile tracing, fused_rms_norm writes to `out` in-place
+        # (returns None) and accesses self.weight.data, which is a DTensor under
+        # HSDP. Both patterns confuse inductor's compute_ancestors scheduler.
+        # Fall back to forward_native so inductor can fuse the pure-PyTorch ops
+        # itself. In eager mode (including HSDP inference) use the fused kernel.
+        if torch.compiler.is_compiling():
+            return self.forward_native(x)
         try:
             return self._forward_fused(x)
         except Exception:
@@ -93,6 +100,8 @@ class RMSNorm(CustomOp):
         self,
         x: torch.Tensor,
     ) -> torch.Tensor:
+        if torch.compiler.is_compiling():
+            return self.forward_native(x)
         try:
             return self._forward_fused(x)
         except Exception:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fix: https://github.com/vllm-project/vllm-omni/issues/3433

fully_shard converts all nn.Parameter tensors inside each ZImageTransformerBlock — including RMSNorm.weight — into DTensor objects. When regionally_compile later triggers dynamo tracing on those blocks, _forward_fused is called inside the trace: `fused_rms_norm(out, x_2d, self.weight.data, self.variance_epsilon)`
Accessing .data on a DTensor triggers an all-gather that is dispatched through FSDP2's communication hook, which runs outside the compile boundary. This produces an orphan node ('op19') that is invisible to inductor's compute_ancestors scheduler, causing the KeyError. The in-place write convention of fused_rms_norm (returns None, writes to out) compounds the issue by creating a mutation node whose predecessor chain points to the orphan.

## Test Plan

```
pytest tests/e2e/online_serving/test_zimage_expansion.py::test_zimage[layerwise_hsdp]
```
regression test
```
pytest tests/diffusion/layers/test_norm.py -k "compile"
```
## Test Result
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
=============================================================================================== 1 passed, 17 warnings in 348.77s (0:05:48) ===============================================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
regression test
```
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/l00807937/vllm-omni/vllm-omni-LJH
configfile: pyproject.toml
plugins: repeat-0.9.4, asyncio-1.3.0, mock-3.15.1, anyio-4.12.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 37 items / 35 deselected / 2 selected                                                                                                                                                                                          

tests/diffusion/layers/test_norm.py ..                                                                                                                                                                                             [100%]

============================================================================================================ warnings summary ============================================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /workspace/l00807937/vllm-omni/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/diffusion/layers/test_norm.py::test_rmsnorm_forward_cuda_does_not_call_fused_during_compile
  /workspace/l00807937/vllm-omni/vllm-omni-LJH/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
   --> vLLM-Omni version 0.18.1.dev446+gb076006c3.d20260506
   --> vLLM version 0.20.0
  This will likely cause compatibility issues.
    warn_if_misaligned_vllm_version()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
============================================================================================= 2 passed, 35 deselected, 17 warnings in 0.40s ==============================================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
