### PR TITLE
[BugFix] Fix LTX-2.3 audio latent padding for sequence parallelism

### DIFF
--- a/tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py
@@ -15,10 +15,27 @@ These tests verify:
 import json
 import os
 import tempfile
+from types import SimpleNamespace
 
 import pytest
+import torch
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _make_ltx23_pipeline(sequence_parallel_size: int = 1):
+    from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import LTX23Pipeline
+
+    pipeline = object.__new__(LTX23Pipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline.audio_vae_temporal_compression_ratio = 4
+    pipeline.audio_vae_mel_compression_ratio = 4
+    pipeline.od_config = SimpleNamespace(parallel_config=SimpleNamespace(sequence_parallel_size=sequence_parallel_size))
+    pipeline.audio_vae = SimpleNamespace(
+        latents_mean=torch.tensor(0.0),
+        latents_std=torch.tensor(1.0),
+    )
+    return pipeline
 
 
 class TestPipelineIndependence:
@@ -228,3 +245,85 @@ class TestInitExports:
         for name in expected_classes:
             assert hasattr(ltx2, name), f"{name} not exported from ltx2 package"
             assert name in ltx2.__all__, f"{name} not in ltx2.__all__"
+
+
+class TestAudioLatentSPPadding:
+    def test_prepare_audio_latents_pads_generated_dummy_length_for_sp(self):
+        pipeline = _make_ltx23_pipeline(sequence_parallel_size=2)
+
+        latents, original_num_frames, padded_num_frames = pipeline.prepare_audio_latents(
+            batch_size=1,
+            num_channels_latents=8,
+            num_mel_bins=64,
+            audio_latent_length=1,
+            dtype=torch.float32,
+            device=torch.device("cpu"),
+        )
+
+        assert original_num_frames == 1
+        assert padded_num_frames == 2
+        assert latents.shape == (1, 2, 128)
+
+    def test_prepare_audio_latents_pads_provided_packed_sequence_dim_for_sp(self):
+        pipeline = _make_ltx23_pipeline(sequence_parallel_size=4)
+        latents = torch.arange(40, dtype=torch.float32).view(1, 10, 4)
+
+        padded, original_num_frames, padded_num_frames = pipeline.prepare_audio_latents(
+            batch_size=1,
+            num_channels_latents=2,
+            num_mel_bins=8,
+            audio_latent_length=10,
+            dtype=torch.float32,
+            device=torch.device("cpu"),
+            latents=latents,
+        )
+
+        assert original_num_frames == 10
+        assert padded_num_frames == 12
+        assert padded.shape == (1, 12, 4)
+        torch.testing.assert_close(padded[:, :10], latents)
+        torch.testing.assert_close(padded[:, 10:], torch.zeros(1, 2, 4))
+
+    def test_prepare_audio_latents_accepts_already_padded_4d_latents_for_sp(self):
+        pipeline = _make_ltx23_pipeline(sequence_parallel_size=4)
+        latents = torch.arange(96, dtype=torch.float32).view(1, 2, 12, 4)
+
+        audio_latent_length = pipeline._resolve_audio_latent_length(10, latents)
+        padded, original_num_frames, padded_num_frames = pipeline.prepare_audio_latents(
+            batch_size=1,
+            num_channels_latents=2,
+            num_mel_bins=16,
+            audio_latent_length=audio_latent_length,
+            dtype=torch.float32,
+            device=torch.device("cpu"),
+            latents=latents,
+        )
+
+        assert audio_latent_length == 10
+        assert original_num_frames == 10
+        assert padded_num_frames == 12
+        assert padded.shape == (1, 12, 8)
+        torch.testing.assert_close(padded, pipeline._pack_audio_latents(latents))
+
+    def test_resolve_audio_latent_length_preserves_legacy_4d_shape_inference(self):
+        pipeline = _make_ltx23_pipeline(sequence_parallel_size=4)
+        latents = torch.zeros(1, 2, 13, 4)
+
+        audio_latent_length = pipeline._resolve_audio_latent_length(10, latents)
+
+        assert audio_latent_length == 13
+
+    def test_prepare_audio_latents_rejects_incompatible_provided_length(self):
+        pipeline = _make_ltx23_pipeline(sequence_parallel_size=4)
+        latents = torch.zeros(1, 11, 4)
+
+        with pytest.raises(ValueError, match="incompatible audio frame count"):
+            pipeline.prepare_audio_latents(
+                batch_size=1,
+                num_channels_latents=2,
+                num_mel_bins=8,
+                audio_latent_length=10,
+                dtype=torch.float32,
+                device=torch.device("cpu"),
+                latents=latents,
+            )

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
@@ -445,6 +445,26 @@ class LTX23Pipeline(nn.Module, ProgressBarMixin):
     def _unpad_audio_latents(latents: torch.Tensor, num_frames: int) -> torch.Tensor:
         return latents[:, :num_frames]
 
+    @staticmethod
+    def _get_sp_padded_audio_latent_length(audio_latent_length: int, sp_size: int) -> int:
+        if sp_size > 1:
+            audio_latent_length += (sp_size - (audio_latent_length % sp_size)) % sp_size
+        return audio_latent_length
+
+    def _resolve_audio_latent_length(self, audio_latent_length: int, audio_latents: torch.Tensor | None) -> int:
+        if audio_latents is None or audio_latents.ndim != 4:
+            return audio_latent_length
+
+        provided_latent_length = audio_latents.shape[2]
+        sp_size = getattr(self.od_config.parallel_config, "sequence_parallel_size", 1) or 1
+        padded_latent_length = self._get_sp_padded_audio_latent_length(audio_latent_length, int(sp_size))
+
+        # Keep requested duration semantics when callers pass 4D latents that
+        # are already padded for SP; other 4D lengths retain shape inference.
+        if provided_latent_length in {audio_latent_length, padded_latent_length}:
+            return audio_latent_length
+        return provided_latent_length
+
     # ------------------------------------------------------------------
     # Latent preparation
     # ------------------------------------------------------------------
@@ -497,8 +517,10 @@ class LTX23Pipeline(nn.Module, ProgressBarMixin):
         latents: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, int, int]:
         original_latent_length = audio_latent_length
