### PR TITLE
[Diffusion]Centralize prompt normalization and strip null negative prompts

### DIFF
--- a/tests/diffusion/test_prompt_utils.py
+++ b/tests/diffusion/test_prompt_utils.py
@@ -21,9 +21,20 @@ def test_none_negative_stripped():
     assert "negative_prompt" not in result
 
 
-def test_empty_negative_stripped():
-    result = normalize_prompt_entry({"prompt": "a cat", "negative_prompt": "  "})
-    assert result == {"prompt": "a cat"}
+def test_whitespace_negative_preserved():
+    """Whitespace-only negative_prompt must be preserved to enable CFG (e.g. Qwen-Image-Edit)."""
+    result = normalize_prompt_entry({"prompt": "a cat", "negative_prompt": " "})
+    assert result == {"prompt": "a cat", "negative_prompt": " "}
+    assert "negative_prompt" in result
+
+
+def test_whitespace_negative_enables_cfg():
+    req = OmniDiffusionRequest(
+        prompts=[{"prompt": "cat", "negative_prompt": " "}],
+        sampling_params=OmniDiffusionSamplingParams(guidance_scale=3.5),
+    )
+    assert req.prompts[0]["negative_prompt"] == " "
+    assert req.sampling_params.do_classifier_free_guidance is True
 
 
 def test_valid_negative_kept():
@@ -50,6 +61,33 @@ def test_preserves_multimodal_keys():
 def test_invalid_type_raises():
     with pytest.raises(TypeError, match="str or dict"):
         normalize_prompt_entry(123)
+
+
+def test_extract_batch_prompts_invalid_type_raises():
+    """extract_batch_prompts should raise TypeError for non-str/dict entries,
+    consistent with normalize_prompt_entry."""
+    with pytest.raises(TypeError, match="str or dict"):
+        extract_batch_prompts([{"prompt": "cat"}, 123])
+
+
+def test_extract_batch_prompts_empty():
+    prompt, negative = extract_batch_prompts([])
+    assert prompt == []
+    assert negative is None
+
+
+def test_normalize_omni_diffusion_prompts():
+    result = normalize_omni_diffusion_prompts(
+        [
+            {"prompt": "a cat", "negative_prompt": None},
+            {"prompt": "  hello  ", "negative_prompt": "blurry"},
+            "plain string",
+        ]
+    )
+    assert result[0] == {"prompt": "a cat"}
+    assert "negative_prompt" not in result[0]
+    assert result[1] == {"prompt": "hello", "negative_prompt": "blurry"}
+    assert result[2] == "plain string"
 
 
 def test_batch_extract_all_none():

--- a/tests/diffusion/test_prompt_utils.py
+++ b/tests/diffusion/test_prompt_utils.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm_omni.diffusion.prompt_utils import (
+    extract_batch_prompts,
+    has_negative_prompt,
+    normalize_omni_diffusion_prompts,
+    normalize_prompt_entry,
+)
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def test_none_negative_stripped():
+    result = normalize_prompt_entry({"prompt": "a cat", "negative_prompt": None})
+    assert result == {"prompt": "a cat"}
+    assert "negative_prompt" not in result
+
+
+def test_empty_negative_stripped():
+    result = normalize_prompt_entry({"prompt": "a cat", "negative_prompt": "  "})
+    assert result == {"prompt": "a cat"}
+
+
+def test_valid_negative_kept():
+    result = normalize_prompt_entry({"prompt": "a cat", "negative_prompt": "blurry"})
+    assert result == {"prompt": "a cat", "negative_prompt": "blurry"}
+
+
+def test_string_prompt_stripped():
+    assert normalize_prompt_entry("  hello  ") == "hello"
+
+
+def test_preserves_multimodal_keys():
+    result = normalize_prompt_entry(
+        {
+            "prompt": "edit",
+            "negative_prompt": None,
+            "multi_modal_data": {"image": "placeholder"},
+        }
+    )
+    assert result["multi_modal_data"] == {"image": "placeholder"}
+    assert "negative_prompt" not in result
+
+
+def test_invalid_type_raises():
+    with pytest.raises(TypeError, match="str or dict"):
+        normalize_prompt_entry(123)
+
+
+def test_batch_extract_all_none():
+    prompts = normalize_omni_diffusion_prompts([{"prompt": "cat", "negative_prompt": None}])
+    prompt, negative = extract_batch_prompts(prompts)
+    assert prompt == ["cat"]
+    assert negative is None
+
+
+def test_batch_extract_mixed():
+    prompt, negative = extract_batch_prompts(
+        [
+            {"prompt": "a cat", "negative_prompt": "blurry"},
+            {"prompt": "a dog"},
+            "plain",
+        ]
+    )
+    assert prompt == ["a cat", "a dog", "plain"]
+    assert negative == ["blurry", "", ""]
+
+
+def test_has_negative_prompt():
+    assert not has_negative_prompt([{"prompt": "x"}])
+    assert has_negative_prompt([{"prompt": "x", "negative_prompt": "blur"}])
+
+
+def test_request_post_init_strips_none_negative():
+    req = OmniDiffusionRequest(
+        prompts=[{"prompt": "cat", "negative_prompt": None}],
+        sampling_params=OmniDiffusionSamplingParams(guidance_scale=3.5),
+    )
+    assert req.prompts[0] == {"prompt": "cat"}
+    assert req.sampling_params.do_classifier_free_guidance is False
+
+
+def test_request_post_init_sets_cfg_with_negative():
+    req = OmniDiffusionRequest(
+        prompts=[{"prompt": "cat", "negative_prompt": "blurry"}],
+        sampling_params=OmniDiffusionSamplingParams(guidance_scale=3.5),
+    )
+    assert req.sampling_params.do_classifier_free_guidance is True

