### PR TITLE
[bugfix] fix default deploy config in hunyuan_image offline example

### DIFF
--- a/examples/offline_inference/hunyuan_image3/end2end.py
+++ b/examples/offline_inference/hunyuan_image3/end2end.py
@@ -17,7 +17,7 @@ from vllm_omni.entrypoints.omni import Omni
 from vllm_omni.inputs.data import OmniPromptType
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
-_DEFAULT_DEPLOY_CONFIG = str(_REPO_ROOT / "vllm_omni" / "deploy" / "hunyuan_image3.yaml")
+_DEFAULT_DEPLOY_CONFIG = str(_REPO_ROOT / "vllm_omni" / "deploy" / "hunyuan_image_3_moe.yaml")
 _DEFAULT_AR_DEPLOY_CONFIG = str(_REPO_ROOT / "vllm_omni" / "deploy" / "hunyuan_image3_ar.yaml")
 
 _MODALITY_TASK_MAP: dict[str, tuple[str, str | None]] = {


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
fix default deploy config in hunyuan_image offline example
error occur when run default offline example with following cmd:
```
python vllm-omni/examples/offline_inference/hunyuan_image3/end2end.py \
  --model tencent/HunyuanImage-3.0-Instruct-Distil \
  --modality img2img \
  --image-path ./input_0_0.png \
  --bot-task think_recaption \
  --prompts "新年宠物海报，Q版圆润的可爱标题“新年快乐汪”，副标题“HAPPY NEW YEAR”。 鱼眼镜头，背景是房间门口，近景，上传的主体歪头笑，围着红色围巾，戴着红色毛线帽，高清，绒毛细节，面部特写。 宝丽莱相纸，超现实主义，写实主义，胶片摄影，打印颗粒感肌理。肌理，超写实，复古感。" \
  | tee output.log
```
error:
```
WARNING 05-26 13:15:44 [stage_config.py:1161] Deploy config not found: /home/zc/vllm-omni/vllm_omni/deploy/hunyuan_image3.yaml — using pipeline defaults only
Traceback (most recent call last):
  File "/home/zc/vllm-omni/examples/offline_inference/hunyuan_image3/end2end.py", line 301, in <module>
    main()
  File "/home/zc/vllm-omni/examples/offline_inference/hunyuan_image3/end2end.py", line 173, in main
    omni = Omni(**omni_kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/zc/vllm-omni/vllm_omni/entrypoints/omni_base.py", line 174, in __init__
    self.engine = AsyncOmniEngine(
                  ^^^^^^^^^^^^^^^^
  File "/home/zc/vllm-omni/vllm_omni/engine/async_omni_engine.py", line 336, in __init__
    self.config_path, self.stage_configs = self._resolve_stage_configs(model, kwargs)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zc/vllm-omni/vllm_omni/engine/async_omni_engine.py", line 2060, in _resolve_stage_configs
    config_path, stage_configs = load_and_resolve_stage_configs(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zc/vllm-omni/vllm_omni/entrypoints/utils.py", line 611, in load_and_resolve_stage_configs
    stage_configs = load_stage_configs_from_model(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zc/vllm-omni/vllm_omni/entrypoints/utils.py", line 399, in load_stage_configs_from_model
    stages = StageConfigFactory.create_from_model(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zc/vllm-omni/vllm_omni/config/stage_config.py", line 1099, in create_from_model
    return cls._create_from_registry(model_type, cli_overrides, deploy_config_path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zc/vllm-omni/vllm_omni/config/stage_config.py", line 1182, in _create_from_registry
    stages = merge_pipeline_deploy(pipeline_cfg, deploy_cfg, cli_overrides)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zc/vllm-omni/vllm_omni/config/stage_config.py", line 858, in merge_pipeline_deploy
    raise ValueError(
ValueError: Pipeline 'hunyuan_image_3_moe' has async_chunk=True in deploy but no stage declares a next-stage input processor (``async_chunk_process_next_stage_input_func`` or ``custom_process_next_stage_input_func``). Either set async_chunk=False or implement an async-chunk processor on the pipeline.
```
it is easy to find default yaml name wrong in offline end2end.py

## Test Plan
offline bash test as shown in Purpose

## Test Result
offline example goes well with default yaml config
```
[Output] Text:
用户希望将参考图中可爱的金毛幼犬转化为一张具有新年氛围的宠物海报。参考图展示了一只坐在木质地板上的金毛幼犬，背景是户外的白色花朵。原始指令非常具体，要求改变背景、添加配饰、调整构图和风格。首先，背景需要从户外切换到室内门口，这涉及到场景的完全重构。其次，为了符合新年主题，需要给小狗戴上红色的毛线帽和红色的围巾，这不仅是配饰的增加，也是色彩氛围的营造。构图上，指令要求采用鱼眼镜头效果，这意味着画面中心会向外扩张，产生一种夸张的视觉冲击力，小狗的头部会显得更大，身体比例也会相应变化。最后，整体风格要模仿宝丽莱相纸，带有胶片颗粒感和复古质感，文字部分则需要添加特定的新年祝福语。在改写指令时，我需要将这些抽象的风格描述转化为具体的视觉特征，比如明确鱼眼镜头带来的透视变形，以及宝丽莱相纸特有的白色边框和质感，确保生成的图像能够精准捕捉到这种复古且温馨的节日氛围。</think><recaption>将参考图中的金毛幼犬重新创作为一张复古风格的宝丽莱新年海报。请将背景从户外的木地板和花朵更换为室内的门口场景，地面改为浅色瓷砖。给小狗戴上一顶红色的针织毛线帽和一条厚实的红色围巾。调整构图，采用鱼眼镜头拍摄视角，使小狗的头部在画面中心显得圆润且巨大，身体向四周延伸产生透视变形。在图像上方添加圆润可爱的艺术字体标题新年快乐汪，并在下方添加较小的英文副标题HAPPY NEW YEAR。整张图片要呈现出宝丽莱相纸的效果，包括标志性的白色宽边框，以及带有胶片颗粒感和轻微噪点的复古写实摄影质感。</recaption>
[Output] Saved image to ./output_0_0.png
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
