### PR TITLE
[Feature] Make TTL configurable in TE connector

### DIFF
--- a/docs/design/feature/omni_connectors/mooncake_transfer_engine_connector.md
+++ b/docs/design/feature/omni_connectors/mooncake_transfer_engine_connector.md
@@ -35,6 +35,7 @@ runtime:
         device_name: ""               # RDMA device (e.g., "mlx5_0"), empty for auto-detect
         memory_pool_size: 4294967296  # 4 GB (CPU); use 2147483648 (2 GB) for GPU
         memory_pool_device: "cpu"     # "cpu" for pinned memory (recommended), "cuda" for GPUDirect RDMA
+        buffer_ttl_seconds: 300       # Fallback TTL for unconsumed buffers (raise for slow consumers)
 ```
 
 Wire stages to the connector:
@@ -66,6 +67,7 @@ stage_args:
 |---|---|---|
 | `memory_pool_size` | 4 GB (CPU) / 2 GB (GPU) | Total size of the RDMA-registered memory pool in bytes. Recommended 4 GB for CPU pinned memory; 2 GB for GPU VRAM to conserve device memory. |
 | `memory_pool_device` | `"cpu"` | `"cpu"`: pinned host memory (recommended, works on all topologies). `"cuda"`: GPU VRAM for GPUDirect RDMA (requires NIC-GPU direct PCIe connectivity, PIX topology). |
+| `buffer_ttl_seconds` | `300` | Fallback TTL (seconds) used by the sender to reclaim buffers that no receiver ever pulled. Normal release happens via `cleanup()` after a successful RDMA pull; TTL only fires when the receiver never arrives. Raise this when the downstream stage's worst-case queue wait can exceed the default (e.g. high HTTP concurrency against a stage with `max_num_seqs: 1`) — otherwise the receiver will time out trying to fetch a buffer that TTL has already evicted. Must be a finite positive number; NaN / ±inf are rejected to prevent the leak-prevention sweep from being silently disabled. |
 
 ### Networking
 
@@ -182,6 +184,7 @@ echo "MC_IB_PCI_RELAXED_ORDERING=${MC_IB_PCI_RELAXED_ORDERING:-<not set>}"
 | `zmq.error.Again: Resource temporarily unavailable` | ZMQ recv timeout (transfer took too long) | Check NIC selection; increase data may need longer timeout |
 | `Mooncake Engine initialization failed` | Missing RDMA drivers or `/dev/infiniband` | Install Mellanox OFED; in Docker add `--device=/dev/infiniband` |
 | `MemoryError` in allocator | Memory pool too small for payload | Increase `memory_pool_size` |
+| `Timeout waiting for KV cache ... after Xs` + sender logs `TTL expired (300s): cleaned up stale buffer` | Downstream stage's queue wait exceeded the buffer TTL (typical under high HTTP concurrency against `max_num_seqs: 1`) | Raise `buffer_ttl_seconds` above the worst-case queue wait, and/or increase downstream `max_num_seqs` or replica count |
 | GPU transfer slower than CPU | GPU BAR1 bandwidth limitation (PXB/NODE topology) | Use `memory_pool_device: "cpu"` instead of `"cuda"` |
 
 ### Multi-NIC Environments (DGX)
@@ -699,6 +702,8 @@ This is intended to reduce false timeouts for large remote writes.
 #### 11.2 Stale Buffer Reclamation
 
 The sender periodically reclaims old entries from `_local_buffers` using a TTL policy. This protects the memory pool from permanent leaks if a receiver crashes or never consumes a prepared payload.
+
+The TTL defaults to 300 seconds and can be overridden via the `buffer_ttl_seconds` field in the connector config. Tune this when the receiving stage's worst-case queue wait can exceed the default — for example, high HTTP concurrency against a diffusion stage configured with `max_num_seqs: 1`: a receiver that picks up a request later than `buffer_ttl_seconds` after the producer's `put()` will find its buffer already evicted, surfacing as `Timeout waiting for KV cache for request ... after Xs` on the receiver side. A rough rule of thumb is `buffer_ttl_seconds ≥ recv_timeout × expected_queue_depth`.
 
 This is a practical recovery mechanism, although the code notes that TTL cleanup can still race with very long-running in-flight transfers.
 

--- a/tests/distributed/omni_connectors/test_mooncake_transfer_engine_rdma.py
+++ b/tests/distributed/omni_connectors/test_mooncake_transfer_engine_rdma.py
@@ -253,6 +253,48 @@ class TestBasicConnector:
             ok, _, _ = c.put("s", "s", "recovery", torch.randn(1000))
             assert ok, "Pool recovery failed after cleanup"
 
+    def test_buffer_ttl_default(self):
+        """Without override, buffer_ttl_seconds keeps its 300s default."""
+        port = _free_port()
+        with MooncakeTransferEngineConnector(_connector_config(port)) as c:
+            assert c.buffer_ttl_seconds == 300.0
+
+    def test_buffer_ttl_override_from_config(self):
+        """``buffer_ttl_seconds`` is read from the connector config."""
+        port = _free_port()
+        cfg = _connector_config(port)
+        cfg["buffer_ttl_seconds"] = 1200
+        with MooncakeTransferEngineConnector(cfg) as c:
+            assert c.buffer_ttl_seconds == 1200.0
+
+    def test_buffer_ttl_invalid_rejected(self):
+        """Reject non-finite, non-positive, and non-numeric TTL values."""
+        for bad in (0, "abc", float("nan"), float("inf")):
+            cfg = _connector_config(_free_port())
+            cfg["buffer_ttl_seconds"] = bad
+            with pytest.raises(ValueError, match="buffer_ttl_seconds"):
+                MooncakeTransferEngineConnector(cfg)
+
+    def test_buffer_ttl_eviction_honors_config(self):
+        """``_cleanup_stale_buffers`` uses the configured TTL, not the default.
+
+        With a 0.2s TTL, a buffer put now should still be present immediately
+        after cleanup runs, but absent after sleeping past the TTL window.
+        """
+        port = _free_port()
+        cfg = _connector_config(port)
+        cfg["buffer_ttl_seconds"] = 0.2
+        with MooncakeTransferEngineConnector(cfg) as c:
+            ok, _, _ = c.put("s", "s", "ttl_test", torch.randn(100))
+            assert ok
+            key = MooncakeTransferEngineConnector._make_key("ttl_test", "s", "s")
+            assert key in c._local_buffers
+            c._cleanup_stale_buffers()
+            assert key in c._local_buffers, "buffer evicted before TTL elapsed"
+            time.sleep(0.3)
+            c._cleanup_stale_buffers()
+            assert key not in c._local_buffers, "buffer not evicted after TTL elapsed"
+
 
 # ---------------------------------------------------------------------------
 # 2. End-to-end RDMA transfer (producer + consumer, single node)

--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 import os
 import queue
 import socket
@@ -27,9 +28,10 @@ try:
 except ImportError:
     TransferEngine = None
 
-# Stale buffer TTL: buffers older than this are automatically reclaimed
-# to prevent memory leaks when receiver crashes or gives up.
-_BUFFER_TTL_SECONDS = 300  # 5 minutes
+# Stale buffer TTL: buffers older than this are reclaimed to prevent leaks
+# when a receiver crashes or never pulls.  Override per-connector via
+# ``buffer_ttl_seconds`` in the connector config.
+_DEFAULT_BUFFER_TTL_SECONDS = 300.0  # 5 minutes
 
 # ZMQ Message constants
 TRANS_DONE = b"trans_done"
@@ -155,6 +157,19 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         self.pool_size = config.get("memory_pool_size", 1024**3)  # Default 1GB
         self.pool_device = config.get("memory_pool_device", "cpu")
 
+        # --- Buffer Lifetime Configuration ---
+        raw_ttl = config.get("buffer_ttl_seconds", _DEFAULT_BUFFER_TTL_SECONDS)
+        try:
+            self.buffer_ttl_seconds = float(raw_ttl)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"buffer_ttl_seconds must be a number, got {raw_ttl!r}"
+            ) from exc
+        if not math.isfinite(self.buffer_ttl_seconds) or self.buffer_ttl_seconds <= 0:
+            raise ValueError(
+                f"buffer_ttl_seconds must be a finite positive number, got {self.buffer_ttl_seconds}"
+            )
+
         # --- Sender Configuration (for receiver to query without metadata) ---
         # When receiver doesn't have metadata, it uses these to connect to sender
         self.sender_host = config.get("sender_host", None)
@@ -217,7 +232,8 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             f"MooncakeTransferEngineConnector config summary:\n"
             f"  Local: host={self.host}, zmq_port={self.zmq_port}, rpc_port={self.rpc_port}\n"
             f"  Remote: sender_host={self.sender_host}, sender_zmq_port={self.sender_zmq_port}\n"
-            f"  Role: can_put={self.can_put}, configured_role={config.get('role', 'sender')}"
+            f"  Role: can_put={self.can_put}, configured_role={config.get('role', 'sender')}\n"
+            f"  Buffer TTL: {self.buffer_ttl_seconds}s"
         )
 
         # Only sender needs ZMQ listener to handle pull requests
@@ -839,6 +855,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             "protocol": self.protocol,
             "pool_device": self.pool_device,
             "pool_size": self.pool_size,
+            "buffer_ttl_seconds": self.buffer_ttl_seconds,
             **self._metrics,
         }
 
@@ -917,21 +934,22 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
     # -------------------------------------------------------
 
     def _cleanup_stale_buffers(self) -> None:
-        """Reclaim buffers older than ``_BUFFER_TTL_SECONDS``.
+        """Reclaim buffers older than ``self.buffer_ttl_seconds``.
         Prevents permanent memory leaks when a receiver crashes or times out
         without ever pulling the data.
         TODO(wzliu): In extreme rare case, long transfer time, there might exist
         TTL cleanup vs in-flight transfer conflict, which will be handled in the next PR.
         """
         now = _time_mod.monotonic()
+        ttl = self.buffer_ttl_seconds
         with self._local_buffers_lock:
-            stale_keys = [k for k, v in self._local_buffers.items() if now - v[5] > _BUFFER_TTL_SECONDS]
+            stale_keys = [k for k, v in self._local_buffers.items() if now - v[5] > ttl]
             for k in stale_keys:
                 item = self._local_buffers.pop(k)
                 _, _, holder, should_release, _, _ = item
                 if should_release and isinstance(holder, ManagedBuffer):
                     holder.release()
-                logger.warning(f"TTL expired ({_BUFFER_TTL_SECONDS}s): cleaned up stale buffer for {k}")
+                logger.warning(f"TTL expired ({ttl}s): cleaned up stale buffer for {k}")
 
     def _zmq_listener_loop(self):
         socket = self.zmq_ctx.socket(zmq.ROUTER)

--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -162,13 +162,9 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         try:
             self.buffer_ttl_seconds = float(raw_ttl)
         except (TypeError, ValueError) as exc:
-            raise ValueError(
-                f"buffer_ttl_seconds must be a number, got {raw_ttl!r}"
-            ) from exc
+            raise ValueError(f"buffer_ttl_seconds must be a number, got {raw_ttl!r}") from exc
         if not math.isfinite(self.buffer_ttl_seconds) or self.buffer_ttl_seconds <= 0:
-            raise ValueError(
-                f"buffer_ttl_seconds must be a finite positive number, got {self.buffer_ttl_seconds}"
-            )
+            raise ValueError(f"buffer_ttl_seconds must be a finite positive number, got {self.buffer_ttl_seconds}")
 
         # --- Sender Configuration (for receiver to query without metadata) ---
         # When receiver doesn't have metadata, it uses these to connect to sender

--- a/vllm_omni/platforms/npu/omni_connectors/yuanrong_transfer_engine_connector.py
+++ b/vllm_omni/platforms/npu/omni_connectors/yuanrong_transfer_engine_connector.py
@@ -135,13 +135,9 @@ class YuanrongTransferEngineConnector(OmniConnectorBase):
         try:
             self.buffer_ttl_seconds = float(raw_ttl)
         except (TypeError, ValueError) as exc:
-            raise ValueError(
-                f"buffer_ttl_seconds must be a number, got {raw_ttl!r}"
-            ) from exc
+            raise ValueError(f"buffer_ttl_seconds must be a number, got {raw_ttl!r}") from exc
         if not math.isfinite(self.buffer_ttl_seconds) or self.buffer_ttl_seconds <= 0:
-            raise ValueError(
-                f"buffer_ttl_seconds must be a finite positive number, got {self.buffer_ttl_seconds}"
-            )
+            raise ValueError(f"buffer_ttl_seconds must be a finite positive number, got {self.buffer_ttl_seconds}")
         self.sender_host = config.get("sender_host")
         sender_zmq_port = config.get("sender_zmq_port")
         self.sender_zmq_port = self._resolve_optional_port(sender_zmq_port, "sender_zmq_port")

--- a/vllm_omni/platforms/npu/omni_connectors/yuanrong_transfer_engine_connector.py
+++ b/vllm_omni/platforms/npu/omni_connectors/yuanrong_transfer_engine_connector.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
 import queue
 import socket
 import threading
@@ -32,7 +33,10 @@ try:
 except ImportError:
     TransferEngine = None
 
-_BUFFER_TTL_SECONDS = 300
+# Stale buffer TTL: buffers older than this are reclaimed to prevent leaks
+# when a receiver crashes or never pulls.  Override per-connector via
+# ``buffer_ttl_seconds`` in the connector config.
+_DEFAULT_BUFFER_TTL_SECONDS = 300.0
 
 QUERY_INFO = b"query_info"
 CLEANUP_KEY = b"cleanup_key"
@@ -126,6 +130,18 @@ class YuanrongTransferEngineConnector(OmniConnectorBase):
         self.device_name = _resolve_device_name(config.get("device_name", "auto"), self.protocol)
         self.pool_size = int(config.get("memory_pool_size", 1024**3))
         self.pool_device = _resolve_pool_device(config.get("memory_pool_device", "npu"))
+
+        raw_ttl = config.get("buffer_ttl_seconds", _DEFAULT_BUFFER_TTL_SECONDS)
+        try:
+            self.buffer_ttl_seconds = float(raw_ttl)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"buffer_ttl_seconds must be a number, got {raw_ttl!r}"
+            ) from exc
+        if not math.isfinite(self.buffer_ttl_seconds) or self.buffer_ttl_seconds <= 0:
+            raise ValueError(
+                f"buffer_ttl_seconds must be a finite positive number, got {self.buffer_ttl_seconds}"
+            )
         self.sender_host = config.get("sender_host")
         sender_zmq_port = config.get("sender_zmq_port")
         self.sender_zmq_port = self._resolve_optional_port(sender_zmq_port, "sender_zmq_port")
@@ -658,6 +674,7 @@ class YuanrongTransferEngineConnector(OmniConnectorBase):
             "protocol": self.protocol,
             "pool_device": self.pool_device,
             "pool_size": self.pool_size,
+            "buffer_ttl_seconds": self.buffer_ttl_seconds,
             **self._metrics,
         }
 
@@ -716,14 +733,15 @@ class YuanrongTransferEngineConnector(OmniConnectorBase):
 
     def _cleanup_stale_buffers(self) -> None:
         now = _time_mod.monotonic()
+        ttl = self.buffer_ttl_seconds
         with self._local_buffers_lock:
-            stale_keys = [k for k, v in self._local_buffers.items() if now - v[5] > _BUFFER_TTL_SECONDS]
+            stale_keys = [k for k, v in self._local_buffers.items() if now - v[5] > ttl]
             for key in stale_keys:
                 item = self._local_buffers.pop(key)
                 _, _, holder, should_release, _, _ = item
                 if should_release and isinstance(holder, ManagedBuffer):
                     holder.release()
-                logger.warning("TTL expired (%ss): cleaned up stale buffer for %s", _BUFFER_TTL_SECONDS, key)
+                logger.warning("TTL expired (%ss): cleaned up stale buffer for %s", ttl, key)
 
     def _zmq_listener_loop(self) -> None:
         socket_obj = self.zmq_ctx.socket(zmq.ROUTER)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Make the stale-buffer reclamation timeout (`_BUFFER_TTL_SECONDS`, hardcoded to 300s) configurable per-connector via a new `buffer_ttl_seconds` field in the YAML `extra` block.  Applies to both `MooncakeTransferEngineConnector` and the new `YuanrongTransferEngineConnector` (NPU), which share the same TTL pattern.

Default behavior is unchanged (300s).

## Background
Tracks #3743.  Under high  concurrency against a downstream stage with `max_num_seqs: 1` (e.g. HunyuanImage-3.0 DiT, which does not yet support continuous batching), requests can sit in the downstream queue longer than `_BUFFER_TTL_SECONDS = 300s`.  The producer's KV buffer is then evicted by `_cleanup_stale_buffers()` before the receiver gets to it, surfacing on the receiver as:

```Timeout waiting for KV cache for request img_edit-... after 30.0s ``` and on the sender as:
  ``` TTL expired (300s): cleaned up stale buffer for ...```

  Until this PR the only mitigation was editing `_BUFFER_TTL_SECONDS` in source (see [#3743 comment](https://github.com/vllm-project/vllm-omni/issues/3743#issuecomment-...) where a solution set it to `1200` and got 128/128 success).  This PR makes that tunable from YAML so operators can size TTL to their workload without forking.

  The TTL is intentionally a fallback — the normal release path is `cleanup()` after a successful RDMA pull (see `_handle_pull_request`).  Long-term, the right fix is producer-side remove the usage of pin memory for KV transfer and utilize block by block transfer. Or back-pressure (block `put()` when downstream is behind) so that TTL only ever fires on a real receiver crash.  This PR is the minimal config-exposure step toward that; back-pressure is left for a follow-up.



## Test Plan
```bash
RDMA_DEVICE_NAME=mlx5_0 pytest -q tests/distributed/omni_connectors/test_mooncake_transfer_engine_rdma.py
```
## Test Result
<img width="1426" height="448" alt="Screenshot from 2026-05-20 06-29-19" src="https://github.com/user-attachments/assets/732a5536-88d5-49e6-ae18-c88962e1e45c" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
