### PR TITLE
[GLM-Image] Add opt-in VAE decode split pipeline

### DIFF
--- a/tests/model_executor/stage_input_processors/test_glm_image.py
+++ b/tests/model_executor/stage_input_processors/test_glm_image.py
@@ -9,11 +9,13 @@ import torch
 
 from vllm_omni.model_executor.stage_input_processors.glm_image import (
     _first_source_image,
+    _extract_latent_payload,
     _has_source_image,
     _parse_generated_tokens,
     _upsample_token_ids,
     ar2diffusion,
     compute_max_tokens,
+    latent2vae,
 )
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -387,3 +389,31 @@ class TestAr2Diffusion:
         assert len(result) == 2
         assert result[0]["prompt"] == "first"
         assert result[1]["prompt"] == "second"
+
+
+class TestLatent2Vae:
+    def test_extract_latent_payload_from_custom_output(self):
+        payload = {"latents": torch.zeros((1, 16, 64, 64)), "height": 1024, "width": 1024, "seed": 42}
+        source_output = SimpleNamespace(custom_output=payload)
+        assert _extract_latent_payload(source_output) is payload
+
+    def test_latent2vae_from_custom_output(self):
+        latents = torch.zeros((1, 16, 64, 64))
+        source_output = SimpleNamespace(
+            request_id="req-1",
+            custom_output={"latents": latents, "height": 1024, "width": 1024, "seed": 42},
+        )
+
+        outputs = latent2vae([source_output])
+
+        assert len(outputs) == 1
+        assert outputs[0]["prompt"] == "vae decode"
+        assert outputs[0]["height"] == 1024
+        assert outputs[0]["width"] == 1024
+        assert torch.equal(outputs[0]["extra"]["latents"], latents)
+        assert outputs[0]["extra"]["seed"] == 42
+
+    def test_latent2vae_missing_latents_raises(self):
+        source_output = SimpleNamespace(request_id="req-2", custom_output={"height": 1024})
+        with pytest.raises(ValueError, match="expects denoise stage output"):
+            latent2vae([source_output])

