### PR TITLE
Fix Ovis image text encoder dtype

### DIFF
--- a/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
+++ b/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
@@ -168,7 +168,10 @@ class OvisImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMi
         )
 
         self.text_encoder = Qwen3Model.from_pretrained(
-            model, subfolder="text_encoder", local_files_only=local_files_only
+            model,
+            subfolder="text_encoder",
+            local_files_only=local_files_only,
+            torch_dtype=od_config.dtype,
         )
 
         self.vae = AutoencoderKL.from_pretrained(model, subfolder="vae", local_files_only=local_files_only).to(


### PR DESCRIPTION
fixes #3863 



## Bug: 
Ovis-Image dtype mismatch with Transformers main/dev

### Summary

`AIDC-AI/Ovis-Image-7B` now fails during offline text-to-image warmup with a dtype mismatch:

```text
RuntimeError: mat1 and mat2 must have the same dtype, but got Float and BFloat16
```

This worked when Ovis-Image was introduced in `4586efe65` (`[Model] Ovis Image Model Addition (#263)`).

### Repro

```bash
python examples/offline_inference/text_to_image/text_to_image.py \
  --model AIDC-AI/Ovis-Image-7B \
  --num-inference-steps 15 \
  --seed 0 \
  --height 256 \
  --width 256
```

Failing environment from the log:

```text
transformers: 5.10.0.dev0
diffusers: 0.38.0
torch: 2.11.0+cu130
GPU: A100
```

### Error

```text
File "vllm_omni/diffusion/models/ovis_image/ovis_image_transformer.py", line 455, in forward
  hidden_states = self.x_embedder(hidden_states)

RuntimeError: mat1 and mat2 must have the same dtype, but got Float and BFloat16
```

### Root Cause

Ovis-Image loads the text encoder without an explicit dtype:

```python
self.text_encoder = Qwen3Model.from_pretrained(
    model, subfolder="text_encoder", local_files_only=local_files_only
)
```

The pipeline previously relied on vLLM-Omni’s outer `set_default_torch_dtype(od_config.dtype)` context.

Recent Transformers dtype-loading changes changed that behavior:

- https://github.com/huggingface/transformers/pull/42805 (`6217adc6c8`, “Default auto”) changed omitted `dtype` to default to `"auto"`.
- https://github.com/huggingface/transformers/pull/42825 (`64a7cc82a6`, “Simplify dtype instantiation”) applies the resolved dtype during model construction via `local_torch_dtype(...)`.

Together, `Qwen3Model.from_pretrained(...)` can now resolve/init as fp32 instead of inheriting vLLM-Omni’s bf16 context. Ovis then prepares fp32 latents from `prompt_embeds.dtype`, while the diffusion transformer weights are bf16.

### Fix

Pin the text encoder dtype to the configured vLLM-Omni dtype:

```python
self.text_encoder = Qwen3Model.from_pretrained(
    model,
    subfolder="text_encoder",
    local_files_only=local_files_only,
    torch_dtype=od_config.dtype,
)
```

This matches existing vLLM-Omni diffusion pipeline patterns used by SD3, Wan2.2, Ernie Image, GLM Image, and LTX2.

### Result :
```bash
--- Python CUDA Stack Status ---
PyTorch: 2.11.0+cu130
CUDA Available: True
CUDA Device: NVIDIA A100-SXM4-40GB
CUDA Version: 13.0
Device Capability: (8, 0)
vllm: 0.21.0
vllm-omni: 0.1.dev1+g65dc6686b
flashinfer-python: 0.6.8.post1
flashinfer-cubin: 0.6.8.post1
flash-attn: not installed
triton: 3.6.0
transformers: 5.10.0.dev0
diffusers: 0.38.0
```
```bash
Generation Configuration:
  Model: AIDC-AI/Ovis-Image-7B
  Inference steps: 15
  Cache backend: None (no acceleration)
  Quantization: None (BF16)
  Parallel configuration: tensor_parallel_size=None, ulysses_degree=1, ulysses_mode=strict, ring_degree=1, cfg_parallel_size=1, vae_patch_parallel_size=1, enable_expert_parallel=False.
  CPU offload: False; CPU Layerwise Offload: False
  Image size: 256x256

```
<img width="256" height="256" alt="ovis_image_output" src="https://github.com/user-attachments/assets/cd069b77-53e6-4885-a5ec-615ba55b202f" />


Colab notebook : [LINK](<https://colab.research.google.com/drive/1iJCROSqmG4DI7D635TMGgkiAymFm-dX6?usp=sharing>)

