### PR TITLE
[New Model]: MiniMind-O 

### DIFF
--- a/tests/model_executor/models/minimind_o/test_minimind_mm_utils.py
+++ b/tests/model_executor/models/minimind_o/test_minimind_mm_utils.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+import torch
+
+from vllm_omni.model_executor.models.minimind_o.minimind_mm_utils import (
+    inject_audio_features,
+    inject_vision_features,
+)
+
+
+def test_inject_audio_replaces_pad_run():
+    tokens = torch.tensor([[1, 16, 16, 2]])
+    hidden = torch.arange(4 * 3, dtype=torch.float32).view(1, 4, 3)
+    audio = [torch.ones(2, 3)]
+    out = inject_audio_features(tokens, hidden, audio, audio_marker=16)
+    assert out.shape[0] == 1
+    assert out.shape[1] >= 4
+
+
+def test_inject_vision_replaces_image_pad():
+    tokens = torch.tensor([[1, 12, 12, 2]])
+    hidden = torch.zeros(1, 4, 4)
+    vision = torch.ones(1, 1, 2, 4)
+    out = inject_vision_features(tokens, hidden, vision, image_marker=12, seqlen=4)
+    assert out.shape == hidden.shape

--- a/tests/model_executor/models/minimind_o/test_minimind_o_config.py
+++ b/tests/model_executor/models/minimind_o/test_minimind_o_config.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+from vllm_omni.model_executor.models.minimind_o.config import (
+    MiniMindOConfig,
+    MiniMindOThinkerConfig,
+    MiniMindOTalkerConfig,
+)
+
+
+def test_minimind_o_nested_configs():
+    cfg = MiniMindOConfig()
+    assert isinstance(cfg.thinker_config, MiniMindOThinkerConfig)
+    assert isinstance(cfg.talker_config, MiniMindOTalkerConfig)
+    assert cfg.thinker_config.text_config.vocab_size == 6400
+    assert cfg.talker_config.text_config.vocab_size == cfg.audio_vocab_size
+    assert cfg.talker_config.audio_pad_token == 2049
+    assert cfg.thinker_config.audio_token_index == 16
+    assert cfg.thinker_config.image_token_index == 12
+
+
+def test_minimind_o_hf_model_type():
+    cfg = MiniMindOConfig.from_pretrained("jingyaogong/minimind-3o", trust_remote_code=True)
+    assert cfg.model_type == "minimind-o"
+    assert cfg.architectures == ["MiniMindOmni"]
+    assert cfg.bridge_layer == 3
+    assert cfg.use_moe is False

--- a/tests/model_executor/models/minimind_o/test_minimind_o_weights.py
+++ b/tests/model_executor/models/minimind_o/test_minimind_o_weights.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+from collections import Counter
+
+import pytest
+
+from vllm_omni.model_executor.models.minimind_o.minimind_o import MiniMindOForConditionalGeneration
+
+
+def _fake_keys():
+    return [
+        ("model.embed_tokens.weight", None),
+        ("lm_head.weight", None),
+        ("audio_proj.mlp.0.weight", None),
+        ("vision_proj.mlp.0.weight", None),
+        ("talker.layers.0.self_attn.q_proj.weight", None),
+        ("talker.lm_head.base.weight", None),
+    ]
+
+
+def test_partition_flat_hf_weights():
+    thinker, talker, code2wav, other = MiniMindOForConditionalGeneration._partition_omni_weights(_fake_keys())
+    assert len(other) == 0
+    assert len(code2wav) == 0
+    assert {k for k, _ in thinker} == {
+        "model.embed_tokens.weight",
+        "lm_head.weight",
+        "audio_proj.mlp.0.weight",
+        "vision_proj.mlp.0.weight",
+    }
+    assert all(k.startswith("talker.") for k, _ in talker)
+
+
+@pytest.mark.parametrize(
+    "mapper_prefix,expected",
+    [
+        ("model.", "language_model.model."),
+        ("talker.layers.", "language_model.model.layers."),
+        ("talker.lm_head.", "mtp_head."),
+    ],
+)
+def test_thinker_talker_weight_mapper_expectations(mapper_prefix, expected):
+    from vllm_omni.model_executor.models.minimind_o.minimind_o_thinker import (
+        MiniMindOThinkerForConditionalGeneration,
+    )
+    from vllm_omni.model_executor.models.minimind_o.minimind_o_talker import (
+        MiniMindOTalkerForConditionalGeneration,
+    )
+
+    cls = MiniMindOThinkerForConditionalGeneration if mapper_prefix == "model." else MiniMindOTalkerForConditionalGeneration
+    mapped = cls.hf_to_vllm_mapper.orig_to_new_prefix.get(mapper_prefix)
+    assert mapped == expected
+
+
+def test_hf_checkpoint_prefixes_match_mappers():
+    pytest.importorskip("huggingface_hub")
+    from huggingface_hub import hf_hub_download
+    import torch
+
+    p = hf_hub_download("jingyaogong/minimind-3o", "pytorch_model.bin")
+    sd = torch.load(p, map_location="cpu", weights_only=True)
+    prefixes = Counter(k.split(".")[0] for k in sd)
+    assert prefixes["model"] > 0
+    assert prefixes["talker"] > 0
+    assert prefixes["audio_proj"] > 0
+    assert prefixes["vision_proj"] > 0

--- a/tests/model_executor/models/minimind_o/test_minimind_talker_mtp.py
+++ b/tests/model_executor/models/minimind_o/test_minimind_talker_mtp.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+import torch
+
+from vllm_omni.model_executor.models.minimind_o.minimind_o_talker import (
+    MiniMindOTalkerForConditionalGeneration,
+)
+
+
+def test_sample_mimi_layer_logits_respects_top_k():
+    logits = torch.zeros(100)
+    logits[42] = 10.0
+    logits[7] = 9.0
+    code = MiniMindOTalkerForConditionalGeneration._sample_mimi_layer_logits(
+        logits,
+        [],
+        temperature=0.2,
+        top_k=50,
+    )
+    assert code in (7, 42)

--- a/vllm_omni/model_executor/models/minimind_o/__init__.py
+++ b/vllm_omni/model_executor/models/minimind_o/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+"""MiniMind-O model exports."""
+
+from vllm_omni.model_executor.models.minimind_o.minimind_o import (
+    MiniMindOForConditionalGeneration,
+    MiniMindOMoeForConditionalGeneration,
+)
+from vllm_omni.model_executor.models.minimind_o.minimind_o_code2wav import (
+    MiniMindOCode2Wav,
+)
+from vllm_omni.model_executor.models.minimind_o.minimind_o_talker import (
+    MiniMindOTalkerForConditionalGeneration,
+)
+from vllm_omni.model_executor.models.minimind_o.minimind_o_thinker import (
+    MiniMindOThinkerForConditionalGeneration,
+)
+
+__all__ = [
+    "MiniMindOForConditionalGeneration",
+    "MiniMindOMoeForConditionalGeneration",
+    "MiniMindOThinkerForConditionalGeneration",
+    "MiniMindOTalkerForConditionalGeneration",
+    "MiniMindOCode2Wav",
+]

