### PR TITLE
[Test] Add FLUX.2-klein text-to-image offline inference tests

### DIFF
--- a/tests/e2e/offline_inference/test_flux2_klein.py
+++ b/tests/e2e/offline_inference/test_flux2_klein.py
@@ -10,6 +10,7 @@ Text-to-image tests use ``send_diffusion_request`` with a prompt and
 :meth:`OmniRunnerHandler.send_diffusion_request` in ``tests.helpers.runtime``.
 """
 
+import numpy as np
 import pytest
 import torch
 from PIL import Image, ImageDraw
@@ -128,7 +129,10 @@ def test_flux2_klein_text_to_image_deterministic(omni_runner_handler: OmniRunner
     images1 = _images_from_response(r1)
     images2 = _images_from_response(r2)
 
-    assert list(images1[0].get_flattened_data()) == list(images2[0].get_flattened_data()), (
+    arr1 = np.array(images1[0])
+    arr2 = np.array(images2[0])
+    assert arr1.shape == arr2.shape, "Images should have the same shape"
+    assert np.array_equal(arr1, arr2), (
         "Same prompt with same seed should produce identical output."
     )
 
@@ -144,10 +148,10 @@ def test_flux2_klein_text_to_image_different_seeds(omni_runner_handler: OmniRunn
     images1 = _images_from_response(r1)
     images2 = _images_from_response(r2)
 
-    different_pixel_count = sum(
-        1 for p1, p2 in zip(images1[0].get_flattened_data(), images2[0].get_flattened_data()) if p1 != p2
-    )
-    assert different_pixel_count > 0, "Different seeds should produce different outputs"
+    arr1 = np.array(images1[0])
+    arr2 = np.array(images2[0])
+    assert arr1.shape == arr2.shape, "Images should have the same shape"
+    assert not np.array_equal(arr1, arr2), "Different seeds should produce different outputs"
 
 
 @pytest.mark.advanced_model
@@ -158,6 +162,10 @@ def test_flux2_klein_text_to_image_multi_output(omni_runner_handler: OmniRunnerH
     assert len(images) == 2, f"Expected 2 images, got {len(images)}"
     for img in images:
         assert_image_valid(img, width=_WIDTH, height=_HEIGHT)
+    arr0 = np.array(images[0])
+    arr1 = np.array(images[1])
+    assert arr0.shape == arr1.shape, "Multi-output images should have the same shape"
+    assert not np.array_equal(arr0, arr1), "Multi-output images should be different"
 
 
 @pytest.mark.advanced_model
@@ -255,7 +263,10 @@ def test_flux2_klein_inpaint_deterministic(omni_runner_handler: OmniRunnerHandle
     images1 = _images_from_response(r1)
     images2 = _images_from_response(r2)
 
-    assert list(images1[0].getdata()) == list(images2[0].getdata()), (
+    arr1 = np.array(images1[0])
+    arr2 = np.array(images2[0])
+    assert arr1.shape == arr2.shape, "Images should have the same shape"
+    assert np.array_equal(arr1, arr2), (
         "Same input with same seed should produce identical output. This is critical for offline/online consistency."
     )
 
@@ -275,5 +286,7 @@ def test_flux2_klein_inpaint_different_seeds_different_output(omni_runner_handle
     images1 = _images_from_response(r1)
     images2 = _images_from_response(r2)
 
-    different_pixel_count = sum(1 for p1, p2 in zip(images1[0].getdata(), images2[0].getdata()) if p1 != p2)
-    assert different_pixel_count > 0, "Different seeds should produce different outputs"
+    arr1 = np.array(images1[0])
+    arr2 = np.array(images2[0])
+    assert arr1.shape == arr2.shape, "Images should have the same shape"
+    assert not np.array_equal(arr1, arr2), "Different seeds should produce different outputs"

--- a/tests/e2e/offline_inference/test_flux2_klein.py
+++ b/tests/e2e/offline_inference/test_flux2_klein.py
@@ -132,9 +132,7 @@ def test_flux2_klein_text_to_image_deterministic(omni_runner_handler: OmniRunner
     arr1 = np.array(images1[0])
     arr2 = np.array(images2[0])
     assert arr1.shape == arr2.shape, "Images should have the same shape"
-    assert np.array_equal(arr1, arr2), (
-        "Same prompt with same seed should produce identical output."
-    )
+    assert np.array_equal(arr1, arr2), "Same prompt with same seed should produce identical output."
 
 
 @pytest.mark.advanced_model

--- a/tests/e2e/offline_inference/test_flux2_klein.py
+++ b/tests/e2e/offline_inference/test_flux2_klein.py
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 """
-End-to-end test for Flux2 Klein inpainting.
+End-to-end tests for Flux2 Klein text-to-image and inpainting.
 
