### PR TITLE
[Bugfix]Fix multimodal cache routing for AR replicas

### DIFF
--- a/tests/engine/test_async_omni_engine_input.py
+++ b/tests/engine/test_async_omni_engine_input.py
@@ -5,13 +5,14 @@ from vllm.v1.engine import EngineCoreRequest
 
 from vllm_omni.engine import OmniEngineCoreRequest
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine, StageRuntimeInfo
+from vllm_omni.engine.stage_pool import StagePool
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
-def _make_engine_core_request() -> EngineCoreRequest:
+def _make_engine_core_request(request_id: str = "req-1") -> EngineCoreRequest:
     return EngineCoreRequest(
-        request_id="req-1",
+        request_id=request_id,
         prompt_token_ids=[1, 1, 1],
         mm_features=None,
         sampling_params=SamplingParams(max_tokens=8),
@@ -88,3 +89,86 @@ def test_build_add_request_message_with_resumable_streaming(mocker: MockerFixtur
     assert msg.type == "streaming_update"
     input_processor.process_inputs.assert_called_once()
     assert input_processor.process_inputs.call_args.kwargs["resumable"] is True
+
+
+class _FakeStageClient:
+    stage_type = "llm"
+    final_output = False
+
+
+def test_build_add_request_message_scopes_mm_uuids_to_selected_stage0_replica(mocker: MockerFixture):
+    engine = object.__new__(AsyncOmniEngine)
+    params = SamplingParams(max_tokens=8)
+    engine.model = "test-model"
+    engine.default_sampling_params_list = [params]
+    engine.stage_metadata = [StageRuntimeInfo(final_output=False, final_output_type=None, stage_type="llm")]
+    engine.supported_tasks = ("generate",)
+    engine.stage_pools = [StagePool(0, [_FakeStageClient(), _FakeStageClient()])]
+
+    seen_uuids: list[str] = []
+
+    def process_inputs(**kwargs):
+        prompt = kwargs["prompt"]
+        seen_uuids.append(prompt["multi_modal_uuids"]["image"][0])
+        return _make_engine_core_request(kwargs["request_id"])
+
+    input_processor = mocker.Mock()
+    input_processor.process_inputs.side_effect = process_inputs
+    engine.input_processor = input_processor
+
+    for request_id in ("req-1", "req-2"):
+        engine._build_add_request_message(
+            request_id=request_id,
+            prompt={
+                "prompt": "describe",
+                "multi_modal_data": {"image": "same-image"},
+            },
+            sampling_params_list=[params],
+            final_stage_id=0,
+        )
+
+    assert seen_uuids[0].startswith("stage0:rep0:")
+    assert seen_uuids[1].startswith("stage0:rep1:")
+    assert seen_uuids[0].removeprefix("stage0:rep0:") == seen_uuids[1].removeprefix("stage0:rep1:")
+
+
+def test_stage_pool_replica_count_falls_back_to_clients():
+    class PoolWithoutLiveNumReplicas:
+        clients = [object(), None, object()]
+
+    assert AsyncOmniEngine._stage_pool_replica_count(PoolWithoutLiveNumReplicas()) == 2
+
+
+def test_stage_pool_is_distributed_falls_back_to_hub():
+    class PoolWithoutIsDistributed:
+        _hub = object()
+
+    assert AsyncOmniEngine._stage_pool_is_distributed(PoolWithoutIsDistributed()) is True
+
+
+def test_build_add_request_message_releases_preselected_replica_on_preprocess_error(mocker: MockerFixture):
+    engine = object.__new__(AsyncOmniEngine)
+    params = SamplingParams(max_tokens=8)
+    engine.model = "test-model"
+    engine.default_sampling_params_list = [params]
+    engine.stage_metadata = [StageRuntimeInfo(final_output=False, final_output_type=None, stage_type="llm")]
+    engine.supported_tasks = ("generate",)
+    stage_pool = StagePool(0, [_FakeStageClient(), _FakeStageClient()])
+    engine.stage_pools = [stage_pool]
+
+    input_processor = mocker.Mock()
+    input_processor.process_inputs.side_effect = RuntimeError("boom")
+    engine.input_processor = input_processor
+
+    with pytest.raises(RuntimeError, match="boom"):
+        engine._build_add_request_message(
+            request_id="req-error",
+            prompt={
+                "prompt": "describe",
+                "multi_modal_data": {"image": "same-image"},
+            },
+            sampling_params_list=[params],
+            final_stage_id=0,
+        )
+
+    assert stage_pool.get_bound_replica_id("req-error") is None

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1317,6 +1317,8 @@ class AsyncOmniEngine:
             return None
 
         stage0_pool = stage_pools[0]
+        # TODO: Currently only supports the ar -> dit process.
+        # Future scenarios (e.g., dit -> ar) need to be added, which will require modifications here.
         if stage0_pool.stage_type == "diffusion" or self._stage_pool_replica_count(stage0_pool) <= 1:
             return None
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1199,6 +1199,156 @@ class AsyncOmniEngine:
 
     # ---- request helpers ----
 
+    @staticmethod
+    def _iter_multimodal_items(value: Any) -> list[Any]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        return [value]
+
+    def _ensure_stage_replica_mm_uuids(
+        self,
+        prompt: Any,
+        *,
+        stage_id: int,
+        replica_id: int,
+    ) -> None:
+        """Make multimodal processor-cache keys local to a stage replica.
+
+        vLLM's frontend multimodal sender cache is process-global, while each
+        vllm-omni stage replica owns a separate EngineCore receiver cache. If
+        two requests with the same image are routed to different stage-0
+        replicas, a plain content hash can make the sender omit the tensor for
+        a replica that has never received it. Prefixing user/content UUIDs with
+        the selected replica keeps cache reuse within the receiver that owns it.
+        """
+
+        if not isinstance(prompt, dict):
+            return
+
+        mm_data = prompt.get("multi_modal_data")
+        if not isinstance(mm_data, dict) or not mm_data:
+            return
+
+        from vllm.multimodal.hasher import MultiModalHasher
+
+        existing_uuids = prompt.get("multi_modal_uuids")
+        if not isinstance(existing_uuids, dict):
+            existing_uuids = {}
+
+        model_id = str(getattr(self, "model", ""))
+        scoped_uuids: dict[str, list[str | None]] = dict(existing_uuids)
+        for modality, raw_items in mm_data.items():
+            items = self._iter_multimodal_items(raw_items)
+            if not items:
+                continue
+
+            modality_existing = existing_uuids.get(modality)
+            if not isinstance(modality_existing, list):
+                modality_existing = [modality_existing] if modality_existing is not None else []
+
+            modality_uuids: list[str | None] = []
+            for idx, item in enumerate(items):
+                user_uuid = modality_existing[idx] if idx < len(modality_existing) else None
+                if user_uuid is not None:
+                    base_uuid = str(user_uuid)
+                elif item is None:
+                    base_uuid = None
+                else:
+                    base_uuid = MultiModalHasher.hash_kwargs(
+                        model_id=model_id,
+                        **{modality: item},
+                    )
+
+                if base_uuid is None:
+                    modality_uuids.append(None)
+                else:
+                    modality_uuids.append(f"stage{stage_id}:rep{replica_id}:{base_uuid}")
+
+            scoped_uuids[modality] = modality_uuids
+
+        if scoped_uuids:
+            prompt["multi_modal_uuids"] = scoped_uuids
+
+    @staticmethod
+    def _stage_pool_replica_count(stage_pool: Any) -> int:
+        try:
+            live_num_replicas = getattr(stage_pool, "live_num_replicas", None)
+            if live_num_replicas is not None:
+                return int(live_num_replicas)
+        except Exception:
+            pass
+
+        try:
+            live_replica_ids = getattr(stage_pool, "live_replica_ids", None)
+            if callable(live_replica_ids):
+                return len(live_replica_ids())
+        except Exception:
+            pass
+
+        try:
+            clients = getattr(stage_pool, "clients", None)
+            if clients is not None:
+                return sum(1 for client in clients if client is not None)
+        except Exception:
+            pass
+
+        return int(getattr(stage_pool, "num_replicas", 1) or 1)
+
+    @staticmethod
+    def _stage_pool_is_distributed(stage_pool: Any) -> bool:
+        try:
+            is_distributed = getattr(stage_pool, "is_distributed", None)
+            if is_distributed is not None:
+                return bool(is_distributed() if callable(is_distributed) else is_distributed)
+        except Exception:
+            pass
+
+        return getattr(stage_pool, "_hub", None) is not None
+
+    def _scope_stage0_multimodal_cache_to_replica(
+        self,
+        request_id: str,
+        prompt: Any,
+    ) -> int | None:
+        stage_pools = getattr(self, "stage_pools", None)
+        if isinstance(prompt, EngineCoreRequest) or not stage_pools:
+            return None
+
+        stage0_pool = stage_pools[0]
+        if stage0_pool.stage_type == "diffusion" or self._stage_pool_replica_count(stage0_pool) <= 1:
+            return None
+
+        # This synchronous request path can safely pre-bind local in-process
+        # replicas. Distributed head mode still uses the async picker inside
+        # StagePool.submit_initial().
+        if self._stage_pool_is_distributed(stage0_pool):
+            logger.debug(
+                "[AsyncOmniEngine] Skipping stage-0 multimodal cache scoping for distributed routing req=%s",
+                request_id,
+            )
+            return None
+
+        prompts = prompt if isinstance(prompt, list) else [prompt]
+        if not any(isinstance(p, dict) and p.get("multi_modal_data") for p in prompts):
+            return None
+
+        replica_id = stage0_pool.select_replica_id(request_id)
+        for p in prompts:
+            self._ensure_stage_replica_mm_uuids(
+                p,
+                stage_id=0,
+                replica_id=replica_id,
+            )
+
+        logger.debug(
+            "[AsyncOmniEngine] Scoped multimodal cache keys to stage-0 replica-%s for req=%s",
+            replica_id,
+            request_id,
+        )
+        return replica_id
+
     def _build_add_request_message(
         self,
         request_id: str,
@@ -1232,6 +1382,7 @@ class AsyncOmniEngine:
         # Keep the original prompt for downstream stages (they need the raw
         # dict, e.g. for multi_modal_data).
         original_prompt = prompt
+        preselected_stage0_replica: int | None = None
 
         stage_type = self.stage_metadata[0].stage_type
         output_prompt_text: Any = None
@@ -1244,21 +1395,31 @@ class AsyncOmniEngine:
                 for item in prompt:
                     _inject_global_id(item, request_id)
 
+            preselected_stage0_replica = self._scope_stage0_multimodal_cache_to_replica(
+                request_id,
+                prompt,
+            )
+
             # Full input processing (tokenization, multimodal, etc.)
             _t_preprocess = time.perf_counter()
-            request = self.input_processor.process_inputs(
-                request_id=request_id,
-                prompt=prompt,
-                params=params,
-                supported_tasks=self.supported_tasks,
-                arrival_time=arrival_time,
-                lora_request=lora_request,
-                tokenization_kwargs=tokenization_kwargs,
-                trace_headers=trace_headers,
-                priority=priority,
-                data_parallel_rank=data_parallel_rank,
-                resumable=resumable,
-            )
+            try:
+                request = self.input_processor.process_inputs(
+                    request_id=request_id,
+                    prompt=prompt,
+                    params=params,
+                    supported_tasks=self.supported_tasks,
+                    arrival_time=arrival_time,
+                    lora_request=lora_request,
+                    tokenization_kwargs=tokenization_kwargs,
+                    trace_headers=trace_headers,
+                    priority=priority,
+                    data_parallel_rank=data_parallel_rank,
+                    resumable=resumable,
+                )
+            except Exception:
+                if preselected_stage0_replica is not None and self.stage_pools:
+                    self.stage_pools[0].release_binding(request_id)
+                raise
             _preprocess_ms = (time.perf_counter() - _t_preprocess) * 1000.0
             # TODO (Peiqi): add this for Qwen3-TTS only. Other models don't have
             # additional_information field in the prompt.


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
This PR aims to settle the issue which mm_cache error when 2 replicas of AR.

## Test Plan
After merging #3569, if it sets 2 replicas of AR with concurrent 2 requests, an mm_cache error occurred.

In the current flow, `InputProcessor.process_inputs()` runs before stage-0 replica selection. This computes the multimodal `mm_hash` and may hit the frontend sender
  cache. However, the receiver cache is local to each AR replica. So if the first image request goes to `stage-0 rep-0`, only `rep-0` has that cached multimodal item. A
  later request with the same image can hit the sender cache before routing, omit the tensor data, and then be routed to `rep-1`, where the receiver cache does not contain
  that `mm_hash`.

  The fix is to select the stage-0 replica before multimodal preprocessing for local multi-replica stage-0 requests, then scope `multi_modal_uuids` with the selected
  replica id before calling `InputProcessor.process_inputs()`.

  The effective cache key changes from:

  ```text
  <image_hash>
  ```

  to:
  ```text
  stage0:rep<replica_id>:<image_hash>
  ```

  This keeps multimodal sender-cache reuse local to the AR replica whose receiver cache actually owns the item. The later stage submission reuses the same request_id ->
  replica_id binding, so the request is still sent to the replica used for cache scoping.

  I also added tests to verify that two requests with the same image routed to different stage-0 replicas receive different scoped multimodal UUIDs, and that the
  preselected replica binding is released if preprocessing fails.


## Test Result

The output log shows:
<details>
  <summary>Click to show log</summary>
(APIServer pid=1145758) INFO:     Started server process [1145758]
(APIServer pid=1145758) INFO:     Waiting for application startup.
(APIServer pid=1145758) INFO:     Application startup complete.
(APIServer pid=1145758) WARNING 05-14 08:42:11 [input_processor.py:274] Passing raw prompts to InputProcessor is deprecated and will be removed in v0.18. You should instead pass the outputs of Renderer.render_cmpl() or Renderer.render_chat().
(APIServer pid=1145758) INFO 05-14 08:42:12 [hunyuan_image3.py:921] Successfully processed 1 image(s). Final tensor shapes: {'vit_pixel_values': (1, 1024, 768), 'vit_pixel_attention_mask': (1, 1024), 'vit_spatial_shapes': (1, 2), 'vae_pixel_values': (1, 3, 832, 1216), 'vae_token_grid_hw': (1, 2), 'base_size': (1,), 'ratio_index': (1,)}
(APIServer pid=1145758) INFO 05-14 08:42:12 [stage_engine_core_client.py:262] [StageEngineCoreClient] stage-0 [rep-0] add request: img_edit-a16b688d0b26a676
(Worker_TP0 pid=1150431) WARNING 05-14 08:42:12 [gpu_model_runner.py:392] additional_information on request data is deprecated, use model_intermediate_buffer
(Worker_TP1 pid=1150435) /mnt/data4/bjf_workspace/.venv/lib/python3.12/site-packages/transformers/modeling_attn_mask_utils.py:202: FutureWarning: The attention mask API under `transformers.modeling_attn_mask_utils` (`AttentionMaskConverter`) is deprecated and will be removed in Transformers v5.10. Please use the new API in `transformers.masking_utils`.
(Worker_TP1 pid=1150435)   warnings.warn(DEPRECATION_MESSAGE, FutureWarning)
(Worker_TP0 pid=1150431) /mnt/data4/bjf_workspace/.venv/lib/python3.12/site-packages/transformers/modeling_attn_mask_utils.py:202: FutureWarning: The attention mask API under `transformers.modeling_attn_mask_utils` (`AttentionMaskConverter`) is deprecated and will be removed in Transformers v5.10. Please use the new API in `transformers.masking_utils`.
(Worker_TP0 pid=1150431)   warnings.warn(DEPRECATION_MESSAGE, FutureWarning)
(APIServer pid=1145758) INFO 05-14 08:42:12 [hunyuan_image3.py:921] Successfully processed 1 image(s). Final tensor shapes: {'vit_pixel_values': (1, 1024, 768), 'vit_pixel_attention_mask': (1, 1024), 'vit_spatial_shapes': (1, 2), 'vae_pixel_values': (1, 3, 832, 1216), 'vae_token_grid_hw': (1, 2), 'base_size': (1,), 'ratio_index': (1,)}
(APIServer pid=1145758) INFO 05-14 08:42:12 [stage_engine_core_client.py:262] [StageEngineCoreClient] stage-0 [rep-1] add request: img_edit-a897887dc20a81c7
(Worker_TP0 pid=1150438) WARNING 05-14 08:42:12 [gpu_model_runner.py:392] additional_information on request data is deprecated, use model_intermediate_buffer
(Worker_TP0 pid=1150438) /mnt/data4/bjf_workspace/.venv/lib/python3.12/site-packages/transformers/modeling_attn_mask_utils.py:202: FutureWarning: The attention mask API under `transformers.modeling_attn_mask_utils` (`AttentionMaskConverter`) is deprecated and will be removed in Transformers v5.10. Please use the new API in `transformers.masking_utils`.
(Worker_TP0 pid=1150438)   warnings.warn(DEPRECATION_MESSAGE, FutureWarning)
(Worker_TP1 pid=1150439) /mnt/data4/bjf_workspace/.venv/lib/python3.12/site-packages/transformers/modeling_attn_mask_utils.py:202: FutureWarning: The attention mask API under `transformers.modeling_attn_mask_utils` (`AttentionMaskConverter`) is deprecated and will be removed in Transformers v5.10. Please use the new API in `transformers.masking_utils`.
(Worker_TP1 pid=1150439)   warnings.warn(DEPRECATION_MESSAGE, FutureWarning)
(APIServer pid=1145758) INFO 05-14 08:42:35 [hunyuan_image3.py:68] [ar2diffusion] Request 0: AR generated 428 tokens, text length=2273, target size=1024x1024
(APIServer pid=1145758) INFO 05-14 08:42:35 [orchestrator.py:913] [Orchestrator] ar2diffusion req=img_edit-a16b688d0b26a676 wall_time=0.419ms stage=0->1
(APIServer pid=1145758) INFO 05-14 08:42:35 [stage_diffusion_client.py:342] [StageDiffusionClient] stage-1 [rep-0] add batch request: img_edit-a16b688d0b26a676 (1 prompts)
INFO 05-14 08:42:36 [kv_transfer_manager.py:1273] Rank-aware KV receive: rank 0 independently receiving (from_tp=2, to_tp=4)
INFO 05-14 08:42:36 [kv_transfer_manager.py:713] Sender info updated: host=172.16.1.247, base_port=50151, adjusted_port=50151 (local_rank=0)
INFO 05-14 08:42:36 [kv_transfer_manager.py:1015] Wait for KV cache for request img_edit-a16b688d0b26a676 from stage 0 to 1 via 1 key(s)...
INFO 05-14 08:42:36 [kv_transfer_manager.py:1273] Rank-aware KV receive: rank 1 independently receiving (from_tp=2, to_tp=4)
INFO 05-14 08:42:36 [kv_transfer_manager.py:713] Sender info updated: host=172.16.1.247, base_port=50151, adjusted_port=50167 (local_rank=1)
INFO 05-14 08:42:36 [kv_transfer_manager.py:1015] Wait for KV cache for request img_edit-a16b688d0b26a676 from stage 0 to 1 via 1 key(s)...
INFO 05-14 08:42:36 [kv_transfer_manager.py:1273] Rank-aware KV receive: rank 2 independently receiving (from_tp=2, to_tp=4)
INFO 05-14 08:42:36 [kv_transfer_manager.py:713] Sender info updated: host=172.16.1.247, base_port=50151, adjusted_port=50183 (local_rank=2)
INFO 05-14 08:42:36 [kv_transfer_manager.py:1015] Wait for KV cache for request img_edit-a16b688d0b26a676 from stage 0 to 1 via 1 key(s)...
INFO 05-14 08:42:36 [kv_transfer_manager.py:1273] Rank-aware KV receive: rank 3 independently receiving (from_tp=2, to_tp=4)
INFO 05-14 08:42:36 [kv_transfer_manager.py:713] Sender info updated: host=172.16.1.247, base_port=50151, adjusted_port=50199 (local_rank=3)
INFO 05-14 08:42:36 [kv_transfer_manager.py:1015] Wait for KV cache for request img_edit-a16b688d0b26a676 from stage 0 to 1 via 1 key(s)...
(Worker_TP1 pid=1150435) INFO 05-14 08:42:36 [kv_transfer_manager.py:906] KV cache serialized for img_edit-a16b688d0b26a676 in 314.6 ms
(Worker_TP0 pid=1150431) INFO 05-14 08:42:36 [kv_transfer_manager.py:906] KV cache serialized for img_edit-a16b688d0b26a676 in 327.0 ms
/mnt/data4/bjf_workspace/vllm-omni-main-pr3569/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py:257: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_new.cpp:1586.)
  return torch.frombuffer(tensor_data_mv, dtype=torch.uint8, offset=offset, count=nbytes)
/mnt/data4/bjf_workspace/vllm-omni-main-pr3569/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py:257: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_new.cpp:1586.)
  return torch.frombuffer(tensor_data_mv, dtype=torch.uint8, offset=offset, count=nbytes)
INFO 05-14 08:42:36 [kv_transfer_manager.py:1105] Successfully received KV cache for img_edit-a16b688d0b26a676, 218111130 bytes across 1 key(s), wait=0.528s, link=217.2ms
INFO 05-14 08:42:36 [pipeline_hunyuan_image3.py:1334] [AR KV Reuse] Extracted 32 layers of AR KV, each with length: torch.Size([6656, 2, 128])
INFO 05-14 08:42:36 [kv_transfer_manager.py:1105] Successfully received KV cache for img_edit-a16b688d0b26a676, 218111130 bytes across 1 key(s), wait=0.543s, link=232.3ms
INFO 05-14 08:42:36 [pipeline_hunyuan_image3.py:1334] [AR KV Reuse] Extracted 32 layers of AR KV, each with length: torch.Size([6656, 2, 128])
(Worker_TP1 pid=1150435) INFO 05-14 08:42:36 [kv_transfer_manager.py:920] KV transfer OK: img_edit-a16b688d0b26a676, 436222260 bytes across 2 key(s), 0.369s, 1126.4 MB/s
(Worker_TP0 pid=1150431) INFO 05-14 08:42:36 [kv_transfer_manager.py:920] KV transfer OK: img_edit-a16b688d0b26a676, 436222260 bytes across 2 key(s), 0.373s, 1114.7 MB/s
/mnt/data4/bjf_workspace/vllm-omni-main-pr3569/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py:257: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_new.cpp:1586.)
  return torch.frombuffer(tensor_data_mv, dtype=torch.uint8, offset=offset, count=nbytes)
