### PR TITLE
[WIP] feat: implement preemptive scheduling for Qwen and Wan2.2

### DIFF
--- a/THIRD_PARTY_TEST_COMMANDS.md
+++ b/THIRD_PARTY_TEST_COMMANDS.md
@@ -1,0 +1,202 @@
+# Third-Party Test Commands
+
+All commands assume the repo root is:
+
+```bash
+cd /vllm-workspace/vllm-omni
+```
+
+## 1. Environment Cleanup
+
+```bash
+pkill -f 'super_p95_dispatcher.py|vllm_omni.entrypoints.cli.main serve Qwen/Qwen-Image|vllm_omni.entrypoints.cli.main serve Wan-AI/Wan2.2-T2V-A14B-Diffusers' || true
+rm -f /dev/shm/* 2>/dev/null || true
+npu-smi info
+```
+
+Check:
+
+- all 8 NPUs show `No running processes found`
+- `/dev/shm` is empty or nearly empty
+
+## 2. Qwen-Image
+
+### 2.1 Qwen-Image Baseline Server
+
+```bash
+env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+python3 benchmarks/diffusion/super_p95_dispatcher.py \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --num-servers 8 \
+  --device-ids 0,1,2,3,4,5,6,7 \
+  --model Qwen/Qwen-Image \
+  --backend-start-port 8091 \
+  --backend-hardware-profiles 910B3 \
+  --backend-scheduler step_baseline \
+  --backend-args=--omni \
+  --backend-args=--vae-use-slicing \
+  --backend-args=--vae-use-tiling
+```
+
+### 2.2 Qwen-Image Super P95 Server
+
+```bash
+env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+python3 benchmarks/diffusion/super_p95_dispatcher.py \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --num-servers 8 \
+  --device-ids 0,1,2,3,4,5,6,7 \
+  --model Qwen/Qwen-Image \
+  --backend-start-port 8091 \
+  --backend-hardware-profiles 910B3 \
+  --backend-scheduler super_p95_step \
+  --quota-every 20 \
+  --quota-amount 1 \
+  --threshold-ratio 0.8 \
+  --sacrificial-load-factor 0.1 \
+  --backend-args=--omni \
+  --backend-args=--vae-use-slicing \
+  --backend-args=--vae-use-tiling
+```
+
+### 2.3 Qwen-Image Benchmark
+
+Baseline:
+```bash
+BASE_URL=http://127.0.0.1:8080 \
+NUM_PROMPTS=500 \
+MAX_CONCURRENCY=1000 \
+REQUEST_RATES=0.8 \
+SEED=0 \
+RANDOM_REQUEST_SEED=8 \
+ARRIVAL_SEED=8 \
+bash eval_qwen_image.sh baseline
+```
+
+Super P95:
+```bash
+BASE_URL=http://127.0.0.1:8080 \
+NUM_PROMPTS=500 \
+MAX_CONCURRENCY=1000 \
+REQUEST_RATES=0.8 \
+SEED=0 \
+RANDOM_REQUEST_SEED=8 \
+ARRIVAL_SEED=8 \
+bash eval_qwen_image.sh super_p95
+```
+
+## 3. Wan2.2
+
+### 3.1 Wan2.2 Baseline Server
+
+```bash
+env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+python3 benchmarks/diffusion/super_p95_dispatcher.py \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --num-servers 1 \
+  --device-ids 0,1,2,3,4,5,6,7 \
+  --model Wan-AI/Wan2.2-T2V-A14B-Diffusers \
+  --backend-start-port 8091 \
+  --backend-hardware-profiles 910B3 \
+  --backend-scheduler step_baseline \
+  --backend-log-dir /tmp/wan22_t2v_baseline_usp8 \
+  --backend-env VLLM_OMNI_MASTER_PORT=30191 \
+  --request-timeout-s 1000000 \
+  --backend-health-timeout-s 1800 \
+  --backend-health-poll-interval-s 10 \
+  --backend-args=--omni \
+  --backend-args=--usp \
+  --backend-args=8 \
+  --backend-args=--enable-layerwise-offload \
+  --backend-args=--boundary-ratio \
+  --backend-args=0.875 \
+  --backend-args=--flow-shift \
+  --backend-args=5.0 \
+  --backend-args=--vae-use-slicing \
+  --backend-args=--vae-use-tiling
+```
+
+### 3.2 Wan2.2 Super P95 Server
+
+```bash
+bash benchmarks/diffusion/run_wan22_super_p95_dispatcher_2x4.sh
+```
+
+This starts one dispatcher on port `8080` and two managed Wan2.2 backends:
+
+- backend `8091`: `ASCEND_RT_VISIBLE_DEVICES=0,1,2,3`, `--usp 4`
+- backend `8092`: `ASCEND_RT_VISIBLE_DEVICES=4,5,6,7`, `--usp 4`
+
+### 3.3 Wan2.2 Benchmark
+
+Baseline:
+
+```bash
+env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+python3 benchmarks/diffusion/diffusion_benchmark_serving.py \
+  --base-url http://127.0.0.1:8080 \
+  --backend v1/videos \
+  --dataset random \
+  --task t2v \
+  --num-prompts 50 \
+  --max-concurrency 50 \
+  --request-rate 0.05 \
+  --enable-negative-prompt \
+  --seed 42 \
+  --random-request-seed 42 \
+  --arrival-seed 42 \
+  --random-request-config '[
+    {"width":854,"height":480,"num_inference_steps":3,"num_frames":80,"fps":16,"weight":0.15},
+    {"width":854,"height":480,"num_inference_steps":4,"num_frames":120,"fps":24,"weight":0.25},
+    {"width":1280,"height":720,"num_inference_steps":6,"num_frames":80,"fps":16,"weight":0.6}
+  ]' \
+  --output-file /tmp/wan22_t2v_baseline_usp8_rps005/run_50req_mix3_rps0.05_seed42.json
+```
+
+Super P95:
+
+```bash
+env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+python3 benchmarks/diffusion/diffusion_benchmark_serving.py \
+  --base-url http://127.0.0.1:8080 \
+  --backend v1/videos \
+  --dataset random \
+  --task t2v \
+  --num-prompts 50 \
+  --max-concurrency 50 \
+  --request-rate 0.05 \
+  --enable-negative-prompt \
+  --seed 42 \
+  --random-request-seed 42 \
+  --arrival-seed 42 \
+  --random-request-config '[
+    {"width":854,"height":480,"num_inference_steps":3,"num_frames":80,"fps":16,"weight":0.15},
+    {"width":854,"height":480,"num_inference_steps":4,"num_frames":120,"fps":24,"weight":0.25},
+    {"width":1280,"height":720,"num_inference_steps":6,"num_frames":80,"fps":16,"weight":0.6}
+  ]' \
+  --output-file /tmp/wan22_t2v_super_p95_2x4/run_50req_mix3_rps0.05_seed42.json
+```
+
+Validated 50-prompt, rps `0.05` results:
+
+| Mode | Deployment | Successful | Duration (s) | Throughput (req/s) | Mean (s) | P95 (s) | P99 (s) |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Baseline | 1 x `--usp 8` | 50/50 | 3716.58 | 0.0135 | 1514.82 | 2750.93 | 2887.74 |
+| Super P95 | 2 x `--usp 4` | 50/50 | 3193.27 | 0.0157 | 1241.44 | 2191.56 | 2724.41 |
+
+## 4. Readiness Check
+
+Wan2.2 is ready when the backend log contains:
+
+```text
+Starting vLLM API server (pure diffusion mode)
+Application startup complete.
+```
+
+Qwen-Image is ready when:
+
+- `/health` returns `200`
+- backend startup log reaches `Application startup complete`

