### PR TITLE
[Frontend][Model][Qwen3-Omni] Enable input audio transcription with inline SSE transcript

### DIFF
--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1042,9 +1042,7 @@ class AsyncOmniEngine:
 
         supported_tasks: set[str] = set()
         comprehension_pools = [
-            pool
-            for pool in self.stage_pools
-            if getattr(pool.stage_client, "is_comprehension", False)
+            pool for pool in self.stage_pools if getattr(pool.stage_client, "is_comprehension", False)
         ]
         if comprehension_pools:
             supported_tasks.add("generate")
@@ -1058,18 +1056,15 @@ class AsyncOmniEngine:
                 for pool in comprehension_pools:
                     model_config = pool.stage_vllm_config.model_config
                     arches = getattr(model_config, "architectures", None) or []
-                    for arch in arches:
-                        resolved = ModelRegistry.resolve_model_cls(arch)
-                        model_cls = resolved[0] if isinstance(resolved, tuple) else resolved
-                        if supports_transcription(model_cls):
-                            supported_tasks.add("transcription")
-                            break
-                    if "transcription" in supported_tasks:
+                    if not arches:
+                        continue
+                    resolved = ModelRegistry.resolve_model_cls(arches, model_config)
+                    model_cls = resolved[0] if isinstance(resolved, tuple) else resolved
+                    if supports_transcription(model_cls):
+                        supported_tasks.add("transcription")
                         break
             except Exception as e:
-                logger.warning(
-                    "[AsyncOmniEngine] transcription capability probe failed: %s", e
-                )
+                logger.warning("[AsyncOmniEngine] transcription capability probe failed: %s", e)
         if any(m.get("final_output_type") == "audio" for m in self.stage_metadata):
             supported_tasks.add("speech")
         self.supported_tasks = tuple(supported_tasks) if supported_tasks else ("generate",)

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1040,10 +1040,36 @@ class AsyncOmniEngine:
         self.stage_vllm_configs = [pool.stage_vllm_config for pool in self.stage_pools]
         self.output_processors = [pool.output_processor for pool in self.stage_pools]
 
-        # TODO(Peiqi): Hack here
         supported_tasks: set[str] = set()
-        if any(getattr(pool.stage_client, "is_comprehension", False) for pool in self.stage_pools):
+        comprehension_pools = [
+            pool
+            for pool in self.stage_pools
+            if getattr(pool.stage_client, "is_comprehension", False)
+        ]
+        if comprehension_pools:
             supported_tasks.add("generate")
+            # If the comprehension stage's model class also implements
+            # SupportsTranscription, expose `/v1/audio/transcriptions` against
+            # the already-loaded model (no extra VRAM, no separate process).
+            try:
+                from vllm.model_executor.models.interfaces import supports_transcription
+                from vllm.model_executor.models.registry import ModelRegistry
+
+                for pool in comprehension_pools:
+                    model_config = pool.stage_vllm_config.model_config
+                    arches = getattr(model_config, "architectures", None) or []
+                    for arch in arches:
+                        resolved = ModelRegistry.resolve_model_cls(arch)
+                        model_cls = resolved[0] if isinstance(resolved, tuple) else resolved
+                        if supports_transcription(model_cls):
+                            supported_tasks.add("transcription")
+                            break
+                    if "transcription" in supported_tasks:
+                        break
+            except Exception as e:
+                logger.warning(
+                    "[AsyncOmniEngine] transcription capability probe failed: %s", e
+                )
         if any(m.get("final_output_type") == "audio" for m in self.stage_metadata):
             supported_tasks.add("speech")
         self.supported_tasks = tuple(supported_tasks) if supported_tasks else ("generate",)

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -67,11 +67,13 @@ from vllm.entrypoints.openai.utils import maybe_filter_parallel_tool_calls
 from vllm.entrypoints.utils import should_include_usage
 from vllm.inputs import PromptType
 from vllm.logger import init_logger
