### PR TITLE
[Perf][HunyuanImage3] Drop redundant .to() on inv_freq in RotaryEmbed…

### DIFF
--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -1398,7 +1398,7 @@ class HunyuanImage3RotaryEmbedding(nn.Module):
         query_shape = query.shape
         key_shape = key.shape
 
-        inv_freq = self.inv_freq.to(device=y_pos.device, dtype=torch.float32)
+        inv_freq = self.inv_freq
 
         inv_freq_y = inv_freq[0::2]  # even indices -> y
         inv_freq_x = inv_freq[1::2]  # odd  indices -> x


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

`HunyuanImage3RotaryEmbedding.forward()` calls `.to(device=y_pos.device, dtype=torch.float32)` on `self.inv_freq` on **every layer of every decode step**. The buffer is already registered as `torch.float32` via `register_buffer(..., persistent=False)` and moves to the correct GPU together with the rest of the module at load time, so the per-call `.to()` is always a no-op: it just dispatches an `aten::to` op, observes that `device` and `dtype` already match, and returns the same tensor.

For HunyuanImage-3.0-Instruct AR (32 transformer layers) this fires 32 x `decode_steps` no-op dispatches per TP rank, which shows up clearly in profiler traces as one of the densest `aten::to` populations in the AR loop. This PR removes the call.

```python
# vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
# before
inv_freq = self.inv_freq.to(device=y_pos.device, dtype=torch.float32)
# after
inv_freq = self.inv_freq
```

No behavior change is intended: `self.inv_freq` is the same tensor object that the old line was producing, just without the redundant trip through the dispatcher. This is the same class of "HF-style on-device `.to()` leftover" that PR #3297 cleaned up on the SigLIP2 padded-to-packed refactor; landing it keeps the AR forward path free of similar dispatch dust.

## Test Plan

Post-rebase same-prompt, same-image, greedy-sampling baseline vs. patched comparison on the remote CUDA node.

**Environment**
- Base: `vllm-project/vllm-omni@2af2a50e0e2981ec2eef32e704f5a66c3d451c95`
- Patch: `TaffyOfficial/vllm-omni@bddc12a5a968c4c3c031ff25e8fe036a1b6bc818`
- `vllm == 0.21.0`, `flashinfer == 0.6.8.post1`
- Model snapshot: `tencent/HunyuanImage-3.0-Instruct` commit `2ec2c78b...`
- Deploy config: `vllm_omni/deploy/hunyuan_image3_ar.yaml`
- `enforce_eager: true`, `tensor_parallel_size: 4`, `max_num_seqs: 1`
- Sampling: `temperature=0.0`, `top_k=1`, `top_p=1.0`, `max_tokens=26`
- Image: 256x256 solid RGB `(128, 200, 100)`; prompt: `"Describe the content of the picture."` (i2t mode)

**Run shape**

```python
omni = Omni(
    model=MODEL_SNAPSHOT,
    deploy_config="vllm_omni/deploy/hunyuan_image3_ar.yaml",
    profiler_config={"profiler": "torch", "torch_profiler_dir": TRACE_DIR},
    stage_init_timeout=900,
    init_timeout=900,
    mode="image-to-text",
    enforce_eager=True,
)
omni.generate(prompts=[prompt_dict], sampling_params_list=params_list)  # warmup
omni.start_profile(profile_prefix="...", stages=[0])
omni.generate(prompts=[prompt_dict], sampling_params_list=params_list)  # measured
omni.stop_profile(stages=[0])
```

Trace analysis streams all `trace_rank*.json.gz` files and sums event counts/durations by event name. Generated `token_ids` of the measured run are compared byte-for-byte across the two builds.

Remote artifact directory: `/home/wzr/perf_results/pr3606_rebase_20260519_174715`.

## Test Result

**Accuracy:** generated text and token IDs are identical on both sides.

Generated 26 tokens:

```text
The image is a solid, uniform green color with no variations, objects, or details present. It is a single-color background without
```

**End-to-end timing (single measured run, 26 decode tokens):**

| metric | base | patched | patched - base |
|---|---:|---:|---:|
| measured wall time | 3.1077 s | 3.1451 s | +37.3 ms |
| stage 0 generation | 3085.14 ms | 3108.24 ms | +23.1 ms |
| preprocess | 21.91 ms | 36.14 ms | +14.2 ms |

This does **not** show an end-to-end latency win. The single-run wall-time delta is noise-level and slightly slower for the patched run.

**Trace event counts (all 4 TP ranks, measured run):**

| op | base | patched | delta |
|---|---:|---:|---:|
| `aten::to` | 55,128 | 51,800 | **-3,328** |
| `aten::_to_copy` | 31,304 | 31,304 | 0 |
| `aten::copy_` | 36,328 | 36,328 | 0 |
| `cudaStreamSynchronize` | 108 | 108 | 0 |
| `cudaEventSynchronize` | 238 | 238 | 0 |
| `cudaDeviceSynchronize` | 4 | 4 | 0 |

Per-rank `aten::to` dropped from 13,782 to 12,950, i.e. **-832 per rank**. That exactly matches `32 layers x 26 decode tokens`, confirming the removed `.to()` was hit once per HunyuanImage3 layer per decode step on each TP rank.

**Trace event duration for `aten::to` (summed CPU event duration across all ranks):**

| metric | base | patched | patched - base |
|---|---:|---:|---:|
| `aten::to` count | 55,128 | 51,800 | **-3,328** |
| `aten::to` summed CPU event duration | 535.13 ms | 551.92 ms | +16.78 ms |

The profiler duration aggregate is not a reliable latency win signal here: despite the stable `aten::to` count reduction, summed `aten::to` event duration and end-to-end wall time are covered by profiler/runtime jitter in this short single-run trace.

Conclusion: this PR is a dispatch-count cleanup with no behavior change. It reliably removes `3,328` redundant `aten::to` dispatches for this 4-rank, 26-token run, but the current profiling data should **not** be presented as an end-to-end speedup.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>**