### PR TITLE
[BugFix] Add audioop-lts dependency for Python 3.13 compatibility (#3…

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -17,3 +17,4 @@ aenum==3.1.16
 pyzmq>=25.0.0
 janus>=1.0.0
 pydub
+audioop-lts>=0.2.1; python_version >= "3.13"


### PR DESCRIPTION
## Purpose

  Fix #3952 — `vllm serve` crashes on Python 3.13 with
  `ModuleNotFoundError: No module named 'pyaudioop'`.

  According to https://docs.python.org/3.13/whatsnew/3.13.html,
  `audioop` is removed in Python 3.13, and should
  "Use `audioop-lts` library from PyPI" instead.

  Add `audioop-lts` dependency (gated on `python_version >= "3.13"`).

  ## Test Plan

  Verified on Python 3.10 / 3.11 / 3.12 / 3.13 that
  `from pydub import AudioSegment` succeeds and CLI starts normally.

  ## Test Result

  | Python | audioop source | audioop-lts installed | pydub import |
  |--------|---------------|----------------------|--------------|
  | 3.10   | stdlib        | No (skipped)         | OK           |
  | 3.11   | stdlib        | No (skipped)         | OK           |
  | 3.12   | stdlib        | No (skipped)         | OK           |
  | 3.13   | audioop-lts   | Yes                  | OK           |
