### PR TITLE
[Quantization] Enable FP8 online quantization for Qwen-image-edit text encoder

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ pytest_plugins = (
     "tests.helpers.fixtures.log",
     "tests.helpers.fixtures.run_args",
     "tests.helpers.fixtures.runtime",
+    "tests.helpers.fixtures.inputs",
     "tests.helpers.fixtures.speaker_cache",
 )
 

--- a/tests/diffusion/quantization/test_quantization_quality.py
+++ b/tests/diffusion/quantization/test_quantization_quality.py
@@ -538,7 +538,7 @@ def test_quantization_quality(config: QualityTestConfig, request: pytest.Fixture
     if quantization is None:
         omni_qt = Omni(model=config.quantized_ref())
     else:
-        omni_qt = Omni(model=config.quantized_ref(), quantization_config=quantization)
+        omni_qt = Omni(model=config.quantized_ref(), diffusion_quantization_config=quantization)
 
     quant_out, qt_mem = generate_fn(omni_qt, config)
     omni_qt.shutdown()

--- a/tests/diffusion/quantization/test_quantization_quality.py
+++ b/tests/diffusion/quantization/test_quantization_quality.py
@@ -39,6 +39,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import numpy as np
 import pytest
@@ -67,11 +68,11 @@ class QualityTestConfig:
     """Defines a single quantization quality test case."""
 
     id: str  # pytest ID, e.g. "fp8_z_image"
-    task: str  # "t2i" or "t2v"
+    task: str  # "t2i", "t2v", or "i2i"
     prompt: str  # generation prompt
     max_lpips: float  # fail threshold — higher = more lenient
     model: str | None = None  # HF model name
-    quantization: str | dict[str, object] | None = None  # quantization method/config, e.g. "fp8"
+    quantization: str | dict[str, Any] | None = None  # quantization method/config, e.g. "fp8"
     baseline_model: str | None = None  # explicit BF16/local baseline path
     quantized_model: str | None = None  # explicit quantized/local model path
     height: int = 1024
@@ -203,6 +204,24 @@ QUALITY_CONFIGS = [
         num_frames=25,
         num_inference_steps=8,
     ),
+    QualityTestConfig(
+        id="fp8_qwen_image_edit_text_encoder",
+        model="Qwen/Qwen-Image-Edit",
+        quantization={
+            "text_encoder": {"method": "fp8"},
+            "transformer": None,
+            "vae": None,
+        },
+        task="i2i",
+        prompt=(
+            "Restyle the input image into a painterly oil artwork with warm colors while preserving the main structure."
+        ),
+        max_lpips=0.15,
+        height=512,
+        width=512,
+        seed=42,
+        num_inference_steps=20,
+    ),
 ]
 
 
@@ -242,7 +261,7 @@ def _maybe_save_output(output_dir: Path | None, config: QualityTestConfig, label
         return
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    if config.task == "t2i":
+    if isinstance(output, Image.Image):
         output.save(_output_path(output_dir, config, label, ".png"))
         return
 
@@ -256,6 +275,10 @@ def _maybe_save_output(output_dir: Path | None, config: QualityTestConfig, label
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _output_peak_memory_gib(output) -> float:
+    return float(getattr(output, "peak_memory_mb", 0.0)) / 1024
 
 
 def _generate_image(omni, config: QualityTestConfig):
@@ -279,8 +302,8 @@ def _generate_image(omni, config: QualityTestConfig):
         ),
     )
 
-    peak_mem = torch.accelerator.max_memory_allocated() / (1024**3)
     first = outputs[0]
+    peak_mem = _output_peak_memory_gib(first)
     if hasattr(first, "images") and first.images:
         return first.images[0], peak_mem
     inner = first.request_output
@@ -312,8 +335,8 @@ def _generate_video(omni, config: QualityTestConfig):
         ),
     )
 
