### PR TITLE
[BUGFIX]: Align prompt_embeds_mask handling with diffusers

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -364,18 +364,10 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
                 f" {negative_prompt_embeds}. Please make sure to only forward one of the two."
             )
 
-        if prompt_embeds is not None and prompt_embeds_mask is None:
-            raise ValueError(
-                "If `prompt_embeds` are provided, `prompt_embeds_mask` also have to be passed. "
-                "Make sure to generate `prompt_embeds_mask` from the same text encoder "
-                "that was used to generate `prompt_embeds`."
-            )
-        if negative_prompt_embeds is not None and negative_prompt_embeds_mask is None:
-            raise ValueError(
-                "If `negative_prompt_embeds` are provided, `negative_prompt_embeds_mask` also have to be passed. "
-                "Make sure to generate `negative_prompt_embeds_mask` from the same text encoder "
-                "that was used to generate `negative_prompt_embeds`."
-            )
+        # NOTE: prompt_embeds_mask=None is valid and means "all tokens are
+        # valid" (matching the diffusers convention set by encode_prompt when
+        # all mask elements are True).  We therefore no longer reject
+        # prompt_embeds without an accompanying mask.
 
         if max_sequence_length is not None and max_sequence_length > self.tokenizer_max_length:
             raise ValueError(
@@ -488,6 +480,11 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         prompt_embeds_mask = prompt_embeds_mask.repeat(1, num_images_per_prompt, 1)
         prompt_embeds_mask = prompt_embeds_mask.view(batch_size * num_images_per_prompt, seq_len)
 
+        # Match diffusers convention: set all-True masks to None so the
+        # transformer skips masked attention and uses the full sequence.
+        if prompt_embeds_mask is not None and prompt_embeds_mask.all():
+            prompt_embeds_mask = None
+
         return prompt_embeds, prompt_embeds_mask
 
     @staticmethod
@@ -525,7 +522,6 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         generator,
         latents=None,
     ) -> torch.Tensor:
