### PR TITLE
docs: fix CUDA pre-built image command

### DIFF
--- a/docs/getting_started/installation/gpu/cuda.inc.md
+++ b/docs/getting_started/installation/gpu/cuda.inc.md
@@ -103,10 +103,10 @@ docker run --runtime nvidia --gpus 2 \
     -p 8091:8091 \
     --ipc=host \
     vllm/vllm-omni:v0.21.0 \
-    --model Qwen/Qwen3-Omni-30B-A3B-Instruct --port 8091
+    vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
 ```
 
 !!! tip
-    You can use this docker image to serve models the same way you would with in vLLM! To do so, make sure you overwrite the default entrypoint (`vllm serve --omni`) which works only for models supported in the vLLM-Omni project.
+    The CUDA image does not define a default entrypoint, so include `vllm serve ... --omni` after the image name.
 
 # --8<-- [end:pre-built-images]


### PR DESCRIPTION
Fixes #3834

### Bug
The CUDA pre-built Docker image docs pass `--model` directly after the image name, but the CUDA image has no `ENTRYPOINT` or `CMD`.

This makes Docker try to execute `--model` as the command.

### Repro


  ```bash
  docker run --runtime nvidia --gpus all \
    -v /model/huggingface:/root/.cache/huggingface \
    -e NVIDIA_VISIBLE_DEVICES=1 \
    --env "HF_TOKEN=$HF_TOKEN" \
    -p 8091:8091 \
    --ipc=host \
    vllm/vllm-omni:latest \
    --model fishaudio/s2-pro --port 8091
```
Error:
```bash
  exec: "--model": executable file not found in $PATH
```
### Image check

  docker image inspect vllm/vllm-omni:latest \
    --format 'Entrypoint={{json .Config.Entrypoint}} Cmd={{json .Config.Cmd}} WorkingDir={{.Config.WorkingDir}}'

  Output:

  Entrypoint=null Cmd=null WorkingDir=/app

### Root cause

  docker/Dockerfile.cuda clears the entrypoint:

  ENTRYPOINT []

ref: https://github.com/vllm-project/vllm-omni/blob/main/docker/Dockerfile.cuda#L22

The docs section is:

  - docs/getting_started/installation/gpu/cuda.inc.md
  - included from docs/getting_started/installation/gpu.md
  - section: pre-built-images

  The current documented command uses:

  vllm/vllm-omni:v0.21.0 \
  --model Qwen/Qwen3-Omni-30B-A3B-Instruct --port 8091

  That only works if the image already has an entrypoint.

  ## Related PRs

  PR #141  (merged) added the CUDA pre-built image docs before docker/Dockerfile.cuda existed:

  - https://github.com/vllm-project/vllm-omni/pull/141
  

  PR #1439 later added docker/Dockerfile.cuda with ENTRYPOINT []:

  - https://github.com/vllm-project/vllm-omni/pull/1439
  
  PR #1386 adds custom CUDA Docker build docs, but it does not fix the pre-built image command:

  - https://github.com/vllm-project/vllm-omni/pull/1386

### Expected docs command

  The CUDA pre-built image docs should include the full command after the image name:

  **Fix**
```diff
  diff --git a/docs/getting_started/installation/gpu/cuda.inc.md b/docs/getting_started/installation/gpu/cuda.inc.md
  index 69fc0535..c7915075 100644
  --- a/docs/getting_started/installation/gpu/cuda.inc.md
  +++ b/docs/getting_started/installation/gpu/cuda.inc.md
  @@ -103,11 +103,11 @@ docker run --runtime nvidia --gpus 2 \
       -p 8091:8091 \
       --ipc=host \
       vllm/vllm-omni:v0.21.0 \
  -    --model Qwen/Qwen3-Omni-30B-A3B-Instruct --port 8091
  +    vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
```

### Additional queries:

CUDA currently differs from ROCm/XPU in Docker entrypoint behavior.

CUDA:

```dockerfile
# docker/Dockerfile.cuda
ENTRYPOINT []
```

ROCm/XPU:

```dockerfile
# docker/Dockerfile.rocm
ENTRYPOINT ["vllm", "serve", "--omni"]

# docker/Dockerfile.xpu
ENTRYPOINT ["vllm", "serve", "--omni"]
```

Should the intended fix be docs-only, keeping CUDA explicit like this?

```bash
docker run ... vllm/vllm-omni:v0.21.0 \
  vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct --omni --port 8091
```

Or should CUDA image behavior be aligned with ROCm/XPU by setting a default entrypoint in `docker/Dockerfile.cuda`?

My current PR uses the docs-only fix because it matches the current CUDA image behavior and avoids changing container runtime behavior.


