### PR TITLE
[CI] skip failing diffusion and accuracy cases (#3432, #3256, #3257, #3488)

### DIFF
--- a/tests/e2e/accuracy/test_diffusers_backend_similarity.py
+++ b/tests/e2e/accuracy/test_diffusers_backend_similarity.py
@@ -279,7 +279,15 @@ def test_diffusers_backend_t2i_matches_diffusers(model_id: str, accuracy_artifac
 
 @pytest.mark.benchmark
 @hardware_test(res={"cuda": "H100"}, num_cards=1)
-@pytest.mark.parametrize("model_id", ["Wan-AI/Wan2.2-I2V-A14B-Diffusers"])
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        pytest.param(
+            "Wan-AI/Wan2.2-I2V-A14B-Diffusers",
+            marks=pytest.mark.skip(reason="#3488"),
+        ),
+    ],
+)
 def test_diffusers_backend_i2v_matches_diffusers(
     model_id: str,
     accuracy_artifact_root: Path,

--- a/tests/e2e/accuracy/test_gebench_h100_smoke.py
+++ b/tests/e2e/accuracy/test_gebench_h100_smoke.py
@@ -14,6 +14,7 @@ pytestmark = [pytest.mark.diffusion, pytest.mark.full_model]
 
 @pytest.mark.benchmark
 @hardware_test(res={"cuda": "H100"}, num_cards=1)
+@pytest.mark.skip(reason="#3256")
 def test_gebench_h100_smoke(
     gebench_accuracy_servers,
     accuracy_artifact_root: Path,

--- a/tests/e2e/accuracy/test_gedit_bench_h100_smoke.py
+++ b/tests/e2e/accuracy/test_gedit_bench_h100_smoke.py
@@ -15,6 +15,7 @@ pytestmark = [pytest.mark.diffusion, pytest.mark.full_model]
 
 @pytest.mark.benchmark
 @hardware_test(res={"cuda": "H100"}, num_cards=1)
+@pytest.mark.skip(reason="#3257")
 def test_gedit_bench_h100_smoke(
     gedit_accuracy_servers,
     accuracy_artifact_root: Path,

--- a/tests/e2e/online_serving/test_sd3_expansion.py
+++ b/tests/e2e/online_serving/test_sd3_expansion.py
@@ -37,7 +37,10 @@ def _get_diffusion_feature_cases(model: str):
                     "2",
                 ],
             ),
-            marks=FOUR_CARD_FEATURE_MARKS,
+            marks=[
+                *FOUR_CARD_FEATURE_MARKS,
+                pytest.mark.skip(reason="#3432"),
+            ],
         ),
     ]
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Temporarily skip several CI / accuracy tests that are failing or unstable until the linked issues are resolved:

- `tests/e2e/online_serving/test_sd3_expansion.py::test_sd3_medium[omni_server0]` — see [#3432](https://github.com/vllm-project/vllm-omni/issues/3432)
- `tests/e2e/accuracy/test_gebench_h100_smoke.py::test_gebench_h100_smoke` — see [#3256](https://github.com/vllm-project/vllm-omni/issues/3256)
- `tests/e2e/accuracy/test_gedit_bench_h100_smoke.py::test_gedit_bench_h100_smoke` — see [#3257](https://github.com/vllm-project/vllm-omni/issues/3257)
- `tests/e2e/accuracy/test_diffusers_backend_similarity.py::test_diffusers_backend_i2v_matches_diffusers[Wan-AI/Wan2.2-I2V-A14B-Diffusers]` — see [#3488](https://github.com/vllm-project/vllm-omni/issues/3488)

## Test Plan


## Test Result


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
