### PR TITLE
[Bugfix] Make prompt upscalers deterministic by propagating generator

### DIFF
--- a/docs/serving/image_generation_api.md
+++ b/docs/serving/image_generation_api.md
@@ -106,6 +106,7 @@ Content-Type: application/json
 | `guidance_scale` | float | model defaults | Classifier-free guidance scale (typically 0.0-20.0) |
 | `true_cfg_scale` | float | model defaults | True CFG scale (model-specific parameter, may be ignored if not supported) |
 | `seed` | integer | null | Random seed for reproducibility |
+| `use_prompt_upscaling` | boolean | false | Enable prompt enhancement/rewriting before generation. Only effective for models that support prompt upscaling (e.g., ERNIE-Image, Flux2, LongCat). |
 
 ### Response Format
 

--- a/docs/serving/image_generation_api.md
+++ b/docs/serving/image_generation_api.md
@@ -106,7 +106,7 @@ Content-Type: application/json
 | `guidance_scale` | float | model defaults | Classifier-free guidance scale (typically 0.0-20.0) |
 | `true_cfg_scale` | float | model defaults | True CFG scale (model-specific parameter, may be ignored if not supported) |
 | `seed` | integer | null | Random seed for reproducibility |
-| `use_prompt_upscaling` | boolean | false | Enable prompt enhancement/rewriting before generation. Only effective for models that support prompt upscaling (e.g., ERNIE-Image, Flux2, LongCat). |
+| `use_prompt_upscaling` | boolean | false | Enable prompt enhancement/rewriting before generation. Only effective for models that support prompt upscaling (e.g., ERNIE-Image, Flux2, LongCat). For models with an external upscaler (e.g., ERNIE-Image), the server must be configured with `enable_external_prompt_upscaler: true` in the stage config. |
 
 ### Response Format
 

--- a/recipes/Baidu/ERNIE-Image.md
+++ b/recipes/Baidu/ERNIE-Image.md
@@ -141,11 +141,14 @@ curl -X POST http://localhost:8091/v1/images/generations \
     for faster generation; configure via `--cache-config`.
   - **Layer offload:** `--enable-layerwise-offload` offloads DiT layers to CPU
     for memory-constrained scenarios.
-- **Prompt Enhancer (PE):** ERNIE-Image includes an optional 3B-parameter
+- **Prompt Upscaling (PE):** ERNIE-Image includes an optional 3B-parameter
   Prompt Enhancer model that expands brief user inputs into richer structured
-  descriptions, improving output quality. Set `use_pe=False` in the request
-  body to disable it if you prefer direct prompt processing or want to use
-  larger LLMs (e.g., Gemini, ChatGPT) for prompt enhancement instead.
+  descriptions, improving output quality. Because this loads an additional
+  model onto GPU, it must be explicitly enabled at server startup with
+  `--enable-external-prompt-upscaler`. Once enabled, set
+  `"use_prompt_upscaling": true` in the request body
+  (`/v1/images/generations`) or in `"extra_body"` (`/v1/chat/completions`)
+  to activate it per request.
 - **Recommended settings:**
   - ERNIE-Image: `num_inference_steps=50`, `guidance_scale=4.0`
   - ERNIE-Image-Turbo: `num_inference_steps=8`, `guidance_scale=1.0`

--- a/tests/diffusion/models/ernie_image/test_ernie_image_pe.py
+++ b/tests/diffusion/models/ernie_image/test_ernie_image_pe.py
@@ -48,7 +48,6 @@ class _FakePEModel:
 
 def test_enhance_prompt_uses_rank0_result_in_distributed(monkeypatch):
     pipe = ErnieImagePipeline.__new__(ErnieImagePipeline)
-    pipe.has_external_prompt_upscaler = True
     pipe.pe_model = None
     pipe.pe_tokenizer = None
 
@@ -107,7 +106,6 @@ def test_enhance_prompt_triggers_lazy_load(monkeypatch):
     pipe = ErnieImagePipeline.__new__(ErnieImagePipeline)
     pipe.pe_model = None
     pipe.pe_tokenizer = None
-    pipe.has_external_prompt_upscaler = True
 
     fake_model = _FakePEModel()
     fake_tokenizer = _FakeTokenizer()
@@ -119,9 +117,21 @@ def test_enhance_prompt_triggers_lazy_load(monkeypatch):
 
     assert pipe.pe_model is fake_model
     assert fake_model.calls == 1
-    # Should get the enanced result back after getting our input
+    # Should get the enhanced result back after getting our input
     assert result == "enhanced-prompt"
     assert "a cat sitting on a mat" in fake_tokenizer.last_chat_input
+
+
+def test_ensure_pe_loaded_skips_when_disabled():
+    """Ensure has pe loaded is False when external upscaler loading is not enabled."""
+    pipe = ErnieImagePipeline.__new__(ErnieImagePipeline)
+    pipe.pe_model = None
+    pipe.pe_tokenizer = None
+    pipe.has_external_prompt_upscaler = True
+    pipe._load_pe = None
+
+    assert pipe._ensure_pe_loaded() is False
+    assert pipe.pe_model is None
 
 
 def test_hybrid_ring_slices_full_attention_mask(monkeypatch):

--- a/tests/diffusion/models/ernie_image/test_ernie_image_pe.py
+++ b/tests/diffusion/models/ernie_image/test_ernie_image_pe.py
@@ -22,14 +22,19 @@ class _FakeTokenizer:
     pad_token_id = 0
     eos_token_id = 1
 
-    def apply_chat_template(self, *_args, **_kwargs):
+    def __init__(self):
+        self.last_chat_input = None
+
+    def apply_chat_template(self, messages, *_args, **_kwargs):
+        # Store the last input for checking prompt enhance
+        self.last_chat_input = messages[0]["content"]
         return "chat prompt"
 
     def __call__(self, *_args, **_kwargs):
         return _TokenInputs(input_ids=torch.tensor([[1, 2]]))
 
     def decode(self, *_args, **_kwargs):
