### PR TITLE
[Perf] Add profiling-based diffusion batching and keyed DRR scheduling

### DIFF
--- a/benchmarks/diffusion/diffusion_batching_profiler.py
+++ b/benchmarks/diffusion/diffusion_batching_profiler.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean, median
+
+PROFILE_RE = re.compile(
+    r"\[DiffusionBatchProfiler\]\s+batch_size=(?P<batch_size>\d+)\s+"
+    r"request_compute_units=(?P<request_compute_units>\d+)\s+"
+    r"total_compute_units=(?P<total_compute_units>\d+)\s+"
+    r"denoise_step_time=(?P<denoise_step_time>[\d.]+)"
+)
+
+
+def parse_profile_records(log_file: Path) -> list[dict[str, int | float]]:
+    records: list[dict[str, int | float]] = []
+    with log_file.open("r", encoding="utf-8") as f:
+        for line in f:
+            match = PROFILE_RE.search(line)
+            if match is None:
+                continue
+            records.append(
+                {
+                    "batch_size": int(match.group("batch_size")),
+                    "request_compute_units": int(match.group("request_compute_units")),
+                    "total_compute_units": int(match.group("total_compute_units")),
+                    "denoise_step_time": float(match.group("denoise_step_time")),
+                }
+            )
+    return records
+
+
+def _iqr_filter(values: list[float]) -> list[float]:
+    if len(values) < 4:
+        return values
+
+    sorted_values = sorted(values)
+    midpoint = len(sorted_values) // 2
+    lower_half = sorted_values[:midpoint]
+    upper_half = sorted_values[-midpoint:]
+    q1 = median(lower_half)
+    q3 = median(upper_half)
+    iqr = q3 - q1
+    if iqr == 0:
+        return values
+
+    lower_bound = q1 - 1.5 * iqr
+    upper_bound = q3 + 1.5 * iqr
+    filtered = [value for value in values if lower_bound <= value <= upper_bound]
+    return filtered or values
+
+
+def _linear_fit(points: list[tuple[int, float]]) -> tuple[float, float, float]:
+    xs = [float(point[0]) for point in points]
+    ys = [point[1] for point in points]
+    x_mean = mean(xs)
+    y_mean = mean(ys)
+    denominator = sum((x - x_mean) ** 2 for x in xs)
+    if denominator == 0:
+        slope = 0.0
+    else:
+        slope = sum((x - x_mean) * (y - y_mean) for x, y in zip(xs, ys)) / denominator
+    intercept = y_mean - slope * x_mean
+    sse = sum((y - (slope * x + intercept)) ** 2 for x, y in zip(xs, ys))
+    return slope, intercept, sse
+
+
+def _piecewise_fit(
+    points: list[tuple[int, float]],
+    min_segment_points: int,
+) -> dict[str, float | int]:
+    min_segment_points = max(2, min_segment_points)
+    if len(points) < min_segment_points * 2:
+        raise ValueError(
+            "Need at least "
+            f"{min_segment_points * 2} profiled batch sizes for piecewise fitting, "
+            f"got {len(points)}."
+        )
+
+    best_fit: dict[str, float | int] | None = None
+    for split_index in range(min_segment_points, len(points) - min_segment_points + 1):
+        left_points = points[:split_index]
+        right_points = points[split_index:]
+        left_slope, left_intercept, left_sse = _linear_fit(left_points)
+        right_slope, right_intercept, right_sse = _linear_fit(right_points)
+        error = left_sse + right_sse
+        if best_fit is None or error < best_fit["sse"]:
+            best_fit = {
+                "split_index": split_index,
+                "split_batch_size": points[split_index][0],
+                "left_slope": left_slope,
+                "left_intercept": left_intercept,
+                "right_slope": right_slope,
+                "right_intercept": right_intercept,
+                "sse": error,
+            }
+
+    assert best_fit is not None
+    denominator = float(best_fit["left_slope"]) - float(best_fit["right_slope"])
+    if abs(denominator) > 1e-12:
+        intersection = (float(best_fit["right_intercept"]) - float(best_fit["left_intercept"])) / denominator
+        if math.isfinite(intersection):
+            best_fit["intersection_batch_size"] = intersection
+    return best_fit
+
+
+def choose_sweet_spot_batch(
+    records: list[dict[str, int | float]],
+    reference_compute_units: int | None,
+    min_samples_per_batch: int,
+    min_segment_points: int,
+) -> tuple[int, int, dict[str, object]]:
+    if not records:
+        raise ValueError("No DiffusionBatchProfiler records found in log file.")
+
+    by_units: dict[int, dict[int, list[float]]] = defaultdict(lambda: defaultdict(list))
+    for record in records:
+        units = int(record["request_compute_units"])
+        batch_size = int(record["batch_size"])
+        by_units[units][batch_size].append(float(record["denoise_step_time"]))
+
+    ref_units = reference_compute_units or min(by_units)
+    if ref_units not in by_units:
+        raise ValueError(
+            f"reference_compute_units={ref_units} not found in logs; "
+            f"available values: {sorted(by_units)}"
+        )
+
+    points: list[tuple[int, float]] = []
+    for batch_size, values in by_units[ref_units].items():
+        if len(values) < min_samples_per_batch:
+            continue
+        filtered_values = _iqr_filter(values)
+        points.append((batch_size, median(filtered_values)))
+    points.sort()
+    if not points:
+        raise ValueError("Need enough samples for at least one profiled batch size.")
+
+    if len(points) >= max(4, min_segment_points * 2):
+        fit = _piecewise_fit(points, min_segment_points)
+        min_batch = points[0][0]
+        max_batch = points[-1][0]
+        intersection = fit.get("intersection_batch_size")
+        if isinstance(intersection, float) and min_batch <= intersection <= max_batch:
+            sweet_spot_batch = round(intersection)
+        else:
+            sweet_spot_batch = int(fit["split_batch_size"])
+        sweet_spot_batch = max(min_batch, min(max_batch, int(sweet_spot_batch)))
+        analysis = {
+            "method": "piecewise_linear_fit",
+            "points": [
+                {
+                    "batch_size": batch_size,
+                    "median_denoise_step_time": median_time,
+                    "median_time_per_request": median_time / batch_size,
+                }
+                for batch_size, median_time in points
+            ],
+            "fit": fit,
+        }
+        return ref_units, sweet_spot_batch, analysis
+
+    best_point = min(points, key=lambda point: point[1] / point[0])
+    analysis = {
+        "method": "best_per_request_fallback",
+        "points": [
+            {
+                "batch_size": batch_size,
+                "median_denoise_step_time": median_time,
+                "median_time_per_request": median_time / batch_size,
+            }
+            for batch_size, median_time in points
+        ],
+    }
+    return ref_units, best_point[0], analysis
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate diffusion compute-budget batching config from profiler logs."
+    )
+    parser.add_argument("--log-file", type=Path, required=True)
+    parser.add_argument(
+        "--reference-compute-units",
+        type=int,
+        default=None,
+        help=(
+            "Compute units for the profiled 512x512 reference request. "
+            "Defaults to the smallest value in logs."
+        ),
+    )
+    parser.add_argument(
+        "--min-samples-per-batch",
+        type=int,
+        default=2,
+        help="Minimum profiler records required for one batch size.",
+    )
+    parser.add_argument(
+        "--min-segment-points",
+        type=int,
+        default=2,
+        help="Minimum points per segment for the piecewise linear fit.",
+    )
+    parser.add_argument("--output-json", type=Path, default=None)
+    args = parser.parse_args()
+
+    records = parse_profile_records(args.log_file)
+    ref_units, sweet_spot_batch, analysis = choose_sweet_spot_batch(
+        records,
+        args.reference_compute_units,
+        args.min_samples_per_batch,
+        args.min_segment_points,
+    )
+    compute_unit_budget = ref_units * sweet_spot_batch
+    output = {
+        "reference_compute_units": ref_units,
+        "sweet_spot_batch_size": sweet_spot_batch,
+        "analysis": analysis,
+        "diffusion_batching_config": {
+            "compute_unit_budget": compute_unit_budget,
+        },
+    }
+
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/user_guide/diffusion/compute_budget_batching.md
+++ b/docs/user_guide/diffusion/compute_budget_batching.md
@@ -1,0 +1,137 @@
+# Compute-Budget Diffusion Batching
+
+Diffusion step execution can batch homogeneous requests together. A fixed
+`max_num_seqs` works for one request shape, but different resolutions have
+different per-step compute cost. Compute-budget batching keeps `max_num_seqs`
+as a hard upper bound and derives the effective batch size from a profiled
+compute-unit budget.
+
+The built-in reference budget is only valid for the same profiling setup:
+
+- reference request: 512x512 text-to-image
+- model: Qwen-Image
+- hardware: one Ascend 910B2 NPU
+- sweet-spot batch size: 10
+- compute-unit budget: `(512 / 16) * (512 / 16) * 10 = 10240`
+
+If the model, hardware, backend, or profiling reference shape is different,
+profile first and pass the generated `compute_unit_budget` explicitly.
+
+For other homogeneous request types, the scheduler uses:
+
+```text
+effective_max_num_seqs = ceil(compute_unit_budget / request_compute_units)
+```
+
+`max_num_seqs` is still respected as the hard upper bound.
+
+## First-Time Use on a New Setup
+
+First run the profiler policy. Keep `max_num_seqs` large enough to cover the
+batch sizes you want to sample. For diffusion batching, the recommended
+reference traffic is high-concurrency 512x512 requests.
+
+```bash
+python3 -m vllm_omni.entrypoints.cli.main serve /data/Qwen-Image \
+  --omni \
+  --step-execution \
+  --max-num-seqs 128 \
+  --diffusion-batching-policy profile
+```
+
+Then send high-concurrency benchmark traffic using the 512x512 reference
+request shape. The server log will contain `[DiffusionBatchProfiler]` records
+with batch size, request compute units, total compute units, and denoise-step
+time.
+
+Generate a compute-budget config from the server log. The profiler groups the
+512x512 records by batch size, filters outliers with IQR, uses median denoise
+step time for each batch size, and applies a two-segment linear fit to locate
+the 512x512 sweet-spot batch size.
+
+```bash
+python3 benchmarks/diffusion/diffusion_batching_profiler.py \
+  --log-file /path/to/server.log \
+  --output-json /tmp/diffusion_batching_config.json
+```
+
+Use the generated budget for later serving. On Ascend NPU, the serving command
+is typically:
+
+```bash
+COMPUTE_UNIT_BUDGET=<generated_compute_unit_budget>
+
+python3 -m vllm_omni.entrypoints.cli.main serve /data/Qwen-Image \
+  --served-model-name Qwen/Qwen-Image \
+  --omni \
+  --port 8081 \
+  --step-execution \
+  --max-num-seqs 128 \
+  --diffusion-batching-policy compute_budget \
+  --diffusion-batching-config "{\"compute_unit_budget\":${COMPUTE_UNIT_BUDGET},\"drr_arrival_window_size\":256,\"log_stats\":true}" \
+  --vae-use-tiling \
+  --vae-use-slicing
+```
+
+The only value that normally needs to be carried from profiling to serving is
+`compute_unit_budget`, which is computed as:
+
+```text
+compute_unit_budget = reference_compute_units * sweet_spot_batch_size
+```
+
+`drr_arrival_window_size` and `log_stats` are optional. The scheduler uses a
+default sliding arrival window if `drr_arrival_window_size` is not set; `log_stats`
+only enables verbose batching-policy logs.
+
+## Use the Built-In Reference Profile
+
+Use this only when the environment matches the built-in reference profile:
+Qwen-Image on one Ascend 910B2 NPU, using 512x512 requests as the profiled
+reference shape.
+
+```bash
+python3 -m vllm_omni.entrypoints.cli.main serve /data/Qwen-Image \
+  --served-model-name Qwen/Qwen-Image \
+  --omni \
+  --port 8081 \
+  --step-execution \
+  --max-num-seqs 128 \
+  --diffusion-batching-policy compute_budget \
+  --diffusion-batching-config '{"compute_unit_budget":10240,"drr_arrival_window_size":256,"log_stats":true}' \
+  --vae-use-tiling \
+  --vae-use-slicing
+```
+
+For a 1024x1024 request, Qwen-Image packed latent compute units are
+`(1024 / 16) * (1024 / 16) = 4096`, so the effective batch size is
+`ceil(10240 / 4096) = 3`.
+
+## Mixed-Shape Scheduling
+
+Step-wise continuous batching still requires requests in the same running batch
+to have compatible `SamplingParamsKey` values. A single FIFO waiting queue can
+therefore suffer head-of-line blocking: a high-cost request at the front may
+delay later low-cost requests even when those later requests could form an
+efficient homogeneous batch.
+
+The scheduler groups waiting requests by `SamplingParamsKey` and applies a
+cost-aware deficit round-robin selection across non-empty queues:
+
+- `cost_i` is estimated from the request shape as visual compute units.
+- `prob_i` is estimated online from a sliding window of recent arrivals.
+- Each non-empty queue accrues a normalized quantum proportional to
+  `prob_i / cost_i`.
+- The first selection starts from the lowest-cost queue. Later selections scan
+  queues in ascending cost order from the DRR cursor and skip queues whose
+  deficit is not yet sufficient.
+
+Once a key is selected, normal homogeneous batching rules still apply. The
+compute-budget policy then caps the batch size for that request type.
+
+## Ascend 910B Result
+
+On one Ascend 910B NPU with Qwen-Image, directly using fixed
+`max_num_seqs=8` for mixed 512x512 and 1024x1024 requests took `830.84s` for
+50 requests. With the profiled compute-budget policy and keyed DRR scheduling,
+the same benchmark finished in `679.94s`, an 18.16% benchmark-duration speedup.

