### PR TITLE
[BugFix] Reject hsdp_replicate_size > 1 in DiffusionParallelConfig

### DIFF
--- a/docs/user_guide/diffusion/parallelism/hsdp.md
+++ b/docs/user_guide/diffusion/parallelism/hsdp.md
@@ -112,12 +112,11 @@ In `DiffusionParallelConfig`:
 |-----------|------|---------|-------------|
 | `use_hsdp` | bool | False | Enable HSDP |
 | `hsdp_shard_size` | int | -1 | Number of GPUs to shard weights across. `-1` = auto (requires other parallelism > 1) |
-| `hsdp_replicate_size` | int | 1 | Number of replica groups. Each group holds a full sharded copy |
 
 **Constraints:**
 
-- `hsdp_replicate_size × hsdp_shard_size == world_size`
 - HSDP cannot be used with Tensor Parallelism (`tensor_parallel_size` must be 1)
+- Only `hsdp_replicate_size = 1` is supported
 
 ---
 

--- a/docs/user_guide/examples/offline_inference/image_to_video.md
+++ b/docs/user_guide/examples/offline_inference/image_to_video.md
@@ -92,7 +92,7 @@ Key arguments:
 - `--enable-cpu-offload`: enable CPU offloading for diffusion models.
 - `--use-hsdp`: Enable Hybrid Sharded Data Parallel to shard model weights across GPUs.
 - `--hsdp-shard-size`: Number of GPUs to shard model weights across within each replica group. -1 (default) auto-calculates as world_size / replicate_size.
-- `--hsdp-replicate-size`: Number of replica groups for HSDP. Each replica holds a full sharded copy. Default 1 means pure sharding (no replication).
+- `--hsdp-replicate-size`: Number of replica groups for HSDP. Each replica holds a full sharded copy. Default 1 means pure sharding (no replication). Only 1 is supported.
 
 
 

--- a/docs/user_guide/examples/offline_inference/text_to_audio.md
+++ b/docs/user_guide/examples/offline_inference/text_to_audio.md
@@ -55,7 +55,7 @@ Key arguments:
 - `--num-inference-steps`: diffusion sampling steps.(more steps = higher quality, slower).
 - `--use-hsdp`: enable HSDP weight sharding for the Stable Audio DiT.
 - `--hsdp-shard-size`: number of GPUs used for HSDP sharding.
-- `--hsdp-replicate-size`: number of HSDP replica groups.
+- `--hsdp-replicate-size`: number of HSDP replica groups. Only 1 is supported.
 - `--output`: path to save the generated WAV file.
 - `--enable-cpu-offload`: enabling model-wise offloading to save gpu memory
 - `--enable-layerwise-offload`: enabling layerwise offloading to save gpu memory

--- a/docs/user_guide/examples/offline_inference/x_to_video_audio.md
+++ b/docs/user_guide/examples/offline_inference/x_to_video_audio.md
@@ -97,7 +97,7 @@ Key arguments:
 - `--cfg-parallel-size`: number of parallel cfg parallel (defaults 1).
 - `--use-hsdp`: enable HSDP weight sharding for DreamID-Omni fused blocks.
 - `--hsdp-shard-size`: number of GPUs used for HSDP sharding.
-- `--hsdp-replicate-size`: number of HSDP replica groups.
+- `--hsdp-replicate-size`: number of HSDP replica groups. Only 1 is supported.
 - `--num-inference-steps`: number of denoising steps (defaults 45).
 - `--video-negative-prompt`: negative prompt for video generation.
 - `--audio-negative-prompt`: negative prompt for audio generation.

--- a/examples/offline_inference/image_to_image/image_edit.py
+++ b/examples/offline_inference/image_to_image/image_edit.py
@@ -407,7 +407,8 @@ def parse_args() -> argparse.Namespace:
         "--hsdp-replicate-size",
         type=int,
         default=1,
