### PR TITLE
Update CUDA Docker base image to vLLM v0.21.0

### DIFF
--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=vllm/vllm-openai:v0.20.0
+ARG BASE_IMAGE=vllm/vllm-openai:v0.21.0
 FROM ${BASE_IMAGE}
 
 ARG COMMON_WORKDIR=/app


### PR DESCRIPTION
## Summary
- Update `docker/Dockerfile.cuda` base image from `vllm/vllm-openai:v0.20.0` to `vllm/vllm-openai:v0.21.0` to match the v0.21.0 rebase on `main` and other GPU Dockerfiles/docs.
- Follow-up to #3858 (version/tag alignment on `main`).

Note: `v0.21.0rc2` has already been pushed on `main` (`5f9aee19`) to fix setuptools-scm reporting `0.20.x.dev` for editable installs with `vllm==0.21.0`. This PR covers the remaining Dockerfile inconsistency called out in that issue.

## Test plan
- [x] Verified local editable install with `vllm==0.21.0` reports `vllm_omni` major.minor `0.21` after `v0.21.0rc2` tag on `main`
- [x] Verified AGENTS.md major/minor alignment check passes
- [ ] CI Docker build (if applicable)

Fixes #3858

Made with [Cursor](https://cursor.com)