### PR TITLE
[CI][NPU] Quote the pytest version constraint in run_npu_test.sh

### DIFF
--- a/.buildkite/scripts/hardware_ci/run_npu_test.sh
+++ b/.buildkite/scripts/hardware_ci/run_npu_test.sh
@@ -40,7 +40,7 @@ RUN pip config set global.index-url http://pypi-cache:${PYPI_CACHE_PORT}/pypi/si
 
 # Install for pytest to make the docker build cache layer always valid
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install pytest>=6.0  pytest-cov modelscope
+    pip install 'pytest>=6.0' pytest-cov modelscope
 
 COPY . .
 


### PR DESCRIPTION
## Summary

This quotes the pytest version constraint in the NPU CI Dockerfile heredoc so the shell passes it through literally during image build.

Closes #3842.

## Root cause

The current command is:

```bash
pip install pytest>=6.0 pytest-cov modelscope
```

In shell syntax, `pytest>=6.0` is parsed as `pip install pytest` with stdout redirected to a file named `=6.0`, so the intended version constraint is never applied.

## Change

- quote `pytest>=6.0` in `.buildkite/scripts/hardware_ci/run_npu_test.sh`

## Validation

- `bash -n .buildkite/scripts/hardware_ci/run_npu_test.sh`
- reproduced that the unquoted form creates `=6.0`
- verified that the quoted form does not create `=6.0`