-    peak_mem = torch.accelerator.max_memory_allocated() / (1024**3)
     first = outputs[0]
+    peak_mem = _output_peak_memory_gib(first)
     if hasattr(first, "request_output") and isinstance(first.request_output, list):
         inner = first.request_output[0]
         if isinstance(inner, OmniRequestOutput) and hasattr(inner, "images"):
@@ -351,6 +374,39 @@ def _generate_video(omni, config: QualityTestConfig):
     return frames_array, peak_mem
 
 
+def _generate_image_edit(omni, config: QualityTestConfig, input_image: Image.Image):
+    """Generate an edited image, return (PIL.Image, peak_mem_gib)."""
+    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+    from vllm_omni.platforms import current_omni_platform
+
+    generator = torch.Generator(
+        device=current_omni_platform.device_type,
+    ).manual_seed(config.seed)
+    outputs = omni.generate(
+        {
+            "prompt": config.prompt,
+            "negative_prompt": "low quality, blurry, artifacts, distortion",
+            "multi_modal_data": {"image": input_image},
+        },
+        OmniDiffusionSamplingParams(
+            height=config.height,
+            width=config.width,
+            generator=generator,
+            num_inference_steps=config.num_inference_steps,
+            true_cfg_scale=4.0,
+        ),
+    )
+
+    first = outputs[0]
+    peak_mem = _output_peak_memory_gib(first)
+    if hasattr(first, "images") and first.images:
+        return first.images[0], peak_mem
+    inner = first.request_output
+    if inner is not None and hasattr(inner, "images") and inner.images:
+        return inner.images[0], peak_mem
+    raise ValueError("Could not extract image from output.")
+
+
 def _compute_lpips(baseline, quantized, task: str) -> float:
     """Compute LPIPS between baseline and quantized outputs."""
     from benchmarks.diffusion.quantization_quality import (
@@ -358,7 +414,7 @@ def _compute_lpips(baseline, quantized, task: str) -> float:
         compute_lpips_video,
     )
 
-    if task == "t2i":
+    if task in ("t2i", "i2i"):
         return compute_lpips_images([baseline], [quantized])[0]
     return compute_lpips_video(baseline, quantized)
 
@@ -452,14 +508,25 @@ def _quality_param(c: QualityTestConfig):
     "config",
     [_quality_param(c) for c in _all_quality_configs()],
 )
-def test_quantization_quality(config: QualityTestConfig):
+def test_quantization_quality(config: QualityTestConfig, request: pytest.FixtureRequest):
     """Validate that quantized output stays within LPIPS threshold of BF16."""
     from vllm_omni.entrypoints.omni import Omni
 
-    generate_fn = _generate_video if config.task == "t2v" else _generate_image
+    if config.task == "t2v":
+        generate_fn = _generate_video
+    elif config.task == "i2i":
+        input_image = request.getfixturevalue("qwen_bear_image")
+
+        def _generate_image_edit_wrapper(omni, cfg):
+            return _generate_image_edit(omni, cfg, input_image)
+
+        generate_fn = _generate_image_edit_wrapper
+    else:
+        generate_fn = _generate_image
 
     # --- BF16 baseline ---
     omni_bl = Omni(model=config.baseline_ref())
+
     baseline_out, bl_mem = generate_fn(omni_bl, config)
     omni_bl.shutdown()
     del omni_bl
@@ -472,6 +539,7 @@ def test_quantization_quality(config: QualityTestConfig):
         omni_qt = Omni(model=config.quantized_ref())
     else:
         omni_qt = Omni(model=config.quantized_ref(), quantization_config=quantization)
+
     quant_out, qt_mem = generate_fn(omni_qt, config)
     omni_qt.shutdown()
     del omni_qt

--- a/tests/e2e/accuracy/conftest.py
+++ b/tests/e2e/accuracy/conftest.py
@@ -216,24 +216,6 @@ def accuracy_assets_root() -> Path:
 
 
 @pytest.fixture(scope="session")
