### PR TITLE
Support qwen3-omni stage transfer via mooncake transfer engine.

### DIFF
--- a/tests/distributed/omni_connectors/test_qwen3_transfer_packet.py
+++ b/tests/distributed/omni_connectors/test_qwen3_transfer_packet.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+
+import torch
+
+from vllm_omni.distributed.omni_connectors.utils import qwen3_transfer_packet as pkt
+from vllm_omni.model_executor.stage_input_processors import qwen3_omni as q3
+
+
+def _sample_thinker_payload() -> dict:
+    return {
+        "embed": {
+            "prefill": torch.ones(2, 4),
+            "tts_bos": torch.zeros(1, 4),
+        },
+        "hidden_states": {"output": torch.full((2, 4), 2.0)},
+        "ids": {"all": [1, 2, 3], "prompt": [1, 2]},
+        "meta": {"finished": torch.tensor(True, dtype=torch.bool)},
+        "next_stage_prompt_len": 7,
+        "speaker": "alice",
+    }
+
+
+def test_split_and_reconstruct_roundtrip() -> None:
+    payload = _sample_thinker_payload()
+    tensor_puts, sidecar = pkt.split_thinker_to_talker_full_payload(
+        payload,
+        request_id="req-1",
+        external_req_id="ext-1",
+        from_stage_id=0,
+        to_stage_id=1,
+        chunk_id=0,
+    )
+    assert sidecar["sidecar_put_key"] == "ext-1_0_0"
+    assert len(tensor_puts) == 3
+    store = {key: tensor for key, tensor in tensor_puts}
+    rebuilt = pkt.reconstruct_thinker_to_talker_full_payload(
+        sidecar,
+        lambda transfer_key: store.get(transfer_key),
+    )
+    assert rebuilt["ids"] == payload["ids"]
+    assert rebuilt["next_stage_prompt_len"] == 7
+    assert rebuilt["speaker"] == "alice"
+    assert torch.equal(rebuilt["embed"]["prefill"], payload["embed"]["prefill"])
+    assert torch.equal(rebuilt["hidden_states"]["output"], payload["hidden_states"]["output"])
+    assert bool(rebuilt["meta"]["finished"].item()) is True
+
+
+def test_reconstruct_clones_managed_buffer_before_release() -> None:
+    from vllm_omni.distributed.omni_connectors.connectors.mooncake_transfer_engine_connector import (
+        ManagedBuffer,
+    )
+
+    class DummyAllocator:
+        def __init__(self) -> None:
+            self.freed: list[tuple[int, int]] = []
+
+        def free(self, offset: int, size: int) -> None:
+            self.freed.append((offset, size))
+
+    source = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    pool = source.view(torch.uint8).clone()
+    allocator = DummyAllocator()
+    buffer = ManagedBuffer(allocator, 0, pool.numel(), pool)
+    sidecar = {
+        "packet_version": pkt.PACKET_VERSION,
+        "payload_kind": pkt.PAYLOAD_KIND_THINKER_TO_TALKER_FULL,
+        "tensor_entries": [
+            {
+                "name": "embed.prefill",
+                "dtype": str(source.dtype),
+                "shape": list(source.shape),
+                "transfer_key": "tensor-key",
+            }
+        ],
+        "metadata": {},
+    }
+
+    rebuilt = pkt.reconstruct_qwen3_full_payload(sidecar, lambda _key: buffer)
+
+    assert allocator.freed == [(0, pool.numel())]
+    assert torch.equal(rebuilt["embed"]["prefill"], source)
+
+    # Simulate the MTE receive pool reusing the released buffer for the next
+    # tensor.  The reconstructed payload must not alias that pool memory.
+    pool.fill_(0)
+    assert torch.equal(rebuilt["embed"]["prefill"], source)
+
+
+def test_should_use_packet_path_gate() -> None:
+    assert pkt.should_use_thinker_to_talker_packet_path(
+        async_chunk=True,
+        supports_raw_data=True,
+        model_arch="Qwen3OmniMoeForConditionalGeneration",
+        from_stage_id=0,
+        to_stage_id=1,
+    )
+    assert not pkt.should_use_thinker_to_talker_packet_path(
+        async_chunk=False,
+        supports_raw_data=True,
+        model_arch="Qwen3OmniMoeForConditionalGeneration",
+        from_stage_id=0,
+        to_stage_id=1,
+    )
+    assert pkt.should_use_thinker_to_talker_packet_path(
+        async_chunk=False,
+        supports_raw_data=True,
+        model_arch="Qwen3OmniMoeForConditionalGeneration",
+        from_stage_id=0,
+        to_stage_id=1,
+        transfer_mode=pkt.MODE_NON_ASYNC_FULL_PAYLOAD,
+    )
+    assert not pkt.should_use_thinker_to_talker_packet_path(
+        async_chunk=True,
+        supports_raw_data=False,
+        model_arch="Qwen3OmniMoeForConditionalGeneration",
+        from_stage_id=0,
+        to_stage_id=1,
+    )
+    assert not pkt.should_use_thinker_to_talker_packet_path(
+        async_chunk=True,
+        supports_raw_data=True,
+        model_arch="Qwen3OmniMoeForConditionalGeneration",
+        from_stage_id=0,
+        to_stage_id=2,
+    )
+    assert pkt.should_use_thinker_to_talker_packet_path(
+        async_chunk=False,
+        supports_raw_data=True,
+        model_arch="Qwen3OmniMoeForConditionalGeneration",
+        from_stage_id=1,
+        to_stage_id=2,
+        transfer_mode=pkt.MODE_NON_ASYNC_FULL_PAYLOAD,
+    )
+
+
+def test_payload_has_packet_tensors() -> None:
+    assert pkt.payload_has_packet_tensors(_sample_thinker_payload())
+    assert pkt.payload_has_packet_tensors({"codes": {"audio": [1, 2, 3]}})
+    assert not pkt.payload_has_packet_tensors({"ids": {"all": [1]}, "meta": {"finished": True}})
+
+
+def test_talker_to_code2wav_split_and_reconstruct_roundtrip() -> None:
+    payload = {
+        "codes": {"audio": [1, 2, 3, 4]},
+        "meta": {"finished": torch.tensor(True, dtype=torch.bool), "left_context_size": 25},
+    }
+    tensor_puts, sidecar = pkt.split_qwen3_full_payload(
+        payload,
+        request_id="req-2",
+        external_req_id="ext-2",
+        from_stage_id=1,
+        to_stage_id=2,
+        chunk_id=0,
+        mode=pkt.MODE_NON_ASYNC_FULL_PAYLOAD,
+    )
+    assert sidecar["payload_kind"] == pkt.PAYLOAD_KIND_TALKER_TO_CODE2WAV_FULL
+    assert len(tensor_puts) == 1
+    store = {key: tensor for key, tensor in tensor_puts}
+    rebuilt = pkt.reconstruct_qwen3_full_payload(
+        sidecar,
+        lambda transfer_key: store.get(transfer_key),
+    )
+    assert "codes" in rebuilt and "audio" in rebuilt["codes"]
+    assert rebuilt["code_predictor_codes"] == [1, 2, 3, 4]
+
+
+def test_thinker2talker_full_payload_processor_roundtrip() -> None:
+    request = SimpleNamespace(
+        request_id="thinker",
+        prompt_token_ids=[151644, 872],
+        output_token_ids=[3],
+        all_token_ids=[151644, 872, 3],
+    )
+    pooling_output = {
+        "hidden_states.layer_0": torch.ones(3, 2),
+        "hidden_states.layer_24": torch.full((3, 2), 2.0),
+        "embed.tts_bos": torch.zeros(1, 2),
+    }
+    payload = q3.thinker2talker_full_payload(None, pooling_output, request)
+    assert payload is not None
+
+    tensor_puts, sidecar = pkt.split_thinker_to_talker_full_payload(
+        payload,
+        request_id="thinker",
+        external_req_id="thinker",
+        from_stage_id=0,
+        to_stage_id=1,
+        chunk_id=0,
+    )
+    store = {key: tensor for key, tensor in tensor_puts}
+    rebuilt = pkt.reconstruct_thinker_to_talker_full_payload(sidecar, store.get)
+    assert rebuilt["ids"]["all"] == payload["ids"]["all"]
+    assert rebuilt["embed"]["prefill"].shape == payload["embed"]["prefill"].shape
+    assert rebuilt["hidden_states"]["output"].shape == payload["hidden_states"]["output"].shape
+    assert rebuilt["next_stage_prompt_len"] == payload["next_stage_prompt_len"]

--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -90,6 +90,7 @@ def _make_llm_plan(
                     is_comprehension=is_comprehension and replica_id == 0,
                 ),
                 stage_connector_spec={},
+                stage_output_connector_spec={},
                 omni_kv_connector=(None, None, None),
                 stage_vllm_config=vllm_config,
                 executor_class=object,
@@ -124,6 +125,7 @@ def _make_diffusion_plan(
                 stage_cfg=stage_cfg,
                 metadata=_make_diffusion_metadata(configured_stage_id, replica_id=replica_id),
                 stage_connector_spec={},
+                stage_output_connector_spec={},
                 omni_kv_connector=(None, None, None),
             )
         )
@@ -350,7 +352,7 @@ def test_build_logical_stage_init_plans_applies_replica_device_splits(monkeypatc
         "extract_stage_metadata",
         lambda cfg: types.SimpleNamespace(**metadata_by_stage[cfg.stage_id].__dict__),
     )
-    monkeypatch.setattr(engine_mod, "get_stage_connector_spec", lambda **_: {})
+    monkeypatch.setattr(engine_mod, "get_stage_worker_connector_specs", lambda **_: ({}, {}))
     monkeypatch.setattr(engine_mod, "resolve_omni_kv_config_for_stage", lambda *_: (None, None, None))
     monkeypatch.setattr(engine_mod, "build_engine_args_dict", lambda *_, **__: {})
     monkeypatch.setattr(
@@ -518,6 +520,7 @@ def test_initialize_llm_replica_passes_stage_init_timeout_to_complete_stage_hand
         stage_cfg=types.SimpleNamespace(engine_args={}, runtime=types.SimpleNamespace(devices="0")),
         metadata=types.SimpleNamespace(stage_id=0, runtime_cfg={"devices": "0"}),
         stage_connector_spec={},
+        stage_output_connector_spec={},
         omni_kv_connector=(None, None, None),
         stage_vllm_config=fake_vllm_config,
         executor_class=object,

--- a/tests/engine/test_single_stage_mode.py
+++ b/tests/engine/test_single_stage_mode.py
@@ -72,6 +72,7 @@ def _make_llm_plan(
                 stage_cfg=stage_cfg,
                 metadata=metadata,
                 stage_connector_spec={},
+                stage_output_connector_spec={},
                 omni_kv_connector=(None, None, None),
                 stage_vllm_config=vllm_config
                 or SimpleNamespace(parallel_config=SimpleNamespace(data_parallel_size_local=1)),
@@ -112,6 +113,7 @@ def _make_diffusion_plan(
                 stage_cfg=stage_cfg,
                 metadata=metadata,
                 stage_connector_spec={},
+                stage_output_connector_spec={},
                 omni_kv_connector=(None, None, None),
             )
         ],
@@ -493,7 +495,7 @@ class TestSingleStageInitialization:
                 runtime_cfg={},
             ),
         )
