### PR TITLE
[Video Stream] Add configurable frame sampling strategies

### DIFF
--- a/docs/serving/video_stream_api.md
+++ b/docs/serving/video_stream_api.md
@@ -63,6 +63,8 @@ WebSocket /v1/video/chat/stream
 | `sampling_params_list` | list or null | null | Optional per-stage sampling parameter overrides. |
 | `enable_frame_filter` | bool | `true` | Enable EVS near-duplicate frame filtering. |
 | `frame_filter_threshold` | float, 0.0-1.0 | `0.95` | EVS similarity threshold. Higher keeps more frames; lower drops more near-duplicates. |
+| `sampling_strategy` | string | `"uniform"` | Frame sampling strategy. One of `"uniform"`, `"latest_frames"`, `"latest_seconds"`. |
+| `window_seconds` | float, 0–300 | `5.0` | Time window for `latest_seconds` strategy. Ignored otherwise. |
 
 ### Legacy Aliases
 
@@ -80,6 +82,14 @@ The server accepts these legacy field names and rewrites them before validation.
 |----------|--------|---------|-------------|
 | `VLLM_VIDEO_ASYNC_CHUNK` | `on`, `off` | `on` | Wire-level streaming switch. `off` buffers server-side deltas and emits coalesced outputs at the end of a query. |
 | `VLLM_VIDEO_AUDIO_DELTA_MODE` | `fast`, `slow` | `fast` | Audio delta extraction strategy. `fast` emits only newly produced chunks; `slow` recomputes from accumulated audio and exists for A/B verification. |
+
+## Frame Sampling Strategies
+
+Before each `video.query`, frames are sampled from the retained frame buffer using the configured `sampling_strategy`:
+
+- **`uniform`** (default): Evenly spaced across the entire buffer with first and last frames anchored. Best for understanding the full timeline.
+- **`latest_frames`**: Takes the most recent `num_frames` frames from the tail of the buffer. Best for reacting to "what just happened".
+- **`latest_seconds`**: Takes all frames whose arrival time falls within the last `window_seconds`. If the window contains more than `num_frames` frames, uniform sub-sampling is applied within the window. If the window is empty or timestamps are unavailable, falls back to the single most recent frame.
 
 ## EVS Semantics
 

--- a/tests/entrypoints/openai_api/test_serving_video_stream.py
+++ b/tests/entrypoints/openai_api/test_serving_video_stream.py
@@ -648,3 +648,209 @@ def test_build_messages_keeps_recent_history_text_only():
     assert messages[1] == {"role": "assistant", "content": "recent answer"}
     assert messages[2] == user_message
     assert user_message["content"][-1] == {"type": "text", "text": "current question"}
