### PR TITLE
[BugFix] Fix Qwen3-TTS Code2Wav compatibility with transformers >= 5.9.0

### DIFF
--- a/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
@@ -17,7 +17,7 @@ import math
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
-
+import inspect
 import numpy as np
 import torch
 from torch import nn
@@ -565,12 +565,17 @@ class Qwen3TTSTokenizerV2DecoderTransformerModel(Qwen3TTSTokenizerV2DecoderPreTr
             # Prepare mask arguments
             mask_kwargs = {
                 "config": self.config,
-                "input_embeds": inputs_embeds,
                 "attention_mask": attention_mask,
-                "cache_position": cache_position,
                 "past_key_values": past_key_values,
                 "position_ids": position_ids,
             }
+            # Handle API changes across transformers versions
+            sig = inspect.signature(create_causal_mask)
+            if "input_embeds" in sig.parameters:
+                mask_kwargs["input_embeds"] = inputs_embeds
+                mask_kwargs["cache_position"] = cache_position
+            else:
+                mask_kwargs["inputs_embeds"] = inputs_embeds
             # Create the masks
             causal_mask_mapping = {
                 "full_attention": create_causal_mask(**mask_kwargs),

--- a/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 """PyTorch Qwen3TTSTokenizerV2 model."""
 
+import inspect
 import math
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
-import inspect
+
 import numpy as np
 import torch
 from torch import nn


### PR DESCRIPTION
## Summary

- Fix compatibility between Qwen3-TTS Code2Wav decoder and transformers >= 5.9.0 by adapting to breaking API changes in `create_causal_mask`.

## Problem

The `transformers` library introduced three breaking changes to `masking_utils.create_causal_mask` that affect vLLM-Omni's Qwen3-TTS tokenizer/decoder model:

| Date       | Commit             | Change                                    |
|------------|--------------------|-------------------------------------------|
| 2026-02-11 | `6c6f70c` (#43916) | Renamed `input_embeds` to `inputs_embeds` |
| 2026-03-04 | `421c7f6` (#44181) | Removed `cache_position` parameter        |
| 2026-05-11 | `2d6815e` (#45885) | Removed backward-compatible `input_embeds` alias |

Since vLLM's dependency constraints allow installing `transformers 5.9.0`, users who build vLLM-Omni from source (e.g., on CUDA 12.x where pre-built wheels require CUDA 13.0+) can hit this incompatibility. The error manifests during CUDA Graph warmup for the Code2Wav decoder:

<details>
<summary>Full error log</summary>

```
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722] Failed to enable CUDA Graph for Code2Wav decoder
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722] Traceback (most recent call last):
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]   File ".../vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_code2wav.py", line 709, in load_weights
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]     self.decoder.enable_cudagraph(
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]   File ".../vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py", line 881, in enable_cudagraph
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]     self._cudagraph_wrapper.warmup(
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]   File ".../vllm_omni/model_executor/models/qwen3_tts/cuda_graph_decoder_wrapper.py", line 334, in warmup
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]     _ = self.decoder(dummy)
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]         ^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]   File ".../torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]     return self._call_impl(*args, **kwargs)
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]   File ".../torch/nn/modules/module.py", line 1790, in _call_impl
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]     return forward_call(*args, **kwargs)
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]   File ".../vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py", line 910, in forward
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]     hidden = self.pre_transformer(inputs_embeds=hidden).last_hidden_state
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]   File ".../vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py", line 576, in forward
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]     "full_attention": create_causal_mask(**mask_kwargs),
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722]                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(StageEngineCoreProc pid=9773) WARNING 05-26 08:42:50 [qwen3_tts_code2wav.py:722] TypeError: create_causal_mask() got an unexpected keyword argument 'input_embeds'
```

</details>

This causes CUDA Graph capture to fail silently, falling back to eager mode with a performance penalty.

## Fix

Use `inspect.signature()` to detect the parameter names accepted by `create_causal_mask` at runtime and pass the correct keyword arguments:

- **Old transformers** (< 5.9.0): passes `input_embeds` and `cache_position`
- **New transformers** (>= 5.9.0): passes `inputs_embeds` only (no `cache_position`)

This approach is fully backward-compatible - no minimum transformers version bump required.

## Changes

- `vllm_omni/model_executor/models/qwen3_tts/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py`: Use runtime introspection of `create_causal_mask` signature to adapt keyword arguments across transformers versions.

## Test Plan

- [ ] Verify Code2Wav decoder loads and CUDA Graph captures successfully with `transformers < 5.9.0`
- [ ] Verify Code2Wav decoder loads and CUDA Graph captures successfully with `transformers >= 5.9.0`
- [ ] Run Qwen3-TTS end-to-end TTS inference on both transformers versions