--- a/benchmarks/diffusion/backends.py
+++ b/benchmarks/diffusion/backends.py
@@ -267,7 +267,7 @@ async def async_request_v1_videos(
 
         # invoke a poll request (GET /v1/videos/{video_id})
         poll_interval = 2.0  # Unit(s)
-        timeout_seconds = 600.0
+        timeout_seconds = 10000.0 # test only
         deadline = time.perf_counter() + timeout_seconds
         job_url = f"{input.api_url}/{job_id}"
 

--- a/benchmarks/diffusion/baseline_dispatcher.py
+++ b/benchmarks/diffusion/baseline_dispatcher.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response
+
+
+@dataclass
+class BackendState:
+    name: str
+    base_url: str
+    inflight: int = 0
+
+
+class BaselineDispatcher:
+    def __init__(self, backend_urls: list[str], request_timeout_s: float) -> None:
+        if not backend_urls:
+            raise ValueError("At least one --backend-url is required")
+        self.backends = [
+            BackendState(name=f"backend-{idx}", base_url=url.rstrip("/"))
+            for idx, url in enumerate(backend_urls)
+        ]
+        self._client: httpx.AsyncClient | None = None
+        self._lock = asyncio.Lock()
+        self._rr_index = 0
+        self._request_timeout_s = request_timeout_s
+
+    async def startup(self) -> None:
+        timeout = self._request_timeout_s if self._request_timeout_s > 0 else None
+        self._client = httpx.AsyncClient(timeout=timeout, trust_env=False)
+
+    async def shutdown(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def _choose_backend(self) -> int:
+        async with self._lock:
+            num_backends = len(self.backends)
+            start = self._rr_index
+            candidate_indices = list(range(num_backends))
+            candidate_indices.sort(
+                key=lambda idx: (
+                    self.backends[idx].inflight,
+                    (idx - start) % num_backends,
+                ))
+            chosen = candidate_indices[0]
+            self.backends[chosen].inflight += 1
+            self._rr_index = (chosen + 1) % num_backends
+            return chosen
+
+    async def _finish_backend(self, backend_index: int) -> None:
+        async with self._lock:
+            self.backends[backend_index].inflight = max(
+                self.backends[backend_index].inflight - 1, 0)
+
+    async def dispatch_json(self, path: str, body: dict, incoming_headers: dict[str, str]) -> Response:
+        backend_index = await self._choose_backend()
+        backend = self.backends[backend_index]
+        headers = {
+            key: value for key, value in incoming_headers.items()
+            if key.lower() not in {"host", "content-length"}
+        }
+        assert self._client is not None
+        try:
+            response = await self._client.post(f"{backend.base_url}{path}", json=body, headers=headers)
+        finally:
+            await self._finish_backend(backend_index)
+
+        return Response(
+            content=response.content,
+            status_code=response.status_code,
+            headers=self._filter_response_headers(response.headers),
+            media_type=response.headers.get("content-type"),
+        )
+
+    async def proxy_get(self, path: str) -> Response:
+        backend = self.backends[0]
+        assert self._client is not None
+        response = await self._client.get(f"{backend.base_url}{path}")
+        return Response(
+            content=response.content,
+            status_code=response.status_code,
+            headers=self._filter_response_headers(response.headers),
+            media_type=response.headers.get("content-type"),
+        )
+
+    async def health(self) -> JSONResponse:
+        assert self._client is not None
+        statuses: list[dict] = []
+        overall_healthy = True
+        for backend in self.backends:
+            try:
+                response = await self._client.get(f"{backend.base_url}/health")
+                healthy = response.status_code == 200
+                detail = response.text
+            except Exception as exc:
+                healthy = False
+                detail = str(exc)
+            overall_healthy = overall_healthy and healthy
+            statuses.append({
+                "backend": backend.name,
+                "url": backend.base_url,
+                "healthy": healthy,
+                "detail": detail,
+                "inflight": backend.inflight,
+            })
+        return JSONResponse(
+            status_code=200 if overall_healthy else 503,
+            content={"status": "healthy" if overall_healthy else "degraded", "backends": statuses},
+        )
+
+    @staticmethod
+    def _filter_response_headers(headers: httpx.Headers) -> dict[str, str]:
+        blocked = {"content-length", "transfer-encoding", "connection", "content-encoding"}
+        return {key: value for key, value in headers.items() if key.lower() not in blocked}
+
+
+def build_app(dispatcher: BaselineDispatcher) -> FastAPI:
+    app = FastAPI(title="baseline dispatcher")
+
+    @app.on_event("startup")
+    async def _startup() -> None:
+        await dispatcher.startup()
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:
+        await dispatcher.shutdown()
+
+    @app.get("/health")
+    async def health() -> JSONResponse:
+        return await dispatcher.health()
+
+    @app.get("/v1/models")
+    async def models() -> Response:
+        return await dispatcher.proxy_get("/v1/models")
+
+    @app.post("/v1/images/generations")
+    async def image_generations(request: Request) -> Response:
+        body = await request.json()
+        return await dispatcher.dispatch_json("/v1/images/generations", body, dict(request.headers))
+
+    return app
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Round-robin baseline dispatcher for diffusion servers")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=18080)
+    parser.add_argument(
+        "--backend-url",
+        dest="backend_urls",
+        action="append",
+        required=True,
+        help="Backend base URL. Repeat for each backend, e.g. http://127.0.0.1:18091",
+    )
+    parser.add_argument(
+        "--request-timeout-s",
+        type=float,
+        default=0.0,
+        help="Dispatcher-to-backend request timeout in seconds. Set to 0 to disable timeout.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dispatcher = BaselineDispatcher(args.backend_urls, args.request_timeout_s)
+    uvicorn.run(build_app(dispatcher), host=args.host, port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/diffusion/diffusion_benchmark_serving.py
+++ b/benchmarks/diffusion/diffusion_benchmark_serving.py
@@ -724,6 +724,7 @@ def _populate_slo_ms_from_warmups(
 async def iter_requests(
     requests_list: list[RequestFuncInput],
     request_rate: float,
+    arrival_seed: int | None = None,
 ) -> AsyncGenerator[RequestFuncInput, None]:
     """Yield requests using a Poisson process if request_rate is set.
 
@@ -734,10 +735,11 @@ async def iter_requests(
     if request_rate != float("inf"):
         if request_rate <= 0:
             raise ValueError(f"request_rate must be positive or inf, got {request_rate}.")
+    arrival_rng = random.Random(arrival_seed) if arrival_seed is not None else random
 
     for i, req in enumerate(requests_list):
         if request_rate != float("inf") and i > 0:
-            interval_s = random.expovariate(request_rate)
+            interval_s = arrival_rng.expovariate(request_rate)
             await asyncio.sleep(interval_s)
         yield req
 
@@ -890,7 +892,8 @@ async def benchmark(args):
     # Run benchmark
     pbar = tqdm(total=len(requests_list), disable=args.disable_tqdm)
 
-    async with aiohttp.ClientSession() as session:
+    client_timeout = aiohttp.ClientTimeout(total=args.client_timeout_s)
+    async with aiohttp.ClientSession(timeout=client_timeout) as session:
         warmup_pairs: list[tuple[RequestFuncInput, RequestFuncOutput]] = []
         if args.warmup_requests and requests_list:
             print(
@@ -919,7 +922,11 @@ async def benchmark(args):
 
         start_time = time.perf_counter()
         tasks = []
-        async for req in iter_requests(requests_list=requests_list, request_rate=args.request_rate):
+        async for req in iter_requests(
+            requests_list=requests_list,
+            request_rate=args.request_rate,
+            arrival_seed=args.arrival_seed,
+        ):
             task = asyncio.create_task(limited_request_func(req, session, pbar))
             tasks.append(task)
 
@@ -1058,6 +1065,12 @@ if __name__ == "__main__":
         help="Number of warmup requests to run before measurement.",
     )
     parser.add_argument(
+        "--client-timeout-s",
+        type=float,
+        default=10000.0,
+        help="Client-side total timeout in seconds for each benchmark request.",
+    )
+    parser.add_argument(
         "--warmup-num-inference-steps",
         type=int,
         default=1,
@@ -1077,6 +1090,18 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help="Random seed (for diffusion models).",
+    )
+    parser.add_argument(
+        "--random-request-seed",
+        type=int,
+        default=42,
+        help="Seed for sampling request profiles when using the random dataset.",
+    )
+    parser.add_argument(
+        "--arrival-seed",
+        type=int,
+        default=42,
+        help="Seed for Poisson inter-arrival sampling when --request-rate is finite.",
     )
     parser.add_argument("--fps", type=int, default=None, help="FPS (for video).")
     parser.add_argument("--output-file", type=str, default=None, help="Output JSON file for metrics.")

--- a/benchmarks/diffusion/run_wan22_super_p95_dispatcher.sh
+++ b/benchmarks/diffusion/run_wan22_super_p95_dispatcher.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8080}"
+MODEL="${MODEL:-Wan-AI/Wan2.2-T2V-A14B-Diffusers}"
+DEVICE_IDS="${DEVICE_IDS:-0,1,2,3,4,5,6,7}"
+BACKEND_START_PORT="${BACKEND_START_PORT:-8091}"
+BACKEND_LOG_DIR="${BACKEND_LOG_DIR:-/tmp/wan22_t2v_super_p95_usp8}"
+HARDWARE_PROFILE="${HARDWARE_PROFILE:-910B3}"
+REQUEST_TIMEOUT_S="${REQUEST_TIMEOUT_S:-1000000}"
+BACKEND_HEALTH_TIMEOUT_S="${BACKEND_HEALTH_TIMEOUT_S:-1800}"
+BACKEND_HEALTH_POLL_INTERVAL_S="${BACKEND_HEALTH_POLL_INTERVAL_S:-10}"
+BOUNDARY_RATIO="${BOUNDARY_RATIO:-0.875}"
+FLOW_SHIFT="${FLOW_SHIFT:-5.0}"
+QUOTA_EVERY="${QUOTA_EVERY:-20}"
+QUOTA_AMOUNT="${QUOTA_AMOUNT:-1}"
+THRESHOLD_RATIO="${THRESHOLD_RATIO:-0.8}"
+SACRIFICIAL_LOAD_FACTOR="${SACRIFICIAL_LOAD_FACTOR:-0.1}"
+CLEAN_BACKEND_LOG_DIR="${CLEAN_BACKEND_LOG_DIR:-1}"
+VLLM_OMNI_MASTER_PORT="${VLLM_OMNI_MASTER_PORT:-30191}"
+
+if [[ "${CLEAN_BACKEND_LOG_DIR}" == "1" ]]; then
+  rm -rf "${BACKEND_LOG_DIR}"
+fi
+mkdir -p "${BACKEND_LOG_DIR}"
+
+exec env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+python3 benchmarks/diffusion/super_p95_dispatcher.py \
+  --host "${HOST}" \
+  --port "${PORT}" \
+  --num-servers 1 \
+  --device-ids "${DEVICE_IDS}" \
+  --model "${MODEL}" \
+  --backend-start-port "${BACKEND_START_PORT}" \
+  --backend-hardware-profiles "${HARDWARE_PROFILE}" \
+  --backend-scheduler super_p95_step \
+  --quota-every "${QUOTA_EVERY}" \
+  --quota-amount "${QUOTA_AMOUNT}" \
+  --threshold-ratio "${THRESHOLD_RATIO}" \
+  --sacrificial-load-factor "${SACRIFICIAL_LOAD_FACTOR}" \
+  --backend-log-dir "${BACKEND_LOG_DIR}" \
+  --backend-env "VLLM_OMNI_MASTER_PORT=${VLLM_OMNI_MASTER_PORT}" \
+  --request-timeout-s "${REQUEST_TIMEOUT_S}" \
+  --backend-health-timeout-s "${BACKEND_HEALTH_TIMEOUT_S}" \
+  --backend-health-poll-interval-s "${BACKEND_HEALTH_POLL_INTERVAL_S}" \
+  --backend-args=--omni \
+  --backend-args=--usp \
+  --backend-args=8 \
+  --backend-args=--enable-layerwise-offload \
+  --backend-args=--boundary-ratio \
+  --backend-args="${BOUNDARY_RATIO}" \
+  --backend-args=--flow-shift \
+  --backend-args="${FLOW_SHIFT}" \
+  --backend-args=--vae-use-slicing \
+  --backend-args=--vae-use-tiling

--- a/benchmarks/diffusion/run_wan22_super_p95_dispatcher_2x4.sh
+++ b/benchmarks/diffusion/run_wan22_super_p95_dispatcher_2x4.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8080}"
+MODEL="${MODEL:-Wan-AI/Wan2.2-T2V-A14B-Diffusers}"
+DEVICE_IDS="${DEVICE_IDS:-0,1,2,3;4,5,6,7}"
+BACKEND_START_PORT="${BACKEND_START_PORT:-8091}"
+BACKEND_LOG_DIR="${BACKEND_LOG_DIR:-/tmp/wan22_t2v_super_p95_2x4}"
+HARDWARE_PROFILE="${HARDWARE_PROFILE:-910B3}"
+REQUEST_TIMEOUT_S="${REQUEST_TIMEOUT_S:-1000000}"
+BACKEND_HEALTH_TIMEOUT_S="${BACKEND_HEALTH_TIMEOUT_S:-1800}"
+BACKEND_HEALTH_POLL_INTERVAL_S="${BACKEND_HEALTH_POLL_INTERVAL_S:-10}"
+BOUNDARY_RATIO="${BOUNDARY_RATIO:-0.875}"
+FLOW_SHIFT="${FLOW_SHIFT:-5.0}"
+QUOTA_EVERY="${QUOTA_EVERY:-20}"
+QUOTA_AMOUNT="${QUOTA_AMOUNT:-1}"
+THRESHOLD_RATIO="${THRESHOLD_RATIO:-0.8}"
+SACRIFICIAL_LOAD_FACTOR="${SACRIFICIAL_LOAD_FACTOR:-0.1}"
+CLEAN_BACKEND_LOG_DIR="${CLEAN_BACKEND_LOG_DIR:-1}"
+
+if [[ "${CLEAN_BACKEND_LOG_DIR}" == "1" ]]; then
+  rm -rf "${BACKEND_LOG_DIR}"
+fi
+mkdir -p "${BACKEND_LOG_DIR}"
+
+exec env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+python3 benchmarks/diffusion/super_p95_dispatcher.py \
+  --host "${HOST}" \
+  --port "${PORT}" \
+  --num-servers 2 \
+  --device-ids "${DEVICE_IDS}" \
+  --model "${MODEL}" \
+  --backend-start-port "${BACKEND_START_PORT}" \
+  --backend-hardware-profiles "${HARDWARE_PROFILE}" \
+  --backend-scheduler super_p95_step \
+  --quota-every "${QUOTA_EVERY}" \
+  --quota-amount "${QUOTA_AMOUNT}" \
+  --threshold-ratio "${THRESHOLD_RATIO}" \
+  --sacrificial-load-factor "${SACRIFICIAL_LOAD_FACTOR}" \
+  --backend-log-dir "${BACKEND_LOG_DIR}" \
+  --request-timeout-s "${REQUEST_TIMEOUT_S}" \
+  --backend-health-timeout-s "${BACKEND_HEALTH_TIMEOUT_S}" \
+  --backend-health-poll-interval-s "${BACKEND_HEALTH_POLL_INTERVAL_S}" \
+  --backend-args=--omni \
+  --backend-args=--usp \
+  --backend-args=4 \
+  --backend-args=--enable-layerwise-offload \
+  --backend-args=--boundary-ratio \
+  --backend-args="${BOUNDARY_RATIO}" \
+  --backend-args=--flow-shift \
+  --backend-args="${FLOW_SHIFT}" \
+  --backend-args=--vae-use-slicing \
+  --backend-args=--vae-use-tiling

--- a/eval_qwen_image.sh
+++ b/eval_qwen_image.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Qwen-Image server launch examples for this script.
+#
+# Notes:
+# - This script only launches the client benchmark. Start the server manually first.
+# - Use the v0.18.0-super-p95 dispatcher for both baseline and super_p95 so the
+#   serving topology stays identical.
+# Baseline, 8x 910B3:
+# env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+# python3 benchmarks/diffusion/super_p95_dispatcher.py \
+#   --host 127.0.0.1 \
+#   --port 8080 \
+#   --num-servers 8 \
+#   --device-ids 0,1,2,3,4,5,6,7 \
+#   --model Qwen/Qwen-Image \
+#   --backend-start-port 8091 \
+#   --backend-hardware-profiles 910B3 \
+#   --backend-scheduler step_baseline \
+#   --backend-args=--omni \
+#   --backend-args=--vae-use-slicing \
+#   --backend-args=--vae-use-tiling
+#
+# Super-P95, 8x 910B3:
+# env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+# python3 benchmarks/diffusion/super_p95_dispatcher.py \
+#   --host 127.0.0.1 \
+#   --port 8080 \
+#   --num-servers 8 \
+#   --device-ids 0,1,2,3,4,5,6,7 \
+#   --model Qwen/Qwen-Image \
+#   --backend-start-port 8091 \
+#   --backend-hardware-profiles 910B3 \
+#   --backend-scheduler super_p95_step \
+#   --quota-every 20 \
+#   --quota-amount 1 \
+#   --threshold-ratio 0.8 \
+#   --sacrificial-load-factor 0.1 \
+#   --backend-args=--omni \
+#   --backend-args=--vae-use-slicing \
+#   --backend-args=--vae-use-tiling
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash eval_qwen_image.sh baseline
+  bash eval_qwen_image.sh super_p95
+
+Description:
+  Run the Qwen-Image client benchmark against an already running server.
+  This script does not launch the server. Start the matching baseline or super_p95
+  server manually first, then run this script.
+
+Environment overrides:
+  BASE_URL          Default: http://127.0.0.1:8080
+  MODEL             Default: Qwen/Qwen-Image
+  NUM_PROMPTS       Default: 500
+  MAX_CONCURRENCY   Default: 1000
+  REQUEST_RATES     Default: "0.8"
+  WARMUP_REQUESTS   Default: 1
+  WARMUP_STEPS      Default: 1
+  SEED              Default: 0
+  RANDOM_REQUEST_SEED Default: 8
+  ARRIVAL_SEED      Default: 8
+  CLIENT_TIMEOUT_S  Default: 1000000
+  OUTPUT_ROOT       Default: benchmarks/diffusion/results/qwen_image_p95_sweep
+EOF
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+RUN_LABEL="$1"
+case "${RUN_LABEL}" in
+  baseline|super_p95)
+    ;;
+  *)
+    echo "Invalid mode: ${RUN_LABEL}" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+MODEL="${MODEL:-Qwen/Qwen-Image}"
+NUM_PROMPTS="${NUM_PROMPTS:-500}"
+MAX_CONCURRENCY="${MAX_CONCURRENCY:-1000}"
+REQUEST_RATES="${REQUEST_RATES:-0.8}"
+WARMUP_REQUESTS="${WARMUP_REQUESTS:-1}"
+WARMUP_STEPS="${WARMUP_STEPS:-1}"
+SEED="${SEED:-0}"
+RANDOM_REQUEST_SEED="${RANDOM_REQUEST_SEED:-8}"
+ARRIVAL_SEED="${ARRIVAL_SEED:-8}"
+CLIENT_TIMEOUT_S="${CLIENT_TIMEOUT_S:-1000000}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-benchmarks/diffusion/results/qwen_image_p95_sweep}"
+
+DEFAULT_QWEN_IMAGE_RANDOM4="$(cat <<'EOF'
+[
+  {"width":512,"height":512,"num_inference_steps":20,"weight":0.15},
+  {"width":768,"height":768,"num_inference_steps":20,"weight":0.25},
+  {"width":1024,"height":1024,"num_inference_steps":25,"weight":0.45},
+  {"width":1536,"height":1536,"num_inference_steps":35,"weight":0.15}
+]
+EOF
+)"
+QWEN_IMAGE_RANDOM4="${QWEN_IMAGE_RANDOM4:-$DEFAULT_QWEN_IMAGE_RANDOM4}"
+
+OUT_DIR="${OUTPUT_ROOT}/${RUN_LABEL}"
+mkdir -p "${OUT_DIR}"
+
+echo "Run label       : ${RUN_LABEL}"
+echo "Base URL        : ${BASE_URL}"
+echo "Model           : ${MODEL}"
+echo "Num prompts     : ${NUM_PROMPTS}"
+echo "Max concurrency : ${MAX_CONCURRENCY}"
+echo "Request rates   : ${REQUEST_RATES}"
+echo "Arrival seed    : ${ARRIVAL_SEED}"
+echo "Output dir      : ${OUT_DIR}"
+echo "Canonical cmd   : BASE_URL=${BASE_URL} NUM_PROMPTS=${NUM_PROMPTS} MAX_CONCURRENCY=${MAX_CONCURRENCY} REQUEST_RATES=${REQUEST_RATES} SEED=${SEED} RANDOM_REQUEST_SEED=${RANDOM_REQUEST_SEED} ARRIVAL_SEED=${ARRIVAL_SEED} bash eval_qwen_image.sh ${RUN_LABEL}"
+
+python - <<'PY' <<<"${QWEN_IMAGE_RANDOM4}" >/dev/null
+import json
+import sys
+json.loads(sys.stdin.read())
+PY
+
+HEALTH_CODE="$(curl --noproxy '*' -s -o /tmp/eval_qwen_image_health.json -w '%{http_code}' "${BASE_URL}/health" || true)"
+if [[ "${HEALTH_CODE}" != "200" ]]; then
+  echo "Server health check failed for ${BASE_URL}/health (status=${HEALTH_CODE})." >&2
+  cat /tmp/eval_qwen_image_health.json 2>/dev/null || true
+  exit 1
+fi
+
+for rate in ${REQUEST_RATES}; do
+  output_file="${OUT_DIR}/rate_${rate}.json"
+  echo
+  echo "=== rate=${rate} -> ${output_file} ==="
+  env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+  python3 benchmarks/diffusion/diffusion_benchmark_serving.py \
+    --base-url "${BASE_URL}" \
+    --model "${MODEL}" \
+    --backend vllm-omni \
+    --dataset random \
+    --task t2i \
+    --num-prompts "${NUM_PROMPTS}" \
+    --max-concurrency "${MAX_CONCURRENCY}" \
+    --request-rate "${rate}" \
+    --warmup-requests "${WARMUP_REQUESTS}" \
+    --warmup-num-inference-steps "${WARMUP_STEPS}" \
+    --client-timeout-s "${CLIENT_TIMEOUT_S}" \
+    --seed "${SEED}" \
+    --random-request-seed "${RANDOM_REQUEST_SEED}" \
+    --arrival-seed "${ARRIVAL_SEED}" \
+    --random-request-config "${QWEN_IMAGE_RANDOM4}" \
+    --output-file "${output_file}"
+done
+
+echo
+echo "Finished. Results written to ${OUT_DIR}"

--- a/examples/online_serving/text_to_video/README.md
+++ b/examples/online_serving/text_to_video/README.md
@@ -4,27 +4,68 @@ This example demonstrates how to deploy the Wan2.2 text-to-video model for onlin
 
 ## Start Server
 
-### Basic Start
+Wan2.2 T2V validation in this branch is intentionally scoped to the old
+`feat/preemption-recovery-v0.16.0-squashed` serving topology:
 
-```bash
-vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --port 8091
-```
+- dispatcher on `:8080`
+- single managed backend on `:8091`
+- backend config fixed to:
+  - `--usp 8`
+  - `--enable-layerwise-offload`
+  - `--boundary-ratio 0.875`
+  - `--vae-use-slicing`
+  - `--vae-use-tiling`
 
-### Start with Parameters
+### Backend Start
 
-Or use the startup script:
+Use the startup script for the backend:
 
 ```bash
 bash run_server.sh
 ```
 
-The script allows overriding:
+The script defaults to the supported validation config and allows overriding:
 - `MODEL` (default: `Wan-AI/Wan2.2-T2V-A14B-Diffusers`)
 - `PORT` (default: `8091`)
+- `USP` (default: `8`)
+- `ENABLE_LAYERWISE_OFFLOAD` (default: `1`)
 - `BOUNDARY_RATIO` (default: `0.875`)
 - `FLOW_SHIFT` (default: `5.0`)
+- `VAE_USE_SLICING` (default: `1`)
+- `VAE_USE_TILING` (default: `1`)
 - `CACHE_BACKEND` (default: `none`)
 - `ENABLE_CACHE_DIT_SUMMARY` (default: `0`)
+
+### Dispatcher Start
+
+Run baseline or `super_p95` through the dispatcher even though there is only one
+backend, so the serving topology stays identical to the old validation setup.
+
+Baseline:
+
+```bash
+env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+VLLM_OMNI_ENABLE_DIFFUSION_SERVER_SCHEDULING=0 \
+VLLM_OMNI_ENABLE_DIFFUSION_PREEMPTION=0 \
+python3 benchmarks/diffusion/super_p95_dispatcher.py \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --backend-url http://127.0.0.1:8091 \
+  --hardware-profile 910B3
+```
+
+super_p95:
+
+```bash
+env NO_PROXY=127.0.0.1,localhost no_proxy=127.0.0.1,localhost \
+VLLM_OMNI_ENABLE_DIFFUSION_SERVER_SCHEDULING=1 \
+VLLM_OMNI_ENABLE_DIFFUSION_PREEMPTION=1 \
+python3 benchmarks/diffusion/super_p95_dispatcher.py \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --backend-url http://127.0.0.1:8091 \
+  --hardware-profile 910B3
+```
 
 ## Async Job Behavior
 

--- a/examples/online_serving/text_to_video/run_server.sh
+++ b/examples/online_serving/text_to_video/run_server.sh
@@ -1,31 +1,62 @@
 #!/bin/bash
-# Wan2.2 online serving startup script
+set -euo pipefail
+
+# Wan2.2 T2V online serving script.
+# This script intentionally matches the old v0.16 squashed validation config:
+#   single backend on :8091
+#   --usp 8
+#   --enable-layerwise-offload
+#   --boundary-ratio 0.875
+#   --vae-use-slicing
+#   --vae-use-tiling
 
 MODEL="${MODEL:-Wan-AI/Wan2.2-T2V-A14B-Diffusers}"
-PORT="${PORT:-8098}"
+PORT="${PORT:-8091}"
+USP="${USP:-8}"
 BOUNDARY_RATIO="${BOUNDARY_RATIO:-0.875}"
 FLOW_SHIFT="${FLOW_SHIFT:-5.0}"
+ENABLE_LAYERWISE_OFFLOAD="${ENABLE_LAYERWISE_OFFLOAD:-1}"
+VAE_USE_SLICING="${VAE_USE_SLICING:-1}"
+VAE_USE_TILING="${VAE_USE_TILING:-1}"
 CACHE_BACKEND="${CACHE_BACKEND:-none}"
 ENABLE_CACHE_DIT_SUMMARY="${ENABLE_CACHE_DIT_SUMMARY:-0}"
 
-echo "Starting Wan2.2 server..."
-echo "Model: $MODEL"
-echo "Port: $PORT"
-echo "Boundary ratio: $BOUNDARY_RATIO"
-echo "Flow shift: $FLOW_SHIFT"
-echo "Cache backend: $CACHE_BACKEND"
-if [ "$ENABLE_CACHE_DIT_SUMMARY" != "0" ]; then
+echo "Starting Wan2.2 T2V server..."
+echo "Model: ${MODEL}"
+echo "Port: ${PORT}"
+echo "USP: ${USP}"
+echo "Layerwise offload: ${ENABLE_LAYERWISE_OFFLOAD}"
+echo "Boundary ratio: ${BOUNDARY_RATIO}"
+echo "Flow shift: ${FLOW_SHIFT}"
+echo "VAE slicing: ${VAE_USE_SLICING}"
+echo "VAE tiling: ${VAE_USE_TILING}"
+echo "Cache backend: ${CACHE_BACKEND}"
+if [ "${ENABLE_CACHE_DIT_SUMMARY}" != "0" ]; then
     echo "Cache-DiT summary: enabled"
 fi
 
-CACHE_BACKEND_FLAG=""
-if [ "$CACHE_BACKEND" != "none" ]; then
-    CACHE_BACKEND_FLAG="--cache-backend $CACHE_BACKEND"
+CMD=(
+    python3 -m vllm_omni.entrypoints.cli.main serve "${MODEL}" --omni
+    --port "${PORT}"
+    --usp "${USP}"
+    --boundary-ratio "${BOUNDARY_RATIO}"
+    --flow-shift "${FLOW_SHIFT}"
+)
+
+if [ "${ENABLE_LAYERWISE_OFFLOAD}" != "0" ]; then
+    CMD+=(--enable-layerwise-offload)
+fi
+if [ "${VAE_USE_SLICING}" != "0" ]; then
+    CMD+=(--vae-use-slicing)
+fi
+if [ "${VAE_USE_TILING}" != "0" ]; then
+    CMD+=(--vae-use-tiling)
+fi
+if [ "${CACHE_BACKEND}" != "none" ]; then
+    CMD+=(--cache-backend "${CACHE_BACKEND}")
+fi
+if [ "${ENABLE_CACHE_DIT_SUMMARY}" != "0" ]; then
+    CMD+=(--enable-cache-dit-summary)
 fi
 
-vllm serve "$MODEL" --omni \
-    --port "$PORT" \
-    --boundary-ratio "$BOUNDARY_RATIO" \
-    --flow-shift "$FLOW_SHIFT" \
-    $CACHE_BACKEND_FLAG \
-    $(if [ "$ENABLE_CACHE_DIT_SUMMARY" != "0" ]; then echo "--enable-cache-dit-summary"; fi)
+exec "${CMD[@]}"

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -541,9 +541,18 @@ class OmniDiffusionConfig:
         )
 
     def __post_init__(self):
-        # TODO: remove hard code
-        initial_master_port = (self.master_port or 30005) + random.randint(0, 100)
-        self.master_port = self.settle_port(initial_master_port, 37)
+        explicit_master_port = os.environ.get("VLLM_OMNI_MASTER_PORT")
+        if explicit_master_port is not None:
+            self.master_port = int(explicit_master_port)
+
+        # Respect an explicit master_port exactly to avoid backend launch races.
+        # Keep randomized probing only for the implicit/default case.
+        if self.master_port is not None:
+            if not is_port_available(self.master_port):
+                raise RuntimeError(f"Configured master_port {self.master_port} is already in use")
+        else:
+            initial_master_port = 30005 + random.randint(0, 100)
+            self.master_port = self.settle_port(initial_master_port, 37)
 
         if isinstance(self.profiler_config, dict):
             from vllm.config import ProfilerConfig

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 import threading
 import time
 from collections.abc import Iterable
@@ -19,11 +20,22 @@ from vllm_omni.diffusion.registry import (
     get_diffusion_pre_process_func,
 )
 from vllm_omni.diffusion.request import OmniDiffusionRequest
-from vllm_omni.diffusion.sched import RequestScheduler, SchedulerInterface
+from vllm_omni.diffusion.sched import RequestScheduler, SchedulerInterface, SuperP95StepScheduler
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
 from vllm_omni.outputs import OmniRequestOutput
 
 logger = init_logger(__name__)
+
+
+def _make_default_scheduler(od_config: OmniDiffusionConfig) -> SchedulerInterface:
+    scheduler_name = os.environ.get("VLLM_OMNI_DIFFUSION_SCHEDULER", "").strip().lower()
+    if scheduler_name == "super_p95_step":
+        od_config.step_execution = True
+        return SuperP95StepScheduler()
+    if scheduler_name == "step_baseline":
+        od_config.step_execution = True
+        return RequestScheduler()
+    return RequestScheduler()
 
 
 def supports_image_input(model_class_name: str) -> bool:
@@ -72,9 +84,13 @@ class DiffusionEngine:
 
         executor_class = DiffusionExecutor.get_class(od_config)
         self.executor = executor_class(od_config)
-        self.scheduler: SchedulerInterface = scheduler or RequestScheduler()
+        self.scheduler: SchedulerInterface = scheduler or _make_default_scheduler(od_config)
         self.scheduler.initialize(od_config)
         self._rpc_lock = threading.Lock()
+        self._scheduler_lock = threading.Lock()
+        self._driver_cv = threading.Condition(self._scheduler_lock)
+        self._driver_active = False
+        self._completed_outputs: dict[str, DiffusionOutput] = {}
 
         try:
             self._dummy_run()
@@ -276,37 +292,118 @@ class DiffusionEngine:
         return DiffusionEngine(config, scheduler=scheduler)
 
     def add_req_and_wait_for_response(self, request: OmniDiffusionRequest) -> DiffusionOutput:
-        with self._rpc_lock:
-            target_sched_req_id = self.scheduler.add_request(request)
+        self._ensure_runtime_state()
+        use_step_execution = bool(getattr(getattr(self, "od_config", None), "step_execution", False))
 
-            # keep scheduling and executing until the target request is finished
+        with self._driver_cv:
+            target_sched_req_id = self.scheduler.add_request(request)
+            self._driver_cv.notify_all()
             while True:
-                sched_output = self.scheduler.schedule()
-                if sched_output.is_empty:
-                    if not self.scheduler.has_requests():
-                        raise RuntimeError("Diffusion scheduler has no runnable requests.")
-                    continue
+                output = self._consume_completed_output_locked(target_sched_req_id)
+                if output is not None:
+                    return output
+                if not self._driver_active:
+                    self._driver_active = True
+                    break
+                self._driver_cv.wait()
+
+        try:
+            while True:
+                with self._driver_cv:
+                    output = self._consume_completed_output_locked(target_sched_req_id)
+                    if output is not None:
+                        self._driver_active = False
+                        self._driver_cv.notify_all()
+                        return output
+
+                    sched_output = self.scheduler.schedule()
+                    if sched_output.is_empty:
+                        if not self.scheduler.has_requests():
+                            self._driver_active = False
+                            self._driver_cv.notify_all()
+                            raise RuntimeError("Diffusion scheduler has no runnable requests.")
+                        self._driver_cv.wait(timeout=0.001)
+                        continue
 
                 # NOTE: add_req_and_wait_for_response() is synchronous, and
                 # the scheduler currently enforces _max_batch_size = 1 (see
                 # vllm_omni/diffusion/sched/base_scheduler.py), so we directly
                 # take the single scheduled request here.
                 sched_req_id = sched_output.scheduled_req_ids[0]
-                req = sched_output.scheduled_new_reqs[0].req
-                try:
-                    output = self.executor.add_req(req)
-                except Exception as exc:
-                    logger.error(
-                        "Execution failed for diffusion request %s",
-                        sched_req_id,
-                        exc_info=True,
-                    )
-                    output = DiffusionOutput(error=str(exc))
+                if use_step_execution:
+                    try:
+                        with self._rpc_lock:
+                            runner_output = self.executor.execute_stepwise(sched_output)
+                    except Exception as exc:
+                        from vllm_omni.diffusion.worker.utils import RunnerOutput
 
-                finished_req_ids = self.scheduler.update_from_output(sched_output, output)
-                if target_sched_req_id in finished_req_ids:
-                    self.scheduler.pop_request_state(target_sched_req_id)
-                    return output
+                        logger.error(
+                            "Stepwise execution failed for diffusion request %s",
+                            sched_req_id,
+                            exc_info=True,
+                        )
+                        runner_output = RunnerOutput(
+                            req_id=sched_req_id,
+                            finished=True,
+                            result=DiffusionOutput(error=str(exc)),
+                        )
+
+                    finished_req_ids = self.scheduler.update_from_runner_output(sched_output, runner_output)
+                    with self._driver_cv:
+                        self._record_finished_output_locked(sched_req_id, finished_req_ids, runner_output.result)
+                        self._driver_cv.notify_all()
+                else:
+                    req = sched_output.scheduled_new_reqs[0].req
+                    try:
+                        with self._rpc_lock:
+                            output = self.executor.add_req(req)
+                    except Exception as exc:
+                        logger.error(
+                            "Execution failed for diffusion request %s",
+                            sched_req_id,
+                            exc_info=True,
+                        )
+                        output = DiffusionOutput(error=str(exc))
+
+                    finished_req_ids = self.scheduler.update_from_output(sched_output, output)
+                    with self._driver_cv:
+                        self._record_finished_output_locked(sched_req_id, finished_req_ids, output)
+                        self._driver_cv.notify_all()
+        finally:
+            with self._driver_cv:
+                if self._driver_active:
+                    self._driver_active = False
+                    self._driver_cv.notify_all()
+
+    def _ensure_runtime_state(self) -> None:
+        if not hasattr(self, "_rpc_lock"):
+            self._rpc_lock = threading.Lock()
+        if not hasattr(self, "_scheduler_lock"):
+            self._scheduler_lock = threading.Lock()
+        if not hasattr(self, "_driver_cv"):
+            self._driver_cv = threading.Condition(self._scheduler_lock)
+        if not hasattr(self, "_driver_active"):
+            self._driver_active = False
+        if not hasattr(self, "_completed_outputs"):
+            self._completed_outputs = {}
+
+    def _consume_completed_output_locked(self, sched_req_id: str) -> DiffusionOutput | None:
+        output = self._completed_outputs.pop(sched_req_id, None)
+        if output is not None:
+            self.scheduler.pop_request_state(sched_req_id)
+        return output
+
+    def _record_finished_output_locked(
+        self,
+        sched_req_id: str,
+        finished_req_ids: set[str],
+        output: DiffusionOutput | None,
+    ) -> None:
+        if sched_req_id not in finished_req_ids:
+            return
+        if output is None:
+            output = DiffusionOutput(error=f"Missing final diffusion output for {sched_req_id}")
+        self._completed_outputs[sched_req_id] = output
 
     def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:
         """Start or stop torch profiling on all diffusion workers.

--- a/vllm_omni/diffusion/executor/abstract.py
+++ b/vllm_omni/diffusion/executor/abstract.py
@@ -64,6 +64,11 @@ class DiffusionExecutor(ABC):
         pass
 
     @abstractmethod
+    def execute_stepwise(self, scheduler_output: Any) -> Any:
+        """Execute one scheduled diffusion step on workers."""
+        pass
+
+    @abstractmethod
     def collective_rpc(
         self,
         method: str,

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -12,6 +12,7 @@ from vllm_omni.diffusion.data import SHUTDOWN_MESSAGE, DiffusionOutput
 from vllm_omni.diffusion.executor.abstract import DiffusionExecutor
 from vllm_omni.diffusion.ipc import unpack_diffusion_output_shm
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.sched.interface import DiffusionSchedulerOutput
 from vllm_omni.diffusion.worker import WorkerProc
 
 logger = init_logger(__name__)
@@ -188,6 +189,40 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
             return response
         except Exception as e:
             logger.error(f"Generate call failed: {e}")
+            raise
+
+    def execute_stepwise(self, scheduler_output: DiffusionSchedulerOutput):
+        self._ensure_open()
+        rpc_request = {
+            "type": "rpc",
+            "method": "execute_stepwise",
+            "args": (scheduler_output,),
+            "kwargs": {},
+            "output_rank": 0,
+            "exec_all_ranks": True,
+        }
+
+        try:
+            self._broadcast_mq.enqueue(rpc_request)
+            response = self._result_mq.dequeue()
+            try:
+                unpack_diffusion_output_shm(response)
+            except Exception as e:
+                logger.warning("SHM unpack failed during stepwise execution (data may already be inline): %s", e)
+            if isinstance(response, dict) and response.get("status") == "error":
+                raise RuntimeError(
+                    f"Worker failed with error '{response.get('error')}', "
+                    "please check the stack trace above for the root cause"
+                )
+            if not (
+                hasattr(response, "req_id")
+                and hasattr(response, "finished")
+                and hasattr(response, "result")
+            ):
+                raise RuntimeError(f"Unexpected response type for execute_stepwise: {type(response)!r}")
+            return response
+        except Exception as e:
+            logger.error(f"Stepwise execution failed: {e}")
             raise
 
     def collective_rpc(

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -3,12 +3,13 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
 import time
 from collections.abc import Iterable
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import PIL.Image
 import torch
@@ -118,10 +119,33 @@ def get_wan22_post_process_func(
 
     video_processor = VideoProcessor(vae_scale_factor=8)
 
+    def _unwrap_video_payload(video: Any) -> Any:
+        if isinstance(video, dict):
+            for key in ("video", "videos", "sample", "samples", "frames", "output"):
+                if key in video:
+                    return _unwrap_video_payload(video[key])
+            if len(video) == 1:
+                return _unwrap_video_payload(next(iter(video.values())))
+            for value in video.values():
+                if isinstance(value, (dict, list, tuple)) or hasattr(value, "shape"):
+                    return _unwrap_video_payload(value)
+        if isinstance(video, (list, tuple)):
+            if len(video) == 1:
+                return _unwrap_video_payload(video[0])
+            for item in video:
+                if isinstance(item, (dict, list, tuple)) or hasattr(item, "shape"):
+                    return _unwrap_video_payload(item)
+        for attr in ("sample", "samples", "video", "videos", "frames", "output"):
+            value = getattr(video, attr, None)
+            if value is not None:
+                return _unwrap_video_payload(value)
+        return video
+
     def post_process_func(
-        video: torch.Tensor,
+        video: torch.Tensor | dict[str, Any] | Any,
         output_type: str = "np",
     ):
+        video = _unwrap_video_payload(video)
         if output_type == "latent":
             return video
         return video_processor.postprocess_video(video, output_type=output_type)
@@ -191,6 +215,8 @@ def get_wan22_pre_process_func(
 
 
 class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin):
+    supports_step_execution: ClassVar[bool] = True
+
     def __init__(
         self,
         *,
@@ -331,6 +357,319 @@ class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipe
     @property
     def current_timestep(self):
         return self._current_timestep
+
+    @property
+    def interrupt(self):
+        return getattr(self, "_interrupt", False)
+
+    def _extract_prompts(self, prompts):
+        prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in prompts] or None
+        if all(isinstance(p, str) or p.get("negative_prompt") is None for p in prompts):
+            negative_prompt = None
+        elif prompts:
+            negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in prompts]
+        else:
+            negative_prompt = None
+        return prompt, negative_prompt
+
+    def _extract_raw_image(self, prompts) -> PIL.Image.Image | torch.Tensor | None:
+        if not prompts:
+            return None
+        prompt = prompts[0]
+        if isinstance(prompt, str):
+            return None
+        multi_modal_data = prompt.get("multi_modal_data", {})
+        raw_image = multi_modal_data.get("image")
+        if isinstance(raw_image, list):
+            if len(raw_image) > 1:
+                logger.warning(
+                    "Received a list of image. Only a single image is supported by this model. "
+                    "Taking only the first image for now."
+                )
+            raw_image = raw_image[0] if raw_image else None
+        if isinstance(raw_image, str):
+            return PIL.Image.open(raw_image)
+        return cast(PIL.Image.Image | torch.Tensor | None, raw_image)
+
+    def _resolve_flow_shift_from_sampling(self, sampling) -> float:
+        request_flow_shift = getattr(sampling, "extra_args", {}).get("flow_shift")
+        if request_flow_shift is not None:
+            return float(request_flow_shift)
+        if sampling.flow_shift is not None:
+            return float(sampling.flow_shift)
+        if self.od_config.flow_shift is not None:
+            return float(self.od_config.flow_shift)
+        return 5.0
+
+    def _prepare_t2v_step_state(
+        self,
+        state: "DiffusionRequestState",
+        *,
+        prompt: str | list[str] | None,
+        negative_prompt: str | list[str] | None,
+        height: int,
+        width: int,
+        num_steps: int,
+        num_frames: int,
+        guidance_low: float,
+        guidance_high: float,
+        generator: torch.Generator | list[torch.Generator] | None,
+        prompt_embeds: torch.Tensor | None = None,
+        negative_prompt_embeds: torch.Tensor | None = None,
+        attention_kwargs: dict[str, Any] | None = None,
+    ) -> "DiffusionRequestState":
+        boundary_ratio = self.boundary_ratio if self.boundary_ratio is not None else state.sampling.boundary_ratio
+        if boundary_ratio is None:
+            boundary_ratio = 0.875
+            logger.warning("boundary_ratio is required for T2V generation. using default value 0.875")
+
+        self.check_inputs(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            height=height,
+            width=width,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            guidance_scale_2=guidance_high if boundary_ratio is not None else None,
+            boundary_ratio=boundary_ratio,
+        )
+
+        if num_frames % self.vae_scale_factor_temporal != 1:
+            num_frames = num_frames // self.vae_scale_factor_temporal * self.vae_scale_factor_temporal + 1
+        num_frames = max(num_frames, 1)
+
+        device = self.device
+        if self.transformer is not None:
+            dtype = self.transformer.dtype
+        elif self.transformer_2 is not None:
+            dtype = self.transformer_2.dtype
+        else:
+            dtype = self.text_encoder.dtype
+
+        if prompt_embeds is None:
+            prompt_embeds, negative_prompt_embeds = self.encode_prompt(
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                do_classifier_free_guidance=guidance_low > 1.0 or guidance_high > 1.0,
+                num_videos_per_prompt=state.sampling.num_outputs_per_prompt or 1,
+                max_sequence_length=state.sampling.max_sequence_length or 512,
+                device=device,
+                dtype=dtype,
+            )
+        else:
+            prompt_embeds = prompt_embeds.to(device=device, dtype=dtype)
+            if negative_prompt_embeds is not None:
+                negative_prompt_embeds = negative_prompt_embeds.to(device=device, dtype=dtype)
+            elif guidance_low > 1.0 or guidance_high > 1.0:
+                raise ValueError("negative_prompt_embeds must be provided when prompt_embeds are given and guidance > 1.")
+
+        flow_shift = self._resolve_flow_shift_from_sampling(state.sampling)
+        req_scheduler = copy.deepcopy(self.scheduler)
+        req_scheduler.set_timesteps(num_steps, device=device, shift=flow_shift)
+
+        timesteps = req_scheduler.timesteps
+        self._num_timesteps = len(timesteps)
+        boundary_timestep = (
+            boundary_ratio * req_scheduler.config.num_train_timesteps if boundary_ratio is not None else None
+        )
+
+        num_channels_latents = self.transformer_config.in_channels
+        latents = self.prepare_latents(
+            batch_size=prompt_embeds.shape[0],
+            num_channels_latents=num_channels_latents,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            dtype=torch.float32,
+            device=device,
+            generator=generator,
+            latents=state.sampling.latents,
+        )
+
+        state.prompt_embeds = prompt_embeds
+        state.negative_prompt_embeds = negative_prompt_embeds
+        state.latents = latents
+        state.timesteps = timesteps
+        state.step_index = 0
+        state.scheduler = req_scheduler
+        state.extra.update(
+            {
+                "height": height,
+                "width": width,
+                "num_frames": num_frames,
+                "boundary_timestep": boundary_timestep,
+                "guidance_low": guidance_low,
+                "guidance_high": guidance_high,
+                "attention_kwargs": attention_kwargs or {},
+                "flow_shift": flow_shift,
+                "num_steps": num_steps,
+            }
+        )
+        return state
+
+    def prepare_encode(
+        self,
+        state: "DiffusionRequestState",
+        **kwargs: Any,
+    ) -> "DiffusionRequestState":
+        prompt, negative_prompt = self._extract_prompts(state.prompts or [])
+        raw_image = self._extract_raw_image(state.prompts or [])
+        if self.expand_timesteps or raw_image is not None:
+            raise NotImplementedError("Wan2.2 step execution currently supports T2V only.")
+
+        sampling = state.sampling
+        height = sampling.height or 480
+        width = sampling.width or 832
+        num_frames = sampling.num_frames if sampling.num_frames else 81
+        patch_size = self.transformer_config.patch_size
+        mod_value = self.vae_scale_factor_spatial * patch_size[1]
+        height = (height // mod_value) * mod_value
+        width = (width // mod_value) * mod_value
+        num_steps = sampling.num_inference_steps or 40
+
+        guidance_scale = sampling.guidance_scale if sampling.guidance_scale_provided else 4.0
+        guidance_low = guidance_scale if isinstance(guidance_scale, (int, float)) else guidance_scale[0]
+        guidance_high = (
+            sampling.guidance_scale_2
+            if sampling.guidance_scale_2 is not None
+            else (
+                guidance_scale[1]
+                if isinstance(guidance_scale, (list, tuple)) and len(guidance_scale) > 1
+                else guidance_low
+            )
+        )
+
+        self._guidance_scale = guidance_low
+        self._guidance_scale_2 = guidance_high
+        self._current_timestep = None
+        self._interrupt = False
+
+        generator = sampling.generator
+        if generator is None and sampling.seed is not None:
+            generator = torch.Generator(device=self.device).manual_seed(sampling.seed)
+
+        return self._prepare_t2v_step_state(
+            state,
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            height=height,
+            width=width,
+            num_steps=num_steps,
+            num_frames=num_frames,
+            guidance_low=guidance_low,
+            guidance_high=guidance_high,
+            generator=generator,
+            attention_kwargs=kwargs.get("attention_kwargs"),
+        )
+
+    def denoise_step(
+        self,
+        state: "DiffusionRequestState",
+        **kwargs: Any,
+    ) -> torch.Tensor | None:
+        if self.interrupt:
+            return None
+
+        t = state.current_timestep
+        self._current_timestep = t
+        boundary_timestep = state.extra["boundary_timestep"]
+        current_guidance_scale = state.extra["guidance_low"]
+        if boundary_timestep is not None and t < boundary_timestep:
+            current_guidance_scale = state.extra["guidance_high"]
+            if self.transformer_2 is not None:
+                current_model = self.transformer_2
+            elif self.transformer is not None:
+                current_model = self.transformer
+            else:
+                raise RuntimeError("No transformer available for low-noise stage")
+        else:
+            if self.transformer is not None:
+                current_model = self.transformer
+            elif self.transformer_2 is not None:
+                current_model = self.transformer_2
+            else:
+                raise RuntimeError("No transformer available for high-noise stage")
+
+        latent_model_input = state.latents.to(current_model.dtype)
+        timestep = t.expand(state.latents.shape[0])
+        do_true_cfg = current_guidance_scale > 1.0 and state.negative_prompt_embeds is not None
+        state.do_true_cfg = do_true_cfg
+        state.extra["current_guidance_scale"] = current_guidance_scale
+
+        positive_kwargs = {
+            "hidden_states": latent_model_input,
+            "timestep": timestep,
+            "encoder_hidden_states": state.prompt_embeds,
+            "attention_kwargs": state.extra["attention_kwargs"],
+            "return_dict": False,
+            "current_model": current_model,
+        }
+        negative_kwargs = None
+        if do_true_cfg:
+            negative_kwargs = {
+                "hidden_states": latent_model_input,
+                "timestep": timestep,
+                "encoder_hidden_states": state.negative_prompt_embeds,
+                "attention_kwargs": state.extra["attention_kwargs"],
+                "return_dict": False,
+                "current_model": current_model,
+            }
+
+        return self.predict_noise_maybe_with_cfg(
+            do_true_cfg=do_true_cfg,
+            true_cfg_scale=current_guidance_scale,
+            positive_kwargs=positive_kwargs,
+            negative_kwargs=negative_kwargs,
+            cfg_normalize=False,
+        )
+
+    def step_scheduler(
+        self,
+        state: "DiffusionRequestState",
+        noise_pred: torch.Tensor,
+        **kwargs: Any,
+    ) -> None:
+        if self.interrupt:
+            return
+        t = state.current_timestep
+        state.latents = self.scheduler_step_maybe_with_cfg(
+            noise_pred,
+            t,
+            state.latents,
+            state.do_true_cfg,
+            per_request_scheduler=state.scheduler,
+        )
+        state.step_index += 1
+
+    def post_decode(
+        self,
+        state: "DiffusionRequestState",
+        **kwargs: Any,
+    ) -> DiffusionOutput:
+        self._current_timestep = None
+        output_type = kwargs.get("output_type", "np")
+        latents = state.latents
+        if output_type == "latent":
+            return DiffusionOutput(
+                output=latents,
+                stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+            )
+
+        latents = latents.to(self.vae.dtype)
+        latents_mean = (
+            torch.tensor(self.vae.config.latents_mean)
+            .view(1, self.vae.config.z_dim, 1, 1, 1)
+            .to(latents.device, latents.dtype)
+        )
+        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+            latents.device, latents.dtype
+        )
+        latents = latents / latents_std + latents_mean
+        output = self.vae.decode(latents, return_dict=False)[0]
+        return DiffusionOutput(
+            output=output,
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
 
     def forward(
         self,

--- a/vllm_omni/diffusion/sched/__init__.py
+++ b/vllm_omni/diffusion/sched/__init__.py
@@ -10,6 +10,7 @@ from vllm_omni.diffusion.sched.interface import (
     SchedulerInterface,
 )
 from vllm_omni.diffusion.sched.request_scheduler import RequestScheduler
+from vllm_omni.diffusion.sched.super_p95_step_scheduler import SuperP95StepScheduler
 
 Scheduler = RequestScheduler
 
@@ -22,4 +23,5 @@ __all__ = [
     "RequestScheduler",
     "Scheduler",
     "SchedulerInterface",
+    "SuperP95StepScheduler",
 ]

--- a/vllm_omni/diffusion/sched/interface.py
+++ b/vllm_omni/diffusion/sched/interface.py
@@ -8,6 +8,7 @@ import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import cached_property
+from typing import Any
 
 from vllm.logger import init_logger
 
@@ -143,6 +144,14 @@ class SchedulerInterface(ABC):
     @abstractmethod
     def update_from_output(self, sched_output: DiffusionSchedulerOutput, output: DiffusionOutput) -> set[str]:
         """Update scheduler state from executor output."""
+
+    @abstractmethod
+    def update_from_runner_output(
+        self,
+        sched_output: DiffusionSchedulerOutput,
+        runner_output: Any,
+    ) -> set[str]:
+        """Update scheduler state from a single step-execution runner output."""
 
     @abstractmethod
     def get_request_state(self, sched_req_id: str) -> DiffusionRequestState | None:

--- a/vllm_omni/diffusion/sched/request_scheduler.py
+++ b/vllm_omni/diffusion/sched/request_scheduler.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.data import DiffusionOutput
@@ -94,6 +96,44 @@ class RequestScheduler(_BaseScheduler):
             else:
                 terminal_statuses[sched_req_id] = DiffusionRequestStatus.FINISHED_COMPLETED
                 terminal_errors[sched_req_id] = None
+
+        finished_req_ids |= self._finish_requests(terminal_statuses, terminal_errors)
+        return finished_req_ids
+
+    def update_from_runner_output(
+        self,
+        sched_output: DiffusionSchedulerOutput,
+        runner_output: Any,
+    ) -> set[str]:
+        scheduled_req_ids = sched_output.scheduled_req_ids
+        if not scheduled_req_ids:
+            return set()
+
+        finished_req_ids = {
+            sched_req_id for sched_req_id in scheduled_req_ids if sched_req_id in self._finished_req_ids
+        }
+        terminal_statuses: dict[str, DiffusionRequestStatus] = {}
+        terminal_errors: dict[str, str | None] = {}
+
+        if runner_output.req_id not in scheduled_req_ids:
+            raise ValueError(
+                f"RunnerOutput req_id {runner_output.req_id!r} does not match scheduled requests {scheduled_req_ids!r}"
+            )
+
+        state = self._request_states.get(runner_output.req_id)
+        if state is None or state.is_finished():
+            return finished_req_ids
+
+        if not runner_output.finished:
+            return finished_req_ids
+
+        result = runner_output.result
+        if result is not None and result.error:
+            terminal_statuses[runner_output.req_id] = DiffusionRequestStatus.FINISHED_ERROR
+            terminal_errors[runner_output.req_id] = result.error
+        else:
+            terminal_statuses[runner_output.req_id] = DiffusionRequestStatus.FINISHED_COMPLETED
+            terminal_errors[runner_output.req_id] = None
 
         finished_req_ids |= self._finish_requests(terminal_statuses, terminal_errors)
         return finished_req_ids

--- a/vllm_omni/diffusion/sched/super_p95_step_scheduler.py
+++ b/vllm_omni/diffusion/sched/super_p95_step_scheduler.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import heapq
+import os
+from dataclasses import dataclass, field
+
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.sched.base_scheduler import _BaseScheduler
+from vllm_omni.diffusion.sched.interface import (
+    CachedRequestData,
+    DiffusionRequestState,
+    DiffusionRequestStatus,
+    DiffusionSchedulerOutput,
+    NewRequestData,
+)
+from vllm_omni.diffusion.super_p95 import (
+    SuperP95LoadSnapshot,
+    estimate_service_time_s,
+    get_super_p95_request_metadata,
+    normalize_super_p95_hardware_profile,
+)
+
+logger = init_logger(__name__)
+
+
+@dataclass(order=True)
+class _QueuedRequest:
+    sort_key: tuple[int, ...] = field(init=False, repr=False)
+    arrival_seq: int
+    arrival_time_s: float
+    sched_req_id: str = field(compare=False)
+    estimated_service_s: float = field(compare=False)
+    total_steps: int = field(compare=False, default=1)
+    completed_steps: int = field(compare=False, default=0)
+    is_sacrificial: bool = field(compare=False, default=False)
+
+    def __post_init__(self) -> None:
+        self.refresh_sort_key()
+
+    @property
+    def remaining_steps(self) -> int:
+        return max(self.total_steps - self.completed_steps, 0)
+
+    @property
+    def remaining_service_s(self) -> float:
+        return self.estimated_service_s * self.remaining_steps / max(self.total_steps, 1)
+
+    def refresh_sort_key(self) -> None:
+        if self.is_sacrificial:
+            # Sacrificial requests are the explicit cost sink: newer sacrificial
+            # arrivals are allowed to jump ahead of older sacrificial requests.
+            self.sort_key = (-self.arrival_seq,)
+        else:
+            # Normal requests preserve FIFO to avoid inflating worst-case delay
+            # by reordering within the main queue.
+            self.sort_key = (self.arrival_seq,)
+
+
+class SuperP95StepScheduler(_BaseScheduler):
+    """Stepwise-native super_p95 scheduler for v0.18 diffusion execution.
+
+    This scheduler assumes engine drives one denoise step per schedule cycle.
+    Preemption is therefore modeled by choosing a different request on the
+    next scheduling cycle rather than by async interruption within a request.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._normal_pending: list[_QueuedRequest] = []
+        self._sacrificial_pending: list[_QueuedRequest] = []
+        self._queue_metadata: dict[str, _QueuedRequest] = {}
+        self._arrival_seq: int = 0
+        self._current_time_s: float = 0.0
+        self._hardware_profile = normalize_super_p95_hardware_profile(
+            os.environ.get("VLLM_OMNI_SUPER_P95_HARDWARE_PROFILE")
+        )
+        self._num_added_normal = 0
+        self._num_added_sacrificial = 0
+        self._num_scheduled_normal = 0
+        self._num_scheduled_sacrificial = 0
+        self._num_preemptions = 0
+
+    def has_requests(self) -> bool:
+        return bool(self._running or self._normal_pending or self._sacrificial_pending)
+
+    def get_load_snapshot(self) -> SuperP95LoadSnapshot:
+        normal = 0.0
+        sacrificial = 0.0
+        for queued in self._queue_metadata.values():
+            state = self._request_states.get(queued.sched_req_id)
+            if state is None or state.is_finished():
+                continue
+            if queued.is_sacrificial:
+                sacrificial += queued.remaining_service_s
+            else:
+                normal += queued.remaining_service_s
+        return SuperP95LoadSnapshot(normal_load_s=normal, sacrificial_load_s=sacrificial)
+
+    def add_request(self, request: OmniDiffusionRequest) -> str:
+        sched_req_id = self._make_sched_req_id(request)
+        state = DiffusionRequestState(sched_req_id=sched_req_id, req=request)
+        self._request_states[sched_req_id] = state
+        self._register_request_ids(request.request_ids, sched_req_id)
+
+        sacrificial, estimated_service_s = get_super_p95_request_metadata(request.sampling_params.extra_args)
+        if estimated_service_s is None:
+            estimated_service_s = estimate_service_time_s(request, hardware_profile=self._hardware_profile)
+
+        queued = _QueuedRequest(
+            arrival_seq=self._arrival_seq,
+            arrival_time_s=self._current_time_s,
+            sched_req_id=sched_req_id,
+            estimated_service_s=estimated_service_s,
+            total_steps=max(int(request.sampling_params.num_inference_steps or 1), 1),
+            is_sacrificial=sacrificial,
+        )
+        self._arrival_seq += 1
+        self._queue_metadata[sched_req_id] = queued
+        self._push_pending(queued)
+        if sacrificial:
+            self._num_added_sacrificial += 1
+        else:
+            self._num_added_normal += 1
+        logger.info(
+            "super_p95 scheduler add req=%s sacrificial=%s estimated_service_s=%.4f "
+            "total_steps=%d added_normal=%d added_sacrificial=%d",
+            sched_req_id,
+            sacrificial,
+            estimated_service_s,
+            queued.total_steps,
+            self._num_added_normal,
+            self._num_added_sacrificial,
+        )
+        return sched_req_id
+
+    def schedule(self) -> DiffusionSchedulerOutput:
+        scheduled_new_reqs: list[NewRequestData] = []
+        scheduled_cached_req_ids: list[str] = []
+
+        active_id = self._running[0] if self._running else None
+        active_queued = self._queue_metadata.get(active_id) if active_id is not None else None
+        candidate = self.peek_next_request()
+
+        if active_queued is not None and candidate is not None and self.request_outranks(candidate, active_queued):
+            self._running.clear()
+            active_state = self._request_states.get(active_queued.sched_req_id)
+            if active_state is not None and not active_state.is_finished():
+                active_state.status = DiffusionRequestStatus.PREEMPTED
+                self._push_pending(active_queued)
+                self._num_preemptions += 1
+                logger.info(
+                    "super_p95 scheduler preempt running=%s sacrificial=%s candidate=%s candidate_sacrificial=%s "
+                    "preemptions=%d normal_pending=%d sacrificial_pending=%d",
+                    active_queued.sched_req_id,
+                    active_queued.is_sacrificial,
+                    candidate.sched_req_id,
+                    candidate.is_sacrificial,
+                    self._num_preemptions,
+                    len(self._normal_pending),
+                    len(self._sacrificial_pending),
+                )
+            active_queued = None
+
+        if active_queued is not None:
+            scheduled_cached_req_ids.append(active_queued.sched_req_id)
+        else:
+            queued = self._pop_next_queued()
+            if queued is not None:
+                state = self._request_states.get(queued.sched_req_id)
+                if state is not None:
+                    was_new_request = state.status == DiffusionRequestStatus.WAITING and queued.completed_steps == 0
+                    state.status = DiffusionRequestStatus.RUNNING
+                    self._running = [queued.sched_req_id]
+                    if queued.is_sacrificial:
+                        self._num_scheduled_sacrificial += 1
+                    else:
+                        self._num_scheduled_normal += 1
+                    logger.info(
+                        "super_p95 scheduler select req=%s sacrificial=%s completed_steps=%d total_steps=%d "
+                        "scheduled_normal=%d scheduled_sacrificial=%d normal_pending=%d sacrificial_pending=%d",
+                        queued.sched_req_id,
+                        queued.is_sacrificial,
+                        queued.completed_steps,
+                        queued.total_steps,
+                        self._num_scheduled_normal,
+                        self._num_scheduled_sacrificial,
+                        len(self._normal_pending),
+                        len(self._sacrificial_pending),
+                    )
+                    if was_new_request:
+                        scheduled_new_reqs.append(NewRequestData.from_state(state))
+                    else:
+                        scheduled_cached_req_ids.append(queued.sched_req_id)
+
+        scheduler_output = DiffusionSchedulerOutput(
+            step_id=self._step_id,
+            scheduled_new_reqs=scheduled_new_reqs,
+            scheduled_cached_reqs=CachedRequestData(sched_req_ids=scheduled_cached_req_ids),
+            finished_req_ids=set(self._finished_req_ids),
+            num_running_reqs=len(self._running),
+            num_waiting_reqs=len(self._normal_pending) + len(self._sacrificial_pending),
+        )
+        self._step_id += 1
+        self._finished_req_ids.clear()
+        return scheduler_output
+
+    def update_from_output(self, sched_output: DiffusionSchedulerOutput, output: DiffusionOutput) -> set[str]:
+        if not sched_output.scheduled_req_ids:
+            return set()
+        sched_req_id = sched_output.scheduled_req_ids[0]
+        if sched_req_id in self._running:
+            self._running.remove(sched_req_id)
+        statuses = {
+            sched_req_id: (
+                DiffusionRequestStatus.FINISHED_ERROR if output.error else DiffusionRequestStatus.FINISHED_COMPLETED
+            )
+        }
+        errors = {sched_req_id: output.error}
+        queued = self._queue_metadata.get(sched_req_id)
+        if queued is not None:
+            self._current_time_s += queued.remaining_service_s
+            queued.completed_steps = queued.total_steps
+        return self._finish_requests(statuses, errors)
+
+    def update_from_runner_output(self, sched_output: DiffusionSchedulerOutput, runner_output) -> set[str]:
+        scheduled_req_ids = sched_output.scheduled_req_ids
+        if not scheduled_req_ids:
+            return set()
+        sched_req_id = scheduled_req_ids[0]
+        if runner_output.req_id != sched_req_id:
+            raise ValueError(f"runner output {runner_output.req_id!r} does not match scheduled {sched_req_id!r}")
+
+        queued = self._queue_metadata.get(sched_req_id)
+        state = self._request_states.get(sched_req_id)
+        if queued is None or state is None or state.is_finished():
+            return set()
+
+        prev_completed_steps = queued.completed_steps
+        completed_steps = prev_completed_steps
+        if runner_output.step_index is not None:
+            completed_steps = min(max(int(runner_output.step_index), prev_completed_steps), queued.total_steps)
+
+        delta_steps = max(completed_steps - prev_completed_steps, 0)
+        self._current_time_s += queued.estimated_service_s * delta_steps / max(queued.total_steps, 1)
+        queued.completed_steps = completed_steps
+        queued.refresh_sort_key()
+
+        if runner_output.finished:
+            if sched_req_id in self._running:
+                self._running.remove(sched_req_id)
+            result = runner_output.result
+            statuses = {
+                sched_req_id: (
+                    DiffusionRequestStatus.FINISHED_ERROR
+                    if result is not None and result.error
+                    else DiffusionRequestStatus.FINISHED_COMPLETED
+                )
+            }
+            errors = {sched_req_id: None if result is None else result.error}
+            queued.completed_steps = queued.total_steps
+            return self._finish_requests(statuses, errors)
+
+        state.status = DiffusionRequestStatus.RUNNING
+        return set()
+
+    def abort_request(self, sched_req_id: str) -> bool:
+        if self.get_request_state(sched_req_id) is None:
+            return False
+        self.finish_requests(sched_req_id, DiffusionRequestStatus.FINISHED_ABORTED)
+        return True
+
+    def preempt_request(self, sched_req_id: str) -> bool:
+        if sched_req_id not in self._request_states:
+            return False
+        if sched_req_id in self._running:
+            self._running.remove(sched_req_id)
+            state = self._request_states[sched_req_id]
+            state.status = DiffusionRequestStatus.PREEMPTED
+            queued = self._queue_metadata.get(sched_req_id)
+            if queued is not None:
+                self._push_pending(queued)
+            return True
+        return False
+
+    def _reset_scheduler_state(self) -> None:
+        self._normal_pending.clear()
+        self._sacrificial_pending.clear()
+        self._queue_metadata.clear()
+        self._arrival_seq = 0
+        self._current_time_s = 0.0
+        self._num_added_normal = 0
+        self._num_added_sacrificial = 0
+        self._num_scheduled_normal = 0
+        self._num_scheduled_sacrificial = 0
+        self._num_preemptions = 0
+
+    def _pop_extra_request_state(self, sched_req_id: str) -> None:
+        self._queue_metadata.pop(sched_req_id, None)
+
+    def _push_pending(self, queued: _QueuedRequest) -> None:
+        queued.refresh_sort_key()
+        heap = self._sacrificial_pending if queued.is_sacrificial else self._normal_pending
+        heapq.heappush(heap, queued)
+
+    def _pop_next_queued(self) -> _QueuedRequest | None:
+        for heap in (self._normal_pending, self._sacrificial_pending):
+            while heap:
+                queued = heapq.heappop(heap)
+                state = self._request_states.get(queued.sched_req_id)
+                if state is None or state.is_finished():
+                    continue
+                return queued
+        return None
+
+    def peek_next_request(self) -> _QueuedRequest | None:
+        for heap in (self._normal_pending, self._sacrificial_pending):
+            while heap:
+                queued = heap[0]
+                state = self._request_states.get(queued.sched_req_id)
+                if state is None or state.is_finished():
+                    heapq.heappop(heap)
+                    continue
+                return queued
+        return None
+
+    @staticmethod
+    def request_outranks(candidate: _QueuedRequest, incumbent: _QueuedRequest) -> bool:
+        return not candidate.is_sacrificial and incumbent.is_sacrificial

--- a/vllm_omni/diffusion/super_p95.py
+++ b/vllm_omni/diffusion/super_p95.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+HEADER_SUPER_P95_SACRIFICIAL = "X-Super-P95-Sacrificial"
+HEADER_SUPER_P95_ESTIMATED_SERVICE_S = "X-Super-P95-Estimated-Service-S"
+HEADER_SUPER_P95_NORMAL_LOAD_S = "X-Super-P95-Normal-Load-S"
+HEADER_SUPER_P95_SACRIFICIAL_LOAD_S = "X-Super-P95-Sacrificial-Load-S"
+
+EXTRA_ARG_SUPER_P95_SACRIFICIAL = "_super_p95_sacrificial"
+EXTRA_ARG_SUPER_P95_ESTIMATED_SERVICE_S = "_super_p95_estimated_service_s"
+
+DEFAULT_SUPER_P95_HARDWARE_PROFILE = "910B2"
+_KNOWN_SUPER_P95_HARDWARE_PROFILES = {"910B2", "910B3"}
+
+_QWEN_IMAGE_HARDWARE_ANCHORS_S: dict[str, dict[tuple[int, int], tuple[int, float]]] = {
+    "910B2": {
+        (512, 512): (20, 8.60),
+        (768, 768): (20, 8.94),
+        (1024, 1024): (25, 14.22),
+        (1536, 1536): (35, 43.22),
+    },
+    "910B3": {
+        (512, 512): (20, 8.64),
+        (768, 768): (20, 8.64),
+        (1024, 1024): (25, 14.22),
+        (1536, 1536): (35, 49.34),
+    },
+}
+
+_WAN2_2_HARDWARE_ANCHORS_S: dict[str, dict[tuple[int, int, int, int], float]] = {
+    "910B2": {
+        (854, 480, 3, 80): 38.07,
+        (854, 480, 4, 120): 71.34,
+        (1280, 720, 6, 80): 119.71,
+    },
+    "910B3": {
+        (854, 480, 3, 80): 38.07,
+        (854, 480, 4, 120): 71.34,
+        (1280, 720, 6, 80): 119.71,
+    },
+}
+
+_QWEN_IMAGE_FALLBACK_BASE_RESOLUTION = (1024, 1024)
+_QWEN_IMAGE_FALLBACK_BASE_STEPS = 25
+_QWEN_IMAGE_PER_PIXEL_STEP_MS: dict[str, dict[tuple[int, int], float]] = {
+    hardware_profile: {
+        resolution: (anchor_latency_s * 1000.0) / (resolution[0] * resolution[1] * anchor_steps)
+        for resolution, (anchor_steps, anchor_latency_s) in anchors.items()
+    }
+    for hardware_profile, anchors in _QWEN_IMAGE_HARDWARE_ANCHORS_S.items()
+}
+_WAN2_2_FALLBACK_BASE_KEY = (1280, 720, 6, 80)
+_WAN2_2_PER_PIXEL_FRAME_STEP_MS: dict[str, float] = {
+    hardware_profile: (
+        anchors[_WAN2_2_FALLBACK_BASE_KEY]
+        * 1000.0
+        / (
+            _WAN2_2_FALLBACK_BASE_KEY[0]
+            * _WAN2_2_FALLBACK_BASE_KEY[1]
+            * _WAN2_2_FALLBACK_BASE_KEY[2]
+            * _WAN2_2_FALLBACK_BASE_KEY[3]
+        )
+    )
+    for hardware_profile, anchors in _WAN2_2_HARDWARE_ANCHORS_S.items()
+    if _WAN2_2_FALLBACK_BASE_KEY in anchors
+}
+
+_WAN2_2_VAE_SCALE_FACTOR_TEMPORAL = 4
+
+
+@dataclass(frozen=True)
+class SuperP95LoadSnapshot:
+    normal_load_s: float = 0.0
+    sacrificial_load_s: float = 0.0
+
+
+def _parse_bool_header(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+def _parse_float_header(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def apply_super_p95_request_headers(extra_args: dict[str, Any], headers: Mapping[str, str] | None) -> None:
+    if not headers:
+        return
+    sacrificial = _parse_bool_header(headers.get(HEADER_SUPER_P95_SACRIFICIAL))
+    if sacrificial is not None:
+        extra_args[EXTRA_ARG_SUPER_P95_SACRIFICIAL] = sacrificial
+    estimated_service_s = _parse_float_header(headers.get(HEADER_SUPER_P95_ESTIMATED_SERVICE_S))
+    if estimated_service_s is not None and estimated_service_s >= 0.0:
+        extra_args[EXTRA_ARG_SUPER_P95_ESTIMATED_SERVICE_S] = estimated_service_s
+
+
+def build_super_p95_response_headers(snapshot: SuperP95LoadSnapshot) -> dict[str, str]:
+    return {
+        HEADER_SUPER_P95_NORMAL_LOAD_S: f"{snapshot.normal_load_s:.6f}",
+        HEADER_SUPER_P95_SACRIFICIAL_LOAD_S: f"{snapshot.sacrificial_load_s:.6f}",
+    }
+
+
+def parse_super_p95_load_headers(headers: Mapping[str, str] | None) -> SuperP95LoadSnapshot | None:
+    if not headers:
+        return None
+
+    normal_load_s = _parse_float_header(headers.get(HEADER_SUPER_P95_NORMAL_LOAD_S))
+    sacrificial_load_s = _parse_float_header(headers.get(HEADER_SUPER_P95_SACRIFICIAL_LOAD_S))
+    if normal_load_s is None or sacrificial_load_s is None:
+        return None
+    return SuperP95LoadSnapshot(
+        normal_load_s=normal_load_s,
+        sacrificial_load_s=sacrificial_load_s,
+    )
+
+
+def get_super_p95_request_metadata(extra_args: Mapping[str, Any] | None) -> tuple[bool, float | None]:
+    if not extra_args:
+        return False, None
+    sacrificial = bool(extra_args.get(EXTRA_ARG_SUPER_P95_SACRIFICIAL, False))
+    estimated_service_s = extra_args.get(EXTRA_ARG_SUPER_P95_ESTIMATED_SERVICE_S)
+    if isinstance(estimated_service_s, (int, float)):
+        return sacrificial, float(estimated_service_s)
+    return sacrificial, None
+
+
+def normalize_super_p95_hardware_profile(hardware_profile: str | None) -> str:
+    normalized = (hardware_profile or DEFAULT_SUPER_P95_HARDWARE_PROFILE).strip().upper()
+    if normalized in _KNOWN_SUPER_P95_HARDWARE_PROFILES:
+        return normalized
+    return DEFAULT_SUPER_P95_HARDWARE_PROFILE
+
+
+def estimate_service_time_s(
+    request: Any,
+    hardware_profile: str | None = None,
+) -> float:
+    params = request.sampling_params
+    frames = max(int(params.num_frames or 1), 1)
+    if frames > 1:
+        return _estimate_wan2_2_service_time_s(request, hardware_profile=hardware_profile)
+
+    params = request.sampling_params
+    width = int(params.width or params.resolution or _QWEN_IMAGE_FALLBACK_BASE_RESOLUTION[0])
+    height = int(params.height or params.resolution or _QWEN_IMAGE_FALLBACK_BASE_RESOLUTION[1])
+    steps = max(int(params.num_inference_steps or _QWEN_IMAGE_FALLBACK_BASE_STEPS), 1)
+
+    profile = normalize_super_p95_hardware_profile(hardware_profile)
+    per_pixel_step_ms = _QWEN_IMAGE_PER_PIXEL_STEP_MS[profile].get((width, height))
+    if per_pixel_step_ms is None:
+        per_pixel_step_ms = _QWEN_IMAGE_PER_PIXEL_STEP_MS[profile][_QWEN_IMAGE_FALLBACK_BASE_RESOLUTION]
+    return per_pixel_step_ms * width * height * steps / 1000.0
+
+
+def _estimate_wan2_2_service_time_s(
+    request: Any,
+    hardware_profile: str | None = None,
+) -> float:
+    params = request.sampling_params
+    width = int(params.width or 854)
+    height = int(params.height or 480)
+    steps = max(int(params.num_inference_steps or 1), 1)
+    frames = max(int(params.num_frames or 1), 1)
+
+    profile = normalize_super_p95_hardware_profile(hardware_profile)
+    anchors = _WAN2_2_HARDWARE_ANCHORS_S.get(profile, _WAN2_2_HARDWARE_ANCHORS_S[DEFAULT_SUPER_P95_HARDWARE_PROFILE])
+    exact_match = anchors.get((width, height, steps, frames))
+    if exact_match is not None:
+        return exact_match
+
+    frames = normalize_wan2_2_num_frames(frames)
+    per_pixel_frame_step_ms = _WAN2_2_PER_PIXEL_FRAME_STEP_MS[profile]
+    return per_pixel_frame_step_ms * width * height * steps * frames / 1000.0
+
+
+def normalize_wan2_2_num_frames(num_frames: int | None) -> int:
+    frames = max(int(num_frames or 1), 1)
+    if frames % _WAN2_2_VAE_SCALE_FACTOR_TEMPORAL != 1:
+        frames = frames // _WAN2_2_VAE_SCALE_FACTOR_TEMPORAL * _WAN2_2_VAE_SCALE_FACTOR_TEMPORAL + 1
+    return max(frames, 1)

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -480,7 +480,23 @@ class WorkerProc:
                 except Exception as e:
                     logger.error(f"Error processing RPC: {e}", exc_info=True)
                     if self.result_mq is not None:
-                        self.return_result(DiffusionOutput(error=str(e)))
+                        if isinstance(msg, dict) and msg.get("method") == "execute_stepwise":
+                            sched_output = msg.get("args", (None,))[0]
+                            sched_req_ids = (
+                                getattr(sched_output, "scheduled_req_ids", [])
+                                if sched_output is not None
+                                else []
+                            )
+                            req_id = sched_req_ids[0] if sched_req_ids else ""
+                            self.return_result(
+                                RunnerOutput(
+                                    req_id=req_id,
+                                    finished=True,
+                                    result=DiffusionOutput(error=str(e)),
+                                )
+                            )
+                        else:
+                            self.return_result(DiffusionOutput(error=str(e)))
 
             elif isinstance(msg, dict) and msg.get("type") == "shutdown":
                 logger.info("Worker %s: Received shutdown message", self.gpu_id)

--- a/vllm_omni/entrypoints/async_omni_diffusion.py
+++ b/vllm_omni/entrypoints/async_omni_diffusion.py
@@ -9,6 +9,7 @@ enabling concurrent request handling and streaming generation.
 """
 
 import asyncio
+import os
 import uuid
 import weakref
 from collections.abc import AsyncGenerator, Iterable
@@ -26,6 +27,34 @@ from vllm_omni.lora.request import LoRARequest
 from vllm_omni.outputs import OmniRequestOutput
 
 logger = init_logger(__name__)
+
+DEFAULT_DIFFUSION_EXECUTOR_WORKERS = 32
+
+
+def _resolve_diffusion_executor_workers() -> int:
+    raw_value = os.getenv("VLLM_OMNI_DIFFUSION_EXECUTOR_WORKERS")
+    if raw_value is None:
+        return DEFAULT_DIFFUSION_EXECUTOR_WORKERS
+
+    try:
+        worker_count = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid VLLM_OMNI_DIFFUSION_EXECUTOR_WORKERS=%r; using default=%d",
+            raw_value,
+            DEFAULT_DIFFUSION_EXECUTOR_WORKERS,
+        )
+        return DEFAULT_DIFFUSION_EXECUTOR_WORKERS
+
+    if worker_count < 1:
+        logger.warning(
+            "Non-positive VLLM_OMNI_DIFFUSION_EXECUTOR_WORKERS=%r; using default=%d",
+            raw_value,
+            DEFAULT_DIFFUSION_EXECUTOR_WORKERS,
+        )
+        return DEFAULT_DIFFUSION_EXECUTOR_WORKERS
+
+    return worker_count
 
 
 def _weak_close_async_omni_diffusion(engine: DiffusionEngine, executor: ThreadPoolExecutor) -> None:
@@ -141,8 +170,15 @@ class AsyncOmniDiffusion:
         # Initialize engine
         self.engine: DiffusionEngine = DiffusionEngine.make_engine(od_config)
 
-        # Thread pool for running sync engine in async context
-        self._executor = ThreadPoolExecutor(max_workers=1)
+        # Allow multiple request threads to enter the diffusion engine.
+        # The engine itself serializes execution internally, but preemption
+        # requires later arrivals to be submitted while an earlier request is
+        # still running.
+        self._executor_workers = _resolve_diffusion_executor_workers()
+        self._executor = ThreadPoolExecutor(
+            max_workers=self._executor_workers,
+            thread_name_prefix="async-omni-diffusion",
+        )
         self._closed = False
         self._weak_finalizer = weakref.finalize(
             self,

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -19,7 +19,7 @@ from typing import Annotated, Any, Literal, cast
 
 import httpx
 import vllm.envs as envs
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, WebSocket
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile, WebSocket
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from PIL import Image
 from pydantic import BaseModel, Field
@@ -111,6 +111,12 @@ from vllm_omni.entrypoints.openai.storage import STORAGE_MANAGER
 from vllm_omni.entrypoints.openai.stores import VIDEO_STORE, VIDEO_TASKS
 from vllm_omni.entrypoints.openai.utils import get_stage_type, parse_lora_request
 from vllm_omni.entrypoints.openai.video_api_utils import decode_input_reference
+from vllm_omni.diffusion.super_p95 import (
+    SuperP95LoadSnapshot,
+    apply_super_p95_request_headers,
+    build_super_p95_response_headers,
+    get_super_p95_request_metadata,
+)
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniSamplingParams, OmniTextPrompt
 
 logger = init_logger(__name__)
@@ -119,6 +125,54 @@ router = APIRouter()
 # Supported resolution buckets for layered models (e.g., Qwen-Image-Layered)
 SUPPORTED_LAYERED_RESOLUTIONS = (640, 1024)
 profiler_router = APIRouter()
+
+
+def _get_super_p95_load_snapshot(raw_request: Request) -> SuperP95LoadSnapshot | None:
+    diffusion_engine = getattr(raw_request.app.state, "diffusion_engine", None)
+    engine = getattr(diffusion_engine, "engine", diffusion_engine)
+    scheduler = getattr(engine, "scheduler", None)
+    if scheduler is None or not hasattr(scheduler, "get_load_snapshot"):
+        return None
+    try:
+        return scheduler.get_load_snapshot()
+    except Exception:
+        logger.exception("Failed to build super_p95 response headers from scheduler snapshot")
+        return None
+
+
+def _get_super_p95_response_headers(raw_request: Request) -> dict[str, str]:
+    snapshot = _get_super_p95_load_snapshot(raw_request)
+    if snapshot is None:
+        return {}
+    return build_super_p95_response_headers(snapshot)
+
+
+def _get_super_p95_post_arrival_headers(raw_request: Request, extra_args: dict[str, Any] | None) -> dict[str, str]:
+    snapshot = _get_super_p95_load_snapshot(raw_request)
+    if snapshot is None:
+        return {}
+
+    sacrificial, estimated_service_s = get_super_p95_request_metadata(extra_args)
+    if estimated_service_s is None:
+        return build_super_p95_response_headers(snapshot)
+
+    if sacrificial:
+        snapshot = SuperP95LoadSnapshot(
+            normal_load_s=snapshot.normal_load_s,
+            sacrificial_load_s=snapshot.sacrificial_load_s + estimated_service_s,
+        )
+    else:
+        snapshot = SuperP95LoadSnapshot(
+            normal_load_s=snapshot.normal_load_s + estimated_service_s,
+            sacrificial_load_s=snapshot.sacrificial_load_s,
+        )
+    return build_super_p95_response_headers(snapshot)
+
+
+def _apply_super_p95_response_headers(raw_request: Request, response: Response) -> None:
+    headers = _get_super_p95_response_headers(raw_request)
+    if headers:
+        response.headers.update(headers)
 
 
 def _should_enable_profiler_endpoints(stage_configs: list | None) -> bool:
@@ -1254,7 +1308,11 @@ async def show_available_models(raw_request: Request) -> JSONResponse:
         HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
     },
 )
-async def generate_images(request: ImageGenerationRequest, raw_request: Request) -> ImageGenerationResponse:
+async def generate_images(
+    request: ImageGenerationRequest,
+    raw_request: Request,
+    raw_response: Response,
+) -> ImageGenerationResponse:
     """Generate images from text prompts using diffusion models.
 
     OpenAI DALL-E compatible endpoint for text-to-image generation.
@@ -1314,6 +1372,7 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
             gen_params, "seed", request.seed if request.seed is not None else random.randint(0, 2**32 - 1)
         )
         _update_if_not_none(gen_params, "generator_device", request.generator_device)
+        apply_super_p95_request_headers(gen_params.extra_args, raw_request.headers)
 
         request_id = f"img_gen-{random_uuid()}"
 
@@ -1342,6 +1401,7 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
         # Encode images to base64
         image_data = [ImageData(b64_json=encode_image_base64(img), revised_prompt=None) for img in images]
 
+        _apply_super_p95_response_headers(raw_request, raw_response)
         return ImageGenerationResponse(
             created=int(time.time()),
             data=image_data,
@@ -1949,6 +2009,7 @@ async def _run_video_generation_job(
 )
 async def create_video(
     raw_request: Request,
+    raw_response: Response,
     prompt: str = Form(...),
     input_reference: UploadFile | None = File(default=None),
     image_reference: str | None = Form(default=None),
@@ -2018,6 +2079,9 @@ async def create_video(
             detail="Provide either input_reference or image_reference, not both.",
         )
 
+    parsed_extra_params = _parse_form_json(extra_params, expected_type=dict) or {}
+    apply_super_p95_request_headers(parsed_extra_params, raw_request.headers)
+
     request_data: dict[str, Any] = {
         "prompt": prompt,
         "model": model,
@@ -2038,7 +2102,7 @@ async def create_video(
         "seed": seed,
         "negative_prompt": negative_prompt,
         "lora": _parse_form_json(lora, expected_type=dict),
-        "extra_params": _parse_form_json(extra_params, expected_type=dict),
+        "extra_params": parsed_extra_params or None,
     }
 
     request_data = {k: v for k, v in request_data.items() if v is not None}
@@ -2080,6 +2144,7 @@ async def create_video(
     await VIDEO_STORE.upsert(ref.id, ref)
     task = asyncio.create_task(_run_video_generation_job(handler, request, ref.id, reference_image))
     await VIDEO_TASKS.upsert(ref.id, task)
+    raw_response.headers.update(_get_super_p95_post_arrival_headers(raw_request, parsed_extra_params))
     return ref
 
 

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -85,6 +85,7 @@ from vllm_omni.entrypoints.openai.audio_utils_mixin import AudioMixin
 from vllm_omni.entrypoints.openai.protocol import OmniChatCompletionStreamResponse
 from vllm_omni.entrypoints.openai.protocol.audio import AudioResponse, CreateAudio
 from vllm_omni.entrypoints.openai.utils import parse_lora_request
+from vllm_omni.diffusion.super_p95 import apply_super_p95_request_headers
 from vllm_omni.lora.request import LoRARequest
 from vllm_omni.outputs import OmniRequestOutput
 
@@ -2122,6 +2123,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 num_outputs_per_prompt=num_outputs_per_prompt,
                 seed=seed,
             )
+            apply_super_p95_request_headers(gen_params.extra_args, raw_request.headers)
 
             # Only override defaults when the user explicitly provides values
             if num_inference_steps is not None:
@@ -2249,16 +2251,18 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 stop_reason=None,
             )
 
-            response = ChatCompletionResponse(
+            usage = UsageInfo(
+                prompt_tokens=len(prompt.split()),
+                completion_tokens=1,
+                total_tokens=len(prompt.split()) + 1,
+            )
+
+            response = OmniChatCompletionResponse(
                 id=request_id,
                 created=created_time,
                 model=self._diffusion_model_name,
                 choices=[choice],
-                usage=UsageInfo(
-                    prompt_tokens=len(prompt.split()),
-                    completion_tokens=1,
-                    total_tokens=len(prompt.split()) + 1,
-                ),
+                usage=usage.model_dump(exclude_none=True),
             )
 
             logger.info(

--- a/vllm_omni/entrypoints/openai/serving_video.py
+++ b/vllm_omni/entrypoints/openai/serving_video.py
@@ -120,6 +120,7 @@ class OmniOpenAIServingVideo:
             gen_params.boundary_ratio,
         )
         if request.flow_shift is not None:
+            gen_params.flow_shift = request.flow_shift
             gen_params.extra_args["flow_shift"] = request.flow_shift
 
         # Apply model-specific extra parameters

--- a/vllm_omni/inputs/data.py
+++ b/vllm_omni/inputs/data.py
@@ -233,6 +233,7 @@ class OmniDiffusionSamplingParams:
     timestep: torch.Tensor | float | int | None = None
     step_index: int | None = None
     boundary_ratio: float | None = None
+    flow_shift: float | None = None
 
     # Scheduler parameters – ``None`` means "not explicitly set by the caller";
     # each pipeline's ``forward()`` decides its own model-specific default.


### PR DESCRIPTION
Refactoring in progress...

## Purpose

Land **`super_p95`** scheduling on the v0.18 diffusion online serving stack to improve **`e2e P95 latency`** under mixed workloads.

- **Inter-card**: the dispatcher estimates service time, marks a small fraction of large requests as low-priority via quota, and selects backends using load / inflight / latency EMA.
- **Intra-card**: normal requests stay FIFO; low-priority requests use a separate queue; at **diffusion step boundaries**, normal requests may preempt a running low-priority request (completed steps are not rolled back).
- **Scope**: `Qwen-Image` (t2i, 8 GPUs / 8 instances) and `Wan2.2` (t2v).

This PR includes the implementation, unit tests, benchmark / third-party reproduction docs, and the design write-up (`docs.md` / technical plan).

## Test Plan

- [ ] **Unit tests**: `tests/diffusion/test_super_p95_dispatcher.py`, `test_super_p95_api_headers.py`, `test_diffusion_scheduler.py`
- [ ] **Environment**: clean NPU processes before startup per `THIRD_PARTY_TEST_COMMANDS.md`
- [ ] **Qwen-Image**: `QWEN_IMAGE_RANDOM4`, 500 requests, `baseline` vs `super_p95` via `eval_qwen_image.sh`, sweep rates 0.2–0.8 rps
- [ ] **Wan2.2**: `WAN22_RANDOM3`, compare `baseline` (`1×8`, `--usp 8`) vs `super_p95` (`2×4`, `--usp 4` ×2), at least:
  - 100 requests @ **0.03 rps**
  - 50 requests @ **0.05 rps**

## Test Result

### Qwen-Image

Workload: `QWEN_IMAGE_RANDOM4`, 500 requests; metric: `latency_p95` (Speedup = Baseline P95 / Super P95)

| Rate (rps) | Baseline P95 (s) | Super P95 (s) | Speedup |
|------------|------------------|---------------|---------|
| 0.2 | 49.79 | 49.35 | 1.009× |
| 0.3 | 49.57 | 49.64 | 0.999× |
| 0.4 | 55.14 | 56.83 | 0.970× |
| 0.5 | 141.63 | 95.30 | 1.486× |
| 0.6 | 276.89 | 181.82 | 1.523× |
| 0.7 | 391.25 | 291.50 | 1.342× |
| 0.8 | 461.92 | 374.87 | 1.232× |

Limited benefit at low load (0.2–0.4 rps). **At rate ≥ 0.5 rps**, P95 improves clearly; peak speedup **1.523×** at 0.6 rps.

### Wan2.2

Workload: `WAN22_RANDOM3`; shared backend flags: `enable-layerwise-offload`, `boundary-ratio=0.875`.

**Note**: baseline uses `1×8` + `--usp 8`; `super_p95` uses `2×4` + `--usp 4` ×2. Topology differs in addition to scheduling.

```
┌────────────────────┬──────────────┬───────────┬─────────┐
│ Scenario           │ Baseline P95 │ Super P95 │ Speedup │
├────────────────────┼──────────────┼───────────┼─────────┤
│ 0.03 rps / 100 req │ 4265s        │ 3010s     │ ~1.42×  │
│ 0.05 rps / 50 req  │ 2751s        │ 2192s     │ ~1.26×  │
└────────────────────┴──────────────┴───────────┴─────────┘
```

Both runs succeeded (50/50 at 0.05 rps). At 0.03 rps, total duration is ~807s shorter; P99 is slightly higher on `super_p95` (5679s vs 4399s).

---

Coauthor with @Lijunzhang0829