-        padded_latent_length = original_latent_length
         latent_mel_bins = num_mel_bins // self.audio_vae_mel_compression_ratio
+
+        sp_size = getattr(self.od_config.parallel_config, "sequence_parallel_size", 1) or 1
+        padded_latent_length = self._get_sp_padded_audio_latent_length(original_latent_length, int(sp_size))
 
         if latents is not None:
             if latents.ndim == 4:
@@ -508,6 +530,23 @@ class LTX23Pipeline(nn.Module, ProgressBarMixin):
             latents = self._normalize_audio_latents(latents, self.audio_vae.latents_mean, self.audio_vae.latents_std)
             noise = randn_tensor(latents.shape, generator=generator, device=latents.device, dtype=latents.dtype)
             latents = noise_scale * noise + (1 - noise_scale) * latents
+
+            if latents.shape[1] not in {original_latent_length, padded_latent_length}:
+                raise ValueError(
+                    "Provided `audio_latents` has incompatible audio frame count "
+                    f"{latents.shape[1]}; expected {original_latent_length} or {padded_latent_length}."
+                )
+
+            if latents.shape[1] == original_latent_length and padded_latent_length > original_latent_length:
+                padding = torch.zeros(
+                    latents.shape[0],
+                    padded_latent_length - original_latent_length,
+                    latents.shape[2],
+                    dtype=latents.dtype,
+                    device=latents.device,
+                )
+                latents = torch.cat([latents, padding], dim=1)
+
             return latents.to(device=device, dtype=dtype), original_latent_length, padded_latent_length
 
         shape = (batch_size, num_channels_latents, padded_latent_length, latent_mel_bins)
