### PR TITLE
fix: propagate env override into runtime config 

### DIFF
--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -120,6 +120,7 @@ class TestStageConfig:
                 "tensor_parallel_size": 2,
                 "devices": "0,1",
                 "max_batch_size": 64,
+                "env": {"HCCL_IF_BASE_PORT": 23000},
             },
         )
         with warnings.catch_warnings():
@@ -131,6 +132,8 @@ class TestStageConfig:
         assert omega_config.runtime.devices == "0,1"
         # max_batch_size is migrated to engine_args.max_num_seqs
         assert omega_config.engine_args.max_num_seqs == 64
+        assert dict(omega_config.runtime.env) == {"HCCL_IF_BASE_PORT": 23000}
+        assert "env" not in dict(omega_config.engine_args)
 
     def test_to_omegaconf_max_batch_size_deprecation(self):
         """Test that runtime.max_batch_size emits a FutureWarning."""

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -135,6 +135,30 @@ class TestStageConfig:
         assert dict(omega_config.runtime.env) == {"HCCL_IF_BASE_PORT": 23000}
         assert "env" not in dict(omega_config.engine_args)
 
+    def test_to_omegaconf_env_override_merges_yaml_defaults(self):
+        """CLI env overrides merge into yaml_runtime.env instead of replacing it."""
+        config = StageConfig(
+            stage_id=1,
+            model_stage="diffusion",
+            yaml_runtime={
+                "env": {
+                    "HCCL_IF_BASE_PORT": 24000,
+                    "HCCL_HOST_SOCKET_PORT_RANGE": "24000-24199",
+                    "HCCL_NPU_SOCKET_PORT_RANGE": "24200-24399",
+                }
+            },
+            runtime_overrides={"env": {"HCCL_IF_BASE_PORT": 23000}},
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            omega_config = config.to_omegaconf()
+
+        assert dict(omega_config.runtime.env) == {
+            "HCCL_IF_BASE_PORT": 23000,
+            "HCCL_HOST_SOCKET_PORT_RANGE": "24000-24199",
+            "HCCL_NPU_SOCKET_PORT_RANGE": "24200-24399",
+        }
+
     def test_to_omegaconf_max_batch_size_deprecation(self):
         """Test that runtime.max_batch_size emits a FutureWarning."""
         config = StageConfig(

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -965,7 +965,7 @@ class StageConfig:
 
         # CLI overrides take precedence over YAML defaults
         for key, value in self.runtime_overrides.items():
-            if value is not None and key not in ("devices", "max_batch_size", "num_replicas"):
+            if value is not None and key not in ("devices", "max_batch_size", "num_replicas", "env"):
                 engine_args[key] = value
 
         # Build runtime config from YAML defaults + CLI overrides
@@ -975,6 +975,8 @@ class StageConfig:
             runtime["devices"] = self.runtime_overrides["devices"]
         if self.runtime_overrides.get("num_replicas") is not None:
             runtime["num_replicas"] = self.runtime_overrides["num_replicas"]
+        if self.runtime_overrides.get("env") is not None:
+            runtime["env"] = self.runtime_overrides["env"]
 
         # Legacy compat: migrate runtime.max_batch_size → engine_args.max_num_seqs
         legacy_mbs = runtime.pop("max_batch_size", None)

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -661,6 +661,25 @@ class PlatformOverrides(NamedTuple):
     env: dict[str, Any] | None
 
 
+def _merge_runtime_env(
+    base_env: Any,
+    override_env: Any,
+    *,
+    stage_id: int,
+) -> Any:
+    """Merge runtime env overrides into base env when both are dicts."""
+    if isinstance(base_env, dict) and isinstance(override_env, dict):
+        return {**base_env, **override_env}
+    if base_env is not None:
+        logger.warning(
+            "Stage %s env override replaces base env entirely (base type=%s, override type=%s)",
+            stage_id,
+            type(base_env).__name__,
+            type(override_env).__name__,
+        )
+    return override_env
+
+
 def _extract_platform_overrides(ps: dict[str, Any]) -> PlatformOverrides:
     """Return overrides, devices, and env from a platform stage entry.
 
@@ -703,16 +722,7 @@ def _apply_platform_overrides(
         if po.devices is not None:
             base.devices = po.devices
         if po.env is not None:
-            if isinstance(base.env, dict) and isinstance(po.env, dict):
-                base.env = {**base.env, **po.env}
-            else:
-                logger.warning(
-                    "Stage %s env override replaces base env entirely (base type=%s, override type=%s)",
-                    ps["stage_id"],
-                    type(base.env).__name__,
-                    type(po.env).__name__,
-                )
-                base.env = po.env
+            base.env = _merge_runtime_env(base.env, po.env, stage_id=ps["stage_id"])
         for key, val in po.overrides.items():
             if hasattr(base, key):
                 # Deep-merge dict-valued fields listed in _DEEP_MERGE_KEYS so
@@ -975,8 +985,9 @@ class StageConfig:
             runtime["devices"] = self.runtime_overrides["devices"]
         if self.runtime_overrides.get("num_replicas") is not None:
             runtime["num_replicas"] = self.runtime_overrides["num_replicas"]
-        if self.runtime_overrides.get("env") is not None:
-            runtime["env"] = self.runtime_overrides["env"]
+        cli_env = self.runtime_overrides.get("env")
+        if cli_env is not None:
+            runtime["env"] = _merge_runtime_env(runtime.get("env"), cli_env, stage_id=self.stage_id)
 
         # Legacy compat: migrate runtime.max_batch_size → engine_args.max_num_seqs
         legacy_mbs = runtime.pop("max_batch_size", None)


### PR DESCRIPTION


## Purpose

Trigger Scenario
  Users pass stage environment variables using  --stage-overrides  CLI parameter (e.g.,  {"1": {"env": {"HCCL_IF_BASE_PORT": 23000}}} ).

Symptoms
  Stage-specific environment variables fail to apply. Stage-dedicated communication parameters (e.g., HCCL port, socket range) do not update, causing  communication port conflicts or configuration errors during multi-stage/multi-process initialization.

  Root Cause
   StageConfig.to_omegaconf()  does not exclude  env  key when iterating  runtime_overrides , causing it to write to  engine_args  instead of  runtime.env . The stage initialization helper  stage_runtime_env()  reads exclusively from  runtime.env .



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
