### PR TITLE
[BugFix] Bind device to thread before import mooncacke

### DIFF
--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -254,10 +254,10 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         # bind each ThreadPoolExecutor thread (vllm-project/vllm#39548).
         self._device_id: int | None = None
         try:
-            from vllm.platforms import current_platform
+            from vllm_omni.platforms import current_omni_platform
 
-            self._device_id = current_platform.current_device()
-            current_platform.set_device(self._device_id)
+            self._device_id = current_omni_platform.current_device()
+            current_omni_platform.set_device(self._device_id)
         except Exception as e:
             logger.warning("Failed to pre-set accelerator device before mooncake import: %s", e)
 
@@ -1198,9 +1198,9 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         if self._device_id is None:
             return
         try:
-            from vllm.platforms import current_platform
+            from vllm_omni.platforms import current_omni_platform
 
-            current_platform.set_device(self._device_id)
+            current_omni_platform.set_device(self._device_id)
         except Exception as e:
             logger.warning("Failed to bind sender thread to device %s: %s", self._device_id, e)
 

--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -250,10 +250,14 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         # mooncake. On Ascend, importing mooncake.engine without a prior set_device
         # can core-dump the worker (see kvcache-ai/Mooncake#1008, fixed upstream in
         # kvcache-ai/Mooncake#1114). Mirrors vLLM upstream mooncake_connector.py.
+        # The captured device_id is also reused by _bind_sender_thread_device to
+        # bind each ThreadPoolExecutor thread (vllm-project/vllm#39548).
+        self._device_id: int | None = None
         try:
             from vllm.platforms import current_platform
 
-            current_platform.set_device(torch.accelerator.current_device_index())
+            self._device_id = current_platform.current_device()
+            current_platform.set_device(self._device_id)
         except Exception as e:
             logger.warning("Failed to pre-set accelerator device before mooncake import: %s", e)
 
@@ -373,7 +377,15 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         # Most fields already initialized at the top of __init__ for teardown
         # safety.  Only create the real ZMQ context and thread pool here.
         self.zmq_ctx = zmq.Context()
