### PR TITLE
fix(multiproc_executor): surface worker crash root cause in EngineDea…

### DIFF
--- a/vllm_omni/diffusion/cache/cache_dit_backend.py
+++ b/vllm_omni/diffusion/cache/cache_dit_backend.py
@@ -1525,6 +1525,11 @@ CUSTOM_DIT_ENABLERS.update(
         "HunyuanVideo15Pipeline": enable_cache_for_hunyuan_video_15,
         "HunyuanVideo15I2VPipeline": enable_cache_for_hunyuan_video_15,
         "HeliosPipeline": enable_cache_for_helios,
+        "QwenImagePipeline": enable_cache_for_dit,
+        "QwenImageEditPipeline": enable_cache_for_dit,
+        "QwenImageEditPlusPipeline": enable_cache_for_dit,
+        "QwenImageLayeredPipeline": enable_cache_for_dit,
+        "QwenImageDMD2Pipeline": enable_cache_for_dit,
     }
 )
 

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -166,6 +166,13 @@ class DiffusionEngine:
 
         try:
             self._dummy_run()
+        except EngineDeadError:
+            logger.error(
+                "Dummy run failed: worker process died. %s",
+                self.executor._failure_reason if hasattr(self.executor, "_failure_reason") else "",
+            )
+            self.close()
+            raise
         except Exception as e:
             logger.error(f"Dummy run failed: {e}")
             self.close()

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -74,6 +74,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         self._processes: list[mp.Process] = []
         self._closed = False
         self.is_failed = False
+        self._failure_reason: str | None = None
         self._failure_callbacks: list[Callable[[], None]] = []
 
         num_workers = self.od_config.num_gpus
@@ -130,7 +131,7 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                 return self._result_mq.dequeue(timeout=chunk_timeout)
             except (TimeoutError, zmq.error.Again):
                 if self.is_failed:
-                    raise EngineDeadError()
+                    raise EngineDeadError(self._failure_reason or "Worker process exited before producing a result.")
                 continue
 
     def _launch_workers(self, broadcast_handle, wake_events):
@@ -233,10 +234,15 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
                         details.append(f"{p.name}(exitcode={code}, {sig})")
                     else:
                         details.append(f"{p.name}(exitcode={code})")
-                logger.error(
-                    "Diffusion worker(s) died unexpectedly: %s",
-                    details,
+                reason = (
+                    f"Diffusion worker(s) died unexpectedly: {details}. "
+                    "Check worker logs above for the root-cause traceback. "
+                    "Common causes: CUDA OOM during warmup, "
+                    "torch.compile + cache_dit interaction, "
+                    "or IPC/collective failure in distributed rank."
                 )
+                logger.error(reason)
+                self._failure_reason = reason
                 self.is_failed = True
 
             self.shutdown()
@@ -402,12 +408,13 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
 
     def check_health(self) -> None:
         if self.is_failed:
-            raise EngineDeadError()
+            raise EngineDeadError(self._failure_reason or "Worker process died (reason unknown).")
         self._ensure_open()
         for p in self._processes:
             if not p.is_alive():
                 self.is_failed = True
-                raise EngineDeadError(f"Worker process {p.name} is dead")
+                self._failure_reason = f"Worker process {p.name} is dead (exitcode={p.exitcode})."
+                raise EngineDeadError(self._failure_reason)
 
     def shutdown(self) -> None:
         self._closed = True

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -161,18 +161,10 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             logger.info(f" Enabling offloader backend: {self.offload_backend.__class__.__name__}")
             self.offload_backend.enable(self.pipeline)
 
-        # Apply torch.compile if not in eager mode
-        if not self.od_config.enforce_eager:
-            if current_omni_platform.supports_torch_inductor():
-                self._compile_transformer("transformer")
-                self._compile_transformer("transformer_2")
-            else:
-                logger.warning(
-                    "Model runner: Platform %s does not support torch inductor, skipping torch.compile.",
-                    current_omni_platform.get_torch_device(),
-                )
-
-        # Setup cache backend
+        # Setup cache backend BEFORE torch.compile so cache_dit's monkey-patches
+        # on attention blocks are captured in the compiled graph. If compile runs
+        # first, the compiled wrappers bypass cache_dit's hooks, causing CUDA
+        # illegal memory access during the forward pass.
         self.cache_backend = get_cache_backend(self.od_config.cache_backend, self.od_config.cache_config)
 
         if self.cache_backend is not None:
@@ -186,6 +178,18 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                 self.od_config.cache_backend = None
             else:
                 self.cache_backend.enable(self.pipeline)
+
+        # Apply torch.compile after cache backend so compiled graphs include
+        # the cache-dit modifications.
+        if not self.od_config.enforce_eager:
+            if current_omni_platform.supports_torch_inductor():
+                self._compile_transformer("transformer")
+                self._compile_transformer("transformer_2")
+            else:
+                logger.warning(
+                    "Model runner: Platform %s does not support torch inductor, skipping torch.compile.",
+                    current_omni_platform.get_torch_device(),
+                )
 
         logger.info("Model runner: Initialization complete.")
 

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -840,14 +840,22 @@ class WorkerProc:
             pass  # setproctitle not installed, skip process title setting
 
         load_omni_general_plugins()
-        worker_proc = WorkerProc(
-            od_config,
-            gpu_id=rank,
-            broadcast_handle=broadcast_handle,
-            wake_event=wake_event,
-            worker_extension_cls=worker_extension_cls,
-            custom_pipeline_args=custom_pipeline_args,
-        )
+        try:
+            worker_proc = WorkerProc(
+                od_config,
+                gpu_id=rank,
+                broadcast_handle=broadcast_handle,
+                wake_event=wake_event,
+                worker_extension_cls=worker_extension_cls,
+                custom_pipeline_args=custom_pipeline_args,
+            )
+        except Exception:
+            logger.exception(
+                "Worker %d: FATAL — failed during initialization. The parent will see EngineDeadError.",
+                rank,
+            )
+            pipe_writer.send({"status": "error", "rank": rank})
+            raise
         logger.info(f"Worker {rank}: Scheduler loop started.")
         pipe_writer.send(
             {
@@ -855,7 +863,14 @@ class WorkerProc:
                 "result_handle": worker_proc.result_mq_handle if rank == 0 else None,
             }
         )
-        worker_proc.worker_busy_loop()
+        try:
+            worker_proc.worker_busy_loop()
+        except Exception:
+            logger.exception(
+                "Worker %d: FATAL — unhandled exception in busy loop. The parent will see EngineDeadError.",
+                rank,
+            )
+            raise
         logger.info(f"Worker {rank}: Shutdown complete.")
 
 


### PR DESCRIPTION
 fix/omni-qwen-image-edit-ci-crash-3753

## Purpose
Capture worker exit codes and log full traceback before subprocess exits so EngineDeadError carries the root cause.

## Test Plan
Run CI test_qwen_image_edit with cache_dit + ulysses-degree 2, assert clear error message when worker dies.

## Test Result
Before: bare `EngineDeadError()` with no context. After: error message includes exitcode, suspected causes, and worker traceback in logs.