@@ -783,8 +822,7 @@ class LTX23Pipeline(nn.Module, ProgressBarMixin):
             self.audio_sampling_rate / self.audio_hop_length / float(self.audio_vae_temporal_compression_ratio)
         )
         audio_num_frames = round(duration_s * audio_latents_per_second)
-        if audio_latents is not None and audio_latents.ndim == 4:
-            _, _, audio_num_frames, _ = audio_latents.shape
+        audio_num_frames = self._resolve_audio_latent_length(audio_num_frames, audio_latents)
 
         num_mel_bins = self.audio_vae.config.mel_bins if self.audio_vae is not None else 64
         latent_mel_bins = num_mel_bins // self.audio_vae_mel_compression_ratio


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fixes LTX-2.3 multi-GPU Ulysses sequence-parallel startup failure during dummy run.

LTX-2.3 currently prepares audio latents with the original audio latent length. During dummy run, the default single audio frame produces `audio_hidden_states` with sequence length 1. The transformer SP plan shards `audio_hidden_states` along dim 1, so `ulysses_degree > 1` fails before serving starts:

```text
RuntimeError: Dummy run failed: Tensor size along dim 1 (1) must be >= world_size (2). Tensor shape: torch.Size([2, 1, 128])
```

This PR aligns LTX-2.3 audio latent handling with LTX-2:

- Pads audio latents to `sequence_parallel_size` when sequence parallelism is enabled.
- Accepts provided audio latents with either original length or padded length.
- Rejects incompatible provided audio latent lengths.
- Keeps existing unpadding before audio decode.

Fixes ##3853
## Test Plan
Unit test:

```bash
python -m pytest tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py::TestAudioLatentSPPadding -q
```

End-to-end offline inference:

```bash
python examples/offline_inference/text_to_video/text_to_video.py \
  --model LTX-2.3-diffusers \
  --model-class-name LTX23Pipeline \
  --prompt "A majestic bald eagle soaring over a misty mountain valley at dawn, golden sunlight breaking through clouds" \
  --negative-prompt "blurry, low quality, distorted, watermark" \
  --width 768 \
  --height 512 \
  --num-frames 128 \
  --fps 24 \
  --frame-rate 24 \
  --num-inference-steps 10 \
  --guidance-scale 4.0 \
  --seed 42 \
  --ulysses-degree 2 \
  --ulysses-mode advanced_uaa \
  --enforce-eager \
  --output results/ltx23_baseline/usp2_uaa_eager_128f.mp4
```

## Test Result
Unit test:

```text
3 passed, 17 warnings in 6.81s
```

End-to-end offline inference result:

```text
dummy run to warm up the model
100%|██████████| 2/2

Generation Configuration:
  Model: /data/models/Lightricks/LTX-2.3-diffusers
  Inference steps: 10
  Frames: 128
  Parallel configuration: ulysses_degree=2, ring_degree=1, cfg_parallel_size=1, tensor_parallel_size=1, vae_patch_parallel_size=1, pipeline_parallel_size=1, enable_expert_parallel=False
  Video size: 768x512

100%|██████████| 10/10
Processed prompts: 100%|██████████| 1/1
Saved generated video to results/ltx23_baseline/usp2_uaa_eager_128f.mp4
```

Before this change, the same LTX-2.3 Ulysses SP configuration failed during dummy run with:

```text
RuntimeError: Dummy run failed: Tensor size along dim 1 (1) must be >= world_size (2). Tensor shape: torch.Size([2, 1, 128])
```

```bash
pre-commit run --files vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py
Passed
```

https://github.com/user-attachments/assets/83a6f662-da0c-4773-be17-81ae1e45ed34

https://github.com/user-attachments/assets/e99d4646-a4be-43f9-8384-edaadd209659

https://github.com/user-attachments/assets/70d69739-9ac8-4a75-8f46-1fd407e88747

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ x ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ x ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
