### PR TITLE
[BugFix] Avoid Voxtral TTS loading error msg

### DIFF
--- a/vllm_omni/transformers_utils/parsers/voxtral_tts.py
+++ b/vllm_omni/transformers_utils/parsers/voxtral_tts.py
@@ -17,6 +17,7 @@ logger = init_logger(__name__)
 
 _VOXTRAL_TTS_ARCHS = frozenset({"VoxtralTTSForConditionalGeneration"})
 _VOXTRAL_TTS_MODEL_TYPE = "voxtral_tts"
+_VOXTRAL_TTS_DTYPE = "bfloat16"
 
 
 def _is_voxtral_tts_params(config_dict: dict) -> bool:
@@ -55,6 +56,10 @@ def _parse_voxtral_tts(config_dict: dict) -> tuple[dict, PretrainedConfig]:
         _remap_mistral_quantization_args,
     )
 
+    if config_dict.get("dtype") is None:
+        config_dict["dtype"] = _VOXTRAL_TTS_DTYPE
+    dtype = config_dict["dtype"]
+
     audio_config: dict[str, Any] = {}
     if (config_dict.get("multimodal") or {}).get("audio_model_args"):
         audio_config = _remap_voxtral_tts_audio_args(config_dict)
@@ -69,6 +74,7 @@ def _parse_voxtral_tts(config_dict: dict) -> tuple[dict, PretrainedConfig]:
         text_config=PretrainedConfig.from_dict(text_config),
         audio_config=audio_config,
         architectures=config_dict.get("architectures", ["VoxtralTTSForConditionalGeneration"]),
+        dtype=dtype,
     )
     return config_dict, config
 


### PR DESCRIPTION
## Purpose
When loading Voxtral TTS, it shows error `ERROR 05-27 17:37:35 [repo_utils.py:47] Error retrieving safetensors: 'mistralai/Voxtral-4B-TTS-2603' is not a safetensors repo. Couldn't find 'model.safetensors.index.json' or 'model.safetensors' files., retrying 1 of 2`. The model can still load properly but the error is noisy.

<img width="1095" height="506" alt="image" src="https://github.com/user-attachments/assets/7446902b-f0c3-4e19-b167-42a68f80bf6c" />

Root cause:
```
1. vLLM builds ModelConfig.
2. It needs to decide the model dtype.
3. If config.dtype is missing, vLLM tries to infer dtype from safetensors metadata.
4. That generic metadata inference calls Hugging Face’s safetensors helper.
5. HF’s helper only looks for model.safetensors / model.safetensors.index.json.
6. Voxtral uses Mistral layout: consolidated.safetensors.
7. The helper logs the scary non-fatal error.
```

Fix it by giving the dtype.

## Test Plan
- regression pipeline
- manually test 
## Test Result
- error message is gone
<img width="2550" height="1327" alt="image" src="https://github.com/user-attachments/assets/12284b7a-8e62-4a07-adfc-dd82d664b90f" />