### PR TITLE
Fix: Prevent IndexError Crash in Distributed VAE When Patch Parallel Size < World Size

### DIFF
--- a/vllm_omni/diffusion/distributed/autoencoders/distributed_vae_executor.py
+++ b/vllm_omni/diffusion/distributed/autoencoders/distributed_vae_executor.py
@@ -125,7 +125,7 @@ class DistributedVaeExecutor:
 
         # 2. local decode
         assigned = self._balance_tasks(tiletask_list, pp_size)
-        local_tasks = assigned[self.rank] if pp_size <= self.world_size else []
+        local_tasks = assigned[self.rank] if self.rank < pp_size else []
         local_results = [(t.tile_id, operator.exec(t)) for t in local_tasks]
 
         # 3. compute shape per rank


### PR DESCRIPTION


## Purpose

This issue occurs in a distributed deployment when a user configures VAE patch parallel execution such that vae_patch_parallel_size  is greater than 1, but less than the total DiT group size (world_size). 
For example, running on 4 GPUs (world_size=4) but dedicating only 2 GPUs for VAE processing (vae_patch_parallel_size=2).
 
The application crashes immediately with an IndexError: 
list index out of range on ranks where self.rank >= vae_patch_parallel_size.

The ranks assigned to VAE processing (ranks < vae_patch_parallel_size) should fetch their tile tasks and compute them. 
The remaining non-participating ranks (ranks >= vae_patch_parallel_size) should receive an empty task list ([]) and bypass the computation, but they must still participate in subsequent collective communications (like all_reduce and all_gather) to prevent the entire distributed cluster from hanging.

 Root Cause: 
The old logic used the condition if pp_size <= self.world_size to determine task assignment. Since pp_size is defined as
     min(parallel_size, world_size), this condition was always True. Consequently, global ranks (e.g., rank 2 or 3) incorrectly attempted to index into the assigned list, which only has a length equal to pp_size (e.g., length 2), leading to an immediate out-of-bounds crash.

Fix Method: 
Modify the assignment condition from if pp_size <= self.world_size to if self.rank < pp_size. This ensures array boundary protection, routing valid tasks to the participating ranks while gracefully assigning empty task lists to the non-participating "bystander" ranks.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