--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -234,7 +234,7 @@ class TestRequestScheduler:
         assert sched_output.num_running_reqs == 2
         assert sched_output.num_waiting_reqs == 0
 
-    def test_incompatible_waiting_head_blocks_later_compatible_request(self) -> None:
+    def test_keyed_drr_starts_from_lower_cost_request_queue(self) -> None:
         scheduler = RequestScheduler()
         scheduler.initialize(SimpleNamespace(max_num_seqs=3))
 
@@ -246,20 +246,20 @@ class TestRequestScheduler:
                 request_ids=["b"],
             )
         )
-        scheduler.add_request(_make_request("c"))
+        req_id_c = scheduler.add_request(_make_request("c"))
 
         first = scheduler.schedule()
 
-        assert _new_ids(first) == [req_id_a]
+        assert _new_ids(first) == [req_id_b]
         assert first.num_running_reqs == 1
         assert first.num_waiting_reqs == 2
 
-        scheduler.update_from_output(first, _make_request_output(req_id_a))
+        scheduler.update_from_output(first, _make_request_output(req_id_b))
         second = scheduler.schedule()
 
-        assert _new_ids(second) == [req_id_b]
-        assert second.num_running_reqs == 1
-        assert second.num_waiting_reqs == 1
+        assert _new_ids(second) == [req_id_a, req_id_c]
+        assert second.num_running_reqs == 2
+        assert second.num_waiting_reqs == 0
 
     def test_abort_request_for_waiting_and_running(self) -> None:
         req_id_a = self.scheduler.add_request(_make_request("a"))
