### PR TITLE
[Bugfix] Fix Hunyuan worker device context

### DIFF
--- a/vllm_omni/diffusion/distributed/utils.py
+++ b/vllm_omni/diffusion/distributed/utils.py
@@ -10,5 +10,7 @@ from vllm_omni.platforms import current_omni_platform
 
 def get_local_device() -> torch.device:
     """Return the torch device for the current rank based on detected device type."""
+    if torch.cuda.is_available() and torch.cuda.is_initialized():
+        return current_omni_platform.get_torch_device(torch.accelerator.current_device_index())
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
     return current_omni_platform.get_torch_device(local_rank)

--- a/vllm_omni/diffusion/distributed/utils.py
+++ b/vllm_omni/diffusion/distributed/utils.py
@@ -10,7 +10,7 @@ from vllm_omni.platforms import current_omni_platform
 
 def get_local_device() -> torch.device:
     """Return the torch device for the current rank based on detected device type."""
-    if torch.cuda.is_available() and torch.cuda.is_initialized():
-        return current_omni_platform.get_torch_device(torch.accelerator.current_device_index())
+    if current_omni_platform.is_initialized():
+        return current_omni_platform.get_torch_device(current_omni_platform.current_device())
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
     return current_omni_platform.get_torch_device(local_rank)


### PR DESCRIPTION
## Summary
<img width="1214" height="240" alt="image" src="https://github.com/user-attachments/assets/03685bb9-ad74-4c30-955a-0a2425e41137" />

Fix unintended CUDA context creation on GPU 0 for HunyuanImage multi-GPU workers.

`get_local_device()` previously relied only on `LOCAL_RANK` and defaulted to rank 0
when `LOCAL_RANK` was not set. In some vLLM worker subprocesses, CUDA has already
been initialized and the worker's current device has already been selected, but
`LOCAL_RANK` is not present in the environment.

This can make non-zero TP workers allocate tensors on `cuda:0`, creating extra
CUDA contexts and unnecessary GPU memory usage on GPU 0.

This PR makes `get_local_device()` prefer the current CUDA device wahen CUDA is
already initialized, and keeps the existing `LOCAL_RANK` fallback for early
initialization and non-CUDA paths.

## Changes

- Use `torch.accelerator.current_device_index()` when CUDA is available and
  initialized.
- Keep the existing `LOCAL_RANK` based fallback.
- Scope the change to `vllm-omni` diffusion distributed utilities.

## Motivation

For HunyuanImage, `get_local_device()` can be called during diffusion/VAE
initialization after the worker process has already selected its CUDA device.

If `LOCAL_RANK` is missing, the old behavior returned `cuda:0` for every worker.
This caused extra ~500MiB CUDA contexts on GPU 0 from non-rank-0 workers.

The current CUDA device is the correct source of truth once CUDA has already been
initialized.

## Validation

Validated with HunyuanImage 3.0 Instruct TP2 deployment:

- Service started successfully.

<img width="703" height="109" alt="image" src="https://github.com/user-attachments/assets/7811c2e6-9943-414c-bc08-5ab5f127d5db" />

- `/v1/models` returned HTTP 200.
- `/v1/images/generations` returned HTTP 200.
- TP workers stayed on their expected devices.
- The extra CUDA context on GPU 0 from non-rank-0 workers disappeared.

Also ran pre-commit successfully.


Could you please help me test if this problem can be resolved on the NPU? @gcanlin  also cc @Bounty-hunter 
