### PR TITLE
[BugFix] Hotfix talker-stage shape mismatch on Qwen3-Omni multi-replica high concurrency

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -72,6 +72,16 @@ TALKER_CODEC_THINK_EOS_ID = 4205  # Think mode end
 logger = init_logger(__name__)
 
 
+def _slice_or_zero_pad(tensor: torch.Tensor, start: int, end: int, hidden_dim: int) -> torch.Tensor:
+    """Return ``tensor[start:end]``, zero-padded along dim 0 to ``end - start`` rows."""
+    sliced = tensor[start:end]
+    missing = (end - start) - sliced.shape[0]
+    if missing <= 0:
+        return sliced
+    padding = torch.zeros((missing, hidden_dim), device=tensor.device, dtype=tensor.dtype)
+    return torch.cat((sliced, padding), dim=0)
+
+
 @MULTIMODAL_REGISTRY.register_processor(
     Qwen3OmniMoeThinkerMultiModalProcessor,
     info=Qwen3OmniMoeThinkerProcessingInfo,
@@ -647,7 +657,17 @@ class Qwen3OmniMoeForConditionalGeneration(
         """
         Postprocess the talker hidden states.
         """
-        return {"hidden_states": {"last": hidden_states[-1, :].detach()}}
+        # hidden_states can be empty under multi-replica chunked-prefill; fall
+        # back to a zero "last" sentinel instead of indexing into an empty tensor.
+        if hidden_states.shape[0] == 0:
+            last = torch.zeros(
+                hidden_states.shape[1:],
+                device=hidden_states.device,
+                dtype=hidden_states.dtype,
+            )
+        else:
+            last = hidden_states[-1, :].detach()
+        return {"hidden_states": {"last": last}}
 
     def talker_preprocess(self, input_ids: torch.Tensor, input_embeds: torch.Tensor, **info_dict: dict):
         """
@@ -1101,19 +1121,18 @@ class Qwen3OmniMoeForConditionalGeneration(
             tts_pad_embed.device
         )  # [t, d]
 
-        # [3 tokens] + [4 pad] + [1 BOS] + [1 first text] = 9 tokens
+        # Fixed layout: [3 prefix] + [4 pad] + [1 BOS] + [1 first text] = 9 rows.
+        # assistant_hidden may be shorter than expected under multi-replica
+        # chunked-prefill, so zero-pad both slices to keep the layout at [9, d].
+        hidden_dim = self.config.talker_config.text_config.hidden_size
+        prefix = _slice_or_zero_pad(assistant_hidden, 0, 3, hidden_dim)
+        first_text = _slice_or_zero_pad(assistant_hidden, 3, 4, hidden_dim)
         assistant_text_hidden = torch.cat(
             (
-                assistant_hidden[:3],
+                prefix,
                 tts_pad_embed.expand(4, -1),
                 tts_bos_embed,
-                assistant_hidden[3:4]
-                if assistant_hidden.shape[0] > 3
-                else torch.zeros(
-                    (1, assistant_hidden.shape[1]),
-                    device=assistant_hidden.device,
-                    dtype=assistant_hidden.dtype,
-                ),  # First text
+                first_text,
             ),
             dim=0,
         )

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -294,6 +294,27 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             )
         return combined_hidden_states, combined_multimodal_outputs
 
+    def _maybe_recompute_talker_logits_indices(
+        self, logits_indices: torch.Tensor, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        """Rebuild ``logits_indices`` from per-req talker output lengths.
+
+        ``logits_indices`` is derived from thinker-side ``num_scheduled_tokens``,
+        but ``talker_preprocess`` may skip segments (e.g. the ChatML system
+        block), leaving ``hidden_states`` with fewer rows. Only applies when the
+        captured seg_lens match both the request count and the row count, so it
+        is a no-op for non-talker stages.
+        """
+        seg_lens = getattr(self, "_omni_talker_seg_lens", None)
+        if (
+            seg_lens is None
+            or len(seg_lens) != logits_indices.numel()
+            or sum(seg_lens) != hidden_states.shape[0]
+        ):
+            return logits_indices
+        seg_lens_t = torch.tensor(seg_lens, device=logits_indices.device, dtype=logits_indices.dtype)
+        return seg_lens_t.cumsum(0) - 1
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -598,6 +619,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                         kv_connector_output,
                     )
 
+                logits_indices = self._maybe_recompute_talker_logits_indices(logits_indices, hidden_states)
                 sample_hidden_states = hidden_states[logits_indices]
                 # Try with sampling_metadata first; fall back to without for models that don't support it
                 try:
@@ -610,6 +632,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 # Rare case.
                 assert not self.is_pooling_model
 
+                logits_indices = self._maybe_recompute_talker_logits_indices(logits_indices, hidden_states)
                 sample_hidden_states = hidden_states[logits_indices]
                 if not get_pp_group().is_last_rank:
                     all_gather_tensors = {

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -45,6 +45,9 @@ class OmniGPUModelRunner(GPUModelRunner):
         self.model_intermediate_buffer: dict[str, dict[str, Any]] = {}
         self._omni_num_scheduled_tokens_np: np.ndarray | None = None
         self._omni_last_model_output: object | None = None
+        # Per-req talker output lengths captured in _preprocess; used by the AR
+        # runner to rebuild logits_indices. None for non-talker stages.
+        self._omni_talker_seg_lens: list[int] | None = None
         # The Omni tensor prefix cache will be allocated
         # when we initialize the metadata builders if enabled
         self.omni_prefix_cache = None
@@ -1285,6 +1288,8 @@ class OmniGPUModelRunner(GPUModelRunner):
             dtype=np.int32,
         )
         self._omni_num_scheduled_tokens_np = num_scheduled_tokens_np
+        # reset; only the talker has_preprocess branch below repopulates it
+        self._omni_talker_seg_lens = None
 
         # Note: only prefill need collect additional_information for now.
         # Decode don't need per_req_additional_information anymore.
@@ -1304,6 +1309,7 @@ class OmniGPUModelRunner(GPUModelRunner):
             # Overlay custom prompt_embeds per request for the prompt portion;
             # collect additional_information (tensor/list) for prefill portion only
             decode_req_ids = []
+            talker_seg_lens: list[int] = []
             for req_index, req_id in enumerate(self.input_batch.req_ids):
                 req_infos = self.model_intermediate_buffer.get(req_id, {})
 
@@ -1343,9 +1349,15 @@ class OmniGPUModelRunner(GPUModelRunner):
 
                 # update the inputs_embeds and input_ids
                 seg_len = min(span_len, req_embeds.shape[0])
+                talker_seg_lens.append(int(seg_len))
                 inputs_embeds[s : s + seg_len] = req_embeds[:seg_len]
                 if isinstance(req_input_ids, torch.Tensor) and req_input_ids.numel() == seg_len:
                     input_ids[s : s + seg_len] = req_input_ids
+
+            # Expose per-req talker output lengths so the AR runner can rebuild
+            # logits_indices (talker_preprocess skips segments, so thinker-side
+            # num_scheduled_tokens over-counts).
+            self._omni_talker_seg_lens = talker_seg_lens
 
             # run talker mtp decode
             if self.has_talker_mtp:


### PR DESCRIPTION
## Purpose
Related to #2995  — similar shape-mismatch error, but #3147 does **not** fix it.

Running the multi-replica nightly perf bench on **Qwen3-Omni-MoE** (`num_replicas=2`) crashes once concurrency reaches 24.

**Environment**
- Model: `Qwen3-Omni-MoE`
- Topology: 4 GPUs — stage 0 (thinker) on `cuda:0`; stages 1/2 (talker, code2wav) with `num_replicas=2` on `cuda:1,2`
- Deploy config: `vllm_omni/deploy/qwen3_omni_moe_multi_replicas.yaml`, with `enable_prefix_caching: false` set on stage 0 (aligned with baseline `qwen3_omni_moe.yaml`)

**Symptom (before this PR)** — `conc=24` fails on the very first prefill batch:
- `RuntimeError: tensor a (6) vs b (9)` in `_get_talker_assistant_parts` — the talker assistant segment collapses to a `[6, d]` tensor that can't broadcast against the always-`[9, d]` codec tensor.
- CUDA `device-side assert` from `vectorized_gather_kernel` — `hidden_states[logits_indices]` indexes out of bounds.
- Both cascade into `EngineDead`, after which all subsequent requests get connection-refused.

**Changes in this PR** — three defensive guards on the talker stage:
1. **Talker assistant-segment guard** (`qwen3_omni.py`, `_get_talker_assistant_parts`): zero-pad the `[:3]` prefix and `[3:4]` first-text slices so `assistant_text_hidden` keeps its fixed `[9, d]` shape even when `assistant_hidden` is shorter than expected.
2. **Talker postprocess guard** (`qwen3_omni.py`, `talker_postprocess`): return a zero "last" sentinel when `hidden_states` is empty, instead of indexing into an empty tensor.
3. **Talker `logits_indices` rebuild** (`gpu_model_runner.py` + `gpu_ar_model_runner.py`): capture per-request talker output lengths in `_preprocess`, and in the AR runner rebuild `logits_indices` from them when they don't line up with the `hidden_states` row count. Self-validating — it is a no-op for non-talker stages and for models that skip no segments.

> ⚠️ **This is a hotfix, not a root-cause fix.** We have **not** confirmed *why* the talker stage receives a partial `embed.prefill` while `ids.prompt` is complete, nor *why* `logits_indices` over-counts under multi-replica high concurrency. 

cc @amy-why-3459 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
