### PR TITLE
[Bugfix] video stream: emit all audio delta chunks in DELTA mode

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_video_stream.py
+++ b/tests/entrypoints/openai_api/test_serving_video_stream.py
@@ -699,3 +699,28 @@ def test_delta_fast_emits_every_call_under_delta_mode(monkeypatch):
     )
     # Same input size after the first call → identical encoded length.
     assert len({len(b) for b in emitted_b64[1:]}) == 1, "post-first-call chunks should have identical encoded length"
+
+
+def test_delta_slow_emits_every_call_under_delta_mode(monkeypatch):
+    """Multi-step assertion that DELTA-mode single-tensor branch in _delta_slow
+    emits b64 on every call — mirrors the _delta_fast regression test."""
+    monkeypatch.setenv("VLLM_VIDEO_AUDIO_DELTA_MODE", "slow")
+
+    sample_count = _CODEC_FRAME_SAMPLES * 4
+
+    chunks_drained = 0
+    emitted_b64: list[str] = []
+    for step in range(5):
+        result = _audio_result(_fake_delta_tensor(sample_count))
+        b64, chunks_drained = OmniStreamingVideoHandler._extract_audio_delta_b64(result, chunks_drained)
+        assert b64 is not None, f"step={step} produced None (truncation bug)"
+        assert isinstance(b64, str) and b64, f"step={step} produced empty b64"
+        emitted_b64.append(b64)
+
+    assert chunks_drained == 5
+
+    # First call strips _CODEC_FRAME_SAMPLES of head transient
+    assert len(emitted_b64[0]) < len(emitted_b64[1]), (
+        "first call should emit a shorter chunk due to head-transient strip"
+    )
+    assert len({len(b) for b in emitted_b64[1:]}) == 1, "post-first-call chunks should have identical encoded length"

--- a/tests/entrypoints/openai_api/test_serving_video_stream.py
+++ b/tests/entrypoints/openai_api/test_serving_video_stream.py
@@ -12,10 +12,12 @@ import threading
 from typing import Any
 
 import pytest
+import torch
 from PIL import Image
 
 from vllm_omni.entrypoints.openai import serving_video_stream, video_stream_envs
 from vllm_omni.entrypoints.openai.serving_video_stream import (
+    _CODEC_FRAME_SAMPLES,
     OmniStreamingVideoHandler,
     StreamingVideoSessionConfig,
 )
@@ -648,3 +650,52 @@ def test_build_messages_keeps_recent_history_text_only():
     assert messages[1] == {"role": "assistant", "content": "recent answer"}
     assert messages[2] == user_message
     assert user_message["content"][-1] == {"type": "text", "text": "current question"}
+
+
+# ---------------------------------------------------------------------------
+# Regression: audio delta truncation under DELTA mode.
+#
+# In DELTA mode the MultimodalOutputProcessor pops mm_accumulated["audio"]
+# on every emit, so OmniRequestOutput.audio_data is a *single fresh tensor*
+# every step, not a growing list. The pre-fix _delta_fast had a
+# `if chunks_drained >= 1: return None` sentinel carried over from
+# CUMULATIVE-mode logic, which silently dropped every audio chunk after
+# the first. These tests pin _delta_fast's single-tensor branch.
+# ---------------------------------------------------------------------------
+
+
+def _fake_delta_tensor(num_samples: int) -> torch.Tensor:
+    """One step's worth of audio samples, shaped like talker output."""
+    return torch.linspace(-0.5, 0.5, steps=num_samples, dtype=torch.float32)
+
+
+def test_delta_fast_emits_every_call_under_delta_mode(monkeypatch):
+    """Multi-step assertion that DELTA-mode single-tensor branch emits b64
+    on every call — the exact truncation this PR fixes."""
+    monkeypatch.setenv("VLLM_VIDEO_AUDIO_DELTA_MODE", "fast")
+
+    # Enough samples so the first-call head-transient strip leaves a
+    # non-empty tail (_encode_tail strips _CODEC_FRAME_SAMPLES when
+    # len(tail) > 2 * _CODEC_FRAME_SAMPLES).
+    sample_count = _CODEC_FRAME_SAMPLES * 4
+
+    chunks_drained = 0
+    emitted_b64: list[str] = []
+    for step in range(5):
+        # DELTA mode: each step we get a fresh single tensor, not a list.
+        result = _audio_result(_fake_delta_tensor(sample_count))
+        b64, chunks_drained = OmniStreamingVideoHandler._extract_audio_delta_b64(result, chunks_drained)
+        assert b64 is not None, f"step={step} produced None (truncation bug)"
+        assert isinstance(b64, str) and b64, f"step={step} produced empty b64"
+        emitted_b64.append(b64)
+
+    # Counter advances monotonically, one per call.
+    assert chunks_drained == 5
+
+    # First call strips _CODEC_FRAME_SAMPLES of head transient, so its
+    # encoded payload is strictly shorter than subsequent ones.
+    assert len(emitted_b64[0]) < len(emitted_b64[1]), (
+        "first call should emit a shorter chunk due to head-transient strip"
+    )
+    # Same input size after the first call → identical encoded length.
+    assert len({len(b) for b in emitted_b64[1:]}) == 1, "post-first-call chunks should have identical encoded length"

--- a/vllm_omni/entrypoints/openai/serving_video_stream.py
+++ b/vllm_omni/entrypoints/openai/serving_video_stream.py
@@ -838,14 +838,24 @@ class OmniStreamingVideoHandler:
         chunks_drained: int,
     ) -> tuple[str | None, int]:
         """Pre-fix behaviour: concat everything each call and slice on CPU."""
