### PR TITLE
[CI][Bugfix]Fix Wan2.2 I2V reference image upload

### DIFF
--- a/tests/e2e/accuracy/wan22_i2v/test_wan22_i2v_video_similarity.py
+++ b/tests/e2e/accuracy/wan22_i2v/test_wan22_i2v_video_similarity.py
@@ -359,8 +359,17 @@ def _validate_image_source(source: str) -> None:
 
 
 def _build_online_image_reference(source: str) -> str:
-    if _is_remote_image_source(source) or source.startswith("data:image"):
+    if source.startswith("data:image"):
         return source
+
+    if _is_remote_image_source(source):
+        response = requests.get(source, timeout=60)
+        response.raise_for_status()
+        mime_type = response.headers.get("Content-Type", "").split(";", 1)[0].strip()
+        if not mime_type.startswith("image/"):
+            mime_type = guess_type(urlparse(source).path)[0] or "image/png"
+        encoded = b64encode(response.content).decode("ascii")
+        return f"data:{mime_type};base64,{encoded}"
 
     image_path = Path(source)
     mime_type = guess_type(image_path.name)[0] or "image/png"
@@ -479,7 +488,10 @@ def _send_video_request_with_timeout(
         headers={"Accept": "application/json"},
         timeout=60,
     )
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        raise requests.HTTPError(f"{exc}; response body: {response.text}", response=response) from exc
     job_data = response.json()
     video_id = job_data["id"]
     openai_client._wait_until_video_completed(video_id, timeout_seconds=timeout_seconds)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

  Fix the Wan2.2 I2V nightly accuracy test by avoiding server-side downloads of the remote reference image. The test now resolves remote image references in the pytest
  process and sends them to /v1/videos as uploaded image data, making the request path more reliable in CI.

  Also include the response body in HTTP errors from the video create request so future 400 failures show the FastAPI error detail directly in CI logs.

  ## Test Plan

  Run the lightweight helper tests for the changed Wan2.2 I2V test file:

  pytest -q tests/e2e/accuracy/wan22_i2v/test_wan22_i2v_video_similarity.py -k 'build_online_image_reference or send_video_request_with_timeout or online_timeout_defaults'

  ## Test Result

  3 passed, 13 deselected

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