/mnt/data4/bjf_workspace/vllm-omni-main-pr3569/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py:257: UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors. This means you can write to the underlying (supposedly non-writable) buffer using the tensor. You may want to copy the buffer to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_new.cpp:1586.)
  return torch.frombuffer(tensor_data_mv, dtype=torch.uint8, offset=offset, count=nbytes)
INFO 05-14 08:42:36 [kv_transfer_manager.py:1105] Successfully received KV cache for img_edit-a16b688d0b26a676, 218111130 bytes across 1 key(s), wait=0.777s, link=146.8ms
INFO 05-14 08:42:36 [pipeline_hunyuan_image3.py:1334] [AR KV Reuse] Extracted 32 layers of AR KV, each with length: torch.Size([6656, 2, 128])
INFO 05-14 08:42:36 [kv_transfer_manager.py:1105] Successfully received KV cache for img_edit-a16b688d0b26a676, 218111130 bytes across 1 key(s), wait=0.780s, link=149.0ms
INFO 05-14 08:42:36 [pipeline_hunyuan_image3.py:1334] [AR KV Reuse] Extracted 32 layers of AR KV, each with length: torch.Size([6656, 2, 128])
INFO 05-14 08:42:37 [hunyuan_image3_transformer.py:2797] Handling AR KV reuse with positive_reuse_len=6655, negative_reuse_len=6209
INFO 05-14 08:42:37 [hunyuan_image3_transformer.py:2797] Handling AR KV reuse with positive_reuse_len=6655, negative_reuse_len=6209
INFO 05-14 08:42:37 [hunyuan_image3_transformer.py:2797] Handling AR KV reuse with positive_reuse_len=6655, negative_reuse_len=6209
INFO 05-14 08:42:37 [hunyuan_image3_transformer.py:2797] Handling AR KV reuse with positive_reuse_len=6655, negative_reuse_len=6209
  0%|                                                                                                                                                 | 0/8 [00:00<?, ?it/s](APIServer pid=1145758) INFO 05-14 08:42:38 [hunyuan_image3.py:68] [ar2diffusion] Request 0: AR generated 443 tokens, text length=2352, target size=1024x1024