+
+
+# ---------------------------------------------------------------------------
+# Frame Sampling Strategy Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSampleFramesUniform:
+    """Tests for the 'uniform' sampling strategy."""
+
+    def test_first_last_anchored(self):
+        from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
+
+        frames = list(range(10))
+        out = sample_frames(frames, strategy="uniform", num_frames=4)
+        assert out[0] == 0
+        assert out[-1] == 9
+        assert len(out) == 4
+
+    def test_no_truncation_when_buffer_small(self):
+        from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
+
+        assert sample_frames([1, 2], strategy="uniform", num_frames=8) == [1, 2]
+
+    def test_single_frame(self):
+        from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
+
+        assert sample_frames(["only"], strategy="uniform", num_frames=4) == ["only"]
+
+    def test_empty_buffer(self):
+        from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
+
+        assert sample_frames([], strategy="uniform", num_frames=4) == []
+
+
+class TestSampleFramesLatestFrames:
+    """Tests for the 'latest_frames' sampling strategy."""
+
+    def test_takes_tail(self):
+        from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
+
+        assert sample_frames(list(range(10)), strategy="latest_frames", num_frames=3) == [7, 8, 9]
+
+    def test_buffer_smaller_than_num_frames(self):
+        from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
+
+        assert sample_frames([1, 2], strategy="latest_frames", num_frames=5) == [1, 2]
+
+
+class TestSampleFramesLatestSeconds:
+    """Tests for the 'latest_seconds' sampling strategy."""
+
+    def test_filters_by_window(self):
+        import time as _time
+
+        from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
+
+        now = _time.monotonic()
+        frames = ["old", "mid", "new"]
+        ts = [now - 100.0, now - 3.0, now - 1.0]
+        out = sample_frames(
+            frames,
+            strategy="latest_seconds",
+            num_frames=8,
+            window_seconds=5.0,
+            frame_timestamps=ts,
+        )
+        assert out == ["mid", "new"]
+
+    def test_falls_back_when_no_timestamps(self):
+        from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
+
+        out = sample_frames(
+            ["a", "b", "c"],
+            strategy="latest_seconds",
+            num_frames=8,
+            window_seconds=5.0,
+        )
+        assert out == ["c"]
+
+    def test_falls_back_when_window_empty(self):
+        import time as _time
+
+        from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
+
+        now = _time.monotonic()
+        frames = ["very_old"]
+        ts = [now - 999.0]
+        out = sample_frames(
+            frames,
+            strategy="latest_seconds",
+            num_frames=8,
+            window_seconds=5.0,
+            frame_timestamps=ts,
+        )
+        assert out == ["very_old"]
+
+    def test_subsamples_when_too_many_in_window(self):
+        import time as _time
+
+        from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
+
+        now = _time.monotonic()
+        frames = list(range(20))
+        ts = [now - 2.0 + i * 0.1 for i in range(20)]  # all within 2s window
+        out = sample_frames(
+            frames,
+            strategy="latest_seconds",
+            num_frames=4,
+            window_seconds=5.0,
+            frame_timestamps=ts,
+        )
+        assert len(out) == 4
+        assert out[0] == 0
+        assert out[-1] == 19
+
+
+class TestSampleFramesUnknownStrategy:
+    """Unknown strategy falls back to uniform."""
+
+    def test_unknown_falls_back_to_uniform(self):
+        from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
+
+        out = sample_frames([1, 2, 3, 4], strategy="bogus", num_frames=2)  # type: ignore[arg-type]
+        assert out == [1, 4]
+
+
+class TestSessionConfigSamplingFields:
+    """session.config correctly exposes sampling_strategy and window_seconds."""
+
+    def test_defaults(self):
+        cfg = StreamingVideoSessionConfig(model="test")
+        assert cfg.sampling_strategy == "uniform"
+        assert cfg.window_seconds == 5.0
+
+    def test_custom_values(self):
+        cfg = StreamingVideoSessionConfig(
+            model="test",
+            sampling_strategy="latest_frames",
+            window_seconds=10.0,
+        )
+        assert cfg.sampling_strategy == "latest_frames"
+        assert cfg.window_seconds == 10.0
+
+
+class TestBuildMessagesSamplingIntegration:
+    """_build_messages respects sampling_strategy."""
+
+    def test_latest_frames_uses_tail(self):
+        handler = OmniStreamingVideoHandler(chat_service=object())
+        f1 = _b64(_make_jpeg(1, 2, 3))
+        f2 = _b64(_make_jpeg(4, 5, 6))
+        f3 = _b64(_make_jpeg(7, 8, 9))
+        cfg = StreamingVideoSessionConfig(
+            model="test",
+            num_frames=2,
+            sampling_strategy="latest_frames",
+        )
+        _, user_message = handler._build_messages(cfg, [f1, f2, f3], bytearray(), [], "q", {})
+        image_urls = [
+            c["image_url"]["url"].split(",", 1)[1] for c in user_message["content"] if c.get("type") == "image_url"
+        ]
+        assert image_urls == [f2, f3]
+
+    def test_latest_seconds_filters_by_window(self):
+        import time as _time
+
+        handler = OmniStreamingVideoHandler(chat_service=object())
+        f_old = _b64(_make_jpeg(1, 2, 3))
+        f_new = _b64(_make_jpeg(4, 5, 6))
+        now = _time.monotonic()
+        cfg = StreamingVideoSessionConfig(
+            model="test",
+            num_frames=8,
+            sampling_strategy="latest_seconds",
+            window_seconds=5.0,
+        )
+        _, user_message = handler._build_messages(
+            cfg,
+            [f_old, f_new],
+            bytearray(),
+            [],
+            "q",
+            {},
+            frame_timestamps=[now - 100.0, now - 1.0],
+        )
+        image_urls = [
+            c["image_url"]["url"].split(",", 1)[1] for c in user_message["content"] if c.get("type") == "image_url"
+        ]
+        assert image_urls == [f_new]
+
+    def test_uniform_default_anchors_first_last(self):
+        handler = OmniStreamingVideoHandler(chat_service=object())
+        frames = [_b64(_make_jpeg(i, i, i)) for i in range(10)]
+        cfg = StreamingVideoSessionConfig(
+            model="test",
+            num_frames=3,
+            sampling_strategy="uniform",
+        )
+        _, user_message = handler._build_messages(cfg, frames, bytearray(), [], "q", {})
+        image_urls = [
+            c["image_url"]["url"].split(",", 1)[1] for c in user_message["content"] if c.get("type") == "image_url"
+        ]
+        assert image_urls[0] == frames[0]
+        assert image_urls[-1] == frames[-1]
+        assert len(image_urls) == 3