-        help="Number of HSDP replica groups.",
+        choices=[1],
+        help="Number of HSDP replica groups. Only 1 is supported.",
     )
     parser.add_argument(
         "--enable-diffusion-pipeline-profiler",

--- a/examples/offline_inference/image_to_video/README.md
+++ b/examples/offline_inference/image_to_video/README.md
@@ -133,7 +133,7 @@ python image_to_video.py \
 | `--cache-backend` | str | `None` | Cache backend: `cache_dit` or `tea_cache` |
 | `--use-hsdp` | flag | off | Enable Hybrid Sharded Data Parallel |
 | `--hsdp-shard-size` | int | `-1` | GPUs per shard group (-1 auto-calculates) |
-| `--hsdp-replicate-size` | int | `1` | Number of replica groups for HSDP |
+| `--hsdp-replicate-size` | int | `1` | Number of replica groups for HSDP. Only 1 is supported |
 
 ## More CLI Examples
 
@@ -274,7 +274,7 @@ Key arguments:
 - `--enable-cpu-offload`: enable CPU offloading for diffusion models.
 - `--use-hsdp`: Enable Hybrid Sharded Data Parallel to shard model weights across GPUs.
 - `--hsdp-shard-size`: Number of GPUs to shard model weights across within each replica group. -1 (default) auto-calculates as world_size / replicate_size.
-- `--hsdp-replicate-size`: Number of replica groups for HSDP. Each replica holds a full sharded copy. Default 1 means pure sharding (no replication).
+- `--hsdp-replicate-size`: Number of replica groups for HSDP. Each replica holds a full sharded copy. Default 1 means pure sharding (no replication). Only 1 is supported.
 
 
 

--- a/examples/offline_inference/image_to_video/image_to_video.py
+++ b/examples/offline_inference/image_to_video/image_to_video.py
@@ -277,9 +277,10 @@ def parse_args() -> argparse.Namespace:
         "--hsdp-replicate-size",
         type=int,
         default=1,
+        choices=[1],
         help=(
             "Number of replica groups for HSDP. Each replica holds a full sharded copy. "
-            "Default 1 means pure sharding (no replication). "
+            "Default 1 means pure sharding (no replication). Only 1 is supported."
         ),
     )
     parser.add_argument(

--- a/examples/offline_inference/speech_to_video/speech_to_video.py
+++ b/examples/offline_inference/speech_to_video/speech_to_video.py
@@ -190,9 +190,10 @@ def parse_args() -> argparse.Namespace:
         "--hsdp-replicate-size",
         type=int,
         default=1,
+        choices=[1],
         help=(
             "Number of replica groups for HSDP. Each replica holds a full sharded copy. "
-            "Default 1 means pure sharding (no replication)."
+            "Default 1 means pure sharding (no replication). Only 1 is supported."
         ),
     )
     parser.add_argument(

--- a/examples/offline_inference/text_to_audio/README.md
+++ b/examples/offline_inference/text_to_audio/README.md
@@ -92,6 +92,6 @@ Key arguments:
 - `--num-inference-steps`: diffusion sampling steps.(more steps = higher quality, slower).
 - `--use-hsdp`: enable HSDP weight sharding for the Stable Audio DiT.
 - `--hsdp-shard-size`: number of GPUs used for HSDP sharding.
-- `--hsdp-replicate-size`: number of HSDP replica groups.
+- `--hsdp-replicate-size`: number of HSDP replica groups. Only 1 is supported.
 - `--cache-backend`: cache acceleration backend. Stable Audio currently supports `tea_cache`.
 - `--output`: path to save the generated WAV file.

--- a/examples/offline_inference/text_to_audio/text_to_audio.py
+++ b/examples/offline_inference/text_to_audio/text_to_audio.py
@@ -207,7 +207,8 @@ def parse_args() -> argparse.Namespace:
         "--hsdp-replicate-size",
         type=int,
         default=1,
-        help="Number of HSDP replica groups. Default 1 means pure sharding.",
+        choices=[1],
+        help="Number of HSDP replica groups. Default 1 means pure sharding. Only 1 is supported.",
     )
     parser.add_argument(
         "--tensor-parallel-size",

--- a/examples/offline_inference/text_to_image/text_to_image.py
+++ b/examples/offline_inference/text_to_image/text_to_image.py
@@ -197,7 +197,8 @@ def parse_args() -> argparse.Namespace:
         "--hsdp-replicate-size",
         type=int,
         default=1,
-        help="Number of HSDP replica groups.",
+        choices=[1],
+        help="Number of HSDP replica groups. Only 1 is supported.",
     )
     parser.add_argument(
         "--quantization",

--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -349,7 +349,8 @@ def parse_args() -> argparse.Namespace:
         "--hsdp-replicate-size",
         type=int,
         default=1,
-        help="Number of HSDP replica groups.",
+        choices=[1],
+        help="Number of HSDP replica groups. Only 1 is supported.",
     )
     return parser.parse_args()
 

