### PR TITLE
[Bugfix] Align the AR and DiT prompt formatting across both online and offline modes.

### DIFF
--- a/examples/offline_inference/hunyuan_image3/end2end.py
+++ b/examples/offline_inference/hunyuan_image3/end2end.py
@@ -193,8 +193,8 @@ def main():
     formatted_prompts: list[OmniPromptType] = []
     for p in prompts:
         result = build_prompt_tokens(p, tokenizer, task=task, sys_type=args.sys_type)
-        token_ids = result["token_ids"]
-        effective_sys_type = result["system_prompt_type"]
+        token_ids = result.token_ids
+        effective_sys_type = result.system_prompt_type
 
         # `prompt_token_ids` drives the AR stage (matches HF byte-for-byte).
         # `prompt` and `use_system_prompt` are forwarded by ar2diffusion to

--- a/examples/offline_inference/hunyuan_image3/end2end.py
+++ b/examples/offline_inference/hunyuan_image3/end2end.py
@@ -192,9 +192,9 @@ def main():
     # Format prompts
     formatted_prompts: list[OmniPromptType] = []
     for p in prompts:
-        token_ids = build_prompt_tokens(p, tokenizer, task=task, sys_type=args.sys_type)
-        preset_sys_type, _, _ = _TASK_PRESETS[task]
-        effective_sys_type = args.sys_type or preset_sys_type
+        result = build_prompt_tokens(p, tokenizer, task=task, sys_type=args.sys_type)
+        token_ids = result["token_ids"]
+        effective_sys_type = result["system_prompt_type"]
 
         # `prompt_token_ids` drives the AR stage (matches HF byte-for-byte).
         # `prompt` and `use_system_prompt` are forwarded by ar2diffusion to

--- a/tests/diffusion/models/hunyuan_image3/test_prompt_utils.py
+++ b/tests/diffusion/models/hunyuan_image3/test_prompt_utils.py
@@ -180,14 +180,16 @@ def test_build_prompt_tokens_segments_each_boundary():
 
 def test_build_prompt_tokens_image_placeholder_present_for_image_tasks():
     tok = FakeTokenizer()
-    ids = build_prompt_tokens("hi", tok, task="i2t")
+    result = build_prompt_tokens("hi", tok, task="i2t")
+    ids = result["token_ids"]
     assert ids[0] == FakeTokenizer.SPECIAL["<|startoftext|>"], "BOS (<|startoftext|>) must be the first token"
     assert FakeTokenizer.SPECIAL["<img>"] in ids, "<img> placeholder must be present for i2t/it2i tasks"
 
 
 def test_build_prompt_tokens_no_image_for_text_only_tasks():
     tok = FakeTokenizer()
-    ids = build_prompt_tokens("hi", tok, task="t2t")
+    result = build_prompt_tokens("hi", tok, task="t2t")
+    ids = result["token_ids"]
     assert FakeTokenizer.SPECIAL["<img>"] not in ids, "<img> must NOT appear for text-only tasks"
 
 
@@ -203,14 +205,16 @@ def test_build_prompt_tokens_no_image_for_text_only_tasks():
 def test_build_prompt_tokens_trigger_is_last_token(task: str, trigger_id: int):
     """Trigger tag id must be the LAST token (after `Assistant: ` segment)."""
     tok = FakeTokenizer()
-    ids = build_prompt_tokens("hi", tok, task=task)
+    result = build_prompt_tokens("hi", tok, task=task)
+    ids = result["token_ids"]
     assert ids[-1] == trigger_id
 
 
 def test_build_prompt_tokens_no_trigger_for_plain_tasks():
     """Tasks without trigger_tag (t2t / i2t) must NOT append a trigger id."""
     tok = FakeTokenizer()
