### PR TITLE
[Bugfix] Fix spatial_merge_size AttributeError in Qwen3OmniMoeTalker …

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py
@@ -107,7 +107,7 @@ class Qwen3OmniMoeTalkerForConditionalGeneration(
         self.codec_head = nn.Linear(self.config.text_config.hidden_size, self.config.text_config.vocab_size, bias=False)
 
         self.rope_deltas = None
-        self.spatial_merge_size = self.config.spatial_merge_size
+        self.spatial_merge_size = self.config.vision_config.spatial_merge_size
 
         self.vocab_size = self.config.code_predictor_config.vocab_size
         self.num_code_groups = self.config.code_predictor_config.num_code_groups


### PR DESCRIPTION
## Description
The talker model's config does not have `spatial_merge_size` at the top level — it lives under `vision_config`. This causes an `AttributeError` when the talker tries to access `self.config.spatial_merge_size`.

Changed the access path from `self.config.spatial_merge_size` to `self.config.vision_config.spatial_merge_size`, matching how the thinker model already accesses it (`qwen3_omni_moe_thinker.py:494`).

## Related Issue
Closes #3757

## Test Plan
1. Run `Qwen3OmniMoeTalkerForConditionalGeneration` forward pass
2. Confirm `self.config.vision_config.spatial_merge_size` resolves without error
3. Verify the thinker model (`qwen3_omni_moe_thinker.py:494`) uses the same access pattern as reference

Existing tests should cover this:
```bash

# Run relevant talker tests
python -m pytest tests/model_executor/models/qwen3_omni/ -x -v

Test Result
N/A (requires GPU; change is verified by inspection — identical access pattern to the thinker model at qwen3_omni_moe_thinker.py:494)

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>
- The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the test style doc (https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- The test results. Please paste the results comparison before and after, or the e2e results.
- (Optional) The necessary documentation update, such as updating supported_models.md and examples for a new model. Please run mkdocs serve to sync the documentation editions to ./docs.
- (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>