### PR TITLE
[CI][bugfix] Fix latency degradation in diffusers backend test 

### DIFF
--- a/tests/e2e/accuracy/test_diffusers_backend_similarity.py
+++ b/tests/e2e/accuracy/test_diffusers_backend_similarity.py
@@ -85,6 +85,7 @@ def _run_vllm_omni_wan22_i2v(
         str(BOUNDARY_RATIO),
         "--flow-shift",
         str(FLOW_SHIFT),
+        "--disable-log-stats",
     ]
     form_data = {
         "prompt": VIDEO_PROMPT,
@@ -174,6 +175,7 @@ def _run_vllm_omni_qwen_image(*, model: str, output_path: Path) -> tuple[Image.I
         "900",
         "--diffusion-load-format",
         "diffusers",
+        "--disable-log-stats",
         # "--enable-diffusion-pipeline-profiler",
     ]
     with OmniServer(model, server_args, use_omni=True) as omni_server:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix #3867.

**Why:**

- The range has no direct Qwen-Image/diffusers backend model changes.
- e996723b adds per-request summary logging in vllm_omni/entrypoints/omni_base.py.
- This test’s OmniServer helper auto-adds --log-stats unless explicitly disabled:

## Test Plan

- explicitly disable stats logging (`--disable-log-stats`) in the diffusers backend server args
- This line is already present in several other tests, and it does not affect the final output.
- After adding this line, the results are as follows


## Test Result

e996723b with the fix:

```
Qwen/Qwen-Image latency metrics:
  Latency=3406.15ms, threshold<=3792.76ms, diffusers latency=3160.64ms, lower is better
Qwen/Qwen-Image latency metrics:
  Latency=3458.66ms, threshold<=3985.40ms, diffusers latency=3321.17ms, lower is better
```

main HEAD plus the fix

```
TBA
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
