### PR TITLE
[Doc] Add OmniGen2 text-to-image recipe on 1 L40S 48 GB

### DIFF
--- a/recipes/OmniGen2/OmniGen2.md
+++ b/recipes/OmniGen2/OmniGen2.md
@@ -19,7 +19,6 @@ single NVIDIA L40S 48GB GPU.
   [`docs/user_guide/examples/online_serving/text_to_image.md`](../../docs/user_guide/examples/online_serving/text_to_image.md)
 - Related example under `examples/`:
   [`examples/online_serving/text_to_image/README.md`](../../examples/online_serving/text_to_image/README.md)
-- Related issue:
 
 ## Hardware Support
 
@@ -93,9 +92,3 @@ Decoded output: 1024x1024 RGB PNG.
 - Memory usage: observed peak memory was 19854 MiB for a 1024x1024 smoke test.
   `nvidia-smi` showed 20407 MiB used after the online server was initialized
   and idle.
-- Key flags:
-  - `--omni` enables vLLM-Omni diffusion serving.
-  - `--init-timeout 2400` and `--stage-init-timeout 2400` allow the first
-    launch to finish model loading and warmup on this host.
-- Known limitations:
-  - OmniGen2 supports a single prompt per request in the current pipeline.

--- a/recipes/OmniGen2/OmniGen2.md
+++ b/recipes/OmniGen2/OmniGen2.md
@@ -1,0 +1,101 @@
+# OmniGen2 for text-to-image serving on 1x L40S 48GB
+
+## Summary
+
+- Vendor: OmniGen2
+- Model: `OmniGen2/OmniGen2`
+- Task: Text-to-image generation
+- Mode: Online serving with the OpenAI-compatible Images API
+- Maintainer: Community
+
+## When to use this recipe
+
+Use this recipe to serve `OmniGen2/OmniGen2` text-to-image generation on a
+single NVIDIA L40S 48GB GPU.
+
+## References
+
+- Upstream or canonical docs:
+  [`docs/user_guide/examples/online_serving/text_to_image.md`](../../docs/user_guide/examples/online_serving/text_to_image.md)
+- Related example under `examples/`:
+  [`examples/online_serving/text_to_image/README.md`](../../examples/online_serving/text_to_image/README.md)
+- Related issue:
+
+## Hardware Support
+
+This recipe documents one validated CUDA GPU configuration. Extend it with
+additional hardware sections as more community validation lands.
+
+## GPU
+
+### 1x L40S 48GB
+
+#### Environment
+
+- OS: Linux
+- Python: 3.12.5
+- GPU: 1x NVIDIA L40S 48GB
+- Driver / runtime: NVIDIA driver 575.51.03, CUDA 12.9
+- PyTorch: 2.11.0+cu129
+- vLLM version: 0.20.0
+- vLLM-Omni version or commit: `efd95567`
+
+#### Command
+
+Start the baseline server:
+
+```bash
+vllm-omni serve OmniGen2/OmniGen2 --omni --port 8091 \
+  --init-timeout 2400 \
+  --stage-init-timeout 2400
+```
+
+#### Verification
+
+After the server is ready, confirm the model is listed:
+
+```bash
+curl -s http://localhost:8091/v1/models
+```
+
+Then run a direct Images API smoke test:
+
+```bash
+curl -s http://localhost:8091/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "OmniGen2/OmniGen2",
+    "prompt": "A small robot painting a watercolor landscape on an easel, studio lighting, highly detailed",
+    "size": "1024x1024",
+    "num_inference_steps": 28,
+    "guidance_scale": 4.0,
+    "seed": 42,
+    "response_format": "b64_json"
+  }' | jq -r '.data[0].b64_json' | base64 -d > /tmp/omnigen2_l40s_recipe.png
+```
+
+Confirm that the decoded image exists:
+
+```bash
+test -s /tmp/omnigen2_l40s_recipe.png
+```
+
+Expected result:
+
+```text
+GET /v1/models returned OmniGen2/OmniGen2.
+POST /v1/images/generations returned one b64_json image.
+Decoded output: 1024x1024 RGB PNG.
+```
+
+#### Notes
+
+- Memory usage: observed peak memory was 19854 MiB for a 1024x1024 smoke test.
+  `nvidia-smi` showed 20407 MiB used after the online server was initialized
+  and idle.
+- Key flags:
+  - `--omni` enables vLLM-Omni diffusion serving.
+  - `--init-timeout 2400` and `--stage-init-timeout 2400` allow the first
+    launch to finish model loading and warmup on this host.
+- Known limitations:
+  - OmniGen2 supports a single prompt per request in the current pipeline.

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -40,6 +40,7 @@ recipes/
 | [`cosmos3/Cosmos3-Super.md`](./cosmos3/Cosmos3-Super.md) | 64B T2I / T2V / I2V generation (+ optional audio) / Action policy | 8x H200/H100/A100 / 2x H200 / B300 |
 | [`OpenBMB/MiniCPM-o-4_5.md`](./OpenBMB/MiniCPM-o-4_5.md) | Online serving for omni multimodal chat (text / image / audio / video → text + 24 kHz speech) | 2x A100/H100 80GB / 3x mid-tier GPU / 8x RTX 4090 24GB |
 | [`OpenBMB/VoxCPM2.md`](./OpenBMB/VoxCPM2.md) | Online + offline TTS with native AR pipeline (48 kHz, 30+ languages) | 1x RTX 4090 24GB |
+| [`OmniGen2/OmniGen2.md`](./OmniGen2/OmniGen2.md) | Text-to-image serving | 1x L40S 48GB |
 | [`Qwen/Qwen-Image.md`](./Qwen/Qwen-Image.md) | Text-to-image serving with step-wise continuous batching replay and ModelOpt mixed FP8/NVFP4 | 1x A100 80GB / 2x B200 |
 | [`Qwen/Qwen-Image.md`](./Qwen/Qwen-Image.md) | Text-to-image serving with step-wise continuous batching replay | 1x A100 80GB |
 | [`Qwen/Qwen-Image-Edit.md`](./Qwen/Qwen-Image-Edit.md) | Text-guided single-image editing | 1x or 2x H200 141GB |
@@ -52,7 +53,6 @@ recipes/
 | [`Wan-AI/Wan2.2-S2V.md`](./Wan-AI/Wan2.2-S2V.md) | Speech-to-video serving (Wan2.2 14B) | 2x A100/H100 80GB |
 | [`zai-org/GLM-TTS.md`](./zai-org/GLM-TTS.md) | Online serving for Chinese/English zero-shot voice-cloned TTS | 1x A40 48GB |
 | [`GLM/GLM-Image.md`](./GLM/GLM-Image.md) | Online serving for image generation | 1x A800 80GB / 2x A800 80GB |
-|
 
 Within a single recipe file, include different hardware support sections such
 as `GPU`, `ROCm`, and `NPU`, and add concrete tested configurations like


### PR DESCRIPTION
<!-- markdownlint-disable -->

  ## Purpose

  Add a community recipe for `OmniGen2/OmniGen2` text-to-image serving on `1x L40S 48GB`.

  ## Test Result

  Validated on `1x NVIDIA L40S 48GB`.

  - `GET /v1/models` returned `OmniGen2/OmniGen2`
  - `POST /v1/images/generations` returned one `b64_json` image
  - decoded output was a `1024x1024` RGB PNG
  - observed peak memory was `19854 MiB`