### PR TITLE
[Bugfix]Allow HunyuanImage3 AR sampler batching

### DIFF
--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -1918,8 +1918,6 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
 
         min_score = torch.finfo(logits.dtype).min
 
-        assert logits.shape[0] == 1, f"HunyuanImage3 sampler requires max_num_seqs=1, got batch size {logits.shape[0]}"
-
         for req_idx in range(logits.shape[0]):
             decoded_tokens: list[int] = (
                 sampling_metadata.output_token_ids[req_idx] if req_idx < len(sampling_metadata.output_token_ids) else []


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
This PR aims to remove the assertion of batch_size in the sampler of Hunyuan-Image-3.0. It enables single ar and multiple DiTs.

## Test Plan

After merging pr #3569, set the deploy yaml like:
* 8 GPUs
* rank0, 1, 2, 3 AR replica0 TP4
* rank4, 5 DiT replica0 TP2
* rank6, 7 DiT replica1 TP2
```
# HunyuanImage-3.0-Instruct AR + DiT deploy for one 8-GPU host.
#
# Legacy stage_args format with explicit stage types:
#   - Stage 0: llm / AR, 1 replica, TP=4 on GPUs 0,1,2,3.
#   - Stage 1: diffusion / DiT+VAE, 2 replicas, TP=2 each on
#     GPUs 4,5 / 6,7.
#
# Use this file with --stage-configs-path. The sibling
# hunyuan_image3_it2i_kv_reuse_replica_stages.yaml is the new --deploy-config
# stages-format version.
async_chunk: false

stage_args:
  - stage_id: 0
    stage_type: llm
    model_stage: AR
    runtime:
      process: true
      devices: "0,1,2,3"
      num_replicas: 1
      max_batch_size: 1
      requires_multimodal_data: true
    engine_args:
      model_stage: AR
      model_arch: HunyuanImage3ForCausalMM
      worker_cls: vllm_omni.worker.gpu_ar_worker.GPUARWorker
      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
      engine_output_type: latent
      trust_remote_code: true
      gpu_memory_utilization: 0.45
      enforce_eager: true
      enable_prefix_caching: false
      max_num_seqs: 2
      max_num_batched_tokens: 16384
      tensor_parallel_size: 4
      pipeline_parallel_size: 1
      hf_overrides:
        rope_parameters:
          mrope_section: [0, 32, 32]
          rope_type: default
      omni_kv_config:
        need_send_cache: true
    is_comprehension: false
    final_output: true
    final_output_type: text
    output_connectors:
      to_stage_1: shared_memory_connector
    default_sampling_params:
      temperature: 0.0
      top_p: 1
      top_k: -1
      max_tokens: 1024
      stop_token_ids: [128025]  # <answer>
      detokenize: true
      skip_special_tokens: false

  - stage_id: 1
    stage_type: diffusion
    runtime:
      process: true
      devices: "4,5,6,7"
      num_replicas: 2
      max_batch_size: 1
      requires_multimodal_data: true
    engine_args:
      model_stage: dit
      model_arch: HunyuanImage3ForCausalMM
      trust_remote_code: true
      gpu_memory_utilization: 0.55
      enforce_eager: true
      distributed_executor_backend: mp
      quantization: fp8
      omni_kv_config:
        need_recv_cache: true
      parallel_config:
        pipeline_parallel_size: 1
        data_parallel_size: 1
        tensor_parallel_size: 2
        enable_expert_parallel: true
        sequence_parallel_size: 1
        ulysses_degree: 1
        ring_degree: 1
        cfg_parallel_size: 1
        vae_patch_parallel_size: 1
        use_hsdp: false
        hsdp_shard_size: -1
        hsdp_replicate_size: 1
    engine_input_source: [0]
    custom_process_input_func: vllm_omni.model_executor.stage_input_processors.hunyuan_image3.ar2diffusion
    final_output: true
    final_output_type: image
    input_connectors:
      from_stage_0: shared_memory_connector
    default_sampling_params:
      num_inference_steps: 50
      guidance_scale: 0
      seed: 42

runtime:
  enabled: true
  connectors:
    shared_memory_connector:
      name: SharedMemoryConnector
      extra:
        shm_threshold_bytes: 65536
  edges:
    - from: 0
      to: 1
      window_size: -1
      max_inflight: 1
```

I command concurrent requests 3 times in a row.

## Test Result

The output shows:

| Request | Stage 0 enter | AR finished / ar2diffusion | DiT stated | DiT finished |
| --- | ---: | ---: | ---: | ---: |
| req1 b13d... | 02:23:50 | 02:24:44 | 02:24:44 rep-0 | about 02:25:16 |
| req2 a9c... | 02:23:51 | 02:24:45 | 02:24:45 rep-1 | about 02:25:17 |
| req3 b858... | 02:23:54 | 02:25:36 | 02:25:36 rep-0 | about 02:26:08 |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
