### PR TITLE
Add NPU support for OmniMRotaryEmbedding

### DIFF
--- a/vllm_omni/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm_omni/model_executor/layers/rotary_embedding/mrope.py
@@ -16,12 +16,18 @@ import itertools
 import torch
 from transformers import PretrainedConfig
 from vllm.logger import init_logger
-from vllm.model_executor.layers.rotary_embedding.mrope import MRotaryEmbedding
+
+from vllm_omni.platforms import current_omni_platform
+
+if current_omni_platform.is_npu():
+    from vllm_ascend.ops.rotary_embedding import AscendMRotaryEmbedding as _BaseMRotaryEmbedding
+else:
+    from vllm.model_executor.layers.rotary_embedding.mrope import MRotaryEmbedding as _BaseMRotaryEmbedding
 
 logger = init_logger(__name__)
 
 
-class OmniMRotaryEmbedding(MRotaryEmbedding):
+class OmniMRotaryEmbedding(_BaseMRotaryEmbedding):
     """Omni-extended MRotaryEmbedding with multimodal position computation.
 
     Extends the upstream MRotaryEmbedding with additional class methods for


### PR DESCRIPTION
# Summary
This PR adds NPU platform support for OmniMRotaryEmbedding to enable NPU-specific optimizations for Qwen3-TTS models, resulting in significant performance improvements on Ascend NPU.

# Problem
OmniMRotaryEmbedding does not support NPU platform. When running Qwen3-TTS on NPU, it imports the default MRotaryEmbedding from upstream vLLM which lacks NPU-specific optimizations, leading to suboptimal performance.

# Root Cause & Fix
The mrope.py file directly imports MRotaryEmbedding from upstream vLLM without platform detection.This prevents using NPU-optimized AscendMRotaryEmbedding from vllm-ascend. Add platform detection to dynamically select the appropriate base class.This enables OmniMRotaryEmbedding to inherit from AscendMRotaryEmbedding on NPU, ensuring proper NPU support while maintaining compatibility with other platforms.

# Testing
Performance benchmark on Ascend 910B NPU shows significant improvements:
Single concurrent (max-concurrency=1):
Metric | Without Optimization | With Optimization | Improvement
-- | -- | -- | --
Mean E2EL (ms) | 4915.17 | 4024.87 | 18.1%
Mean AUDIO_TTFP (ms) | 347.30 | 298.54 | 14.1%
Mean AUDIO_RTF | 1.38 | 1.15 | 16.7%
Audio throughput (audio/s) | 0.72 | 0.87 | 20.8%
Request throughput (req/s) | 0.20 | 0.25 | 25.0%

10 concurrent (max-concurrency=10):
Metric | Without Optimization | With Optimization | Improvement
-- | -- | -- | --
Mean E2EL (ms) | 10891.91 | 7910.01 | 27.4%
Mean AUDIO_TTFP (ms) | 876.74 | 700.04 | 20.2%
Mean AUDIO_RTF | 2.51 | 1.84 | 26.9%
Audio throughput (audio/s) | 3.66 | 5.07 | 38.5%
Request throughput (req/s) | 0.84 | 1.17 | 39.3%