### PR TITLE
[BugFix][HunyuanImage3] Set MRoPE dynamic_arg_dims so graph mode can compile

### DIFF
--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -105,7 +105,16 @@ from vllm_omni.model_executor.models.hunyuan_image3.siglip2 import LightProjecto
 logger = init_logger(__name__)
 
 
-@support_torch_compile
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        # positions is (3, num_tokens) for mRoPE, so the token dimension is
+        # the last dimension rather than dim 0.
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+    }
+)
 class HunyuanModel(HunYuanModel):
     def _split_qkv_weight(self, qkv: torch.Tensor):
         num_attention_heads = self.config.num_attention_heads


### PR DESCRIPTION
## Serving Benchmark Verification (L20X TP=2, AR-only i2t)

Verified the MRoPE `dynamic_arg_dims` fix end-to-end via `vllm bench serve` on
the AR (image-to-text) path, with PR 3611 (graph support, no MRoPE fix) as
the apples-to-apples baseline on the same machine. The only delta between
runs is this PR's one-line `dynamic_arg_dims` correction.

### Hardware / environment

- 2× NVIDIA L20X (TP=2)
- HunyuanImage-3.0-Instruct AR-only (image → text), `enforce_eager=false`
  (graph mode), `max_num_seqs=128`
- vLLM 0.20.0, vLLM-Omni at PR head

### Files used

`hunyuan_image3_ar_graph.yaml` (deploy config, AR-only stage with
`is_comprehension: true` via local `owns_tokenizer=True` patch on
`HUNYUAN_IMAGE3_AR_PIPELINE`):

```yaml
pipeline: hunyuan_image3_ar
async_chunk: false

stages:
  - stage_id: 0
    is_comprehension: true
    final_output: true
    final_output_type: text
    max_num_seqs: 128
    gpu_memory_utilization: 0.9
    trust_remote_code: true
    enforce_eager: false
    enable_prefix_caching: false
    max_num_batched_tokens: 32768
    devices: "0,1"
    tensor_parallel_size: 2
    hf_overrides:
      rope_parameters:
        mrope_section: [0, 32, 32]
        rope_type: default
    default_sampling_params:
      temperature: 0.0
      top_p: 1.0
      top_k: -1
      max_tokens: 512
      detokenize: true
```

`hunyuan_image3_i2t.jinja` (chat template; HunyuanImage-3.0 tokenizer ships
no template, so we emit the i2t prompt format `build_prompt()` produces in
`vllm_omni/diffusion/models/hunyuan_image3/prompt_utils.py`):

```jinja
{{- '<|startoftext|>' -}}
{%- for message in messages -%}
  {%- if message.role == 'system' -%}
    {%- if message.content is string -%}
      {{- message.content -}}
    {%- else -%}
      {%- for c in message.content -%}
        {%- if c.type == 'text' -%}{{- c.text -}}{%- endif -%}
      {%- endfor -%}
    {%- endif -%}
    {{- '\n\n' -}}
  {%- endif -%}
{%- endfor -%}
{%- for message in messages -%}
  {%- if message.role == 'user' -%}
    {{- 'User: ' -}}
    {%- if message.content is string -%}
      {{- message.content -}}
    {%- else -%}
      {%- for c in message.content -%}
        {%- if (c.type == 'image_url' or c.type == 'image') -%}{{- '<img>' -}}{%- endif -%}
        {%- if c.type == 'text' -%}{{- c.text -}}{%- endif -%}
      {%- endfor -%}
    {%- endif -%}
    {{- '\n\nAssistant: ' -}}
  {%- elif message.role == 'assistant' -%}
    {%- if message.content is string -%}
      {{- message.content -}}
    {%- else -%}
      {%- for c in message.content -%}
        {%- if c.type == 'text' -%}{{- c.text -}}{%- endif -%}
      {%- endfor -%}
    {%- endif -%}
  {%- endif -%}
{%- endfor -%}
```

### Serve

```bash
CUDA_VISIBLE_DEVICES=0,1 vllm serve tencent/HunyuanImage-3.0-Instruct \
  --omni \
  --port 8091 \
  --trust-remote-code \
  --deploy-config hunyuan_image3_ar_graph.yaml \
  --chat-template hunyuan_image3_i2t.jinja \
  --chat-template-content-format openai
```

### Bench command

```bash
vllm bench serve \
  --omni \
  --backend openai-chat-omni \
  --host 127.0.0.1 \
  --port 8091 \
  --endpoint /v1/chat/completions \
  --model tencent/HunyuanImage-3.0-Instruct \
  --dataset-name random-mm \
  --num-prompts 10 \
  --request-rate inf \
  --max-concurrency 1 \
  --random-input-len 256 \
  --random-output-len 512 \
  --random-range-ratio 0 \
  --random-mm-base-items-per-request 1 \
  --random-mm-num-mm-items-range-ratio 0 \
  --random-mm-limit-mm-per-prompt '{"image":1,"video":0,"audio":0}' \
  --random-mm-bucket-config '{"(1024, 1024, 1)": 1.0}' \
  --extra-body '{"modalities":["text"]}' \
  --temperature 0 \
  --ignore-eos \
  --percentile-metrics ttft,tpot,itl,e2el \
  --metric-percentiles 50,90,99
```

