### PR TITLE
Added GQA support for CUDNNAttention backend

### DIFF
--- a/vllm_omni/diffusion/attention/backends/cudnn_attn.py
+++ b/vllm_omni/diffusion/attention/backends/cudnn_attn.py
@@ -51,6 +51,7 @@ class CuDNNAttentionImpl(AttentionImpl):
     ) -> None:
         self.causal = causal
         self.softmax_scale = softmax_scale
+        self.requires_gqa = num_heads != num_kv_heads
 
     def forward_cuda(
         self,
@@ -84,6 +85,7 @@ class CuDNNAttentionImpl(AttentionImpl):
                     dropout_p=0.0,
                     is_causal=self.causal,
                     scale=self.softmax_scale,
+                    enable_gqa=self.requires_gqa,
                 )
         except RuntimeError as e:
             if "No available kernel" not in str(e):
@@ -100,5 +102,6 @@ class CuDNNAttentionImpl(AttentionImpl):
                 dropout_p=0.0,
                 is_causal=self.causal,
                 scale=self.softmax_scale,
+                enable_gqa=self.requires_gqa,
             )
         return output.permute(0, 2, 1, 3)


### PR DESCRIPTION
<!-- markdownlint-disable -->
This PR adds GQA support for `CUDNNAttentionBackend`, similar to how SDPA was handled here: https://github.com/vllm-project/vllm-omni/pull/3728

## Purpose
Enabling models to use `CUDNNAttentionBackend` with GQA. One example is Bagel, other is Cosmos3 that is being added here: https://github.com/vllm-project/vllm-omni/pull/3454

## Test Plan
Since `CUDNNAttentionBackend` or GQA for SDPA didn't contain any tests, not extending it here, since it's out of scope of the PR and the change is very simple.
## Test Result
No relevant test results
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