-    ids = build_prompt_tokens("hi", tok, task="t2t")
+    result = build_prompt_tokens("hi", tok, task="t2t")
+    ids = result["token_ids"]
     assert ids[-1] not in {
         FakeTokenizer.SPECIAL["<think>"],
         FakeTokenizer.SPECIAL["<recaption>"],
@@ -305,7 +309,8 @@ def test_segment_tokenize_diverges_from_full_string_encode():
     tok = AutoTokenizer.from_pretrained(_HUNYUAN_MODEL_ID, trust_remote_code=True)
 
     user_prompt = "写一首关于夜的诗。"
-    seg_ids = build_prompt_tokens(user_prompt, tok, task="i2t")
+    result = build_prompt_tokens(user_prompt, tok, task="i2t")
+    seg_ids = result["token_ids"]
     full_ids = tok.encode(build_prompt(user_prompt, task="i2t"), add_special_tokens=False)
 
     assert seg_ids != full_ids, (

--- a/tests/diffusion/models/hunyuan_image3/test_prompt_utils.py
+++ b/tests/diffusion/models/hunyuan_image3/test_prompt_utils.py
@@ -181,7 +181,7 @@ def test_build_prompt_tokens_segments_each_boundary():
 def test_build_prompt_tokens_image_placeholder_present_for_image_tasks():
     tok = FakeTokenizer()
     result = build_prompt_tokens("hi", tok, task="i2t")
-    ids = result["token_ids"]
+    ids = result.token_ids
     assert ids[0] == FakeTokenizer.SPECIAL["<|startoftext|>"], "BOS (<|startoftext|>) must be the first token"
     assert FakeTokenizer.SPECIAL["<img>"] in ids, "<img> placeholder must be present for i2t/it2i tasks"
 
@@ -189,7 +189,7 @@ def test_build_prompt_tokens_image_placeholder_present_for_image_tasks():
 def test_build_prompt_tokens_no_image_for_text_only_tasks():
     tok = FakeTokenizer()
     result = build_prompt_tokens("hi", tok, task="t2t")
-    ids = result["token_ids"]
+    ids = result.token_ids
     assert FakeTokenizer.SPECIAL["<img>"] not in ids, "<img> must NOT appear for text-only tasks"
 
 
@@ -206,7 +206,7 @@ def test_build_prompt_tokens_trigger_is_last_token(task: str, trigger_id: int):
     """Trigger tag id must be the LAST token (after `Assistant: ` segment)."""
     tok = FakeTokenizer()
     result = build_prompt_tokens("hi", tok, task=task)
-    ids = result["token_ids"]
+    ids = result.token_ids
     assert ids[-1] == trigger_id
 
 
@@ -214,7 +214,7 @@ def test_build_prompt_tokens_no_trigger_for_plain_tasks():
     """Tasks without trigger_tag (t2t / i2t) must NOT append a trigger id."""
     tok = FakeTokenizer()
     result = build_prompt_tokens("hi", tok, task="t2t")
-    ids = result["token_ids"]
+    ids = result.token_ids
     assert ids[-1] not in {
         FakeTokenizer.SPECIAL["<think>"],
         FakeTokenizer.SPECIAL["<recaption>"],
@@ -310,7 +310,7 @@ def test_segment_tokenize_diverges_from_full_string_encode():
 
     user_prompt = "写一首关于夜的诗。"
     result = build_prompt_tokens(user_prompt, tok, task="i2t")
-    seg_ids = result["token_ids"]
+    seg_ids = result.token_ids
     full_ids = tok.encode(build_prompt(user_prompt, task="i2t"), add_special_tokens=False)
 
     assert seg_ids != full_ids, (

--- a/tests/e2e/accuracy/test_hunyuan_image3.py
+++ b/tests/e2e/accuracy/test_hunyuan_image3.py
@@ -93,7 +93,9 @@ def _run(stage_config_path: str, output_path: Path) -> tuple[Image.Image, str, f
     from vllm_omni.platforms import current_omni_platform
 
     tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, trust_remote_code=True)
-    token_ids = build_prompt_tokens(PROMPT, tokenizer, task="it2i_recaption", sys_type="en_unified")
+    result = build_prompt_tokens(PROMPT, tokenizer, task="it2i_recaption", sys_type="en_unified")
+    token_ids = result["token_ids"]
+    system_prompt_type = result["system_prompt_type"]
 
     with OmniRunner(MODEL_NAME, stage_configs_path=stage_config_path) as runner:
         params_list = list(runner.omni.default_sampling_params_list)
@@ -108,7 +110,7 @@ def _run(stage_config_path: str, output_path: Path) -> tuple[Image.Image, str, f
             {
                 "prompt_token_ids": token_ids,
                 "prompt": PROMPT,
-                "use_system_prompt": "en_unified",
+                "use_system_prompt": system_prompt_type,
                 "height": HEIGHT,
                 "width": WIDTH,
             }

--- a/tests/e2e/accuracy/test_hunyuan_image3.py
+++ b/tests/e2e/accuracy/test_hunyuan_image3.py
@@ -94,8 +94,8 @@ def _run(stage_config_path: str, output_path: Path) -> tuple[Image.Image, str, f
 
     tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME, trust_remote_code=True)
     result = build_prompt_tokens(PROMPT, tokenizer, task="it2i_recaption", sys_type="en_unified")
-    token_ids = result["token_ids"]
-    system_prompt_type = result["system_prompt_type"]
+    token_ids = result.token_ids
+    system_prompt_type = result.system_prompt_type
 
     with OmniRunner(MODEL_NAME, stage_configs_path=stage_config_path) as runner:
         params_list = list(runner.omni.default_sampling_params_list)

--- a/vllm_omni/diffusion/models/hunyuan_image3/prompt_utils.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/prompt_utils.py
@@ -134,7 +134,7 @@ def build_prompt_tokens(
     task: str = "it2i_think",
     sys_type: str | None = None,
     custom_system_prompt: str | None = None,
-) -> list[int]:
+) -> dict[str, Any]:
     """Segment-by-segment tokenization that matches HF apply_chat_template.
 
     Calling tokenizer.encode(build_prompt(...)) on the full string lets BPE
@@ -144,6 +144,11 @@ def build_prompt_tokens(
     each segment independently and concatenates token_ids, so no cross-
     boundary merge happens. We replicate that here and feed the result to
     Omni via OmniTokensPrompt (prompt_token_ids).
+
+    Returns:
+        A dictionary containing:
+        - token_ids: list[int] - The tokenized prompt
+        - system_prompt_type: str - The effective system prompt type used
     """
     if task not in _TASK_PRESETS:
         raise ValueError(f"Unknown task {task!r}. Choose from: {available_tasks()}")
@@ -162,7 +167,11 @@ def build_prompt_tokens(
     # protect, fall back to whole-string encode.
     if task == "t2i_vanilla":
         s = build_prompt(user_prompt, task, sys_type, custom_system_prompt)
-        return tokenizer.encode(s, add_special_tokens=False)
+        token_ids = tokenizer.encode(s, add_special_tokens=False)
+        return {
+            "token_ids": token_ids,
+            "system_prompt_type": effective_sys_type,
+        }
 
     system_prompt = get_system_prompt(effective_sys_type, preset_bot_task, custom_system_prompt)
     # Do NOT strip -- HF apply_chat_template keeps the system prompt's
@@ -180,7 +189,11 @@ def build_prompt_tokens(
     ids += tokenizer.encode("\n\nAssistant: ", add_special_tokens=False)
     if trig_id is not None:
         ids += [trig_id]
-    return ids
+
+    return {
+        "token_ids": ids,
+        "system_prompt_type": effective_sys_type,
+    }
 
 
 __all__ = ["build_prompt", "build_prompt_tokens", "resolve_stop_token_ids", _TASK_PRESETS]

--- a/vllm_omni/diffusion/models/hunyuan_image3/prompt_utils.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/prompt_utils.py
@@ -17,6 +17,7 @@ canonical mapping for both flows.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from .system_prompt import get_system_prompt
@@ -128,13 +129,19 @@ def build_prompt(
     return "".join(parts)
 
 
+@dataclass
+class PromptTokensResult:
+    token_ids: list[int]  # The tokenized prompt
+    system_prompt_type: str  # The effective system prompt type used
+
+
 def build_prompt_tokens(
     user_prompt: str,
     tokenizer,
     task: str = "it2i_think",
     sys_type: str | None = None,
     custom_system_prompt: str | None = None,
-) -> dict[str, Any]:
+) -> PromptTokensResult:
     """Segment-by-segment tokenization that matches HF apply_chat_template.
 
     Calling tokenizer.encode(build_prompt(...)) on the full string lets BPE
@@ -146,9 +153,7 @@ def build_prompt_tokens(
     Omni via OmniTokensPrompt (prompt_token_ids).
 
     Returns:
-        A dictionary containing:
-        - token_ids: list[int] - The tokenized prompt
-        - system_prompt_type: str - The effective system prompt type used
+        PromptTokensResult
     """
     if task not in _TASK_PRESETS:
         raise ValueError(f"Unknown task {task!r}. Choose from: {available_tasks()}")
@@ -168,10 +173,10 @@ def build_prompt_tokens(
     if task == "t2i_vanilla":
         s = build_prompt(user_prompt, task, sys_type, custom_system_prompt)
         token_ids = tokenizer.encode(s, add_special_tokens=False)
-        return {
-            "token_ids": token_ids,
-            "system_prompt_type": effective_sys_type,
-        }
+        return PromptTokensResult(
+            token_ids=token_ids,
+            system_prompt_type=effective_sys_type,
+        )
 
     system_prompt = get_system_prompt(effective_sys_type, preset_bot_task, custom_system_prompt)
     # Do NOT strip -- HF apply_chat_template keeps the system prompt's
@@ -190,10 +195,10 @@ def build_prompt_tokens(
     if trig_id is not None:
         ids += [trig_id]
 
-    return {
-        "token_ids": ids,
-        "system_prompt_type": effective_sys_type,
-    }
+    return PromptTokensResult(
+        token_ids=ids,
+        system_prompt_type=effective_sys_type,
+    )
 
 
 __all__ = ["build_prompt", "build_prompt_tokens", "resolve_stop_token_ids", _TASK_PRESETS]

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2256,7 +2256,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 engine_prompt_data = {"image": reference_images}
 
         engine_prompt: OmniTextPrompt = {"prompt": prompt}
-        if bot_task:  # model-specific
+        if bot_task:
             from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import (
                 build_prompt,
                 build_prompt_tokens,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2255,31 +2255,33 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             else:
                 engine_prompt_data = {"image": reference_images}
 
-        prompt_token_ids: list[int] | None = None
-        system_prompt_type: str | None = None
+        engine_prompt: OmniTextPrompt = {"prompt": prompt}
         if bot_task:  # model-specific
             from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import (
                 build_prompt,
                 build_prompt_tokens,
             )
 
+            prompt_token_ids: list[int] | None = None
+            system_prompt_type: str | None = None
             if tokenizer is not None:
                 result = build_prompt_tokens(prompt, tokenizer, task=bot_task)
                 prompt_token_ids = result.token_ids
                 system_prompt_type = result.system_prompt_type
             else:
                 prompt = build_prompt(prompt, task=bot_task)
+                engine_prompt["prompt"] = prompt
 
             if reference_images and len(reference_images) == 1:
                 engine_prompt_data = {"image": reference_images[0]}
                 modalities = ["image"]
+            if prompt_token_ids is not None:
+                engine_prompt["prompt_token_ids"] = prompt_token_ids
+            if system_prompt_type is not None:
+                engine_prompt["use_system_prompt"] = system_prompt_type
 
         engine_prompt: OmniTextPrompt = {"prompt": prompt}
         engine_prompt["modalities"] = modalities
-        if prompt_token_ids is not None:
-            engine_prompt["prompt_token_ids"] = prompt_token_ids
-        if bot_task and system_prompt_type is not None:
-            engine_prompt["use_system_prompt"] = system_prompt_type
         if negative_prompt is not None:
             engine_prompt["negative_prompt"] = negative_prompt
 

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2257,7 +2257,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
         prompt_token_ids: list[int] | None = None
         system_prompt_type: str | None = None
-        if bot_task:
+        if bot_task:  # model-specific
             from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import (
                 build_prompt,
                 build_prompt_tokens,
@@ -2278,7 +2278,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         engine_prompt["modalities"] = modalities
         if prompt_token_ids is not None:
             engine_prompt["prompt_token_ids"] = prompt_token_ids
-        if system_prompt_type is not None:
+        if bot_task and system_prompt_type is not None:
             engine_prompt["use_system_prompt"] = system_prompt_type
         if negative_prompt is not None:
             engine_prompt["negative_prompt"] = negative_prompt

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2280,7 +2280,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             if system_prompt_type is not None:
                 engine_prompt["use_system_prompt"] = system_prompt_type
 
-        engine_prompt: OmniTextPrompt = {"prompt": prompt}
         engine_prompt["modalities"] = modalities
         if negative_prompt is not None:
             engine_prompt["negative_prompt"] = negative_prompt

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2256,6 +2256,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 engine_prompt_data = {"image": reference_images}
 
         prompt_token_ids: list[int] | None = None
+        system_prompt_type: str | None = None
         if bot_task:
             from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import (
                 build_prompt,
@@ -2263,7 +2264,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             )
 
             if tokenizer is not None:
-                prompt_token_ids = build_prompt_tokens(prompt, tokenizer, task=bot_task)
+                result = build_prompt_tokens(prompt, tokenizer, task=bot_task)
+                prompt_token_ids = result["token_ids"]
+                system_prompt_type = result["system_prompt_type"]
             else:
                 prompt = build_prompt(prompt, task=bot_task)
 
@@ -2275,6 +2278,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         engine_prompt["modalities"] = modalities
         if prompt_token_ids is not None:
             engine_prompt["prompt_token_ids"] = prompt_token_ids
+        if system_prompt_type is not None:
+            engine_prompt["use_system_prompt"] = system_prompt_type
         if negative_prompt is not None:
             engine_prompt["negative_prompt"] = negative_prompt
 

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2265,8 +2265,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
             if tokenizer is not None:
                 result = build_prompt_tokens(prompt, tokenizer, task=bot_task)
-                prompt_token_ids = result["token_ids"]
-                system_prompt_type = result["system_prompt_type"]
+                prompt_token_ids = result.token_ids
+                system_prompt_type = result.system_prompt_type
             else:
                 prompt = build_prompt(prompt, task=bot_task)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Making the AR prompt template consistent with DiT, mainly by aligning their system prompts.

**Before the change**:
AR called build_prompt_tokens to construct token IDs from the user prompt. During this process, the system prompt was automatically prepended. However, the information indicating that a system prompt had been applied was not propagated to the downstream DiT module, resulting in inconsistent prompts between AR and DiT.

**After the change**:
AR calls build_prompt_tokens and, in addition to returning the token IDs, also returns whether a system prompt was used. This information is then passed to DiT, allowing DiT to construct the exact same prompt as AR.




## Test Plan
(1) unitest
```
pytest -s -v tests/diffusion/models/hunyuan_image3/test_prompt_utils.py
```
(2) end2end test
```
curl -X POST http://localhost:8091/v1/images/edits \
  -F "image=@./input_0_0.png" \
  -F "prompt=新年宠物海报，Q版圆润的可爱标题\"新年快乐汪\"，副标题\"HAPPY NEW YEAR\"。 鱼眼镜头，背景是房间门口，近景，上传的主体歪头笑，围着红色围巾，戴着红色毛线帽，高清，绒毛细节，面部特写。 宝丽莱相纸，超现实主义，写实主义，胶片摄影，打印颗粒感肌理。肌理，超写实，复古感。" \
  -F "bot_task=it2i_think" \
  -F "n=1" \
  -F "num_inference_steps=50" \
  -F "guidance_scale=2.5" \
  -F "seed=42" \
  | jq -r '.data[0].b64_json' \
  | base64 -d > result.png
```

## Test Result
### Unitest
<img width="2386" height="198" alt="image" src="https://github.com/user-attachments/assets/c6a07da1-083c-4f0b-b54e-67d99ad2368d" />



### end2end 
| task | kv reuse | online/offline  | output |
|-----|-----|-----|-----|
| it2i  | False  | online  | <img width="208" height="304" alt="online_no_reuse" src="https://github.com/user-attachments/assets/19b5f92e-7d52-468f-9969-b91e925003f8" /> |
| it2i  | True  | online  | <img width="208" height="304" alt="online_reuse" src="https://github.com/user-attachments/assets/fadeb6f0-a659-454a-b904-5ccf8900eddd" /> |
| it2i  | False  | offline | <img width="208" height="304" alt="offline_no_reuse" src="https://github.com/user-attachments/assets/1eea6b5c-f03d-4fd1-9887-8efd3b8a30fb" /> |
| it2i  | True  | offline | <img width="208" height="304" alt="offline_reuse" src="https://github.com/user-attachments/assets/562fafae-dd1f-4c11-b56a-51274716d8b8" /> |


---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
