### PR TITLE
[Bugfix] Remove duplicate ffmpeg options in random video generation

### DIFF
--- a/vllm_omni/benchmarks/data_modules/random_multi_modal_dataset.py
+++ b/vllm_omni/benchmarks/data_modules/random_multi_modal_dataset.py
@@ -123,10 +123,6 @@ class OmniRandomMultiModalDataset(RandomMultiModalDataset):
                 "23",
                 "-movflags",
                 "+faststart",
-                "-pix_fmt",
-                "yuv420p",
-                "-vf",
-                f"scale={width}:{height}",
             ],
         }
 


### PR DESCRIPTION
## Purpose

Fixes #3465 by removing duplicate FFmpeg options from synthetic random video generation.

`imageio` already receives `pixelformat="yuv420p"`, which emits `-pix_fmt yuv420p` internally. The code also passed `-pix_fmt yuv420p` manually through `ffmpeg_params`, causing duplicate FFmpeg warnings.

Similarly, `macro_block_size=16` can trigger imageio's own compatibility scaling, while the code also passed a manual `-vf scale=...`, causing duplicate filter warnings.

## Test Plan

- Reproduced the warning with the original writer options using a synthetic `(732, 668, 7)` video.
- Removed duplicate `-pix_fmt yuv420p` and `-vf scale=...` from `ffmpeg_params`.
- Re-ran the synthetic video generation script and confirmed the duplicate FFmpeg warnings disappeared.

## Test Result

Before:

    IMAGEIO FFMPEG_WRITER WARNING: input image is not divisible by macro_block_size=16, resizing from (732, 668) to (736, 672) to ensure video compatibility with most codecs and players.
    Multiple -pix_fmt options specified for stream 0, only the last option '-pix_fmt yuv420p' will be used.
    Multiple -filter/-af/-vf options specified for stream 0, only the last option '-filter:v scale=732:668' will be used.
    generated bytes: 1496818

After:

    IMAGEIO FFMPEG_WRITER WARNING: input image is not divisible by macro_block_size=16, resizing from (732, 668) to (736, 672) to ensure video compatibility with most codecs and players.
    generated bytes: 1403120

The remaining `macro_block_size=16` warning is expected and unrelated to the duplicate FFmpeg options fixed here.