### PR TITLE
[BugFix] Fix the type mismatch issue with code2wav

### DIFF
--- a/tests/model_executor/models/qwen3_tts/test_cuda_graph_decoder.py
+++ b/tests/model_executor/models/qwen3_tts/test_cuda_graph_decoder.py
@@ -312,16 +312,19 @@ def test_compute_capture_sizes(kwargs, expected_in, not_expected):
     "batch,channels,seq_len",
     [(2, 64, 1000), (1, 32, 1), (1, 32, 7), (1, 32, 128), (1, 32, 1024), (1, 32, 4096)],
 )
-def test_snakebeta_triton_vs_eager(batch, channels, seq_len):
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_snakebeta_triton_vs_eager(batch, channels, seq_len, dtype):
     """Fused Triton SnakeBeta kernel must match eager PyTorch output."""
     from vllm_omni.model_executor.models.common.snake_activation import SnakeBeta
 
     if not SnakeBeta._init_triton():
         pytest.skip("Triton not available")
+    if dtype is torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        pytest.skip("bf16 not supported on this CUDA device")
 
     torch.manual_seed(42)
     snake = SnakeBeta(in_features=channels).to(DEVICE).eval()
-    x = torch.randn(batch, channels, seq_len, device=DEVICE)
+    x = torch.randn(batch, channels, seq_len, device=DEVICE, dtype=dtype)
 
     with torch.no_grad():
         eager_out = snake._eager_forward(x)

--- a/vllm_omni/model_executor/models/common/snake_activation.py
+++ b/vllm_omni/model_executor/models/common/snake_activation.py
@@ -58,9 +58,11 @@ class SnakeBeta(nn.Module):
             t_off = tl.program_id(2) * block_t + tl.arange(0, block_t)
             mask = t_off < t_len
 
-            x = tl.load(x_ptr + bid * stride_b + cid * stride_c + t_off, mask=mask, other=0.0)
-            ea = tl.load(exp_alpha_ptr + cid)
-            ib = tl.load(inv_beta_ptr + cid)
+            # tl.sin in Triton expects fp32/fp64 inputs. Cast explicitly so bf16
+            # activations don't fail at compile time.
+            x = tl.load(x_ptr + bid * stride_b + cid * stride_c + t_off, mask=mask, other=0.0).to(tl.float32)
+            ea = tl.load(exp_alpha_ptr + cid).to(tl.float32)
+            ib = tl.load(inv_beta_ptr + cid).to(tl.float32)
             sin_val = tl.sin(x * ea)
             result = x + ib * sin_val * sin_val
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fix the type mismatch issue with code2wav
https://github.com/vllm-project/vllm-omni/issues/3464

```
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101]     block_t: tl.constexpr,
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101] ):
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101]     """Fused SnakeBeta using precomputed exp(α) and 1/(exp(β)+ε)."""
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101]     bid = tl.program_id(0)
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101]     cid = tl.program_id(1)
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101]     t_off = tl.program_id(2) * block_t + tl.arange(0, block_t)
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101]     mask = t_off < t_len
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101] 
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101]     x = tl.load(x_ptr + bid * stride_b + cid * stride_c + t_off, mask=mask, other=0.0)
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101]     ea = tl.load(exp_alpha_ptr + cid)
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101]     ib = tl.load(inv_beta_ptr + cid)
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101]     sin_val = tl.sin(x * ea)
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101]               ^
(StageEngineCoreProc pid=849819) WARNING 05-09 17:44:50 [snake_activation.py:101] Expected dtype ['fp32', 'fp64'] but got bf16
```
## Test Plan
```
vllm bench serve \
    --omni \
  --port 28889 \
  --max-concurrency 10 \
  --dataset-name seed-tts \
  --dataset-path /home/why00613459/vllm_omni_gpu/seed-tts-data \
  --num-prompts 2000 \
  --no-oversample \
  --seed-tts-wer-save-items \
  --model /home/models/Qwen3-Omni-30B-A3B-Instruct \
  --endpoint /v1/chat/completions \
  --backend openai-chat-omni \
  --percentile-metrics ttft,tpot,itl,e2el,audio_ttfp,audio_rtf \
  --extra_body '{"modalities": ["text", "audio"]}'
```
## Test Result
```
===== Seed-TTS eval (seed-tts-eval protocol) =====
Evaluated (WER, lower is better):        1088
Mean WER:                                0.4533
Median WER:                              0.0000
Request failed:                          0
No PCM captured:                         0
ASR / WER failed:                        0
==================================================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
