### PR TITLE
[Docs] Onboarding docs, README i18n (zh/fr/ja), and small bug/typo fixes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,84 @@
+cff-version: 1.2.0
+message: "If you use vLLM-Omni in your research, please cite the following paper."
+title: "vLLM-Omni: Fully Disaggregated Serving for Any-to-Any Multimodal Models"
+abstract: >
+  vLLM-Omni extends vLLM to omni-modality model inference and serving, with support for
+  text, image, video and audio inputs and outputs, non-autoregressive (Diffusion
+  Transformer) architectures, and fully disaggregated execution across heterogeneous
+  hardware (NVIDIA CUDA, AMD ROCm, Intel XPU, MThreads MUSA, and Ascend NPU).
+type: software
+url: "https://github.com/vllm-project/vllm-omni"
+repository-code: "https://github.com/vllm-project/vllm-omni"
+license: Apache-2.0
+authors:
+  - family-names: Yin
+    given-names: Peiqi
+  - family-names: Zhu
+    given-names: Jiangyun
+  - family-names: Gao
+    given-names: Han
+  - family-names: Zheng
+    given-names: Chenguang
+  - family-names: Huang
+    given-names: Yongxiang
+  - family-names: Zhou
+    given-names: Taichang
+  - family-names: Yang
+    given-names: Ruirui
+  - family-names: Liu
+    given-names: Weizhi
+  - family-names: Chen
+    given-names: Weiqing
+  - family-names: Guo
+    given-names: Canlin
+  - family-names: Deng
+    given-names: Didan
+  - family-names: Mo
+    given-names: Zifeng
+  - family-names: Wang
+    given-names: Cong
+  - family-names: Cheng
+    given-names: James
+  - family-names: Wang
+    given-names: Roger
+  - family-names: Liu
+    given-names: Hongsheng
+preferred-citation:
+  type: article
+  title: "vLLM-Omni: Fully Disaggregated Serving for Any-to-Any Multimodal Models"
+  year: 2026
+  journal: "arXiv preprint"
+  url: "https://arxiv.org/abs/2602.02204"
+  authors:
+    - family-names: Yin
+      given-names: Peiqi
+    - family-names: Zhu
+      given-names: Jiangyun
+    - family-names: Gao
+      given-names: Han
+    - family-names: Zheng
+      given-names: Chenguang
+    - family-names: Huang
+      given-names: Yongxiang
+    - family-names: Zhou
+      given-names: Taichang
+    - family-names: Yang
+      given-names: Ruirui
+    - family-names: Liu
+      given-names: Weizhi
+    - family-names: Chen
+      given-names: Weiqing
+    - family-names: Guo
+      given-names: Canlin
+    - family-names: Deng
+      given-names: Didan
+    - family-names: Mo
+      given-names: Zifeng
+    - family-names: Wang
+      given-names: Cong
+    - family-names: Cheng
+      given-names: James
+    - family-names: Wang
+      given-names: Roger
+    - family-names: Liu
+      given-names: Hongsheng

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,69 @@
 # Contributing to vLLM-Omni
 