--- a/vllm_omni/model_executor/models/minimind_o/config.py
+++ b/vllm_omni/model_executor/models/minimind_o/config.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+"""MiniMind-O configuration classes for vLLM-Omni integration."""
+
+from transformers import PretrainedConfig
+
+from vllm_omni.model_executor.models.minimind_o.minimind_llm import MiniMindConfig as MiniMindTextConfig
+
+
+def _build_text_config(
+    *,
+    vocab_size: int,
+    hidden_size: int,
+    num_hidden_layers: int,
+    num_attention_heads: int,
+    num_key_value_heads: int,
+    head_dim: int,
+    intermediate_size: int,
+    max_position_embeddings: int,
+    rms_norm_eps: float,
+    rope_theta: float,
+    hidden_act: str,
+    tie_word_embeddings: bool = True,
+    use_moe: bool = False,
+    num_experts: int = 4,
+    num_experts_per_tok: int = 1,
+    moe_intermediate_size: int = 2432,
+    norm_topk_prob: bool = True,
+) -> MiniMindTextConfig:
+    return MiniMindTextConfig(
+        vocab_size=vocab_size,
+        hidden_size=hidden_size,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=num_key_value_heads,
+        head_dim=head_dim,
+        intermediate_size=intermediate_size,
+        max_position_embeddings=max_position_embeddings,
+        rms_norm_eps=rms_norm_eps,
+        rope_theta=rope_theta,
+        hidden_act=hidden_act,
+        tie_word_embeddings=tie_word_embeddings,
+        use_moe=use_moe,
+        num_experts=num_experts,
+        num_experts_per_tok=num_experts_per_tok,
+        moe_intermediate_size=moe_intermediate_size,
+        norm_topk_prob=norm_topk_prob,
+    )
+
+
+class MiniMindOThinkerConfig(PretrainedConfig):
+    model_type = "minimind_o_thinker"
+
+    def __init__(
+        self,
+        *,
+        vocab_size: int = 6400,
+        hidden_size: int = 768,
+        num_hidden_layers: int = 8,
+        num_attention_heads: int = 8,
+        num_key_value_heads: int = 4,
+        head_dim: int = 96,
+        intermediate_size: int = 2432,
+        max_position_embeddings: int = 32768,
+        rms_norm_eps: float = 1e-6,
+        rope_theta: float = 1e6,
+        rope_scaling=None,
+        hidden_act: str = "silu",
+        audio_hidden_size: int = 512,
+        audio_ids: list[int] | None = None,
+        image_hidden_size: int = 768,
+        image_token_len: int = 64,
+        image_ids: list[int] | None = None,
+        bridge_layer: int = 3,
+        audio_token_index: int | None = None,
+        image_token_index: int | None = None,
+        video_token_index: int = 13,
+        use_moe: bool = False,
+        num_experts: int = 4,
+        num_experts_per_tok: int = 1,
+        moe_intermediate_size: int = 2432,
+        norm_topk_prob: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        audio_ids = audio_ids or [16]
+        image_ids = image_ids or [12]
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.intermediate_size = intermediate_size
+        self.max_position_embeddings = max_position_embeddings
+        self.rms_norm_eps = rms_norm_eps
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self.hidden_act = hidden_act
+        self.audio_hidden_size = audio_hidden_size
+        self.audio_ids = audio_ids
+        self.image_hidden_size = image_hidden_size
+        self.image_token_len = image_token_len
+        self.image_ids = image_ids
+        self.bridge_layer = bridge_layer
+        self.audio_token_index = audio_token_index if audio_token_index is not None else audio_ids[0]
+        self.image_token_index = image_token_index if image_token_index is not None else image_ids[0]
+        self.video_token_index = video_token_index
+        self.audio_start_token_id = None
+        self.audio_end_token_id = None
+        self.vision_start_token_id = None
+        self.vision_end_token_id = None
+        self.seconds_per_chunk = 1.0
+        self.spatial_merge_size = 2
+        self.vision_config = type(
+            "VisionCfg",
+            (),
+            {"spatial_merge_size": 2, "tokens_per_second": 25},
+        )()
+        self.text_config = _build_text_config(
+            vocab_size=vocab_size,
+            hidden_size=hidden_size,
+            num_hidden_layers=num_hidden_layers,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            intermediate_size=intermediate_size,
+            max_position_embeddings=max_position_embeddings,
+            rms_norm_eps=rms_norm_eps,
+            rope_theta=rope_theta,
+            hidden_act=hidden_act,
+            tie_word_embeddings=True,
+            use_moe=use_moe,
+            num_experts=num_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            moe_intermediate_size=moe_intermediate_size,
+            norm_topk_prob=norm_topk_prob,
+        )
+
+
+class MiniMindOTalkerConfig(PretrainedConfig):
+    model_type = "minimind_o_talker"
+
+    def __init__(
+        self,
+        *,
+        vocab_size: int = 6400,
+        hidden_size: int = 768,
+        talker_hidden_size: int = 768,
+        num_talker_hidden_layers: int = 4,
+        num_attention_heads: int = 8,
+        num_key_value_heads: int = 4,
+        head_dim: int = 96,
+        intermediate_size: int = 2432,
+        max_position_embeddings: int = 32768,
+        rms_norm_eps: float = 1e-6,
+        rope_theta: float = 1e6,
+        hidden_act: str = "silu",
+        audio_vocab_size: int = 2112,
+        audio_pad_token: int = 2049,
+        audio_stop_token: int = 2050,
+        audio_spk_token: int = 2051,
+        spk_emb_size: int = 192,
+        mtp_num_layers: int = 8,
+        mtp_rank: int = 256,
+        use_moe: bool = False,
+        num_experts: int = 4,
+        num_experts_per_tok: int = 1,
+        moe_intermediate_size: int = 2432,
+        norm_topk_prob: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.talker_hidden_size = talker_hidden_size
+        self.num_talker_hidden_layers = num_talker_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.intermediate_size = intermediate_size
+        self.max_position_embeddings = max_position_embeddings
+        self.rms_norm_eps = rms_norm_eps
+        self.rope_theta = rope_theta
+        self.hidden_act = hidden_act
+        self.audio_vocab_size = audio_vocab_size
+        self.audio_pad_token = audio_pad_token
+        self.audio_stop_token = audio_stop_token
+        self.audio_spk_token = audio_spk_token
+        self.spk_emb_size = spk_emb_size
+        self.mtp_num_layers = mtp_num_layers
+        self.mtp_rank = mtp_rank
+        self.tts_codec_start_token_id = audio_pad_token
+        self.tts_codec_end_token_id = audio_stop_token
+        self.tts_codec_pad_token_id = audio_pad_token
+        self.tts_codec_mask_token_id = audio_pad_token
+        self.tts_text_start_token_id = 1
+        self.tts_text_end_token_id = 2
+        self.tts_text_pad_token_id = 0
+        self.text_config = _build_text_config(
+            vocab_size=audio_vocab_size,
+            hidden_size=talker_hidden_size,
+            num_hidden_layers=num_talker_hidden_layers,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            intermediate_size=intermediate_size,
+            max_position_embeddings=max_position_embeddings,
+            rms_norm_eps=rms_norm_eps,
+            rope_theta=rope_theta,
+            hidden_act=hidden_act,
+            tie_word_embeddings=False,
+            use_moe=use_moe,
+            num_experts=num_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            moe_intermediate_size=moe_intermediate_size,
+            norm_topk_prob=norm_topk_prob,
+        )
+
+
+class MiniMindOCode2WavConfig(PretrainedConfig):
+    model_type = "minimind_o_code2wav"
+
+    def __init__(
+        self,
+        *,
+        codebook_size: int = 2112,
+        num_quantizers: int = 8,
+        hidden_size: int = 512,
+        frame_rate: float = 12.5,
+        sample_rate: int = 24000,
+        num_decoder_layers: int = 8,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.codebook_size = codebook_size
+        self.num_quantizers = num_quantizers
+        self.hidden_size = hidden_size
+        self.frame_rate = frame_rate
+        self.sample_rate = sample_rate
+        self.num_decoder_layers = num_decoder_layers
+
+
+class MiniMindOConfig(PretrainedConfig):
+    """Top-level HF config for jingyaogong/minimind-3o (flat checkpoint)."""
+
+    model_type = "minimind-o"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        architectures=None,
+        model_type="minimind-o",
+        vocab_size=6400,
+        hidden_size=768,
+        num_hidden_layers=8,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        head_dim=96,
+        intermediate_size=2432,
+        max_position_embeddings=32768,
+        rms_norm_eps=1e-6,
+        rope_theta=1000000.0,
+        rope_scaling=None,
+        hidden_act="silu",
+        dropout=0.0,
+        dtype="bfloat16",
+        flash_attn=True,
+        inference_rope_scaling=False,
+        use_moe=False,
+        num_experts=4,
+        num_experts_per_tok=1,
+        moe_intermediate_size=2432,
+        router_aux_loss_coef=0.0005,
+        norm_topk_prob=True,
+        audio_hidden_size=512,
+        audio_vocab_size=2112,
+        audio_pad_token=2049,
+        audio_stop_token=2050,
+        audio_spk_token=2051,
+        audio_ids=None,
+        audio_special_token="<|audio_pad|>",
+        image_hidden_size=768,
+        image_token_len=64,
+        image_ids=None,
+        image_special_token="<|image_pad|>",
+        num_talker_hidden_layers=4,
+        talker_hidden_size=768,
+        spk_emb_size=192,
+        bridge_layer=3,
+        think_end_ids=None,
+        bos_token_id=1,
+        eos_token_id=2,
+        auto_map=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        audio_ids = audio_ids if audio_ids is not None else [16]
+        image_ids = image_ids if image_ids is not None else [12]
+        think_end_ids = think_end_ids if think_end_ids is not None else [26, 234, 234]
+
+        default_arch = "MiniMindOMoeForConditionalGeneration" if use_moe else "MiniMindOForConditionalGeneration"
+        self.architectures = architectures or [default_arch]
+        self.model_type = model_type
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.intermediate_size = intermediate_size
+        self.max_position_embeddings = max_position_embeddings
+        self.rms_norm_eps = rms_norm_eps
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self.hidden_act = hidden_act
+        self.dropout = dropout
+        self.dtype = dtype
+        self.flash_attn = flash_attn
+        self.inference_rope_scaling = inference_rope_scaling
+        self.use_moe = use_moe
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.moe_intermediate_size = moe_intermediate_size
+        self.router_aux_loss_coef = router_aux_loss_coef
+        self.norm_topk_prob = norm_topk_prob
+        self.audio_hidden_size = audio_hidden_size
+        self.audio_vocab_size = audio_vocab_size
+        self.audio_pad_token = audio_pad_token
+        self.audio_stop_token = audio_stop_token
+        self.audio_spk_token = audio_spk_token
+        self.audio_ids = audio_ids
+        self.audio_special_token = audio_special_token
+        self.image_hidden_size = image_hidden_size
+        self.image_token_len = image_token_len
+        self.image_ids = image_ids
+        self.image_special_token = image_special_token
+        self.num_talker_hidden_layers = num_talker_hidden_layers
+        self.talker_hidden_size = talker_hidden_size
+        self.spk_emb_size = spk_emb_size
+        self.bridge_layer = bridge_layer
+        self.think_end_ids = think_end_ids
+        self.bos_token_id = bos_token_id
+        self.eos_token_id = eos_token_id
+        self.auto_map = auto_map
+
+        self.thinker_config = MiniMindOThinkerConfig(
+            vocab_size=vocab_size,
+            hidden_size=hidden_size,
+            num_hidden_layers=num_hidden_layers,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            intermediate_size=intermediate_size,
+            max_position_embeddings=max_position_embeddings,
+            rms_norm_eps=rms_norm_eps,
+            rope_theta=rope_theta,
+            rope_scaling=rope_scaling,
+            hidden_act=hidden_act,
+            audio_hidden_size=audio_hidden_size,
+            audio_ids=audio_ids,
+            image_hidden_size=image_hidden_size,
+            image_token_len=image_token_len,
+            image_ids=image_ids,
+            bridge_layer=bridge_layer,
+            use_moe=use_moe,
+            num_experts=num_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            moe_intermediate_size=moe_intermediate_size,
+            norm_topk_prob=norm_topk_prob,
+        )
+        self.talker_config = MiniMindOTalkerConfig(
+            vocab_size=vocab_size,
+            hidden_size=hidden_size,
+            talker_hidden_size=talker_hidden_size,
+            num_talker_hidden_layers=num_talker_hidden_layers,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            intermediate_size=intermediate_size,
+            max_position_embeddings=max_position_embeddings,
+            rms_norm_eps=rms_norm_eps,
+            rope_theta=rope_theta,
+            hidden_act=hidden_act,
+            audio_vocab_size=audio_vocab_size,
+            audio_pad_token=audio_pad_token,
+            audio_stop_token=audio_stop_token,
+            audio_spk_token=audio_spk_token,
+            spk_emb_size=spk_emb_size,
+            use_moe=use_moe,
+            num_experts=num_experts,
+            num_experts_per_tok=num_experts_per_tok,
+            moe_intermediate_size=moe_intermediate_size,
+            norm_topk_prob=norm_topk_prob,
+        )
+        self.code2wav_config = MiniMindOCode2WavConfig(
+            codebook_size=audio_vocab_size,
+            hidden_size=audio_hidden_size,
+        )
+
+
+# HF AutoConfig alias (model_omni.OmniConfig)
+MiniMindOmniConfig = MiniMindOConfig

--- a/vllm_omni/model_executor/models/minimind_o/minimind_llm.py
+++ b/vllm_omni/model_executor/models/minimind_o/minimind_llm.py
@@ -1,0 +1,461 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+"""MiniMind dense decoder for vLLM-Omni (thinker + talker backbones)."""
+
+from collections.abc import Iterable
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import CacheConfig, VllmConfig
+from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import MergedColumnParallelLinear, QKVParallelLinear, RowParallelLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead, VocabParallelEmbedding
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader, maybe_remap_kv_scale_name
+from vllm.model_executor.models.interfaces import SupportsLoRA, SupportsPP
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    is_pp_missing_parameter,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+    maybe_prefix,
+)
+from vllm.sequence import IntermediateTensors
+from vllm.v1.attention.backend import AttentionType
+from vllm.v1.outputs import SamplerOutput
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.sampler import Sampler
+
+
+class MiniMindConfig(PretrainedConfig):
+    model_type = "minimind"
+
+    def __init__(
+        self,
+        vocab_size: int = 6400,
+        hidden_size: int = 768,
+        intermediate_size: int = 2432,
+        num_hidden_layers: int = 8,
+        num_attention_heads: int = 8,
+        num_key_value_heads: int = 4,
+        head_dim: int = 96,
+        max_position_embeddings: int = 32768,
+        rms_norm_eps: float = 1e-6,
+        rope_theta: float = 1e6,
+        hidden_act: str = "silu",
+        tie_word_embeddings: bool = True,
+        use_moe: bool = False,
+        num_experts: int = 4,
+        num_experts_per_tok: int = 1,
+        moe_intermediate_size: int | None = None,
+        norm_topk_prob: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.max_position_embeddings = max_position_embeddings
+        self.rms_norm_eps = rms_norm_eps
+        self.rope_theta = rope_theta
+        self.hidden_act = hidden_act
+        self.tie_word_embeddings = tie_word_embeddings
+        self.use_moe = use_moe
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.moe_intermediate_size = moe_intermediate_size or intermediate_size
+        self.norm_topk_prob = norm_topk_prob
+
+
+class MiniMindMLP(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size] * 2,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+        )
+        if hidden_act != "silu":
+            raise ValueError(f"Unsupported activation: {hidden_act}")
+        self.act_fn = SiluAndMul()
+
+    def forward(self, x):
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x, _ = self.down_proj(x)
+        return x
+
+
+class MiniMindAttention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        max_position: int,
+        rope_theta: float,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = num_kv_heads
+        if self.total_num_kv_heads >= tp_size:
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            assert tp_size % self.total_num_kv_heads == 0
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = head_dim
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+        self.q_norm = RMSNorm(self.head_dim, eps=1e-6)
+        self.k_norm = RMSNorm(self.head_dim, eps=1e-6)
+
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            max_position=max_position,
+            is_neox_style=True,
+            rope_parameters={"base": rope_theta},
+        )
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            num_kv_heads=self.num_kv_heads,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
+            attn_type=AttentionType.DECODER,
+        )
+
+    def forward(self, positions: torch.Tensor, hidden_states: torch.Tensor) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q = q.view(*q.shape[:-1], self.num_heads, self.head_dim)
+        k = k.view(*k.shape[:-1], self.num_kv_heads, self.head_dim)
+        q = self.q_norm(q).view(q.shape[0], -1)
+        k = self.k_norm(k).view(k.shape[0], -1)
+        q, k = self.rotary_emb(positions, q, k)
+        attn_output = self.attn(q, k, v)
+        output, _ = self.o_proj(attn_output)
+        return output
+
+
+class MiniMindMoEFeedForward(nn.Module):
+    """MoE FFN (HF MiniMind MOEFeedForward), inference-only."""
+
+    def __init__(
+        self,
+        config: MiniMindConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
+        self.experts = nn.ModuleList(
+            [
+                MiniMindMLP(
+                    config.hidden_size,
+                    config.moe_intermediate_size,
+                    config.hidden_act,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.experts.{i}",
+                )
+                for i in range(config.num_experts)
+            ]
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        bsz, seq_len, hidden_dim = x.shape
+        x_flat = x.view(-1, hidden_dim)
+        scores = torch.softmax(self.gate(x_flat), dim=-1)
+        topk_weight, topk_idx = torch.topk(scores, k=self.config.num_experts_per_tok, dim=-1, sorted=False)
+        if self.config.norm_topk_prob:
+            topk_weight = topk_weight / (topk_weight.sum(dim=-1, keepdim=True) + 1e-20)
+        y = torch.zeros_like(x_flat)
+        for i, expert in enumerate(self.experts):
+            token_idx, weight_idx = torch.where(topk_idx == i)
+            if token_idx.numel() > 0:
+                y[token_idx] += (
+                    expert(x_flat[token_idx])
+                    * topk_weight[token_idx, weight_idx].unsqueeze(1).to(y.dtype)
+                )
+        return y.view(bsz, seq_len, hidden_dim)
+
+
+class MiniMindDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: MiniMindConfig,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.self_attn = MiniMindAttention(
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            head_dim=config.head_dim,
+            max_position=config.max_position_embeddings,
+            rope_theta=config.rope_theta,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.self_attn",
+        )
+        if config.use_moe:
+            self.mlp = MiniMindMoEFeedForward(config, quant_config=quant_config, prefix=f"{prefix}.mlp")
+        else:
+            self.mlp = MiniMindMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+            )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        hidden_states = self.self_attn(positions=positions, hidden_states=hidden_states)
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+    }
+)
+class MiniMindModel(nn.Module):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config: MiniMindConfig = vllm_config.model_config.hf_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+
+        self.config = config
+        self.quant_config = quant_config
+        self.vocab_size = config.vocab_size
+
+        if get_pp_group().is_first_rank or (config.tie_word_embeddings and get_pp_group().is_last_rank):
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=f"{prefix}.embed_tokens",
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers,
+            lambda p: MiniMindDecoderLayer(
+                config=config,
+                cache_config=cache_config,
+                quant_config=quant_config,
+                prefix=p,
+            ),
+            prefix=f"{prefix}.layers",
+        )
+
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], config.hidden_size
+        )
+        if get_pp_group().is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer()
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        if get_pp_group().is_first_rank:
+            hidden_states = inputs_embeds if inputs_embeds is not None else self.embed_input_ids(input_ids)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+        for layer in self.layers[self.start_layer : self.end_layer]:
+            hidden_states, residual = layer(positions, hidden_states, residual)
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+            if self.quant_config is not None and (scale_name := self.quant_config.get_cache_scale(name)):
+                param = params_dict[scale_name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                loaded_weight = loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
+                weight_loader(param, loaded_weight)
+                loaded_params.add(scale_name)
+                continue
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if is_pp_missing_parameter(name, self):
+                    continue
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+                if is_pp_missing_parameter(name, self):
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class MiniMindForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config: MiniMindConfig = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        self.config = config
+        self.quant_config = quant_config
+        self.model = MiniMindModel(vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model"))
+
+        if get_pp_group().is_last_rank:
+            if config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.sampler = Sampler()
+        self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def sample(self, logits: torch.Tensor, sampling_metadata: SamplingMetadata) -> SamplerOutput | None:
+        return self.sampler(logits, sampling_metadata)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
+        )
+        return loader.load_weights(weights)

--- a/vllm_omni/model_executor/models/minimind_o/minimind_mm_utils.py
+++ b/vllm_omni/model_executor/models/minimind_o/minimind_mm_utils.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+"""MiniMind-O multimodal injection helpers (aligned with HF model_omni)."""
+
+from __future__ import annotations
+
+import torch
+
+
+def inject_audio_features(
+    tokens: torch.Tensor,
+    hidden_states: torch.Tensor,
+    audio_feats: list[torch.Tensor | None],
+    *,
+    audio_marker: int,
+) -> torch.Tensor:
+    if audio_feats is None or not audio_marker:
+        return hidden_states
+    out = []
+    for b in range(hidden_states.size(0)):
+        hb = hidden_states[b]
+        seq = tokens[b].tolist()
+        af = audio_feats[b] if b < len(audio_feats) else None
+        i = 0
+        while i < len(seq):
+            if seq[i] == audio_marker:
+                start = i
+                while i < len(seq) and seq[i] == audio_marker:
+                    i += 1
+                if af is not None:
+                    inject_len = min(af.size(0), i - start)
+                    hb = torch.cat((hb[:start], af[:inject_len], hb[start + inject_len :]), dim=0)
+                    af = None
+            else:
+                i += 1
+        out.append(hb)
+    return torch.stack(out)
+
+
+def inject_vision_features(
+    tokens: torch.Tensor,
+    hidden_states: torch.Tensor,
+    vision_tensors: torch.Tensor | None,
+    *,
+    image_marker: int,
+    seqlen: int | None = None,
+) -> torch.Tensor:
+    if vision_tensors is None or not image_marker:
+        return hidden_states
+    vf = vision_tensors
+    if vf.dim() == 3:
+        vf = vf.unsqueeze(1)
+    out = []
+    for b in range(hidden_states.size(0)):
+        hb = hidden_states[b]
+        seq = tokens[b].tolist()
+        k = 0
+        i = 0
+        while i < len(seq):
+            if seq[i] == image_marker:
+                start = i
+                while i < len(seq) and seq[i] == image_marker:
+                    i += 1
+                if k < vf.size(1):
+                    chunk = vf[b][k][: i - start]
+                    hb = torch.cat((hb[:start], chunk, hb[i:]), dim=0)
+                    k += 1
+            else:
+                i += 1
+        if seqlen is not None:
+            hb = hb[:seqlen]
+        out.append(hb)
+    return torch.stack(out)

--- a/vllm_omni/model_executor/models/minimind_o/minimind_o.py
+++ b/vllm_omni/model_executor/models/minimind_o/minimind_o.py
@@ -1,0 +1,945 @@
+import glob
+import os
+from collections.abc import Iterable
+from functools import cached_property
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.models.interfaces import SupportsMultiModal, SupportsPP
+from vllm.model_executor.models.utils import init_vllm_registered_model, maybe_prefix
+
+# from vllm.model_executor.models.qwen2_code2wav_dit import Qwen2Code2wav
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.sequence import IntermediateTensors
+from vllm.v1.outputs import SamplerOutput
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.sampler import Sampler
+
+from vllm_omni.data_entry_keys import OmniPayload
+from vllm_omni.model_executor.custom_process_mixin import CustomProcessMixin
+from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
+from vllm_omni.model_executor.models.minimind_o.config import (
+    MiniMindOConfig,
+    MiniMindOTalkerConfig,
+    MiniMindOThinkerConfig,
+)
+from vllm_omni.model_executor.models.minimind_o.processor import (
+    MiniMindOThinkerDummyInputsBuilder,
+    MiniMindOThinkerMultiModalProcessor,
+    MiniMindOThinkerProcessingInfo,
+)
+from vllm_omni.model_executor.models.output_templates import OmniOutput
+from vllm_omni.model_executor.models.utils import add_prefix_to_loaded_weights
+from vllm_omni.platforms import current_omni_platform
+
+# MiniMind-O token IDs (to be updated from actual config)
+MIMI_CODEC_EOS_TOKEN_ID = 2050  # audio_stop_token
+MIMI_CODEC_BOS_TOKEN_ID = 2049  # audio_pad_token
+MIMI_CODEC_PAD_TOKEN_ID = 2049
+MIMI_CODEC_SPK_TOKEN_ID = 2051  # audio_spk_token
+
+
+logger = init_logger(__name__)
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    MiniMindOThinkerMultiModalProcessor,
+    info=MiniMindOThinkerProcessingInfo,
+    dummy_inputs=MiniMindOThinkerDummyInputsBuilder,
+)
+class MiniMindOForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP, CustomProcessMixin):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        self.has_preprocess = False
+        self.have_multimodal_outputs = True
+        config: MiniMindOConfig = vllm_config.model_config.hf_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        # keep vllm_config for later submodule init
+        self.vllm_config = vllm_config
+
+        # Initialize thinker components
+        thinker_config: MiniMindOThinkerConfig = config.thinker_config
+        self.thinker_config = thinker_config
+        self.multimodal_config = multimodal_config
+
+        # Initialize talker components
+        talker_config: MiniMindOTalkerConfig = config.talker_config
+        self.talker_config = talker_config
+
+        self.model_stage = vllm_config.model_config.model_stage
+        if self.model_stage == "thinker":
+            # Initialize thinker model (multimodal processing)
+            self.thinker = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "thinker"),
+                hf_config=thinker_config,
+                architectures=["MiniMindOThinkerForConditionalGeneration"],
+            )
+            self.talker = None
+            self.code2wav = None
+
+        elif self.model_stage == "talker":
+            multimodal_config.skip_mm_profiling = True
+            self.has_preprocess = True
+            self.has_postprocess = True
+            self.set_custom_preprocess(self.talker_preprocess)
+            self.set_custom_postprocess(self.talker_postprocess)
+            self.thinker = None
+            self.talker = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "talker"),
+                hf_config=talker_config,
+                architectures=["MiniMindOTalkerForConditionalGeneration"],
+            )
+            self.code2wav = None
+            self.talker_mtp = self.talker
+            c2w_token_end_id = getattr(getattr(config, "code2wav_config", None), "codebook_size", None)
+            if c2w_token_end_id:
+                self.talker.set_suppress_start_id(c2w_token_end_id + 1)
+            self.requires_raw_input_tokens = True
+            self.thinker_embedding = nn.Embedding(
+                self.thinker_config.text_config.vocab_size,
+                self.thinker_config.text_config.hidden_size,
+            )
+            self._init_special_tokens_embeddings()
+
+        elif self.model_stage == "code2wav":
+            multimodal_config.skip_mm_profiling = True
+            self.thinker = None
+            self.talker = None
+            self.code2wav_config = getattr(config, "code2wav_config", None)
+            self.code2wav = None
+            if self.code2wav_config is not None:
+                self.code2wav = init_vllm_registered_model(
+                    vllm_config=vllm_config,
+                    prefix=maybe_prefix(prefix, "code2wav"),
+                    hf_config=self.code2wav_config,
+                    architectures=["MiniMindOCode2Wav"],
+                )
+            self._code2wav_conds: dict[str, torch.Tensor] = {}
+            self._code2wav_ref_mels: dict[str, torch.Tensor] = {}
+            self.requires_raw_input_tokens = True
+        else:
+            raise ValueError("Invalid model stage")
+
+        # Runner hooks (preprocess/MTP/sampler) live on the orchestrator module.
+        self.model = self
+
+        self.make_empty_intermediate_tensors = (
+            (self.thinker.make_empty_intermediate_tensors) if self.model_stage == "thinker" else lambda: None
+        )
+
+    def _stage_module(self) -> nn.Module:
+        if self.model_stage == "thinker":
+            return self.thinker
+        if self.model_stage == "talker":
+            return self.talker
+        if self.model_stage == "code2wav":
+            return self.code2wav
+        raise ValueError(f"Invalid model stage: {self.model_stage}")
+
+    # -------------------- Device utilities --------------------
+    @staticmethod
+    def _module_device(module: nn.Module) -> torch.device:
+        try:
+            return next(module.parameters()).device
+        except StopIteration:
+            # No parameters; fall back to buffers or cpu
+            for _, buf in module.named_buffers(recurse=True):
+                return buf.device
+            return torch.device("cpu")
+
+    def move_submodules_to_devices(
+        self,
+        *,
+        thinker_device: str | torch.device | None = None,
+        talker_device: str | torch.device | None = None,
+        code2wav_device: str | torch.device | None = None,
+    ) -> None:
+        """Optionally move thinker/talker/code2wav to different devices.
+
+        Example:
+            model.move_submodules_to_devices(
+                thinker_device='cuda:0',
+                talker_device='cuda:1',
+                code2wav_device='cpu',
+            )
+        """
+        if thinker_device is not None and self.thinker is not None:
+            self.thinker.to(thinker_device)
+        if talker_device is not None and self.talker is not None:
+            self.talker.to(talker_device)
+        if code2wav_device is not None and self.code2wav is not None:
+            self.code2wav.to(code2wav_device)
+
+    @cached_property
+    def sampler(self):
+        stage = self._stage_module()
+        if hasattr(stage, "sampler"):
+            return stage.sampler
+        return Sampler()
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings=None,
+        is_multimodal=None,
+    ) -> torch.Tensor:
+        if self.model_stage == "code2wav":
+            return torch.zeros_like(input_ids).reshape(-1, 1).repeat(1, self.vllm_config.model_config.get_hidden_size())
+        stage = self._stage_module()
+        if self.model_stage == "talker":
+            return stage.embed_input_ids(input_ids)
+        return stage.embed_input_ids(
+            input_ids=input_ids, multimodal_embeddings=multimodal_embeddings, is_multimodal=is_multimodal
+        )
+
+    def embed_multimodal(self, **kwargs):
+        return self._stage_module().embed_multimodal(**kwargs)
+
+    def last_index_of(self, list, value):
+        return len(list) - 1 - list[::-1].index(value)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        generate_audio: bool = True,
+        voice_type: str = "Chelsie",
+        codec: torch.Tensor | None = None,
+        sampling_metadata: SamplingMetadata | None = None,
+        logits_index: int | None = None,
+        sampler=None,
+        additional_information: dict[str, object] | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors | OmniOutput:
+        """
+        Workflow:
+        1) Thinker: multimodal understanding → text hidden states.
+        2) If audio requested and codec not provided, use talker to derive codec.
+        3) If audio requested (or codec provided), use code2wav to synthesize waveform.
+        4) Return text hidden states (and audio when applicable).
+        """
+        if self.model_stage == "thinker":
+            # Normalize to batched inputs if caller provides 1D/2D unbatched tensors
+            # TODO: Remove this hack when NPU supports batched inputs properly
+            added_batch_dim = False
+            if input_ids is not None and input_ids.ndim == 1:
+                input_ids = input_ids.unsqueeze(0)
+                added_batch_dim = True
+            if positions is not None and positions.ndim == 1:
+                positions = positions.unsqueeze(0)
+                added_batch_dim = True
+            if inputs_embeds is not None and inputs_embeds.ndim == 2:
+                inputs_embeds = inputs_embeds.unsqueeze(0)
+                added_batch_dim = True
+            thinker_dev = self._module_device(self.thinker)
+
+            # if input_ids is None, set it to a zero tensor, in the length of the
+            # same as the embedding seq length
+            if input_ids is None:
+                input_ids = torch.zeros(inputs_embeds.shape[1], dtype=torch.long, device=thinker_dev).unsqueeze(
+                    0
+                )  # (1, 0)
+                added_batch_dim = True
+
+            # 1) Thinker (ensure inputs on thinker's device)
+            if input_ids is not None and input_ids.device != thinker_dev:
+                input_ids = input_ids.to(thinker_dev)
+            if positions is not None and positions.device != thinker_dev:
+                positions = positions.to(thinker_dev)
+            if inputs_embeds is not None and inputs_embeds.device != thinker_dev:
+                inputs_embeds = inputs_embeds.to(thinker_dev)
+
+            if current_omni_platform.is_npu():
+                # TODO: remove this hack when NPU supports batched inputs properly
+                thinker_input_ids = input_ids[0] if input_ids is not None and added_batch_dim else input_ids
+                # For MRoPE, positions shape is [3, num_tokens] (T/H/W), don't slice it
+                if positions.ndim == 2 and positions.shape[0] == 3:
+                    thinker_positions = positions  # MRoPE positions, keep as is
+                else:
+                    thinker_positions = positions[0] if positions.ndim > 1 else positions
+                thinker_inputs_embeds = (
+                    inputs_embeds[0] if inputs_embeds is not None and added_batch_dim else inputs_embeds
+                )
+            else:
+                # Squeeze back if we added batch dim earlier
+                thinker_input_ids = input_ids[0] if input_ids is not None and added_batch_dim else input_ids
+                # For MRoPE, positions shape is [3, num_tokens] (T/H/W), don't slice it
+                if positions.ndim == 2 and positions.shape[0] == 3:
+                    thinker_positions = positions  # MRoPE positions, keep as is
+                elif added_batch_dim:
+                    thinker_positions = positions[0]
+                else:
+                    thinker_positions = positions
+                thinker_inputs_embeds = (
+                    inputs_embeds[0] if inputs_embeds is not None and added_batch_dim else inputs_embeds
+                )
+
+            # Run thinker
+            thinker_output = self.thinker(
+                input_ids=thinker_input_ids,
+                positions=thinker_positions,
+                intermediate_tensors=intermediate_tensors,
+                inputs_embeds=thinker_inputs_embeds,
+                **kwargs,
+            )
+
+            if isinstance(thinker_output, tuple):
+                embeds, text_hidden_states = thinker_output
+            else:
+                text_hidden_states = thinker_output
+
+            # Text-only path
+            return OmniOutput(
+                text_hidden_states=(text_hidden_states.reshape(-1, text_hidden_states.shape[-1])),
+                multimodal_outputs=None,
+            )
+
+        # 2) Talker (if codec not provided)
+        if self.model_stage == "talker":
+            # mock data for profile
+            if input_ids is None:
+                input_ids = torch.zeros(inputs_embeds.shape[0], dtype=torch.long, device=inputs_embeds.device)
+                self.thinker_reply_part = torch.zeros_like(inputs_embeds)
+
+            # TODO(Peiqi): temporal hack here to support voice_type.
+            if not hasattr(self, "voice_type"):
+                self.voice_type = voice_type
+
+            talker_positions = positions[0] if positions.ndim > 1 else positions
+
+            with torch.inference_mode():
+                talker_hidden = self.talker(
+                    input_ids=input_ids,
+                    positions=talker_positions,
+                    inputs_embeds=inputs_embeds,
+                )
+
+            multimodal_outputs = None
+            info_dicts = kwargs.get("model_intermediate_buffer")
+            if info_dicts is None:
+                info_dicts = kwargs.get("runtime_additional_information")
+            if isinstance(info_dicts, dict):
+                code_rows = []
+                for info in info_dicts.values():
+                    if not isinstance(info, dict):
+                        continue
+                    audio = info.get("codes", {}).get("audio")
+                    if isinstance(audio, torch.Tensor) and audio.numel() > 0:
+                        code_rows.append(audio.reshape(-1, 8) if audio.dim() == 1 else audio)
+                if code_rows:
+                    multimodal_outputs = {"codes": {"audio": torch.cat(code_rows, dim=0)}}
+
+            return OmniOutput(
+                text_hidden_states=talker_hidden,
+                multimodal_outputs=multimodal_outputs,
+            )
+
+        if self.model_stage == "code2wav":
+            code = (
+                input_ids
+                if input_ids is not None
+                else torch.zeros(
+                    inputs_embeds.shape[0],
+                    dtype=torch.long,
+                    device=inputs_embeds.device,
+                )
+            )
+
+            if code.numel() and code[-1] == MIMI_CODEC_EOS_TOKEN_ID:
+                code = code[:-1]
+            if code.numel() and code[0] == MIMI_CODEC_BOS_TOKEN_ID:
+                code = code[1:]
+
+            audio_tensor = self.generate_audio(code, voice_type) if code.numel() else torch.zeros(0, device=code.device)
+            return OmniOutput(text_hidden_states=None, multimodal_outputs={"model_outputs": audio_tensor})
+
+        return OmniOutput(
+            text_hidden_states=torch.zeros(
+                [inputs_embeds.shape[0], self.talker_config.talker_hidden_size],
+                dtype=torch.bfloat16,
+                device=self._module_device(self.model),
+            ),
+            multimodal_outputs=None,
+        )
+
+    def generate_audio(self, code, voice_type):
+        code2wav_dev = self._module_device(self.code2wav)
+        if isinstance(code, torch.Tensor):
+            code_tensor = code.to(dtype=torch.long, device=code2wav_dev)
+        else:
+            code_tensor = torch.as_tensor(code, dtype=torch.long, device=code2wav_dev)
+        if code_tensor.ndim == 2 and code_tensor.shape[0] == 1:
+            code_tensor = code_tensor.squeeze(0)
+
+        audio_tensor = self._codec_to_audio(code_tensor, voice_type)
+
+        return audio_tensor
+
+    def _load_talker_embedding(
+        self,
+    ) -> torch.nn.Embedding:
+        return self.talker.embed_tokens.base
+
+    def _init_special_tokens_embeddings(
+        self,
+    ):
+        # talker embeddings
+        self.talker_embedding = self._load_talker_embedding()
+
+        # embed_text_bos_token
+        talker_hf_config = self.talker_config
+        if hasattr(talker_hf_config, "talker_config"):
+            talker_hf_config = talker_hf_config.talker_config
+
+        spk_id = int(getattr(talker_hf_config, "audio_spk_token", talker_hf_config.tts_text_start_token_id))
+        self.tts_text_spk_token_ids = {"default": spk_id}
+        self.default_tts_text_spk_type = "default"
+
+        self.embed_text_bos_token = self.thinker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_text_start_token_id],
+                dtype=torch.long,
+                device=self._module_device(self.talker),
+            )
+        )
+        self.embed_text_spk_tokens = {
+            key: self.thinker_embedding(
+                torch.tensor(
+                    [value],
+                    dtype=torch.long,
+                    device=self._module_device(self.talker),
+                )
+            )
+            for key, value in self.tts_text_spk_token_ids.items()
+        }
+        self.embed_text_eos_token = self.thinker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_text_end_token_id],
+                dtype=torch.long,
+                device=self._module_device(self.talker),
+            )
+        )
+        self.embed_text_pad_token = self.thinker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_text_pad_token_id],
+                dtype=torch.long,
+                device=self._module_device(self.talker),
+            )
+        )
+        self.embed_codec_bos_token = self.talker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_codec_start_token_id],
+                dtype=torch.long,
+                device=self._module_device(self.talker),
+            )
+        )
+        self.embed_codec_eos_token = self.talker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_codec_end_token_id],
+                dtype=torch.long,
+                device=self._module_device(self.talker),
+            )
+        )
+        self.embed_codec_pad_token = self.talker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_codec_pad_token_id],
+                dtype=torch.long,
+                device=self._module_device(self.talker),
+            )
+        )
+        return set(["thinker_embedding.weight", "talker_embedding.weight"])
+
+    def _get_embed_text_spk_token(self, voice_type: str):
+        if not hasattr(self, "embed_text_spk_tokens") or voice_type not in self.embed_text_spk_tokens:
+            return self.embed_text_bos_token
+        return self.embed_text_spk_tokens[voice_type]
+
+    def _get_text_spk_token_id(self, voice_type: str):
+        talker_hf_config = self.talker_config
+        if hasattr(talker_hf_config, "talker_config"):
+            talker_hf_config = talker_hf_config.talker_config
+
+        if voice_type not in self.tts_text_spk_token_ids:
+            return talker_hf_config.tts_text_start_token_id
+        return self.tts_text_spk_token_ids[voice_type]
+
+    def talker_preprocess(
+        self,
+        input_ids: torch.Tensor,
+        input_embeds: torch.Tensor,
+        **info_dict: object,
+    ):
+        # Mixed-mode support: In a single step, both Prefill*n and Decode*n are supported.
+        # Rules:
+        # - Prefill segments are wrapped with special tokens: [BOS][PAD...][EOS]
+        # - Decode segments consist of a single non-special token.
+        # - If additional_information is provided (can be a list split by request or a
+        #   concatenated tensor plus a list of shapes), then for each request, reconstruct
+        #   the thinker→talker input embeddings for the Prefill segments;
+        # - For Decode segments, if per-request auxiliary decode embeddings are provided (optional),
+        #   add them; otherwise, keep the original embedding.
+
+        payload: OmniPayload = info_dict
+
+        # Ensure we have base embeddings when only ids are provided
+        if input_embeds is None and input_ids is not None:
+            input_embeds = self.talker.embed_input_ids(input_ids)
+
+        span_len = input_ids.shape[0]
+        if span_len > 1:
+            # prefill
+            return self.thinker_to_talker_process(input_ids, input_embeds, payload)
+        else:
+            # decode
+            return self.thinker_to_talker_decode_one_step(input_ids, input_embeds, payload)
+
+    def thinker_to_talker_process(
+        self,
+        input_ids: torch.Tensor,
+        input_embeds: torch.Tensor,
+        payload: OmniPayload,
+    ):
+        embed = payload.get("embed", {})
+        hs = payload.get("hidden_states", {})
+        ids = payload.get("ids", {})
+
+        update_dict = {}
+
+        prompt_embeds = embed.get("prefill")  # Tensor [P,H]
+        thinker_result = hs.get("output")  # Tensor [K,H]
+        prompt_token_ids = ids.get("prompt")  # list[int]
+        thinker_output_token_ids = ids.get("output")  # list[int]
+
+        if not isinstance(prompt_embeds, torch.Tensor):
+            prompt_embeds = torch.zeros(
+                0, self.talker.config.hidden_size, dtype=input_embeds.dtype, device=self._module_device(self.model)
+            )
+        if not isinstance(thinker_result, torch.Tensor):
+            thinker_result = torch.zeros(
+                0, self.talker.config.hidden_size, dtype=input_embeds.dtype, device=self._module_device(self.model)
+            )
+        if not isinstance(prompt_token_ids, (list, torch.Tensor)):
+            prompt_token_ids = []
+        if not isinstance(thinker_output_token_ids, (list, torch.Tensor)):
+            thinker_output_token_ids = []
+
+        audio_ids = embed.get("audio_ids")
+        if not isinstance(audio_ids, torch.Tensor):
+            seq_len = max(len(prompt_token_ids) + 1, 1)
+            audio_ids = torch.full(
+                (8, seq_len),
+                MIMI_CODEC_PAD_TOKEN_ID,
+                dtype=torch.long,
+                device=self._module_device(self.model),
+            )
+
+        req_input_ids, req_embeds = self._thinker_to_talker_prefill(
+            speaker=self.voice_type,
+            output_prompt_embeds=thinker_result.to(input_embeds.dtype).to(self._module_device(self.model)),
+            output_token_ids=thinker_output_token_ids,
+            thinker_prompt_embeds=prompt_embeds.to(input_embeds.dtype).to(self._module_device(self.model)),
+            prompt_token_ids=prompt_token_ids,
+            audio_ids=audio_ids,
+        )
+
+        if thinker_result.ndim == 2 and thinker_result.shape[0] > 0:
+            update_dict.setdefault("embed", {})["thinker_reply"] = thinker_result[1:].detach().to("cpu").contiguous()
+
+        update_dict.setdefault("meta", {})["audio_step"] = -1
+        update_dict.setdefault("embed", {})["audio_ids"] = audio_ids
+        return req_input_ids, req_embeds, update_dict
+
+    def _thinker_to_talker_prefill(
+        self,
+        speaker: str,
+        output_prompt_embeds,
+        output_token_ids,
+        thinker_prompt_embeds,
+        prompt_token_ids,
+        audio_ids: torch.Tensor,
+    ):
+        if thinker_prompt_embeds.numel() == 0 and output_prompt_embeds.numel() == 0:
+            bridge = thinker_prompt_embeds.new_zeros(0, self.talker_config.hidden_size)
+        else:
+            parts = [thinker_prompt_embeds]
+            if output_prompt_embeds.numel() > 0:
+                parts.append(output_prompt_embeds[:1])
+            bridge = torch.cat(parts, dim=0)
+
+        bridge_b = bridge.unsqueeze(0)
+        if audio_ids.dim() == 2:
+            audio_b = audio_ids.unsqueeze(0)
+        else:
+            audio_b = audio_ids
+        if audio_b.shape[-1] < bridge_b.shape[1]:
+            pad_cols = bridge_b.shape[1] - audio_b.shape[-1]
+            audio_b = torch.cat(
+                [
+                    audio_b,
+                    audio_b.new_full(
+                        (*audio_b.shape[:-1], pad_cols),
+                        self.talker_config.audio_pad_token,
+                    ),
+                ],
+                dim=-1,
+            )
+        elif audio_b.shape[-1] > bridge_b.shape[1]:
+            audio_b = audio_b[..., : bridge_b.shape[1]]
+
+        req_embeds = self.talker.build_fused_embeds(bridge_b, audio_b).squeeze(0)
+        req_input_ids = torch.full(
+            (bridge_b.shape[1],),
+            self.talker_config.audio_pad_token,
+            dtype=torch.int64,
+            device=self._module_device(self.talker),
+        )
+        return req_input_ids, req_embeds
+
+    def thinker_to_talker_decode_one_step(self, input_ids, input_embeds, payload: OmniPayload):
+        embed = payload.get("embed", {})
+        hs = payload.get("hidden_states", {})
+
+        update_dict = {}
+        step_vec = None
+        q = embed.get("thinker_reply", None)
+        if isinstance(q, torch.Tensor) and q.numel() > 0:
+            step_vec = q[0:1]
+            new_q = q[1:].detach().to("cpu").contiguous()
+            update_dict.setdefault("embed", {})["thinker_reply"] = new_q
+        else:
+            # B) per-request provided decode vector (optional)
+            dv = embed.get("decode")
+            if isinstance(dv, torch.Tensor) and dv.numel() > 0:
+                step_vec = dv[0:1] if dv.ndim == 2 else dv.view(1, -1)
+            elif (
+                hasattr(self, "thinker_reply_part")
+                and isinstance(self.thinker_reply_part, torch.Tensor)
+                and self.thinker_reply_part.numel() > 0
+            ):
+                # C) fallback shared pool
+                step_vec = self.thinker_reply_part[0:1]
+                self.thinker_reply_part = self.thinker_reply_part[1:]
+
+        audio_ids = embed.get("audio_ids")
+        meta = payload.get("meta", {})
+        audio_step = int(meta.get("audio_step", -1)) + 1
+        update_dict.setdefault("meta", {})["audio_step"] = audio_step
+
+        last_hidden = hs.get("last")
+        if not isinstance(last_hidden, torch.Tensor):
+            last_hidden = torch.zeros(
+                self.talker_config.talker_hidden_size,
+                device=input_embeds.device,
+                dtype=input_embeds.dtype,
+            )
+
+        if isinstance(step_vec, torch.Tensor) and step_vec.numel() > 0:
+            one_id = input_ids[0:1]
+            if not isinstance(audio_ids, torch.Tensor):
+                audio_ids = torch.full(
+                    (8, 1),
+                    self.talker_config.audio_pad_token,
+                    dtype=torch.long,
+                    device=step_vec.device,
+                )
+            else:
+                if audio_ids.dim() == 2:
+                    audio_ids = audio_ids[:, -1:].contiguous()
+                else:
+                    audio_ids = audio_ids[..., -1:].contiguous()
+            _, one_embed = self._thinker_to_talker_decode_one_step(
+                output_prompt_embeds=step_vec.to(input_embeds.dtype).to(self._module_device(self.talker)),
+                output_token_ids=one_id,
+                audio_ids=audio_ids,
+            )
+            input_embeds = one_embed.unsqueeze(0) if one_embed.dim() == 1 else one_embed
+
+        update_dict["mtp_inputs"] = (
+            last_hidden.detach().to(device=input_embeds.device, dtype=input_embeds.dtype),
+            step_vec.detach().to(device=input_embeds.device, dtype=input_embeds.dtype)
+            if isinstance(step_vec, torch.Tensor) and step_vec.numel() > 0
+            else torch.zeros(self.talker_config.hidden_size, device=input_embeds.device, dtype=input_embeds.dtype),
+        )
+        update_dict.setdefault("embed", {})["audio_ids"] = audio_ids
+        return input_ids[0:1], input_embeds[0:1], update_dict
+
+    def _thinker_to_talker_decode_one_step(
+        self,
+        output_prompt_embeds,
+        output_token_ids,
+        audio_ids: torch.Tensor,
+    ):
+        bridge_b = output_prompt_embeds.unsqueeze(0)
+        audio_b = audio_ids.unsqueeze(0) if audio_ids.dim() == 2 else audio_ids
+        fused = self.talker.build_fused_embeds(bridge_b, audio_b).squeeze(0)
+        return output_token_ids, fused
+
+    def compute_logits(self, hidden_states: torch.Tensor | OmniOutput, **kwargs: object) -> torch.Tensor | None:
+        # Handle OmniOutput type
+        if isinstance(hidden_states, OmniOutput):
+            hidden_states = hidden_states.text_hidden_states
+
+        # Use thinker model for logits computation
+        return self._stage_module().compute_logits(hidden_states)
+
+    def sample(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> SamplerOutput | None:
+        return self._stage_module().sample(logits, sampling_metadata)
+
+    def talker_postprocess(self, hidden_states: torch.Tensor, **info_dict: object):
+        return self.talker.talker_postprocess(hidden_states, **info_dict)
+
+    def preprocess_decode_batch(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        req_infos: list[dict],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, list[dict]]:
+        input_ids_flat = input_ids.reshape(-1)
+        out_ids: list[torch.Tensor] = []
+        out_embeds: list[torch.Tensor] = []
+        last_hidden: list[torch.Tensor] = []
+        text_steps: list[torch.Tensor] = []
+        updates: list[dict] = []
+        audio_steps: list[int] = []
+        audio_ids_batch: list[torch.Tensor] = []
+
+        for row, info_dict in enumerate(req_infos):
+            start = int(row)
+            one_id = input_ids_flat[start : start + 1]
+            embed_slice = None
+            _, one_embed, upd = self.talker_preprocess(one_id, embed_slice, **info_dict)
+            mtp = upd.pop("mtp_inputs")
+            last_h, text_s = mtp
+            out_ids.append(one_id)
+            out_embeds.append(one_embed.reshape(1, -1))
+            last_hidden.append(last_h.reshape(1, -1))
+            text_steps.append(text_s.reshape(1, -1))
+            updates.append(upd)
+            audio_steps.append(int(upd.get("meta", {}).get("audio_step", -1)))
+            audio_ids_batch.append(upd.get("embed", {}).get("audio_ids"))
+
+        self.talker._pending_audio_steps = torch.tensor(audio_steps, dtype=torch.long, device=out_embeds[0].device)
+        self.talker._pending_audio_ids = audio_ids_batch
+        return (
+            torch.stack(out_ids, dim=0),
+            torch.cat(out_embeds, dim=0),
+            torch.cat(last_hidden, dim=0),
+            torch.cat(text_steps, dim=0),
+            updates,
+        )
+
+    def talker_mtp(
+        self,
+        input_ids: torch.Tensor,
+        input_embeds: torch.Tensor,
+        last_talker_hidden: torch.Tensor,
+        text_step: torch.Tensor,
+        **kwargs: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        pending_steps = getattr(self.talker, "_pending_audio_steps", None)
+        pending_audio = getattr(self.talker, "_pending_audio_ids", None)
+        bsz = int(input_ids.reshape(-1).shape[0])
+        if pending_steps is not None and pending_steps.numel() >= bsz:
+            kwargs = dict(kwargs)
+            kwargs["audio_steps"] = pending_steps[:bsz]
+        if pending_audio is not None:
+            kwargs = dict(kwargs)
+            kwargs["audio_ids_list"] = pending_audio[:bsz]
+        return self.talker.talker_mtp(
+            input_ids,
+            input_embeds,
+            last_talker_hidden,
+            text_step,
+            **kwargs,
+        )
+
+    def generate_speech(self, text_tokens: torch.Tensor, voice_type: str = "default") -> torch.Tensor:
+        """
+        Generate speech from text tokens using the talker and token2wav models.
+        This method is kept for backward compatibility and direct speech generation.
+
+        Args:
+            text_tokens: Text tokens from thinker model
+            voice_type: Voice type for speech generation
+
+        Returns:
+            Audio tensor
+        """
+        # Generate codec tokens using talker model
+        talker_output = self.talker(input_ids=None, positions=None, inputs_embeds=text_tokens)
+
+        # Convert talker output to codec tokens
+        codec_tokens = self._convert_to_codec_tokens(talker_output)
+
+        # Generate audio using code2wav model
+        return self._codec_to_audio(codec_tokens, voice_type=voice_type)
+
+    def _convert_to_codec_tokens(
+        self, talker_output: torch.Tensor, sampling_metadata: SamplingMetadata
+    ) -> torch.Tensor:
+        """
+        Reference (HF): use the talker's codec head to obtain logits, suppress BOS,
+        then greedily select the next codec token for the current step.
+        """
+        with torch.inference_mode():
+            logits = self.talker.compute_logits(talker_output, None)
+            if logits is None:
+                return torch.zeros(
+                    (talker_output.size(0), 0),
+                    dtype=torch.long,
+                    device=talker_output.device,
+                )
+
+            # Suppress only codec_bos, consistent with HF generate's
+            # suppress_tokens behavior
+            bos_id = None
+            if hasattr(self, "talker_config") and hasattr(self.talker_config, "tts_codec_start_token_id"):
+                bos_id = int(getattr(self.talker_config, "tts_codec_start_token_id"))
+            if bos_id is not None:
+                logits[..., bos_id] = -1e9
+
+            # Take the distribution at the last step and select greedily
+            next_id = self.talker.sample(logits, sampling_metadata).sampled_token_ids
+            return next_id.to(dtype=torch.long)
+
+    def _init_code2wav_model(self, hf_model_folder):
+        """Initialize speaker resources if provided; model is constructed in
+        __init__."""
+        if self.code2wav is None or self.code2wav_config is None:
+            return
+        device = self._module_device(self.code2wav)
+        # optional speaker resources
+        conds = getattr(self.code2wav_config, "conds", None)
+        ref_mels = getattr(self.code2wav_config, "ref_mels", None)
+        if isinstance(conds, dict) and isinstance(ref_mels, dict):
+            self._code2wav_conds = {k: torch.as_tensor(v, device=device) for k, v in conds.items()}
+            self._code2wav_ref_mels = {k: torch.as_tensor(v, device=device) for k, v in ref_mels.items()}
+        # legacy: load from directory if provided
+        model_path = hf_model_folder
+        if isinstance(model_path, str) and os.path.isdir(model_path):
+            spk_pt = os.path.join(model_path, "spk_dict.pt")
+            if os.path.exists(spk_pt):
+                data = torch.load(spk_pt, map_location=device)
+                for key, value in data.items():
+                    self._code2wav_conds[key] = value["cond"].to(device)
+                    self._code2wav_ref_mels[key] = value["ref_mel"].to(device)
+            else:
+                # legacy npy inputs
+                for f in sorted(glob.glob(os.path.join(model_path, "inputs", "*spk_emb.npy"))):
+                    key = os.path.basename(f).split("_")[0].lower()
+                    self._code2wav_conds[key] = torch.as_tensor(np.load(f), device=device)
+                for f in sorted(glob.glob(os.path.join(model_path, "inputs", "*ref_mel.npy"))):
+                    key = os.path.basename(f).split("_")[0].lower()
+                    self._code2wav_ref_mels[key] = torch.as_tensor(np.load(f), device=device)
+
+    def _codec_to_audio(self, codec_tokens: torch.Tensor, voice_type: str = "default") -> torch.Tensor | None:
+        del voice_type  # placeholder decoder has no per-speaker conditioning yet
+        if self.code2wav is None:
+            return None
+        code2wav_dev = self._module_device(self.code2wav)
+        if isinstance(codec_tokens, torch.Tensor):
+            codec = codec_tokens.to(dtype=torch.long, device=code2wav_dev)
+            if codec.ndim == 1:
+                codec = codec.unsqueeze(0)
+        else:
+            codec = torch.as_tensor(codec_tokens, dtype=torch.long, device=code2wav_dev).unsqueeze(0)
+        with torch.inference_mode():
+            waveform = self.code2wav(input_ids=codec)
+        return waveform.squeeze().reshape(-1)
+
+    @staticmethod
+    def _partition_omni_weights(
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> tuple[list, list, list, list]:
+        """Split flat MiniMind-O HF keys or staged thinker./talker./ prefixes."""
+        thinker_weights = []
+        talker_weights = []
+        code2wav_weights = []
+        other = []
+        thinker_prefixes = ("model.", "lm_head.", "audio_proj.", "vision_proj.")
+        for k, v in weights:
+            if k.startswith("thinker."):
+                thinker_weights.append((k[len("thinker.") :], v))
+            elif k.startswith("talker."):
+                talker_weights.append((k, v))
+            elif k.startswith("code2wav."):
+                code2wav_weights.append((k, v))
+            elif k.startswith(thinker_prefixes):
+                thinker_weights.append((k, v))
+            else:
+                other.append((k, v))
+        return thinker_weights, talker_weights, code2wav_weights, other
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load weights for all components of the omni model."""
+        loaded_weights = set()
+        thinker_weights, talker_weights, code2wav_weights, other = self._partition_omni_weights(weights)
+        if other:
+            raise ValueError(f"Unknown weight keys: {[k for k, _ in other[:5]]}")
+
+        # Load thinker weights
+        if self.thinker:
+            if thinker_weights:
+                thinker_loaded = self.thinker.load_weights(thinker_weights)
+            else:
+                thinker_loaded = set([k for k, v in thinker_weights])
+            thinker_loaded = add_prefix_to_loaded_weights(thinker_loaded, "thinker")
+            loaded_weights.update(thinker_loaded)
+
+        # Load talker weights
+        if talker_weights and self.talker is not None:
+            # Map talker weights to appropriate components
+            if self.thinker is None:
+                thinker_embedding_weights = [
+                    w
+                    for n, w in thinker_weights
+                    if n in ("model.embed_tokens.weight", "thinker.model.embed_tokens.weight")
+                ]
+                if thinker_embedding_weights:
+                    self.thinker_embedding = nn.Embedding(
+                        thinker_embedding_weights[0].shape[0],
+                        thinker_embedding_weights[0].shape[1],
+                    )
+                    self.thinker_embedding.weight = nn.Parameter(
+                        thinker_embedding_weights[0].to(self._module_device(self.talker))
+                    )
+            talker_loaded = self.talker.load_weights(talker_weights)
+            talker_loaded = add_prefix_to_loaded_weights(talker_loaded, "talker")
+            loaded_weights.update(talker_loaded)
+            loaded_weights.update(self._init_special_tokens_embeddings())
+
+        # Load code2wav weights (if any)
+        if code2wav_weights and self.code2wav is not None:
+            # download weights from huggingface for spk_dict.pt
+            model_path = self.vllm_config.model_config.model
+            download_dir = self.vllm_config.load_config.download_dir
+            if os.path.exists(model_path):
+                hf_model_folder = model_path
+            else:
+                hf_model_folder = download_weights_from_hf_specific(
+                    model_path,
+                    download_dir,
+                    allow_patterns=["*.pt"],
+                )
+            self._init_code2wav_model(hf_model_folder)
+            c2w_loaded = self.code2wav.load_weights(code2wav_weights, os.path.join(hf_model_folder, "spk_dict.pt"))
+            c2w_loaded = add_prefix_to_loaded_weights(c2w_loaded, "code2wav")
+            loaded_weights.update(c2w_loaded)
+
+        return loaded_weights
+
+
+class MiniMindOMoeForConditionalGeneration(MiniMindOForConditionalGeneration):
+    """Same staged omni stack; enable MoE via HF config ``use_moe: true``."""

--- a/vllm_omni/model_executor/models/minimind_o/minimind_o_code2wav.py
+++ b/vllm_omni/model_executor/models/minimind_o/minimind_o_code2wav.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+# MiniMind-O Code2Wav stage - Mimi codec decoder.
+
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+)
+from vllm.sequence import IntermediateTensors
+
+from vllm_omni.model_executor.models.minimind_o.config import MiniMindOCode2WavConfig
+
+logger = init_logger(__name__)
+
+
+class MiniMindOCode2Wav(nn.Module):
+    """
+    Mimi codec decoder - converts 8-layer Mimi codes to 24kHz waveform.
+
+    Specs:
+    - 8-layer codebook
+    - 12.5 Hz frame rate
+    - 24 kHz output sample rate
+    - Upsampling factor: ~1920x (24000 / 12.5)
+
+    Note: This is a placeholder implementation. The actual Mimi decoder
+    architecture needs to be obtained from the MiniMind-O repository.
+    """
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "code2wav.": "",
+        }
+    )
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config: MiniMindOCode2WavConfig = vllm_config.model_config.hf_config
+        self.config = config
+        self.prefix = prefix
+
+        # Code embedding for 8-layer Mimi codes
+        self.code_embedding = nn.Embedding(
+            config.codebook_size * config.num_quantizers,
+            config.hidden_size,
+        )
+
+        # Pre-transformer for temporal context
+        self.pre_transformer = nn.TransformerEncoder(
+            nn.TransformerEncoderLayer(
+                d_model=config.hidden_size,
+                nhead=8,
+                dim_feedforward=config.hidden_size * 4,
+                dropout=0.0,
+                batch_first=True,
+            ),
+            num_layers=2,
+        )
+
+        # Upsampling blocks
+        # Upsampling from 12.5 Hz to 24 kHz requires ~1920x upsampling
+        self.upsample = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.ConvTranspose1d(
+                        config.hidden_size,
+                        config.hidden_size,
+                        kernel_size=4,
+                        stride=2,
+                        padding=1,
+                    ),
+                    nn.GELU(),
+                )
+                for _ in range(10)  # 2^10 = 1024x, need more for 1920x
+            ]
+        )
+
+        # Final decoder to waveform
+        self.decoder = nn.Conv1d(
+            config.hidden_size,
+            1,
+            kernel_size=3,
+            padding=1,
+        )
+
+        self.make_empty_intermediate_tensors = lambda: None
+
+    def forward(
+        self,
+        input_ids: torch.Tensor = None,
+        positions: torch.Tensor = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor:
+        """
+        Convert 8-layer Mimi codes to audio waveform.
+
+        Args:
+            input_ids: [batch, seq_len] Mimi code IDs (flattened 8 layers)
+
+        Returns:
+            [batch, 1, waveform_len] audio waveform at 24 kHz
+        """
+        assert input_ids is not None, "input_ids must be provided"
+
+        # Embed codes
+        x = self.code_embedding(input_ids)  # [batch, seq_len, hidden_size]
+
+        # Pre-transformer for temporal context
+        x = self.pre_transformer(x)  # [batch, seq_len, hidden_size]
+
+        # Transpose for conv1d
+        x = x.transpose(1, 2)  # [batch, hidden_size, seq_len]
+
+        # Upsample
+        for upsample_block in self.upsample:
+            x = upsample_block(x)
+
+        # Decode to waveform
+        waveform = self.decoder(x)  # [batch, 1, waveform_len]
+
+        return waveform
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        loaded = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+        # Log load summary
+        try:
+            total_bytes = 0
+            for name, param in self.named_parameters():
+                if param is not None and param.data is not None:
+                    total_bytes += param.data.numel() * param.data.element_size()
+            device = next(self.parameters()).device
+            logger.info(
+                "[Model Loaded] name=%s, success=%s, size=%.2f MB, device=%s",
+                self.__class__.__name__,
+                True,
+                total_bytes / (1024**2),
+                str(device),
+            )
+        except Exception:
+            pass
+        return loaded

--- a/vllm_omni/model_executor/models/minimind_o/minimind_o_talker.py
+++ b/vllm_omni/model_executor/models/minimind_o/minimind_o_talker.py
@@ -1,0 +1,465 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+# MiniMind-O Talker stage with MTP head for 8-layer Mimi codes.
+
+from collections.abc import Iterable
+from functools import cached_property
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    init_vllm_registered_model,
+    maybe_prefix,
+)
+from vllm.sequence import IntermediateTensors
+from vllm.v1.outputs import SamplerOutput
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.sampler import Sampler
+
+from vllm_omni.model_executor.models.minimind_o.config import MiniMindOTalkerConfig
+
+logger = init_logger(__name__)
+
+
+class MiniMindOMTPHead(nn.Module):
+    """MTP (Multi-Token Prediction) head for generating 8-layer Mimi codes.
+
+    Pattern from MiniMind-O: base linear + 8 adapter layers.
+    Each adapter is a low-rank bottleneck (Linear → GELU → Linear).
+    """
+
+    def __init__(self, in_features: int, out_features: int, num_layers: int = 8, rank: int = 256):
+        super().__init__()
+        self.num_layers = num_layers
+        self.base = nn.Linear(in_features, out_features, bias=False)
+        self.adapters = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(in_features, rank, bias=False), nn.GELU(), nn.Linear(rank, out_features, bias=False)
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(self, x: torch.Tensor):
+        """Generate logits for all 8 layers.
+
+        Args:
+            x: [batch, seq_len, in_features] hidden states
+
+        Returns:
+            List of [batch, seq_len, out_features] logits for each layer
+        """
+        base_out = self.base(x)
+        return [base_out + adapter(x) for adapter in self.adapters]
+
+
+class MiniMindOTalkerEmbedding(nn.Module):
+    """Embedding with adapters for 8-layer Mimi codes.
+
+    Pattern from MiniMind-O: base embedding + 8 adapter layers.
+    """
+
+    def __init__(self, num_embeddings: int, embedding_dim: int, num_layers: int = 8, rank: int = 256):
+        super().__init__()
+        self.num_layers = num_layers
+        self.base = nn.Embedding(num_embeddings, embedding_dim)
+        self.adapters = nn.ModuleList(
+            [
+                nn.Sequential(nn.Embedding(num_embeddings, rank), nn.GELU(), nn.Linear(rank, embedding_dim, bias=False))
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(self, x: torch.Tensor):
+        """Embed 8-layer codes and average across layers.
+
+        Args:
+            x: [batch, 8, seq_len] 8-layer code IDs
+
+        Returns:
+            [batch, seq_len, embedding_dim] averaged embeddings
+        """
+        base_out = self.base(x)
+        # Sum base + adapter outputs for each layer, then average
+        layer_outputs = []
+        for i in range(len(self.adapters)):
+            layer_outputs.append(base_out[:, i, :] + self.adapters[i](x[:, i, :]))
+        return sum(layer_outputs) / self.num_layers
+
+
+class MiniMindOTalkerForConditionalGeneration(
+    nn.Module,
+    SupportsPP,
+):
+    """
+    MiniMind-O Talker stage with MTP head.
+
+    Components:
+    - thinker_to_talker_proj: Projection from thinker to talker dimension
+    - language_model: LLM backbone (generates layer 0)
+    - mtp_head: MTP head (generates layers 1-7)
+    - codec_head: Projects to Mimi vocabulary
+    - embed_tokens: Embedding for 8-layer codes
+    """
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "talker.layers.": "language_model.model.layers.",
+            "talker.lm_head.": "mtp_head.",
+            "talker.embed_tokens.": "embed_tokens.",
+            "talker.codec_proj.": "codec_proj.",
+            "talker.embed_proj.": "embed_proj.",
+            "talker.spk_proj.": "spk_proj.",
+            "talker.text_scale": "text_scale",
+            "talker.audio_scale": "audio_scale",
+            "talker.": "",
+        }
+    )
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config: MiniMindOTalkerConfig = vllm_config.model_config.hf_config
+        self.vllm_config = vllm_config
+        self.prefix = prefix
+        self.config = config
+
+        self.language_model = init_vllm_registered_model(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "language_model"),
+            hf_config=config.text_config,
+            architectures=["MiniMindForCausalLM"],
+        )
+
+        self.make_empty_intermediate_tensors = self.language_model.make_empty_intermediate_tensors
+
+        # MTP head for 8-layer code generation
+        self.mtp_head = MiniMindOMTPHead(
+            config.talker_hidden_size,
+            config.audio_vocab_size,
+            num_layers=config.mtp_num_layers,
+            rank=config.mtp_rank,
+        )
+
+        # Embedding for 8-layer codes
+        self.embed_tokens = MiniMindOTalkerEmbedding(
+            config.audio_vocab_size,
+            config.talker_hidden_size,
+            num_layers=config.mtp_num_layers,
+            rank=config.mtp_rank,
+        )
+
+        # Codec projection (from MiniMind-O)
+        self.codec_proj = nn.Sequential(
+            nn.Linear(config.talker_hidden_size, config.talker_hidden_size),
+            nn.GELU(),
+            nn.Linear(config.talker_hidden_size, config.talker_hidden_size),
+            RMSNorm(config.talker_hidden_size, eps=config.rms_norm_eps),
+        )
+
+        self.embed_proj = nn.Sequential(
+            nn.Linear(config.hidden_size, config.hidden_size),
+            nn.GELU(),
+            nn.Linear(config.hidden_size, config.talker_hidden_size),
+            RMSNorm(config.talker_hidden_size, eps=config.rms_norm_eps),
+        )
+
+        # Speaker projection (from MiniMind-O)
+        self.spk_proj = nn.Linear(config.spk_emb_size, config.talker_hidden_size, bias=False)
+
+        # Learnable scales (from MiniMind-O)
+        self.text_scale = nn.Parameter(torch.tensor(3.0))
+        self.audio_scale = nn.Parameter(torch.tensor(1.0))
+
+        # Special tokens
+        self.audio_pad_token = config.audio_pad_token
+        self.audio_stop_token = config.audio_stop_token
+        self.audio_spk_token = config.audio_spk_token
+
+        # suppress start id
+        self.suppress_start_id = None
+
+        self.talker_mtp = self
+        self.talker_mtp_output_key = ("codes", "audio")
+        self.mtp_temperature = 0.2
+        self.mtp_top_k = 50
+
+    def get_language_model(self) -> torch.nn.Module:
+        return self.language_model
+
+    @cached_property
+    def sampler(self):
+        if hasattr(self.language_model, "sampler"):
+            return self.language_model.sampler
+        return Sampler()
+
+    @staticmethod
+    def _parse_stacked_input_ids(
+        input_ids: torch.Tensor | None,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        if input_ids is None:
+            return None, None
+        if input_ids.dim() == 3:
+            if input_ids.shape[1] == 9:
+                return input_ids[:, :8, :], input_ids[:, 8, :]
+            if input_ids.shape[1] == 8:
+                return input_ids, None
+        return None, input_ids
+
+    def build_fused_embeds(
+        self,
+        bridge_states: torch.Tensor,
+        audio_ids: torch.Tensor | None = None,
+        *,
+        spk_emb: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """HF: embed_proj(bridge)*text_scale + codec_proj(embed_tokens(audio))*audio_scale."""
+        if bridge_states.dim() == 2:
+            bridge_states = bridge_states.unsqueeze(0)
+        batch_size, seq_len, _ = bridge_states.shape
+        device = bridge_states.device
+        dtype = bridge_states.dtype
+
+        if audio_ids is None:
+            audio_ids = torch.full(
+                (batch_size, self.config.mtp_num_layers, seq_len),
+                self.audio_pad_token,
+                dtype=torch.long,
+                device=device,
+            )
+        elif audio_ids.dim() == 2:
+            audio_ids = audio_ids.unsqueeze(0)
+        if audio_ids.size(0) == 1 and batch_size > 1:
+            audio_ids = audio_ids.expand(batch_size, -1, -1)
+        if audio_ids.size(2) != seq_len:
+            if audio_ids.size(2) > seq_len:
+                audio_ids = audio_ids[..., :seq_len]
+            else:
+                pad = audio_ids.new_full(
+                    (audio_ids.size(0), audio_ids.size(1), seq_len - audio_ids.size(2)),
+                    self.audio_pad_token,
+                )
+                audio_ids = torch.cat([audio_ids, pad], dim=-1)
+
+        talker_emb = self.embed_tokens(audio_ids)
+        if spk_emb is not None:
+            spk_mask = (audio_ids[:, 0, :] == self.audio_spk_token).unsqueeze(-1)
+            spk = self.spk_proj(spk_emb.to(device=device, dtype=dtype))
+            if spk.dim() == 1:
+                spk = spk.unsqueeze(0)
+            talker_emb = torch.where(spk_mask, spk.unsqueeze(1), talker_emb)
+
+        text_part = self.embed_proj(bridge_states) * self.text_scale
+        audio_part = self.codec_proj(talker_emb) * self.audio_scale
+        return text_part + audio_part
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Flat codec ids → base talker embedding (prefill without bridge states)."""
+        if input_ids.dim() == 3:
+            audio_ids, _ = self._parse_stacked_input_ids(input_ids)
+            return self.embed_tokens(audio_ids)
+        return self.language_model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor = None,
+        positions: torch.Tensor = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        assert input_ids is not None or inputs_embeds is not None, "input_ids or inputs_embeds must be provided"
+
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+        else:
+            bridge_states = kwargs.pop("bridge_states", None)
+            audio_ids = kwargs.pop("audio_ids", None)
+            spk_emb = kwargs.pop("spk_emb", None)
+            if audio_ids is None:
+                parsed_audio, _ = self._parse_stacked_input_ids(input_ids)
+                audio_ids = parsed_audio
+
+            if bridge_states is not None or audio_ids is not None:
+                if bridge_states is None:
+                    bridge_states = inputs_embeds
+                inputs_embeds = self.build_fused_embeds(
+                    bridge_states,
+                    audio_ids=audio_ids,
+                    spk_emb=spk_emb if isinstance(spk_emb, torch.Tensor) else None,
+                )
+            elif inputs_embeds is None and input_ids is not None:
+                inputs_embeds = self.embed_input_ids(input_ids)
+
+        input_ids = None
+
+        hidden_states = self.language_model.model(
+            input_ids, positions, intermediate_tensors, inputs_embeds=inputs_embeds
+        )
+        return hidden_states
+
+    def compute_mtp_logits(self, hidden_states: torch.Tensor) -> list[torch.Tensor]:
+        """Compute logits for all 8 layers using MTP head."""
+        return self.mtp_head(hidden_states)
+
+    def bad_word_processor(self, logits: torch.Tensor) -> torch.Tensor:
+        """Suppress unsupported token IDs."""
+        if self.suppress_start_id and self.suppress_start_id < logits.size(-1):
+            end_id = int(getattr(self.config, "tts_codec_end_token_id", self.audio_stop_token))
+            if self.suppress_start_id == end_id:
+                logits[..., end_id + 1 : logits.size(-1)] = -1e9
+            elif self.suppress_start_id < end_id:
+                logits[..., self.suppress_start_id : end_id] = -1e9
+                logits[..., end_id + 1 : logits.size(-1)] = -1e9
+            else:
+                logits[..., self.suppress_start_id : logits.size(-1)] = -1e9
+
+        if hasattr(self.config, "tts_codec_start_token_id"):
+            bos_id = int(getattr(self.config, "tts_codec_start_token_id", self.audio_pad_token))
+            logits[..., bos_id] = -1e9
+        return logits
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        # Layer-0 logits from MTP head (matches talker.lm_head.base + adapters[0])
+        logits = self.mtp_head(hidden_states)[0]
+        logits = self.bad_word_processor(logits)
+        return logits
+
+    def sample(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> SamplerOutput | None:
+        return self.language_model.sample(logits, sampling_metadata)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=["thinker.", "code2wav."],
+        )
+        loaded = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+        # Log load summary
+        try:
+            total_bytes = 0
+            for name, param in self.named_parameters():
+                if param is not None and param.data is not None:
+                    total_bytes += param.data.numel() * param.data.element_size()
+            device = next(self.parameters()).device
+            logger.info(
+                "[Model Loaded] name=%s, success=%s, size=%.2f MB, device=%s",
+                self.__class__.__name__,
+                True,
+                total_bytes / (1024**2),
+                str(device),
+            )
+        except Exception:
+            pass
+        return loaded
+
+    def set_suppress_start_id(self, start_id: int):
+        self.suppress_start_id = start_id
+        logger.debug(f"Set suppress start id to {self.suppress_start_id}")
+
+    def talker_postprocess(self, hidden_states: torch.Tensor, **info_dict: object) -> dict:
+        return {"hidden_states": {"last": hidden_states[-1].detach()}}
+
+    @staticmethod
+    def _sample_mimi_layer_logits(
+        logits: torch.Tensor,
+        prev_codes: list[int],
+        *,
+        generator: torch.Generator | None = None,
+        temperature: float = 0.2,
+        top_k: int = 50,
+    ) -> int:
+        logits = logits.clone() / max(temperature, 1e-9)
+        for code in prev_codes[-3:]:
+            if 0 <= code < logits.numel():
+                logits[code] /= 1.05
+        top_val, top_idx = torch.topk(logits, top_k)
+        pick = torch.multinomial(F.softmax(top_val, dim=-1), 1, generator=generator).item()
+        return int(top_idx[pick].item())
+
+    @torch.inference_mode()
+    def talker_mtp(
+        self,
+        input_ids: torch.Tensor,
+        input_embeds: torch.Tensor,
+        last_talker_hidden: torch.Tensor,
+        text_step: torch.Tensor,
+        *,
+        audio_step: int | None = None,
+        audio_ids: torch.Tensor | None = None,
+        audio_code_history: torch.Tensor | None = None,
+        audio_steps: torch.Tensor | None = None,
+        audio_ids_list: list | None = None,
+        generator: torch.Generator | None = None,
+        temperature: float | None = None,
+        top_k: int | None = None,
+        **kwargs: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """GPU fast-path: sample 8-layer Mimi codes (HF stream_generate delay pattern)."""
+        del kwargs
+        bsz = int(input_ids.reshape(-1).shape[0])
+        device = input_embeds.device
+        dtype = input_embeds.dtype
+        hidden = last_talker_hidden.reshape(bsz, 1, -1)
+        text_step = text_step.reshape(bsz, 1, -1).to(device=device, dtype=dtype)
+        logits_layers = self.mtp_head(hidden)
+
+        temp = self.mtp_temperature if temperature is None else float(temperature)
+        k = self.mtp_top_k if top_k is None else int(top_k)
+
+        codes = torch.full((bsz, self.config.mtp_num_layers), self.audio_pad_token, dtype=torch.long, device=device)
+        for b in range(bsz):
+            step_i = int(audio_steps[b].item()) if audio_steps is not None and b < audio_steps.numel() else (
+                int(audio_step) if audio_step is not None else -1
+            )
+            row_audio = audio_ids
+            if audio_ids_list is not None and b < len(audio_ids_list):
+                row_audio = audio_ids_list[b]
+            if row_audio is not None and row_audio.dim() == 2:
+                audio_code_history = row_audio
+
+            for layer_idx, layer_logits in enumerate(logits_layers):
+                if step_i < layer_idx:
+                    continue
+                prev: list[int] = []
+                if audio_code_history is not None and audio_code_history.ndim == 2:
+                    hist = audio_code_history[layer_idx]
+                    prev = [int(x) for x in hist.tolist() if int(x) != self.audio_pad_token][-3:]
+                codes[b, layer_idx] = self._sample_mimi_layer_logits(
+                    layer_logits[b, 0, :],
+                    prev,
+                    generator=generator,
+                    temperature=temp,
+                    top_k=k,
+                )
+
+            if row_audio is None:
+                row_audio = codes[b : b + 1].unsqueeze(-1)
+            else:
+                if row_audio.dim() == 2:
+                    row_audio = row_audio.unsqueeze(0)
+                pad_col = row_audio.new_full((row_audio.size(0), row_audio.size(1), 1), self.audio_pad_token)
+                row_audio = torch.cat([row_audio, pad_col], dim=-1)
+                row_audio[0, :, -1] = codes[b]
+
+            if b == 0:
+                audio_ids = row_audio
+            else:
+                audio_ids = torch.cat([audio_ids, row_audio], dim=0)
+
+        bridge = text_step
+        fused = self.build_fused_embeds(bridge, audio_ids=audio_ids)
+        return fused.reshape(bsz, -1), codes
+

--- a/vllm_omni/model_executor/models/minimind_o/minimind_o_thinker.py
+++ b/vllm_omni/model_executor/models/minimind_o/minimind_o_thinker.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+# MiniMind-O Thinker stage with frozen SenseVoice-Small and SigLIP2 encoders.
+# Following vLLM standalone model pattern.
+
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.models.interfaces import (
+    MultiModalEmbeddings,
+    SupportsLoRA,
+    SupportsMRoPE,
+    SupportsMultiModal,
+    SupportsPP,
+)
+from vllm.model_executor.models.module_mapping import MultiModelKeys
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    init_vllm_registered_model,
+    maybe_prefix,
+)
+from vllm.sequence import IntermediateTensors
+
+from vllm.model_executor.models.qwen2_5_omni_thinker import (
+    Qwen2_5OmniConditionalGenerationMixin,
+)
+
+from vllm_omni.model_executor.models.minimind_o.config import MiniMindOThinkerConfig
+from vllm_omni.model_executor.models.minimind_o.minimind_mm_utils import (
+    inject_audio_features,
+    inject_vision_features,
+)
+from vllm_omni.model_executor.models.minimind_o.projectors import (
+    MiniMindOAudioProjector,
+    MiniMindOVisionProjector,
+)
+
+logger = init_logger(__name__)
+
+
+class MiniMindOThinkerForConditionalGeneration(
+    nn.Module,
+    SupportsMultiModal,
+    SupportsPP,
+    SupportsLoRA,
+    SupportsMRoPE,
+    Qwen2_5OmniConditionalGenerationMixin,
+):
+    """
+    MiniMind-O Thinker stage with frozen encoders.
+
+    Components:
+    - SenseVoice-Small encoder (frozen, loaded as audio_tower)
+    - SigLIP2 encoder (frozen, loaded as visual)
+    - Audio projector (2-layer MLP)
+    - Vision projector (2-layer MLP)
+    - LLM backbone (dense or MoE)
+    """
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "model.": "language_model.model.",
+            "lm_head.": "language_model.lm_head.",
+            "audio_proj.": "audio_tower.projector.",
+            "vision_proj.": "visual.projector.",
+        }
+    )
+
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        if modality.startswith("image"):
+            return "<|image_pad|>"
+        if modality.startswith("audio"):
+            return "<|audio_pad|>"
+        raise ValueError("Only image or audio modality is supported")
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config: MiniMindOThinkerConfig = vllm_config.model_config.hf_config
+        self.vllm_config = vllm_config
+        self.config = config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        self.multimodal_config = multimodal_config
+
+        # Initialize audio tower (SenseVoice-Small encoder + projector)
+        with self._mark_tower_model(vllm_config, "audio"):
+            if multimodal_config.get_limit_per_prompt("audio"):
+                self.audio_tower = nn.Module()
+                self.audio_tower.encoder = None  # Will be loaded from HF weights
+                self.audio_tower.projector = MiniMindOAudioProjector(
+                    config.audio_hidden_size,
+                    config.hidden_size,
+                )
+            else:
+                self.audio_tower = None
+
+        # Initialize visual tower (SigLIP2 encoder + projector)
+        with self._mark_tower_model(vllm_config, {"image"}):
+            if multimodal_config.get_limit_per_prompt("image"):
+                self.visual = nn.Module()
+                self.visual.encoder = None  # Will be loaded from HF weights
+                self.visual.projector = MiniMindOVisionProjector(
+                    config.image_hidden_size,
+                    config.hidden_size,
+                    target_tokens=config.image_token_len,
+                )
+            else:
+                self.visual = None
+
+        # Initialize LLM backbone (dense or MoE)
+        with self._mark_language_model(vllm_config):
+            self.language_model = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+                hf_config=config.text_config,
+                architectures=["MiniMindForCausalLM"],
+            )
+
+        self.make_empty_intermediate_tensors = self.language_model.make_empty_intermediate_tensors
+
+        # Special tokens
+        self.audio_pad_token = config.audio_pad_token
+        self.audio_stop_token = config.audio_stop_token
+        self.audio_spk_token = config.audio_spk_token
+        self.audio_ids = config.audio_ids
+        self.image_ids = config.image_ids
+
+    def get_language_model(self) -> torch.nn.Module:
+        return self.language_model
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if multimodal_embeddings is None or is_multimodal is None:
+            return self.language_model.embed_input_ids(input_ids)
+
+        inputs_embeds = self._embed_text_input_ids(
+            input_ids,
+            self.get_language_model().embed_input_ids,
+            is_multimodal=is_multimodal,
+        )
+
+        if len(multimodal_embeddings) == 0:
+            return inputs_embeds
+
+        # Standard merge for multimodal embeddings
+        return self._merge_multimodal_embeddings(
+            inputs_embeds,
+            multimodal_embeddings,
+            is_multimodal,
+            input_ids,
+        )
+
+    def _merge_multimodal_embeddings(
+        self,
+        inputs_embeds: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings,
+        is_multimodal: torch.Tensor,
+        input_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        """Merge multimodal embeddings into input embeddings."""
+        # Simple merge: replace multimodal token positions with embeddings
+        # This is a simplified version - full implementation would handle interleaving
+        merged_embeds = inputs_embeds.clone()
+        mm_idx = 0
+        for i in range(input_ids.shape[1]):
+            if is_multimodal[0, i]:
+                if mm_idx < len(multimodal_embeddings):
+                    merged_embeds[:, i] = multimodal_embeddings[mm_idx]
+                    mm_idx += 1
+        return merged_embeds
+
+    def _maybe_inject_multimodal(
+        self,
+        input_ids: torch.Tensor,
+        inputs_embeds: torch.Tensor,
+        kwargs: dict,
+    ) -> torch.Tensor:
+        if inputs_embeds is None or input_ids is None:
+            return inputs_embeds
+        if input_ids.dim() == 1:
+            input_ids = input_ids.unsqueeze(0)
+        if inputs_embeds.dim() == 2:
+            inputs_embeds = inputs_embeds.unsqueeze(0)
+
+        audio_inputs = kwargs.get("audio_inputs")
+        audio_lens = kwargs.get("audio_lens")
+        pixel_values = kwargs.get("pixel_values")
+
+        hidden_states = inputs_embeds
+        if audio_inputs is not None and self.audio_tower is not None and self.config.audio_ids:
+            # Encoder is optional (loaded from funasr at runtime); skip if not present.
+            if getattr(self.audio_tower, "encoder", None) is not None:
+                hidden_states = inject_audio_features(
+                    input_ids,
+                    hidden_states,
+                    self._encode_audio_inputs(audio_inputs, audio_lens),
+                    audio_marker=self.config.audio_ids[0],
+                )
+        if pixel_values is not None and self.visual is not None and self.config.image_ids:
+            vision_tensors = self._encode_image_inputs(pixel_values)
+            if vision_tensors is not None:
+                hidden_states = inject_vision_features(
+                    input_ids,
+                    hidden_states,
+                    vision_tensors,
+                    image_marker=self.config.image_ids[0],
+                    seqlen=hidden_states.size(1),
+                )
+        return hidden_states.squeeze(0) if hidden_states.size(0) == 1 else hidden_states
+
+    def _encode_audio_inputs(self, audio_inputs, audio_lens):
+        return None
+
+    def _encode_image_inputs(self, pixel_values):
+        if self.visual is None or getattr(self.visual, "encoder", None) is None:
+            return None
+        mask = pixel_values.flatten(1).any(1)
+        if not mask.any():
+            return pixel_values.new_zeros(
+                pixel_values.size(0),
+                self.config.image_token_len,
+                self.config.hidden_size,
+            )
+        with torch.no_grad():
+            emb = self.visual.encoder(pixel_values=pixel_values[mask]).last_hidden_state
+        if emb.dim() == 2:
+            emb = emb.unsqueeze(0)
+        emb = self.visual.projector(emb)
+        if mask.all():
+            return emb
+        idx = mask.nonzero().view(-1, 1, 1).expand_as(emb)
+        return emb.new_zeros(pixel_values.size(0), *emb.shape[1:]).scatter(0, idx, emb)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor = None,
+        positions: torch.Tensor = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+        elif inputs_embeds is None and input_ids is not None:
+            inputs_embeds = self.embed_input_ids(input_ids)
+        if inputs_embeds is not None and intermediate_tensors is None:
+            inputs_embeds = self._maybe_inject_multimodal(input_ids, inputs_embeds, kwargs)
+
+        hidden_states = self.language_model.model(
+            input_ids, positions, intermediate_tensors, inputs_embeds=inputs_embeds
+        )
+        return hidden_states
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        return self.language_model.compute_logits(hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        skip_prefixes = ["talker.", "code2wav."]
+        if self.audio_tower is None:
+            skip_prefixes.extend(["audio_tower."])
+        if self.visual is None:
+            skip_prefixes.extend(["visual."])
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+        )
+        loaded_weights = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+        return loaded_weights
+
+    def get_mm_mapping(self) -> MultiModelKeys:
+        """Get the module prefix in multimodal models."""
+        return MultiModelKeys.from_string_field(
+            language_model="language_model",
+            connector="",
+            tower_model=["visual.", "audio_tower."],
+        )

--- a/vllm_omni/model_executor/models/minimind_o/minimind_omni_config.py
+++ b/vllm_omni/model_executor/models/minimind_o/minimind_omni_config.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+"""HuggingFace AutoConfig registration entry for minimind-o."""
+
+from vllm_omni.model_executor.models.minimind_o.config import MiniMindOConfig
+
+MiniMindOmniConfig = MiniMindOConfig
+
+__all__ = ["MiniMindOmniConfig", "MiniMindOConfig"]

--- a/vllm_omni/model_executor/models/minimind_o/pipeline.py
+++ b/vllm_omni/model_executor/models/minimind_o/pipeline.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+"""MiniMind-O pipeline topology (frozen).
+
+Stage 0: Thinker  — multimodal understanding + text generation
+Stage 1: Talker   — text embeddings → 8-layer Mimi codec tokens
+Stage 2: Code2Wav — Mimi codec tokens → 24kHz audio waveform
+"""
+
+from vllm_omni.config.stage_config import (
+    PipelineConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
+
+_PROC = "vllm_omni.model_executor.stage_input_processors.minimind_o"
+
+MINIMIND_O_PIPELINE = PipelineConfig(
+    model_type="minimind_o",
+    model_arch="MiniMindOForConditionalGeneration",
+    hf_architectures=(
+        "MiniMindOmni",
+        "MiniMindOForConditionalGeneration",
+        "MiniMindOMoeForConditionalGeneration",
+    ),
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="thinker",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            final_output=True,
+            final_output_type="text",
+            owns_tokenizer=True,
+            requires_multimodal_data=True,
+            engine_output_type="latent",
+            sampling_constraints={"detokenize": True},
+        ),
+        StagePipelineConfig(
+            stage_id=1,
+            model_stage="talker",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(0,),
+            engine_output_type="latent",
+            custom_process_input_func=f"{_PROC}.thinker2talker",
+            sampling_constraints={
+                "detokenize": True,
+                "stop_token_ids": [2050],  # MIMI_CODEC_EOS_TOKEN_ID
+            },
+        ),
+        StagePipelineConfig(
+            stage_id=2,
+            model_stage="code2wav",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            input_sources=(1,),
+            final_output=True,
+            final_output_type="audio",
+            engine_output_type="audio",
+            custom_process_input_func=f"{_PROC}.talker2code2wav",
+            sampling_constraints={"detokenize": True},
+        ),
+    ),
+)
+
+
+# Single-stage thinker-only variant
+MINIMIND_O_THINKER_ONLY_PIPELINE = PipelineConfig(
+    model_type="minimind_o_thinker_only",
+    model_arch="MiniMindOForConditionalGeneration",
+    stages=(
+        StagePipelineConfig(
+            stage_id=0,
+            model_stage="thinker",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            final_output=True,
+            final_output_type="text",
+            owns_tokenizer=True,
+            requires_multimodal_data=True,
+            engine_output_type="latent",
+            sampling_constraints={"detokenize": True},
+        ),
+    ),
+)

