### PR TITLE
[CI] Harden Qwen3-TTS perf nightly: enable Base voice_clone, add c=64/128, 2-GPU split

### DIFF
--- a/.buildkite/test-merge.yml
+++ b/.buildkite/test-merge.yml
@@ -172,7 +172,7 @@ steps:
               pytest -s -v tests/e2e/online_serving/test_qwen3_tts_customvoice.py tests/e2e/offline_inference/test_qwen3_tts_customvoice.py -m 'advanced_model and cuda' --run-level 'advanced_model'
             "
         agents:
-          queue: "gpu_1_queue"
+          queue: "gpu_4_queue"
         plugins:
           - docker#v5.2.0:
               image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
@@ -193,7 +193,7 @@ steps:
               pytest -s -v tests/e2e/online_serving/test_qwen3_tts_base.py tests/e2e/offline_inference/test_qwen3_tts_base.py -m 'advanced_model and cuda' --run-level 'advanced_model'
             "
         agents:
-          queue: "gpu_1_queue"
+          queue: "gpu_4_queue"
         plugins:
           - docker#v5.2.0:
               image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT

--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -298,7 +298,7 @@ steps:
                   - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
                     resources:
                       limits:
-                        nvidia.com/gpu: 1
+                        nvidia.com/gpu: 2
                     volumeMounts:
                       - name: devshm
                         mountPath: /dev/shm

--- a/.buildkite/test-ready.yml
+++ b/.buildkite/test-ready.yml
@@ -283,7 +283,7 @@ steps:
               pytest -s -v tests/e2e/online_serving/test_qwen3_tts_customvoice.py -m 'core_model' --run-level 'core_model'
             "
         agents:
-          queue: "gpu_1_queue"
+          queue: "gpu_4_queue"
         plugins:
           - docker#v5.2.0:
               image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
@@ -306,7 +306,7 @@ steps:
               pytest -s -v tests/e2e/online_serving/test_qwen3_tts_base.py -m 'core_model' --run-level 'core_model'
             "
         agents:
-          queue: "gpu_1_queue"
+          queue: "gpu_4_queue"
         plugins:
           - docker#v5.2.0:
               image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT

--- a/benchmarks/build_dataset/seed_tts_design/en/meta.lst
+++ b/benchmarks/build_dataset/seed_tts_design/en/meta.lst
@@ -18,3 +18,13 @@ vd017|||The quarterly results exceed expectations across all major metrics.|A sh
 vd018|||Chapter one. The morning sun filtered gently through the forest canopy.|A smooth, rich male audiobook narrator voice, expressive and engaging.
 vd019|||To be or not to be, that is the question.|A theatrical female voice, dramatic and expressive, stage projection quality.
 vd020|||And that is all for tonight. Stay well out there, everyone.|A warm, velvety male late-night radio DJ voice, smooth and intimate.
+vd021|||Please fasten your seatbelts; we will be experiencing some turbulence shortly.|A calm, professional female flight attendant voice, reassuring and clear.
+vd022|||The fossil record suggests these creatures lived more than sixty million years ago.|A measured male documentary narrator voice, scientific and curious.
+vd023|||Hey kiddo, did you finish your homework before dinner today?|A gentle, caring father voice, warm and slightly tired after a long day.
+vd024|||Live from courtside, the home team has just taken a commanding lead.|A high-energy male sports broadcaster, urgent and engaged.
+vd025|||Please remain on the line while I transfer you to the next available agent.|A polite, neutral female call-center voice, professional and patient.
+vd026|||I have a dream that one day this nation will rise up and live out the true meaning of its creed.|A powerful, resonant male orator voice, slow and impassioned.
+vd027|||Mama always said life was like a box of chocolates; you never know what you're gonna get.|A folksy male voice with a Southern American accent, warm and reflective.
+vd028|||Ahoy there, matey! Hoist the colors and prepare to set sail.|A theatrical pirate male voice, gruff and boisterous.
+vd029|||Ladies and gentlemen, please welcome to the stage our keynote speaker.|A polished female event MC voice, gracious and articulate.
+vd030|||Once you've completed the form, click submit and we'll review it within two business days.|A friendly female product-onboarding voice, encouraging and clear.

