### PR TITLE
[Refactor] Remove CFG-related constraints for diffusion batching

### DIFF
--- a/tests/diffusion/batching/test_diffusion_batching.py
+++ b/tests/diffusion/batching/test_diffusion_batching.py
@@ -33,6 +33,7 @@ import time
 import uuid
 from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
 
@@ -73,6 +74,9 @@ TEST_PROMPTS: list[dict[str, str]] = [
     {"prompt": "a spaceship flying above a volcano", "negative_prompt": "low contrast"},
     {"prompt": "a watercolor painting of a mountain lake", "negative_prompt": "photo, realistic"},
 ]
+
+TRUE_CFG_PARITY_SCALES = [1.0, 3.0, 6.0]
+TRUE_CFG_PARITY_SEEDS = [123, 456, 789]
 
 
 # ------------------------------------------------------------------
@@ -129,6 +133,38 @@ def _extract_images(output: OmniRequestOutput) -> list:
     if inner is not None and hasattr(inner, "images") and inner.images:
         return inner.images
     return []
+
+
+def _image_to_array(image) -> np.ndarray:
+    array = np.asarray(image)
+    if array.dtype == np.uint8:
+        return array.astype(np.float32)
+    return array
+
+
+def _assert_image_close(actual, expected, *, label: str) -> None:
+    actual_array = _image_to_array(actual)
+    expected_array = _image_to_array(expected)
+    assert actual_array.shape == expected_array.shape, (
+        f"{label}: shape mismatch, actual={actual_array.shape}, expected={expected_array.shape}"
+    )
+    diff = np.abs(actual_array.astype(np.float32) - expected_array.astype(np.float32))
+    max_diff = float(diff.max()) if diff.size else 0.0
+    mean_diff = float(diff.mean()) if diff.size else 0.0
+    print(f"   {label}: max_abs_diff={max_diff:.4f}, mean_abs_diff={mean_diff:.4f}")
+    np.testing.assert_array_equal(
+        actual_array,
+        expected_array,
+        err_msg=f"{label}: image parity mismatch",
+    )
+
+
+def _true_cfg_sampling_params(scale: float, seed: int) -> OmniDiffusionSamplingParams:
+    return _default_sampling_params(
+        guidance_scale=0.0,
+        true_cfg_scale=scale,
+        seed=seed,
+    )
 
 
 # ------------------------------------------------------------------
@@ -313,6 +349,64 @@ async def validate_concurrent(omni: AsyncOmni, prompts: list[dict[str, str]]) ->
     print("   ✅ All request_ids matched, results count correct.\n")
 
 
+async def validate_true_cfg_scale_parity(omni: AsyncOmni, prompts: list[dict[str, str]]) -> None:
+    """Compare separate vs concurrent requests with mixed true CFG scale patterns."""
+    num_parity_requests = len(TRUE_CFG_PARITY_SCALES)
+    if len(prompts) < num_parity_requests:
+        raise ValueError(f"true CFG parity validation requires at least {num_parity_requests} prompts")
+
+    prompts = prompts[:num_parity_requests]
+    samplings = [
+        _true_cfg_sampling_params(scale, seed)
+        for scale, seed in zip(TRUE_CFG_PARITY_SCALES, TRUE_CFG_PARITY_SEEDS, strict=True)
+    ]
+
+    print("🔍 Validating true CFG scale parity with separate vs concurrent requests ...")
+    separate_images = []
+    separate_start = time.perf_counter()
+    for i, (prompt, sampling, scale) in enumerate(zip(prompts, samplings, TRUE_CFG_PARITY_SCALES, strict=True)):
+        result = await _collect_generate(
+            omni,
+            prompt=prompt,
+            request_id=f"true-cfg-separate-{i}-{uuid.uuid4().hex[:8]}",
+            sampling_params_list=[sampling],
+        )
+        images = _extract_images(result)
+        assert len(images) == 1, f"Expected one separate image for prompt {i}, got {len(images)}"
+        separate_images.append(images[0])
+        print(f"   separate prompt {i}: scale={scale}, request_id={result.request_id}")
+    separate_time = time.perf_counter() - separate_start
+
+    concurrent_request_ids = [f"true-cfg-batched-{i}-{uuid.uuid4().hex[:8]}" for i in range(len(prompts))]
+    concurrent_start = time.perf_counter()
+    concurrent_results = await asyncio.gather(
+        *(
+            _collect_generate(
+                omni,
+                prompt=prompt,
+                request_id=request_id,
+                sampling_params_list=[sampling],
+            )
+            for prompt, request_id, sampling in zip(prompts, concurrent_request_ids, samplings, strict=True)
+        )
+    )
+    concurrent_time = time.perf_counter() - concurrent_start
+
+    returned_ids = [result.request_id for result in concurrent_results]
+    assert returned_ids == concurrent_request_ids, (
+        f"Request ID order mismatch: {returned_ids} != {concurrent_request_ids}"
+    )
+
+    for i, result in enumerate(concurrent_results):
+        images = _extract_images(result)
+        assert len(images) == 1, f"Expected one concurrent image for prompt {i}, got {len(images)}"
+        _assert_image_close(images[0], separate_images[i], label=f"prompt {i}, scale={TRUE_CFG_PARITY_SCALES[i]}")
+
+    print(f"   ✅ Separate true-CFG time: {separate_time:.2f}s")
+    print(f"   ✅ Concurrent true-CFG time: {concurrent_time:.2f}s")
+    print("   ✅ true CFG scale parity passed.\n")
+
+
 # ------------------------------------------------------------------
 # Single vs Parallel comparison (CLI only)
 # ------------------------------------------------------------------
@@ -364,6 +458,8 @@ async def main(model: str, num_prompts: int, mode: str, batch_size: int = 1) -> 
             await validate_concurrent(omni, prompts)
         elif mode == "validate_batch":
             await validate_batch_explicit(omni, prompts)
+        elif mode == "true_cfg_parity":
+            await validate_true_cfg_scale_parity(omni, prompts)
         elif mode == "batch":
             await run_batch(omni, prompts, label="measurement")
         elif mode == "batch_explicit":
