### PR TITLE
[Bugfix] Remove stale OmniStage import and type annotation

### DIFF
--- a/vllm_omni/entrypoints/pd_utils.py
+++ b/vllm_omni/entrypoints/pd_utils.py
@@ -13,8 +13,6 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from vllm import SamplingParams
 
-    from vllm_omni.entrypoints.omni_stage import OmniStage
-
 _DEFAULT_MOONCAKE_BOOTSTRAP_PORT = 25201
 
 logger = logging.getLogger(__name__)
@@ -131,7 +129,7 @@ class PDDisaggregationMixin:
         p_stage = self.stage_configs[p_id]
         d_stage = self.stage_configs[d_id]
 
-        def _get_kv_cfg(stage: "OmniStage") -> dict[str, Any]:
+        def _get_kv_cfg(stage: Any) -> dict[str, Any]:
             ea = stage.engine_args
             cfg = getattr(ea, "kv_transfer_config", None)
             if cfg is None:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Remove stale OmniStage import and type annotation

## Test Plan


**No new tests required.** Both changes are compile-time / static-analysis only and have zero runtime effect:

1. **Import removal** (`from vllm_omni.entrypoints.omni_stage import OmniStage`): This import lives inside `if TYPE_CHECKING:`, which Python evaluates as `False` at runtime. The symbol `OmniStage` was never imported during execution, so removing it cannot affect any runtime behavior or test outcome.

2. **Type annotation change** (`"OmniStage"` → `Any`): The annotation on `_get_kv_cfg`'s `stage` parameter is a forward-reference string used only by static type checkers (mypy/pyright). Python does not enforce function annotations at runtime, so this change is invisible to any test. Relaxing `OmniStage` to `Any` is strictly backward-compatible — it widens the accepted type set, not narrows it.

**Existing coverage:** The `_validate_pd_separation_config` method (which contains `_get_kv_cfg`) is exercised by the existing PD disaggregation tests. Those tests passing after this change confirms no behavioral regression.

**Verification:** `import vllm_omni.entrypoints.pd_utils` succeeds without error — this alone proves the stale import caused no import-time failure and its removal is safe.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (#3542 )".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
