### PR TITLE
[Bugfix] UnspecifiedOmniPlatform.get_device_count returns 0

### DIFF
--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -204,3 +204,11 @@ class OmniPlatform(Platform):
 class UnspecifiedOmniPlatform(OmniPlatform):
     _omni_enum = OmniPlatformEnum.UNSPECIFIED
     device_type = ""
+
+    @classmethod
+    def get_device_count(cls) -> int:
+        # An unspecified platform reports zero accelerators. This is what
+        # ``PackagesEnvChecker`` (in ``vllm_omni.diffusion.envs``) relies on
+        # at module-import time on CPU-only environments (e.g. CI sanity
+        # runners or documentation builds), so the fallback must not raise.
+        return 0

--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -207,8 +207,4 @@ class UnspecifiedOmniPlatform(OmniPlatform):
 
     @classmethod
     def get_device_count(cls) -> int:
-        # An unspecified platform reports zero accelerators. This is what
-        # ``PackagesEnvChecker`` (in ``vllm_omni.diffusion.envs``) relies on
-        # at module-import time on CPU-only environments (e.g. CI sanity
-        # runners or documentation builds), so the fallback must not raise.
         return 0


### PR DESCRIPTION
## Propose

Related: https://github.com/verl-project/verl-omni/pull/78, this bug let the CI failed.

PackagesEnvChecker is constructed at module-import time of `vllm_omni.diffusion.envs` and calls
`current_omni_platform.get_device_count()`. On hosts where no built-in platform plugin matches (CPU-only CI runners, documentation builds, etc.) the active platform is `UnspecifiedOmniPlatform`, which inherited `OmniPlatform.get_device_count`'s `raise NotImplementedError`. That made any `import vllm_omni.diffusion.*` chain crash with NotImplementedError before the test or doc build could even start.

Override `get_device_count` on `UnspecifiedOmniPlatform` to return 0, which is the semantically correct answer for a platform that has not been identified -- there are zero accelerators attributable to it. 