--- a/vllm_omni/entrypoints/openai/serving_video_stream.py
+++ b/vllm_omni/entrypoints/openai/serving_video_stream.py
@@ -45,6 +45,7 @@ from vllm_omni.entrypoints.openai.video_frame_filter import FrameSimilarityFilte
 from vllm_omni.entrypoints.openai.video_stream_context import (
     text_only_message,
 )
+from vllm_omni.entrypoints.openai.video_stream_samplers import sample_frames
 from vllm_omni.outputs import OmniRequestOutput
 
 logger = init_logger(__name__)
@@ -105,6 +106,21 @@ class StreamingVideoSessionConfig(BaseModel):
         le=1.0,
         description="EVS similarity threshold (higher = keep more frames).",
     )
+    sampling_strategy: str = Field(
+        default="uniform",
+        description=(
+            "Frame sampling strategy: "
+            "'uniform' (even across buffer), "
+            "'latest_frames' (most recent N frames), "
+            "'latest_seconds' (frames within last T seconds)."
+        ),
+    )
+    window_seconds: float = Field(
+        default=5.0,
+        gt=0.0,
+        le=300.0,
+        description="Time window in seconds (only used with 'latest_seconds').",
+    )
 
 
 class OmniStreamingVideoHandler:
@@ -140,6 +156,7 @@ class OmniStreamingVideoHandler:
                 return
 
             frame_buffer: list[str] = []  # base64-encoded JPEG frames
+            frame_timestamps: list[float] = []  # monotonic timestamps aligned with frame_buffer
             # Per-frame PIL cache + uuid for mm_hash reuse. Aligned with frame_buffer by index.
             frame_pil_cache: dict[str, tuple[Any, str] | object] = {}  # b64 -> (PIL.Image, uuid) or _BAD_FRAME
             frame_filter = (
@@ -227,7 +244,10 @@ class OmniStreamingVideoHandler:
                         frame_data = msg.get("b64", "")
                         removed = frame_data in frame_buffer
                         if removed:
-                            frame_buffer[:] = [f for f in frame_buffer if f != frame_data]
+                            # Remove matching frame(s) and their aligned timestamps.
+                            keep = [(f, ts) for f, ts in zip(frame_buffer, frame_timestamps) if f != frame_data]
+                            frame_buffer[:] = [f for f, _ in keep]
+                            frame_timestamps[:] = [ts for _, ts in keep]
                         if frame_pil_cache.get(frame_data) is _BAD_FRAME:
                             frame_pil_cache.pop(frame_data, None)
                         if removed:
@@ -255,8 +275,10 @@ class OmniStreamingVideoHandler:
                         max_buf = config.max_frames
                         if len(frame_buffer) >= max_buf:
                             dropped = frame_buffer.pop(0)
+                            frame_timestamps.pop(0)
                             frame_pil_cache.pop(dropped, None)
                         frame_buffer.append(frame_data)
+                        frame_timestamps.append(_time.monotonic())
                         # Prewarm: decode PIL off the event loop so query-time chat_template
                         # can skip base64+Image.open. uuid=md5 lets mm_cache dedupe identical frames.
                         if frame_data not in frame_pil_cache:
@@ -329,6 +351,7 @@ class OmniStreamingVideoHandler:
                         active_request_id = request_id
                         interrupt_event.clear()
                         query_frames = list(frame_buffer)
+                        query_frame_timestamps = list(frame_timestamps)
                         query_audio_buffer = bytearray(audio_buffer)
                         audio_buffer.clear()
                         query_prewarmed_frames = dict(frame_pil_cache)
@@ -346,6 +369,7 @@ class OmniStreamingVideoHandler:
                                     request_id,
                                     interrupt_event,
                                     query_prewarmed_frames,
+                                    query_frame_timestamps,
                                 )
                             finally:
                                 if active_request_id == request_id:
