### PR TITLE
fix: prevent InternVLA-A1 inference crashes under transformers >= 5.9.0

### DIFF
--- a/vllm_omni/diffusion/models/internvla_a1/adapter_qwen3_vl.py
+++ b/vllm_omni/diffusion/models/internvla_a1/adapter_qwen3_vl.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import inspect
+
 import torch
 import torch.nn as nn
 from transformers.models.qwen3_vl.modeling_qwen3_vl import (
@@ -174,14 +176,22 @@ class Qwen3VLTextModel(HFQwen3VLTextModel):
         else:
             text_position_ids = position_ids[0]
 
-        attention_mask = create_causal_mask(
-            config=self.config,
-            input_embeds=inputs_embeds,
-            attention_mask=attention_mask,
-            cache_position=cache_position,
-            past_key_values=past_key_values,
-            position_ids=text_position_ids,
-        )
+        # Prepare mask arguments
+        mask_kwargs = {
+            "config": self.config,
+            "attention_mask": attention_mask,
+            "past_key_values": past_key_values,
+            "position_ids": text_position_ids,
+        }
+        # Handle API changes across transformers versions
+        sig = inspect.signature(create_causal_mask)
+        if "input_embeds" in sig.parameters:
+            mask_kwargs["input_embeds"] = inputs_embeds
+            mask_kwargs["cache_position"] = cache_position
+        else:
+            mask_kwargs["inputs_embeds"] = inputs_embeds
+
+        attention_mask = create_causal_mask(**mask_kwargs)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)


### PR DESCRIPTION
 

## Purpose

Upstream  transformers >= 5.9.0  changed  create_causal_mask  signature: 
     renamed  input_embeds  to  inputs_embeds  and removed  cache_position .


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
