### PR TITLE
[Test] Preserve multi-pytest nightly step execution

### DIFF
--- a/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_cfgp2.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_cfgp2.json
@@ -5,12 +5,28 @@
         "server_type": "vllm-omni",
         "server_params": {
             "model": "tencent/HunyuanImage-3.0-Instruct",
+            "stage_overrides": {
+                "0": {
+                    "parallel_config": {
+                        "pipeline_parallel_size": 1,
+                        "data_parallel_size": 1,
+                        "tensor_parallel_size": 2,
+                        "enable_expert_parallel": true,
+                        "sequence_parallel_size": 1,
+                        "ulysses_degree": 1,
+                        "ring_degree": 1,
+                        "cfg_parallel_size": 2,
+                        "vae_patch_parallel_size": 1,
+                        "use_hsdp": false,
+                        "hsdp_shard_size": -1,
+                        "hsdp_replicate_size": 1
+                    }
+                }
+            },
             "serve_args": {
-                "tensor-parallel-size": 2,
-                "cfg-parallel-size": 2,
+                "deploy-config": "vllm_omni/deploy/hunyuan_image3_dit.yaml",
                 "quantization": "fp8",
                 "distributed-executor-backend": "mp",
-                "enforce-eager": true,
                 "enable-diffusion-pipeline-profiler": true
             }
         },

--- a/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_sp2.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_sp2.json
@@ -5,12 +5,28 @@
         "server_type": "vllm-omni",
         "server_params": {
             "model": "tencent/HunyuanImage-3.0-Instruct",
+            "stage_overrides": {
+                "0": {
+                    "parallel_config": {
+                        "pipeline_parallel_size": 1,
+                        "data_parallel_size": 1,
+                        "tensor_parallel_size": 2,
+                        "enable_expert_parallel": true,
+                        "sequence_parallel_size": 2,
+                        "ulysses_degree": 2,
+                        "ring_degree": 1,
+                        "cfg_parallel_size": 1,
+                        "vae_patch_parallel_size": 1,
+                        "use_hsdp": false,
+                        "hsdp_shard_size": -1,
+                        "hsdp_replicate_size": 1
+                    }
+                }
+            },
             "serve_args": {
-                "tensor-parallel-size": 2,
-                "usp": 2,
+                "deploy-config": "vllm_omni/deploy/hunyuan_image3_dit.yaml",
                 "quantization": "fp8",
                 "distributed-executor-backend": "mp",
-                "enforce-eager": true,
                 "enable-diffusion-pipeline-profiler": true
             }
         },

--- a/tests/dfx/perf/tests/test_hunyuan_image_tp4_fp8.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp4_fp8.json
@@ -6,10 +6,9 @@
         "server_params": {
             "model": "tencent/HunyuanImage-3.0-Instruct",
             "serve_args": {
-                "tensor-parallel-size": 4,
+                "deploy-config": "vllm_omni/deploy/hunyuan_image3_dit.yaml",
                 "quantization": "fp8",
                 "distributed-executor-backend": "mp",
-                "enforce-eager": true,
                 "enable-diffusion-pipeline-profiler": true
             }
         },


### PR DESCRIPTION
## Purpose

Keep the nightly local runner aligned with Buildkite steps that contain multiple pytest commands.

Previously `tools/nightly/run_nightly_jobs.sh` appended every extracted pytest command into a generated job script under `set -euo pipefail`. For a Buildkite step such as `Diffusion X2I(&A&T) · HunyuanImage3 · DiT Perf Test`, this meant the generated local job could stop at the first failing pytest command and skip the remaining configs in the same step.

This PR now wraps multi-pytest steps so each pytest command runs, records its status, and exits with the combined failure status at the end. Single-pytest steps keep the existing direct command emission.

## Test Plan

```bash
"C:\Program Files\Git\bin\bash.exe" -n tools/nightly/run_nightly_jobs.sh

"C:\Program Files\Git\bin\bash.exe" tools/nightly/run_nightly_jobs.sh \
  --dry-run \
  --test-type perf \
  --model-type diffusion \
  --label-substr HunyuanImage3

pre-commit run --files tools/nightly/run_nightly_jobs.sh
```

## Test Result

- Syntax check passed.
- Dry-run generated `nightly-hunyuan-image3-performance` with all three pytest commands preserved:
  - `test_hunyuan_image_tp4_fp8.json`
  - `test_hunyuan_image_tp2_fp8_sp2.json`
  - `test_hunyuan_image_tp2_fp8_cfgp2.json`
- Generated script uses `set +e`, accumulates each pytest exit code, restores `set -e`, and exits with the combined status.
- `pre-commit run --files tools/nightly/run_nightly_jobs.sh` passed.

No docs update is required because this only changes local nightly job generation behavior.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [x] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