--- a/vllm_omni/model_executor/models/minimind_o/processor.py
+++ b/vllm_omni/model_executor/models/minimind_o/processor.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+# MiniMind-O multimodal processor.
+
+from collections.abc import Mapping
+from typing import Any
+
+from vllm.logger import init_logger
+from vllm.model_executor.models.qwen2_5_omni_thinker import (
+    Qwen2_5OmniAudioFeatureInputs,
+    Qwen2_5OmniThinkerDummyInputsBuilder,
+    Qwen2_5OmniThinkerProcessingInfo,
+    Qwen2_5OmniThinkerMultiModalProcessor as _Qwen2_5OmniThinkerMultiModalProcessorBase,
+)
+from vllm.multimodal.inputs import MultiModalKwargsItems
+from vllm.multimodal.parse import MultiModalDataItems
+from vllm.multimodal.processing.processor import (
+    MultiModalPromptUpdates,
+    PlaceholderFeaturesInfo,
+)
+
+logger = init_logger(__name__)
+
+
+class MiniMindOThinkerProcessingInfo(Qwen2_5OmniThinkerProcessingInfo):
+    """MiniMind-O specific processing info."""
+    
+    def get_hf_config(self):
+        """Get MiniMind-O config."""
+        return self.model_config.hf_config
+
+
+class MiniMindOThinkerMultiModalProcessor(_Qwen2_5OmniThinkerMultiModalProcessorBase):
+    """MiniMind-O specific multimodal processor.
+    
+    Inherits from Qwen2.5-Omni base processor with MiniMind-O specific
+    token handling for audio and vision.
+    """
+
+    def _maybe_apply_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        prompt_ids: list[int],
+        mm_kwargs: MultiModalKwargsItems,
+        mm_prompt_updates: MultiModalPromptUpdates,
+        is_update_applied: bool,
+    ) -> tuple[list[int], Mapping[str, list[PlaceholderFeaturesInfo]]]:
+        """Apply prompt updates for MiniMind-O specific tokens."""
+        mm_item_counts = mm_items.get_all_counts()
+        self._validate_mm_kwargs(mm_kwargs, mm_item_counts)
+        self._validate_mm_updates(mm_prompt_updates, mm_item_counts)
+
+        # MiniMind-O uses simpler audio/vision token handling
+        # No interleaved audio-in-video like Qwen2.5-Omni
+        if is_update_applied:
+            mm_placeholders = self._find_mm_placeholders(
+                prompt_ids,
+                mm_prompt_updates,
+            )
+            self._validate_mm_placeholders(
+                mm_placeholders,
+                mm_item_counts,
+            )
+        else:
+            prompt_ids, mm_placeholders = self._apply_prompt_updates(
+                prompt_ids,
+                mm_prompt_updates,
+            )
+            self._validate_mm_placeholders(
+                mm_placeholders,
+                mm_item_counts,
+            )
+
+        return prompt_ids, mm_placeholders
+
+
+class MiniMindOThinkerDummyInputsBuilder(Qwen2_5OmniThinkerDummyInputsBuilder):
+    """MiniMind-O specific dummy inputs builder."""
+    
+    def get_dummy_audio_inputs(self, seq_len: int, num_audio: int):
+        """Get dummy audio inputs for MiniMind-O."""
+        # MiniMind-O uses audio_pad_token (2049)
+        return super().get_dummy_audio_inputs(seq_len, num_audio)
+    
+    def get_dummy_image_inputs(self, seq_len: int, num_images: int):
+        """Get dummy image inputs for MiniMind-O."""
+        # MiniMind-O uses image_pad_token (12)
+        return super().get_dummy_image_inputs(seq_len, num_images)