-def qwen_bear_image(accuracy_artifact_root: Path):
-    """Download the Qwen bear image from the URL and save it to the accuracy artifact root."""
-    QWEN_BEAR_IMAGE_URL = "https://vllm-public-assets.s3.us-west-2.amazonaws.com/omni-assets/qwen-bear.png"
-    image_path = accuracy_artifact_root / "qwen_bear.png"
-    if image_path.exists():
-        image = Image.open(image_path).convert("RGB")
-        yield image
-        image.close()
-        return
-    response = requests.get(QWEN_BEAR_IMAGE_URL, timeout=60)
-    response.raise_for_status()
-    image = Image.open(BytesIO(response.content)).convert("RGB")
-    image.save(image_path)
-    yield image
-    image.close()
-
-
-@pytest.fixture(scope="session")
 def rabbit_image(accuracy_artifact_root: Path):
     """Download the rabbit image from the URL and save it to the accuracy artifact root."""
     RABBIT_IMAGE_URL = "https://vllm-public-assets.s3.us-west-2.amazonaws.com/omni-assets/rabbit.png"

--- a/tests/helpers/fixtures/inputs.py
+++ b/tests/helpers/fixtures/inputs.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+import requests
+from PIL import Image
+
+QWEN_BEAR_IMAGE_URL = "https://vllm-public-assets.s3.us-west-2.amazonaws.com/omni-assets/qwen-bear.png"
+
+
+def load_qwen_bear_image(cache_dir: Path) -> Image.Image:
+    """Load the shared Qwen bear image, downloading it into cache_dir if needed."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    image_path = cache_dir / "qwen_bear.png"
+    if image_path.exists():
+        with Image.open(image_path) as image:
+            return image.convert("RGB")
+
+    response = requests.get(QWEN_BEAR_IMAGE_URL, timeout=60)
+    response.raise_for_status()
+    with Image.open(BytesIO(response.content)) as image:
+        rgb_image = image.convert("RGB")
+    rgb_image.save(image_path)
+    return rgb_image
+
+
+@pytest.fixture(scope="session")
+def shared_artifact_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "artifacts"
+
+
+@pytest.fixture(scope="session")
+def qwen_bear_image(shared_artifact_root: Path) -> Image.Image:
+    """Shared Qwen bear image for image-edit tests."""
+    image = load_qwen_bear_image(shared_artifact_root)
+    yield image
+    image.close()

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit.py
@@ -21,13 +21,13 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
 )
 from diffusers.utils.torch_utils import randn_tensor
 from torch import nn
-from transformers import Qwen2_5_VLForConditionalGeneration, Qwen2Tokenizer, Qwen2VLProcessor
-from vllm.model_executor.models.utils import AutoWeightsLoader
+from transformers import AutoConfig, AutoModelForImageTextToText, Qwen2Tokenizer, Qwen2VLProcessor
+from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
+from vllm_omni.diffusion.model_loader.hub_prefetch import prefetch_subfolders
 from vllm_omni.diffusion.models.interface import SupportImageInput
 from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
@@ -36,6 +36,7 @@ from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import calculate_
 from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
+from vllm_omni.diffusion.models.utils import create_transformers_model
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import (
@@ -233,57 +234,73 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
         self.weights_sources = [
             DiffusersPipelineLoader.ComponentSource(
                 model_or_path=od_config.model,
+                subfolder="text_encoder",
+                revision=od_config.revision,
+                prefix="text_encoder.",
+            ),
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
                 subfolder="transformer",
-                revision=None,
+                revision=od_config.revision,
                 prefix="transformer.",
                 fall_back_to_pt=True,
-            )
+            ),
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
+                subfolder="vae",
+                revision=od_config.revision,
+                prefix="vae.",
+            ),
         ]
         self.device = get_local_device()
         model = od_config.model
 
+        # weight mapping from HuggingFace model keys to vLLM model keys
+        self.hf_to_vllm_mapper = WeightsMapper(
+            orig_to_new_substr={
+                "text_encoder.visual.": "text_encoder.model.visual.",
+                "text_encoder.model.layers.": "text_encoder.model.language_model.layers.",
+                "text_encoder.model.norm.": "text_encoder.model.language_model.norm.",
+                "text_encoder.model.embed_tokens.": "text_encoder.model.language_model.embed_tokens.",
+                "text_encoder.model.rotary_emb.": "text_encoder.model.language_model.rotary_emb.",
+            }
+        )
+
         # Check if model is a local path
-        local_files_only = os.path.isdir(model)
+        local_files_only = os.path.exists(model)
 
         # See pipeline_qwen_image_edit_plus: guard against transformers v5
         # multi-worker race on partial subfolder shard sets (Buildkite #1043).
-        qwen_subfolders = ["scheduler", "text_encoder", "vae", "tokenizer", "processor"]
         prefetch_subfolders(
             model,
-            qwen_subfolders,
+            ["scheduler", "text_encoder", "vae", "tokenizer", "processor"],
+            local_files_only=local_files_only,
         )
 
         self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
             model, subfolder="scheduler", local_files_only=local_files_only
         )
-        # ``from_pretrained_with_prefetch`` re-prefetches and retries on a
-        # half-written cache (missing-shard ``OSError`` *and* the default
-        # -config size-mismatch ``RuntimeError`` that ``retry_on_missing_shard``
-        # could not recover) instead of crashing the worker.
-        self.text_encoder = from_pretrained_with_prefetch(
-            Qwen2_5_VLForConditionalGeneration.from_pretrained,
-            model,
-            subfolder="text_encoder",
-            prefetch_list=qwen_subfolders,
-            local_files_only=local_files_only,
-        ).to(self.device)
+        text_encoder_config = AutoConfig.from_pretrained(
+            model, subfolder="text_encoder", revision=od_config.revision, local_files_only=local_files_only
+        )
+        self.text_encoder = create_transformers_model(
+            AutoModelForImageTextToText, od_config, text_encoder_config, root_prefix="text_encoder"
+        )
+        if text_encoder_config.tie_word_embeddings:
+            self.text_encoder.lm_head.weight = self.text_encoder.get_input_embeddings().weight
 
-        self.vae = from_pretrained_with_prefetch(
-            AutoencoderKLQwenImage.from_pretrained,
-            model,
-            subfolder="vae",
-            prefetch_list=qwen_subfolders,
-            local_files_only=local_files_only,
-        ).to(self.device)
+        self.vae_config = AutoencoderKLQwenImage.load_config(
+            model, subfolder="vae", revision=od_config.revision, local_files_only=local_files_only
+        )
+        self.vae = AutoencoderKLQwenImage.from_config(self.vae_config).to(self.device)
+
         transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, QwenImageTransformer2DModel)
         self.transformer = QwenImageTransformer2DModel(od_config=od_config, **transformer_kwargs)
-        self.tokenizer = Qwen2Tokenizer.from_pretrained(model, subfolder="tokenizer", local_files_only=local_files_only)
-        self.processor = from_pretrained_with_prefetch(
-            Qwen2VLProcessor.from_pretrained,
-            model,
-            subfolder="processor",
-            prefetch_list=qwen_subfolders,
-            local_files_only=local_files_only,
+        self.tokenizer = Qwen2Tokenizer.from_pretrained(
+            model, subfolder="tokenizer", revision=od_config.revision, local_files_only=local_files_only
+        )
+        self.processor = Qwen2VLProcessor.from_pretrained(
+            model, subfolder="processor", revision=od_config.revision, local_files_only=local_files_only
         )
 
         self.stage = None
@@ -889,4 +906,4 @@ class QwenImageEditPipeline(nn.Module, SupportImageInput, QwenImageCFGParallelMi
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)

--- a/vllm_omni/diffusion/models/utils.py
+++ b/vllm_omni/diffusion/models/utils.py
@@ -72,7 +72,12 @@ def replace_linear_class(
     )
 
 
-def recursive_replace_linear(model: nn.Module, od_config: OmniDiffusionConfig):
+def recursive_replace_linear(
+    model: nn.Module,
+    od_config: OmniDiffusionConfig,
+    *,
+    root_prefix: str = "",
+):
     """Recursively replace modules in the model as needed.
     Currently, this replaces:
     - `nn.Linear` with vLLM's tensor parallel linear classes
