### PR TITLE
[CI/Build] Add typos check workflow

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,14 @@
+name: Typos
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1.46.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,6 +254,7 @@ extend-ignore-re = [
     "\\.\\.\\.n,d->\\.\\.\\.nd",
 ]
 [tool.typos.default.extend-words]
+updator = "updator"
 ue = "ue"
 semantics = "semantics"
 fullset = "fullset"


### PR DESCRIPTION
## Purpose

Fixes #3521 by wiring the existing `[tool.typos.default]` configuration in `pyproject.toml` into CI via `crate-ci/typos`.

## Test Plan

- Confirmed `pyproject.toml` already contains typos configuration:
  - `[tool.typos.default]`
  - `[tool.typos.default.extend-words]`
- Confirmed `.github/` previously had no `typos` or `codespell` workflow.
- Added `.github/workflows/typos.yml`.
- Confirmed `.github/workflows/typos.yml` is now found when searching `.github`.

## Test Result

```text
.github/workflows/typos.yml:10:  typos:
.github/workflows/typos.yml:14:      - uses: crate-ci/typos@v1.46.3
```