@@ -448,6 +472,7 @@ class OmniStreamingVideoHandler:
         request_id: str,
         interrupt_event: asyncio.Event,
         prewarmed_frames: dict[str, tuple[Any, str]],
+        frame_timestamps: list[float] | None = None,
     ) -> None:
         """Build prompt, run inference, stream text + audio response."""
 
@@ -465,6 +490,7 @@ class OmniStreamingVideoHandler:
             request_id,
             interrupt_event,
             prewarmed_frames,
+            frame_timestamps,
         )
 
     # ------------------------------------------------------------------
@@ -482,6 +508,7 @@ class OmniStreamingVideoHandler:
         request_id: str,
         interrupt_event: asyncio.Event,
         prewarmed_frames: dict[str, tuple[Any, str]],
+        frame_timestamps: list[float] | None = None,
     ) -> None:
         """Direct engine_client.generate() path for async_chunk audio."""
         from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -495,6 +522,7 @@ class OmniStreamingVideoHandler:
             message_history,
             query_text,
             prewarmed_frames,
+            frame_timestamps,
         )
 
         request_kwargs: dict[str, Any] = {
@@ -671,19 +699,20 @@ class OmniStreamingVideoHandler:
         message_history: list[dict[str, Any]],
         query_text: str,
         prewarmed_frames: dict[str, tuple[Any, str]],
+        frame_timestamps: list[float] | None = None,
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Build OpenAI-style messages list and the current user message.
 
         Returns (messages, user_message).
         """
-        # Stride sampling (index 0 anchor, last slot = newest). Covers full buffer + stable mm_hash.
-        n_buf = len(frame_buffer)
-        if n_buf <= config.num_frames:
-            frames = list(frame_buffer)
-        else:
-            stride = max(1, n_buf // config.num_frames)
-            idx = [i * stride for i in range(config.num_frames - 1)] + [n_buf - 1]
-            frames = [frame_buffer[i] for i in idx]
+        # Sample frames from buffer using the configured strategy.
+        frames = sample_frames(
+            frame_buffer,
+            strategy=config.sampling_strategy,  # type: ignore[arg-type]
+            num_frames=config.num_frames,
+            window_seconds=config.window_seconds,
+            frame_timestamps=frame_timestamps,
+        )
 
         # Prefer prewarmed PIL + uuid so mm_cache can dedupe by hash.
         prewarmed = prewarmed_frames or {}

--- a/vllm_omni/entrypoints/openai/video_stream_samplers.py
+++ b/vllm_omni/entrypoints/openai/video_stream_samplers.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Frame sampling strategies for streaming video input.
+
+Three strategies are supported:
+
+- ``uniform``: Sample frames evenly across the entire buffer (first/last
+  anchored). Best for understanding the full timeline.
+- ``latest_frames``: Take only the most recent *N* frames. Best for
+  reacting to "what just happened".
+- ``latest_seconds``: Take all frames within the last *T* seconds.
+  Best for time-bounded context windows.
+"""
+
+from __future__ import annotations
+
+import time as _time
+from typing import Any, Literal
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+SamplingStrategy = Literal["uniform", "latest_frames", "latest_seconds"]
+
+_DEFAULT_NUM_FRAMES = 8
+_DEFAULT_WINDOW_SECONDS = 5.0
+
+
+def sample_frames(
+    frame_buffer: list[Any],
+    *,
+    strategy: SamplingStrategy = "uniform",
+    num_frames: int = _DEFAULT_NUM_FRAMES,
+    window_seconds: float = _DEFAULT_WINDOW_SECONDS,
+    frame_timestamps: list[float] | None = None,
+) -> list[Any]:
+    """Sample frames from *frame_buffer* using the given strategy.
+
+    Args:
+        frame_buffer: Ordered list of frame objects (newest at the end).
+        strategy: One of ``"uniform"``, ``"latest_frames"``,
+            ``"latest_seconds"``.
+        num_frames: Target number of frames for ``uniform`` and
+            ``latest_frames``; cap for ``latest_seconds`` when too many
+            frames fall within the window.
+        window_seconds: Time window in seconds (only for
+            ``latest_seconds``).
+        frame_timestamps: Monotonic timestamps aligned with
+            *frame_buffer* (required for ``latest_seconds``).
+
+    Returns:
+        A list of sampled frame objects (subset of *frame_buffer*).
+    """
+    if not frame_buffer:
+        return []
+
+    if strategy == "uniform":
+        return _sample_uniform(frame_buffer, num_frames)
+    if strategy == "latest_frames":
+        return _sample_latest_frames(frame_buffer, num_frames)
+    if strategy == "latest_seconds":
+        return _sample_latest_seconds(
+            frame_buffer,
+            num_frames,
+            window_seconds,
+            frame_timestamps,
+        )
+
+    # Should never reach here if Pydantic validates the Literal,
+    # but be defensive.
+    logger.warning("Unknown sampling strategy %r, falling back to uniform", strategy)
+    return _sample_uniform(frame_buffer, num_frames)
+
+
+def _sample_uniform(frames: list[Any], num_frames: int) -> list[Any]:
+    """First/last anchored uniform stride sampling."""
+    n = len(frames)
+    if n <= num_frames:
+        return list(frames)
+    indices = [round(i * (n - 1) / (num_frames - 1)) for i in range(num_frames)]
+    return [frames[i] for i in indices]
+
+
+def _sample_latest_frames(frames: list[Any], num_frames: int) -> list[Any]:
+    """Take the most recent *num_frames* frames."""
+    return list(frames[-num_frames:])
+
+
+def _sample_latest_seconds(
+    frames: list[Any],
+    num_frames: int,
+    window_seconds: float,
+    frame_timestamps: list[float] | None,
+) -> list[Any]:
+    """Take frames within the last *window_seconds*.
+
+    Falls back to the single most recent frame if timestamps are
+    unavailable or the window is empty.  If the window contains more
+    than *num_frames*, applies uniform sub-sampling.
+    """
+    if frame_timestamps is None or len(frame_timestamps) != len(frames):
+        logger.warning("latest_seconds requires frame_timestamps; falling back to latest single frame")
+        return [frames[-1]]
+
+    now = _time.monotonic()
+    cutoff = now - window_seconds
+
+    recent = [f for f, ts in zip(frames, frame_timestamps) if ts >= cutoff]
+
+    if not recent:
+        # Window is empty (all frames are older than cutoff).
+        return [frames[-1]]
+
+    if len(recent) > num_frames:
+        return _sample_uniform(recent, num_frames)
+
+    return recent


### PR DESCRIPTION
Introduce a dedicated frame sampling module (video_stream_samplers.py) with three strategies for selecting frames before inference:

- uniform: evenly spaced across the entire buffer (default, matches previous stride-based behavior)
- latest_frames: selects the most recent N frames
- latest_seconds: selects frames within a sliding time window

Changes:
- New file: video_stream_samplers.py with pure-function samplers
- StreamingVideoSessionConfig: add sampling_strategy and window_seconds
- handle_session: maintain frame_timestamps aligned with frame_buffer
- _build_messages: replace inline stride logic with sample_frames() call
- Plumb frame_timestamps through _process_query → _process_query_engine → _build_messages

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