-        self._sender_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="mooncake-sender")
+        # initializer runs once per pool thread on first start (not per task),
+        # binding the thread to this worker's device. Required because device
+        # selection is thread-local on NPU/CUDA — without it, pool threads
+        # default to device 0 and Mooncake transfers fail for TP>0 ranks.
+        self._sender_executor = ThreadPoolExecutor(
+            max_workers=4,
+            thread_name_prefix="mooncake-sender",
+            initializer=self._bind_sender_thread_device,
+        )
 
         # Log complete connector configuration for debugging
         logger.info(
@@ -1176,6 +1188,21 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
                 socket.close(linger=0)
             except Exception:
                 pass  # Best-effort cleanup during listener shutdown
+
+    def _bind_sender_thread_device(self) -> None:
+        """ThreadPoolExecutor initializer — bind each pool thread to the worker's
+        device once on thread startup. Device selection is thread-local on
+        NPU/CUDA, so without this, Mooncake transport calls run with the pool
+        thread's default device (0) instead of the worker's actual device,
+        causing IPC failures or crashes for TP>0 ranks."""
+        if self._device_id is None:
+            return
+        try:
+            from vllm.platforms import current_platform
+
+            current_platform.set_device(self._device_id)
+        except Exception as e:
+            logger.warning("Failed to bind sender thread to device %s: %s", self._device_id, e)
 
     def _handle_pull_request(self, response_queue: queue.Queue, notify_addr: str, identity, payload):
         """

--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -21,11 +21,6 @@ from .base import OmniConnectorBase
 
 logger = get_connector_logger(__name__)
 
-try:
-    from mooncake.engine import TransferEngine
-except ImportError:
-    TransferEngine = None
-
 # Stale buffer TTL: buffers older than this are automatically reclaimed
 # to prevent memory leaks when receiver crashes or gives up.
 _BUFFER_TTL_SECONDS = 300  # 5 minutes
@@ -251,8 +246,23 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
     supports_raw_data: bool = True
 
     def __init__(self, config: dict[str, Any]):
-        if TransferEngine is None:
-            raise ImportError("Mooncake not available")
+        # Bind the accelerator device to this thread before importing/instantiating
+        # mooncake. On Ascend, importing mooncake.engine without a prior set_device
+        # can core-dump the worker (see kvcache-ai/Mooncake#1008, fixed upstream in
+        # kvcache-ai/Mooncake#1114). Mirrors vLLM upstream mooncake_connector.py.
+        try:
+            from vllm.platforms import current_platform
+
+            current_platform.set_device(torch.accelerator.current_device_index())
+        except Exception as e:
+            logger.warning("Failed to pre-set accelerator device before mooncake import: %s", e)
+
+        try:
+            from mooncake.engine import TransferEngine
+        except ImportError as e:
+            raise ImportError(
+                "Mooncake not available. Install per https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md"
+            ) from e
 
         self._closed = False
         self._bind_error: Exception | None = None  # fatal ZMQ bind error from listener thread

--- a/vllm_omni/distributed/omni_connectors/factory.py
+++ b/vllm_omni/distributed/omni_connectors/factory.py
@@ -46,7 +46,7 @@ class OmniConnectorFactory:
             logger.info(f"Created connector: {spec.name}")
             return connector
         except Exception as e:
-            logger.error(f"Failed to create connector {spec.name}: {e}")
+            logger.warning(f"Failed to create connector {spec.name}: {e}")
             raise ValueError(f"Failed to create connector {spec.name}: {e}")
 
     @classmethod

--- a/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
+++ b/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
@@ -431,8 +431,8 @@ class OmniKVTransferManager:
                         c_extra.get("role", "N/A"),
                     )
                     self._connector = OmniConnectorFactory.create_connector(ConnectorSpec(name=c_type, extra=c_extra))
-                except Exception:
-                    logger.exception("Failed to initialize OmniConnector")
+                except Exception as e:
+                    logger.warning("Failed to initialize OmniConnector (%s): %s", c_type, e)
                     self._connector = False
 
         return self._connector if self._connector else None


### PR DESCRIPTION
## Summary

- **Fix the unfriendly log when users don't install mooncake.** Previously a missing `mooncake` package surfaced as an `ERROR` with a full traceback on every connector init, even though the connector init is allowed to fail gracefully (`_connector` falls back to `None`). Demoted to a single `WARNING` with install instructions.

- **Add a guard binding for device to thread to avoid the core dump in [kvcache-ai/Mooncake#1008](https://github.com/kvcache-ai/Mooncake/issues/1008) / [#1338](https://github.com/kvcache-ai/Mooncake/issues/1338) on NPU.** Importing `mooncake.engine` before `torch.npu.set_device(...)` aborts the worker when Ascend Direct Transport is enabled; root cause is fixed upstream by [Mooncake#1114](https://github.com/kvcache-ai/Mooncake/pull/1114), so this is a transitional workaround until our dockerfile picks up that tag. The same `set_device` is also applied per `ThreadPoolExecutor` thread via `initializer=`. Considering vLLM has the same guard ([vllm-project/vllm#39548](https://github.com/vllm-project/vllm/pull/39548)), it's safe on CUDA. But we currently haven't met the same issue as #39548 because we default to the **RDMA protocol**, which doesn't depend on the caller thread's device context (NIC-driven transfers, per #39548's own analysis). The per-thread bind is added defensively so future switches to Ascend Direct Transport / any IPC-style protocol won't regress.

## Changes

- `factory.py` / `kv_transfer_manager.py`: `ERROR` → `WARNING` on missing Mooncake; drop the duplicate traceback.
- `mooncake_transfer_engine_connector.py`:
  - Move `from mooncake.engine import TransferEngine` from module-top to `__init__`, with an actionable `ImportError` message.
  - Call `current_platform.set_device(...)` in `__init__` before mooncake import; capture `self._device_id` for reuse.
  - Pass `initializer=self._bind_sender_thread_device` to the sender `ThreadPoolExecutor` (runs once per thread, no per-task cost).

## Test Plan

- [ ] Run without `mooncake` installed → expect one WARNING line, no traceback; connector returns `None`, model serving still works.
- [ ] Run with mooncake + Ascend Direct Transport (TP>1) → expect no core dump at worker startup, no ghost context on NPU 0 from non-rank-0 workers (`npu-smi info -t proc-mem`).
- [ ] Run KV transfer end-to-end with default RDMA protocol → expect no regression.