-        monkeypatch.setattr(engine_mod, "get_stage_connector_spec", lambda **_: {})
+        monkeypatch.setattr(engine_mod, "get_stage_worker_connector_specs", lambda **_: ({}, {}))
         monkeypatch.setattr(engine_mod, "resolve_omni_kv_config_for_stage", lambda *_: (None, None, None))
         monkeypatch.setattr(engine_mod, "build_engine_args_dict", lambda *_, **__: {})
         monkeypatch.setattr(engine_mod, "build_vllm_config", lambda *_, **__: (SimpleNamespace(), object))
@@ -571,7 +573,7 @@ class TestSingleStageInitialization:
                 runtime_cfg={"devices": "0"},
             ),
         )
-        monkeypatch.setattr(engine_mod, "get_stage_connector_spec", lambda **_: {})
+        monkeypatch.setattr(engine_mod, "get_stage_worker_connector_specs", lambda **_: ({}, {}))
         monkeypatch.setattr(engine_mod, "resolve_omni_kv_config_for_stage", lambda *_: (None, None, None))
         monkeypatch.setattr(engine_mod, "build_engine_args_dict", lambda *_, **__: {})
         monkeypatch.setattr(
@@ -620,7 +622,7 @@ class TestSingleStageInitialization:
                 replica_id=0,
             ),
         )
-        monkeypatch.setattr(engine_mod, "get_stage_connector_spec", lambda **_: {})
+        monkeypatch.setattr(engine_mod, "get_stage_worker_connector_specs", lambda **_: ({}, {}))
         monkeypatch.setattr(engine_mod, "resolve_omni_kv_config_for_stage", lambda *_: (None, None, None))
         try:
             stage_plans, _ = engine._build_logical_stage_init_plans(None, [2], {0: ["0", "1"]})

--- a/tests/entrypoints/test_serve.py
+++ b/tests/entrypoints/test_serve.py
@@ -146,20 +146,37 @@ def test_run_headless_llm_registers_with_auto_assigned_replica_id(mocker: Mocker
     )
     vllm_config = SimpleNamespace(parallel_config=parallel_config, needs_dp_coordinator=False)
     engine_manager = mocker.Mock()
+    omni_transfer_config = mocker.Mock()
+    stage_connector_spec = {"name": "MooncakeTransferEngineConnector", "extra": {"role": "receiver"}}
+    stage_output_connector_spec = {
+        "name": "MooncakeTransferEngineConnector",
+        "extra": {"role": "sender"},
+        "to_stage": 1,
+    }
+    engine_args_dict = {"max_model_len": 128}
 
     mocker.patch(
         "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
         return_value=("/fake/stages.yaml", [stage_cfg]),
     )
     mocker.patch("vllm_omni.engine.stage_init_utils.prepare_engine_environment")
-    mocker.patch("vllm_omni.engine.stage_init_utils.load_omni_transfer_config_for_model", return_value=None)
+    mock_load_transfer_config = mocker.patch(
+        "vllm_omni.engine.stage_init_utils.load_omni_transfer_config_for_model",
+        return_value=omni_transfer_config,
+    )
+    mock_worker_specs = mocker.patch(
+        "vllm_omni.engine.stage_init_utils.get_stage_worker_connector_specs",
+        return_value=(stage_connector_spec, stage_output_connector_spec),
+    )
     mocker.patch(
         "vllm_omni.distributed.omni_connectors.utils.initialization.resolve_omni_kv_config_for_stage",
         return_value=(None, None, None),
     )
