### PR TITLE
[CI][Bugfix] Use get_open_port for Ulysses perf and diffusion benchmark to fix port conflict

### DIFF
--- a/tests/dfx/perf/scripts/run_diffusion_benchmark.py
+++ b/tests/dfx/perf/scripts/run_diffusion_benchmark.py
@@ -33,6 +33,8 @@ from typing import Any, cast
 import psutil
 import pytest
 
+from tests.helpers.runtime import get_open_port
+
 pytestmark = [pytest.mark.diffusion, pytest.mark.full_model]
 
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
@@ -144,14 +146,6 @@ _server_lock = threading.Lock()
 # ---------------------------------------------------------------------------
 
 
-def _get_open_port() -> int:
-    """Return an available TCP port on localhost."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.getsockname()[1]
-
-
 def _wait_for_port(host: str, port: int, timeout: int = 1200) -> None:
     """Block until the given host:port accepts connections or timeout expires."""
     start = time.time()
@@ -233,7 +227,7 @@ class DiffusionServer:
         self.model = server_cfg["model"]
         self.serve_args = server_cfg["serve_args"]
         self.host = "127.0.0.1"
-        self.port = port if port is not None else _get_open_port()
+        self.port = port if port is not None else get_open_port()
         self.proc: subprocess.Popen | None = None
         self.test_name: str = ""
 

--- a/tests/diffusion/distributed/test_ulysses_uaa_perf.py
+++ b/tests/diffusion/distributed/test_ulysses_uaa_perf.py
@@ -10,7 +10,6 @@ This test is intended for CI monitoring only:
 from __future__ import annotations
 
 import os
-import socket
 from dataclasses import dataclass
 
 import pytest
@@ -18,6 +17,7 @@ import torch
 import torch.distributed as dist
 
 from tests.helpers.mark import hardware_test
+from tests.helpers.runtime import get_open_port
 from vllm_omni.diffusion.attention.parallel.ulysses import (
     _all_gather_int,
     _ulysses_all_to_all_any_o,
@@ -31,12 +31,6 @@ from vllm_omni.diffusion.distributed.parallel_state import (
     initialize_model_parallel,
 )
 from vllm_omni.platforms import current_omni_platform
-
-
-def _find_free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return int(s.getsockname()[1])
 
 
 def _set_dist_env(*, rank: int, world_size: int, master_port: int) -> None:
@@ -77,7 +71,7 @@ def test_ulysses_advanced_uaa_comm_overhead(case: _PerfCase) -> None:
     if available_gpus < case.world_size:
         pytest.skip(f"Requires {case.world_size} GPUs, got {available_gpus}")
 
-    master_port = _find_free_port()
+    master_port = get_open_port()
     torch.multiprocessing.spawn(
         _perf_worker,
         args=(case.world_size, master_port, case.ulysses_degree, case.ring_degree),


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
To fix torch.distributed.DistNetworkError: The server socket has failed to listen on any local network address. port: 45729, useIpv6: false, code: -98, name: EADDRINUSE, message: address already in use in  tests/diffusion/distributed/test_ulysses_uaa_perf.py::test_ulysses_advanced_uaa_comm_overhead[case1]
https://buildkite.com/vllm/vllm-omni/builds/9297/canvas?jid=019e0a68-6cbc-49c1-825b-069514cdda16&tab=output

- Replace ad-hoc “pick ephemeral port then close socket” helpers with `tests.helpers.runtime.get_open_port()`, which re-probes `bind` to reduce `EADDRINUSE` / distributed `DistNetworkError` races under parallel or back-to-back test runs.
- Remove redundant local port helpers and update call sites:
  - `tests/diffusion/distributed/test_ulysses_uaa_perf.py` (`MASTER_PORT` for `torch.multiprocessing.spawn`)
  - `tests/dfx/perf/scripts/run_diffusion_benchmark.py` (`DiffusionServer` default port; server still uses `127.0.0.1`, matching `get_open_port()` default host)
 
## Test Plan
```
pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py --test-config-file tests/dfx/perf/tests/test_qwen_image_vllm_omni.json
pytest tests/diffusion/distributed/test_ulysses_uaa_perf.py -m core_model --count 20
```

## Test Result
<img width="2216" height="526" alt="60297b10b8776235d715d049514c1d76" src="https://github.com/user-attachments/assets/eda53205-9921-4e4b-b12c-f1e598b0002c" />
<img width="2220" height="156" alt="6f811847ae2cbb9dc343f28894fad9d9" src="https://github.com/user-attachments/assets/7bc8bac3-5973-4e74-97a9-eb2db79c851e" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
