### PR TITLE
Disable sampler kernel for XPU test

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-xpu-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-xpu-test.sh
@@ -52,5 +52,6 @@ time timeout -k 30 30m docker run \
     pip install tblib==3.1.0
     cd /workspace/vllm-omni
     pytest -v -s -m "core_model and xpu and B60"
-    pytest -v -s -m "advanced_model and xpu and B60" -k "not omni_expansion"
+    export VLLM_XPU_USE_SAMPLER_KERNEL=0    # NOTE: Remove this after vLLM v0.21.1 is merged. Fixes Qwen2-5 omni-expansion tests.
+    pytest -v -s -m "advanced_model and xpu and B60"
 '


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Migration to vLLM v0.21.0 (#3530) broke two tests (Qwen2.5 Omni-expansion) that were disabled in #3675. This PR re-enables these tests via a patch. This should be removed once we migrate to v0.21.1 or later which includes the fix: https://github.com/vllm-project/vllm/pull/41771

## Test Plan

```
VLLM_XPU_USE_SAMPLER_KERNEL=0 pytest -v -s -m "advanced_model and xpu and B60" -k "omni_expansion"
```

## Test Result

Tests all pass without hanging.

<img width="691" height="47" alt="image" src="https://github.com/user-attachments/assets/24e41a1c-a50d-40f1-9f3d-7ac2fda78c54" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
