### PR TITLE
[Bugfix] fix compatibility of _hunyuan_image3_unpack_packed_topk between vllm / vllm ascend

### DIFF
--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -1167,7 +1167,7 @@ def _hunyuan_image3_unpack_packed_topk(
     gating_output: torch.Tensor,
     topk: int,
     renormalize: bool,
-    num_experts: int,
+    num_experts: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Unpack pre-computed ``(topk_weights, topk_indices)`` packed by
     :class:`HunyuanImage3SparseMoeBlock` into ``gating_output``.


### PR DESCRIPTION
## Summary
- Make `_hunyuan_image3_unpack_packed_topk` compatible with both vLLM and vLLM Ascend custom routing function call signatures.
- Add a default value for `num_experts` so callers that do not pass it explicitly continue to work.

## Motivation
At this stage, the custom routing function interfaces in vLLM and vLLM Ascend are not fully consistent. vLLM Ascend passes the `num_experts` argument, while the vLLM-side usage may not provide it, which causes a compatibility issue for `_hunyuan_image3_unpack_packed_topk`.

This change gives `num_experts` a default value so the same helper remains compatible across both platforms without changing the existing packed top-k unpacking behavior.

Impl of vllm can be seen in https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/transformers/moe.py#L53
Impl of vllm ascend can be seen in https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/ops/fused_moe/experts_selector.py#L318
## Validation
- `python -m compileall -q vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py`