-    mocker.patch("vllm_omni.engine.stage_init_utils.get_stage_connector_spec", return_value={})
-    mocker.patch("vllm_omni.engine.stage_init_utils.build_engine_args_dict", return_value={})
-    mocker.patch(
+    mock_build_engine_args = mocker.patch(
+        "vllm_omni.engine.stage_init_utils.build_engine_args_dict",
+        return_value=engine_args_dict,
+    )
+    mock_build_vllm_config = mocker.patch(
         "vllm_omni.engine.stage_init_utils.build_vllm_config",
         return_value=(vllm_config, object),
     )
@@ -180,6 +197,24 @@ def test_run_headless_llm_registers_with_auto_assigned_replica_id(mocker: Mocker
     mocker.patch("signal.signal")
 
     run_headless(_make_headless_args(stage_id=0))
+
+    mock_load_transfer_config.assert_called_once_with("fake-model", "/fake/stages.yaml")
+    mock_worker_specs.assert_called_once_with(omni_transfer_config=omni_transfer_config, stage_id=0)
+    mock_build_engine_args.assert_called_once_with(
+        stage_cfg,
+        "fake-model",
+        stage_connector_spec=stage_connector_spec,
+        stage_output_connector_spec=stage_output_connector_spec,
+        cli_tokenizer=None,
+    )
+    mock_build_vllm_config.assert_called_once_with(
+        stage_cfg,
+        "fake-model",
+        stage_connector_spec=stage_connector_spec,
+        stage_output_connector_spec=stage_output_connector_spec,
+        engine_args_dict=engine_args_dict,
+        headless=True,
+    )
 
     # The launcher must request auto-assignment (replica_id=None) and the
     # full response so it can wire the master-allocated coordinator into the
@@ -208,6 +243,59 @@ def test_run_headless_llm_registers_with_auto_assigned_replica_id(mocker: Mocker
     engine_manager.shutdown.assert_called_once_with()
 
 
+def test_run_headless_honors_explicit_log_stats_flag(mocker: MockerFixture) -> None:
+    from vllm_omni.engine.stage_engine_startup import StageRegistrationResponse
+
+    stage_cfg = _make_stage_cfg(0, stage_type="llm")
+    parallel_config = SimpleNamespace(
+        data_parallel_size_local=1,
+        data_parallel_rank=0,
+        data_parallel_rank_local=0,
+        node_rank_within_dp=0,
+    )
+    vllm_config = SimpleNamespace(parallel_config=parallel_config, needs_dp_coordinator=False)
+    engine_manager = mocker.Mock()
+
+    mocker.patch(
+        "vllm_omni.entrypoints.utils.load_and_resolve_stage_configs",
+        return_value=("/fake/stages.yaml", [stage_cfg]),
+    )
+    mocker.patch("vllm_omni.engine.stage_init_utils.prepare_engine_environment")
+    mocker.patch("vllm_omni.engine.stage_init_utils.load_omni_transfer_config_for_model", return_value=None)
+    mocker.patch(
+        "vllm_omni.engine.stage_init_utils.get_stage_worker_connector_specs",
+        return_value=({}, {}),
+    )
+    mocker.patch(
+        "vllm_omni.distributed.omni_connectors.utils.initialization.resolve_omni_kv_config_for_stage",
+        return_value=(None, None, None),
+    )
+    mocker.patch("vllm_omni.engine.stage_init_utils.build_engine_args_dict", return_value={})
+    mocker.patch(
+        "vllm_omni.engine.stage_init_utils.build_vllm_config",
+        return_value=(vllm_config, object),
+    )
+    mocker.patch(
+        "vllm_omni.engine.stage_engine_startup.register_stage_with_omni_master",
+        return_value=StageRegistrationResponse(
+            handshake_address="tcp://127.0.0.1:26001",
+            input_address="tcp://127.0.0.1:26002",
+            output_address="tcp://127.0.0.1:26003",
+            replica_id=0,
+            coordinator_router_address=None,
+        ),
+    )
+    mock_manager_cls = mocker.patch(
+        "vllm_omni.engine.omni_core_engine_proc_manager.OmniCoreEngineProcManager",
+        return_value=engine_manager,
+    )
+    mocker.patch("signal.signal")
+
+    run_headless(_make_headless_args(stage_id=0, log_stats=True))
+
+    assert mock_manager_cls.call_args.kwargs["log_stats"] is True
+
+
 def test_run_headless_llm_launches_one_manager_per_omni_dp_size_local(mocker: MockerFixture) -> None:
     """``--omni-dp-size-local=N`` must spawn N managers, each with its own
     master-assigned replica_id, and join all of them before returning."""
@@ -234,7 +322,10 @@ def test_run_headless_llm_launches_one_manager_per_omni_dp_size_local(mocker: Mo
         "vllm_omni.distributed.omni_connectors.utils.initialization.resolve_omni_kv_config_for_stage",
         return_value=(None, None, None),
     )
-    mocker.patch("vllm_omni.engine.stage_init_utils.get_stage_connector_spec", return_value={})
+    mocker.patch(
+        "vllm_omni.engine.stage_init_utils.get_stage_worker_connector_specs",
+        return_value=({}, {}),
+    )
     mocker.patch("vllm_omni.engine.stage_init_utils.build_engine_args_dict", return_value={})
     mocker.patch(
         "vllm_omni.engine.stage_init_utils.build_vllm_config",

--- a/tests/model_executor/stage_input_processors/test_qwen3_omni_streaming_helpers.py
+++ b/tests/model_executor/stage_input_processors/test_qwen3_omni_streaming_helpers.py
@@ -167,6 +167,55 @@ def test_talker2code2wav_full_payload_keeps_all_zero_codec_rows() -> None:
     assert payload["code_predictor_codes"] == payload["codes"]["audio"]
 
 
+def test_talker2code2wav_full_payload_keeps_rows_when_output_ids_are_incomplete() -> None:
+    request = SimpleNamespace(
+        request_id="codec_incomplete_ids",
+        output_token_ids=[1771, 2150, -1],
+    )
+    rows = torch.tensor(
+        [
+            [0, 0, 0],
+            [10, 11, 12],
+            [20, 21, 22],
+            [30, 31, 32],
+            [40, 41, 42],
+            [50, 51, 52],
+            [60, 61, 62],
+            [70, 71, 72],
+            [2048, 1, 2],
+        ],
+        dtype=torch.long,
+    )
+
+    payload = q3.talker2code2wav_full_payload(None, {"codes.audio": rows}, request)
+
+    assert payload is not None
+    assert payload["codes"]["audio"] == [
+        10,
+        20,
+        30,
+        40,
+        50,
+        60,
+        70,
+        11,
+        21,
+        31,
+        41,
+        51,
+        61,
+        71,
+        12,
+        22,
+        32,
+        42,
+        52,
+        62,
+        72,
+    ]
+    assert payload["code_predictor_codes"] == payload["codes"]["audio"]
+
+
 def test_thinker2talker_full_payload_packs_complete_tensors() -> None:
     request = SimpleNamespace(
         request_id="thinker",

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -32,6 +32,8 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 class MockConnector:
     """In-memory connector for testing (mimics OmniConnectorBase)."""
 
+    supports_raw_data: bool = False
+
     def __init__(self, stage_id: int = 0):
         self.stage_id = stage_id
         self._store: dict[str, Any] = {}
@@ -50,6 +52,10 @@ class MockConnector:
 
     def close(self):
         pass
+
+
+class RawDataMockConnector(MockConnector):
+    supports_raw_data = True
 
 
 def _make_model_config(
@@ -330,6 +336,44 @@ class TestMixinNoConnector(unittest.TestCase):
         host.shutdown_omni_connectors()
 
 
+class TestDualConnectorWiring(unittest.TestCase):
+    """Stage can receive and send via different connectors."""
+
+    def test_send_uses_output_connector_and_recv_uses_input_connector(self):
+        host = MixinHost()
+        host.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=1, async_chunk=False),
+        )
+        in_connector = MockConnector(stage_id=1)
+        out_connector = MockConnector(stage_id=1)
+        host._omni_connector = in_connector
+        host._omni_output_connector = out_connector
+        host._stage_id = 1
+        host._next_stage_id = 2
+
+        sent = host.send_full_payload_outputs(
+            scheduler_output=None,
+            outputs={"req-1": {"meta": {"finished": True}, "ids": {"all": [1]}}},
+        )
+        self.assertEqual(sent, ["req-1"])
+        _drain_pending_connector_sends(host)
+
+        self.assertTrue(any(key.startswith("1_2_") for key in out_connector._store.keys()))
+        self.assertEqual(in_connector._store, {})
+
+        in_connector.put("0", "1", "req-2_0_0", {"engine_inputs": {"ids": {"all": [2]}}})
+        host._request_ids_mapping["req-2"] = "req-2"
+        host._pending_load_reqs["req-2"] = _make_request("req-2")
+        self.assertTrue(host._poll_single_request("req-2"))
+        results = host.recv_full_payload_inputs(scheduler_output=None)
+        self.assertIsNotNone(results)
+        assert results is not None
+        self.assertEqual(results["req-2"]["ids"]["all"], [2])
+
+        host.shutdown_omni_connectors()
+
+
 class TestFinishedLoadReqsDrain(unittest.TestCase):
     """Test A1 fix: get_omni_connector_output drains _finished_load_reqs."""
 
@@ -442,6 +486,214 @@ class TestFullPayloadSendWithCustomFunc(unittest.TestCase):
 
         time.sleep(0.1)
         host.shutdown_omni_connectors()
+
+
+def _make_qwen3_async_chunk_model_config(stage_id: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        stage_connector_config=None,
+        async_chunk=True,
+        worker_type="ar",
+        model_arch="Qwen3OmniMoeForConditionalGeneration",
+        model_stage="thinker" if stage_id == 0 else "talker",
+        custom_process_next_stage_input_func=None,
+    )
+
+
+def _make_qwen3_full_payload_model_config(stage_id: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        stage_connector_config=None,
+        async_chunk=False,
+        worker_type="ar",
+        model_arch="Qwen3OmniMoeForConditionalGeneration",
+        model_stage="thinker" if stage_id == 0 else "talker",
+        custom_process_next_stage_input_func=None,
+    )
+
+
+def _drain_pending_connector_sends(host: MixinHost) -> None:
+    for _ in range(64):
+        task = None
+        with host._lock:
+            for req_id in list(host._pending_save_reqs.keys()):
+                dq = host._pending_save_reqs.get(req_id)
+                if dq:
+                    task = dq.popleft()
+                    if not dq:
+                        del host._pending_save_reqs[req_id]
+                    break
+        if task is None:
+            return
+        host._send_single_request(task)
+
+
+class TestQwen3PacketAsyncChunk(unittest.TestCase):
+    """Thinker→talker async_chunk packet path over a raw-data-capable connector."""
+
+    def test_packet_send_recv_roundtrip(self):
+        payload = {
+            "embed": {"prefill": torch.ones(2, 3), "tts_bos": torch.zeros(1, 3)},
+            "hidden_states": {"output": torch.full((2, 3), 2.0)},
+            "ids": {"all": [1, 2, 3], "prompt": [1, 2]},
+            "meta": {"finished": torch.tensor(True, dtype=torch.bool)},
+            "next_stage_prompt_len": 5,
+        }
+        connector = RawDataMockConnector(stage_id=0)
+
+        sender = MixinHost()
+        sender.model_config = _make_qwen3_async_chunk_model_config(0)
+        sender.init_omni_connectors(
+            vllm_config=None,
+            model_config=sender.model_config,
+        )
+        sender._omni_connector = connector
+        sender._stage_id = 0
+        sender._next_stage_id = 1
+        sender._custom_process_func = lambda **kwargs: payload
+
+        req = _make_request("req-1")
+        self.assertTrue(sender.send_chunk(req, pooling_output={}))
+        _drain_pending_connector_sends(sender)
+        self.assertGreater(len(connector._store), 1)
+        self.assertTrue(any("@tensor/" in key for key in connector._store))
+
+        receiver = MixinHost()
+        receiver.model_config = _make_qwen3_async_chunk_model_config(1)
+        receiver.init_omni_connectors(
+            vllm_config=None,
+            model_config=receiver.model_config,
+        )
+        receiver._omni_connector = connector
+        receiver._stage_id = 1
+        receiver._request_ids_mapping["req-1"] = "req-1"
+        receiver._pending_load_reqs["req-1"] = _make_request("req-1")
+
+        self.assertTrue(receiver._poll_single_request("req-1"))
+        cached = receiver.get_local_stage_payload("req-1")
+        self.assertIsNotNone(cached)
+        assert cached is not None
+        self.assertEqual(cached["ids"], payload["ids"])
+        self.assertEqual(cached["next_stage_prompt_len"], payload["next_stage_prompt_len"])
+        self.assertTrue(torch.equal(cached["embed"]["prefill"], payload["embed"]["prefill"]))
+        self.assertTrue(torch.equal(cached["hidden_states"]["output"], payload["hidden_states"]["output"]))
+
+        sender.shutdown_omni_connectors()
+        receiver.shutdown_omni_connectors()
+
+
+class TestQwen3PacketFullPayload(unittest.TestCase):
+    """Thinker→talker non-async full-payload packet path over raw-data connector."""
+
+    def test_packet_send_recv_roundtrip(self):
+        payload = {
+            "embed": {"prefill": torch.ones(2, 3), "tts_bos": torch.zeros(1, 3)},
+            "hidden_states": {"output": torch.full((2, 3), 2.0)},
+            "ids": {"all": [1, 2, 3], "prompt": [1, 2]},
+            "meta": {"finished": torch.tensor(True, dtype=torch.bool)},
+            "next_stage_prompt_len": 5,
+        }
+        connector = RawDataMockConnector(stage_id=0)
+
+        sender = MixinHost()
+        sender.model_config = _make_qwen3_full_payload_model_config(0)
+        sender.init_omni_connectors(
+            vllm_config=None,
+            model_config=sender.model_config,
+        )
+        sender._omni_connector = connector
+        sender._stage_id = 0
+        sender._next_stage_id = 1
+        sender._custom_process_func = lambda **kwargs: payload
+
+        req = _make_request("req-1")
+        req.is_finished = lambda: True
+        sent = sender.send_full_payload_outputs(
+            scheduler_output=None,
+            outputs={"req-1": ({}, req)},
+        )
+        self.assertEqual(sent, ["req-1"])
+        _drain_pending_connector_sends(sender)
+        self.assertGreater(len(connector._store), 1)
+        self.assertTrue(any("@tensor/" in key for key in connector._store))
+
+        receiver = MixinHost()
+        receiver.model_config = _make_qwen3_full_payload_model_config(1)
+        receiver.init_omni_connectors(
+            vllm_config=None,
+            model_config=receiver.model_config,
+        )
+        receiver._omni_connector = connector
+        receiver._stage_id = 1
+        receiver._request_ids_mapping["req-1"] = "req-1"
+        receiver._pending_load_reqs["req-1"] = _make_request("req-1")
+
+        self.assertTrue(receiver._poll_single_request("req-1"))
+        results = receiver.recv_full_payload_inputs(scheduler_output=None)
+        self.assertIsNotNone(results)
+        assert results is not None
+        self.assertIn("req-1", results)
+        self.assertEqual(results["req-1"]["ids"], payload["ids"])
+        self.assertEqual(results["req-1"]["next_stage_prompt_len"], payload["next_stage_prompt_len"])
+        self.assertTrue(torch.equal(results["req-1"]["embed"]["prefill"], payload["embed"]["prefill"]))
+
+        connector_output = receiver.get_omni_connector_output()
+        self.assertIn("req-1", connector_output.stage_recv_req_ids)
+
+        sender.shutdown_omni_connectors()
+        receiver.shutdown_omni_connectors()
+
+
+class TestQwen3TalkerPacketFullPayload(unittest.TestCase):
+    """Talker→code2wav non-async full-payload packet path over raw-data connector."""
+
+    def test_packet_send_recv_roundtrip(self):
+        payload = {
+            "codes": {"audio": [1, 2, 3, 4]},
+            "meta": {"finished": torch.tensor(True, dtype=torch.bool), "left_context_size": 25},
+        }
+        connector = RawDataMockConnector(stage_id=1)
+
+        sender = MixinHost()
+        sender.model_config = _make_qwen3_full_payload_model_config(1)
+        sender.init_omni_connectors(
+            vllm_config=None,
+            model_config=sender.model_config,
+        )
+        sender._omni_connector = connector
+        sender._omni_output_connector = connector
+        sender._stage_id = 1
+        sender._next_stage_id = 2
+        sender._custom_process_func = lambda **kwargs: payload
+
+        req = _make_request("req-1")
+        req.is_finished = lambda: True
+        sent = sender.send_full_payload_outputs(
+            scheduler_output=None,
+            outputs={"req-1": ({}, req)},
+        )
+        self.assertEqual(sent, ["req-1"])
+        _drain_pending_connector_sends(sender)
+        self.assertTrue(any("@tensor/" in key for key in connector._store))
+
+        receiver = MixinHost()
+        receiver.model_config = _make_qwen3_full_payload_model_config(2)
+        receiver.init_omni_connectors(
+            vllm_config=None,
+            model_config=receiver.model_config,
+        )
+        receiver._omni_connector = connector
+        receiver._stage_id = 2
+        receiver._request_ids_mapping["req-1"] = "req-1"
+        receiver._pending_load_reqs["req-1"] = _make_request("req-1")
+
+        self.assertTrue(receiver._poll_single_request("req-1"))
+        results = receiver.recv_full_payload_inputs(scheduler_output=None)
+        self.assertIsNotNone(results)
+        assert results is not None
+        self.assertEqual(results["req-1"]["code_predictor_codes"], [1, 2, 3, 4])
+        self.assertTrue(torch.is_tensor(results["req-1"]["codes"]["audio"]))
+
+        sender.shutdown_omni_connectors()
+        receiver.shutdown_omni_connectors()
 
 
 class TestKVSentReqIdsAccumulation(unittest.TestCase):

--- a/vllm_omni/config/model.py
+++ b/vllm_omni/config/model.py
@@ -101,6 +101,7 @@ class OmniModelConfig(ModelConfig):
              "audio", "latents"). If None, output type is inferred.
          stage_connector_config: Stage connector configuration dictionary.
              Contains "name" (connector name), "extra" (extra connector config).
+         stage_output_connector_config: Output connector configuration dictionary.
          task_type: Default task type for TTS models (CustomVoice, VoiceDesign, or Base).
              If not specified, will be inferred from model path.
 
@@ -126,6 +127,12 @@ class OmniModelConfig(ModelConfig):
     hf_config_name: str | None = None
     custom_process_next_stage_input_func: str | None = None
     stage_connector_config: dict[str, Any] = field(
+        default_factory=lambda: {
+            "name": "SharedMemoryConnector",
+            "extra": {},
+        }
+    )
+    stage_output_connector_config: dict[str, Any] = field(
         default_factory=lambda: {
             "name": "SharedMemoryConnector",
             "extra": {},

--- a/vllm_omni/distributed/omni_connectors/__init__.py
+++ b/vllm_omni/distributed/omni_connectors/__init__.py
@@ -23,6 +23,7 @@ from .utils.initialization import (
     build_stage_connectors,
     get_connectors_config_for_stage,
     get_stage_connector_config,
+    get_worker_connector_specs_for_stage,
     initialize_connectors_from_config,
     initialize_orchestrator_connectors,
     load_omni_transfer_config,
@@ -51,6 +52,7 @@ __all__ = [
     "load_omni_transfer_config",
     "initialize_connectors_from_config",
     "get_connectors_config_for_stage",
+    "get_worker_connector_specs_for_stage",
     # Manager helpers
     "initialize_orchestrator_connectors",
     "get_stage_connector_config",

--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -431,8 +431,9 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
                     tensor_data = data
                 else:
                     size = len(data)
-                    # Convert bytes to tensor for copy
-                    tensor_data = torch.frombuffer(data, dtype=torch.uint8)
+                    # Convert bytes to a writable tensor buffer to avoid
+                    # PyTorch's non-writable frombuffer warning.
+                    tensor_data = torch.frombuffer(bytearray(data), dtype=torch.uint8)
 
                 # 2. Alloc from pool
                 try:
@@ -542,8 +543,14 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             return self._sender_endpoints[sender_rank]
         host = getattr(self, "sender_host", None)
         port = getattr(self, "sender_zmq_port", None)
-        if host and port and str(host).lower() != "auto":
-            return (host, int(port))
+        if host and port:
+            host_str = str(host).strip()
+            if host_str and host_str.lower() != "auto":
+                return (host_str, int(port))
+            # Single-node deploys often leave sender_host as "auto" in config.
+            # In that case, fall back to this process's resolved local host.
+            if host_str.lower() == "auto" and getattr(self, "host", None):
+                return (str(self.host), int(port))
         return None
 
     def _query_metadata_at(self, get_key: str, host: str, port: int) -> dict[str, Any] | None:
@@ -638,15 +645,14 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
 
         if not metadata:
             # Path 3: no metadata at all — query default sender
-            if not self.sender_host or not self.sender_zmq_port or str(self.sender_host).lower() == "auto":
-                raise RuntimeError(
-                    f"get(metadata=None) requires sender info to be resolved, "
-                    f"but sender_host={self.sender_host!r}, sender_zmq_port={self.sender_zmq_port!r}. "
-                    f"Call update_sender_info(host, port) before using get() without metadata."
-                )
             metadata = self._query_metadata_from_sender(get_key)
             if not metadata:
-                return None
+                raise RuntimeError(
+                    f"get(metadata=None) requires sender info to be resolved, "
+                    f"but sender_host={self.sender_host!r}, sender_zmq_port={self.sender_zmq_port!r}, "
+                    f"resolved_local_host={getattr(self, 'host', None)!r}. "
+                    f"Call update_sender_info(host, port) before using get() without metadata."
+                )
         elif "data_size" not in metadata:
             # Path 2: partial metadata (host/port only) — query that sender
             partial_host = metadata.get("source_host")

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -75,10 +75,30 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                 "extra": getattr(connector_config, "extra", {}),
             }
 
-        connector_specs = ConnectorSpec(
-            name=connector_config.get("name", "SharedMemoryConnector"),
-            extra=connector_config.get("extra", {}),
-        )
+        name = connector_config.get("name", "SharedMemoryConnector")
+        extra = dict(connector_config.get("extra", {}) or {})
+        stage_id = extra.get("stage_id", getattr(model_config, "stage_id", 0))
+        try:
+            stage_id_int = int(stage_id)
+        except (TypeError, ValueError):
+            stage_id_int = 0
+
+        # Stage-0 GPU workers own Mooncake ZMQ bind for async_chunk puts.
+        # The engine-core scheduler must not bind the same port.
+        if (
+            name == "MooncakeTransferEngineConnector"
+            and stage_id_int == 0
+            and str(extra.get("role", "sender")).lower() == "sender"
+        ):
+            logger.info(
+                "Stage-0 scheduler uses SharedMemoryConnector instead of "
+                "MooncakeTransferEngineConnector to avoid ZMQ port collision "
+                "with the stage worker sender."
+            )
+            name = "SharedMemoryConnector"
+            extra = {"stage_id": stage_id_int}
+
+        connector_specs = ConnectorSpec(name=name, extra=extra)
         return OmniConnectorFactory.create_connector(connector_specs)
 
     def load_async(self, request: Request):

--- a/vllm_omni/distributed/omni_connectors/utils/initialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/initialization.py
@@ -40,6 +40,33 @@ KV_RANK_PORT_STRIDE = 16
 KV_REPLICA_PORT_STRIDE = 1024
 
 
+def apply_mooncake_stage_connector_extra(
+    extra: dict[str, Any],
+    *,
+    from_stage: str | int,
+    role: str,
+) -> dict[str, Any]:
+    """Apply per-edge ZMQ port offsets for a stage-local Mooncake connector.
+
+    Senders bind ``zmq_port = base + from_stage``. Receivers do not bind but
+    need ``sender_zmq_port`` pointing at the upstream sender's bound port.
+    """
+    extra = dict(extra)
+    base_port = int(extra.get("zmq_port", 50051))
+    try:
+        stage_offset = int(from_stage)
+    except (TypeError, ValueError):
+        stage_offset = 0
+    sender_port = base_port + stage_offset
+    role_l = str(role).lower()
+    if role_l == "sender":
+        extra["zmq_port"] = sender_port
+    elif role_l == "receiver":
+        extra.setdefault("sender_host", extra.get("host", "127.0.0.1"))
+        extra["sender_zmq_port"] = sender_port
+    return extra
+
+
 def initialize_connectors_from_config(
     config_path: str | Path | None = None,
     default_shm_threshold: int = 65536,
@@ -176,15 +203,73 @@ def get_connectors_config_for_stage(transfer_config: OmniTransferConfig | None, 
             # Incoming edge → this stage is the receiver
             extra = dict(spec.extra) if spec.extra else {}
             extra.setdefault("role", "receiver")
+            if spec.name == "MooncakeTransferEngineConnector":
+                extra = apply_mooncake_stage_connector_extra(
+                    extra, from_stage=from_stage, role="receiver"
+                )
             stage_connectors_config[f"from_stage_{from_stage}"] = {"spec": {"name": spec.name, "extra": extra}}
         elif from_stage == target_stage and target_stage == "0":
             # Outgoing edge for stage 0 — included for async_chunk spec
             # extraction (omni_stage.py), NOT for connector instantiation.
             extra = dict(spec.extra) if spec.extra else {}
             extra.setdefault("role", "sender")
+            if spec.name == "MooncakeTransferEngineConnector":
+                extra = apply_mooncake_stage_connector_extra(
+                    extra, from_stage=from_stage, role="sender"
+                )
             stage_connectors_config[f"to_stage_{to_stage}"] = {"spec": {"name": spec.name, "extra": extra}}
 
     return stage_connectors_config
+
+
+def get_worker_connector_specs_for_stage(
+    transfer_config: OmniTransferConfig | None,
+    stage_id: str | int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return (input_spec, output_spec) for a stage worker.
+
+    ``input_spec`` is used for recv (upstream -> this stage).
+    ``output_spec`` is used for send (this stage -> downstream).
+    When a side is missing, the corresponding dict is empty.
+    """
+    if not transfer_config:
+        return {}, {}
+
+    target_stage = str(stage_id)
+    input_spec: dict[str, Any] = {}
+    output_spec: dict[str, Any] = {}
+
+    for (from_stage, to_stage), spec in transfer_config.connectors.items():
+        if to_stage == target_stage and not input_spec:
+            extra = dict(spec.extra) if spec.extra else {}
+            extra.setdefault("role", "receiver")
+            if spec.name == "MooncakeTransferEngineConnector":
+                extra = apply_mooncake_stage_connector_extra(
+                    extra,
+                    from_stage=from_stage,
+                    role="receiver",
+                )
+            input_spec = {"name": spec.name, "extra": extra}
+
+        if from_stage == target_stage and not output_spec:
+            extra = dict(spec.extra) if spec.extra else {}
+            extra.setdefault("role", "sender")
+            if spec.name == "MooncakeTransferEngineConnector":
+                extra = apply_mooncake_stage_connector_extra(
+                    extra,
+                    from_stage=from_stage,
+                    role="sender",
+                )
+            output_spec = {
+                "name": spec.name,
+                "extra": extra,
+                "to_stage": int(to_stage) if str(to_stage).isdigit() else to_stage,
+            }
+
+        if input_spec and output_spec:
+            break
+
+    return input_spec, output_spec
 
 
 def load_omni_transfer_config(

--- a/vllm_omni/distributed/omni_connectors/utils/qwen3_transfer_packet.py
+++ b/vllm_omni/distributed/omni_connectors/utils/qwen3_transfer_packet.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen3-Omni stage transfer packet helpers (async_chunk thinker→talker MVP).
+
+Splits large thinker→talker tensors into connector raw-data puts and a small
+versioned sidecar for reconstruction. Legacy single-dict put/get remains the fallback.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+PACKET_VERSION = 1
+MODE_ASYNC_CHUNK = "async_chunk"
+MODE_NON_ASYNC_FULL_PAYLOAD = "non_async_full_payload"
+PAYLOAD_KIND_THINKER_TO_TALKER_FULL = "thinker_to_talker_full_payload"
+PAYLOAD_KIND_TALKER_TO_CODE2WAV_FULL = "talker_to_code2wav_full_payload"
+EDGE_THINKER_TO_TALKER = "thinker_to_talker"
+EDGE_TALKER_TO_CODE2WAV = "talker_to_code2wav"
+
+# Tensor field names for thinker→talker full payload (dot-separated paths).
+_THINKER_TO_TALKER_TENSOR_PATHS: tuple[str, ...] = (
+    "embed.prefill",
+    "embed.tts_bos",
+    "embed.tts_eos",
+    "embed.tts_pad",
+    "hidden_states.output",
+)
+
+_TALKER_TO_CODE2WAV_TENSOR_PATHS: tuple[str, ...] = (
+    "codes.audio",
+)
+
+
+def build_full_payload_base_key(external_req_id: str, from_stage: int, chunk_id: int) -> str:
+    """Legacy-compatible connector key used for the sidecar put/get."""
+    return f"{external_req_id}_{from_stage}_{chunk_id}"
+
+
+def build_tensor_transfer_key(base_key: str, entry_name: str) -> str:
+    return f"{base_key}@tensor/{entry_name}"
+
+
+def is_packet_sidecar(data: Any) -> bool:
+    return (
+        isinstance(data, dict)
+        and data.get("packet_version") == PACKET_VERSION
+        and isinstance(data.get("tensor_entries"), list)
+    )
+
+
+def should_use_thinker_to_talker_packet_path(
+    *,
+    async_chunk: bool,
+    supports_raw_data: bool,
+    model_arch: str | None,
+    from_stage_id: int,
+    to_stage_id: int,
+    transfer_mode: str | None = None,
+) -> bool:
+    if not supports_raw_data:
+        return False
+    if model_arch != "Qwen3OmniMoeForConditionalGeneration":
+        return False
+    if (from_stage_id, to_stage_id) not in {(0, 1), (1, 2)}:
+        return False
+
+    mode = transfer_mode or MODE_ASYNC_CHUNK
+    if mode == MODE_ASYNC_CHUNK:
+        return bool(async_chunk)
+    if mode == MODE_NON_ASYNC_FULL_PAYLOAD:
+        return not bool(async_chunk)
+    return False
+
+
+def _get_nested(payload: dict[str, Any], path: str) -> Any:
+    cur: Any = payload
+    for part in path.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+    return cur
+
+
+def _set_nested(target: dict[str, Any], path: str, value: Any) -> None:
+    parts = path.split(".")
+    cur = target
+    for part in parts[:-1]:
+        nxt = cur.get(part)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            cur[part] = nxt
+        cur = nxt
+    cur[parts[-1]] = value
+
+
+def _tensor_entry_descriptor(name: str, tensor: torch.Tensor, transfer_key: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "dtype": str(tensor.dtype),
+        "shape": list(tensor.shape),
+        "device": tensor.device.type,
+        "layout": "contiguous",
+        "transfer_key": transfer_key,
+    }
+
+
+def _coerce_tensor_payload_value(value: Any) -> torch.Tensor | None:
+    if isinstance(value, torch.Tensor):
+        if value.numel() == 0:
+            return None
+        return value.detach().contiguous()
+    if isinstance(value, list):
+        if not value:
+            return None
+        try:
+            tensor = torch.as_tensor(value)
+        except Exception:
+            return None
+        if tensor.numel() == 0:
+            return None
+        return tensor.detach().contiguous()
+    return None
+
+
+def _extract_sidecar_metadata(payload: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    if "ids" in payload:
+        metadata["ids"] = payload["ids"]
+    if "next_stage_prompt_len" in payload:
+        metadata["next_stage_prompt_len"] = payload["next_stage_prompt_len"]
+    if "speaker" in payload:
+        metadata["speaker"] = payload["speaker"]
+    if "language" in payload:
+        metadata["language"] = payload["language"]
+    if "left_context_size" in payload:
+        metadata["left_context_size"] = payload["left_context_size"]
+    meta = payload.get("meta")
+    if isinstance(meta, dict):
+        sidecar_meta: dict[str, Any] = dict(meta)
+        finished = sidecar_meta.get("finished")
+        if isinstance(finished, torch.Tensor):
+            sidecar_meta["finished"] = bool(finished.item())
+        metadata["meta"] = sidecar_meta
+    return metadata
+
+
+def payload_has_packet_tensors(payload: dict[str, Any]) -> bool:
+    """True when the payload carries at least one non-empty packet tensor field."""
+    for path in _THINKER_TO_TALKER_TENSOR_PATHS + _TALKER_TO_CODE2WAV_TENSOR_PATHS:
+        value = _get_nested(payload, path)
+        if _coerce_tensor_payload_value(value) is not None:
+            return True
+    return False
+
+
+def split_qwen3_full_payload(
+    payload: dict[str, Any],
+    *,
+    request_id: str,
+    external_req_id: str,
+    from_stage_id: int,
+    to_stage_id: int,
+    chunk_id: int,
+    mode: str = MODE_ASYNC_CHUNK,
+) -> tuple[list[tuple[str, torch.Tensor]], dict[str, Any]]:
+    """Split a Qwen3 full payload into tensor puts and a sidecar."""
+    base_key = build_full_payload_base_key(external_req_id, from_stage_id, chunk_id)
+    tensor_puts: list[tuple[str, torch.Tensor]] = []
+    tensor_entries: list[dict[str, Any]] = []
+    payload_kind = PAYLOAD_KIND_THINKER_TO_TALKER_FULL
+    edge_id = EDGE_THINKER_TO_TALKER
+    tensor_paths = _THINKER_TO_TALKER_TENSOR_PATHS
+    if from_stage_id == 1 and to_stage_id == 2:
+        payload_kind = PAYLOAD_KIND_TALKER_TO_CODE2WAV_FULL
+        edge_id = EDGE_TALKER_TO_CODE2WAV
+        tensor_paths = _TALKER_TO_CODE2WAV_TENSOR_PATHS
+
+    for path in tensor_paths:
+        value = _get_nested(payload, path)
+        tensor = _coerce_tensor_payload_value(value)
+        if tensor is None:
+            continue
+        transfer_key = build_tensor_transfer_key(base_key, path)
+        tensor_puts.append((transfer_key, tensor))
+        tensor_entries.append(_tensor_entry_descriptor(path, tensor, transfer_key))
+
+    sidecar = {
+        "packet_version": PACKET_VERSION,
+        "request_id": request_id,
+        "external_req_id": external_req_id,
+        "source_stage_id": from_stage_id,
+        "target_stage_id": to_stage_id,
+        "edge_id": edge_id,
+        "mode": mode,
+        "payload_kind": payload_kind,
+        "sequence_id": chunk_id,
+        "is_terminal": True,
+        "is_empty": len(tensor_entries) == 0,
+        "sidecar_put_key": base_key,
+        "tensor_entries": tensor_entries,
+        "metadata": _extract_sidecar_metadata(payload),
+    }
+    return tensor_puts, sidecar
+
+
+def split_thinker_to_talker_full_payload(
+    payload: dict[str, Any],
+    *,
+    request_id: str,
+    external_req_id: str,
+    from_stage_id: int,
+    to_stage_id: int,
+    chunk_id: int,
+    mode: str = MODE_ASYNC_CHUNK,
+) -> tuple[list[tuple[str, torch.Tensor]], dict[str, Any]]:
+    return split_qwen3_full_payload(
+        payload,
+        request_id=request_id,
+        external_req_id=external_req_id,
+        from_stage_id=from_stage_id,
+        to_stage_id=to_stage_id,
+        chunk_id=chunk_id,
+        mode=mode,
+    )
+
+
+def _parse_dtype(dtype_str: str) -> torch.dtype:
+    if dtype_str.startswith("torch."):
+        return getattr(torch, dtype_str.split(".", 1)[1])
+    return getattr(torch, dtype_str)
+
+
+def _tensor_from_connector_result(
+    data: Any,
+    entry: dict[str, Any],
+    *,
+    to_cpu: bool = True,
+) -> torch.Tensor:
+    dtype = _parse_dtype(str(entry["dtype"]))
+    shape = tuple(int(x) for x in entry["shape"])
+
+    managed_buffer_cls = None
+    try:
+        from vllm_omni.distributed.omni_connectors.connectors.mooncake_transfer_engine_connector import (
+            ManagedBuffer,
+        )
+
+        managed_buffer_cls = ManagedBuffer
+    except ImportError:
+        pass
+
+    if managed_buffer_cls is not None and isinstance(data, managed_buffer_cls):
+        try:
+            tensor = data.as_tensor(dtype, shape)
+            if to_cpu:
+                tensor = tensor.detach().cpu().clone()
+            else:
+                tensor = tensor.detach().clone()
+            return tensor
+        finally:
+            data.release()
+
+    if isinstance(data, torch.Tensor):
+        tensor = data.to(dtype).reshape(shape)
+        if to_cpu:
+            return tensor.detach().cpu()
+        return tensor.detach()
+
+    raise TypeError(f"Unsupported connector tensor payload type: {type(data)!r}")
+
+
+def reconstruct_qwen3_full_payload(
+    sidecar: dict[str, Any],
+    get_tensor: Callable[[str], Any],
+    *,
+    to_cpu: bool = True,
+) -> dict[str, Any]:
+    """Rebuild the semantic payload dict from a sidecar and tensor fetches."""
+    if sidecar.get("packet_version") != PACKET_VERSION:
+        raise ValueError(f"Unsupported packet_version: {sidecar.get('packet_version')!r}")
+    payload_kind = sidecar.get("payload_kind")
+    if payload_kind not in {
+        PAYLOAD_KIND_THINKER_TO_TALKER_FULL,
+        PAYLOAD_KIND_TALKER_TO_CODE2WAV_FULL,
+    }:
+        raise ValueError(f"Unsupported payload_kind: {payload_kind!r}")
+
+    payload: dict[str, Any] = {}
+    for entry in sidecar.get("tensor_entries", []):
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        transfer_key = entry.get("transfer_key")
+        if not name or not transfer_key:
+            continue
+        raw = get_tensor(str(transfer_key))
+        if raw is None:
+            raise KeyError(f"Missing tensor entry for transfer_key={transfer_key!r}")
+        _set_nested(payload, str(name), _tensor_from_connector_result(raw, entry, to_cpu=to_cpu))
+
+    metadata = sidecar.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("ids", "speaker", "language"):
+            if key in metadata:
+                payload[key] = metadata[key]
+        if "left_context_size" in metadata:
+            payload["left_context_size"] = metadata["left_context_size"]
+        meta = metadata.get("meta")
+        if isinstance(meta, dict):
+            payload_meta = dict(meta)
+            if "finished" in payload_meta and not isinstance(payload_meta["finished"], torch.Tensor):
+                payload_meta["finished"] = torch.tensor(bool(payload_meta["finished"]), dtype=torch.bool)
+        else:
+            payload_meta = {}
+        if "next_stage_prompt_len" in metadata:
+            # Prefer nested metadata contract to avoid legacy flat-key warnings.
+            payload_meta.setdefault("next_stage_prompt_len", metadata["next_stage_prompt_len"])
+            payload["next_stage_prompt_len"] = metadata["next_stage_prompt_len"]
+        if payload_meta:
+            payload["meta"] = payload_meta
+
+    if payload_kind == PAYLOAD_KIND_TALKER_TO_CODE2WAV_FULL:
+        audio_codes = _get_nested(payload, "codes.audio")
+        if isinstance(audio_codes, torch.Tensor):
+            payload["code_predictor_codes"] = audio_codes.reshape(-1).tolist()
+
+    return payload
+
+
+def reconstruct_thinker_to_talker_full_payload(
+    sidecar: dict[str, Any],
+    get_tensor: Callable[[str], Any],
+    *,
+    to_cpu: bool = True,
+) -> dict[str, Any]:
+    return reconstruct_qwen3_full_payload(sidecar, get_tensor, to_cpu=to_cpu)

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -98,7 +98,8 @@ class OmniEngineArgs(EngineArgs):
         custom_process_next_stage_input_func: Optional path to a custom function for processing
             inputs from previous stages
             If None, default processing is used.
-        stage_connector_spec: Extra configuration for stage connector
+        stage_connector_spec: Extra configuration for stage input connector
+        stage_output_connector_spec: Extra configuration for stage output connector
         async_chunk: If set to True, perform async chunk
         worker_type: Model Type, e.g., "ar" or "generation"
         task_type: Default task type for TTS models (CustomVoice, VoiceDesign, or Base).
@@ -127,6 +128,7 @@ class OmniEngineArgs(EngineArgs):
     hf_config_name: str | None = None
     custom_process_next_stage_input_func: str | None = None
     stage_connector_spec: dict[str, Any] = field(default_factory=dict)
+    stage_output_connector_spec: dict[str, Any] = field(default_factory=dict)
     subtalker_sampling_params: dict[str, Any] | None = None
     async_chunk: bool = False
     omni_kv_config: dict | None = None
@@ -242,6 +244,13 @@ class OmniEngineArgs(EngineArgs):
             "extra": self.stage_connector_spec.get("extra", {}).copy(),
         }
         stage_connector_config["extra"]["stage_id"] = self.stage_id
+        stage_output_connector_config = {
+            "name": self.stage_output_connector_spec.get("name", "SharedMemoryConnector"),
+            "extra": self.stage_output_connector_spec.get("extra", {}).copy(),
+        }
+        stage_output_connector_config["extra"]["stage_id"] = self.stage_id
+        if "to_stage" in self.stage_output_connector_spec:
+            stage_output_connector_config["to_stage"] = self.stage_output_connector_spec.get("to_stage")
 
         # If model_arch is specified, inject it into hf_overrides so vLLM can
         # resolve the architecture even when config.json lacks 'architectures'.
@@ -334,6 +343,7 @@ class OmniEngineArgs(EngineArgs):
             hf_config_name=self.hf_config_name,
             custom_process_next_stage_input_func=self.custom_process_next_stage_input_func,
             stage_connector_config=stage_connector_config,
+            stage_output_connector_config=stage_output_connector_config,
             subtalker_sampling_params=self.subtalker_sampling_params,
             omni_kv_config=self.omni_kv_config,
             task_type=self.task_type,

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -94,7 +94,7 @@ from vllm_omni.engine.stage_init_utils import (
     capture_stage_factory_contexts,
     compute_replica_layout,
     extract_stage_metadata,
-    get_stage_connector_spec,
+    get_stage_worker_connector_specs,
     initialize_diffusion_stage,
     inject_kv_stage_info,
     load_omni_transfer_config_for_model,
@@ -521,10 +521,9 @@ class AsyncOmniEngine:
             if base_metadata.prompt_expand_func is not None:
                 prompt_expand_func = base_metadata.prompt_expand_func
 
-            stage_connector_spec = get_stage_connector_spec(
+            stage_connector_spec, stage_output_connector_spec = get_stage_worker_connector_specs(
                 omni_transfer_config=omni_transfer_config,
                 stage_id=configured_stage_id,
-                async_chunk=self.async_chunk,
             )
             omni_kv_connector = resolve_omni_kv_config_for_stage(omni_transfer_config, configured_stage_id)
             num_replicas = replicas_per_stage[stage_idx]
@@ -544,6 +543,7 @@ class AsyncOmniEngine:
                     stage_cfg,
                     self.model,
                     stage_connector_spec=stage_connector_spec,
+                    stage_output_connector_spec=stage_output_connector_spec,
                     cli_tokenizer=getattr(self, "tokenizer", None),
                 )
                 omni_conn_cfg, omni_from, omni_to = omni_kv_connector
@@ -566,6 +566,7 @@ class AsyncOmniEngine:
                     stage_cfg,
                     self.model,
                     stage_connector_spec=stage_connector_spec,
+                    stage_output_connector_spec=stage_output_connector_spec,
                     engine_args_dict=engine_args_dict,
                 )
 
@@ -597,6 +598,7 @@ class AsyncOmniEngine:
                         stage_cfg=replica_cfg,
                         metadata=replica_metadata,
                         stage_connector_spec=stage_connector_spec,
+                        stage_output_connector_spec=stage_output_connector_spec,
                         omni_kv_connector=omni_kv_connector,
                         stage_vllm_config=stage_vllm_config,
                         executor_class=executor_class,
@@ -884,6 +886,7 @@ class AsyncOmniEngine:
                                 stage_cfg,
                                 self.model,
                                 stage_connector_spec=plan.stage_connector_spec,
+                                stage_output_connector_spec=plan.stage_output_connector_spec,
                                 cli_tokenizer=getattr(self, "tokenizer", None),
                             )
                             lock_fds = acquire_device_locks(

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -47,6 +47,7 @@ class ReplicaInitPlan:
     stage_cfg: Any
     metadata: Any
     stage_connector_spec: dict[str, Any]
+    stage_output_connector_spec: dict[str, Any]
     omni_kv_connector: tuple[dict[str, Any] | None, str | None, str | None]
     stage_vllm_config: Any | None = None
     executor_class: type | None = None
@@ -639,6 +640,7 @@ def build_engine_args_dict(
     stage_config: Any,
     model: str,
     stage_connector_spec: dict[str, Any] | None = None,
+    stage_output_connector_spec: dict[str, Any] | None = None,
     cli_tokenizer: str | None = None,
 ) -> dict[str, Any]:
     """Build the normalized engine args dict for one stage."""
@@ -667,8 +669,10 @@ def build_engine_args_dict(
     # Stage id must come from stage config instead of inherited CLI kwargs
     # (e.g. `--stage-id` defaulting to None).
     engine_args_dict["stage_id"] = stage_id
-    if engine_args_dict.get("async_chunk", False):
+    if stage_connector_spec is not None:
         engine_args_dict["stage_connector_spec"] = dict(stage_connector_spec or {})
+    if stage_output_connector_spec is not None:
+        engine_args_dict["stage_output_connector_spec"] = dict(stage_output_connector_spec or {})
 
     if stage_type == "diffusion":
         from vllm_omni.diffusion.data import parse_attention_config
@@ -699,6 +703,7 @@ def build_vllm_config(
     stage_config: Any,
     model: str,
     stage_connector_spec: dict[str, Any] | None = None,
+    stage_output_connector_spec: dict[str, Any] | None = None,
     engine_args_dict: dict[str, Any] | None = None,
     headless: bool = False,
 ) -> tuple[Any, type]:
@@ -712,6 +717,7 @@ def build_vllm_config(
             stage_config,
             model,
             stage_connector_spec=stage_connector_spec,
+            stage_output_connector_spec=stage_output_connector_spec,
         )
 
     filtered_engine_args_dict = filter_dataclass_kwargs(OmniEngineArgs, engine_args_dict)
@@ -981,6 +987,16 @@ def get_stage_connector_spec(
     for cfg in stage_connectors_cfg.values():
         return dict(cfg.get("spec", {}))
     return {}
+
+
+def get_stage_worker_connector_specs(
+    omni_transfer_config: Any,
+    stage_id: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return (input_spec, output_spec) for worker-side recv/send connectors."""
+    from vllm_omni.distributed.omni_connectors import get_worker_connector_specs_for_stage
+
+    return get_worker_connector_specs_for_stage(omni_transfer_config, stage_id)
 
 
 def build_diffusion_config(

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -694,7 +694,7 @@ def run_headless(args: argparse.Namespace) -> None:
         build_engine_args_dict,
         build_vllm_config,
         extract_stage_metadata,
-        get_stage_connector_spec,
+        get_stage_worker_connector_specs,
         get_stage_devices_per_replica,
         inject_kv_stage_info,
         load_omni_transfer_config_for_model,
@@ -912,10 +912,9 @@ def run_headless(args: argparse.Namespace) -> None:
                 if p.is_alive():
                     terminate_alive_proc(p)
 
-    stage_connector_spec = get_stage_connector_spec(
+    stage_connector_spec, stage_output_connector_spec = get_stage_worker_connector_specs(
         omni_transfer_config=omni_transfer_config,
         stage_id=stage_id,
-        async_chunk=False,
     )
 
     # ``runtime_cfg`` is mostly inherited from the parent's
@@ -926,6 +925,7 @@ def run_headless(args: argparse.Namespace) -> None:
         stage_cfg,
         model,
         stage_connector_spec=stage_connector_spec,
+        stage_output_connector_spec=stage_output_connector_spec,
         cli_tokenizer=getattr(args, "tokenizer", None),
     )
 
@@ -945,6 +945,7 @@ def run_headless(args: argparse.Namespace) -> None:
         stage_cfg,
         model,
         stage_connector_spec=stage_connector_spec,
+        stage_output_connector_spec=stage_output_connector_spec,
         engine_args_dict=engine_args_dict,
         headless=True,
     )

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
@@ -151,13 +151,37 @@ def _extract_qwen3_full_payload_codec_rows(
     ):
         trailing_placeholder_count += 1
 
-    aligned_len = min(int(code_predictor_codes.shape[0]), len(output_token_ids))
+    raw_rows = int(code_predictor_codes.shape[0])
+    row_in_codebook_mask_all = (code_predictor_codes.max(dim=1).values < _QWEN3_CODEC_CODEBOOK_SIZE) & (
+        code_predictor_codes.min(dim=1).values >= 0
+    )
+
+    # In some non-async runs the Request snapshot only carries the final few
+    # output token ids while the accumulated codec tensor is complete.  Treat
+    # that as an incomplete alignment signal instead of dropping most audio.
+    if 0 < len(output_token_ids) < max(1, raw_rows // 2):
+        non_placeholder_mask = code_predictor_codes.any(dim=1)
+        filtered_rows = code_predictor_codes[row_in_codebook_mask_all & non_placeholder_mask]
+        if filtered_rows.numel() == 0:
+            filtered_rows = code_predictor_codes[:0]
+        return filtered_rows, {
+            "raw_rows": raw_rows,
+            "aligned_rows": len(output_token_ids),
+            "valid_rows": int(filtered_rows.shape[0]) if filtered_rows.ndim > 0 else 0,
+            "trailing_placeholder_count": trailing_placeholder_count,
+            "alignment_fallback": 1,
+            "zero_placeholder_rows": int((~non_placeholder_mask).sum().item()),
+        }
+
+    aligned_len = min(raw_rows, len(output_token_ids))
     if aligned_len <= 0:
         return code_predictor_codes[:0], {
-            "raw_rows": int(code_predictor_codes.shape[0]),
+            "raw_rows": raw_rows,
             "aligned_rows": 0,
             "valid_rows": 0,
             "trailing_placeholder_count": trailing_placeholder_count,
+            "alignment_fallback": 0,
+            "zero_placeholder_rows": 0,
         }
 
     aligned_rows = code_predictor_codes[-aligned_len:]
@@ -174,10 +198,12 @@ def _extract_qwen3_full_payload_codec_rows(
     if filtered_rows.numel() == 0:
         filtered_rows = aligned_rows[:0]
     return filtered_rows, {
-        "raw_rows": int(code_predictor_codes.shape[0]),
+        "raw_rows": raw_rows,
         "aligned_rows": aligned_len,
         "valid_rows": int(filtered_rows.shape[0]) if filtered_rows.ndim > 0 else 0,
         "trailing_placeholder_count": trailing_placeholder_count,
+        "alignment_fallback": 0,
+        "zero_placeholder_rows": 0,
     }
 
 

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -77,7 +77,14 @@ class OmniConnectorModelRunnerMixin:
             model_config: Stage-level model config with connector settings.
             kv_transfer_manager: Existing KV transfer manager to delegate to.
         """
-        self._omni_connector: OmniConnectorBase | None = self._create_connector(model_config)
+        self._omni_connector: OmniConnectorBase | None = self._create_connector(
+            model_config,
+            config_attr="stage_connector_config",
+        )
+        self._omni_output_connector: OmniConnectorBase | None = self._create_connector(
+            model_config,
+            config_attr="stage_output_connector_config",
+        )
         self._kv_transfer_manager = kv_transfer_manager
 
         self._async_chunk: bool = getattr(model_config, "async_chunk", False)
@@ -90,11 +97,13 @@ class OmniConnectorModelRunnerMixin:
         self._custom_process_func_path, self._custom_process_func = self._load_custom_func(model_config)
         self._custom_process_supports_is_finished = self._custom_process_supports_is_finished_kwarg()
         logger.info(
-            "[Stage-%s] init_omni_connectors: async_chunk=%s, custom_process_func=%s, connector=%s, func_path=%s",
+            "[Stage-%s] init_omni_connectors: async_chunk=%s, custom_process_func=%s, "
+            "in_connector=%s, out_connector=%s, func_path=%s",
             self._stage_id,
             self._async_chunk,
             self._custom_process_func,
             type(self._omni_connector).__name__ if self._omni_connector else None,
+            type(self._get_send_connector()).__name__ if self._get_send_connector() else None,
             self._custom_process_func_path,
         )
 
@@ -172,7 +181,7 @@ class OmniConnectorModelRunnerMixin:
         self._stop_event = threading.Event()
         self._work_available = threading.Event()
 
-        # Start background threads only when there's a connector
+        # Start background threads only when there is corresponding I/O work.
         self._recv_thread: threading.Thread | None = None
         self._save_thread: threading.Thread | None = None
         if self._omni_connector is not None:
@@ -182,6 +191,7 @@ class OmniConnectorModelRunnerMixin:
                 name="omni-mixin-recv",
             )
             self._recv_thread.start()
+        if self._get_send_connector() is not None:
             self._save_thread = threading.Thread(
                 target=self._save_loop,
                 daemon=True,
@@ -196,9 +206,17 @@ class OmniConnectorModelRunnerMixin:
             self._recv_thread.join(timeout=5)
         if self._save_thread is not None:
             self._save_thread.join(timeout=5)
+        closed_ids: set[int] = set()
         if self._omni_connector is not None:
             try:
                 self._omni_connector.close()
+                closed_ids.add(id(self._omni_connector))
+            except Exception:
+                pass
+        out_connector = getattr(self, "_omni_output_connector", None)
+        if out_connector is not None and id(out_connector) not in closed_ids:
+            try:
+                out_connector.close()
             except Exception:
                 pass
 
@@ -444,9 +462,9 @@ class OmniConnectorModelRunnerMixin:
     def _payload_audio_codes(payload: Any) -> Any:
         if not isinstance(payload, dict):
             return None
-        if "code_predictor_codes" in payload:
-            logger.warning_once("legacy flat 'code_predictor_codes' key in payload; expected 'codes.audio'")
         codes = payload.get("codes")
+        if "code_predictor_codes" in payload and not isinstance(codes, dict):
+            logger.warning_once("legacy flat 'code_predictor_codes' key in payload; expected 'codes.audio'")
         if isinstance(codes, dict):
             return codes.get("audio")
         return None
@@ -706,6 +724,131 @@ class OmniConnectorModelRunnerMixin:
         return False
 
     @staticmethod
+    def _coerce_connector_payload_dict(payload_data: Any) -> dict[str, Any] | None:
+        if isinstance(payload_data, dict):
+            return payload_data
+        to_dict_fn = getattr(payload_data, "to_dict", None)
+        if callable(to_dict_fn):
+            coerced = to_dict_fn()
+            return coerced if isinstance(coerced, dict) else None
+        try:
+            from vllm_omni.data_entry_keys import to_dict
+
+            coerced = to_dict(payload_data)
+            return coerced if isinstance(coerced, dict) else None
+        except Exception:
+            return None
+
+    def _should_use_qwen3_thinker_to_talker_packet_path(
+        self,
+        *,
+        for_recv: bool = False,
+        transfer_mode: str | None = None,
+    ) -> bool:
+        from vllm_omni.distributed.omni_connectors.utils.qwen3_transfer_packet import (
+            MODE_ASYNC_CHUNK,
+            MODE_NON_ASYNC_FULL_PAYLOAD,
+            should_use_thinker_to_talker_packet_path,
+        )
+
+        connector = self._omni_connector if for_recv else self._get_send_connector()
+        if connector is None:
+            return False
+        model_config = self._get_model_config()
+        if for_recv:
+            from_stage_id = self._stage_id - 1
+            to_stage_id = self._stage_id
+        else:
+            from_stage_id = self._stage_id
+            to_stage_id = self._next_stage_id
+        resolved_mode = transfer_mode
+        if resolved_mode is None:
+            resolved_mode = MODE_ASYNC_CHUNK if self._async_chunk else MODE_NON_ASYNC_FULL_PAYLOAD
+        return should_use_thinker_to_talker_packet_path(
+            async_chunk=self._async_chunk,
+            supports_raw_data=getattr(connector, "supports_raw_data", False),
+            model_arch=getattr(model_config, "model_arch", None) if model_config is not None else None,
+            from_stage_id=from_stage_id,
+            to_stage_id=to_stage_id,
+            transfer_mode=resolved_mode,
+        )
+
+    def _enqueue_full_payload_packet_send(
+        self,
+        *,
+        req_id: str,
+        external_req_id: str,
+        connector_put_key: str,
+        payload: dict[str, Any],
+        next_stage_id: int,
+        chunk_id: int,
+        packet_mode: str | None = None,
+    ) -> None:
+        from vllm_omni.distributed.omni_connectors.utils.qwen3_transfer_packet import (
+            MODE_ASYNC_CHUNK,
+            split_qwen3_full_payload,
+        )
+
+        mode = packet_mode or MODE_ASYNC_CHUNK
+        tensor_puts, sidecar = split_qwen3_full_payload(
+            payload,
+            request_id=req_id,
+            external_req_id=external_req_id,
+            from_stage_id=self._stage_id,
+            to_stage_id=next_stage_id,
+            chunk_id=chunk_id,
+            mode=mode,
+        )
+        tasks: list[dict[str, Any]] = []
+        send_connector = self._get_send_connector()
+        for put_key, tensor in tensor_puts:
+            tasks.append(
+                {
+                    "stage_id": self._stage_id,
+                    "next_stage_id": next_stage_id,
+                    "put_key": put_key,
+                    "data": tensor,
+                    "request_id": req_id,
+                    "connector": send_connector,
+                }
+            )
+        tasks.append(
+            {
+                "stage_id": self._stage_id,
+                "next_stage_id": next_stage_id,
+                "put_key": connector_put_key,
+                "data": sidecar,
+                "request_id": req_id,
+                "connector": send_connector,
+            }
+        )
+        with self._lock:
+            dq = self._pending_save_reqs.setdefault(req_id, deque())
+            for task in tasks:
+                dq.append(task)
+                self._pending_save_counts[req_id] += 1
+
+    def _reconstruct_qwen3_packet_payload(
+        self,
+        connector: OmniConnectorBase,
+        sidecar: dict[str, Any],
+        from_stage: str,
+        to_stage: str,
+    ) -> dict[str, Any]:
+        from vllm_omni.distributed.omni_connectors.utils.qwen3_transfer_packet import (
+            reconstruct_qwen3_full_payload,
+        )
+
+        def get_tensor(transfer_key: str) -> Any:
+            result = connector.get(from_stage, to_stage, transfer_key)
+            if result is None:
+                return None
+            data, _size = result
+            return data
+
+        return reconstruct_qwen3_full_payload(sidecar, get_tensor)
+
+    @staticmethod
     def _new_full_payload_accumulator(output: dict[str, Any]):
         chunks: dict[str, list[torch.Tensor]] = {}
         latest: dict[str, Any] = {}
@@ -873,16 +1016,46 @@ class OmniConnectorModelRunnerMixin:
                 connector_put_key,
                 next_stage_id,
             )
-            task = {
-                "stage_id": self._stage_id,
-                "next_stage_id": next_stage_id,
-                "put_key": connector_put_key,
-                "data": payload,
-                "request_id": req_id,
-            }
-            with self._lock:
-                self._pending_save_reqs.setdefault(req_id, deque()).append(task)
-                self._pending_save_counts[req_id] += 1
+            payload_dict = self._coerce_connector_payload_dict(payload)
+            from vllm_omni.distributed.omni_connectors.utils.qwen3_transfer_packet import (
+                payload_has_packet_tensors,
+            )
+
+            use_packet = (
+                payload_dict is not None
+                and payload_has_packet_tensors(payload_dict)
+                and self._should_use_qwen3_thinker_to_talker_packet_path(
+                    transfer_mode="non_async_full_payload",
+                )
+            )
+            if use_packet:
+                self._enqueue_full_payload_packet_send(
+                    req_id=req_id,
+                    external_req_id=external_req_id,
+                    connector_put_key=connector_put_key,
+                    payload=payload_dict,
+                    next_stage_id=next_stage_id,
+                    chunk_id=chunk_id,
+                    packet_mode="non_async_full_payload",
+                )
+                logger.info(
+                    "[Stage-%s] send_full_payload_outputs: packet_put req=%s key=%s mode=non_async_full_payload",
+                    self._stage_id,
+                    req_id,
+                    connector_put_key,
+                )
+            else:
+                task = {
+                    "stage_id": self._stage_id,
+                    "next_stage_id": next_stage_id,
+                    "put_key": connector_put_key,
+                    "data": payload,
+                    "request_id": req_id,
+                    "connector": self._get_send_connector(),
+                }
+                with self._lock:
+                    self._pending_save_reqs.setdefault(req_id, deque()).append(task)
+                    self._pending_save_counts[req_id] += 1
             sent_ids.append(req_id)
         if sent_ids:
             self._work_available.set()
@@ -1017,24 +1190,48 @@ class OmniConnectorModelRunnerMixin:
         next_stage_id = self._next_stage_id
         connector_put_key = f"{request_id}_{self._stage_id}_{chunk_id}"
 
-        if chunk_id == 0:
+        from vllm_omni.distributed.omni_connectors.utils.qwen3_transfer_packet import (
+            payload_has_packet_tensors,
+        )
+
+        payload_dict = self._coerce_connector_payload_dict(payload_data)
+        use_packet = (
+            payload_dict is not None
+            and self._should_use_qwen3_thinker_to_talker_packet_path()
+            and payload_has_packet_tensors(payload_dict)
+        )
+        if chunk_id == 0 or use_packet:
             logger.info(
-                "[Stage-%s] send_chunk: first chunk enqueued, req=%s key=%s",
+                "[Stage-%s] send_chunk: enqueue req=%s key=%s chunk=%s packet=%s",
                 self._stage_id,
                 request_id,
                 connector_put_key,
+                chunk_id,
+                use_packet,
             )
 
-        task = {
-            "stage_id": self._stage_id,
-            "next_stage_id": next_stage_id,
-            "put_key": connector_put_key,
-            "data": payload_data,
-            "request_id": request_id,
-        }
-        with self._lock:
-            self._pending_save_reqs.setdefault(request_id, deque()).append(task)
-            self._pending_save_counts[request_id] += 1
+        if use_packet:
+            assert payload_dict is not None
+            self._enqueue_full_payload_packet_send(
+                req_id=request_id,
+                external_req_id=request_id,
+                connector_put_key=connector_put_key,
+                payload=payload_dict,
+                next_stage_id=next_stage_id,
+                chunk_id=chunk_id,
+            )
+        else:
+            task = {
+                "stage_id": self._stage_id,
+                "next_stage_id": next_stage_id,
+                "put_key": connector_put_key,
+                "data": payload_data,
+                "request_id": request_id,
+                "connector": self._get_send_connector(),
+            }
+            with self._lock:
+                self._pending_save_reqs.setdefault(request_id, deque()).append(task)
+                self._pending_save_counts[request_id] += 1
         self._work_available.set()
         return True
 
@@ -1503,6 +1700,12 @@ class OmniConnectorModelRunnerMixin:
 
     @property
     def connector(self) -> Any | None:
+        return self._get_send_connector()
+
+    def _get_send_connector(self) -> OmniConnectorBase | None:
+        connector = getattr(self, "_omni_output_connector", None)
+        if connector is not None:
+            return connector
         return self._omni_connector
 
     # ------------------------------------------------------------------ #
@@ -1537,6 +1740,15 @@ class OmniConnectorModelRunnerMixin:
                     break
                 try:
                     made_progress = self._poll_single_request(req_id) or made_progress
+                except RuntimeError as exc:
+                    if "get(metadata=None) requires sender info to be resolved" in str(exc):
+                        logger.debug(
+                            "[Stage-%s] recv_loop pending sender endpoint for req=%s; retrying",
+                            self._stage_id,
+                            req_id,
+                        )
+                        continue
+                    logger.warning("Error receiving data for %s", req_id, exc_info=True)
                 except Exception:
                     logger.warning("Error receiving data for %s", req_id, exc_info=True)
 
@@ -1651,6 +1863,28 @@ class OmniConnectorModelRunnerMixin:
         payload_data, _size = result
         if not payload_data:
             return False
+
+        if isinstance(payload_data, dict) and self._should_use_qwen3_thinker_to_talker_packet_path(for_recv=True):
+            from vllm_omni.distributed.omni_connectors.utils.qwen3_transfer_packet import is_packet_sidecar
+
+            if is_packet_sidecar(payload_data):
+                try:
+                    payload_data = self._reconstruct_qwen3_packet_payload(
+                        connector,
+                        payload_data,
+                        str(target_stage_id),
+                        str(self._stage_id),
+                    )
+                except Exception:
+                    logger.warning(
+                        "[Stage-%s] failed to reconstruct Qwen3 packet payload for req=%s key=%s",
+                        self._stage_id,
+                        req_id,
+                        connector_get_key,
+                        exc_info=True,
+                    )
+                    return False
+
         if isinstance(payload_data, dict):
             logger.info(
                 "[Stage-%s] recv_chunk_result: req=%s ext=%s key=%s keys=%s finished=%s",
@@ -1820,7 +2054,7 @@ class OmniConnectorModelRunnerMixin:
         ``success=False``), returns False **without** decrementing
         ``_pending_save_counts`` so the caller can retry or clean up.
         """
-        connector = self._omni_connector
+        connector = task.get("connector") or self._get_send_connector()
         if connector is None:
             return True
 
@@ -1997,9 +2231,9 @@ class OmniConnectorModelRunnerMixin:
         return snapshot
 
     @staticmethod
-    def _create_connector(model_config: Any) -> OmniConnectorBase | None:
+    def _create_connector(model_config: Any, config_attr: str = "stage_connector_config") -> OmniConnectorBase | None:
         """Create a connector from model_config, or None if unconfigured."""
-        connector_config = getattr(model_config, "stage_connector_config", None)
+        connector_config = getattr(model_config, config_attr, None)
         if connector_config is None:
             return None
 
@@ -2024,7 +2258,7 @@ class OmniConnectorModelRunnerMixin:
         try:
             return OmniConnectorFactory.create_connector(spec)
         except Exception as exc:
-            raise RuntimeError(f"Failed to create connector {name}") from exc
+            raise RuntimeError(f"Failed to create connector {name} from {config_attr}") from exc
 
     @staticmethod
     def _load_custom_func(model_config: Any) -> tuple[str | None, Any | None]:
@@ -2124,8 +2358,10 @@ class OmniConnectorModelRunnerMixin:
         Falls back to ``stage_id + 1`` when the config does not specify
         a ``to_stage`` explicitly.
         """
-        connector_config = getattr(model_config, "stage_connector_config", None)
-        if connector_config is not None:
+        for config_attr in ("stage_output_connector_config", "stage_connector_config"):
+            connector_config = getattr(model_config, config_attr, None)
+            if connector_config is None:
+                continue
             if isinstance(connector_config, dict):
                 to_stage = connector_config.get("to_stage")
             else:
@@ -2143,7 +2379,9 @@ class OmniConnectorModelRunnerMixin:
         Returns ``{"from_tp": int, "to_tp": int, "local_rank": int}``.
         When ``rank_mapping`` is absent, assumes 1:1 homogeneous mapping.
         """
-        connector_config = getattr(model_config, "stage_connector_config", None)
+        connector_config = getattr(model_config, "stage_output_connector_config", None)
+        if connector_config is None:
+            connector_config = getattr(model_config, "stage_connector_config", None)
         if connector_config is not None and not isinstance(connector_config, dict):
             connector_config = getattr(connector_config, "__dict__", {})
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
implemented the initial Qwen3-Omni thinker→talker→code2wav transfer path over Mooncake Transfer Engine (MTE), following the RFC packet design with tensor entries plus a sidecar metadata payload. (https://github.com/vllm-project/vllm-omni/issues/3635)

This MVP currently supports the non-async_chunk full-payload path only. It wires the full three-stage pipeline end to end: Stage 0 thinker output is transferred to Stage 1 talker, and Stage 1 codec output is transferred to Stage 2 code2wav through MTE. Local end-to-end validation passed, including generated audio verification.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
