### PR TITLE
[Bugfix] Preserve video outputs for audio-enabled diffusion pipelines

### DIFF
--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -294,6 +294,10 @@ class DiffusionEngine:
         if is_audio_output and model_audio_sample_rate is None:
             model_cls = DiffusionModelRegistry._try_load_model_cls(self.od_config.model_class_name)
             model_audio_sample_rate = getattr(model_cls, "audio_sample_rate", None)
+        # Some pipelines, such as LTX-2/LTX-2.3, return video as the primary
+        # output and attach audio through the post-process dict. Only treat the
+        # request as audio-only when no separate audio payload was extracted.
+        is_audio_only_output = is_audio_output and audio_payload is None
 
         def _audio_mm(payload: Any) -> dict[str, Any]:
             mm: dict[str, Any] = {"audio": payload}
@@ -319,7 +323,7 @@ class DiffusionEngine:
                         peak_memory_mb=output.peak_memory_mb,
                     ),
                 ]
-            if is_audio_output:
+            if is_audio_only_output:
                 request_audio_payload = outputs[0] if len(outputs) == 1 else outputs
                 return [
                     OmniRequestOutput.from_diffusion(
@@ -378,7 +382,7 @@ class DiffusionEngine:
                 request_outputs = outputs[start_idx:end_idx] if output_idx < len(outputs) else []
                 output_idx = end_idx
 
-                if is_audio_output:
+                if is_audio_only_output:
                     request_audio_payload = request_outputs[0] if len(request_outputs) == 1 else request_outputs
                     results.append(
                         OmniRequestOutput.from_diffusion(


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Raised by #3962:

Fix a regression in `DiffusionEngine.step()` output packaging for diffusion
pipelines that produce both video and audio, such as `LTX23Pipeline`.

After #3079 373d3c747 [Blackwell] Add CUDNN_ATTN and FLASHINFER_ATTN backends for diffusion (auto-route), `LTX23Pipeline` declares:

```python
support_audio_output = True
```

This is correct for warmup and sizing because LTX-2.3 generates audio together
with video. However, the existing engine logic treated
`supports_audio_output(model_class_name) == True` as an audio-only signal.

As a result, the online `/v1/videos` path wrapped LTX-2.3 outputs as:

```python
images=[]
multimodal_output={"audio": ...}
final_output_type="audio"
```

Then `serving_video.py::_extract_video_outputs()` could not find any video
output and failed with:

```text
500: No video outputs found in generation result.
```

This was surfaced by:

```text
tests/e2e/accuracy/test_ltx2_3_video_similarity.py::test_ltx2_3_pipeline_matches_diffusers
```

This PR changes the engine to use the audio-only packaging path only when the
post-process result does not contain a separate `audio_payload`. For video+audio
pipelines, the video remains in `images`, while audio stays in
`multimodal_output`.

## Test Plan


```
pytest tests/e2e/accuracy/test_ltx2_3_video_similarity.py::test_ltx2_3_pipeline_matches_diffusers -q -s
```

## Test Result

```
1 passed, 17 warnings in 407.06s.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