--- a/tests/model_executor/stage_input_processors/test_glm_image.py
+++ b/tests/model_executor/stage_input_processors/test_glm_image.py
@@ -8,8 +8,8 @@ import pytest
 import torch
 
 from vllm_omni.model_executor.stage_input_processors.glm_image import (
-    _first_source_image,
     _extract_latent_payload,
+    _first_source_image,
     _has_source_image,
     _parse_generated_tokens,
     _upsample_token_ids,

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -899,6 +899,36 @@ class TestDeployConfigLoading:
         assert deploy.stages[0].compilation_config == {"pass_config": {"fuse_allreduce_rms": False}}
         assert "compilation_config" not in deploy.stages[0].engine_extras
 
+    def test_load_deploy_config_preserves_explicit_engine_extras(self, tmp_path):
+        from vllm_omni.config.stage_config import load_deploy_config
+
+        deploy_path = tmp_path / "deploy.yaml"
+        deploy_path.write_text(
+            """
+pipeline: glm_image_vae_split
+stages:
+  - stage_id: 1
+    devices: "1"
+    engine_extras:
+      enable_diffusion_pipeline_profiler: true
+""".strip()
+        )
+
+        deploy = load_deploy_config(deploy_path)
+        assert deploy.stages[0].engine_extras["enable_diffusion_pipeline_profiler"] is True
+
+    def test_glm_image_vae_split_deploy_enables_profiler_on_diffusion_stages(self):
+        from pathlib import Path
+
+        from vllm_omni.config.stage_config import load_deploy_config
+
+        deploy_path = Path(__file__).parent.parent / "vllm_omni" / "deploy" / "glm_image_vae_split.yaml"
+        deploy = load_deploy_config(deploy_path)
+
+        stages_by_id = {stage.stage_id: stage for stage in deploy.stages}
+        assert stages_by_id[1].engine_extras["enable_diffusion_pipeline_profiler"] is True
+        assert stages_by_id[2].engine_extras["enable_diffusion_pipeline_profiler"] is True
+
     def test_merge_pipeline_deploy(self):
         from pathlib import Path
 

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -69,6 +69,10 @@ _OMNI_PIPELINES: dict[str, tuple[str, str]] = {
         "vllm_omni.model_executor.models.glm_image.pipeline",
         "GLM_IMAGE_PIPELINE",
     ),
+    "glm_image_vae_split": (
+        "vllm_omni.model_executor.models.glm_image.pipeline",
+        "GLM_IMAGE_VAE_SPLIT_PIPELINE",
+    ),
     "hunyuan_image3": (
         "vllm_omni.model_executor.models.hunyuan_image3.pipeline",
         "HUNYUAN_IMAGE3_PIPELINE",

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -491,6 +491,7 @@ _STAGE_DEPLOY_FIELDS = {f.name: f for f in fields(StageDeployConfig) if f.name n
 
 def _parse_stage_deploy(stage_data: dict[str, Any]) -> StageDeployConfig:
     """Parse a single stage entry from deploy YAML into StageDeployConfig."""
+    explicit_engine_extras = dict(stage_data.get("engine_extras", {}) or {})
     if "engine_args" in stage_data:
         runtime_cfg = dict(stage_data.get("runtime", {}))
         engine_args = dict(stage_data["engine_args"])
@@ -513,7 +514,7 @@ def _parse_stage_deploy(stage_data: dict[str, Any]) -> StageDeployConfig:
     kwargs["output_connectors"] = stage_data.get("output_connectors")
     kwargs["input_connectors"] = stage_data.get("input_connectors")
     kwargs["default_sampling_params"] = stage_data.get("default_sampling_params")
-    kwargs["engine_extras"] = engine_args
+    kwargs["engine_extras"] = {**engine_args, **explicit_engine_extras}
     return StageDeployConfig(**kwargs)
 
 

--- a/vllm_omni/deploy/glm_image_vae_split.yaml
+++ b/vllm_omni/deploy/glm_image_vae_split.yaml
@@ -1,0 +1,51 @@
+# GLM-Image deploy: AR (stage 0) + DiT denoise (stage 1) + VAE decode (stage 2).
+# The default 2-stage GLM-Image topology remains unchanged; this file opts into
+# the split pipeline declared in
+# vllm_omni/model_executor/models/glm_image/pipeline.py.
+
+pipeline: glm_image_vae_split
+async_chunk: false
+
+stages:
+  - stage_id: 0
+    max_num_seqs: 1
+    gpu_memory_utilization: 0.7
+    enforce_eager: false
+    trust_remote_code: true
+    enable_prefix_caching: false
+    max_num_batched_tokens: 32768
+    max_model_len: 32768
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 0.75
+      top_k: 16512
+      stop_token_ids: [16385]
+      max_tokens: 4353
+      seed: 42
+      detokenize: false
+
+  - stage_id: 1
+    max_num_batched_tokens: 32768
+    max_num_seqs: 1
+    enforce_eager: true
+    trust_remote_code: true
+    enable_prefix_caching: false
+    devices: "1"
+    default_sampling_params:
+      seed: 42
+      num_inference_steps: 50
+      guidance_scale: 1.5
+      height: 1024
+      width: 1024
+
+  - stage_id: 2
+    max_num_seqs: 1
+    enforce_eager: true
+    trust_remote_code: true
+    enable_prefix_caching: false
+    devices: "2"
+    default_sampling_params:
+      seed: 42
+      height: 1024
+      width: 1024

--- a/vllm_omni/deploy/glm_image_vae_split.yaml
+++ b/vllm_omni/deploy/glm_image_vae_split.yaml
@@ -32,6 +32,8 @@ stages:
     trust_remote_code: true
     enable_prefix_caching: false
     devices: "1"
+    engine_extras:
+      enable_diffusion_pipeline_profiler: true
     default_sampling_params:
       seed: 42
       num_inference_steps: 50
@@ -45,6 +47,8 @@ stages:
     trust_remote_code: true
     enable_prefix_caching: false
     devices: "2"
+    engine_extras:
+      enable_diffusion_pipeline_profiler: true
     default_sampling_params:
       seed: 42
       height: 1024

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -356,6 +356,7 @@ class DiffusionCacheConfig:
 class OmniDiffusionConfig:
     # Model and path configuration (for convenience)
     stage_id: int = 0
+    model_stage: str = "diffusion"
 
     model: str | None = None
 

--- a/vllm_omni/diffusion/models/glm_image/pipeline_glm_image.py
+++ b/vllm_omni/diffusion/models/glm_image/pipeline_glm_image.py
@@ -154,7 +154,9 @@ def get_glm_image_post_process_func(od_config: OmniDiffusionConfig):
 
     image_processor = VaeImageProcessor(vae_scale_factor=vae_scale_factor)
 
-    def post_process_func(images: torch.Tensor) -> list[PIL.Image.Image]:
+    def post_process_func(images: torch.Tensor | dict) -> list[PIL.Image.Image] | dict:
+        if isinstance(images, dict):
+            return images
         return image_processor.postprocess(images, output_type="pil")
 
     return post_process_func
@@ -255,6 +257,20 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
     4. VAE decodes final latents to image
     """
 
+    _GLM_IMAGE_PROFILER_TARGETS = [
+        "forward",
+        "forward_full_or_denoise",
+        "forward_vae_decode",
+        "encode_prompt",
+        "prepare_latents",
+        "diffuse",
+        "decode_latents",
+        "vae.encode",
+        "vae.decode",
+        "text_encoder.forward",
+        "tokenizer.forward",
+    ]
+
     def __init__(
         self,
         *,
@@ -274,59 +290,130 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
         else:
             model_path = download_weights_from_hf_specific(model, od_config.revision, ["*"])
 
-        # Load scheduler
-        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
-            model_path, subfolder="scheduler", local_files_only=True
-        )
+        self.model_stage = str(getattr(od_config, "model_stage", "dit") or "dit").lower()
+        self.is_full = self.model_stage in {"dit", "diffusion", "full"}
+        self.is_denoise_only = self.model_stage == "dit_denoise"
+        self.is_vae_decode_only = self.model_stage == "vae_decode"
 
-        # Load text encoder (T5 for glyph embeddings)
-        logger.info("Loading T5EncoderModel (glyph encoder)...")
-        self.text_encoder = T5EncoderModel.from_pretrained(
-            model_path,
-            subfolder="text_encoder",
-            local_files_only=True,
-            torch_dtype=torch.bfloat16,
-        ).to(self.device)
-        self.text_encoder.eval()
-
-        # Load tokenizer for glyph encoding
-        self.tokenizer = ByT5Tokenizer.from_pretrained(model_path, subfolder="tokenizer", local_files_only=True)
-
-        # Load VAE
-        logger.info("Loading AutoencoderKL (VAE)...")
-        self.vae = AutoencoderKL.from_pretrained(
-            model_path, subfolder="vae", local_files_only=True, torch_dtype=torch.bfloat16
-        ).to(self.device)
-        self.vae.eval()
-
-        # Load transformer (DiT)
-        logger.info("Loading GlmImageTransformer2DModel (DiT)...")
-        self.transformer = GlmImageTransformer2DModel(
-            od_config=od_config,
-            quant_config=od_config.quantization_config,
-        )
-
-        # Weight sources for DiT loading
-        self.weights_sources = [
-            DiffusersPipelineLoader.ComponentSource(
-                model_or_path=od_config.model,
-                subfolder="transformer",
-                revision=od_config.revision,
-                prefix="transformer.",
-                fall_back_to_pt=True,
-            )
-        ]
-
-        # Configure scale factors
-        self.vae_scale_factor = 2 ** (len(self.vae.config.block_out_channels) - 1)
+        self.vae_config = self._load_vae_config(model_path)
+        block_out_channels = self.vae_config.get("block_out_channels", [128, 256, 512, 512])
+        self.vae_scale_factor = 2 ** (len(block_out_channels) - 1)
         self.image_processor = VaeImageProcessor(vae_scale_factor=self.vae_scale_factor)
         self.default_sample_size = 128
 
-        # Get transformer config for patch size
-        self._patch_size = getattr(self.transformer, "patch_size", 2)
-        self.setup_diffusion_pipeline_profiler(
-            enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
+        load_scheduler = self.is_full or self.is_denoise_only
+        load_text_encoder = self.is_full or self.is_denoise_only
+        load_transformer = self.is_full or self.is_denoise_only
+        load_vae = self.is_full or self.is_vae_decode_only
+
+        self.scheduler = None
+        if load_scheduler:
+            self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+                model_path, subfolder="scheduler", local_files_only=True
+            )
+
+        self.text_encoder = None
+        self.tokenizer = None
+        if load_text_encoder:
+            logger.info("Loading T5EncoderModel (glyph encoder)...")
+            self.text_encoder = T5EncoderModel.from_pretrained(
+                model_path,
+                subfolder="text_encoder",
+                local_files_only=True,
+                torch_dtype=torch.bfloat16,
+            ).to(self.device)
+            self.text_encoder.eval()
+
+            self.tokenizer = ByT5Tokenizer.from_pretrained(model_path, subfolder="tokenizer", local_files_only=True)
+
+        self.vae = None
+        if load_vae:
+            logger.info("Loading AutoencoderKL (VAE)...")
+            self.vae = AutoencoderKL.from_pretrained(
+                model_path, subfolder="vae", local_files_only=True, torch_dtype=torch.bfloat16
+            ).to(self.device)
+            self.vae.eval()
+
+        self.transformer = None
+        if load_transformer:
+            logger.info("Loading GlmImageTransformer2DModel (DiT)...")
+            self.transformer = GlmImageTransformer2DModel(
+                od_config=od_config,
+                quant_config=od_config.quantization_config,
+            )
+
+            # Weight sources for DiT loading
+            self.weights_sources = [
+                DiffusersPipelineLoader.ComponentSource(
+                    model_or_path=od_config.model,
+                    subfolder="transformer",
+                    revision=od_config.revision,
+                    prefix="transformer.",
+                    fall_back_to_pt=True,
+                )
+            ]
+            self._patch_size = getattr(self.transformer, "patch_size", 2)
+        else:
+            self.weights_sources = []
+            self._patch_size = 2
+
+        logger.info(
+            "Initialized GLM-Image stage '%s' on %s (full=%s denoise_only=%s vae_decode_only=%s)",
+            self.model_stage,
+            self.device,
+            self.is_full,
+            self.is_denoise_only,
+            self.is_vae_decode_only,
         )
+
+        self.setup_diffusion_pipeline_profiler(
+            profiler_targets=self._GLM_IMAGE_PROFILER_TARGETS,
+            enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler,
+        )
+
+    def _load_vae_config(self, model_path: str) -> dict[str, object]:
+        vae_config_path = os.path.join(model_path, "vae", "config.json")
+        with open(vae_config_path) as f:
+            return json.load(f)
+
+    def _latent_channels(self) -> int:
+        return int(self.vae_config.get("latent_channels", 16))
+
+    @staticmethod
+    def _is_warmup_request(req: OmniDiffusionRequest) -> bool:
+        request_ids = getattr(req, "request_ids", None) or ()
+        return len(request_ids) == 1 and request_ids[0] == "dummy_req_id"
+
+    def _make_dummy_latents(
+        self,
+        *,
+        height: int,
+        width: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        latent_height = max(1, height // self.vae_scale_factor)
+        latent_width = max(1, width // self.vae_scale_factor)
+        vae_dtype = next(self.vae.parameters()).dtype if self.vae is not None else torch.float32
+        return torch.zeros(
+            (1, self._latent_channels(), latent_height, latent_width),
+            device=device,
+            dtype=vae_dtype,
+        )
+
+    def _latents_mean_std(
+        self,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        latent_channels = self._latent_channels()
+        latents_mean = (
+            torch.tensor(self.vae_config["latents_mean"]).view(1, latent_channels, 1, 1).to(device=device, dtype=dtype)
+        )
+        latents_std = (
+            torch.tensor(self.vae_config["latents_std"]).view(1, latent_channels, 1, 1).to(device=device, dtype=dtype)
+        )
+        return latents_mean, latents_std
 
     # ==================== Input Validation ====================
 
@@ -384,6 +471,8 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
         dtype: torch.dtype | None = None,
     ) -> torch.Tensor:
         """Get glyph embeddings from T5 encoder for text rendering."""
+        if self.text_encoder is None or self.tokenizer is None:
+            raise RuntimeError("GLM-Image glyph encoder is not loaded in this stage")
         device = device or self.device
         dtype = dtype or self.text_encoder.dtype
 
@@ -504,6 +593,8 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
         Returns:
             Denoised latents ready for VAE decode
         """
+        if self.scheduler is None or self.transformer is None:
+            raise RuntimeError("GLM-Image denoise stage requires scheduler and transformer")
         # Prepare conditional/unconditional drop flags
         prior_token_drop_cond = torch.full_like(prior_token_id, False, dtype=torch.bool)
         prior_token_drop_uncond = torch.full_like(prior_token_id, True, dtype=torch.bool)
@@ -624,20 +715,13 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
         Returns:
             GlmImageKVCache with cached KV states from condition images
         """
+        if self.vae is None or self.transformer is None:
+            raise RuntimeError("Image-edit KV-cache preparation requires both VAE and transformer")
         kv_caches = self.transformer.create_kv_cache()
         kv_caches.set_mode("write")
 
         # Prepare VAE normalization parameters
-        latents_mean = (
-            torch.tensor(self.vae.config.latents_mean)
-            .view(1, self.vae.config.latent_channels, 1, 1)
-            .to(device=self.device, dtype=prompt_embeds.dtype)
-        )
-        latents_std = (
-            torch.tensor(self.vae.config.latents_std)
-            .view(1, self.vae.config.latent_channels, 1, 1)
-            .to(device=self.device, dtype=prompt_embeds.dtype)
-        )
+        latents_mean, latents_std = self._latents_mean_std(device=self.device, dtype=prompt_embeds.dtype)
 
         # Process each condition image through transformer to populate KV cache
         for condition_image, condition_prior_token_id in zip(condition_images, prior_token_image_ids):
@@ -669,17 +753,35 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
 
         return kv_caches
 
+    def decode_latents(
+        self,
+        latents: torch.Tensor,
+        *,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        if self.vae is None:
+            raise RuntimeError("VAE is not loaded in this GLM-Image stage")
+
+        latents = latents.to(device=self.device, dtype=self.vae.dtype)
+        latents_mean, latents_std = self._latents_mean_std(device=latents.device, dtype=latents.dtype)
+        latents = latents * latents_std + latents_mean
+        return self.vae.decode(latents, return_dict=False, generator=generator)[0]
+
+    def _build_generator(self, seed: int | None) -> torch.Generator | None:
+        if seed is None:
+            return None
+        return torch.Generator(device=self.device).manual_seed(seed)
+
     @torch.inference_mode()
     def forward(self, req: OmniDiffusionRequest) -> DiffusionOutput:
-        """
-        Main generation forward pass.
+        """Main generation forward pass."""
+        if self.is_vae_decode_only:
+            return self.forward_vae_decode(req)
+        return self.forward_full_or_denoise(req)
 
-        Args:
-            req: OmniDiffusionRequest with generation parameters
-
-        Returns:
-            DiffusionOutput containing generated image
-        """
+    @torch.inference_mode()
+    def forward_full_or_denoise(self, req: OmniDiffusionRequest) -> DiffusionOutput:
+        """Run the default full path or denoise-only split path."""
         if len(req.prompts) > 1:
             logger.warning(
                 """This model only supports a single prompt, not a batched request.""",
@@ -748,9 +850,7 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
         batch_size = 1
         do_classifier_free_guidance = guidance_scale > 1.0
 
-        generator = None
-        if req.sampling_params.seed is not None:
-            generator = torch.Generator(device=self.device).manual_seed(req.sampling_params.seed)
+        generator = self._build_generator(req.sampling_params.seed)
 
         # 1. Get prior tokens - either from external source (multistage) or generate internally
         # Check if prior_token_ids are provided externally (from AR stage in multistage mode)
@@ -833,6 +933,8 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
             raise ValueError(
                 "Image edit (i2i) requires req.extra['prior_token_image_ids'] from the AR stage to build KV cache."
             )
+        if is_image_edit and self.is_denoise_only:
+            raise ValueError("GLM-Image VAE split MVP currently supports text-to-image only")
         if is_image_edit and prior_token_image_ids is not None:
             kv_caches = self._prepare_condition_image_kv_cache(
                 condition_images=preprocessed_images,
@@ -888,27 +990,73 @@ class GlmImagePipeline(nn.Module, DiffusionPipelineProfilerMixin):
             kv_caches=kv_caches,
         )
 
-        # 8. VAE decode
-        latents = latents.to(self.vae.dtype)
-        latents_mean = (
-            torch.tensor(self.vae.config.latents_mean)
-            .view(1, self.vae.config.latent_channels, 1, 1)
-            .to(latents.device, latents.dtype)
-        )
-        latents_std = (
-            torch.tensor(self.vae.config.latents_std)
-            .view(1, self.vae.config.latent_channels, 1, 1)
-            .to(latents.device, latents.dtype)
-        )
-        latents = latents * latents_std + latents_mean
-        image = self.vae.decode(latents, return_dict=False, generator=generator)[0]
+        if self.is_denoise_only:
+            latent_payload = {
+                "latents": latents.detach().cpu(),
+                "height": height,
+                "width": width,
+                "seed": req.sampling_params.seed,
+            }
+            return DiffusionOutput(
+                output={"video": [], "custom_output": latent_payload},
+                custom_output=latent_payload,
+                stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+            )
+
+        image = self.decode_latents(latents, generator=generator)
 
         return DiffusionOutput(
             output=image, stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None
         )
 
+    @torch.inference_mode()
+    def forward_vae_decode(self, req: OmniDiffusionRequest) -> DiffusionOutput:
+        """Decode final latents produced by the denoise-only split stage."""
+        if len(req.prompts) > 1:
+            logger.warning("GLM-Image VAE decode stage only supports a single prompt; taking the first request.")
+
+        first_prompt = req.prompts[0]
+        extra = req.sampling_params.extra_args
+        if isinstance(first_prompt, dict):
+            extra = first_prompt.get("extra", {}) or extra
+
+        latents = extra.get("latents")
+        if latents is None:
+            if self._is_warmup_request(req):
+                height = int(extra.get("height") or req.sampling_params.height or 512)
+                width = int(extra.get("width") or req.sampling_params.width or 512)
+                logger.info(
+                    "Synthesizing dummy latents for GLM-Image VAE decode warmup: %sx%s",
+                    height,
+                    width,
+                )
+                latents = self._make_dummy_latents(height=height, width=width, device=self.device)
+            else:
+                raise ValueError("GLM-Image VAE decode stage expects 'latents' from the denoise stage")
+
+        if not isinstance(latents, torch.Tensor):
+            latents = torch.as_tensor(latents)
+
+        seed = extra.get("seed", req.sampling_params.seed)
+        generator = self._build_generator(seed)
+        image = self.decode_latents(latents, generator=generator)
+        return DiffusionOutput(
+            output=image,
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        """Load transformer weights."""
+        """Report checkpoint-backed weights for the active split path.
+
+        GLM-Image loads some components directly via ``from_pretrained()``
+        during pipeline construction. For split VAE-decode stages we still
+        need to report those parameters as checkpoint-initialized so the
+        strict loader validation does not treat them as missing.
+        """
+        if self.transformer is None:
+            if self.vae is not None:
+                return {f"vae.{name}" for name, _ in self.vae.named_parameters()}
+            return set()
         transformer_weights = (
             (name.replace("transformer.", "", 1), weight) for name, weight in weights if name.startswith("transformer.")
         )

--- a/vllm_omni/model_executor/models/glm_image/pipeline.py
+++ b/vllm_omni/model_executor/models/glm_image/pipeline.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""GLM-Image pipeline topologies (frozen).
+"""GLM-Image pipeline topologies.
+
 Two-stage (default):
   Stage 0: AR — multimodal understanding + token_ids generation
-  Stage 1: DiT     — diffusion image generation
+  Stage 1: DiT + VAE — diffusion image generation
+
+Three-stage (opt-in):
+  Stage 0: AR
+  Stage 1: DiT denoise only
+  Stage 2: VAE decode only
 """
 
 from vllm_omni.config.stage_config import (
@@ -41,6 +47,53 @@ GLM_IMAGE_PIPELINE = PipelineConfig(
             final_output_type="image",
             model_arch="GlmImagePipeline",
             custom_process_input_func="vllm_omni.model_executor.stage_input_processors.glm_image.ar2diffusion",
+            omni_kv_config={"need_recv_cache": False},
+        ),
+    ),
+)
+
+
+GLM_IMAGE_VAE_SPLIT_PIPELINE = PipelineConfig(
+    model_type="glm_image_vae_split",
+    model_arch="GlmImageForConditionalGeneration",
+    hf_architectures=("GlmImageForConditionalGeneration",),
+    diffusers_class_name="GlmImagePipeline",
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="ar",
+            execution_type=StageExecutionType.LLM_AR,
+            requires_multimodal_data=True,
+            input_sources=(),
+            final_output=False,
+            owns_tokenizer=True,
+            model_arch="GlmImageForConditionalGeneration",
+            engine_output_type="token_ids",
+            model_subdir="vision_language_encoder",
+            tokenizer_subdir="processor",
+        ),
+        StagePipelineConfig(
+            stage_id=1,
+            model_stage="dit_denoise",
+            execution_type=StageExecutionType.DIFFUSION,
+            input_sources=(0,),
+            requires_multimodal_data=True,
+            final_output=False,
+            final_output_type="latent",
+            model_arch="GlmImagePipeline",
+            custom_process_input_func="vllm_omni.model_executor.stage_input_processors.glm_image.ar2diffusion",
+            omni_kv_config={"need_recv_cache": False},
+        ),
+        StagePipelineConfig(
+            stage_id=2,
+            model_stage="vae_decode",
+            execution_type=StageExecutionType.DIFFUSION,
+            input_sources=(1,),
+            requires_multimodal_data=False,
+            final_output=True,
+            final_output_type="image",
+            model_arch="GlmImagePipeline",
+            custom_process_input_func="vllm_omni.model_executor.stage_input_processors.glm_image.latent2vae",
             omni_kv_config={"need_recv_cache": False},
         ),
     ),

--- a/vllm_omni/model_executor/stage_input_processors/glm_image.py
+++ b/vllm_omni/model_executor/stage_input_processors/glm_image.py
@@ -405,3 +405,79 @@ def ar2diffusion(
     )
 
     return diffusion_inputs
+
+
+def _extract_latent_payload(source_output: Any) -> dict[str, Any] | None:
+    candidates: list[Any] = [
+        source_output,
+        getattr(source_output, "custom_output", None),
+        getattr(source_output, "_custom_output", None),
+        getattr(source_output, "multimodal_output", None),
+    ]
+
+    request_output = getattr(source_output, "request_output", None)
+    if request_output is not None:
+        candidates.extend(
+            [
+                request_output,
+                getattr(request_output, "custom_output", None),
+                getattr(request_output, "_custom_output", None),
+                getattr(request_output, "multimodal_output", None),
+            ]
+        )
+
+    outputs = getattr(source_output, "outputs", None)
+    if outputs:
+        first_output = outputs[0]
+        candidates.extend(
+            [
+                first_output,
+                getattr(first_output, "custom_output", None),
+                getattr(first_output, "_custom_output", None),
+                getattr(first_output, "multimodal_output", None),
+            ]
+        )
+
+    for candidate in candidates:
+        if isinstance(candidate, dict) and candidate.get("latents") is not None:
+            return candidate
+    return None
+
+
+def latent2vae(
+    source_outputs: list[Any],
+    prompt: OmniTokensPrompt | TextPrompt | list | None = None,
+    requires_multimodal_data: bool = False,
+    streaming_context: Any | None = None,
+) -> list[dict[str, Any]]:
+    """Process GLM-Image denoise-stage outputs into VAE-stage inputs."""
+    del prompt, requires_multimodal_data, streaming_context
+
+    vae_inputs: list[dict[str, Any]] = []
+    for idx, source_output in enumerate(source_outputs):
+        payload = _extract_latent_payload(source_output)
+        if payload is None:
+            raise ValueError(
+                "GLM-Image VAE split expects denoise stage output with "
+                f"'latents' in custom_output. request_id={getattr(source_output, 'request_id', None)}"
+            )
+
+        latents = payload.get("latents")
+        if latents is None:
+            raise ValueError(f"GLM-Image latent2vae missing latents for request index {idx}")
+
+        vae_inputs.append(
+            {
+                "prompt": "vae decode",
+                "height": payload.get("height"),
+                "width": payload.get("width"),
+                "extra": {
+                    "latents": latents,
+                    "height": payload.get("height"),
+                    "width": payload.get("width"),
+                    "seed": payload.get("seed"),
+                },
+            }
+        )
+
+    return vae_inputs


### PR DESCRIPTION
## Purpose

This PR adds an **opt-in** 3-stage GLM-Image serving topology that separates VAE decode from the denoising stage:

- Stage 0: AR
- Stage 1: DiT denoise
- Stage 2: VAE decode

The default GLM-Image 2-stage pipeline (`AR → full diffusion`) is **unchanged**. Users only enter the new path by explicitly passing `--deploy-config vllm_omni/deploy/glm_image_vae_split.yaml`.

### Why

Today the default GLM-Image diffusion stage keeps both the DiT denoiser and `AutoencoderKL` resident on the same GPU. VAE decode is only needed once at the end of the denoising loop, so the denoising GPU carries memory pressure for a component it does not need step-by-step.

Splitting VAE decode into its own stage lets operators:

- avoid holding the VAE resident on the denoising GPU,
- place the (much lighter) VAE stage on a separate device, and
- keep the default path bit-for-bit identical for users who don't opt in.

### Scope (intentionally narrow)

**Included:**

- GLM-Image-only opt-in 3-stage split
- denoise → VAE latent handoff (`latent2vae`)
- new split deploy config: `vllm_omni/deploy/glm_image_vae_split.yaml`
- regression tests for config plumbing and latent payload extraction

**Not included (deliberately deferred):**

- changes to the default 2-stage GLM-Image topology
- a generic diffusion split framework across models
- further decomposition of the denoise stage
- image-to-image expansion
- broader scheduling / MemoryCoordinator work

This PR makes a **serving-topology and memory-placement** claim, not a throughput claim.

## Test Plan

### 1. No-GPU regression tests (focused unit tests)

```bash
pytest tests/test_config_factory.py::test_deploy_config_preserves_explicit_engine_extras
pytest tests/test_config_factory.py::test_glm_image_vae_split_deploy_enables_profiler_on_diffusion_stages
pytest tests/model_executor/stage_input_processors/test_glm_image.py::test_latent2vae
pytest tests/model_executor/stage_input_processors/test_glm_image.py::test_extract_latent_payload
```

### 2. End-to-end sanity comparison (baseline vs split)

Default 2-stage path:

```bash
vllm serve <glm-image-model> --omni
```

Opt-in 3-stage path:

```bash
vllm serve <glm-image-model> --omni \
  --deploy-config vllm_omni/deploy/glm_image_vae_split.yaml
```

A single text-to-image request was issued twice on each path to sanity-check single-request latency and stage initialization.

## Test Result

### No-GPU regression tests

All 4 focused tests pass on the rebased branch.

### Default 2-stage baseline

- Single-request latency: `44.433s` / `44.538s`
- Diffusion-stage model loading: `Model loading took 14.0673 GiB`
- Logs confirm:
  - `Loading AutoencoderKL (VAE)...`
  - `Loading GlmImageTransformer2DModel (DiT)...`
  - `Initialized GLM-Image stage 'dit' ... full=True`

### Opt-in 3-stage split

- Single-request latency: `44.659s` / `44.476s` (same range as baseline)
- Logs confirm split stage initialization:
  - `Initialized GLM-Image stage 'dit_denoise'`
  - `Initialized GLM-Image stage 'vae_decode'`
- Per-stage model loading footprint:
  - denoise stage: `Model loading took 13.3091 GiB`
  - VAE decode stage: `Model loading took 0.7581 GiB`
- VAE-only warmup log:
  - `Synthesizing dummy latents for GLM-Image VAE decode warmup: 512x512`

### Interpretation

- The opt-in split path runs end-to-end on the latest `main` baseline.
- Denoise and VAE decode responsibilities are separated in serving.
- The VAE-only stage is much lighter than the denoise stage, as expected.
- Single-request latency stays in the same ~45s range as the default path; this is a sanity check, **not a throughput claim**.

## Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR is clearly stated.
- [x] The test plan is included with concrete commands.
- [x] The test results are pasted with before / after comparison.
- [x] Default-path behavior is unchanged (opt-in only).
- [ ] (Optional) Documentation update — happy to add a short note under the GLM-Image online-serving example pointing to this opt-in deploy config if reviewers want it in this PR.
- [ ] (Optional) Release notes update — can add if user-facing.

## AI assistance disclosure

Portions of this change (test scaffolding and PR description drafting) were developed with AI assistance. All code was reviewed, tested, and validated end-to-end on the GPU by the submitter.