### PR TITLE
[Bugfix] Make prompt upscalers deterministic by propagating generator

### DIFF
--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -196,6 +196,7 @@ class ErnieImagePipeline(
         height: int = 1024,
         temperature: float = 0.6,
         top_p: float = 0.95,
+        generator: torch.Generator | None = None,
     ) -> str:
         if not self.use_pe or self.pe_model is None:
             return prompt
@@ -229,6 +230,7 @@ class ErnieImagePipeline(
                 top_p=top_p,
                 pad_token_id=self.pe_tokenizer.pad_token_id,
                 eos_token_id=self.pe_tokenizer.eos_token_id,
+                generator=generator,
             )
             output_ids = output_ids[0][inputs.input_ids.shape[1] :]
             result = self.pe_tokenizer.decode(output_ids, skip_special_tokens=True).strip()
@@ -267,6 +269,7 @@ class ErnieImagePipeline(
         width: int = 1024,
         height: int = 1024,
         apply_pe: bool = True,
+        generator: torch.Generator | None = None,
     ) -> list[torch.Tensor]:
         if isinstance(prompt, str):
             prompt = [prompt]
@@ -275,7 +278,7 @@ class ErnieImagePipeline(
 
         for p in prompt:
             if apply_pe and self.use_pe and self.pe_model is not None:
-                enhanced = self._enhance_prompt(p, device, width=width, height=height)
+                enhanced = self._enhance_prompt(p, device, width=width, height=height, generator=generator)
                 logger.info("PE: original='%s...' enhanced='%s...'", p[:50], enhanced[:50])
                 p = enhanced
             ids = self.tokenizer(
@@ -458,6 +461,7 @@ class ErnieImagePipeline(
                 width=width,
                 height=height,
                 apply_pe=self._should_apply_pe(req),
+                generator=generator,
             )
 
         if self.do_classifier_free_guidance:

--- a/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
+++ b/vllm_omni/diffusion/models/flux2/pipeline_flux2.py
@@ -641,6 +641,7 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
         images: list[PIL.Image.Image] | list[list[PIL.Image.Image]] = None,
         temperature: float = 0.15,
         device: torch.device = None,
+        generator: torch.Generator | None = None,
     ) -> list[str]:
         if images:
             images = _validate_and_process_images(images, self.image_processor, self.upsampling_max_image_size)
@@ -649,6 +650,7 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
             images=images,
             temperature=temperature,
             device=device,
+            generator=generator,
         )
 
     def encode_prompt(
@@ -951,7 +953,9 @@ class Flux2Pipeline(nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarM
 
         # 3. prepare text embeddings
         if caption_upsample_temperature:
-            prompt = self.upsample_prompt(prompt, images=image, temperature=caption_upsample_temperature, device=device)
+            prompt = self.upsample_prompt(
+                prompt, images=image, temperature=caption_upsample_temperature, device=device, generator=generator
+            )
         prompt_embeds, text_ids = self.encode_prompt(
             prompt=prompt,
             prompt_embeds=prompt_embeds,

--- a/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
+++ b/vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py
@@ -255,7 +255,7 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
 
-    def rewire_prompt(self, prompt, device):
+    def rewire_prompt(self, prompt, device, generator: torch.Generator | None = None):
         prompt = [prompt] if isinstance(prompt, str) else prompt
         all_text = []
         for each_prompt in prompt:
@@ -278,7 +278,9 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
         inputs = self.text_processor(text=all_text, padding=True, return_tensors="pt").to(device)
 
         self.text_encoder.to(device)
-        generated_ids = self.text_encoder.generate(**inputs, max_new_tokens=self.tokenizer_max_length)
+        generated_ids = self.text_encoder.generate(
+            **inputs, max_new_tokens=self.tokenizer_max_length, generator=generator
+        )
         generated_ids_trimmed = [out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)]
         output_text = self.text_processor.batch_decode(
             generated_ids_trimmed, skip_special_tokens=True, clean_up_tokenization_spaces=False
@@ -559,7 +561,7 @@ class LongCatImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfile
 
         device = self.device
         if enable_prompt_rewrite and prompt is not None:
-            prompt = self.rewire_prompt(prompt if isinstance(prompt, list) else [prompt], device)
+            prompt = self.rewire_prompt(prompt if isinstance(prompt, list) else [prompt], device, generator=generator)
 
         negative_prompt = "" if negative_prompt is None else negative_prompt
 

--- a/vllm_omni/diffusion/models/mistral_encoder/mistral_encoder.py
+++ b/vllm_omni/diffusion/models/mistral_encoder/mistral_encoder.py
@@ -458,12 +458,13 @@ class MistralEncoderModel(nn.Module):
         logits: torch.Tensor,
         do_sample: bool,
         temperature: float,
+        generator: torch.Generator | None = None,
     ) -> torch.Tensor:
         """Sample or greedily select the next token from logits. Returns (batch, 1)."""
         if do_sample:
             logits = logits / max(temperature, 1e-7)
             probs = F.softmax(logits, dim=-1)
-            return torch.multinomial(probs, num_samples=1)
+            return torch.multinomial(probs, num_samples=1, generator=generator)
         return logits.argmax(dim=-1, keepdim=True)
 
     # TODO make common. Potentially with HF mixin
@@ -476,6 +477,7 @@ class MistralEncoderModel(nn.Module):
         do_sample: bool = True,
         temperature: float = 1.0,
         eos_token_id: int | list[int] | None = None,
+        generator: torch.Generator | None = None,
         **kwargs,
     ) -> torch.Tensor:
         """Autoregressive text generation with KV caching.
@@ -507,7 +509,7 @@ class MistralEncoderModel(nn.Module):
         past_key_values = output.past_key_values
 
         logits = self._compute_logits(output.last_hidden_state[:, -1:, :])
-        next_token = self._sample(logits.squeeze(1), do_sample, temperature)
+        next_token = self._sample(logits.squeeze(1), do_sample, temperature, generator=generator)
         if get_tensor_model_parallel_world_size() > 1:
             torch.distributed.broadcast(next_token, src=0)
         generated = torch.cat([generated, next_token], dim=1)
@@ -537,7 +539,7 @@ class MistralEncoderModel(nn.Module):
             past_key_values = output.past_key_values
 
             logits = self._compute_logits(output.last_hidden_state)
-            next_token = self._sample(logits.squeeze(1), do_sample, temperature)
+            next_token = self._sample(logits.squeeze(1), do_sample, temperature, generator=generator)
             if get_tensor_model_parallel_world_size() > 1:
                 torch.distributed.broadcast(next_token, src=0)
             generated = torch.cat([generated, next_token], dim=1)
@@ -572,6 +574,7 @@ class MistralEncoderModel(nn.Module):
         device: torch.device | None = None,
         max_new_tokens: int = 512,
         max_length: int = 2048,
+        generator: torch.Generator | None = None,
     ) -> list[str]:
         if self._processor is None:
             raise RuntimeError("upsample_prompt() requires a processor; call set_processor() first")
@@ -608,6 +611,7 @@ class MistralEncoderModel(nn.Module):
             do_sample=True,
             temperature=temperature,
             use_cache=True,
+            generator=generator,
         )
 
         input_length = inputs["input_ids"].shape[1]


### PR DESCRIPTION
## Summary

This PR makes all prompt upscalers deterministic by propagating the user-supplied `torch.Generator` through every `generate()` call inside the upscaling path.

Previously, when a user set a seed via `sampling_params.generator`, the diffusion denoising loop respected it, but the prompt upscaler ran its own `generate()` call without any seed, so the final output was still non-deterministic even with a fixed seed. This fixes #3881.

## Changes

| File | Change |
|---|---|
| `vllm_omni/diffusion/models/mistral_encoder/mistral_encoder.py` | Add `generator` param to `_sample()`, `generate()`, and `upsample_prompt()`; pass it to `torch.multinomial()` |
| `vllm_omni/diffusion/models/flux2/pipeline_flux2.py` | Add `generator` param to `upsample_prompt()`; forward to `text_encoder.upsample_prompt()` and propagate from `__call__` |
| `vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py` | Add `generator` param to `_enhance_prompt()` and `encode_prompt()`; propagate from `__call__` |
| `vllm_omni/diffusion/models/longcat_image/pipeline_longcat_image.py` | Add `generator` param to `rewire_prompt()`; propagate from `__call__` |

All new parameters default to `generator=None`, so existing behaviour is fully preserved when no seed is specified.

## Testing

- `ruff check` and `ruff format --check`: all passed
- `typos`: all passed
- `py_compile` syntax check: all passed

Fixes #3881
