### PR TITLE
[CI][Bugfix] Add request id to LTX2.3 CFG parallel test

### DIFF
--- a/tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py
@@ -339,6 +339,7 @@ class TestCFGParallelForwardPath:
                 audio_latents=audio_latents,
                 output_type="latent",
             ),
+            request_id="ltx23-cfg-parallel-forward-test",
         )
 
         output = pipe.forward(req)


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Fix the LTX2.3 CFG-parallel forward-path unit test by passing `request_id` and `request_ids` when constructing the mocked `OmniDiffusionRequest`. CI tests require `request_id` which is not needed on local run, so the test failed before reaching the CFG-parallel forward path.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)