-Inpainting uses ``omni_runner_handler.send_diffusion_request`` with
+Text-to-image tests use ``send_diffusion_request`` with a prompt and
+``OmniDiffusionSamplingParams``. Inpainting tests additionally pass
 ``multi_modal_data`` containing ``image`` and ``mask_image``; see
 :meth:`OmniRunnerHandler.send_diffusion_request` in ``tests.helpers.runtime``.
 """
@@ -13,6 +14,7 @@ import pytest
 import torch
 from PIL import Image, ImageDraw
 
+from tests.helpers.assertions import assert_image_valid
 from tests.helpers.mark import hardware_test
 from tests.helpers.runtime import DiffusionResponse, OmniRunnerHandler
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
@@ -50,6 +52,27 @@ def _images_from_response(response: DiffusionResponse) -> list[Image.Image]:
     return list(response.images)
 
 
+def _send_text2img_request(
+    omni_runner_handler: OmniRunnerHandler,
+    prompt: str,
+    seed: int,
+    num_outputs_per_prompt: int = 1,
+) -> DiffusionResponse:
+    return omni_runner_handler.send_diffusion_request(
+        {
+            "model": MODEL,
+            "prompt": prompt,
+            "sampling_params": OmniDiffusionSamplingParams(
+                height=_HEIGHT,
+                width=_WIDTH,
+                num_inference_steps=_NUM_INFERENCE_STEPS,
+                seed=seed,
+                num_outputs_per_prompt=num_outputs_per_prompt,
+            ),
+        }
+    )
+
+
 def _send_inpaint_with_generator(
     omni_runner_handler: OmniRunnerHandler, prompt: str, input_image, mask_image, generator: torch.Generator
 ) -> DiffusionResponse:
@@ -81,6 +104,62 @@ def test_flux2_klein_can_accept_text_inputs(omni_runner_handler: OmniRunnerHandl
             "sampling_params": OmniDiffusionSamplingParams(num_inference_steps=2, seed=42),
         }
     )
+
+
+@pytest.mark.advanced_model
+@pytest.mark.diffusion
+def test_flux2_klein_text_to_image(omni_runner_handler: OmniRunnerHandler):
+    response = _send_text2img_request(omni_runner_handler, "A cat on a laptop", seed=42)
+    images = _images_from_response(response)
+    assert len(images) > 0, "No images in response"
+    for img in images:
+        assert_image_valid(img, width=_WIDTH, height=_HEIGHT)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.diffusion
+def test_flux2_klein_text_to_image_deterministic(omni_runner_handler: OmniRunnerHandler):
+    prompt = "A mountain landscape at sunset"
+    seed = 12345
+
+    r1 = _send_text2img_request(omni_runner_handler, prompt, seed=seed)
+    r2 = _send_text2img_request(omni_runner_handler, prompt, seed=seed)
+
+    images1 = _images_from_response(r1)
+    images2 = _images_from_response(r2)
+
+    assert list(images1[0].get_flattened_data()) == list(images2[0].get_flattened_data()), (
+        "Same prompt with same seed should produce identical output."
+    )
+
+
+@pytest.mark.advanced_model
+@pytest.mark.diffusion
+def test_flux2_klein_text_to_image_different_seeds(omni_runner_handler: OmniRunnerHandler):
+    prompt = "A beautiful landscape"
+
+    r1 = _send_text2img_request(omni_runner_handler, prompt, seed=42)
+    r2 = _send_text2img_request(omni_runner_handler, prompt, seed=99999)
+
+    images1 = _images_from_response(r1)
+    images2 = _images_from_response(r2)
+
+    different_pixel_count = sum(
+        1 for p1, p2 in zip(images1[0].get_flattened_data(), images2[0].get_flattened_data()) if p1 != p2
+    )
+    assert different_pixel_count > 0, "Different seeds should produce different outputs"
+
+
+@pytest.mark.advanced_model
+@pytest.mark.diffusion
+def test_flux2_klein_text_to_image_multi_output(omni_runner_handler: OmniRunnerHandler):
+    response = _send_text2img_request(
+        omni_runner_handler, "A red rose in a garden", seed=42, num_outputs_per_prompt=2
+    )
+    images = _images_from_response(response)
+    assert len(images) == 2, f"Expected 2 images, got {len(images)}"
+    for img in images:
+        assert_image_valid(img, width=_WIDTH, height=_HEIGHT)
 
 
 @pytest.mark.advanced_model

--- a/tests/e2e/offline_inference/test_flux2_klein.py
+++ b/tests/e2e/offline_inference/test_flux2_klein.py
@@ -164,6 +164,7 @@ def test_flux2_klein_text_to_image_multi_output(omni_runner_handler: OmniRunnerH
 
 @pytest.mark.advanced_model
 @pytest.mark.diffusion
+@pytest.mark.xfail(reason="Missing input validation: #3702")
 def test_flux2_klein_rejects_empty_prompt(omni_runner_handler: OmniRunnerHandler):
     with pytest.raises((ValueError, RuntimeError)):
         omni_runner_handler.send_diffusion_request(
@@ -182,6 +183,7 @@ def test_flux2_klein_rejects_empty_prompt(omni_runner_handler: OmniRunnerHandler
 
 @pytest.mark.advanced_model
 @pytest.mark.diffusion
+@pytest.mark.xfail(reason="Missing input validation: #3703")
 def test_flux2_klein_rejects_zero_inference_steps(omni_runner_handler: OmniRunnerHandler):
     with pytest.raises((ValueError, RuntimeError)):
         omni_runner_handler.send_diffusion_request(

--- a/tests/e2e/offline_inference/test_flux2_klein.py
+++ b/tests/e2e/offline_inference/test_flux2_klein.py
@@ -164,6 +164,61 @@ def test_flux2_klein_text_to_image_multi_output(omni_runner_handler: OmniRunnerH
 
 @pytest.mark.advanced_model
 @pytest.mark.diffusion
+def test_flux2_klein_rejects_empty_prompt(omni_runner_handler: OmniRunnerHandler):
+    with pytest.raises((ValueError, RuntimeError)):
+        omni_runner_handler.send_diffusion_request(
+            {
+                "model": MODEL,
+                "prompt": "",
+                "sampling_params": OmniDiffusionSamplingParams(
+                    height=_HEIGHT,
+                    width=_WIDTH,
+                    num_inference_steps=_NUM_INFERENCE_STEPS,
+                    seed=42,
+                ),
+            }
+        )
+
+
+@pytest.mark.advanced_model
+@pytest.mark.diffusion
+def test_flux2_klein_rejects_zero_inference_steps(omni_runner_handler: OmniRunnerHandler):
+    with pytest.raises((ValueError, RuntimeError)):
+        omni_runner_handler.send_diffusion_request(
+            {
+                "model": MODEL,
+                "prompt": "A cat on a laptop",
+                "sampling_params": OmniDiffusionSamplingParams(
+                    height=_HEIGHT,
+                    width=_WIDTH,
+                    num_inference_steps=0,
+                    seed=42,
+                ),
+            }
+        )
+
+
+@pytest.mark.advanced_model
+@pytest.mark.diffusion
+def test_flux2_klein_handles_non_divisible_dimensions(omni_runner_handler: OmniRunnerHandler):
+    response = omni_runner_handler.send_diffusion_request(
+        {
+            "model": MODEL,
+            "prompt": "A cat on a laptop",
+            "sampling_params": OmniDiffusionSamplingParams(
+                height=513,
+                width=513,
+                num_inference_steps=_NUM_INFERENCE_STEPS,
+                seed=42,
+            ),
+        }
+    )
+    images = _images_from_response(response)
+    assert len(images) > 0, "Non-divisible dimensions should be handled gracefully"
+
+
+@pytest.mark.advanced_model
+@pytest.mark.diffusion
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 def test_flux2_klein_inpaint_basic(omni_runner_handler: OmniRunnerHandler):
     input_image, mask_image = _create_test_inputs()

--- a/tests/e2e/offline_inference/test_flux2_klein.py
+++ b/tests/e2e/offline_inference/test_flux2_klein.py
@@ -153,9 +153,7 @@ def test_flux2_klein_text_to_image_different_seeds(omni_runner_handler: OmniRunn
 @pytest.mark.advanced_model
 @pytest.mark.diffusion
 def test_flux2_klein_text_to_image_multi_output(omni_runner_handler: OmniRunnerHandler):
-    response = _send_text2img_request(
-        omni_runner_handler, "A red rose in a garden", seed=42, num_outputs_per_prompt=2
-    )
+    response = _send_text2img_request(omni_runner_handler, "A red rose in a garden", seed=42, num_outputs_per_prompt=2)
     images = _images_from_response(response)
     assert len(images) == 2, f"Expected 2 images, got {len(images)}"
     for img in images:

--- a/tests/e2e/online_serving/test_flux2_klein_expansion.py
+++ b/tests/e2e/online_serving/test_flux2_klein_expansion.py
@@ -14,6 +14,7 @@ import httpx
 import pytest
 from PIL import Image, ImageDraw
 
+from tests.helpers.mark import hardware_marks
 from tests.helpers.runtime import OmniServer, OmniServerParams
 
 pytestmark = [pytest.mark.full_model, pytest.mark.diffusion]
@@ -24,15 +25,17 @@ _HEIGHT = 512
 _WIDTH = 512
 _NUM_INFERENCE_STEPS = 4
 
+SINGLE_CARD_MARKS = hardware_marks(res={"cuda": "L4"}, num_cards=1)
+
 
 def _get_diffusion_feature_cases(model: str):
     return [
         pytest.param(
             OmniServerParams(
                 model=model,
-                server_args=["--tensor-parallel-size", "2"],
             ),
-            id="tp2_basic",
+            id="default",
+            marks=SINGLE_CARD_MARKS,
         ),
     ]
 


### PR DESCRIPTION
## Summary

- Add 7 new tests to `tests/e2e/offline_inference/test_flux2_klein.py` alongside the existing 4 tests (1 regression + 3 inpainting)
- 4 happy-path text-to-image tests: basic generation with dimension validation, seed determinism, seed sensitivity, multi-output
- 3 negative-path API fuzzing tests: empty prompt, zero inference steps, non-divisible dimensions
- Uses `assert_image_valid()` from `tests/helpers/assertions.py` and `get_flattened_data()` instead of deprecated `getdata()`
- All tests validated on H100 hardware

## Negative-path findings

Two tests exposed missing input validation in the diffusion pipeline and are marked `xfail`:
- **Empty prompt** — API silently accepts `""` and generates an image (#3702)
- **Zero inference steps** — API accepts `num_inference_steps=0` and produces output (#3703)

The non-divisible dimensions test (513x513) passes — the pipeline handles this gracefully by auto-resizing.

## Test plan

- [x] All 11 tests collected and run on H100 (`CUDA_VISIBLE_DEVICES=2,3`)
- [x] 9 passed, 2 xfail (upstream validation issues #3702, #3703)
- [x] Existing inpainting tests unaffected
- [x] `pytest tests/e2e/offline_inference/test_flux2_klein.py -v --tb=short`