### PR TITLE
[Feat] opt qwen image model load use ColumnParallelLinear replace ReplicatedLinear

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -729,7 +729,7 @@ class QwenImageTransformerBlock(nn.Module):
                 gather_output=True,
                 return_bias=False,
                 quant_config=None,
-                prefix="img_mod.1",
+                prefix=_join_prefix(prefix, "txt_mod.1"),
             ),
         )
         self.img_norm1 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)
@@ -760,7 +760,7 @@ class QwenImageTransformerBlock(nn.Module):
                 gather_output=True,
                 return_bias=False,
                 quant_config=None,
-                prefix="txt_mod.1",
+                prefix=_join_prefix(prefix, "img_mod.1"),
             ),
         )
         self.txt_norm1 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -729,7 +729,7 @@ class QwenImageTransformerBlock(nn.Module):
                 gather_output=True,
                 return_bias=False,
                 quant_config=None,
-                prefix=_join_prefix(prefix, "txt_mod.1"),
+                prefix=_join_prefix(prefix, "img_mod.1"),
             ),
         )
         self.img_norm1 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)
@@ -760,7 +760,7 @@ class QwenImageTransformerBlock(nn.Module):
                 gather_output=True,
                 return_bias=False,
                 quant_config=None,
-                prefix=_join_prefix(prefix, "img_mod.1"),
+                prefix=_join_prefix(prefix, "txt_mod.1"),
             ),
         )
         self.txt_norm1 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -716,18 +716,20 @@ class QwenImageTransformerBlock(nn.Module):
         self.attention_head_dim = attention_head_dim
 
         # Image processing modules.
-        # Modulation linear is kept full precision (quant_config=None) — it
+        # Modulation linear is kept unquantized (quant_config=None) — it
         # produces shift/scale/gate values that are precision-sensitive
-        # (see #2728).
+        # (see #2728). Use column TP with gather_output=True so weights are
+        # sharded while downstream modulation still receives full [B, 6 * dim].
         self.img_mod = nn.Sequential(
             nn.SiLU(),
-            ReplicatedLinear(
+            ColumnParallelLinear(
                 dim,
                 6 * dim,
                 bias=True,
+                gather_output=True,
                 return_bias=False,
                 quant_config=None,
-                prefix=_join_prefix(prefix, "img_mod.1"),
+                prefix="img_mod.1",
             ),
         )
         self.img_norm1 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)
