### PR TITLE
[CI] Increase timeout for Quantization Test in nightly build to 60 minutes

### DIFF
--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -1086,9 +1086,8 @@ steps:
     if: build.env("NIGHTLY") == "1" || build.pull_request.labels includes "nightly-test" || build.pull_request.labels includes "diffusion-x2iat-test"
     steps:
       - label: ":full_moon: Quantization Test with H100"
-        timeout_in_minutes: 90
         commands:
-          - timeout 30m pytest -sv tests/diffusion/quantization -m 'full_model and cuda and H100' --run-level "full_model"
+          - timeout 60m pytest -sv tests/diffusion/quantization -m 'full_model and cuda and H100' --run-level "full_model"
         agents:
           queue: "mithril-h100-pool"
         plugins:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
The timeout duration for the "Quantization Test with H100" in the current nightly CI is set to 30 minutes. Due to the fluctuation in running time, there might be cases of timeout. Therefore, the timeout duration for this job has been set to 60 minutes.

nightly ci (timeout): https://buildkite.com/vllm/vllm-omni/builds/10268/canvas?sid=019e5b2e-d55d-4fbf-9329-3c4a2581b5b7&tab=output

nightly ci (pass, 25min): https://buildkite.com/vllm/vllm-omni/builds/10254/canvas?sid=019e5608-9ca6-4022-88b4-1c37638175f9&tab=output

nightly ci (pass, 26min): https://buildkite.com/vllm/vllm-omni/builds/10254/canvas?sid=019e5608-9ca6-4022-88b4-1c37638175f9&tab=output
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