+from vllm.model_executor.models.interfaces import supports_transcription
+from vllm.model_executor.models.registry import ModelRegistry
 from vllm.outputs import RequestOutput
 from vllm.reasoning import ReasoningParser
 from vllm.renderers import BaseRenderer, merge_kwargs
 from vllm.renderers.inputs import TokPrompt
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.tokenizers import TokenizerLike
 from vllm.tokenizers import TokenizerLike as AnyTokenizer
 from vllm.tokenizers.mistral import (
@@ -82,6 +84,7 @@ from vllm.tokenizers.mistral import (
 )
 from vllm.tool_parsers import ToolParser
 from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
+from vllm.utils.async_utils import merge_async_iterators
 from vllm.utils.collection_utils import as_list
 from vllm.v1.engine.exceptions import EngineDeadError
 
@@ -896,6 +899,134 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             lora_request=lora_request,
         )
 
+    @staticmethod
+    def _extract_last_user_audio(request: ChatCompletionRequest) -> bytes | None:
+        """Pull base64 WAV bytes out of the most recent user message's
+        `input_audio` content part, if any. Used to drive parallel input
+        transcription so the SSE stream can emit the user's transcript inline."""
+        messages = getattr(request, "messages", None) or []
+        for msg in reversed(messages):
+            role = getattr(msg, "role", None) if not isinstance(msg, dict) else msg.get("role")
+            if role != "user":
+                continue
+            content = getattr(msg, "content", None) if not isinstance(msg, dict) else msg.get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                part_d = (
+                    part if isinstance(part, dict) else (part.model_dump() if hasattr(part, "model_dump") else None)
+                )
+                if not isinstance(part_d, dict):
+                    continue
+                if part_d.get("type") != "input_audio":
+                    continue
+                audio = part_d.get("input_audio") or {}
+                data = audio.get("data") if isinstance(audio, dict) else None
+                if isinstance(data, str):
+                    try:
+                        return base64.b64decode(data)
+                    except (ValueError, TypeError):
+                        return None
+            # Only inspect the most recent user message
+            break
+        return None
+
+    def _transcription_model_cls(self):
+        """Resolve the model class for the comprehension stage and return it
+        only if it implements SupportsTranscription, else None."""
+        try:
+            arches = getattr(self.model_config, "architectures", None) or []
+            if not arches:
+                return None
+            resolved = ModelRegistry.resolve_model_cls(arches, self.model_config)
+            model_cls = resolved[0] if isinstance(resolved, tuple) else resolved
+            if supports_transcription(model_cls):
+                return model_cls
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("transcription model resolution failed: %s", e)
+        return None
+
+    async def _stream_user_transcription(
+        self,
+        audio_bytes: bytes,
+        request_id: str,
+    ) -> AsyncGenerator[RequestOutput, None]:
+        """Run user-side ASR on the captured audio bytes against the same
+        loaded Qwen3-Omni weights and stream the resulting text deltas.
+
+        Yields RequestOutput-shaped chunks identical to what the regular chat
+        completion generator yields, so the caller can interleave them through
+        `merge_async_iterators` into the same SSE stream.
+        """
+        if soundfile is None:
+            return
+        model_cls = self._transcription_model_cls()
+        if model_cls is None:
+            return
+
+        try:
+            from vllm.config.speech_to_text import SpeechToTextParams
+        except Exception as e:
+            logger.warning("SpeechToTextParams import failed: %s", e)
+            return
+
+        # 1) decode WAV bytes → float32 PCM at the model's expected sample rate
+        try:
+            stt_config = model_cls.get_speech_to_text_config(self.model_config, "transcribe")
+            with BytesIO(audio_bytes) as buf:
+                pcm, sr = soundfile.read(buf, dtype="float32", always_2d=False)
+            if pcm.ndim > 1:  # downmix
+                pcm = pcm.mean(axis=1)
+            if sr != stt_config.sample_rate:
+                # cheap linear resample to model SR — input is short
+                import numpy as np
+
+                ratio = stt_config.sample_rate / float(sr)
+                new_len = int(round(len(pcm) * ratio))
+                pcm = np.interp(
+                    np.linspace(0, len(pcm), new_len, endpoint=False),
+                    np.arange(len(pcm)),
+                    pcm,
+                ).astype("float32")
+        except Exception as e:
+            logger.warning("input ASR audio decode failed: %s", e)
+            return
+
+        # 2) build the ASR prompt via the model's own template
+        try:
+            stt_params = SpeechToTextParams(
+                audio=pcm,
+                stt_config=stt_config,
+                model_config=self.model_config,
+                task_type="transcribe",
+            )
+            prompt = model_cls.get_generation_prompt(stt_params)
+        except Exception as e:
+            logger.warning("input ASR prompt build failed: %s", e)
+            return
+
+        # 3) submit to the engine as a text-only generation; the comprehension
+        # stage will run ASR. RequestOutputKind.DELTA gives us token-by-token
+        # deltas so we can stream the transcript live alongside the chat reply.
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=512,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        asr_request_id = f"asr-{request_id}"
+        try:
+            async for output in self.engine_client.generate(
+                prompt=prompt,
+                sampling_params=sampling_params,
+                request_id=asr_request_id,
+                output_modalities=["text"],
+            ):
+                yield output
+        except Exception as e:
+            logger.warning("input ASR generation aborted: %s", e)
+            return
+
     async def chat_completion_stream_generator(
         self,
         request: ChatCompletionRequest,
@@ -973,8 +1104,61 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         include_usage, include_continuous_usage = should_include_usage(stream_options, self.enable_force_include_usage)
 
         last_metrics: dict[str, Any] | None = None
+
+        # If the user message includes audio AND the model supports
+        # transcription, spawn a parallel ASR pass and merge its text deltas
+        # into the same SSE stream tagged with modality="transcription". This
+        # lets the client display the heard user-side transcript inline,
+        # without a second HTTP round-trip to /v1/audio/transcriptions.
+        asr_gen: AsyncGenerator[RequestOutput, None] | None = None
         try:
-            async for omni_res in result_generator:
+            audio_bytes = self._extract_last_user_audio(request)
+            if audio_bytes is not None:
+                asr_gen = self._stream_user_transcription(audio_bytes, request_id)
+        except Exception as _asr_e:  # pragma: no cover - defensive
+            logger.warning("user transcription setup failed: %s", _asr_e)
+            asr_gen = None
+
+        async def _wrapped_results():
+            """Yield ("chat", omni_res) or ("asr_text", delta_str)."""
+            if asr_gen is None:
+                async for omni_res in result_generator:
+                    yield ("chat", omni_res)
+                return
+            async for src_idx, item in merge_async_iterators(result_generator, asr_gen):
+                if src_idx == 0:
+                    yield ("chat", item)
+                else:
+                    # ASR RequestOutput with output_kind=DELTA — outputs[0].text
+                    # is the delta token string
+                    try:
+                        delta_text = item.outputs[0].text if item.outputs else ""
+                    except Exception:
+                        delta_text = ""
+                    if delta_text:
+                        yield ("asr_text", delta_text)
+
+        try:
+            async for _src_kind, _src_item in _wrapped_results():
+                if _src_kind == "asr_text":
+                    asr_chunk = OmniChatCompletionStreamResponse(
+                        id=request_id,
+                        object=chunk_object_type,
+                        created=created_time,
+                        choices=[
+                            ChatCompletionResponseStreamChoice(
+                                index=0,
+                                delta=DeltaMessage(content=_src_item),
+                                logprobs=None,
+                                finish_reason=None,
+                            )
+                        ],
+                        model=model_name,
+                        modality="transcription",
+                    )
+                    yield f"data: {asr_chunk.model_dump_json(exclude_unset=True)}\n\n"
+                    continue
+                omni_res = _src_item
                 final_output_type = omni_res.final_output_type
                 res = omni_res.request_output
                 if final_output_type not in first_iteration_dict:

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -117,9 +117,7 @@ class Qwen3OmniMoeForConditionalGeneration(
 
     @classmethod
     def get_speech_to_text_config(cls, model_config: ModelConfig, task_type: str):
-        return Qwen3OmniMoeThinkerForConditionalGeneration.get_speech_to_text_config(
-            model_config, task_type
-        )
+        return Qwen3OmniMoeThinkerForConditionalGeneration.get_speech_to_text_config(model_config, task_type)
 
     @classmethod
     def get_generation_prompt(cls, stt_params):

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -21,7 +21,13 @@ from vllm.config import ModelConfig, VllmConfig
 from vllm.inputs import PromptType, TokensPrompt
 from vllm.logger import init_logger
 from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding
-from vllm.model_executor.models.interfaces import SupportsMRoPE, SupportsMultiModal, SupportsPP, SupportsRealtime
+from vllm.model_executor.models.interfaces import (
+    SupportsMRoPE,
+    SupportsMultiModal,
+    SupportsPP,
+    SupportsRealtime,
+    SupportsTranscription,
+)
 from vllm.model_executor.models.qwen3_asr_realtime import Qwen3ASRRealtimeBuffer
 from vllm.model_executor.models.qwen3_omni_moe_thinker import (
     Qwen3OmniMoeConditionalGenerationMixin,
@@ -85,6 +91,7 @@ class Qwen3OmniMoeForConditionalGeneration(
     CustomProcessMixin,
     SupportsMRoPE,
     SupportsRealtime,
+    SupportsTranscription,
 ):
     """
     Unified Qwen3 Omni MoE model combining thinker, talker, and code2wav.
@@ -99,6 +106,38 @@ class Qwen3OmniMoeForConditionalGeneration(
     """
 
     realtime_max_tokens = 64
+
+    # SupportsTranscription is implemented by the inner Thinker
+    # (Qwen3OmniMoeThinkerForConditionalGeneration). Delegate the protocol's
+    # classmethods so the omni wrapper — which is what the model registry
+    # resolves and what OpenAIServingTranscription instantiates — exposes the
+    # same ASR surface and `/v1/audio/transcriptions` works end-to-end on the
+    # already-loaded model (no extra VRAM, no separate process).
+    supported_languages = Qwen3OmniMoeThinkerForConditionalGeneration.supported_languages
+
+    @classmethod
+    def get_speech_to_text_config(cls, model_config: ModelConfig, task_type: str):
+        return Qwen3OmniMoeThinkerForConditionalGeneration.get_speech_to_text_config(
+            model_config, task_type
+        )
+
+    @classmethod
+    def get_generation_prompt(cls, stt_params):
+        return Qwen3OmniMoeThinkerForConditionalGeneration.get_generation_prompt(stt_params)
+
+    @classmethod
+    def validate_language(cls, language):
+        return Qwen3OmniMoeThinkerForConditionalGeneration.validate_language(language)
+
+    @classmethod
+    def get_num_audio_tokens(cls, audio_duration_s, stt_config, model_config):
+        return Qwen3OmniMoeThinkerForConditionalGeneration.get_num_audio_tokens(
+            audio_duration_s, stt_config, model_config
+        )
+
+    @classmethod
+    def post_process_output(cls, text: str) -> str:
+        return Qwen3OmniMoeThinkerForConditionalGeneration.post_process_output(text)
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()


### PR DESCRIPTION
## Purpose

Qwen3-Omni's Thinker subcomponent implements `SupportsTranscription` (it has `get_speech_to_text_config`, `get_generation_prompt`, the supported-language map, etc.) but the omni wrapper that the model registry resolves does not, so:

1. **`/v1/audio/transcriptions` is unreachable** — `AsyncOmniEngine` hard-codes `supported_tasks` to `{generate, speech}` regardless of the loaded model's capability (the existing `# TODO(Peiqi): Hack here` comment flags it). Even if the route were registered, `OpenAIServingTranscription.__init__` crashes with `AttributeError: type object 'Qwen3OmniMoeForConditionalGeneration' has no attribute 'get_speech_to_text_config'`.

2. **`/v1/chat/completions` cannot return the user-side transcript** — only the assistant's text/audio modalities. Users who want a live conversation transcript have to make a separate ASR call per turn, doubling HTTP round-trips.

This PR addresses [RFC #1481](https://github.com/vllm-project/vllm-omni/issues/1481), which lists `{\"type\": \"transcript\", \"text\": ...}` SSE events as future work.

## Changes

**Three files, ~260 LoC.**

### 1. `vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py`
The omni wrapper now declares `SupportsTranscription` and delegates the protocol's classmethods (`get_speech_to_text_config`, `get_generation_prompt`, `validate_language`, `get_num_audio_tokens`, `post_process_output`) to the inner Thinker. No new behavior — just exposes the Thinker's existing ASR surface through the class the entrypoint resolves.

### 2. `vllm_omni/engine/async_omni_engine.py`
Replaces the hardcoded \`supported_tasks\` set with a **capability-based probe**: when the comprehension stage's model class passes \`supports_transcription(model_cls)\`, \`\"transcription\"\` is added to \`self.supported_tasks\`. Resolves via \`ModelRegistry.resolve_model_cls(architectures, model_config)\`. Removes the \`TODO(Peiqi): Hack here\` comment. Works generically — any future omni model whose comprehension stage implements the interface gets the route for free.

### 3. \`vllm_omni/entrypoints/openai/serving_chat.py\`
When a chat-completions request includes an \`input_audio\` content part AND the model supports transcription, spawns a parallel ASR pass and merges its deltas into the existing SSE stream tagged with \`modality: \"transcription\"\`. Three additions:
- \`_extract_last_user_audio(request)\` — pulls base64 WAV bytes from the most recent user message's \`input_audio\` part.
- \`_stream_user_transcription(audio_bytes, request_id)\` — decodes/resamples PCM to the model's expected sample rate, builds STT params, generates via \`engine_client.generate(prompt=Thinker.get_generation_prompt(stt_params), output_modalities=[\"text\"])\` with \`RequestOutputKind.DELTA\` for live streaming.
- \`chat_completion_stream_generator\` — merges the chat and ASR generators with \`merge_async_iterators\`, emits ASR deltas as \`modality: \"transcription\"\` SSE chunks alongside the existing \`text\`/\`audio\` modalities.

All paths are **strictly additive**: text-only requests, or requests against models that don't implement \`SupportsTranscription\`, behave exactly as before.

## Test Plan

Built a v0.20.0-based overlay image (\`ghcr.io/nicko170/vllm-omni:v0.20.0-transcription\`) and deployed it to a Qwen3-Omni-30B-A3B-Instruct cluster (4x NVIDIA A40, k8s with containerd).

Test commands:

\`\`\`bash
# 1) Verify route registration
curl -s http://server:8091/openapi.json | jq '.paths | keys[]' | grep transcript
# Expected: \"/v1/audio/transcriptions\"

# 2) Verify supported_tasks include transcription
kubectl logs <pod> | grep \"Supported tasks\"
# Expected: Supported tasks: {'transcription', 'speech', 'generate'}

# 3) End-to-end voice chat with inline transcript
# Client posts WAV (mono 16kHz PCM16) as input_audio in chat-completions with stream:true,
# observes modality:\"transcription\" SSE chunks interleaved with text/audio.
\`\`\`

## Test Result

**Before this PR:**
- \`/v1/audio/transcriptions\` not in OpenAPI spec.
- \`Supported tasks: {'speech', 'generate'}\`.
- Adding \`\"transcription\"\` manually causes startup crash: \`AttributeError: type object 'Qwen3OmniMoeForConditionalGeneration' has no attribute 'get_speech_to_text_config'\`.

**After this PR:**
- \`/v1/audio/transcriptions\` registered, accepts WAV uploads, returns JSON \`{\"text\": \"...\"}\`.
- \`Supported tasks: {'transcription', 'speech', 'generate'}\` in engine logs.
- Chat completion SSE stream emits \`modality:\"transcription\"\` chunks with the user's transcribed speech inline alongside \`text\`/\`audio\` modalities, via a single HTTP request. Verified end-to-end in a voice chat client where \`[voice — 1.7s]\` placeholders are rewritten to actual transcribed text as the model responds.

## Notes

- AI assistance was used in preparing this change. All code was reviewed and verified end-to-end against a running Qwen3-Omni cluster by the submitter.
- The capability probe is wrapped in a try/except so it cannot break engine startup for any model; failure is logged at WARNING level and \`supported_tasks\` falls back to the prior \`{generate, speech}\` set.
- No new dependencies. \`soundfile\` (used to decode the WAV in the SSE handler) is already an indirect dep via \`vllm.entrypoints.openai.speech_to_text.audio\`; the helper guards against import failure.