--- a/examples/offline_inference/x_to_video_audio/x_to_video_audio.md
+++ b/examples/offline_inference/x_to_video_audio/x_to_video_audio.md
@@ -153,7 +153,7 @@ Key arguments:
 - `--cfg-parallel-size`: number of parallel cfg parallel (defaults 1).
 - `--use-hsdp`: enable HSDP weight sharding for DreamID-Omni fused blocks.
 - `--hsdp-shard-size`: number of GPUs used for HSDP sharding.
-- `--hsdp-replicate-size`: number of HSDP replica groups.
+- `--hsdp-replicate-size`: number of HSDP replica groups. Only 1 is supported.
 - `--num-inference-steps`: number of denoising steps (defaults 45).
 - `--video-negative-prompt`: negative prompt for video generation.
 - `--audio-negative-prompt`: negative prompt for audio generation.

--- a/examples/offline_inference/x_to_video_audio/x_to_video_audio.py
+++ b/examples/offline_inference/x_to_video_audio/x_to_video_audio.py
@@ -106,7 +106,8 @@ def parse_args() -> argparse.Namespace:
         "--hsdp-replicate-size",
         type=int,
         default=1,
-        help="Number of HSDP replica groups. Default 1 means pure sharding.",
+        choices=[1],
+        help="Number of HSDP replica groups. Default 1 means pure sharding. Only 1 is supported.",
     )
     return parser.parse_args()
 

--- a/tests/config/test_omni_config.py
+++ b/tests/config/test_omni_config.py
@@ -506,10 +506,10 @@ def test_diffusion_parallel_config_supports_diffusion_hsdp_auto_sharding():
         ulysses_degree=2,
         use_hsdp=True,
         hsdp_shard_size=-1,
-        hsdp_replicate_size=2,
+        hsdp_replicate_size=1,
     )
 
-    assert cfg.hsdp_shard_size == 2
+    assert cfg.hsdp_shard_size == 4
     assert cfg.world_size == 4
 
 
@@ -519,6 +519,15 @@ def test_diffusion_parallel_config_rejects_hsdp_with_tp_or_dp():
 
     with pytest.raises(ValueError, match="cannot be used with TP or DP"):
         OmniStageDiffusionParallelConfig(data_parallel_size=2, use_hsdp=True, hsdp_shard_size=2)
+
+
+def test_diffusion_parallel_config_rejects_hsdp_replicate_size():
+    with pytest.raises(ValueError, match="hsdp_replicate_size > 1 is not supported. Set hsdp_replicate_size = 1."):
+        OmniStageDiffusionParallelConfig(
+            use_hsdp=True,
+            hsdp_shard_size=-1,
+            hsdp_replicate_size=2,
+        )
 
 
 def test_from_pipeline_config_preserves_legacy_pp_dp_for_world_size():

--- a/tests/diffusion/distributed/test_hsdp.py
+++ b/tests/diffusion/distributed/test_hsdp.py
@@ -159,29 +159,14 @@ class TestDiffusionParallelConfigHSDP:
         assert config.hsdp_shard_size == 4
         assert config.hsdp_replicate_size == 1
 
-    def test_hsdp_standalone_with_replicate(self):
-        """Test standalone HSDP with replication."""
-        config = DiffusionParallelConfig(
-            use_hsdp=True,
-            hsdp_shard_size=4,
-            hsdp_replicate_size=2,
-        )
-        # world_size = shard_size * replicate_size
-        assert config.world_size == 8
-        assert config.hsdp_shard_size == 4
-        assert config.hsdp_replicate_size == 2
-
-    def test_hsdp_with_replicate(self):
-        """Test HSDP with replication (hybrid mode) combined with other parallelism."""
-        # world_size=8, replicate=2 -> shard_size should be 4
-        config = DiffusionParallelConfig(
-            ulysses_degree=8,
-            use_hsdp=True,
-            hsdp_replicate_size=2,
-        )
-        assert config.world_size == 8
-        assert config.hsdp_shard_size == 4
-        assert config.hsdp_replicate_size == 2
+    def test_hsdp_replicate_rejected(self):
+        """Test HSDP with replication is rejected."""
+        with pytest.raises(ValueError, match="hsdp_replicate_size > 1 is not supported. Set hsdp_replicate_size = 1."):
+            DiffusionParallelConfig(
+                use_hsdp=True,
+                hsdp_shard_size=4,
+                hsdp_replicate_size=2,
+            )
 
     def test_hsdp_explicit_shard_size_valid(self):
         """Test explicit hsdp_shard_size that matches world_size."""
