### PR TITLE
[CosyVoice3] Add online serving example and harden sampler

### DIFF
--- a/docs/user_guide/examples/online_serving/text_to_speech.md
+++ b/docs/user_guide/examples/online_serving/text_to_speech.md
@@ -17,14 +17,13 @@ For the full list of supported architectures across all modalities, see
 
 | Model | HuggingFace repo | Voice cloning | Streaming | Voice presets / upload | Gradio demo |
 |---|---|---|---|---|---|
+| CosyVoice3 | `FunAudioLLM/Fun-CosyVoice3-0.5B-2512` | ✓ (`ref_audio`+`ref_text`) | ✓ (PCM + WebSocket) | upload | — |
 | Fish Speech S2 Pro | `fishaudio/s2-pro` | ✓ (`ref_audio`+`ref_text`) | ✓ (PCM stream) | — | ✓ |
 | OmniVoice | `k2-fsa/OmniVoice` | (offline only) | — | — | — |
 | Qwen3-TTS | `Qwen/Qwen3-TTS-12Hz-1.7B-{CustomVoice,VoiceDesign,Base}` | ✓ (Base) | ✓ (PCM + WebSocket) | ✓ (presets + `/v1/audio/voices` upload) | ✓ (standard + FastRTC) |
 | VoxCPM | local model dir | ✓ | ✓ (PCM stream) | — | — |
 | VoxCPM2 | `openbmb/VoxCPM2` | ✓ | ✓ (AudioWorklet via gradio) | — | ✓ |
 | Voxtral TTS | `mistralai/Voxtral-4B-TTS-2603` | ✓ (gated upstream) | ✓ | ✓ (presets) | ✓ |