@@ -652,7 +652,7 @@ class TestStepScheduler:
         assert sched_output.num_running_reqs == 2
         assert sched_output.num_waiting_reqs == 0
 
-    def test_step_batch_rejects_different_sampling_key(self) -> None:
+    def test_step_keyed_drr_avoids_head_of_line_blocking(self) -> None:
         scheduler = StepScheduler()
         scheduler.initialize(SimpleNamespace(max_num_seqs=3))
 
@@ -666,23 +666,139 @@ class TestStepScheduler:
                 ),
             )
         )
-        scheduler.add_request(_make_step_request("c"))
+        req_c = scheduler.add_request(_make_step_request("c"))
 
         sched_output = scheduler.schedule()
 
-        assert _new_ids(sched_output) == [req_a]
+        assert _new_ids(sched_output) == [req_b]
         assert sched_output.num_running_reqs == 1
         assert sched_output.num_waiting_reqs == 2
 
         scheduler.update_from_output(
             sched_output,
-            _make_step_output(req_a, step_index=4, finished=True),
+            _make_step_output(req_b, step_index=4, finished=True),
         )
         second = scheduler.schedule()
 
-        assert _new_ids(second) == [req_b]
-        assert second.num_running_reqs == 1
-        assert second.num_waiting_reqs == 1
+        assert _new_ids(second) == [req_a, req_c]
+        assert second.num_running_reqs == 2
+        assert second.num_waiting_reqs == 0
+
+    def test_compute_budget_batching_caps_1024_requests_from_512_profile(self) -> None:
+        scheduler = StepScheduler()
+        scheduler.initialize(
+            SimpleNamespace(
+                max_num_seqs=128,
+                diffusion_batching_config={
+                    "policy": "compute_budget",
+                },
+            )
+        )
+
+        req_ids = [
+            scheduler.add_request(
+                _make_step_request(
+                    f"req-{i}",
+                    sampling_params=OmniDiffusionSamplingParams(
+                        height=1024,
+                        width=1024,
+                        num_inference_steps=4,
+                    ),
+                )
+            )
+            for i in range(8)
+        ]
+
+        sched_output = scheduler.schedule()
+
+        # Qwen-Image packed latent units:
+        # 512x512 -> (512 / 16)^2 = 1024, profiled budget = 1024 * 10.
+        # 1024x1024 -> (1024 / 16)^2 = 4096, ceil(10240 / 4096) = 3.
+        assert _new_ids(sched_output) == req_ids[:3]
+        assert sched_output.num_running_reqs == 3
+        assert sched_output.num_waiting_reqs == 5
+
+    def test_compute_budget_batching_keeps_profiled_512_batch_size(self) -> None:
+        scheduler = StepScheduler()
+        scheduler.initialize(
+            SimpleNamespace(
+                max_num_seqs=128,
+                diffusion_batching_config={
+                    "policy": "compute_budget",
+                },
+            )
+        )
+
+        req_ids = [
+            scheduler.add_request(
+                _make_step_request(
+                    f"req-{i}",
+                    sampling_params=OmniDiffusionSamplingParams(
+                        height=512,
+                        width=512,
+                        num_inference_steps=4,
+                    ),
+                )
+            )
+            for i in range(12)
+        ]
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == req_ids[:10]
+        assert sched_output.num_running_reqs == 10
+        assert sched_output.num_waiting_reqs == 2
+
+    def test_compute_budget_batching_respects_max_num_seqs_hard_cap(self) -> None:
+        scheduler = StepScheduler()
+        scheduler.initialize(
+            SimpleNamespace(
+                max_num_seqs=4,
+                diffusion_batching_config={
+                    "policy": "compute_budget",
+                },
+            )
+        )
+
+        req_ids = [
+            scheduler.add_request(
+                _make_step_request(
+                    f"req-{i}",
+                    sampling_params=OmniDiffusionSamplingParams(
+                        height=512,
+                        width=512,
+                        num_inference_steps=4,
+                    ),
+                )
+            )
+            for i in range(8)
+        ]
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == req_ids[:4]
+        assert sched_output.num_running_reqs == 4
+        assert sched_output.num_waiting_reqs == 4
+
+    def test_profile_batching_policy_ramps_batch_size(self) -> None:
+        scheduler = StepScheduler()
+        scheduler.initialize(
+            SimpleNamespace(
+                max_num_seqs=4,
+                diffusion_batching_config={
+                    "policy": "profile",
+                    "profiler_interval": 1,
+                },
+            )
+        )
+
+        req_ids = [scheduler.add_request(_make_step_request(f"req-{i}")) for i in range(4)]
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == req_ids[:2]
+        assert sched_output.num_running_reqs == 2
+        assert sched_output.num_waiting_reqs == 2
 
     def test_preempt_request_preserves_step_index(self) -> None:
         request = _make_step_request("preempt", num_inference_steps=3)

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -401,6 +401,99 @@ class DiffusionCacheConfig:
 
 
 @dataclass
