### PR TITLE
[Frontend/Model] Support Optional Prompt Upscale

### DIFF
--- a/docs/serving/image_generation_api.md
+++ b/docs/serving/image_generation_api.md
@@ -150,6 +150,7 @@ Content-Type: application/json
 | `guidance_scale` | float | model defaults | Classifier-free guidance scale (typically 0.0-20.0) |
 | `true_cfg_scale` | float | model defaults | True CFG scale (model-specific parameter, may be ignored if not supported) |
 | `seed` | integer | null | Random seed for reproducibility |
+| `use_prompt_upscaling` | boolean | false | Enable prompt enhancement/rewriting before generation. Only effective for models that support prompt upscaling (e.g., ERNIE-Image, Flux2, LongCat). |
 
 ### Response Format
 

--- a/docs/serving/image_generation_api.md
+++ b/docs/serving/image_generation_api.md
@@ -150,7 +150,7 @@ Content-Type: application/json
 | `guidance_scale` | float | model defaults | Classifier-free guidance scale (typically 0.0-20.0) |
 | `true_cfg_scale` | float | model defaults | True CFG scale (model-specific parameter, may be ignored if not supported) |
 | `seed` | integer | null | Random seed for reproducibility |
-| `use_prompt_upscaling` | boolean | false | Enable prompt enhancement/rewriting before generation. Only effective for models that support prompt upscaling (e.g., ERNIE-Image, Flux2, LongCat). |
+| `use_prompt_upscaling` | boolean | false | Enable prompt enhancement/rewriting before generation. Only effective for models that support prompt upscaling (e.g., ERNIE-Image, Flux2, LongCat). For models with an external upscaler (e.g., ERNIE-Image), the server must be configured with `enable_external_prompt_upscaler: true` in the stage config. |
 
 ### Response Format
 

--- a/recipes/Baidu/ERNIE-Image.md
+++ b/recipes/Baidu/ERNIE-Image.md
@@ -141,11 +141,14 @@ curl -X POST http://localhost:8091/v1/images/generations \
     for faster generation; configure via `--cache-config`.
   - **Layer offload:** `--enable-layerwise-offload` offloads DiT layers to CPU
     for memory-constrained scenarios.
-- **Prompt Enhancer (PE):** ERNIE-Image includes an optional 3B-parameter
+- **Prompt Upscaling (PE):** ERNIE-Image includes an optional 3B-parameter
   Prompt Enhancer model that expands brief user inputs into richer structured
-  descriptions, improving output quality. Set `use_pe=False` in the request
-  body to disable it if you prefer direct prompt processing or want to use
-  larger LLMs (e.g., Gemini, ChatGPT) for prompt enhancement instead.
+  descriptions, improving output quality. Because this loads an additional
+  model onto GPU, it must be explicitly enabled at server startup with
+  `--enable-external-prompt-upscaler`. Once enabled, set
+  `"use_prompt_upscaling": true` in the request body
+  (`/v1/images/generations`) or in `"extra_body"` (`/v1/chat/completions`)
+  to activate it per request.
 - **Recommended settings:**
   - ERNIE-Image: `num_inference_steps=50`, `guidance_scale=4.0`
   - ERNIE-Image-Turbo: `num_inference_steps=8`, `guidance_scale=1.0`

--- a/tests/diffusion/models/ernie_image/test_ernie_image_pe.py
+++ b/tests/diffusion/models/ernie_image/test_ernie_image_pe.py
@@ -48,7 +48,6 @@ class _FakePEModel:
 
 def test_enhance_prompt_uses_rank0_result_in_distributed(monkeypatch):
     pipe = ErnieImagePipeline.__new__(ErnieImagePipeline)
-    pipe.has_external_prompt_upscaler = True
     pipe.pe_model = None
     pipe.pe_tokenizer = None
 
@@ -107,7 +106,6 @@ def test_enhance_prompt_triggers_lazy_load(monkeypatch):
     pipe = ErnieImagePipeline.__new__(ErnieImagePipeline)
     pipe.pe_model = None
     pipe.pe_tokenizer = None
-    pipe.has_external_prompt_upscaler = True
 
     fake_model = _FakePEModel()
     fake_tokenizer = _FakeTokenizer()
@@ -119,9 +117,21 @@ def test_enhance_prompt_triggers_lazy_load(monkeypatch):
 
     assert pipe.pe_model is fake_model
     assert fake_model.calls == 1
-    # Should get the enanced result back after getting our input
+    # Should get the enhanced result back after getting our input
     assert result == "enhanced-prompt"
     assert "a cat sitting on a mat" in fake_tokenizer.last_chat_input
+
+
+def test_ensure_pe_loaded_skips_when_disabled():
+    """Ensure has pe loaded is False when external upscaler loading is not enabled."""
+    pipe = ErnieImagePipeline.__new__(ErnieImagePipeline)
+    pipe.pe_model = None
+    pipe.pe_tokenizer = None
+    pipe.has_external_prompt_upscaler = True
+    pipe._load_pe = None
+
+    assert pipe._ensure_pe_loaded() is False
+    assert pipe.pe_model is None
 
 
 def test_hybrid_ring_slices_full_attention_mask(monkeypatch):

--- a/tests/diffusion/models/ernie_image/test_ernie_image_pe.py
+++ b/tests/diffusion/models/ernie_image/test_ernie_image_pe.py
@@ -22,14 +22,19 @@ class _FakeTokenizer:
     pad_token_id = 0
     eos_token_id = 1
 
-    def apply_chat_template(self, *_args, **_kwargs):
+    def __init__(self):
+        self.last_chat_input = None
+
+    def apply_chat_template(self, messages, *_args, **_kwargs):
+        # Store the last input for checking prompt enhance
+        self.last_chat_input = messages[0]["content"]
         return "chat prompt"
 
     def __call__(self, *_args, **_kwargs):
         return _TokenInputs(input_ids=torch.tensor([[1, 2]]))
 
     def decode(self, *_args, **_kwargs):
-        return "rank1-enhanced"
+        return "enhanced-prompt"
 
 
 class _FakePEModel:
@@ -43,9 +48,13 @@ class _FakePEModel:
 
 def test_enhance_prompt_uses_rank0_result_in_distributed(monkeypatch):
     pipe = ErnieImagePipeline.__new__(ErnieImagePipeline)
