### PR TITLE
tests: add Qwen3-TTS offline inference tests (happy + negative path)

### DIFF
--- a/tests/e2e/offline_inference/test_qwen3_tts_base.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_base.py
@@ -116,16 +116,16 @@ def test_base_voice_clone_special_characters(omni_runner, omni_runner_handler) -
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-def test_base_voice_clone_with_typos(omni_runner, omni_runner_handler) -> None:
+def test_base_voice_clone_with_disfluent_text(omni_runner, omni_runner_handler) -> None:
     """
-    Test voice cloning with deliberately misspelled/malformed input text.
+    Test voice cloning with disfluent/malformed input text (filler words, repetition).
     Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: text with deliberate typos
+    Input Modal: text with disfluencies and filler words
     Output Modal: audio
     Extra Setting: task_type=Base, voice=clone, ref_audio/ref_text provided
     """
     request_config = {
-        "input": "Ths is a tset of teh text too speech systm with typoes.",
+        "input": "Uh um so like, ya know, the the the thing is... mhmm, kinda sorta maybe?!",
         "task_type": "Base",
         "voice": "clone",
         "ref_audio": REF_AUDIO_URL,

--- a/tests/e2e/offline_inference/test_qwen3_tts_base.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_base.py
@@ -73,7 +73,7 @@ def get_prompt():
 def test_text_to_audio_001(omni_runner, omni_runner_handler) -> None:
     """
     Test text input processing and audio output via offline Omni runner.
-Input Modality: text
+    Input Modality: text
     Output Modality: audio
     Input Setting: stream=False
     Extra Setting: task_type=Base, voice=clone, ref_audio/ref_text provided
@@ -96,7 +96,7 @@ Input Modality: text
 def test_base_voice_clone_special_characters(omni_runner, omni_runner_handler) -> None:
     """
     Test voice cloning with special characters and punctuation in input text.
-Input Modality: text with special characters (!,$,—,...)
+    Input Modality: text with special characters (!,$,—,...)
     Output Modality: audio
     Extra Setting: task_type=Base, voice=clone, ref_audio/ref_text provided
     """
@@ -117,7 +117,7 @@ Input Modality: text with special characters (!,$,—,...)
 def test_base_voice_clone_with_disfluent_text(omni_runner, omni_runner_handler) -> None:
     """
     Test voice cloning with disfluent/malformed input text (filler words, repetition).
-Input Modality: text with disfluencies and filler words
+    Input Modality: text with disfluencies and filler words
     Output Modality: audio
     Extra Setting: task_type=Base, voice=clone, ref_audio/ref_text provided
     """
@@ -138,7 +138,7 @@ Input Modality: text with disfluencies and filler words
 def test_base_rejects_empty_input(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: empty input text should be rejected even with valid ref_audio.
-Input Modality: empty string
+    Input Modality: empty string
     Expected: ValueError
     """
     request_config = {
@@ -160,7 +160,7 @@ Input Modality: empty string
 def test_base_rejects_missing_ref_audio(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: Base task without ref_audio or ref_text should be rejected.
-Input Modality: valid text, task_type=Base, no ref_audio/ref_text
+    Input Modality: valid text, task_type=Base, no ref_audio/ref_text
     Expected: ValueError
     """
     request_config = {
@@ -179,7 +179,7 @@ Input Modality: valid text, task_type=Base, no ref_audio/ref_text
 def test_base_rejects_missing_ref_text(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: Base task with ref_audio but no ref_text should be rejected.
-Input Modality: valid text, task_type=Base, ref_audio provided, no ref_text
+    Input Modality: valid text, task_type=Base, ref_audio provided, no ref_text
     Expected: ValueError
     """
     request_config = {

--- a/tests/e2e/offline_inference/test_qwen3_tts_base.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_base.py
@@ -88,3 +88,112 @@ def test_text_to_audio_001(omni_runner, omni_runner_handler) -> None:
         "ref_text": REF_TEXT,
     }
     omni_runner_handler.send_audio_speech_request(request_config)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
+def test_base_voice_clone_special_characters(omni_runner, omni_runner_handler) -> None:
+    """
+    Test voice cloning with special characters and punctuation in input text.
+    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
+    Input Modal: text with special characters (!,$,—,...)
+    Output Modal: audio
+    Extra Setting: task_type=Base, voice=clone, ref_audio/ref_text provided
+    """
+    request_config = {
+        "input": "Hello! Can you believe it? The price is $19.99 — what a deal...",
+        "task_type": "Base",
+        "voice": "clone",
+        "ref_audio": REF_AUDIO_URL,
+        "ref_text": REF_TEXT,
+    }
+    omni_runner_handler.send_audio_speech_request(request_config)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
+def test_base_voice_clone_with_typos(omni_runner, omni_runner_handler) -> None:
+    """
+    Test voice cloning with deliberately misspelled/malformed input text.
+    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
+    Input Modal: text with deliberate typos
+    Output Modal: audio
+    Extra Setting: task_type=Base, voice=clone, ref_audio/ref_text provided
+    """
+    request_config = {
+        "input": "Ths is a tset of teh text too speech systm with typoes.",
+        "task_type": "Base",
+        "voice": "clone",
+        "ref_audio": REF_AUDIO_URL,
+        "ref_text": REF_TEXT,
+    }
+    omni_runner_handler.send_audio_speech_request(request_config)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
+@pytest.mark.xfail(reason="Offline pipeline does not validate empty input", strict=True)
+def test_base_rejects_empty_input(omni_runner, omni_runner_handler) -> None:
+    """
+    Negative test: empty input text should be rejected even with valid ref_audio.
+    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
+    Input Modal: empty string
+    Expected: ValueError or RuntimeError
+    """
+    request_config = {
+        "input": "",
+        "task_type": "Base",
+        "voice": "clone",
+        "ref_audio": REF_AUDIO_URL,
+        "ref_text": REF_TEXT,
+    }
+    with pytest.raises((ValueError, RuntimeError)):
+        omni_runner_handler.send_audio_speech_request(request_config)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
+@pytest.mark.xfail(reason="Offline pipeline does not validate missing ref_audio for Base task", strict=True)
+def test_base_rejects_missing_ref_audio(omni_runner, omni_runner_handler) -> None:
+    """
+    Negative test: Base task without ref_audio or ref_text should be rejected.
+    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
+    Input Modal: valid text, task_type=Base, no ref_audio/ref_text
+    Expected: ValueError or RuntimeError
+    """
+    request_config = {
+        "input": get_prompt(),
+        "task_type": "Base",
+    }
+    with pytest.raises((ValueError, RuntimeError)):
+        omni_runner_handler.send_audio_speech_request(request_config)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
+@pytest.mark.xfail(reason="Offline pipeline does not validate missing ref_text for Base task", strict=True)
+def test_base_rejects_missing_ref_text(omni_runner, omni_runner_handler) -> None:
+    """
+    Negative test: Base task with ref_audio but no ref_text should be rejected.
+    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
+    Input Modal: valid text, task_type=Base, ref_audio provided, no ref_text
+    Expected: ValueError or RuntimeError
+    """
+    request_config = {
+        "input": get_prompt(),
+        "task_type": "Base",
+        "voice": "clone",
+        "ref_audio": REF_AUDIO_URL,
+    }
+    with pytest.raises((ValueError, RuntimeError)):
+        omni_runner_handler.send_audio_speech_request(request_config)

--- a/tests/e2e/offline_inference/test_qwen3_tts_base.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_base.py
@@ -138,7 +138,6 @@ def test_base_voice_clone_with_typos(omni_runner, omni_runner_handler) -> None:
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-@pytest.mark.xfail(reason="Offline pipeline does not validate empty input", strict=True)
 def test_base_rejects_empty_input(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: empty input text should be rejected even with valid ref_audio.

--- a/tests/e2e/offline_inference/test_qwen3_tts_base.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_base.py
@@ -160,7 +160,7 @@ def test_base_rejects_empty_input(omni_runner, omni_runner_handler) -> None:
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-@pytest.mark.xfail(reason="Offline pipeline does not validate missing ref_audio for Base task", strict=True)
+@pytest.mark.xfail(reason="Offline pipeline does not validate missing ref_audio for Base task (#3707)", strict=True)
 def test_base_rejects_missing_ref_audio(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: Base task without ref_audio or ref_text should be rejected.
@@ -180,7 +180,7 @@ def test_base_rejects_missing_ref_audio(omni_runner, omni_runner_handler) -> Non
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-@pytest.mark.xfail(reason="Offline pipeline does not validate missing ref_text for Base task", strict=True)
+@pytest.mark.xfail(reason="Offline pipeline does not validate missing ref_text for Base task (#3708)", strict=True)
 def test_base_rejects_missing_ref_text(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: Base task with ref_audio but no ref_text should be rejected.

--- a/tests/e2e/offline_inference/test_qwen3_tts_base.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_base.py
@@ -89,40 +89,27 @@ def test_text_to_audio_001(omni_runner, omni_runner_handler) -> None:
     omni_runner_handler.send_audio_speech_request(request_config)
 
 
-@pytest.mark.advanced_model
-@pytest.mark.tts
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
-@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-def test_base_voice_clone_special_characters(omni_runner, omni_runner_handler) -> None:
-    """
-    Test voice cloning with special characters and punctuation in input text.
-    Input Modality: text with special characters (!,$,—,...)
-    Output Modality: audio
-    Extra Setting: task_type=Base, voice=clone, ref_audio/ref_text provided
-    """
-    request_config = {
-        "input": "Hello! Can you believe it? The price is $19.99 — what a deal...",
-        "task_type": "Base",
-        "voice": "clone",
-        "ref_audio": REF_AUDIO_URL,
-        "ref_text": REF_TEXT,
-    }
-    omni_runner_handler.send_audio_speech_request(request_config)
+BASE_SMOKE_INPUTS = [
+    pytest.param(
+        "Hello! Can you believe it? The price is $19.99 — what a deal...",
+        id="special-characters",
+    ),
+    pytest.param(
+        "Uh um so like, ya know, the the the thing is... mhmm, kinda sorta maybe?!",
+        id="disfluent-text",
+    ),
+]
 
 
 @pytest.mark.advanced_model
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-def test_base_voice_clone_with_disfluent_text(omni_runner, omni_runner_handler) -> None:
-    """
-    Test voice cloning with disfluent/malformed input text (filler words, repetition).
-    Input Modality: text with disfluencies and filler words
-    Output Modality: audio
-    Extra Setting: task_type=Base, voice=clone, ref_audio/ref_text provided
-    """
+@pytest.mark.parametrize("input_text", BASE_SMOKE_INPUTS)
+def test_base_voice_clone_smoke(omni_runner, omni_runner_handler, input_text) -> None:
+    """Smoke test: verify Base voice-clone pipeline produces audio without crashing."""
     request_config = {
-        "input": "Uh um so like, ya know, the the the thing is... mhmm, kinda sorta maybe?!",
+        "input": input_text,
         "task_type": "Base",
         "voice": "clone",
         "ref_audio": REF_AUDIO_URL,

--- a/tests/e2e/offline_inference/test_qwen3_tts_base.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_base.py
@@ -73,9 +73,8 @@ def get_prompt():
 def test_text_to_audio_001(omni_runner, omni_runner_handler) -> None:
     """
     Test text input processing and audio output via offline Omni runner.
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: text
-    Output Modal: audio
+Input Modality: text
+    Output Modality: audio
     Input Setting: stream=False
     Extra Setting: task_type=Base, voice=clone, ref_audio/ref_text provided
     Datasets: few requests
@@ -97,9 +96,8 @@ def test_text_to_audio_001(omni_runner, omni_runner_handler) -> None:
 def test_base_voice_clone_special_characters(omni_runner, omni_runner_handler) -> None:
     """
     Test voice cloning with special characters and punctuation in input text.
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: text with special characters (!,$,—,...)
-    Output Modal: audio
+Input Modality: text with special characters (!,$,—,...)
+    Output Modality: audio
     Extra Setting: task_type=Base, voice=clone, ref_audio/ref_text provided
     """
     request_config = {
@@ -119,9 +117,8 @@ def test_base_voice_clone_special_characters(omni_runner, omni_runner_handler) -
 def test_base_voice_clone_with_disfluent_text(omni_runner, omni_runner_handler) -> None:
     """
     Test voice cloning with disfluent/malformed input text (filler words, repetition).
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: text with disfluencies and filler words
-    Output Modal: audio
+Input Modality: text with disfluencies and filler words
+    Output Modality: audio
     Extra Setting: task_type=Base, voice=clone, ref_audio/ref_text provided
     """
     request_config = {
@@ -141,9 +138,8 @@ def test_base_voice_clone_with_disfluent_text(omni_runner, omni_runner_handler) 
 def test_base_rejects_empty_input(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: empty input text should be rejected even with valid ref_audio.
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: empty string
-    Expected: ValueError or RuntimeError
+Input Modality: empty string
+    Expected: ValueError
     """
     request_config = {
         "input": "",
@@ -152,7 +148,7 @@ def test_base_rejects_empty_input(omni_runner, omni_runner_handler) -> None:
         "ref_audio": REF_AUDIO_URL,
         "ref_text": REF_TEXT,
     }
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises(ValueError):
         omni_runner_handler.send_audio_speech_request(request_config)
 
 
@@ -164,15 +160,14 @@ def test_base_rejects_empty_input(omni_runner, omni_runner_handler) -> None:
 def test_base_rejects_missing_ref_audio(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: Base task without ref_audio or ref_text should be rejected.
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: valid text, task_type=Base, no ref_audio/ref_text
-    Expected: ValueError or RuntimeError
+Input Modality: valid text, task_type=Base, no ref_audio/ref_text
+    Expected: ValueError
     """
     request_config = {
         "input": get_prompt(),
         "task_type": "Base",
     }
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises(ValueError):
         omni_runner_handler.send_audio_speech_request(request_config)
 
 
@@ -184,9 +179,8 @@ def test_base_rejects_missing_ref_audio(omni_runner, omni_runner_handler) -> Non
 def test_base_rejects_missing_ref_text(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: Base task with ref_audio but no ref_text should be rejected.
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: valid text, task_type=Base, ref_audio provided, no ref_text
-    Expected: ValueError or RuntimeError
+Input Modality: valid text, task_type=Base, ref_audio provided, no ref_text
+    Expected: ValueError
     """
     request_config = {
         "input": get_prompt(),
@@ -194,5 +188,5 @@ def test_base_rejects_missing_ref_text(omni_runner, omni_runner_handler) -> None
         "voice": "clone",
         "ref_audio": REF_AUDIO_URL,
     }
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises(ValueError):
         omni_runner_handler.send_audio_speech_request(request_config)

--- a/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
@@ -139,7 +139,6 @@ def test_customvoice_chinese_text(omni_runner, omni_runner_handler) -> None:
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-@pytest.mark.xfail(reason="Offline pipeline does not validate empty input", strict=True)
 def test_customvoice_rejects_empty_input(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: empty input text should be rejected.

--- a/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
@@ -80,23 +80,23 @@ def test_text_to_audio_001(omni_runner, omni_runner_handler) -> None:
 
 CUSTOMVOICE_SMOKE_INPUTS = [
     pytest.param(
-        {"input": "Wait — really?! That costs $99.99; not £50 (or €45)... wow!",
-         "voice": "vivian"},
+        {"input": "Wait — really?! That costs $99.99; not £50 (or €45)... wow!", "voice": "vivian"},
         id="special-characters",
     ),
     pytest.param(
-        {"input": "The CEO of NASA, e.g. Dr. Smith, will arrive at 3 p.m. i.e. before the Q&A.",
-         "voice": "vivian"},
+        {"input": "The CEO of NASA, e.g. Dr. Smith, will arrive at 3 p.m. i.e. before the Q&A.", "voice": "vivian"},
         id="acronyms",
     ),
     pytest.param(
-        {"input": "北京是中国的首都，有着悠久的历史和丰富的文化。",
-         "voice": "vivian", "language": "Chinese"},
+        {"input": "北京是中国的首都，有着悠久的历史和丰富的文化。", "voice": "vivian", "language": "Chinese"},
         id="chinese-text",
     ),
     pytest.param(
-        {"input": "This is a sentence that will be repeated many times to create a very long input. " * 60,
-         "voice": "vivian", "max_new_tokens": 512},
+        {
+            "input": "This is a sentence that will be repeated many times to create a very long input. " * 60,
+            "voice": "vivian",
+            "max_new_tokens": 512,
+        },
         id="long-input",
     ),
 ]

--- a/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
@@ -78,56 +78,37 @@ def test_text_to_audio_001(omni_runner, omni_runner_handler) -> None:
     omni_runner_handler.send_audio_speech_request(request_config)
 
 
-@pytest.mark.advanced_model
-@pytest.mark.tts
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
-@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-def test_customvoice_special_characters(omni_runner, omni_runner_handler) -> None:
-    """
-    Test text-to-audio with heavy punctuation and special characters.
-    Input Modality: text with special characters (!,;$£€%...)
-    Output Modality: audio
-    """
-    request_config = {
-        "input": "Wait — really?! That costs $99.99; not £50 (or €45)... wow!",
-        "voice": "vivian",
-    }
-    omni_runner_handler.send_audio_speech_request(request_config)
+CUSTOMVOICE_SMOKE_INPUTS = [
+    pytest.param(
+        {"input": "Wait — really?! That costs $99.99; not £50 (or €45)... wow!",
+         "voice": "vivian"},
+        id="special-characters",
+    ),
+    pytest.param(
+        {"input": "The CEO of NASA, e.g. Dr. Smith, will arrive at 3 p.m. i.e. before the Q&A.",
+         "voice": "vivian"},
+        id="acronyms",
+    ),
+    pytest.param(
+        {"input": "北京是中国的首都，有着悠久的历史和丰富的文化。",
+         "voice": "vivian", "language": "Chinese"},
+        id="chinese-text",
+    ),
+    pytest.param(
+        {"input": "This is a sentence that will be repeated many times to create a very long input. " * 60,
+         "voice": "vivian", "max_new_tokens": 512},
+        id="long-input",
+    ),
+]
 
 
 @pytest.mark.advanced_model
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-def test_customvoice_acronyms_and_abbreviations(omni_runner, omni_runner_handler) -> None:
-    """
-    Test text-to-audio with acronyms and abbreviations.
-    Input Modality: text with e.g., i.e., Dr., p.m., acronyms
-    Output Modality: audio
-    """
-    request_config = {
-        "input": "The CEO of NASA, e.g. Dr. Smith, will arrive at 3 p.m. i.e. before the Q&A.",
-        "voice": "vivian",
-    }
-    omni_runner_handler.send_audio_speech_request(request_config)
-
-
-@pytest.mark.advanced_model
-@pytest.mark.tts
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
-@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-def test_customvoice_chinese_text(omni_runner, omni_runner_handler) -> None:
-    """
-    Test text-to-audio with Chinese language text.
-    Input Modality: Chinese text
-    Output Modality: audio
-    Extra Setting: language=Chinese
-    """
-    request_config = {
-        "input": "北京是中国的首都，有着悠久的历史和丰富的文化。",
-        "voice": "vivian",
-        "language": "Chinese",
-    }
+@pytest.mark.parametrize("request_config", CUSTOMVOICE_SMOKE_INPUTS)
+def test_customvoice_smoke(omni_runner, omni_runner_handler, request_config) -> None:
+    """Smoke test: verify the pipeline produces audio without crashing."""
     omni_runner_handler.send_audio_speech_request(request_config)
 
 
@@ -160,23 +141,3 @@ def test_customvoice_rejects_whitespace_only_input(omni_runner, omni_runner_hand
     request_config = {"input": "   \t\n  ", "voice": "vivian"}
     with pytest.raises(ValueError):
         omni_runner_handler.send_audio_speech_request(request_config)
-
-
-@pytest.mark.advanced_model
-@pytest.mark.tts
-@hardware_test(res={"cuda": "L4"}, num_cards=1)
-@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-def test_customvoice_handles_very_long_input(omni_runner, omni_runner_handler) -> None:
-    """
-    Test text-to-audio with very long input text (~5000 chars).
-    Input Modality: long repeated text
-    Output Modality: audio
-    Extra Setting: max_new_tokens=512 to cap generation time
-    """
-    long_text = "This is a sentence that will be repeated many times to create a very long input. " * 60
-    request_config = {
-        "input": long_text,
-        "voice": "vivian",
-        "max_new_tokens": 512,
-    }
-    omni_runner_handler.send_audio_speech_request(request_config)

--- a/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
@@ -77,3 +77,114 @@ def test_text_to_audio_001(omni_runner, omni_runner_handler) -> None:
     """
     request_config = {"input": get_prompt(), "voice": "vivian"}
     omni_runner_handler.send_audio_speech_request(request_config)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
+def test_customvoice_special_characters(omni_runner, omni_runner_handler) -> None:
+    """
+    Test text-to-audio with heavy punctuation and special characters.
+    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
+    Input Modal: text with special characters (!,;$£€%...)
+    Output Modal: audio
+    """
+    request_config = {
+        "input": "Wait — really?! That costs $99.99; not £50 (or €45)... wow!",
+        "voice": "vivian",
+    }
+    omni_runner_handler.send_audio_speech_request(request_config)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
+def test_customvoice_acronyms_and_abbreviations(omni_runner, omni_runner_handler) -> None:
+    """
+    Test text-to-audio with acronyms and abbreviations.
+    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
+    Input Modal: text with e.g., i.e., Dr., p.m., acronyms
+    Output Modal: audio
+    """
+    request_config = {
+        "input": "The CEO of NASA, e.g. Dr. Smith, will arrive at 3 p.m. i.e. before the Q&A.",
+        "voice": "vivian",
+    }
+    omni_runner_handler.send_audio_speech_request(request_config)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
+def test_customvoice_chinese_text(omni_runner, omni_runner_handler) -> None:
+    """
+    Test text-to-audio with Chinese language text.
+    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
+    Input Modal: Chinese text
+    Output Modal: audio
+    Extra Setting: language=Chinese
+    """
+    request_config = {
+        "input": "北京是中国的首都，有着悠久的历史和丰富的文化。",
+        "voice": "vivian",
+        "language": "Chinese",
+    }
+    omni_runner_handler.send_audio_speech_request(request_config)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
+@pytest.mark.xfail(reason="Offline pipeline does not validate empty input", strict=True)
+def test_customvoice_rejects_empty_input(omni_runner, omni_runner_handler) -> None:
+    """
+    Negative test: empty input text should be rejected.
+    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
+    Input Modal: empty string
+    Expected: ValueError or RuntimeError
+    """
+    request_config = {"input": "", "voice": "vivian"}
+    with pytest.raises((ValueError, RuntimeError)):
+        omni_runner_handler.send_audio_speech_request(request_config)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
+@pytest.mark.xfail(reason="Offline pipeline does not validate whitespace-only input", strict=True)
+def test_customvoice_rejects_whitespace_only_input(omni_runner, omni_runner_handler) -> None:
+    """
+    Negative test: whitespace-only input (spaces, tabs, newlines) should be rejected.
+    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
+    Input Modal: whitespace/tabs/newlines only
+    Expected: ValueError or RuntimeError
+    """
+    request_config = {"input": "   \t\n  ", "voice": "vivian"}
+    with pytest.raises((ValueError, RuntimeError)):
+        omni_runner_handler.send_audio_speech_request(request_config)
+
+
+@pytest.mark.advanced_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
+def test_customvoice_handles_very_long_input(omni_runner, omni_runner_handler) -> None:
+    """
+    Test text-to-audio with very long input text (~5000 chars).
+    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
+    Input Modal: long repeated text
+    Output Modal: audio
+    Extra Setting: max_new_tokens=512 to cap generation time
+    """
+    long_text = "This is a sentence that will be repeated many times to create a very long input. " * 60
+    request_config = {
+        "input": long_text,
+        "voice": "vivian",
+        "max_new_tokens": 512,
+    }
+    omni_runner_handler.send_audio_speech_request(request_config)

--- a/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
@@ -69,7 +69,7 @@ def get_prompt():
 def test_text_to_audio_001(omni_runner, omni_runner_handler) -> None:
     """
     Test text input processing and audio output via offline Omni runner.
-Input Modality: text
+    Input Modality: text
     Output Modality: audio
     Input Setting: stream=False
     Datasets: few requests
@@ -85,7 +85,7 @@ Input Modality: text
 def test_customvoice_special_characters(omni_runner, omni_runner_handler) -> None:
     """
     Test text-to-audio with heavy punctuation and special characters.
-Input Modality: text with special characters (!,;$£€%...)
+    Input Modality: text with special characters (!,;$£€%...)
     Output Modality: audio
     """
     request_config = {
@@ -102,7 +102,7 @@ Input Modality: text with special characters (!,;$£€%...)
 def test_customvoice_acronyms_and_abbreviations(omni_runner, omni_runner_handler) -> None:
     """
     Test text-to-audio with acronyms and abbreviations.
-Input Modality: text with e.g., i.e., Dr., p.m., acronyms
+    Input Modality: text with e.g., i.e., Dr., p.m., acronyms
     Output Modality: audio
     """
     request_config = {
@@ -119,7 +119,7 @@ Input Modality: text with e.g., i.e., Dr., p.m., acronyms
 def test_customvoice_chinese_text(omni_runner, omni_runner_handler) -> None:
     """
     Test text-to-audio with Chinese language text.
-Input Modality: Chinese text
+    Input Modality: Chinese text
     Output Modality: audio
     Extra Setting: language=Chinese
     """
@@ -138,7 +138,7 @@ Input Modality: Chinese text
 def test_customvoice_rejects_empty_input(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: empty input text should be rejected.
-Input Modality: empty string
+    Input Modality: empty string
     Expected: ValueError
     """
     request_config = {"input": "", "voice": "vivian"}
@@ -154,7 +154,7 @@ Input Modality: empty string
 def test_customvoice_rejects_whitespace_only_input(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: whitespace-only input (spaces, tabs, newlines) should be rejected.
-Input Modality: whitespace/tabs/newlines only
+    Input Modality: whitespace/tabs/newlines only
     Expected: ValueError
     """
     request_config = {"input": "   \t\n  ", "voice": "vivian"}
@@ -169,7 +169,7 @@ Input Modality: whitespace/tabs/newlines only
 def test_customvoice_handles_very_long_input(omni_runner, omni_runner_handler) -> None:
     """
     Test text-to-audio with very long input text (~5000 chars).
-Input Modality: long repeated text
+    Input Modality: long repeated text
     Output Modality: audio
     Extra Setting: max_new_tokens=512 to cap generation time
     """

--- a/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
@@ -69,9 +69,8 @@ def get_prompt():
 def test_text_to_audio_001(omni_runner, omni_runner_handler) -> None:
     """
     Test text input processing and audio output via offline Omni runner.
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: text
-    Output Modal: audio
+Input Modality: text
+    Output Modality: audio
     Input Setting: stream=False
     Datasets: few requests
     """
@@ -86,9 +85,8 @@ def test_text_to_audio_001(omni_runner, omni_runner_handler) -> None:
 def test_customvoice_special_characters(omni_runner, omni_runner_handler) -> None:
     """
     Test text-to-audio with heavy punctuation and special characters.
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: text with special characters (!,;$£€%...)
-    Output Modal: audio
+Input Modality: text with special characters (!,;$£€%...)
+    Output Modality: audio
     """
     request_config = {
         "input": "Wait — really?! That costs $99.99; not £50 (or €45)... wow!",
@@ -104,9 +102,8 @@ def test_customvoice_special_characters(omni_runner, omni_runner_handler) -> Non
 def test_customvoice_acronyms_and_abbreviations(omni_runner, omni_runner_handler) -> None:
     """
     Test text-to-audio with acronyms and abbreviations.
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: text with e.g., i.e., Dr., p.m., acronyms
-    Output Modal: audio
+Input Modality: text with e.g., i.e., Dr., p.m., acronyms
+    Output Modality: audio
     """
     request_config = {
         "input": "The CEO of NASA, e.g. Dr. Smith, will arrive at 3 p.m. i.e. before the Q&A.",
@@ -122,9 +119,8 @@ def test_customvoice_acronyms_and_abbreviations(omni_runner, omni_runner_handler
 def test_customvoice_chinese_text(omni_runner, omni_runner_handler) -> None:
     """
     Test text-to-audio with Chinese language text.
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: Chinese text
-    Output Modal: audio
+Input Modality: Chinese text
+    Output Modality: audio
     Extra Setting: language=Chinese
     """
     request_config = {
@@ -142,12 +138,11 @@ def test_customvoice_chinese_text(omni_runner, omni_runner_handler) -> None:
 def test_customvoice_rejects_empty_input(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: empty input text should be rejected.
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: empty string
-    Expected: ValueError or RuntimeError
+Input Modality: empty string
+    Expected: ValueError
     """
     request_config = {"input": "", "voice": "vivian"}
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises(ValueError):
         omni_runner_handler.send_audio_speech_request(request_config)
 
 
@@ -159,12 +154,11 @@ def test_customvoice_rejects_empty_input(omni_runner, omni_runner_handler) -> No
 def test_customvoice_rejects_whitespace_only_input(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: whitespace-only input (spaces, tabs, newlines) should be rejected.
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: whitespace/tabs/newlines only
-    Expected: ValueError or RuntimeError
+Input Modality: whitespace/tabs/newlines only
+    Expected: ValueError
     """
     request_config = {"input": "   \t\n  ", "voice": "vivian"}
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises(ValueError):
         omni_runner_handler.send_audio_speech_request(request_config)
 
 
@@ -175,9 +169,8 @@ def test_customvoice_rejects_whitespace_only_input(omni_runner, omni_runner_hand
 def test_customvoice_handles_very_long_input(omni_runner, omni_runner_handler) -> None:
     """
     Test text-to-audio with very long input text (~5000 chars).
-    Deploy Setting: qwen3_tts_no_async_chunk.yaml + enforce_eager=true
-    Input Modal: long repeated text
-    Output Modal: audio
+Input Modality: long repeated text
+    Output Modality: audio
     Extra Setting: max_new_tokens=512 to cap generation time
     """
     long_text = "This is a sentence that will be repeated many times to create a very long input. " * 60

--- a/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
+++ b/tests/e2e/offline_inference/test_qwen3_tts_customvoice.py
@@ -155,7 +155,7 @@ def test_customvoice_rejects_empty_input(omni_runner, omni_runner_handler) -> No
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_runner", tts_server_params, indirect=True)
-@pytest.mark.xfail(reason="Offline pipeline does not validate whitespace-only input", strict=True)
+@pytest.mark.xfail(reason="Offline pipeline does not validate whitespace-only input (#3706)", strict=True)
 def test_customvoice_rejects_whitespace_only_input(omni_runner, omni_runner_handler) -> None:
     """
     Negative test: whitespace-only input (spaces, tabs, newlines) should be rejected.


### PR DESCRIPTION
## Summary

- Add 11 new offline inference tests for both Qwen3-TTS models (Base 0.6B and CustomVoice 1.7B)
- Tests cover happy-path generation (special characters, acronyms, Chinese text, typos, long input) and negative-path validation (empty input, whitespace-only, missing ref_audio, missing ref_text)
- Negative-path testing exposed 3 offline pipeline validation gaps where the pipeline silently accepts invalid input that the HTTP serving layer correctly rejects

**CustomVoice** (`test_qwen3_tts_customvoice.py`) — 6 new tests:
| Test | Type | Status |
|------|------|--------|
| `test_customvoice_special_characters` | Happy path | PASSED |
| `test_customvoice_acronyms_and_abbreviations` | Happy path | PASSED |
| `test_customvoice_chinese_text` | Happy path | PASSED |
| `test_customvoice_rejects_empty_input` | Negative | PASSED |
| `test_customvoice_rejects_whitespace_only_input` | Negative | XFAIL (#3706) |
| `test_customvoice_handles_very_long_input` | Robustness | PASSED |

**Base** (`test_qwen3_tts_base.py`) — 5 new tests:
| Test | Type | Status |
|------|------|--------|
| `test_base_voice_clone_special_characters` | Happy path | PASSED |
| `test_base_voice_clone_with_typos` | Happy path | PASSED |
| `test_base_rejects_empty_input` | Negative | PASSED |
| `test_base_rejects_missing_ref_audio` | Negative | XFAIL (#3707) |
| `test_base_rejects_missing_ref_text` | Negative | XFAIL (#3708) |

**Upstream issues filed:**
- #3706 — Offline pipeline accepts whitespace-only input
- #3707 — Offline pipeline accepts missing ref_audio for Base task
- #3708 — Offline pipeline accepts missing ref_text for Base task

## Test plan

- [x] All 13 tests validated on H100 (`l42-h06-000-xe8640.rdu3.labs.perfscale.redhat.com`)
- [x] 10 passed, 3 xfailed (known upstream validation gaps)
- [x] Existing `test_text_to_audio_001` in both files unaffected
- [x] `ruff format` and `ruff check` pass
- [x] All commits GPG signed

```
CUDA_VISIBLE_DEVICES=2 pytest tests/e2e/offline_inference/test_qwen3_tts_customvoice.py tests/e2e/offline_inference/test_qwen3_tts_base.py -v --tb=short
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)