### PR TITLE
[Bugfix] Fix omni processing test for non-multimodal talker stage

### DIFF
--- a/tests/model_executor/models/registry.py
+++ b/tests/model_executor/models/registry.py
@@ -120,7 +120,6 @@ _OMNI_EXAMPLE_MODELS: dict[str, _OmniExamplesInfo] = {
         default="Qwen/Qwen2.5-Omni-7B",
         model_stage="talker",
         hf_config_name="talker_config",
-        has_multimodal_processor=True,
     ),
     "Qwen2_5OmniToken2WavModel": _OmniExamplesInfo(
         default="Qwen/Qwen2.5-Omni-7B",


### PR DESCRIPTION
## Purpose

After dca369d4 (#3425) removed multimodal support from the Qwen2.5-Omni talker stage, the processing correctness test crashes with AttributeError on multimodal_config.

Fix: remove has_multimodal_processor=True from the talker entry in the test registry so it's excluded from the multimodal processing test.

## Test Plan

```
pytest tests/model_executor/models/test_omni_processing.py
```

## Test Result

PASSED

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