--- a/benchmarks/build_dataset/seed_tts_smoke/en/meta.lst
+++ b/benchmarks/build_dataset/seed_tts_smoke/en/meta.lst
@@ -18,3 +18,13 @@ smoke017|||In the distance, the mountains were shrouded in thick morning fog.
 smoke018|||Our company reported record revenue for the fourth quarter of the fiscal year.
 smoke019|||She explained the new policy in detail during the staff meeting this morning.
 smoke020|||The children laughed and played in the garden until the sun began to set.
+smoke021|||A long line of cars stretched along the coastal highway after the lighthouse opened.
+smoke022|||The chef recommended the seared scallops with a lemon butter sauce as the special.
+smoke023|||Our quarterly engineering review begins promptly at two in the afternoon on Thursday.
+smoke024|||Despite the heavy rain, the marathon runners kept a steady pace through downtown.
+smoke025|||She finished the crossword puzzle in under fifteen minutes while sipping her tea.
+smoke026|||The new release adds streaming output, faster startup, and better error reporting.
+smoke027|||His grandfather taught him how to whittle small wooden birds from cedar offcuts.
+smoke028|||Travelers were advised to check the timetable since trains were running on a holiday schedule.
+smoke029|||The startup launched a public beta after eighteen months of closed development.
+smoke030|||At night the desert sky filled with stars so bright the Milky Way was clearly visible.

