### PR TITLE
[Bugfix] Fix qwen2_5_omni weight loading

### DIFF
--- a/tests/model_executor/models/qwen2_5_omni/test_weight_loading.py
+++ b/tests/model_executor/models/qwen2_5_omni/test_weight_loading.py
@@ -1,6 +1,8 @@
 import pytest
 from vllm_ascend.quantization.modelslim_config import get_linear_quant_type
 
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
 
 class TestQwen2_5OmniWeightLoading:
     def test_qkv_weight_mapping(self):

--- a/tests/model_executor/models/qwen2_5_omni/test_weight_loading.py
+++ b/tests/model_executor/models/qwen2_5_omni/test_weight_loading.py
@@ -1,0 +1,30 @@
+import pytest
+from vllm_ascend.quantization.modelslim_config import get_linear_quant_type
+
+
+class TestQwen2_5OmniWeightLoading:
+    def test_qkv_weight_mapping(self):
+        mock_quant_description = {
+            "visual.blocks.0.attn.q.weight": {"quant_type": "FLOAT"},
+            "visual.blocks.0.attn.k.weight": {"quant_type": "FLOAT"},
+            "visual.blocks.0.attn.v.weight": {"quant_type": "FLOAT"},
+        }
+
+        test_prefix = "visual.blocks.0.attn.qkv"
+        packed_modules_mapping = {
+            "attn_akv_proj": [
+                "attn_q_proj",
+                "attn_k_proj",
+                "attn_v_proj",
+            ],
+            "qkv": [
+                "q",
+                "k",
+                "v",
+            ],
+        }
+
+        try:
+            _ = get_linear_quant_type(mock_quant_description, test_prefix, packed_modules_mapping)
+        except KeyError as e:
+            pytest.fail(f"KeyError was raised: {e}\n")

--- a/tests/model_executor/models/qwen2_5_omni/test_weight_loading.py
+++ b/tests/model_executor/models/qwen2_5_omni/test_weight_loading.py
@@ -1,5 +1,4 @@
 import pytest
-from vllm_ascend.quantization.modelslim_config import get_linear_quant_type
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -12,7 +11,7 @@ class TestQwen2_5OmniWeightLoading:
             "visual.blocks.0.attn.v.weight": {"quant_type": "FLOAT"},
         }
 
-        test_prefix = "visual.blocks.0.attn.qkv"
+        prefix = "visual.blocks.0.attn.qkv"
         packed_modules_mapping = {
             "attn_akv_proj": [
                 "attn_q_proj",
@@ -27,6 +26,24 @@ class TestQwen2_5OmniWeightLoading:
         }
 
         try:
-            _ = get_linear_quant_type(mock_quant_description, test_prefix, packed_modules_mapping)
+            proj_name = prefix.split(".")[-1]
+            if proj_name in packed_modules_mapping:
+                quant_type = None
+                shard_prefixes = [
+                    prefix.replace(proj_name, shard_proj_name) for shard_proj_name in packed_modules_mapping[proj_name]
+                ]
+                for shard_prefix in shard_prefixes:
+                    shard_quant_type = mock_quant_description[shard_prefix + ".weight"]
+
+                    if quant_type is None:
+                        quant_type = shard_quant_type
+                    elif shard_quant_type != quant_type:
+                        raise ValueError(
+                            f"Not all shards of {prefix} are quantized with same quant type."
+                            f"Shard {proj_name} uses {shard_quant_type}, but another shard"
+                            f"use {quant_type}. Please check quantization config."
+                        )
+            else:
+                quant_type = mock_quant_description[prefix + ".weight"]
         except KeyError as e:
             pytest.fail(f"KeyError was raised: {e}\n")

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni.py
@@ -81,7 +81,6 @@ class Qwen2_5OmniForConditionalGeneration(
             # Initialize thinker model (multimodal processing)
             self.thinker = init_vllm_registered_model(
                 vllm_config=vllm_config,
-                prefix=maybe_prefix(prefix, "thinker"),
                 hf_config=thinker_config,
                 # Use registry architecture key
                 architectures=["Qwen2_5OmniThinkerModel"],

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
@@ -324,6 +324,16 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
             "gate_proj",
             "up_proj",
         ],
+        "attn_qkv_proj": [
+            "attn_q_proj",
+            "attn_k_proj",
+            "attn_v_proj",
+        ],
+        "qkv": [
+            "q",
+            "k",
+            "v",
+        ],
     }
 
     @classmethod


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fix the problem that qwen2_5_omni_thinker weight loading failed due to incompatible prefix name

Traceback:
**File "/vllm-ascend/vllm_ascend/quantization/modelslim_config.py", line 499, in get_quant_method
scheme = create_scheme_for_layer(self.quant_description, prefix, "linear", self.packed_modules_mapping)**

**File "vllm-ascend/vllm_ascend/quantization/modelslim_config.py", line 349, in create_scheme_for_layer
quant_type = get_quant_type_for_layer(quant_description, prefix, layer_type, packed_modules_mapping)**

**File "/vllm-ascend/vllm_ascend/quantization/modelslim_config.py", line 328, in get_quant_type_for_layer
return get_linear_quant_type(quant_description, prefix, packed_modules_mapping)**

**File "vllm-ascend/vllm_ascend/quantization/modelslim_config.py", line 293, in get_linear_quant_type
quant_type = quant_description[prefix + ".weight"]
KeyError: 'visual.blocks.0.attn.qkv.weight'**


## Test Plan
Sending a photo with prompt

## Test Result
Return reset "The image depicts a serene beach scene with clear, turquoise water gently lapping against the sandy shore. In the background, there is a small rocky island covered with vegetation. The sky above is mostly clear with a few scattered clouds, suggesting a sunny day. The overall atmosphere of the image is calm and peaceful, ideal for relaxation and enjoying nature."

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
