### PR TITLE
Fix OmniDiffusionConfig master_port selection for parallel launches

### DIFF
--- a/tests/diffusion/test_omni_diffusion_config_master_port.py
+++ b/tests/diffusion/test_omni_diffusion_config_master_port.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for OmniDiffusionConfig master_port resolution (issue #3794)."""
+
+import socket
+
+import pytest
+
+from vllm_omni.diffusion.data import OmniDiffusionConfig
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class TestOmniDiffusionConfigMasterPort:
+    def test_honors_master_port_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MASTER_PORT", "43210")
+        config = OmniDiffusionConfig(model="test")
+        assert config.master_port == 43210
+
+    def test_honors_explicit_master_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MASTER_PORT", raising=False)
+        config = OmniDiffusionConfig(model="test", master_port=40000)
+        assert config.master_port == 40000
+
+    def test_master_port_env_takes_precedence_over_kwarg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MASTER_PORT", "43210")
+        config = OmniDiffusionConfig(model="test", master_port=40000)
+        assert config.master_port == 43210
+
+    def test_explicit_master_port_is_stable_without_jitter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MASTER_PORT", raising=False)
+        ports = {OmniDiffusionConfig(model="test", master_port=40123).master_port for _ in range(5)}
+        assert ports == {40123}
+
+    def test_default_master_port_is_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MASTER_PORT", raising=False)
+        config = OmniDiffusionConfig(model="test")
+        assert config.master_port is not None
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(("", config.master_port))
+
+    def test_settle_port_steps_when_port_is_busy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MASTER_PORT", raising=False)
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("", 0))
+            busy_port = sock.getsockname()[1]
+            config = OmniDiffusionConfig(model="test", master_port=busy_port)
+            assert config.master_port == busy_port + 37

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -606,6 +606,25 @@ class OmniDiffusionConfig:
 
         return False
 
+    def _resolve_master_port(self) -> int:
+        """Resolve torch.distributed master port without unnecessary random jitter.
+
+        Precedence:
+        1. ``MASTER_PORT`` environment variable (set by orchestrators for multi-replica launch).
+        2. Explicit ``master_port`` passed at construction time.
+        3. An OS-assigned ephemeral port when neither is provided.
+        """
+        from vllm.utils.network_utils import get_open_port
+
+        from vllm_omni.diffusion import envs
+
+        env_port = envs.MASTER_PORT
+        if env_port is not None:
+            return self.settle_port(env_port, port_inc=37)
+        if self.master_port is not None:
+            return self.settle_port(self.master_port, port_inc=37)
+        return self.settle_port(get_open_port(), port_inc=37)
+
     def settle_port(self, port: int, port_inc: int = 42, max_attempts: int = 100) -> int:
         """
         Find an available port with retry logic.
@@ -642,9 +661,7 @@ class OmniDiffusionConfig:
         )
 
     def __post_init__(self):
-        # TODO: remove hard code
-        initial_master_port = (self.master_port or 30005) + random.randint(0, 100)
-        self.master_port = self.settle_port(initial_master_port, 37)
+        self.master_port = self._resolve_master_port()
 
         if isinstance(self.profiler_config, dict):
             from vllm.config import ProfilerConfig


### PR DESCRIPTION
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Fixes #3794.

When multiple diffusion rollout servers start in parallel (e.g. Ray actors in verl-omni), `OmniDiffusionConfig.__post_init__` previously always picked `30005 + rand(0, 100)`, causing intermittent `EADDRINUSE` on `torch.distributed.init_process_group`. It also ignored upstream `MASTER_PORT` and added random jitter even when `master_port` was explicitly set.

This PR adds `_resolve_master_port()` with clear precedence:
1. `MASTER_PORT` environment variable (orchestrator-assigned)
2. Explicit `master_port` passed at construction
3. OS ephemeral port via vLLM's `get_open_port()` when neither is set

In all cases, `settle_port` is only used to step to the next port if the chosen one is busy — no random jitter is applied.

## Test Plan

Added unit tests in `tests/diffusion/test_omni_diffusion_config_master_port.py`:

```bash
pytest tests/diffusion/test_omni_diffusion_config_master_port.py -v
```

Coverage:
- Honors `MASTER_PORT` env var
- Honors explicit `master_port` kwarg without jitter
- Env var takes precedence over kwarg
- Default path returns an available port
- `settle_port` steps when the requested port is busy

## Test Result

```
tests/diffusion/test_omni_diffusion_config_master_port.py::TestOmniDiffusionConfigMasterPort::test_honors_master_port_env PASSED
tests/diffusion/test_omni_diffusion_config_master_port.py::TestOmniDiffusionConfigMasterPort::test_honors_explicit_master_port PASSED
tests/diffusion/test_omni_diffusion_config_master_port.py::TestOmniDiffusionConfigMasterPort::test_master_port_env_takes_precedence_over_kwarg PASSED
tests/diffusion/test_omni_diffusion_config_master_port.py::TestOmniDiffusionConfigMasterPort::test_explicit_master_port_is_stable_without_jitter PASSED
tests/diffusion/test_omni_diffusion_config_master_port.py::TestOmniDiffusionConfigMasterPort::test_default_master_port_is_available PASSED
tests/diffusion/test_omni_diffusion_config_master_port.py::TestOmniDiffusionConfigMasterPort::test_settle_port_steps_when_port_is_busy PASSED

6 passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>