@@ -540,6 +636,23 @@ def test_diffusion_batching_async_explicit_batch(model_name: str):
 @pytest.mark.diffusion
 @hardware_test(res={"cuda": "L4", "rocm": "MI325", "xpu": "B60"})
 @pytest.mark.parametrize("model_name", models)
+def test_diffusion_batching_true_cfg_scale_parity(model_name: str):
+    """Mixed true CFG branch patterns should preserve per-request results under concurrency."""
+
+    async def _inner():
+        omni = AsyncOmni(model=model_name, diffusion_batch_size=2)
+        try:
+            await validate_true_cfg_scale_parity(omni, TEST_PROMPTS[: len(TRUE_CFG_PARITY_SCALES)])
+        finally:
+            omni.shutdown()
+
+    asyncio.run(_inner())
+
+
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@hardware_test(res={"cuda": "L4", "rocm": "MI325", "xpu": "B60"})
+@pytest.mark.parametrize("model_name", models)
 def test_diffusion_batching_num_outputs(model_name: str):
     """Test that the diffusion model respects num_outputs_per_prompt and
     generates the correct number of images per request."""
@@ -613,12 +726,21 @@ if __name__ == "__main__":
     parser.add_argument("--batch-size", type=int, default=1, help="Diffusion batch size (1 = no batching)")
     parser.add_argument(
         "--mode",
-        choices=["batch", "batch_explicit", "single", "compare", "validate", "validate_batch"],
+        choices=[
+            "batch",
+            "batch_explicit",
+            "single",
+            "compare",
+            "validate",
+            "validate_batch",
+            "true_cfg_parity",
+        ],
         default="compare",
         help=(
             "Run mode: 'batch' (parallel gather), 'batch_explicit' (list-prompt batch API), "
             "'single' (sequential), 'compare' (all three), "
-            "'validate' (concurrent correctness), 'validate_batch' (list-prompt correctness)"
+            "'validate' (concurrent correctness), 'validate_batch' (list-prompt correctness), "
+            "'true_cfg_parity' (separate vs concurrent true-CFG image parity)"
         ),
     )
     args = parser.parse_args()

--- a/tests/diffusion/distributed/test_cfg_parallel.py
+++ b/tests/diffusion/distributed/test_cfg_parallel.py
@@ -136,6 +136,23 @@ class TestCFGPipeline(CFGParallelMixin):
             torch.nn.init.normal_(param, mean=0.0, std=0.02)
 
 