--- a/vllm_omni/diffusion/models/flux/pipeline_flux.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux.py
@@ -30,6 +30,7 @@ from vllm_omni.diffusion.models.flux import FluxTransformer2DModel
 from vllm_omni.diffusion.models.flux.flux_pipeline_mixin import FluxPipelineMixin
 from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+from vllm_omni.diffusion.prompt_utils import extract_batch_prompts
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
@@ -520,13 +521,9 @@ class FluxPipeline(nn.Module, FluxPipelineMixin, CFGParallelMixin, DiffusionPipe
         max_sequence_length: int = 512,
     ):
         """Forward pass for flux."""
-        # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
-        # TODO: May be some data formatting operations on the API side. Hack for now.
-        prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts] or prompt
-        if all(isinstance(p, str) or p.get("negative_prompt") is None for p in req.prompts):
-            negative_prompt = None
-        elif req.prompts:
-            negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in req.prompts]
+        extracted_prompt, extracted_negative = extract_batch_prompts(req.prompts)
+        prompt = extracted_prompt or prompt
+        negative_prompt = extracted_negative if extracted_negative is not None else negative_prompt
 
         height = req.sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = req.sampling_params.width or self.default_sample_size * self.vae_scale_factor

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import (
     QwenImageTransformer2DModel,
 )
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+from vllm_omni.diffusion.prompt_utils import extract_batch_prompts
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import (
     validate_prompt_sequence_lengths,
@@ -602,14 +603,8 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
 
     def _extract_prompts(self, prompts):
         """Extract prompt and negative_prompt from OmniPromptType list."""
-        prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in prompts] or None
-        if all(isinstance(p, str) or p.get("negative_prompt") is None for p in prompts):
-            negative_prompt = None
-        elif prompts:
-            negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in prompts]
-        else:
-            negative_prompt = None
-        return prompt, negative_prompt
+        prompt, negative_prompt = extract_batch_prompts(prompts)
+        return prompt or None, negative_prompt
 
     def _prepare_generation_context(
         self,

--- a/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
+++ b/vllm_omni/diffusion/models/sd3/pipeline_sd3.py
@@ -24,6 +24,7 @@ from vllm_omni.diffusion.models.sd3.sd3_transformer import (
     SD3Transformer2DModel,
 )
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+from vllm_omni.diffusion.prompt_utils import extract_batch_prompts
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
@@ -629,12 +630,9 @@ class StableDiffusion3Pipeline(nn.Module, CFGParallelMixin, DiffusionPipelinePro
         negative_pooled_prompt_embeds: torch.Tensor | None = None,
         max_sequence_length: int = 256,
     ) -> DiffusionOutput:
-        # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
-        # TODO: May be some data formatting operations on the API side. Hack for now.
-        prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts] or prompt
-        negative_prompt = [
-            "" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in req.prompts
-        ] or negative_prompt
+        extracted_prompt, extracted_negative = extract_batch_prompts(req.prompts)
+        prompt = extracted_prompt or prompt
+        negative_prompt = extracted_negative if extracted_negative is not None else negative_prompt
 
         height = req.sampling_params.height or self.default_sample_size * self.vae_scale_factor
         width = req.sampling_params.width or self.default_sample_size * self.vae_scale_factor

