### PR TITLE
Fix: Prevent Query RoPE Loss and Key Double-Rotation in HiDreamAttention

### DIFF
--- a/vllm_omni/diffusion/models/hidream_image/hidream_image_transformer.py
+++ b/vllm_omni/diffusion/models/hidream_image/hidream_image_transformer.py
@@ -321,7 +321,7 @@ class HiDreamAttention(nn.Module):
         else:
             query_1, query_2 = query.chunk(2, dim=-1)
             key_1, key_2 = key.chunk(2, dim=-1)
-            key_1 = self.rope(query_1, cos, sin)
+            query_1 = self.rope(query_1, cos, sin)
             key_1 = self.rope(key_1, cos, sin)
             query = torch.cat([query_1, query_2], dim=-1)
             key = torch.cat([key_1, key_2], dim=-1)


### PR DESCRIPTION
Fixes incorrect RoPE assignment in HiDreamAttention: query_1 rotation was incorrectly assigned to key_1, causing query to miss rotation and key to be rotated twice. Now query_1 and key_1 are each rotated once.


## Purpose

Issue scenario: 
HiDreamAttention enters partial RoPE path, where query/key head dim does not match full rotary dim condition.
query_1 misses RoPE rotation, while key_1 is derived from rotated query data and then rotated again. Attention  uses wrong query/key positional encoding, causing degraded or incorrect HiDream image generation quality.

  Expected behavior: 
query_1 and key_1 should each apply RoPE once to their own tensor, then concatenate back with unrotated halves.

Root cause: 
Partial RoPE assignment typo in pr https://github.com/vllm-project/vllm-omni/pull/2572
Old code wrote self.rope(query_1, ...) into key_1, so query output was lost and key  input was corrupted.



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