-
-CosyVoice3 is intentionally absent: no online example exists for it yet. See its [offline section](https://github.com/vllm-project/vllm-omni/tree/main/examples/offline_inference/text_to_speech/README.md#cosyvoice3) instead.
 
 ## Common Quick Start
 
@@ -93,6 +92,95 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 Adjust the player's sample rate to match the model (44.1 kHz for Fish Speech, 48 kHz for VoxCPM2, 24 kHz for the others).
 
 For full request-shape documentation (all parameters, response formats, error codes), see the [Speech API reference](https://github.com/vllm-project/vllm-omni/tree/main/docs/serving/speech_api.md).
+
+---
+
+## CosyVoice3
+
+2-stage TTS pipeline (`talker` + `code2wav`) at 24 kHz. Online serving uses voice cloning: every request must provide `ref_audio` and `ref_text`.
+
+The upstream zero-shot prompt audio should be paired with the full prompt text shown below. Dropping the `You are a helpful assistant.<|endofprompt|>` prefix changes the conditioning prompt.
+
+### Launch
+```bash
+vllm-omni serve FunAudioLLM/Fun-CosyVoice3-0.5B-2512 \
+    --tokenizer FunAudioLLM/Fun-CosyVoice3-0.5B-2512/CosyVoice-BlankEN \
+    --deploy-config vllm_omni/deploy/cosyvoice3.yaml \
+    --trust-remote-code \
+    --omni \
+    --port 8091
+# or:
+./cosyvoice3/run_server.sh
+```
+
+`vllm_omni/deploy/cosyvoice3.yaml` defaults to `async_chunk: true`. Pass `--no-async-chunk` or run `./cosyvoice3/run_server.sh sync` for the legacy synchronous code2wav path.
+
+Stage-0 sampling defaults intentionally match the CosyVoice3 reference setup: `temperature=1.0`, `top_p=0.8`, `top_k=25`, `repetition_penalty=2.0`, `stop_token_ids=[6562]`, with `min_tokens` and `max_tokens` set per request from the text length. No-stop stress settings are not equivalent to this baseline.
+
+### Sending requests
+```bash
+python cosyvoice3/speech_client.py \
+    --text "CosyVoice is undergoing a comprehensive upgrade." \
+    --ref-audio https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav \
+    --ref-text "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。" \
+    --output cosyvoice3_output.wav
+```
+
+Equivalent curl request:
+```bash
+curl -X POST http://localhost:8091/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{
+        "input": "CosyVoice is undergoing a comprehensive upgrade.",
+        "ref_audio": "https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav",
+        "ref_text": "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。",
+        "response_format": "wav"
+    }' --output cosyvoice3_output.wav
+```
+
+### Streaming PCM
+```bash
+python cosyvoice3/speech_client.py \
+    --text "CosyVoice can stream audio chunks over HTTP." \
+    --ref-audio https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav \
+    --ref-text "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。" \
+    --stream \
+    --output cosyvoice3_output.pcm
+```
+
+For direct playback:
+```bash
+curl -s -X POST http://localhost:8091/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{
+        "input": "CosyVoice can stream audio chunks over HTTP.",
+        "ref_audio": "https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav",
+        "ref_text": "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。",
+        "stream": true,
+        "response_format": "pcm"
+    }' --no-buffer | play -t raw -r 24000 -e signed -b 16 -c 1 -
+```
+
+### Streaming WebSocket
+The `/v1/audio/speech/stream` endpoint accepts text incrementally, splits it at sentence boundaries, and emits one audio stream per sentence:
+```bash
+python cosyvoice3/streaming_speech_client.py \
+    --text "CosyVoice streams sentence by sentence. This is the second sentence." \
+    --ref-audio https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav \
+    --ref-text "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。"
+
+python cosyvoice3/streaming_speech_client.py \
+    --text "CosyVoice streams sentence by sentence. This is the second sentence." \
+    --ref-audio https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav \
+    --ref-text "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。" \
+    --response-format pcm \
+    --stream-audio
+```
+
+### Notes
+- Output is 24 kHz mono.
+- `--stream-audio` on the WebSocket client requires `--response-format pcm`.
+- For offline reference inference and local snapshot notes, see the [offline CosyVoice3 section](https://github.com/vllm-project/vllm-omni/tree/main/examples/offline_inference/text_to_speech/README.md#cosyvoice3).
 
 ---
 
@@ -407,6 +495,18 @@ The demo handles voice-preset selection and reference-audio upload. `voxtral_tts
 
 ## Example materials
 
+??? abstract "cosyvoice3/run_server.sh"
+    ``````sh
+    --8<-- "examples/online_serving/text_to_speech/cosyvoice3/run_server.sh"
+    ``````
+??? abstract "cosyvoice3/speech_client.py"
+    ``````py
+    --8<-- "examples/online_serving/text_to_speech/cosyvoice3/speech_client.py"
+    ``````
+??? abstract "cosyvoice3/streaming_speech_client.py"
+    ``````py
+    --8<-- "examples/online_serving/text_to_speech/cosyvoice3/streaming_speech_client.py"
+    ``````
 ??? abstract "fish_speech/gradio_demo.py"
     ``````py
     --8<-- "examples/online_serving/text_to_speech/fish_speech/gradio_demo.py"

--- a/examples/online_serving/text_to_speech/README.md
+++ b/examples/online_serving/text_to_speech/README.md
@@ -14,6 +14,7 @@ For the full list of supported architectures across all modalities, see
 
 | Model | HuggingFace repo | Voice cloning | Streaming | Voice presets / upload | Gradio demo |
 |---|---|---|---|---|---|
+| CosyVoice3 | `FunAudioLLM/Fun-CosyVoice3-0.5B-2512` | ✓ (`ref_audio`+`ref_text`) | ✓ (PCM + WebSocket) | upload | — |
 | Fish Speech S2 Pro | `fishaudio/s2-pro` | ✓ (`ref_audio`+`ref_text`) | ✓ (PCM stream) | — | ✓ |
 | Ming-flash-omni-TTS | `Jonathan1909/Ming-flash-omni-2.0` | — (caption-controlled) | — | caption fields (`instructions`) | — |
 | MOSS-TTS-Nano | `OpenMOSS-Team/MOSS-TTS-Nano` | ✓ (`ref_audio` required) | ✓ (PCM stream) | — | ✓ |
@@ -22,8 +23,6 @@ For the full list of supported architectures across all modalities, see
 | VoxCPM | `openbmb/VoxCPM-0.5B` | ✓ | ✓ (PCM stream) | — | — |
 | VoxCPM2 | `openbmb/VoxCPM2` | ✓ | ✓ (AudioWorklet via gradio) | — | ✓ |
 | Voxtral TTS | `mistralai/Voxtral-4B-TTS-2603` | ✓ (gated upstream) | ✓ | ✓ (presets) | ✓ |
-
-CosyVoice3 is intentionally absent: no online example exists for it yet. See its [offline section](../../offline_inference/text_to_speech/README.md#cosyvoice3) instead.
 
 ## Common Quick Start
 
@@ -92,6 +91,95 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 Adjust the player's sample rate to match the model (44.1 kHz for Fish Speech, 48 kHz for VoxCPM2, 24 kHz for the others).
 
 For full request-shape documentation (all parameters, response formats, error codes), see the [Speech API reference](../../../docs/serving/speech_api.md).
+
+---
+
+## CosyVoice3
+
+2-stage TTS pipeline (`talker` + `code2wav`) at 24 kHz. Online serving uses voice cloning: every request must provide `ref_audio` and `ref_text`.
+
+The upstream zero-shot prompt audio should be paired with the full prompt text shown below. Dropping the `You are a helpful assistant.<|endofprompt|>` prefix changes the conditioning prompt.
+
+### Launch
+```bash
+vllm-omni serve FunAudioLLM/Fun-CosyVoice3-0.5B-2512 \
+    --tokenizer FunAudioLLM/Fun-CosyVoice3-0.5B-2512/CosyVoice-BlankEN \
+    --deploy-config vllm_omni/deploy/cosyvoice3.yaml \
+    --trust-remote-code \
+    --omni \
+    --port 8091
+# or:
+./cosyvoice3/run_server.sh
+```
+
+`vllm_omni/deploy/cosyvoice3.yaml` defaults to `async_chunk: true`. Pass `--no-async-chunk` or run `./cosyvoice3/run_server.sh sync` for the legacy synchronous code2wav path.
+
+Stage-0 sampling defaults intentionally match the CosyVoice3 reference setup: `temperature=1.0`, `top_p=0.8`, `top_k=25`, `repetition_penalty=2.0`, `stop_token_ids=[6562]`, with `min_tokens` and `max_tokens` set per request from the text length. No-stop stress settings are not equivalent to this baseline.
+
+### Sending requests
+```bash
+python cosyvoice3/speech_client.py \
+    --text "CosyVoice is undergoing a comprehensive upgrade." \
+    --ref-audio https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav \
+    --ref-text "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。" \
+    --output cosyvoice3_output.wav
+```
+
+Equivalent curl request:
+```bash
+curl -X POST http://localhost:8091/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{
+        "input": "CosyVoice is undergoing a comprehensive upgrade.",
+        "ref_audio": "https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav",
+        "ref_text": "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。",
+        "response_format": "wav"
+    }' --output cosyvoice3_output.wav
+```
+
+### Streaming PCM
+```bash
+python cosyvoice3/speech_client.py \
+    --text "CosyVoice can stream audio chunks over HTTP." \
+    --ref-audio https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav \
+    --ref-text "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。" \
+    --stream \
+    --output cosyvoice3_output.pcm
+```
+
+For direct playback:
+```bash
+curl -s -X POST http://localhost:8091/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{
+        "input": "CosyVoice can stream audio chunks over HTTP.",
+        "ref_audio": "https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav",
+        "ref_text": "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。",
+        "stream": true,
+        "response_format": "pcm"
+    }' --no-buffer | play -t raw -r 24000 -e signed -b 16 -c 1 -
+```
+
+### Streaming WebSocket
+The `/v1/audio/speech/stream` endpoint accepts text incrementally, splits it at sentence boundaries, and emits one audio stream per sentence:
+```bash
+python cosyvoice3/streaming_speech_client.py \
+    --text "CosyVoice streams sentence by sentence. This is the second sentence." \
+    --ref-audio https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav \
+    --ref-text "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。"
+
+python cosyvoice3/streaming_speech_client.py \
+    --text "CosyVoice streams sentence by sentence. This is the second sentence." \
+    --ref-audio https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav \
+    --ref-text "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。" \
+    --response-format pcm \
+    --stream-audio
+```
+
+### Notes
+- Output is 24 kHz mono.
+- `--stream-audio` on the WebSocket client requires `--response-format pcm`.
+- For offline reference inference and local snapshot notes, see the [offline CosyVoice3 section](../../offline_inference/text_to_speech/README.md#cosyvoice3).
 
 ---
 

--- a/examples/online_serving/text_to_speech/cosyvoice3/run_server.sh
+++ b/examples/online_serving/text_to_speech/cosyvoice3/run_server.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Launch vLLM-Omni server for CosyVoice3 online serving.
+#
+# Usage:
+#   ./run_server.sh        # async_chunk mode (default)
+#   ./run_server.sh async
+#   ./run_server.sh sync   # legacy full-sequence code2wav path
+#
+# Environment overrides:
+#   COSYVOICE3_MODEL=/path/or/hf-repo
+#   COSYVOICE3_TOKENIZER=/path/to/CosyVoice-BlankEN
+#   COSYVOICE3_PORT=8091
+#   COSYVOICE3_DEPLOY_CONFIG=/path/to/cosyvoice3.yaml
+#   VLLM_OMNI_BIN=vllm-omni
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../../.." && pwd)"
+
+MODE="${1:-async}"
+VLLM_OMNI_BIN="${VLLM_OMNI_BIN:-vllm-omni}"
+MODEL="${COSYVOICE3_MODEL:-FunAudioLLM/Fun-CosyVoice3-0.5B-2512}"
+TOKENIZER="${COSYVOICE3_TOKENIZER:-${MODEL}/CosyVoice-BlankEN}"
+PORT="${COSYVOICE3_PORT:-8091}"
+DEPLOY_CONFIG="${COSYVOICE3_DEPLOY_CONFIG:-${REPO_ROOT}/vllm_omni/deploy/cosyvoice3.yaml}"
+EXTRA_ARGS=()
+
+case "${MODE}" in
+    async|async_chunk)
+        ;;
+    sync)
+        EXTRA_ARGS+=("--no-async-chunk")
+        ;;
+    *)
+        echo "Unknown mode: ${MODE}"
+        echo "Supported modes: async, async_chunk, sync"
+        exit 1
+        ;;
+esac
+
+echo "Starting CosyVoice3 server"
+echo "  model: ${MODEL}"
+echo "  tokenizer: ${TOKENIZER}"
+echo "  mode: ${MODE}"
+echo "  port: ${PORT}"
+
+"${VLLM_OMNI_BIN}" serve "${MODEL}" \
+    --tokenizer "${TOKENIZER}" \
+    --deploy-config "${DEPLOY_CONFIG}" \
+    --host 0.0.0.0 \
+    --port "${PORT}" \
+    --trust-remote-code \
+    --stage-init-timeout 900 \
+    --init-timeout 1200 \
+    --omni \
+    "${EXTRA_ARGS[@]}"

--- a/examples/online_serving/text_to_speech/cosyvoice3/speech_client.py
+++ b/examples/online_serving/text_to_speech/cosyvoice3/speech_client.py
@@ -1,0 +1,155 @@
+"""OpenAI-compatible client for CosyVoice3 via /v1/audio/speech.
+
+Examples:
+    python speech_client.py \
+        --text "CosyVoice is undergoing a comprehensive upgrade." \
+        --ref-audio https://raw.githubusercontent.com/FunAudioLLM/CosyVoice/main/asset/zero_shot_prompt.wav \
+        --ref-text "You are a helpful assistant.<|endofprompt|>希望你以后能够做的比我还好呦。" \
+        --output cosyvoice3_output.wav
+
+    python speech_client.py \
+        --text "CosyVoice streaming over HTTP." \
+        --ref-audio /path/to/reference.wav \
+        --ref-text "Reference transcript." \
+        --stream \
+        --output cosyvoice3_output.pcm
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_API_BASE = "http://localhost:8091"
+DEFAULT_API_KEY = "EMPTY"
+DEFAULT_MODEL = "FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+
+MIME_BY_SUFFIX = {
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".mpeg": "audio/mpeg",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+}
+
+
+def encode_audio_to_base64(audio_path: str) -> str:
+    """Encode a local audio file as a data URL."""
+    path = Path(audio_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Audio file not found: {audio_path}")
+
+    mime_type = MIME_BY_SUFFIX.get(path.suffix.lower(), "audio/wav")
+    audio_b64 = base64.b64encode(path.read_bytes()).decode("utf-8")
+    return f"data:{mime_type};base64,{audio_b64}"
+
+
+def normalize_ref_audio(ref_audio: str) -> str:
+    """Return a server-consumable reference audio URI."""
+    if ref_audio.startswith(("http://", "https://", "data:", "file:")):
+        return ref_audio
+    return encode_audio_to_base64(ref_audio)
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    response_format = "pcm" if args.stream else args.response_format
+    payload: dict[str, Any] = {
+        "model": args.model,
+        "input": args.text,
+        "ref_audio": normalize_ref_audio(args.ref_audio),
+        "ref_text": args.ref_text,
+        "response_format": response_format,
+    }
+
+    if args.stream:
+        payload["stream"] = True
+    if args.seed is not None:
+        payload["seed"] = args.seed
+    if args.max_new_tokens is not None:
+        payload["max_new_tokens"] = args.max_new_tokens
+    if args.extra_params is not None:
+        payload["extra_params"] = json.loads(args.extra_params)
+
+    return payload
+
+
+def run_tts(args: argparse.Namespace) -> None:
+    try:
+        import httpx
+    except ImportError:
+        raise SystemExit("Please install httpx: pip install httpx") from None
+
+    payload = build_payload(args)
+    api_url = f"{args.api_base}/v1/audio/speech"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {args.api_key}",
+    }
+
+    print(f"Model: {args.model}")
+    print(f"Text: {args.text}")
+    print(f"Reference audio: {args.ref_audio}")
+    print("Generating audio...")
+
+    output_path = args.output or ("cosyvoice3_output.pcm" if args.stream else "cosyvoice3_output.wav")
+    if args.stream:
+        with httpx.Client(timeout=300.0, trust_env=False) as client:
+            with client.stream("POST", api_url, json=payload, headers=headers) as response:
+                if response.status_code != 200:
+                    raise SystemExit(f"Error {response.status_code}: {response.read().decode(errors='ignore')}")
+                total_bytes = 0
+                with open(output_path, "wb") as f:
+                    for chunk in response.iter_bytes():
+                        if not chunk:
+                            continue
+                        f.write(chunk)
+                        total_bytes += len(chunk)
+        print(f"Streamed {total_bytes} bytes to: {output_path}")
+        return
+
+    with httpx.Client(timeout=300.0, trust_env=False) as client:
+        response = client.post(api_url, json=payload, headers=headers)
+
+    if response.status_code != 200:
+        raise SystemExit(f"Error {response.status_code}: {response.text}")
+
+    Path(output_path).write_bytes(response.content)
+    print(f"Audio saved to: {output_path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="CosyVoice3 OpenAI-compatible speech client")
+    parser.add_argument("--api-base", default=DEFAULT_API_BASE, help="API base URL")
+    parser.add_argument("--api-key", default=DEFAULT_API_KEY, help="API key")
+    parser.add_argument("--model", "-m", default=DEFAULT_MODEL, help="Model name or path")
+    parser.add_argument("--text", required=True, help="Text to synthesize")
+    parser.add_argument("--ref-audio", required=True, help="Reference audio path, URL, data URL, or file URI")
+    parser.add_argument("--ref-text", required=True, help="Transcript of the reference audio")
+    parser.add_argument("--stream", action="store_true", help="Enable streaming PCM output")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed for reproducible generation")
+    parser.add_argument("--max-new-tokens", type=int, default=None, help="Optional maximum generated tokens")
+    parser.add_argument(
+        "--extra-params",
+        default=None,
+        help="Optional JSON object passed to the speech endpoint extra_params field",
+    )
+    parser.add_argument(
+        "--response-format",
+        default="wav",
+        choices=["wav", "mp3", "flac", "pcm", "aac", "opus"],
+        help="Audio format for non-streaming mode (default: wav)",
+    )
+    parser.add_argument("--output", "-o", default=None, help="Output file path")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    run_tts(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/online_serving/text_to_speech/cosyvoice3/streaming_speech_client.py
+++ b/examples/online_serving/text_to_speech/cosyvoice3/streaming_speech_client.py
@@ -1,0 +1,160 @@
+"""WebSocket client for CosyVoice3 streaming text-input TTS.
+
+Connects to /v1/audio/speech/stream, sends text incrementally, and saves one
+audio file per generated sentence. Use --stream-audio with --response-format pcm
+to receive progressive PCM frames while each sentence is decoded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import inspect
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+try:
+    import websockets
+except ImportError:
+    websockets = None
+
+DEFAULT_WS_URL = "ws://localhost:8091/v1/audio/speech/stream"
+DEFAULT_MODEL = "FunAudioLLM/Fun-CosyVoice3-0.5B-2512"
+
+MIME_BY_SUFFIX = {
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".mpeg": "audio/mpeg",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+}
+
+
+def encode_audio_to_base64(audio_path: str) -> str:
+    path = Path(audio_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Audio file not found: {audio_path}")
+
+    mime_type = MIME_BY_SUFFIX.get(path.suffix.lower(), "audio/wav")
+    audio_b64 = base64.b64encode(path.read_bytes()).decode("utf-8")
+    return f"data:{mime_type};base64,{audio_b64}"
+
+
+def normalize_ref_audio(ref_audio: str) -> str:
+    if ref_audio.startswith(("http://", "https://", "data:", "file:")):
+        return ref_audio
+    return encode_audio_to_base64(ref_audio)
+
+
+def build_session_config(args: argparse.Namespace) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "model": args.model,
+        "response_format": args.response_format,
+        "ref_audio": normalize_ref_audio(args.ref_audio),
+        "ref_text": args.ref_text,
+        "split_granularity": args.split_granularity,
+    }
+    if args.stream_audio:
+        config["stream_audio"] = True
+    if args.max_new_tokens is not None:
+        config["max_new_tokens"] = args.max_new_tokens
+    return config
+
+
+async def send_text(ws: Any, text: str, simulate_stt: bool, stt_delay: float) -> None:
+    if simulate_stt:
+        words = text.split(" ")
+        for index, word in enumerate(words):
+            chunk = word + (" " if index < len(words) - 1 else "")
+            await ws.send(json.dumps({"type": "input.text", "text": chunk}))
+            print(f"sent: {chunk!r}")
+            await asyncio.sleep(stt_delay)
+    else:
+        await ws.send(json.dumps({"type": "input.text", "text": text}))
+        print(f"sent text: {text!r}")
+    await ws.send(json.dumps({"type": "input.done"}))
+    print("sent input.done")
+
+
+async def stream_tts(args: argparse.Namespace) -> None:
+    if websockets is None:
+        raise SystemExit("Please install websockets: pip install websockets")
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    config = build_session_config(args)
+
+    connect_kwargs: dict[str, Any] = {"max_size": 64 * 1024 * 1024}
+    if "proxy" in inspect.signature(websockets.connect).parameters:
+        connect_kwargs["proxy"] = None
+
+    async with websockets.connect(args.url, **connect_kwargs) as ws:
+        await ws.send(json.dumps({"type": "session.config", **config}))
+        print(f"sent session.config: response_format={args.response_format}, stream_audio={args.stream_audio}")
+        sender = asyncio.create_task(send_text(ws, args.text, args.simulate_stt, args.stt_delay))
+
+        current_sentence_index = 0
+        current_chunks: list[bytes] = []
+
+        try:
+            while True:
+                message = await ws.recv()
+                if isinstance(message, bytes):
+                    current_chunks.append(message)
+                    print(f"received audio chunk: {len(message)} bytes")
+                    continue
+
+                msg = json.loads(message)
+                msg_type = msg.get("type")
+                if msg_type == "audio.start":
+                    current_sentence_index = int(msg["sentence_index"])
+                    current_chunks = []
+                    print(f"[sentence {current_sentence_index}] {msg['sentence_text']!r}")
+                elif msg_type == "audio.done":
+                    filename = Path(args.output_dir) / f"sentence_{current_sentence_index:03d}.{args.response_format}"
+                    filename.write_bytes(b"".join(current_chunks))
+                    print(f"saved {filename} ({msg.get('total_bytes', filename.stat().st_size)} bytes)")
+                    current_chunks = []
+                elif msg_type == "session.done":
+                    print(f"complete: {msg['total_sentences']} sentence(s)")
+                    break
+                elif msg_type == "error":
+                    print(f"error: {msg['message']}")
+                else:
+                    print(f"unknown message: {msg}")
+        finally:
+            sender.cancel()
+            try:
+                await sender
+            except asyncio.CancelledError:
+                pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="CosyVoice3 WebSocket streaming speech client")
+    parser.add_argument("--url", default=DEFAULT_WS_URL, help="WebSocket endpoint URL")
+    parser.add_argument("--model", "-m", default=DEFAULT_MODEL, help="Model name or path")
+    parser.add_argument("--text", required=True, help="Text to synthesize")
+    parser.add_argument("--ref-audio", required=True, help="Reference audio path, URL, data URL, or file URI")
+    parser.add_argument("--ref-text", required=True, help="Transcript of the reference audio")
+    parser.add_argument("--output-dir", default="cosyvoice3_streaming_output")
+    parser.add_argument("--response-format", default="wav", choices=["wav", "pcm", "flac", "mp3", "aac", "opus"])
+    parser.add_argument("--stream-audio", action="store_true", help="Receive progressive PCM frames")
+    parser.add_argument("--split-granularity", default="sentence", choices=["sentence", "clause"])
+    parser.add_argument("--simulate-stt", action="store_true", help="Send words incrementally")
+    parser.add_argument("--stt-delay", type=float, default=0.1, help="Delay between simulated STT words")
+    parser.add_argument("--max-new-tokens", type=int, default=None)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.stream_audio and args.response_format != "pcm":
+        raise SystemExit("--stream-audio requires --response-format pcm")
+    asyncio.run(stream_tts(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/examples/online_serving/test_cosyvoice3_tts.py
+++ b/tests/examples/online_serving/test_cosyvoice3_tts.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for CosyVoice3 online serving example clients."""
+
+import argparse
+import importlib.util
+import re
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+EXAMPLE_DIR = (
+    Path(__file__).parent.parent.parent.parent
+    / "examples"
+    / "online_serving"
+    / "text_to_speech"
+    / "cosyvoice3"
+)
+
+
+def _load_example_module(name: str, filename: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, EXAMPLE_DIR / filename)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_speech_client_builds_non_streaming_payload(tmp_path: Path):
+    client = _load_example_module("cosyvoice3_speech_client", "speech_client.py")
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"RIFFfake")
+
+    args = argparse.Namespace(
+        model="FunAudioLLM/Fun-CosyVoice3-0.5B-2512",
+        text="Hello CosyVoice3.",
+        ref_audio=str(ref_audio),
+        ref_text="You are a helpful assistant.<|endofprompt|>reference text",
+        response_format="wav",
+        stream=False,
+        seed=123,
+        max_new_tokens=64,
+        extra_params='{"custom_flag": true}',
+    )
+
+    payload = client.build_payload(args)
+
+    assert payload["model"] == args.model
+    assert payload["input"] == args.text
+    assert payload["ref_audio"].startswith("data:audio/wav;base64,")
+    assert payload["ref_text"] == args.ref_text
+    assert payload["response_format"] == "wav"
+    assert "stream" not in payload
+    assert payload["seed"] == 123
+    assert payload["max_new_tokens"] == 64
+    assert payload["extra_params"] == {"custom_flag": True}
+
+
+def test_speech_client_builds_streaming_pcm_payload():
+    client = _load_example_module("cosyvoice3_speech_client_stream", "speech_client.py")
+    args = argparse.Namespace(
+        model="cosyvoice3",
+        text="Stream this.",
+        ref_audio="https://example.com/ref.wav",
+        ref_text="reference text",
+        response_format="wav",
+        stream=True,
+        seed=None,
+        max_new_tokens=None,
+        extra_params=None,
+    )
+
+    payload = client.build_payload(args)
+
+    assert payload["ref_audio"] == "https://example.com/ref.wav"
+    assert payload["response_format"] == "pcm"
+    assert payload["stream"] is True
+
+
+def test_streaming_client_imports_without_websockets_and_builds_config():
+    client = _load_example_module("cosyvoice3_streaming_speech_client", "streaming_speech_client.py")
+    args = argparse.Namespace(
+        model="cosyvoice3",
+        response_format="pcm",
+        ref_audio="data:audio/wav;base64,AAAA",
+        ref_text="reference text",
+        split_granularity="clause",
+        stream_audio=True,
+        max_new_tokens=128,
+    )
+
+    config = client.build_session_config(args)
+
+    assert config == {
+        "model": "cosyvoice3",
+        "response_format": "pcm",
+        "ref_audio": "data:audio/wav;base64,AAAA",
+        "ref_text": "reference text",
+        "split_granularity": "clause",
+        "stream_audio": True,
+        "max_new_tokens": 128,
+    }
+
+
+def test_cosyvoice3_deploy_uses_pr_aligned_stage0_sampling_defaults():
+    deploy_path = Path(__file__).parent.parent.parent.parent / "vllm_omni" / "deploy" / "cosyvoice3.yaml"
+    text = deploy_path.read_text(encoding="utf-8")
+    match = re.search(r"stage_id:\s*0.*?default_sampling_params:\n(?P<body>.*?)(?:\n\s{4}\S|\n\n)", text, re.S)
+    assert match is not None
+    sampling_body = match.group("body")
+
+    assert re.search(r"temperature:\s*1\.0\b", sampling_body)
+    assert re.search(r"top_p:\s*0\.8\b", sampling_body)
+    assert re.search(r"top_k:\s*25\b", sampling_body)
+    assert re.search(r"repetition_penalty:\s*2\.0\b", sampling_body)
+    assert re.search(r"stop_token_ids:\s*\n\s*-\s*6562\b", sampling_body)
+    assert re.search(r"detokenize:\s*false\b", sampling_body)

--- a/tests/model_executor/models/cosyvoice3/test_cosyvoice3_model_helpers.py
+++ b/tests/model_executor/models/cosyvoice3/test_cosyvoice3_model_helpers.py
@@ -127,7 +127,7 @@ def _make_sampling_metadata(
         generators={},
         max_num_logprobs=None,
         no_penalties=False,
-        prompt_token_ids=None,
+        prompt_token_ids=torch.empty((1, 0), dtype=torch.long),
         frequency_penalties=torch.zeros(1, dtype=torch.float32),
         presence_penalties=torch.zeros(1, dtype=torch.float32),
         repetition_penalties=torch.tensor([repetition_penalty], dtype=torch.float32),
@@ -397,6 +397,17 @@ def test_sample_tolerates_ras_fallback_with_no_valid_candidates():
     assert out.sampled_token_ids.tolist() == [[0]]
 
 
+def test_sample_applies_repetition_penalty_before_ras():
+    model = _make_talker_model()
+    metadata = _make_sampling_metadata(output_token_ids=[[1]])
+    logits = torch.tensor([[-1e9, 8.0, 5.0]], dtype=torch.float32)
+
+    out = model.sample(logits, metadata)
+
+    assert out is not None
+    assert out.sampled_token_ids.tolist() == [[2]]
+
+
 def test_sample_maps_any_cosyvoice3_stop_token_to_canonical_eos():
     model = _make_talker_model()
     metadata = _make_sampling_metadata(output_token_ids=[[1] * 10])
@@ -477,7 +488,7 @@ def test_gpu_ar_model_runner_prefers_model_sampler_when_opted_in():
     out = runner._sample(torch.tensor([[0.1, 0.2]], dtype=torch.float32), spec_decode_metadata=None)
 
     assert out is expected
-    assert runner.input_batch.updated is False
+    assert runner.input_batch.updated is True
     assert len(calls) == 1
 
 
@@ -493,9 +504,10 @@ def test_gpu_ar_model_runner_supplies_req_output_history_to_model_sampler():
             self.sampled_token_ids_cpu = None
             self.async_copy_ready_event = None
             self.prev_req_id_to_index = None
+            self.updated = False
 
         def update_async_output_token_ids(self):
-            raise AssertionError("fallback async repair should not run for model sampler path")
+            self.updated = True
 
     _, GPUARModelRunner = _cosyvoice3_model_and_runner()
     runner = object.__new__(GPUARModelRunner)
@@ -511,6 +523,7 @@ def test_gpu_ar_model_runner_supplies_req_output_history_to_model_sampler():
 
     runner._sample(torch.tensor([[0.1, 0.2]], dtype=torch.float32), spec_decode_metadata=None)
 
+    assert runner.input_batch.updated is True
     assert seen_histories == [[[1, 2, 3]]]
 
 
@@ -535,7 +548,11 @@ def test_gpu_ar_model_runner_repairs_async_placeholders_for_model_sampler():
             self.prev_req_id_to_index = {"rid-1": 0}
 
         def update_async_output_token_ids(self):
-            raise AssertionError("fallback async repair should not run for model sampler path")
+            output_token_ids = self.sampling_metadata.output_token_ids
+            if self.sampled_token_ids_cpu is None or not output_token_ids:
+                return
+            self.async_copy_ready_event.synchronize()
+            output_token_ids[0][output_token_ids[0].index(-1)] = int(self.sampled_token_ids_cpu[0, 0])
 
     _, GPUARModelRunner = _cosyvoice3_model_and_runner()
     runner = object.__new__(GPUARModelRunner)

--- a/tests/model_executor/models/cosyvoice3/test_cosyvoice3_model_helpers.py
+++ b/tests/model_executor/models/cosyvoice3/test_cosyvoice3_model_helpers.py
@@ -375,6 +375,63 @@ def test_sample_uses_ras_rejection_for_recent_repetition():
     assert out.sampled_token_ids.tolist() == [[2]]
 
 
+def test_sample_tolerates_invalid_probabilities_after_processors():
+    model = _make_talker_model()
+    metadata = _make_sampling_metadata(output_token_ids=[[1] * 10])
+    logits = torch.tensor([[float("nan"), 10.0, 0.0]], dtype=torch.float32)
+
+    out = model.sample(logits, metadata)
+
+    assert out is not None
+    assert out.sampled_token_ids.tolist() == [[2]]
+
+
+def test_sample_tolerates_ras_fallback_with_no_valid_candidates():
+    model = _make_talker_model()
+    metadata = _make_sampling_metadata(output_token_ids=[[1] * 10])
+    logits = torch.tensor([[float("-inf"), 10.0, float("-inf")]], dtype=torch.float32)
+
+    out = model.sample(logits, metadata)
+
+    assert out is not None
+    assert out.sampled_token_ids.tolist() == [[0]]
+
+
+def test_sample_maps_any_cosyvoice3_stop_token_to_canonical_eos():
+    model = _make_talker_model()
+    metadata = _make_sampling_metadata(output_token_ids=[[1] * 10])
+    logits = torch.full((1, 6761), -1e9, dtype=torch.float32)
+    logits[0, 6599] = 10.0
+
+    out = model.sample(logits, metadata)
+
+    assert out is not None
+    assert out.sampled_token_ids.tolist() == [[6562]]
+
+
+def test_sample_rejects_cosyvoice3_stop_tokens_before_min_tokens():
+    class _FakeMinTokensProcessor:
+        min_toks = {0: (5, [], {6562})}
+
+        def is_argmax_invariant(self):
+            return False
+
+        def apply(self, logits):
+            return logits
+
+    model = _make_talker_model()
+    metadata = _make_sampling_metadata(output_token_ids=[[42, 43, 44]])
+    metadata.logitsprocs = LogitsProcessors([_FakeMinTokensProcessor()])
+    logits = torch.full((1, 6761), -1e9, dtype=torch.float32)
+    logits[0, 2] = 9.0
+    logits[0, 6599] = 10.0
+
+    out = model.sample(logits, metadata)
+
+    assert out is not None
+    assert out.sampled_token_ids.tolist() == [[2]]
+
+
 def test_sample_tolerates_padded_rows_without_history():
     model = _make_talker_model()
     metadata = _make_sampling_metadata(output_token_ids=[[1] * 10])

--- a/vllm_omni/deploy/cosyvoice3.yaml
+++ b/vllm_omni/deploy/cosyvoice3.yaml
@@ -38,11 +38,13 @@ stages:
       to_stage_1: connector_of_shared_memory
     default_sampling_params:
       max_tokens: 2048
+      temperature: 1.0
       top_k: 25
       top_p: 0.8
-      # near-identity repetition penalty forces vLLM to track
-      # output_token_ids for RAS (stop-token logit logsumexp).
-      repetition_penalty: 1.0001
+      repetition_penalty: 2.0
+      stop_token_ids:
+        - 6562
+      detokenize: false
     disable_hybrid_kv_cache_manager: true
     mm_processor_cache_gb: 0
     skip_mm_profiling: true

--- a/vllm_omni/model_executor/models/cosyvoice3/cosyvoice3.py
+++ b/vllm_omni/model_executor/models/cosyvoice3/cosyvoice3.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import replace
 from functools import partial
 from threading import Lock
 
@@ -378,7 +377,10 @@ class CosyVoice3Model(
         qwen_hf_config = Qwen2Config.from_pretrained(qwen_config_path)
 
         # Use parent's cache config - critical for PagedAttention to work correctly
-        return parent_config.with_hf_config(qwen_hf_config, architectures=["Qwen2Model"])
+        llm_vllm_config = parent_config.with_hf_config(qwen_hf_config, architectures=["Qwen2Model"])
+        llm_vllm_config.model_config.hf_text_config = llm_vllm_config.model_config.hf_config
+        llm_vllm_config.model_config.model_arch_config = llm_vllm_config.model_config.get_model_arch_config()
+        return llm_vllm_config
 
     @staticmethod
     def _cross_fade_audio(audio: torch.Tensor, prev_tail: torch.Tensor) -> torch.Tensor:
@@ -612,8 +614,7 @@ class CosyVoice3Model(
             return sampler(logits=logits, sampling_metadata=sampling_metadata)
 
         logits = logits.to(torch.float32)
-        sampling_for_processors = replace(sampling_metadata, no_penalties=True)
-        logits = sampler.apply_logits_processors(logits, sampling_for_processors, predict_bonus_token=False)
+        logits = sampler.apply_logits_processors(logits, sampling_metadata, predict_bonus_token=False)
 
         sampling_cfg = dict(self.config.llm.get("sampling", {}))
         default_top_p = float(sampling_cfg.get("top_p", 0.8))

--- a/vllm_omni/model_executor/models/cosyvoice3/cosyvoice3.py
+++ b/vllm_omni/model_executor/models/cosyvoice3/cosyvoice3.py
@@ -455,6 +455,56 @@ class CosyVoice3Model(
     def _multinomial_sample(probs: torch.Tensor, generator: torch.Generator | None = None) -> torch.Tensor:
         return torch.multinomial(probs, 1, replacement=True, generator=generator).reshape(())
 
+    @staticmethod
+    def _valid_probs(probs: torch.Tensor) -> bool:
+        return bool(torch.isfinite(probs).all().item() and torch.all(probs >= 0).item() and probs.sum().item() > 0)
+
+    @staticmethod
+    def _sanitize_sampling_scores(scores: torch.Tensor) -> torch.Tensor:
+        posinf_mask = scores == float("inf")
+        if bool(posinf_mask.any().item()):
+            return torch.where(
+                posinf_mask,
+                torch.zeros_like(scores),
+                torch.full_like(scores, float("-inf")),
+            )
+        return torch.where(
+            torch.isfinite(scores),
+            scores,
+            torch.full_like(scores, float("-inf")),
+        )
+
+    def _canonical_stop_token_id(self) -> int:
+        return int(self.config.llm["eos_token_id"])
+
+    def _stop_token_slice(self) -> slice:
+        speech_token_size = int(self.config.llm["speech_token_size"])
+        return slice(speech_token_size, speech_token_size + 200)
+
+    def _is_cosyvoice3_stop_token_id(self, token_id: int) -> bool:
+        speech_token_size = int(self.config.llm["speech_token_size"])
+        return speech_token_size <= int(token_id) < speech_token_size + 200
+
+    @staticmethod
+    def _under_min_tokens(sampling_metadata: SamplingMetadata, req_idx: int) -> bool:
+        current_len = len(sampling_metadata.output_token_ids[req_idx]) if req_idx < len(
+            sampling_metadata.output_token_ids
+        ) else 0
+        for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
+            min_toks = getattr(processor, "min_toks", None)
+            if not isinstance(min_toks, dict) or req_idx not in min_toks:
+                continue
+            min_tok_entry = min_toks[req_idx]
+            if isinstance(min_tok_entry, (tuple, list)) and min_tok_entry:
+                min_tokens = min_tok_entry[0]
+            else:
+                min_tokens = min_tok_entry
+            try:
+                return current_len < int(min_tokens)
+            except (TypeError, ValueError):
+                return True
+        return False
+
     @classmethod
     def _nucleus_sample_one(
         cls,
@@ -464,7 +514,12 @@ class CosyVoice3Model(
         top_k: int,
         generator: torch.Generator | None,
     ) -> int:
+        weighted_scores = cls._sanitize_sampling_scores(weighted_scores)
+        if not torch.isfinite(weighted_scores).any().item():
+            return 0
         probs = weighted_scores.softmax(dim=0)
+        if not cls._valid_probs(probs):
+            return int(torch.argmax(weighted_scores).item())
         sorted_prob, sorted_idx = probs.sort(descending=True, stable=True)
         kept_probs: list[torch.Tensor] = []
         kept_indices: list[torch.Tensor] = []
@@ -482,6 +537,8 @@ class CosyVoice3Model(
             return int(sorted_idx[0].item())
 
         sample_probs = torch.stack(kept_probs)
+        if not cls._valid_probs(sample_probs):
+            return int(torch.stack(kept_indices)[0].item())
         sample_idx = cls._multinomial_sample(sample_probs, generator=generator)
         return int(torch.stack(kept_indices)[int(sample_idx.item())].item())
 
@@ -513,8 +570,12 @@ class CosyVoice3Model(
             if rep_num >= win_size * tau_r:
                 weighted_scores = weighted_scores.clone()
                 weighted_scores[top_id] = float("-inf")
-                fallback_probs = weighted_scores.softmax(dim=0)
-                top_id = int(cls._multinomial_sample(fallback_probs, generator=generator).item())
+                top_id = cls._nucleus_sample_one(
+                    weighted_scores,
+                    top_p=top_p,
+                    top_k=top_k,
+                    generator=generator,
+                )
         return top_id
 
     def _cosyvoice3_ras_enabled(self, sampling_metadata: SamplingMetadata) -> bool:
@@ -563,30 +624,36 @@ class CosyVoice3Model(
         sampled_ids: list[int] = []
         for req_idx in range(int(logits.shape[0])):
             row_logits = logits[req_idx]
+            if self._under_min_tokens(sampling_metadata, req_idx):
+                row_logits = row_logits.clone()
+                row_logits[self._stop_token_slice()] = float("-inf")
 
             temperature = float(self._req_scalar(sampling_metadata.temperature, req_idx, 1.0))
             if temperature < self._sampling_eps:
                 sampled_ids.append(int(torch.argmax(row_logits).item()))
+                if self._is_cosyvoice3_stop_token_id(sampled_ids[-1]):
+                    sampled_ids[-1] = self._canonical_stop_token_id()
                 continue
 
             top_p = float(self._req_scalar(sampling_metadata.top_p, req_idx, default_top_p))
             top_k = int(self._req_scalar(sampling_metadata.top_k, req_idx, default_top_k))
             generator = sampling_metadata.generators.get(req_idx)
-            weighted_scores = torch.log_softmax(row_logits / max(temperature, self._sampling_eps), dim=0)
+            weighted_scores = row_logits / max(temperature, self._sampling_eps)
             decoded_tokens = (
                 sampling_metadata.output_token_ids[req_idx] if req_idx < len(sampling_metadata.output_token_ids) else []
             )
-            sampled_ids.append(
-                self._ras_sample_one(
-                    weighted_scores,
-                    decoded_tokens,
-                    top_p=top_p,
-                    top_k=top_k,
-                    win_size=win_size,
-                    tau_r=tau_r,
-                    generator=generator,
-                )
+            sampled_id = self._ras_sample_one(
+                weighted_scores,
+                decoded_tokens,
+                top_p=top_p,
+                top_k=top_k,
+                win_size=win_size,
+                tau_r=tau_r,
+                generator=generator,
             )
+            if self._is_cosyvoice3_stop_token_id(sampled_id):
+                sampled_id = self._canonical_stop_token_id()
+            sampled_ids.append(sampled_id)
 
         sampled = torch.tensor(sampled_ids, device=logits.device, dtype=torch.int32)
         return SamplerOutput(sampled_token_ids=sampled.unsqueeze(-1), logprobs_tensors=None)
@@ -604,6 +671,11 @@ class CosyVoice3Model(
             speech_token_size = self.config.llm["speech_token_size"]
             eos_idx = self.config.llm["eos_token_id"]
             stop_logits = logits[..., speech_token_size:]  # last 200
+            stop_logits = torch.where(
+                torch.isfinite(stop_logits),
+                stop_logits,
+                torch.full_like(stop_logits, float("-inf")),
+            )
             merged_stop = torch.logsumexp(stop_logits, dim=-1, keepdim=True)
             logits[..., speech_token_size:] = float("-inf")  # mask all
             logits[..., eos_idx] = merged_stop.squeeze(-1)  # restore merged

--- a/vllm_omni/model_executor/models/cosyvoice3/cosyvoice3_talker.py
+++ b/vllm_omni/model_executor/models/cosyvoice3/cosyvoice3_talker.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import torch
 from torch import nn
 from vllm.config import VllmConfig
+from vllm.config.vllm import set_current_vllm_config
 from vllm.model_executor.models.qwen2 import Qwen2Model
 
 
@@ -18,7 +19,8 @@ class VLLMQwen2Encoder(torch.nn.Module):
 
     def __init__(self, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
-        self.model = Qwen2Model(vllm_config=vllm_config, prefix=prefix)
+        with set_current_vllm_config(vllm_config, prefix=prefix):
+            self.model = Qwen2Model(vllm_config=vllm_config, prefix=prefix)
         self.hidden_size = vllm_config.model_config.hf_config.hidden_size
 
     def forward(self, inputs_embeds: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -708,6 +708,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
     ):
         sampling_metadata = self.input_batch.sampling_metadata
         if spec_decode_metadata is None:
+            self.input_batch.update_async_output_token_ids()
             model_sample = getattr(self.model, "sample", None)
             if logits is not None and callable(model_sample) and getattr(self.model, "prefer_model_sampler", False):
                 # Apply logit bias (min_tokens, allowed_token_ids) before
@@ -726,7 +727,6 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 )
                 if sampler_output is not None:
                     return sampler_output
-            self.input_batch.update_async_output_token_ids()
             return self.sampler(
                 logits=logits,
                 sampling_metadata=sampling_metadata,


### PR DESCRIPTION
## Purpose

Fixes #2841.

This PR adds a CosyVoice3 online serving example for `/v1/audio/speech`, including:

- a deploy YAML-backed launch script for async-chunk serving
- HTTP non-streaming and streaming PCM example clients
- WebSocket streaming text-input TTS client
- user-guide/example documentation for CosyVoice3 voice cloning requests

It also hardens the CosyVoice3 online serving path by:

- keeping the stage-0 sampling defaults aligned with the CosyVoice3 reference setup:
  `temperature=1.0`, `top_p=0.8`, `top_k=25`, `repetition_penalty=2.0`, `stop_token_ids=[6562]`
- preserving per-request dynamic `min_tokens`/`max_tokens` based on text length
- applying repetition penalty before the CosyVoice3 RAS sampler
- repairing async output-token history before model-level sampling
- making the inner Qwen2 model construction compatible with the current vLLM config path

The CosyVoice3 launch script uses `vllm-omni serve` so it consistently reaches the Omni CLI parser for `--deploy-config` and `--async-chunk`.

## Test Plan

```bash
bash -n examples/online_serving/text_to_speech/cosyvoice3/run_server.sh
pytest -q tests/examples/online_serving/test_cosyvoice3_tts.py
pytest -q tests/model_executor/models/cosyvoice3/test_cosyvoice3_model_helpers.py
vllm-omni serve --omni --help=all | rg -- '--deploy-config|--async-chunk|--stage-init-timeout|--init-timeout'
```

GPU online E2E:

```bash
CUDA_VISIBLE_DEVICES=3 \
COSYVOICE3_MODEL=/path/to/Fun-CosyVoice3-0.5B-2512 \
COSYVOICE3_TOKENIZER=/path/to/Fun-CosyVoice3-0.5B-2512/CosyVoice-BlankEN \
COSYVOICE3_PORT=18094 \
bash examples/online_serving/text_to_speech/cosyvoice3/run_server.sh async
```

Then run both non-streaming wav and streaming PCM requests with the same text, reference audio, reference text, and seed.

## Test Result

- `bash -n examples/online_serving/text_to_speech/cosyvoice3/run_server.sh`: passed
- `pytest -q tests/examples/online_serving/test_cosyvoice3_tts.py`: `4 passed`
- `pytest -q tests/model_executor/models/cosyvoice3/test_cosyvoice3_model_helpers.py`: `19 passed`
- `vllm-omni serve --omni --help=all`: verified Omni CLI flags including `--deploy-config` and `--async-chunk`
- CosyVoice3 online server started successfully with async chunk mode and `/health` returned `200`

Same-input E2E output check:
[cosyvoice3_final_script_nonstream.wav](https://github.com/user-attachments/files/28275127/cosyvoice3_final_script_nonstream.wav)
[cosyvoice3_final_script_stream.wav](https://github.com/user-attachments/files/28275159/cosyvoice3_final_script_stream.wav)

- non-streaming wav payload: `351360 bytes`, `175680 samples`, `7.32s`, RMS `-21.5 dBFS`
- streaming PCM: `351360 bytes`, `175680 samples`, `7.32s`, RMS `-21.1 dBFS`