### PR TITLE
Fix /v1/omni/sleep crash for pure diffusion models

### DIFF
--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -632,6 +632,7 @@ async def omni_init_app_state(
 
         state.enable_server_load_tracking = getattr(args, "enable_server_load_tracking", False)
         state.server_load_metrics = 0
+        state.sleeping_stages = set()
         logger.info("Pure diffusion API server initialized for model: %s", model_name)
         return
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

`POST /v1/omni/sleep` to a vLLM-Omni server running a pure diffusion model (e.g. FLUX.2-dev)  currently crashes because state.sleeping_stages does not get initalized.

Note: this does not actually enable sleep mode for diffusion models since that requires `enable_sleep_mode` which is not configurable with the Diffusion pipeline's legacy config format: https://github.com/vllm-project/vllm-omni/pull/2987. It simply makes it so that `POST /v1/omni/sleep` does not crash the server.

## Test Plan

Spawn vLLM-Omni with FLUX.2-dev
`POST /v1/omni/sleep`
`POST /v1/omni/wakeup`
`POST /v1/images/edits`

## Test Result

`POST /v1/omni/sleep`: 200
`POST /v1/omni/wakeup`: 200
`POST /v1/images/edits`: 200

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
