### PR TITLE
[Bugfix][HunyuanImage3.0] Fix KV reuse compatibility in SP scenarios

### DIFF
--- a/vllm_omni/diffusion/hooks/sequence_parallel.py
+++ b/vllm_omni/diffusion/hooks/sequence_parallel.py
@@ -316,6 +316,13 @@ class SequenceParallelSplitHook(ModelHook):
             logger.warning_once(f"Expected tensor with {sp_input.expected_dims} dims, got {x.dim()}. Skipping split.")
             return x
 
+        split_dim = (
+            sp_input.split_dim if isinstance(sp_input, (SequenceParallelInput, SequenceParallelPartialInput)) else None
+        )
+        if split_dim is not None and x.size(split_dim) == 0:
+            logger.warning_once("Skip sharding for zero-sized tensors.")
+            return x
+
         def _raise_strict_divisibility_error(*, dim: int, seq_len: int, sp_size: int) -> None:
             # Keep message actionable: strict mode must be evenly shardable at the split hook level.
             msg = (

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -1032,14 +1032,14 @@ class ImageKVCacheManager:
             self.image_kv_cache_map = None  # reset first
             key, value = self._cache_prompt_kv(key, value, seq_len, shard_image_size)
             if self.sp_size > 1:
-                local_prompt_len = q_len - shard_image_size
-                joint_text_query = query[:, :local_prompt_len, :, :]
+                local_prompt_len = seq_len - shard_image_size
+                join_query_len = query.shape[1] - shard_image_size
+                joint_text_query = query[:, :join_query_len, :, :]
                 joint_text_key = key[:, :local_prompt_len, :, :]
                 joint_text_value = value[:, :local_prompt_len, :, :]
-                query = query[:, local_prompt_len:, :, :]
+                query = query[:, join_query_len:, :, :]
                 key = key[:, local_prompt_len:, :, :]
                 value = value[:, local_prompt_len:, :, :]
-        else:
             if self.sp_size <= 1:
                 key, value = self._reuse_prompt_kv(key, value, seq_len, bs)
             else:

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -1040,6 +1040,7 @@ class ImageKVCacheManager:
                 query = query[:, join_query_len:, :, :]
                 key = key[:, local_prompt_len:, :, :]
                 value = value[:, local_prompt_len:, :, :]
+        else:
             if self.sp_size <= 1:
                 key, value = self._reuse_prompt_kv(key, value, seq_len, bs)
             else:

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -2250,7 +2250,7 @@ class HunyuanImage3Model(nn.Module):
         num_image_tokens: int | None = None,
         gen_timestep_scatter_index: torch.Tensor | None = None,
         uncond_cfg_prefill: bool = False,
-        ar_kv_reuse_len: int = None,
+        ar_kv_reuse_len: int = 0,
         full_attn_spans: list[list[tuple[int, int]]] | None = None,
     ) -> tuple | BaseModelOutputWithPast:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
@@ -2735,6 +2735,7 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
             query_lens=[prefill_query_len],
             seq_lens=[prefill_seq_len],
             num_image_tokens=0,
+            ar_kv_reuse_len=negative_reuse_len,
             full_attn_spans=model_kwargs["full_attn_spans"][batch_slice]
             if model_kwargs.get("full_attn_spans")
             else None,

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -2250,6 +2250,7 @@ class HunyuanImage3Model(nn.Module):
         num_image_tokens: int | None = None,
         gen_timestep_scatter_index: torch.Tensor | None = None,
         uncond_cfg_prefill: bool = False,
+        ar_kv_reuse_len: int = None,
         full_attn_spans: list[list[tuple[int, int]]] | None = None,
     ) -> tuple | BaseModelOutputWithPast:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
@@ -2305,7 +2306,7 @@ class HunyuanImage3Model(nn.Module):
             else:  # [image tokens, last token]
                 shard_padding_size = shard_image_size * sp_world_size - num_image_tokens
             if first_step:
-                seq_lens = [prompt_size + shard_image_size for _ in seq_lens]
+                seq_lens = [prompt_size + shard_image_size + ar_kv_reuse_len for _ in seq_lens]
             else:
                 seq_lens = [x - y for x, y in zip(seq_lens, query_lens)]
                 seq_lens = [seq_len + shard_image_size - 1 for seq_len in seq_lens]
@@ -2787,7 +2788,7 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
     ):
         ar_kv_data = model_kwargs.pop("ar_kv_data", None)
         if ar_kv_data is None:
-            return input_ids
+            return input_ids, 0
 
         # 1. positive prefix len
         positive_reuse_len, negative_reuse_len = self._get_kv_reuse_len(model_kwargs, batch_size)
