### PR TITLE
[Bugfix] Add missing stop_token_ids to HunyuanImage3 NPU deploy YAML …

### DIFF
--- a/vllm_omni/deploy/hunyuan_image3.yaml
+++ b/vllm_omni/deploy/hunyuan_image3.yaml
@@ -93,6 +93,8 @@ platforms:
         devices: "0,1,2,3"
         tensor_parallel_size: 4
         max_num_batched_tokens: 8192
+        default_sampling_params:
+          stop_token_ids: [128025]
       - stage_id: 1
         gpu_memory_utilization: 0.65
         devices: "4,5,6,7"


### PR DESCRIPTION
## Description
The NPU platform section for HunyuanImage-3.0 was missing `default_sampling_params` with `stop_token_ids`. This caused image generation to loop on NPU because the EOS token was never emitted. Mirrors the CUDA platform section which already has this setting.

## Related Issue
Closes #3722

## Test Plan
Manual verification on Ascend NPU:
1. Load the deploy YAML with `--platform npu`
2. Send an image generation request
3. Confirm the generation terminates properly instead of looping
No new test script needed — the fix is a config addition that mirrors the existing CUDA config.

## Test Result
N/A (no NPU hardware available for testing; change is trivially verified by inspection — identical to the CUDA section's `default_sampling_params` block)
---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>