### PR TITLE
[Feat/Bugfix] Fix API Server model tag <-> model sync & flag normalization

### DIFF
--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -43,6 +43,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
     ChatCompletionResponse,
 )
+from vllm.entrypoints.openai.cli_args import make_arg_parser
 
 # yapf conflicts with isort for this block
 # yapf: disable
@@ -3826,26 +3827,14 @@ async def omni_wakeup(request: OmniWakeupRequest, raw_request: Request):
 
 
 if __name__ == "__main__":
-    import asyncio
-
-    from vllm.entrypoints.openai.cli_args import make_arg_parser
-
     parser = TrackingArgumentParser(description="vLLM-Omni OpenAI-Compatible REST API server")
     parser = make_arg_parser(parser)
-    registered_flags = set()
-    for action in parser._actions:
-        registered_flags.update(action.option_strings)
-
-    # FIXME - this is broken on `main`. `make_arg_parser` does not handle omni engine args properly.
-    if "--omni" not in registered_flags:
-        parser.add_argument("--omni", action="store_true", default=False, help="Enable vLLM-Omni mode.")
-    if "--enable-sleep-mode" not in registered_flags:
-        parser.add_argument(
-            "--enable-sleep-mode", action="store_true", default=False, help="Enable GPU memory pool for sleep mode."
-        )
+    # Ensure that passing --omni won't crash the server
+    parser.add_argument("--omni", action="store_true", default=True)
     args = parser.parse_args()
-    if not hasattr(args, "model_tag"):
-        setattr(args, "model_tag", args.model)
-    if hasattr(args, "model_tag") and args.model_tag is None:
-        args.model_tag = args.model
+    # sync args.model to model_tag, because if we pass the model positionally,
+    # args.model will be the default from vLLM's ModelConfig (currently
+    # Qwen/Qwen3-0.6B) and crash cryptically.
+    if args.model_tag is not None:
+        args.model = args.model_tag
     asyncio.run(omni_run_server(args))

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -3829,8 +3829,10 @@ async def omni_wakeup(request: OmniWakeupRequest, raw_request: Request):
 if __name__ == "__main__":
     parser = TrackingArgumentParser(description="vLLM-Omni OpenAI-Compatible REST API server")
     parser = make_arg_parser(parser)
-    # Ensure that passing --omni won't crash the server
-    parser.add_argument("--omni", action="store_true", default=True)
+    # Ensure that passing --omni won't crash the server.
+    # NOTE: the value here does not matter since we are always running the Omni server
+    # when __main__ is called, i.e., --omni is only used when called through the entrypoints.
+    parser.add_argument("--omni", action="store_true", default=False)
     args = parser.parse_args()
     # sync args.model to model_tag, because if we pass the model positionally,
     # args.model will be the default from vLLM's ModelConfig (currently


### PR DESCRIPTION
## Purpose
Fixes 2 issues in the main for the api server for when you try to run it directly.

1. Switches to use vLLM's `FlexibleArgumentParser`  instead of an argparse parser; this is needed for consistent behavior, because `FlexibleArgumentParser` handles things like hypen normalization.

Example:
```bash
# This is ok because --gpu_memory_utilization normalizes to hyphens 
vllm serve stabilityai/stable-diffusion-3.5-medium --gpu_memory_utilization 0.8  --omni
```
```bash
python -m vllm_omni.entrypoints.openai.api_server --model  stabilityai/stable-diffusion-3.5-medium --gpu_memory_utilization 0.8  --omni

# Will crash with:
# api_server.py: error: unrecognized arguments: --gpu_memory_utilization since we don't use FlexibleArgumentParser in the __main__
```



2. The API server can give pretty unintuitive behavior if you try to pass the model positionally like you would to `vllm serve`. For example, I think because this check:

```python
    if not hasattr(args, "model_tag"):
        setattr(args, "model_tag", args.model)
    if hasattr(args, "model_tag") and args.model_tag is None:
        args.model_tag = args.model
```

When you run the entrypoint directly, the `model_tag` is the positional arg, so the first `if` shouldn't be executed and it shouldn't be `None` since it can't be passed as a flag. In practice, `args.model` is the one that might end up unset. For example:

```bash
python -m vllm_omni.entrypoints.openai.api_server  stabilityai/stable-diffusion-3.5-medium
```

```
(APIServer pid=4129594) INFO 05-22 00:09:03 [utils.py:240] non-default args: {'model_tag': 'stabilityai/stable-diffusion-3.5-medium', ...}
# ^ This doesn't have 'model'
```
^ See the model tag is set positionally, but the model is not set as a non-default; this means the `model` actually falls back to the default in vLLM's ModelConfig, which is `Qwen/Qwen3-0.6B`, and will eventually crash because `Qwen3ForCausalLM` isn't a registered diffusion model.

```
  File "/home/alex-jw-brooks/vllm-omni/vllm_omni/diffusion/model_loader/diffusers_loader.py", line 318, in load_model
    model = initialize_model(od_config)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alex-jw-brooks/vllm-omni/vllm_omni/diffusion/registry.py", line 358, in initialize_model
    raise ValueError(f"Model class {od_config.model_class_name} not found in diffusion model registry.")
ValueError: Model class Qwen3ForCausalLM not found in diffusion model registry.
```

If you pass `--model` as a kwarg: 
```bash
python -m vllm_omni.entrypoints.openai.api_server --model  stabilityai/stable-diffusion-3.5-medium
```

you'll see both the `model` and `model_tag` are correctly set, so it'll work correctly.
```
(APIServer pid=4131513) INFO 05-22 00:13:06 [utils.py:240] non-default args: {'model_tag': 'stabilityai/stable-diffusion-3.5-medium', 'model': 'stabilityai/stable-diffusion-3.5-medium', ...}
```

I think the intention of this check is to keep the model tag <-> model in sync, but is logically backward, i.e., it should just be 
```python
    if args.model_tag is not None:
        args.model = args.model_tag
```

## Test Plan
This should work because `--gpu_memory_utilization` should be normalized to match `--gpu-memory-utilization`
```bash
python -m vllm_omni.entrypoints.openai.api_server --model  stabilityai/stable-diffusion-3.5-medium --gpu_memory_utilization 0.8  --omni
```

Also, both of these should have sensical behavior:
```bash
python -m vllm_omni.entrypoints.openai.api_server  stabilityai/stable-diffusion-3.5-medium
python -m vllm_omni.entrypoints.openai.api_server --model  stabilityai/stable-diffusion-3.5-medium
```

## Test Result

Both start the server with the SD model, instead of crashing in the first one due to the model not being used, and the default ModelConfig LLM trying to load directly.