### PR TITLE
Mooncake Transfer Engine Connector : Performance Profiling & Optimization

### DIFF
--- a/benchmarks/connectors/benchmark_mooncake_te.py
+++ b/benchmarks/connectors/benchmark_mooncake_te.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Micro-benchmark MooncakeTransferEngineConnector put/get latency.
+
+Example:
+    VLLM_OMNI_CONNECTOR_PROFILE=1 python benchmarks/connectors/benchmark_mooncake_te.py \
+        --protocols tcp rdma --payload-types tensor tensor_dict --sizes 1MB 10MB 100MB \
+        --output-json mooncake_te_results.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import statistics
+import time
+import uuid
+from typing import Any
+
+import torch
+
+
+def _parse_size(value: str) -> int:
+    text = value.strip().upper()
+    units = {
+        "KB": 1024,
+        "MB": 1024**2,
+        "GB": 1024**3,
+        "B": 1,
+    }
+    for suffix, multiplier in units.items():
+        if text.endswith(suffix):
+            return int(float(text[: -len(suffix)]) * multiplier)
+    return int(text)
+
+
+def _format_size(size: int) -> str:
+    for suffix, divisor in (("GB", 1024**3), ("MB", 1024**2), ("KB", 1024)):
+        if size >= divisor and size % divisor == 0:
+            return f"{size // divisor}{suffix}"
+    return f"{size}B"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _make_payload(payload_type: str, size: int) -> Any:
+    if payload_type == "bytes":
+        return bytes(size)
+    if payload_type == "tensor":
+        return torch.empty(size, dtype=torch.uint8)
+    if payload_type == "tensor_dict":
+        first = size // 2
+        second = size - first
+        return {
+            "tokens": torch.empty(first, dtype=torch.uint8),
+            "codes": torch.empty(second, dtype=torch.uint8),
+        }
+    raise ValueError(f"Unsupported payload type: {payload_type}")
+
+
+def _release_result(result: tuple[Any, int] | None) -> None:
+    if result is None:
+        return
+    value, _ = result
+    if hasattr(value, "release"):
+        value.release()
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, max(0, round((percentile / 100.0) * (len(ordered) - 1))))
+    return ordered[idx]
+
+
+def _run_case(args: argparse.Namespace, protocol: str, payload_type: str, size: int) -> dict[str, Any]:
+    from vllm_omni.distributed.omni_connectors.connectors.mooncake_transfer_engine_connector import (
+        MooncakeTransferEngineConnector,
+    )
+
+    sender_port = _free_port()
+    receiver_port = _free_port()
+    pool_size = max(args.memory_pool_size, size * 4, 64 * 1024 * 1024)
+    common = {
+        "host": args.host,
+        "protocol": protocol,
+        "memory_pool_size": pool_size,
+        "memory_pool_device": args.memory_pool_device,
+        "pool_prewarm_slots": args.pool_prewarm_slots,
+        "pool_prewarm_size": args.pool_prewarm_size or size,
+        "socket_health_interval_s": args.socket_health_interval_s,
+        "enable_tensor_dict_fast_path": not args.disable_tensor_dict_fast_path,
+    }
+    sender = MooncakeTransferEngineConnector({**common, "role": "sender", "zmq_port": sender_port})
+    receiver = MooncakeTransferEngineConnector(
+        {
+            **common,
+            "role": "receiver",
+            "zmq_port": receiver_port,
+            "sender_host": args.host,
+            "sender_zmq_port": sender_port,
+        }
+    )
+
+    latencies_ms: list[float] = []
+    profile_records: list[dict[str, Any]] = []
+    try:
+        for i in range(args.warmup + args.iterations):
+            payload = _make_payload(payload_type, size)
+            request_id = f"bench-{uuid.uuid4()}"
+            start = time.perf_counter()
+            ok, written, metadata = sender.put("stage_a", "stage_b", request_id, payload)
+            if not ok or metadata is None:
+                raise RuntimeError(f"put() failed for {payload_type}/{_format_size(size)}")
+            result = receiver.get("stage_a", "stage_b", request_id, metadata)
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            if result is None:
+                raise RuntimeError(f"get() failed for {payload_type}/{_format_size(size)}")
+            _release_result(result)
+
+            if i >= args.warmup:
+                latencies_ms.append(elapsed_ms)
+            if args.profile:
+                profile_records.extend(sender.pop_profile_records())
+                profile_records.extend(receiver.pop_profile_records())
+
+            if written != metadata["data_size"]:
+                raise RuntimeError(f"metadata size mismatch: written={written}, metadata={metadata}")
+    finally:
+        receiver.close()
+        sender.close()
+
+    return {
+        "protocol": protocol,
+        "payload_type": payload_type,
+        "payload_size": size,
+        "payload_size_label": _format_size(size),
+        "iterations": args.iterations,
+        "p50_ms": statistics.median(latencies_ms),
+        "p95_ms": _percentile(latencies_ms, 95),
+        "min_ms": min(latencies_ms),
+        "max_ms": max(latencies_ms),
+        "profile_records": profile_records,
+    }
+
+
+def _markdown_table(results: list[dict[str, Any]]) -> str:
+    lines = [
+        "| Payload Size | Protocol | Payload Type | p50 put+get (ms) | p95 put+get (ms) |",
+        "|---|---|---|---:|---:|",
+    ]
+    for result in results:
+        lines.append(
+            f"| {result['payload_size_label']} | {result['protocol']} | {result['payload_type']} | "
+            f"{result['p50_ms']:.3f} | {result['p95_ms']:.3f} |"
+        )
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--protocols", nargs="+", default=["tcp"], choices=["tcp", "rdma"])
+    parser.add_argument(
+        "--payload-types",
+        nargs="+",
+        default=["tensor", "tensor_dict"],
+        choices=["bytes", "tensor", "tensor_dict"],
+    )
+    parser.add_argument("--sizes", nargs="+", default=["1MB", "10MB", "100MB", "1GB"])
+    parser.add_argument("--iterations", type=int, default=10)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--memory-pool-size", type=_parse_size, default=1024**3)
+    parser.add_argument("--memory-pool-device", default="cpu")
+    parser.add_argument("--pool-prewarm-slots", type=int, default=0)
+    parser.add_argument("--pool-prewarm-size", type=_parse_size, default=0)
+    parser.add_argument("--socket-health-interval-s", type=float, default=30.0)
+    parser.add_argument("--disable-tensor-dict-fast-path", action="store_true")
+    parser.add_argument("--profile", action="store_true")
+    parser.add_argument("--output-json")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.profile:
+        os.environ["VLLM_OMNI_CONNECTOR_PROFILE"] = "1"
+
+    sizes = [_parse_size(size) for size in args.sizes]
+    results = [
+        _run_case(args, protocol, payload_type, size)
+        for protocol in args.protocols
+        for payload_type in args.payload_types
+        for size in sizes
+    ]
+
+    print(_markdown_table(results))
+    if args.output_json:
+        with open(args.output_json, "w", encoding="utf-8") as f:
+            json.dump({"results": results}, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/design/feature/omni_connectors/mooncake_transfer_engine_connector.md
+++ b/docs/design/feature/omni_connectors/mooncake_transfer_engine_connector.md
@@ -118,10 +118,84 @@ receiver_connect  = remote_side_channel_port + tp_rank
 
 ## Environment Variables
 
-| Variable | Description |
+| Variable | Default | Description |
+|---|---|---|
+| `RDMA_DEVICE_NAME` | *(auto)* | Override RDMA device name (e.g., `mlx5_0`). |
+| `MC_IB_PCI_RELAXED_ORDERING` | `0` | Set to `1` to enable PCIe relaxed ordering for GPUDirect. |
+| `VLLM_OMNI_CONNECTOR_PROFILE` | `0` | Set to `1` to enable per-operation latency profiling. Records `serialize`, `pool_alloc`, and `zmq_notify` span durations (ms) for each `put()` and `get()` call. Retrieve records via `connector.pop_profile_records()`. Disabled by default — enabling adds a small overhead on every operation. |
+
+## Warm Pool (Pre-Allocation)
+
+By default the memory pool allocates on first use. You can pre-allocate slots at
+startup to eliminate pool-miss latency on the first batch of transfers.
+
+| Config key | Type | Default | Description |
+|---|---|---|---|
+| `pool_prewarm_slots` | `int` | `0` | Number of pool slots to allocate at connector init. |
+| `pool_prewarm_size` | `int` | `0` | Size (bytes) of each pre-warmed slot. Set to the expected payload size for best results. |
+
+Example:
+```yaml
+connector:
+  type: mooncake_transfer_engine
+  pool_prewarm_slots: 4
+  pool_prewarm_size: 209715200   # 200 MB per slot
+```
+
+Pre-warming is useful when your workload has a predictable, uniform KV cache
+size (e.g., fixed sequence length). For variable-size workloads, leave at `0`.
+
+## Tensor-Dict Wire Format
+
+When `data` is a `dict[str, torch.Tensor]`, the connector bypasses generic
+serialization and uses a compact binary wire format for lower CPU overhead and
+faster deserialization on the receiver side.
+
+### Frame layout
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Header (64-byte aligned)                                 │
+│  [4] magic = "OMDI"  (0x4F4D4449)                       │
+│  [2] version = 1                                        │
+│  [2] header_len (bytes, multiple of 64)                 │
+│  [4] n_tensors                                          │
+│  [4] CRC-32 of header (computed with checksum field=0)  │
+│  per-tensor entries:                                    │
+│    [2]       key_len                                    │
+│    [key_len] key  (UTF-8)                               │
+│    [2]       dtype_id  (see table below)                │
+│    [1]       ndim                                       │
+│    [1]       layout = 0 (contiguous)                    │
+│    [ndim×8]  shape  (int64, little-endian)              │
+│    [8]       data_offset (from body start, 64-byte aligned) │
+│    [8]       nbytes                                     │
+│  padding to next 64-byte boundary                       │
+├─────────────────────────────────────────────────────────┤
+│ Body (tensor payloads, each 64-byte aligned)            │
+└─────────────────────────────────────────────────────────┘
+```
+
+### dtype_id mapping
+
+| dtype_id | torch dtype |
 |---|---|
-| `RDMA_DEVICE_NAME` | Override RDMA device name (e.g., `mlx5_0`). |
-| `MC_IB_PCI_RELAXED_ORDERING` | Set to `1` to enable PCIe relaxed ordering for GPUDirect. |
+| 1 | `torch.bool` |
+| 2 | `torch.uint8` |
+| 3 | `torch.int8` |
+| 4 | `torch.int16` |
+| 5 | `torch.int32` |
+| 6 | `torch.int64` |
+| 7 | `torch.float16` |
+| 8 | `torch.bfloat16` |
+| 9 | `torch.float32` |
+| 10 | `torch.float64` |
+| 11 | `torch.complex64` |
+| 12 | `torch.complex128` |
+
+Tensors are always serialized to CPU, contiguous, and 64-byte-aligned in the
+body. The receiver reconstructs them as CPU tensors; device placement is the
+caller's responsibility.
 
 ## Docker / Container Setup
 

--- a/tests/distributed/omni_connectors/test_basic_connectors.py
+++ b/tests/distributed/omni_connectors/test_basic_connectors.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+import torch
 from pytest_mock import MockerFixture
 
 from vllm_omni.distributed.omni_connectors.connectors.shm_connector import SharedMemoryConnector
@@ -24,8 +25,6 @@ def test_basic_serialization():
 
 def test_tensor_serialization():
     """Test torch.Tensor serialization."""
-    import torch
-
     tensor = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
     serialized = OmniSerializer.serialize(tensor)
     deserialized = OmniSerializer.deserialize(serialized)
@@ -193,5 +192,78 @@ def test_mooncake_connector_defaults_missing_host_to_detected_ip(monkeypatch: py
         assert connector.host == "10.20.30.40"
         assert connector.engine.host == "10.20.30.40"
         assert connector.get_connection_info()["host"] == "10.20.30.40"
+    finally:
+        connector.close()
+
+
+def test_mooncake_tensor_dict_put_bypasses_omni_serializer(monkeypatch: pytest.MonkeyPatch):
+    import vllm_omni.distributed.omni_connectors.connectors.mooncake_transfer_engine_connector as mooncake_module
+
+    class _FakePool:
+        is_cuda = False
+
+        def __init__(self, size):
+            self.tensor = torch.zeros(size, dtype=torch.uint8)
+
+        def pin_memory(self):
+            return self
+
+        def data_ptr(self):
+            return self.tensor.data_ptr()
+
+        def __getitem__(self, item):
+            return self.tensor[item]
+
+        def __setitem__(self, item, value):
+            self.tensor[item] = value
+
+    class _FakeTransferEngine:
+        def initialize(self, host, mode, protocol, device_name):
+            del host, mode, protocol, device_name
+            return 0
+
+        def get_rpc_port(self):
+            return 23456
+
+        def register_memory(self, base_ptr, pool_size):
+            del base_ptr, pool_size
+            return 0
+
+        def unregister_memory(self, base_ptr):
+            del base_ptr
+            return 0
+
+    monkeypatch.setattr(mooncake_module, "TransferEngine", _FakeTransferEngine)
+    monkeypatch.setattr(mooncake_module.torch, "empty", lambda size, *args, **kwargs: _FakePool(size))
+    monkeypatch.setattr(
+        mooncake_module.MooncakeTransferEngineConnector,
+        "_zmq_listener_loop",
+        lambda self: self._listener_ready.set(),
+    )
+    monkeypatch.setattr(
+        mooncake_module.OmniSerializer,
+        "serialize",
+        lambda obj: (_ for _ in ()).throw(AssertionError("OmniSerializer should not handle tensor_dict")),
+    )
+
+    connector = mooncake_module.MooncakeTransferEngineConnector(
+        {
+            "host": "127.0.0.1",
+            "zmq_port": 50052,
+            "memory_pool_size": 4096,
+        }
+    )
+    try:
+        ok, size, metadata = connector.put(
+            "stage_0",
+            "stage_1",
+            "req_tensor_dict",
+            {"tokens": torch.arange(4, dtype=torch.int64)},
+        )
+
+        assert ok is True
+        assert size > 0
+        assert metadata["payload_kind"] == mooncake_module.PAYLOAD_KIND_TENSOR_DICT
+        assert metadata["is_fast_path"] is False
     finally:
         connector.close()

--- a/tests/distributed/omni_connectors/test_mooncake_transfer_engine_buffer.py
+++ b/tests/distributed/omni_connectors/test_mooncake_transfer_engine_buffer.py
@@ -11,9 +11,12 @@ import threading
 import pytest
 import torch
 
+import vllm_omni.distributed.omni_connectors.connectors.mooncake_transfer_engine_connector as mooncake_module
 from vllm_omni.distributed.omni_connectors.connectors.mooncake_transfer_engine_connector import (
     BufferAllocator,
     ManagedBuffer,
+    MooncakeTransferEngineConnector,
+    _WarmPool,
 )
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import KVCacheTransferData
 
@@ -293,3 +296,136 @@ class TestMooncakePackedPayloadSmoke:
         assert decoded["layer_blocks"]["value_cache"][0].is_cuda
         assert torch.equal(decoded["layer_blocks"]["key_cache"][0].cpu(), key_tensor.cpu())
         assert torch.equal(decoded["layer_blocks"]["value_cache"][0].cpu(), value_tensor.cpu())
+
+
+@pytest.mark.core_model
+class TestManagedBufferReleaseCallback:
+    """Unit tests for ManagedBuffer release callbacks."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.allocator = BufferAllocator(total_size=4096, alignment=64)
+        self.pool = torch.zeros(4096, dtype=torch.uint8)
+
+    def test_release_callback_can_retain_allocation(self):
+        """Verify warm-pool style release callbacks can retain an allocation."""
+        retained = []
+        offset = self.allocator.alloc(128)
+
+        def retain(buf):
+            retained.append(buf)
+            return True
+
+        buf = ManagedBuffer(
+            self.allocator,
+            offset,
+            64,
+            self.pool,
+            release_callback=retain,
+            allocation_size=128,
+        )
+
+        buf.release()
+
+        assert buf._released
+        assert retained == [buf]
+        with pytest.raises(MemoryError):
+            self.allocator.alloc(4096)
+
+        buf._release_callback = None
+        buf._released = False
+        buf.release()
+        assert self.allocator.alloc(4096) == 0
+
+
+class TestWarmPool:
+    """Unit tests for pre-warmed ManagedBuffer leasing."""
+
+    def _connector(self, slots=2, slot_size=128):
+        connector = MooncakeTransferEngineConnector.__new__(MooncakeTransferEngineConnector)
+        connector._closed = False
+        connector.allocator = BufferAllocator(total_size=1024, alignment=64)
+        connector.pool = torch.zeros(1024, dtype=torch.uint8)
+        connector.pool_prewarm_slots = slots
+        connector.pool_prewarm_size = slot_size
+        connector._warm_pool = _WarmPool()
+        connector._warm_pool_lock = threading.Lock()
+        connector._metrics = {"warm_pool_hits": 0, "warm_pool_misses": 0}
+        return connector
+
+    def test_warm_pool_no_stall_for_prewarmed_slots(self):
+        connector = self._connector(slots=2, slot_size=128)
+
+        MooncakeTransferEngineConnector._prewarm_pool(connector)
+        buffers = [MooncakeTransferEngineConnector._alloc_managed_buffer(connector, 64) for _ in range(2)]
+
+        assert connector._metrics["warm_pool_hits"] == 2
+        assert connector._metrics["warm_pool_misses"] == 0
+        assert len(connector._warm_pool.buffers) == 0
+
+        for buf in buffers:
+            buf.release()
+        assert len(connector._warm_pool.buffers) == 2
+
+
+class TestCachedSocket:
+    """Unit tests for idle/error-triggered socket recreation."""
+
+    class _FakeSocket:
+        def __init__(self):
+            self.closed = False
+            self.connected_to = None
+            self.options = {}
+
+        def connect(self, addr):
+            self.connected_to = addr
+
+        def setsockopt(self, key, value):
+            self.options[key] = value
+
+        def close(self, linger=0):
+            del linger
+            self.closed = True
+
+    class _FakeContext:
+        def __init__(self):
+            self.sockets = []
+
+        def socket(self, socket_type):
+            del socket_type
+            sock = TestCachedSocket._FakeSocket()
+            self.sockets.append(sock)
+            return sock
+
+    def _connector(self):
+        connector = MooncakeTransferEngineConnector.__new__(MooncakeTransferEngineConnector)
+        connector._req_local = threading.local()
+        connector.zmq_ctx = self._FakeContext()
+        connector.socket_health_interval_s = 30.0
+        connector._metrics = {"socket_recreates": 0}
+        return connector
+
+    def test_socket_recovery_recreates_failed_cached_socket(self):
+        connector = self._connector()
+        addr = "tcp://127.0.0.1:5555"
+
+        first = MooncakeTransferEngineConnector._get_req_socket(connector, addr, timeout_ms=100)
+        connector._req_local.cache[addr].had_error = True
+        second = MooncakeTransferEngineConnector._get_req_socket(connector, addr, timeout_ms=100)
+
+        assert first is not second
+        assert first.closed
+        assert second.connected_to == addr
+        assert connector._metrics["socket_recreates"] == 2
+
+
+def test_profile_disabled_does_not_define_span():
+    """Use _Span non-existence as the CI-safe proxy for zero profiling overhead.
+
+    Full put/get profiling overhead needs Mooncake, but when profiling is off
+    this verifies the module does not even define the span context manager that
+    would allocate and enter/exit on hot paths.
+    """
+    if mooncake_module._PROFILE:
+        pytest.skip("VLLM_OMNI_CONNECTOR_PROFILE is enabled for this test process")
+    assert not hasattr(mooncake_module, "_Span")

--- a/tests/distributed/omni_connectors/test_wire_types.py
+++ b/tests/distributed/omni_connectors/test_wire_types.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import struct
+
+import msgspec
+import pytest
+import torch
+
+from vllm_omni.distributed.omni_connectors.utils.wire_types import (
+    TENSOR_DICT_COMPRESSION_NONE,
+    deserialize_tensor_dict,
+    is_tensor_dict,
+    serialize_tensor_dict,
+)
+
+pytestmark = [pytest.mark.cpu, pytest.mark.parallel, pytest.mark.core_model]
+
+
+def test_is_tensor_dict_requires_string_tensor_items():
+    assert is_tensor_dict({"tokens": torch.arange(4)})
+    assert not is_tensor_dict({"tokens": [1, 2, 3]})
+    assert not is_tensor_dict({1: torch.arange(4)})
+    assert not is_tensor_dict([torch.arange(4)])
+
+
+def test_tensor_dict_wire_format_round_trip():
+    payload = {
+        "tokens": torch.arange(12, dtype=torch.int64).reshape(3, 4),
+        "codes": torch.arange(8, dtype=torch.int32)[::2].contiguous(),
+        "scores": torch.tensor([[1.25, 2.5]], dtype=torch.float32),
+        "scalar": torch.tensor(7, dtype=torch.int64),
+        "empty": torch.empty((0, 3), dtype=torch.float16),
+    }
+
+    restored = deserialize_tensor_dict(serialize_tensor_dict(payload))
+
+    assert restored.keys() == payload.keys()
+    for key, expected in payload.items():
+        assert restored[key].dtype == expected.dtype
+        assert restored[key].shape == expected.shape
+        assert torch.equal(restored[key], expected.cpu())
+
+
+def test_tensor_dict_wire_format_rejects_unknown_compression():
+    encoded = bytearray(serialize_tensor_dict({"tokens": torch.arange(4, dtype=torch.int64)}))
+
+    prefix = struct.Struct("<4sII")
+    _magic, _version, header_len = prefix.unpack(encoded[: prefix.size])
+    header_start = prefix.size
+    header_end = header_start + header_len
+    header = msgspec.msgpack.decode(encoded[header_start:header_end])
+    header["entries"][0]["compression"] = TENSOR_DICT_COMPRESSION_NONE + 1
+    new_header = msgspec.msgpack.encode(header)
+    encoded[: prefix.size] = prefix.pack(b"OMTD", 1, len(new_header))
+    encoded[header_start:header_end] = new_header
+
+    with pytest.raises(ValueError, match="Unsupported tensor-dict compression"):
+        deserialize_tensor_dict(encoded)

--- a/tests/distributed/omni_connectors/test_wire_types.py
+++ b/tests/distributed/omni_connectors/test_wire_types.py
@@ -3,12 +3,11 @@
 
 import struct
 
-import msgspec
 import pytest
 import torch
 
 from vllm_omni.distributed.omni_connectors.utils.wire_types import (
-    TENSOR_DICT_COMPRESSION_NONE,
+    TENSOR_DICT_MAGIC,
     deserialize_tensor_dict,
     is_tensor_dict,
     serialize_tensor_dict,
@@ -27,7 +26,7 @@ def test_is_tensor_dict_requires_string_tensor_items():
 def test_tensor_dict_wire_format_round_trip():
     payload = {
         "tokens": torch.arange(12, dtype=torch.int64).reshape(3, 4),
-        "codes": torch.arange(8, dtype=torch.int32)[::2].contiguous(),
+        "codes": torch.arange(8, dtype=torch.int32)[::2],
         "scores": torch.tensor([[1.25, 2.5]], dtype=torch.float32),
         "scalar": torch.tensor(7, dtype=torch.int64),
         "empty": torch.empty((0, 3), dtype=torch.float16),
@@ -42,18 +41,30 @@ def test_tensor_dict_wire_format_round_trip():
         assert torch.equal(restored[key], expected.cpu())
 
 
-def test_tensor_dict_wire_format_rejects_unknown_compression():
+def test_tensor_dict_wire_format_header_matches_rfc_layout():
     encoded = bytearray(serialize_tensor_dict({"tokens": torch.arange(4, dtype=torch.int64)}))
 
-    prefix = struct.Struct("<4sII")
-    _magic, _version, header_len = prefix.unpack(encoded[: prefix.size])
-    header_start = prefix.size
-    header_end = header_start + header_len
-    header = msgspec.msgpack.decode(encoded[header_start:header_end])
-    header["entries"][0]["compression"] = TENSOR_DICT_COMPRESSION_NONE + 1
-    new_header = msgspec.msgpack.encode(header)
-    encoded[: prefix.size] = prefix.pack(b"OMTD", 1, len(new_header))
-    encoded[header_start:header_end] = new_header
+    prefix = struct.Struct("<4sHHII")
+    magic, version, header_len, n_tensors, checksum = prefix.unpack(encoded[: prefix.size])
 
-    with pytest.raises(ValueError, match="Unsupported tensor-dict compression"):
+    assert magic == TENSOR_DICT_MAGIC == b"OMDI"
+    assert version == 1
+    assert header_len % 64 == 0
+    assert n_tensors == 1
+    assert checksum != 0
+
+
+def test_tensor_dict_wire_format_rejects_header_checksum_mismatch():
+    encoded = bytearray(serialize_tensor_dict({"tokens": torch.arange(4, dtype=torch.int64)}))
+    prefix = struct.Struct("<4sHHII")
+    encoded[prefix.size + 1] ^= 0xFF
+
+    with pytest.raises(ValueError, match="checksum"):
         deserialize_tensor_dict(encoded)
+
+
+def test_tensor_dict_wire_format_rejects_truncated_payload():
+    encoded = serialize_tensor_dict({"tokens": torch.arange(4, dtype=torch.int64)})
+
+    with pytest.raises(ValueError, match="truncated"):
+        deserialize_tensor_dict(encoded[:-1])

--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -537,7 +537,6 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             return False, 0, None
 
         put_key = self._make_key(put_key, from_stage, to_stage)
-        spans: dict[str, float] = {}
 
         # Serialize concurrent put() calls on the same connector to prevent
         # races in the alloc -> copy -> store-metadata flow at the Mooncake
@@ -548,6 +547,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
     def _put_impl(self, put_key: str, data: Any) -> tuple[bool, int, dict[str, Any] | None]:
         """Internal put implementation, called under _put_lock."""
         try:
+            spans: dict[str, float] = {}
             src_addr = 0
             size = 0
             holder = None

--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -8,7 +8,7 @@ import threading
 import time as _time_mod
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import msgspec
@@ -31,6 +31,7 @@ except ImportError:
 # Stale buffer TTL: buffers older than this are automatically reclaimed
 # to prevent memory leaks when receiver crashes or gives up.
 _BUFFER_TTL_SECONDS = 300  # 5 minutes
+_PROFILE: bool = os.getenv("VLLM_OMNI_CONNECTOR_PROFILE", "0") == "1"
 
 # ZMQ Message constants
 TRANS_DONE = b"trans_done"
@@ -40,6 +41,38 @@ INFO_NOT_FOUND = b"info_not_found"
 PAYLOAD_KIND_RAW = "raw"
 PAYLOAD_KIND_MSGPACK = "msgpack"
 PAYLOAD_KIND_TENSOR_DICT = "tensor_dict"
+
+
+if _PROFILE:
+
+    class _Span:
+        __slots__ = ("name", "start", "store")
+
+        def __init__(self, name: str, store: dict[str, float]):
+            self.name = name
+            self.store = store
+
+        def __enter__(self):
+            self.start = _time_mod.perf_counter()
+            return self
+
+        def __exit__(self, *_):
+            self.store[self.name] = self.store.get(self.name, 0.0) + (_time_mod.perf_counter() - self.start)
+
+
+@dataclass
+class _CachedSocket:
+    socket: zmq.Socket
+    created_at: float
+    last_used_at: float
+    had_error: bool = False
+
+
+@dataclass
+class _WarmPool:
+    buffers: list["ManagedBuffer"] = field(default_factory=list)
+    hits: int = 0
+    misses: int = 0
 
 
 @dataclass
@@ -124,6 +157,10 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         self._worker_local = threading.local()
         self._last_ttl_check: float = _time_mod.monotonic()
         self._sender_endpoints: dict[int, tuple[str, int]] = {}
+        self._warm_pool = _WarmPool()
+        self._warm_pool_lock = threading.Lock()
+        self._profile_records: list[dict[str, float | str | int]] = []
+        self._profile_lock = threading.Lock()
 
         self._metrics = {
             "puts": 0,
@@ -131,6 +168,9 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             "bytes_transferred": 0,
             "errors": 0,
             "timeouts": 0,
+            "warm_pool_hits": 0,
+            "warm_pool_misses": 0,
+            "socket_recreates": 0,
         }
 
         self.config = config
@@ -160,6 +200,11 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         # --- Memory Pool Configuration ---
         self.pool_size = config.get("memory_pool_size", 1024**3)  # Default 1GB
         self.pool_device = config.get("memory_pool_device", "cpu")
+        self.enable_tensor_dict_fast_path = bool(config.get("enable_tensor_dict_fast_path", True))
+        self.enable_pipelined_zmq_write = bool(config.get("enable_pipelined_zmq_write", False))
+        self.pool_prewarm_slots = int(config.get("pool_prewarm_slots", 0) or 0)
+        self.pool_prewarm_size = int(config.get("pool_prewarm_size", 0) or 0)
+        self.socket_health_interval_s = float(config.get("socket_health_interval_s", 30.0))
 
         # --- Sender Configuration (for receiver to query without metadata) ---
         # When receiver doesn't have metadata, it uses these to connect to sender
@@ -211,6 +256,15 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             raise
 
         self.allocator = BufferAllocator(self.pool_size, alignment=4096)  # 4KB alignment for safety
+        self._prewarm_pool()
+
+        if self.enable_pipelined_zmq_write:
+            logger.warning(
+                "enable_pipelined_zmq_write=True requested, but this connector uses sender-side "
+                "batch_transfer_sync_write() into receiver-provided addresses. Early TRANS_DONE would "
+                "let callers read before the write is visible, so Opt A remains disabled for correctness."
+            )
+            self.enable_pipelined_zmq_write = False
 
         # --- State Management & Background Threads ---
         # Most fields already initialized at the top of __init__ for teardown
@@ -264,6 +318,81 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             "rpc_port": self.rpc_port,
             "can_put": self.can_put,
         }
+
+    def _record_profile(self, operation: str, key: str, spans: dict[str, float], size: int = 0) -> None:
+        if not _PROFILE:
+            return
+        record: dict[str, float | str | int] = {
+            "operation": operation,
+            "key": key,
+            "size": size,
+        }
+        record.update({name: seconds * 1000.0 for name, seconds in spans.items()})
+        with self._profile_lock:
+            self._profile_records.append(record)
+        logger.debug("Mooncake TE profile span: %s", record)
+
+    def pop_profile_records(self) -> list[dict[str, float | str | int]]:
+        """Return and clear collected profiling records.
+
+        Records are populated only when ``VLLM_OMNI_CONNECTOR_PROFILE=1``.
+        This keeps profiling data out of ``health()``, which remains an
+        operational API rather than a benchmark transport.
+        """
+        if not _PROFILE:
+            return []
+        with self._profile_lock:
+            records = list(self._profile_records)
+            self._profile_records.clear()
+        return records
+
+    def _return_warm_buffer(self, buf: ManagedBuffer) -> bool:
+        if self._closed:
+            return False
+        buf.size = buf.allocation_size
+        with self._warm_pool_lock:
+            self._warm_pool.buffers.append(buf)
+        return True
+
+    def _prewarm_pool(self) -> None:
+        if self.pool_prewarm_slots <= 0:
+            return
+        if self.pool_prewarm_size <= 0:
+            raise ValueError("pool_prewarm_size must be > 0 when pool_prewarm_slots is enabled")
+
+        for _ in range(self.pool_prewarm_slots):
+            offset = self.allocator.alloc(self.pool_prewarm_size)
+            buf = ManagedBuffer(
+                self.allocator,
+                offset,
+                self.pool_prewarm_size,
+                self.pool,
+                release_callback=self._return_warm_buffer,
+                allocation_size=self.pool_prewarm_size,
+            )
+            buf._released = True
+            self._warm_pool.buffers.append(buf)
+        logger.info(
+            "Pre-warmed Mooncake memory pool with %s slots of %s bytes",
+            self.pool_prewarm_slots,
+            self.pool_prewarm_size,
+        )
+
+    def _alloc_managed_buffer(self, size: int) -> ManagedBuffer:
+        with self._warm_pool_lock:
+            for i, buf in enumerate(self._warm_pool.buffers):
+                if buf.allocation_size >= size:
+                    self._warm_pool.hits += 1
+                    self._metrics["warm_pool_hits"] += 1
+                    leased = self._warm_pool.buffers.pop(i)
+                    leased.size = size
+                    leased._released = False
+                    return leased
+            self._warm_pool.misses += 1
+            self._metrics["warm_pool_misses"] += 1
+
+        offset = self.allocator.alloc(size)
+        return ManagedBuffer(self.allocator, offset, size, self.pool)
 
     def update_sender_info(
         self,
@@ -335,16 +464,35 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         If a call fails, use ``_invalidate_req_socket()`` to discard the
         broken socket; the next call will transparently create a fresh one.
         """
-        cache: dict[str, zmq.Socket] = getattr(self._req_local, "cache", None)  # type: ignore[assignment]
+        cache: dict[str, _CachedSocket] = getattr(self._req_local, "cache", None)  # type: ignore[assignment]
         if cache is None:
             cache = {}
             self._req_local.cache = cache
 
-        sock = cache.get(zmq_addr)
-        if sock is None:
+        now = _time_mod.monotonic()
+        cached = cache.get(zmq_addr)
+        idle_too_long = (
+            cached is not None
+            and self.socket_health_interval_s > 0
+            and now - cached.last_used_at >= self.socket_health_interval_s
+        )
+        if cached is not None and (cached.had_error or idle_too_long):
+            try:
+                cached.socket.close(linger=0)
+            except Exception:
+                pass
+            cache.pop(zmq_addr, None)
+            cached = None
+
+        if cached is None:
             sock = self.zmq_ctx.socket(zmq.REQ)
             sock.connect(zmq_addr)
-            cache[zmq_addr] = sock
+            cached = _CachedSocket(socket=sock, created_at=now, last_used_at=now)
+            cache[zmq_addr] = cached
+            self._metrics["socket_recreates"] += 1
+
+        cached.last_used_at = now
+        sock = cached.socket
         # Set timeouts per-call (safe to change between send/recv cycles).
         # SNDTIMEO guards against send() blocking when the peer is unreachable
         # or its receive buffer is full.
@@ -354,13 +502,14 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
 
     def _invalidate_req_socket(self, zmq_addr: str) -> None:
         """Close and remove a thread-local cached REQ socket (e.g., after recv timeout)."""
-        cache: dict[str, zmq.Socket] = getattr(self._req_local, "cache", None)  # type: ignore[assignment]
+        cache: dict[str, _CachedSocket] = getattr(self._req_local, "cache", None)  # type: ignore[assignment]
         if cache is None:
             return
-        sock = cache.pop(zmq_addr, None)
-        if sock is not None:
+        cached = cache.pop(zmq_addr, None)
+        if cached is not None:
+            cached.had_error = True
             try:
-                sock.close(linger=0)
+                cached.socket.close(linger=0)
             except Exception:
                 pass  # Best-effort; zmq_ctx.term() will reclaim if needed
 
@@ -388,6 +537,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             return False, 0, None
 
         put_key = self._make_key(put_key, from_stage, to_stage)
+        spans: dict[str, float] = {}
 
         # Serialize concurrent put() calls on the same connector to prevent
         # races in the alloc -> copy -> store-metadata flow at the Mooncake
@@ -418,12 +568,20 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             # Pre-process: serialize non-raw types before entering the copy path.
             # This avoids the previous recursive put() pattern and keeps
             # _local_buffers writes atomic (single write, no override needed).
-            if is_tensor_dict(data):
-                data = serialize_tensor_dict(data)
+            if self.enable_tensor_dict_fast_path and is_tensor_dict(data):
+                if _PROFILE:
+                    with _Span("serialize", spans):
+                        data = serialize_tensor_dict(data)
+                else:
+                    data = serialize_tensor_dict(data)
                 is_fast_path = False
                 payload_kind = PAYLOAD_KIND_TENSOR_DICT
             elif not isinstance(data, ManagedBuffer | torch.Tensor | bytes):
-                data = OmniSerializer.serialize(data)
+                if _PROFILE:
+                    with _Span("serialize", spans):
+                        data = OmniSerializer.serialize(data)
+                else:
+                    data = OmniSerializer.serialize(data)
                 is_fast_path = False  # Receiver must deserialize
                 payload_kind = PAYLOAD_KIND_MSGPACK
 
@@ -457,8 +615,12 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
 
                 # 2. Alloc from pool
                 try:
-                    offset = self.allocator.alloc(size)
-                    holder = ManagedBuffer(self.allocator, offset, size, self.pool)
+                    if _PROFILE:
+                        with _Span("pool_alloc", spans):
+                            holder = self._alloc_managed_buffer(size)
+                    else:
+                        holder = self._alloc_managed_buffer(size)
+                    offset = holder.offset
                     should_release_holder = True  # We created it, we release it
                 except MemoryError:
                     logger.error(f"Pool exhausted, cannot put data size {size}")
@@ -545,6 +707,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
 
             self._metrics["puts"] += 1
             self._metrics["bytes_transferred"] += size
+            self._record_profile("put", put_key, spans, size)
 
             return True, size, metadata
 
@@ -623,6 +786,30 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             return None
         return self._query_metadata_at(get_key, *endpoint)
 
+    def _resolve_get_metadata(self, get_key: str, metadata: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not metadata:
+            if not self.sender_host or not self.sender_zmq_port or str(self.sender_host).lower() == "auto":
+                raise RuntimeError(
+                    f"get(metadata=None) requires sender info to be resolved, "
+                    f"but sender_host={self.sender_host!r}, sender_zmq_port={self.sender_zmq_port!r}. "
+                    f"Call update_sender_info(host, port) before using get() without metadata."
+                )
+            return self._query_metadata_from_sender(get_key)
+
+        if "data_size" in metadata:
+            return metadata
+
+        partial_host = metadata.get("source_host")
+        partial_port = metadata.get("source_port")
+        if not partial_host or not partial_port:
+            logger.warning(
+                "get(%s): partial metadata missing source_host/source_port, cannot resolve data_size. metadata=%s",
+                get_key,
+                metadata,
+            )
+            return None
+        return self._query_metadata_at(get_key, str(partial_host), int(partial_port))
+
     def get(
         self,
         from_stage: str,
@@ -659,33 +846,15 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         get_key = self._make_key(get_key, from_stage, to_stage)
 
         _t0 = _time_mod.perf_counter()
+        spans: dict[str, float] = {}
 
+        if _PROFILE:
+            with _Span("zmq_query", spans):
+                metadata = self._resolve_get_metadata(get_key, metadata)
+        else:
+            metadata = self._resolve_get_metadata(get_key, metadata)
         if not metadata:
-            # Path 3: no metadata at all — query default sender
-            if not self.sender_host or not self.sender_zmq_port or str(self.sender_host).lower() == "auto":
-                raise RuntimeError(
-                    f"get(metadata=None) requires sender info to be resolved, "
-                    f"but sender_host={self.sender_host!r}, sender_zmq_port={self.sender_zmq_port!r}. "
-                    f"Call update_sender_info(host, port) before using get() without metadata."
-                )
-            metadata = self._query_metadata_from_sender(get_key)
-            if not metadata:
-                return None
-        elif "data_size" not in metadata:
-            # Path 2: partial metadata (host/port only) — query that sender
-            partial_host = metadata.get("source_host")
-            partial_port = metadata.get("source_port")
-            if not partial_host or not partial_port:
-                logger.warning(
-                    "get(%s): partial metadata missing source_host/source_port, cannot resolve data_size. metadata=%s",
-                    get_key,
-                    metadata,
-                )
-                return None
-            queried = self._query_metadata_at(get_key, str(partial_host), int(partial_port))
-            if not queried:
-                return None
-            metadata = queried
+            return None
 
         _t1 = _time_mod.perf_counter()
         _query_ms = (_t1 - _t0) * 1000
@@ -709,8 +878,12 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
 
         # 1. Allocate Destination Buffer from Pool
         try:
-            offset = self.allocator.alloc(data_size)
-            recv_buffer = ManagedBuffer(self.allocator, offset, data_size, self.pool)
+            if _PROFILE:
+                with _Span("dest_alloc", spans):
+                    recv_buffer = self._alloc_managed_buffer(data_size)
+            else:
+                recv_buffer = self._alloc_managed_buffer(data_size)
+            offset = recv_buffer.offset
             dst_ptr = self.base_ptr + offset
         except MemoryError:
             logger.error(f"Failed to allocate {data_size} bytes in receive pool")
@@ -741,7 +914,11 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
 
         try:
             req_socket.send(msgspec.msgpack.encode(agent_meta))
-            resp = req_socket.recv()
+            if _PROFILE:
+                with _Span("te_read", spans):
+                    resp = req_socket.recv()
+            else:
+                resp = req_socket.recv()
 
             _t3 = _time_mod.perf_counter()
             _rdma_ms = (_t3 - _t2) * 1000
@@ -780,6 +957,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
                     )
                     self._metrics["gets"] += 1
                     self._metrics["bytes_transferred"] += data_size
+                    self._record_profile("get", get_key, spans, data_size)
                     return recv_buffer, data_size
                 else:
                     # If it was a serialized object or generic bytes, we assume standard Omni behavior:
@@ -792,7 +970,13 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
                         _copy_ms = (_t_copy_end - _t_copy_start) * 1000
 
                         _t_deser_start = _time_mod.perf_counter()
-                        if payload_kind == PAYLOAD_KIND_TENSOR_DICT:
+                        if _PROFILE:
+                            with _Span("deserialize", spans):
+                                if payload_kind == PAYLOAD_KIND_TENSOR_DICT:
+                                    val = deserialize_tensor_dict(raw_bytes)
+                                else:
+                                    val = OmniSerializer.deserialize(raw_bytes)
+                        elif payload_kind == PAYLOAD_KIND_TENSOR_DICT:
                             val = deserialize_tensor_dict(raw_bytes)
                         else:
                             val = OmniSerializer.deserialize(raw_bytes)
@@ -808,6 +992,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
                         )
                         self._metrics["gets"] += 1
                         self._metrics["bytes_transferred"] += data_size
+                        self._record_profile("get", get_key, spans, data_size)
                         return val, data_size
                     finally:
                         recv_buffer.release()
@@ -905,16 +1090,23 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
                     holder.release()
             self._local_buffers.clear()
 
+        with self._warm_pool_lock:
+            for buf in self._warm_pool.buffers:
+                buf._release_callback = None
+                buf._released = False
+                buf.release()
+            self._warm_pool.buffers.clear()
+
         # 5. Close thread-local cached REQ sockets (for the calling thread).
         #    Sockets cached in *other* threads are not directly accessible here
         #    because they live in per-thread ``threading.local()`` storage.
         #    They will be forcefully closed when ``zmq_ctx.term()`` is called
         #    in step 7 below, which is the intended cleanup path.
-        cache: dict[str, zmq.Socket] = getattr(self._req_local, "cache", None)  # type: ignore[assignment]
+        cache: dict[str, _CachedSocket] = getattr(self._req_local, "cache", None)  # type: ignore[assignment]
         if cache:
-            for addr, sock in cache.items():
+            for addr, cached in cache.items():
                 try:
-                    sock.close(linger=0)
+                    cached.socket.close(linger=0)
                 except Exception:
                     pass  # Best-effort; zmq_ctx.term() below will reclaim
             cache.clear()
@@ -1066,13 +1258,19 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
 
             src_addrs, src_lengths, _, _, _, _, _ = item
             remote_session = f"{meta.remote_hostname}:{meta.remote_port}"
+            spans: dict[str, float] = {}
 
             # RDMA Write
-            ret = self.engine.batch_transfer_sync_write(remote_session, src_addrs, meta.dst_addrs, src_lengths)
+            if _PROFILE:
+                with _Span("te_write", spans):
+                    ret = self.engine.batch_transfer_sync_write(remote_session, src_addrs, meta.dst_addrs, src_lengths)
+            else:
+                ret = self.engine.batch_transfer_sync_write(remote_session, src_addrs, meta.dst_addrs, src_lengths)
 
             if ret == 0:
                 self.cleanup(meta.request_id)
                 response_queue.put((identity, TRANS_DONE))
+                self._record_profile("write", meta.request_id, spans, sum(src_lengths))
             else:
                 # Keep buffer in _local_buffers so receiver can retry on transient failures.
                 # Buffer will be cleaned up when: (a) a retry succeeds, (b) close() is called,

--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -18,6 +18,7 @@ import zmq
 from ..utils.logging import get_connector_logger
 from ..utils.memory_pool import BufferAllocator, ManagedBuffer
 from ..utils.serialization import OmniSerializer
+from ..utils.wire_types import deserialize_tensor_dict, is_tensor_dict, serialize_tensor_dict
 from .base import OmniConnectorBase
 
 logger = get_connector_logger(__name__)
@@ -36,6 +37,9 @@ TRANS_DONE = b"trans_done"
 TRANS_ERROR = b"trans_error"
 QUERY_INFO = b"query_info"
 INFO_NOT_FOUND = b"info_not_found"
+PAYLOAD_KIND_RAW = "raw"
+PAYLOAD_KIND_MSGPACK = "msgpack"
+PAYLOAD_KIND_TENSOR_DICT = "tensor_dict"
 
 
 @dataclass
@@ -52,6 +56,7 @@ class QueryResponse:
     request_id: str
     data_size: int
     is_fast_path: bool
+    payload_kind: str = PAYLOAD_KIND_RAW
 
 
 @dataclass
@@ -368,6 +373,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         - ManagedBuffer (from this pool): Zero-copy, is_fast_path=True
         - ManagedBuffer (different pool): Fallback to tensor copy path
         - torch.Tensor / bytes: Copy to pool, is_fast_path=True
+        - dict[str, torch.Tensor]: Binary tensor-dict wire format, is_fast_path=False
         - Other (dict, etc.): Serialize to bytes, copy to pool, is_fast_path=False
           (receiver will deserialize automatically)
         """
@@ -396,6 +402,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             size = 0
             holder = None
             is_fast_path = True
+            payload_kind = PAYLOAD_KIND_RAW
             should_release_holder = False
 
             # Reject empty data early — alloc(0) has undefined behaviour and
@@ -411,9 +418,14 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             # Pre-process: serialize non-raw types before entering the copy path.
             # This avoids the previous recursive put() pattern and keeps
             # _local_buffers writes atomic (single write, no override needed).
-            if not isinstance(data, (ManagedBuffer, torch.Tensor, bytes)):
+            if is_tensor_dict(data):
+                data = serialize_tensor_dict(data)
+                is_fast_path = False
+                payload_kind = PAYLOAD_KIND_TENSOR_DICT
+            elif not isinstance(data, ManagedBuffer | torch.Tensor | bytes):
                 data = OmniSerializer.serialize(data)
                 is_fast_path = False  # Receiver must deserialize
+                payload_kind = PAYLOAD_KIND_MSGPACK
 
             if isinstance(data, ManagedBuffer):
                 # Zero-Copy Path
@@ -432,7 +444,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
 
             # Use 'if' (not 'elif') so the ManagedBuffer fallback above can
             # convert to Tensor and flow into this branch seamlessly.
-            if isinstance(data, (torch.Tensor, bytes)):
+            if isinstance(data, torch.Tensor | bytes):
                 # Copy Path
                 # 1. Determine size
                 if isinstance(data, torch.Tensor):
@@ -506,18 +518,19 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
                 # Release old buffer if put_key already exists (prevents pool leak)
                 old_item = self._local_buffers.pop(put_key, None)
                 if old_item:
-                    _, _, old_holder, old_should_release, _, _ = old_item
+                    _, _, old_holder, old_should_release, _, _, _ = old_item
                     if old_should_release and isinstance(old_holder, ManagedBuffer):
                         old_holder.release()
                         logger.warning(f"Released old buffer for duplicate put_key: {put_key}")
 
-                # Store: (src_addrs, lengths, holder, should_release, is_fast_path, created_at)
+                # Store: (src_addrs, lengths, holder, should_release, is_fast_path, payload_kind, created_at)
                 self._local_buffers[put_key] = (
                     [src_addr],
                     [size],
                     holder,
                     should_release_holder,
                     is_fast_path,
+                    payload_kind,
                     _time_mod.monotonic(),
                 )
 
@@ -527,6 +540,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
                 "source_port": self.zmq_port,
                 "data_size": size,
                 "is_fast_path": is_fast_path,  # Hint: True = return ManagedBuffer, False = deserialize
+                "payload_kind": payload_kind,
             }
 
             self._metrics["puts"] += 1
@@ -558,7 +572,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
     def _query_metadata_at(self, get_key: str, host: str, port: int) -> dict[str, Any] | None:
         """Query metadata from a sender endpoint via ZMQ.
 
-        Returns ``{source_host, source_port, data_size, is_fast_path}``
+        Returns ``{source_host, source_port, data_size, is_fast_path, payload_kind}``
         or ``None`` when the key is not found / the query fails.
         """
         zmq_addr = f"tcp://{host}:{port}"
@@ -574,6 +588,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
                 "source_port": port,
                 "data_size": query_resp.data_size,
                 "is_fast_path": query_resp.is_fast_path,
+                "payload_kind": query_resp.payload_kind,
             }
         except Exception as e:
             self._invalidate_req_socket(zmq_addr)
@@ -679,6 +694,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         src_port = metadata.get("source_port")
         data_size = metadata.get("data_size", 0)
         is_fast_path = metadata.get("is_fast_path", False)
+        payload_kind = metadata.get("payload_kind", PAYLOAD_KIND_RAW if is_fast_path else PAYLOAD_KIND_MSGPACK)
 
         if not src_host or not src_port or str(src_host).lower() == "auto":
             logger.error(
@@ -776,7 +792,10 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
                         _copy_ms = (_t_copy_end - _t_copy_start) * 1000
 
                         _t_deser_start = _time_mod.perf_counter()
-                        val = OmniSerializer.deserialize(raw_bytes)
+                        if payload_kind == PAYLOAD_KIND_TENSOR_DICT:
+                            val = deserialize_tensor_dict(raw_bytes)
+                        else:
+                            val = OmniSerializer.deserialize(raw_bytes)
                         _t_deser_end = _time_mod.perf_counter()
                         _deser_ms = (_t_deser_end - _t_deser_start) * 1000
 
@@ -828,8 +847,8 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         with self._local_buffers_lock:
             item = self._local_buffers.pop(request_id, None)
             if item:
-                # item is (src_addrs, lengths, holder, should_release, is_fast_path, created_at)
-                _, _, holder, should_release, _, _ = item
+                # item is (src_addrs, lengths, holder, should_release, is_fast_path, payload_kind, created_at)
+                _, _, holder, should_release, _, _, _ = item
                 if should_release and isinstance(holder, ManagedBuffer):
                     # We own this buffer (created internally), so we must release it.
                     holder.release()
@@ -881,7 +900,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         # 4. Release all pending buffers
         with self._local_buffers_lock:
             for req_id, item in list(self._local_buffers.items()):
-                _, _, holder, should_release, _, _ = item
+                _, _, holder, should_release, _, _, _ = item
                 if should_release and isinstance(holder, ManagedBuffer):
                     holder.release()
             self._local_buffers.clear()
@@ -934,10 +953,10 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         """
         now = _time_mod.monotonic()
         with self._local_buffers_lock:
-            stale_keys = [k for k, v in self._local_buffers.items() if now - v[5] > _BUFFER_TTL_SECONDS]
+            stale_keys = [k for k, v in self._local_buffers.items() if now - v[6] > _BUFFER_TTL_SECONDS]
             for k in stale_keys:
                 item = self._local_buffers.pop(k)
-                _, _, holder, should_release, _, _ = item
+                _, _, holder, should_release, _, _, _ = item
                 if should_release and isinstance(holder, ManagedBuffer):
                     holder.release()
                 logger.warning(f"TTL expired ({_BUFFER_TTL_SECONDS}s): cleaned up stale buffer for {k}")
@@ -1045,7 +1064,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
                 self._notify_listener(notify_addr)
                 return
 
-            src_addrs, src_lengths, _, _, _, _ = item
+            src_addrs, src_lengths, _, _, _, _, _ = item
             remote_session = f"{meta.remote_hostname}:{meta.remote_port}"
 
             # RDMA Write
@@ -1082,12 +1101,13 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             if not item:
                 response_queue.put((identity, INFO_NOT_FOUND))
             else:
-                src_addrs, src_lengths, _, _, is_fast_path, _ = item
+                src_addrs, src_lengths, _, _, is_fast_path, payload_kind, _ = item
 
                 resp = QueryResponse(
                     request_id=query.request_id,
                     data_size=src_lengths[0] if src_lengths else 0,
                     is_fast_path=is_fast_path,
+                    payload_kind=payload_kind,
                 )
                 response_queue.put((identity, msgspec.msgpack.encode(resp)))
 

--- a/vllm_omni/distributed/omni_connectors/utils/config.py
+++ b/vllm_omni/distributed/omni_connectors/utils/config.py
@@ -25,6 +25,20 @@ class ConnectorSpec:
     extra: dict[str, Any] = field(default_factory=dict)  # backend-specific config
 
 
+@dataclass(frozen=True)
+class MooncakeTransferEngineExtraKeys:
+    """Recognized ``ConnectorSpec.extra`` keys for MooncakeTransferEngineConnector."""
+
+    enable_tensor_dict_fast_path: str = "enable_tensor_dict_fast_path"
+    enable_pipelined_zmq_write: str = "enable_pipelined_zmq_write"
+    pool_prewarm_slots: str = "pool_prewarm_slots"
+    pool_prewarm_size: str = "pool_prewarm_size"
+    socket_health_interval_s: str = "socket_health_interval_s"
+
+
+MOONCAKE_TRANSFER_ENGINE_EXTRA_KEYS = MooncakeTransferEngineExtraKeys()
+
+
 @dataclass
 class OmniTransferConfig:
     """

--- a/vllm_omni/distributed/omni_connectors/utils/memory_pool.py
+++ b/vllm_omni/distributed/omni_connectors/utils/memory_pool.py
@@ -89,17 +89,30 @@ class ManagedBuffer:
     Must be kept alive while the data view is being used.
     """
 
-    def __init__(self, allocator: BufferAllocator, offset: int, size: int, pool_tensor: torch.Tensor):
+    def __init__(
+        self,
+        allocator: BufferAllocator,
+        offset: int,
+        size: int,
+        pool_tensor: torch.Tensor,
+        release_callback=None,
+        allocation_size: int | None = None,
+    ):
         self.allocator = allocator
         self.offset = offset
         self.size = size
+        self.allocation_size = size if allocation_size is None else allocation_size
         self.pool_tensor = pool_tensor
+        self._release_callback = release_callback
         self._released = False
 
     def release(self) -> None:
         """Explicitly release the buffer back to the pool."""
         if not self._released:
-            self.allocator.free(self.offset, self.size)
+            if self._release_callback is not None and self._release_callback(self):
+                self._released = True
+                return
+            self.allocator.free(self.offset, self.allocation_size)
             self._released = True
 
     def __del__(self):

--- a/vllm_omni/distributed/omni_connectors/utils/wire_types.py
+++ b/vllm_omni/distributed/omni_connectors/utils/wire_types.py
@@ -4,16 +4,21 @@
 from __future__ import annotations
 
 import struct
+import zlib
 from typing import Any
 
-import msgspec
 import torch
 
-TENSOR_DICT_MAGIC = b"OMTD"
+TENSOR_DICT_MAGIC = b"OMDI"
 TENSOR_DICT_VERSION = 1
 TENSOR_DICT_COMPRESSION_NONE = 0
+TENSOR_DICT_LAYOUT_CONTIGUOUS = 0
+TENSOR_DICT_ALIGNMENT = 64
 
-_HEADER_PREFIX = struct.Struct("<4sII")
+_HEADER_PREFIX = struct.Struct("<4sHHII")
+_TENSOR_ENTRY_PREFIX = struct.Struct("<H")
+_TENSOR_ENTRY_META = struct.Struct("<HBB")
+_TENSOR_ENTRY_SUFFIX = struct.Struct("<QQ")
 
 _DTYPE_TO_ID: dict[torch.dtype, int] = {
     torch.bool: 1,
@@ -40,13 +45,13 @@ def is_tensor_dict(obj: Any) -> bool:
 def serialize_tensor_dict(tensors: dict[str, torch.Tensor]) -> bytes:
     """Serialize a dict[str, torch.Tensor] without generic object serialization.
 
-    The v1 wire format stores a small msgpack header followed by concatenated
-    tensor bytes. A per-tensor compression field is reserved for future use;
-    v1 only accepts ``TENSOR_DICT_COMPRESSION_NONE``.
+    The v1 wire format follows the RFC binary header contract:
+    magic/version/header length/count/checksum, per-tensor binary metadata,
+    64-byte header padding, then each tensor payload 64-byte aligned.
     """
-    entries: list[dict[str, Any]] = []
-    chunks: list[bytes] = []
-    offset = 0
+    entries = bytearray()
+    chunks: list[tuple[int, bytes]] = []
+    data_offset = 0
 
     for name, tensor in tensors.items():
         dtype_id = _DTYPE_TO_ID.get(tensor.dtype)
@@ -60,21 +65,48 @@ def serialize_tensor_dict(tensors: dict[str, torch.Tensor]) -> bytes:
             host_tensor = host_tensor.cpu()
 
         raw = host_tensor.reshape(-1).view(torch.uint8).numpy().tobytes()
-        entries.append(
-            {
-                "name": name,
-                "dtype": dtype_id,
-                "shape": list(tensor.shape),
-                "offset": offset,
-                "nbytes": len(raw),
-                "compression": TENSOR_DICT_COMPRESSION_NONE,
-            }
-        )
-        chunks.append(raw)
-        offset += len(raw)
+        aligned_offset = _align(data_offset)
+        key = name.encode("utf-8")
+        if len(key) > 0xFFFF:
+            raise ValueError(f"Tensor key is too long for tensor-dict wire format: {name!r}")
+        if tensor.dim() > 0xFF:
+            raise ValueError(f"Tensor rank is too large for tensor-dict wire format: {tensor.dim()}")
 
-    header = msgspec.msgpack.encode({"version": TENSOR_DICT_VERSION, "entries": entries})
-    return _HEADER_PREFIX.pack(TENSOR_DICT_MAGIC, TENSOR_DICT_VERSION, len(header)) + header + b"".join(chunks)
+        entries.extend(_TENSOR_ENTRY_PREFIX.pack(len(key)))
+        entries.extend(key)
+        entries.extend(
+            _TENSOR_ENTRY_META.pack(
+                dtype_id,
+                tensor.dim(),
+                TENSOR_DICT_LAYOUT_CONTIGUOUS,
+            )
+        )
+        for dim in tensor.shape:
+            entries.extend(struct.pack("<q", dim))
+        entries.extend(_TENSOR_ENTRY_SUFFIX.pack(aligned_offset, len(raw)))
+        chunks.append((aligned_offset, raw))
+        data_offset = aligned_offset + len(raw)
+
+    header_len = _align(_HEADER_PREFIX.size + len(entries))
+    if header_len > 0xFFFF:
+        raise ValueError(f"Tensor-dict header is too large: {header_len} bytes")
+
+    header = bytearray(_HEADER_PREFIX.pack(TENSOR_DICT_MAGIC, TENSOR_DICT_VERSION, header_len, len(tensors), 0))
+    header.extend(entries)
+    header.extend(b"\x00" * (header_len - len(header)))
+    checksum = zlib.crc32(header) & 0xFFFFFFFF
+    header[: _HEADER_PREFIX.size] = _HEADER_PREFIX.pack(
+        TENSOR_DICT_MAGIC,
+        TENSOR_DICT_VERSION,
+        header_len,
+        len(tensors),
+        checksum,
+    )
+
+    body = bytearray(data_offset)
+    for offset, raw in chunks:
+        body[offset : offset + len(raw)] = raw
+    return bytes(header + body)
 
 
 def deserialize_tensor_dict(data: bytes | bytearray | memoryview) -> dict[str, torch.Tensor]:
@@ -83,51 +115,75 @@ def deserialize_tensor_dict(data: bytes | bytearray | memoryview) -> dict[str, t
     if len(view) < _HEADER_PREFIX.size:
         raise ValueError("Tensor-dict payload is shorter than the wire header")
 
-    magic, version, header_len = _HEADER_PREFIX.unpack(view[: _HEADER_PREFIX.size])
+    magic, version, header_len, n_tensors, checksum = _HEADER_PREFIX.unpack(view[: _HEADER_PREFIX.size])
     if magic != TENSOR_DICT_MAGIC:
         raise ValueError("Tensor-dict payload has an invalid magic value")
     if version != TENSOR_DICT_VERSION:
         raise ValueError(f"Unsupported tensor-dict wire format version: {version}")
 
-    header_start = _HEADER_PREFIX.size
-    header_end = header_start + header_len
-    if header_end > len(view):
+    if header_len < _HEADER_PREFIX.size or header_len % TENSOR_DICT_ALIGNMENT != 0:
+        raise ValueError(f"Tensor-dict payload has an invalid header length: {header_len}")
+    if header_len > len(view):
         raise ValueError("Tensor-dict payload has a truncated header")
 
-    header = msgspec.msgpack.decode(view[header_start:header_end])
-    if header.get("version") != TENSOR_DICT_VERSION:
-        raise ValueError(f"Unsupported tensor-dict header version: {header.get('version')}")
+    header = bytearray(view[:header_len])
+    header[: _HEADER_PREFIX.size] = _HEADER_PREFIX.pack(magic, version, header_len, n_tensors, 0)
+    actual_checksum = zlib.crc32(header) & 0xFFFFFFFF
+    if actual_checksum != checksum:
+        raise ValueError("Tensor-dict payload header checksum mismatch")
 
-    body = view[header_end:]
+    body = view[header_len:]
     result: dict[str, torch.Tensor] = {}
-    for entry in header["entries"]:
-        compression = entry.get("compression", TENSOR_DICT_COMPRESSION_NONE)
-        if compression != TENSOR_DICT_COMPRESSION_NONE:
-            raise ValueError(f"Unsupported tensor-dict compression id: {compression}")
-
-        dtype = _ID_TO_DTYPE.get(entry["dtype"])
+    cursor = _HEADER_PREFIX.size
+    for _ in range(n_tensors):
+        if cursor + _TENSOR_ENTRY_PREFIX.size > header_len:
+            raise ValueError("Tensor-dict payload has a truncated tensor entry")
+        (key_len,) = _TENSOR_ENTRY_PREFIX.unpack(view[cursor : cursor + _TENSOR_ENTRY_PREFIX.size])
+        cursor += _TENSOR_ENTRY_PREFIX.size
+        if cursor + key_len + _TENSOR_ENTRY_META.size > header_len:
+            raise ValueError("Tensor-dict payload has a truncated tensor entry")
+        name = bytes(view[cursor : cursor + key_len]).decode("utf-8")
+        cursor += key_len
+        dtype_id, ndim, layout = _TENSOR_ENTRY_META.unpack(view[cursor : cursor + _TENSOR_ENTRY_META.size])
+        cursor += _TENSOR_ENTRY_META.size
+        if layout != TENSOR_DICT_LAYOUT_CONTIGUOUS:
+            raise ValueError(f"Unsupported tensor-dict layout id: {layout}")
+        dtype = _ID_TO_DTYPE.get(dtype_id)
         if dtype is None:
-            raise ValueError(f"Unsupported tensor-dict dtype id: {entry['dtype']}")
-
-        offset = entry["offset"]
-        nbytes = entry["nbytes"]
+            raise ValueError(f"Unsupported tensor-dict dtype id: {dtype_id}")
+        shape: list[int] = []
+        shape_bytes = ndim * 8
+        if cursor + shape_bytes + _TENSOR_ENTRY_SUFFIX.size > header_len:
+            raise ValueError("Tensor-dict payload has a truncated tensor entry")
+        for _ in range(ndim):
+            (dim,) = struct.unpack("<q", view[cursor : cursor + 8])
+            if dim < 0:
+                raise ValueError(f"Tensor-dict tensor {name!r} has invalid negative dimension: {dim}")
+            shape.append(dim)
+            cursor += 8
+        offset, nbytes = _TENSOR_ENTRY_SUFFIX.unpack(view[cursor : cursor + _TENSOR_ENTRY_SUFFIX.size])
+        cursor += _TENSOR_ENTRY_SUFFIX.size
+        if offset % TENSOR_DICT_ALIGNMENT != 0:
+            raise ValueError(f"Tensor-dict tensor {name!r} has unaligned data offset: {offset}")
         raw = body[offset : offset + nbytes]
         if len(raw) != nbytes:
-            raise ValueError(f"Tensor-dict payload is truncated for tensor {entry['name']!r}")
+            raise ValueError(f"Tensor-dict payload is truncated for tensor {name!r}")
 
         expected_nbytes = torch.empty((), dtype=dtype).element_size()
-        for dim in entry["shape"]:
+        for dim in shape:
             expected_nbytes *= dim
         if expected_nbytes != nbytes:
-            raise ValueError(
-                f"Tensor-dict tensor {entry['name']!r} expected {expected_nbytes} bytes, got {nbytes}"
-            )
+            raise ValueError(f"Tensor-dict tensor {name!r} expected {expected_nbytes} bytes, got {nbytes}")
 
         if nbytes == 0:
-            result[entry["name"]] = torch.empty(entry["shape"], dtype=dtype)
+            result[name] = torch.empty(shape, dtype=dtype)
         else:
             buffer = bytearray(raw)
             tensor = torch.frombuffer(buffer, dtype=torch.uint8)
-            result[entry["name"]] = tensor.view(dtype).reshape(entry["shape"])
+            result[name] = tensor.view(dtype).reshape(shape)
 
     return result
+
+
+def _align(value: int, alignment: int = TENSOR_DICT_ALIGNMENT) -> int:
+    return (value + alignment - 1) // alignment * alignment

--- a/vllm_omni/distributed/omni_connectors/utils/wire_types.py
+++ b/vllm_omni/distributed/omni_connectors/utils/wire_types.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import struct
+from typing import Any
+
+import msgspec
+import torch
+
+TENSOR_DICT_MAGIC = b"OMTD"
+TENSOR_DICT_VERSION = 1
+TENSOR_DICT_COMPRESSION_NONE = 0
+
+_HEADER_PREFIX = struct.Struct("<4sII")
+
+_DTYPE_TO_ID: dict[torch.dtype, int] = {
+    torch.bool: 1,
+    torch.uint8: 2,
+    torch.int8: 3,
+    torch.int16: 4,
+    torch.int32: 5,
+    torch.int64: 6,
+    torch.float16: 7,
+    torch.bfloat16: 8,
+    torch.float32: 9,
+    torch.float64: 10,
+    torch.complex64: 11,
+    torch.complex128: 12,
+}
+_ID_TO_DTYPE = {v: k for k, v in _DTYPE_TO_ID.items()}
+
+
+def is_tensor_dict(obj: Any) -> bool:
+    """Return True when *obj* is a dict[str, torch.Tensor]."""
+    return isinstance(obj, dict) and all(isinstance(k, str) and isinstance(v, torch.Tensor) for k, v in obj.items())
+
+
+def serialize_tensor_dict(tensors: dict[str, torch.Tensor]) -> bytes:
+    """Serialize a dict[str, torch.Tensor] without generic object serialization.
+
+    The v1 wire format stores a small msgpack header followed by concatenated
+    tensor bytes. A per-tensor compression field is reserved for future use;
+    v1 only accepts ``TENSOR_DICT_COMPRESSION_NONE``.
+    """
+    entries: list[dict[str, Any]] = []
+    chunks: list[bytes] = []
+    offset = 0
+
+    for name, tensor in tensors.items():
+        dtype_id = _DTYPE_TO_ID.get(tensor.dtype)
+        if dtype_id is None:
+            raise TypeError(f"Unsupported tensor dtype for tensor-dict wire format: {tensor.dtype}")
+
+        host_tensor = tensor.detach()
+        if not host_tensor.is_contiguous():
+            host_tensor = host_tensor.contiguous()
+        if host_tensor.device.type != "cpu":
+            host_tensor = host_tensor.cpu()
+
+        raw = host_tensor.reshape(-1).view(torch.uint8).numpy().tobytes()
+        entries.append(
+            {
+                "name": name,
+                "dtype": dtype_id,
+                "shape": list(tensor.shape),
+                "offset": offset,
+                "nbytes": len(raw),
+                "compression": TENSOR_DICT_COMPRESSION_NONE,
+            }
+        )
+        chunks.append(raw)
+        offset += len(raw)
+
+    header = msgspec.msgpack.encode({"version": TENSOR_DICT_VERSION, "entries": entries})
+    return _HEADER_PREFIX.pack(TENSOR_DICT_MAGIC, TENSOR_DICT_VERSION, len(header)) + header + b"".join(chunks)
+
+
+def deserialize_tensor_dict(data: bytes | bytearray | memoryview) -> dict[str, torch.Tensor]:
+    """Deserialize bytes produced by :func:`serialize_tensor_dict`."""
+    view = memoryview(data)
+    if len(view) < _HEADER_PREFIX.size:
+        raise ValueError("Tensor-dict payload is shorter than the wire header")
+
+    magic, version, header_len = _HEADER_PREFIX.unpack(view[: _HEADER_PREFIX.size])
+    if magic != TENSOR_DICT_MAGIC:
+        raise ValueError("Tensor-dict payload has an invalid magic value")
+    if version != TENSOR_DICT_VERSION:
+        raise ValueError(f"Unsupported tensor-dict wire format version: {version}")
+
+    header_start = _HEADER_PREFIX.size
+    header_end = header_start + header_len
+    if header_end > len(view):
+        raise ValueError("Tensor-dict payload has a truncated header")
+
+    header = msgspec.msgpack.decode(view[header_start:header_end])
+    if header.get("version") != TENSOR_DICT_VERSION:
+        raise ValueError(f"Unsupported tensor-dict header version: {header.get('version')}")
+
+    body = view[header_end:]
+    result: dict[str, torch.Tensor] = {}
+    for entry in header["entries"]:
+        compression = entry.get("compression", TENSOR_DICT_COMPRESSION_NONE)
+        if compression != TENSOR_DICT_COMPRESSION_NONE:
+            raise ValueError(f"Unsupported tensor-dict compression id: {compression}")
+
+        dtype = _ID_TO_DTYPE.get(entry["dtype"])
+        if dtype is None:
+            raise ValueError(f"Unsupported tensor-dict dtype id: {entry['dtype']}")
+
+        offset = entry["offset"]
+        nbytes = entry["nbytes"]
+        raw = body[offset : offset + nbytes]
+        if len(raw) != nbytes:
+            raise ValueError(f"Tensor-dict payload is truncated for tensor {entry['name']!r}")
+
+        expected_nbytes = torch.empty((), dtype=dtype).element_size()
+        for dim in entry["shape"]:
+            expected_nbytes *= dim
+        if expected_nbytes != nbytes:
+            raise ValueError(
+                f"Tensor-dict tensor {entry['name']!r} expected {expected_nbytes} bytes, got {nbytes}"
+            )
+
+        if nbytes == 0:
+            result[entry["name"]] = torch.empty(entry["shape"], dtype=dtype)
+        else:
+            buffer = bytearray(raw)
+            tensor = torch.frombuffer(buffer, dtype=torch.uint8)
+            result[entry["name"]] = tensor.view(dtype).reshape(entry["shape"])
+
+    return result


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>RFC #3426 : MooncakeTransferEngineConnector Profiling &amp; Optimization Hooks</h1>
<h2>Purpose</h2>
<p>Implements the <code>MooncakeTransferEngineConnector</code> profiling and optimization hooks proposed in RFC #3426.</p>
<h3>This PR adds:</h3>
<ul>
<li><strong><code>VLLM_OMNI_CONNECTOR_PROFILE</code>-gated per-phase profiling spans</strong> for connector operations.</li>
<li><strong>Standalone benchmark script</strong> at <code>benchmarks/connectors/benchmark_mooncake_te.py</code>.</li>
<li><strong>Tensor-dict wire format</strong> for <code>dict[str, torch.Tensor]</code> payloads using the RFC binary header contract:
<ul>
<li><code>OMDI</code> magic</li>
<li>Stable dtype IDs</li>
<li>CRC32 header checksum</li>
<li>64-byte alignment</li>
</ul>
</li>
<li><strong>Config-gated tensor-dict fast path</strong> support via <code>enable_tensor_dict_fast_path</code>.</li>
<li><strong>Operator-configured memory pool prewarming</strong> via <code>pool_prewarm_slots</code> and <code>pool_prewarm_size</code>.</li>
<li><strong>Idle/error-triggered cached ZMQ socket recreation</strong> via <code>socket_health_interval_s</code>.</li>
<li><strong>Guarded <code>enable_pipelined_zmq_write</code> flag</strong> — intentionally forced off for now because the current connector uses sender-side <code>batch_transfer_sync_write()</code> into receiver-provided addresses; returning <code>TRANS_DONE</code> early would be unsafe without a dedicated correctness change.</li>
</ul>
<blockquote>
<p><strong>Note:</strong> The public connector APIs remain unchanged.</p>
</blockquote>
<hr>
<h2>Test Plan</h2>
<h3>Unit / Static Validation</h3>
<pre><code class="language-bash">python -m ruff check \
  vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py \
  vllm_omni/distributed/omni_connectors/utils/wire_types.py \
  vllm_omni/distributed/omni_connectors/utils/config.py \
  tests/distributed/omni_connectors/test_wire_types.py \
  tests/distributed/omni_connectors/test_mooncake_transfer_engine_buffer.py \
  tests/distributed/omni_connectors/test_basic_connectors.py \
  benchmarks/connectors/benchmark_mooncake_te.py

python -m py_compile \
  vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py \
  vllm_omni/distributed/omni_connectors/utils/wire_types.py \
  vllm_omni/distributed/omni_connectors/utils/config.py \
  tests/distributed/omni_connectors/test_wire_types.py \
  tests/distributed/omni_connectors/test_mooncake_transfer_engine_buffer.py \
  tests/distributed/omni_connectors/test_basic_connectors.py \
  benchmarks/connectors/benchmark_mooncake_te.py
</code></pre>
<h3>Benchmark CLI Validation</h3>
<pre><code class="language-bash">python benchmarks/connectors/benchmark_mooncake_te.py --help
</code></pre>
<h3>Wire-Format Smoke Validation</h3>
<p>The following cases are covered:</p>
<ul>
<li>Tensor-dict round trip</li>
<li>Non-contiguous tensor input</li>
<li>Scalar tensor</li>
<li>Empty tensor</li>
<li>RFC magic header <code>OMDI</code></li>
<li>Checksum rejection after header corruption</li>
</ul>
<h3>Full Mooncake / RDMA Benchmark</h3>
<blockquote>
<p>Execution is environment-dependent. Run on a Mooncake-enabled TCP/RDMA host:</p>
</blockquote>
<pre><code class="language-bash">VLLM_OMNI_CONNECTOR_PROFILE=1 python benchmarks/connectors/benchmark_mooncake_te.py \
  --protocols tcp rdma \
  --payload-types tensor tensor_dict \
  --sizes 1MB 10MB 100MB 1GB \
  --output-json mooncake_te_results.json
</code></pre>
<hr>
<h2>Test Results</h2>

Check | Result
-- | --
python -m ruff check ... | ✅ All checks passed
python -m py_compile ... | ✅ Passed
Benchmark CLI (--help) | ✅ Passed
Wire-format smoke validation | ✅ wire_types smoke ok

</body></html><!--EndFragment-->
</body>
</html>