### PR TITLE
[Bugfix] Add bot_task option of think_recaption for hunyuanimage3 it2i

### DIFF
--- a/examples/offline_inference/hunyuan_image3/end2end.py
+++ b/examples/offline_inference/hunyuan_image3/end2end.py
@@ -136,7 +136,7 @@ def main():
     if task not in _TASK_PRESETS:
         valid_bot_tasks = {
             "text2img": ["think", "recaption", "vanilla"],
-            "img2img": ["think", "recaption"],
+            "img2img": ["think", "recaption", "think_recaption"],
             "img2text": ["auto"],
             "text2text": ["auto"],
         }[args.modality]

--- a/tests/diffusion/models/hunyuan_image3/test_prompt_utils.py
+++ b/tests/diffusion/models/hunyuan_image3/test_prompt_utils.py
@@ -78,6 +78,7 @@ def test_available_tasks_covers_all_modalities():
         "i2t",
         "it2i_think",
         "it2i_recaption",
+        "it2i_think_recaption",
         "t2i_think",
         "t2i_recaption",
         "t2i_vanilla",
@@ -99,6 +100,7 @@ def test_resolve_stop_token_ids_uses_answer_for_generation_tasks():
         "i2t",
         "it2i_think",
         "it2i_recaption",
+        "it2i_think_recaption",
         "t2i_think",
         "t2i_recaption",
     ],
@@ -125,7 +127,7 @@ def test_build_prompt_string_structure_chat_template(task: str):
     # documentation, so substring index() catches the wrong occurrence -- use
     # endswith() which directly captures "trigger is at the tail" (the Part A
     # fix: trigger goes AFTER `Assistant: `, not before user_prompt).
-    if task in ("it2i_think", "t2i_think"):
+    if task in ("it2i_think", "t2i_think", "it2i_think_recaption"):
         assert s.endswith("Assistant: <think>"), (
             f"Trigger <think> must be appended right after `Assistant: ` (Part A fix). Got tail: ...{s[-40:]!r}"
         )

--- a/vllm_omni/diffusion/models/hunyuan_image3/prompt_utils.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/prompt_utils.py
@@ -51,6 +51,7 @@ _TASK_PRESETS: dict[str, tuple[str, str | None, str | None]] = {
     "i2t": ("en_unified", None, None),
     "it2i_think": ("en_unified", "think", "<think>"),
     "it2i_recaption": ("en_unified", "recaption", "<recaption>"),
+    "it2i_think_recaption": ("en_unified", "think_recaption", "<think>"),
     "t2i": ("en_unified", "image", None),
     "t2i_vanilla": ("en_vanilla", "image", None),
     "t2i_think": ("en_unified", "think", "<think>"),


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Add think_recaption bot_task for Huanyuan-Image offline test example，detail as follow: 
**HuanyuanImage official it2i demo use a bot-task of think_recaption.** 
```
# TI2I
python3 run_image_gen.py \
    --model-id $MODEL_PATH  \
    --verbose 2 \
    --prompt "新年宠物海报，Q版圆润的可爱标题“新年快乐汪”，副标题“HAPPY NEW YEAR”。 鱼眼镜头，背景是房间门口，近景，上传的主体歪头笑，围着红色围巾，戴着红色毛线帽，高清，绒毛细节，面部特写。 宝丽莱相纸，超现实主义，写实主义，胶片摄影，打印颗粒感肌理。肌理，超写实，复古感。" \
    --seed 42 \
    --reproduce \
    --bot-task think_recaption \
    --image-size auto \
    --use-system-prompt en_unified  \
    --infer-align-image-size \
    --image ./assets/demo_instruct_imgs/input_0_0.png \
    --save ./image_edit_0.png \
    --moe-impl flashinfer  
```
**exception** occurred when bot-task think_recaption used in omni example:
```
python vllm-omni/examples/offline_inference/hunyuan_image3/end2end.py \
  --model tencent/HunyuanImage-3.0-Instruct \
  --modality img2img \
  --image-path ./input_0_0.png \
  --bot-task think_recaption \
  --prompts "新年宠物海报，Q版圆润的可爱标题“新年快乐汪”，副标题“HAPPY NEW YEAR”。 鱼眼镜头，背景是房间门口，近景，上传的主体歪头笑，围着红色围巾，戴着红色毛线帽，高清，绒毛细节，面部特写。 宝丽莱相纸，超现实主义，写实主义，胶片摄影，打印颗粒感肌理。肌理，超写实，复古感。" \
  | tee output.log
```
```
Traceback (most recent call last):
  File "/data/zc/vllm-omni/examples/offline_inference/hunyuan_image3/end2end.py", line 302, in <module>
    main()
  File "/data/zc/vllm-omni/examples/offline_inference/hunyuan_image3/end2end.py", line 143, in main
    raise ValueError(
ValueError: --bot-task 'think_recaption' is not supported for img2img. Choose from: ['think', 'recaption']
```

## Test Plan
offline test with official it2i demo (default HunyuanImage yaml config vllm-omni/vllm-omni/deploy/hunyuan-image3.yaml)
image_input:
<img width="736" height="1105" alt="image" src="https://github.com/user-attachments/assets/3a36710e-c250-4710-b194-c7683c396259" />

## Test Result
```
[Output] Text:
用户希望将一张可爱的金毛幼犬照片改造成一张充满节日氛围的新年宠物海报。这张参考图展示了一只坐在木质地板上的金毛幼犬，背景是户外的蒲公英。原始指令非常具体，要求添加特定的标题文字、改变背景、调整构图以及应用特定的艺术风格。首先，我需要分析文字部分的添加，标题“新年快乐汪”需要采用Q版圆润且可爱的字体，并放置在画面上方，下方配以较小的英文副标题。其次，背景需要从户外的木质地板和蒲公英切换到室内的房间门口，这涉及到场景的完全重构。构图上，指令提到了鱼眼镜头和近景特写，这意味着画面中心的小狗头部会因为透视效果而显得更大，产生一种夸张的视觉冲击力。小狗本身的配饰也需要改变，从原来的粉色项圈换成更具节日气息的红色针织围巾和红色毛线帽。最后，整体风格要模拟宝丽莱相纸的效果，带有胶片颗粒感和复古质感。在改写指令时，我会将这些零散的要求整合为一个逻辑连贯的描述，详细说明小狗的新装扮、背景的具体环境、文字的样式与位置，以及整体的摄影风格，确保生成的结果既保留了小狗可爱的神态，又具备浓厚的新年海报质感。</think>请将这张金毛幼犬的照片改造成一张复古风格的新年宠物海报。首先，将背景从户外的木质地板和蒲公英替换为室内的房间门口，背景中应包含白色的门框和浅色的墙壁。对画面进行鱼眼镜头处理，使位于画面中心的小狗头部呈现出近景特写的夸张效果。给小狗戴上一顶红色的针织毛线帽，并在脖子上围上一条厚实的红色针织围巾，同时保留它原本开心的表情。在画面的最上方，添加一行大号的、圆润可爱的艺术字体标题“新年快乐汪”，并在其下方用较小的字体标注英文“HAPPY NEW YEAR”。最后，为整张图片应用宝丽莱相纸的滤镜效果，增加明显的胶片颗粒感和复古的暖色调，使其看起来像是一张冲洗出来的实体照片。</recaption>
```
image_output:
<img width="818" height="1070" alt="image" src="https://github.com/user-attachments/assets/d789b832-4a46-453c-bf7d-15ce2b9c99dc" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