@@ -201,15 +186,6 @@ class TestDiffusionParallelConfigHSDP:
                 use_hsdp=True,
                 hsdp_shard_size=3,  # 1 * 3 != 4
                 hsdp_replicate_size=1,
-            )
-
-    def test_hsdp_replicate_size_exceeds_world_size(self):
-        """Test that replicate_size > world_size raises an error."""
-        with pytest.raises(ValueError, match="replicate_size.*must evenly divide world_size"):
-            DiffusionParallelConfig(
-                ulysses_degree=4,  # world_size=4
-                use_hsdp=True,
-                hsdp_replicate_size=8,  # 8 > 4, invalid
             )
 
     def test_hsdp_combined_world_size(self):
@@ -256,12 +232,11 @@ class TestDiffusionParallelConfigHSDP:
             {
                 "ulysses_degree": 4,
                 "use_hsdp": True,
-                "hsdp_replicate_size": 2,
             }
         )
         assert config.use_hsdp is True
-        assert config.hsdp_replicate_size == 2
-        assert config.hsdp_shard_size == 2  # auto: 4 // 2
+        assert config.hsdp_replicate_size == 1
+        assert config.hsdp_shard_size == 4  # auto: 4 // 1
 
 
 class TestStandaloneHSDPDetection:

--- a/vllm_omni/config/omni_config.py
+++ b/vllm_omni/config/omni_config.py
@@ -400,6 +400,9 @@ class OmniStageDiffusionParallelConfig(OmniStageParallelConfig):
             * self.cfg_parallel_size
         )
         if self.use_hsdp:
+            if self.hsdp_replicate_size > 1:
+                # Extra replicas receive identical requests and waste compute with no throughput benefit.
+                raise ValueError("hsdp_replicate_size > 1 is not supported. Set hsdp_replicate_size = 1.")
             if self.tensor_parallel_size > 1 or self.data_parallel_size > 1:
                 raise ValueError(
                     "HSDP (use_hsdp=True) cannot be used with TP or DP "

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -292,6 +292,9 @@ class DiffusionParallelConfig:
         # 1. Standalone: when other parallelism is all 1, HSDP determines world_size
         # 2. Combined: HSDP overlays on top of other parallelism
         if self.use_hsdp:
+            if self.hsdp_replicate_size > 1:
+                # Extra replicas receive identical requests and waste compute with no throughput benefit.
+                raise ValueError("hsdp_replicate_size > 1 is not supported. Set hsdp_replicate_size = 1.")
             if self.tensor_parallel_size > 1 or self.data_parallel_size > 1:
                 raise ValueError(
                     "HSDP (use_hsdp=True) cannot be used with TP or DP "

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -232,7 +232,7 @@ class DiffusionParallelConfig:
     """Number of GPUs to shard weights across within each replica group. -1 means auto-calculate."""
 
     hsdp_replicate_size: int = 1
-    """Number of replica groups for HSDP. Each replica holds a full sharded copy."""
+    """Number of replica groups for HSDP. Each replica holds a full sharded copy. Only 1 is supported."""
 
     @model_validator(mode="after")
     def _validate_parallel_config(self) -> Self:


### PR DESCRIPTION
## Purpose

The diffusion executor broadcasts every request to all workers via exec_all_ranks=True on a single MessageQueue. The scheduler runs on rank 0 only and maintains a single _running list with no awareness of HSDP replicate groups. This means every worker — regardless of which replicate group it belongs to — receives and executes the exact same request. With hsdp_replicate_size > 1, the extra replicate groups perform identical computation on the same input and produce the same output, wasting GPU memory and compute with zero throughput benefit.

Until per-replicate request routing is implemented (separate schedulers or replicate-aware dispatch in the executor), reject hsdp_replicate_size > 1 at config validation time with a clear error message. Mark the 4 existing tests that construct configs with hsdp_replicate_size > 1 as xfail.

## Test Plan

```
pytest tests/diffusion/distributed/test_hsdp.py
```

## Test Result

PASSED

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
