### PR TITLE
Add Windows-safe local IPC and locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,19 @@ Easy, fast, and cheap omni-modality model serving for everyone
 
 ---
 
-*Latest News* 🔥
+## What's new
+
+- [2026/05/19] Windows async Omni streaming is now documented and validated on
+  the `windows-compat` branch. See [WINDOWS_COMPAT.md](WINDOWS_COMPAT.md) for a
+  start-from-scratch vLLM + vLLM-Omni Windows setup, runtime environment
+  variables, and focused verification commands.
+- [2026/05/19] Added a Windows single-GPU Qwen3-Omni deploy config at
+  [vllm_omni/deploy/qwen3_omni_moe_windows_single_gpu.yaml](vllm_omni/deploy/qwen3_omni_moe_windows_single_gpu.yaml),
+  including FlashInfer runtime attention and Torch SDPA multimodal encoder
+  attention for Blackwell-safe execution.
+- [2026/05/19] Added a streaming Qwen3-Omni audio in -> audio out probe at
+  [examples/offline_inference/qwen3_omni/windows_audio_stream_probe.py](examples/offline_inference/qwen3_omni/windows_audio_stream_probe.py).
+  It verifies async audio chunk delivery without writing an output WAV file.
 - [2026/05] We released [0.20.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.20.0) - refreshes the serving/runtime stack for large-scale omni workloads, and improves diffusion model performance, quantization, and hardware readiness across CUDA, ROCm, MUSA, NPU, and XPU backends.
 - [2026/03] We released [0.18.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.18.0) - strengthens the core runtime through a large entrypoint refactor and scheduler/runtime cleanups, expands unified quantization and diffusion execution, broadens multimodal model coverage, and improves production readiness across audio, omni, image, video, RL, and multi-platform deployments.
 - [2026/03] Check out our first public [project deepdive](https://youtu.be/sgwNfsNnR9I) at the vLLM Hong Kong Meetup!

--- a/WINDOWS_COMPAT.md
+++ b/WINDOWS_COMPAT.md
@@ -14,12 +14,117 @@ Branch: `windows-compat`
 - Avoid registering `multiprocessing.Process.sentinel` handles in `zmq.Poller` on Windows.
 - Set `asyncio.WindowsSelectorEventLoopPolicy()` before creating the vLLM-Omni orchestrator loop on Windows, because pyzmq async sockets require `add_reader`.
 - Apply the same sentinel polling fix to diffusion stage handshake code.
+- Preserve non-final `OmniRequestOutput` chunks so async audio/text streams surface before terminal completion.
+- Keep abort-after-shutdown idempotent for `janus` queues used by `AsyncOmni`.
+- Support Windows shared-memory chunk transfer through a file-backed payload fallback.
+- Add Windows-compatible Qwen3-Omni single-GPU smoke deploy:
+  `vllm_omni/deploy/qwen3_omni_moe_windows_single_gpu.yaml`.
+- Add a Windows Qwen3-Omni audio-in/audio-out streaming probe:
+  `examples/offline_inference/qwen3_omni/windows_audio_stream_probe.py`.
+
+## Start From Scratch
+
+These notes assume PowerShell on Windows, Visual Studio 2022 Build Tools, CUDA
+13, and an NVIDIA GPU with enough VRAM for the selected model. The full
+Qwen3-Omni audio-in/audio-out smoke below was validated on an RTX PRO 6000
+Blackwell-class GPU.
+
+1. Create the shared venv:
+
+```powershell
+py -3.12 -m venv C:\tmp\vllmvenv
+C:\tmp\vllmvenv\Scripts\python.exe -m pip install -U pip setuptools wheel ninja cmake
+```
+
+2. Clone and build the Windows vLLM fork first:
+
+```powershell
+cd C:\Users\ericl\Documents\ai-agents\Claude
+git clone -b windows-compat https://github.com/ericleigh007/vllm-windows.git
+cd vllm-windows
+
+$env:CUDA_HOME = "C:\tmp\cuda13"
+$env:CUDA_PATH = "C:\tmp\cuda13"
+$env:CUDACXX = "C:\tmp\cuda13\bin\nvcc.exe"
+$env:VLLM_TARGET_DEVICE = "cuda"
+$env:MAX_JOBS = "4"
+$env:NVCC_THREADS = "1"
+$env:FETCHCONTENT_BASE_DIR = "C:\tmp\vllm_deps"
+$env:CMAKE_ARGS = "-DCMAKE_CUDA_ARCHITECTURES=120 -DCMAKE_CUDA_FLAGS=--allow-unsupported-compiler"
+
+C:\tmp\vllmvenv\Scripts\python.exe setup.py build_ext --inplace
+C:\tmp\vllmvenv\Scripts\python.exe -m pip install -e .
+```
+
+Use the CUDA install path appropriate for your machine. On systems where CUDA is
+installed under `C:\Program Files\...`, create a junction such as
+`C:\tmp\cuda13` to avoid spaces in toolchain paths.
+
+3. Clone and install the Windows vLLM-Omni fork:
+
+```powershell
+cd C:\Users\ericl\Documents\ai-agents\Claude
+git clone -b windows-compat https://github.com/ericleigh007/vllm-omni-windows.git
+cd vllm-omni-windows
+C:\tmp\vllmvenv\Scripts\python.exe -m pip install -e .
+```
+
+4. Use these runtime variables for local source runs:
+
+```powershell
+$env:PATH = "C:\tmp\cuda13\bin;C:\tmp\vllmvenv\Lib\site-packages\torch\lib;" + $env:PATH
+$env:CUDA_HOME = "C:\tmp\cuda13"
+$env:CUDA_PATH = "C:\tmp\cuda13"
+$env:PYTHONPATH = "C:\Users\ericl\Documents\ai-agents\Claude\vllm-omni-windows"
+$env:HF_HUB_DISABLE_SYMLINKS = "1"
+$env:HF_HUB_DISABLE_SYMLINKS_WARNING = "1"
+```
+
+The Hugging Face symlink variables avoid `WinError 1314` on Windows machines
+without Developer Mode or Administrator symlink privileges.
+
+## Smoke Tests
+
+Run focused unit coverage first:
+
+```powershell
+C:\tmp\vllmvenv\Scripts\python.exe -m pytest `
+  tests/distributed/omni_connectors/test_chunk_transfer_adapter.py `
+  tests/engine/test_async_omni_engine_outputs.py
+```
+
+Then run the full Qwen3-Omni streaming smoke. It exercises audio input,
+thinker-to-talker async chunk transfer, code2wav output, and stops after the
+first streamed audio tensor without writing a WAV:
+
+```powershell
+C:\tmp\vllmvenv\Scripts\python.exe `
+  examples/offline_inference/qwen3_omni/windows_audio_stream_probe.py `
+  --stop-after-audio-chunks 1 `
+  --out windows_qwen3_omni_audio_stream_probe.json
+```
+
+On the validated workstation this produced `ok: true`, recognized the built-in
+`mary_had_lamb` audio input, and emitted one stage-2 audio tensor with shape
+`[1, 47445]`.
+
+For Blackwell Windows systems, keep
+`mm_encoder_attn_backend: TORCH_SDPA` in the Windows Qwen3-Omni deploy config.
+FlashAttention for the multimodal encoder hit `cudaErrorUnsupportedPtxVersion`
+in local testing.
 
 ## Validation
 
-- `python -m py_compile` passes for all modified vLLM-Omni files.
-- Direct source import against the local installed vLLM wheel is currently blocked by a vLLM/vLLM-Omni main-branch API mismatch (`split_routed_experts`), so this branch still needs a matched source build / wheel CI pass.
+- Focused unit suite passes under `C:\tmp\vllmvenv`.
+- `python -m py_compile` passes for modified vLLM-Omni files.
+- Qwen3-TTS CustomVoice streams non-final audio chunks under Windows.
+- Qwen3-Omni thinker mode streams image-to-text and audio-to-text under Windows.
+- Qwen3-Omni full 3-stage audio-in/audio-out emits streamed stage-2 audio on
+  Windows with the single-GPU deploy config above.
 
 ## Runtime Evidence
 
-These changes mirror the monkeypatches that allowed native Windows vLLM-Omni to initialize `Qwen/Qwen2.5-Omni-3B` Stage 0, Stage 1, and Stage 2 and complete embedded text plus text-to-audio generation without an HTTP server.
+These changes now go beyond the earlier runtime monkeypatches: native Windows
+vLLM-Omni can initialize Qwen3-TTS and Qwen3-Omni from source, preserve
+non-final async outputs, and stream audio tensors directly from `AsyncOmni`
+without writing an output WAV.

--- a/WINDOWS_COMPAT.md
+++ b/WINDOWS_COMPAT.md
@@ -1,0 +1,25 @@
+# Windows Compatibility Work
+
+This fork tracks native Windows fixes needed by OmniChat's embedded vLLM-Omni experiments.
+
+## Current Branch
+
+Branch: `windows-compat`
+
+## Changes
+
+- Replace POSIX-only top-level `fcntl` imports with platform-gated locking.
+- Move shared-memory lock files from hardcoded `/dev/shm` to `%TEMP%\vllm_omni_shm` on Windows.
+- Move device initialization lock files from hardcoded `/tmp` to `%TEMP%\vllm_omni_locks` on Windows.
+- Avoid registering `multiprocessing.Process.sentinel` handles in `zmq.Poller` on Windows.
+- Set `asyncio.WindowsSelectorEventLoopPolicy()` before creating the vLLM-Omni orchestrator loop on Windows, because pyzmq async sockets require `add_reader`.
+- Apply the same sentinel polling fix to diffusion stage handshake code.
+
+## Validation
+
+- `python -m py_compile` passes for all modified vLLM-Omni files.
+- Direct source import against the local installed vLLM wheel is currently blocked by a vLLM/vLLM-Omni main-branch API mismatch (`split_routed_experts`), so this branch still needs a matched source build / wheel CI pass.
+
+## Runtime Evidence
+
+These changes mirror the monkeypatches that allowed native Windows vLLM-Omni to initialize `Qwen/Qwen2.5-Omni-3B` Stage 0, Stage 1, and Stage 2 and complete embedded text plus text-to-audio generation without an HTTP server.

--- a/examples/offline_inference/qwen2_5_omni/end2end.py
+++ b/examples/offline_inference/qwen2_5_omni/end2end.py
@@ -305,7 +305,7 @@ def main(args):
 
     # Get the query function and call it with appropriate parameters
     query_func = query_map[args.query_type]
-    if args.query_type == "mixed_modalities":
+    if args.query_type == "use_mixed_modalities":
         query_result = query_func(
             video_path=video_path,
             image_path=image_path,
@@ -315,7 +315,7 @@ def main(args):
         )
     elif args.query_type == "use_audio_in_video":
         query_result = query_func(video_path=video_path, num_frames=num_frames, sampling_rate=sampling_rate)
-    elif args.query_type == "multi_audios":
+    elif args.query_type == "use_multi_audios":
         query_result = query_func(audio_path=audio_path, sampling_rate=sampling_rate)
     elif args.query_type == "use_image":
         query_result = query_func(image_path=image_path)
@@ -487,6 +487,11 @@ def parse_args():
         "--output-wav",
         default="output_audio",
         help="[Deprecated] Output wav directory (use --output-dir).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory for generated text and audio files.",
     )
     parser.add_argument(
         "--num-prompts",

--- a/examples/offline_inference/qwen3_omni/windows_audio_stream_probe.py
+++ b/examples/offline_inference/qwen3_omni/windows_audio_stream_probe.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Windows Qwen3-Omni audio-in/audio-out streaming smoke test.
+
+This validates the full thinker -> talker -> code2wav path and records event
+metadata only. It stops after the first streamed audio tensor by default and
+does not write a WAV file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import inspect
+import json
+import os
+import socket
+import sys
+import time
+import types
+from pathlib import Path
+from typing import Any
+
+from end2end import get_audio_query
+
+
+def install_windows_runtime_shims() -> None:
+    os.environ.setdefault("HF_HUB_DISABLE_SYMLINKS", "1")
+    os.environ.setdefault("HF_HUB_DISABLE_SYMLINKS_WARNING", "1")
+    os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+    if hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    module = types.ModuleType("fcntl")
+    module.LOCK_EX = 2
+    module.LOCK_NB = 4
+    module.LOCK_UN = 8
+    module.flock = lambda _file, _flags: None
+    sys.modules.setdefault("fcntl", module)
+
+
+def get_open_tcp_zmq_path() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    return f"tcp://127.0.0.1:{port}"
+
+
+def patch_zmq_ipc_to_tcp() -> None:
+    import vllm.utils.network_utils as network_utils
+
+    network_utils.get_open_zmq_ipc_path = get_open_tcp_zmq_path
+    try:
+        import vllm_omni.engine.stage_engine_core_proc as proc
+
+        proc.get_open_zmq_ipc_path = get_open_tcp_zmq_path
+        patch_stage_handshake_for_windows(proc)
+    except Exception:
+        pass
+
+
+def patch_stage_handshake_for_windows(proc_module: Any) -> None:
+    """Avoid polling a Windows multiprocessing sentinel with pyzmq."""
+    import msgspec
+    import zmq
+    from vllm.utils.network_utils import zmq_socket_ctx
+    from vllm.v1.engine.utils import EngineHandshakeMetadata
+
+    def recv_socket_only(poller, handshake_socket, proc, expected: str, timeout_s: int):
+        while True:
+            events = dict(poller.poll(timeout=timeout_s * 1000))
+            if not events:
+                if proc.exitcode is not None:
+                    raise RuntimeError(f"StageEngineCoreProc died during {expected} (exit code {proc.exitcode})")
+                raise TimeoutError(f"Timed out waiting for {expected} from StageEngineCoreProc.")
+            if handshake_socket in events:
+                identity, raw = handshake_socket.recv_multipart()
+                return identity, msgspec.msgpack.decode(raw)
+            if proc.exitcode is not None:
+                raise RuntimeError(f"StageEngineCoreProc died during {expected} (exit code {proc.exitcode})")
+
+    def perform_handshake(proc, handshake_address, addresses, vllm_config, handshake_timeout):
+        with zmq_socket_ctx(handshake_address, zmq.ROUTER, bind=True) as handshake_socket:
+            poller = zmq.Poller()
+            poller.register(handshake_socket, zmq.POLLIN)
+
+            identity, msg = recv_socket_only(poller, handshake_socket, proc, "HELLO", handshake_timeout)
+            if msg.get("status") != "HELLO":
+                raise RuntimeError(f"Expected HELLO, got: {msg}")
+
+            init_payload = EngineHandshakeMetadata(addresses=addresses, parallel_config={})
+            handshake_socket.send_multipart([identity, msgspec.msgpack.encode(init_payload)])
+
+            identity, msg = recv_socket_only(poller, handshake_socket, proc, "READY", handshake_timeout)
+            if msg.get("status") != "READY":
+                raise RuntimeError(f"Expected READY, got: {msg}")
+            num_gpu_blocks = msg.get("num_gpu_blocks")
+            if num_gpu_blocks is not None:
+                vllm_config.cache_config.num_gpu_blocks = num_gpu_blocks
+
+    proc_module._perform_handshake = perform_handshake
+
+
+def tensor_summary(value: Any) -> dict[str, Any]:
+    return {
+        "shape": list(value.shape) if hasattr(value, "shape") else None,
+        "numel": int(value.numel()) if hasattr(value, "numel") else None,
+        "type": type(value).__name__,
+    }
+
+
+def summarize_output(output: Any, elapsed_s: float, state: dict[str, int]) -> dict[str, Any]:
+    request_output = getattr(output, "request_output", None)
+    completions = getattr(request_output, "outputs", None) or []
+    completion = completions[0] if completions else None
+    final_output_type = getattr(output, "final_output_type", None)
+    event: dict[str, Any] = {
+        "elapsed_seconds": elapsed_s,
+        "stage_id": getattr(output, "stage_id", None),
+        "finished": bool(getattr(output, "finished", False)),
+        "final_output_type": final_output_type,
+        "request_id": getattr(output, "request_id", None),
+    }
+    if final_output_type == "text" and completion is not None:
+        text = getattr(completion, "text", None)
+        event["text"] = text
+        event["text_len"] = len(text) if isinstance(text, str) else None
+    if final_output_type == "audio" and completion is not None:
+        mm = getattr(completion, "multimodal_output", None) or {}
+        audio = mm.get("audio") if isinstance(mm, dict) else None
+        sr = mm.get("sr") if isinstance(mm, dict) else None
+        if hasattr(sr, "item"):
+            sr = int(sr.item())
+        elif sr is not None:
+            sr = int(sr)
+        event["sample_rate"] = sr
+        if isinstance(audio, list):
+            consumed = state.get("audio_list_consumed", 0)
+            new_chunks = audio[consumed:]
+            state["audio_list_consumed"] = len(audio)
+            event["audio_chunks_total"] = len(audio)
+            event["audio_chunks_new"] = len(new_chunks)
+            event["audio_new"] = [tensor_summary(chunk) for chunk in new_chunks]
+        elif audio is not None:
+            numel = int(audio.numel()) if hasattr(audio, "numel") else 0
+            previous = state.get("audio_tensor_numel", 0)
+            state["audio_tensor_numel"] = max(previous, numel)
+            event["audio_chunks_total"] = 1
+            event["audio_chunks_new"] = 1 if numel > previous else 0
+            event["audio_new"] = [tensor_summary(audio)]
+    return event
+
+
+async def run(args: argparse.Namespace) -> dict[str, Any]:
+    started = time.perf_counter()
+    result: dict[str, Any] = {
+        "ok": False,
+        "model": args.model,
+        "deploy_config": args.deploy_config,
+        "events": [],
+        "error_type": None,
+        "error": None,
+    }
+    omni = None
+    try:
+        install_windows_runtime_shims()
+        patch_zmq_ipc_to_tcp()
+
+        from vllm_omni import AsyncOmni
+
+        query = get_audio_query(question=args.question)
+        prompt = dict(query.inputs)
+        prompt["modalities"] = ["audio"]
+        omni = AsyncOmni(
+            model=args.model,
+            deploy_config=args.deploy_config,
+            init_timeout=args.init_timeout,
+            stage_init_timeout=args.stage_init_timeout,
+            output_modalities=["audio"],
+            log_stats=False,
+        )
+
+        stream_state: dict[str, int] = {}
+        try:
+            async with asyncio.timeout(args.generation_timeout):
+                async for output in omni.generate(
+                    prompt,
+                    request_id=args.request_id,
+                    sampling_params_list=None,
+                    output_modalities=["audio"],
+                ):
+                    event = summarize_output(output, time.perf_counter() - started, stream_state)
+                    result["events"].append(event)
+                    audio_chunk_count = sum(
+                        int(item.get("audio_chunks_new") or 0)
+                        for item in result["events"]
+                        if item.get("final_output_type") == "audio"
+                    )
+                    if args.stop_after_audio_chunks > 0 and audio_chunk_count >= args.stop_after_audio_chunks:
+                        result["stop_reason"] = "audio_chunk_target"
+                        break
+                    if event["finished"] and event["final_output_type"] == "audio":
+                        result["stop_reason"] = "audio_finished"
+                        break
+        except TimeoutError:
+            result["error_type"] = "TimeoutError"
+            result["error"] = f"Timed out after {args.generation_timeout}s waiting for audio output."
+
+        close_result = omni.close()
+        if inspect.isawaitable(close_result):
+            await close_result
+        audio_events = [event for event in result["events"] if event.get("final_output_type") == "audio"]
+        result["audio_event_count"] = len(audio_events)
+        result["audio_chunk_count"] = sum(int(event.get("audio_chunks_new") or 0) for event in audio_events)
+        result["ok"] = result["error_type"] is None and result["audio_chunk_count"] > 0
+    except Exception as exc:
+        result["error_type"] = type(exc).__name__
+        result["error"] = str(exc)
+        if omni is not None:
+            try:
+                close_result = omni.close()
+                if inspect.isawaitable(close_result):
+                    await close_result
+            except Exception:
+                pass
+    finally:
+        result["elapsed_seconds"] = time.perf_counter() - started
+    return result
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[3]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="Qwen/Qwen3-Omni-30B-A3B-Instruct")
+    parser.add_argument(
+        "--deploy-config",
+        default=str(repo_root / "vllm_omni/deploy/qwen3_omni_moe_windows_single_gpu.yaml"),
+    )
+    parser.add_argument(
+        "--question",
+        default="After hearing this audio, respond aloud in one short sentence saying what was recited.",
+    )
+    parser.add_argument("--request-id", default="qwen3_omni_audio_stream_probe")
+    parser.add_argument("--init-timeout", type=int, default=600)
+    parser.add_argument("--stage-init-timeout", type=int, default=600)
+    parser.add_argument("--generation-timeout", type=float, default=180.0)
+    parser.add_argument("--stop-after-audio-chunks", type=int, default=1)
+    parser.add_argument("--out", default="windows_qwen3_omni_audio_stream_probe.json")
+    args = parser.parse_args()
+
+    result = asyncio.run(run(args))
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps(result, indent=2))
+    return 0 if result["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -203,7 +203,7 @@ Push-Location $OmniRepoPath
 try {
     if (-not $SkipDependencyInstall) {
         Write-Step "Installing vLLM-Omni runtime dependencies"
-        Invoke-Native $pythonExe "-m" "pip" "install" "-r" "requirements\common.txt" "onnxruntime>=1.23.2"
+        Invoke-Native $pythonExe "-m" "pip" "install" "-r" "requirements\common.txt" "onnxruntime>=1.23.2" "pytest>=8.0.0"
     }
 
     Write-Step "Installing vLLM-Omni editable"

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -123,7 +123,8 @@ function Set-OmniEnvironment {
     $script:ResolvedCudaPath = Resolve-CudaToolkitPath -PreferredPath $CudaPath
     $script:CudaPath = $script:ResolvedCudaPath
     $torchLib = Join-Path (Split-Path -Parent (Split-Path -Parent $PythonExe)) "Lib\site-packages\torch\lib"
-    $env:PATH = "$CudaPath\bin;$torchLib;$env:PATH"
+    $venvScripts = Split-Path -Parent $PythonExe
+    $env:PATH = "$venvScripts;$CudaPath\bin;$torchLib;$env:PATH"
     $env:CUDA_HOME = $CudaPath
     $env:CUDA_PATH = $CudaPath
     $env:PYTHONPATH = $OmniRepoPath

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -207,7 +207,7 @@ try {
     }
 
     Write-Step "Installing vLLM-Omni editable"
-    Invoke-Native $pythonExe "-m" "pip" "install" "-e" "." "--no-build-isolation"
+    Invoke-Native $pythonExe "-m" "pip" "install" "-e" "." "--no-build-isolation" "--no-deps"
 
     if (-not $SkipUnitTests) {
         Write-Step "Running focused Windows async streaming tests"

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+<#
+.SYNOPSIS
+Build and prove the Windows vLLM + vLLM-Omni Qwen3-Omni stack from scratch.
+
+.DESCRIPTION
+This script bootstraps the Windows vLLM source build, installs vLLM-Omni from
+source, downloads the Qwen3-Omni model through Hugging Face, and runs the
+Windows audio in -> audio out streaming probe. The probe records metadata only
+and does not write an output WAV file.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$InstallRoot = "C:\tmp\vllm-omni-windows-bootstrap",
+    [string]$VllmRepoUrl = "https://github.com/ericleigh007/vllm-windows.git",
+    [string]$OmniRepoUrl = "https://github.com/ericleigh007/vllm-omni-windows.git",
+    [string]$Branch = "windows-compat",
+    [string]$VllmRepoPath = "",
+    [string]$OmniRepoPath = "",
+    [string]$VenvPath = "C:\tmp\vllmvenv",
+    [string]$CudaPath = "C:\tmp\cuda13",
+    [string]$CudaArch = "120",
+    [string]$FetchContentBaseDir = "C:\tmp\vllm_deps",
+    [int]$MaxJobs = 4,
+    [int]$NvccThreads = 1,
+    [string]$ModelId = "Qwen/Qwen3-Omni-30B-A3B-Instruct",
+    [string]$ModelLocalDir = "",
+    [string]$ProofOut = "",
+    [switch]$SkipVllmBootstrap,
+    [switch]$SkipDependencyInstall,
+    [switch]$SkipModelDownload,
+    [switch]$SkipUnitTests,
+    [switch]$SkipProof,
+    [switch]$AllowDirtyRepo
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function Require-Command {
+    param([string]$Name, [string]$InstallHint)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "$Name was not found on PATH. $InstallHint"
+    }
+}
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments
+    )
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code ${LASTEXITCODE}: $FilePath $($Arguments -join ' ')"
+    }
+}
+
+function Ensure-Repo {
+    param([string]$Path, [string]$Url, [string]$Ref)
+    if (-not (Test-Path $Path)) {
+        Write-Step "Cloning $Url ($Ref) to $Path"
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Path) | Out-Null
+        Invoke-Native "git.exe" "clone" "-b" $Ref $Url $Path
+        return
+    }
+
+    if (-not (Test-Path (Join-Path $Path ".git"))) {
+        throw "$Path exists but is not a Git repository."
+    }
+
+    Push-Location $Path
+    try {
+        $dirty = git status --porcelain
+        if ($dirty -and -not $AllowDirtyRepo) {
+            throw "$Path has uncommitted changes. Re-run with -AllowDirtyRepo to skip the safety check."
+        }
+        Write-Step "Updating existing repository at $Path"
+        Invoke-Native "git.exe" "fetch" "origin" $Ref
+        Invoke-Native "git.exe" "checkout" $Ref
+        Invoke-Native "git.exe" "pull" "--ff-only" "origin" $Ref
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Get-PythonExe {
+    param([string]$Path)
+    $python = Join-Path $Path "Scripts\python.exe"
+    if (-not (Test-Path $python)) {
+        throw "Python virtualenv was not found at $Path. Run without -SkipVllmBootstrap first."
+    }
+    return $python
+}
+
+function Set-OmniEnvironment {
+    param([string]$PythonExe)
+    if (-not (Test-Path $CudaPath)) {
+        throw "CUDA path $CudaPath was not found. Install CUDA or pass -CudaPath."
+    }
+    $torchLib = Join-Path (Split-Path -Parent (Split-Path -Parent $PythonExe)) "Lib\site-packages\torch\lib"
+    $env:PATH = "$CudaPath\bin;$torchLib;$env:PATH"
+    $env:CUDA_HOME = $CudaPath
+    $env:CUDA_PATH = $CudaPath
+    $env:PYTHONPATH = $OmniRepoPath
+    $env:HF_HUB_DISABLE_SYMLINKS = "1"
+    $env:HF_HUB_DISABLE_SYMLINKS_WARNING = "1"
+    $env:VLLM_WORKER_MULTIPROC_METHOD = "spawn"
+}
+
+function Download-HfSnapshot {
+    param([string]$PythonExe, [string]$RepoId, [string]$LocalDir)
+    $code = @"
+from huggingface_hub import snapshot_download
+
+kwargs = {
+    "repo_id": r"$RepoId",
+    "resume_download": True,
+}
+if r"$LocalDir":
+    kwargs["local_dir"] = r"$LocalDir"
+snapshot_download(**kwargs)
+print("Downloaded", r"$RepoId")
+"@
+    Invoke-Native $PythonExe "-c" $code
+}
+
+Require-Command "git.exe" "Install Git for Windows."
+
+if (-not $VllmRepoPath) {
+    $VllmRepoPath = Join-Path $InstallRoot "vllm-windows"
+}
+if (-not $OmniRepoPath) {
+    $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $candidateRepo = Resolve-Path (Join-Path $scriptRoot "..") -ErrorAction SilentlyContinue
+    if ($candidateRepo -and (Test-Path (Join-Path $candidateRepo ".git"))) {
+        $OmniRepoPath = $candidateRepo.Path
+    }
+    else {
+        $OmniRepoPath = Join-Path $InstallRoot "vllm-omni-windows"
+    }
+}
+if (-not $ProofOut) {
+    $ProofOut = Join-Path $OmniRepoPath "demo_outputs\bootstrap_qwen3_omni_audio_stream_probe.json"
+}
+
+if (-not $SkipVllmBootstrap) {
+    Ensure-Repo -Path $VllmRepoPath -Url $VllmRepoUrl -Ref $Branch
+    $vllmBootstrap = Join-Path $VllmRepoPath "scripts\bootstrap_windows.ps1"
+    if (-not (Test-Path $vllmBootstrap)) {
+        throw "vLLM bootstrap script was not found at $vllmBootstrap."
+    }
+
+    Write-Step "Bootstrapping vLLM Windows source build"
+    $vllmArgs = @(
+        "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $vllmBootstrap,
+        "-RepoPath", $VllmRepoPath,
+        "-VenvPath", $VenvPath,
+        "-CudaPath", $CudaPath,
+        "-CudaArch", $CudaArch,
+        "-FetchContentBaseDir", $FetchContentBaseDir,
+        "-MaxJobs", [string]$MaxJobs,
+        "-NvccThreads", [string]$NvccThreads
+    )
+    if ($AllowDirtyRepo) {
+        $vllmArgs += "-AllowDirtyRepo"
+    }
+    Invoke-Native "powershell.exe" @vllmArgs
+}
+
+Ensure-Repo -Path $OmniRepoPath -Url $OmniRepoUrl -Ref $Branch
+$pythonExe = Get-PythonExe -Path $VenvPath
+Set-OmniEnvironment -PythonExe $pythonExe
+
+Push-Location $OmniRepoPath
+try {
+    if (-not $SkipDependencyInstall) {
+        Write-Step "Installing vLLM-Omni runtime dependencies"
+        Invoke-Native $pythonExe "-m" "pip" "install" "-r" "requirements\cuda.txt"
+    }
+
+    Write-Step "Installing vLLM-Omni editable"
+    Invoke-Native $pythonExe "-m" "pip" "install" "-e" "." "--no-build-isolation"
+
+    if (-not $SkipUnitTests) {
+        Write-Step "Running focused Windows async streaming tests"
+        Invoke-Native $pythonExe "-m" "pytest" "tests\distributed\omni_connectors\test_chunk_transfer_adapter.py" "tests\engine\test_async_omni_engine_outputs.py"
+    }
+
+    if (-not $SkipModelDownload) {
+        Write-Step "Downloading Qwen3-Omni model snapshot"
+        Download-HfSnapshot -PythonExe $pythonExe -RepoId $ModelId -LocalDir $ModelLocalDir
+    }
+
+    if (-not $SkipProof) {
+        Write-Step "Running Qwen3-Omni audio in -> audio out streaming proof"
+        Invoke-Native $pythonExe "examples\offline_inference\qwen3_omni\windows_audio_stream_probe.py" "--model" $ModelId "--deploy-config" "vllm_omni\deploy\qwen3_omni_moe_windows_single_gpu.yaml" "--stop-after-audio-chunks" "1" "--out" $ProofOut
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Step "vLLM-Omni Windows bootstrap complete"
+Write-Host "vLLM repo:     $VllmRepoPath"
+Write-Host "Omni repo:     $OmniRepoPath"
+Write-Host "Virtualenv:    $VenvPath"
+Write-Host "CUDA:          $CudaPath"
+Write-Host "Proof output:  $ProofOut"

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -227,7 +227,7 @@ try {
 
     if (-not $SkipProof) {
         Write-Step "Running Qwen3-Omni audio in -> audio out streaming proof"
-        Invoke-Native $pythonExe "examples\offline_inference\qwen3_omni\windows_audio_stream_probe.py" "--model" $ModelId "--deploy-config" "vllm_omni\deploy\qwen3_omni_moe_windows_single_gpu.yaml" "--init-timeout" "1800" "--stage-init-timeout" "1800" "--generation-timeout" "600" "--stop-after-audio-chunks" "1" "--out" $ProofOut
+        Invoke-Native $pythonExe "examples\offline_inference\qwen3_omni\windows_audio_stream_probe.py" "--model" $ModelId "--deploy-config" "vllm_omni\deploy\qwen3_omni_moe_windows_single_gpu.yaml" "--init-timeout" "21600" "--stage-init-timeout" "21600" "--generation-timeout" "600" "--stop-after-audio-chunks" "1" "--out" $ProofOut
     }
 }
 finally {

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -131,6 +131,7 @@ function Set-OmniEnvironment {
     $env:HF_HUB_DISABLE_SYMLINKS = "1"
     $env:HF_HUB_DISABLE_SYMLINKS_WARNING = "1"
     $env:VLLM_WORKER_MULTIPROC_METHOD = "spawn"
+    $env:VLLM_USE_FLASHINFER_SAMPLER = "0"
 }
 
 function Download-HfSnapshot {

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -100,11 +100,28 @@ function Get-PythonExe {
     return $python
 }
 
+function Resolve-CudaToolkitPath {
+    param([string]$PreferredPath)
+    $candidates = @(
+        $PreferredPath,
+        $env:CUDA_PATH,
+        $env:CUDA_HOME,
+        "C:\tmp\cuda13_system",
+        "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0"
+    ) | Where-Object { $_ } | Select-Object -Unique
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path (Join-Path $candidate "bin\nvcc.exe")) {
+            return $candidate
+        }
+    }
+    throw "Could not find a CUDA Toolkit with bin\nvcc.exe. Pass -CudaPath or create a space-free CUDA junction."
+}
+
 function Set-OmniEnvironment {
     param([string]$PythonExe)
-    if (-not (Test-Path $CudaPath)) {
-        throw "CUDA path $CudaPath was not found. Install CUDA or pass -CudaPath."
-    }
+    $script:ResolvedCudaPath = Resolve-CudaToolkitPath -PreferredPath $CudaPath
+    $script:CudaPath = $script:ResolvedCudaPath
     $torchLib = Join-Path (Split-Path -Parent (Split-Path -Parent $PythonExe)) "Lib\site-packages\torch\lib"
     $env:PATH = "$CudaPath\bin;$torchLib;$env:PATH"
     $env:CUDA_HOME = $CudaPath

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -104,9 +104,9 @@ function Resolve-CudaToolkitPath {
     param([string]$PreferredPath)
     $candidates = @(
         $PreferredPath,
+        "C:\tmp\cuda13_system",
         $env:CUDA_PATH,
         $env:CUDA_HOME,
-        "C:\tmp\cuda13_system",
         "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0"
     ) | Where-Object { $_ } | Select-Object -Unique
 

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -137,17 +137,20 @@ function Set-OmniEnvironment {
 
 function Download-HfSnapshot {
     param([string]$PythonExe, [string]$RepoId, [string]$LocalDir)
+    $env:VLLM_OMNI_BOOTSTRAP_MODEL_ID = $RepoId
+    $env:VLLM_OMNI_BOOTSTRAP_MODEL_LOCAL_DIR = $LocalDir
     $code = @"
+import os
 from huggingface_hub import snapshot_download
 
 kwargs = {
-    "repo_id": r"$RepoId",
-    "resume_download": True,
+    'repo_id': os.environ['VLLM_OMNI_BOOTSTRAP_MODEL_ID'],
+    'resume_download': True,
 }
-if r"$LocalDir":
-    kwargs["local_dir"] = r"$LocalDir"
+if os.environ.get('VLLM_OMNI_BOOTSTRAP_MODEL_LOCAL_DIR'):
+    kwargs['local_dir'] = os.environ['VLLM_OMNI_BOOTSTRAP_MODEL_LOCAL_DIR']
 snapshot_download(**kwargs)
-print("Downloaded", r"$RepoId")
+print('Downloaded', os.environ['VLLM_OMNI_BOOTSTRAP_MODEL_ID'])
 "@
     Invoke-Native $PythonExe "-c" $code
 }

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -203,7 +203,7 @@ Push-Location $OmniRepoPath
 try {
     if (-not $SkipDependencyInstall) {
         Write-Step "Installing vLLM-Omni runtime dependencies"
-        Invoke-Native $pythonExe "-m" "pip" "install" "-r" "requirements\common.txt" "onnxruntime>=1.23.2" "pytest>=8.0.0"
+        Invoke-Native $pythonExe "-m" "pip" "install" "-r" "requirements\common.txt" "onnxruntime>=1.23.2" "pytest>=8.0.0" "pytest-asyncio>=0.24.0" "pytest-mock>=3.14.0"
     }
 
     Write-Step "Installing vLLM-Omni editable"

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -203,7 +203,7 @@ Push-Location $OmniRepoPath
 try {
     if (-not $SkipDependencyInstall) {
         Write-Step "Installing vLLM-Omni runtime dependencies"
-        Invoke-Native $pythonExe "-m" "pip" "install" "-r" "requirements\cuda.txt"
+        Invoke-Native $pythonExe "-m" "pip" "install" "-r" "requirements\common.txt" "onnxruntime>=1.23.2"
     }
 
     Write-Step "Installing vLLM-Omni editable"

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -224,7 +224,7 @@ try {
 
     if (-not $SkipProof) {
         Write-Step "Running Qwen3-Omni audio in -> audio out streaming proof"
-        Invoke-Native $pythonExe "examples\offline_inference\qwen3_omni\windows_audio_stream_probe.py" "--model" $ModelId "--deploy-config" "vllm_omni\deploy\qwen3_omni_moe_windows_single_gpu.yaml" "--stop-after-audio-chunks" "1" "--out" $ProofOut
+        Invoke-Native $pythonExe "examples\offline_inference\qwen3_omni\windows_audio_stream_probe.py" "--model" $ModelId "--deploy-config" "vllm_omni\deploy\qwen3_omni_moe_windows_single_gpu.yaml" "--init-timeout" "1800" "--stage-init-timeout" "1800" "--generation-timeout" "600" "--stop-after-audio-chunks" "1" "--out" $ProofOut
     }
 }
 finally {

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -132,6 +132,7 @@ function Set-OmniEnvironment {
     $env:HF_HUB_DISABLE_SYMLINKS_WARNING = "1"
     $env:VLLM_WORKER_MULTIPROC_METHOD = "spawn"
     $env:VLLM_USE_FLASHINFER_SAMPLER = "0"
+    $env:VLLM_HOST_IP = "127.0.0.1"
 }
 
 function Download-HfSnapshot {

--- a/scripts/bootstrap_windows_omni.ps1
+++ b/scripts/bootstrap_windows_omni.ps1
@@ -18,7 +18,7 @@ param(
     [string]$Branch = "windows-compat",
     [string]$VllmRepoPath = "",
     [string]$OmniRepoPath = "",
-    [string]$VenvPath = "C:\tmp\vllmvenv",
+    [string]$VenvPath = "",
     [string]$CudaPath = "C:\tmp\cuda13",
     [string]$CudaArch = "120",
     [string]$FetchContentBaseDir = "C:\tmp\vllm_deps",
@@ -169,6 +169,9 @@ if (-not $OmniRepoPath) {
     else {
         $OmniRepoPath = Join-Path $InstallRoot "vllm-omni-windows"
     }
+}
+if (-not $VenvPath) {
+    $VenvPath = Join-Path $InstallRoot "venv"
 }
 if (-not $ProofOut) {
     $ProofOut = Join-Path $OmniRepoPath "demo_outputs\bootstrap_qwen3_omni_audio_stream_probe.json"

--- a/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
+++ b/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
@@ -551,6 +551,94 @@ def test_generation_scheduler_calls_cleanup_on_finished(monkeypatch, mocker: Moc
     assert args[1] == "ext-s1"
 
 
+def test_generation_scheduler_keeps_nonterminal_async_chunk_unfinished(mocker: MockerFixture):
+    """A consumed async chunk should emit output without terminal finish_reason.
+
+    The upstream stream may have more chunks, so the request must move back to
+    WAITING_FOR_CHUNK instead of being freed as FINISHED_STOPPED.
+    """
+    cleanup_calls = []
+
+    adapter_mock = mocker.MagicMock()
+    adapter_mock.finished_requests = set()
+    adapter_mock.cleanup = lambda *a, **kw: cleanup_calls.append((a, kw))
+
+    from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
+
+    scheduler = mocker.MagicMock()
+    scheduler.chunk_transfer_adapter = adapter_mock
+    scheduler.connector = None
+    scheduler.ec_connector = None
+    scheduler.perf_metrics = None
+    scheduler.log_stats = False
+    scheduler.recompute_kv_load_failures = False
+    scheduler.structured_output_manager = mocker.MagicMock()
+    scheduler.structured_output_manager.should_advance.return_value = False
+    scheduler.finished_req_ids_dict = {}
+    scheduler.kv_cache_manager.take_events.return_value = None
+    scheduler.kv_event_publisher = mocker.MagicMock()
+    scheduler._pending_finish_reqs = []
+
+    request = _HashableRequest(
+        request_id="req-chunk",
+        external_req_id="ext-chunk",
+        status=RequestStatus.RUNNING,
+        is_finished=lambda: False,
+        num_computed_tokens=16,
+        num_prompt_tokens=16,
+        prompt_token_ids=list(range(16)),
+        num_output_placeholders=0,
+        sampling_params=None,
+        pooling_params=None,
+        stop_reason=None,
+        client_index=0,
+        take_events=lambda: [],
+        trace_headers=None,
+        has_encoder_inputs=False,
+        take_prefill_stats=lambda: None,
+        num_nans_in_logits=0,
+        get_finished_reason=lambda: "stop",
+    )
+    scheduler.requests = {"req-chunk": request}
+    scheduler.running = [request]
+    scheduler.waiting = mocker.MagicMock()
+    scheduler.waiting.remove_requests = mocker.MagicMock()
+    scheduler.make_stats = mocker.MagicMock(return_value=None)
+    scheduler._handle_stopped_request = mocker.MagicMock(return_value=True)
+    scheduler._free_request = mocker.MagicMock(return_value=None)
+
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={"req-chunk": 16},
+        scheduled_spec_decode_tokens={},
+        num_invalid_spec_tokens=0,
+    )
+    model_runner_output = SimpleNamespace(
+        sampled_token_ids=None,
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[{"audio": torch.ones(4)}],
+        num_nans_in_logits=None,
+        kv_connector_output=None,
+        cudagraph_stats=None,
+        req_id_to_index={"req-chunk": 0},
+        routed_experts_dict=None,
+    )
+
+    result = OmniGenerationScheduler.update_from_output(scheduler, scheduler_output, model_runner_output)
+
+    assert request.status == RequestStatus.WAITING_FOR_CHUNK
+    scheduler._handle_stopped_request.assert_not_called()
+    scheduler._free_request.assert_not_called()
+    assert cleanup_calls == []
+    assert scheduler.running == [request]
+
+    eco = result[0]
+    assert len(eco.outputs) == 1
+    assert eco.outputs[0].request_id == "req-chunk"
+    assert eco.outputs[0].finish_reason is None
+    assert torch.equal(eco.outputs[0].pooling_output["audio"], torch.ones(4))
+
+
 def test_ar_scheduler_defers_cleanup_and_queues_save_on_finished(mocker: MockerFixture):
     """OmniARScheduler should enqueue save; adapter cleanup is handled in save thread."""
     cleanup_calls = []

--- a/tests/engine/test_async_omni_engine_outputs.py
+++ b/tests/engine/test_async_omni_engine_outputs.py
@@ -5,10 +5,13 @@ subsequent attempts to collect output raise RuntimeError.
 """
 
 import queue
+from types import SimpleNamespace
 
+import janus
 import pytest
 from pytest_mock import MockerFixture
 
+from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.engine.messages import ErrorMessage, OutputMessage
 from vllm_omni.outputs import OmniRequestOutput
@@ -111,3 +114,64 @@ async def test_fatal_error_message_surfaces_through_try_get_output_async(mocker:
     assert msg is not None
     assert msg.type == "error"
     assert msg.fatal is True
+
+
+def test_process_single_result_preserves_nonfinal_stage_output(mocker: MockerFixture):
+    """Public OmniRequestOutput must keep incremental final-stage chunks open."""
+    omni = object.__new__(AsyncOmni)
+    omni._enable_ar_profiler = False
+    omni.engine = mocker.MagicMock()
+    omni.engine.get_stage_metadata.return_value = SimpleNamespace(
+        final_output=True,
+        final_output_type="audio",
+    )
+
+    metrics = SimpleNamespace(
+        stage_events={},
+        stage_first_ts=[None],
+        stage_last_ts=[None],
+        e2e_done=set(),
+        on_finalize_request=mocker.MagicMock(),
+        on_stage_metrics=mocker.MagicMock(),
+    )
+    stage_output = SimpleNamespace(
+        request_id="r1",
+        finished=False,
+        final_output_type="audio",
+        stage_durations={},
+        peak_memory_mb=0.0,
+    )
+    result = OutputMessage(
+        request_id="r1",
+        stage_id=0,
+        engine_outputs=stage_output,
+        metrics=None,
+        finished=False,
+    )
+
+    output = omni._process_single_result(
+        result,
+        stage_id=0,
+        metrics=metrics,
+        req_start_ts={"r1": 1.0},
+        wall_start_ts=1.0,
+        final_stage_id_for_e2e=0,
+    )
+
+    assert output is not None
+    assert output.finished is False
+    metrics.on_finalize_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_omni_abort_ignores_closed_engine_queue(mocker: MockerFixture):
+    """Closing an async generator during shutdown should not leak janus errors."""
+    omni = object.__new__(AsyncOmni)
+    omni.engine = mocker.MagicMock()
+    omni.engine.abort_async = mocker.AsyncMock(side_effect=janus.SyncQueueShutDown)
+    omni.request_states = {"r1": object()}
+    omni.log_stats = False
+
+    await omni.abort("r1")
+
+    assert "r1" not in omni.request_states

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -237,7 +237,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 self.input_coordinator.restore_queues(self.waiting, self.running)
         try:
             # Late import to avoid circulars in some launch modes
-            from .output import OmniNewRequestData
+            from .output import OmniNewRequestData, filter_new_request_data_kwargs
 
             # Rewrap base NewRequestData entries with OmniNewRequestData,
             # enriching with request-level payloads
@@ -246,21 +246,22 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 req_id = getattr(nr, "req_id", None)
                 request = self.requests.get(req_id) if req_id else None
                 # Build omni entry preserving all base fields
-                omni_nr = OmniNewRequestData(
-                    req_id=nr.req_id,
-                    external_req_id=(getattr(request, "external_req_id", None) if request else None),
-                    prompt_token_ids=nr.prompt_token_ids,
-                    mm_features=nr.mm_features,
-                    sampling_params=nr.sampling_params,
-                    pooling_params=nr.pooling_params,
-                    block_ids=nr.block_ids,
-                    num_computed_tokens=nr.num_computed_tokens,
-                    lora_request=nr.lora_request,
+                kwargs = {
+                    "req_id": nr.req_id,
+                    "external_req_id": (getattr(request, "external_req_id", None) if request else None),
+                    "prompt_token_ids": nr.prompt_token_ids,
+                    "mm_features": nr.mm_features,
+                    "sampling_params": nr.sampling_params,
+                    "pooling_params": nr.pooling_params,
+                    "block_ids": nr.block_ids,
+                    "num_computed_tokens": nr.num_computed_tokens,
+                    "lora_request": nr.lora_request,
                     # Enrich with omni payloads from the live request object
-                    prompt_embeds=(getattr(request, "prompt_embeds", None) if request else None),
-                    prompt_is_token_ids=nr.prompt_is_token_ids,
-                    additional_information=(getattr(request, "additional_information", None) if request else None),
-                )
+                    "prompt_embeds": (getattr(request, "prompt_embeds", None) if request else None),
+                    "prompt_is_token_ids": getattr(nr, "prompt_is_token_ids", None),
+                    "additional_information": (getattr(request, "additional_information", None) if request else None),
+                }
+                omni_nr = OmniNewRequestData(**filter_new_request_data_kwargs(OmniNewRequestData, kwargs))
                 new_list.append(omni_nr)
 
             scheduler_output.scheduled_new_reqs = new_list  # type: ignore[assignment]

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -28,7 +28,12 @@ from vllm_omni.core.sched.omni_scheduling_coordinator import (
     OmniSchedulingCoordinator,
     uses_qwen3_omni_full_payload_input_coordinator,
 )
-from vllm_omni.core.sched.output import OmniCachedRequestData, OmniNewRequestData, OmniSchedulerOutput
+from vllm_omni.core.sched.output import (
+    OmniCachedRequestData,
+    OmniNewRequestData,
+    OmniSchedulerOutput,
+    filter_new_request_data_kwargs,
+)
 from vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapter import (
     OmniChunkTransferAdapter,
 )
@@ -315,21 +320,22 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                 req_id = getattr(nr, "req_id", None)
                 request = self.requests.get(req_id) if req_id else None
                 # Build omni entry preserving all base fields
-                omni_nr = OmniNewRequestData(
-                    req_id=nr.req_id,
-                    external_req_id=(getattr(request, "external_req_id", None) if request else None),
-                    prompt_token_ids=nr.prompt_token_ids,
-                    mm_features=nr.mm_features,
-                    sampling_params=nr.sampling_params,
-                    pooling_params=nr.pooling_params,
-                    block_ids=nr.block_ids,
-                    num_computed_tokens=nr.num_computed_tokens,
-                    lora_request=nr.lora_request,
+                kwargs = {
+                    "req_id": nr.req_id,
+                    "external_req_id": (getattr(request, "external_req_id", None) if request else None),
+                    "prompt_token_ids": nr.prompt_token_ids,
+                    "mm_features": nr.mm_features,
+                    "sampling_params": nr.sampling_params,
+                    "pooling_params": nr.pooling_params,
+                    "block_ids": nr.block_ids,
+                    "num_computed_tokens": nr.num_computed_tokens,
+                    "lora_request": nr.lora_request,
                     # Enrich with omni payloads from the live request object
-                    prompt_embeds=(getattr(request, "prompt_embeds", None) if request else None),
-                    prompt_is_token_ids=nr.prompt_is_token_ids,
-                    additional_information=(getattr(request, "additional_information", None) if request else None),
-                )
+                    "prompt_embeds": (getattr(request, "prompt_embeds", None) if request else None),
+                    "prompt_is_token_ids": getattr(nr, "prompt_is_token_ids", None),
+                    "additional_information": (getattr(request, "additional_information", None) if request else None),
+                }
+                omni_nr = OmniNewRequestData(**filter_new_request_data_kwargs(OmniNewRequestData, kwargs))
                 new_list.append(omni_nr)
 
             scheduler_output.scheduled_new_reqs = new_list  # type: ignore[assignment]
@@ -494,21 +500,30 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             finish_reason = None
             routed_experts = None
 
-            # Diffusion request: completes in one step; mark finished and free resources
+            async_chunk_consumed = (
+                self.chunk_transfer_adapter is not None
+                and request.num_computed_tokens >= len(request.prompt_token_ids)
+            )
+            async_chunk_terminal = (
+                async_chunk_consumed
+                and request.request_id in self.chunk_transfer_adapter.finished_requests
+            )
+
+            # Diffusion request: completes in one step. In async_chunk mode,
+            # consuming one chunk is only a segment boundary; wait for the next
+            # upstream chunk unless the adapter has observed the terminal chunk.
             if (
                 request.status == RequestStatus.FINISHED_STOPPED
                 or (self.chunk_transfer_adapter is None and request.num_computed_tokens >= request.num_prompt_tokens)
-                or (
-                    self.chunk_transfer_adapter is not None
-                    and request.request_id in self.chunk_transfer_adapter.finished_requests
-                    and request.num_computed_tokens >= len(request.prompt_token_ids)
-                )
+                or async_chunk_terminal
             ):
                 request.status = RequestStatus.FINISHED_STOPPED
                 # Optional: set a stop_reason for front-end clarity
                 # (does not affect protocol)
                 request.stop_reason = request.stop_reason  # or "generation_done"
                 stopped = True
+            elif async_chunk_consumed:
+                request.status = RequestStatus.WAITING_FOR_CHUNK
 
             if stopped:
                 if (

--- a/vllm_omni/core/sched/output.py
+++ b/vllm_omni/core/sched/output.py
@@ -1,10 +1,16 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import Any
 
 from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, SchedulerOutput
 from vllm.v1.request import Request
 
 from vllm_omni.engine import AdditionalInformationPayload
+
+
+def filter_new_request_data_kwargs(cls: type, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Keep scheduler data construction compatible across vLLM versions."""
+    accepted = {item.name for item in fields(cls)}
+    return {key: value for key, value in kwargs.items() if key in accepted}
 
 
 @dataclass
@@ -43,21 +49,22 @@ class OmniNewRequestData(NewRequestData):
         Returns:
             OmniNewRequestData instance with data from the request
         """
-        return cls(
-            req_id=request.request_id,
-            external_req_id=getattr(request, "external_req_id", None),
-            prompt_token_ids=request.prompt_token_ids,
-            mm_features=request.mm_features,
-            sampling_params=request.sampling_params,
-            pooling_params=request.pooling_params,
-            block_ids=block_ids,
-            num_computed_tokens=request.num_computed_tokens,
-            lora_request=request.lora_request,
-            prompt_embeds=getattr(request, "prompt_embeds", None),
-            prompt_is_token_ids=getattr(request, "prompt_is_token_ids", None),
-            prefill_token_ids=prefill_token_ids,
-            additional_information=getattr(request, "additional_information", None),
-        )
+        kwargs = {
+            "req_id": request.request_id,
+            "external_req_id": getattr(request, "external_req_id", None),
+            "prompt_token_ids": request.prompt_token_ids,
+            "mm_features": request.mm_features,
+            "sampling_params": request.sampling_params,
+            "pooling_params": request.pooling_params,
+            "block_ids": block_ids,
+            "num_computed_tokens": request.num_computed_tokens,
+            "lora_request": request.lora_request,
+            "prompt_embeds": getattr(request, "prompt_embeds", None),
+            "prompt_is_token_ids": getattr(request, "prompt_is_token_ids", None),
+            "prefill_token_ids": prefill_token_ids,
+            "additional_information": getattr(request, "additional_information", None),
+        }
+        return cls(**filter_new_request_data_kwargs(cls, kwargs))
 
 
 @dataclass

--- a/vllm_omni/deploy/qwen3_omni_moe_windows_single_gpu.yaml
+++ b/vllm_omni/deploy/qwen3_omni_moe_windows_single_gpu.yaml
@@ -1,0 +1,77 @@
+# Windows single-GPU Qwen3-Omni-MoE smoke deploy.
+#
+# This is intentionally conservative. It was validated on an RTX PRO 6000
+# Blackwell-class GPU with the Windows CUDA source build of vLLM, and keeps all
+# three stages on one device for audio-in/audio-out streaming smoke tests.
+pipeline: qwen3_omni_moe
+async_chunk: true
+
+trust_remote_code: true
+distributed_executor_backend: "mp"
+enable_prefix_caching: false
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      codec_chunk_frames: 25
+      codec_left_context_frames: 25
+
+stages:
+  - stage_id: 0
+    devices: "0"
+    max_num_seqs: 1
+    max_num_batched_tokens: 4096
+    max_model_len: 2048
+    gpu_memory_utilization: 0.70
+    enforce_eager: true
+    attention_backend: FLASHINFER
+    mm_encoder_attn_backend: TORCH_SDPA
+    mm_processor_cache_gb: 0
+    default_sampling_params:
+      temperature: 0.4
+      top_p: 0.9
+      top_k: 1
+      max_tokens: 48
+      seed: 42
+      repetition_penalty: 1.05
+
+  - stage_id: 1
+    devices: "0"
+    max_num_seqs: 1
+    max_num_batched_tokens: 2048
+    max_model_len: 2048
+    gpu_memory_utilization: 0.18
+    enforce_eager: true
+    attention_backend: FLASHINFER
+    mm_encoder_attn_backend: TORCH_SDPA
+    mm_processor_cache_gb: 0
+    input_connectors:
+      from_stage_0: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.9
+      top_k: 50
+      max_tokens: 256
+      seed: 42
+      repetition_penalty: 1.05
+
+  - stage_id: 2
+    devices: "0"
+    max_num_seqs: 1
+    max_num_batched_tokens: 4096
+    max_model_len: 4096
+    gpu_memory_utilization: 0.05
+    enforce_eager: true
+    attention_backend: FLASHINFER
+    mm_encoder_attn_backend: TORCH_SDPA
+    async_scheduling: false
+    mm_processor_cache_gb: 0
+    input_connectors:
+      from_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 4096
+      seed: 42
+      repetition_penalty: 1.1

--- a/vllm_omni/deploy/qwen3_omni_moe_windows_single_gpu.yaml
+++ b/vllm_omni/deploy/qwen3_omni_moe_windows_single_gpu.yaml
@@ -25,7 +25,7 @@ stages:
     max_model_len: 2048
     gpu_memory_utilization: 0.70
     enforce_eager: true
-    attention_backend: FLASHINFER
+    attention_backend: TRITON_ATTN
     mm_encoder_attn_backend: TORCH_SDPA
     mm_processor_cache_gb: 0
     default_sampling_params:
@@ -43,7 +43,7 @@ stages:
     max_model_len: 2048
     gpu_memory_utilization: 0.18
     enforce_eager: true
-    attention_backend: FLASHINFER
+    attention_backend: TRITON_ATTN
     mm_encoder_attn_backend: TORCH_SDPA
     mm_processor_cache_gb: 0
     input_connectors:
@@ -62,7 +62,7 @@ stages:
     max_model_len: 4096
     gpu_memory_utilization: 0.05
     enforce_eager: true
-    attention_backend: FLASHINFER
+    attention_backend: TRITON_ATTN
     mm_encoder_attn_backend: TORCH_SDPA
     async_scheduling: false
     mm_processor_cache_gb: 0

--- a/vllm_omni/deploy/qwen3_omni_moe_windows_single_gpu.yaml
+++ b/vllm_omni/deploy/qwen3_omni_moe_windows_single_gpu.yaml
@@ -26,6 +26,7 @@ stages:
     gpu_memory_utilization: 0.70
     enforce_eager: true
     attention_backend: TRITON_ATTN
+    moe_backend: triton
     mm_encoder_attn_backend: TORCH_SDPA
     mm_processor_cache_gb: 0
     default_sampling_params:
@@ -44,6 +45,7 @@ stages:
     gpu_memory_utilization: 0.18
     enforce_eager: true
     attention_backend: TRITON_ATTN
+    moe_backend: triton
     mm_encoder_attn_backend: TORCH_SDPA
     mm_processor_cache_gb: 0
     input_connectors:
@@ -63,6 +65,7 @@ stages:
     gpu_memory_utilization: 0.05
     enforce_eager: true
     attention_backend: TRITON_ATTN
+    moe_backend: triton
     mm_encoder_attn_backend: TORCH_SDPA
     async_scheduling: false
     mm_processor_cache_gb: 0

--- a/vllm_omni/diffusion/stage_diffusion_proc.py
+++ b/vllm_omni/diffusion/stage_diffusion_proc.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import signal
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing.process import BaseProcess
@@ -609,12 +610,15 @@ def _perform_diffusion_handshake(
     with zmq_socket_ctx(handshake_address, zmq.ROUTER, bind=True) as handshake_socket:
         poller = zmq.Poller()
         poller.register(handshake_socket, zmq.POLLIN)
-        poller.register(proc.sentinel, zmq.POLLIN)
+        if sys.platform != "win32":
+            poller.register(proc.sentinel, zmq.POLLIN)
 
         timeout_ms = handshake_timeout * 1000
         while True:
             events = dict(poller.poll(timeout=timeout_ms))
             if not events:
+                if proc.exitcode is not None:
+                    raise RuntimeError(f"StageDiffusionProc died during handshake (exit code {proc.exitcode})")
                 raise TimeoutError(
                     f"Timed out waiting for READY from StageDiffusionProc after {handshake_timeout}s. "
                     f"This typically indicates model loading or warmup is taking too long. "

--- a/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
@@ -8,7 +8,11 @@ from contextlib import contextmanager
 from multiprocessing import shared_memory as shm_pkg
 from typing import Any
 
-from vllm_omni.entrypoints.stage_utils import shm_read_bytes, shm_write_bytes
+from vllm_omni.entrypoints.stage_utils import (
+    shm_read_bytes,
+    shm_write_bytes,
+    windows_shm_payload_path,
+)
 
 from ..utils.logging import get_connector_logger
 from .base import OmniConnectorBase
@@ -136,6 +140,19 @@ class SharedMemoryConnector(OmniConnectorBase):
 
     def _get_by_key(self, get_key: str) -> tuple[Any, int] | None:
         """Read a SHM segment addressed purely by *get_key*."""
+        if sys.platform == "win32":
+            path = windows_shm_payload_path(get_key)
+            if not os.path.exists(path):
+                return None
+            lock_file = _get_lock_file(get_key)
+            result = self._get_data_with_lock(
+                lock_file,
+                {"name": get_key, "size": os.path.getsize(path), "win_file": path},
+            )
+            if result is not None:
+                self._pending_keys.discard(get_key)
+            return result
+
         shm = None
         try:
             shm = shm_pkg.SharedMemory(name=get_key)
@@ -208,15 +225,23 @@ class SharedMemoryConnector(OmniConnectorBase):
         ]
         for key in stale:
             self._pending_keys.discard(key)
-            try:
-                seg = shm_pkg.SharedMemory(name=key)
-                seg.close()
-                seg.unlink()
-                logger.debug("cleanup: unlinked unconsumed SHM segment %s", key)
-            except FileNotFoundError:
-                pass
-            except Exception as e:
-                logger.debug("cleanup: failed to unlink SHM segment %s: %s", key, e)
+            if sys.platform == "win32":
+                payload_path = windows_shm_payload_path(key)
+                if os.path.exists(payload_path):
+                    try:
+                        os.remove(payload_path)
+                    except OSError as e:
+                        logger.debug("cleanup: failed to remove SHM payload file %s: %s", payload_path, e)
+            else:
+                try:
+                    seg = shm_pkg.SharedMemory(name=key)
+                    seg.close()
+                    seg.unlink()
+                    logger.debug("cleanup: unlinked unconsumed SHM segment %s", key)
+                except FileNotFoundError:
+                    pass
+                except Exception as e:
+                    logger.debug("cleanup: failed to unlink SHM segment %s: %s", key, e)
             lock_file = _get_lock_file(key)
             if os.path.exists(lock_file):
                 try:
@@ -227,12 +252,18 @@ class SharedMemoryConnector(OmniConnectorBase):
     def close(self) -> None:
         """Unlink all remaining tracked SHM segments."""
         for key in list(self._pending_keys):
-            try:
-                seg = shm_pkg.SharedMemory(name=key)
-                seg.close()
-                seg.unlink()
-            except Exception:
-                pass
+            if sys.platform == "win32":
+                try:
+                    os.remove(windows_shm_payload_path(key))
+                except Exception:
+                    pass
+            else:
+                try:
+                    seg = shm_pkg.SharedMemory(name=key)
+                    seg.close()
+                    seg.unlink()
+                except Exception:
+                    pass
             lock_file = _get_lock_file(key)
             if os.path.exists(lock_file):
                 try:

--- a/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import fcntl
 import os
+import sys
+import tempfile
+from contextlib import contextmanager
 from multiprocessing import shared_memory as shm_pkg
 from typing import Any
 
@@ -12,6 +14,43 @@ from ..utils.logging import get_connector_logger
 from .base import OmniConnectorBase
 
 logger = get_connector_logger(__name__)
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
+
+def _get_lock_dir() -> str:
+    if sys.platform == "win32":
+        lock_dir = os.path.join(tempfile.gettempdir(), "vllm_omni_shm")
+        os.makedirs(lock_dir, exist_ok=True)
+        return lock_dir
+    return "/dev/shm"
+
+
+def _get_lock_file(key: str) -> str:
+    return os.path.join(_get_lock_dir(), f"shm_{key}_lockfile.lock")
+
+
+@contextmanager
+def _exclusive_file_lock(lock_file: str):
+    with open(lock_file, "wb+") as lockf:
+        if sys.platform == "win32":
+            lockf.write(b"\0")
+            lockf.flush()
+            lockf.seek(0)
+            msvcrt.locking(lockf.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            fcntl.flock(lockf, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if sys.platform == "win32":
+                lockf.seek(0)
+                msvcrt.locking(lockf.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(lockf, fcntl.LOCK_UN)
 
 
 class SharedMemoryConnector(OmniConnectorBase):
@@ -56,11 +95,9 @@ class SharedMemoryConnector(OmniConnectorBase):
             # Currently, we always use SHM.
             if True:
                 # Use Shared Memory
-                lock_file = f"/dev/shm/shm_{put_key}_lockfile.lock"
-                with open(lock_file, "wb+") as lockf:
-                    fcntl.flock(lockf, fcntl.LOCK_EX)
+                lock_file = _get_lock_file(put_key)
+                with _exclusive_file_lock(lock_file):
                     meta = shm_write_bytes(payload, name=put_key)
-                    fcntl.flock(lockf, fcntl.LOCK_UN)
 
                 # meta contains {'name': ..., 'size': ...}
                 metadata = {"shm": meta, "size": size}
@@ -85,10 +122,8 @@ class SharedMemoryConnector(OmniConnectorBase):
     def _get_data_with_lock(self, lock_file: str, shm_handle: dict):
         obj = None
         try:
-            with open(lock_file, "rb+") as lockf:
-                fcntl.flock(lockf, fcntl.LOCK_EX)
+            with _exclusive_file_lock(lock_file):
                 data_bytes = shm_read_bytes(shm_handle)
-                fcntl.flock(lockf, fcntl.LOCK_UN)
             obj = self.deserialize_obj(data_bytes)
             return obj, int(shm_handle.get("size", 0))
         except Exception as e:
@@ -106,7 +141,7 @@ class SharedMemoryConnector(OmniConnectorBase):
             shm = shm_pkg.SharedMemory(name=get_key)
             if shm is None or shm.size == 0:
                 return None
-            lock_file = f"/dev/shm/shm_{get_key}_lockfile.lock"
+            lock_file = _get_lock_file(get_key)
             shm_handle = {"name": get_key, "size": shm.size}
             result = self._get_data_with_lock(lock_file, shm_handle)
             if result is not None:
@@ -146,7 +181,7 @@ class SharedMemoryConnector(OmniConnectorBase):
 
             if "shm" in metadata:
                 shm_handle = metadata["shm"]
-                lock_file = f"/dev/shm/shm_{shm_handle['name']}_lockfile.lock"
+                lock_file = _get_lock_file(shm_handle["name"])
                 result = self._get_data_with_lock(lock_file, shm_handle)
                 if result is not None:
                     self._pending_keys.discard(get_key)
@@ -182,7 +217,7 @@ class SharedMemoryConnector(OmniConnectorBase):
                 pass
             except Exception as e:
                 logger.debug("cleanup: failed to unlink SHM segment %s: %s", key, e)
-            lock_file = f"/dev/shm/shm_{key}_lockfile.lock"
+            lock_file = _get_lock_file(key)
             if os.path.exists(lock_file):
                 try:
                     os.remove(lock_file)
@@ -198,7 +233,7 @@ class SharedMemoryConnector(OmniConnectorBase):
                 seg.unlink()
             except Exception:
                 pass
-            lock_file = f"/dev/shm/shm_{key}_lockfile.lock"
+            lock_file = _get_lock_file(key)
             if os.path.exists(lock_file):
                 try:
                     os.remove(lock_file)

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -74,10 +74,14 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 "name": getattr(connector_config, "name", None),
                 "extra": getattr(connector_config, "extra", {}),
             }
+        extra = dict(connector_config.get("extra", {}) or {})
+        stage_id = getattr(model_config, "stage_id", None)
+        if stage_id is not None:
+            extra.setdefault("stage_id", int(stage_id))
 
         connector_specs = ConnectorSpec(
             name=connector_config.get("name", "SharedMemoryConnector"),
-            extra=connector_config.get("extra", {}),
+            extra=extra,
         )
         return OmniConnectorFactory.create_connector(connector_specs)
 
@@ -139,6 +143,9 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             self._save_cond.notify()
 
     def _poll_single_request(self, request: Request):
+        if request.status == RequestStatus.RUNNING:
+            return False
+
         stage_id = self.connector.stage_id
         target_stage_id = stage_id - 1
         req_id = request.request_id

--- a/vllm_omni/engine/__init__.py
+++ b/vllm_omni/engine/__init__.py
@@ -91,29 +91,31 @@ class OmniEngineCoreRequest(EngineCoreRequest):
         if additional_information is None:
             additional_information = getattr(request, "additional_information", None)
 
-        return cls(
-            request_id=request.request_id,
-            prompt_token_ids=request.prompt_token_ids,
-            prompt_is_token_ids=request.prompt_is_token_ids,
-            mm_features=request.mm_features,
-            sampling_params=request.sampling_params,
-            pooling_params=request.pooling_params,
-            arrival_time=request.arrival_time,
-            lora_request=request.lora_request,
-            cache_salt=request.cache_salt,
-            data_parallel_rank=request.data_parallel_rank,
-            prompt_embeds=prompt_embeds,
-            client_index=request.client_index,
-            current_wave=request.current_wave,
-            priority=request.priority,
-            trace_headers=request.trace_headers,
-            resumable=request.resumable,
-            external_req_id=request.external_req_id,
-            reasoning_ended=request.reasoning_ended,
-            reasoning_parser_kwargs=request.reasoning_parser_kwargs,
-            abort_immediately=request.abort_immediately,
-            additional_information=additional_information,
-        )
+        kwargs = {
+            "request_id": request.request_id,
+            "prompt_token_ids": request.prompt_token_ids,
+            "prompt_is_token_ids": getattr(request, "prompt_is_token_ids", None),
+            "mm_features": request.mm_features,
+            "sampling_params": request.sampling_params,
+            "pooling_params": request.pooling_params,
+            "arrival_time": request.arrival_time,
+            "lora_request": request.lora_request,
+            "cache_salt": request.cache_salt,
+            "data_parallel_rank": request.data_parallel_rank,
+            "prompt_embeds": prompt_embeds,
+            "client_index": request.client_index,
+            "current_wave": request.current_wave,
+            "priority": request.priority,
+            "trace_headers": request.trace_headers,
+            "resumable": request.resumable,
+            "external_req_id": request.external_req_id,
+            "reasoning_ended": request.reasoning_ended,
+            "reasoning_parser_kwargs": getattr(request, "reasoning_parser_kwargs", None),
+            "abort_immediately": getattr(request, "abort_immediately", False),
+            "additional_information": additional_information,
+        }
+        fields = set(getattr(cls, "__struct_fields__", kwargs))
+        return cls(**{key: value for key, value in kwargs.items() if key in fields})
 
 
 class OmniEngineCoreOutput(EngineCoreOutput):

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -14,6 +14,7 @@ import dataclasses
 import json
 import os
 import queue
+import sys
 import threading
 import time
 import uuid
@@ -1118,6 +1119,8 @@ class AsyncOmniEngine:
     ) -> None:
         """Create loop, initialize stages, then run Orchestrator."""
 
+        if sys.platform == "win32" and hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -1,11 +1,44 @@
+from inspect import signature
 from typing import Any
 
 import numpy as np
 import torch
 from vllm.logger import init_logger
-from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
-    split_routed_experts,
-)
+try:
+    from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
+        split_routed_experts,
+    )
+except ImportError:
+
+    def split_routed_experts(
+        routed_experts: np.ndarray,
+        prompt_len: int,
+        num_gen: int | None,
+    ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Split routed expert data across old and current vLLM APIs.
+
+        Older vLLM builds returned prompt and generation routing together and
+        exposed a helper to split them. Current vLLM slices routing data in the
+        scheduler, so Omni may already receive only generation routing.
+        """
+        if routed_experts is None:
+            return None, None
+
+        routed_len = routed_experts.shape[0]
+        if num_gen is not None and routed_len <= num_gen:
+            return None, routed_experts
+
+        prompt_routed_experts = routed_experts[:prompt_len] if prompt_len else None
+        gen_routed_experts = (
+            routed_experts[prompt_len : prompt_len + num_gen]
+            if num_gen is not None
+            else routed_experts[prompt_len:]
+        )
+        if gen_routed_experts is not None and gen_routed_experts.shape[0] == 0:
+            gen_routed_experts = None
+
+        return prompt_routed_experts, gen_routed_experts
+
 from vllm.outputs import PoolingRequestOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.tokenizers import TokenizerLike
@@ -253,12 +286,20 @@ class OmniRequestState(RequestState):
                 return None
             external_req_id = self.parent_req.external_req_id
 
+        new_request_output_params = signature(self._new_request_output).parameters
+        if "routed_experts" in new_request_output_params:
+            return self._new_request_output(
+                external_req_id,
+                outputs,
+                finished,
+                kv_transfer_params,
+                prompt_routed_experts,
+            )
         return self._new_request_output(
             external_req_id,
             outputs,
             finished,
             kv_transfer_params,
-            prompt_routed_experts,
         )
 
     def _new_completion_output(

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -310,7 +310,15 @@ class OmniRequestState(RequestState):
         routed_experts: np.ndarray | None = None,
     ) -> Any:
         # Reuse base text/logprobs logic, then annotate with pooling_result.
-        base_output = super()._new_completion_output(token_ids, finish_reason, stop_reason, routed_experts)
+        base_params = signature(super()._new_completion_output).parameters
+        if "routed_experts" in base_params:
+            base_output = super()._new_completion_output(
+                token_ids, finish_reason, stop_reason, routed_experts
+            )
+        else:
+            base_output = super()._new_completion_output(
+                token_ids, finish_reason, stop_reason
+            )
 
         # Inter-stage processors need the full cumulative token sequence.
         # In DELTA mode, base_output.token_ids only has the latest step's

--- a/vllm_omni/engine/stage_engine_core_proc.py
+++ b/vllm_omni/engine/stage_engine_core_proc.py
@@ -8,6 +8,7 @@ busy loop in a subprocess, communicating with StageEngineCoreClient via ZMQ.
 from __future__ import annotations
 
 import signal
+import sys
 from multiprocessing.process import BaseProcess
 from typing import TYPE_CHECKING, Any
 
@@ -177,7 +178,8 @@ def _perform_handshake(
     with zmq_socket_ctx(handshake_address, zmq.ROUTER, bind=True) as handshake_socket:
         poller = zmq.Poller()
         poller.register(handshake_socket, zmq.POLLIN)
-        poller.register(proc.sentinel, zmq.POLLIN)
+        if sys.platform != "win32":
+            poller.register(proc.sentinel, zmq.POLLIN)
 
         identity, msg = _recv(poller, handshake_socket, proc, "HELLO", handshake_timeout)
         if msg.get("status") != "HELLO":
@@ -209,6 +211,8 @@ def _recv(
     while True:
         events = dict(poller.poll(timeout=timeout_ms))
         if not events:
+            if proc.exitcode is not None:
+                raise RuntimeError(f"StageEngineCoreProc died during {expected} (exit code {proc.exitcode})")
             raise TimeoutError(
                 f"Timed out waiting for {expected} from StageEngineCoreProc after {timeout_s}s. "
                 f"This typically indicates model loading or initialization is taking too long. "

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -8,10 +8,11 @@ out of StageEngineCoreClient into reusable functions.
 
 from __future__ import annotations
 
-import fcntl
 import importlib
 import multiprocessing as mp
 import os
+import sys
+import tempfile
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
@@ -35,6 +36,45 @@ from vllm_omni.platforms import current_omni_platform
 from vllm_omni.quantization.inc_config import OmniINCConfig
 
 logger = init_logger(__name__)
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
+
+def _device_lock_path(device_id: str | int) -> str:
+    if sys.platform == "win32":
+        lock_dir = os.path.join(tempfile.gettempdir(), "vllm_omni_locks")
+        os.makedirs(lock_dir, exist_ok=True)
+        return os.path.join(lock_dir, f"vllm_omni_device_{device_id}_init.lock")
+    return f"/tmp/vllm_omni_device_{device_id}_init.lock"
+
+
+def _try_lock_fd(lock_fd: int) -> bool:
+    if sys.platform == "win32":
+        try:
+            os.lseek(lock_fd, 0, os.SEEK_SET)
+            os.write(lock_fd, b"\0")
+            os.lseek(lock_fd, 0, os.SEEK_SET)
+            msvcrt.locking(lock_fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except BlockingIOError:
+        return False
+
+
+def _unlock_fd(lock_fd: int) -> None:
+    if sys.platform == "win32":
+        os.lseek(lock_fd, 0, os.SEEK_SET)
+        msvcrt.locking(lock_fd, msvcrt.LK_UNLCK, 1)
+    else:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
 
 
 @dataclass
@@ -753,21 +793,20 @@ def acquire_device_locks(
         # Acquire locks
         wait_start = time.time()
         for device_id in devices_to_lock:
-            lock_file = f"/tmp/vllm_omni_device_{device_id}_init.lock"
+            lock_file = _device_lock_path(device_id)
             lock_acquired = False
 
             while not lock_acquired:
                 try:
                     lock_fd = os.open(lock_file, os.O_CREAT | os.O_RDWR, 0o644)
-                    try:
-                        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    if _try_lock_fd(lock_fd):
                         os.ftruncate(lock_fd, 0)
                         os.write(lock_fd, f"{os.getpid()}\n".encode())
                         os.fsync(lock_fd)
                         lock_acquired = True
                         lock_fds.append(lock_fd)
                         logger.debug("Acquired exclusive lock for device %s", device_id)
-                    except BlockingIOError:
+                    else:
                         os.close(lock_fd)
                         if time.time() - wait_start > stage_init_timeout:
                             logger.warning(
@@ -802,7 +841,7 @@ def release_device_locks(lock_fds: list[int]) -> None:
     """Release file locks acquired by acquire_device_locks."""
     for lock_fd in lock_fds:
         try:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            _unlock_fd(lock_fd)
             os.close(lock_fd)
             logger.debug("Released initialization lock (fd=%s)", lock_fd)
         except (OSError, ValueError):

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -13,6 +13,7 @@ import uuid
 from collections.abc import AsyncGenerator, Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
+import janus
 from vllm import TokensPrompt
 from vllm.engine.protocol import EngineClient, StreamingInput
 from vllm.logger import init_logger
@@ -687,7 +688,10 @@ class AsyncOmni(EngineClient, OmniBase):
     async def abort(self, request_id: str | Iterable[str]) -> None:
         """Abort request(s) via the Orchestrator."""
         request_ids = [request_id] if isinstance(request_id, str) else list(request_id)
-        await self.engine.abort_async(request_ids)
+        try:
+            await self.engine.abort_async(request_ids)
+        except (janus.SyncQueueShutDown, janus.AsyncQueueShutDown):
+            logger.debug("[AsyncOmni] abort ignored after engine queue shutdown: %s", ",".join(request_ids))
         for req_id in request_ids:
             self.request_states.pop(req_id, None)
         if self.log_stats:

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -446,6 +446,7 @@ class OmniBase(PDDisaggregationMixin):
         images = getattr(engine_outputs, "images", []) if output_type == "image" else []
         return OmniRequestOutput(
             request_id=req_id or "",
+            finished=finished,
             stage_id=stage_id,
             final_output_type=output_type,
             request_output=engine_outputs,

--- a/vllm_omni/entrypoints/stage_utils.py
+++ b/vllm_omni/entrypoints/stage_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+import tempfile
 from multiprocessing import shared_memory as _shm
 from typing import Any
 
@@ -9,6 +11,17 @@ from vllm_omni.config.yaml_util import to_dict as _omega_to_dict
 from vllm_omni.platforms import current_omni_platform
 
 logger = logging.getLogger(__name__)
+
+
+def _win_shm_dir() -> str:
+    path = os.path.join(tempfile.gettempdir(), "vllm_omni_shm_payloads")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def windows_shm_payload_path(name: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+    return os.path.join(_win_shm_dir(), f"{safe}.bin")
 
 
 def set_stage_devices(
@@ -137,6 +150,14 @@ def shm_write_bytes(payload: bytes, name: str | None = None) -> dict[str, Any]:
 
     Caller should close the segment; the receiver should unlink.
     """
+    if os.name == "nt" and name:
+        path = windows_shm_payload_path(name)
+        tmp_path = f"{path}.tmp"
+        with open(tmp_path, "wb") as f:
+            f.write(payload)
+        os.replace(tmp_path, path)
+        return {"name": name, "size": len(payload), "win_file": path}
+
     try:
         shm = _shm.SharedMemory(create=True, size=len(payload), name=name)
     except FileExistsError:
@@ -164,6 +185,16 @@ def shm_write_bytes(payload: bytes, name: str | None = None) -> dict[str, Any]:
 
 def shm_read_bytes(meta: dict[str, Any]) -> bytes:
     """Read bytes from SharedMemory by meta {name,size} and cleanup."""
+    win_file = meta.get("win_file") if isinstance(meta, dict) else None
+    if os.name == "nt" and win_file:
+        with open(win_file, "rb") as f:
+            data = f.read(meta["size"])
+        try:
+            os.remove(win_file)
+        except FileNotFoundError:
+            pass
+        return data
+
     shm = _shm.SharedMemory(name=meta["name"])  # type: ignore[index]
     mv = memoryview(shm.buf)
     data = bytes(mv[: meta["size"]])

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_tts.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_tts.py
@@ -1,5 +1,6 @@
 """Stage input processor for Qwen3-TTS: Talker -> Code2Wav."""
 
+import os
 from typing import Any
 
 import torch
@@ -24,6 +25,20 @@ from vllm_omni.model_executor.stage_input_processors.tts_utils import (
 )
 
 logger = init_logger(__name__)
+
+
+def _debug_enabled() -> bool:
+    return os.environ.get("VLLM_OMNI_QWEN3_TTS_DEBUG", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _debug_log(message: str, *args: Any) -> None:
+    if _debug_enabled():
+        logger.info("[qwen3_tts_async_chunk] " + message, *args)
 
 
 def talker2code2wav(
@@ -152,10 +167,21 @@ def talker2code2wav_async_chunk(
         if frame is not None:
             codec_codes = frame.cpu().tolist()
             transfer_manager.code_prompt_token_ids[request_id].append(codec_codes)
+            _debug_log(
+                "request=%s appended frame; buffered_frames=%d frame_quantizers=%d finished=%s",
+                request_id,
+                len(transfer_manager.code_prompt_token_ids[request_id]),
+                len(codec_codes),
+                finished,
+            )
+        else:
+            _debug_log("request=%s received pooling output without a valid frame; finished=%s", request_id, finished)
         ref_code = pooling_output.get("codes", {}).get("ref")
         if isinstance(ref_code, torch.Tensor) and ref_code.numel() > 0 and request_payload.get(request_id) is None:
             request_payload[request_id] = ref_code.to(torch.long).cpu().contiguous()
+            _debug_log("request=%s cached ref_code shape=%s", request_id, tuple(ref_code.shape))
     elif not finished:
+        _debug_log("request=%s no pooling output and not finished; holding", request_id)
         return None
 
     connector = getattr(transfer_manager, "connector", None)
@@ -208,19 +234,37 @@ def talker2code2wav_async_chunk(
         )
         initial_chunk_size = chunk_size
     length = len(transfer_manager.code_prompt_token_ids[request_id])
+    _debug_log(
+        "request=%s evaluating length=%d chunk_size=%d left_context=%d initial_chunk=%d fixed_initial=%s finished=%s",
+        request_id,
+        length,
+        chunk_size,
+        left_context_size_config,
+        initial_chunk_size,
+        fixed_initial_chunk_size,
+        finished,
+    )
 
     if length <= 0:
         if finished:
+            _debug_log("request=%s finished without frames; emitting empty EOF payload", request_id)
             return OmniPayloadStruct(
                 codes=CodesStruct(audio=torch.empty(0, dtype=torch.long)),
                 meta=MetaStruct(finished=torch.tensor(True, dtype=torch.bool)),
             )
+        _debug_log("request=%s has no frames yet; holding", request_id)
         return None
 
     use_first_chunk = initial_chunk_size > 0 and initial_chunk_size < chunk_size
 
     if use_first_chunk and length <= initial_chunk_size:
         if not finished and length < initial_chunk_size:
+            _debug_log(
+                "request=%s holding first chunk; length=%d initial_chunk=%d",
+                request_id,
+                length,
+                initial_chunk_size,
+            )
             return None
         context_length = length if finished and length < initial_chunk_size else initial_chunk_size
     else:
@@ -229,6 +273,13 @@ def talker2code2wav_async_chunk(
         initial_coverage = initial_chunk_size if use_first_chunk else 0
         adjusted = length - initial_coverage
         if not finished and adjusted % chunk_size != 0:
+            _debug_log(
+                "request=%s holding normal chunk; length=%d adjusted=%d chunk_size=%d",
+                request_id,
+                length,
+                adjusted,
+                chunk_size,
+            )
             return None
         chunk_length = adjusted % chunk_size
         context_length = chunk_length if chunk_length != 0 else chunk_size
@@ -254,6 +305,17 @@ def talker2code2wav_async_chunk(
     code_predictor_codes = torch.tensor(
         [window_frames[f][q] for q in range(num_quantizers) for f in range(num_frames)],
         dtype=torch.long,
+    )
+
+    _debug_log(
+        "request=%s emitting chunk frames=%d context_length=%d left_context=%d quantizers=%d finished=%s codes=%d",
+        request_id,
+        num_frames,
+        context_length,
+        left_context_size,
+        num_quantizers,
+        finished,
+        int(code_predictor_codes.numel()),
     )
 
     return OmniPayloadStruct(

--- a/vllm_omni/outputs.py
+++ b/vllm_omni/outputs.py
@@ -48,6 +48,7 @@ class OmniModelRunnerOutput(ModelRunnerOutput):
     """
 
     multimodal_outputs: dict[str, torch.Tensor] | None = None
+    routed_experts_dict: dict[str, Any] | None = None
     # IDs of requests whose KV cache has been extracted from GPU/NPU to CPU.
     # The Scheduler can safely free the block tables for these requests.
     kv_extracted_req_ids: list[str] | None = None
@@ -146,7 +147,7 @@ class OmniRequestOutput:
             stage_id=stage_id,
             final_output_type=final_output_type,
             request_output=request_output,
-            finished=True,
+            finished=bool(getattr(request_output, "finished", True)),
         )
 
     @classmethod

--- a/vllm_omni/request.py
+++ b/vllm_omni/request.py
@@ -1,12 +1,13 @@
 from collections.abc import Callable
 from dataclasses import dataclass
+from inspect import signature
 from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.sampling_params import SamplingParams
-from vllm.v1.request import Request
+from vllm.v1.request import Request as BaseRequest
 
 if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_utils import BlockHash
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
 from vllm_omni.engine import AdditionalInformationPayload, OmniEngineCoreRequest, PromptEmbedsPayload
 
 
-class OmniRequest(Request):
+class OmniRequest(BaseRequest):
     """Request class for omni models, extending the base Request.
 
     This class extends the base vLLM Request with support for prompt
@@ -75,29 +76,34 @@ class OmniRequest(Request):
         Returns:
             OmniRequest instance created from the engine core request
         """
-        return cls(
-            request_id=request.request_id,
+        kwargs = {
+            "request_id": request.request_id,
             # Optional external request ID for tracking
-            external_req_id=request.external_req_id,
-            client_index=request.client_index,
-            prompt_token_ids=request.prompt_token_ids,
-            prompt_embeds=request.prompt_embeds,
-            prompt_is_token_ids=request.prompt_is_token_ids,
-            mm_features=request.mm_features,
-            sampling_params=request.sampling_params,
-            pooling_params=request.pooling_params,
-            arrival_time=request.arrival_time,
-            lora_request=request.lora_request,
-            cache_salt=request.cache_salt,
-            priority=request.priority,
-            trace_headers=request.trace_headers,
-            block_hasher=block_hasher,
-            additional_information=request.additional_information,
-            resumable=request.resumable,
-            reasoning_ended=request.reasoning_ended,
-            reasoning_parser_kwargs=request.reasoning_parser_kwargs,
-            abort_immediately=request.abort_immediately,
-        )
+            "external_req_id": request.external_req_id,
+            "client_index": request.client_index,
+            "prompt_token_ids": request.prompt_token_ids,
+            "prompt_embeds": request.prompt_embeds,
+            "prompt_is_token_ids": getattr(request, "prompt_is_token_ids", None),
+            "mm_features": request.mm_features,
+            "sampling_params": request.sampling_params,
+            "pooling_params": request.pooling_params,
+            "arrival_time": request.arrival_time,
+            "lora_request": request.lora_request,
+            "cache_salt": request.cache_salt,
+            "priority": request.priority,
+            "trace_headers": request.trace_headers,
+            "block_hasher": block_hasher,
+            "additional_information": request.additional_information,
+            "resumable": request.resumable,
+            "reasoning_ended": request.reasoning_ended,
+            "reasoning_parser_kwargs": getattr(request, "reasoning_parser_kwargs", None),
+            "abort_immediately": getattr(request, "abort_immediately", False),
+        }
+        params = set(signature(BaseRequest.__init__).parameters) | {
+            "external_req_id",
+            "additional_information",
+        }
+        return cls(**{key: value for key, value in kwargs.items() if key in params})
 
 
 @dataclass

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -19,18 +19,8 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
 from vllm.distributed.parallel_state import get_pp_group, get_tp_group
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
-from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
-    extract_routed_experts_for_current_batch,
-    get_global_experts_capturer,
-    issue_routing_d2h_copy,
-)
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.outputs import AsyncModelRunnerOutput, make_empty_encoder_model_runner_output
-from vllm.v1.spec_decode.dflash import DFlashProposer
-from vllm.v1.spec_decode.draft_model import DraftModelProposer
-from vllm.v1.spec_decode.eagle import EagleProposer
-from vllm.v1.spec_decode.extract_hidden_states import ExtractHiddenStatesProposer
-from vllm.v1.spec_decode.gemma4 import Gemma4Proposer
 from vllm.v1.structured_output.utils import apply_grammar_bitmask
 from vllm.v1.utils import record_function_or_nullcontext
 from vllm.v1.worker.gpu_model_runner import (
@@ -44,6 +34,18 @@ from vllm.v1.worker.utils import is_residual_scattered_for_sp
 from vllm_omni.data_entry_keys import flatten_payload
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import OmniKVTransferManager
 from vllm_omni.outputs import OmniModelRunnerOutput
+from vllm_omni.worker.routed_experts_compat import (
+    extract_routed_experts_for_current_batch,
+    get_global_experts_capturer,
+    issue_routing_d2h_copy,
+)
+from vllm_omni.worker.spec_decode_compat import (
+    DFlashProposer,
+    DraftModelProposer,
+    EagleProposer,
+    ExtractHiddenStatesProposer,
+    Gemma4Proposer,
+)
 from vllm_omni.utils.mm_outputs import build_mm_cpu, to_payload_element
 from vllm_omni.worker.gpu_model_runner import OmniGPUModelRunner
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
@@ -1054,8 +1056,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 ec_connector_output=ec_connector_output if self.supports_mm_inputs else None,
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
-                routed_experts_dict=routed_experts_dict,
             )
+            output.routed_experts_dict = routed_experts_dict
             output.kv_extracted_req_ids = kv_extracted_req_ids
             output.omni_connector_output = self.get_omni_connector_output()
 

--- a/vllm_omni/worker/gpu_generation_model_runner.py
+++ b/vllm_omni/worker/gpu_generation_model_runner.py
@@ -18,19 +18,9 @@ from vllm.distributed.ec_transfer import get_ec_transfer, has_ec_transfer
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.forward_context import set_forward_context
-from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
-    extract_routed_experts_for_current_batch,
-    get_global_experts_capturer,
-    issue_routing_d2h_copy,
-)
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.outputs import AsyncModelRunnerOutput, make_empty_encoder_model_runner_output
-from vllm.v1.spec_decode.dflash import DFlashProposer
-from vllm.v1.spec_decode.draft_model import DraftModelProposer
-from vllm.v1.spec_decode.eagle import EagleProposer
-from vllm.v1.spec_decode.extract_hidden_states import ExtractHiddenStatesProposer
-from vllm.v1.spec_decode.gemma4 import Gemma4Proposer
 from vllm.v1.utils import record_function_or_nullcontext
 from vllm.v1.worker.gpu_model_runner import (
     EMPTY_MODEL_RUNNER_OUTPUT,
@@ -45,6 +35,18 @@ from vllm_omni.outputs import OmniModelRunnerOutput
 from vllm_omni.worker.gpu_ar_model_runner import ExecuteModelState
 from vllm_omni.worker.gpu_model_runner import OmniGPUModelRunner
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
+from vllm_omni.worker.routed_experts_compat import (
+    extract_routed_experts_for_current_batch,
+    get_global_experts_capturer,
+    issue_routing_d2h_copy,
+)
+from vllm_omni.worker.spec_decode_compat import (
+    DFlashProposer,
+    DraftModelProposer,
+    EagleProposer,
+    ExtractHiddenStatesProposer,
+    Gemma4Proposer,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -473,8 +475,8 @@ class GPUGenerationModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin
             num_nans_in_logits={},
             cudagraph_stats=cudagraph_stats,
             ec_connector_output=ec_connector_output if self.supports_mm_inputs else None,
-            routed_experts_dict=routed_experts_dict,
         )
+        output.routed_experts_dict = routed_experts_dict
         output.omni_connector_output = self.get_omni_connector_output()
 
         if not self.use_async_scheduling:

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -15,11 +15,6 @@ from vllm.sampling_params import SamplingType
 from vllm.tracing import instrument
 from vllm.utils.import_utils import LazyLoader
 from vllm.utils.math_utils import cdiv
-from vllm.v1.spec_decode.dflash import DFlashProposer
-from vllm.v1.spec_decode.draft_model import DraftModelProposer
-from vllm.v1.spec_decode.eagle import EagleProposer
-from vllm.v1.spec_decode.extract_hidden_states import ExtractHiddenStatesProposer
-from vllm.v1.spec_decode.gemma4 import Gemma4Proposer
 from vllm.v1.spec_decode.ngram_proposer_gpu import (
     update_ngram_gpu_tensors_incremental,
     update_scheduler_for_invalid_drafts,
@@ -32,6 +27,13 @@ from vllm_omni.core.prefix_cache import OmniTensorPrefixCache
 from vllm_omni.engine.serialization import deserialize_additional_information
 from vllm_omni.model_executor.layers.rotary_embedding.mrope import OmniMRotaryEmbedding as MRotaryEmbedding
 from vllm_omni.model_executor.models.output_templates import OmniOutput
+from vllm_omni.worker.spec_decode_compat import (
+    DFlashProposer,
+    DraftModelProposer,
+    EagleProposer,
+    ExtractHiddenStatesProposer,
+    Gemma4Proposer,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput

--- a/vllm_omni/worker/routed_experts_compat.py
+++ b/vllm_omni/worker/routed_experts_compat.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+try:
+    from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
+        extract_routed_experts_for_current_batch,
+        get_global_experts_capturer,
+        issue_routing_d2h_copy,
+    )
+except ImportError:
+
+    def get_global_experts_capturer() -> Any | None:
+        return None
+
+    def issue_routing_d2h_copy(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    def extract_routed_experts_for_current_batch(*args: Any, **kwargs: Any) -> None:
+        return None

--- a/vllm_omni/worker/spec_decode_compat.py
+++ b/vllm_omni/worker/spec_decode_compat.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from vllm.v1.spec_decode.dflash import DFlashProposer
+from vllm.v1.spec_decode.draft_model import DraftModelProposer
+from vllm.v1.spec_decode.eagle import EagleProposer
+from vllm.v1.spec_decode.extract_hidden_states import ExtractHiddenStatesProposer
+
+try:
+    from vllm.v1.spec_decode.gemma4 import Gemma4Proposer
+except ImportError:
+
+    class Gemma4Proposer:
+        """Compatibility placeholder for vLLM wheels without Gemma 4 proposer."""
+
+        pass


### PR DESCRIPTION
## Summary\n- gate POSIX fcntl usage and add Windows msvcrt file locks\n- use temp-directory lock files on Windows instead of /dev/shm and /tmp\n- avoid registering process sentinel handles in zmq.Poller on Windows\n- use WindowsSelectorEventLoopPolicy for pyzmq async sockets in the orchestrator thread\n- apply the same sentinel polling fix to diffusion stage handshake code\n\n## Validation\n- C:\\tmp\\vllmvenv\\Scripts\\python.exe -m py_compile vllm_omni\\distributed\\omni_connectors\\connectors\\shm_connector.py vllm_omni\\engine\\stage_engine_core_proc.py vllm_omni\\engine\\async_omni_engine.py vllm_omni\\diffusion\\stage_diffusion_proc.py vllm_omni\\engine\\stage_init_utils.py\n- Direct source import against the local installed vLLM wheel is currently blocked by a main-branch API mismatch around split_routed_experts; this needs matched source-build CI coverage.\n\n## Context\nThese changes mirror the runtime shims that allowed Qwen/Qwen2.5-Omni-3B to initialize all three native Windows stages and complete embedded text plus text-to-audio generation without an HTTP server.