### PR TITLE
[Feature]: Inject model-specific defaults from deploy YAML via OmniArgumentParser

### DIFF
--- a/tests/engine/test_omni_argument_parser.py
+++ b/tests/engine/test_omni_argument_parser.py
@@ -1,0 +1,414 @@
+"""
+Tests for ``OmniArgumentParser`` — model-aware default injection from deploy YAML.
+"""
+
+import argparse
+import json
+
+import pytest
+
+from vllm_omni.engine.arg_utils import OmniArgumentParser, _deep_merge
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+OAP = OmniArgumentParser
+
+
+# ===========================================================================
+# A — Peek helpers
+# ===========================================================================
+
+
+class TestPeekModel:
+    def test_positional_after_serve(self):
+        assert OAP._peek_model(["serve", "Qwen/Qwen2.5-Omni-7B", "--omni"]) == "Qwen/Qwen2.5-Omni-7B"
+
+    def test_model_flag_separate(self):
+        assert OAP._peek_model(["serve", "--model", "foo/bar", "--omni"]) == "foo/bar"
+
+    def test_model_flag_equals(self):
+        assert OAP._peek_model(["serve", "--model=foo/bar", "--omni"]) == "foo/bar"
+
+    def test_config_yaml_with_model(self, tmp_path):
+        yaml = tmp_path / "cfg.yaml"
+        yaml.write_text("model: Qwen/Qwen2.5-Omni-7B\nport: 8000\n")
+        assert OAP._peek_model(["serve", "--config", str(yaml), "--omni"]) == "Qwen/Qwen2.5-Omni-7B"
+
+    def test_config_yaml_equals(self, tmp_path):
+        yaml = tmp_path / "cfg.yaml"
+        yaml.write_text("model: my-model\n")
+        assert OAP._peek_model(["serve", f"--config={yaml}", "--omni"]) == "my-model"
+
+    def test_config_yaml_no_model_key(self, tmp_path):
+        yaml = tmp_path / "cfg.yaml"
+        yaml.write_text("port: 8000\n")
+        assert OAP._peek_model(["serve", "--config", str(yaml)]) is None
+
+    def test_no_model(self):
+        assert OAP._peek_model(["serve", "--port", "8000"]) is None
+
+    def test_empty_args(self):
+        assert OAP._peek_model([]) is None
+
+
+class TestPeekModelFlat:
+    def test_positional_at_start(self):
+        # We can't call _peek_model_flat directly because it's an instance
+        # method that needs self._subparsers.  Use the fact that when
+        # _subparsers is None, the flat peek is used.
+        parser = OmniArgumentParser("test")
+        model = parser._peek_model_flat(["my-model", "--port", "8000"])
+        assert model == "my-model"
+
+    def test_flag_first_returns_none(self):
+        parser = OmniArgumentParser("test")
+        assert parser._peek_model_flat(["--port", "8000"]) is None
+
+    def test_empty_returns_none(self):
+        parser = OmniArgumentParser("test")
+        assert parser._peek_model_flat([]) is None
+
+
+class TestPeekStageId:
+    def test_space_form(self):
+        assert OAP._peek_stage_id(["--stage-id", "2"]) == 2
+
+    def test_equals_form(self):
+        assert OAP._peek_stage_id(["--stage-id=3"]) == 3
+
+    def test_missing(self):
+        assert OAP._peek_stage_id(["serve", "foo"]) is None
+
+    def test_invalid(self):
+        assert OAP._peek_stage_id(["--stage-id", "abc"]) is None
+
+
+class TestPeekDeployConfig:
+    def test_space_form(self):
+        assert OAP._peek_deploy_config(["--deploy-config", "/path/to/d.yaml"]) == "/path/to/d.yaml"
+
+    def test_equals_form(self):
+        assert OAP._peek_deploy_config(["--deploy-config=/path/to/d.yaml"]) == "/path/to/d.yaml"
+
+    def test_missing(self):
+        assert OAP._peek_deploy_config(["serve", "foo"]) is None
+
+
+class TestIsHelpOrVersion:
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["--help"],
+            ["-h"],
+            ["--version"],
+            ["-v"],
+            ["--help=OmniConfig"],
+        ],
+    )
+    def test_positive(self, args):
+        assert OAP._is_help_or_version(args) is True
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["serve", "foo", "--omni"],
+            [],
+            ["--port", "8000"],
+        ],
+    )
+    def test_negative(self, args):
+        assert OAP._is_help_or_version(args) is False
+
+
+class TestIsServeOrFlat:
+    def test_serve_subcommand(self):
+        parser = OmniArgumentParser("test")
+        sub = parser.add_subparsers(dest="s")
+        sub.add_parser("serve")
+        assert parser._is_serve_or_flat(["serve", "foo"]) is True
+
+    def test_not_serve(self):
+        parser = OmniArgumentParser("test")
+        sub = parser.add_subparsers(dest="s")
+        sub.add_parser("bench")
+        assert parser._is_serve_or_flat(["bench", "foo"]) is False
+
+    def test_flat_parser(self):
+        parser = OmniArgumentParser("test")
+        assert parser._is_serve_or_flat(["my-model", "--port", "8000"]) is True
+
+
+# ===========================================================================
+# B — _set_action_default
+# ===========================================================================
+
+
+class TestSetActionDefault:
+    def test_sets_matching_dest(self):
+        p = argparse.ArgumentParser()
+        p.add_argument("--dtype", type=str, default="auto")
+        OAP._set_action_default(p, "dtype", "bfloat16")
+        args = p.parse_args([])
+        assert args.dtype == "bfloat16"
+
+    def test_noop_on_missing_dest(self):
+        p = argparse.ArgumentParser()
+        p.add_argument("--dtype", type=str, default="auto")
+        OAP._set_action_default(p, "nonexistent", 999)
+        args = p.parse_args([])
+        assert args.dtype == "auto"
+
+    def test_preserves_type_converter(self):
+        p = argparse.ArgumentParser()
+        p.add_argument("--gpu-mem", type=float, default=0.9)
+        OAP._set_action_default(p, "gpu_mem", 0.5)
+        args = p.parse_args(["--gpu-mem", "0.3"])
+        assert args.gpu_mem == 0.3
+        assert isinstance(args.gpu_mem, float)
+
+    def test_bool_default(self):
+        p = argparse.ArgumentParser()
+        p.add_argument("--enforce-eager", action="store_true", default=False)
+        OAP._set_action_default(p, "enforce_eager", True)
+        args = p.parse_args([])
+        assert args.enforce_eager is True
+        args = p.parse_args(["--enforce-eager"])
+        assert args.enforce_eager is True
+        args = p.parse_args(["--no-enforce-eager"]) if False else None
+        # BooleanOptionalAction not used here; store_true default works
+
+
+# ===========================================================================
+# C — _deep_merge
+# ===========================================================================
+
+
+class TestDeepMerge:
+    def test_simple_override(self):
+        assert _deep_merge({"a": 1}, {"a": 2}) == {"a": 2}
+
+    def test_nested_merge(self):
+        assert _deep_merge({"a": {"x": 1, "y": 2}}, {"a": {"y": 99, "z": 100}}) == {
+            "a": {"x": 1, "y": 99, "z": 100},
+        }
+
+    def test_type_mismatch_overrides(self):
+        assert _deep_merge({"a": {"x": 1}}, {"a": "str"}) == {"a": "str"}
+
+    def test_preserves_untouched(self):
+        result = _deep_merge({"a": 1, "b": {"x": 1}, "c": 3}, {"b": {"y": 2}})
+        assert result == {"a": 1, "b": {"x": 1, "y": 2}, "c": 3}
+
+    def test_normalizes_int_keys_to_strings(self):
+        """Fix P5: int keys from callers should merge with string keys from YAML."""
+        result = _deep_merge({"0": {"a": 1}}, {0: {"b": 2}})
+        assert result == {"0": {"a": 1, "b": 2}}
+
+
+# ===========================================================================
+# D — parse_args integration (mocked model detection)
+# ===========================================================================
+
+
+def _make_serve_parser() -> OmniArgumentParser:
+    """Build an OmniArgumentParser with a 'serve' subparser and typical flags."""
+    parser = OmniArgumentParser("test")
+    subparsers = parser.add_subparsers(dest="subparser")
+    serve = subparsers.add_parser("serve")
+    serve.add_argument("model_tag", nargs="?", default=None)
+    serve.add_argument("--async-chunk", action=argparse.BooleanOptionalAction, default=None)
+    serve.add_argument("--dtype", type=str, default="auto")
+    serve.add_argument("--gpu-memory-utilization", "-gmu", type=float, default=0.9)
+    serve.add_argument("--enforce-eager", action="store_true", default=False)
+    serve.add_argument("--stage-overrides", type=str, default=None)
+    serve.add_argument("--stage-id", type=int, default=None)
+    serve.add_argument("--deploy-config", type=str, default=None)
+    parser.set_defaults(subparser="serve")
+    return parser
+
+
+def _write_deploy_yaml(path, *, async_chunk=None, dtype=None, stages=None):
+    """Write a minimal deploy YAML to *path*."""
+    lines = []
+    if async_chunk is not None:
+        lines.append(f"async_chunk: {str(async_chunk).lower()}")
+    if dtype is not None:
+        lines.append(f"dtype: {dtype}")
+    if stages is not None:
+        if stages:
+            lines.append("stages:")
+            for s in stages:
+                lines.append(f"  - stage_id: {s['stage_id']}")
+                for k, v in s.items():
+                    if k == "stage_id":
+                        continue
+                    if isinstance(v, bool):
+                        lines.append(f"    {k}: {str(v).lower()}")
+                    elif isinstance(v, str):
+                        lines.append(f"    {k}: {v}")
+                    else:
+                        lines.append(f"    {k}: {v}")
+        else:
+            lines.append("stages: []")
+    path.write_text("\n".join(lines) + "\n")
+
+
+@pytest.fixture
+def mock_model_detection(mocker, tmp_path):
+    """Patch model_type detection and deploy dir to point at tmp_path."""
+    mocker.patch(
+        "vllm_omni.config.stage_config.StageConfigFactory._auto_detect_model_type",
+        return_value=("test_model", None),
+    )
+    mocker.patch("vllm_omni.config.stage_config._DEPLOY_DIR", tmp_path)
+
+
+class TestParseArgsIntegration:
+    def test_injects_pipeline_defaults(self, mocker, tmp_path, mock_model_detection):
+        _write_deploy_yaml(tmp_path / "test_model.yaml", async_chunk=False, dtype="bfloat16")
+        parser = _make_serve_parser()
+        args = parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B"])
+        assert args.async_chunk is False
+        assert args.dtype == "bfloat16"
+        # gpu-memory-utilization was not in deploy YAML, keeps vLLM default
+        assert args.gpu_memory_utilization == 0.9
+
+    def test_cli_overrides_yaml_defaults(self, mocker, tmp_path, mock_model_detection):
+        _write_deploy_yaml(tmp_path / "test_model.yaml", async_chunk=False, dtype="bfloat16")
+        parser = _make_serve_parser()
+        args = parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B", "--dtype", "float32"])
+        assert args.dtype == "float32"  # CLI wins
+        assert args.async_chunk is False  # YAML still applies
+
+    def test_help_skips_injection(self, mocker, tmp_path, mock_model_detection):
+        _write_deploy_yaml(tmp_path / "test_model.yaml", async_chunk=False, dtype="bfloat16")
+        parser = _make_serve_parser()
+        # parse_args exits on --help, so we verify via _is_help_or_version gate
+        # and confirm that help text does not crash
+        with pytest.raises(SystemExit):
+            parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B", "--help"])
+
+    def test_nonserve_skips_injection(self, mocker, tmp_path, mock_model_detection):
+        _write_deploy_yaml(tmp_path / "test_model.yaml", async_chunk=False)
+        parser = OmniArgumentParser("test")
+        subparsers = parser.add_subparsers(dest="subparser")
+        bench = subparsers.add_parser("bench")
+        bench.add_argument("--dtype", type=str, default="auto")
+        bench.add_argument("model_tag", nargs="?", default=None)
+        parser.set_defaults(subparser="bench")
+
+        args = parser.parse_args(["bench", "--dtype", "float16"])
+        # dtype should NOT get YAML default because bench is not serve
+        assert args.dtype == "float16"
+
+    def test_deploy_not_found_noop(self, mocker, tmp_path, mock_model_detection):
+        # No test_model.yaml written
+        parser = _make_serve_parser()
+        args = parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B", "--dtype", "float16"])
+        assert args.dtype == "float16"  # user value only
+
+    def test_custom_deploy_config(self, mocker, tmp_path, mock_model_detection):
+        custom = tmp_path / "custom_deploy.yaml"
+        _write_deploy_yaml(custom, async_chunk=True, dtype="custom_dtype", stages=[])
+        parser = _make_serve_parser()
+        args = parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B", "--deploy-config", str(custom)])
+        assert args.dtype == "custom_dtype"
+        assert args.async_chunk is True
+
+    def test_custom_deploy_config_equals_form(self, mocker, tmp_path, mock_model_detection):
+        custom = tmp_path / "custom_deploy.yaml"
+        _write_deploy_yaml(custom, async_chunk=True, dtype="equals_form_dtype", stages=[])
+        parser = _make_serve_parser()
+        args = parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B", f"--deploy-config={custom}"])
+        assert args.dtype == "equals_form_dtype"
+
+    def test_state_cleanup_between_parses(self, mocker, tmp_path, mock_model_detection):
+        """Fix P4: _yaml_stage_overrides cleared between parse_args calls."""
+        _write_deploy_yaml(
+            tmp_path / "test_model.yaml",
+            async_chunk=True,
+            stages=[{"stage_id": 0, "gpu_memory_utilization": 0.5}],
+        )
+        parser = _make_serve_parser()
+        parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B"])  # first parse seeds yaml defaults
+        # Second parse should not carry over stale defaults
+        args2 = parser.parse_args(
+            ["serve", "Qwen/Qwen2.5-Omni-7B", "--stage-overrides", '{"0": {"enforce_eager": true}}']
+        )
+        so2 = json.loads(args2.stage_overrides)
+        # User override should win, YAML gpu_memory_utilization should still be present
+        assert so2["0"]["enforce_eager"] is True
+        assert so2["0"]["gpu_memory_utilization"] == 0.5
+
+
+# ===========================================================================
+# E — post-parse stage_overrides merge
+# ===========================================================================
+
+
+class TestPostParseMerge:
+    def test_yaml_only_stage_overrides(self, mocker, tmp_path, mock_model_detection):
+        _write_deploy_yaml(
+            tmp_path / "test_model.yaml",
+            stages=[{"stage_id": 0, "gpu_memory_utilization": 0.5, "enforce_eager": True}],
+        )
+        parser = _make_serve_parser()
+        args = parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B"])
+        so = json.loads(args.stage_overrides)
+        assert so["0"]["gpu_memory_utilization"] == 0.5
+        assert so["0"]["enforce_eager"] is True
+
+    def test_user_merges_with_yaml_stage_overrides(self, mocker, tmp_path, mock_model_detection):
+        _write_deploy_yaml(
+            tmp_path / "test_model.yaml",
+            stages=[
+                {"stage_id": 0, "gpu_memory_utilization": 0.8, "enforce_eager": True},
+                {"stage_id": 1, "gpu_memory_utilization": 0.4},
+            ],
+        )
+        parser = _make_serve_parser()
+        args = parser.parse_args(
+            ["serve", "Qwen/Qwen2.5-Omni-7B", "--stage-overrides", '{"0": {"gpu_memory_utilization": 0.5}}']
+        )
+        so = json.loads(args.stage_overrides)
+        assert so["0"]["gpu_memory_utilization"] == 0.5  # user wins
+        assert so["0"]["enforce_eager"] is True  # YAML preserved
+        assert so["1"]["gpu_memory_utilization"] == 0.4  # YAML preserved
+
+    def test_no_merge_when_no_yaml_overrides(self, mocker, tmp_path, mock_model_detection):
+        # Deploy YAML with pipeline defaults but no per-stage fields
+        _write_deploy_yaml(tmp_path / "test_model.yaml", async_chunk=False)
+        parser = _make_serve_parser()
+        args = parser.parse_args(
+            ["serve", "Qwen/Qwen2.5-Omni-7B", "--stage-overrides", '{"0": {"enforce_eager": true}}']
+        )
+        so = json.loads(args.stage_overrides)
+        assert so == {"0": {"enforce_eager": True}}
+
+
+# ===========================================================================
+# F — _inject_model_defaults edge cases
+# ===========================================================================
+
+
+class TestInjectModelDefaults:
+    def test_engine_extras_skipped(self, mocker, tmp_path, mock_model_detection):
+        """engine_extras should not be set as action.default."""
+        _write_deploy_yaml(
+            tmp_path / "test_model.yaml",
+            stages=[{"stage_id": 0, "gpu_memory_utilization": 0.5, "enforce_eager": True}],
+        )
+        parser = _make_serve_parser()
+        args = parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B"])
+        so = json.loads(args.stage_overrides)
+        assert "engine_extras" not in so.get("0", {})
+
+    def test_headless_per_stage_defaults(self, mocker, tmp_path, mock_model_detection):
+        _write_deploy_yaml(
+            tmp_path / "test_model.yaml",
+            stages=[{"stage_id": 0, "gpu_memory_utilization": 0.5, "enforce_eager": True}],
+        )
+        parser = _make_serve_parser()
+        args = parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B", "--stage-id", "0"])
+        assert args.gpu_memory_utilization == 0.5
+        assert args.enforce_eager is True

