### PR TITLE
[Doc] Simplify template example subtitle

### DIFF
--- a/recipes/TEMPLATE.md
+++ b/recipes/TEMPLATE.md
@@ -1,6 +1,6 @@
 # Recipe Title
 
-> Example: Qwen3-Omni for speech chat on 1x A100 80GB
+> Example: Qwen3-Omni for speech chat
 
 ## Summary
 


### PR DESCRIPTION
## Summary
- Removed hardware-specific detail ("on 1x A100 80GB") from the example subtitle in `recipes/TEMPLATE.md` to keep the template example generic.

## Test plan
- Visual inspection of the markdown file

🤖 Generated with [Claude Code](https://claude.com/claude-code)