@@ -751,13 +753,14 @@ class QwenImageTransformerBlock(nn.Module):
         # Text processing modules.
         self.txt_mod = nn.Sequential(
             nn.SiLU(),
-            ReplicatedLinear(
+            ColumnParallelLinear(
                 dim,
                 6 * dim,
                 bias=True,
+                gather_output=True,
                 return_bias=False,
                 quant_config=None,
-                prefix=_join_prefix(prefix, "txt_mod.1"),
+                prefix="txt_mod.1",
             ),
         )
         self.txt_norm1 = AdaLayerNorm(dim, elementwise_affine=False, eps=eps)


### PR DESCRIPTION
…licatedLinear

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

I attempted to launch the `Qwen/Qwen-Image-Edit-2511` model on a node equipped with eight NVIDIA GeForce RTX 5090 GPUs using Omni. However, upon setting the `--tensor-parallel-size` parameter to 8, I found that the service failed to start, throwing an OOM (Out of Memory) error.

```
CUDA out of memory. Tried to allocate 20.00 MiB. GPU 2 has a total capacity of 31.36 GiB of which 3.19 MiB is free. Including non-PyTorch memory, this process has 31.35 GiB memory in use. Of the allocated memory 30.75 GiB is allocated by PyTorch, and 9.90 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)
```

I analyzed the model structure; the structure and dimensions are as follows:
```
text_encoder:               ~16.6 GB / GPU
vae:                         ~0.25 GB / GPU
transformer replicated part: Per GPU = ~13 GB
transformer TP :    Per GPU =  40.9GB / TP Size ~ 5.1GB
```
All told, loading the model requires 30GB+ of memory per GPU.
If we attempt to launch on a 32GB GPU, we will encounter an out-of-memory error.

I discovered that the replicated Transformer model was not being loaded with Tensor Parallelism (TP) sharding; however, once loaded with TP sharding, it runs successfully on 32GB of memory.

## Test Plan

After making the modifications, I conducted a basic test and a comparative performance test.

- Base Test
```
import base64
from openai import OpenAI
from pathlib import Path
client = OpenAI(
    api_key="None",
    base_url="http://localhost:8000/v1"
)

input_image_url = "https://vllm-public-assets.s3.us-west-2.amazonaws.com/omni-assets/qwen-bear.png"

result = client.images.edit(
    image=[],
    model="public/qwen-image-edit-2512",
    prompt="Change the bears in the two input images into walking together.",
    size='512x512',
    stream=False,
    output_format='jpeg',
    # url格式
    extra_body={
        "url": [input_image_url,input_image_url],
        "num_inference_steps": 50,
        "guidance_scale": 1,
        "seed": 777,
    }
)

image_base64 = result.data[0].b64_json
image_bytes = base64.b64decode(image_base64)

# Save the image to a file
with open("edit_out_http.jpeg", "wb") as f:
    f.write(image_bytes)
```

<img width="512" height="512" alt="edit_out_http (1)" src="https://github.com/user-attachments/assets/31b33aa1-5dec-4d72-b553-0393fb509d0b" />

- Benchmark test
```
python3 /app/vllm-omni/benchmarks/diffusion/diffusion_benchmark_serving.py \
  --backend vllm-omni \
  --base-url http://127.0.0.1:8000 \
  --model public/qwen-image-edit-2512 \
  --task i2i \
  --dataset random \
  --num-prompts 5 \
  --max-concurrency 1 \
  --width 512 \
  --height 512 \
  --num-inference-steps 25 \
  --num-input-images 1 \
  --output-file /tmp/qwen_image_edit_2511_tp8_smoke.json
```

- BaseLine:
```
$ vllm serve /data/serving-model --served-model-name public/qwen-image-edit-2512 --use-hsdp --hsdp-shard-size 8  --omni  
```

```
================= Serving Benchmark Result =================
Backend:                                 vllm-omni      
Model:                                   public/qwen-image-edit-2512
Dataset:                                 random         
Task:                                    i2i            
--------------------------------------------------
Benchmark duration (s):                  145.34         
Request rate:                            inf            
Max request concurrency:                 1              
Successful requests:                     5/5              
--------------------------------------------------
Request throughput (req/s):              0.03           
Latency Mean (s):                        29.0683        
Latency Median (s):                      29.0748        
Latency P99 (s):                         29.0867        
Latency P95 (s):                         29.0849        
--------------------------------------------------
Peak Memory Max (MB):                    23548.00       
Peak Memory Mean (MB):                   23548.00       
Peak Memory Median (MB):                 23548.00       
--------------------------------------------------
Stage Durations Mean (s):
  queue_wait_ms:                         0.7627         
  stage_0_gen_ms:                        28861.9870     

============================================================
```

- Optimization after：

```
vllm serve /data/serving-model --served-model-name public/qwen-image-edit-2512 --tensor-parallel-size 8  --omni
```

```
================= Serving Benchmark Result =================
Backend:                                 vllm-omni      
Model:                                   public/qwen-image-edit-2512
Dataset:                                 random         
Task:                                    i2i            
--------------------------------------------------
Benchmark duration (s):                  39.63          
Request rate:                            inf            
Max request concurrency:                 1              
Successful requests:                     5/5              
--------------------------------------------------
Request throughput (req/s):              0.13           
Latency Mean (s):                        7.9247         
Latency Median (s):                      7.9300         
Latency P99 (s):                         7.9620         
Latency P95 (s):                         7.9570         
--------------------------------------------------
Peak Memory Max (MB):                    23196.00       
Peak Memory Mean (MB):                   23196.00       
Peak Memory Median (MB):                 23196.00       
--------------------------------------------------
Stage Durations Mean (s):
  queue_wait_ms:                         0.9937         
  stage_0_gen_ms:                        7712.8094      

============================================================
```

After optimization, P99 latency performance improved 3.5-fold. from 29.0849s -> 7.9570s.

## Test Result

---
- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [X] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