(APIServer pid=1145758) INFO 05-14 08:42:38 [orchestrator.py:913] [Orchestrator] ar2diffusion req=img_edit-a897887dc20a81c7 wall_time=0.478ms stage=0->1
(APIServer pid=1145758) INFO 05-14 08:42:38 [stage_diffusion_client.py:342] [StageDiffusionClient] stage-1 [rep-0] add batch request: img_edit-a897887dc20a81c7 (1 prompts)
 12%|█████████████████▏                                                                                                                       | 1/8 [00:00<00:04,  1.54it/s](Worker_TP0 pid=1150438) INFO 05-14 08:42:38 [kv_transfer_manager.py:906] KV cache serialized for img_edit-a897887dc20a81c7 in 316.8 ms
(Worker_TP1 pid=1150439) INFO 05-14 08:42:38 [kv_transfer_manager.py:906] KV cache serialized for img_edit-a897887dc20a81c7 in 345.2 ms
 25%|██████████████████████████████████▎                                                                                                      | 2/8 [00:00<00:02,  2.46it/s](Worker_TP0 pid=1150438) INFO 05-14 08:42:39 [kv_transfer_manager.py:920] KV transfer OK: img_edit-a897887dc20a81c7, 437205308 bytes across 2 key(s), 0.356s, 1170.5 MB/s
