### PR TITLE
[BugFix] fix mult cli timeout with get kv

### DIFF
--- a/tests/entrypoints/test_serve.py
+++ b/tests/entrypoints/test_serve.py
@@ -325,7 +325,10 @@ def test_run_headless_diffusion_registers_and_spawns_proc(mocker: MockerFixture)
 
     run_headless(_make_headless_args(stage_id=1))
 
-    mock_inject.assert_called_once_with(stage_cfg, 1)
+    mock_inject.assert_called_once()
+    assert mock_inject.call_args.args[0] is stage_cfg
+    assert mock_inject.call_args.args[1] == 1
+    assert mock_inject.call_args.args[2] == [stage_cfg]
 
     reg_kwargs = mock_register.call_args.kwargs
     assert reg_kwargs["omni_master_address"] == "127.0.0.1"

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -803,7 +803,10 @@ def run_headless(args: argparse.Namespace) -> None:
         metadata = extract_stage_metadata(stage_cfg)
         if omni_conn_cfg:
             inject_omni_kv_config(stage_cfg, omni_conn_cfg, omni_from, omni_to)
-        inject_kv_stage_info(stage_cfg, stage_id)
+        # Headless single-stage launch must still infer cross-stage TP topology
+        # from the loaded deploy config so heterogeneous KV routing keys match
+        # the head process (e.g. from_tp=2, to_tp=1).
+        inject_kv_stage_info(stage_cfg, stage_id, stage_configs)
         od_config = build_diffusion_config(model, stage_cfg, metadata)
 
         logger.info(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
For heterogeneous tp topologies, headless stage need to know the others stage config, so the kv transfer manager can compute rank mappings.

## Test Plan
(1) unit test
```
 pytest -s -v tests/entrypoints/test_serve.py
```
(2) end2end test
```
AR TP2, DIT TP1 + FP8
```
## Test Result
(1) Unit test

```
--- Running Summary
========================================================= 11 passed, 20 warnings in 7.07s ==========================================================
```
(2) end2end
Send
```
(Worker_TP1 pid=2131054) INFO 05-19 21:21:14 [kv_transfer_manager.py:913] KV cache serialized for img_edit-b5b287fc25cbcef3 in 1.0 ms
(Worker_TP0 pid=2131048) INFO 05-19 21:21:14 [kv_transfer_manager.py:913] KV cache serialized for img_edit-b5b287fc25cbcef3 in 1.0 ms
(Worker_TP1 pid=2131054) INFO 05-19 21:21:14 [kv_transfer_manager.py:927] KV transfer OK: img_edit-b5b287fc25cbcef3, 759374199 bytes across 1 key(s), 0.016s, 46540.4 MB/s
(Worker_TP0 pid=2131048) INFO 05-19 21:21:14 [kv_transfer_manager.py:927] KV transfer OK: img_edit-b5b287fc25cbcef3, 759374199 bytes across 1 key(s), 0.016s, 46477.8 MB/s
```
Recive
```

INFO 05-19 21:21:14 [kv_transfer_manager.py:720] Sender info updated: host=192.168.16.241, base_port=50151, adjusted_port=50151 (local_rank=0)
INFO 05-19 21:21:14 [kv_transfer_manager.py:1022] Wait for KV cache for request img_edit-b5b287fc25cbcef3 from stage 0 to 1 via 2 key(s)...
INFO 05-19 21:21:14 [mooncake_transfer_engine_connector.py:904] [RDMA GET] img_edit-b5b287fc25cbcef3_0_0_0_0@0_1: query=2.7ms, alloc=0.0ms, rdma=130.2ms, sync=0.0ms, total=133.0ms, 5446.8 MB/s (fast_path, zero-copy)
INFO 05-19 21:21:15 [mooncake_transfer_engine_connector.py:904] [RDMA GET] img_edit-b5b287fc25cbcef3_0_0_1_0@0_1: query=2.2ms, alloc=0.0ms, rdma=193.3ms, sync=0.0ms, total=195.5ms, 3705.1 MB/s (fast_path, zero-copy)
INFO 05-19 21:21:15 [kv_transfer_manager.py:1112] Successfully received KV cache for img_edit-b5b287fc25cbcef3, 1518748398 bytes across 2 key(s), wait=0.437s, link=436.9ms
INFO 05-19 21:21:15 [pipeline_hunyuan_image3.py:1345] [AR KV Reuse] Extracted 32 layers of AR KV, each with length: torch.Size([11587, 8, 128])
INFO 05-19 21:21:15 [hunyuan_image3_transformer.py:2829] Handling AR KV reuse with positive_reuse_len=6456, negative_reuse_len=5876
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