+class DiffusionBatchingConfig:
+    """Configuration for diffusion batching policy plugins.
+
+    The built-in reference budget is profiled from Qwen-Image on one 910B2
+    NPU, where 512x512 requests have batch-size sweet spot 10:
+    ``(512 / 16) * (512 / 16) * 10 = 10240``.
+
+    For other models, hardware, or backend setups, run the profiler policy and
+    set ``compute_unit_budget`` from the generated config.
+    """
+
+    policy: str = "fixed"
+    compute_unit_budget: int = 10240
+
+    # Qwen-Image packs VAE latents into 2x2 patches. The effective sequence
+    # length is (height / (vae_scale_factor * latent_patch_size)) *
+    # (width / (vae_scale_factor * latent_patch_size)).
+    vae_scale_factor: int = 8
+    latent_patch_size: int = 2
+
+    # Cost multiplier for true CFG / negative-branch execution.
+    cfg_compute_multiplier: float = 2.0
+
+    default_height: int = 1024
+    default_width: int = 1024
+
+    profiler_interval: int = 20
+    drr_arrival_window_size: int = 1024
+    log_stats: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DiffusionBatchingConfig":
+        if not isinstance(data, dict):
+            raise TypeError(f"Expected batching config dict, got {type(data)!r}")
+        field_names = {f.name for f in fields(cls)}
+        known_params = {k: v for k, v in data.items() if k in field_names}
+        return cls(**known_params)
+
+    @property
+    def uses_compute_budget(self) -> bool:
+        return self.policy == "compute_budget"
+
+    @property
+    def uses_profiler(self) -> bool:
+        return self.policy in {"profile", "profiler"}
+
+    @property
+    def latent_divisor(self) -> int:
+        return max(1, int(self.vae_scale_factor) * int(self.latent_patch_size))
+
+    def spatial_compute_units(
+        self,
+        height: int | None,
+        width: int | None,
+        num_frames: int | None = None,
+    ) -> int:
+        h = int(height or self.default_height)
+        w = int(width or self.default_width)
+        frames = max(1, int(num_frames or 1))
+        divisor = self.latent_divisor
+        latent_h = max(1, h // divisor)
+        latent_w = max(1, w // divisor)
+        return latent_h * latent_w * frames
+
+    def request_compute_units(self, sampling_params: Any, prompts: list[Any]) -> int:
+        units = self.spatial_compute_units(
+            getattr(sampling_params, "height", None),
+            getattr(sampling_params, "width", None),
+            getattr(sampling_params, "num_frames", 1),
+        )
+        if self._uses_true_cfg(sampling_params, prompts):
+            units = int(units * float(self.cfg_compute_multiplier))
+        return max(1, units)
+
+    def effective_compute_unit_budget(self) -> int:
+        return max(1, int(self.compute_unit_budget))
+
+    @staticmethod
+    def _uses_true_cfg(sampling_params: Any, prompts: list[Any]) -> bool:
+        if bool(getattr(sampling_params, "do_classifier_free_guidance", False)):
+            return True
+
+        true_cfg_scale = getattr(sampling_params, "true_cfg_scale", None)
+        if true_cfg_scale is None or true_cfg_scale <= 1:
+            return False
+
+        for prompt in prompts:
+            if isinstance(prompt, dict) and prompt.get("negative_prompt"):
+                return True
+        return False
+
+
+@dataclass
 class OmniDiffusionConfig:
     # Model and path configuration (for convenience)
     stage_id: int = 0
@@ -592,6 +685,9 @@ class OmniDiffusionConfig:
 
     # Maximum number of sequences to generate in a batch
     max_num_seqs: int = 1
+    diffusion_batching_config: DiffusionBatchingConfig | dict[str, Any] = field(
+        default_factory=DiffusionBatchingConfig
+    )
 
     @property
     def is_moe(self) -> bool:
@@ -702,6 +798,11 @@ class OmniDiffusionConfig:
         elif not isinstance(self.cache_config, DiffusionCacheConfig):
             # If it's neither dict nor DiffusionCacheConfig, convert to empty config
             self.cache_config = DiffusionCacheConfig()
+
+        if isinstance(self.diffusion_batching_config, dict):
+            self.diffusion_batching_config = DiffusionBatchingConfig.from_dict(self.diffusion_batching_config)
+        elif not isinstance(self.diffusion_batching_config, DiffusionBatchingConfig):
+            self.diffusion_batching_config = DiffusionBatchingConfig()
 
         # Auto-detect quantization from TransformerConfig if not explicitly set.
         # This covers the case where tf_model_config is passed at construction

--- a/vllm_omni/diffusion/sched/base_scheduler.py
+++ b/vllm_omni/diffusion/sched/base_scheduler.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import fields
+from typing import Any
 
 from vllm.logger import init_logger
 
-from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.data import DiffusionBatchingConfig, OmniDiffusionConfig
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.sched.batching_policy import (
+    DiffusionBatchingPolicy,
+    create_diffusion_batching_policy,
+)
 from vllm_omni.diffusion.sched.interface import (
     CachedRequestData,
     DiffusionRequestState,
@@ -43,10 +48,20 @@ class _BaseScheduler(SchedulerInterface):
         self._request_id_to_sched_req_id: dict[str, str] = {}
         self._step_id: int = 0
         self._waiting: deque[str] = deque()
+        self._waiting_by_key: dict[SamplingParamsKey | None, deque[str]] = {}
         self._running: list[str] = []
         self._running_sampling_params_key: SamplingParamsKey | None = None
         self._finished_req_ids: set[str] = set()
+        self._key_arrivals: dict[SamplingParamsKey | None, int] = {}
+        self._arrival_window: deque[SamplingParamsKey | None] = deque()
+        self._key_deficits: dict[SamplingParamsKey | None, float] = {}
+        self._drr_started: bool = False
+        self._drr_cursor_index: int = 0
         self.max_num_running_reqs: int = 1
+        self.batching_config: DiffusionBatchingConfig = DiffusionBatchingConfig()
+        self.batching_policy: DiffusionBatchingPolicy = create_diffusion_batching_policy(
+            self.batching_config
+        )
 
     def initialize(self, od_config: OmniDiffusionConfig) -> None:
         self.od_config = od_config
@@ -54,14 +69,22 @@ class _BaseScheduler(SchedulerInterface):
         self._request_id_to_sched_req_id.clear()
         self._step_id = 0
         self._waiting.clear()
+        self._waiting_by_key.clear()
         self._running.clear()
         self._running_sampling_params_key = None
         self._finished_req_ids.clear()
+        self._key_arrivals.clear()
+        self._arrival_window.clear()
+        self._key_deficits.clear()
+        self._drr_started = False
+        self._drr_cursor_index = 0
         max_num_seqs = getattr(od_config, "max_num_seqs", 1)
         try:
             self.max_num_running_reqs = max(1, int(max_num_seqs))
         except (TypeError, ValueError):
             self.max_num_running_reqs = 1
+        self.batching_config = self._resolve_batching_config(od_config)
+        self.batching_policy = create_diffusion_batching_policy(self.batching_config)
         self._reset_scheduler_state()
 
     def add_request(self, request: OmniDiffusionRequest) -> str:
@@ -72,13 +95,14 @@ class _BaseScheduler(SchedulerInterface):
         state = self._make_request_state(sched_req_id, request)
         self._request_states[sched_req_id] = state
         self._register_request_ids(request.request_ids, sched_req_id)
-        self._waiting.append(sched_req_id)
+        self._enqueue_waiting(state)
         logger.debug("%s add_request: %s (waiting=%d)", self.__class__.__name__, sched_req_id, len(self._waiting))
         return sched_req_id
 
     def schedule(self) -> DiffusionSchedulerOutput:
         scheduled_new_reqs: list[NewRequestData] = []
         scheduled_cached_req_ids: list[str] = []
+        self.batching_policy.on_schedule_start()
 
         # First, schedule the RUNNING request(s)
         for sched_req_id in self._running:
@@ -88,24 +112,24 @@ class _BaseScheduler(SchedulerInterface):
 
         # Second, schedule WAITING requests while capacity remains.
         while self._waiting and len(self._running) < self.max_num_running_reqs:
-            sched_req_id = self._waiting[0]
-            state = self._request_states.get(sched_req_id)
+            state = self._peek_next_waiting_state()
             if state is None:
-                self._waiting.popleft()
-                continue
+                break
             if not self._can_schedule_waiting(state):
                 break
+            if len(self._running) >= self._effective_max_running_reqs(state):
+                break
 
-            self._waiting.popleft()
+            self._pop_waiting_state(state)
             was_new_request = state.status == DiffusionRequestStatus.WAITING
             if not self._running:
                 self._running_sampling_params_key = state.sampling_params_key
             state.status = DiffusionRequestStatus.RUNNING
-            self._running.append(sched_req_id)
+            self._running.append(state.sched_req_id)
             if was_new_request:
                 scheduled_new_reqs.append(NewRequestData.from_state(state))
             else:
-                scheduled_cached_req_ids.append(sched_req_id)
+                scheduled_cached_req_ids.append(state.sched_req_id)
 
         scheduler_output = DiffusionSchedulerOutput(
             step_id=self._step_id,
@@ -144,8 +168,9 @@ class _BaseScheduler(SchedulerInterface):
             self._running.remove(sched_req_id)
             if not self._running:
                 self._running_sampling_params_key = None
-            self._waiting.appendleft(sched_req_id)
-            self._request_states[sched_req_id].status = DiffusionRequestStatus.PREEMPTED
+            state = self._request_states[sched_req_id]
+            state.status = DiffusionRequestStatus.PREEMPTED
+            self._enqueue_waiting(state, front=True, count_arrival=False)
             return True
         return False
 
@@ -159,9 +184,15 @@ class _BaseScheduler(SchedulerInterface):
         self._request_states.clear()
         self._request_id_to_sched_req_id.clear()
         self._waiting.clear()
+        self._waiting_by_key.clear()
         self._running.clear()
         self._running_sampling_params_key = None
         self._finished_req_ids.clear()
+        self._key_arrivals.clear()
+        self._arrival_window.clear()
+        self._key_deficits.clear()
+        self._drr_started = False
+        self._drr_cursor_index = 0
         self._reset_scheduler_state()
 
     def _finish_requests(
@@ -192,10 +223,8 @@ class _BaseScheduler(SchedulerInterface):
             self._running = [sched_req_id for sched_req_id in self._running if sched_req_id not in running_to_remove]
             if not self._running:
                 self._running_sampling_params_key = None
-        if waiting_to_remove:
-            self._waiting = deque(
-                sched_req_id for sched_req_id in self._waiting if sched_req_id not in waiting_to_remove
-            )
+        for sched_req_id in waiting_to_remove:
+            self._remove_waiting_id(sched_req_id)
 
         for sched_req_id in finished_req_ids:
             state = self._request_states[sched_req_id]
@@ -237,6 +266,147 @@ class _BaseScheduler(SchedulerInterface):
             req=request,
             sampling_params_key=get_sampling_params_key(request),
         )
+
+    def _resolve_batching_config(self, od_config: OmniDiffusionConfig) -> DiffusionBatchingConfig:
+        cfg: Any = getattr(od_config, "diffusion_batching_config", None)
+        if isinstance(cfg, DiffusionBatchingConfig):
+            return cfg
+        if isinstance(cfg, dict):
+            return DiffusionBatchingConfig.from_dict(cfg)
+        return DiffusionBatchingConfig()
+
+    def _effective_max_running_reqs(self, candidate_state: DiffusionRequestState) -> int:
+        """Return the request-count cap for the current homogeneous batch."""
+        return self.batching_policy.get_max_running_reqs(self.max_num_running_reqs, candidate_state)
+
+    def _enqueue_waiting(
+        self,
+        state: DiffusionRequestState,
+        *,
+        front: bool = False,
+        count_arrival: bool = True,
+    ) -> None:
+        sched_req_id = state.sched_req_id
+        if front:
+            self._waiting.appendleft(sched_req_id)
+            self._waiting_by_key.setdefault(state.sampling_params_key, deque()).appendleft(sched_req_id)
+        else:
+            self._waiting.append(sched_req_id)
+            self._waiting_by_key.setdefault(state.sampling_params_key, deque()).append(sched_req_id)
+
+        if count_arrival:
+            self._record_key_arrival(state.sampling_params_key)
+        self._key_deficits.setdefault(state.sampling_params_key, 0.0)
+
+    def _record_key_arrival(self, key: SamplingParamsKey | None) -> None:
+        self._arrival_window.append(key)
+        self._key_arrivals[key] = self._key_arrivals.get(key, 0) + 1
+
+        window_size = max(1, int(getattr(self.batching_config, "drr_arrival_window_size", 1024)))
+        while len(self._arrival_window) > window_size:
+            expired_key = self._arrival_window.popleft()
+            new_count = self._key_arrivals.get(expired_key, 0) - 1
+            if new_count > 0:
+                self._key_arrivals[expired_key] = new_count
+            else:
+                self._key_arrivals.pop(expired_key, None)
+
+    def _peek_next_waiting_state(self) -> DiffusionRequestState | None:
+        if self._running:
+            return self._peek_waiting_state_for_key(self._current_sampling_params_key())
+
+        key = self._select_next_waiting_key()
+        if key is None and key not in self._waiting_by_key:
+            return None
+        return self._peek_waiting_state_for_key(key)
+
+    def _peek_waiting_state_for_key(self, key: SamplingParamsKey | None) -> DiffusionRequestState | None:
+        queue = self._waiting_by_key.get(key)
+        while queue:
+            state = self._request_states.get(queue[0])
+            if state is not None and not state.is_finished():
+                return state
+            queue.popleft()
+        if key in self._waiting_by_key:
+            self._waiting_by_key.pop(key, None)
+        return None
+
+    def _pop_waiting_state(self, state: DiffusionRequestState) -> None:
+        self._remove_waiting_id(state.sched_req_id)
+
+    def _remove_waiting_id(self, sched_req_id: str) -> None:
+        self._waiting = deque(req_id for req_id in self._waiting if req_id != sched_req_id)
+        state = self._request_states.get(sched_req_id)
+        if state is None:
+            return
+        key = state.sampling_params_key
+        queue = self._waiting_by_key.get(key)
+        if queue is None:
+            return
+        self._waiting_by_key[key] = deque(req_id for req_id in queue if req_id != sched_req_id)
+        if not self._waiting_by_key[key]:
+            self._waiting_by_key.pop(key, None)
+
+    def _select_next_waiting_key(self) -> SamplingParamsKey | None:
+        active_keys = []
+        for key in list(self._waiting_by_key):
+            queue = self._waiting_by_key.get(key)
+            if queue and self._peek_waiting_state_for_key(key) is not None:
+                active_keys.append(key)
+        if not active_keys:
+            return None
+
+        active_keys.sort(key=lambda key: (self._key_cost(key), repr(key)))
+        if not self._drr_started:
+            self._drr_started = True
+            selected = active_keys[0]
+            self._drr_cursor_index = 1 % len(active_keys)
+            return selected
+
+        start = self._drr_cursor_index % len(active_keys)
+        min_cost = self._key_cost(active_keys[0])
+        active_arrivals = sum(self._key_arrivals.get(key, 0) for key in active_keys)
+        for offset in range(len(active_keys)):
+            index = (start + offset) % len(active_keys)
+            key = active_keys[index]
+            self._key_deficits[key] = self._key_deficits.get(key, 0.0) + self._key_quantum(
+                key,
+                min_cost,
+                active_arrivals,
+                len(active_keys),
+            )
+            if self._key_deficits[key] >= 1.0:
+                self._key_deficits[key] -= 1.0
+                self._drr_cursor_index = (index + 1) % len(active_keys)
+                return key
+
+        # All non-empty queues were visited but did not have enough budget.
+        self._drr_cursor_index = start
+        return None
+
+    def _key_quantum(
+        self,
+        key: SamplingParamsKey | None,
+        min_cost: int,
+        active_arrivals: int,
+        active_queue_count: int,
+    ) -> float:
+        # prob_i is estimated from a sliding arrival window. If all active queues
+        # have aged out of the window, fall back to uniform probability to avoid
+        # starving already-waiting requests.
+        if active_arrivals <= 0:
+            prob = 1.0 / max(1, active_queue_count)
+        else:
+            prob = self._key_arrivals.get(key, 0) / active_arrivals
+        return prob * max(1, min_cost) / self._key_cost(key)
+
+    def _key_cost(self, key: SamplingParamsKey | None) -> int:
+        if key is None:
+            return self.batching_config.spatial_compute_units(None, None, 1)
+        units = self.batching_config.spatial_compute_units(key.height, key.width, key.num_frames)
+        if key.do_classifier_free_guidance or (key.true_cfg_scale is not None and key.true_cfg_scale > 1):
+            units = int(units * float(self.batching_config.cfg_compute_multiplier))
+        return max(1, units)
 
     def _can_schedule_waiting(self, state: DiffusionRequestState) -> bool:
         if not self._running:

--- a/vllm_omni/diffusion/sched/batching_policy.py
+++ b/vllm_omni/diffusion/sched/batching_policy.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.data import DiffusionBatchingConfig
+from vllm_omni.diffusion.sched.interface import DiffusionRequestState
+
+logger = init_logger(__name__)
+
+
+class DiffusionBatchingPolicy(ABC):
+    """Policy plugin that derives a request-count batch cap."""
+
+    def on_schedule_start(self) -> None:
+        """Hook called once at the beginning of a scheduler cycle."""
+
+    @abstractmethod
+    def get_max_running_reqs(
+        self,
+        hard_cap: int,
+        candidate_state: DiffusionRequestState,
+    ) -> int:
+        """Return the effective request cap for admitting ``candidate_state``."""
+
+
+class FixedDiffusionBatchingPolicy(DiffusionBatchingPolicy):
+    """Preserve the existing fixed ``max_num_seqs`` behavior."""
+
+    def get_max_running_reqs(
+        self,
+        hard_cap: int,
+        candidate_state: DiffusionRequestState,
+    ) -> int:
+        del candidate_state
+        return max(1, int(hard_cap))
+
+
+class ComputeBudgetDiffusionBatchingPolicy(DiffusionBatchingPolicy):
+    """Map a profiled reference workload to per-request-type batch caps."""
+
+    def __init__(self, config: DiffusionBatchingConfig) -> None:
+        self.config = config
+
+    def get_max_running_reqs(
+        self,
+        hard_cap: int,
+        candidate_state: DiffusionRequestState,
+    ) -> int:
+        hard_cap = max(1, int(hard_cap))
+        request_units = self.config.request_compute_units(
+            candidate_state.req.sampling_params,
+            candidate_state.req.prompts,
+        )
+        budget = self.config.effective_compute_unit_budget()
+        dynamic_cap = (budget + request_units - 1) // request_units
+        capped = max(1, min(hard_cap, dynamic_cap))
+
+        if self.config.log_stats:
+            logger.info(
+                "[DiffusionBatching] request_compute_units=%s compute_unit_budget=%s "
+                "dynamic_max_num_seqs=%s hard_max_num_seqs=%s effective_max_num_seqs=%s",
+                request_units,
+                budget,
+                dynamic_cap,
+                hard_cap,
+                capped,
+            )
+        return capped
+
+
+class DiffusionBatchProfilerPolicy(DiffusionBatchingPolicy):
+    """Gradually increases batch cap so users can collect sweet-spot logs."""
+
+    def __init__(self, config: DiffusionBatchingConfig) -> None:
+        self.config = config
+        self._schedule_count = 0
+        self._current_cap = 1
+        logger.info(
+            "DiffusionBatchProfiler enabled (profiler_interval=%s)",
+            self.config.profiler_interval,
+        )
+
+    def on_schedule_start(self) -> None:
+        interval = max(1, int(self.config.profiler_interval))
+        self._schedule_count += 1
+        self._current_cap = self._schedule_count // interval + 1
+
+    def get_max_running_reqs(
+        self,
+        hard_cap: int,
+        candidate_state: DiffusionRequestState,
+    ) -> int:
+        del candidate_state
+        hard_cap = max(1, int(hard_cap))
+        cap = min(hard_cap, self._current_cap)
+        logger.info("[DiffusionBatchProfiler] max_num_seqs=%s", cap)
+        return cap
+
+
+def create_diffusion_batching_policy(config: DiffusionBatchingConfig) -> DiffusionBatchingPolicy:
+    if config.uses_compute_budget:
+        logger.info(
+            "ComputeBudgetDiffusionBatchingPolicy enabled (compute_unit_budget=%s)",
+            config.effective_compute_unit_budget(),
+        )
+        return ComputeBudgetDiffusionBatchingPolicy(config)
+    if config.uses_profiler:
+        return DiffusionBatchProfilerPolicy(config)
+    return FixedDiffusionBatchingPolicy()

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -418,6 +418,30 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             return {}
         return prepare_attn(input_batch)
 
+    def _log_batch_profile(
+        self,
+        states: list[DiffusionRequestState],
+        elapsed: float,
+    ) -> None:
+        batching_config = getattr(self.od_config, "diffusion_batching_config", None)
+        if batching_config is None or not getattr(batching_config, "uses_profiler", False):
+            return
+        if not states:
+            return
+
+        request_units = batching_config.request_compute_units(
+            states[0].req.sampling_params,
+            states[0].req.prompts,
+        )
+        logger.info(
+            "[DiffusionBatchProfiler] batch_size=%s request_compute_units=%s "
+            "total_compute_units=%s denoise_step_time=%.6f",
+            len(states),
+            request_units,
+            request_units * len(states),
+            elapsed,
+        )
+
     def execute_stepwise(self, scheduler_output: DiffusionSchedulerOutput) -> BatchRunnerOutput:
         """Execute one step for one scheduled request and return runner output."""
         assert self.pipeline is not None, "Model not loaded. Call load_model() first."
@@ -441,7 +465,9 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                 omni_diffusion_config=self.od_config,
                 attn_metadata=attn_metadata,
             ):
+                denoise_start = time.perf_counter()
                 noise_pred = self.pipeline.denoise_step(input_batch)
+                self._log_batch_profile(states, time.perf_counter() - denoise_start)
 
                 runner_output_list = []
                 pipeline_interrupted = getattr(self.pipeline, "interrupt", False)

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1497,6 +1497,9 @@ class AsyncOmniEngine:
         devices = ",".join(str(i) for i in range(num_devices))
         model_class_name = kwargs.get("model_class_name", None)
         final_output_type = "audio" if model_class_name and supports_audio_output(model_class_name) else "image"
+        diffusion_batching_config = dict(kwargs.get("diffusion_batching_config") or {})
+        if kwargs.get("diffusion_batching_policy") is not None:
+            diffusion_batching_config["policy"] = kwargs["diffusion_batching_policy"]
 
         attention_config = None
         if (
@@ -1510,6 +1513,7 @@ class AsyncOmniEngine:
 
         stage_engine_args = {
             "max_num_seqs": kwargs.get("max_num_seqs") or 1,
+            "diffusion_batching_config": diffusion_batching_config,
             "parallel_config": parallel_config,
             "model_class_name": kwargs.get("model_class_name", None),
             "additional_config": kwargs.get("additional_config", None),

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -415,6 +415,24 @@ class OmniServeCommand(CLISubcommand):
             help="Enable cache-dit summary logging after diffusion forward passes.",
         )
         omni_config_group.add_argument(
+            "--diffusion-batching-config",
+            type=json.loads,
+            default=None,
+            help=(
+                "JSON config for diffusion continuous-batching policy. "
+                'Example: \'{"compute_unit_budget":10240}\'.'
+            ),
+        )
+        omni_config_group.add_argument(
+            "--diffusion-batching-policy",
+            choices=["fixed", "compute_budget", "profile"],
+            default=None,
+            help=(
+                "Diffusion batching policy. 'compute_budget' uses a profiled compute-unit budget; "
+                "'profile' ramps batch size and logs data for profiling."
+            ),
+        )
+        omni_config_group.add_argument(
             "--step-execution",
             action="store_true",
             help="Enable per-step diffusion execution so running requests can be aborted between denoise steps.",


### PR DESCRIPTION
### Summary

This PR optimizes diffusion step-wise continuous batching for request-shape- and hardware-dependent workloads.

It adds:

- A profiling-based diffusion batching policy that derives per-request-type batch caps from a profiled compute-unit budget.
- A profiler tool that finds the 512x512 reference request sweet spot from denoise-step profiling logs.
- Keyed DRR scheduling across `SamplingParamsKey` queues to reduce head-of-line blocking in mixed-resolution traffic.
- Documentation for profiling a new setup, using the built-in Qwen-Image/Ascend 910B2 reference profile, and enabling DRR-related options.

Closes https://github.com/vllm-project/vllm-omni/issues/3831.

### Motivation

In vLLM-Omni 0.20.0, I validated the release version performance on a single Ascend 910B NPU with the Qwen/Qwen-Image model.

PR #2729 introduced step-wise continuous batching for diffusion models, and the PR benchmark showed performance gains on a single A100 GPU with `max-num-seqs=8`. However, when running the same configuration on a single Ascend 910B NPU, directly using `max-num-seqs=8` does not bring a performance improvement. In my validation, it slightly regressed end-to-end benchmark duration and average latency.

This suggests that the optimal `max-num-seqs` for diffusion continuous batching is hardware- and request-shape-dependent. A fixed value such as `8` may work well on A100, but is not necessarily optimal on Ascend 910B.

### Problems

I ran the text-to-image benchmark with:

- vLLM-Omni version: `0.20.0`
- Backend: `vllm-omni`
- Model: `Qwen/Qwen-Image`
- Hardware: single Ascend 910B NPU
- Dataset: `vbench`
- Number of prompts: `100`
- Resolution: `1024x1024`
- Inference steps: `50`
- Max concurrency: `8`

Benchmark command:

```bash
python benchmarks/diffusion/diffusion_benchmark_serving.py \
  --backend vllm-omni \
  --dataset vbench \
  --task t2i \
  --model Qwen/Qwen-Image \
  --port 8080 \
  --num-prompts 100 \
  --max-concurrency 8 \
  --width 1024 \
  --height 1024 \
  --num-inference-steps 50
```

#### Baseline: `max-num-seqs=1`

Server command:

```bash
python3 -m vllm_omni.entrypoints.cli.main serve Qwen/Qwen-Image \
  --omni \
  --port 8080 \
  --step-execution \
  --max-num-seqs 1
```

Result:

```text
================= Serving Benchmark Result =================
Backend:                         vllm-omni
Model:                           Qwen/Qwen-Image
Dataset:                         vbench
Task:                            t2i
--------------------------------------------------
Benchmark duration (s):          2387.01
Request rate:                    inf
Max request concurrency:         8
Successful requests:             100/100
--------------------------------------------------
Request throughput (req/s):      0.04
Latency Mean (s):                184.2836
Latency Median (s):              190.7596
Latency P99 (s):                 192.1131
Latency P95 (s):                 191.8620
```

#### Continuous batching: `max-num-seqs=8`

Server command:

```bash
python3 -m vllm_omni.entrypoints.cli.main serve Qwen/Qwen-Image \
  --omni \
  --port 8080 \
  --step-execution \
  --max-num-seqs 8
```

Result:

```text
================= Serving Benchmark Result =================
Backend:                         vllm-omni
Model:                           Qwen/Qwen-Image
Dataset:                         vbench
Task:                            t2i
--------------------------------------------------
Benchmark duration (s):          2444.79
Request rate:                    inf
Max request concurrency:         8
Successful requests:             100/100
--------------------------------------------------
Request throughput (req/s):      0.04
Latency Mean (s):                191.9775
Latency Median (s):              197.1824
Latency P99 (s):                 197.8310
Latency P95 (s):                 197.7747
```

Compared with `max-num-seqs=1`, `max-num-seqs=8` regressed benchmark duration by about **2.42%** and average latency by about **4.17%**.

This suggests that a single fixed `max-num-seqs` is not robust across hardware and request shapes. A good batch size for A100 is not necessarily a good batch size for Ascend 910B, and a good batch size for 512x512 requests is not necessarily a good batch size for 1024x1024 requests.

### Profiling-Based Batch Size

This PR adds a small policy layer for diffusion continuous batching:

- `fixed`: preserves the existing fixed `max_num_seqs` behavior.
- `profile`: ramps the effective batch cap and logs `[DiffusionBatchProfiler]` records.
- `compute_budget`: derives the effective homogeneous batch cap from a profiled compute-unit budget.

The profiling workflow is: first profile a reference request shape, find the batch-size sweet spot from execution-time behavior, then use that profiled parameter for normal serving.

For diffusion, the reference shape is 512x512. The profiler records:

```text
batch_size
request_compute_units
total_compute_units
denoise_step_time
```

`benchmarks/diffusion/diffusion_batching_profiler.py` parses these logs, groups 512x512 records by batch size, filters outliers with IQR, uses median denoise-step time for each batch size, and applies a two-segment linear fit to locate the 512x512 sweet-spot batch size.

The generated policy parameter is:

```text
compute_unit_budget = reference_compute_units * sweet_spot_batch_size
```

During serving, the scheduler estimates each request type by visual compute units:

```text
request_compute_units ~= latent_h * latent_w * latent_frames * cfg_multiplier
```

Then it derives:

```text
effective_max_num_seqs = ceil(compute_unit_budget / request_compute_units)
```

`max_num_seqs` remains a hard upper bound.

For the built-in Qwen-Image reference profile on one Ascend 910B2 NPU:

```text
512x512 sweet-spot batch size = 10
compute_unit_budget = (512 / 16) * (512 / 16) * 10 = 10240
1024x1024 effective batch size = ceil(10240 / ((1024 / 16) * (1024 / 16))) = 3
```

The built-in `10240` profile should only be used when the model, backend, hardware, and reference profiling shape match this setup. Other environments should run the profiler first and pass the generated `compute_unit_budget`.

Example profiling run:

```bash
python3 -m vllm_omni.entrypoints.cli.main serve /data/Qwen-Image \
  --omni \
  --step-execution \
  --max-num-seqs 128 \
  --diffusion-batching-policy profile
```

Generate the serving config:

```bash
python3 benchmarks/diffusion/diffusion_batching_profiler.py \
  --log-file /path/to/server.log \
  --output-json /tmp/diffusion_batching_config.json
```

Example serving command on Ascend NPU:

```bash
COMPUTE_UNIT_BUDGET=<generated_compute_unit_budget>

python3 -m vllm_omni.entrypoints.cli.main serve /data/Qwen-Image \
  --served-model-name Qwen/Qwen-Image \
  --omni \
  --port 8081 \
  --step-execution \
  --max-num-seqs 128 \
  --diffusion-batching-policy compute_budget \
  --diffusion-batching-config "{\"compute_unit_budget\":${COMPUTE_UNIT_BUDGET},\"drr_arrival_window_size\":256,\"log_stats\":true}" \
  --vae-use-tiling \
  --vae-use-slicing
```

`drr_arrival_window_size` and `log_stats` are optional. The former controls the sliding window used to estimate request arrival probabilities for DRR; the latter only enables verbose batching-policy logs.

### Keyed DRR Scheduling

Step-wise continuous batching still requires requests in one running batch to share the same `SamplingParamsKey`. With a single FIFO waiting queue, a high-cost or incompatible request at the head can block later lower-cost requests, even when those later requests could form an efficient homogeneous batch.

This PR changes the waiting side of the scheduler to keep per-key queues:

```text
SamplingParamsKey -> deque[request]
```

The scheduler then selects the next homogeneous queue with a cost-aware DRR policy:

- `cost_i` is estimated from the request shape as visual compute units.
- `prob_i` is estimated online from a sliding arrival window.
- Non-empty queues accrue normalized budget proportional to `prob_i / cost_i`.
- The first selection starts from the lowest-cost queue.
- Later selections scan queues in ascending cost order from the DRR cursor and skip queues whose budget is insufficient.

After a key is selected, the existing homogeneous batching rule is preserved: only requests with the same `SamplingParamsKey` can join the running batch. The `compute_budget` policy then caps the batch size for that selected request type.

### Performance

I evaluated a mixed-resolution Qwen-Image workload on one Ascend 910B NPU. Requests arrive at high concurrency with a 50/50 mix of 512x512 and 1024x1024 requests, each using 50 inference steps.

Benchmark command:

```bash
python benchmarks/diffusion/diffusion_benchmark_serving.py \
  --backend vllm-omni \
  --dataset random \
  --task t2i \
  --model Qwen/Qwen-Image \
  --port 8080 \
  --num-prompts 50 \
  --max-concurrency 100 \
  --random-request-config '[
    {"width":512, "height":512, "num_inference_steps":50, "weight":0.5},
    {"width":1024, "height":1024, "num_inference_steps":50, "weight":0.5}
  ]'
```

Fixed continuous batching, `max-num-seqs=8`:

```text
Benchmark duration (s):          830.84
Request throughput (req/s):      0.06
Latency Mean (s):                468.4024
Latency Median (s):              473.7393
Latency P99 (s):                 819.0828
Latency P95 (s):                 806.8418
Successful requests:             50/50
```

Profiled compute-budget batching plus keyed DRR scheduling:

```text
Benchmark duration (s):          679.94
Request throughput (req/s):      0.07
Latency Mean (s):                475.3142
Latency Median (s):              578.9919
Latency P99 (s):                 679.9409
Latency P95 (s):                 679.9369
Successful requests:             50/50
```

The optimized strategy improves benchmark duration from `830.84s` to `679.94s`, which is about an 18.16% speedup.

### Documentation

This PR adds `docs/user_guide/diffusion/compute_budget_batching.md`, which documents:

- How to profile a new device or model with 512x512 reference requests.
- How the profiler derives `compute_unit_budget`.
- When the built-in Qwen-Image/Ascend 910B2 reference profile is valid.
- How keyed DRR handles mixed request types.
- The Ascend 910B performance result.