@@ -2796,7 +2797,7 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
             f"negative_reuse_len={negative_reuse_len}"
         )
         if positive_reuse_len <= 0:
-            return input_ids
+            return input_ids, 0
 
         # 2. inject positive kv
         self.model.inject_ar_kv_into_layers(ar_kv_data, positive_reuse_len)
@@ -2821,7 +2822,7 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
             positive_reuse_len=positive_reuse_len,
         )
 
-        return input_ids
+        return input_ids, positive_reuse_len
 
     @torch.no_grad()
     def __call__(
@@ -2975,9 +2976,12 @@ class HunyuanImage3Text2ImagePipeline(DiffusionPipeline):
 
         # Attempt to reuse KV cache from the AR stage.
         # Note: the reusable KV length may differ between positive and negative prompts.
-        input_ids = self._maybe_handle_ar_kv_reuse(
+        input_ids, ar_kv_reuse_len = self._maybe_handle_ar_kv_reuse(
             input_ids, model_kwargs, batch_size, cfg_parallel_ready, cfg_rank, device
         )
+
+        # Store ar_kv_reuse_len in model_kwargs for use in forward method (SP mode)
+        model_kwargs["ar_kv_reuse_len"] = ar_kv_reuse_len
 
         # Sampling loop
         num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -1011,6 +1011,7 @@ class HunyuanImage3Pipeline(
                 "query_lens": kwargs.get("query_lens"),
                 "seq_lens": kwargs.get("seq_lens"),
                 "num_image_tokens": kwargs.get("num_image_tokens"),
+                "ar_kv_reuse_len": kwargs.get("ar_kv_reuse_len", 0),
                 "full_attn_spans": kwargs.get("full_attn_spans"),
             }
         )
@@ -1162,6 +1163,7 @@ class HunyuanImage3Pipeline(
         seq_lens: list[int] | None = None,
         num_image_tokens: int | None = None,
         uncond_cfg_prefill: bool = False,
+        ar_kv_reuse_len: int = 0,
         full_attn_spans: list[list[tuple[int, int]]] | None = None,
     ) -> tuple | CausalMMOutputWithPast:
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -1258,6 +1260,7 @@ class HunyuanImage3Pipeline(
                 num_image_tokens=num_image_tokens,
                 gen_timestep_scatter_index=gen_timestep_scatter_index,
                 uncond_cfg_prefill=uncond_cfg_prefill,
+                ar_kv_reuse_len=ar_kv_reuse_len,
                 full_attn_spans=full_attn_spans,
             )
         hidden_states = outputs[0]


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
In the SP scenario, seq_len is recalculated based on the sharded image size and query text length. Before this change, the recalculation logic did not take the AR KV reuse length into account. After the modification, the KV length is included in the calculation, making the behavior more accurate and consistent.


## Test Plan
(1) unitest
```
pytest -s -v tests/diffusion/models/hunyuan_image3/test_image_kv_cache_manager.py
```
(2) end2end test
```
AR TP2
DIT SP2 + fp8
```


## Test Result
<img width="2404" height="116" alt="image" src="https://github.com/user-attachments/assets/e3594ce8-fa1d-4ce8-8720-0f34e1cd2c39" />




| online/offline | kv_reuse |cfg | results |
|-----|-----|-----|-----|
| offline  |  True|  False | <img width="104" height="152" alt="offline_kv_reuse_non_cfg" src="https://github.com/user-attachments/assets/95fb4858-01dd-4d06-b8be-2564bda00a4f" />  |
| offline  | True  | True  | <img width="104" height="152" alt="offline_kv_reuse_cfg" src="https://github.com/user-attachments/assets/177423cb-4186-409e-96dc-800c248378ba" />  |
| offline | False  | True  |  <img width="104" height="152" alt="offline_no_kv_reuse_cfg" src="https://github.com/user-attachments/assets/1a33626e-bb5d-4878-a0a3-f111f9fa21d3" /> |
| online | True  | False  | <img width="104" height="152" alt="online_kv_reuse_cfg" src="https://github.com/user-attachments/assets/73190073-0ed4-4252-b618-4bc01907abf1" />  |
| online | Flase | False  | <img width="104" height="152" alt="online_no_kv_reuse_no_cfg" src="https://github.com/user-attachments/assets/ea57347b-898d-4755-8462-4c9bc21f4bde" /> |
---

**Also test with tp2cfg2**:
<img width="104" height="152" alt="offline_tp2_cfgp2" src="https://github.com/user-attachments/assets/1f22034a-7fd2-479a-89d3-03fb7bddf87b" />

**sp2cfg2**:

<img width="104" height="152" alt="offline_sp2_cfgp2" src="https://github.com/user-attachments/assets/e012822e-cc03-4a39-9fd0-e85f5ba53a87" />


<details>

<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
