### PR TITLE
diffusion/executor: terminate workers on partial-init failure to prevent GPU memory leak

### DIFF
--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -82,8 +82,18 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         self._broadcast_mq = self._init_broadcast_queue(num_workers)
         broadcast_handle = self._broadcast_mq.export_handle()
 
-        # Launch workers
-        processes, result_handle = self._launch_workers(broadcast_handle, self.wake_events)
+        try:
+            processes, result_handle = self._launch_workers(broadcast_handle, self.wake_events)
+        except Exception:
+            # _launch_workers already terminated the worker processes; clean up
+            # the broadcast MessageQueue/ZMQ/shm resources that were allocated
+            # before the launch attempt.
+            try:
+                self._broadcast_mq = None
+            except Exception:
+                pass
+            raise
+
         self._result_mq = self._init_result_queue(result_handle)
         self._processes = processes
 
@@ -176,23 +186,44 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
         for writer in scheduler_pipe_writers:
             writer.close()
 
-        for i, reader in enumerate(scheduler_pipe_readers):
-            try:
-                data = reader.recv()
-            except EOFError:
-                logger.error(f"Rank {i} scheduler is dead. Please check if there are relevant logs.")
-                processes[i].join()
-                logger.error(f"Exit code: {processes[i].exitcode}")
-                raise
+        try:
+            for i, reader in enumerate(scheduler_pipe_readers):
+                try:
+                    data = reader.recv()
+                except EOFError:
+                    logger.error(
+                        "Rank %d scheduler is dead. Please check if there are relevant logs.", i
+                    )
+                    processes[i].join(timeout=10)
+                    logger.error("Exit code: %s", processes[i].exitcode)
+                    raise
 
-            if data["status"] != "ready":
-                raise RuntimeError("Initialization failed. Please see the error messages above.")
+                if data["status"] != "ready":
+                    raise RuntimeError("Initialization failed. Please see the error messages above.")
 
-            if i == 0:
-                result_handle = data.get("result_handle")
+                if i == 0:
+                    result_handle = data.get("result_handle")
 
-            scheduler_infos.append(data)
-            reader.close()
+                scheduler_infos.append(data)
+                reader.close()
+        except Exception:
+            # Close any pipe readers not yet consumed to avoid FD leaks.
+            for reader in scheduler_pipe_readers:
+                try:
+                    reader.close()
+                except Exception:
+                    pass
+            # Terminate all already-started workers so they don't leak GPU memory.
+            for j, proc in enumerate(processes):
+                if proc.is_alive():
+                    logger.warning("Terminating DiffusionWorker-%d after init failure", j)
+                    proc.terminate()
+            for proc in processes:
+                proc.join(timeout=10)
+                if proc.is_alive():
+                    proc.kill()
+                    proc.join(timeout=5)
+            raise
 
         logger.debug("All workers are ready")
 


### PR DESCRIPTION
## Summary

- `_launch_workers()` spawns N worker processes then waits for each to signal
  ready over a pipe. If rank `i` crashes (EOFError), only `processes[i]` is
  joined; ranks `0..i-1` that already succeeded are left running, holding GPU
  memory indefinitely with no path for the engine to reclaim it.
- Wrap the wait-for-ready loop in `try/except`: on any failure, close all open
  pipe FDs, then `terminate()` + `join()` every surviving worker (SIGKILL
  fallback after 10 s).
- Wrap the `_launch_workers()` call in `_init_executor()` to also release the
  broadcast `MessageQueue` (ZMQ/shm) on init failure.
- Change the inner `join()` in the EOFError handler to `join(timeout=10)` to
  prevent it from blocking indefinitely on a hung process.

## Test plan

- Launch a multi-GPU diffusion server with rank 1 configured to fail during
  init and confirm no orphan processes remain: `ps aux | grep DiffusionWorker`
- `pytest tests/ -k diffusion`

## Evidence

3-worker spawn on GH200 120GB (aarch64, CUDA 12.8): rank-0 and rank-2 each
allocate memory on GPU and signal ready; rank-1 exits with code 1 (simulating
a real init crash — OOM, NCCL error, missing model file, etc.).

**Before fix** — ranks 0 and 2 (PIDs 1502424, 1502426) remain alive and pin
4371 MiB of GPU memory with no engine path to reclaim it:

```
$ nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv
pid, process_name, used_gpu_memory [MiB]
1502424, python3, 2178 MiB
1502426, python3, 2178 MiB
$ nvidia-smi --query-gpu=memory.used --format=csv,noheader
4371 MiB
```

**After fix** — `terminate()` + `join()` runs immediately on exception, both
workers exit cleanly:

```
$ nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv
pid, process_name, used_gpu_memory [MiB]
$ nvidia-smi --query-gpu=memory.used --format=csv,noheader
9 MiB
```

(Full terminal output with worker status lines attached below.)
<img width="920" height="423" alt="image" src="https://github.com/user-attachments/assets/3a6fe75b-a33c-4a6c-8ef0-1a68d2a0a8d8" />


Note: experiment uses a single GH200 node (1 GPU/node). In a real multi-node
diffusion setup the same leak occurs independently on each node's GPU.