### PR TITLE
[Test] Fix HunyuanImage3 nightly perf startup

### DIFF
--- a/tests/dfx/perf/scripts/run_benchmark.py
+++ b/tests/dfx/perf/scripts/run_benchmark.py
@@ -53,7 +53,7 @@ if CONFIG_FILE_PATH is None:
 BENCHMARK_CONFIGS = load_configs(CONFIG_FILE_PATH)
 
 
-DEPLOY_CONFIGS_DIR = Path(__file__).parent.parent / "deploy"
+DEPLOY_CONFIGS_DIR = Path(__file__).resolve().parent.parent.parent.parent.parent / "vllm_omni" / "deploy"
 test_params = create_unique_server_params(BENCHMARK_CONFIGS, DEPLOY_CONFIGS_DIR)
 server_to_benchmark_mapping = create_test_parameter_mapping(BENCHMARK_CONFIGS)
 

--- a/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_cfgp2.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_cfgp2.json
@@ -5,12 +5,29 @@
         "server_type": "vllm-omni",
         "server_params": {
             "model": "tencent/HunyuanImage-3.0-Instruct",
+            "stage_overrides": {
+                "0": {
+                    "parallel_config": {
+                        "pipeline_parallel_size": 1,
+                        "data_parallel_size": 1,
+                        "tensor_parallel_size": 2,
+                        "enable_expert_parallel": true,
+                        "sequence_parallel_size": 1,
+                        "ulysses_degree": 1,
+                        "ring_degree": 1,
+                        "cfg_parallel_size": 2,
+                        "vae_patch_parallel_size": 1,
+                        "use_hsdp": false,
+                        "hsdp_shard_size": -1,
+                        "hsdp_replicate_size": 1
+                    }
+                }
+            },
             "serve_args": {
-                "tensor-parallel-size": 2,
-                "cfg-parallel-size": 2,
+                "deploy-config": "vllm_omni/deploy/hunyuan_image3_dit.yaml",
                 "quantization": "fp8",
                 "distributed-executor-backend": "mp",
-                "enforce-eager": true,
+                "trust-remote-code": true,
                 "enable-diffusion-pipeline-profiler": true
             }
         },

