### PR TITLE
[Feature] Auto-detect model from vLLM-Omni server in ComfyUI nodes

### DIFF
--- a/apps/ComfyUI-vLLM-Omni/__init__.py
+++ b/apps/ComfyUI-vLLM-Omni/__init__.py
@@ -1,4 +1,6 @@
-"""Top-level package for comfyui_vllm_omni."""  # noqa: N999  # This is not a python library intended to be imported
+# SPDX-License-Identifier: Apache-2.0  # noqa: N999
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Top-level package for comfyui_vllm_omni."""
 
 __all__ = [
     "NODE_CLASS_MAPPINGS",
@@ -10,7 +12,68 @@ __author__ = """vLLM-Omni Team"""
 __email__ = "vllm-omni@vllm.ai"
 __version__ = "0.0.1"
 
-from .comfyui_vllm_omni.nodes import (
+import logging
+from urllib.parse import urlparse
+
+import aiohttp
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Server route: proxy model list from a vLLM-Omni server
+# ---------------------------------------------------------------------------
+# The PromptServer import is guarded because this module may be imported
+# outside of a running ComfyUI process (e.g. during linting or testing).
+try:
+    from server import PromptServer  # type: ignore[import-untyped]
+
+    @PromptServer.instance.routes.get("/vllm_omni/models")
+    async def get_vllm_models(request: web.Request) -> web.Response:
+        """Proxy endpoint to fetch available models from a vLLM-Omni server.
+
+        Query Parameters:
+            url: Base URL of the vLLM-Omni server (e.g. ``http://localhost:8000/v1``).
+
+        Returns:
+            JSON object with a ``models`` key containing a list of model ID strings.
+        """
+        url = request.query.get("url", "").strip()
+        if not url:
+            return web.json_response({"error": "Missing 'url' query parameter"}, status=400)
+
+        # Basic SSRF protection: only allow http(s) schemes.
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return web.json_response({"error": f"Unsupported URL scheme: {parsed.scheme}"}, status=400)
+
+        models_url = url.rstrip("/") + "/models"
+        timeout = aiohttp.ClientTimeout(total=5)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(models_url) as response:
+                    if not response.ok:
+                        return web.json_response(
+                            {"error": f"Server returned status {response.status}"},
+                            status=502,
+                        )
+                    data = await response.json()
+                    model_ids = [m["id"] for m in data.get("data", [])]
+                    return web.json_response({"models": model_ids})
+        except Exception:
+            logger.debug("Failed to fetch models from %s", models_url, exc_info=True)
+            return web.json_response(
+                {"error": f"Could not connect to vLLM-Omni server at {url}"},
+                status=502,
+            )
+
+except ImportError:
+    logger.debug("PromptServer not available; skipping route registration.")
+
+# ---------------------------------------------------------------------------
+# Node registration
+# ---------------------------------------------------------------------------
+from .comfyui_vllm_omni.nodes import (  # noqa: E402
     VLLMOmniARSampling,
     VLLMOmniDiffusionSampling,
     VLLMOmniGenerateImage,
@@ -24,7 +87,6 @@ from .comfyui_vllm_omni.nodes import (
     VLLMOmniWanParams,
 )
 
-# A dictionary that contains all nodes you want to export with their names
 NODE_CLASS_MAPPINGS = {
     # === Generation ===
     "VLLMOmniGenerateImage": VLLMOmniGenerateImage,
@@ -41,7 +103,6 @@ NODE_CLASS_MAPPINGS = {
     "VLLMOmniWanParams": VLLMOmniWanParams,
 }
 
-# A dictionary that contains the friendly/humanly readable titles for the nodes
 NODE_DISPLAY_NAME_MAPPINGS = {
     # === Generation ===
     "VLLMOmniGenerateImage": "Generate Image",

--- a/apps/ComfyUI-vLLM-Omni/web/main.js
+++ b/apps/ComfyUI-vLLM-Omni/web/main.js
@@ -1,21 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 /**
- * @file This file is intended to add dynamic fields to vLLM-Omni nodes
- * based on widget (in-node form fields) and input (connection link) values and changes.
- * However, this functionality is currently disabled/commented out.
- * Because it introduces too much complexity,
- * and it may even conflict with the current backend (Python) validation for unknown reasons (pending ComfyUI upstream fixes).
+ * vLLM-Omni ComfyUI frontend extension.
+ *
+ * Automatically detects available models from the configured vLLM-Omni
+ * server and replaces the manual model text input with a dropdown.
+ *
+ * Behaviour:
+ *  - On node creation the extension fetches ``/vllm_omni/models`` with the
+ *    current ``url`` widget value.
+ *  - When the ``url`` widget changes the model list is re-fetched (debounced).
+ *  - A "Refresh Models" right-click menu entry allows manual refresh.
+ *  - If the server is unreachable the widget stays as a plain text input so
+ *    users can still type a model name manually.
  */
 
 import { app } from "../../scripts/app.js";
+
+/** Node class names that have ``url`` + ``model`` widgets. */
+const VLLM_NODE_NAMES = new Set([
+    "VLLMOmniGenerateImage",
+    "VLLMOmniGenerateVideo",
+    "VLLMOmniUnderstanding",
+    "VLLMOmniTTS",
+    "VLLMOmniVoiceClone",
+]);
+
+// ---------------------------------------------------------------------------
+// Model list cache (per URL, with TTL)
+// ---------------------------------------------------------------------------
+
+const modelCache = new Map();
+const CACHE_TTL_MS = 30_000;
+
+/**
+ * Fetch available model IDs from the ComfyUI proxy route.
+ * Returns ``null`` on any failure so the caller can fall back gracefully.
+ */
+async function fetchModels(url) {
+    const now = Date.now();
+    const cached = modelCache.get(url);
+    if (cached && now - cached.ts < CACHE_TTL_MS) {
+        return cached.models;
+    }
+
+    try {
+        const resp = await fetch(
+            `/vllm_omni/models?url=${encodeURIComponent(url)}`
+        );
+        if (!resp.ok) {
+            return null;
+        }
+        const data = await resp.json();
+        const models = data.models || [];
+        if (models.length > 0) {
+            modelCache.set(url, { models, ts: now });
+        }
+        return models;
+    } catch (_err) {
+        return null;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Widget helpers
+// ---------------------------------------------------------------------------
+
+function findWidget(node, name) {
+    return node.widgets?.find((w) => w.name === name);
+}
+
+/**
+ * Convert the ``model`` STRING widget into a combo dropdown populated with
+ * the models served by the vLLM-Omni instance at the current ``url``.
+ *
+ * If models cannot be fetched the widget is left unchanged (still editable
+ * as a plain text field).
+ */
+async function updateModelWidget(node) {
+    const urlWidget = findWidget(node, "url");
+    const modelWidget = findWidget(node, "model");
+    if (!urlWidget || !modelWidget) {
+        return;
+    }
+
+    const url = urlWidget.value;
+    if (!url) {
+        return;
+    }
+
+    const models = await fetchModels(url);
+    if (!models || models.length === 0) {
+        return;
+    }
+
+    const currentValue = modelWidget.value;
+
+    // Skip update if options haven't changed.
+    if (modelWidget.type === "combo" && modelWidget.options?.values) {
+        if (JSON.stringify(modelWidget.options.values) === JSON.stringify(models)) {
+            return;
+        }
+    }
+
+    // Convert STRING → combo.
+    modelWidget.type = "combo";
+    modelWidget.options = modelWidget.options || {};
+    modelWidget.options.values = models;
+
+    // Preserve current selection when possible.
+    modelWidget.value = models.includes(currentValue)
+        ? currentValue
+        : models[0];
+
+    // Redraw the node to reflect the new widget type.
+    node.setSize(node.computeSize());
+    app.graph.setDirtyCanvas(true, true);
+}
+
+// ---------------------------------------------------------------------------
+// Extension registration
+// ---------------------------------------------------------------------------
+
 app.registerExtension({
     name: "vllm.vllm_omni",
-    async beforeRegisterNodeDef(nodeType, nodeData, app) {
-        if (!nodeData.name.startsWith("VLLMOmni")) {
-            return
+
+    async nodeCreated(node) {
+        if (!VLLM_NODE_NAMES.has(node.comfyClass)) {
+            return;
         }
-        // Stub frontend plugin for now
+
+        // Slight delay so that widget initialisation is complete.
+        setTimeout(() => updateModelWidget(node), 500);
+
+        // Re-fetch when the URL widget value changes (debounced).
+        const urlWidget = findWidget(node, "url");
+        if (urlWidget) {
+            const origCallback = urlWidget.callback;
+            urlWidget.callback = function (...args) {
+                if (origCallback) {
+                    origCallback.apply(this, args);
+                }
+                clearTimeout(node._vllmModelTimeout);
+                node._vllmModelTimeout = setTimeout(
+                    () => updateModelWidget(node),
+                    800
+                );
+            };
+        }
+
+        // Right-click context menu entry for manual refresh.
+        const origGetExtraMenuOptions = node.getExtraMenuOptions;
+        node.getExtraMenuOptions = function (_, options) {
+            if (origGetExtraMenuOptions) {
+                origGetExtraMenuOptions.apply(this, arguments);
+            }
+            options.unshift({
+                content: "🔄 Refresh Models",
+                callback: () => {
+                    const currentUrl = findWidget(node, "url")?.value;
+                    if (currentUrl) {
+                        modelCache.delete(currentUrl);
+                    }
+                    updateModelWidget(node);
+                },
+            });
+        };
     },
+
     async setup() {
-        console.info("vLLM-Omni Setup complete!")
+        console.info("vLLM-Omni: Model auto-detect extension loaded.");
     },
-})
+});


### PR DESCRIPTION
## Summary

The ComfyUI-vLLM-Omni custom nodes currently require users to manually type the full model name (e.g. `Tongyi-MAI/Z-Image-Turbo`) into a text field. This PR adds automatic model detection: the node queries the vLLM-Omni server and populates a dropdown with available models.

## Changes

### Backend (`__init__.py`)
- Add a ComfyUI server route `GET /vllm_omni/models?url=<server_url>` that proxies the model list from the vLLM-Omni server
- 5-second timeout to avoid hanging the UI if the server is down
- Basic SSRF protection (only allows `http`/`https` schemes)
- Guarded `PromptServer` import for compatibility outside ComfyUI context

### Frontend (`web/main.js`)
- On node creation, fetches available models from the server and converts the `model` STRING widget to a combo dropdown
- Re-fetches when the `url` widget value changes (800ms debounce)
- 30-second client-side cache to avoid redundant requests
- Right-click "🔄 Refresh Models" context menu entry for manual refresh
- Graceful fallback: if server is unreachable, keeps the original STRING input for manual entry

## Affected nodes
All five generation nodes benefit: Generate Image, Generate Video, Multimodal Understanding, TTS, and Voice Cloning.

## Testing
- Verified with Z-Image-Turbo served on `localhost:8000`
- Node auto-detects model on creation ✅
- URL change triggers re-fetch ✅
- Server unreachable → falls back to manual text input ✅
- `ruff check` and `ruff format` pass ✅