### PR TITLE
[Bugfix] Set separate CFG flag in Helios for CacheDiT

### DIFF
--- a/tests/diffusion/cache/test_cache_dit.py
+++ b/tests/diffusion/cache/test_cache_dit.py
@@ -16,6 +16,7 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 SEPARATE_CFG_ENABLERS = [
     cd_backend.enable_cache_for_ltx2,
+    cd_backend.enable_cache_for_helios,
     cd_backend.enable_cache_for_wan22,
     cd_backend.enable_cache_for_longcat_image,
 ]

--- a/vllm_omni/diffusion/cache/cache_dit_backend.py
+++ b/vllm_omni/diffusion/cache/cache_dit_backend.py
@@ -1413,7 +1413,7 @@ def enable_cache_for_helios(pipeline: Any, cache_config: Any) -> Callable[[int],
             params_modifiers=[
                 ParamsModifier(cache_config=db_cache_config, calibrator_config=calibrator_config),
             ],
-            has_separate_cfg=False,
+            has_separate_cfg=True,
         ),
         cache_config=db_cache_config,
         calibrator_config=calibrator_config,


### PR DESCRIPTION
## Purpose
Related: https://github.com/vllm-project/vllm-omni/pull/2527

It looks like Helios should have `has_separate_cfg=True` for Cache-DiT, since we always handle +/- embeds separately, both for standard cfg & cfg zero* ([here](https://github.com/vllm-project/vllm-omni/blob/main/vllm_omni/diffusion/models/helios/pipeline_helios.py#L712)). You can also see this is the case in the Cache DiT adapter for Helios, [here](https://github.com/vipshop/cache-dit/blob/f5712a36faa525ce25b162b411dd55044e1c5156/src/cache_dit/caching/block_adapters/adapters.py#L914).

Currently, the output with cache DiT on using some models, e.g., helios base, will come out fuzzy:

For example, ground truth:

https://github.com/user-attachments/assets/69cd45ce-4f27-4d0b-af67-46fdad82843c

Example with Cache DiT on:

https://github.com/user-attachments/assets/50384462-0f20-45c8-a298-cbf5318b22f6

Result after fix:

https://github.com/user-attachments/assets/0d07602e-973d-446e-a334-849c8b0c2f27



## Test Plan

Added Helios to explicit checks for has CFG=True (which were previously added for the same issue on Longcat/ltx2 https://github.com/vllm-project/vllm-omni/pull/2860) 