### Results — PR 3611 baseline vs this PR (3630), same machine, same config

| Metric | PR 3611 (no fix) | **PR 3630 (this PR)** | Δ |
| --- | ---: | ---: | ---: |
| Benchmark duration (s) | 43.14 | 41.45 | -3.9% |
| Mean E2EL (ms) | 4 313.40 | **4 145.13** | **-3.9%** |
| P90 E2EL (ms) | 4 820.75 | 4 167.49 | **-13.6%** |
| P99 E2EL (ms) | 5 343.69 | 4 184.06 | **-21.7%** |
| Mean TTFT (ms) | 830.96 | **633.93** | **-23.7%** |
| P99 TTFT (ms) | 1 865.79 | 668.01 | **-64.2%** |
| Mean TPOT (ms) | 21.12 | **16.37** | **-22.5%** |
| Output tok/s | 47.87 | **68.70** | **+43.5%** |
| Total Token tok/s | 1 297.37 | 1 368.92 | +5.5% |
| ITL mean (ms) | 6.80 | 6.86 | +0.9% |
| Total generated tokens | 2 065 | 2 848 | +37.9% |

ITL is essentially unchanged (6.80 vs 6.86 ms), so the per-token decode
kernel cost is the same — both runs are on the same graph kernels. The win
comes from the AR entry / prefill path: with the wrong `dynamic_arg_dims`
in PR 3611, MRoPE's dim-0 dynamic assumption forced graph compilation to
fall back to eager for the `positions` tensor (whose dynamic axis is
actually the last dim), inflating TTFT (P99 -64%) and TPOT (-22%) and
truncating decode early (3611 produced 2065 generated tokens vs 2848 with
the fix). With the fix in this PR, graph mode covers the full AR step end
to end.

### Raw bench outputs

**PR 3611 baseline (graph compile silently falls back via mis-tagged MRoPE dim):**

```
============ Serving Benchmark Result ============
Successful requests:                     10
Failed requests:                         0
Maximum request concurrency:             1
Benchmark duration (s):                  43.14
Request throughput (req/s):              0.23
Peak concurrent requests:                2.00
----------------End-to-end Latency----------------
Mean E2EL (ms):                          4313.40
Median E2EL (ms):                        4126.74
P50 E2EL (ms):                           4126.74
P90 E2EL (ms):                           4820.75
P99 E2EL (ms):                           5343.69
================== Text Result ===================
Total input tokens:                      53900
Total generated tokens:                  2065
Output token throughput (tok/s):         47.87
Peak output token throughput (tok/s):    148.00
Peak concurrent requests:                2.00
Total Token throughput (tok/s):          1297.37
---------------Time to First Token----------------
Mean TTFT (ms):                          830.96
Median TTFT (ms):                        640.60
P50 TTFT (ms):                           640.60
P90 TTFT (ms):                           1339.68
P99 TTFT (ms):                           1865.79
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.12
Median TPOT (ms):                        22.73
P50 TPOT (ms):                           22.73
P90 TPOT (ms):                           28.33
P99 TPOT (ms):                           34.06
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.80
Median ITL (ms):                         6.47
P50 ITL (ms):                            6.47
P90 ITL (ms):                            7.51
P99 ITL (ms):                            7.67
================== Audio Result ==================
Total audio duration generated(s):       0.00
Total audio frames generated:            0
Audio throughput(audio duration/s):      0.00
==================================================
```

**PR 3630 with MRoPE `dynamic_arg_dims` fix:**

```
============ Serving Benchmark Result ============
Successful requests:                     10
Failed requests:                         0
Maximum request concurrency:             1
Benchmark duration (s):                  41.45
Request throughput (req/s):              0.24
Peak concurrent requests:                2.00
----------------End-to-end Latency----------------
Mean E2EL (ms):                          4145.13
Median E2EL (ms):                        4146.25
P50 E2EL (ms):                           4146.25
P90 E2EL (ms):                           4167.49
P99 E2EL (ms):                           4184.06
================== Text Result ===================
Total input tokens:                      53900
Total generated tokens:                  2848
Output token throughput (tok/s):         68.70
Peak output token throughput (tok/s):    147.00
Peak concurrent requests:                2.00
Total Token throughput (tok/s):          1368.92
---------------Time to First Token----------------
Mean TTFT (ms):                          633.93
Median TTFT (ms):                        629.26
P50 TTFT (ms):                           629.26
P90 TTFT (ms):                           657.37
P99 TTFT (ms):                           668.01
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.37
Median TPOT (ms):                        17.12
P50 TPOT (ms):                           17.12
P90 TPOT (ms):                           23.30
P99 TPOT (ms):                           33.31
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.86
Median ITL (ms):                         6.50
P50 ITL (ms):                            6.50
P90 ITL (ms):                            7.52
P99 ITL (ms):                            7.79
================== Audio Result ==================
Total audio duration generated(s):       0.00
Total audio frames generated:            0
Audio throughput(audio duration/s):      0.00
==================================================
```
