### PR TITLE
[Qwen-Image] Drop unused vision tower from text encoder

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -290,7 +290,22 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         )
         self.text_encoder = Qwen2_5_VLForConditionalGeneration.from_pretrained(
             model, subfolder="text_encoder", local_files_only=local_files_only
-        ).to(self.device)
+        )
+        # Qwen2.5-VL ships a vision tower that text-to-image does not use.
+        # Drop it while the model is still on CPU, before moving to GPU, so
+        # the vision tower never consumes GPU memory. Handle both transformers
+        # layouts: newer puts visual under .model, older puts it directly on
+        # the model.
+        visual_owner = None
+        if hasattr(self.text_encoder, "model") and hasattr(self.text_encoder.model, "visual"):
+            visual_owner = self.text_encoder.model
+        elif hasattr(self.text_encoder, "visual"):
+            visual_owner = self.text_encoder
+        if visual_owner is not None:
+            del visual_owner.visual
+        else:
+            logger.warning("Qwen-Image: vision tower not found on text encoder; skipping drop")
+        self.text_encoder = self.text_encoder.to(self.device)
         self.vae = DistributedAutoencoderKLQwenImage.from_pretrained(
             model, subfolder="vae", local_files_only=local_files_only
         ).to(self.device)


### PR DESCRIPTION
  <!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Drops Qwen2.5-VL's unused vision tower from the Qwen-Image text encoder, freeing ~7 GB of GPU memory.

Qwen-Image's text encoder is `Qwen2_5_VLForConditionalGeneration`, which loads a vision tower (`model.visual`) that is never invoked during text-to-image generation. Deleting it immediately after `from_pretrained` is a pure memory optimization and does not affect generation quality.

### ⚠️  Upstream finding while testing — `--quantization fp8` produces dark images on A100 SXM4

  While testing this PR I also ran `--quantization fp8` and observed that **the existing FP8 path in main produces a dark / NaN image on NVIDIA A100 SXM4 (Ampere) for Qwen-Image**, independent of any change in this PR

Isolated by running `--quantization fp8` with `del visual` toggled both ways — both produce dark output.

## Test Plan 
Run BF16 baseline and FP8 inference end-to-end on Qwen-Image at 1024×1024, comparing memory and image quality.

  ```bash
  # BF16 baseline (this PR's only meaningful path on A100)
  python examples/offline_inference/text_to_image/text_to_image.py \
      --model Qwen/Qwen-Image --width 1024 --height 1024
 ```

 Visually inspect the saved qwen_image_output.png after each run.

## Test Result
 Hardware: NVIDIA A100 SXM4 80GB (Vast.ai), Qwen/Qwen-Image, 1024×1024, 50 inference steps, prompt "a cup of coffee
   on the table".

```  ┌───────────────────────────────────────────┬──────────────┬───────────────────────────────────────┐
  │                    Run                    │ Peak GPU mem │            Generated image            │
  ├───────────────────────────────────────────┼──────────────┼───────────────────────────────────────┤
  │ BF16 baseline (main, before this PR)      │ 53.7 GB      │ clear coffee cup ✓                    │
  ├───────────────────────────────────────────┼──────────────┼───────────────────────────────────────┤
  │ BF16 + del visual (this PR)               │ ~46.5 GB     │ clear coffee cup ✓                    │
  ├───────────────────────────────────────────┼──────────────┼───────────────────────────────────────┤
  │ FP8 + del visual (this PR)                │ 38.0 GB      │ dark / NaN ✗ (upstream — see Purpose) │
  ├───────────────────────────────────────────┼──────────────┼───────────────────────────────────────┤
  │ FP8 without del visual (this PR reverted) │ ~45 GB       │ dark / NaN ✗ (upstream — see Purpose) │
  └───────────────────────────────────────────┴──────────────┴───────────────────────────────────────┘
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