(Worker_TP1 pid=1150439) INFO 05-14 08:42:39 [kv_transfer_manager.py:920] KV transfer OK: img_edit-a897887dc20a81c7, 437205308 bytes across 2 key(s), 0.373s, 1117.8 MB/s
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:03<00:00,  2.04it/s]
INFO 05-14 08:42:43 [kv_transfer_manager.py:1273] Rank-aware KV receive: rank 2 independently receiving (from_tp=2, to_tp=4)
INFO 05-14 08:42:43 [kv_transfer_manager.py:713] Sender info updated: host=172.16.1.247, base_port=50151, adjusted_port=50183 (local_rank=2)
INFO 05-14 08:42:43 [kv_transfer_manager.py:1015] Wait for KV cache for request img_edit-a897887dc20a81c7 from stage 0 to 1 via 1 key(s)...
INFO 05-14 08:42:43 [kv_transfer_manager.py:1273] Rank-aware KV receive: rank 1 independently receiving (from_tp=2, to_tp=4)
INFO 05-14 08:42:43 [kv_transfer_manager.py:713] Sender info updated: host=172.16.1.247, base_port=50151, adjusted_port=50167 (local_rank=1)
INFO 05-14 08:42:43 [kv_transfer_manager.py:1015] Wait for KV cache for request img_edit-a897887dc20a81c7 from stage 0 to 1 via 1 key(s)...
INFO 05-14 08:42:43 [kv_transfer_manager.py:1273] Rank-aware KV receive: rank 0 independently receiving (from_tp=2, to_tp=4)
INFO 05-14 08:42:43 [kv_transfer_manager.py:713] Sender info updated: host=172.16.1.247, base_port=50151, adjusted_port=50151 (local_rank=0)
INFO 05-14 08:42:43 [kv_transfer_manager.py:1015] Wait for KV cache for request img_edit-a897887dc20a81c7 from stage 0 to 1 via 1 key(s)...
INFO 05-14 08:42:43 [kv_transfer_manager.py:1273] Rank-aware KV receive: rank 3 independently receiving (from_tp=2, to_tp=4)
INFO 05-14 08:42:43 [kv_transfer_manager.py:713] Sender info updated: host=172.16.1.247, base_port=50151, adjusted_port=50199 (local_rank=3)
INFO 05-14 08:42:43 [kv_transfer_manager.py:1015] Wait for KV cache for request img_edit-a897887dc20a81c7 from stage 0 to 1 via 1 key(s)...
(APIServer pid=1145758) INFO:     127.0.0.1:39692 - "POST /v1/images/edits HTTP/1.1" 200 OK
INFO 05-14 08:42:43 [kv_transfer_manager.py:1105] Successfully received KV cache for img_edit-a897887dc20a81c7, 218602654 bytes across 1 key(s), wait=0.143s, link=142.8ms
INFO 05-14 08:42:43 [pipeline_hunyuan_image3.py:1334] [AR KV Reuse] Extracted 32 layers of AR KV, each with length: torch.Size([6671, 2, 128])
INFO 05-14 08:42:43 [kv_transfer_manager.py:1105] Successfully received KV cache for img_edit-a897887dc20a81c7, 218602654 bytes across 1 key(s), wait=0.152s, link=152.2ms
INFO 05-14 08:42:43 [pipeline_hunyuan_image3.py:1334] [AR KV Reuse] Extracted 32 layers of AR KV, each with length: torch.Size([6671, 2, 128])
INFO 05-14 08:42:43 [kv_transfer_manager.py:1105] Successfully received KV cache for img_edit-a897887dc20a81c7, 218602654 bytes across 1 key(s), wait=0.158s, link=157.9ms
INFO 05-14 08:42:43 [kv_transfer_manager.py:1105] Successfully received KV cache for img_edit-a897887dc20a81c7, 218602654 bytes across 1 key(s), wait=0.159s, link=159.3ms
INFO 05-14 08:42:43 [pipeline_hunyuan_image3.py:1334] [AR KV Reuse] Extracted 32 layers of AR KV, each with length: torch.Size([6671, 2, 128])
INFO 05-14 08:42:43 [pipeline_hunyuan_image3.py:1334] [AR KV Reuse] Extracted 32 layers of AR KV, each with length: torch.Size([6671, 2, 128])
INFO 05-14 08:42:44 [hunyuan_image3_transformer.py:2797] Handling AR KV reuse with positive_reuse_len=6670, negative_reuse_len=6209
INFO 05-14 08:42:44 [hunyuan_image3_transformer.py:2797] Handling AR KV reuse with positive_reuse_len=6670, negative_reuse_len=6209
INFO 05-14 08:42:44 [hunyuan_image3_transformer.py:2797] Handling AR KV reuse with positive_reuse_len=6670, negative_reuse_len=6209
INFO 05-14 08:42:44 [hunyuan_image3_transformer.py:2797] Handling AR KV reuse with positive_reuse_len=6670, negative_reuse_len=6209
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:03<00:00,  2.11it/s]
(APIServer pid=1145758) INFO:     127.0.0.1:39694 - "POST /v1/images/edits HTTP/1.1" 200 OK
</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
