### PR TITLE
[Perf]  Enable fused RMSNorm for HunyuanImage3

### DIFF
--- a/benchmarks/accuracy/common.py
+++ b/benchmarks/accuracy/common.py
@@ -151,6 +151,9 @@ class VllmOmniImageClient:
         seed: int | None = None,
         negative_prompt: str | None = None,
         output_compression: int | None = None,
+        bot_task: str | None = None,
+        sys_type: str | None = None,
+        system_prompt: str | None = None,
     ) -> Image.Image:
         if not isinstance(images, list):
             images = [images]
@@ -170,6 +173,12 @@ class VllmOmniImageClient:
             data["negative_prompt"] = negative_prompt
         if output_compression is not None:
             data["output_compression"] = str(output_compression)
+        if bot_task is not None:
+            data["bot_task"] = bot_task
+        if sys_type is not None:
+            data["sys_type"] = sys_type
+        if system_prompt is not None:
+            data["system_prompt"] = system_prompt
 
         files = [
             (

--- a/benchmarks/accuracy/image_to_image/gedit_bench.py
+++ b/benchmarks/accuracy/image_to_image/gedit_bench.py
@@ -64,6 +64,47 @@ def resolve_model_name(*, model_name: str | None, model: str | None = None, outp
     raise ValueError("model-name is required when it cannot be inferred from model or output-root")
 
 
+def _coerce_score_int(value: Any) -> int:
+    if isinstance(value, bool):
+        raise TypeError(f"Expected numeric score, got bool: {value!r}")
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.lstrip("-").isdigit():
+            return int(stripped)
+    raise TypeError(f"Expected numeric score, got {type(value).__name__}: {value!r}")
+
+
+def _expand_score_entry(entry: Any) -> list[int]:
+    if isinstance(entry, dict):
+        if "score" in entry:
+            return [_coerce_score_int(entry["score"])]
+        if "value" in entry:
+            return [_coerce_score_int(entry["value"])]
+        numeric_values = [_coerce_score_int(value) for value in entry.values()]
+        if numeric_values:
+            return numeric_values
+        raise TypeError(f"Score dict has no numeric values: {entry!r}")
+    return [_coerce_score_int(entry)]
+
+
+def _normalize_score_list(score: Any) -> list[int]:
+    if isinstance(score, dict):
+        entries: list[Any] = [score]
+    elif isinstance(score, list):
+        entries = score
+    else:
+        entries = [score]
+
+    normalized: list[int] = []
+    for entry in entries:
+        normalized.extend(_expand_score_entry(entry))
+    if not normalized:
+        raise ValueError(f"Empty score list after normalization: {score!r}")
+    return normalized
+
+
 def parse_score_payload(raw_text: str) -> dict[str, Any]:
     try:
         parsed = extract_json_object(raw_text)
@@ -73,10 +114,7 @@ def parse_score_payload(raw_text: str) -> dict[str, Any]:
             parsed = {"score": json.loads(stripped), "reasoning": ""}
         else:
             raise
-    score = parsed.get("score", [])
-    if not isinstance(score, list):
-        score = [score]
-    parsed["score"] = [int(value) for value in score]
+    parsed["score"] = _normalize_score_list(parsed.get("score", []))
     return parsed
 
 
@@ -391,6 +429,9 @@ class GEditBenchRunner:
         num_inference_steps: int = 20,
         guidance_scale: float | None = None,
         seed: int | None = 42,
+        bot_task: str | None = None,
+        sys_type: str | None = None,
+        system_prompt: str | None = None,
     ):
         self.dataset_ref = dataset_ref
         self.output_root = output_root
@@ -400,6 +441,9 @@ class GEditBenchRunner:
         self.num_inference_steps = num_inference_steps
         self.guidance_scale = guidance_scale
         self.seed = seed
+        self.bot_task = bot_task
+        self.sys_type = sys_type
+        self.system_prompt = system_prompt
         self.client = VllmOmniImageClient(base_url=base_url, api_key=api_key)
 
     def generate(
@@ -478,6 +522,9 @@ class GEditBenchRunner:
             num_inference_steps=self.num_inference_steps,
             guidance_scale=self.guidance_scale,
             seed=self.seed,
+            bot_task=self.bot_task,
+            sys_type=self.sys_type,
+            system_prompt=self.system_prompt,
         )
         edited_image.save(output_path)
         return {
@@ -633,6 +680,25 @@ def build_parser() -> argparse.ArgumentParser:
     generate.add_argument("--num-inference-steps", type=int, default=20)
     generate.add_argument("--guidance-scale", type=float, default=None)
     generate.add_argument("--seed", type=int, default=42)
+    generate.add_argument(
+        "--bot-task",
+        type=str,
+        default=None,
+        choices=["think", "recaption", "think_recaption", "vanilla"],
+        help="HunyuanImage-3 prompting mode for /v1/images/edits (optional).",
+    )
+    generate.add_argument(
+        "--sys-type",
+        type=str,
+        default=None,
+        help="Hunyuan system-prompt type (e.g. en_unified). Defaults from --bot-task when omitted.",
+    )
+    generate.add_argument(
+        "--system-prompt",
+        type=str,
+        default=None,
+        help="Custom Hunyuan system prompt body (sys_type=custom).",
+    )
     generate.add_argument("--workers", type=int, default=1)
     generate.add_argument("--max-samples", type=int, default=None)
     generate.add_argument("--samples-per-group", type=int, default=None)
@@ -675,6 +741,9 @@ def main(argv: list[str] | None = None) -> int:
             num_inference_steps=args.num_inference_steps,
             guidance_scale=args.guidance_scale,
             seed=args.seed,
+            bot_task=args.bot_task,
+            sys_type=args.sys_type,
+            system_prompt=args.system_prompt,
         )
         records = runner.generate(
             model_name=model_name,

--- a/tests/benchmarks/test_accuracy_bench_utils.py
+++ b/tests/benchmarks/test_accuracy_bench_utils.py
@@ -345,6 +345,14 @@ def test_parse_score_payload_handles_raw_json_and_delimited_json():
     assert parse_score_payload(wrapped)["score"] == [6]
 
 
+def test_parse_score_payload_handles_qwen_vl_nested_score_dicts():
+    qwen_style = '{"score": [{"naturalness": 8, "artifact_free": 7}], "reasoning": "good quality"}'
+    assert parse_score_payload(qwen_style)["score"] == [8, 7]
+
+    nested_values = '{"score": [{"score": 9}, {"score": 6}], "reasoning": "ok"}'
+    assert parse_score_payload(nested_values)["score"] == [9, 6]
+
+
 def test_summarize_gedit_generated_records_groups_by_task_and_language():
     records = []
     for group in GEDIT_GROUPS[:2]:

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -32,7 +32,6 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.model_executor.layers.activation import SiluAndMul
-from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
     QKVParallelLinear,
@@ -73,6 +72,7 @@ from vllm_omni.diffusion.distributed.sp_plan import (
 )
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.forward_context import set_forward_context_denoise_step_idx
+from vllm_omni.diffusion.layers.norm import RMSNorm
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
 from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_fused_moe import HunyuanFusedMoE
 from vllm_omni.model_executor.layers.timestep_embedding import timestep_embedding

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -2016,12 +2016,12 @@ async def edit_images(
         _update_if_not_none(gen_params, "resolution", resolution)
 
         extra_args = dict(getattr(gen_params, "extra_args", {}) or {})
-        if bot_task is not None:
-            extra_args["bot_task"] = bot_task
-        if sys_type is not None:
-            extra_args["use_system_prompt"] = sys_type
-        if system_prompt is not None:
-            extra_args["system_prompt"] = system_prompt
+        edit_extra_args = _build_hunyuan_edit_extra_args(
+            bot_task=bot_task,
+            sys_type=sys_type,
+            system_prompt=system_prompt,
+        )
+        extra_args.update(edit_extra_args)
         if extra_args:
             gen_params.extra_args = extra_args
 
@@ -2321,6 +2321,28 @@ def _check_max_generated_image_size(
                 detail=f"Requested resolution {resolution} (max {resolution}x{resolution} pixels) "
                 f"exceeds the maximum allowed size of {max_generated_image_size} pixels.",
             )
+
+
+def _build_hunyuan_edit_extra_args(
+    *,
+    bot_task: str | None,
+    sys_type: str | None,
+    system_prompt: str | None,
+) -> dict[str, Any]:
+    """Map Hunyuan /v1/images/edits form fields to DiT ``extra_args``."""
+    extra_args: dict[str, Any] = {}
+    effective_use_system_prompt = sys_type
+    if effective_use_system_prompt is None and bot_task is not None:
+        from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import resolve_sys_type
+
+        effective_use_system_prompt = resolve_sys_type(bot_task)
+    if effective_use_system_prompt is not None:
+        extra_args["use_system_prompt"] = effective_use_system_prompt
+    if system_prompt is not None:
+        extra_args["system_prompt"] = system_prompt
+    if bot_task is not None:
+        extra_args["bot_task"] = bot_task
+    return extra_args
 
 
 def _update_if_not_none(object: Any, key: str, val: Any) -> None:


### PR DESCRIPTION
## Purpose
Fix RMSNorm import path in Hunyuan Image3 transformer to use `vllm_omni.diffusion.layers.norm` instead of `vllm.model_executor.layers.layernorm`.

## Test Plan

### GPU Verification
- Generated images MD5 comparison
- Performance benchmark

### NPU Verification
- Generated images visual comparison (see Test Result section below)
- Performance benchmark
- **GEdit-Bench** accuracy regression (1212 cases: EN/CN × all task types, VIEScore via Qwen3-VL judge)

### Test Commands

Start server:
```bash
vllm serve "/workspace/models/HunyuanImage-3.0-Instruct" \
    --omni \
    --port "8099" \
    --deploy-config "vllm_omni/deploy/hunyuan_image3_dit.yaml" \
    > /workspace/logs/vllm_omni_online.log 2>&1 &
```

Benchmark:
```bash
python3 benchmarks/diffusion/diffusion_benchmark_serving.py \
  --backend vllm-omni \
  --dataset vbench \
  --task t2i \
  --num-prompts 50 \
  --height 512 \
  --width 512 \
  --port 8099 \
  --max-concurrency 4 \
  --warmup-requests 10 \
  --warmup-concurrency 2 \
  --warmup-num-inference-steps 8 \
  --num-inference-steps 50 \
  --disable-tqdm
```

Image generation test:
```bash
export PROMPT='新年宠物海报，Q版圆润的可爱标题"新年快乐汪"，副标题"HAPPY NEW YEAR"。鱼眼镜头，背景是房间门口，近景，主体歪头笑，围着红色围巾，戴着红色毛线帽，高清，绒毛细节，面部特写。宝丽莱相纸，超现实主义，写实主义，胶片摄影，打印颗粒感肌理，复古感'

python3 examples/offline_inference/hunyuan_image3/end2end.py \
  --modality img2img \
  --model /workspace/models/HunyuanImage-3.0 \
  --image-path /workspace/input_images/edit_dog.png \
  --prompts "$PROMPT" \
  --bot-task think \
  --seed 42 \
  --steps 50 \
  --guidance-scale 2.5 \
  --output /workspace/output_images/new_year_pre_1 \
  --deploy-config vllm_omni/deploy/hunyuan_image3_dit.yaml
```

GEdit-Bench (generate + evaluate on NPU A3):
```bash
# Generate edited images (after change; before change uses GEdit_out_old, after uses GEdit_out_new)
python benchmarks/accuracy/image_to_image/run_gedit_bench.py generate \
  --dataset-ref /workspace/benchmark/GEdit-Bench \
  --output-root /workspace/GEdit_out_new \
  --base-url http://127.0.0.1:8099 \
  --model /workspace/models/HunyuanImage-3.0-Instruct \
  --model-name hunyuan_image3_instruct \
  --task-type all --instruction-language all \
  --width 1024 --height 1024 \
  --num-inference-steps 50 --guidance-scale 2.5 --seed 42 \
  --bot-task think --workers 1

# VIEScore evaluation (Qwen3-VL judge)
# Scores dir: before → GEdit_scores/old, after → GEdit_scores/new
python benchmarks/accuracy/image_to_image/run_gedit_bench.py evaluate \
  --dataset-ref /workspace/benchmark/GEdit-Bench \
  --output-root /workspace/GEdit_out_new \
  --model-name hunyuan_image3_instruct \
  --save-dir /workspace/GEdit_scores/new \
  --task-type all --instruction-language all \
  --judge-base-url http://127.0.0.1:8100 \
  --judge-model /workspace/models/Qwen3-VL-30B-A3B-Instruct \
  --judge-api-key EMPTY --workers 4
```

## Test Result

### GPU
- Generated images: **Identical** (no visual/MD5 difference)
- Performance: **No change**

**GPU Generated Images Comparison (md5):**
root@hwuser:/home/xxx/Projects/vllm-omni# md5sum dog_0.png 
43050e7ba7438cbbcf9f264d7004da1e  dog_0.png
root@hwuser:/home/xxx/Projects/vllm-omni# md5sum dog_0_bf16_1024_dcb.png 
43050e7ba7438cbbcf9f264d7004da1e  dog_0_bf16_1024_dcb.png

### NPU
- Generated images: No visual difference, MD5 differs (expected due to numerical precision)
- Performance: **Improved**

**NPU Generated Images Comparison:**

| Before | After |
|--------|-------|
| ![mmexport1780024773888.jpg](https://github.com/user-attachments/assets/a9049cfe-bc01-4de1-a2a2-32a76a49e2fb)

 | ![mmexport1780024769910.jpg](https://github.com/user-attachments/assets/15c6cd80-ca75-4382-8bf0-3dd0e6c3348c)

|

**Before:**
```
Running 10 warmup request(s) with num_inference_steps=8 and warmup_concurrency=2...

================= Serving Benchmark Result =================
Backend:                                 vllm-omni      
Model:                                   default        
Dataset:                                 vbench         
Task:                                    t2i            
--------------------------------------------------
Benchmark duration (s):                  1450.03        
Request rate:                            inf            
Max request concurrency:                 4              
Successful requests:                     50/50             
--------------------------------------------------
Request throughput (req/s):              0.03           
Latency Mean (s):                        112.5296       
Latency Median (s):                      115.9240       
Latency P99 (s):                         116.6692       
Latency P95 (s):                         116.3683       
--------------------------------------------------
Peak Memory Max (MB):                    58280.00       
Peak Memory Mean (MB):                   58280.00       
Peak Memory Median (MB):                 58280.00       
--------------------------------------------------
Stage Durations Mean (s):
  queue_wait_ms:                         0.7277         
  stage_0_gen_ms:                        111973.2250    

============================================================
```

**After:**
```
================= Serving Benchmark Result =================
Backend:                                 vllm-omni      
Model:                                   default        
Dataset:                                 vbench         
Task:                                    t2i            
--------------------------------------------------
Benchmark duration (s):                  1360.10        
Request rate:                            inf            
Max request concurrency:                 4              
Successful requests:                     50/50             
--------------------------------------------------
Request throughput (req/s):              0.04           
Latency Mean (s):                        105.5558       
Latency Median (s):                      108.6828       
Latency P99 (s):                         109.5295       
Latency P95 (s):                         109.3129       
--------------------------------------------------
Peak Memory Max (MB):                    58280.00       
Peak Memory Mean (MB):                   58280.00       
Peak Memory Median (MB):                 58280.00       
--------------------------------------------------
Stage Durations Mean (s):
  queue_wait_ms:                         0.8568         
  stage_0_gen_ms:                        104991.5642    

============================================================
```

**Serving benchmark improvement:**
| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Latency Mean | 112.53s | 105.56s | **-6.2%** |
| Stage 0 gen | 111973ms | 104992ms | **-6.2%** |

**GEdit-Bench accuracy (NPU A3, 1212 cases):**

Dataset: GEdit-Bench (`task-type=all`, `instruction-language=all`, 606 EN + 606 CN).  
Inference: HunyuanImage-3.0-Instruct, 1024×1024, 50 steps, `guidance-scale=2.5`, `seed=42`, `bot-task=think`.  
Evaluation: VIEScore with Qwen3-VL-30B-A3B-Instruct judge (`Q_SC` = semantics, `Q_PQ` = quality, `Q_O` = overall; higher is better).

| Scope | Cases | Metric | Before | After | Δ | Δ% |
|-------|------:|--------|-------------:|------------:|--:|---:|
| **All** | **1212** | Q_SC | 7.282 | 7.280 | -0.002 | -0.03% |
| | | Q_PQ | 5.235 | 5.244 | +0.009 | +0.18% |
| | | **Q_O** | **6.075** | **6.083** | **+0.008** | **+0.13%** |
| EN | 606 | Q_SC | 7.318 | 7.336 | +0.018 | +0.24% |
| | | Q_PQ | 5.204 | 5.219 | +0.015 | +0.28% |
| | | Q_O | 6.071 | 6.089 | +0.017 | +0.28% |
| CN | 606 | Q_SC | 7.245 | 7.223 | -0.022 | -0.30% |
| | | Q_PQ | 5.265 | 5.269 | +0.004 | +0.08% |
| | | Q_O | 6.079 | 6.078 | -0.001 | -0.02% |

**Conclusion:** On the full 1212-case GEdit-Bench suite, overall score (Q_O) is essentially unchanged (+0.13%), with a slight gain in perceptual quality (Q_PQ) and negligible semantics drift (Q_SC). No accuracy regression observed relative to the before baseline.