@@ -93,7 +98,7 @@ def recursive_replace_linear(model: nn.Module, od_config: OmniDiffusionConfig):
             if new_module is not child_module:
                 setattr(module, child_name, new_module)
 
-    _recursive_replace(model, prefix="")
+    _recursive_replace(model, prefix=root_prefix)
 
 
 def init_parameters(
@@ -122,13 +127,15 @@ def create_transformers_model(
     hf_config: PretrainedConfig,
     dtype: torch.dtype | None = None,
     device: torch.device | None = None,
+    *,
+    root_prefix: str = "",
 ) -> PreTrainedModel:
     """Create a HuggingFace model using the given auto class and model name."""
     dtype = dtype or od_config.dtype
     device = device or torch.get_default_device()
     with init_on_device_without_buffers("meta"):
         model = auto_cls.from_config(hf_config)
-    recursive_replace_linear(model, od_config)
+    recursive_replace_linear(model, od_config, root_prefix=root_prefix)
     init_parameters(model, dtype=dtype, device=device)
     return model
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
ref #1854

## Purpose

Support FP8 quantization for the Qwen-Image-Edit text encoder part by following #1338.

This PR updates the Qwen Image Edit diffusion pipeline to:

- Load `text_encoder`, `transformer`, and `vae` through component weight sources.
- Instantiate the text encoder with `create_transformers_model(...)` so vLLM-Omni quantization replacement can be applied.
- Add a `root_prefix` path for recursive linear replacement, allowing quantization config entries such as `text_encoder`.
- Map HuggingFace Qwen-Image-Edit text encoder weight names to the vLLM model structure during weight loading.
- Load the VAE from config so it is populated through the unified weight loader.

It also adds a quantization quality test case for `Qwen/Qwen-Image-Edit` with FP8 applied to the text encoder.

## Test Plan

Run the targeted full-model quality test:

```bash
VLLM_OMNI_QUALITY_OUTPUT_DIR=/tmp/modelopt_quality_outputs \
.venv/bin/python -m pytest tests/diffusion/quantization/test_quantization_quality.py \
  -v -m "" -k "fp8_qwen_image_edit_text_encoder"
```

Run the e2e qwen image edit test:

```bash
.venv/bin/python -m pytest tests/e2e/accuracy/test_qwen_image_edit.py::test_qwen_image_edit_single_matches_diffusers -v -s
```

## Test Result

The result of full-model quality test is: 

```bash

============================================================
Quantization Quality: fp8_qwen_image_edit_text_encoder
============================================================
  Baseline:      Qwen/Qwen-Image-Edit
  Quantized:     Qwen/Qwen-Image-Edit
  Method:        {'text_encoder': {'method': 'fp8'}, 'transformer': None, 'vae': None}
  LPIPS:         0.0167  (threshold: 0.15)
  PSNR:          33.3159 dB  (higher is better)
  MAE:           0.014689  (lower is better)
  BF16 memory:   56.87 GiB
  Quant memory:  49.58 GiB  (13% reduction)
  Result:        PASS
============================================================

PASSED

PASSED
```

The result of e2e qwen image edit is:

```bash
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
============== 1 passed, 19 warnings in 188.01s (0:03:08) ==============
``` 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)