-        # generator=torch.Generator(device="cuda").manual_seed(42)
         # VAE applies 8x compression on images but we must also account for packing which requires
         # latent height and width to be divisible by 2.
         height = 2 * (int(height) // (self.vae_scale_factor * 2))
@@ -703,10 +699,18 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         else:
             guidance = None
 
-        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
-        negative_txt_seq_lens = (
-            negative_prompt_embeds_mask.sum(dim=1).tolist() if negative_prompt_embeds_mask is not None else None
-        )
+        # When the mask is None (all tokens valid), derive txt_seq_lens from
+        # the embedding shape — matching diffusers' internal convention.
+        if prompt_embeds_mask is not None:
+            txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist()
+        else:
+            txt_seq_lens = [prompt_embeds.shape[1]] * prompt_embeds.shape[0]
+        if negative_prompt_embeds_mask is not None:
+            negative_txt_seq_lens = negative_prompt_embeds_mask.sum(dim=1).tolist()
+        elif negative_prompt_embeds is not None:
+            negative_txt_seq_lens = [negative_prompt_embeds.shape[1]] * negative_prompt_embeds.shape[0]
+        else:
+            negative_txt_seq_lens = None
 
         return {
             "prompt_embeds": prompt_embeds,

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -379,18 +379,10 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
                 f" {negative_prompt_embeds}. Please make sure to only forward one of the two."
             )
 
-        if prompt_embeds is not None and prompt_embeds_mask is None:
-            raise ValueError(
-                "If `prompt_embeds` are provided, `prompt_embeds_mask` also have to be passed. "
-                "Make sure to generate `prompt_embeds_mask` from the same text encoder "
-                "that was used to generate `prompt_embeds`."
-            )
-        if negative_prompt_embeds is not None and negative_prompt_embeds_mask is None:
-            raise ValueError(
-                "If `negative_prompt_embeds` are provided, `negative_prompt_embeds_mask` also have to be passed. "
-                "Make sure to generate `negative_prompt_embeds_mask` from the same text encoder "
-                "that was used to generate `negative_prompt_embeds`."
-            )
+        # NOTE: prompt_embeds_mask=None is valid and means "all tokens are
+        # valid" (matching the diffusers convention set by encode_prompt when
+        # all mask elements are True).  We therefore no longer reject
+        # prompt_embeds without an accompanying mask.
 
         if max_sequence_length is not None and max_sequence_length > self.tokenizer_max_length:
             raise ValueError(
@@ -503,6 +495,11 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         prompt_embeds_mask = prompt_embeds_mask.repeat(1, num_images_per_prompt, 1)
         prompt_embeds_mask = prompt_embeds_mask.view(batch_size * num_images_per_prompt, seq_len)
 
+        # Match diffusers convention: set all-True masks to None so the
+        # transformer skips masked attention and uses the full sequence.
+        if prompt_embeds_mask is not None and prompt_embeds_mask.all():
+            prompt_embeds_mask = None
+
         return prompt_embeds, prompt_embeds_mask
 
     @staticmethod
@@ -540,7 +537,6 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         generator,
         latents=None,
     ) -> torch.Tensor:
-        # generator=torch.Generator(device="cuda").manual_seed(42)
         # VAE applies 8x compression on images but we must also account for packing which requires
         # latent height and width to be divisible by 2.
         height = 2 * (int(height) // (self.vae_scale_factor * 2))
@@ -718,10 +714,18 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         else:
             guidance = None
 
-        txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist() if prompt_embeds_mask is not None else None
-        negative_txt_seq_lens = (
-            negative_prompt_embeds_mask.sum(dim=1).tolist() if negative_prompt_embeds_mask is not None else None
-        )
+        # When the mask is None (all tokens valid), derive txt_seq_lens from
+        # the embedding shape — matching diffusers' internal convention.
+        if prompt_embeds_mask is not None:
+            txt_seq_lens = prompt_embeds_mask.sum(dim=1).tolist()
+        else:
+            txt_seq_lens = [prompt_embeds.shape[1]] * prompt_embeds.shape[0]
+        if negative_prompt_embeds_mask is not None:
+            negative_txt_seq_lens = negative_prompt_embeds_mask.sum(dim=1).tolist()
+        elif negative_prompt_embeds is not None:
+            negative_txt_seq_lens = [negative_prompt_embeds.shape[1]] * negative_prompt_embeds.shape[0]
+        else:
+            negative_txt_seq_lens = None
 
         return {
             "prompt_embeds": prompt_embeds,


### PR DESCRIPTION
Fixes #3370 

## Purpose
Fix PSNR regression in test_qwen_image_matches_diffusers where vllm-omni's Qwen-Image output diverges from the diffusers reference (PSNR 29.924 < 30.0 threshold).
Root cause: The encode_prompt method in QwenImagePipeline returns prompt_embeds_mask as a tensor of all 1s for short prompts (no padding). The diffusers reference pipeline sets this to None when all-True. This difference causes txt_seq_lens to be computed via mask.sum() instead of being inferred from the embedding shape, leading to subtly different RoPE positional embeddings that compound over 20 diffusion steps.
Fix (3 parts):
1. encode_prompt: Set prompt_embeds_mask = None when all elements are True, matching the diffusers convention so the transformer skips unnecessary masked attention.
2. _prepare_generation_context: When prompt_embeds_mask is None, compute txt_seq_lens from prompt_embeds.shape[1] instead of leaving it as None, since the vllm-omni transformer requires explicit sequence lengths for RoPE computation (unlike diffusers which infers them internally).
3. check_inputs: Remove the validation that rejects prompt_embeds without an accompanying mask, since None mask is now a valid convention meaning "all tokens valid". This keeps encode_prompt outputs reusable when passed back as pre-computed embeddings.
Also removes a leftover commented-out debug generator line.

## Test Plan
No new test scripts required — this fix is validated by the existing accuracy test:
pytest -sv tests/e2e/accuracy/test_qwen_image.py::test_qwen_image_matches_diffusers \
  -m "full_model" --run-level "full_model"
This test generates an image with vllm-omni via the HTTP API, generates a reference image with the diffusers pipeline, and compares SSIM (threshold >= 0.97) and PSNR (threshold >= 30.0 dB).
Tested on bare-metal 4x H100 80GB HBM3 (driver 580.159.03, CUDA 13.0) with vllm 0.20.2, diffusers 0.38.0, Python 3.12.

## Test Result
Before fix (from CI build, issue #3370):
Qwen/Qwen-Image similarity metrics:
  PSNR: value=29.924038 dB, threshold>=30.000000 dB
FAILED
After fix (on H100):
Qwen/Qwen-Image similarity metrics:
  SSIM: value=0.972616, threshold>=0.970000, range=[-1, 1], higher_is_better=True
  PSNR: value=30.022175 dB, threshold>=30.000000 dB, range=[0, +inf), higher_is_better=True
PASSED
================== 1 passed, 18 warnings in 91.85s (0:01:31) ===================
PSNR improved from 29.924 dB to 30.022 dB (+0.098 dB), crossing the 30.0 threshold. The test was run 3 times across iterations of the fix (including after addressing the check_inputs review feedback) with identical PSNR/SSIM results.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts.
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update — N/A, no user-facing documentation changes.
- [ ] (Optional) Release notes update — N/A, internal numerical parity fix.
</details>