### PR TITLE
[Bugfix][CI] Run Whisper validation on CPU for single-GPU runners

### DIFF
--- a/tests/helpers/media.py
+++ b/tests/helpers/media.py
@@ -623,9 +623,11 @@ def _whisper_transcribe_in_current_process(output_path: str) -> str:
 
     if current_omni_platform.is_available():
         n = current_omni_platform.get_device_count()
-        if n == 1:
-            device_index = 0
-        elif n > 1:
+        # Single-GPU runners (e.g. the L4 nightly): the model server already
+        # occupies device 0. Loading Whisper there, once per concurrent
+        # request, competes for VRAM and OOMs. Only borrow an accelerator
+        # when a spare device exists; otherwise validate on CPU.
+        if n > 1:
             device_index = n - 1
 
     if device_index is not None:


### PR DESCRIPTION
## Purpose

Fixes the CUDA OOM in the L4 nightly TTS function test `test_qwen3_tts_base_expansion.py::test_voice_clone_streaming_001[async_chunk]`, reported in #3788 and #3809.

The failure is **test-side**, not a server bug. The e2e audio helper validates server output by transcribing it with Whisper `small`. In `tests/helpers/media.py`, `_whisper_transcribe_in_current_process` loads Whisper onto a GPU; on a single-GPU runner the `n == 1` branch selects device 0, which is the GPU the model server already occupies. The streaming speech test sends `request_num=5` concurrent requests, and each spawns its own Whisper validator subprocess, so up to 5 Whisper models pile onto the server's card.

On an L4 (22 GiB) the two server stages hold ~18 GiB, leaving ~4 GiB. Each Whisper `small` validator needs ~2.4 GiB, so the concurrent validators exhaust VRAM and the request fails with `CUDA out of memory`, surfacing as `AssertionError: The request failed`. The server itself returns HTTP 200 for every request; only the client-side validation OOMs.

The device heuristic already avoids the server GPU on multi-GPU hosts by selecting device `n - 1`. The single-GPU case had nowhere else to go. This PR drops it so single-GPU runners validate on CPU. Multi-GPU behaviour is unchanged.

Closes #3788
Closes #3809

## Test Plan

Run the real helper `tests.helpers.media.convert_audio_bytes_to_text` under a single visible GPU (`CUDA_VISIBLE_DEVICES` set to one device, so `device_count == 1` like the L4 runner), with a filler tensor capping free VRAM at the L4's post-server budget (~4 GiB). Launch 5 concurrent validator calls (mirroring `request_num=5`), before and after this change.

## Test Result

Single Whisper `small` validator footprint: **2.41 GiB** of GPU memory.

**Before** (buggy `n == 1` -> device 0), ~4 GiB free, 5 concurrent validators:

```
RESULT: 2/5 ok, 3 OOM, 0 other-err; min free during run = 0.01 GiB
CUDA out of memory. Tried to allocate 20.00 MiB ... 12 MiB free
```

Same error signature as the CI log in #3788.

**After** (this PR, single-GPU -> CPU), same ~4 GiB free, 5 concurrent validators:

```
RESULT: 5/5 ok, 0 OOM, 0 other-err; min free during run = 4.00 GiB
```

GPU free memory stays flat (validators run on CPU); transcripts are byte-identical to the GPU path.

Note: reducing the test's `"few"` batch size from 5 to 2 (suggested in #3809) does not fix it. Two validators alone need 18 + 2 x 2.4 = 22.9 GiB, already over the L4's 22 GiB.

Thanks to @congw729 for the original nightly report in #3788 and to @tzhouam for #3809. @yenuo26, flagging this for you as the author of the test-helper restructure (#2556 and #2620) in case the multi-GPU device heuristic deserves a follow-up.

<details>
<summary>Checklist</summary>

- [x] Purpose of the PR, linking the issues it resolves (#3788, #3809).
- [x] Test plan: reproduction script and command described above.
- [x] Test results: before/after comparison pasted above.
- [ ] Documentation update: not applicable (test-helper only).
- [ ] Release notes update: not applicable (CI-only change).
</details>
