### PR TITLE
[refactor](entrypoints)Split sync/async ClientRequestState

### DIFF
--- a/docs/design/module/async_omni_architecture.md
+++ b/docs/design/module/async_omni_architecture.md
@@ -79,10 +79,10 @@
 
 [6] AsyncOmni._final_output_loop (background coroutine)
     -> AsyncOmniEngine.try_get_output_async()
-    -> route by request_id to ClientRequestState.queue
+    -> route by request_id to AsyncClientRequestState.queue
 
 [7] AsyncOmni._process_orchestrator_results
-    -> read from ClientRequestState.queue
+    -> read from AsyncClientRequestState.queue
     -> _process_single_result(...)
     -> yield OmniRequestOutput
 

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -139,7 +139,6 @@ class AsyncOmni(EngineClient, OmniBase):
 
     def __init__(self, *args: Any, model: str = "", **kwargs: Any) -> None:
         OmniBase.__init__(self, model=model, **kwargs)
-        self.request_states = {}
         self._pause_cond: asyncio.Condition = asyncio.Condition()
         self._paused: bool = False
         self._is_sleeping: bool = False

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -27,7 +27,7 @@ from vllm.v1.engine.exceptions import EngineDeadError
 
 from vllm_omni.diffusion.data import OmniACK, OmniSleepTask, OmniWakeTask
 from vllm_omni.engine.messages import ErrorMessage, OutputMessage
-from vllm_omni.entrypoints.client_request_state import ClientRequestState
+from vllm_omni.entrypoints.client_request_state import AsyncClientRequestState
 from vllm_omni.entrypoints.omni_base import (
     OmniBase,
     OmniEngineDeadError,
@@ -135,8 +135,11 @@ class AsyncOmni(EngineClient, OmniBase):
         ...     print(output)
     """
 
+    request_states: dict[str, AsyncClientRequestState]
+
     def __init__(self, *args: Any, model: str = "", **kwargs: Any) -> None:
         OmniBase.__init__(self, model=model, **kwargs)
+        self.request_states = {}
         self._pause_cond: asyncio.Condition = asyncio.Condition()
         self._paused: bool = False
         self._is_sleeping: bool = False
@@ -302,7 +305,7 @@ class AsyncOmni(EngineClient, OmniBase):
                 wall_start_ts,
                 final_stage_id_for_e2e,
             )
-            req_state = ClientRequestState(request_id)
+            req_state = AsyncClientRequestState(request_id)
             req_state.metrics = metrics
             self.request_states[request_id] = req_state
 

--- a/vllm_omni/entrypoints/client_request_state.py
+++ b/vllm_omni/entrypoints/client_request_state.py
@@ -6,8 +6,15 @@ from vllm_omni.metrics import OrchestratorAggregator
 class ClientRequestState:
     """Tracks the state of an individual request in the orchestrator."""
 
-    def __init__(self, request_id: str, queue: asyncio.Queue | None = None):
+    def __init__(self, request_id: str):
         self.request_id = request_id
         self.stage_id: int | None = None
-        self.queue = queue if queue is not None else asyncio.Queue()
         self.metrics: OrchestratorAggregator | None = None
+
+
+class AsyncClientRequestState(ClientRequestState):
+    """Per-request state for AsyncOmni; includes a queue for output routing."""
+
+    def __init__(self, request_id: str, queue: asyncio.Queue | None = None):
+        super().__init__(request_id)
+        self.queue = queue if queue is not None else asyncio.Queue()

--- a/vllm_omni/entrypoints/omni.py
+++ b/vllm_omni/entrypoints/omni.py
@@ -68,11 +68,7 @@ class Omni(OmniBase):
         use_tqdm: bool | Callable[..., tqdm] = True,
     ) -> Generator[OmniRequestOutput, None, None] | list[OmniRequestOutput]:
         # Expand sampling params for PD disaggregation (user may provide N-1 params)
-        if (
-            sampling_params_list is not None
-            and isinstance(sampling_params_list, Sequence)
-            and not isinstance(sampling_params_list, (str, bytes))
-        ):
+        if isinstance(sampling_params_list, Sequence) and not isinstance(sampling_params_list, (str, bytes)):
             sampling_params_list = self._maybe_expand_sampling_params(list(sampling_params_list))
         sampling_params_list = self.resolve_sampling_params_list(sampling_params_list)
         try:


### PR DESCRIPTION
## Purpose

Split per-request state for sync and async entrypoints so synchronous Omni no longer allocates an unused `asyncio.Queue` on every request.

- `ClientRequestState`: shared fields only (`request_id, stage_id, metrics`) — used by sync `Omni` via `OmniBase`.
- `AsyncClientRequestState`: extends the base class with a per-request `asyncio.Queue` for `_final_output_handler` → `_process_orchestrator_results` output routing in `AsyncOmni`.
- `AsyncOmni`: constructs `AsyncClientRequestState` and narrows `request_states` to `dict[str, AsyncClientRequestState]` for clearer typing.
- Docs: update `async_omni_architecture.md` to reference `AsyncClientRequestState.queue`.
- Minor cleanup: remove redundant `sampling_params_list is not None` check in `Omni.generate` before PD param expansion (sequence check is sufficient).

No intended behavior change for generate() / abort() / OpenAI serving paths.

## Test
No new unit tests (refactor only; existing entrypoint integration tests cover the async queue routing path).

## Test Result

None