-        if isinstance(audio_data, list):
-            if not audio_data:
+        # In DELTA mode the output processor pops the modality key after
+        # every emit, so audio_data is a *single fresh tensor* on every step.
+        # Encode the entire tensor unconditionally and advance chunks_drained.
+        if not isinstance(audio_data, list):
+            full_np = cls._tensor_to_1d_np(audio_data)
+            if full_np is None:
                 return None, chunks_drained
-            audio_tensor = torch.cat(audio_data, dim=-1)
-            new_drained = len(audio_data)
-        else:
-            audio_tensor = audio_data
-            new_drained = 1
+            return cls._encode_tail(
+                full_np,
+                chunks_drained,
+                new_drained=chunks_drained + 1,
+                is_first=(chunks_drained == 0),
+            )
+
+        if not audio_data:
+            return None, chunks_drained
+        audio_tensor = torch.cat(audio_data, dim=-1)
+        new_drained = len(audio_data)
 
         full_np = cls._tensor_to_1d_np(audio_tensor)
         if full_np is None:
@@ -861,7 +871,7 @@ class OmniStreamingVideoHandler:
             # Recover prefix length by re-concatenating the already-drained
             # prefix tensors (cost intentionally identical to the baseline
             # implementation this was lifted from).
-            if isinstance(audio_data, list) and chunks_drained < len(audio_data):
+            if chunks_drained < len(audio_data):
                 prefix_len = sum(int(t.shape[-1]) for t in audio_data[:chunks_drained])
                 tail_np = full_np[prefix_len:]
             else:

--- a/vllm_omni/entrypoints/openai/serving_video_stream.py
+++ b/vllm_omni/entrypoints/openai/serving_video_stream.py
@@ -807,14 +807,20 @@ class OmniStreamingVideoHandler:
         audio_data,
         chunks_drained: int,
     ) -> tuple[str | None, int]:
-        """Emit only tensors appended since the last call."""
-        # Single tensor: output_processor hands us one tensor before it becomes a
-        # list (see output_processor.py:89). Treat it as chunk #0.
+        # In DELTA mode the output processor pops the modality key after
+        # every emit (output_processor.py: _new_completion_output), so the
+        # single-tensor form is what we see on every step — not just the
+        # first one. We must encode every call and let chunks_drained grow
+        # monotonically; the previous `chunks_drained >= 1` guard caused
+        # all chunks after the first to be silently dropped.
         if not isinstance(audio_data, list):
-            if chunks_drained >= 1:
-                return None, chunks_drained
             tail_np = cls._tensor_to_1d_np(audio_data)
-            return cls._encode_tail(tail_np, chunks_drained, new_drained=1, is_first=True)
+            return cls._encode_tail(
+                tail_np,
+                chunks_drained,
+                new_drained=chunks_drained + 1,
+                is_first=(chunks_drained == 0),
+            )
 
         n = len(audio_data)
         if n <= chunks_drained:


### PR DESCRIPTION

## Purpose

`_delta_fast` previously only emitted the very first audio segment when
`OmniRequestOutput.multimodal_output["audio"]` was a single tensor.
The guard `if chunks_drained >= 1: return None` assumed the single-tensor
form would only appear once and then upgrade to a list, but in DELTA mode
`MultimodalOutputProcessor` pops the modality key after every emit, so
the single-tensor form is what `serving_video_stream` sees on every step.
The sentinel therefore dropped every chunk after the first.

This PR encodes every call in the single-tensor branch and treats
`chunks_drained` as a monotonic emit counter. The `is_first` flag is kept
so that the CausalConv leading artifact is only trimmed from the first
segment.

Fixes silent truncation of streamed speech in `serving_video_stream` when
`VLLM_VIDEO_ASYNC_CHUNK=on` (default) and `VLLM_VIDEO_AUDIO_DELTA_MODE=fast`
(default).

Affected code paths:
- `vllm_omni/entrypoints/openai/serving_video_stream.py::_delta_fast`
  single-tensor branch — replace the `chunks_drained >= 1` early return
  with `new_drained=chunks_drained + 1`, `is_first=(chunks_drained == 0)`.

No public API or env-var change. Default behavior only — DELTA-mode
streaming users get the rest of the audio back.

## Test Plan

Added one regression test pinning the single-tensor branch:

- `tests/entrypoints/openai_api/test_serving_video_stream.py::test_delta_fast_emits_every_call_under_delta_mode`

What it pins:
1. Calling `_extract_audio_delta_b64` 5 times in a row with a fresh
   single tensor each step (mirroring DELTA mode's pop-per-emit shape)
   must produce a non-empty base64 string on **every** call — this is
   the exact regression: the old `chunks_drained >= 1` sentinel returned
   `None` on calls 2..N.
2. `chunks_drained` advances monotonically (one per call, ending at 5).
3. The first emitted chunk is strictly shorter than the second, because
   `_encode_tail` strips `_CODEC_FRAME_SAMPLES` of CausalConv head
   transient only when `is_first=True`. This pins the `is_first` wiring
   so a future refactor can't silently regress it back to "always trim"
   or "never trim".

## Test Result

E2E sanity (manual, DELTA-fast default config, single video query
streaming a multi-second TTS reply):
- Before fix: client receives only the first ~80 ms of audio, then
  silence until end-of-stream.
- After fix: full reply audio is streamed, chunk count matches the
  number of talker steps observed in the engine log.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