--- a/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_cfgp2.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_cfgp2.json
@@ -5,6 +5,7 @@
         "server_type": "vllm-omni",
         "server_params": {
             "model": "tencent/HunyuanImage-3.0-Instruct",
+            "stage_config_name": "hunyuan_image3_dit.yaml",
             "stage_overrides": {
                 "0": {
                     "parallel_config": {
@@ -24,7 +25,6 @@
                 }
             },
             "serve_args": {
-                "deploy-config": "vllm_omni/deploy/hunyuan_image3_dit.yaml",
                 "quantization": "fp8",
                 "distributed-executor-backend": "mp",
                 "trust-remote-code": true,

--- a/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_sp2.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_sp2.json
@@ -5,12 +5,29 @@
         "server_type": "vllm-omni",
         "server_params": {
             "model": "tencent/HunyuanImage-3.0-Instruct",
+            "stage_overrides": {
+                "0": {
+                    "parallel_config": {
+                        "pipeline_parallel_size": 1,
+                        "data_parallel_size": 1,
+                        "tensor_parallel_size": 2,
+                        "enable_expert_parallel": true,
+                        "sequence_parallel_size": 2,
+                        "ulysses_degree": 2,
+                        "ring_degree": 1,
+                        "cfg_parallel_size": 1,
+                        "vae_patch_parallel_size": 1,
+                        "use_hsdp": false,
+                        "hsdp_shard_size": -1,
+                        "hsdp_replicate_size": 1
+                    }
+                }
+            },
             "serve_args": {
-                "tensor-parallel-size": 2,
-                "usp": 2,
+                "deploy-config": "vllm_omni/deploy/hunyuan_image3_dit.yaml",
                 "quantization": "fp8",
                 "distributed-executor-backend": "mp",
-                "enforce-eager": true,
+                "trust-remote-code": true,
                 "enable-diffusion-pipeline-profiler": true
             }
         },

--- a/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_sp2.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_sp2.json
@@ -5,6 +5,7 @@
         "server_type": "vllm-omni",
         "server_params": {
             "model": "tencent/HunyuanImage-3.0-Instruct",
+            "stage_config_name": "hunyuan_image3_dit.yaml",
             "stage_overrides": {
                 "0": {
                     "parallel_config": {
@@ -24,7 +25,6 @@
                 }
             },
             "serve_args": {
-                "deploy-config": "vllm_omni/deploy/hunyuan_image3_dit.yaml",
                 "quantization": "fp8",
                 "distributed-executor-backend": "mp",
                 "trust-remote-code": true,

--- a/tests/dfx/perf/tests/test_hunyuan_image_tp4_fp8.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp4_fp8.json
@@ -5,8 +5,8 @@
         "server_type": "vllm-omni",
         "server_params": {
             "model": "tencent/HunyuanImage-3.0-Instruct",
+            "stage_config_name": "hunyuan_image3_dit.yaml",
             "serve_args": {
-                "deploy-config": "vllm_omni/deploy/hunyuan_image3_dit.yaml",
                 "quantization": "fp8",
                 "distributed-executor-backend": "mp",
                 "trust-remote-code": true,

--- a/tests/dfx/perf/tests/test_hunyuan_image_tp4_fp8.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp4_fp8.json
@@ -6,10 +6,10 @@
         "server_params": {
             "model": "tencent/HunyuanImage-3.0-Instruct",
             "serve_args": {
-                "tensor-parallel-size": 4,
+                "deploy-config": "vllm_omni/deploy/hunyuan_image3_dit.yaml",
                 "quantization": "fp8",
                 "distributed-executor-backend": "mp",
-                "enforce-eager": true,
+                "trust-remote-code": true,
                 "enable-diffusion-pipeline-profiler": true
             }
         },

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_tokenizer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_tokenizer.py
@@ -45,9 +45,13 @@ class Conversation:
 
 
 class TokenizerWrapper:
-    def __init__(self, tokenizer):
+    def __init__(self, tokenizer, *, trust_remote_code: bool = False, revision: str | None = None):
         if isinstance(tokenizer, str):
-            self.tokenizer = AutoTokenizer.from_pretrained(tokenizer)
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                tokenizer,
+                revision=revision,
+                trust_remote_code=trust_remote_code,
+            )
         else:
             self.tokenizer = tokenizer
 

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -351,7 +351,11 @@ class HunyuanImage3Pipeline(
         self.vae = DistributedAutoencoderKLHunyuan.from_config(self.hf_config.vae)
         self.vae.use_spatial_tiling = self.od_config.vae_use_tiling
         self._pipeline = None
-        self._tkwrapper = TokenizerWrapper(od_config.model)
+        self._tkwrapper = TokenizerWrapper(
+            od_config.model,
+            revision=od_config.revision,
+            trust_remote_code=od_config.trust_remote_code,
+        )
         self.image_processor = HunyuanImage3ImageProcessor(self.hf_config)
         self.vision_model = Siglip2VisionTransformer(self.hf_config.vit)
         # self.vision_model = vision_model.vision_model


### PR DESCRIPTION
## Purpose

Fix the HunyuanImage3 nightly perf path so the run-nightly script executes every selected pytest command, starts HunyuanImage3 perf with the intended DiT-only deploy topology, and survives an offline cache that lacks `generation_config.json`.

### What Was Broken

1. `tools/nightly/run_nightly_jobs.sh` generated one shell job from a Buildkite step, but some Buildkite steps contain multiple pytest commands. With `set -e`, the first failing pytest stopped the job and later Hunyuan variants could be skipped.

2. The HunyuanImage3 perf JSONs launched `tencent/HunyuanImage-3.0-Instruct` without the DiT-only deploy config. In the single-server perf topology, async chunking is invalid because there is no next-stage input processor.

3. HunyuanImage3 requires Hugging Face remote code, so the perf server args need `--trust-remote-code`.

4. In offline cache, `HunyuanImage3Pipeline.__init__` could fail before loading weights when the snapshot had `config.json` and tokenizer files but no `generation_config.json`.

### How This PR Fixes It

- Preserve all pytest commands generated from one Buildkite step and return the combined failure status after every command has run.
- Use the existing `hunyuan_image3_dit.yaml` deploy config for all three HunyuanImage3 perf cases, then keep only the per-case CLI overrides for TP/SP/CFG/quantization/profiler/trust-remote-code.
- Resolve perf deploy configs from the repository `vllm_omni/deploy` directory so `stage_config_name` can point at the shared Hunyuan deploy YAML.
- Add a HunyuanImage3 generation-config loader that preserves real hub/snapshot values when available, but logs a warning and fills the bundled Hunyuan defaults when loading generation config fails in offline cache.

This PR does not change perf baselines or model execution logic. It only fixes nightly job execution and startup metadata/configuration needed for HunyuanImage3 perf startup.

## Test Plan

```bash
git diff --check
python -m json.tool tests/dfx/perf/tests/test_hunyuan_image_tp4_fp8.json
python -m json.tool tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_sp2.json
python -m json.tool tests/dfx/perf/tests/test_hunyuan_image_tp2_fp8_cfgp2.json
python -m ruff check vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py tests/diffusion/models/hunyuan_image3/test_generation_config.py tests/dfx/perf/scripts/run_benchmark.py
python -m ruff format --check --diff vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py tests/diffusion/models/hunyuan_image3/test_generation_config.py tests/dfx/perf/scripts/run_benchmark.py
bash -n tools/nightly/run_nightly_jobs.sh
PYTHONPATH=/data/wzr/wt-nightly-pr3582-tests-codex python3 -m pytest tests/diffusion/models/hunyuan_image3/test_generation_config.py -q
bash tools/nightly/run_nightly_jobs.sh --test-type perf --model-type diffusion --label-substr HunyuanImage3
```

Remote validation used only `/data/wzr` for persistent files, with:

```bash
HF_HUB_OFFLINE=1
TRANSFORMERS_OFFLINE=1
CUDA_VISIBLE_DEVICES=2,3,4,5
```

## Test Result

Local/static checks:

```text
git diff --check: passed
json.tool for all three Hunyuan perf JSONs: passed
Hunyuan deploy path resolution check: passed
ruff check: All checks passed!
ruff format --check --diff: 3 files already formatted
bash -n tools/nightly/run_nightly_jobs.sh: passed
```

Local Windows pytest collection is blocked by missing full `vllm` package in this environment:

```text
ModuleNotFoundError: No module named 'vllm'
```

Remote unit test before the latest local-path fallback case:

```text
PYTHONPATH=/data/wzr/wt-nightly-pr3582-tests-codex python3 -m pytest tests/diffusion/models/hunyuan_image3/test_generation_config.py -q
..                                                                       [100%]
2 passed, 18 warnings
```

Remote Hunyuan nightly startup evidence:

```text
Before this PR:
1. failed on async_chunk=True with no next-stage input processor
2. after disabling async chunk, failed because trust_remote_code=True was missing
3. after adding trust_remote_code, failed because generation_config.json was missing in offline cache

After this PR:
1. server args include trust_remote_code=True
2. all three Hunyuan perf configs use the DiT-only deploy config with async_chunk=false
3. the missing generation_config.json failure is gone
4. TP4 proceeds to diffusion weight loading
```

The full Hunyuan nightly still cannot finish on the tested server because the model cache itself is incomplete there. `/data/wzr` has no HunyuanImage3 weight files, and the available cached snapshot only contains config/tokenizer files. After this PR, the next and current blocker is:

```text
RuntimeError: Cannot find any model weights with `tencent/HunyuanImage-3.0-Instruct`
```

That final error is expected for this server state: the code now reaches weight loading, but the required model weights are not present in the allowed `/data/wzr` path.