-    pipe.use_pe = True
-    pipe.pe_tokenizer = _FakeTokenizer()
-    pipe.pe_model = _FakePEModel()
+    pipe.has_external_prompt_upscaler = True
+    pipe.pe_model = None
+    pipe.pe_tokenizer = None
+
+    fake_model = _FakePEModel()
+    fake_tokenizer = _FakeTokenizer()
+    pipe._load_pe = lambda: (fake_model, fake_tokenizer)
 
     broadcasts = []
 
@@ -62,20 +71,57 @@ def test_enhance_prompt_uses_rank0_result_in_distributed(monkeypatch):
     enhanced = pipe._enhance_prompt("original", torch.device("cpu"))
 
     assert enhanced == "rank0-enhanced"
-    assert pipe.pe_model.calls == 0
+    assert fake_model.calls == 0
     assert broadcasts == [([None], 0)]
 
 
-def test_should_apply_pe_respects_sampling_extra_args():
-    req = SimpleNamespace(sampling_params=SimpleNamespace(extra_args={"apply_pe": False}))
+def test_should_apply_pe_true_when_requested():
+    """Ensure that use_prompt_upscaling forwards through."""
+    req = SimpleNamespace(
+        request_ids=["real_req"],
+        sampling_params=SimpleNamespace(extra_args={"use_prompt_upscaling": True}),
+    )
+    assert ErnieImagePipeline._should_apply_pe(req) is True
 
+
+def test_should_apply_pe_false_when_not_requested():
+    """Ensure that use_prompt_upscaling is False by default."""
+    req = SimpleNamespace(
+        request_ids=["real_req"],
+        sampling_params=SimpleNamespace(extra_args={}),
+    )
     assert ErnieImagePipeline._should_apply_pe(req) is False
 
 
 def test_should_apply_pe_disables_dummy_warmup_request():
-    req = SimpleNamespace(is_dummy_run=lambda: True, sampling_params=SimpleNamespace(extra_args={}))
-
+    """Ensure that use_prompt_upscaling is False during warmup."""
+    req = SimpleNamespace(
+        is_dummy_run=lambda: True,
+        sampling_params=SimpleNamespace(extra_args={"use_prompt_upscaling": True}),
+    )
     assert ErnieImagePipeline._should_apply_pe(req) is False
+
+
+def test_enhance_prompt_triggers_lazy_load(monkeypatch):
+    """_enhance_prompt lazy-loads the PE model on first call."""
+    pipe = ErnieImagePipeline.__new__(ErnieImagePipeline)
+    pipe.pe_model = None
+    pipe.pe_tokenizer = None
+    pipe.has_external_prompt_upscaler = True
+
+    fake_model = _FakePEModel()
+    fake_tokenizer = _FakeTokenizer()
+    pipe._load_pe = lambda: (fake_model, fake_tokenizer)
+
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: False)
+
+    result = pipe._enhance_prompt("a cat sitting on a mat", torch.device("cpu"))
+
+    assert pipe.pe_model is fake_model
+    assert fake_model.calls == 1
+    # Should get the enanced result back after getting our input
+    assert result == "enhanced-prompt"
+    assert "a cat sitting on a mat" in fake_tokenizer.last_chat_input
 
 
 def test_hybrid_ring_slices_full_attention_mask(monkeypatch):

--- a/tests/diffusion/models/ernie_image/test_ernie_image_pe.py
+++ b/tests/diffusion/models/ernie_image/test_ernie_image_pe.py
@@ -74,31 +74,42 @@ def test_enhance_prompt_uses_rank0_result_in_distributed(monkeypatch):
     assert broadcasts == [([None], 0)]
 
 
+def _make_batch(*requests):
+    return SimpleNamespace(
+        num_reqs=len(requests),
+        requests=list(requests),
+        request_id=requests[0].request_id if requests else "test",
+    )
+
+
+def _make_request(extra_args=None, *, request_id="real_req"):
+    return SimpleNamespace(
+        request_id=request_id,
+        sampling_params=SimpleNamespace(extra_args=extra_args or {}),
+    )
+
+
 def test_should_apply_pe_true_when_requested():
     """Ensure that use_prompt_upscaling forwards through."""
-    req = SimpleNamespace(
-        request_ids=["real_req"],
-        sampling_params=SimpleNamespace(extra_args={"use_prompt_upscaling": True}),
-    )
-    assert ErnieImagePipeline._should_apply_pe(req) is True
+    batch = _make_batch(_make_request({"use_prompt_upscaling": True}))
+    assert ErnieImagePipeline._should_apply_pe(batch) is True
 
 
 def test_should_apply_pe_false_when_not_requested():
     """Ensure that use_prompt_upscaling is False by default."""
-    req = SimpleNamespace(
-        request_ids=["real_req"],
-        sampling_params=SimpleNamespace(extra_args={}),
-    )
-    assert ErnieImagePipeline._should_apply_pe(req) is False
+    batch = _make_batch(_make_request({}))
+    assert ErnieImagePipeline._should_apply_pe(batch) is False
 
 
 def test_should_apply_pe_disables_dummy_warmup_request():
     """Ensure that use_prompt_upscaling is False during warmup."""