-        return "rank1-enhanced"
+        return "enhanced-prompt"
 
 
 class _FakePEModel:
@@ -43,9 +48,13 @@ class _FakePEModel:
 
 def test_enhance_prompt_uses_rank0_result_in_distributed(monkeypatch):
     pipe = ErnieImagePipeline.__new__(ErnieImagePipeline)
-    pipe.use_pe = True
-    pipe.pe_tokenizer = _FakeTokenizer()
-    pipe.pe_model = _FakePEModel()
+    pipe.has_external_prompt_upscaler = True
+    pipe.pe_model = None
+    pipe.pe_tokenizer = None
+
+    fake_model = _FakePEModel()
+    fake_tokenizer = _FakeTokenizer()
+    pipe._load_pe = lambda: (fake_model, fake_tokenizer)
 
     broadcasts = []
 
@@ -62,20 +71,57 @@ def test_enhance_prompt_uses_rank0_result_in_distributed(monkeypatch):
     enhanced = pipe._enhance_prompt("original", torch.device("cpu"))
 
     assert enhanced == "rank0-enhanced"
-    assert pipe.pe_model.calls == 0
+    assert fake_model.calls == 0
     assert broadcasts == [([None], 0)]
 
 
-def test_should_apply_pe_respects_sampling_extra_args():
-    req = SimpleNamespace(sampling_params=SimpleNamespace(extra_args={"apply_pe": False}))
+def test_should_apply_pe_true_when_requested():
+    """Ensure that use_prompt_upscaling forwards through."""
+    req = SimpleNamespace(
+        request_ids=["real_req"],
+        sampling_params=SimpleNamespace(extra_args={"use_prompt_upscaling": True}),
+    )
+    assert ErnieImagePipeline._should_apply_pe(req) is True
 
+
+def test_should_apply_pe_false_when_not_requested():
+    """Ensure that use_prompt_upscaling is False by default."""
+    req = SimpleNamespace(
+        request_ids=["real_req"],
+        sampling_params=SimpleNamespace(extra_args={}),
+    )
     assert ErnieImagePipeline._should_apply_pe(req) is False
 
 
 def test_should_apply_pe_disables_dummy_warmup_request():
-    req = SimpleNamespace(request_ids=["dummy_req_id"], sampling_params=SimpleNamespace(extra_args={}))
-
+    """Ensure that use_prompt_upscaling is False during warmup."""
+    req = SimpleNamespace(
+        request_ids=["dummy_req_id"],
+        sampling_params=SimpleNamespace(extra_args={"use_prompt_upscaling": True}),
+    )
     assert ErnieImagePipeline._should_apply_pe(req) is False
+
+
+def test_enhance_prompt_triggers_lazy_load(monkeypatch):
+    """_enhance_prompt lazy-loads the PE model on first call."""
+    pipe = ErnieImagePipeline.__new__(ErnieImagePipeline)
+    pipe.pe_model = None
+    pipe.pe_tokenizer = None
+    pipe.has_external_prompt_upscaler = True
+
+    fake_model = _FakePEModel()
+    fake_tokenizer = _FakeTokenizer()
+    pipe._load_pe = lambda: (fake_model, fake_tokenizer)
+
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: False)
+
+    result = pipe._enhance_prompt("a cat sitting on a mat", torch.device("cpu"))
+
+    assert pipe.pe_model is fake_model
+    assert fake_model.calls == 1
+    # Should get the enanced result back after getting our input
+    assert result == "enhanced-prompt"
+    assert "a cat sitting on a mat" in fake_tokenizer.last_chat_input
 
 
 def test_hybrid_ring_slices_full_attention_mask(monkeypatch):

--- a/tests/diffusion/models/test_prompt_upscaling_utils.py
+++ b/tests/diffusion/models/test_prompt_upscaling_utils.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.prompt_utils import do_prompt_upscaling
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def mock_request(extra_args: dict[str, Any]) -> OmniDiffusionRequest:
+    return cast(
+        OmniDiffusionRequest,
+        SimpleNamespace(
+            sampling_params=SimpleNamespace(extra_args=extra_args),
+        ),
+    )
+
+
+def mock_config(enable: bool) -> OmniDiffusionConfig:
+    return cast(OmniDiffusionConfig, SimpleNamespace(enable_prompt_upscaling=enable))
+
+
+@pytest.mark.parametrize(
+    "allow_upscale,extra_args,expected",
+    [
+        (True, {"prompt_upscaling": True}, True),
+        (True, {"prompt_upscaling": False}, False),
+        (True, {}, False),
+        (False, {"prompt_upscaling": True}, False),
+        (False, {}, False),
+    ],
+)
+def test_do_prompt_upscaling(allow_upscale, extra_args, expected):
+    """Ensure we only do upscale if it's enabled and requested."""
+    res = do_prompt_upscaling(mock_request(extra_args), mock_config(allow_upscale))
+    assert res is expected
+
+
+def test_do_prompt_upscaling_rejects_non_bool():
+    """Ensure do_prompt_upscaling requires a boolean value."""
+    with pytest.raises(TypeError, match="must be a bool"):
+        do_prompt_upscaling(mock_request({"prompt_upscaling": object()}), mock_config(True))

--- a/tests/diffusion/models/test_prompt_upscaling_utils.py
+++ b/tests/diffusion/models/test_prompt_upscaling_utils.py
@@ -3,7 +3,6 @@ from typing import Any, cast
 
 import pytest
 
-from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.prompt_utils import do_prompt_upscaling
 