--- a/tests/engine/test_omni_argument_parser.py
+++ b/tests/engine/test_omni_argument_parser.py
@@ -412,3 +412,28 @@ class TestInjectModelDefaults:
         args = parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B", "--stage-id", "0"])
         assert args.gpu_memory_utilization == 0.5
         assert args.enforce_eager is True
+
+
+# ===========================================================================
+# G — Edge cases: model_type detection fails, malformed YAML
+# ===========================================================================
+
+
+class TestEdgeCases:
+    def test_model_type_detection_returns_none(self, mocker, tmp_path, mock_model_detection):
+        """When _auto_detect_model_type returns (None, None), injection is skipped cleanly."""
+        mocker.patch(
+            "vllm_omni.config.stage_config.StageConfigFactory._auto_detect_model_type",
+            return_value=(None, None),
+        )
+        parser = _make_serve_parser()
+        args = parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B", "--dtype", "float32"])
+        assert args.dtype == "float32"  # user value used, no crash
+
+    def test_malformed_deploy_yaml_noop(self, mocker, tmp_path, mock_model_detection):
+        """Malformed deploy YAML is caught gracefully — injection skipped, no crash."""
+        yaml = tmp_path / "test_model.yaml"
+        yaml.write_text("{ invalid: yaml: content: [")  # malformed YAML
+        parser = _make_serve_parser()
+        args = parser.parse_args(["serve", "Qwen/Qwen2.5-Omni-7B", "--dtype", "float32"])
+        assert args.dtype == "float32"  # no crash, user value used