-You may find information about contributing to vLLM-Omni on [Contributing](https://vllm-omni.readthedocs.io/en/latest/contributing/)
+Thank you for your interest in contributing to vLLM-Omni! We welcome contributions of all
+kinds: bug reports, feature proposals, documentation improvements, translations, model
+ports, performance work, and more.
+
+For the authoritative and most up-to-date guide, see the
+[Contributing section of the documentation](https://vllm-omni.readthedocs.io/en/latest/contributing/).
+This file is a short quick-reference checklist to help new contributors get oriented.
+
+## Quick Links
+
+- Full contributing guide: <https://vllm-omni.readthedocs.io/en/latest/contributing/>
+- Documentation guide: [docs/contributing/DOCS_GUIDE.md](docs/contributing/DOCS_GUIDE.md)
+- CI / testing guide: [docs/contributing/ci/test_guide.md](docs/contributing/ci/test_guide.md)
+- Adding a model:
+  [diffusion](docs/contributing/model/adding_diffusion_model.md) ·
+  [omni](docs/contributing/model/adding_omni_model.md) ·
+  [tts](docs/contributing/model/adding_tts_model.md)
+- Code of Conduct: see the upstream
+  [vLLM Code of Conduct](https://github.com/vllm-project/vllm/blob/main/CODE_OF_CONDUCT.md)
+- Discussion channels: `#sig-omni` on [vLLM Slack](https://slack.vllm.ai) ·
+  [vLLM Forum](https://discuss.vllm.ai)
+
+## Before You Start
+
+1. **Search existing issues and PRs** to avoid duplicating work.
+2. For **non-trivial features** or design changes, please open an
+   [RFC issue](https://github.com/vllm-project/vllm-omni/issues/new?template=750-RFC.yml)
+   first so the community can align on the approach.
+3. For **new models**, please open a
+   [New Model issue](https://github.com/vllm-project/vllm-omni/issues/new?template=600-new-model.yml)
+   so that we can track model coverage and avoid duplicate ports.
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a topic branch from `main`.
+2. Make your changes; keep the PR scoped to one logical change.
+3. Run the relevant tests locally. See the
+   [tests guide](docs/contributing/ci/test_guide.md) for how the 5-level CI works
+   and which tests apply to your change.
+4. Follow the project's commit style (see the recent `git log` for examples — most
+   commits use a `[Tag]` prefix such as `[Bugfix]`, `[Docs]`, `[Model]`, `[CI]`).
+5. Fill in the
+   [Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md) — in particular, the
+   **Test Plan** section is required.
+6. Be ready to iterate on review feedback. Maintainers may request changes,
+   additional tests, or further benchmarks for performance-sensitive code.
+
+## Reporting Bugs
+
+Please use the appropriate issue template:
+
+- [🐛 Bug report](https://github.com/vllm-project/vllm-omni/issues/new?template=400-bug-report.yml)
+- [📚 Documentation issue](https://github.com/vllm-project/vllm-omni/issues/new?template=100-documentation.yml)
+- [⚙️ Installation issue](https://github.com/vllm-project/vllm-omni/issues/new?template=200-installation.yml)
+- [🚀 Feature request](https://github.com/vllm-project/vllm-omni/issues/new?template=500-feature-request.yml)
+- [🆕 New model request](https://github.com/vllm-project/vllm-omni/issues/new?template=600-new-model.yml)
+- [⚡ Performance discussion](https://github.com/vllm-project/vllm-omni/issues/new?template=700-performance-discussion.yml)
+- [📋 RFC](https://github.com/vllm-project/vllm-omni/issues/new?template=750-RFC.yml)
+
+A good bug report includes a minimal reproduction, the exact command used,
+hardware/platform (e.g. CUDA / ROCm / NPU / XPU), `pip freeze` output for the relevant
+packages, and the model identifier.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[Apache License, Version 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Easy, fast, and cheap omni-modality model serving for everyone
 | <a href="https://vllm-omni.readthedocs.io/en/latest/"><b>Documentation</b></a> | <a href="https://discuss.vllm.ai"><b>User Forum</b></a> | <a href="https://slack.vllm.ai"><b>Developer Slack</b></a> | <a href="docs/assets/WeChat.jpg"><b>WeChat</b></a> | <a href="https://arxiv.org/abs/2602.02204"><b>Paper</b></a> | <a href="https://docs.google.com/presentation/d/1XJWgv79lORl8rbaVvp2d5Sqs6ZEBgAgj/edit?slide=id.p1#slide=id.p1"><b>Slides</b></a> |
 </p>
 
+<p align="center">
+  <b>English</b> ·
+  <a href="docs/i18n/README.zh-CN.md">简体中文</a> ·
+  <a href="docs/i18n/README.fr.md">Français</a> ·
+  <a href="docs/i18n/README.ja.md">日本語</a>
+</p>
+
 
 ---
 

--- a/docs/getting_started/installation/gpu/cuda.inc.md
+++ b/docs/getting_started/installation/gpu/cuda.inc.md
@@ -5,7 +5,7 @@
 # --8<-- [end:requirements]
 # --8<-- [start:set-up-using-python]
 
-vLLM-Omni depends vLLM. So please follow instructions below mainly for vLLM.
+vLLM-Omni depends on vLLM. So please follow the instructions below mainly for vLLM.
 
 !!! note
     PyTorch installed via `conda` will statically link `NCCL` library, which can cause issues when vLLM tries to use `NCCL`. See <gh-issue:8420> for more details.
@@ -107,6 +107,6 @@ docker run --runtime nvidia --gpus 2 \
 ```
 
 !!! tip
-    You can use this docker image to serve models the same way you would with in vLLM! To do so, make sure you overwrite the default entrypoint (`vllm serve --omni`) which works only for models supported in the vLLM-Omni project.
+    You can use this docker image to serve models the same way you would in vLLM! To do so, make sure you overwrite the default entrypoint (`vllm serve --omni`) which works only for models supported in the vLLM-Omni project.
 
 # --8<-- [end:pre-built-images]

--- a/docs/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/getting_started/installation/gpu/rocm.inc.md
@@ -5,7 +5,7 @@
 # --8<-- [end:requirements]
 # --8<-- [start:set-up-using-python]
 
-vLLM-Omni current recommends the steps in under setup through Docker Images.
+vLLM-Omni currently recommends the setup steps using Docker Images.
 
 # --8<-- [start:pre-built-wheels]
 

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -120,3 +120,49 @@ curl -s http://localhost:8091/v1/chat/completions \
 ```
 
 For more details, please refer to [online serving](../user_guide/examples/online_serving/text_to_image.md).
+
+## Troubleshooting
+
+If you hit issues during your first run, please check the items below before opening
+an installation/bug issue. The first three problems make up the majority of new-user
+reports.
+
+### `vllm` does not recognise `--omni`
+
+The `--omni` flag is provided by vLLM-Omni and only works when its version is aligned
+with the installed vLLM. If you installed vLLM < 0.20.0 and vLLM-Omni 0.20.0, the
+entrypoint will no longer be hijacked and `--omni` will look unknown. Run
+`pip show vllm vllm-omni` and confirm that the major and minor versions match, then
+upgrade vLLM as needed.
+
+### `ModuleNotFoundError: No module named 'vllm_omni'`
+
+Most often this means you ran `python …` from a different environment than the one
+where vLLM-Omni was installed. Activate the same virtualenv used for `uv pip install -e .`
+and re-run; on Linux/macOS that is `source .venv/bin/activate`.
+
+### Out-of-memory (OOM) at startup
+
+Diffusion models in particular hold large weight, scheduler, and KV-cache buffers in
+GPU memory. If the engine OOMs before the first request:
+
+- Lower `gpu_memory_utilization` (defaults to 0.9; try 0.8 or 0.7). See the
+  [GPU memory configuration guide](../configuration/gpu_memory_utilization.md).
+- Reduce `max_num_seqs` for the AR stage.
+- Pick a smaller or quantized variant of the model.
+
+### Generated image / audio is silent or blank
+
+Make sure you saved the raw bytes returned by the API rather than the JSON envelope.
+The serving snippet above pipes through `jq` and `base64 -d` for that reason — without
+the decoding step the file will be a base64-encoded text blob, not a valid PNG or WAV.
+
+### Running on Windows
+
+vLLM-Omni is not natively supported on Windows. Please use WSL2 with Ubuntu 22.04+
+(`wsl --install -d Ubuntu-22.04`) and follow the Linux instructions inside the WSL
+shell.
+
+If your problem isn't covered here, open an
+[installation issue](https://github.com/vllm-project/vllm-omni/issues/new?template=200-installation.yml)
+with the output of `python collect_env.py` attached.

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -1,0 +1,107 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/vllm-omni/refs/heads/main/docs/source/logos/vllm-omni-logo.png">
+    <img alt="vllm-omni" src="https://raw.githubusercontent.com/vllm-project/vllm-omni/refs/heads/main/docs/source/logos/vllm-omni-logo.png" width=55%>
+  </picture>
+</p>
+<h3 align="center">
+Serving de modèles omni-modaux simple, rapide et économique, pour tout le monde
+</h3>
+
+<p align="center">
+| <a href="https://vllm-omni.readthedocs.io/en/latest/"><b>Documentation</b></a> | <a href="https://discuss.vllm.ai"><b>Forum utilisateurs</b></a> | <a href="https://slack.vllm.ai"><b>Slack développeurs</b></a> | <a href="../assets/WeChat.jpg"><b>WeChat</b></a> | <a href="https://arxiv.org/abs/2602.02204"><b>Article</b></a> | <a href="https://docs.google.com/presentation/d/1XJWgv79lORl8rbaVvp2d5Sqs6ZEBgAgj/edit?slide=id.p1#slide=id.p1"><b>Slides</b></a> |
+</p>
+
+<p align="center">
+  <a href="../../README.md">English</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <b>Français</b> ·
+  <a href="README.ja.md">日本語</a>
+</p>
+
+---
+
+*Dernières nouvelles* 🔥
+- [2026/03] Nous avons publié la version [0.18.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.18.0) — elle renforce le runtime de base grâce à un important remaniement du point d'entrée et au nettoyage du planificateur et du runtime, étend la quantification unifiée ainsi que l'exécution des modèles de diffusion, élargit la couverture des modèles multimodaux et améliore la maturité production sur les axes audio, omni, image, vidéo, RL et déploiements multi-plateformes.
+- [2026/03] Découvrez notre première [présentation publique approfondie](https://youtu.be/sgwNfsNnR9I) lors du Meetup vLLM de Hong Kong !
+- [2026/03] **[vllm-omni-skills](https://github.com/hsliuustc0106/vllm-omni-skills)** est une collection communautaire de compétences pour assistants IA, conçue pour aider les développeurs à travailler plus efficacement avec vLLM-Omni. Ces compétences sont compatibles avec les principaux assistants de codage agentiques tels que **Cursor IDE**, **Claude**, **Codex**, et d'autres.
+- [2026/02] Nous avons publié la version [0.16.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.16.0) — une version majeure d'alignement et de fonctionnalités qui rebase le projet sur **vLLM v0.16.0 en amont** et étend significativement les performances, l'exécution distribuée et la maturité production pour **Qwen3-Omni / Qwen3-TTS**, **Bagel**, **MiMo-Audio**, **GLM-Image** et la pile **Diffusion (DiT) image/vidéo** — tout en améliorant la couverture des plateformes (CUDA / ROCm / NPU / XPU), la qualité de la CI et la documentation.
+- [2026/02] Nous avons publié la version [0.14.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.14.0) — il s'agit de la première version **stable** de vLLM-Omni, qui étend la pile de diffusion / génération image-vidéo et la pile audio / TTS d'Omni, améliore l'exécution distribuée et l'efficacité mémoire, et élargit la couverture plateformes/back-ends (GPU/ROCm/NPU/XPU). Elle apporte également des améliorations notables aux API de serving, au profilage, au benchmarking et à la stabilité globale. Consultez notre [article](https://arxiv.org/abs/2602.02204) le plus récent pour les détails sur l'architecture et les performances.
+- [2026/01] Nous avons publié la version [0.12.0rc1](https://github.com/vllm-project/vllm-omni/releases/tag/v0.12.0rc1) — une étape RC majeure axée sur la maturité de la pile de diffusion, le renforcement du serving compatible OpenAI, l'élargissement de la couverture des modèles omni et l'amélioration de la stabilité sur l'ensemble des plateformes (GPU/NPU/ROCm).
+- [2025/11] La communauté vLLM a officiellement publié [vllm-project/vllm-omni](https://github.com/vllm-project/vllm-omni) afin de prendre en charge le serving des modèles omni-modaux.
+
+---
+
+## À propos
+
+[vLLM](https://github.com/vllm-project/vllm) a été conçu à l'origine pour prendre en charge les grands modèles de langage pour des tâches de génération auto-régressive basées sur le texte. vLLM-Omni est un framework qui étend cette prise en charge à l'inférence et au serving de modèles **omni-modaux** :
+
+- **Omni-modalité** : traitement de texte, d'images, de vidéos et de données audio
+- **Architectures non auto-régressives** : extension du support AR de vLLM aux Diffusion Transformers (DiT) et à d'autres modèles à génération parallèle
+- **Sorties hétérogènes** : de la génération de texte traditionnelle aux sorties multimodales
+
+<p align="center">
+  <picture>
+    <img alt="vllm-omni" src="https://raw.githubusercontent.com/vllm-project/vllm-omni/refs/heads/main/docs/source/architecture/omni-modality-model-architecture.png" width=55%>
+  </picture>
+</p>
+
+vLLM-Omni est rapide grâce à :
+
+- Un support AR à la pointe, qui s'appuie sur la gestion efficace du cache KV de vLLM
+- Un recouvrement de l'exécution par étapes en pipeline pour un haut débit
+- Une désagrégation complète basée sur OmniConnector, et une allocation dynamique des ressources entre les étapes
+
+vLLM-Omni est flexible et facile à utiliser grâce à :
+
+- Une abstraction de pipeline hétérogène pour gérer des workflows de modèles complexes
+- Une intégration transparente avec les modèles populaires de Hugging Face
+- Le support du parallélisme tensoriel, pipeline, de données et d'experts pour l'inférence distribuée
+- Le streaming des sorties
+- Un serveur d'API compatible OpenAI
+
+vLLM-Omni prend en charge sans effort la plupart des modèles open source populaires sur HuggingFace, notamment :
+
+- Modèles omni-modaux (ex. Qwen-Omni)
+- Modèles de génération multimodale (ex. Qwen-Image)
+
+## Démarrage
+
+Consultez notre [documentation](https://vllm-omni.readthedocs.io/en/latest/) pour en savoir plus.
+
+- [Installation](https://vllm-omni.readthedocs.io/en/latest/getting_started/installation/)
+- [Démarrage rapide](https://vllm-omni.readthedocs.io/en/latest/getting_started/quickstart/)
+- [Liste des modèles pris en charge](https://vllm-omni.readthedocs.io/en/latest/models/supported_models/)
+
+## Contribuer
+
+Nous accueillons et apprécions toute contribution et collaboration.
+Veuillez consulter [Contribuer à vLLM-Omni](https://vllm-omni.readthedocs.io/en/latest/contributing/) pour savoir comment participer.
+
+## Citation
+
+Si vous utilisez vLLM-Omni dans vos recherches, veuillez citer notre [article](https://arxiv.org/abs/2602.02204) :
+
+```bibtex
+@article{yin2026vllmomni,
+  title={vLLM-Omni: Fully Disaggregated Serving for Any-to-Any Multimodal Models},
+  author={Peiqi Yin, Jiangyun Zhu, Han Gao, Chenguang Zheng, Yongxiang Huang, Taichang Zhou, Ruirui Yang, Weizhi Liu, Weiqing Chen, Canlin Guo, Didan Deng, Zifeng Mo, Cong Wang, James Cheng, Roger Wang, Hongsheng Liu},
+  journal={arXiv preprint arXiv:2602.02204},
+  year={2026}
+}
+```
+
+## Rejoindre la communauté
+N'hésitez pas à poser vos questions, partager vos retours et échanger avec les autres utilisateurs de vLLM-Omni sur le canal Slack `#sig-omni` à [slack.vllm.ai](https://slack.vllm.ai), ou sur le forum utilisateurs vLLM à [discuss.vllm.ai](https://discuss.vllm.ai).
+
+## Historique des étoiles
+
+[![Star History Chart](https://api.star-history.com/svg?repos=vllm-project/vllm-omni&type=date&legend=top-left)](https://www.star-history.com/#vllm-project/vllm-omni&type=date&legend=top-left)
+
+## Licence
+
+Apache License 2.0, comme indiqué dans le fichier [LICENSE](../../LICENSE).
+
+---
+
+> **Note** : ce fichier est une traduction du [`README.md`](../../README.md) anglais et est fourni à titre informatif. En cas de divergence avec la version anglaise, c'est cette dernière qui fait foi.

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -1,0 +1,107 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/vllm-omni/refs/heads/main/docs/source/logos/vllm-omni-logo.png">
+    <img alt="vllm-omni" src="https://raw.githubusercontent.com/vllm-project/vllm-omni/refs/heads/main/docs/source/logos/vllm-omni-logo.png" width=55%>
+  </picture>
+</p>
+<h3 align="center">
+誰もが使える、簡単・高速・低コストなオムニモーダル推論サービング
+</h3>
+
+<p align="center">
+| <a href="https://vllm-omni.readthedocs.io/en/latest/"><b>ドキュメント</b></a> | <a href="https://discuss.vllm.ai"><b>ユーザーフォーラム</b></a> | <a href="https://slack.vllm.ai"><b>開発者 Slack</b></a> | <a href="../assets/WeChat.jpg"><b>WeChat</b></a> | <a href="https://arxiv.org/abs/2602.02204"><b>論文</b></a> | <a href="https://docs.google.com/presentation/d/1XJWgv79lORl8rbaVvp2d5Sqs6ZEBgAgj/edit?slide=id.p1#slide=id.p1"><b>スライド</b></a> |
+</p>
+
+<p align="center">
+  <a href="../../README.md">English</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.fr.md">Français</a> ·
+  <b>日本語</b>
+</p>
+
+---
+
+*最新情報* 🔥
+- [2026/03] [0.18.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.18.0) をリリースしました — 大規模なエントリポイントのリファクタリングおよびスケジューラ／ランタイムのクリーンアップによりコアランタイムを強化し、統合された量子化と拡散モデルの実行を拡張し、マルチモーダルモデルのカバレッジを広げ、音声・オムニ・画像・動画・RL・マルチプラットフォーム展開全般にわたって本番運用適性を向上させました。
+- [2026/03] vLLM 香港ミートアップで行った初の公開[プロジェクトディープダイブ](https://youtu.be/sgwNfsNnR9I)をぜひご覧ください！
+- [2026/03] **[vllm-omni-skills](https://github.com/hsliuustc0106/vllm-omni-skills)** は、開発者が vLLM-Omni をより効果的に活用できるよう支援する、コミュニティ主導の AI アシスタントスキル集です。**Cursor IDE**、**Claude**、**Codex** など、主要なエージェント型コーディングアシスタントと組み合わせて利用できます。
+- [2026/02] [0.16.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.16.0) をリリースしました — **アップストリームの vLLM v0.16.0** にリベースする大規模なアラインメント＋機能拡張リリースで、**Qwen3-Omni / Qwen3-TTS**、**Bagel**、**MiMo-Audio**、**GLM-Image**、および **拡散 (DiT) 画像／動画スタック** において、性能・分散実行・本番運用適性を大きく拡張しています。あわせて、プラットフォームカバレッジ (CUDA / ROCm / NPU / XPU)、CI 品質、ドキュメントも改善されています。
+- [2026/02] [0.14.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.14.0) をリリースしました — vLLM-Omni 初の **安定版リリース** であり、Omni の拡散／画像・動画生成および音声／TTS スタックを拡張し、分散実行とメモリ効率を改善、プラットフォーム／バックエンドのカバレッジ (GPU/ROCm/NPU/XPU) を拡大しました。さらに、サービング API、プロファイリング・ベンチマーク、全体的な安定性にも意義ある改善があります。アーキテクチャ設計と性能結果については、最新の[論文](https://arxiv.org/abs/2602.02204) をご参照ください。
+- [2026/01] [0.12.0rc1](https://github.com/vllm-project/vllm-omni/releases/tag/v0.12.0rc1) をリリースしました — 拡散スタックの成熟、OpenAI 互換サービングの強化、オムニモデルのカバレッジ拡大、各プラットフォーム (GPU/NPU/ROCm) での安定性向上に焦点をあてた、主要な RC マイルストーンです。
+- [2025/11] vLLM コミュニティは、オムニモーダルモデルのサービングをサポートするため、 [vllm-project/vllm-omni](https://github.com/vllm-project/vllm-omni) を正式に公開しました。
+
+---
+
+## 概要
+
+[vLLM](https://github.com/vllm-project/vllm) は本来、テキストベースの自己回帰生成タスク向けの大規模言語モデルをサポートする目的で設計されました。vLLM-Omni はその対象を **オムニモーダルモデル** の推論・サービングへと拡張するフレームワークです:
+
+- **オムニモーダル**: テキスト、画像、動画、音声データの処理に対応
+- **非自己回帰アーキテクチャ**: vLLM の AR サポートを Diffusion Transformer (DiT) などの並列生成モデルへと拡張
+- **多様な出力**: 従来のテキスト生成からマルチモーダル出力まで
+
+<p align="center">
+  <picture>
+    <img alt="vllm-omni" src="https://raw.githubusercontent.com/vllm-project/vllm-omni/refs/heads/main/docs/source/architecture/omni-modality-model-architecture.png" width=55%>
+  </picture>
+</p>
+
+vLLM-Omni は次の点で高速です:
+
+- vLLM の効率的な KV キャッシュ管理を活用した、最先端の AR サポート
+- パイプライン化されたステージ実行のオーバーラップによる高スループット
+- OmniConnector に基づく完全分離アーキテクチャと、ステージ間の動的なリソース割り当て
+
+vLLM-Omni は次の点で柔軟かつ使いやすいです:
+
+- 複雑なモデルワークフローを扱う、ヘテロジニアスなパイプライン抽象
+- Hugging Face の人気モデルとのシームレスな統合
+- 分散推論向けの、テンソル／パイプライン／データ／エキスパート並列のサポート
+- ストリーミング出力
+- OpenAI 互換 API サーバー
+
+vLLM-Omni は、HuggingFace 上の主要なオープンソースモデルの大半をシームレスにサポートしています。例:
+
+- オムニモーダルモデル (例: Qwen-Omni)
+- マルチモーダル生成モデル (例: Qwen-Image)
+
+## はじめに
+
+詳しくは[ドキュメント](https://vllm-omni.readthedocs.io/en/latest/) をご覧ください。
+
+- [インストール](https://vllm-omni.readthedocs.io/en/latest/getting_started/installation/)
+- [クイックスタート](https://vllm-omni.readthedocs.io/en/latest/getting_started/quickstart/)
+- [サポート対象モデル一覧](https://vllm-omni.readthedocs.io/en/latest/models/supported_models/)
+
+## コントリビュート
+
+あらゆる形のコントリビュートやコラボレーションを歓迎します。
+参加方法については [Contributing to vLLM-Omni](https://vllm-omni.readthedocs.io/en/latest/contributing/) をご参照ください。
+
+## 引用
+
+vLLM-Omni を研究に利用される場合は、当プロジェクトの[論文](https://arxiv.org/abs/2602.02204) を引用してください:
+
+```bibtex
+@article{yin2026vllmomni,
+  title={vLLM-Omni: Fully Disaggregated Serving for Any-to-Any Multimodal Models},
+  author={Peiqi Yin, Jiangyun Zhu, Han Gao, Chenguang Zheng, Yongxiang Huang, Taichang Zhou, Ruirui Yang, Weizhi Liu, Weiqing Chen, Canlin Guo, Didan Deng, Zifeng Mo, Cong Wang, James Cheng, Roger Wang, Hongsheng Liu},
+  journal={arXiv preprint arXiv:2602.02204},
+  year={2026}
+}
+```
+
+## コミュニティに参加する
+質問・フィードバック・他ユーザーとのディスカッションは、[slack.vllm.ai](https://slack.vllm.ai) の `#sig-omni` Slack チャンネルや、vLLM ユーザーフォーラム [discuss.vllm.ai](https://discuss.vllm.ai) でお気軽にどうぞ。
+
+## スター履歴
+
+[![Star History Chart](https://api.star-history.com/svg?repos=vllm-project/vllm-omni&type=date&legend=top-left)](https://www.star-history.com/#vllm-project/vllm-omni&type=date&legend=top-left)
+
+## ライセンス
+
+Apache License 2.0。詳細は [LICENSE](../../LICENSE) ファイルをご覧ください。
+
+---
+
+> **注記**: 本ファイルは英語版 [`README.md`](../../README.md) の参考訳です。英語版と内容に差異がある場合は、英語版を正としてご参照ください。

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -1,0 +1,107 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/vllm-omni/refs/heads/main/docs/source/logos/vllm-omni-logo.png">
+    <img alt="vllm-omni" src="https://raw.githubusercontent.com/vllm-project/vllm-omni/refs/heads/main/docs/source/logos/vllm-omni-logo.png" width=55%>
+  </picture>
+</p>
+<h3 align="center">
+面向所有人的简单、快速、低成本的全模态模型推理服务
+</h3>
+
+<p align="center">
+| <a href="https://vllm-omni.readthedocs.io/en/latest/"><b>文档</b></a> | <a href="https://discuss.vllm.ai"><b>用户论坛</b></a> | <a href="https://slack.vllm.ai"><b>开发者 Slack</b></a> | <a href="../assets/WeChat.jpg"><b>微信</b></a> | <a href="https://arxiv.org/abs/2602.02204"><b>论文</b></a> | <a href="https://docs.google.com/presentation/d/1XJWgv79lORl8rbaVvp2d5Sqs6ZEBgAgj/edit?slide=id.p1#slide=id.p1"><b>幻灯片</b></a> |
+</p>
+
+<p align="center">
+  <a href="../../README.md">English</a> ·
+  <b>简体中文</b> ·
+  <a href="README.fr.md">Français</a> ·
+  <a href="README.ja.md">日本語</a>
+</p>
+
+---
+
+*最新动态* 🔥
+- [2026/03] 我们发布了 [0.18.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.18.0) —— 通过大规模的入口（entrypoint）重构以及调度器与运行时清理，进一步强化了核心运行时；扩展了统一量化与扩散模型执行；拓宽了多模态模型的覆盖；并在音频、Omni、图像、视频、强化学习以及多平台部署等方向上提升了生产可用性。
+- [2026/03] 欢迎观看我们在 vLLM 香港 Meetup 上首次公开的 [项目深度分享](https://youtu.be/sgwNfsNnR9I)！
+- [2026/03] **[vllm-omni-skills](https://github.com/hsliuustc0106/vllm-omni-skills)** 是一个由社区驱动的 AI 助手技能集合，旨在帮助开发者更高效地使用 vLLM-Omni。这些技能可以与 **Cursor IDE**、**Claude**、**Codex** 等主流智能体编码助手一起使用。
+- [2026/02] 我们发布了 [0.16.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.16.0) —— 这是一次重要的对齐 + 能力升级版本，将代码 rebase 到 **vLLM 上游 v0.16.0**，并显著扩展了 **Qwen3-Omni / Qwen3-TTS**、**Bagel**、**MiMo-Audio**、**GLM-Image** 以及 **扩散（DiT）图像/视频** 技术栈的性能、分布式执行能力与生产可用性；同时改善了平台覆盖（CUDA / ROCm / NPU / XPU）、CI 质量与文档。
+- [2026/02] 我们发布了 [0.14.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.14.0) —— 这是 vLLM-Omni 的首个 **稳定版本**，扩展了 Omni 的扩散 / 图像视频生成能力以及音频 / TTS 技术栈，改进了分布式执行与显存效率，并扩大了平台/后端覆盖（GPU/ROCm/NPU/XPU）。同时还显著增强了推理服务 API、性能分析与基准测试以及整体稳定性。请参阅最新 [论文](https://arxiv.org/abs/2602.02204) 了解架构设计与性能结果。
+- [2026/01] 我们发布了 [0.12.0rc1](https://github.com/vllm-project/vllm-omni/releases/tag/v0.12.0rc1) —— 一个重要的 RC 里程碑，重点完善扩散模型技术栈、强化 OpenAI 兼容服务、扩大 Omni 模型覆盖范围，并提升跨平台稳定性（GPU/NPU/ROCm）。
+- [2025/11] vLLM 社区正式发布 [vllm-project/vllm-omni](https://github.com/vllm-project/vllm-omni)，为全模态模型推理服务提供支持。
+
+---
+
+## 关于
+
+[vLLM](https://github.com/vllm-project/vllm) 最初是为支持基于文本的大语言模型自回归生成任务而设计的。vLLM-Omni 是在其基础上扩展、面向 **全模态模型** 推理与服务的框架：
+
+- **全模态**：支持文本、图像、视频和音频数据的处理
+- **非自回归架构**：将 vLLM 的 AR 支持扩展到 Diffusion Transformer（DiT）等并行生成模型
+- **异构输出**：从传统的文本生成扩展到多模态输出
+
+<p align="center">
+  <picture>
+    <img alt="vllm-omni" src="https://raw.githubusercontent.com/vllm-project/vllm-omni/refs/heads/main/docs/source/architecture/omni-modality-model-architecture.png" width=55%>
+  </picture>
+</p>
+
+vLLM-Omni 的高性能体现在：
+
+- 通过复用 vLLM 高效的 KV 缓存管理，提供业界领先的 AR 支持
+- 流水线式分阶段执行重叠，带来高吞吐性能
+- 基于 OmniConnector 的完全解耦执行，以及跨阶段的动态资源分配
+
+vLLM-Omni 的灵活与易用体现在：
+
+- 异构流水线抽象，便于管理复杂的模型工作流
+- 与 Hugging Face 主流模型无缝集成
+- 张量 / 流水线 / 数据 / 专家并行，支持分布式推理
+- 流式输出
+- 兼容 OpenAI 的 API 服务
+
+vLLM-Omni 无缝支持 HuggingFace 上大多数主流开源模型，包括：
+
+- 全模态模型（如 Qwen-Omni）
+- 多模态生成模型（如 Qwen-Image）
+
+## 快速开始
+
+请访问我们的 [文档](https://vllm-omni.readthedocs.io/en/latest/) 了解更多信息。
+
+- [安装](https://vllm-omni.readthedocs.io/en/latest/getting_started/installation/)
+- [快速入门](https://vllm-omni.readthedocs.io/en/latest/getting_started/quickstart/)
+- [支持的模型列表](https://vllm-omni.readthedocs.io/en/latest/models/supported_models/)
+
+## 参与贡献
+
+我们欢迎并珍视各种形式的贡献与合作。
+请查阅 [为 vLLM-Omni 做贡献](https://vllm-omni.readthedocs.io/en/latest/contributing/) 了解如何参与。
+
+## 引用
+
+如果您在研究中使用了 vLLM-Omni，请引用我们的 [论文](https://arxiv.org/abs/2602.02204)：
+
+```bibtex
+@article{yin2026vllmomni,
+  title={vLLM-Omni: Fully Disaggregated Serving for Any-to-Any Multimodal Models},
+  author={Peiqi Yin, Jiangyun Zhu, Han Gao, Chenguang Zheng, Yongxiang Huang, Taichang Zhou, Ruirui Yang, Weizhi Liu, Weiqing Chen, Canlin Guo, Didan Deng, Zifeng Mo, Cong Wang, James Cheng, Roger Wang, Hongsheng Liu},
+  journal={arXiv preprint arXiv:2602.02204},
+  year={2026}
+}
+```
+
+## 加入社区
+欢迎在 [slack.vllm.ai](https://slack.vllm.ai) 的 `#sig-omni` Slack 频道，或 vLLM 用户论坛 [discuss.vllm.ai](https://discuss.vllm.ai) 提问、反馈意见，并与其他 vLLM-Omni 用户交流。
+
+## Star 趋势
+
+[![Star History Chart](https://api.star-history.com/svg?repos=vllm-project/vllm-omni&type=date&legend=top-left)](https://www.star-history.com/#vllm-project/vllm-omni&type=date&legend=top-left)
+
+## 许可证
+
+Apache License 2.0，详见 [LICENSE](../../LICENSE) 文件。
+
+---
+
+> **注意**：本文件是英文版 [`README.md`](../../README.md) 的翻译，仅供参考。如内容与英文版有差异，请以英文版为准。

--- a/examples/offline_inference/image_to_video/image_to_video.py
+++ b/examples/offline_inference/image_to_video/image_to_video.py
@@ -75,7 +75,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prompt", default="", help="Text prompt describing the desired motion.")
     parser.add_argument("--negative-prompt", default="", help="Negative prompt.")
     parser.add_argument("--seed", type=int, default=42, help="Random seed.")
-    parser.add_argument("--guidance-scale", type=float, default=5.0, help="CFG scale.")
+    parser.add_argument(
+        "--guidance-scale",
+        type=float,
+        default=None,
+        help="CFG scale. Defaults to 4.0 for LTX2, 5.0 otherwise.",
+    )
     parser.add_argument(
         "--guidance-scale-high", type=float, default=None, help="Optional separate CFG for high-noise (MoE only)."
     )
@@ -83,8 +88,18 @@ def parse_args() -> argparse.Namespace:
         "--height", type=int, default=None, help="Video height (auto-calculated from image if not set)."
     )
     parser.add_argument("--width", type=int, default=None, help="Video width (auto-calculated from image if not set).")
-    parser.add_argument("--num-frames", type=int, default=81, help="Number of frames.")
-    parser.add_argument("--num-inference-steps", type=int, default=50, help="Sampling steps.")
+    parser.add_argument(
+        "--num-frames",
+        type=int,
+        default=None,
+        help="Number of frames. Defaults to 121 for LTX2, 81 otherwise.",
+    )
+    parser.add_argument(
+        "--num-inference-steps",
+        type=int,
+        default=None,
+        help="Sampling steps. Defaults to 40 for LTX2, 50 otherwise.",
+    )
     parser.add_argument("--boundary-ratio", type=float, default=0.875, help="Boundary split ratio for MoE models.")
     parser.add_argument(
         "--frame-rate",
@@ -327,8 +342,8 @@ def main():
     print(f"\n{'=' * 60}")
     print("Generation Configuration:")
     print(f"  Model: {args.model}")
-    print(f"  Inference steps: {args.num_inference_steps}")
-    print(f"  Frames: {args.num_frames}")
+    print(f"  Inference steps: {num_inference_steps}")
+    print(f"  Frames: {num_frames}")
     print(f"  Solver: {args.sample_solver}")
     print(
         f"  Parallel configuration: cfg_parallel_size={args.cfg_parallel_size},"

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_tokenizer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_tokenizer.py
@@ -384,7 +384,7 @@ class TokenizerWrapper:
                     drop_last_break = True
                     break
                 if source.get("front_boi", use_front_boi_token):
-                    token_seq.append(self.boi_token_id)  # Use patched boi for Janus, otherwise useing default <boi>
+                    token_seq.append(self.boi_token_id)  # Use patched boi for Janus, otherwise using default <boi>
                     extra_token_pos["boi"].append(token_count)
                     token_count += 1
                 token_count = self._add_image_meta_info_token(

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -304,14 +304,14 @@ def resolve_model_config_path(model: str) -> str:
     try:
         hf_config = get_config(model, trust_remote_code=True)
         model_type = hf_config.model_type
-    except (ValueError, Exception):
+    except Exception:
         # If standard transformers format fails, try diffusers format
         if file_or_path_exists(model, "model_index.json", revision=None):
             model_type = _try_get_class_name_from_diffusers_config(model)
             if model_type is None:
                 raise ValueError(
                     f"Could not determine model_type for diffusers model: {model}. "
-                    f"Please ensure the model has 'model_type' in transformer/config.json or model_index.json"
+                    "Please ensure the model has 'model_type' in transformer/config.json or model_index.json"
                 )
         elif file_or_path_exists(model, "config.json", revision=None):
             # Try to read config.json manually for custom models like Bagel that fail get_config
@@ -331,8 +331,8 @@ def resolve_model_config_path(model: str) -> str:
         else:
             raise ValueError(
                 f"Could not determine model_type for model: {model}. "
-                f"Model is not in standard transformers format and does not have model_index.json. "
-                f"Please ensure the model has proper configuration files with 'model_type' field"
+                "Model is not in standard transformers format and does not have model_index.json. "
+                "Please ensure the model has proper configuration files with 'model_type' field"
             )
 
     default_config_path = current_omni_platform.get_default_stage_config_path()


### PR DESCRIPTION
## Purpose

This PR groups three independent, self-contained improvements that were spotted while reading through the tree as part of a course-organised open-source contribution exercise. Each commit stands alone — happy to split into separate PRs on request.

### 1. Onboarding documentation (`[Docs]` commit)

- Expand the placeholder `CONTRIBUTING.md` into a proper quick-reference: links to the docs/contributing/ tree, the issue templates under `.github/ISSUE_TEMPLATE/`, the PR template, and the Apache-2.0 license, with the canonical guide pointer kept to ReadTheDocs.
- Add `CITATION.cff` so GitHub renders the **Cite this repository** widget. The content mirrors the BibTeX block already in `README.md` (paper [arXiv:2602.02204](https://arxiv.org/abs/2602.02204), 16-author roster).
- Add a **Troubleshooting** section to `docs/getting_started/quickstart.md` covering the most-reported new-user issues from the installation tracker:
  - `vllm` not recognising `--omni` (vLLM / vLLM-Omni version skew),
  - `ModuleNotFoundError: No module named 'vllm_omni'` (wrong venv),
  - Startup OOM tuning knobs (`gpu_memory_utilization`, `max_num_seqs`),
  - Missing `base64 -d` step in the curl snippet,
  - Windows → WSL2 redirect.
- Grammar fixes in two installation includes:
  - `gpu/cuda.inc.md`: *"vLLM-Omni depends vLLM"* → *"vLLM-Omni depends on vLLM"*; *"the same way you would with in vLLM"* → *"the same way you would in vLLM"*.
  - `gpu/rocm.inc.md`: *"vLLM-Omni current recommends the steps in under setup through Docker Images"* → *"vLLM-Omni currently recommends the setup steps using Docker Images"*.

### 2. README internationalisation (`[Docs]` commit)

- Add three localised copies of the top-level README under `docs/i18n/`:
  - `README.zh-CN.md` — Simplified Chinese
  - `README.fr.md` — French
  - `README.ja.md` — Japanese
- Add a small language switcher block at the top of the English `README.md` so each translation links back to the others.
- Image URLs in the translations are kept **absolute** to the upstream raw.githubusercontent URLs so they render correctly when GitHub serves the files from `docs/i18n/`. Intra-repo links (`docs/assets/WeChat.jpg`, `LICENSE`) are relinked with the right relative depth.
- The BibTeX block is kept verbatim so citation tools that grep for the key still match against the translated files.
- Each translation ends with a small "English is canonical" disclaimer so contributors know not to treat them as authoritative.

If the maintainers prefer to gate the translations behind a community-review pass first (e.g. for terminology consistency on `attention backend`, `KV cache`, `non-autoregressive`), happy to either drop them from this PR or wait on a review before merging that commit.

### 3. Small bug / lint fixes (`[BugFix]` commit)

Four independent fixes:

1. **`examples/offline_inference/image_to_video/image_to_video.py`** — the script aimed to provide model-aware defaults for **LTX2 vs. Wan2.2** (e.g. 121 frames / 40 steps / guidance 4.0 for LTX2 vs. 81 / 50 / 5.0 for Wan2.2), but the LTX2 branch was unreachable:

   ```python
   parser.add_argument(\"--num-frames\", type=int, default=81, ...)
   ...
   num_frames = args.num_frames if args.num_frames is not None \
                else (121 if is_ltx2 else 81)   # <-- is_ltx2 branch never runs
   ```

   Because argparse always filled `args.num_frames` with `81`, the `is_ltx2` fallback was dead code and LTX2 users silently got the Wan2.2 numbers. Fix: switch the three argparse defaults (`--num-frames`, `--num-inference-steps`, `--guidance-scale`) to `None`, mirroring the existing pattern used by `--fps`, update the `--help` text to spell out the per-model defaults, and have the "Generation Configuration" printout use the resolved local variables so users see what was actually fed into `Omni()`.

2. **`vllm_omni/entrypoints/utils.py`** — `except (ValueError, Exception):` is redundant since `ValueError` is a subclass of `Exception` (Ruff B014). Simplified to `except Exception:`.

3. **`vllm_omni/entrypoints/utils.py`** — drop the `f` prefix on the trailing lines of two `raise ValueError(...)` blocks where only the first line had a `{model}` placeholder; the remaining lines were plain strings under implicit concatenation (Ruff F541).

4. **`vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_tokenizer.py`** — fix `useing` → `using` in an inline comment.

## Test Plan

This PR is documentation- and lint-grade. No new test scripts are added; each touched area is validated as follows:

- **Docs / translations**: rendered locally via `mkdocs serve` (where applicable) and verified the language-switcher links resolve from the English README and from each translated file. Image URLs use absolute raw.githubusercontent URLs so GitHub renders them from `docs/i18n/`.
- **`CITATION.cff`**: validated as YAML (`python -c "import yaml; yaml.safe_load(open('CITATION.cff'))"`); fields match the BibTeX block already present in `README.md`.
- **`image_to_video.py`**: parsed with `python -m py_compile` and dry-run argparse (`python image_to_video.py --help`); verified the resolved defaults for both the LTX2 and Wan2.2 paths print correctly in the `Generation Configuration` block.
- **`entrypoints/utils.py` / tokenizer comment**: parsed with `python -m py_compile`; no behavioural change beyond the type-error narrowing of the exception handler. The two F541 fixes are equivalent at runtime.

Happy to add explicit unit coverage for the `image_to_video.py` default-resolution logic if the maintainers want it (the change is in an example script, so historically untested, but the underlying logic is now non-trivial enough to be worth a small parametrized test).

## Test Result

No regression observed across the affected files. The previous behaviour of `image_to_video.py` on the default Wan2.2 model is preserved (same 81 / 50 / 5.0 values), and the LTX2 path now activates its documented defaults instead of silently re-using the Wan2.2 ones.

---