### PR TITLE
[CI] Replace c=128 perf cell with c=16; loosen new-cell baselines

### DIFF
--- a/tests/dfx/perf/tests/test_tts.json
+++ b/tests/dfx/perf/tests/test_tts.json
@@ -31,14 +31,14 @@
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",
         "dataset_path": "linyueqian/seed-tts-eval-subset",
-        "num_prompts": [80, 128, 256],
-        "max_concurrency": [8, 64, 128],
+        "num_prompts": [80, 128, 128],
+        "max_concurrency": [8, 16, 64],
         "seed_tts_locale": "en",
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
-          "median_audio_ttfp_ms": [3500, 7000, 12000],
-          "median_audio_rtf": [0.75, 1.5, 2.5],
-          "audio_throughput": [10.0, 40.0, 50.0]
+          "median_audio_ttfp_ms": [3500, 30000, 7000],
+          "median_audio_rtf": [0.75, 10.0, 1.5],
+          "audio_throughput": [10.0, 1.0, 40.0]
         }
       },
       {
@@ -93,15 +93,15 @@
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",
         "dataset_path": "benchmarks/build_dataset/seed_tts_smoke",
-        "num_prompts": [80, 128, 256],
-        "max_concurrency": [8, 64, 128],
+        "num_prompts": [80, 128, 128],
+        "max_concurrency": [8, 16, 64],
         "seed_tts_locale": "en",
         "extra_body": {"voice": "Vivian", "language": "English", "task_type": "CustomVoice"},
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
-          "median_audio_ttfp_ms": [1500, 3000, 5500],
-          "median_audio_rtf": [0.30, 0.60, 1.0],
-          "audio_throughput": [30.0, 100.0, 120.0]
+          "median_audio_ttfp_ms": [1500, 30000, 3000],
+          "median_audio_rtf": [0.30, 10.0, 0.60],
+          "audio_throughput": [30.0, 1.0, 100.0]
         }
       },
       {
@@ -164,15 +164,15 @@
         "backend": "openai-audio-speech",
         "endpoint": "/v1/audio/speech",
         "dataset_path": "benchmarks/build_dataset/seed_tts_design",
-        "num_prompts": [80, 128, 256],
-        "max_concurrency": [8, 64, 128],
+        "num_prompts": [80, 128, 128],
+        "max_concurrency": [8, 16, 64],
         "seed_tts_locale": "en",
         "extra_body": {"task_type": "VoiceDesign", "language": "English"},
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
-          "median_audio_ttfp_ms": [1500, 3500, 6000],
-          "median_audio_rtf": [0.35, 0.70, 1.2],
-          "audio_throughput": [25.0, 80.0, 100.0]
+          "median_audio_ttfp_ms": [1500, 30000, 3500],
+          "median_audio_rtf": [0.35, 10.0, 0.70],
+          "audio_throughput": [25.0, 1.0, 80.0]
         }
       },
       {


### PR DESCRIPTION
## Summary

The c=128 cell in three Qwen3-TTS throughput sweeps (Base voice_clone, CustomVoice default_voice, CustomVoice voice_design) **deadlocked the 2026-05-14 L40S nightly** ([build 9671](https://buildkite.com), tag `full-moon-tts-star-perf-test`): 256 requests were accepted, stage 1 went silent ~85 s in, the job ran out the Buildkite 3 h budget with no traceback. c=64 in that same nightly already showed a perf cliff (TTFP 19.3 s vs 7 s baseline, RTF 5.16 vs 1.5, throughput 10.3 vs 40) — that's the existing Stage 1 codec window interleaving issue, RFC #3535 territory, orthogonal to this PR.

This PR replaces `[8, 64, 128]` with `[8, 16, 64]` in all three throughput sweeps so we keep mid-concurrency coverage and remove the cell that hangs the L40S runner. The new c=16 cell runs with very loose baselines (TTFP 30 s, RTF 10.0, throughput 1.0) so it records metrics without gating CI until we have data to set realistic numbers. c=8 and c=64 baselines are unchanged so the existing perf-cliff signal still surfaces in nightlies.

## Test plan

Reproduced the nightly's behavior on H20-server-0 (8x H20-3e 141GB) at upstream `main@4f13b871` with `CUDA_VISIBLE_DEVICES=5,6` and the same 2-GPU stage split (`--stage-overrides '{"1": {"devices": "1"}}'`):

| concurrency | nightly L40S | H20-server-0 | baseline |
|---|---|---|---|
| c=64 (n=128) | 19.3 s TTFP, completed in 54 s | 21.5 s TTFP, P99 43 s, 128/128, in 73 s | 7 s |
| c=128 (n=256) | **HUNG 3 h, killed by Buildkite** | 14.0 s TTFP, P99 16.3 s, 256/256, in 45 s | 12 s |

Two findings:

1. **The c=64 perf cliff is hardware-agnostic** — H20 and L40S both clock TTFP at ~3x baseline. That's the existing Stage 1 issue, not in scope here.
2. **The c=128 deadlock is L40S / Buildkite-specific** — H20 finishes c=128 in 45 s with better TTFP than c=64. Probable cause is something about L40S HBM bandwidth, CUDA-driver / NCCL version on the runner image, or 256-concurrent-stream TCP / OS limits inside the Buildkite container. Diagnosing that is out of scope here; immediate need is to stop bleeding nightlies.

## Test Result

No regressions expected (config-only change, lists are length-3 in both sweeps).

- [ ] Next nightly will exercise c=8 / c=16 / c=64 across the three throughput sweeps with no c=128 cell to hang on.

cc @vllm-project/vllm-omni-maintainers