--- a/tests/entrypoints/test_omni_entrypoints.py
+++ b/tests/entrypoints/test_omni_entrypoints.py
@@ -1053,3 +1053,118 @@ def test_omni_errored_property_dead_stage(monkeypatch: pytest.MonkeyPatch):
         assert app.errored is True
     finally:
         app.shutdown()
+
+
+# ===========================================================================
+# Offline _inject_deploy_defaults
+# ===========================================================================
+
+
+class TestInjectDeployDefaults:
+    def test_normal_serve_fills_pipeline_defaults(self, tmp_path, mocker):
+        """Pipeline-wide DeployConfig fields filled via setdefault."""
+        from vllm_omni.entrypoints.omni_base import _inject_deploy_defaults
+
+        yaml = tmp_path / "test_model.yaml"
+        yaml.write_text("async_chunk: false\ndtype: bfloat16\nstages: []\n")
+
+        mocker.patch(
+            "vllm_omni.config.stage_config.StageConfigFactory._auto_detect_model_type",
+            return_value=("test_model", None),
+        )
+        mocker.patch("vllm_omni.config.stage_config._DEPLOY_DIR", tmp_path)
+
+        kwargs = {"model": "Qwen/Qwen2.5-Omni-7B", "dtype": "float32"}
+        _inject_deploy_defaults(kwargs["model"], kwargs)
+
+        assert kwargs["dtype"] == "float32"  # user value preserved
+        assert kwargs["async_chunk"] is False  # YAML injected
+
+    def test_headless_fills_per_stage_defaults(self, tmp_path, mocker):
+        """Per-stage StageDeployConfig fields filled in headless mode."""
+        from vllm_omni.entrypoints.omni_base import _inject_deploy_defaults
+
+        yaml = tmp_path / "test_model.yaml"
+        yaml.write_text("stages:\n  - stage_id: 0\n    gpu_memory_utilization: 0.5\n    enforce_eager: true\n")
+
+        mocker.patch(
+            "vllm_omni.config.stage_config.StageConfigFactory._auto_detect_model_type",
+            return_value=("test_model", None),
+        )
+        mocker.patch("vllm_omni.config.stage_config._DEPLOY_DIR", tmp_path)
+
+        kwargs = {"model": "Qwen/Qwen2.5-Omni-7B", "stage_id": 0, "gpu_memory_utilization": 0.3}
+        _inject_deploy_defaults(kwargs["model"], kwargs)
+
+        assert kwargs["gpu_memory_utilization"] == 0.3  # user value preserved
+        assert kwargs["enforce_eager"] is True  # YAML injected
+
+    def test_custom_deploy_config_used(self, tmp_path, mocker):
+        """When deploy_config is in kwargs, it's used instead of model_type detection."""
+        from vllm_omni.entrypoints.omni_base import _inject_deploy_defaults
+
+        custom = tmp_path / "custom_deploy.yaml"
+        custom.write_text("async_chunk: true\ndtype: custom_dtype\nstages: []\n")
+
+        kwargs = {"model": "Qwen/Qwen2.5-Omni-7B", "deploy_config": str(custom), "dtype": "float32"}
+        _inject_deploy_defaults(kwargs["model"], kwargs)
+
+        assert kwargs["dtype"] == "float32"  # user preserved
+        assert kwargs["async_chunk"] is True  # from custom YAML
+
+    def test_normal_serve_generates_stage_overrides(self, tmp_path, mocker):
+        """Per-stage defaults collapsed into stage_overrides JSON for normal serve."""
+        from vllm_omni.entrypoints.omni_base import _inject_deploy_defaults
+
+        yaml = tmp_path / "test_model.yaml"
+        yaml.write_text(
+            "stages:\n"
+            "  - stage_id: 0\n"
+            "    gpu_memory_utilization: 0.5\n"
+            "    enforce_eager: true\n"
+            "  - stage_id: 1\n"
+            "    gpu_memory_utilization: 0.8\n"
+            "    enforce_eager: false\n"
+        )
+
+        mocker.patch(
+            "vllm_omni.config.stage_config.StageConfigFactory._auto_detect_model_type",
+            return_value=("test_model", None),
+        )
+        mocker.patch("vllm_omni.config.stage_config._DEPLOY_DIR", tmp_path)
+
+        kwargs = {"model": "Qwen/Qwen2.5-Omni-7B"}
+        _inject_deploy_defaults(kwargs["model"], kwargs)
+
+        import json
+
+        so = json.loads(kwargs["stage_overrides"])
+        assert so["0"]["gpu_memory_utilization"] == 0.5
+        assert so["0"]["enforce_eager"] is True
+        assert so["1"]["gpu_memory_utilization"] == 0.8
+        assert so["1"]["enforce_eager"] is False
+
+    def test_stage_overrides_deep_merged_with_existing(self, tmp_path, mocker):
+        """Existing stage_overrides deep-merged with YAML defaults."""
+        from vllm_omni.entrypoints.omni_base import _inject_deploy_defaults
+
+        yaml = tmp_path / "test_model.yaml"
+        yaml.write_text("stages:\n  - stage_id: 0\n    gpu_memory_utilization: 0.5\n    enforce_eager: true\n")
+
+        mocker.patch(
+            "vllm_omni.config.stage_config.StageConfigFactory._auto_detect_model_type",
+            return_value=("test_model", None),
+        )
+        mocker.patch("vllm_omni.config.stage_config._DEPLOY_DIR", tmp_path)
+
+        kwargs = {
+            "model": "Qwen/Qwen2.5-Omni-7B",
+            "stage_overrides": '{"0": {"gpu_memory_utilization": 0.3}}',
+        }
+        _inject_deploy_defaults(kwargs["model"], kwargs)
+
+        import json
+
+        so = json.loads(kwargs["stage_overrides"])
+        assert so["0"]["gpu_memory_utilization"] == 0.3  # user wins
+        assert so["0"]["enforce_eager"] is True  # YAML preserved

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -753,7 +753,22 @@ _PIPELINE_WIDE_ENGINE_FIELDS: tuple[str, ...] = (
 
 
 def deploy_override_field_names() -> frozenset[str]:
-    """Return deploy-schema fields whose CLI defaults must not override YAML."""
+    """Return deploy-schema fields whose CLI defaults must not override YAML.
+
+    .. deprecated::
+        ``OmniArgumentParser`` and ``_inject_deploy_defaults`` now inject
+        model-specific defaults from deploy YAML by iterating dataclass
+        ``fields()`` dynamically — no hardcoded field set is needed.
+    """
+    import warnings
+
+    warnings.warn(
+        "deploy_override_field_names is deprecated. "
+        "OmniArgumentParser and _inject_deploy_defaults use dataclass "
+        "fields() iteration instead — no hardcoded field set is needed.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return (
         frozenset(_STAGE_DEPLOY_FIELDS)
         | frozenset(_PIPELINE_WIDE_ENGINE_FIELDS)

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -643,18 +643,30 @@ class OmniArgumentParser(FlexibleArgumentParser):
         if args is None:
             args = sys.argv[1:]
 
-        # Skip model detection for help/version — avoid unnecessary HF downloads
-        if not self._is_help_or_version(args):
-            model = self._peek_model(args)
+        # Clear stale state from a previous parse_args() call (fixes P4).
+        self._yaml_stage_overrides = None
+
+        # Gate: only inject defaults for "serve" subcommand or flat-parser
+        # mode (api_server direct launch).  Avoids unnecessary HF config
+        # fetches for unrelated subcommands like "bench" (fixes P3).
+        if self._is_serve_or_flat(args) and not self._is_help_or_version(args):
+            # Use flat-parser peek when there are no subparsers (api_server),
+            # otherwise use the standard serve-subcommand peek.
+            if self._subparsers is None:
+                model = self._peek_model_flat(args)
+            else:
+                model = self._peek_model(args)
             if model:
                 stage_id = self._peek_stage_id(args)
                 self._inject_model_defaults(model, stage_id)
 
         result = super().parse_args(args, namespace)
 
-        # Post-parse: deep-merge stashed YAML stage_overrides with user value
+        # Post-parse: deep-merge stashed YAML stage_overrides with user value.
+        # Only apply when stage_overrides is present in the parsed namespace
+        # and we actually stashed yaml defaults (fixes P4).
         yaml_overrides = getattr(self, "_yaml_stage_overrides", None)
-        if yaml_overrides is not None:
+        if yaml_overrides is not None and hasattr(result, "stage_overrides"):
             user_raw = getattr(result, "stage_overrides", None)
             if user_raw:
                 user_overrides = json.loads(user_raw) if isinstance(user_raw, str) else user_raw
@@ -674,23 +686,34 @@ class OmniArgumentParser(FlexibleArgumentParser):
                 return True
         return False
 
+    def _is_serve_or_flat(self, args: list[str]) -> bool:
+        """True when injection should proceed: ``serve`` subcommand or flat-parser (api_server)."""
+        if self._subparsers is None:
+            return True
+        return bool(args) and args[0] == "serve"
+
     @classmethod
     def _peek_model(cls, args: list[str]) -> str | None:
         """Extract model from raw CLI args before full preprocessing.
 
-        Handles the three cases FlexibleArgumentParser handles:
-        1. --config config.yaml → reads yaml['model']
+        Handles the cases FlexibleArgumentParser handles:
+        1. --config config.yaml / --config=config.yaml → reads yaml['model']
         2. --model foo/bar → promoted to positional by FlexibleArgumentParser
         3. vllm serve foo/bar → first positional after subcommand
+        4. python -m ...api_server foo/bar → first positional (flat parser)
         """
         current = list(args)
 
-        # Case 1: --config YAML
-        if "--config" in current:
-            idx = current.index("--config")
-            if idx + 1 < len(current):
+        # Case 1: --config YAML (both --config <path> and --config=<path>)
+        for i, arg in enumerate(current):
+            path: str | None = None
+            if arg == "--config" and i + 1 < len(current):
+                path = current[i + 1]
+            elif arg.startswith("--config="):
+                path = arg.split("=", 1)[1]
+            if path:
                 try:
-                    with open(current[idx + 1]) as fh:
+                    with open(path) as fh:
                         cfg = yaml.safe_load(fh)
                     if isinstance(cfg, dict) and cfg.get("model"):
                         return cfg["model"]
@@ -709,6 +732,13 @@ class OmniArgumentParser(FlexibleArgumentParser):
             if not current[1].startswith("-"):
                 return current[1]
 
+        return None
+
+    def _peek_model_flat(self, args: list[str]) -> str | None:
+        """Peek model for flat-parser mode (no subparsers — api_server direct launch)."""
+        current = list(args)
+        if current and not current[0].startswith("-"):
+            return current[0]
         return None
 
     @staticmethod

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -2,12 +2,15 @@ import argparse
 import dataclasses
 import json
 import os
+import sys
 import tempfile
 from dataclasses import dataclass, field, fields
 from typing import Any
 
+import yaml
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
 from vllm.logger import init_logger
+from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 from vllm_omni.config import OmniModelConfig
 from vllm_omni.engine.output_modality import OutputModality
@@ -606,10 +609,227 @@ def orchestrator_args_from_argparse(args: Any) -> OrchestratorArgs:
     return OrchestratorArgs(**kwargs)
 
 
+# ============================================================================
+# OmniArgumentParser — model-aware default injection
+# ============================================================================
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge *override* into *base*; override keys win."""
+    result = dict(base)
+    for key, val in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(val, dict):
+            result[key] = _deep_merge(result[key], val)
+        else:
+            result[key] = val
+    return result
+
+
+class OmniArgumentParser(FlexibleArgumentParser):
+    """FlexibleArgumentParser that injects model-specific defaults from deploy YAML.
+
+    On ``parse_args()``, peeks the model from raw ``sys.argv``, detects its
+    ``model_type`` via HuggingFace config, loads the corresponding
+    ``deploy/<model_type>.yaml``, and sets YAML values as ``action.default`` on
+    the serve subparser.  Argparse then uses these as fallback values — any
+    explicit CLI flag typed by the user naturally takes precedence.
+
+    Per-stage fields in normal-serve mode are collapsed into a JSON default on
+    ``--stage-overrides`` and deep-merged post-parse with any user-supplied
+    ``--stage-overrides`` value.
+    """
+
+    def parse_args(self, args: list[str] | None = None, namespace: argparse.Namespace | None = None):
+        if args is None:
+            args = sys.argv[1:]
+
+        # Skip model detection for help/version — avoid unnecessary HF downloads
+        if not self._is_help_or_version(args):
+            model = self._peek_model(args)
+            if model:
+                stage_id = self._peek_stage_id(args)
+                self._inject_model_defaults(model, stage_id)
+
+        result = super().parse_args(args, namespace)
+
+        # Post-parse: deep-merge stashed YAML stage_overrides with user value
+        yaml_overrides = getattr(self, "_yaml_stage_overrides", None)
+        if yaml_overrides is not None:
+            user_raw = getattr(result, "stage_overrides", None)
+            if user_raw:
+                user_overrides = json.loads(user_raw) if isinstance(user_raw, str) else user_raw
+                merged = _deep_merge(yaml_overrides, user_overrides)
+            else:
+                merged = yaml_overrides
+            setattr(result, "stage_overrides", json.dumps(merged, sort_keys=True))
+
+        return result
+
+    # ── Peek helpers ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def _is_help_or_version(args: list[str]) -> bool:
+        for a in args:
+            if a in ("--help", "-h", "--version", "-v") or a.startswith("--help="):
+                return True
+        return False
+
+    @classmethod
+    def _peek_model(cls, args: list[str]) -> str | None:
+        """Extract model from raw CLI args before full preprocessing.
+
+        Handles the three cases FlexibleArgumentParser handles:
+        1. --config config.yaml → reads yaml['model']
+        2. --model foo/bar → promoted to positional by FlexibleArgumentParser
+        3. vllm serve foo/bar → first positional after subcommand
+        """
+        current = list(args)
+
+        # Case 1: --config YAML
+        if "--config" in current:
+            idx = current.index("--config")
+            if idx + 1 < len(current):
+                try:
+                    with open(current[idx + 1]) as fh:
+                        cfg = yaml.safe_load(fh)
+                    if isinstance(cfg, dict) and cfg.get("model"):
+                        return cfg["model"]
+                except Exception:
+                    pass
+
+        # Case 2: --model flag
+        for i, arg in enumerate(current):
+            if arg == "--model" and i + 1 < len(current):
+                return current[i + 1]
+            if arg.startswith("--model="):
+                return arg.split("=", 1)[1]
+
+        # Case 3: positional model for "serve" subcommand
+        if current and current[0] == "serve" and len(current) > 1:
+            if not current[1].startswith("-"):
+                return current[1]
+
+        return None
+
+    @staticmethod
+    def _peek_stage_id(args: list[str]) -> int | None:
+        for i, arg in enumerate(args):
+            if arg == "--stage-id" and i + 1 < len(args):
+                try:
+                    return int(args[i + 1])
+                except (ValueError, IndexError):
+                    pass
+            if arg.startswith("--stage-id="):
+                try:
+                    return int(arg.split("=", 1)[1])
+                except ValueError:
+                    pass
+        return None
+
+    # ── Default injection ───────────────────────────────────────────────────
+
+    def _inject_model_defaults(self, model: str, stage_id: int | None) -> None:
+        """Load deploy YAML and set ``action.default`` on the serve subparser."""
+        from dataclasses import fields as dc_fields
+
+        from vllm_omni.config.stage_config import (
+            _DEPLOY_DIR,
+            DeployConfig,
+            StageConfigFactory,
+            StageDeployConfig,
+            load_deploy_config,
+        )
+
+        model_type, _hf_config = StageConfigFactory._auto_detect_model_type(model)
+        if not model_type:
+            return
+
+        deploy_path = _DEPLOY_DIR / f"{model_type}.yaml"
+        if not deploy_path.exists():
+            return
+
+        deploy = load_deploy_config(deploy_path)
+        serve_parser = self._get_serve_subparser()
+        if serve_parser is None:
+            if self._subparsers is None:
+                serve_parser = self  # flat-parser mode (api_server direct invocation)
+            else:
+                return
+
+        # ── Pipeline-wide: DeployConfig fields → action.default ──
+        for f in dc_fields(DeployConfig):
+            val = getattr(deploy, f.name)
+            if val is not None:
+                self._set_action_default(serve_parser, f.name, val)
+
+        # ── Per-stage ──
+        if stage_id is not None:
+            # Headless: set per-stage action.defaults directly
+            stage_dep = next((s for s in deploy.stages if s.stage_id == stage_id), None)
+            if stage_dep:
+                for f in dc_fields(StageDeployConfig):
+                    if f.name == "engine_extras":
+                        continue
+                    val = getattr(stage_dep, f.name)
+                    if val is not None:
+                        self._set_action_default(serve_parser, f.name, val)
+        else:
+            # Normal serve: collapse all stages into stage_overrides JSON
+            stage_overrides: dict[str, dict[str, Any]] = {}
+            for stage in deploy.stages:
+                d: dict[str, Any] = {}
+                for f in dc_fields(StageDeployConfig):
+                    if f.name == "engine_extras":
+                        continue
+                    val = getattr(stage, f.name)
+                    if val is not None:
+                        d[f.name] = val
+                if d:
+                    stage_overrides[str(stage.stage_id)] = d
+
+            if stage_overrides:
+                yaml_json = json.dumps(stage_overrides, sort_keys=True)
+                self._set_action_default(serve_parser, "stage_overrides", yaml_json)
+                self._yaml_stage_overrides = stage_overrides
+
+    @staticmethod
+    def _set_action_default(parser: argparse.ArgumentParser, dest: str, value: Any) -> None:
+        for action in parser._actions:
+            if action.dest == dest:
+                action.default = value
+                break
+
+    def _get_serve_subparser(self) -> argparse.ArgumentParser | None:
+        if self._subparsers is None:
+            return None
+        subparsers_action = self._subparsers._group_actions[0]
+        return subparsers_action.choices.get("serve")
+
+
+# ============================================================================
+# End OmniArgumentParser
+# ============================================================================
+
+
 def nullify_stage_engine_defaults(parser: argparse.ArgumentParser) -> None:
     """Reset stage-level engine flag defaults to ``None``; preserve real
     default in help text. Only deploy-YAML override fields are touched.
-    Idempotent."""
+    Idempotent.
+
+    .. deprecated::
+        Use :class:`OmniArgumentParser` instead — it injects model-specific
+        defaults from deploy YAML directly as argparse defaults, eliminating
+        the need for nullify-then-refill.
+    """
+    import warnings
+
+    warnings.warn(
+        "nullify_stage_engine_defaults is deprecated. "
+        "Use OmniArgumentParser instead, which injects model-specific "
+        "defaults from deploy YAML directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     from vllm_omni.config.stage_config import deploy_override_field_names
 
     override_dests = deploy_override_field_names()

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -805,7 +805,11 @@ class OmniArgumentParser(FlexibleArgumentParser):
             if not deploy_path.exists():
                 return
 
-        deploy = load_deploy_config(deploy_path)
+        try:
+            deploy = load_deploy_config(deploy_path)
+        except Exception:
+            logger.warning("Failed to load deploy config from %s", deploy_path)
+            return
         serve_parser = self._get_serve_subparser()
         if serve_parser is None:
             if self._subparsers is None:

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -658,7 +658,8 @@ class OmniArgumentParser(FlexibleArgumentParser):
                 model = self._peek_model(args)
             if model:
                 stage_id = self._peek_stage_id(args)
-                self._inject_model_defaults(model, stage_id)
+                deploy_config_path = self._peek_deploy_config(args)
+                self._inject_model_defaults(model, stage_id, deploy_config_path=deploy_config_path)
 
         result = super().parse_args(args, namespace)
 
@@ -756,11 +757,29 @@ class OmniArgumentParser(FlexibleArgumentParser):
                     pass
         return None
 
+    @staticmethod
+    def _peek_deploy_config(args: list[str]) -> str | None:
+        """Peek --deploy-config from raw argv (supports both --deploy-config <p> and --deploy-config=<p>)."""
+        for i, arg in enumerate(args):
+            if arg == "--deploy-config" and i + 1 < len(args):
+                return args[i + 1]
+            if arg.startswith("--deploy-config="):
+                return arg.split("=", 1)[1]
+        return None
+
     # ── Default injection ───────────────────────────────────────────────────
 
-    def _inject_model_defaults(self, model: str, stage_id: int | None) -> None:
-        """Load deploy YAML and set ``action.default`` on the serve subparser."""
+    def _inject_model_defaults(
+        self, model: str, stage_id: int | None, *, deploy_config_path: str | None = None
+    ) -> None:
+        """Load deploy YAML and set ``action.default`` on the serve subparser.
+
+        If *deploy_config_path* is given (from ``--deploy-config``), that file
+        is used directly.  Otherwise the per-model ``deploy/<model_type>.yaml``
+        is resolved from the HuggingFace config.
+        """
         from dataclasses import fields as dc_fields
+        from pathlib import Path
 
         from vllm_omni.config.stage_config import (
             _DEPLOY_DIR,
@@ -770,13 +789,17 @@ class OmniArgumentParser(FlexibleArgumentParser):
             load_deploy_config,
         )
 
-        model_type, _hf_config = StageConfigFactory._auto_detect_model_type(model)
-        if not model_type:
-            return
-
-        deploy_path = _DEPLOY_DIR / f"{model_type}.yaml"
-        if not deploy_path.exists():
-            return
+        if deploy_config_path:
+            deploy_path = Path(deploy_config_path)
+            if not deploy_path.exists():
+                return
+        else:
+            model_type, _hf_config = StageConfigFactory._auto_detect_model_type(model)
+            if not model_type:
+                return
+            deploy_path = _DEPLOY_DIR / f"{model_type}.yaml"
+            if not deploy_path.exists():
+                return
 
         deploy = load_deploy_config(deploy_path)
         serve_parser = self._get_serve_subparser()

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -615,13 +615,17 @@ def orchestrator_args_from_argparse(args: Any) -> OrchestratorArgs:
 
 
 def _deep_merge(base: dict, override: dict) -> dict:
-    """Recursively merge *override* into *base*; override keys win."""
+    """Recursively merge *override* into *base*; override keys win.
+
+    Keys are normalised to strings to avoid duplicate keys when
+    callers provide integer keys alongside string keys."""
     result = dict(base)
     for key, val in override.items():
-        if key in result and isinstance(result[key], dict) and isinstance(val, dict):
-            result[key] = _deep_merge(result[key], val)
+        key_str = str(key)
+        if key_str in result and isinstance(result[key_str], dict) and isinstance(val, dict):
+            result[key_str] = _deep_merge(result[key_str], val)
         else:
-            result[key] = val
+            result[key_str] = val
     return result
 
 

--- a/vllm_omni/entrypoints/cli/main.py
+++ b/vllm_omni/entrypoints/cli/main.py
@@ -24,10 +24,10 @@ def main():
             os.environ["VLLM_LOGGING_COLOR"] = "1"
 
         from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG, cli_env_setup
-        from vllm.utils.argparse_utils import FlexibleArgumentParser
 
         import vllm_omni.entrypoints.cli.benchmark.main
         import vllm_omni.entrypoints.cli.serve
+        from vllm_omni.engine.arg_utils import OmniArgumentParser
 
         CMD_MODULES = [
             vllm_omni.entrypoints.cli.serve,
@@ -40,7 +40,7 @@ def main():
 
         _ensure_vllm_platform()
 
-        parser = FlexibleArgumentParser(
+        parser = OmniArgumentParser(
             description="vLLM OMNI CLI",
             epilog=VLLM_SUBCMD_PARSER_EPILOG.format(subcmd="[subcommand]"),
         )

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -21,7 +21,6 @@ from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
-from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
 from vllm_omni.entrypoints.cli.logo import log_logo
 from vllm_omni.entrypoints.openai.api_server import omni_run_server
 
@@ -654,7 +653,6 @@ class OmniServeCommand(CLISubcommand):
         # sandboxed globals dict via ``DummySelf``) doesn't fail on a NameError.
         type(self)._parser = serve_parser
 
-        nullify_stage_engine_defaults(serve_parser)
         return serve_parser
 
 

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -97,13 +97,17 @@ OutputMessageHandleResult = tuple[Literal[True], None, None, None] | tuple[Liter
 
 
 def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
-    """Recursively merge *override* into *base*; override keys win."""
+    """Recursively merge *override* into *base*; override keys win.
+
+    Stage IDs are normalised to strings to avoid duplicate keys when
+    callers provide integer keys alongside YAML's string keys."""
     result = dict(base)
     for key, val in override.items():
-        if key in result and isinstance(result[key], dict) and isinstance(val, dict):
-            result[key] = _deep_merge(result[key], val)
+        key_str = str(key)
+        if key_str in result and isinstance(result[key_str], dict) and isinstance(val, dict):
+            result[key_str] = _deep_merge(result[key_str], val)
         else:
-            result[key] = val
+            result[key_str] = val
     return result
 
 

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -96,6 +96,88 @@ def omni_snapshot_download(model_id: str) -> str:
 OutputMessageHandleResult = tuple[Literal[True], None, None, None] | tuple[Literal[False], str, int, ClientRequestState]
 
 
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge *override* into *base*; override keys win."""
+    result = dict(base)
+    for key, val in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(val, dict):
+            result[key] = _deep_merge(result[key], val)
+        else:
+            result[key] = val
+    return result
+
+
+def _inject_deploy_defaults(model: str, kwargs: dict[str, Any]) -> None:
+    """Inject model-specific defaults from deploy YAML into *kwargs* in place.
+
+    Pipeline-wide ``DeployConfig`` fields and (for headless) per-stage
+    ``StageDeployConfig`` fields are set via ``setdefault`` so explicit
+    user-supplied values always win.  For normal serve, per-stage defaults
+    are deep-merged into ``stage_overrides``.
+    """
+    import json as _json
+    from dataclasses import fields as dc_fields
+
+    from vllm_omni.config.stage_config import (
+        _DEPLOY_DIR,
+        DeployConfig,
+        StageConfigFactory,
+        StageDeployConfig,
+        load_deploy_config,
+    )
+
+    model_type, _hf_config = StageConfigFactory._auto_detect_model_type(model)
+    if not model_type:
+        return
+
+    deploy_path = _DEPLOY_DIR / f"{model_type}.yaml"
+    if not deploy_path.exists():
+        return
+
+    deploy = load_deploy_config(deploy_path)
+
+    # Pipeline-wide: fill missing from DeployConfig
+    for f in dc_fields(DeployConfig):
+        val = getattr(deploy, f.name)
+        if val is not None:
+            kwargs.setdefault(f.name, val)
+
+    # Per-stage
+    stage_id = kwargs.get("stage_id")
+    if stage_id is not None:
+        # Headless: fill per-stage kwargs directly
+        stage_dep = next((s for s in deploy.stages if s.stage_id == stage_id), None)
+        if stage_dep:
+            for f in dc_fields(StageDeployConfig):
+                if f.name == "engine_extras":
+                    continue
+                val = getattr(stage_dep, f.name)
+                if val is not None:
+                    kwargs.setdefault(f.name, val)
+    else:
+        # Normal serve: collapse all stages into stage_overrides dict
+        overrides: dict[str, dict[str, Any]] = {}
+        for stage in deploy.stages:
+            d: dict[str, Any] = {}
+            for f in dc_fields(StageDeployConfig):
+                if f.name == "engine_extras":
+                    continue
+                val = getattr(stage, f.name)
+                if val is not None:
+                    d[f.name] = val
+            if d:
+                overrides[str(stage.stage_id)] = d
+
+        if overrides:
+            existing = kwargs.get("stage_overrides")
+            if existing:
+                if isinstance(existing, str):
+                    existing = _json.loads(existing)
+                kwargs["stage_overrides"] = _json.dumps(_deep_merge(overrides, existing), sort_keys=True)
+            else:
+                kwargs["stage_overrides"] = _json.dumps(overrides, sort_keys=True)
+
+
 class OmniBase(PDDisaggregationMixin):
     """Shared runtime foundation for AsyncOmni and Omni."""
 
@@ -158,6 +240,14 @@ class OmniBase(PDDisaggregationMixin):
 
         if "log_requests" in kwargs:
             raise TypeError("`log_requests` has been removed in Omni/AsyncOmni. Use `log_stats`.")
+
+        # Inject model-specific defaults from deploy YAML into remaining kwargs.
+        # Pipeline-wide DeployConfig fields and (for headless) per-stage
+        # StageDeployConfig fields are set via kwargs.setdefault so explicit
+        # user-supplied values always win.  For normal serve, per-stage defaults
+        # are deep-merged into stage_overrides.
+        _inject_deploy_defaults(model, kwargs)
+
         model = omni_snapshot_download(model)
         self.__dict__["_name"] = self.__class__.__name__
         self.model = model

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -118,9 +118,14 @@ def _inject_deploy_defaults(model: str, kwargs: dict[str, Any]) -> None:
     ``StageDeployConfig`` fields are set via ``setdefault`` so explicit
     user-supplied values always win.  For normal serve, per-stage defaults
     are deep-merged into ``stage_overrides``.
+
+    If *kwargs* contains ``deploy_config`` (from ``--deploy-config``), that
+    file is used directly.  Otherwise ``deploy/<model_type>.yaml`` is
+    resolved from the HuggingFace config.
     """
     import json as _json
     from dataclasses import fields as dc_fields
+    from pathlib import Path
 
     from vllm_omni.config.stage_config import (
         _DEPLOY_DIR,
@@ -130,13 +135,18 @@ def _inject_deploy_defaults(model: str, kwargs: dict[str, Any]) -> None:
         load_deploy_config,
     )
 
-    model_type, _hf_config = StageConfigFactory._auto_detect_model_type(model)
-    if not model_type:
-        return
-
-    deploy_path = _DEPLOY_DIR / f"{model_type}.yaml"
-    if not deploy_path.exists():
-        return
+    deploy_config_path = kwargs.get("deploy_config")
+    if deploy_config_path:
+        deploy_path = Path(deploy_config_path)
+        if not deploy_path.exists():
+            return
+    else:
+        model_type, _hf_config = StageConfigFactory._auto_detect_model_type(model)
+        if not model_type:
+            return
+        deploy_path = _DEPLOY_DIR / f"{model_type}.yaml"
+        if not deploy_path.exists():
+            return
 
     deploy = load_deploy_config(deploy_path)
 

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -148,7 +148,14 @@ def _inject_deploy_defaults(model: str, kwargs: dict[str, Any]) -> None:
         if not deploy_path.exists():
             return
 
-    deploy = load_deploy_config(deploy_path)
+    try:
+        deploy = load_deploy_config(deploy_path)
+    except Exception:
+        import logging
+
+        logger = logging.getLogger("vllm_omni.entrypoints.omni_base")
+        logger.warning("Failed to load deploy config from %s", deploy_path)
+        return
 
     # Pipeline-wide: fill missing from DeployConfig
     for f in dc_fields(DeployConfig):

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -2945,14 +2945,13 @@ async def omni_wakeup(request: OmniWakeupRequest, raw_request: Request):
 
 
 if __name__ == "__main__":
-    import argparse
     import asyncio
 
     from vllm.entrypoints.openai.cli_args import make_arg_parser
 
-    from vllm_omni.engine.arg_utils import nullify_stage_engine_defaults
+    from vllm_omni.engine.arg_utils import OmniArgumentParser
 
-    parser = argparse.ArgumentParser(description="vLLM-Omni OpenAI-Compatible REST API server")
+    parser = OmniArgumentParser(description="vLLM-Omni OpenAI-Compatible REST API server")
     parser = make_arg_parser(parser)
     registered_flags = set()
     for action in parser._actions:
@@ -2963,7 +2962,6 @@ if __name__ == "__main__":
         parser.add_argument(
             "--enable-sleep-mode", action="store_true", default=False, help="Enable GPU memory pool for sleep mode."
         )
-    nullify_stage_engine_defaults(parser)
     args = parser.parse_args()
     if not hasattr(args, "model_tag"):
         setattr(args, "model_tag", args.model)


### PR DESCRIPTION
## Purpose

### Problem

vLLM-Omni reuses vLLM's `FlexibleArgumentParser`, but CLI args need **model-dependent
default values** from `deploy/<model_type>.yaml`. Today the codebase handles this
through:

- `nullify_stage_engine_defaults()` — resets parser defaults to `None` for
  hardcoded field lists, then downstream YAML merge re-fills them. Nullify-then-refill.
- `deploy_override_field_names()` — frozen set of field names that must be
  manually synced with `StageDeployConfig` and `DeployConfig` each time a field
  changes.
- `detect_explicit_cli_keys()` — walks raw `sys.argv` tokens, string-matching
  against option strings, to guess which values the user explicitly typed.

### Solution

`OmniArgumentParser(FlexibleArgumentParser)` peeks the model from `sys.argv`,
detects its `model_type`, loads `deploy/<model_type>.yaml`, and sets YAML values
as `action.default` before delegating to `super().parse_args()`. Argparse then
handles user-override precedence natively — no tracking infrastructure needed.

**Before (nullify-then-refill):**
```
vLLM default → nullify to None → parse → YAML merge fills None fields
                                       ↑
                         Must track which fields user set
                         so YAML doesn't silently override them
```

**After (YAML as argparse defaults):**
```
vLLM default → overwrite with YAML default → parse
                                               ↑
                         Argparse uses YAML value unless user
                         explicitly types a different value
```

### What's removed / deprecated

| Removed | Why |
|---|---|
| `nullify_stage_engine_defaults()` | Replaced by YAML injection into `action.default` |
| `deploy_override_field_names()` | `dataclasses.fields()` iteration replaces hardcoded sets |
| `detect_explicit_cli_keys()` in serve path | No longer needed — argparse handles precedence |

### Config precedence (after this change)

1. **User CLI flags** (highest — argparse overrides `action.default`)
2. **`--stage-overrides` JSON** (deep-merged on top of YAML stage_overrides)
3. **`--deploy-config <path>`** (if specified, replaces auto-detected `deploy/<model_type>.yaml`)
4. **`deploy/<model_type>.yaml`** (auto-detected from model's HF `config.json`)
5. **vLLM EngineArgs defaults** (lowest)

### Migration

No breaking changes. `nullify_stage_engine_defaults()` and `deploy_override_field_names()`
still work — they emit `DeprecationWarning` and can be removed in a future release.

Related: RFC #3735, Config Refactor #3672

## Test Plan

```bash
# Unit & config tests
pytest tests/test_arg_utils.py tests/engine/test_omni_argument_parser.py -v
pytest tests/entrypoints/test_serve.py -v
pytest tests/config/ tests/test_config_factory.py -v --run-level core_model -m "core_model and cpu"
pytest tests/entrypoints/ -v -k "not (openai_api or test_pd_disaggregation)"

# E2E online diffusion (L20X, GPU 2,3)
CUDA_VISIBLE_DEVICES=2,3 pytest tests/e2e/online_serving/test_qwen_image.py -v --run-level core_model -m "core_model"
CUDA_VISIBLE_DEVICES=2,3 pytest tests/e2e/online_serving/test_flux2_klein.py -v --run-level core_model -m "core_model"
CUDA_VISIBLE_DEVICES=2,3 pytest tests/e2e/online_serving/test_longcat_image.py -v --run-level core_model -m "core_model"

# E2E online LLM multi-stage (L20X, GPU 2,3, L3)
CUDA_VISIBLE_DEVICES=2,3 pytest tests/e2e/online_serving/test_qwen3_omni.py::test_text_to_text_001 -v --run-level advanced_model -m "advanced_model"
CUDA_VISIBLE_DEVICES=2,3 pytest tests/e2e/online_serving/test_qwen3_omni.py::test_mix_to_text_audio_001 -v --run-level advanced_model -m "advanced_model"
```

## Test Result

**295 passed, 0 failures** (remote: `ssh -p 31342 root@106.15.124.84`, NVIDIA L20X × 4)

| Test suite | Results |
|---|---|
| `tests/test_arg_utils.py` | 18/18 passed |
| `tests/engine/test_omni_argument_parser.py` | 35/35 passed |
| `tests/entrypoints/test_serve.py` | 11/11 passed |
| `tests/entrypoints/test_omni_entrypoints.py` | 50/50 passed |
| `tests/config/` + `test_config_factory.py` | 114/114 passed |
| `tests/entrypoints/test_async_omni_diffusion_config.py` | 5/5 passed |
| `tests/entrypoints/test_utils.py` + `test_stage_utils.py` | 44/44 passed |
| `tests/e2e/online_serving/test_qwen_image.py` | 2/2 passed (65s) |
| `tests/e2e/online_serving/test_flux2_klein.py` | 1/1 passed (48s) |
| `tests/e2e/online_serving/test_longcat_image.py` | 1/1 passed (128s) |
| `tests/e2e/online_serving/test_qwen3_omni.py` (L3) | 2/2 passed (193s, 213s) |
