### PR TITLE
[Cleanup] Enable stale advanced_model marker post-#1272 and fix typo

### DIFF
--- a/tests/diffusion/distributed/test_sequence_parallel.py
+++ b/tests/diffusion/distributed/test_sequence_parallel.py
@@ -291,8 +291,7 @@ def test_sp_correctness(model_name: str):
     print("=" * 70)
 
 
-# TODO: After PR#1272 is merged, add markers
-# @pytest.mark.advanced_model
+@pytest.mark.advanced_model
 @pytest.mark.diffusion
 @pytest.mark.parallel
 @hardware_test(res={"cuda": "L4", "rocm": "MI325"}, num_cards={"cuda": 4, "rocm": 2})

--- a/vllm_omni/diffusion/model_loader/gguf_adapters/base.py
+++ b/vllm_omni/diffusion/model_loader/gguf_adapters/base.py
@@ -54,7 +54,7 @@ class GGUFAdapter(ABC):
         raise NotImplementedError
 
 
-# FIXME(Isotr0py): Sync implemnentation with upstream vLLM?
+# FIXME(Isotr0py): Sync implementation with upstream vLLM?
 def gguf_quant_weights_iterator(gguf_file: str) -> Generator[tuple[str, torch.Tensor]]:
     """
     Iterate over the quant weights in the model gguf files and convert


### PR DESCRIPTION
## Summary
This PR addresses two minor cleanup items found during codebase exploration:

1. **Enable `@pytest.mark.advanced_model` marker**
   `tests/diffusion/distributed/test_sequence_parallel.py` had a TODO comment indicating that `@pytest.mark.advanced_model` should be uncommented after PR #1272 is merged. Since #1272 has already been merged, this marker is now enabled.

2. **Fix typo in gguf adapter**  
   Fixed `implemnentation` → `implementation` in `vllm_omni/diffusion/model_loader/gguf_adapters/base.py`.

## Changes
- `tests/diffusion/distributed/test_sequence_parallel.py`: Removed TODO comment and uncommented `@pytest.mark.advanced_model`
- `vllm_omni/diffusion/model_loader/gguf_adapters/base.py`: Fixed spelling typo in FIXME comment

Signed-off-by: Schatten czhengt@qq.com