@@ -13,33 +12,24 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 def mock_request(extra_args: dict[str, Any]) -> OmniDiffusionRequest:
     return cast(
         OmniDiffusionRequest,
-        SimpleNamespace(
-            sampling_params=SimpleNamespace(extra_args=extra_args),
-        ),
+        SimpleNamespace(sampling_params=SimpleNamespace(extra_args=extra_args)),
     )
 
 
-def mock_config(enable: bool) -> OmniDiffusionConfig:
-    return cast(OmniDiffusionConfig, SimpleNamespace(enable_prompt_upscaling=enable))
-
-
 @pytest.mark.parametrize(
-    "allow_upscale,extra_args,expected",
+    "extra_args,expected",
     [
-        (True, {"prompt_upscaling": True}, True),
-        (True, {"prompt_upscaling": False}, False),
-        (True, {}, False),
-        (False, {"prompt_upscaling": True}, False),
-        (False, {}, False),
+        ({"use_prompt_upscaling": True}, True),
+        ({"use_prompt_upscaling": False}, False),
+        ({}, False),
     ],
 )
-def test_do_prompt_upscaling(allow_upscale, extra_args, expected):
-    """Ensure we only do upscale if it's enabled and requested."""
-    res = do_prompt_upscaling(mock_request(extra_args), mock_config(allow_upscale))
-    assert res is expected
+def test_do_prompt_upscaling(extra_args, expected):
+    """Ensure we only enable upscale if it's explicitly requested."""
+    assert do_prompt_upscaling(mock_request(extra_args)) is expected
 
 
 def test_do_prompt_upscaling_rejects_non_bool():
     """Ensure do_prompt_upscaling requires a boolean value."""
     with pytest.raises(TypeError, match="must be a bool"):
-        do_prompt_upscaling(mock_request({"prompt_upscaling": object()}), mock_config(True))
+        do_prompt_upscaling(mock_request({"use_prompt_upscaling": object()}))

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -590,6 +590,11 @@ class OmniDiffusionConfig:
     # sleep mode
     enable_sleep_mode: bool = False
 
+    # Allow lazy-loading external prompt upscaler models, e.g., in Ernie Image.
+    # This is disabled by default to ensure that if prompt scaling is not desired
+    # in low resource environments, we don't try to lazily load it and OOM.
+    enable_external_prompt_upscaler: bool = False
+
     # Maximum number of sequences to generate in a batch
     max_num_seqs: int = 1
 

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -590,6 +590,11 @@ class OmniDiffusionConfig:
     # sleep mode
     enable_sleep_mode: bool = False
 
+    # Whether or not the Diffusion model should allow prompt upscaling;
+    # If enabled, we may load the text upscaler on the first call it is
+    # needed. If it's disabled, the text upscaler is always skipped.
+    enable_prompt_upscaling: bool = True
+
     # Maximum number of sequences to generate in a batch
     max_num_seqs: int = 1
 

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -590,11 +590,6 @@ class OmniDiffusionConfig:
     # sleep mode
     enable_sleep_mode: bool = False
 
