### PR TITLE
[model, omni] feat: Qwen3-Omni Thinker LoRA for RL training

### DIFF
--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -928,8 +928,12 @@ class AsyncOmni(EngineClient, OmniBase):
         for result in results:
             if isinstance(result, dict) and result.get("todo"):
                 continue
-            if isinstance(result, list):
-                merged.update(result)
+            if isinstance(result, (list, set)):
+                for item in result:
+                    if isinstance(item, (list, set)):
+                        merged.update(item)
+                    elif isinstance(item, int):
+                        merged.add(item)
         return sorted(merged)
 
     async def pin_lora(self, adapter_id: int) -> bool:

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -934,6 +934,8 @@ class AsyncOmni(EngineClient, OmniBase):
                         merged.update(item)
                     elif isinstance(item, int):
                         merged.add(item)
+            elif isinstance(result, int):
+                merged.add(result)
         return sorted(merged)
 
     async def pin_lora(self, adapter_id: int) -> bool:

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -295,6 +295,15 @@ class AsyncOmni(EngineClient, OmniBase):
             # Start final output dispatcher on the first call to generate()
             self._final_output_handler()
 
+            # Forward bare sampling_params (e.g. from /v1/completions) as the stage-0 entry.
+            if sampling_params_list is None and sampling_params is not None:
+                if self.num_stages == 1:
+                    sampling_params_list = [sampling_params]
+                else:
+                    default = list(self.default_sampling_params_list)
+                    default[0] = sampling_params
+                    sampling_params_list = default
+
             # Expand sampling params for PD disaggregation (user may provide N-1 params)
             if (
                 sampling_params_list is not None

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -1118,7 +1118,8 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         self.vllm_config = vllm_config  # needed for torch compile forward context
-        thinker_config: Qwen3OmniMoeThinkerConfig = vllm_config.model_config.hf_config
+        hf_config = vllm_config.model_config.hf_config
+        thinker_config: Qwen3OmniMoeThinkerConfig = getattr(hf_config, "thinker_config", None) or hf_config
         quant_config = vllm_config.quant_config
         multimodal_config = vllm_config.model_config.multimodal_config
         self.config = thinker_config
@@ -1667,6 +1668,7 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
         self,
         input_tokens: list[int],
         mm_features: list[MultiModalFeatureSpec],
+        **kwargs,
     ) -> tuple[torch.Tensor, int]:
         """Compute M-RoPE input positions using mm_features directly."""
         seq_len = len(input_tokens)

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -64,6 +64,7 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 from vllm.model_executor.models.interfaces import (
     MultiModalEmbeddings,
+    SupportsLoRA,
     SupportsMRoPE,
     SupportsMultiModal,
     SupportsPP,
@@ -1071,6 +1072,7 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
     nn.Module,
     SupportsMultiModal,
     SupportsPP,
+    SupportsLoRA,
     SupportsMRoPE,
     Qwen3OmniMoeConditionalGenerationMixin,
     SupportsTranscription,
@@ -1088,6 +1090,11 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
             "q_proj",
             "k_proj",
             "v_proj",
+        ],
+        "attn.qkv": [
+            "attn.q",
+            "attn.k",
+            "attn.v",
         ],
         "gate_up_proj": [
             "gate_proj",


### PR DESCRIPTION
## Purpose

Enable **Qwen3-Omni Thinker** as a LoRA-capable model in vLLM-Omni and fix logprobs forwarding for `/v1/completions` requests — the two vLLM-Omni prerequisites for RL fine-tuning of the Thinker.

Supersedes #3081.

### `vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py`

- Declare `SupportsLoRA` on `Qwen3OmniMoeThinkerForConditionalGeneration`
  so vLLM's LoRA loader recognises the model.
- Extend `packed_modules_mapping` with `attn.qkv → [attn.q, attn.k,
  attn.v]` for the vision encoder's fused QKV projection.
- Read Thinker config from `hf_config.thinker_config` when present,
  falling back to `hf_config` itself — the model now loads whether
  `model_config.hf_config` is the wrapper `Qwen3OmniMoeConfig` or the
  inner `Qwen3OmniMoeThinkerConfig`.
- `compute_mrope_input_positions` accepts `**kwargs` so callers that
  pass extra context no longer get a `TypeError`.

### `vllm_omni/entrypoints/async_omni.py`

- `AsyncOmni.generate` was ignoring the bare `sampling_params` argument
  when `sampling_params_list` was not supplied. Callers that pass
  `SamplingParams(logprobs=N)` via `/v1/completions` silently lost the
  field. Inject the bare params as the stage-0 entry before dispatch.
- `list_loras` collected adapter IDs assuming each per-stage result is
  a flat `list`; multi-process runners may return `set` or individual
  `int` values. Handle all three types.
