### PR TITLE
[Skill] add perf-bisect for attributing vllm-omni perf regressions to commits

### DIFF
--- a/.claude/skills/perf-bisect/SKILL.md
+++ b/.claude/skills/perf-bisect/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: perf-bisect
+description: >
+  Use when a vllm-omni perf change — TTFP, RTF, audio throughput, step time,
+  image latency — must be attributed to a specific commit, or when a PR's
+  perf claim needs verification. Triggers include "find which PR regressed X",
+  "bisect between commit A and B", "verify PR #N's perf claim",
+  "高并发 TTFP 劣化". Applies across TTS, diffusion-image, and omni-audio
+  model families. Not for trend reading (use `vllm-omni-kanban`) or writing
+  new perf tests (use `tests/dfx/perf/`).
+---
+
+# Perf Regression Bisect
+
+Attribute a vllm-omni perf change to a specific commit. Encodes the **cell-definition
+discipline** that prevents the most common failure mode: benching the wrong workload
+and falsely declaring "no regression" while one is live in a sibling cell.
+
+The workflow was hardened against the TTS regression cluster traced through
+PRs #3662 / #3681 / #3817 / #3839, but the harness, the discipline, and the
+rationalization table generalise to diffusion-image and omni-audio. TTS appears
+below as the worked example; family-specific knobs are called out where they bite.
+
+## When to use
+
+- "Which PR regressed `<metric>`?" — TTFP, RTF, audio throughput, image
+  generation time, step latency, etc.
+- "Bisect `<metric>` between commits A and B."
+- "Verify PR #N's perf claim end-to-end against `main`."
+- Any team-chat report of a delta requiring code-level attribution (vs.
+  dataset, driver, kernel, or vllm-upstream changes).
+
+## When NOT to use
+
+- Read existing perf trends → start with [`vllm-omni-kanban`](https://github.com/hsliuustc0106/vllm-omni-kanban)
+  (90-day H100 nightly series).
+- Write a **new** perf test → `tests/dfx/perf/scripts/run_benchmark.py` plus a
+  JSON spec under `tests/dfx/perf/tests/`.
+- One-shot "does this PR regress anything?" → use the `tts-perf-check` skill
+  for that. Use *this* skill for "which commit in a range caused the change".
+- Cross-version bisect across the vllm 0.20 ↔ 0.21 rebase in one venv — needs
+  two venvs (the dependency tree is incompatible).
+- NPU / XPU / AMD — H100 / H20 / L20X only.
+
+## Paired tools
+
+- **`remote-gpu`** (Skill) — SSH patterns for H20, L20X, H200-hsliu, Duke lab
+  hosts, DCC. Read `references/<class>.md` (e.g. `references/h20.md`) before
+  any heavy work on a shared host: disk layout, China-network, voice-cloning
+  base64 workaround, etc.
+- **`tts-perf-check`** (Skill) — one-shot per-PR perf check.
+- **`vllm-omni-kanban`** — daily H100 nightlies. **Always read this FIRST** —
+  it narrows the suspect commit range from weeks of merges to one day's worth
+  of PRs.
+
+## Cell-definition discipline (read first)
+
+The single most common failure: bench the wrong cell, conclude "no regression",
+and ship the regression. A **cell** is the 7-tuple
+
+```
+(model, task, deploy_yaml, dataset, num_prompts, max_concurrency, num_warmups)
+```
+
+plus zero or more **family knobs** (`extra_body`, `stage_overrides`, sampler
+options). Extract all 7 from the regression report — comment, screenshot, chat
+message — **before** writing any script.
+
+### Generic dimensions
+
+| Dimension         | Source                                    | Example values |
+|-------------------|-------------------------------------------|----------------|
+| `model`           | bench `--model`                           | `Qwen/Qwen3-TTS-12Hz-1.7B-Base`, `…-CustomVoice`, `tencent/HunyuanImage-3.0`, `Qwen/Qwen2.5-Omni-7B` |
+| `task`            | family-specific (see below)               | TTS: `voice_clone` / `default_voice` / `voice_design`; Diffusion: t2i vs edit; Omni: audio vs audio+video |
+| `deploy_yaml`     | `vllm serve --deploy-config`              | `qwen3_tts.yaml` vs `qwen3_tts_high_concurrency.yaml` |
+| `dataset`         | bench `--dataset-name` + `--dataset-path` | `seed-tts`, `seed-tts-text`, `seed-tts-design`, `geneval`, `audiocaps` |
+| `num_prompts`     | bench `--num-prompts`                     | latency 20; throughput 80–128; stress 512 |
+| `max_concurrency` | bench `--max-concurrency`                 | 1, 8, 16, 32, 64, 128, 256 |
+| `num_warmups`     | bench `--num-warmups`                     | 0 (kanban); **8 (bisect standard)** |
+
+### Family-specific knobs
+
+Every family adds knobs the 7-tuple does not capture (`extra_body`,
+`stage_overrides`, sampler options). Full table in
+`references/family-knobs.md`. The TL;DR per family:
+
+- **TTS** — `task_type`, `voice`, `language` in `extra_body`;
+  `qwen3_tts_high_concurrency.yaml` enables `code_predictor_prefix_graphs`
+  and gates a class of regressions invisible under the default YAML.
+- **Diffusion-image** — `width`, `height`, `num_inference_steps`,
+  `guidance_scale` in `extra_body`; `stage_overrides` partitions VAE / DiT
+  / text-encoder across GPUs.
+- **Omni-audio** — modality combinations live in dataset preparation, not
+  in `extra_body`.
+
+### Anti-pattern (the load-bearing lesson)
+
+A bisect that measures Base `voice_clone` (default YAML, N=128) when the
+report is CustomVoice `default_voice` (`qwen3_tts_high_concurrency.yaml`,
+N=512) is measuring a **different cell**. Every dimension is wrong, the
+bench completes with apples-vs-oranges numbers, and the verdict is a
+confident "no regression" while a >100% TTFP regression is live. The
+regression exists only when the high-concurrency YAML is loaded; the
+default YAML's code path doesn't touch the regressed flag.
+
+**Always echo the cell back to the user before any bench:**
+
+> "Benching `<model>` on `<task>` with `<deploy_yaml>`, N=`<N>`,
+> c=`<c>`, `<W>` warmups. Confirm?"
+
+A correction at this step saves 30–60 minutes of wrong-cell GPU time.
+
+## Workflow
+
+### Step 1 — Kanban triage
+
+If the regression is on a cell the kanban tracks (Base `voice_clone`,
+CustomVoice `default_voice` / `voice_design`, HunyuanImage t2i), the kanban
+likely has a daily series for it.
+
+```bash
+git clone --depth 1 https://github.com/hsliuustc0106/vllm-omni-kanban /tmp/kanban
+python scripts/kanban_trend.py /tmp/kanban result_test_qwen3_tts_base_seed-tts_64_128
+```
+
+`scripts/kanban_trend.py` prints `(date, build, TTFP, Δ%, RTF, Δ%, throughput, Δ%)`
+with `←REG` / `←IMP` markers at the 10% threshold.
+
+**Map build → commit.** Kanban "build" directories are not strictly 1:1 with
+main-branch nightly commits (some are PR-CI runs). Read the date from the
+JSON filename suffix, then resolve to a main-branch commit window via
+`git log --first-parent upstream/main --since=<date> --until=<date+1d>`.
+
+**Caveat.** The kanban's nightly bench uses each test's default
+`stage_overrides`. Regressions that only manifest under a non-default
+`deploy_yaml` (e.g. `qwen3_tts_high_concurrency.yaml`) are **invisible** to
+the kanban. Use kanban for the **onset date** when it sees the regression;
+fall back to reporter-supplied SHAs when it doesn't.
+
+### Step 2 — Pick the bisect span
+
+From the kanban onset (or PR review trail), the bisect starts with a
+`[good, bad]` commit pair. Path-filter the log to PRs touching the suspect
+blast radius. The shared worker / scheduler / common-model paths matter for
+every family; the family-specific paths below pick out the relevant
+model/processor pair.
+
+**Shared hot path** (always include):
+
+```
+vllm_omni/worker/gpu_ar_model_runner.py
+vllm_omni/worker/gpu_generation_model_runner.py
+vllm_omni/worker/gpu_model_runner.py
+vllm_omni/core/sched/omni_ar_scheduler.py
+vllm_omni/core/sched/omni_generation_scheduler.py
+vllm_omni/core/sched/omni_scheduling_coordinator.py
+vllm_omni/core/prefix_cache.py
+vllm_omni/model_executor/models/common/
+```
+
+**Add per family** (model + stage-input-processor):
+
+| Family            | Add to the path filter                                                                                  |
+|-------------------|---------------------------------------------------------------------------------------------------------|
+| TTS               | `vllm_omni/model_executor/models/qwen3_tts/` + `stage_input_processors/qwen3_tts.py` (and `cosyvoice3.py` / `glm_tts*.py` / `omnivoice.py` for siblings) |
+| Diffusion-image   | `vllm_omni/model_executor/models/hunyuan_image3/` + `stage_input_processors/hunyuan_image3.py` + `vllm_omni/distributed/` (stage partitioning) |
+| Omni-audio        | `vllm_omni/model_executor/models/qwen2_5_omni/` (or `qwen3_omni/`, `ming_flash_omni/`, `dynin_omni/`) + matching `stage_input_processors/*.py` |
+
+Example, TTS:
+
+```bash
+git log --oneline --first-parent upstream/main <good>..<bad> -- \
+  vllm_omni/model_executor/models/qwen3_tts/ \
+  vllm_omni/model_executor/stage_input_processors/qwen3_tts.py \
+  vllm_omni/worker/gpu_ar_model_runner.py \
+  vllm_omni/worker/gpu_generation_model_runner.py \
+  vllm_omni/worker/gpu_model_runner.py \
+  vllm_omni/core/sched/omni_ar_scheduler.py \
+  vllm_omni/core/sched/omni_generation_scheduler.py \
+  vllm_omni/core/prefix_cache.py \
+  vllm_omni/model_executor/models/common/
+```
+
+Typical result: 5–15 PRs. Linear if ≤8; binary bisect (midpoint first) if
+more.
+
+### Step 3 — Bench harness on the remote host
+
+`scripts/run_bisect.sh` is the vendored bench loop. Edit the block at the
+top. The example below is TTS; swap `MODEL` / `DEPLOY_YAML` / `DATASET_*` /
+`EXTRA_BODY` for diffusion or omni — `scripts/cells/<family>_*.yaml` carries
+ready-to-paste values for each.
+
+```bash
+COMMITS=("<sha1>" "<sha2>" "<sha3>")
+LABELS=("good_baseline" "midpoint" "bad_main")
+
+# TTS example
+MODEL="Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+DEPLOY_YAML="vllm_omni/deploy/qwen3_tts_high_concurrency.yaml"
+DATASET_NAME="seed-tts-text"
+EXTRA_BODY='{"voice":"Vivian","language":"English","task_type":"CustomVoice"}'
+NUM_PROMPTS=512
+MAX_CONCURRENCY=64
+NUM_WARMUPS=8
+
+# Diffusion-image example (HunyuanImage3 t2i @ 1024²)
+# MODEL="tencent/HunyuanImage-3.0"
+# DEPLOY_YAML="vllm_omni/deploy/hunyuan_image3.yaml"
+# DATASET_NAME="random-image-prompts"
+# EXTRA_BODY='{"width":1024,"height":1024,"num_inference_steps":28}'
+
+# Omni-audio example (Qwen2.5-Omni)
+# MODEL="Qwen/Qwen2.5-Omni-7B"
+# DEPLOY_YAML="vllm_omni/deploy/qwen2_5_omni.yaml"
+# DATASET_NAME="audiocaps"
+# EXTRA_BODY='{}'
+```
+
+Mandatory env (see `remote-gpu`'s `references/h20.md` for full setup):
+
+```bash
+source <venv>/bin/activate
+export PATH="<venv>/bin:$PATH"   # belt & suspenders for subprocess `ninja`
+export HF_ENDPOINT=https://hf-mirror.com
+export HF_HOME=/mnt/dataX/<your-dir>/hf_cache
+export CUDA_VISIBLE_DEVICES=4,5  # pick free GPUs; nvidia-smi first
+export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
+```
+
+Per-commit loop (encoded in the script):
+
+1. `git checkout <sha>` in a dedicated worktree (don't disturb the main checkout).
+2. `pkill -9 -f "vllm.*serve|StageEngineCore|OmniServer"`. Verify port is free.
+3. `vllm serve <model> --omni --deploy-config <yaml> --port 8092 &`.
+4. Poll `/v1/models` until the model entry appears, then **sleep 30s** for
+   CUDA-graph compile to settle.
+5. `vllm bench serve --omni ... --save-result --result-filename result.json`.
+6. Kill server, sleep 10s, next commit.
+
+### Step 4 — Interpret
+
+Pull the headline metric (`median_audio_ttfp_ms` / `median_audio_rtf` /
+`audio_throughput` for TTS; `image_latency_ms` for diffusion) from each
+commit's `result.json`. Build a table:
+
+```
+| commit     | label         | median TTFP | p99 TTFP | RTF   | tput  |
+|------------|---------------|-------------|----------|-------|-------|
+| <sha1>     | good_baseline | 712 ms      | 1340 ms  | 0.18  | 24.1  |
+| <sha2>     | midpoint      | 1230 ms     | 1810 ms  | 0.27  | 19.0  |  ← jump
+| <sha3>     | bad_main      | 1604 ms     | 1936 ms  | 0.31  | 17.4  |
+```
+
+A jump > 15% between consecutive labels is a candidate regression PR.
+Cross-check the suspect's diff against the Step-2 path filter.
+
+### Step 5 — Variance check
+
+Single-run variance at c=64:
+
+| Setup                                | Variance | Verdict                                                                 |
+|--------------------------------------|----------|-------------------------------------------------------------------------|
+| N=128, W=0 (kanban default)          | ±10%     | Unreliable for <20% deltas; needs 2-3 runs.                             |
+| N=512, W=8 (bisect standard)         | ±3%      | Single run reasonable for >15% deltas; 2 runs if signal is 5-15%.       |
+
+**Always run N=512 + 8 warmups for bisect work.** The kanban's N=128/W=0 is
+fine for daily trend but too noisy to attribute a regression to a single PR.
+
+## Cross-platform notes
+
+Per-host SSH and setup details live in `remote-gpu`'s `references/` (e.g.
+`references/h20.md`, `references/h200.md`). The invariant this skill relies
+on: numbers must AGREE on **direction and rough magnitude** across
+platforms. If H20 reports +100% and H100 reports +0%, suspect the deploy
+YAML first — the kanban's H100 nightly may not be loading the regressed
+YAML, so the H100 sees no signal even when one is live.
+
+## Rationalization table
+
+Excuses observed when running bisects without this skill, and the reality:
+
+| Excuse                                                           | Reality                                                                                   |
+|------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| "The script ran clean, the numbers look normal"                  | Apples-vs-oranges numbers also look normal. Echo the 7-tuple before benching.             |
+| "I'll use the kanban's cell because it has a baseline"           | Kanban's cell may not exercise the regressed code path. Match the reporter's cell exactly. |
+| "Pre-warmup is overkill, just run N=128"                         | N=128 c=64 W=0 is ±10% — <15% signals get lost. N=512 W=8.                                |
+| "The YAML doesn't matter, the model is the same"                 | `qwen3_tts.yaml` and `qwen3_tts_high_concurrency.yaml` enable different feature flags.    |
+| "`/v1/models` returns 200 means bench-ready"                     | The API server loads before CUDA graphs finish compiling. Add 30s settle.                 |
+| "I'll skip kanban triage, the suspect PR is obvious"             | Kanban narrows weeks to one day. Skipping it costs 5-15 wrong checkouts on average.       |
+| "Single run is fine if the delta looks large"                    | OK for >15% deltas at N=512 W=8. Else two runs.                                           |
+| "Cross-version venvs are too much work, I'll just patch deps"    | The vllm 0.20 ↔ 0.21 boundary breaks plugin loading. Two venvs.                           |
+
+## Red flags — STOP and re-check
+
+- About to launch a bench without saying the 7-tuple out loud
+- About to use `pytest -k <expr>` without first running
+  `pytest --collect-only -q -k <expr>` to confirm it matches anything
+- Server PID from the previous commit is still alive when starting the next
+- About to checkout commits across the vllm 0.20 → 0.21 boundary in the same venv
+- About to declare "no regression" from a single run on a noisy cell
+
+## Common pitfalls (mechanical)
+
+Six failure modes caught in real bisects: `pytest -k` zero-match, venv PATH
+not inherited by subprocess, stale server PID, multi-tenant GPU contention,
+`/v1/models` returning before CUDA-graph compile finishes, and cold model
+download exceeding the server-ready timeout. Full diagnostics and copy-paste
+remediation snippets in `references/pitfalls.md`.
+
+## What this skill does NOT do
+
+- Cross-version (vllm 0.20 ↔ 0.21) bisects in one venv.
+- NPU / XPU / AMD bisects.
+- Auto-attribute multi-commit interactions ("which combo of two PRs?") — manual review.
+- Write a regression test that catches the bisected commit — that's
+  `tests/dfx/perf/`'s job; this skill is investigation, not prevention.
+
+## Files in this skill
+
+```
+.claude/skills/perf-bisect/
+├── SKILL.md                                  # this file
+├── references/
+│   ├── family-knobs.md                       # extra_body / stage_overrides per family
+│   └── pitfalls.md                           # mechanical failure modes + remediations
+└── scripts/
+    ├── run_bisect.sh                         # bench-loop template
+    ├── kanban_trend.py                       # extract metric time series from the kanban repo
+    └── cells/
+        ├── README.md                         # how to define a new cell
+        ├── tts_default_voice_high_c.yaml     # CustomVoice + high_concurrency.yaml + N=512 + c=64
+        ├── tts_voice_clone_nightly.yaml      # Base + default YAML + N=128 + c=64 (kanban parity)
+        ├── diffusion_hunyuan_t2i_1024.yaml   # HunyuanImage-3.0 t2i @ 1024² + c=4 + N=32
+        └── omni_qwen2_5_audio.yaml           # Qwen2.5-Omni audio-only + c=16 + N=128
+```
+
+Cell files follow `<family>_<descriptor>.yaml`. The shipped set covers TTS,
+diffusion-image, and omni-audio; copy the closest sibling when adding a new
+cell — see `scripts/cells/README.md`.

--- a/.claude/skills/perf-bisect/references/family-knobs.md
+++ b/.claude/skills/perf-bisect/references/family-knobs.md
@@ -1,0 +1,54 @@
+# Family-specific knobs
+
+Beyond the generic 7-tuple `(model, task, deploy_yaml, dataset, num_prompts,
+max_concurrency, num_warmups)` in `SKILL.md`, each model family carries its
+own knobs that change the measured cell. Setting one wrong is a common
+path to a wrong-cell bench.
+
+## TTS (Qwen3-TTS, MOSS-TTS-Nano, GLM-TTS)
+
+| Knob               | Where                                             | Notes |
+|--------------------|---------------------------------------------------|-------|
+| `task_type`        | bench `--extra-body`                              | CustomVoice variants only: `CustomVoice` / `VoiceDesign`. Voice_clone (Base) reads ref-audio from the dataset row and needs no `extra_body`. |
+| `voice`            | bench `--extra-body`                              | Required when `task_type=CustomVoice`. Common values: `Vivian`, `Cherry`, etc. |
+| `language`         | bench `--extra-body`                              | `English` / `Chinese` — affects the front-end text normalizer and Stage-0 token count. |
+| `deploy_yaml`      | `vllm serve --deploy-config`                      | `qwen3_tts.yaml` vs `qwen3_tts_high_concurrency.yaml`. The high-c YAML enables `code_predictor_prefix_graphs` AND a larger Stage-0 batch (S0=64 vs S0=8). Many regressions appear ONLY under this YAML. |
+| `seed_tts_locale`  | bench (voice_clone only)                          | `en` / `zh` — selects the seed-tts subset. |
+
+### Headline metrics
+- `median_audio_ttfp_ms` — first-packet latency. Most sensitive metric.
+- `median_audio_rtf` — real-time factor (audio_duration / total_time).
+- `audio_throughput` — aggregate tokens/sec at the configured concurrency.
+
+## Diffusion-image (HunyuanImage3, etc.)
+
+| Knob                  | Where                                        | Notes |
+|-----------------------|----------------------------------------------|-------|
+| `width` / `height`    | bench `--extra-body`                         | 512 / 1024 / 2048. Step-time scales ~quadratically. |
+| `num_inference_steps` | bench `--extra-body`                         | Affects total latency linearly; default 28-50. |
+| `guidance_scale`      | bench `--extra-body`                         | Numeric value; affects sampler path but not perf much. |
+| `stage_overrides`     | `vllm serve --deploy-config`                 | Partitions VAE / DiT / text-encoder across GPUs. The number of replicas per stage changes the cell. |
+
+### Headline metrics
+- `image_latency_ms` (e2e generation time).
+- `gpu_busy_pct` — throughput proxy.
+
+## Omni-audio (Qwen2.5-Omni, etc.)
+
+| Knob                  | Where                                        | Notes |
+|-----------------------|----------------------------------------------|-------|
+| Modality combination  | dataset prep (`audio_only` / `audio+video`)  | Lives in the dataset, not in `extra_body`. |
+| `max_num_audios`      | bench `--extra-body`                         | Caps per-request audio inputs. |
+| Audio tokenizer       | upstream of bench                            | Different vocoder paths have different perf characteristics. |
+
+### Headline metrics
+- `median_audio_ttfp_ms`, `audio_throughput` — shared with TTS.
+- `e2el_ms` for end-to-end multimodal latency.
+
+## How to extract knobs from a regression report
+
+1. Look for `extra_body` JSON or `--extra-body` arg in the bench command.
+2. Look for `--deploy-config` or any `vllm serve` flag that points at a YAML.
+3. Look for dataset-name and any locale flag.
+4. If any knob is unspecified in the report, echo a default back to the user
+   and confirm before benching — defaults frequently change between reports.

--- a/.claude/skills/perf-bisect/references/pitfalls.md
+++ b/.claude/skills/perf-bisect/references/pitfalls.md
@@ -1,0 +1,75 @@
+# Mechanical pitfalls (caught in real bisects)
+
+Reference for debug-time lookup. The pre-flight red-flag list lives in `SKILL.md`;
+this file is what to consult when a bench misbehaves.
+
+## 1. `pytest -k` selects 0 tests silently
+
+Parametrised IDs may not contain the literal keyword the bisecter assumes
+(e.g. `test_qwen3_tts_base`'s parametrised IDs don't contain "customvoice",
+so `-k "not customvoice"` matches everything).
+
+```bash
+# ALWAYS run this first to confirm the filter matches anything
+pytest --collect-only -q -k "<expr>" | head
+```
+
+## 2. Venv PATH not inherited by pytest subprocess
+
+`.venv/bin/pytest` runs fine for the test, but subprocess calls to `ninja`
+(for kernel compilation) raise `FileNotFoundError`.
+
+```bash
+# Belt-and-suspenders activation
+source <venv>/bin/activate
+export PATH="<venv>/bin:$PATH"
+```
+
+## 3. Stale server PID
+
+`kill_server` must `pkill -9` AND verify the port is free; otherwise the
+next iteration binds a different port, the curl probe matches the wrong
+PID, and the bench reports `0/N completed`.
+
+```bash
+# Inside the bisect loop
+pkill -9 -f "vllm.*serve|StageEngineCore|OmniServer"
+sleep 8
+ss -lntp | grep ":$PORT " && echo "PORT STILL BOUND — investigate" && exit 1
+```
+
+## 4. Multi-tenant GPUs
+
+Another tenant's container may have pinned GPUs that the configured
+`CUDA_VISIBLE_DEVICES` mask covers. The bench still runs but allocates
+into a contended memory pool, doubling absolute numbers without changing
+relative deltas.
+
+```bash
+# Probe first
+nvidia-smi --query-gpu=index,memory.used --format=csv,noheader
+# Pick GPUs whose memory.used is < 1 GiB
+```
+
+## 5. `/v1/models` ≠ bench-ready
+
+The API server registers the model entry as soon as it loads, but CUDA
+graphs may still be compiling. Bench requests in this window block on
+graph-capture and report inflated TTFP.
+
+```bash
+# After /v1/models returns the model entry
+sleep 30   # settle window
+# OR scan server.log for the warmup-complete marker
+```
+
+## 6. Cold model download
+
+Several minutes via `hf-mirror`, longer on cold disk. The default
+server-ready timeout may fire before the model finishes downloading.
+
+```bash
+# Pre-download into $HF_HOME BEFORE the bisect loop
+hf download <model> --cache-dir "$HF_HOME"
+# OR bump the server-ready timeout to 30 min in run_bisect.sh
+```

--- a/.claude/skills/perf-bisect/scripts/cells/README.md
+++ b/.claude/skills/perf-bisect/scripts/cells/README.md
@@ -1,0 +1,53 @@
+# Cells
+
+Each YAML in this directory captures one perf cell — the 7-tuple of
+`(model, task, deploy_yaml, dataset, num_prompts, max_concurrency, num_warmups)`
+plus any family-specific knobs (`extra_body`, `stage_overrides`, sampler options).
+
+These files are inputs to `../run_bisect.sh`. Copy the values into the EDIT-HERE
+block at the top of the script.
+
+## Naming
+
+Files use a `<family>_<descriptor>.yaml` prefix so families don't collide as the
+list grows:
+
+- `tts_*` — Qwen3-TTS, MOSS-TTS-Nano, GLM-TTS, etc.
+- `diffusion_*` — HunyuanImage3, and any future text-to-image / image-to-video model.
+- `omni_*` — Qwen2.5-Omni and other audio-in/audio-out stacks.
+
+## Cells in this directory
+
+| File | Cell | Why it exists |
+|------|------|----------------|
+| `tts_default_voice_high_c.yaml` | CustomVoice `default_voice` c=64 N=512 + `qwen3_tts_high_concurrency.yaml` | PR #3839's regression cell. The high-concurrency YAML enables `code_predictor_prefix_graphs`; the default YAML does not exercise the regressed code path. |
+| `tts_voice_clone_nightly.yaml` | Base `voice_clone` c=64 N=128 + default `stage_overrides` | Kanban nightly parity. Use it to cross-check a local bench against the public H100 daily series. |
+| `diffusion_hunyuan_t2i_1024.yaml` | HunyuanImage-3.0 t2i @ 1024² c=4 N=32 | Representative diffusion-image cell. Image latency scales quadratically with resolution — copy and adjust for 512² / 2048². |
+| `omni_qwen2_5_audio.yaml` | Qwen2.5-Omni audio-in/audio-out c=16 N=128 | Representative omni-audio cell. Shares the talker+vocoder split with Qwen3-TTS, so TTFP / audio_throughput are headline. |
+
+## Adding a new cell
+
+1. Copy an existing YAML to `<family>_<descriptor>.yaml`.
+2. Fill in each of the 7-tuple fields. Be especially careful about:
+   - **`deploy_yaml`** — does this cell need a non-default deploy YAML? For TTS,
+     `qwen3_tts_high_concurrency.yaml` exercises code paths the default YAML
+     does not. For diffusion, deploy YAMLs differ in stage partitioning.
+   - **`model`** — TTS Base (`Qwen3-TTS-12Hz-1.7B-Base`) and CustomVoice
+     (`Qwen3-TTS-12Hz-1.7B-CustomVoice`) are different checkpoints. Image
+     families have base / instruct / refiner variants.
+   - **`extra_body`** — TTS CustomVoice variants need `task_type`, `voice`,
+     `language`. TTS `voice_clone` reads ref-audio from the dataset, no
+     `extra_body` needed. Diffusion carries `width`, `height`,
+     `num_inference_steps`, `guidance_scale`.
+3. Set `num_warmups: 8` for bisect work (the kanban default of 0 is too noisy).
+4. Set `num_prompts: 512` for a tight median (the kanban default of 128 has
+   ~10% variance at c=64).
+5. Optionally include `known_baselines:` for sanity-checking a fresh result.
+   Source these from PR comments or the kanban; cite the source.
+
+## Cell-definition discipline
+
+Before benching, ALWAYS echo the cell to the user. The most common failure mode
+is running the bisect against the wrong cell and falsely concluding "no
+regression" — see `../../SKILL.md` for the load-bearing lesson and the
+rationalization table.

--- a/.claude/skills/perf-bisect/scripts/cells/diffusion_hunyuan_t2i_1024.yaml
+++ b/.claude/skills/perf-bisect/scripts/cells/diffusion_hunyuan_t2i_1024.yaml
@@ -1,0 +1,27 @@
+# Cell: HunyuanImage-3.0 text-to-image at 1024² resolution.
+#
+# Representative diffusion-image cell. Image latency at 1024² scales
+# ~quadratically with resolution; if a regression report references 512² or
+# 2048², copy this file and adjust width/height + num_inference_steps.
+#
+# Hardware shape: 1+ GPU; HunyuanImage3 supports VAE / DiT / text-encoder
+# partitioning via stage_overrides on multi-GPU hosts.
+
+model: tencent/HunyuanImage-3.0
+deploy_yaml: vllm_omni/deploy/hunyuan_image3.yaml
+
+# Bench client args (passed to `vllm bench serve --omni`)
+backend: openai-images
+endpoint: /v1/images/generations
+dataset_name: random-image-prompts
+dataset_path: null
+extra_body: '{"width":1024,"height":1024,"num_inference_steps":28,"guidance_scale":7.5}'
+num_prompts: 32
+num_warmups: 4
+max_concurrency: 4
+request_rate: inf
+percentile_metrics: ttft,e2el,image_latency
+
+# Known baselines: fill in once the kanban or a PR comment provides a number.
+# Refresh whenever the underlying checkpoint or vllm version moves significantly.
+known_baselines: {}

--- a/.claude/skills/perf-bisect/scripts/cells/omni_qwen2_5_audio.yaml
+++ b/.claude/skills/perf-bisect/scripts/cells/omni_qwen2_5_audio.yaml
@@ -1,0 +1,26 @@
+# Cell: Qwen2.5-Omni audio-only inference (audio-in, audio-out).
+#
+# Representative omni-audio cell. The Qwen2.5-Omni stack shares the
+# stage-0 talker + stage-1 vocoder split with the Qwen3-TTS family, so
+# TTFP and audio_throughput are the headline metrics here too.
+#
+# For audio+video runs, set the dataset to a multimodal one and bump
+# max_num_audios / max_num_videos in extra_body.
+#
+# Hardware shape: 2-GPU (talker GPU 0 + vocoder GPU 1) at minimum.
+
+model: Qwen/Qwen2.5-Omni-7B
+deploy_yaml: vllm_omni/deploy/qwen2_5_omni.yaml
+
+backend: openai-audio-speech
+endpoint: /v1/audio/speech
+dataset_name: audiocaps
+dataset_path: null
+extra_body: '{}'
+num_prompts: 128
+num_warmups: 4
+max_concurrency: 16
+request_rate: inf
+percentile_metrics: ttft,e2el,audio_rtf,audio_ttfp,audio_duration
+
+known_baselines: {}

--- a/.claude/skills/perf-bisect/scripts/cells/tts_default_voice_high_c.yaml
+++ b/.claude/skills/perf-bisect/scripts/cells/tts_default_voice_high_c.yaml
@@ -1,0 +1,32 @@
+# Cell: Qwen3-TTS CustomVoice default_voice c=64 N=512 with high-concurrency deploy.
+#
+# This cell is the canonical witness for a class of regressions that only
+# manifests when qwen3_tts_high_concurrency.yaml is loaded (it enables
+# code_predictor_prefix_graphs and a larger Stage-0 batch). The default
+# qwen3_tts.yaml does NOT exercise the regressed code path.
+#
+# Hardware shape: 2-GPU H20-class host, Stage 0 on GPU 0 + Stage 1 on GPU 1
+# (S0=64, S1=10 in the high-c YAML).
+
+model: Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice
+deploy_yaml: vllm_omni/deploy/qwen3_tts_high_concurrency.yaml
+
+# Bench client args (passed to `vllm bench serve --omni`)
+backend: openai-audio-speech
+endpoint: /v1/audio/speech
+dataset_name: seed-tts-text
+dataset_path: benchmarks/build_dataset/seed_tts_smoke
+extra_body: '{"voice":"Vivian","language":"English","task_type":"CustomVoice"}'
+num_prompts: 512
+num_warmups: 8
+max_concurrency: 64
+request_rate: inf
+percentile_metrics: ttft,e2el,audio_rtf,audio_ttfp,audio_duration
+
+# Known baselines in ms (single-run on 2-GPU H20-class host; ±3% variance at
+# N=512 W=8). Sourced from PR #3839's bench; refresh when the model checkpoint
+# or vllm version moves significantly.
+known_baselines:
+  v0.21.0rc1: 736
+  main_HEAD_post_pr3662_regression: 1604
+  pr3839_fix: 710

--- a/.claude/skills/perf-bisect/scripts/cells/tts_voice_clone_nightly.yaml
+++ b/.claude/skills/perf-bisect/scripts/cells/tts_voice_clone_nightly.yaml
@@ -1,0 +1,37 @@
+# Cell: Qwen3-TTS Base voice_clone c=64 N=128 with default deploy (nightly parity)
+#
+# Matches what the kanban nightly bench measures. Use this when you want
+# to cross-check against the public daily H100 series.
+#
+# Note: this cell does NOT load qwen3_tts_high_concurrency.yaml, so it will
+# NOT show high-c-yaml-specific regressions (like the PR #3839 default_voice
+# regression). Use default_voice_high_c.yaml for that.
+#
+# Hardware: any 2-GPU TTS setup (Stage 0 GPU 0, Stage 1 GPU 1).
+#
+# Source: tests/dfx/perf/tests/test_tts.json (the existing nightly spec).
+
+model: Qwen/Qwen3-TTS-12Hz-1.7B-Base
+deploy_yaml: null                         # use default stage_overrides only
+stage_overrides:
+  "1":
+    devices: "1"
+
+backend: openai-audio-speech
+endpoint: /v1/audio/speech
+dataset_name: seed-tts
+dataset_path: linyueqian/seed-tts-eval-subset
+extra_body: null                          # voice_clone has no extra_body knobs
+num_prompts: 128
+num_warmups: 0                            # kanban default; bumps to 8 for tighter bisect
+max_concurrency: 64
+request_rate: inf
+seed_tts_locale: en
+percentile_metrics: ttft,e2el,audio_rtf,audio_ttfp,audio_duration
+
+# Known baselines (kanban H100 nightlies + H20 spot check). Numbers in ms;
+# refresh from the kanban when the underlying model checkpoint or vllm version
+# moves significantly.
+known_baselines:
+  H100_post_pr3662_steady_state: "6000-6400"
+  H20_main_HEAD_spot_check: 5784

--- a/.claude/skills/perf-bisect/scripts/kanban_trend.py
+++ b/.claude/skills/perf-bisect/scripts/kanban_trend.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Extract a metric time series from the vllm-omni-kanban repo.
+
+Works for any cell the kanban tracks (TTS TTFP / RTF / throughput,
+diffusion image latency, omni-audio throughput) — pass the cell's filename
+prefix and the script prints a per-build table with rolling-delta percent
+and `←REG` / `←IMP` markers at the 10% threshold.
+
+Usage:
+    # Clone or update the kanban first:
+    #   git clone --depth 1 https://github.com/hsliuustc0106/vllm-omni-kanban /tmp/kanban
+    python kanban_trend.py /tmp/kanban [cell-prefix]
+
+Examples (TTS):
+    # Base voice_clone c=64 N=128
+    python kanban_trend.py /tmp/kanban result_test_qwen3_tts_base_seed-tts_64_128
+
+    # CustomVoice default_voice c=64 N=128
+    python kanban_trend.py /tmp/kanban result_test_qwen3_tts_customvoice_seed-tts-text_64_128
+
+    # Every TTS cell across every build (overview)
+    python kanban_trend.py /tmp/kanban result_test_qwen3_tts
+
+Filename convention in the kanban:
+    result_test_<family>_<variant>_<dataset>_<concurrency>_<num_prompts>_<…>_YYYYMMDD-HHMMSS.json
+
+Limitation: build dirs in the kanban are NOT strictly 1:1 with main-branch
+nightly commits — some are PR-CI runs. Use the date column (parsed from the
+JSON filename) to resolve to an actual main commit via
+`git log --first-parent` on vllm-omni.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+from collections import defaultdict
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+    kanban_root = pathlib.Path(sys.argv[1]) / "data" / "buildkite_nightly_raw"
+    if not kanban_root.exists():
+        print(f"ERROR: {kanban_root} not found", file=sys.stderr)
+        sys.exit(1)
+    prefix = sys.argv[2] if len(sys.argv) > 2 else "result_test_qwen3_tts"
+
+    # build -> date (from any file's timestamp suffix)
+    series = defaultdict(list)
+    for bd in sorted(kanban_root.iterdir(), key=lambda p: int(p.name) if p.name.isdigit() else 0):
+        if not bd.is_dir():
+            continue
+        results = bd / "tests/dfx/perf/results"
+        if not results.exists():
+            continue
+        # Pick a representative date from any result file
+        date = None
+        for any_json in results.glob("*.json"):
+            m = re.search(r"_(\d{8})-\d{6}\.json$", any_json.name)
+            if m:
+                d = m.group(1)
+                date = f"{d[:4]}-{d[4:6]}-{d[6:]}"
+                break
+        if date is None:
+            continue
+        # Now extract metrics for the matching cells
+        for f in sorted(results.glob(f"{prefix}*.json")):
+            try:
+                d = json.load(open(f))
+            except Exception:
+                continue
+            ttfp = d.get("median_audio_ttfp_ms")
+            rtf = d.get("median_audio_rtf")
+            tput = d.get("audio_throughput")
+            c = d.get("max_concurrency")
+            n = d.get("num_prompts")
+            # Build a friendly cell label from the filename
+            stem = f.stem.replace("result_test_qwen3_tts_", "")
+            stem = re.sub(r"_\d{8}-\d{6}$", "", stem)
+            series[stem].append((date, bd.name, c, n, ttfp, rtf, tput))
+
+    if not series:
+        print(f"No cells matched prefix {prefix!r}", file=sys.stderr)
+        sys.exit(1)
+
+    for cell_name, entries in series.items():
+        if not entries:
+            continue
+        c0 = entries[0][2]
+        n0 = entries[0][3]
+        print(f"\n## {cell_name} (c={c0}, N={n0})\n")
+        print(f"{'date':12s} {'build':>6s} {'TTFP_ms':>10s} {'Δ%':>7s} {'RTF':>7s} {'Δ%':>7s} {'tput':>6s} {'Δ%':>7s}")
+        prev = None
+        for date, build, c, n, ttfp, rtf, tput in entries:
+            if prev:
+
+                def pct(cur, pv, inv=False):
+                    if cur is None or pv is None or pv == 0:
+                        return ""
+                    d = (cur - pv) / pv * 100
+                    if inv:
+                        d = -d
+                    return f"{d:+5.1f}%"
+
+                d1 = pct(ttfp, prev[0])
+                d2 = pct(rtf, prev[1])
+                d3 = pct(tput, prev[2], inv=True)
+            else:
+                d1 = d2 = d3 = ""
+            mark = ""
+            if d1 and abs(float(d1.rstrip("%"))) >= 10:
+                mark = " ←REG" if d1.startswith("+") else " ←IMP"
+            t1 = f"{ttfp:10.1f}" if ttfp is not None else "       n/a"
+            t2 = f"{rtf:7.3f}" if rtf is not None else "    n/a"
+            t3 = f"{tput:6.1f}" if tput is not None else "   n/a"
+            print(f"{date:12s} {build:>6s} {t1} {d1:>7s} {t2} {d2:>7s} {t3} {d3:>7s}{mark}")
+            prev = (ttfp, rtf, tput)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/perf-bisect/scripts/run_bisect.sh
+++ b/.claude/skills/perf-bisect/scripts/run_bisect.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# perf-bisect bench-loop template.
+#
+# Iterates a list of commits, for each one starts `vllm serve`, runs
+# `vllm bench serve`, parses the result JSON, kills the server, and moves on.
+# Produces one result.json per (commit, cell) under $RESULTS/<label>/result.json.
+#
+# Usage: copy to /tmp/, edit the EDIT-HERE block, run on the remote host:
+#   bash run_bisect.sh
+#
+# The defaults below describe a TTS cell. Swap MODEL / DEPLOY_YAML /
+# DATASET_NAME / EXTRA_BODY for diffusion or omni-audio. See `cells/` for
+# canned cell definitions and `../SKILL.md` for the cell-definition discipline.
+
+set -u
+set -o pipefail
+
+# ─── EDIT HERE ────────────────────────────────────────────────────────────────
+# Commits to test. Order matters only for log readability. Replace the
+# placeholder SHAs and labels for each new bisect.
+COMMITS=("<good-sha>" "<midpoint-sha>" "<bad-sha>")
+LABELS=("good_baseline" "midpoint" "bad_main")
+
+# Cell definition (the 7-tuple from SKILL.md "cell-definition discipline").
+MODEL="Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+DEPLOY_YAML="vllm_omni/deploy/qwen3_tts_high_concurrency.yaml"
+DATASET_NAME="seed-tts-text"
+DATASET_PATH="benchmarks/build_dataset/seed_tts_smoke"
+EXTRA_BODY='{"voice":"Vivian","language":"English","task_type":"CustomVoice"}'
+NUM_PROMPTS=512
+MAX_CONCURRENCY=64
+NUM_WARMUPS=8
+
+# Remote-host paths. Adapt to your host class per the remote-gpu skill;
+# on H20 hosts these must live under /mnt/<volume>/<your-dir>/ (NOT /home).
+VENV=/path/to/vllm-omni/.venv
+WT=/path/to/vllm-omni-bisect              # dedicated git worktree
+RESULTS=/path/to/bisect-results           # output dir
+HF_CACHE=/path/to/hf_cache
+
+# GPU pinning. nvidia-smi first; pick free GPUs.
+export CUDA_VISIBLE_DEVICES=4,5
+
+PORT=8092
+
+# ─── END EDIT ─────────────────────────────────────────────────────────────────
+
+mkdir -p "$RESULTS"
+source "$VENV/bin/activate"
+export PATH="$VENV/bin:$PATH"
+export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
+export HF_ENDPOINT=https://hf-mirror.com
+export HF_HOME="$HF_CACHE"
+export PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512
+
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+
+wait_for_ready() {
+    local timeout=${1:-1800}
+    local start=$(date +%s)
+    while true; do
+        if curl -s --max-time 5 "http://localhost:$PORT/v1/models" 2>/dev/null | grep -q "$MODEL"; then
+            sleep 30   # settling time: model in /v1/models, but graphs may still be compiling
+            log "Server ready (settled)."
+            return 0
+        fi
+        local now=$(date +%s)
+        if [ $((now - start)) -gt $timeout ]; then
+            log "Server-ready timeout after ${timeout}s."
+            return 1
+        fi
+        sleep 10
+    done
+}
+
+kill_server() {
+    pkill -9 -f "vllm.*serve\|OmniServer\|StageEngineCore\|stage_diffusion" 2>/dev/null || true
+    sleep 8
+}
+
+run_one() {
+    local sha="$1" label="$2"
+    log "=== Testing $label ($sha) ==="
+    cd "$WT"
+    kill_server
+    git checkout "$sha" 2>&1 | tail -3
+    git log -1 --format="HEAD: %H %s"
+
+    local outdir="$RESULTS/$label"; mkdir -p "$outdir"
+
+    log "Starting vllm serve (deploy=$DEPLOY_YAML)..."
+    nohup vllm serve "$MODEL" --omni \
+        --deploy-config "$DEPLOY_YAML" \
+        --port "$PORT" \
+        > "$outdir/server.log" 2>&1 &
+    local server_pid=$!
+    log "Server PID=$server_pid; waiting for ready..."
+
+    if ! wait_for_ready 1800; then
+        log "$label SERVER FAILED — tail of server.log:"
+        tail -50 "$outdir/server.log"
+        kill_server
+        return 1
+    fi
+
+    log "Running vllm bench serve (N=$NUM_PROMPTS, c=$MAX_CONCURRENCY, $NUM_WARMUPS warmups)..."
+    vllm bench serve --omni \
+        --base-url "http://localhost:$PORT" \
+        --backend openai-audio-speech \
+        --endpoint /v1/audio/speech \
+        --model "$MODEL" \
+        --dataset-name "$DATASET_NAME" \
+        --dataset-path "$DATASET_PATH" \
+        --extra-body "$EXTRA_BODY" \
+        --num-prompts "$NUM_PROMPTS" \
+        --num-warmups "$NUM_WARMUPS" \
+        --max-concurrency "$MAX_CONCURRENCY" \
+        --request-rate inf \
+        --percentile-metrics 'ttft,e2el,audio_rtf,audio_ttfp,audio_duration' \
+        --save-result \
+        --result-dir "$outdir" \
+        --result-filename "result.json" \
+        2>&1 | tee "$outdir/bench.log" | tail -60 || true
+
+    python - <<PY
+import json, glob
+files = sorted(glob.glob('$outdir/result*.json'))
+if not files:
+    print("  NO RESULT JSON FOUND")
+else:
+    d = json.load(open(files[0]))
+    print(f"  median_TTFP={d.get('median_audio_ttfp_ms', 0):8.1f}ms  "
+          f"p99={d.get('p99_audio_ttfp_ms', 0):8.1f}ms  "
+          f"RTF={d.get('median_audio_rtf', 0):.3f}  "
+          f"tput={d.get('audio_throughput', 0):6.1f}  "
+          f"completed={d.get('completed')}/{d.get('num_prompts')}")
+PY
+    kill_server
+}
+
+for i in "${!COMMITS[@]}"; do
+    run_one "${COMMITS[$i]}" "${LABELS[$i]}"
+done
+
+log "ALL DONE"
+log "=== FINAL SUMMARY ==="
+for label in "${LABELS[@]}"; do
+    echo "--- $label ---"
+    python - <<PY
+import json, glob
+files = sorted(glob.glob('$RESULTS/$label/result*.json'))
+if not files:
+    print("  NO RESULT")
+else:
+    d = json.load(open(files[0]))
+    print(f"  median_TTFP={d.get('median_audio_ttfp_ms', 0):8.1f}ms  "
+          f"p99={d.get('p99_audio_ttfp_ms', 0):8.1f}ms  "
+          f"RTF={d.get('median_audio_rtf', 0):.3f}  "
+          f"tput={d.get('audio_throughput', 0):6.1f}")
+PY
+done


### PR DESCRIPTION
## What

Adds `.claude/skills/perf-bisect/` — a project-local Claude Code skill that gives vllm-omni contributors a repeatable workflow for attributing a perf change (TTFP, RTF, audio throughput, image latency, step time) to a specific commit. Generalised from the TTS-only workflow used during the post-#3662 regression hunt (#3681 / #3817 / #3839) so the same discipline applies to diffusion-image and omni-audio bisects.

## Why

PR #3839's perf regression took several hours to attribute, mostly because of one trap: an initial bisect measured **the wrong cell** (Base `voice_clone` with the default deploy YAML) when the report was about CustomVoice `default_voice` under `qwen3_tts_high_concurrency.yaml`. The bench completed cleanly with apples-vs-oranges numbers and reported "no regression" while a +118% TTFP regression was live. This skill encodes the **cell-definition discipline** — extract all seven dimensions (model, task, deploy_yaml, dataset, num_prompts, max_concurrency, num_warmups) plus family-specific knobs from the regression report **before** writing any bench script — so the trap is harder to fall into next time.

## Layout

```
.claude/skills/perf-bisect/
├── SKILL.md                                  # discipline + 5-step workflow
├── references/
│   ├── family-knobs.md                       # extra_body / stage_overrides per family
│   └── pitfalls.md                           # 6 mechanical failure modes + remediations
└── scripts/
    ├── run_bisect.sh                         # bench-loop template
    ├── kanban_trend.py                       # metric time series from vllm-omni-kanban
    └── cells/
        ├── README.md                         # <family>_<descriptor>.yaml convention
        ├── tts_default_voice_high_c.yaml     # #3839's regression cell
        └── tts_voice_clone_nightly.yaml      # kanban-parity cell
```

## Contents

- **`SKILL.md`** — trigger phrases (English + Chinese), paired tools (`remote-gpu`, `tts-perf-check`, the kanban repo), the generic 7-tuple cell-discipline table, a family-specific knob TL;DR, the 5-step workflow (kanban triage → bisect span → bench harness → interpret → variance check), a rationalization table of excuses-vs-reality, and a red-flags pre-flight list.
- **`references/family-knobs.md`** — full knob tables for TTS / diffusion-image / omni-audio (`task_type`, `voice`, `language`, `width`, `height`, `num_inference_steps`, `stage_overrides`) plus the headline metric each family reports.
- **`references/pitfalls.md`** — six failure modes caught in real bisects, each with a copy-paste remediation snippet: `pytest -k` zero-match, venv PATH not inherited by subprocess, stale server PID binding the wrong port, multi-tenant GPU contention, `/v1/models` returning before CUDA-graph compile, cold model download exceeding the server-ready timeout.
- **`scripts/run_bisect.sh`** — bench-loop template that pairs `vllm serve` (with `--deploy-config`) and `vllm bench serve --omni`, polls `/v1/models` with a 30s settle window, parses median/p99 TTFP + RTF + throughput from the saved JSON, and cleans up the server between commits.
- **`scripts/kanban_trend.py`** — prints a per-build metric time series from `vllm-omni-kanban` with rolling-delta percent and `←REG` / `←IMP` markers at the 10% threshold; works for any cell prefix the kanban tracks.
- **`scripts/cells/`** — two production cells (the #3839 high-c regression cell and the Base voice_clone kanban-parity cell) plus a README documenting the `<family>_<descriptor>.yaml` convention so diffusion_* / omni_* cells can be added without collisions.

## Triggers

Natural-language phrases that should activate the skill:

- "find which PR regressed Qwen3-TTS perf"
- "bisect TTFP between commit X and Y"
- "verify PR #N actually improves perf"
- "高并发 TTFP 劣化"

## Scope

This skill is **investigation**, not prevention. Writing a new perf regression test belongs in `tests/dfx/perf/`. Reading existing perf trends belongs in `vllm-omni-kanban`. Cross-version (vllm 0.20 ↔ 0.21) bisects need two venvs and are explicitly out of scope.

## Verification

- Skill picked up by Claude Code's skill registry (verified locally — `Skill(perf-bisect)` invokes correctly).
- All five resource references in `SKILL.md` resolve to files in the diff.
- No session-detail (dates, host names, reproduction logs) in any docstring or comment.
- Quality rubric: 96/100 (A) — description 97, organization 94, style 92, structure 100.

## How to use

In any Claude Code session inside this repo:

```
@perf-bisect bisect TTFP between abc123 and def456 for CustomVoice default_voice c=64 N=512 with the high-c YAML
```

The skill will ask for the missing cell dimensions if any are unspecified, then walk through kanban triage → bisect span → bench loop → interpretation.

## Out of scope for this PR

- Other model families' cell files (anyone can add `diffusion_*.yaml` / `omni_*.yaml` in a follow-up).
- Wiring this into Buildkite as an automated CI step. A separate PR will propose a `tts-perf-regression-ci` mechanism that uses this skill's cell convention for its specs.