-    # Whether or not the Diffusion model should allow prompt upscaling;
-    # If enabled, we may load the text upscaler on the first call it is
-    # needed. If it's disabled, the text upscaler is always skipped.
-    enable_prompt_upscaling: bool = True
-
     # Maximum number of sequences to generate in a batch
     max_num_seqs: int = 1
 

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -196,9 +196,9 @@ class ErnieImagePipeline(
     def _ensure_pe_loaded(self) -> bool:
         if self._load_pe is None:
             logger.warning(
-                "Prompt upscaling for a model with an external prompt upscaler, but "
+                "Requested prompt upscaling on a model with an external prompt upscaler, but "
                 "enable_external_prompt_upscaler is not set in the server config; "
-                "skipping prompt upscaling"
+                "prompt upscaling will be skipped"
             )
             return False
         self.pe_model, self.pe_tokenizer = self._load_pe()

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -160,14 +160,16 @@ class ErnieImagePipeline(
             model,
             getattr(od_config, "revision", None),
         )
+
         self.has_external_prompt_upscaler = os.path.exists(
             os.path.join(pe_base_path, "pe"),
         )
-        # Defer loading the prompt upscaler unless we actually need it
-        self._load_pe = _make_pe_loader(
-            pe_base_path,
-            od_config.dtype,
-            self._execution_device,
+        # Only create the loader if the server config allows external
+        # upscaler loading. This prevents a user request from OOMing
+        # the server by lazy-loading a large model.
+        pe_loader = _make_pe_loader(pe_base_path, od_config.dtype, self._execution_device)
+        self._load_pe = (
+            pe_loader if self.has_external_prompt_upscaler and od_config.enable_external_prompt_upscaler else None
         )
         self.pe_model = None
         self.pe_tokenizer = None
@@ -192,6 +194,13 @@ class ErnieImagePipeline(
         )
 
     def _ensure_pe_loaded(self) -> bool:
+        if self._load_pe is None:
+            logger.warning(
+                "Prompt upscaling for a model with an external prompt upscaler, but "
+                "enable_external_prompt_upscaler is not set in the server config; "
+                "skipping prompt upscaling"
+            )
+            return False
         self.pe_model, self.pe_tokenizer = self._load_pe()
         return True
 

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Adapted from: https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/ernie_image/pipeline_ernie_image.py
 
+import functools
 import json
 import os
 from collections.abc import Callable, Iterable
@@ -26,10 +27,42 @@ from vllm_omni.diffusion.models.interface import SupportImageInput
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.prompt_utils import do_prompt_upscaling
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 
 logger = init_logger(__name__)
+
+
+def _make_pe_loader(
+    pe_base_path: str,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> Callable[[], tuple[AutoModelForCausalLM, AutoTokenizer]]:
+    """Build a cached factory that lazily loads the PE model + tokenizer."""
+    pe_model_path = os.path.join(pe_base_path, "pe")
+
+    @functools.cache
+    def _load():
+        # NOTE: Prior to this point, PE files are already downloaded, which
+        # is why we use local files here.
+        pe_model = AutoModelForCausalLM.from_pretrained(
+            pe_model_path,
+            torch_dtype=dtype,
+            local_files_only=True,
+            trust_remote_code=True,
+        ).to(device)
+        pe_tokenizer = AutoTokenizer.from_pretrained(
+            pe_base_path,
+            subfolder="pe_tokenizer",
+            local_files_only=True,
+            trust_remote_code=True,
+            use_fast=False,
+        )
+        logger.info("Lazy-loaded PE model from %s", pe_model_path)
+        return pe_model, pe_tokenizer
+
+    return _load
 
 
 def _resolve_model_path_for_optional_pe(model: str, revision: str | None) -> str:
@@ -121,36 +154,23 @@ class ErnieImagePipeline(
             local_files_only=local_files_only,
         ).to(self._execution_device)
 
-        # Load PE (Prompt Enhancement) model if available. For repo IDs,
-        # resolve/download only PE files first so the existence check works.
-        pe_base_path = _resolve_model_path_for_optional_pe(model, getattr(od_config, "revision", None))
-        pe_model_path = os.path.join(pe_base_path, "pe")
-        if os.path.exists(pe_model_path):
-            try:
-                self.pe_model = AutoModelForCausalLM.from_pretrained(
-                    pe_model_path,
-                    torch_dtype=od_config.dtype,
-                    local_files_only=True,
-                    trust_remote_code=True,
-                ).to(self._execution_device)
-                self.pe_tokenizer = AutoTokenizer.from_pretrained(
-                    pe_base_path,
-                    subfolder="pe_tokenizer",
-                    local_files_only=True,
-                    trust_remote_code=True,
-                    use_fast=False,
-                )
-                self.use_pe = True
-                logger.info("Loaded PE model from %s", pe_model_path)
-            except Exception as e:
-                logger.warning("Failed to load PE model: %s", e)
-                self.pe_model = None
-                self.pe_tokenizer = None
-                self.use_pe = False
-        else:
-            self.pe_model = None
-            self.pe_tokenizer = None
-            self.use_pe = False
+        # Resolve/download PE files at init (not inference time) so the
+        # HF download doesn't block the first upscaling request.
+        pe_base_path = _resolve_model_path_for_optional_pe(
+            model,
+            getattr(od_config, "revision", None),
+        )
+        self.has_external_prompt_upscaler = os.path.exists(
+            os.path.join(pe_base_path, "pe"),
+        )
+        # Defer loading the prompt upscaler unless we actually need it
+        self._load_pe = _make_pe_loader(
+            pe_base_path,
+            od_config.dtype,
+            self._execution_device,
+        )
+        self.pe_model = None
+        self.pe_tokenizer = None
 
         transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, ErnieImageTransformer2DModel)
         self.transformer = ErnieImageTransformer2DModel(
@@ -170,6 +190,10 @@ class ErnieImagePipeline(
         self.setup_diffusion_pipeline_profiler(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
+
+    def _ensure_pe_loaded(self) -> bool:
+        self.pe_model, self.pe_tokenizer = self._load_pe()
+        return True
 
     @staticmethod
     def _distributed_prompt_sync_state() -> tuple[bool, int]:
@@ -197,7 +221,7 @@ class ErnieImagePipeline(
         temperature: float = 0.6,
         top_p: float = 0.95,
     ) -> str:
-        if not self.use_pe or self.pe_model is None:
+        if not self._ensure_pe_loaded():
             return prompt
 
         sync_prompt, rank = self._distributed_prompt_sync_state()
@@ -254,8 +278,7 @@ class ErnieImagePipeline(
     def _should_apply_pe(req: OmniDiffusionRequest) -> bool:
         if ErnieImagePipeline._is_warmup_request(req):
             return False
-        extra_args = getattr(req.sampling_params, "extra_args", {}) or {}
-        return bool(extra_args.get("apply_pe", True))
+        return do_prompt_upscaling(req)
 
     def encode_prompt(
         self,
@@ -272,7 +295,7 @@ class ErnieImagePipeline(
         text_hiddens = []
 
         for p in prompt:
-            if apply_pe and self.use_pe and self.pe_model is not None:
+            if apply_pe and self.has_external_prompt_upscaler:
                 enhanced = self._enhance_prompt(p, device, width=width, height=height)
                 logger.info("PE: original='%s...' enhanced='%s...'", p[:50], enhanced[:50])
                 p = enhanced

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -154,23 +154,21 @@ class ErnieImagePipeline(
             local_files_only=local_files_only,
         ).to(self._execution_device)
 
-        # Resolve/download PE files at init (not inference time) so the
-        # HF download doesn't block the first upscaling request.
-        pe_base_path = _resolve_model_path_for_optional_pe(
-            model,
-            getattr(od_config, "revision", None),
-        )
-
-        self.has_external_prompt_upscaler = os.path.exists(
-            os.path.join(pe_base_path, "pe"),
-        )
-        # Only create the loader if the server config allows external
-        # upscaler loading. This prevents a user request from OOMing
-        # the server by lazy-loading a large model.
-        pe_loader = _make_pe_loader(pe_base_path, od_config.dtype, self._execution_device)
-        self._load_pe = (
-            pe_loader if self.has_external_prompt_upscaler and od_config.enable_external_prompt_upscaler else None
-        )
+        # Only resolve/download PE files if the server config allows
+        # external upscaler loading to avoid downloading files we'll never use.
+        self.has_external_prompt_upscaler = od_config.enable_external_prompt_upscaler
+        if self.has_external_prompt_upscaler:
+            pe_base_path = _resolve_model_path_for_optional_pe(
+                model,
+                getattr(od_config, "revision", None),
+            )
+            self._load_pe = _make_pe_loader(
+                pe_base_path,
+                od_config.dtype,
+                self._execution_device,
+            )
+        else:
+            self._load_pe = None
         self.pe_model = None
         self.pe_tokenizer = None
 

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -227,6 +227,7 @@ class ErnieImagePipeline(
         height: int = 1024,
         temperature: float = 0.6,
         top_p: float = 0.95,
+        generator: torch.Generator | None = None,
     ) -> str:
         if not self._ensure_pe_loaded():
             return prompt
@@ -260,6 +261,7 @@ class ErnieImagePipeline(
                 top_p=top_p,
                 pad_token_id=self.pe_tokenizer.pad_token_id,
                 eos_token_id=self.pe_tokenizer.eos_token_id,
+                generator=generator,
             )
             output_ids = output_ids[0][inputs.input_ids.shape[1] :]
             result = self.pe_tokenizer.decode(output_ids, skip_special_tokens=True).strip()
@@ -295,6 +297,7 @@ class ErnieImagePipeline(
         width: int = 1024,
         height: int = 1024,
         apply_pe: bool = True,
+        generator: torch.Generator | None = None,
     ) -> list[torch.Tensor]:
         if isinstance(prompt, str):
             prompt = [prompt]
@@ -303,7 +306,7 @@ class ErnieImagePipeline(
 
         for p in prompt:
             if apply_pe and self.has_external_prompt_upscaler:
-                enhanced = self._enhance_prompt(p, device, width=width, height=height)
+                enhanced = self._enhance_prompt(p, device, width=width, height=height, generator=generator)
                 logger.info("PE: original='%s...' enhanced='%s...'", p[:50], enhanced[:50])
                 p = enhanced
             ids = self.tokenizer(
@@ -486,6 +489,7 @@ class ErnieImagePipeline(
                 width=width,
                 height=height,
                 apply_pe=self._should_apply_pe(req),
+                generator=generator,
             )
 
         if self.do_classifier_free_guidance:

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -886,7 +886,7 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
         )
         max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
         text_encoder_out_layers = req.sampling_params.extra_args.get("text_encoder_out_layers", text_encoder_out_layers)
-        should_upsample_prompt = do_prompt_upscaling(req, self.od_config)
+        should_upsample_prompt = do_prompt_upscaling(req)
 
         req_prompt_embeds = [p.get("prompt_embeds") if not isinstance(p, str) else None for p in req.prompts]
         if any(p is not None for p in req_prompt_embeds):

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -943,6 +943,7 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
                 prompt,
                 images=upsample_images,
                 device=device,
+                generator=generator,
             )
         prompt_embeds, text_ids = self.encode_prompt(
             prompt=prompt,

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.models.mistral_encoder import MistralEncoderModel
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.prompt_utils import do_prompt_upscaling
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 
@@ -633,22 +634,6 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
 
         return torch.stack(x_list, dim=0)
 
-    def upsample_prompt(
-        self,
-        prompt: str | list[str],
-        images: list[PIL.Image.Image] | list[list[PIL.Image.Image]] = None,
-        temperature: float = 0.15,
-        device: torch.device = None,
-    ) -> list[str]:
-        if images:
-            images = _validate_and_process_images(images, self.image_processor, self.upsampling_max_image_size)
-        return self.text_encoder.upsample_prompt(
-            prompt,
-            images=images,
-            temperature=temperature,
-            device=device,
-        )
-
     def encode_prompt(
         self,
         prompt: str | list[str],
@@ -866,7 +851,6 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
         callback_on_step_end_tensor_inputs: list[str] = ["latents"],
         max_sequence_length: int = 512,
         text_encoder_out_layers: tuple[int, ...] = (10, 20, 30),
-        caption_upsample_temperature: float = None,
     ) -> DiffusionOutput:
         if len(req.prompts) > 1:
             logger.warning(
@@ -902,9 +886,7 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
         )
         max_sequence_length = req.sampling_params.max_sequence_length or max_sequence_length
         text_encoder_out_layers = req.sampling_params.extra_args.get("text_encoder_out_layers", text_encoder_out_layers)
-        caption_upsample_temperature = req.sampling_params.extra_args.get(
-            "caption_upsample_temperature", caption_upsample_temperature
-        )
+        should_upsample_prompt = do_prompt_upscaling(req, self.od_config)
 
         req_prompt_embeds = [p.get("prompt_embeds") if not isinstance(p, str) else None for p in req.prompts]
         if any(p is not None for p in req_prompt_embeds):
@@ -948,8 +930,20 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
         device = self._execution_device
 
         # 3. prepare text embeddings
-        if caption_upsample_temperature:
-            prompt = self.upsample_prompt(prompt, images=image, temperature=caption_upsample_temperature, device=device)
+        if should_upsample_prompt:
+            upsample_images = (
+                _validate_and_process_images(image, self.image_processor, self.upsampling_max_image_size)
+                if image
+                else None
+            )
+            # NOTE (Alex): For now we don't expose temperature as a param for
+            # prompt upscaling to avoid too many obscure model specific params.
+            # If configuring this seems useful across several models, revisit.
+            prompt = self.text_encoder.upsample_prompt(
+                prompt,
+                images=upsample_images,
+                device=device,
+            )
         prompt_embeds, text_ids = self.encode_prompt(
             prompt=prompt,
             prompt_embeds=prompt_embeds,

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
@@ -517,7 +517,7 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
             if req.sampling_params.num_outputs_per_prompt is not None
             else num_images_per_prompt
         )
-        should_rewrite = do_prompt_upscaling(req, self.od_config)
+        should_rewrite = do_prompt_upscaling(req)
         enable_cfg_renorm = req.sampling_params.extra_args.get("enable_cfg_renorm", enable_cfg_renorm)
         cfg_renorm_min = req.sampling_params.extra_args.get("cfg_renorm_min", cfg_renorm_min)
 

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
@@ -30,6 +30,7 @@ from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineL
 from vllm_omni.diffusion.models.longcat_image.longcat_image_transformer import LongCatImageTransformer2DModel
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.prompt_utils import do_prompt_upscaling
 from vllm_omni.model_executor.model_loader.weight_utils import (
     download_weights_from_hf_specific,
 )
@@ -494,7 +495,6 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
         joint_attention_kwargs: dict[str, Any] | None = None,
         enable_cfg_renorm: bool | None = True,
         cfg_renorm_min: float | None = 0.0,
-        enable_prompt_rewrite: bool | None = True,
     ) -> DiffusionOutput:
         # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
         # TODO: May be some data formatting operations on the API side. Hack for now.
@@ -517,7 +517,7 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
             if req.sampling_params.num_outputs_per_prompt is not None
             else num_images_per_prompt
         )
-        enable_prompt_rewrite = req.sampling_params.extra_args.get("enable_prompt_rewrite", enable_prompt_rewrite)
+        should_rewrite = do_prompt_upscaling(req, self.od_config)
         enable_cfg_renorm = req.sampling_params.extra_args.get("enable_cfg_renorm", enable_cfg_renorm)
         cfg_renorm_min = req.sampling_params.extra_args.get("cfg_renorm_min", cfg_renorm_min)
 
@@ -558,7 +558,7 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
             batch_size = prompt_embeds.shape[0]
 
         device = self.device
-        if enable_prompt_rewrite and prompt is not None:
+        if should_rewrite and prompt is not None:
             prompt = self.rewire_prompt(prompt if isinstance(prompt, list) else [prompt], device)
 
         negative_prompt = "" if negative_prompt is None else negative_prompt

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
@@ -256,7 +256,7 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
 
-    def rewire_prompt(self, prompt, device):
+    def rewire_prompt(self, prompt, device, generator: torch.Generator | None = None):
         prompt = [prompt] if isinstance(prompt, str) else prompt
         all_text = []
         for each_prompt in prompt:
@@ -279,7 +279,9 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
         inputs = self.text_processor(text=all_text, padding=True, return_tensors="pt").to(device)
 
         self.text_encoder.to(device)
-        generated_ids = self.text_encoder.generate(**inputs, max_new_tokens=self.tokenizer_max_length)
+        generated_ids = self.text_encoder.generate(
+            **inputs, max_new_tokens=self.tokenizer_max_length, generator=generator
+        )
         generated_ids_trimmed = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)]
         output_text = self.text_processor.batch_decode(
             generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
@@ -518,6 +520,7 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
             else num_images_per_prompt
         )
         should_rewrite = do_prompt_upscaling(req)
+        enable_prompt_rewrite = req.sampling_params.extra_args.get("enable_prompt_rewrite", should_rewrite)
         enable_cfg_renorm = req.sampling_params.extra_args.get("enable_cfg_renorm", enable_cfg_renorm)
         cfg_renorm_min = req.sampling_params.extra_args.get("cfg_renorm_min", cfg_renorm_min)
 
@@ -558,8 +561,8 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
             batch_size = prompt_embeds.shape[0]
 
         device = self.device
-        if should_rewrite and prompt is not None:
-            prompt = self.rewire_prompt(prompt if isinstance(prompt, list) else [prompt], device)
+        if enable_prompt_rewrite and prompt is not None:
+            prompt = self.rewire_prompt(prompt if isinstance(prompt, list) else [prompt], device, generator=generator)
 
         negative_prompt = "" if negative_prompt is None else negative_prompt
 

--- a/vllm_omni/diffusion/models/mistral_encoder/mistral_encoder.py
+++ b/vllm_omni/diffusion/models/mistral_encoder/mistral_encoder.py
@@ -458,12 +458,13 @@ class MistralEncoderModel(nn.Module):
         logits: torch.Tensor,
         do_sample: bool,
         temperature: float,
+        generator: torch.Generator | None = None,
     ) -> torch.Tensor:
         """Sample or greedily select the next token from logits. Returns (batch, 1)."""
         if do_sample:
             logits = logits / max(temperature, 1e-7)
             probs = F.softmax(logits, dim=-1)
-            return torch.multinomial(probs, num_samples=1)
+            return torch.multinomial(probs, num_samples=1, generator=generator)
         return logits.argmax(dim=-1, keepdim=True)
 
     # TODO make common. Potentially with HF mixin
@@ -476,6 +477,7 @@ class MistralEncoderModel(nn.Module):
         do_sample: bool = True,
         temperature: float = 1.0,
         eos_token_id: int | list[int] | None = None,
+        generator: torch.Generator | None = None,
         **kwargs,
     ) -> torch.Tensor:
         """Autoregressive text generation with KV caching.
@@ -507,7 +509,7 @@ class MistralEncoderModel(nn.Module):
         past_key_values = output.past_key_values
 
         logits = self._compute_logits(output.last_hidden_state[:, -1:, :])
-        next_token = self._sample(logits.squeeze(1), do_sample, temperature)
+        next_token = self._sample(logits.squeeze(1), do_sample, temperature, generator=generator)
         if get_tensor_model_parallel_world_size() > 1:
             torch.distributed.broadcast(next_token, src=0)
         generated = torch.cat([generated, next_token], dim=1)
@@ -537,7 +539,7 @@ class MistralEncoderModel(nn.Module):
             past_key_values = output.past_key_values
 
             logits = self._compute_logits(output.last_hidden_state)
-            next_token = self._sample(logits.squeeze(1), do_sample, temperature)
+            next_token = self._sample(logits.squeeze(1), do_sample, temperature, generator=generator)
             if get_tensor_model_parallel_world_size() > 1:
                 torch.distributed.broadcast(next_token, src=0)
             generated = torch.cat([generated, next_token], dim=1)
@@ -572,6 +574,7 @@ class MistralEncoderModel(nn.Module):
         device: torch.device | None = None,
         max_new_tokens: int = 512,
         max_length: int = 2048,
+        generator: torch.Generator | None = None,
     ) -> list[str]:
         if self._processor is None:
             raise RuntimeError("upsample_prompt() requires a processor; call set_processor() first")
@@ -608,6 +611,7 @@ class MistralEncoderModel(nn.Module):
             do_sample=True,
             temperature=temperature,
             use_cache=True,
+            generator=generator,
         )
 
         input_length = inputs["input_ids"].shape[1]

--- a/vllm_omni/diffusion/utils/prompt_utils.py
+++ b/vllm_omni/diffusion/utils/prompt_utils.py
@@ -1,20 +1,19 @@
 import torch
 
-from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 
 
-def do_prompt_upscaling(
-    req: OmniDiffusionRequest,
-    od_config: OmniDiffusionConfig,
-) -> bool:
+def do_prompt_upscaling(req: OmniDiffusionRequest) -> bool:
     """Check whether prompt upscaling should run for this request."""
-    if not od_config.enable_prompt_upscaling:
-        return False
-    do_upscale = req.sampling_params.extra_args.get("prompt_upscaling", False)
-    if not isinstance(do_upscale, bool):
-        raise TypeError(f"prompt_upscaling must be a bool, got {type(do_upscale).__name__}")
-    return do_upscale
+    # NOTE: This may get more complex in the future since some models
+    # Use their text encoder directly, while others have an externally
+    # loaded component. Since only Ernie Image does this for now
+    # though, we currently don't distinguish at load time to avoid having
+    # too many obscure flags.
+    value = req.sampling_params.extra_args.get("use_prompt_upscaling", False)
+    if not isinstance(value, bool):
+        raise TypeError(f"use_prompt_upscaling must be a bool, got {type(value).__name__}")
+    return value
 
 
 def validate_prompt_sequence_lengths(

--- a/vllm_omni/diffusion/utils/prompt_utils.py
+++ b/vllm_omni/diffusion/utils/prompt_utils.py
@@ -10,10 +10,10 @@ def do_prompt_upscaling(req: OmniDiffusionRequest) -> bool:
     # loaded component. Since only Ernie Image does this for now
     # though, we currently don't distinguish at load time to avoid having
     # too many obscure flags.
-    value = req.sampling_params.extra_args.get("use_prompt_upscaling", False)
+    value = req.sampling_params.extra_args.get("use_prompt_upscaling")
     if not isinstance(value, bool):
         raise TypeError(f"use_prompt_upscaling must be a bool, got {type(value).__name__}")
-    return value
+    return bool(value)
 
 
 def validate_prompt_sequence_lengths(

--- a/vllm_omni/diffusion/utils/prompt_utils.py
+++ b/vllm_omni/diffusion/utils/prompt_utils.py
@@ -1,5 +1,21 @@
 import torch
 
+from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+
+
+def do_prompt_upscaling(
+    req: OmniDiffusionRequest,
+    od_config: OmniDiffusionConfig,
+) -> bool:
+    """Check whether prompt upscaling should run for this request."""
+    if not od_config.enable_prompt_upscaling:
+        return False
+    do_upscale = req.sampling_params.extra_args.get("prompt_upscaling", False)
+    if not isinstance(do_upscale, bool):
+        raise TypeError(f"prompt_upscaling must be a bool, got {type(do_upscale).__name__}")
+    return do_upscale
+
 
 def validate_prompt_sequence_lengths(
     attention_mask: torch.Tensor,

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1940,6 +1940,7 @@ class AsyncOmniEngine:
                 "mp" if kwargs.get("distributed_executor_backend") is None else kwargs["distributed_executor_backend"]
             ),
             "enable_sleep_mode": kwargs.get("enable_sleep_mode", False),
+            "enable_external_prompt_upscaler": kwargs.get("enable_external_prompt_upscaler", False),
             "enable_multithread_weight_load": kwargs.get("enable_multithread_weight_load", True),
             "num_weight_load_threads": kwargs.get("num_weight_load_threads", 4),
             "quantization": kwargs.get("quantization", None),

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -565,6 +565,14 @@ class OmniServeCommand(CLISubcommand):
             help="Enable layerwise (blockwise) offloading on DiT modules.",
         )
 
+        # For models with external prompt upscalers
+        omni_config_group.add_argument(
+            "--enable-external-prompt-upscaler",
+            action="store_true",
+            help="Allow lazy-loading external prompt upscaler models (e.g., ERNIE PE). "
+            "Required for use_prompt_upscaling to work on models with external upscalers.",
+        )
+
         # Video model parameters (e.g., Wan2.2) - engine-level
         omni_config_group.add_argument(
             "--boundary-ratio",

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1569,6 +1569,7 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
             extra_args["system_prompt"] = request.system_prompt
         if request.bot_task is not None:
             extra_args["bot_task"] = request.bot_task
+        extra_args["use_prompt_upscaling"] = request.use_prompt_upscaling
         if extra_args:
             gen_params.extra_args = extra_args
         # Parse per-request LoRA (compatible with chat's extra_body.lora shape).

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1571,7 +1571,8 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
             extra_args["system_prompt"] = request.system_prompt
         if request.bot_task is not None:
             extra_args["bot_task"] = request.bot_task
-        extra_args["use_prompt_upscaling"] = request.use_prompt_upscaling
+        if request.use_prompt_upscaling is not None:
+            extra_args["use_prompt_upscaling"] = request.use_prompt_upscaling
         if extra_args:
             gen_params.extra_args = extra_args
         # Parse per-request LoRA (compatible with chat's extra_body.lora shape).

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1529,6 +1529,8 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
                 extra_body["guidance_scale"] = request.guidance_scale
             if request.true_cfg_scale is not None:
                 extra_body["true_cfg_scale"] = request.true_cfg_scale
+            if request.use_prompt_upscaling is not None:
+                extra_body["use_prompt_upscaling"] = request.use_prompt_upscaling
             if request.generator_device is not None:
                 extra_body["generator_device"] = request.generator_device
             if request.lora is not None:

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -94,6 +94,11 @@ class ImageGenerationRequest(BaseModel):
         description="System prompt type. Options: None, dynamic, en_vanilla, "
         "en_recaption, en_think_recaption, en_unified, custom",
     )
+    use_prompt_upscaling: bool = Field(
+        default=False,
+        description="Enable prompt upscaling/enhancement for this request. "
+        "Only effective for models that support prompt upscaling.",
+    )
 
     @field_validator("use_system_prompt")
     @classmethod

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -94,8 +94,8 @@ class ImageGenerationRequest(BaseModel):
         description="System prompt type. Options: None, dynamic, en_vanilla, "
         "en_recaption, en_think_recaption, en_unified, custom",
     )
-    use_prompt_upscaling: bool = Field(
-        default=False,
+    use_prompt_upscaling: bool | None = Field(
+        default=None,
         description="Enable prompt upscaling/enhancement for this request. "
         "Only effective for models that support prompt upscaling.",
     )

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -392,6 +392,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 negative_prompt = extra_body.get("negative_prompt")
                 cfg_text_scale = extra_body.get("cfg_text_scale")
                 cfg_img_scale = extra_body.get("cfg_img_scale")
+                use_prompt_upscaling = extra_body.get("use_prompt_upscaling")
 
                 engine_prompt_image: dict[str, Any] | None = None
                 if reference_images:
@@ -504,6 +505,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                             sp.extra_args["cfg_text_scale"] = cfg_text_scale
                         if cfg_img_scale is not None:
                             sp.extra_args["cfg_img_scale"] = cfg_img_scale
+                        if use_prompt_upscaling is not None:
+                            sp.extra_args["use_prompt_upscaling"] = use_prompt_upscaling
                         for _key in self._get_diffusion_extra_body_params():
                             _val = extra_body.get(_key)
                             if _val is not None:
@@ -2621,6 +2624,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             true_cfg_scale = extra_body.get("true_cfg_scale") or extra_body.get("cfg_scale")
             cfg_text_scale = extra_body.get("cfg_text_scale")
             cfg_img_scale = extra_body.get("cfg_img_scale")
+            use_prompt_upscaling = extra_body.get("use_prompt_upscaling")
             seed = extra_body.get("seed")
             if seed is None:
                 seed = getattr(request, "seed", None)
@@ -2681,6 +2685,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 gen_params.extra_args["cfg_text_scale"] = cfg_text_scale
             if cfg_img_scale is not None:
                 gen_params.extra_args["cfg_img_scale"] = cfg_img_scale
+            if use_prompt_upscaling is not None:
+                gen_params.extra_args["use_prompt_upscaling"] = use_prompt_upscaling
             for _key in self._get_diffusion_extra_body_params():
                 _val = extra_body.get(_key)
                 if _val is not None:

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -393,6 +393,12 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 cfg_text_scale = extra_body.get("cfg_text_scale")
                 cfg_img_scale = extra_body.get("cfg_img_scale")
                 use_prompt_upscaling = extra_body.get("use_prompt_upscaling")
+                # TODO (Alex): Make extra body validation common & validate all extra body params
+                if use_prompt_upscaling is not None and not isinstance(use_prompt_upscaling, bool):
+                    return self._create_error_response(
+                        f"use_prompt_upscaling must be a bool, got {type(use_prompt_upscaling).__name__}",
+                        status_code=400,
+                    )
 
                 engine_prompt_image: dict[str, Any] | None = None
                 if reference_images:
@@ -2625,6 +2631,12 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             cfg_text_scale = extra_body.get("cfg_text_scale")
             cfg_img_scale = extra_body.get("cfg_img_scale")
             use_prompt_upscaling = extra_body.get("use_prompt_upscaling")
+            # TODO (Alex): Make extra body validation common & validate all extra body params
+            if use_prompt_upscaling is not None and not isinstance(use_prompt_upscaling, bool):
+                return self._create_error_response(
+                    f"use_prompt_upscaling must be a bool, got {type(use_prompt_upscaling).__name__}",
+                    status_code=400,
+                )
             seed = extra_body.get("seed")
             if seed is None:
                 seed = getattr(request, "seed", None)


### PR DESCRIPTION
## Summary

This PR makes all prompt upscalers deterministic by propagating the user-supplied `torch.Generator` through every `generate()` call inside the upscaling path.

Previously, when a user set a seed via `sampling_params.generator`, the diffusion denoising loop respected it, but the prompt upscaler ran its own `generate()` call without any seed, so the final output was still non-deterministic even with a fixed seed. This fixes #3881.

## Changes

| File | Change |
|---|---|
| `vllm_omni/diffusion/models/mistral_encoder/mistral_encoder.py` | Add `generator` param to `_sample()`, `generate()`, and `upsample_prompt()`; pass it to `torch.multinomial()` |
| `vllm_omni/diffusion/models/flux2/pipeline_flux2.py` | Forward `generator` to `text_encoder.upsample_prompt()` |
| `vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py` | Add `generator` param to `_enhance_prompt()` and `encode_prompt()`; propagate from `__call__` |
| `vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py` | Add `generator` param to `rewire_prompt()`; propagate from `__call__` |

All new parameters default to `generator=None`, so existing behaviour is fully preserved when no seed is specified.

## Testing

- `ruff check` and `ruff format --check`: all passed
- `typos`: all passed
- `py_compile` syntax check: all passed

Fixes #3881