--- a/vllm_omni/diffusion/prompt_utils.py
+++ b/vllm_omni/diffusion/prompt_utils.py
@@ -9,14 +9,14 @@ from typing import Any
 
 
 def _effective_negative(negative: Any) -> str | None:
-    """Return a non-empty negative prompt string, or None if unset/blank."""
+    """Return the negative prompt as a string, or None if it is None.
+
+    Whitespace-only strings (e.g. ``" "``) are intentionally preserved;
+    some models (e.g. Qwen-Image-Edit) pass them to enable CFG.
+    """
     if negative is None:
         return None
-    if isinstance(negative, str):
-        stripped = negative.strip()
-        return stripped if stripped else None
-    text = str(negative).strip()
-    return text if text else None
+    return negative if isinstance(negative, str) else str(negative)
 
 
 def normalize_prompt_entry(raw: Any) -> str | dict[str, Any]:
@@ -73,7 +73,7 @@ def extract_batch_prompts(
         elif isinstance(entry, dict):
             prompt.append(str(entry.get("prompt") or ""))
         else:
-            prompt.append("")
+            raise TypeError(f"Diffusion prompt must be str or dict, got {type(entry)!r}")
 
     if not has_negative_prompt(prompts):
         return prompt, None

--- a/vllm_omni/diffusion/prompt_utils.py
+++ b/vllm_omni/diffusion/prompt_utils.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Shared helpers for normalizing diffusion request prompts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _effective_negative(negative: Any) -> str | None:
+    """Return a non-empty negative prompt string, or None if unset/blank."""
+    if negative is None:
+        return None
+    if isinstance(negative, str):
+        stripped = negative.strip()
+        return stripped if stripped else None
+    text = str(negative).strip()
+    return text if text else None
+
+
+def normalize_prompt_entry(raw: Any) -> str | dict[str, Any]:
+    """Coerce one prompt entry to ``str`` or a dict with a normalized ``prompt`` field.
+
+    Removes ``negative_prompt`` when it is ``None`` or blank so downstream code can
+    distinguish "no negative prompt" from an explicit empty CFG string.
+    Other dict keys (e.g. ``multi_modal_data``) are preserved.
+    """
+    if isinstance(raw, str):
+        return raw.strip()
+    if isinstance(raw, dict):
+        out = dict(raw)
+        out["prompt"] = str(out.get("prompt") or "").strip()
+        negative = _effective_negative(out.get("negative_prompt"))
+        if negative is None:
+            out.pop("negative_prompt", None)
+        else:
+            out["negative_prompt"] = negative
+        return out
+    raise TypeError(f"Diffusion prompt must be str or dict, got {type(raw)!r}")
+
+
+def normalize_omni_diffusion_prompts(prompts: list[Any]) -> list[Any]:
+    """Normalize every prompt entry in a diffusion request."""
+    return [normalize_prompt_entry(p) for p in prompts]
+
+
+def has_negative_prompt(prompts: list[Any]) -> bool:
+    """Return True if any prompt entry carries a non-empty negative prompt."""
+    for entry in prompts:
+        if isinstance(entry, dict) and _effective_negative(entry.get("negative_prompt")) is not None:
+            return True
+    return False
+
+
+def extract_batch_prompts(
+    prompts: list[Any],
+) -> tuple[list[str], list[str] | None]:
+    """Extract batched text prompts and optional negative prompts for diffusion pipelines.
+
+    Returns:
+        A pair ``(prompt, negative_prompt)`` where ``prompt`` is a list of strings.
+        ``negative_prompt`` is ``None`` when no entry has a negative prompt; otherwise
+        a list aligned with ``prompt`` (``""`` for entries without one).
+    """
+    if not prompts:
+        return [], None
+
+    prompt: list[str] = []
+    for entry in prompts:
+        if isinstance(entry, str):
+            prompt.append(entry)
+        elif isinstance(entry, dict):
+            prompt.append(str(entry.get("prompt") or ""))
+        else:
+            prompt.append("")
+
+    if not has_negative_prompt(prompts):
+        return prompt, None
+
+    negative_prompt: list[str] = []
+    for entry in prompts:
+        if isinstance(entry, dict):
+            negative_prompt.append(_effective_negative(entry.get("negative_prompt")) or "")
+        else:
+            negative_prompt.append("")
+    return prompt, negative_prompt

--- a/vllm_omni/diffusion/request.py
+++ b/vllm_omni/diffusion/request.py
@@ -5,6 +5,7 @@
 import random
 from dataclasses import dataclass, field
 
+from vllm_omni.diffusion.prompt_utils import has_negative_prompt, normalize_omni_diffusion_prompts
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniPromptType
 
 
@@ -31,6 +32,8 @@ class OmniDiffusionRequest:
 
     def __post_init__(self):
         """Initialize dependent fields after dataclass initialization."""
+        self.prompts = normalize_omni_diffusion_prompts(self.prompts)
+
         # When neither a generator nor a seed is provided, assign a random seed
         # so that all ranks derive the same generator state.
         if self.sampling_params.generator is None and self.sampling_params.seed is None:
@@ -47,9 +50,7 @@ class OmniDiffusionRequest:
             self.sampling_params.guidance_scale = 1.0
 
         # Set do_classifier_free_guidance based on guidance scale and negative prompt
-        if self.sampling_params.guidance_scale > 1.0 and any(
-            (not isinstance(p, str) and p.get("negative_prompt")) for p in self.prompts
-        ):
+        if self.sampling_params.guidance_scale > 1.0 and has_negative_prompt(self.prompts):
             self.sampling_params.do_classifier_free_guidance = True
 
         # Auto-fill guidance_scale_2 from the (now-resolved) guidance_scale

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2474,10 +2474,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             except Exception as e:  # pragma: no cover - safeguard
                 logger.warning("Failed to parse LoRA request: %s", e)
 
-        gen_prompt: OmniTextPrompt = {
-            "prompt": prompt,
-            "negative_prompt": negative_prompt,
-        }
+        gen_prompt: OmniTextPrompt = {"prompt": prompt}
+        if negative_prompt is not None:
+            gen_prompt["negative_prompt"] = negative_prompt
         if pil_images:
             if len(pil_images) == 1:
                 gen_prompt["multi_modal_data"] = {"image": pil_images[0]}
@@ -2645,10 +2644,9 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     logger.warning("Failed to decode reference image: %s", e)
 
             # Build generation kwargs
-            gen_prompt: OmniTextPrompt = {
-                "prompt": prompt,
-                "negative_prompt": negative_prompt,
-            }
+            gen_prompt: OmniTextPrompt = {"prompt": prompt}
+            if negative_prompt is not None:
+                gen_prompt["negative_prompt"] = negative_prompt
             gen_params = OmniDiffusionSamplingParams(
                 height=height,
                 width=width,


### PR DESCRIPTION
## Purpose
Fix inconsistent diffusion prompt handling in online serving where `serving_chat` always injected `negative_prompt`: `None` into `OmniTextPrompt`, even when the client did not provide a negative prompt. Downstream pipelines then had to duplicate ad-hoc parsing logic, and SD3 could treat missing negatives as empty strings and unintentionally enable CFG-style behavior.

This PR (PR1 of a two-part cleanup):

- Adds shared helpers in `vllm_omni/diffusion/prompt_utils.py` to normalize prompt entries (strip None/blank negative_prompt keys while preserving multimodal fields) and to extract batched (prompt, negative_prompt) pairs.
- Normalizes `OmniDiffusionRequest.prompts in __post_init__ `and uses `has_negative_prompt()` for `do_classifier_free_guidance`.
- Updates `serving_chat` diffusion paths to only set `negative_prompt` when it is non-None (aligned with api_server image generation).
- Migrates Flux, SD3, and Qwen-Image pipelines to extract_batch_prompts() and removes duplicated TODO/hack blocks.

## Test Plan
New unit tests:
- pytest tests/diffusion/test_prompt_utils.py -v

## Test Result
 PASS