--- a/vllm_omni/model_executor/models/minimind_o/projectors.py
+++ b/vllm_omni/model_executor/models/minimind_o/projectors.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+# Adapted from MiniMind-O repository
+
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+logger = init_logger(__name__)
+
+
+class MiniMindOAudioProjector(nn.Module):
+    """2-layer MLP projector from SenseVoice output to LLM hidden space.
+
+    Pattern from MiniMind-O: LayerNorm → Linear → GELU → Linear
+    """
+
+    def __init__(self, in_dim: int, out_dim: int):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.LayerNorm(in_dim),
+            nn.Linear(in_dim, out_dim),
+            nn.GELU(),
+            nn.Linear(out_dim, out_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Project audio features.
+
+        Args:
+            x: [seq_len, in_dim] or [B, seq_len, in_dim]
+
+        Returns:
+            Projected features with last dim = out_dim.
+        """
+        return self.mlp(x)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if not name.startswith("mlp."):
+                name = f"mlp.{name}"
+            if name not in params_dict:
+                logger.warning("Skipping unknown audio projector weight: %s", name)
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class MiniMindOVisionProjector(nn.Module):
+    """2-layer MLP projector from SigLIP2 output to LLM hidden space.
+
+    Pattern from MiniMind-O: LayerNorm → Linear → GELU → Linear
+    """
+
+    def __init__(self, in_dim: int, out_dim: int, source_tokens: int = 64, target_tokens: int = 64):
+        super().__init__()
+        self.source_tokens = source_tokens
+        self.target_tokens = target_tokens
+        self.mlp = nn.Sequential(
+            nn.LayerNorm(in_dim),
+            nn.Linear(in_dim, out_dim),
+            nn.GELU(),
+            nn.Linear(out_dim, out_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Project vision features.
+
+        Args:
+            x: [seq_len, in_dim] or [B, seq_len, in_dim]
+
+        Returns:
+            Projected features with last dim = out_dim.
+        """
+        return self.mlp(x)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if not name.startswith("mlp."):
+                name = f"mlp.{name}"
+            if name not in params_dict:
+                logger.warning("Skipping unknown vision projector weight: %s", name)
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params

--- a/vllm_omni/model_executor/models/registry.py
+++ b/vllm_omni/model_executor/models/registry.py
@@ -31,6 +31,7 @@ _OMNI_MODELS = {
         "Qwen2_5OmniToken2WavModel",
     ),
     "Qwen2ForCausalLM_old": ("qwen2_5_omni", "qwen2_old", "Qwen2ForCausalLM"),  # need to discuss
+    "MiniMindForCausalLM": ("minimind_o", "minimind_llm", "MiniMindForCausalLM"),
     # Qwen3 Omni MoE models
     "Qwen3OmniMoeForConditionalGeneration": (
         "qwen3_omni",
@@ -193,6 +194,38 @@ _OMNI_MODELS = {
         "covo_audio",
         "covo_audio_code2wav",
         "CovoAudioCode2WavForConditionalGeneration",
+    ),
+    # MiniMind-O models (HF checkpoint uses architecture MiniMindOmni)
+    "MiniMindOmni": (
+        "minimind_o",
+        "minimind_o",
+        "MiniMindOForConditionalGeneration",
+    ),
+    "MiniMindOForConditionalGeneration": (
+        "minimind_o",
+        "minimind_o",
+        "MiniMindOForConditionalGeneration",
+    ),
+    "MiniMindOMoeForConditionalGeneration": (
+        "minimind_o",
+        "minimind_o",
+        "MiniMindOMoeForConditionalGeneration",
+    ),
+    # Stage-specific models (if needed for individual stage serving)
+    "MiniMindOThinkerForConditionalGeneration": (
+        "minimind_o",
+        "minimind_o_thinker",
+        "MiniMindOThinkerForConditionalGeneration",
+    ),
+    "MiniMindOTalkerForConditionalGeneration": (
+        "minimind_o",
+        "minimind_o_talker",
+        "MiniMindOTalkerForConditionalGeneration",
+    ),
+    "MiniMindOCode2Wav": (
+        "minimind_o",
+        "minimind_o_code2wav",
+        "MiniMindOCode2Wav",
     ),
     ## MOSS-TTS-Nano
     "MossTTSNanoForCausalLM": (

--- a/vllm_omni/model_executor/stage_input_processors/minimind_o.py
+++ b/vllm_omni/model_executor/stage_input_processors/minimind_o.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 The vLLM-Omni team.
+"""Stage input processors for MiniMind-O (thinker → talker → code2wav)."""
+
+import torch
+from vllm.inputs import TextPrompt
+
+from vllm_omni.data_entry_keys import (
+    EmbeddingsStruct,
+    HiddenStatesStruct,
+    IdsStruct,
+    OmniPayloadStruct,
+    to_dict,
+)
+from vllm_omni.inputs.data import OmniTokensPrompt
+
+MIMI_CODEC_PAD_TOKEN_ID = 2049
+MIMI_CODEC_STOP_TOKEN_ID = 2050
+MIMI_NUM_CODEC_LAYERS = 8
+
+
+def _build_initial_audio_ids(seq_len: int, device: torch.device | None = None) -> torch.Tensor:
+    """8-layer Mimi code buffer, all pads (HF stream_generate audio_buffer)."""
+    return torch.full(
+        (MIMI_NUM_CODEC_LAYERS, seq_len),
+        MIMI_CODEC_PAD_TOKEN_ID,
+        dtype=torch.long,
+        device=device,
+    )
+
+
+def thinker2talker(
+    source_outputs,
+    prompt: OmniTokensPrompt | TextPrompt = None,
+    requires_multimodal_data: bool = False,
+):
+    talker_inputs = []
+    if not isinstance(prompt, list):
+        prompt = [prompt]
+    multi_modal_data = {
+        thinker_output.request_id: p.get("multi_modal_data", None)
+        for thinker_output, p in zip(source_outputs, prompt)
+    }
+
+    for i, thinker_output in enumerate(source_outputs):
+        output = thinker_output.outputs[0]
+        prompt_token_ids = list(thinker_output.prompt_token_ids)
+        thinker_output_ids = list(output.cumulative_token_ids)
+        mm = output.multimodal_output
+        latent = mm["latent"]
+        thinker_hidden_states = latent.clone().detach().to(latent.device)
+        prompt_token_ids_len = len(prompt_token_ids)
+        decode_hidden = thinker_hidden_states[prompt_token_ids_len:].to(torch.float32)
+        prefill_hidden = thinker_hidden_states[:prompt_token_ids_len].to(torch.float32)
+
+        # Talker prefill length: prompt + first generated text token (HF delay pattern).
+        talker_seq_len = max(prompt_token_ids_len + 1, 1)
+        audio_ids = _build_initial_audio_ids(talker_seq_len, device=prefill_hidden.device)
+
+        additional_information = to_dict(
+            OmniPayloadStruct(
+                hidden_states=HiddenStatesStruct(
+                    output=decode_hidden,
+                    output_shape=list(decode_hidden.shape),
+                ),
+                embed=EmbeddingsStruct(
+                    prefill=prefill_hidden,
+                    prefill_shape=list(prefill_hidden.shape),
+                    audio_ids=audio_ids,
+                ),
+                ids=IdsStruct(prompt=prompt_token_ids, output=thinker_output_ids),
+            )
+        )
+
+        # Flat prompt ids for the talker AR stage (codec stream); fusion uses additional_information.
+        flat_ids = [MIMI_CODEC_PAD_TOKEN_ID] * talker_seq_len
+        talker_inputs.append(
+            OmniTokensPrompt(
+                prompt_token_ids=flat_ids,
+                additional_information=additional_information,
+                multi_modal_data=(
+                    multi_modal_data[thinker_output.request_id]
+                    if requires_multimodal_data and multi_modal_data is not None
+                    else None
+                ),
+                mm_processor_kwargs=None,
+            )
+        )
+    return talker_inputs
+
+
+def talker2code2wav(
+    source_outputs,
+    _prompt: OmniTokensPrompt | TextPrompt = None,
+    _requires_multimodal_data: bool = False,
+):
+    code2wav_inputs = []
+    for talker_output in source_outputs:
+        output = talker_output.outputs[0]
+        mm = getattr(output, "multimodal_output", None) or {}
+        codes = None
+        if isinstance(mm, dict):
+            codes = mm.get("codes", {}).get("audio")
+        if isinstance(codes, torch.Tensor) and codes.numel() > 0:
+            if codes.dim() == 2 and codes.size(-1) == MIMI_NUM_CODEC_LAYERS:
+                token_ids = codes.reshape(-1).tolist()
+            else:
+                token_ids = codes.reshape(-1).tolist()
+        else:
+            token_ids = list(output.cumulative_token_ids)
+            while token_ids and token_ids[-1] == MIMI_CODEC_STOP_TOKEN_ID:
+                token_ids = token_ids[:-1]
+            while token_ids and token_ids[0] == MIMI_CODEC_PAD_TOKEN_ID:
+                token_ids = token_ids[1:]
+        if not token_ids:
+            continue
+        code2wav_inputs.append(
+            OmniTokensPrompt(
+                prompt_token_ids=token_ids,
+                multi_modal_data=None,
+                mm_processor_kwargs=None,
+            )
+        )
+    return code2wav_inputs


### PR DESCRIPTION
Summary
Closes #3399.

Adds [MiniMind-O](https://huggingface.co/jingyaogong/minimind-3o) ([MoE variant](https://huggingface.co/jingyaogong/minimind-3o-moe)) to vLLM-Omni using the same Thinker → Talker → Code2Wav staged layout as Qwen2.5-Omni: flat HF checkpoint loading, pipeline registration, stage input processors, and vLLM-backed dense/MoE LLM backbones for thinker and talker.

What’s included
Config & HF wiring: MiniMindOConfig (model_type: minimind-o), minimind-o in engine config registration, MiniMindOmni / MiniMindOMoeForConditionalGeneration registry aliases.
Thinker: MiniMindForCausalLM backbone, audio_proj / vision_proj MLPs, weight map from HF model.* keys; multimodal towers scaffolded (encoders are not in pytorch_model.bin—upstream loads SenseVoice/SigLIP separately).
Talker: fused text/codec embeddings, MTP head + 8-layer codec sampling path, custom preprocess/postprocess and talker_mtp for staged serving.
MoE: use_moe in config + MiniMindMoEFeedForward in minimind_llm (156 MoE keys in MoE checkpoint); same partition/load path as dense.
Code2Wav: stage module and pipeline hook (placeholder decoder—not upstream Mimi weights/arch yet).
Pipeline: minimind_o (3-stage) and minimind_o_thinker_only; hf_architectures for MiniMindOmni.



Test plan

 pytest tests/model_executor/models/minimind_o/ (config, weight partition, MM utils, talker MTP)

 Manual: thinker-only serve with jingyaogong/minimind-3o (text generation)

 Manual: same with jingyaogong/minimind-3o-moe and confirm use_moe loads expert/gate weights