-    req = SimpleNamespace(
-        is_dummy_run=lambda: True,
-        sampling_params=SimpleNamespace(extra_args={"use_prompt_upscaling": True}),
+    batch = _make_batch(
+        _make_request(
+            {"use_prompt_upscaling": True},
+            request_id="dummy_req_id",
+        )
     )
-    assert ErnieImagePipeline._should_apply_pe(req) is False
+    assert ErnieImagePipeline._should_apply_pe(batch) is False
 
 
 def test_enhance_prompt_triggers_lazy_load(monkeypatch):

--- a/tests/diffusion/models/test_prompt_upscaling_utils.py
+++ b/tests/diffusion/models/test_prompt_upscaling_utils.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.prompt_utils import do_prompt_upscaling
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def mock_request(extra_args: dict[str, Any]) -> OmniDiffusionRequest:
+    return cast(
+        OmniDiffusionRequest,
+        SimpleNamespace(
+            sampling_params=SimpleNamespace(extra_args=extra_args),
+        ),
+    )
+
+
+def mock_config(enable: bool) -> OmniDiffusionConfig:
+    return cast(OmniDiffusionConfig, SimpleNamespace(enable_prompt_upscaling=enable))
+
+
+@pytest.mark.parametrize(
+    "allow_upscale,extra_args,expected",
+    [
+        (True, {"prompt_upscaling": True}, True),
+        (True, {"prompt_upscaling": False}, False),
+        (True, {}, False),
+        (False, {"prompt_upscaling": True}, False),
+        (False, {}, False),
+    ],
+)
+def test_do_prompt_upscaling(allow_upscale, extra_args, expected):
+    """Ensure we only do upscale if it's enabled and requested."""
+    res = do_prompt_upscaling(mock_request(extra_args), mock_config(allow_upscale))
+    assert res is expected
+
+
+def test_do_prompt_upscaling_rejects_non_bool():
+    """Ensure do_prompt_upscaling requires a boolean value."""
+    with pytest.raises(TypeError, match="must be a bool"):
+        do_prompt_upscaling(mock_request({"prompt_upscaling": object()}), mock_config(True))

--- a/tests/diffusion/models/test_prompt_upscaling_utils.py
+++ b/tests/diffusion/models/test_prompt_upscaling_utils.py
@@ -3,7 +3,6 @@ from typing import Any, cast
 
 import pytest
 
-from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import do_prompt_upscaling
 
@@ -13,33 +12,24 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 def mock_request(extra_args: dict[str, Any]) -> OmniDiffusionRequest:
     return cast(
         OmniDiffusionRequest,
-        SimpleNamespace(
-            sampling_params=SimpleNamespace(extra_args=extra_args),
-        ),
+        SimpleNamespace(sampling_params=SimpleNamespace(extra_args=extra_args)),
     )
 
 
-def mock_config(enable: bool) -> OmniDiffusionConfig:
-    return cast(OmniDiffusionConfig, SimpleNamespace(enable_prompt_upscaling=enable))
-
-
 @pytest.mark.parametrize(
-    "allow_upscale,extra_args,expected",
+    "extra_args,expected",
     [
-        (True, {"prompt_upscaling": True}, True),
-        (True, {"prompt_upscaling": False}, False),
-        (True, {}, False),
-        (False, {"prompt_upscaling": True}, False),
-        (False, {}, False),
+        ({"use_prompt_upscaling": True}, True),
+        ({"use_prompt_upscaling": False}, False),
+        ({}, False),
     ],
 )
-def test_do_prompt_upscaling(allow_upscale, extra_args, expected):
-    """Ensure we only do upscale if it's enabled and requested."""
-    res = do_prompt_upscaling(mock_request(extra_args), mock_config(allow_upscale))
-    assert res is expected
+def test_do_prompt_upscaling(extra_args, expected):
+    """Ensure we only enable upscale if it's explicitly requested."""
+    assert do_prompt_upscaling(mock_request(extra_args)) is expected
 
 
 def test_do_prompt_upscaling_rejects_non_bool():
     """Ensure do_prompt_upscaling requires a boolean value."""
     with pytest.raises(TypeError, match="must be a bool"):
-        do_prompt_upscaling(mock_request({"prompt_upscaling": object()}), mock_config(True))
+        do_prompt_upscaling(mock_request({"use_prompt_upscaling": object()}))

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -845,11 +845,6 @@ class OmniDiffusionConfig:
     # Streaming mode settings
     streaming_output: bool = False  # Start (video) generation with initial prompt, but streaming output in chunks
 
-    # Whether or not the Diffusion model should allow prompt upscaling;
-    # If enabled, we may load the text upscaler on the first call it is
-    # needed. If it's disabled, the text upscaler is always skipped.
-    enable_prompt_upscaling: bool = True
-
     # Allow lazy-loading external prompt upscaler models, e.g., in Ernie Image.
     # This is disabled by default to ensure that if prompt scaling is not desired
     # in low resource environments, we don't try to lazily load it and OOM.

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -850,6 +850,11 @@ class OmniDiffusionConfig:
     # needed. If it's disabled, the text upscaler is always skipped.
     enable_prompt_upscaling: bool = True
 
+    # Allow lazy-loading external prompt upscaler models, e.g., in Ernie Image.
+    # This is disabled by default to ensure that if prompt scaling is not desired
+    # in low resource environments, we don't try to lazily load it and OOM.
+    enable_external_prompt_upscaler: bool = False
+
     # Maximum number of sequences to generate in a batch
     max_num_seqs: int = 1
 

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -845,6 +845,11 @@ class OmniDiffusionConfig:
     # Streaming mode settings
     streaming_output: bool = False  # Start (video) generation with initial prompt, but streaming output in chunks
 
+    # Whether or not the Diffusion model should allow prompt upscaling;
+    # If enabled, we may load the text upscaler on the first call it is
+    # needed. If it's disabled, the text upscaler is always skipped.
+    enable_prompt_upscaling: bool = True
+
     # Maximum number of sequences to generate in a batch
     max_num_seqs: int = 1
 

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -286,13 +286,13 @@ class ErnieImagePipeline(
 
     @staticmethod
     def _should_apply_pe(req: DiffusionRequestBatch) -> bool:
-        if ErnieImagePipeline._is_warmup_request(req):
-            return False
         if req.num_reqs != 1:
             logger.warning(
                 "ErnieImage prompt upscaling only supports single-request batches; skipping for batch of %d requests",
                 req.num_reqs,
             )
+            return False
+        if ErnieImagePipeline._is_warmup_request(req.requests[0]):
             return False
         return do_prompt_upscaling(req.requests[0])
 
@@ -311,7 +311,7 @@ class ErnieImagePipeline(
         text_hiddens = []
 
         for p in prompt:
-            if apply_pe and self.has_external_prompt_upscaler:
+            if apply_pe:
                 enhanced = self._enhance_prompt(p, device, width=width, height=height)
                 logger.info("PE: original='%s...' enhanced='%s...'", p[:50], enhanced[:50])
                 p = enhanced

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -161,14 +161,16 @@ class ErnieImagePipeline(
             model,
             getattr(od_config, "revision", None),
         )
+
         self.has_external_prompt_upscaler = os.path.exists(
             os.path.join(pe_base_path, "pe"),
         )
-        # Defer loading the prompt upscaler unless we actually need it
-        self._load_pe = _make_pe_loader(
-            pe_base_path,
-            od_config.dtype,
-            self._execution_device,
+        # Only create the loader if the server config allows external
+        # upscaler loading. This prevents a user request from OOMing
+        # the server by lazy-loading a large model.
+        pe_loader = _make_pe_loader(pe_base_path, od_config.dtype, self._execution_device)
+        self._load_pe = (
+            pe_loader if self.has_external_prompt_upscaler and od_config.enable_external_prompt_upscaler else None
         )
         self.pe_model = None
         self.pe_tokenizer = None
@@ -193,6 +195,13 @@ class ErnieImagePipeline(
         )
 
     def _ensure_pe_loaded(self) -> bool:
+        if self._load_pe is None:
+            logger.warning(
+                "Prompt upscaling for a model with an external prompt upscaler, but "
+                "enable_external_prompt_upscaler is not set in the server config; "
+                "skipping prompt upscaling"
+            )
+            return False
         self.pe_model, self.pe_tokenizer = self._load_pe()
         return True
 

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -197,9 +197,9 @@ class ErnieImagePipeline(
     def _ensure_pe_loaded(self) -> bool:
         if self._load_pe is None:
             logger.warning(
-                "Prompt upscaling for a model with an external prompt upscaler, but "
+                "Requested prompt upscaling on a model with an external prompt upscaler, but "
                 "enable_external_prompt_upscaler is not set in the server config; "
-                "skipping prompt upscaling"
+                "prompt upscaling will be skipped"
             )
             return False
         self.pe_model, self.pe_tokenizer = self._load_pe()

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Adapted from: https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/ernie_image/pipeline_ernie_image.py
 
+import functools
 import json
 import os
 from collections.abc import Callable, Iterable
@@ -26,11 +27,43 @@ from vllm_omni.diffusion.models.interface import SupportImageInput
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.prompt_utils import do_prompt_upscaling
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 
 logger = init_logger(__name__)
+
+
+def _make_pe_loader(
+    pe_base_path: str,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> Callable[[], tuple[AutoModelForCausalLM, AutoTokenizer]]:
+    """Build a cached factory that lazily loads the PE model + tokenizer."""
+    pe_model_path = os.path.join(pe_base_path, "pe")
+
+    @functools.cache
+    def _load():
+        # NOTE: Prior to this point, PE files are already downloaded, which
+        # is why we use local files here.
+        pe_model = AutoModelForCausalLM.from_pretrained(
+            pe_model_path,
+            torch_dtype=dtype,
+            local_files_only=True,
+            trust_remote_code=True,
+        ).to(device)
+        pe_tokenizer = AutoTokenizer.from_pretrained(
+            pe_base_path,
+            subfolder="pe_tokenizer",
+            local_files_only=True,
+            trust_remote_code=True,
+            use_fast=False,
+        )
+        logger.info("Lazy-loaded PE model from %s", pe_model_path)
+        return pe_model, pe_tokenizer
+
+    return _load
 
 
 def _resolve_model_path_for_optional_pe(model: str, revision: str | None) -> str:
@@ -122,36 +155,23 @@ class ErnieImagePipeline(
             local_files_only=local_files_only,
         ).to(self._execution_device)
 
-        # Load PE (Prompt Enhancement) model if available. For repo IDs,
-        # resolve/download only PE files first so the existence check works.
-        pe_base_path = _resolve_model_path_for_optional_pe(model, getattr(od_config, "revision", None))
-        pe_model_path = os.path.join(pe_base_path, "pe")
-        if os.path.exists(pe_model_path):
-            try:
-                self.pe_model = AutoModelForCausalLM.from_pretrained(
-                    pe_model_path,
-                    torch_dtype=od_config.dtype,
-                    local_files_only=True,
-                    trust_remote_code=True,
-                ).to(self._execution_device)
-                self.pe_tokenizer = AutoTokenizer.from_pretrained(
-                    pe_base_path,
-                    subfolder="pe_tokenizer",
-                    local_files_only=True,
-                    trust_remote_code=True,
-                    use_fast=False,
-                )
-                self.use_pe = True
-                logger.info("Loaded PE model from %s", pe_model_path)
-            except Exception as e:
-                logger.warning("Failed to load PE model: %s", e)
-                self.pe_model = None
-                self.pe_tokenizer = None
-                self.use_pe = False
-        else:
-            self.pe_model = None
-            self.pe_tokenizer = None
-            self.use_pe = False
+        # Resolve/download PE files at init (not inference time) so the
+        # HF download doesn't block the first upscaling request.
+        pe_base_path = _resolve_model_path_for_optional_pe(
+            model,
+            getattr(od_config, "revision", None),
+        )
+        self.has_external_prompt_upscaler = os.path.exists(
+            os.path.join(pe_base_path, "pe"),
+        )
+        # Defer loading the prompt upscaler unless we actually need it
+        self._load_pe = _make_pe_loader(
+            pe_base_path,
+            od_config.dtype,
+            self._execution_device,
+        )
+        self.pe_model = None
+        self.pe_tokenizer = None
 
         transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, ErnieImageTransformer2DModel)
         self.transformer = ErnieImageTransformer2DModel(
@@ -171,6 +191,10 @@ class ErnieImagePipeline(
         self.setup_diffusion_pipeline_profiler(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
+
+    def _ensure_pe_loaded(self) -> bool:
+        self.pe_model, self.pe_tokenizer = self._load_pe()
+        return True
 
     @staticmethod
     def _distributed_prompt_sync_state() -> tuple[bool, int]:
@@ -198,7 +222,7 @@ class ErnieImagePipeline(
         temperature: float = 0.6,
         top_p: float = 0.95,
     ) -> str:
-        if not self.use_pe or self.pe_model is None:
+        if not self._ensure_pe_loaded():
             return prompt
 
         sync_prompt, rank = self._distributed_prompt_sync_state()
@@ -257,8 +281,7 @@ class ErnieImagePipeline(
     def _should_apply_pe(req: OmniDiffusionRequest) -> bool:
         if ErnieImagePipeline._is_warmup_request(req):
             return False
-        extra_args = getattr(req.sampling_params, "extra_args", {}) or {}
-        return bool(extra_args.get("apply_pe", True))
+        return do_prompt_upscaling(req)
 
     def encode_prompt(
         self,
@@ -275,7 +298,7 @@ class ErnieImagePipeline(
         text_hiddens = []
 
         for p in prompt:
-            if apply_pe and self.use_pe and self.pe_model is not None:
+            if apply_pe and self.has_external_prompt_upscaler:
                 enhanced = self._enhance_prompt(p, device, width=width, height=height)
                 logger.info("PE: original='%s...' enhanced='%s...'", p[:50], enhanced[:50])
                 p = enhanced

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -285,10 +285,16 @@ class ErnieImagePipeline(
         return OmniDiffusionRequest.is_dummy_run_request_id(getattr(req, "request_id", None))
 
     @staticmethod
-    def _should_apply_pe(req: OmniDiffusionRequest) -> bool:
+    def _should_apply_pe(req: DiffusionRequestBatch) -> bool:
         if ErnieImagePipeline._is_warmup_request(req):
             return False
-        return do_prompt_upscaling(req)
+        if req.num_reqs != 1:
+            logger.warning(
+                "ErnieImage prompt upscaling only supports single-request batches; skipping for batch of %d requests",
+                req.num_reqs,
+            )
+            return False
+        return do_prompt_upscaling(req.requests[0])
 
     def encode_prompt(
         self,

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -155,23 +155,21 @@ class ErnieImagePipeline(
             local_files_only=local_files_only,
         ).to(self._execution_device)
 
-        # Resolve/download PE files at init (not inference time) so the
-        # HF download doesn't block the first upscaling request.
-        pe_base_path = _resolve_model_path_for_optional_pe(
-            model,
-            getattr(od_config, "revision", None),
-        )
-
-        self.has_external_prompt_upscaler = os.path.exists(
-            os.path.join(pe_base_path, "pe"),
-        )
-        # Only create the loader if the server config allows external
-        # upscaler loading. This prevents a user request from OOMing
-        # the server by lazy-loading a large model.
-        pe_loader = _make_pe_loader(pe_base_path, od_config.dtype, self._execution_device)
-        self._load_pe = (
-            pe_loader if self.has_external_prompt_upscaler and od_config.enable_external_prompt_upscaler else None
-        )
+        # Only resolve/download PE files if the server config allows
+        # external upscaler loading to avoid downloading files we'll never use.
+        self.has_external_prompt_upscaler = od_config.enable_external_prompt_upscaler
+        if self.has_external_prompt_upscaler:
+            pe_base_path = _resolve_model_path_for_optional_pe(
+                model,
+                getattr(od_config, "revision", None),
+            )
+            self._load_pe = _make_pe_loader(
+                pe_base_path,
+                od_config.dtype,
+                self._execution_device,
+            )
+        else:
+            self._load_pe = None
         self.pe_model = None
         self.pe_tokenizer = None
 

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComp
 from vllm_omni.diffusion.models.mistral_encoder import MistralEncoderModel
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+from vllm_omni.diffusion.utils.prompt_utils import do_prompt_upscaling
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
@@ -659,22 +660,6 @@ class Flux2Pipeline(
 
         return torch.stack(x_list, dim=0)
 
-    def upsample_prompt(
-        self,
-        prompt: str | list[str],
-        images: list[PIL.Image.Image] | list[list[PIL.Image.Image]] = None,
-        temperature: float = 0.15,
-        device: torch.device = None,
-    ) -> list[str]:
-        if images:
-            images = _validate_and_process_images(images, self.image_processor, self.upsampling_max_image_size)
-        return self.text_encoder.upsample_prompt(
-            prompt,
-            images=images,
-            temperature=temperature,
-            device=device,
-        )
-
     def encode_prompt(
         self,
         prompt: str | list[str],
@@ -892,7 +877,6 @@ class Flux2Pipeline(
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
         max_sequence_length: int = 512,
         text_encoder_out_layers: tuple[int, ...] = (10, 20, 30),
-        caption_upsample_temperature: float = None,
     ) -> DiffusionOutput:
         if len(req.prompts) > 1:
             logger.warning(
@@ -928,9 +912,7 @@ class Flux2Pipeline(
         )
         max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
         text_encoder_out_layers = req.sampling_params.extra_args.get("text_encoder_out_layers", text_encoder_out_layers)
-        caption_upsample_temperature = req.sampling_params.extra_args.get(
-            "caption_upsample_temperature", caption_upsample_temperature
-        )
+        should_upsample_prompt = do_prompt_upscaling(req, self.od_config)
 
         req_prompt_embeds = [p.get("prompt_embeds") if not isinstance(p, str) else None for p in req.prompts]
         if any(p is not None for p in req_prompt_embeds):
@@ -974,8 +956,20 @@ class Flux2Pipeline(
         device = self._execution_device
 
         # 3. prepare text embeddings
-        if caption_upsample_temperature:
-            prompt = self.upsample_prompt(prompt, images=image, temperature=caption_upsample_temperature, device=device)
+        if should_upsample_prompt:
+            upsample_images = (
+                _validate_and_process_images(image, self.image_processor, self.upsampling_max_image_size)
+                if image
+                else None
+            )
+            # NOTE (Alex): For now we don't expose temperature as a param for
+            # prompt upscaling to avoid too many obscure model specific params.
+            # If configuring this seems useful across several models, revisit.
+            prompt = self.text_encoder.upsample_prompt(
+                prompt,
+                images=upsample_images,
+                device=device,
+            )
         prompt_embeds, text_ids = self.encode_prompt(
             prompt=prompt,
             prompt_embeds=prompt_embeds,

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -912,7 +912,12 @@ class Flux2Pipeline(
         )
         max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
         text_encoder_out_layers = req.sampling_params.extra_args.get("text_encoder_out_layers", text_encoder_out_layers)
-        should_upsample_prompt = do_prompt_upscaling(req)
+        if req.num_reqs != 1:
+            logger.warning(
+                "Flux2 prompt upscaling only supports single-request batches; skipping for batch of %d requests",
+                req.num_reqs,
+            )
+        should_upsample_prompt = do_prompt_upscaling(req.requests[0]) if req.num_reqs == 1 else False
 
         req_prompt_embeds = [p.get("prompt_embeds") if not isinstance(p, str) else None for p in req.prompts]
         if any(p is not None for p in req_prompt_embeds):

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -912,7 +912,7 @@ class Flux2Pipeline(
         )
         max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
         text_encoder_out_layers = req.sampling_params.extra_args.get("text_encoder_out_layers", text_encoder_out_layers)
-        should_upsample_prompt = do_prompt_upscaling(req, self.od_config)
+        should_upsample_prompt = do_prompt_upscaling(req)
 
         req_prompt_embeds = [p.get("prompt_embeds") if not isinstance(p, str) else None for p in req.prompts]
         if any(p is not None for p in req_prompt_embeds):

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
@@ -522,7 +522,7 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
         extra_args = getattr(req.sampling_params, "extra_args", {}) or {}
         # Batch can be heterogeneous with prompt rewrite,
         # so consider each request individually
-        should_rewrite = [do_prompt_upscaling(req) for req in req.requests]
+        should_rewrite = [do_prompt_upscaling(sub_req) for sub_req in req.requests]
         enable_cfg_renorm: bool = extra_args.get("enable_cfg_renorm", True)
         cfg_renorm_min: float = extra_args.get("cfg_renorm_min", 0.0)
         joint_attention_kwargs: dict[str, Any] | None = None

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
@@ -31,6 +31,7 @@ from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_p
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.longcat_image.longcat_image_transformer import LongCatImageTransformer2DModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+from vllm_omni.diffusion.utils.prompt_utils import do_prompt_upscaling
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
@@ -519,7 +520,9 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
         latents = req.sampling_params.latents
 
         extra_args = getattr(req.sampling_params, "extra_args", {}) or {}
-        enable_prompt_rewrite: bool = extra_args.get("enable_prompt_rewrite", True)
+        # Batch can be heterogeneous with prompt rewrite,
+        # so consider each request individually
+        should_rewrite = [do_prompt_upscaling(req, self.od_config) for req in req.requests]
         enable_cfg_renorm: bool = extra_args.get("enable_cfg_renorm", True)
         cfg_renorm_min: float = extra_args.get("cfg_renorm_min", 0.0)
         joint_attention_kwargs: dict[str, Any] | None = None
@@ -543,8 +546,13 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
         batch_size = len(prompt)
 
         device = self.device
-        if enable_prompt_rewrite and prompt is not None:
-            prompt = self.rewire_prompt(prompt if isinstance(prompt, list) else [prompt], device)
+        # If any requests in the batch enable prompt rewrite, rewrite just those prompts
+        rewrite_indices = [idx for idx, do_rewrite in enumerate(should_rewrite) if do_rewrite]
+        if rewrite_indices and prompt is not None:
+            prompts_to_rewrite = [prompt[idx] for idx in rewrite_indices]
+            rewired_prompts = self.rewire_prompt(prompts_to_rewrite, device)
+            for rewrite_idx, rewired_prompt in zip(rewrite_indices, rewired_prompts):
+                prompt[rewrite_idx] = rewired_prompt
 
         negative_prompt = "" if negative_prompt is None else negative_prompt
 

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
@@ -522,7 +522,7 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
         extra_args = getattr(req.sampling_params, "extra_args", {}) or {}
         # Batch can be heterogeneous with prompt rewrite,
         # so consider each request individually
-        should_rewrite = [do_prompt_upscaling(req, self.od_config) for req in req.requests]
+        should_rewrite = [do_prompt_upscaling(req) for req in req.requests]
         enable_cfg_renorm: bool = extra_args.get("enable_cfg_renorm", True)
         cfg_renorm_min: float = extra_args.get("cfg_renorm_min", 0.0)
         joint_attention_kwargs: dict[str, Any] | None = None

--- a/vllm_omni/diffusion/utils/prompt_utils.py
+++ b/vllm_omni/diffusion/utils/prompt_utils.py
@@ -1,20 +1,19 @@
 import torch
 
-from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 
 
-def do_prompt_upscaling(
-    req: OmniDiffusionRequest,
-    od_config: OmniDiffusionConfig,
-) -> bool:
+def do_prompt_upscaling(req: OmniDiffusionRequest) -> bool:
     """Check whether prompt upscaling should run for this request."""
-    if not od_config.enable_prompt_upscaling:
-        return False
-    do_upscale = req.sampling_params.extra_args.get("prompt_upscaling", False)
-    if not isinstance(do_upscale, bool):
-        raise TypeError(f"prompt_upscaling must be a bool, got {type(do_upscale).__name__}")
-    return do_upscale
+    # NOTE: This may get more complex in the future since some models
+    # Use their text encoder directly, while others have an externally
+    # loaded component. Since only Ernie Image does this for now
+    # though, we currently don't distinguish at load time to avoid having
+    # too many obscure flags.
+    value = req.sampling_params.extra_args.get("use_prompt_upscaling", False)
+    if not isinstance(value, bool):
+        raise TypeError(f"use_prompt_upscaling must be a bool, got {type(value).__name__}")
+    return value
 
 
 def validate_prompt_sequence_lengths(

--- a/vllm_omni/diffusion/utils/prompt_utils.py
+++ b/vllm_omni/diffusion/utils/prompt_utils.py
@@ -10,10 +10,10 @@ def do_prompt_upscaling(req: OmniDiffusionRequest) -> bool:
     # loaded component. Since only Ernie Image does this for now
     # though, we currently don't distinguish at load time to avoid having
     # too many obscure flags.
-    value = req.sampling_params.extra_args.get("use_prompt_upscaling", False)
+    value = req.sampling_params.extra_args.get("use_prompt_upscaling")
     if not isinstance(value, bool):
         raise TypeError(f"use_prompt_upscaling must be a bool, got {type(value).__name__}")
-    return value
+    return bool(value)
 
 
 def validate_prompt_sequence_lengths(

--- a/vllm_omni/diffusion/utils/prompt_utils.py
+++ b/vllm_omni/diffusion/utils/prompt_utils.py
@@ -1,5 +1,21 @@
 import torch
 
+from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+
+
+def do_prompt_upscaling(
+    req: OmniDiffusionRequest,
+    od_config: OmniDiffusionConfig,
+) -> bool:
+    """Check whether prompt upscaling should run for this request."""
+    if not od_config.enable_prompt_upscaling:
+        return False
+    do_upscale = req.sampling_params.extra_args.get("prompt_upscaling", False)
+    if not isinstance(do_upscale, bool):
+        raise TypeError(f"prompt_upscaling must be a bool, got {type(do_upscale).__name__}")
+    return do_upscale
+
 
 def validate_prompt_sequence_lengths(
     attention_mask: torch.Tensor,

--- a/vllm_omni/diffusion/utils/prompt_utils.py
+++ b/vllm_omni/diffusion/utils/prompt_utils.py
@@ -10,7 +10,7 @@ def do_prompt_upscaling(req: OmniDiffusionRequest) -> bool:
     # loaded component. Since only Ernie Image does this for now
     # though, we currently don't distinguish at load time to avoid having
     # too many obscure flags.
-    value = req.sampling_params.extra_args.get("use_prompt_upscaling")
+    value = req.sampling_params.extra_args.get("use_prompt_upscaling", False)
     if not isinstance(value, bool):
         raise TypeError(f"use_prompt_upscaling must be a bool, got {type(value).__name__}")
     return bool(value)

--- a/vllm_omni/diffusion/utils/prompt_utils.py
+++ b/vllm_omni/diffusion/utils/prompt_utils.py
@@ -10,8 +10,8 @@ def do_prompt_upscaling(req: OmniDiffusionRequest) -> bool:
     # loaded component. Since only Ernie Image does this for now
     # though, we currently don't distinguish at load time to avoid having
     # too many obscure flags.
-    value = req.sampling_params.extra_args.get("use_prompt_upscaling", False)
-    if not isinstance(value, bool):
+    value = req.sampling_params.extra_args.get("use_prompt_upscaling")
+    if not isinstance(value, bool) and value is not None:
         raise TypeError(f"use_prompt_upscaling must be a bool, got {type(value).__name__}")
     return bool(value)
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1062,6 +1062,7 @@ class AsyncOmniEngine:
             "enable_sleep_mode": kwargs.get("enable_sleep_mode", False),
             "enable_prompt_embed_cache": kwargs.get("enable_prompt_embed_cache", False),
             "prompt_embed_cache_size": kwargs.get("prompt_embed_cache_size", 32),
+            "enable_external_prompt_upscaler": kwargs.get("enable_external_prompt_upscaler", False),
             "enable_multithread_weight_load": kwargs.get("enable_multithread_weight_load", True),
             "num_weight_load_threads": kwargs.get("num_weight_load_threads", 4),
             "quantization": kwargs.get("quantization", None),

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -695,6 +695,7 @@ class OmniServeCommand(CLISubcommand):
             action="store_true",
             help="Enable layerwise (blockwise) offloading on DiT modules.",
         )
+<<<<<<< HEAD
         omni_config_group.add_argument(
             "--enable-distributed-layerwise-offload",
             action="store_true",
@@ -729,6 +730,17 @@ class OmniServeCommand(CLISubcommand):
             help="Keep this many leading main-DiT blocks resident on the device "
             "while distributed layerwise offload streams the remaining blocks.",
         )
+=======
+
+        # For models with external prompt upscalers
+        omni_config_group.add_argument(
+            "--enable-external-prompt-upscaler",
+            action="store_true",
+            help="Allow lazy-loading external prompt upscaler models (e.g., ERNIE PE). "
+            "Required for use_prompt_upscaling to work on models with external upscalers.",
+        )
+
+>>>>>>> 081ad3ef (expose flag and add to default eng)
         # Video model parameters (e.g., Wan2.2) - engine-level
         omni_config_group.add_argument(
             "--boundary-ratio",

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -695,7 +695,6 @@ class OmniServeCommand(CLISubcommand):
             action="store_true",
             help="Enable layerwise (blockwise) offloading on DiT modules.",
         )
-<<<<<<< HEAD
         omni_config_group.add_argument(
             "--enable-distributed-layerwise-offload",
             action="store_true",
@@ -730,7 +729,6 @@ class OmniServeCommand(CLISubcommand):
             help="Keep this many leading main-DiT blocks resident on the device "
             "while distributed layerwise offload streams the remaining blocks.",
         )
-=======
 
         # For models with external prompt upscalers
         omni_config_group.add_argument(
@@ -740,7 +738,6 @@ class OmniServeCommand(CLISubcommand):
             "Required for use_prompt_upscaling to work on models with external upscalers.",
         )
 
->>>>>>> 081ad3ef (expose flag and add to default eng)
         # Video model parameters (e.g., Wan2.2) - engine-level
         omni_config_group.add_argument(
             "--boundary-ratio",

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1968,6 +1968,7 @@ async def generate_images(
             extra_args["bot_task"] = request.bot_task
         if request.flow_shift is not None:
             extra_args["flow_shift"] = request.flow_shift
+        extra_args["use_prompt_upscaling"] = request.use_prompt_upscaling
         if extra_args:
             gen_params.extra_args = extra_args
         # Parse per-request LoRA (compatible with chat's extra_body.lora shape).

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1970,7 +1970,8 @@ async def generate_images(
             extra_args["bot_task"] = request.bot_task
         if request.flow_shift is not None:
             extra_args["flow_shift"] = request.flow_shift
-        extra_args["use_prompt_upscaling"] = request.use_prompt_upscaling
+        if request.use_prompt_upscaling is not None:
+            extra_args["use_prompt_upscaling"] = request.use_prompt_upscaling
         if extra_args:
             gen_params.extra_args = extra_args
         # Parse per-request LoRA (compatible with chat's extra_body.lora shape).

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1921,6 +1921,8 @@ async def generate_images(
                 extra_body["flow_shift"] = request.flow_shift
             if request.extra_params is not None:
                 extra_body["extra_params"] = request.extra_params
+            if request.use_prompt_upscaling is not None:
+                extra_body["use_prompt_upscaling"] = request.use_prompt_upscaling
             if request.generator_device is not None:
                 extra_body["generator_device"] = request.generator_device
             if request.lora is not None:

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -109,6 +109,11 @@ class ImageGenerationRequest(BaseModel):
         description="System prompt type. Options: None, dynamic, en_vanilla, "
         "en_recaption, en_think_recaption, en_unified, custom",
     )
+    use_prompt_upscaling: bool = Field(
+        default=False,
+        description="Enable prompt upscaling/enhancement for this request. "
+        "Only effective for models that support prompt upscaling.",
+    )
 
     @field_validator("use_system_prompt")
     @classmethod

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -109,8 +109,8 @@ class ImageGenerationRequest(BaseModel):
         description="System prompt type. Options: None, dynamic, en_vanilla, "
         "en_recaption, en_think_recaption, en_unified, custom",
     )
-    use_prompt_upscaling: bool = Field(
-        default=False,
+    use_prompt_upscaling: bool | None = Field(
+        default=None,
         description="Enable prompt upscaling/enhancement for this request. "
         "Only effective for models that support prompt upscaling.",
     )

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3507,20 +3507,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             num_inference_steps = extra_body.get("num_inference_steps")
             quality = extra_body.get("quality")
             guidance_scale = extra_body.get("guidance_scale")
-<<<<<<< HEAD
             true_cfg_scale = extra_body.get("true_cfg_scale")
-=======
-            true_cfg_scale = extra_body.get("true_cfg_scale") or extra_body.get("cfg_scale")
-            cfg_text_scale = extra_body.get("cfg_text_scale")
-            cfg_img_scale = extra_body.get("cfg_img_scale")
-            use_prompt_upscaling = extra_body.get("use_prompt_upscaling")
-            # TODO (Alex): Make extra body validation common & validate all extra body params
-            if use_prompt_upscaling is not None and not isinstance(use_prompt_upscaling, bool):
-                return self._create_error_response(
-                    f"use_prompt_upscaling must be a bool, got {type(use_prompt_upscaling).__name__}",
-                    status_code=400,
-                )
->>>>>>> 0540cb1d (review comments)
             seed = extra_body.get("seed")
             if seed is None:
                 seed = getattr(request, "seed", None)

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3507,7 +3507,20 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             num_inference_steps = extra_body.get("num_inference_steps")
             quality = extra_body.get("quality")
             guidance_scale = extra_body.get("guidance_scale")
+<<<<<<< HEAD
             true_cfg_scale = extra_body.get("true_cfg_scale")
+=======
+            true_cfg_scale = extra_body.get("true_cfg_scale") or extra_body.get("cfg_scale")
+            cfg_text_scale = extra_body.get("cfg_text_scale")
+            cfg_img_scale = extra_body.get("cfg_img_scale")
+            use_prompt_upscaling = extra_body.get("use_prompt_upscaling")
+            # TODO (Alex): Make extra body validation common & validate all extra body params
+            if use_prompt_upscaling is not None and not isinstance(use_prompt_upscaling, bool):
+                return self._create_error_response(
+                    f"use_prompt_upscaling must be a bool, got {type(use_prompt_upscaling).__name__}",
+                    status_code=400,
+                )
+>>>>>>> 0540cb1d (review comments)
             seed = extra_body.get("seed")
             if seed is None:
                 seed = getattr(request, "seed", None)

--- a/vllm_omni/model_extras/ernie_image.py
+++ b/vllm_omni/model_extras/ernie_image.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+ERNIE_IMAGE_EXTRA_BODY_PARAMS = frozenset(
+    {
+        "use_prompt_upscaling",
+    }
+)

--- a/vllm_omni/model_extras/flux2.py
+++ b/vllm_omni/model_extras/flux2.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+FLUX2_EXTRA_BODY_PARAMS = frozenset(
+    {
+        "use_prompt_upscaling",
+    }
+)

--- a/vllm_omni/model_extras/longcat_image.py
+++ b/vllm_omni/model_extras/longcat_image.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+LONGCAT_IMAGE_EXTRA_BODY_PARAMS = frozenset(
+    {
+        "use_prompt_upscaling",
+    }
+)

--- a/vllm_omni/model_extras/registry.py
+++ b/vllm_omni/model_extras/registry.py
@@ -28,12 +28,15 @@ from vllm_omni.model_extras.cosmos3 import (
     COSMOS3_EXTRA_BODY_PARAMS,
     COSMOS3_EXTRA_OUTPUT_PARAMS,
 )
+from vllm_omni.model_extras.ernie_image import ERNIE_IMAGE_EXTRA_BODY_PARAMS
+from vllm_omni.model_extras.flux2 import FLUX2_EXTRA_BODY_PARAMS
 from vllm_omni.model_extras.helios import (
     HELIOS_EXTRA_BODY_PARAMS,
     HELIOS_EXTRA_OUTPUT_PARAMS,
 )
 from vllm_omni.model_extras.hunyuan_image3 import build_x_to_text_prompt as build_hunyuan_x_to_text_prompt
 from vllm_omni.model_extras.lingbot_video import LINGBOT_VIDEO_EXTRA_BODY_PARAMS
+from vllm_omni.model_extras.longcat_image import LONGCAT_IMAGE_EXTRA_BODY_PARAMS
 from vllm_omni.model_extras.ltx2 import LTX_EXTRA_BODY_PARAMS, LTX_EXTRA_OUTPUT_PARAMS
 from vllm_omni.model_extras.magi_human import (
     MAGI_HUMAN_EXTRA_BODY_PARAMS,
@@ -207,6 +210,15 @@ _EXTRA_SPECS: dict[str, dict[str, Any]] = {
             "LTX2Pipeline",
             "LTX2DistilledPipeline",
         )
+    },
+    "Flux2Pipeline": {
+        "extra_body_params": FLUX2_EXTRA_BODY_PARAMS,
+    },
+    "LongCatImagePipeline": {
+        "extra_body_params": LONGCAT_IMAGE_EXTRA_BODY_PARAMS,
+    },
+    "ErnieImagePipeline": {
+        "extra_body_params": ERNIE_IMAGE_EXTRA_BODY_PARAMS,
     },
     "WanVACEPipeline": {
         "extra_body_params": VACE_EXTRA_BODY_PARAMS,


### PR DESCRIPTION
## Purpose
FIX https://github.com/vllm-project/vllm-omni/issues/3713

Exposes param to turn prompt upscaling on/off and unifies the behavior for the following Diffusion models:
- Flux2Dev
- Longcat
- Ernie Image

In cases where the model prompt upscaler is external (i.e., of the above, Ernie Image), the download for the extra files is gated on whether or not it's actually going to be used, and the prompt upscaler won't be loaded until you actually make a request using it, since the prompt upscaler takes a nontrivial amount of extra VRAM.  For models like this, you need to pass an additional opt-in flag `enable_external_prompt_upscaler` (or the corresponding CLI arg), which is set to False by default.  If you try to make a request with prompt upscale on while its disabled, and the model has an external upscaler component, you will get a warning and it'll skip the upscale part:

```
WARNING 05-21 00:09:43 [pipeline_ernie_image.py:198] Requested prompt upscaling on a model with an external prompt upscaler, but enable_external_prompt_upscaler is not set in the server config; prompt upscaling will be skipped
```

- Also worth considering that technically we could have sampling params for the upscaling / rewrite, but I opted to not expose those here as well, since I thought it would be best to minimize the number of new params / flags in this PR. Open to discussion / exploring this in potential follow-ups though.

## Test Plan
Validated for all 3 models that outputs do not match the raw gen with same seed when upscale is enabled for:
- Offline path
- Chat completions endpoint
- Image generation endpoint

## Test Result
Upscale results are different (i.e., due to prompt manipulation) on all paths for each of the models. Added additional tests for Ernie since the other changes were very straightforward. Also verified when running the server online that the GPU usage was low (~24 Gi) until I made a request with the upscale param, which increased it (to ~30 Gi) and that we get a warning instead of blowing up the memory if it's disabled. For Flux2/LongCat, we don't need to externally disable it since the component is always loaded anyway, which is why it would still work without issues.

@RuixiangMa @retowyss could you please take a look?