--- a/tests/dfx/perf/tests/test_tts.json
+++ b/tests/dfx/perf/tests/test_tts.json
@@ -77,23 +77,6 @@
       },
       {
         "task": "voice_clone",
-        "eval_phase": "throughput",
-        "dataset_name": "seed-tts",
-        "backend": "openai-audio-speech",
-        "endpoint": "/v1/audio/speech",
-        "dataset_path": "linyueqian/seed-tts-eval-subset",
-        "num_prompts": [512],
-        "max_concurrency": [256],
-        "seed_tts_locale": "en",
-        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
-        "baseline": {
-          "median_audio_ttfp_ms": [22000],
-          "median_audio_rtf": [4.5],
-          "audio_throughput": [55.0]
-        }
-      },
-      {
-        "task": "voice_clone",
         "eval_phase": "quality",
         "enabled": false,
         "dataset_name": "seed-tts",
@@ -189,24 +172,6 @@
           "median_audio_ttfp_ms": [5500],
           "median_audio_rtf": [1.0],
           "audio_throughput": [120.0]
-        }
-      },
-      {
-        "task": "default_voice",
-        "eval_phase": "throughput",
-        "dataset_name": "seed-tts-text",
-        "backend": "openai-audio-speech",
-        "endpoint": "/v1/audio/speech",
-        "dataset_path": "benchmarks/build_dataset/seed_tts_smoke",
-        "num_prompts": [512],
-        "max_concurrency": [256],
-        "seed_tts_locale": "en",
-        "extra_body": {"voice": "Vivian", "language": "English", "task_type": "CustomVoice"},
-        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
-        "baseline": {
-          "median_audio_ttfp_ms": [10000],
-          "median_audio_rtf": [2.0],
-          "audio_throughput": [130.0]
         }
       },
       {
@@ -314,24 +279,6 @@
           "median_audio_ttfp_ms": [6000],
           "median_audio_rtf": [1.2],
           "audio_throughput": [100.0]
-        }
-      },
-      {
-        "task": "voice_design",
-        "eval_phase": "throughput",
-        "dataset_name": "seed-tts-design",
-        "backend": "openai-audio-speech",
-        "endpoint": "/v1/audio/speech",
-        "dataset_path": "benchmarks/build_dataset/seed_tts_design",
-        "num_prompts": [512],
-        "max_concurrency": [256],
-        "seed_tts_locale": "en",
-        "extra_body": {"task_type": "VoiceDesign", "language": "English"},
-        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
-        "baseline": {
-          "median_audio_ttfp_ms": [11000],
-          "median_audio_rtf": [2.2],
-          "audio_throughput": [110.0]
         }
       },
       {

--- a/tests/dfx/perf/tests/test_tts.json
+++ b/tests/dfx/perf/tests/test_tts.json
@@ -8,7 +8,7 @@
       {
         "task": "voice_clone",
         "eval_phase": "latency",
-        "enabled": false,
+        "enabled": true,
         "dataset_name": "seed-tts",
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",
@@ -24,7 +24,7 @@
       {
         "task": "voice_clone",
         "eval_phase": "throughput",
-        "enabled": false,
+        "enabled": true,
         "dataset_name": "seed-tts",
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",
@@ -41,7 +41,7 @@
       {
         "task": "voice_clone",
         "eval_phase": "quality",
-        "enabled": false,
+        "enabled": true,
         "dataset_name": "seed-tts",
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",

--- a/tests/dfx/perf/tests/test_tts.json
+++ b/tests/dfx/perf/tests/test_tts.json
@@ -31,48 +31,14 @@
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",
         "dataset_path": "linyueqian/seed-tts-eval-subset",
-        "num_prompts": [80],
-        "max_concurrency": [8],
+        "num_prompts": [80, 128, 256],
+        "max_concurrency": [8, 64, 128],
         "seed_tts_locale": "en",
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
-          "median_audio_ttfp_ms": [3500],
-          "median_audio_rtf": [0.75],
-          "audio_throughput": [10.0]
-        }
-      },
-      {
-        "task": "voice_clone",
-        "eval_phase": "throughput",
-        "dataset_name": "seed-tts",
-        "backend": "openai-audio-speech",
-        "endpoint": "/v1/audio/speech",
-        "dataset_path": "linyueqian/seed-tts-eval-subset",
-        "num_prompts": [128],
-        "max_concurrency": [64],
-        "seed_tts_locale": "en",
-        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
-        "baseline": {
-          "median_audio_ttfp_ms": [7000],
-          "median_audio_rtf": [1.5],
-          "audio_throughput": [40.0]
-        }
-      },
-      {
-        "task": "voice_clone",
-        "eval_phase": "throughput",
-        "dataset_name": "seed-tts",
-        "backend": "openai-audio-speech",
-        "endpoint": "/v1/audio/speech",
-        "dataset_path": "linyueqian/seed-tts-eval-subset",
-        "num_prompts": [256],
-        "max_concurrency": [128],
-        "seed_tts_locale": "en",
-        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
-        "baseline": {
-          "median_audio_ttfp_ms": [12000],
-          "median_audio_rtf": [2.5],
-          "audio_throughput": [50.0]
+          "median_audio_ttfp_ms": [3500, 7000, 12000],
+          "median_audio_rtf": [0.75, 1.5, 2.5],
+          "audio_throughput": [10.0, 40.0, 50.0]
         }
       },
       {
@@ -127,51 +93,15 @@
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",
         "dataset_path": "benchmarks/build_dataset/seed_tts_smoke",
-        "num_prompts": [80],
-        "max_concurrency": [8],
+        "num_prompts": [80, 128, 256],
+        "max_concurrency": [8, 64, 128],
         "seed_tts_locale": "en",
         "extra_body": {"voice": "Vivian", "language": "English", "task_type": "CustomVoice"},
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
-          "median_audio_ttfp_ms": [1500],
-          "median_audio_rtf": [0.30],
-          "audio_throughput": [30.0]
-        }
-      },
-      {
-        "task": "default_voice",
-        "eval_phase": "throughput",
-        "dataset_name": "seed-tts-text",
-        "backend": "openai-audio-speech",
-        "endpoint": "/v1/audio/speech",
-        "dataset_path": "benchmarks/build_dataset/seed_tts_smoke",
-        "num_prompts": [128],
-        "max_concurrency": [64],
-        "seed_tts_locale": "en",
-        "extra_body": {"voice": "Vivian", "language": "English", "task_type": "CustomVoice"},
-        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
-        "baseline": {
-          "median_audio_ttfp_ms": [3000],
-          "median_audio_rtf": [0.60],
-          "audio_throughput": [100.0]
-        }
-      },
-      {
-        "task": "default_voice",
-        "eval_phase": "throughput",
-        "dataset_name": "seed-tts-text",
-        "backend": "openai-audio-speech",
-        "endpoint": "/v1/audio/speech",
-        "dataset_path": "benchmarks/build_dataset/seed_tts_smoke",
-        "num_prompts": [256],
-        "max_concurrency": [128],
-        "seed_tts_locale": "en",
-        "extra_body": {"voice": "Vivian", "language": "English", "task_type": "CustomVoice"},
-        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
-        "baseline": {
-          "median_audio_ttfp_ms": [5500],
-          "median_audio_rtf": [1.0],
-          "audio_throughput": [120.0]
+          "median_audio_ttfp_ms": [1500, 3000, 5500],
+          "median_audio_rtf": [0.30, 0.60, 1.0],
+          "audio_throughput": [30.0, 100.0, 120.0]
         }
       },
       {
@@ -234,51 +164,15 @@
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",
         "dataset_path": "benchmarks/build_dataset/seed_tts_design",
-        "num_prompts": [80],
-        "max_concurrency": [8],
+        "num_prompts": [80, 128, 256],
+        "max_concurrency": [8, 64, 128],
         "seed_tts_locale": "en",
         "extra_body": {"task_type": "VoiceDesign", "language": "English"},
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
-          "median_audio_ttfp_ms": [1500],
-          "median_audio_rtf": [0.35],
-          "audio_throughput": [25.0]
-        }
-      },
-      {
-        "task": "voice_design",
-        "eval_phase": "throughput",
-        "dataset_name": "seed-tts-design",
-        "backend": "openai-audio-speech",
-        "endpoint": "/v1/audio/speech",
-        "dataset_path": "benchmarks/build_dataset/seed_tts_design",
-        "num_prompts": [128],
-        "max_concurrency": [64],
-        "seed_tts_locale": "en",
-        "extra_body": {"task_type": "VoiceDesign", "language": "English"},
-        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
-        "baseline": {
-          "median_audio_ttfp_ms": [3500],
-          "median_audio_rtf": [0.70],
-          "audio_throughput": [80.0]
-        }
-      },
-      {
-        "task": "voice_design",
-        "eval_phase": "throughput",
-        "dataset_name": "seed-tts-design",
-        "backend": "openai-audio-speech",
-        "endpoint": "/v1/audio/speech",
-        "dataset_path": "benchmarks/build_dataset/seed_tts_design",
-        "num_prompts": [256],
-        "max_concurrency": [128],
-        "seed_tts_locale": "en",
-        "extra_body": {"task_type": "VoiceDesign", "language": "English"},
-        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
-        "baseline": {
-          "median_audio_ttfp_ms": [6000],
-          "median_audio_rtf": [1.2],
-          "audio_throughput": [100.0]
+          "median_audio_ttfp_ms": [1500, 3500, 6000],
+          "median_audio_rtf": [0.35, 0.70, 1.2],
+          "audio_throughput": [25.0, 80.0, 100.0]
         }
       },
       {

--- a/tests/dfx/perf/tests/test_tts.json
+++ b/tests/dfx/perf/tests/test_tts.json
@@ -2,16 +2,19 @@
   {
     "test_name": "test_qwen3_tts_base",
     "server_params": {
-      "model": "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+      "model": "Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+      "stage_overrides": {
+        "1": {"devices": "1"}
+      }
     },
     "benchmark_params": [
       {
         "task": "voice_clone",
         "eval_phase": "latency",
-        "enabled": true,
         "dataset_name": "seed-tts",
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",
+        "dataset_path": "linyueqian/seed-tts-eval-subset",
         "num_prompts": [20],
         "max_concurrency": [1],
         "seed_tts_locale": "en",
@@ -24,10 +27,10 @@
       {
         "task": "voice_clone",
         "eval_phase": "throughput",
-        "enabled": true,
         "dataset_name": "seed-tts",
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",
+        "dataset_path": "linyueqian/seed-tts-eval-subset",
         "num_prompts": [80],
         "max_concurrency": [8],
         "seed_tts_locale": "en",
@@ -40,11 +43,63 @@
       },
       {
         "task": "voice_clone",
-        "eval_phase": "quality",
-        "enabled": true,
+        "eval_phase": "throughput",
         "dataset_name": "seed-tts",
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",
+        "dataset_path": "linyueqian/seed-tts-eval-subset",
+        "num_prompts": [128],
+        "max_concurrency": [64],
+        "seed_tts_locale": "en",
+        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
+        "baseline": {
+          "median_audio_ttfp_ms": [7000],
+          "median_audio_rtf": [1.5],
+          "audio_throughput": [40.0]
+        }
+      },
+      {
+        "task": "voice_clone",
+        "eval_phase": "throughput",
+        "dataset_name": "seed-tts",
+        "backend": "openai-audio-speech",
+        "endpoint": "/v1/audio/speech",
+        "dataset_path": "linyueqian/seed-tts-eval-subset",
+        "num_prompts": [256],
+        "max_concurrency": [128],
+        "seed_tts_locale": "en",
+        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
+        "baseline": {
+          "median_audio_ttfp_ms": [12000],
+          "median_audio_rtf": [2.5],
+          "audio_throughput": [50.0]
+        }
+      },
+      {
+        "task": "voice_clone",
+        "eval_phase": "throughput",
+        "dataset_name": "seed-tts",
+        "backend": "openai-audio-speech",
+        "endpoint": "/v1/audio/speech",
+        "dataset_path": "linyueqian/seed-tts-eval-subset",
+        "num_prompts": [512],
+        "max_concurrency": [256],
+        "seed_tts_locale": "en",
+        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
+        "baseline": {
+          "median_audio_ttfp_ms": [22000],
+          "median_audio_rtf": [4.5],
+          "audio_throughput": [55.0]
+        }
+      },
+      {
+        "task": "voice_clone",
+        "eval_phase": "quality",
+        "enabled": false,
+        "dataset_name": "seed-tts",
+        "backend": "openai-audio-speech",
+        "endpoint": "/v1/audio/speech",
+        "dataset_path": "linyueqian/seed-tts-eval-subset",
         "num_prompts": [200],
         "max_concurrency": [4],
         "seed_tts_locale": "en",
@@ -59,7 +114,10 @@
   {
     "test_name": "test_qwen3_tts_customvoice",
     "server_params": {
-      "model": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+      "model": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+      "stage_overrides": {
+        "1": {"devices": "1"}
+      }
     },
     "benchmark_params": [
       {
@@ -95,6 +153,60 @@
           "median_audio_ttfp_ms": [1500],
           "median_audio_rtf": [0.30],
           "audio_throughput": [30.0]
+        }
+      },
+      {
+        "task": "default_voice",
+        "eval_phase": "throughput",
+        "dataset_name": "seed-tts-text",
+        "backend": "openai-audio-speech",
+        "endpoint": "/v1/audio/speech",
+        "dataset_path": "benchmarks/build_dataset/seed_tts_smoke",
+        "num_prompts": [128],
+        "max_concurrency": [64],
+        "seed_tts_locale": "en",
+        "extra_body": {"voice": "Vivian", "language": "English", "task_type": "CustomVoice"},
+        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
+        "baseline": {
+          "median_audio_ttfp_ms": [3000],
+          "median_audio_rtf": [0.60],
+          "audio_throughput": [100.0]
+        }
+      },
+      {
+        "task": "default_voice",
+        "eval_phase": "throughput",
+        "dataset_name": "seed-tts-text",
+        "backend": "openai-audio-speech",
+        "endpoint": "/v1/audio/speech",
+        "dataset_path": "benchmarks/build_dataset/seed_tts_smoke",
+        "num_prompts": [256],
+        "max_concurrency": [128],
+        "seed_tts_locale": "en",
+        "extra_body": {"voice": "Vivian", "language": "English", "task_type": "CustomVoice"},
+        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
+        "baseline": {
+          "median_audio_ttfp_ms": [5500],
+          "median_audio_rtf": [1.0],
+          "audio_throughput": [120.0]
+        }
+      },
+      {
+        "task": "default_voice",
+        "eval_phase": "throughput",
+        "dataset_name": "seed-tts-text",
+        "backend": "openai-audio-speech",
+        "endpoint": "/v1/audio/speech",
+        "dataset_path": "benchmarks/build_dataset/seed_tts_smoke",
+        "num_prompts": [512],
+        "max_concurrency": [256],
+        "seed_tts_locale": "en",
+        "extra_body": {"voice": "Vivian", "language": "English", "task_type": "CustomVoice"},
+        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
+        "baseline": {
+          "median_audio_ttfp_ms": [10000],
+          "median_audio_rtf": [2.0],
+          "audio_throughput": [130.0]
         }
       },
       {
@@ -166,6 +278,60 @@
           "median_audio_ttfp_ms": [1500],
           "median_audio_rtf": [0.35],
           "audio_throughput": [25.0]
+        }
+      },
+      {
+        "task": "voice_design",
+        "eval_phase": "throughput",
+        "dataset_name": "seed-tts-design",
+        "backend": "openai-audio-speech",
+        "endpoint": "/v1/audio/speech",
+        "dataset_path": "benchmarks/build_dataset/seed_tts_design",
+        "num_prompts": [128],
+        "max_concurrency": [64],
+        "seed_tts_locale": "en",
+        "extra_body": {"task_type": "VoiceDesign", "language": "English"},
+        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
+        "baseline": {
+          "median_audio_ttfp_ms": [3500],
+          "median_audio_rtf": [0.70],
+          "audio_throughput": [80.0]
+        }
+      },
+      {
+        "task": "voice_design",
+        "eval_phase": "throughput",
+        "dataset_name": "seed-tts-design",
+        "backend": "openai-audio-speech",
+        "endpoint": "/v1/audio/speech",
+        "dataset_path": "benchmarks/build_dataset/seed_tts_design",
+        "num_prompts": [256],
+        "max_concurrency": [128],
+        "seed_tts_locale": "en",
+        "extra_body": {"task_type": "VoiceDesign", "language": "English"},
+        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
+        "baseline": {
+          "median_audio_ttfp_ms": [6000],
+          "median_audio_rtf": [1.2],
+          "audio_throughput": [100.0]
+        }
+      },
+      {
+        "task": "voice_design",
+        "eval_phase": "throughput",
+        "dataset_name": "seed-tts-design",
+        "backend": "openai-audio-speech",
+        "endpoint": "/v1/audio/speech",
+        "dataset_path": "benchmarks/build_dataset/seed_tts_design",
+        "num_prompts": [512],
+        "max_concurrency": [256],
+        "seed_tts_locale": "en",
+        "extra_body": {"task_type": "VoiceDesign", "language": "English"},
+        "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
+        "baseline": {
+          "median_audio_ttfp_ms": [11000],
+          "median_audio_rtf": [2.2],
+          "audio_throughput": [110.0]
         }
       },
       {


### PR DESCRIPTION
## Purpose

Originally this PR just enabled the three disabled Base voice_clone phases in nightly perf CI (per the v0.18→v0.20 latency regression caught externally). After build 9556 surfaced both a dataset-staging gap and a 2-GPU stage-split cliff at very high concurrency, scope expanded to make Qwen3-TTS nightly perf a real, runnable gate for the high-throughput regime called out in [RFC #3535](https://github.com/vllm-project/vllm-omni/issues/3535).

## Changes

**`tests/dfx/perf/tests/test_tts.json`**
- Enable Base voice_clone `latency` (c=1) and `throughput` (c=8). Keep `quality` (c=4) `enabled: false` (WER infra not staged in the Buildkite container, matching the existing CustomVoice-quality precedent).
- Add `throughput` cells at c=64 and c=128 across all three task variants: Base voice_clone, CustomVoice default_voice, and CustomVoice voice_design.
- Point Base voice_clone at `linyueqian/seed-tts-eval-subset` on HF Hub (the bench's `SeedTTSDataset` auto-`snapshot_download`s into the existing `hf-cache` volume on first nightly).
- Add `stage_overrides: {"1": {"devices": "1"}}` on both `server_params` so stage 0 (talker) and stage 1 (code2wav) split across two GPUs — matches the `2-GPU split` bench shape in RFC #3535.

**Dataset assets**
- `linyueqian/seed-tts-eval-subset` (new HF dataset, public): 100 rows / 98 unique prompt-WAVs, deterministic seed=42 shuffle of `zhaochenyang20/seed-tts-eval` (the SGLang Omni TTS mirror of `BytedanceSpeech/seed-tts-eval`). 4-field meta.lst + `en/prompt-wavs/`, ~22MB total.
- `benchmarks/build_dataset/seed_tts_smoke/en/meta.lst`: 20 → 30 rows.
- `benchmarks/build_dataset/seed_tts_design/en/meta.lst`: 20 → 30 rows.
- The 30-row pools give every high-c cell at least 30 distinct voices before the bench's oversampler reuses entries.

**`.buildkite/test-nightly.yml`** — TTS Perf job `nvidia.com/gpu: 1 → 2` to back the 2-GPU split topology.

**`.buildkite/test-ready.yml` + `test-merge.yml`** — switch TTS CustomVoice + Base function-test queues `gpu_1_queue → gpu_4_queue` so the host can later host 2-GPU serving cases (function tests themselves still run `num_cards=1` — that migration is a separate PR).

## Test Plan

`test-nightly.yml` already runs `tests/dfx/perf` when the `omni-test` / `nightly-test` label is applied or `NIGHTLY=1` is set. With this change the nightly will exercise:

| test | task | latency (c=1) | throughput (c=8) | throughput (c=64) | throughput (c=128) | stress | quality |
|---|---|---|---|---|---|---|---|
| `test_qwen3_tts_base` | voice_clone | enabled | enabled | enabled | enabled | — | disabled (WER) |
| `test_qwen3_tts_customvoice` | default_voice | enabled | enabled | enabled | enabled | enabled | disabled (WER) |
| `test_qwen3_tts_customvoice` | voice_design | enabled | enabled | enabled | enabled | enabled | — |

= 14 active cells per nightly. Baselines for new cells are conservative extrapolations from existing c=32 numbers; the runner only `print`s on baseline miss (does not fail the build), so they're informational placeholders to be tightened after first nightly produces real H100 numbers.

## Test Result

Build 9556 confirmed the new pipeline runs end-to-end through c=128:
- c=1 (latency): completed
- c=8 (throughput): completed
- c=64 (throughput): completed
- c=128 (throughput): completed
- c=256 (throughput): **stalled** under 2-GPU split — stage 1 (code2wav on GPU 1) flooded with `Code2Wav input_ids length 1 not divisible by num_quantizers 16` warnings, request stream never drained, job hit 180-min timeout.

c=256 cells were dropped from this PR. The c=128 → c=256 cliff under stage split is a real scheduler/connector interaction (length-1 chunk emission across the GPU boundary) and belongs to a follow-up workstream tied to RFC #3535 (WS-4 backpressure / WS-5 SHM routing). Tracking is open; this PR ships the c=1/8/64/128 envelope today and removes the v0.20 regression blind spot.

## Out of scope (follow-up)

- c=256 cells — separate root-cause investigation (chunk fragmentation under 2-GPU split)
- Function-test 2-GPU coverage — queue resource is provisioned here; updating `num_cards=2` and Deploy YAML is a separate change
- WER quality phases — depends on seed-tts-eval being staged in the Buildkite container

---
<details>
<summary>Checklist</summary>

- [x] Purpose
- [x] Test plan / scripts
- [x] Test results (build 9556 evidence)
- [ ] Docs update — not needed (CI-only change)
- [ ] Release notes — not user-facing
</details>