+class CombineOnlyPipeline(CFGParallelMixin):
+    """Minimal pipeline for combine_cfg_noise tests."""
+
+
+def test_combine_cfg_noise_supports_per_row_scale():
+    """Vector CFG scales apply row-wise across the prediction batch."""
+    pipeline = CombineOnlyPipeline()
+    positive = torch.tensor([[[[2.0]]], [[[5.0]]]])
+    negative = torch.tensor([[[[1.0]]], [[[3.0]]]])
+    scale = torch.tensor([3.0, 6.0])
+
+    result = pipeline.combine_cfg_noise(positive, negative, scale, cfg_normalize=False)
+
+    expected = torch.tensor([[[[4.0]]], [[[15.0]]]])
+    torch.testing.assert_close(result, expected, rtol=0, atol=0)
+
+
 def _test_cfg_parallel_worker(
     local_rank: int,
     world_size: int,
@@ -199,12 +216,15 @@ def _test_cfg_parallel_worker(
     # Prepare kwargs for predict_noise_maybe_with_cfg
     positive_kwargs = {"x": positive_input}
     negative_kwargs = {"x": negative_input}
+    cfg_scale = test_config["cfg_scale"]
+    if isinstance(cfg_scale, list):
+        cfg_scale = torch.tensor(cfg_scale, device=device, dtype=dtype)
 
     with torch.no_grad():
         # Call predict_noise_maybe_with_cfg
         noise_pred = pipeline.predict_noise_maybe_with_cfg(
             do_true_cfg=True,
-            true_cfg_scale=test_config["cfg_scale"],
+            true_cfg_scale=cfg_scale,
             positive_kwargs=positive_kwargs,
             negative_kwargs=negative_kwargs,
             cfg_normalize=test_config["cfg_normalize"],
@@ -276,11 +296,14 @@ def _test_cfg_sequential_worker(
 
     positive_kwargs = {"x": positive_input}
     negative_kwargs = {"x": negative_input}
+    cfg_scale = test_config["cfg_scale"]
+    if isinstance(cfg_scale, list):
+        cfg_scale = torch.tensor(cfg_scale, device=device, dtype=dtype)
 
     with torch.no_grad():
         noise_pred = pipeline.predict_noise_maybe_with_cfg(
             do_true_cfg=True,
-            true_cfg_scale=test_config["cfg_scale"],
+            true_cfg_scale=cfg_scale,
             positive_kwargs=positive_kwargs,
             negative_kwargs=negative_kwargs,
             cfg_normalize=test_config["cfg_normalize"],
@@ -297,7 +320,14 @@ def _test_cfg_sequential_worker(
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("batch_size", [2])
 @pytest.mark.parametrize("cfg_normalize", [False, True])
-def test_predict_noise_maybe_with_cfg(cfg_parallel_size: int, dtype: torch.dtype, batch_size: int, cfg_normalize: bool):
+@pytest.mark.parametrize("cfg_scale", [7.5, [3.0, 6.0]])
+def test_predict_noise_maybe_with_cfg(
+    cfg_parallel_size: int,
+    dtype: torch.dtype,
+    batch_size: int,
+    cfg_normalize: bool,
+    cfg_scale: float | list[float],
+):
     """
     Test that predict_noise_maybe_with_cfg produces identical results
     with and without CFG parallel.
@@ -318,7 +348,7 @@ def test_predict_noise_maybe_with_cfg(cfg_parallel_size: int, dtype: torch.dtype
         "height": 16,
         "width": 16,
         "hidden_dim": 128,
-        "cfg_scale": 7.5,
+        "cfg_scale": cfg_scale,
         "cfg_normalize": cfg_normalize,
         "model_seed": 42,  # Fixed seed for model initialization
         "input_seed": 123,  # Fixed seed for input generation
@@ -379,14 +409,16 @@ def test_predict_noise_maybe_with_cfg(cfg_parallel_size: int, dtype: torch.dtype
         atol=atol,
         msg=(
             f"CFG parallel output differs from sequential CFG\n"
-            f"  dtype={dtype}, batch_size={batch_size}, cfg_normalize={cfg_normalize}\n"
+            f"  dtype={dtype}, batch_size={batch_size}, cfg_scale={cfg_scale}, "
+            f"cfg_normalize={cfg_normalize}\n"
             f"  Max diff: {(cfg_parallel_output - baseline_output).abs().max().item():.6e}"
         ),
     )
 
     print(
         f"✓ Test passed: cfg_size={cfg_parallel_size}, dtype={dtype}, "
-        f"batch_size={batch_size}, cfg_normalize={cfg_normalize}"
+        f"batch_size={batch_size}, cfg_scale={cfg_scale}, "
+        f"cfg_normalize={cfg_normalize}"
     )
 
 

--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -157,10 +157,15 @@ class TestGetSamplingParamsKey:
     """Pure-function tests for the batch-compatibility key builder."""
 
     @staticmethod
-    def _make(lora_int_id: int | None = None, lora_scale: float = 1.0) -> OmniDiffusionRequest:
+    def _make(
+        lora_int_id: int | None = None,
+        lora_scale: float = 1.0,
+        prompts=None,
+        **sampling_kwargs,
+    ) -> OmniDiffusionRequest:
         from vllm_omni.lora.request import LoRARequest
 
-        sp = OmniDiffusionSamplingParams(num_inference_steps=2)
+        sp = OmniDiffusionSamplingParams(num_inference_steps=2, **sampling_kwargs)
         if lora_int_id is not None:
             sp.lora_request = LoRARequest(
                 lora_name=f"adapter-{lora_int_id}",
@@ -169,7 +174,7 @@ class TestGetSamplingParamsKey:
             )
         sp.lora_scale = lora_scale
         return OmniDiffusionRequest(
-            prompts=["prompt"],
+            prompts=["prompt"] if prompts is None else prompts,
             sampling_params=sp,
             request_ids=[f"req-{lora_int_id}-{lora_scale}"],
         )
@@ -199,6 +204,87 @@ class TestGetSamplingParamsKey:
         a = get_sampling_params_key(self._make(lora_int_id=1, lora_scale=0.5))
         b = get_sampling_params_key(self._make(lora_int_id=1, lora_scale=0.5))
         assert a == b
+
+    def test_equal_for_different_non_one_guidance_scales(self) -> None:
+        from vllm_omni.diffusion.sched.base_scheduler import get_sampling_params_key
+
+        assert get_sampling_params_key(self._make(guidance_scale=4.0)) == get_sampling_params_key(
+            self._make(guidance_scale=7.5)
+        )
+
+    def test_distinguishes_default_and_non_one_guidance_scales(self) -> None:
+        from vllm_omni.diffusion.sched.base_scheduler import get_sampling_params_key
+
+        assert get_sampling_params_key(self._make(guidance_scale=1.0)) != get_sampling_params_key(
+            self._make(guidance_scale=7.5)
+        )
+
+    def test_equal_for_different_non_one_second_guidance_scales(self) -> None:
+        from vllm_omni.diffusion.sched.base_scheduler import get_sampling_params_key
+
+        assert get_sampling_params_key(
+            self._make(
+                guidance_scale=4.0,
+                guidance_scale_2=8.0,
+            )
+        ) == get_sampling_params_key(
+            self._make(
+                guidance_scale=7.5,
+                guidance_scale_2=3.0,
+            )
+        )
+
+    def test_distinguishes_second_guidance_branch_pattern(self) -> None:
+        from vllm_omni.diffusion.sched.base_scheduler import get_sampling_params_key
+
+        assert get_sampling_params_key(
+            self._make(
+                guidance_scale=4.0,
+                guidance_scale_2=1.0,
+            )
+        ) != get_sampling_params_key(
+            self._make(
+                guidance_scale=7.5,
+                guidance_scale_2=3.0,
+            )
+        )
+
+    def test_equal_for_different_non_one_true_cfg_scales(self) -> None:
+        from vllm_omni.diffusion.sched.base_scheduler import get_sampling_params_key
+
+        assert get_sampling_params_key(
+            self._make(
+                prompts=[{"prompt": "prompt", "negative_prompt": "bad"}],
+                true_cfg_scale=3.0,
+            )
+        ) == get_sampling_params_key(
+            self._make(
+                prompts=[{"prompt": "prompt", "negative_prompt": "bad"}],
+                true_cfg_scale=5.0,
+            )
+        )
+
+    def test_distinguishes_true_cfg_branch_pattern(self) -> None:
+        from vllm_omni.diffusion.sched.base_scheduler import get_sampling_params_key
+
+        assert get_sampling_params_key(
+            self._make(
+                prompts=[{"prompt": "prompt", "negative_prompt": "bad"}],
+                true_cfg_scale=1.0,
+            )
+        ) != get_sampling_params_key(
+            self._make(
+                prompts=[{"prompt": "prompt", "negative_prompt": "bad"}],
+                true_cfg_scale=5.0,
+            )
+        )
+
+    def test_distinguishes_resolution(self) -> None:
+        from vllm_omni.diffusion.sched.base_scheduler import get_sampling_params_key
+
+        assert get_sampling_params_key(self._make(guidance_scale=4.0, width=512)) != get_sampling_params_key(
+            self._make(guidance_scale=7.5, width=768)
+        )
 
 
 class TestRequestScheduler:
@@ -281,6 +367,99 @@ class TestRequestScheduler:
         assert _new_ids(sched_output) == [req_id_a, req_id_b]
         assert sched_output.num_running_reqs == 2
         assert sched_output.num_waiting_reqs == 0
+
+    def test_batches_requests_with_different_non_one_guidance_scales(self) -> None:
+        scheduler = RequestScheduler()
+        scheduler.initialize(SimpleNamespace(max_num_seqs=2))
+
+        req_id_a = scheduler.add_request(
+            OmniDiffusionRequest(
+                prompts=["prompt_a"],
+                sampling_params=OmniDiffusionSamplingParams(
+                    guidance_scale=4.0,
+                    num_inference_steps=1,
+                ),
+                request_ids=["a"],
+            )
+        )
+        req_id_b = scheduler.add_request(
+            OmniDiffusionRequest(
+                prompts=["prompt_b"],
+                sampling_params=OmniDiffusionSamplingParams(
+                    guidance_scale=7.5,
+                    num_inference_steps=1,
+                ),
+                request_ids=["b"],
+            )
+        )
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == [req_id_a, req_id_b]
+        assert sched_output.num_running_reqs == 2
+        assert sched_output.num_waiting_reqs == 0
+
+    def test_batches_requests_with_different_non_one_true_cfg_scales(self) -> None:
+        scheduler = RequestScheduler()
+        scheduler.initialize(SimpleNamespace(max_num_seqs=2))
+
+        req_id_a = scheduler.add_request(
+            OmniDiffusionRequest(
+                prompts=[{"prompt": "prompt_a", "negative_prompt": "bad"}],
+                sampling_params=OmniDiffusionSamplingParams(
+                    true_cfg_scale=3.0,
+                    num_inference_steps=1,
+                ),
+                request_ids=["a"],
+            )
+        )
+        req_id_b = scheduler.add_request(
+            OmniDiffusionRequest(
+                prompts=[{"prompt": "prompt_b", "negative_prompt": "bad"}],
+                sampling_params=OmniDiffusionSamplingParams(
+                    true_cfg_scale=6.0,
+                    num_inference_steps=1,
+                ),
+                request_ids=["b"],
+            )
+        )
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == [req_id_a, req_id_b]
+        assert sched_output.num_running_reqs == 2
+        assert sched_output.num_waiting_reqs == 0
+
+    def test_rejects_mixed_default_and_non_one_guidance_scales(self) -> None:
+        scheduler = RequestScheduler()
+        scheduler.initialize(SimpleNamespace(max_num_seqs=2))
+
+        req_id_a = scheduler.add_request(
+            OmniDiffusionRequest(
+                prompts=["prompt_a"],
+                sampling_params=OmniDiffusionSamplingParams(
+                    guidance_scale=1.0,
+                    num_inference_steps=1,
+                ),
+                request_ids=["a"],
+            )
+        )
+        scheduler.add_request(
+            OmniDiffusionRequest(
+                prompts=["prompt_b"],
+                sampling_params=OmniDiffusionSamplingParams(
+                    guidance_scale=7.5,
+                    num_inference_steps=1,
+                ),
+                request_ids=["b"],
+            )
+        )
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == [req_id_a]
+        assert sched_output.num_running_reqs == 1
+        assert sched_output.num_waiting_reqs == 1
 
     def test_incompatible_waiting_head_blocks_later_compatible_request(self) -> None:
         scheduler = RequestScheduler()

--- a/tests/diffusion/test_diffusion_step_pipeline.py
+++ b/tests/diffusion/test_diffusion_step_pipeline.py
@@ -211,15 +211,30 @@ class _DistributedStepPipeline(CFGParallelMixin):
     def prepare_encode(self, state, **kwargs):
         del kwargs
         state.timesteps = [torch.tensor(1.0, device=self.device)]
-        state.latents = torch.ones((1, 1), device=self.device)
+        if self.mode == "cfg_batched":
+            state.latents = torch.tensor([[float(state.sampling.seed)]], device=self.device)
+        else:
+            state.latents = torch.ones((1, 1), device=self.device)
         state.step_index = 0
         state.scheduler = self.scheduler
-        state.do_true_cfg = self.mode == "cfg"
+        state.do_true_cfg = self.mode in ("cfg", "cfg_batched")
         state.prompt_embeds = torch.tensor([[0.0, 0.0], [1.0, 1.0]])
         return state
 
     def denoise_step(self, state, **kwargs):
         del kwargs
+        if self.mode == "cfg_batched":
+            positive_pred, negative_pred = _true_cfg_branch_predictions(state.latents)
+            positive_kwargs = {"x": positive_pred}
+            negative_kwargs = {"x": negative_pred}
+            return self.predict_noise_maybe_with_cfg(
+                do_true_cfg=state.do_true_cfg,
+                true_cfg_scale=state.true_cfg_scale,
+                positive_kwargs=positive_kwargs,
+                negative_kwargs=negative_kwargs,
+                cfg_normalize=False,
+            )
+
         if self.mode == "ulysses":
             sp_group = get_sp_group().ulysses_group
             seq_world_size = torch.distributed.get_world_size(sp_group)
@@ -255,7 +270,9 @@ class _DistributedStepPipeline(CFGParallelMixin):
 
     def step_scheduler(self, state, noise_pred, **kwargs):
         del kwargs
-        if self.mode == "cfg":
+        if self.mode == "cfg_batched":
+            state.latents = noise_pred
+        elif self.mode == "cfg":
             state.latents = self.scheduler_step_maybe_with_cfg(
                 noise_pred,
                 state.current_timestep,
@@ -422,6 +439,17 @@ def _expected_output_for_mode(mode: str) -> torch.Tensor:
     return torch.tensor([[2.0]])
 
 
+def _true_cfg_branch_predictions(latents: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    return latents + 1.0, latents - 1.0
+
+
+def _expected_true_cfg_output(seed: int, true_cfg_scale: float) -> torch.Tensor:
+    latents = torch.tensor([[float(seed)]])
+    positive, negative = _true_cfg_branch_predictions(latents)
+    guided = negative + true_cfg_scale * (positive - negative)
+    return guided
+
+
 def _distributed_step_worker(local_rank: int, world_size: int, mode: str, master_port: str):
     device = torch.device(f"{current_omni_platform.device_type}:{local_rank}")
     current_omni_platform.set_device(device)
@@ -458,6 +486,47 @@ def _distributed_step_worker(local_rank: int, world_size: int, mode: str, master
         assert output.result is not None
         torch.testing.assert_close(output.result.output, _expected_output_for_mode(mode), rtol=1e-5, atol=1e-5)
         assert "req-1" not in runner.state_cache
+    finally:
+        destroy_distributed_env()
+
+
+def _distributed_batched_cfg_step_worker(local_rank: int, world_size: int, master_port: str):
+    device = torch.device(f"{current_omni_platform.device_type}:{local_rank}")
+    current_omni_platform.set_device(device)
+    _update_environment_variables(
+        {
+            "RANK": str(local_rank),
+            "LOCAL_RANK": str(local_rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": master_port,
+        }
+    )
+    model_runner_module.set_forward_context = _noop_forward_context
+
+    try:
+        init_distributed_environment()
+        initialize_model_parallel(cfg_parallel_size=world_size)
+
+        runner = _make_distributed_runner("cfg_batched", device)
+        req_1_seed, req_1_scale = 10, 3.0
+        req_2_seed, req_2_scale = 20, 6.0
+        req_1 = _make_true_cfg_request("req-1", seed=req_1_seed, true_cfg_scale=req_1_scale)
+        req_2 = _make_true_cfg_request("req-2", seed=req_2_seed, true_cfg_scale=req_2_scale)
+        result = DiffusionModelRunner.execute_stepwise(
+            runner,
+            _make_batch_scheduler_output([req_1, req_2], step_id=0),
+        )
+
+        output_1 = result.get_req_output("req-1")
+        output_2 = result.get_req_output("req-2")
+        assert output_1.finished is True
+        assert output_2.finished is True
+        assert output_1.result is not None
+        assert output_2.result is not None
+        torch.testing.assert_close(output_1.result.output, _expected_true_cfg_output(req_1_seed, req_1_scale))
+        torch.testing.assert_close(output_2.result.output, _expected_true_cfg_output(req_2_seed, req_2_scale))
+        assert runner.state_cache == {}
     finally:
         destroy_distributed_env()
 
@@ -553,8 +622,10 @@ class TestRunner:
         assert batched_runner.pipeline.denoise_calls == 1
 
     def test_batch_preserves_per_request_true_cfg_scale(self, monkeypatch):
-        req_1 = _make_true_cfg_request("req-1", seed=10, true_cfg_scale=3.0)
-        req_2 = _make_true_cfg_request("req-2", seed=20, true_cfg_scale=6.0)
+        req_1_seed, req_1_scale = 10, 3.0
+        req_2_seed, req_2_scale = 20, 6.0
+        req_1 = _make_true_cfg_request("req-1", seed=req_1_seed, true_cfg_scale=req_1_scale)
+        req_2 = _make_true_cfg_request("req-2", seed=req_2_seed, true_cfg_scale=req_2_scale)
 
         batched_runner = _make_runner()
         batched_runner.pipeline = _TrueCfgStepPipeline()
@@ -583,8 +654,14 @@ class TestRunner:
             assert separate.finished is True
             torch.testing.assert_close(batched_output.result.output, separate.result.output)
 
-        assert batched.get_req_output("req-1").result.output.item() == 15.0
-        assert batched.get_req_output("req-2").result.output.item() == 31.0
+        torch.testing.assert_close(
+            batched.get_req_output("req-1").result.output,
+            _expected_true_cfg_output(req_1_seed, req_1_scale),
+        )
+        torch.testing.assert_close(
+            batched.get_req_output("req-2").result.output,
+            _expected_true_cfg_output(req_2_seed, req_2_scale),
+        )
         assert batched_runner.pipeline.denoise_calls == 1
 
     def test_rejects_missing_cached_state(self):
@@ -1017,5 +1094,21 @@ def test_execute_stepwise_with_cfg_parallel():
     torch.multiprocessing.spawn(
         _distributed_step_worker,
         args=(world_size, "cfg", "29542"),
+        nprocs=world_size,
+    )
+
+
+@hardware_test(
+    res={"cuda": "L4"},
+    num_cards=2,
+)
+def test_execute_stepwise_batched_true_cfg_scales_with_cfg_parallel():
+    world_size = 2
+    if current_omni_platform.get_device_count() < world_size:
+        pytest.skip(f"Test requires {world_size} devices")
+
+    torch.multiprocessing.spawn(
+        _distributed_batched_cfg_step_worker,
+        args=(world_size, "29543"),
         nprocs=world_size,
     )

--- a/tests/diffusion/test_diffusion_step_pipeline.py
+++ b/tests/diffusion/test_diffusion_step_pipeline.py
@@ -13,6 +13,7 @@ import pytest
 import torch
 from pytest_mock import MockerFixture
 
+import vllm_omni.diffusion.distributed.cfg_parallel as cfg_parallel_module
 import vllm_omni.diffusion.worker.diffusion_model_runner as model_runner_module
 from tests.helpers.mark import hardware_test
 from vllm_omni.diffusion.data import DiffusionOutput
@@ -94,6 +95,74 @@ class _StepPipeline:
         del kwargs
         self.decode_calls += 1
         return DiffusionOutput(output=torch.tensor([state.step_index], dtype=torch.float32))
+
+
+class _GuidanceStepPipeline(_StepPipeline):
+    """Pipeline stub that makes per-request guidance affect the step output."""
+
+    def prepare_encode(self, state, **kwargs):
+        del kwargs
+        self.prepare_calls += 1
+        state.timesteps = [torch.tensor(1.0)]
+        state.latents = torch.tensor([[float(state.sampling.seed)]])
+        state.prompt_embeds = torch.tensor([[[0.0, 0.0]]])
+        state.guidance = torch.tensor([state.sampling.guidance_scale])
+        return state
+
+    def denoise_step(self, input_batch, **kwargs):
+        del kwargs
+        self.denoise_calls += 1
+        return input_batch.latents + input_batch.guidance.reshape(-1, 1)
+
+    def step_scheduler(self, state, noise_pred, **kwargs):
+        del kwargs
+        self.scheduler_calls += 1
+        state.latents = noise_pred
+        state.step_index += 1
+
+    def post_decode(self, state, **kwargs):
+        del kwargs
+        self.decode_calls += 1
+        return DiffusionOutput(output=state.latents.clone())
+
+
+class _TrueCfgStepPipeline(_StepPipeline, CFGParallelMixin):
+    """Pipeline stub that makes per-request true CFG scale affect output."""
+
+    def prepare_encode(self, state, **kwargs):
+        del kwargs
+        self.prepare_calls += 1
+        state.timesteps = [torch.tensor(1.0)]
+        state.latents = torch.tensor([[float(state.sampling.seed)]])
+        state.prompt_embeds = torch.tensor([[[0.0, 0.0]]])
+        state.negative_prompt_embeds = torch.tensor([[[1.0, 1.0]]])
+        state.do_true_cfg = True
+        return state
+
+    def predict_noise(self, **kwargs):
+        return kwargs["x"]
+
+    def denoise_step(self, input_batch, **kwargs):
+        del kwargs
+        self.denoise_calls += 1
+        return self.predict_noise_maybe_with_cfg(
+            input_batch.do_true_cfg,
+            input_batch.true_cfg_scale,
+            {"x": input_batch.latents + 1},
+            {"x": input_batch.latents - 1},
+            cfg_normalize=False,
+        )
+
+    def step_scheduler(self, state, noise_pred, **kwargs):
+        del kwargs
+        self.scheduler_calls += 1
+        state.latents = noise_pred
+        state.step_index += 1
+
+    def post_decode(self, state, **kwargs):
+        del kwargs
+        self.decode_calls += 1
+        return DiffusionOutput(output=state.latents.clone())
 
 
 class _InterruptingStepPipeline(_StepPipeline):
@@ -227,6 +296,30 @@ def _make_engine_request(req_id: str = "req-1", num_inference_steps: int = 2) ->
     return OmniDiffusionRequest(
         prompts=[f"prompt-{req_id}"],
         sampling_params=OmniDiffusionSamplingParams(num_inference_steps=num_inference_steps),
+        request_ids=[req_id],
+    )
+
+
+def _make_guidance_request(req_id: str, *, seed: int, guidance_scale: float) -> OmniDiffusionRequest:
+    return OmniDiffusionRequest(
+        prompts=[f"prompt-{req_id}"],
+        sampling_params=OmniDiffusionSamplingParams(
+            guidance_scale=guidance_scale,
+            num_inference_steps=1,
+            seed=seed,
+        ),
+        request_ids=[req_id],
+    )
+
+
+def _make_true_cfg_request(req_id: str, *, seed: int, true_cfg_scale: float) -> OmniDiffusionRequest:
+    return OmniDiffusionRequest(
+        prompts=[{"prompt": f"prompt-{req_id}", "negative_prompt": "bad"}],
+        sampling_params=OmniDiffusionSamplingParams(
+            true_cfg_scale=true_cfg_scale,
+            num_inference_steps=1,
+            seed=seed,
+        ),
         request_ids=[req_id],
     )
 
@@ -426,6 +519,73 @@ class TestRunner:
 
         result = DiffusionModelRunner.execute_stepwise(runner, scheduler_output)
         assert len(result) == 2
+
+    def test_batch_preserves_per_request_guidance(self, monkeypatch):
+        req_1 = _make_guidance_request("req-1", seed=10, guidance_scale=4.0)
+        req_2 = _make_guidance_request("req-2", seed=20, guidance_scale=7.5)
+
+        batched_runner = _make_runner()
+        batched_runner.pipeline = _GuidanceStepPipeline()
+        monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+
+        batched = DiffusionModelRunner.execute_stepwise(
+            batched_runner,
+            _make_batch_scheduler_output([req_1, req_2]),
+        )
+
+        separate_outputs = []
+        for req in (req_1, req_2):
+            runner = _make_runner()
+            runner.pipeline = _GuidanceStepPipeline()
+            separate_outputs.append(
+                DiffusionModelRunner.execute_stepwise(
+                    runner,
+                    _make_scheduler_output(req, sched_req_id=req.request_ids[0]),
+                ).get_req_output(req.request_ids[0])
+            )
+
+        for req, separate in zip((req_1, req_2), separate_outputs, strict=True):
+            batched_output = batched.get_req_output(req.request_ids[0])
+            assert batched_output.finished is True
+            assert separate.finished is True
+            torch.testing.assert_close(batched_output.result.output, separate.result.output)
+
+        assert batched_runner.pipeline.denoise_calls == 1
+
+    def test_batch_preserves_per_request_true_cfg_scale(self, monkeypatch):
+        req_1 = _make_true_cfg_request("req-1", seed=10, true_cfg_scale=3.0)
+        req_2 = _make_true_cfg_request("req-2", seed=20, true_cfg_scale=6.0)
+
+        batched_runner = _make_runner()
+        batched_runner.pipeline = _TrueCfgStepPipeline()
+        monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+        monkeypatch.setattr(cfg_parallel_module, "get_classifier_free_guidance_world_size", lambda: 1)
+
+        batched = DiffusionModelRunner.execute_stepwise(
+            batched_runner,
+            _make_batch_scheduler_output([req_1, req_2]),
+        )
+
+        separate_outputs = []
+        for req in (req_1, req_2):
+            runner = _make_runner()
+            runner.pipeline = _TrueCfgStepPipeline()
+            separate_outputs.append(
+                DiffusionModelRunner.execute_stepwise(
+                    runner,
+                    _make_scheduler_output(req, sched_req_id=req.request_ids[0]),
+                ).get_req_output(req.request_ids[0])
+            )
+
+        for req, separate in zip((req_1, req_2), separate_outputs, strict=True):
+            batched_output = batched.get_req_output(req.request_ids[0])
+            assert batched_output.finished is True
+            assert separate.finished is True
+            torch.testing.assert_close(batched_output.result.output, separate.result.output)
+
+        assert batched.get_req_output("req-1").result.output.item() == 15.0
+        assert batched.get_req_output("req-2").result.output.item() == 31.0
+        assert batched_runner.pipeline.denoise_calls == 1
 
     def test_rejects_missing_cached_state(self):
         runner = _make_runner()

--- a/vllm_omni/diffusion/distributed/cfg_parallel.py
+++ b/vllm_omni/diffusion/distributed/cfg_parallel.py
@@ -36,6 +36,18 @@ def _slice_pred(pred: tuple[torch.Tensor, ...], output_slice: int) -> tuple[torc
     return tuple(p[:, :output_slice] for p in pred)
 
 
+def _reshape_cfg_scale(true_cfg_scale: float | torch.Tensor, pred: torch.Tensor) -> float | torch.Tensor:
+    if not torch.is_tensor(true_cfg_scale):
+        return true_cfg_scale
+
+    scale = true_cfg_scale.to(device=pred.device, dtype=pred.dtype)
+    if scale.ndim == 0:
+        return scale
+    if scale.numel() == pred.shape[0]:
+        return scale.reshape(pred.shape[0], *([1] * (pred.ndim - 1)))
+    return scale
+
+
 def _dispatch_branches(n_branches: int, n_ranks: int) -> list[list[int]]:
     """
     Round-robin dispatch N branches to M ranks.
@@ -76,7 +88,7 @@ class CFGParallelMixin(metaclass=ABCMeta):
     def predict_noise_maybe_with_cfg(
         self,
         do_true_cfg: bool,
-        true_cfg_scale: float,
+        true_cfg_scale: float | torch.Tensor,
         positive_kwargs: dict[str, Any],
         negative_kwargs: dict[str, Any] | None,
         cfg_normalize: bool = True,
@@ -171,7 +183,7 @@ class CFGParallelMixin(metaclass=ABCMeta):
         self,
         positive_noise_pred: torch.Tensor | tuple[torch.Tensor, ...],
         negative_noise_pred: torch.Tensor | tuple[torch.Tensor, ...],
-        true_cfg_scale: float,
+        true_cfg_scale: float | torch.Tensor,
         cfg_normalize: bool = False,
     ) -> torch.Tensor | tuple[torch.Tensor, ...]:
         """
@@ -205,7 +217,8 @@ class CFGParallelMixin(metaclass=ABCMeta):
 
         results = []
         for p, n in zip(pos_t, neg_t):
-            comb = n + true_cfg_scale * (p - n)
+            scale = _reshape_cfg_scale(true_cfg_scale, p)
+            comb = n + scale * (p - n)
             if cfg_normalize:
                 comb = self.cfg_normalize_function(p, comb)
             results.append(comb)
@@ -216,7 +229,7 @@ class CFGParallelMixin(metaclass=ABCMeta):
     def predict_noise_with_multi_branch_cfg(
         self,
         do_true_cfg: bool,
-        true_cfg_scale: float | dict[str, float],
+        true_cfg_scale: float | torch.Tensor | dict[str, float],
         branches_kwargs: list[dict[str, Any]],
         cfg_normalize: bool = False,
         output_slice: int | None = None,
@@ -276,7 +289,7 @@ class CFGParallelMixin(metaclass=ABCMeta):
         branches_kwargs: list[dict[str, Any]],
         n_branches: int,
         cfg_world_size: int,
-        true_cfg_scale: float,
+        true_cfg_scale: float | torch.Tensor,
         cfg_normalize: bool,
         output_slice: int | None,
     ) -> torch.Tensor | tuple[torch.Tensor, ...]:
@@ -342,7 +355,7 @@ class CFGParallelMixin(metaclass=ABCMeta):
     def combine_multi_branch_cfg_noise(
         self,
         predictions: list[torch.Tensor | tuple[torch.Tensor, ...]],
-        true_cfg_scale: float | dict[str, float],
+        true_cfg_scale: float | torch.Tensor | dict[str, float],
         cfg_normalize: bool = False,
     ) -> torch.Tensor | tuple[torch.Tensor, ...]:
         """
@@ -359,16 +372,11 @@ class CFGParallelMixin(metaclass=ABCMeta):
         Returns:
             Combined noise prediction.
         """
-        positive = _wrap(predictions[0])
-        negative = _wrap(predictions[1])
-
-        results = []
-        for p, n in zip(positive, negative):
-            comb = n + true_cfg_scale * (p - n)
-            if cfg_normalize:
-                comb = self.cfg_normalize_function(p, comb)
-            results.append(comb)
-        return _unwrap(tuple(results))
+        if len(predictions) < 2:
+            raise ValueError("Multi-branch CFG requires at least positive and negative predictions.")
+        if isinstance(true_cfg_scale, dict):
+            raise TypeError("Default multi-branch CFG combine requires a scalar or tensor scale.")
+        return self.combine_cfg_noise(predictions[0], predictions[1], true_cfg_scale, cfg_normalize)
 
     def predict_noise(self, *args: Any, **kwargs: Any) -> torch.Tensor | tuple[torch.Tensor, ...] | IntermediateTensors:
         """

--- a/vllm_omni/diffusion/distributed/pipeline_parallel.py
+++ b/vllm_omni/diffusion/distributed/pipeline_parallel.py
@@ -179,7 +179,7 @@ class PipelineParallelMixin:
     def predict_noise_maybe_with_cfg(
         self,
         do_true_cfg: bool,
-        true_cfg_scale: float,
+        true_cfg_scale: float | torch.Tensor,
         positive_kwargs: dict[str, Any],
         negative_kwargs: dict[str, Any] | None,
         cfg_normalize: bool = True,

--- a/vllm_omni/diffusion/sched/base_scheduler.py
+++ b/vllm_omni/diffusion/sched/base_scheduler.py
@@ -25,6 +25,11 @@ logger = init_logger(__name__)
 # LoRA identity is derived from `sampling.lora_request`, not a same-named field
 # on sampling params, so it must be resolved separately from the bulk lookup.
 _KEY_FIELD_NAMES = frozenset(f.name for f in fields(SamplingParamsKey)) - {"lora_int_id"}
+_CFG_SCALE_USES_CFG_BRANCHES_KEY = -1.0
+
+
+def _has_negative_prompt(request: OmniDiffusionRequest) -> bool:
+    return any(not isinstance(prompt, str) and prompt.get("negative_prompt") for prompt in request.prompts)
 
 
 def get_sampling_params_key(request: OmniDiffusionRequest) -> SamplingParamsKey | None:
@@ -34,9 +39,23 @@ def get_sampling_params_key(request: OmniDiffusionRequest) -> SamplingParamsKey 
 
     sampling = request.sampling_params
     lora_request = getattr(sampling, "lora_request", None)
+    values = {name: getattr(sampling, name) for name in _KEY_FIELD_NAMES}
+
+    # Qwen true CFG also needs the positive/negative branch scheduler bucket.
+    true_cfg_scale = values.get("true_cfg_scale")
+    if true_cfg_scale is not None:
+        if true_cfg_scale > 1.0 and _has_negative_prompt(request):
+            values["do_classifier_free_guidance"] = True
+        if true_cfg_scale != 1.0:
+            values["true_cfg_scale"] = _CFG_SCALE_USES_CFG_BRANCHES_KEY
+
+    for cfg_scale_field in ("guidance_scale", "guidance_scale_2"):
+        cfg_scale = values.get(cfg_scale_field)
+        if cfg_scale is not None and cfg_scale != 1.0:
+            values[cfg_scale_field] = _CFG_SCALE_USES_CFG_BRANCHES_KEY
     return SamplingParamsKey(
         lora_int_id=lora_request.lora_int_id if lora_request is not None else None,
-        **{name: getattr(sampling, name) for name in _KEY_FIELD_NAMES},
+        **values,
     )
 
 

--- a/vllm_omni/diffusion/worker/input_batch.py
+++ b/vllm_omni/diffusion/worker/input_batch.py
@@ -402,17 +402,37 @@ def _prepare_timesteps(
 
 def _prepare_cfg_scalars(
     states: Sequence[DiffusionRequestState],
-) -> tuple[bool, float, bool]:
-    def _cfg_scalars(state: DiffusionRequestState) -> tuple[bool, float, bool]:
-        true_cfg_scale = getattr(state.sampling, "true_cfg_scale", None) or 4.0
-        cfg_normalize = bool(getattr(state.sampling, "cfg_normalize", False))
-        return state.do_true_cfg, true_cfg_scale, cfg_normalize
+) -> tuple[bool, torch.Tensor, bool]:
+    do_true_cfg = states[0].do_true_cfg
+    cfg_normalize = bool(getattr(states[0].sampling, "cfg_normalize", False))
 
-    scalars = _cfg_scalars(states[0])
-    for state in states[1:]:
-        if _cfg_scalars(state) != scalars:
-            raise ValueError("Mixed CFG settings in one diffusion batch are not supported.")
-    return scalars
+    gathered_scales: list[torch.Tensor] = []
+    for state in states:
+        if state.do_true_cfg != do_true_cfg:
+            raise ValueError("Mixed true CFG settings in one diffusion batch are not supported.")
+        if bool(getattr(state.sampling, "cfg_normalize", False)) != cfg_normalize:
+            raise ValueError("Mixed CFG normalization settings in one diffusion batch are not supported.")
+
+        latents = _require_state_latents(state, for_field="true_cfg_scale")
+        true_cfg_scale = getattr(state.sampling, "true_cfg_scale", None) or 4.0
+        scale_tensor = torch.as_tensor(
+            true_cfg_scale,
+            device=latents.device,
+            dtype=latents.dtype,
+        )
+        gathered_scales.append(
+            _expand_scalar_or_vector(
+                scale_tensor,
+                num_rows=int(latents.shape[0]),
+                field_name="true_cfg_scale",
+            )
+        )
+
+    return (
+        do_true_cfg,
+        _gather_tensor_rows(gathered_scales, field_name="true_cfg_scale"),
+        cfg_normalize,
+    )
 
 
 def _prepare_guidance(
@@ -593,9 +613,9 @@ class InputBatch:
     prompt_embeds_mask: torch.Tensor | None
     negative_prompt_embeds: torch.Tensor | None
     negative_prompt_embeds_mask: torch.Tensor | None
+    true_cfg_scale: torch.Tensor
     guidance: torch.Tensor | None = None
     do_true_cfg: bool = False
-    true_cfg_scale: float = 4.0
     cfg_normalize: bool = False
     image_latents: torch.Tensor | None = None
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

This PR addresses the single-GPU scheduler/runner slice of #3846.

Previously, the diffusion scheduler batch-compatibility key included exact CFG scale values. This PR changes the compatibility key to track CFG branch pattern rather than exact scale value:

  - `1.0` remains distinct from non-1 scales.
  - different non-1 `guidance_scale` values can share a scheduler bucket.
  - different non-1 `guidance_scale_2` values can share a scheduler bucket.
  - different non-1 Qwen `true_cfg_scale` values can share a scheduler bucket when true CFG is active.

This is intended as a mergeable first step toward #3846. It does not yet implement or validate CFG parallelism, Ring/ Ulysses padding-free execution, or StagePool/diffusion scheduler optimization.


## Test Plan


  - Add scheduler-key tests for non-1 CFG scale compatibility and `1.0` vs non-1 separation.
  - Add request scheduler tests showing compatible non-1 guidance/true-CFG requests can be scheduled together.
  - Add runner-level tests showing per-request `true_cfg_scale` is preserved through a batched denoise step.
  - Add end-to-end true-CFG parity coverage comparing separate vs concurrent requests for scales `1.0`, `3.0`, and `6.0`.

## Test Result
  Remote focused scheduler test:
  ```
  PYTHONPATH=/workspace/vllm-omni .venv/bin/python -m pytest \
    tests/diffusion/test_diffusion_scheduler.py -q
```
  Result:
  
  ```
  54 passed, 18 warnings in 1.35s
  ```

  Remote focused scheduler + runner tests:
```
  PYTHONPATH=/workspace/vllm-omni .venv/bin/python -m pytest \
    tests/diffusion/test_diffusion_scheduler.py \
    tests/diffusion/test_diffusion_step_pipeline.py -q
```
  Result:
```
  77 passed, 3 skipped
```


  End-to-end true-CFG parity with tiny-random/Qwen-Image:
```
  PYTHONPATH=/workspace/vllm-omni timeout 900 .venv/bin/python \
    tests/diffusion/batching/test_diffusion_batching.py \
    --model tiny-random/Qwen-Image \
    --num-prompts 3 \
    --batch-size 2 \
    --mode true_cfg_parity
```
  Result:
```
  scale=1.0: max_abs_diff=0.0000, mean_abs_diff=0.0000
  scale=3.0: max_abs_diff=0.0000, mean_abs_diff=0.0000
  scale=6.0: max_abs_diff=0.0000, mean_abs_diff=0.0000
  ```
---