### PR TITLE
[Bugfix][Qwen3-Omni] Handle short Code2Wav chunk outputs

### DIFF
--- a/tests/model_executor/models/qwen3_tts/test_cuda_graph_decoder.py
+++ b/tests/model_executor/models/qwen3_tts/test_cuda_graph_decoder.py
@@ -74,6 +74,14 @@ class SyntheticDecoder(nn.Module):
         return self.out(x).clamp(min=-1, max=1)
 
 
+class ShortOutputDecoder(SyntheticDecoder):
+    """Decoder variant that returns fewer samples than seq_len * total_upsample."""
+
+    def forward(self, codes):
+        out = super().forward(codes)
+        return out[..., :-5] if out.shape[-1] > 5 else out
+
+
 @pytest.fixture(scope="module")
 def decoder():
     """Create a synthetic decoder on CUDA with fixed weights."""
@@ -226,6 +234,35 @@ def test_chunked_decode_output_survives_later_replay(wrapper):
         _ = wrapper.decode(overwrite_codes)
 
     torch.testing.assert_close(graph_out, expected, atol=0, rtol=0)
+
+
+def test_chunked_decode_preserves_short_chunk_concat_semantics():
+    """Chunked decode must allow shorter-than-nominal chunk outputs.
+
+    Qwen3-Omni non-async startup can hit a decoder path where a chunk returns
+    fewer waveform samples than ``code_len * total_upsample``. The wrapper must
+    preserve the original eager concat behavior instead of copying into exact
+    nominal slices.
+    """
+    torch.manual_seed(123)
+    short_decoder = ShortOutputDecoder().to(DEVICE).eval()
+    short_wrapper = CUDAGraphDecoderWrapper(
+        decoder=short_decoder,
+        capture_sizes=[50],
+        capture_batch_sizes=[1],
+        num_quantizers=NUM_QUANTIZERS,
+        enabled=True,
+    )
+    short_wrapper.warmup(DEVICE)
+    codes = _random_codes(100)
+
+    with torch.no_grad():
+        eager_out = _eager_chunked(short_decoder, codes, chunk_size=50, left_context_size=0)
+        graph_out = short_wrapper.chunked_decode_with_cudagraph(codes, chunk_size=50, left_context_size=0)
+
+    assert graph_out.shape == eager_out.shape
+    assert graph_out.shape[-1] < 100 * TOTAL_UPSAMPLE
+    torch.testing.assert_close(graph_out, eager_out, atol=0, rtol=0)
 
 
 def test_batched_chunked_decode_variable_lengths_matches_per_request_eager(decoder, wrapper):

--- a/vllm_omni/model_executor/models/qwen3_tts/cuda_graph_decoder_wrapper.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/cuda_graph_decoder_wrapper.py
@@ -554,10 +554,10 @@ class CUDAGraphDecoderWrapper:
         chunk_size: int = 300,
         left_context_size: int = 25,
     ) -> torch.Tensor:
+        wavs = []
         start_index = 0
         total_len = codes.shape[-1]
         total_upsample = self.decoder.total_upsample
-        wav_out = None
 
         while start_index < total_len:
             end_index = min(start_index + chunk_size, total_len)
@@ -566,21 +566,16 @@ class CUDAGraphDecoderWrapper:
             codes_chunk = codes[..., start_index - context_size : end_index]
             wav_chunk = self._decode(codes_chunk, clone_graph_output=False)
 
-            if wav_out is None:
-                wav_out = torch.empty(
-                    (*wav_chunk.shape[:-1], total_len * total_upsample),
-                    dtype=wav_chunk.dtype,
-                    device=wav_chunk.device,
-                )
-            src_start = context_size * total_upsample
-            dst_start = start_index * total_upsample
-            dst_end = end_index * total_upsample
-            wav_out[..., dst_start:dst_end].copy_(wav_chunk[..., src_start:])
+            # Keep origin/main's concat semantics: Qwen3-Omni can return a chunk
+            # that is shorter than the nominal code_len * total_upsample length.
+            # Clone each slice because graph outputs are static buffers that later
+            # replays may overwrite.
+            wavs.append(wav_chunk[..., context_size * total_upsample :].clone())
             start_index = end_index
 
-        if wav_out is None:
+        if not wavs:
             return self.decoder(codes)
-        return wav_out
+        return torch.cat(wavs, dim=-1)
 
     def batched_chunked_decode_with_cudagraph(
         self,


### PR DESCRIPTION
## Summary
- restore concat-style chunked decode semantics in `CUDAGraphDecoderWrapper` so shorter-than-nominal Code2Wav chunk outputs are accepted
- keep cloned chunk slices so CUDA graph static output buffers are not aliased by later replays
- add a CUDA regression test covering shorter-than-nominal chunk output

Fixes #3682

## Root Cause
#3662 switched chunked decode to preallocate `code_len * total_upsample` samples and copy each chunk into exact slices. Qwen3-Omni no-async can return a shorter final Code2Wav chunk, so that exact-size copy hit a shape mismatch.

## Compatibility
- The nominal Qwen3-TTS and Qwen3-Omni async chunk paths should keep the same waveform semantics: each decoded chunk is trimmed for left context and concatenated, matching the eager decoder path.
- This only removes the preallocated-copy assumption that every chunk output is exactly `code_len * total_upsample`; it does not change the batched chunked decode path.

## Verification
- `ruff format --check vllm_omni/model_executor/models/qwen3_tts/cuda_graph_decoder_wrapper.py tests/model_executor/models/qwen3_tts/test_cuda_graph_decoder.py`
- `ruff check vllm_omni/model_executor/models/qwen3_tts/cuda_graph_decoder_wrapper.py tests/model_executor/models/qwen3_tts/test_cuda_graph_decoder.py`
- `python3 -m py_compile vllm_omni/model_executor/models/qwen3_tts/cuda_graph_decoder_wrapper.py tests/model_executor/models/qwen3_tts/test_cuda_graph_decoder.py`
- Remote H20 CUDA test: `CUDA_VISIBLE_DEVICES=0 python3 -m pytest tests/model_executor/models/qwen3_tts/test_cuda_graph_decoder.py -q` (`46 passed`)
- Remote Qwen3-Omni E2E smoke with `--no-async-chunk`: server reached `Stage 2 engine startup completed` and `Application startup complete`; a text+audio streaming request succeeded and saved `audio_chatcmpl-ad17b1533310c107_0.wav`; no `RuntimeError` or `7680/7125` size mismatch was found in the server log.
