### PR TITLE
[Docs] Reduce rendered docs page weight

### DIFF
--- a/docs/mkdocs/hooks/generate_examples.py
+++ b/docs/mkdocs/hooks/generate_examples.py
@@ -16,6 +16,7 @@ ROOT_DIR_RELATIVE = "../../../../.."
 EXAMPLE_DIR = ROOT_DIR / "examples"
 EXAMPLE_DOC_DIR = ROOT_DIR / "docs/user_guide/examples"
 NAV_FILE = ROOT_DIR / "docs/.nav.yml"
+MAX_INLINE_MATERIAL_SIZE = 256 * 1024
 
 
 def fix_case(text: str) -> str:
@@ -183,26 +184,27 @@ class Example:
             gh_file = gh_file.relative_to(ROOT_DIR)
 
             # Make GitHub URL
-            url = "https://github.com/vllm-project/vllm-omni/"
-            url += "tree/main" if self.path.is_dir() else "blob/main"
-            gh_url = f"{url}/{gh_file}"
+            gh_url = self.github_url(ROOT_DIR / gh_file)
 
             return f"[{link_text}]({gh_url})"
 
         return re.sub(link_pattern, replace_link, content)
 
+    def github_url(self, path: Path) -> str:
+        url = "https://github.com/vllm-project/vllm-omni/"
+        url += "tree/main" if path.is_dir() else "blob/main"
+        return f"{url}/{path.relative_to(ROOT_DIR).as_posix()}"
+
     def generate(self) -> str:
         content = f"# {self.title}\n\n"
-        url = "https://github.com/vllm-project/vllm-omni/"
-        url += "tree/main" if self.path.is_dir() else "blob/main"
-        content += f"Source <{url}/{self.path.relative_to(ROOT_DIR)}>.\n\n"
+        content += f"Source <{self.github_url(self.path)}>.\n\n"
 
         # Use long code fence to avoid issues with
         # included files containing code fences too
         code_fence = "``````"
 
         if self.is_code:
-            main_file_rel = self.main_file.relative_to(ROOT_DIR)
+            main_file_rel = self.main_file.relative_to(ROOT_DIR).as_posix()
             content += f'{code_fence}{self.main_file.suffix[1:]}\n--8<-- "{main_file_rel}"\n{code_fence}\n'
         else:
             with open(self.main_file, encoding="utf-8") as f:
@@ -216,10 +218,15 @@ class Example:
 
         content += "## Example materials\n\n"
         for file in sorted(self.other_files):
-            content += f'??? abstract "{file.relative_to(self.path)}"\n'
+            content += f'??? abstract "{file.relative_to(self.path).as_posix()}"\n'
+            if file.stat().st_size > MAX_INLINE_MATERIAL_SIZE:
+                content += (
+                    f"    Large file omitted from the rendered docs. View it on GitHub: <{self.github_url(file)}>.\n\n"
+                )
+                continue
             if file.suffix != ".md":
                 content += f"    {code_fence}{file.suffix[1:]}\n"
-            content += f'    --8<-- "{file.relative_to(ROOT_DIR)}"\n'
+            content += f'    --8<-- "{file.relative_to(ROOT_DIR).as_posix()}"\n'
             if file.suffix != ".md":
                 content += f"    {code_fence}\n"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,8 +38,6 @@ theme:
   features:
     - content.action.edit
     - content.code.copy
-    - navigation.instant
-    - navigation.instant.progress
     - navigation.tracking
     - navigation.tabs
     - navigation.tabs.sticky
@@ -117,6 +115,7 @@ plugins:
             separate_signature: true
             show_overloads: true
             signature_crossrefs: true
+            show_source: false
           inventories:
           - https://docs.python.org/3/objects.inv
           - https://typing-extensions.readthedocs.io/en/latest/objects.inv


### PR DESCRIPTION
## Summary

- Skip inlining large generated example material files and link them to GitHub instead.
- Disable API source rendering from mkdocstrings to reduce generated API page size.
- Disable MkDocs Material instant navigation so heavy docs pages use normal browser navigation and release page state on route changes.

## Root Cause

The docs build can render very large pages. The examples generator may inline non-binary material files such as `message_base64_wav.json`, and mkdocstrings embeds source blocks on API pages by default. With instant navigation enabled, repeated clicks through these heavy pages can accumulate browser work and make local `mkdocs serve` sessions unstable.

## Validation

- Ran the examples hook with `uv run --no-project --with regex --with pyyaml` and confirmed `message_base64_wav.json` is replaced with a GitHub link.
- Ran `mkdocs build` successfully in a docs-only environment with `PYTHONUTF8=1`.
- Served the generated `site/` locally and opened several heavy example/API pages in the browser; page headings rendered correctly and no console errors were reported.
- Ran `ruff check docs/mkdocs/hooks/generate_examples.py`.
- Ran `git diff --check`.