### PR TITLE
[BAGEL] Add aligned force-interleaved two-stage path

### DIFF
--- a/tests/diffusion/test_diffusion_batch_wait.py
+++ b/tests/diffusion/test_diffusion_batch_wait.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from types import SimpleNamespace
+
+from vllm_omni.diffusion.diffusion_engine import DiffusionEngine
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.sched import RequestScheduler
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+
+def _make_request(req_id: str) -> OmniDiffusionRequest:
+    return OmniDiffusionRequest(
+        prompts=[f"prompt_{req_id}"],
+        sampling_params=OmniDiffusionSamplingParams(num_inference_steps=1),
+        request_ids=[req_id],
+    )
+
+
+def test_request_batch_idle_cutoff_dispatches_partial_batch() -> None:
+    engine = DiffusionEngine.__new__(DiffusionEngine)
+    engine.scheduler = RequestScheduler()
+    engine.scheduler.initialize(SimpleNamespace(max_num_seqs=4))
+    engine.scheduler.add_request(_make_request("req-idle"))
+    engine.request_batching = True
+    engine._request_batch_wait_s = 1.0
+    engine._request_batch_idle_s = 0.01
+    engine._request_batch_idle_min_size = 1
+    engine._rpc_queue = queue.Queue()
+    engine.abort_queue = queue.Queue()
+    engine.stop_event = threading.Event()
+    engine._cv = threading.Condition(threading.RLock())
+
+    start = time.monotonic()
+    with engine._cv:
+        engine._wait_for_request_batch_if_needed()
+
+    assert time.monotonic() - start < 0.2

--- a/tests/engine/test_stage_pool.py
+++ b/tests/engine/test_stage_pool.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.engine.stage_pool import StagePool
+
+
+class _FakeDiffusionClient:
+    stage_type = "diffusion"
+    final_output = True
+
+    def __init__(self) -> None:
+        self.submitted: list[str] = []
+        self.outputs: list[SimpleNamespace] = []
+
+    async def add_request_async(self, request_id, request, params, **kwargs):
+        self.submitted.append(request_id)
+
+    def get_diffusion_output_nowait(self):
+        return self.outputs.pop(0) if self.outputs else None
+
+
+@pytest.mark.asyncio
+async def test_stage_pool_routes_to_replica_with_less_inflight_work():
+    clients = [_FakeDiffusionClient(), _FakeDiffusionClient()]
+    pool = StagePool(1, clients)
+    req_state = SimpleNamespace(sampling_params_list=[None, object()])
+
+    assert await pool.submit_initial("r0", req_state, "prompt") == 0
+    assert await pool.submit_initial("r1", req_state, "prompt") == 1
+
+    clients[1].outputs.append(SimpleNamespace(request_id="r1", finished=True))
+    assert pool.poll_diffusion_output(1).request_id == "r1"
+
+    assert await pool.submit_initial("r2", req_state, "prompt") == 1
+    assert clients[0].submitted == ["r0"]
+    assert clients[1].submitted == ["r1", "r2"]

--- a/tests/model_executor/test_bagel_vqa_reference_layout.py
+++ b/tests/model_executor/test_bagel_vqa_reference_layout.py
@@ -1,0 +1,142 @@
+import torch
+
+from vllm_omni.utils.bagel_vqa import (
+    BAGEL_VLM_THINK_SYSTEM_PROMPT,
+    bagel_vqa_reference_layout_enabled,
+    build_bagel_vqa_image_spans,
+    build_bagel_vqa_rope_positions,
+    build_bagel_vqa_reference_prompt_token_ids,
+)
+
+
+class FakeTokenizer:
+    vocab = {
+        "<|im_start|>": 100,
+        "<|im_end|>": 101,
+        "<|image_pad|>": 102,
+    }
+
+    def convert_tokens_to_ids(self, token):
+        return self.vocab[token]
+
+    def encode(self, text):
+        return [ord(ch) for ch in text]
+
+
+def test_bagel_vqa_serving_prompt_uses_reference_layout():
+    messages = [
+        {"role": "system", "content": BAGEL_VLM_THINK_SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+                {
+                    "type": "text",
+                    "text": f"{BAGEL_VLM_THINK_SYSTEM_PROMPT}\n\nquestion",
+                },
+                {"type": "text", "text": "briefly"},
+            ],
+        },
+        {"role": "assistant", "content": "<think>\n"},
+    ]
+
+    ids, prompt, image_count = build_bagel_vqa_reference_prompt_token_ids(
+        messages,
+        FakeTokenizer(),
+    )
+
+    assert ids[0] == FakeTokenizer.vocab["<|im_start|>"]
+    assert ids[-1] == FakeTokenizer.vocab["<|im_start|>"]
+    assert FakeTokenizer.vocab["<|image_pad|>"] in ids
+    assert prompt == "<img><|image_1|></img> question briefly"
+    assert image_count == 1
+
+
+def test_bagel_vqa_logical_rope_collapses_vision_block_and_decode_continues():
+    states = {}
+    input_ids = torch.tensor([1, 10, 2, 3, 11, 4])
+    positions = torch.arange(6)
+
+    rope = build_bagel_vqa_rope_positions(
+        input_ids=input_ids,
+        positions=positions,
+        req_ids=["r0"],
+        num_computed_tokens=[0],
+        num_scheduled_tokens=[6],
+        rope_states=states,
+        start_of_image_id=10,
+        end_of_image_id=11,
+    )
+
+    assert rope.tolist() == [0, 1, 1, 1, 1, 2]
+
+    decode_rope = build_bagel_vqa_rope_positions(
+        input_ids=torch.tensor([5]),
+        positions=torch.tensor([6]),
+        req_ids=["r0"],
+        num_computed_tokens=[6],
+        num_scheduled_tokens=[1],
+        rope_states=states,
+        start_of_image_id=10,
+        end_of_image_id=11,
+    )
+
+    assert decode_rope.tolist() == [3]
+
+
+def test_bagel_vqa_logical_rope_survives_chunked_image_prefill():
+    states = {}
+
+    first = build_bagel_vqa_rope_positions(
+        input_ids=torch.tensor([1, 10, 2]),
+        positions=torch.tensor([0, 1, 2]),
+        req_ids=["r0"],
+        num_computed_tokens=[0],
+        num_scheduled_tokens=[3],
+        rope_states=states,
+        start_of_image_id=10,
+        end_of_image_id=11,
+    )
+    second = build_bagel_vqa_rope_positions(
+        input_ids=torch.tensor([3, 11, 4]),
+        positions=torch.tensor([3, 4, 5]),
+        req_ids=["r0"],
+        num_computed_tokens=[3],
+        num_scheduled_tokens=[3],
+        rope_states=states,
+        start_of_image_id=10,
+        end_of_image_id=11,
+    )
+
+    assert first.tolist() == [0, 1, 1]
+    assert second.tolist() == [1, 1, 2]
+
+
+def test_bagel_reference_prefill_implies_reference_layout(monkeypatch):
+    monkeypatch.delenv("BAGEL_VQA_REFERENCE_LAYOUT", raising=False)
+    monkeypatch.setenv("BAGEL_VQA_REFERENCE_PREFILL", "1")
+
+    assert bagel_vqa_reference_layout_enabled()
+
+
+def test_bagel_vqa_image_spans_include_kv_end_before_future_text():
+    spans = build_bagel_vqa_image_spans(
+        input_ids=torch.tensor([1, 10, 2, 3, 11, 4, 5]),
+        req_ids=["r0"],
+        num_computed_tokens=[20],
+        num_scheduled_tokens=[7],
+        start_of_image_id=10,
+        end_of_image_id=11,
+    )
+
+    assert spans == [
+        {
+            "req_idx": 0,
+            "request_start": 0,
+            "num_computed_tokens": 20,
+            "q_start": 1,
+            "q_end": 5,
+            "kv_local_end": 5,
+            "kv_end": 25,
+        }
+    ]

--- a/vllm_omni/deploy/bagel.yaml
+++ b/vllm_omni/deploy/bagel.yaml
@@ -17,10 +17,14 @@ stages:
     enable_prefix_caching: false
     devices: "0"
     default_sampling_params:
-      temperature: 0.4
+      # Iter2 set top_k=0 (disable) which REGRESSED to 0.495 (-0.15 from iter1).
+      # Reverting to top_k=1 (the model was trained/fine-tuned with greedy-like
+      # decoding). Keeping iter1's working request-level overrides as defaults:
+      # T=0.3 (was 0.4) and max_tokens=4096 (was 2048).
+      temperature: 0.3
       top_p: 0.9
       top_k: 1
-      max_tokens: 2048
+      max_tokens: 4096
       seed: 52
       detokenize: true
       repetition_penalty: 1.05

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -602,6 +602,18 @@ class OmniDiffusionConfig:
     # Maximum number of sequences to generate in a batch
     max_num_seqs: int = 1
 
+    # Optional request-mode micro-batch fill wait. Diffusion request-mode
+    # execution is expensive enough that waiting briefly for compatible
+    # requests can improve throughput substantially.
+    request_batch_wait_ms: int = 0
+    # Optional idle cutoff while filling a request-mode micro-batch. When set,
+    # dispatch a partial batch after this many milliseconds without additional
+    # compatible arrivals instead of always waiting until request_batch_wait_ms.
+    request_batch_idle_ms: int = 0
+    # Minimum waiting requests before request_batch_idle_ms may dispatch a
+    # partial batch. This avoids accidentally launching singleton batches.
+    request_batch_idle_min_size: int = 2
+
     # Supplementary model specific parameters
     extras: dict[str, Any] = Field(default_factory=dict)
 

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -118,6 +118,14 @@ def get_extra_output_params(model_class_name: str) -> frozenset[str]:
     return frozenset(getattr(model_cls, "EXTRA_OUTPUT_PARAMS", frozenset()))
 
 
+def supports_request_batching(od_config: OmniDiffusionConfig) -> bool:
+    """Return whether request-mode scheduler batching is supported."""
+    model_cls = DiffusionModelRegistry._try_load_model_cls(od_config.model_class_name)
+    if model_cls is None:
+        return False
+    return bool(getattr(model_cls, "SUPPORTS_REQUEST_BATCHING", False))
+
+
 class DiffusionEngine:
     """The diffusion engine for vLLM-Omni diffusion models."""
 
@@ -149,10 +157,17 @@ class DiffusionEngine:
             StepScheduler() if self.step_execution else RequestScheduler()
         )
         self.scheduler.initialize(od_config)
-        if self.scheduler.max_num_running_reqs > 1 and not self.step_execution:
+        self.request_batching = (not self.step_execution) and supports_request_batching(od_config)
+        if self.scheduler.max_num_running_reqs > 1 and not self.step_execution and not self.request_batching:
             max_num_seqs = self.scheduler.max_num_running_reqs
             self.scheduler.max_num_running_reqs = 1
             logger.warning(f"Non-stepwise-execution does not support max-num-seqs={max_num_seqs}, set it to 1.")
+        elif self.scheduler.max_num_running_reqs > 1 and self.request_batching:
+            logger.info(
+                "Request-mode batching enabled for %s with max-num-seqs=%d.",
+                od_config.model_class_name,
+                self.scheduler.max_num_running_reqs,
+            )
         self.main_loop: asyncio.AbstractEventLoop | None = None
         self.stop_event: threading.Event | None = None
         self.worker_thread: threading.Thread | None = None
@@ -170,6 +185,18 @@ class DiffusionEngine:
         self.abort_queue: queue.Queue[str] = queue.Queue()
         self._rpc_queue: queue.Queue[_RpcTask] = queue.Queue()
         self.execute_fn = self.executor.execute_step if self.step_execution else self.executor.execute_request
+        self._request_batch_wait_s = max(
+            0.0,
+            float(getattr(self.od_config, "request_batch_wait_ms", 0) or 0) / 1000.0,
+        )
+        self._request_batch_idle_s = max(
+            0.0,
+            float(getattr(self.od_config, "request_batch_idle_ms", 0) or 0) / 1000.0,
+        )
+        self._request_batch_idle_min_size = max(
+            1,
+            int(getattr(self.od_config, "request_batch_idle_min_size", 2) or 2),
+        )
 
         try:
             self._dummy_run()
@@ -463,6 +490,7 @@ class DiffusionEngine:
                     # Only RPC / abort work pending; loop back to drain it.
                     continue
 
+                self._wait_for_request_batch_if_needed()
                 sched_output = self.scheduler.schedule()
 
             if sched_output.is_empty:
@@ -494,6 +522,50 @@ class DiffusionEngine:
 
         # Engine is stopping: fail any RPCs still queued so callers don't hang.
         self._fail_pending_rpcs(RuntimeError("DiffusionEngine is shutting down."))
+
+    def _wait_for_request_batch_if_needed(self) -> None:
+        """Briefly wait for a fuller request-mode batch before scheduling.
+
+        This is intentionally only active for request-mode pipelines that
+        advertise native request batching. It keeps the default zero-wait
+        behavior for other diffusion models while allowing expensive BAGEL
+        Stage 1 calls to launch with fuller batches.
+        """
+        if self._request_batch_wait_s <= 0 or not self.request_batching:
+            return
+        if self.scheduler.num_running > 0:
+            return
+
+        deadline = time.monotonic() + self._request_batch_wait_s
+        idle_deadline = None
+        last_waiting = self.scheduler.num_waiting
+        if self._request_batch_idle_s > 0 and last_waiting >= self._request_batch_idle_min_size:
+            idle_deadline = time.monotonic() + self._request_batch_idle_s
+        while (
+            self.scheduler.num_waiting > 0
+            and self.scheduler.num_waiting < self.scheduler.max_num_running_reqs
+            and self._rpc_queue.empty()
+            and self.abort_queue.empty()
+            and not self.stop_event.is_set()
+        ):
+            now = time.monotonic()
+            remaining = deadline - now
+            if remaining <= 0:
+                break
+            if self._request_batch_idle_s > 0:
+                current_waiting = self.scheduler.num_waiting
+                if current_waiting != last_waiting:
+                    last_waiting = current_waiting
+                    if current_waiting >= self._request_batch_idle_min_size:
+                        idle_deadline = now + self._request_batch_idle_s
+                    else:
+                        idle_deadline = None
+                if idle_deadline is not None:
+                    idle_remaining = idle_deadline - now
+                    if idle_remaining <= 0:
+                        break
+                    remaining = min(remaining, idle_remaining)
+            self._cv.wait(timeout=remaining)
 
     def _process_rpc_queue(self) -> None:
         """Execute pending collective_rpc tasks from the busy-loop thread.

--- a/vllm_omni/diffusion/executor/multiproc_executor.py
+++ b/vllm_omni/diffusion/executor/multiproc_executor.py
@@ -291,14 +291,26 @@ class MultiprocDiffusionExecutor(DiffusionExecutor):
 
     def execute_request(self, scheduler_output: DiffusionSchedulerOutput) -> BaseRunnerOutput:
         """Adapt request-mode scheduler output to worker execute_model RPC."""
-        from vllm_omni.diffusion.worker.utils import RunnerOutput
+        from vllm_omni.diffusion.worker.utils import BaseRunnerOutput, BatchRunnerOutput, RunnerOutput
 
         self._ensure_open()
-        if scheduler_output.num_scheduled_reqs != 1:
-            raise ValueError(
-                f"Request mode currently supports batch_size=1, "
-                f"but got {scheduler_output.num_scheduled_reqs} scheduled requests."
+        if scheduler_output.num_scheduled_reqs == 0:
+            return BatchRunnerOutput.from_list([])
+        if scheduler_output.scheduled_cached_reqs.sched_req_ids:
+            raise ValueError("Request-mode batching only supports newly scheduled requests.")
+
+        if scheduler_output.num_scheduled_reqs > 1:
+            sched_req_ids = [new_req.sched_req_id for new_req in scheduler_output.scheduled_new_reqs]
+            reqs = [new_req.req for new_req in scheduler_output.scheduled_new_reqs]
+            result = self.collective_rpc(
+                "execute_model_batch",
+                args=(reqs, sched_req_ids, self.od_config),
+                unique_reply_rank=0,
+                exec_all_ranks=True,
             )
+            if isinstance(result, BaseRunnerOutput):
+                return result
+            raise RuntimeError(f"Unexpected response type for execute_model_batch: {type(result)!r}")
 
         new_req = scheduler_output.scheduled_new_reqs[0]
         result = self.collective_rpc(

--- a/vllm_omni/diffusion/models/bagel/bagel_transformer.py
+++ b/vllm_omni/diffusion/models/bagel/bagel_transformer.py
@@ -1295,6 +1295,17 @@ class Bagel(nn.Module):
         packed_position_ids: torch.LongTensor,
         packed_seqlens: torch.IntTensor,
     ):
+        packed_text_embedding = self.language_model.forward(
+            packed_text_ids=packed_text_ids,
+            return_embeddings_only=True,
+        ).packed_query_sequence
+        packed_sequence = packed_text_embedding.new_zeros((sum(packed_seqlens), self.hidden_size))
+        packed_sequence[packed_text_indexes] = packed_text_embedding
+
+        padded_images = padded_images.to(
+            device=packed_text_embedding.device,
+            dtype=torch.bfloat16,
+        )
         padded_latent = vae_model.encode(padded_images)
 
         p = self.latent_patch_size
@@ -1307,6 +1318,9 @@ class Bagel(nn.Module):
         packed_pos_embed = self.latent_pos_embed(packed_vae_position_ids)
         packed_timestep_embeds = self.time_embedder(packed_timesteps)
         packed_latent = self.vae2llm(packed_latent) + packed_timestep_embeds + packed_pos_embed
+        if packed_latent.dtype != packed_sequence.dtype:
+            packed_latent = packed_latent.to(packed_sequence.dtype)
+        packed_sequence[packed_vae_token_indexes] = packed_latent
 
         # Mirror forward_cache_update_vit: build a full packed_sequence so MoE gen-mode
         # indexes (packed_text_indexes / packed_vae_token_indexes) match tensor length.
@@ -1443,15 +1457,22 @@ class Bagel(nn.Module):
 
         return past_key_values
 
-    def prepare_input(self, curr_kvlens, curr_rope, image_sizes, new_token_ids=None):
+    def prepare_input(self, curr_kvlens, curr_rope, image_sizes, new_token_ids=None, noise_seeds=None):
         packed_text_ids, packed_text_indexes = list(), list()
         packed_vae_position_ids, packed_vae_token_indexes, packed_init_noises = list(), list(), list()
-        packed_position_ids, packed_seqlens = list(), list()
+        packed_position_ids, packed_seqlens, packed_indexes = list(), list(), list()
+        packed_key_value_indexes = list()
 
-        query_curr = 0
-        for (H, W), curr_kvlen, curr_position_id in zip(image_sizes, curr_kvlens, curr_rope):
+        query_curr = curr = 0
+        for sample_idx, ((H, W), curr_kvlen, curr_position_id) in enumerate(zip(image_sizes, curr_kvlens, curr_rope)):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
             packed_text_ids.append(new_token_ids["start_of_image"])
             packed_text_indexes.append(query_curr)
+
+            packed_indexes.append(curr)
+            curr += 1
             query_curr += 1
 
             vae_position_ids = self.get_flattened_position_ids(
@@ -1462,13 +1483,28 @@ class Bagel(nn.Module):
             h, w = H // self.latent_downsample, W // self.latent_downsample
             num_image_tokens = h * w
 
-            packed_init_noises.append(torch.randn(num_image_tokens, self.latent_channel * self.latent_patch_size**2))
+            generator = None
+            if noise_seeds is not None and noise_seeds[sample_idx] is not None:
+                generator = torch.Generator(device="cpu").manual_seed(int(noise_seeds[sample_idx]))
+            packed_init_noises.append(
+                torch.randn(
+                    num_image_tokens,
+                    self.latent_channel * self.latent_patch_size**2,
+                    generator=generator,
+                )
+            )
             packed_vae_token_indexes.extend(range(query_curr, query_curr + num_image_tokens))
             packed_seqlens.append(num_image_tokens + 2)
+
+            packed_indexes.extend(range(curr, curr + num_image_tokens))
+            curr += num_image_tokens
             query_curr += num_image_tokens
 
             packed_text_ids.append(new_token_ids["end_of_image"])
             packed_text_indexes.append(query_curr)
+
+            packed_indexes.append(curr)
+            curr += 1
             query_curr += 1
 
             packed_position_ids.extend([curr_position_id] * (num_image_tokens + 2))
@@ -1482,23 +1518,45 @@ class Bagel(nn.Module):
             "packed_vae_token_indexes": torch.tensor(packed_vae_token_indexes, dtype=torch.long),
             "packed_seqlens": torch.tensor(packed_seqlens, dtype=torch.int),
             "packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+            "packed_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
         }
 
         return generation_input
 
-    def prepare_vae_latent(self, curr_kvlens, curr_rope, image_sizes, new_token_ids):
-        return self.prepare_input(curr_kvlens, curr_rope, image_sizes, new_token_ids)
+    def prepare_vae_latent(self, curr_kvlens, curr_rope, image_sizes, new_token_ids, noise_seeds=None):
+        return self.prepare_input(curr_kvlens, curr_rope, image_sizes, new_token_ids, noise_seeds=noise_seeds)
 
     def prepare_vae_latent_cfg(self, curr_kvlens, curr_rope, image_sizes):
-        packed_position_ids = list()
+        packed_position_ids, packed_indexes, packed_key_value_indexes = list(), list(), list()
 
+        query_curr = curr = 0
         for (H, W), curr_kvlen, curr_position_id in zip(image_sizes, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
             h, w = H // self.latent_downsample, W // self.latent_downsample
             num_image_tokens = h * w
+            packed_indexes.extend(range(curr, curr + num_image_tokens))
+            curr += num_image_tokens
+            query_curr += num_image_tokens
+
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
             packed_position_ids.extend([curr_position_id] * (num_image_tokens + 2))
 
         generation_input = {
             "cfg_packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
+            "cfg_key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+            "cfg_packed_query_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "cfg_packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
         }
 
         return generation_input
@@ -1547,6 +1605,7 @@ class Bagel(nn.Module):
         do_sample: bool = False,
         temperature: float = 1.0,
         end_token_id: int | None = None,
+        repeat_stop_n: int | None = None,
     ):
         """Autoregressive text generation (ported from original BAGEL).
 
@@ -1555,8 +1614,11 @@ class Bagel(nn.Module):
         """
         step = 0
         generated_sequence = []
+        repeat_limit = int(repeat_stop_n or 0)
+        repeat_count = 1
         curr_tokens = packed_start_tokens
         while step < max_length:
+            prev_tokens = curr_tokens.clone()
             generated_sequence.append(curr_tokens)
             query_lens = torch.ones_like(curr_tokens)
 
@@ -1584,9 +1646,148 @@ class Bagel(nn.Module):
 
             if end_token_id is not None and curr_tokens[0] == end_token_id:
                 break
+            if repeat_limit > 0:
+                if bool((curr_tokens == prev_tokens).all()):
+                    repeat_count += 1
+                else:
+                    repeat_count = 1
+                if repeat_count >= repeat_limit:
+                    break
 
         output_device = generated_sequence[0].device
         return torch.stack([i.to(output_device) for i in generated_sequence], dim=0)
+
+    @torch.no_grad()
+    def batch_generate_text(
+        self,
+        past_key_values: NaiveCache,
+        packed_key_value_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
+        packed_start_tokens: torch.LongTensor,
+        packed_query_position_ids: torch.LongTensor,
+        max_length: int,
+        do_sample: bool = False,
+        temperature: float = 1.0,
+        end_token_id: int | None = None,
+        sampling_generators: list[torch.Generator | None] | None = None,
+        repeat_stop_n: int | None = None,
+    ) -> list[torch.Tensor]:
+        """Autoregressive batched text generation with per-row EOS tracking."""
+        device = None
+        for layer_idx in range(past_key_values.num_layers):
+            if past_key_values.key_cache[layer_idx] is not None:
+                device = past_key_values.key_cache[layer_idx].device
+                break
+        if device is None:
+            device = packed_start_tokens.device
+
+        packed_key_value_indexes = packed_key_value_indexes.to(device)
+        key_values_lens = key_values_lens.to(device)
+        packed_start_tokens = packed_start_tokens.to(device)
+        packed_query_position_ids = packed_query_position_ids.to(device)
+
+        batch_size = int(key_values_lens.numel())
+        generated_sequences: list[list[torch.Tensor]] = [[] for _ in range(batch_size)]
+        finished = torch.zeros(batch_size, dtype=torch.bool, device=device)
+        repeat_limit = int(repeat_stop_n or 0)
+        repeat_counts = torch.ones(batch_size, dtype=torch.int, device=device)
+        curr_tokens = packed_start_tokens.clone()
+
+        step = 0
+        while step < max_length:
+            prev_tokens = curr_tokens.clone()
+            active_before_sample = ~finished
+            for row_idx in range(batch_size):
+                if not bool(finished[row_idx]):
+                    generated_sequences[row_idx].append(curr_tokens[row_idx].clone())
+
+            query_lens = torch.ones_like(curr_tokens)
+            packed_query_indexes = torch.cumsum(key_values_lens, dim=0) + torch.arange(
+                0,
+                len(key_values_lens),
+                device=key_values_lens.device,
+                dtype=key_values_lens.dtype,
+            )
+
+            uppacked = list(packed_key_value_indexes.split(key_values_lens.tolist(), dim=0))
+            for row_idx in range(len(uppacked)):
+                uppacked[row_idx] += row_idx
+            packed_key_value_indexes = torch.cat(uppacked, dim=0)
+
+            output = self.language_model(
+                packed_text_ids=curr_tokens,
+                query_lens=query_lens,
+                packed_query_position_ids=packed_query_position_ids,
+                packed_query_indexes=packed_query_indexes,
+                past_key_values=past_key_values,
+                key_values_lens=key_values_lens,
+                packed_key_value_indexes=packed_key_value_indexes,
+                update_past_key_values=True,
+                is_causal=True,
+                mode="und",
+            )
+            past_key_values = output.past_key_values
+            pred_logits = self.language_model.lm_head(output.packed_query_sequence)
+
+            if do_sample:
+                probs = nn.functional.softmax(pred_logits / temperature, dim=-1)
+                if sampling_generators is not None:
+                    sampled_tokens = []
+                    for row_idx in range(batch_size):
+                        if bool(finished[row_idx]):
+                            sampled_tokens.append(curr_tokens[row_idx : row_idx + 1])
+                            continue
+                        generator = (
+                            sampling_generators[row_idx]
+                            if row_idx < len(sampling_generators)
+                            else None
+                        )
+                        sampled_tokens.append(
+                            torch.multinomial(
+                                probs[row_idx : row_idx + 1],
+                                num_samples=1,
+                                generator=generator,
+                            ).squeeze(0)
+                        )
+                    curr_tokens = torch.stack(sampled_tokens, dim=0).squeeze(1)
+                else:
+                    curr_tokens = torch.multinomial(probs, num_samples=1).squeeze(1)
+            else:
+                curr_tokens = torch.argmax(pred_logits, dim=-1)
+
+            if end_token_id is not None:
+                finished = finished | (curr_tokens == end_token_id)
+
+            if repeat_limit > 0:
+                repeated = (curr_tokens == prev_tokens) & active_before_sample
+                repeat_counts = torch.where(
+                    repeated,
+                    repeat_counts + 1,
+                    torch.ones_like(repeat_counts),
+                )
+                finished = finished | (repeat_counts >= repeat_limit)
+
+            uppacked = list(packed_key_value_indexes.split(key_values_lens.tolist(), dim=0))
+            for row_idx in range(len(uppacked)):
+                uppacked[row_idx] = torch.cat(
+                    [
+                        uppacked[row_idx],
+                        torch.tensor([uppacked[row_idx][-1] + 1], device=uppacked[row_idx].device),
+                    ],
+                    dim=0,
+                )
+            packed_key_value_indexes = torch.cat(uppacked, dim=0)
+            key_values_lens = key_values_lens + 1
+            packed_query_position_ids = packed_query_position_ids + 1
+            step += 1
+
+            if bool(finished.all()):
+                break
+
+        return [
+            torch.stack(seq, dim=0) if seq else torch.empty(0, dtype=torch.long, device=device)
+            for seq in generated_sequences
+        ]
 
     def generate_image(
         self,
@@ -1860,29 +2061,30 @@ class Bagel(nn.Module):
         scheduler: object | None = None,
         scheduler_kwargs: dict | None = None,
     ):
-        """CFG parallel denoising loop: each rank computes one CFG branch.
+        """CFG parallel denoising loop.
 
-        Rank 0: gen branch (full conditioning)
-        Rank 1: text_cfg branch (unconditional text)
-        Rank 2: img_cfg branch (no image condition), only when cfg_img_scale > 1.0
+        cfg_parallel_size=2:
+            Rank 0 computes gen and, when enabled, img_cfg.
+            Rank 1 computes text_cfg.
+        cfg_parallel_size=3:
+            Rank 0 computes gen, rank 1 computes text_cfg, rank 2 computes img_cfg.
         """
         cfg_group = get_cfg_group()
         cfg_rank = get_classifier_free_guidance_rank()
         cfg_world_size = get_classifier_free_guidance_world_size()
         use_cfg_img = cfg_img_scale > 1.0
 
-        # Validate cfg_parallel_size vs cfg_img_scale consistency
+        # Validate cfg_parallel_size vs cfg_img_scale consistency.
+        if cfg_world_size not in (2, 3):
+            raise ValueError(
+                f"BAGEL CFG parallel supports cfg_parallel_size=2 or 3, "
+                f"but got cfg_parallel_size={cfg_world_size}."
+            )
         if cfg_world_size == 3 and not use_cfg_img:
             raise ValueError(
                 f"cfg_parallel_size=3 requires cfg_img_scale > 1.0, "
                 f"but got cfg_img_scale={cfg_img_scale}. "
                 f"Use cfg_parallel_size=2 for text-only CFG parallel(text2img), or set cfg_img_scale > 1.0."
-            )
-        if cfg_world_size == 2 and use_cfg_img:
-            raise ValueError(
-                f"Image CFG (cfg_img_scale={cfg_img_scale}) requires cfg_parallel_size=3, "
-                f"but got cfg_parallel_size=2. "
-                f"Use cfg_parallel_size=3 to enable image CFG in parallel mode."
             )
 
         # Ensure all ranks start with the same x_t (initial noise may differ
@@ -1890,21 +2092,40 @@ class Bagel(nn.Module):
         x_t = x_t.contiguous()
         cfg_group.broadcast(x_t, src=0)
 
-        # Select this rank's branch inputs
+        gen_branch = (
+            packed_position_ids,
+            packed_indexes,
+            past_key_values,
+            key_values_lens,
+            packed_key_value_indexes,
+        )
+        text_branch = (
+            cfg_text_packed_position_ids,
+            cfg_text_packed_query_indexes,
+            cfg_text_past_key_values,
+            cfg_text_key_values_lens,
+            cfg_text_packed_key_value_indexes,
+        )
+        img_branch = (
+            cfg_img_packed_position_ids,
+            cfg_img_packed_query_indexes,
+            cfg_img_past_key_values,
+            cfg_img_key_values_lens,
+            cfg_img_packed_key_value_indexes,
+        )
+
+        # Select this rank's primary branch for all_gather.
         if cfg_rank == 0:
-            # Gen branch: use main inputs directly
-            branch_position_ids = packed_position_ids
-            branch_past_key_values = past_key_values
+            branch = gen_branch
         elif cfg_rank == 1:
-            # Text CFG branch
-            branch_position_ids = cfg_text_packed_position_ids
-            branch_past_key_values = cfg_text_past_key_values
+            branch = text_branch
         elif cfg_rank == 2:
-            # Image CFG branch
-            branch_position_ids = cfg_img_packed_position_ids
-            branch_past_key_values = cfg_img_past_key_values
+            branch = img_branch
         else:
-            raise RuntimeError(f"Unexpected cfg_rank={cfg_rank} for Bagel 3-branch CFG parallel")
+            raise RuntimeError(f"Unexpected cfg_rank={cfg_rank} for BAGEL CFG parallel")
+        branch_position_ids, branch_indexes, branch_past_key_values, branch_key_values_lens, branch_key_value_indexes = (
+            branch
+        )
 
         trajectory_latents: list[torch.Tensor] | None = [] if return_trajectory_latents else None
         trajectory_timesteps: list[torch.Tensor] | None = [] if return_trajectory_latents else None
@@ -1921,7 +2142,7 @@ class Bagel(nn.Module):
             use_cfg_this_step = t > cfg_interval[0] and t <= cfg_interval[1] and cfg_text_scale > 1.0
 
             if use_cfg_this_step:
-                # CFG interval: each rank computes its own branch
+                # CFG interval: each rank computes its primary branch.
                 local_v_t = self.forward_single_branch(
                     x_t=x_t,
                     timestep=timestep,
@@ -1934,11 +2155,39 @@ class Bagel(nn.Module):
                     past_key_values=branch_past_key_values,
                 )
 
+                cfg_img_v_t = None
+                if use_cfg_img and cfg_world_size == 2:
+                    if cfg_rank == 0:
+                        (
+                            img_position_ids,
+                            img_indexes,
+                            img_past_key_values,
+                            img_key_values_lens,
+                            img_key_value_indexes,
+                        ) = img_branch
+                        cfg_img_v_t = self.forward_single_branch(
+                            x_t=x_t,
+                            timestep=timestep,
+                            packed_vae_token_indexes=packed_vae_token_indexes,
+                            packed_vae_position_ids=packed_vae_position_ids,
+                            packed_text_ids=packed_text_ids,
+                            packed_text_indexes=packed_text_indexes,
+                            packed_indexes=img_indexes,
+                            packed_position_ids=img_position_ids,
+                            packed_seqlens=packed_seqlens,
+                            key_values_lens=img_key_values_lens,
+                            past_key_values=img_past_key_values,
+                            packed_key_value_indexes=img_key_value_indexes,
+                        )
+                    else:
+                        cfg_img_v_t = torch.empty_like(local_v_t)
+                    cfg_img_v_t = cfg_group.broadcast(cfg_img_v_t.contiguous(), src=0)
+
                 gathered = cfg_group.all_gather(local_v_t, separate_tensors=True)
                 v_t = self._combine_cfg(
                     gathered[0],
                     gathered[1],
-                    gathered[2] if (use_cfg_img and len(gathered) > 2) else None,
+                    cfg_img_v_t if cfg_world_size == 2 else (gathered[2] if use_cfg_img else None),
                     cfg_text_scale,
                     cfg_img_scale,
                     cfg_renorm_type,

--- a/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
+++ b/vllm_omni/diffusion/models/bagel/pipeline_bagel.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 
 import json
 import os
+import random
+import time
 from collections.abc import Iterable
 from copy import deepcopy
 from dataclasses import dataclass
 from math import isqrt
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 import torch
@@ -37,16 +39,101 @@ from .bagel_transformer import Bagel, NaiveCache, Qwen2MoTConfig, Qwen2MoTForCau
 
 logger = init_logger(__name__)
 
+GEN_THINK_SYSTEM_PROMPT = (
+    "You should first think about the planning process in the mind and then "
+    "generate the image.\n"
+    "The planning process is enclosed within <think> </think> tags, i.e. "
+    "<think> planning process here </think> image here"
+)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
 
 @dataclass
 class BagelGenParams:
     num_timesteps: int = 50
     timestep_shift: float = 3.0
-    cfg_text_scale: float = 4.0
+    # Defaults aligned with ThinkMorphInterleaved / Bagel.py canonical values
+    # (see VLMEvalKit_Thinkmorph/vlmeval/vlm/ThinkMorphInterleaved.py:171-176).
+    # Previously cfg_text_scale=4.0 / cfg_renorm_min=0.0 — diverged from canonical.
+    cfg_text_scale: float = 3.0
     cfg_img_scale: float = 1.5
     cfg_interval: tuple = (0.4, 1.0)
-    cfg_renorm_min: float = 0.0
+    cfg_renorm_min: float = 1.0
     cfg_renorm_type: str = "global"
+
+
+# ---------------------------------------------------------------------------
+# Canonical Bagel image preprocessing — port of bagel/src/models/bagel/transforms.py
+# (MaxLongEdgeMinShortEdgeResize + ImageTransform). The transforms themselves
+# are separate (VAE: 1024/512/16, ViT: 980/224/14), but the local
+# force-interleaved path first VAE-resizes image inputs and then feeds that
+# resized image into both VAE and ViT context updates.
+# ---------------------------------------------------------------------------
+
+
+class _MaxLongEdgeMinShortEdgeResize:
+    def __init__(self, max_size: int, min_size: int, stride: int, max_pixels: int):
+        self.max_size = max_size
+        self.min_size = min_size
+        self.stride = stride
+        self.max_pixels = max_pixels
+
+    def _make_divisible(self, v: float) -> int:
+        return max(self.stride, int(round(v / self.stride) * self.stride))
+
+    def _apply_scale(self, w: int, h: int, scale: float) -> tuple[int, int]:
+        return self._make_divisible(round(w * scale)), self._make_divisible(round(h * scale))
+
+    def __call__(self, img: Image.Image, img_num: int = 1) -> Image.Image:
+        if img.mode != "RGB":
+            img = img.convert("RGB")
+        w, h = img.size
+        scale = min(self.max_size / max(w, h), 1.0)
+        scale = max(scale, self.min_size / min(w, h))
+        new_w, new_h = self._apply_scale(w, h, scale)
+        if new_w * new_h > self.max_pixels / img_num:
+            scale = self.max_pixels / img_num / (new_w * new_h)
+            new_w, new_h = self._apply_scale(new_w, new_h, scale)
+        if max(new_w, new_h) > self.max_size:
+            scale = self.max_size / max(new_w, new_h)
+            new_w, new_h = self._apply_scale(new_w, new_h, scale)
+        if (new_w, new_h) != (w, h):
+            img = img.resize((new_w, new_h), Image.BICUBIC)
+        return img
+
+
+class _ImageTransform:
+    """Resize PIL → [-1, 1] CHW tensor. Mirrors bagel/src/models/bagel/transforms.py:92."""
+
+    def __init__(
+        self,
+        max_image_size: int,
+        min_image_size: int,
+        image_stride: int,
+        max_pixels: int = 14 * 14 * 9 * 1024,
+        image_mean: tuple[float, float, float] = (0.5, 0.5, 0.5),
+        image_std: tuple[float, float, float] = (0.5, 0.5, 0.5),
+    ):
+        self.resize = _MaxLongEdgeMinShortEdgeResize(max_image_size, min_image_size, image_stride, max_pixels)
+        self.mean = torch.tensor(image_mean).view(3, 1, 1)
+        self.std = torch.tensor(image_std).view(3, 1, 1)
+
+    def resize_only(self, img: Image.Image, img_num: int = 1) -> Image.Image:
+        return self.resize(img, img_num=img_num)
+
+    def __call__(self, img: Image.Image, img_num: int = 1) -> torch.Tensor:
+        img = self.resize(img, img_num=img_num)
+        arr = torch.from_numpy(np.array(img)).float() / 255.0  # HWC, [0, 1]
+        arr = arr.permute(2, 0, 1)  # CHW
+        mean = self.mean.to(device=arr.device, dtype=arr.dtype)
+        std = self.std.to(device=arr.device, dtype=arr.dtype)
+        arr = (arr - mean) / std  # → [-1, 1] with mean=std=0.5
+        return arr
 
 
 def add_special_tokens(tokenizer):
@@ -147,7 +234,8 @@ class SiglipNaViTWrapper(nn.Module):
             mask[..., start:end, start:end] = 0.0
 
         outputs = self.vision_model.encoder(inputs_embeds=hidden_states, attention_mask=mask)
-        return outputs.last_hidden_state.squeeze(0)
+        hidden_states = outputs.last_hidden_state.squeeze(0)
+        return self.vision_model.post_layernorm(hidden_states)
 
 
 class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProfilerMixin):
@@ -156,6 +244,7 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
     This pipeline is self-contained and uses the ported Bagel core files.
     """
 
+    SUPPORTS_REQUEST_BATCHING: ClassVar[bool] = True
     _dit_modules: ClassVar[list[str]] = ["language_model.model"]
     _encoder_modules: ClassVar[list[str]] = []
     _vae_modules: ClassVar[list[str]] = ["vae"]
@@ -168,6 +257,35 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
         "bagel.connector",
         "bagel.vit_pos_embed",
     ]
+    EXTRA_BODY_PARAMS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "force_interleaved",
+            "force_stage1_continue",
+            "force_batch_text",
+            "force_reencode_text",
+            "max_think_token_n",
+            "max_think_tokens",
+            "max_answer_token_n",
+            "max_answer_tokens",
+            "do_sample",
+            "answer_do_sample",
+            "text_temperature",
+            "text_repeat_stop_n",
+            "cfg_text_scale",
+            "cfg_img_scale",
+            "cfg_interval",
+            "cfg_renorm_min",
+            "cfg_renorm_type",
+            "timestep_shift",
+            "num_timesteps",
+        }
+    )
+    EXTRA_OUTPUT_PARAMS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "force_interleaved",
+            "think_text",
+        }
+    )
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
         super().__init__()
@@ -234,6 +352,24 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
 
         self.tokenizer, self.new_token_ids, _ = add_special_tokens(self.tokenizer)
 
+        # Register the ThinkMorph action token <gen_image>. Canonical
+        # ThinkMorphInterleaved adapter does this at init time
+        # (VLMEvalKit_Thinkmorph/vlmeval/vlm/ThinkMorphInterleaved.py:131-136).
+        # Without it, the model never emits the token id that triggers
+        # interleaved image generation, even if the checkpoint expects it.
+        _action_token = "<gen_image>"
+        if _action_token not in self.tokenizer.get_vocab():
+            self.tokenizer.add_tokens([_action_token])
+        self.new_token_ids["image_action_token_id"] = self.tokenizer.convert_tokens_to_ids(_action_token)
+        self.new_token_ids["register_action_token"] = True
+
+        # Two canonical image transforms — VAE-side and ViT-side use different
+        # max/min/stride ladders (1024/512/16 vs 980/224/14). See
+        # bagel/src/models/bagel/transforms.py and
+        # VLMEvalKit_Thinkmorph/vlmeval/vlm/Bagel.py:226-227.
+        self._vae_transform = _ImageTransform(1024, 512, 16)
+        self._vit_transform = _ImageTransform(980, 224, 14)
+
         tok_len = len(self.tokenizer)
         required_max_id = max(int(v) for v in self.new_token_ids.values())
         llm_config.vocab_size = max(
@@ -269,7 +405,14 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
                 connector_act=str(bagel_cfg.get("connector_act", "gelu_pytorch_tanh")),
                 interpolate_pos=bool(bagel_cfg.get("interpolate_pos", False)),
                 latent_patch_size=int(bagel_cfg.get("latent_patch_size", 2)),
-                max_latent_size=int(bagel_cfg.get("max_latent_size", 32)),
+                # The public BAGEL config.json says 32, but the released
+                # checkpoint and the canonical VLMEvalKit loader use a 64x64
+                # latent positional table. Using 32 makes 1024px VAE inputs
+                # index past latent_pos_embed and trips a CUDA gather assert.
+                max_latent_size=int(os.environ.get(
+                    "BAGEL_MAX_LATENT_SIZE",
+                    max(64, int(bagel_cfg.get("max_latent_size", 64))),
+                )),
                 timestep_shift=float(bagel_cfg.get("timestep_shift", 1.0)),
             ),
         )
@@ -295,9 +438,40 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
         #    rather than eagerly placing the full model on one GPU.
         if quant_config is None and not (od_config.enable_layerwise_offload or od_config.parallel_config.use_hsdp):
             self.to(self.device)
+        self._bagel_global_seed: int | None = None
+        self._bagel_reseeded_after_warmup = False
+        seed_raw = os.environ.get("BAGEL_GLOBAL_SEED", "").strip().lower()
+        if seed_raw not in {"", "none", "null", "-1"}:
+            self._bagel_global_seed = int(seed_raw)
+            self._seed_global_rng(self._bagel_global_seed)
         self.setup_diffusion_pipeline_profiler(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
+
+    @staticmethod
+    def _seed_global_rng(seed: int) -> None:
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+    @staticmethod
+    def _is_dummy_request(req: OmniDiffusionRequest) -> bool:
+        request_ids = getattr(req, "request_ids", None) or ()
+        return len(request_ids) == 1 and request_ids[0] == "dummy_req_id"
+
+    def _maybe_reseed_after_warmup(self, reqs: OmniDiffusionRequest | list[OmniDiffusionRequest]) -> None:
+        if self._bagel_global_seed is None or self._bagel_reseeded_after_warmup:
+            return
+        req_list = reqs if isinstance(reqs, list) else [reqs]
+        if req_list and all(self._is_dummy_request(req) for req in req_list):
+            return
+        self._seed_global_rng(self._bagel_global_seed)
+        self._bagel_reseeded_after_warmup = True
+        logger.info("BAGEL global RNG reseeded after warmup with seed=%d", self._bagel_global_seed)
 
     @staticmethod
     def _decode_image_from_latent(
@@ -319,8 +493,1274 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
         image = (image * 0.5 + 0.5).clamp(0, 1)[0].permute(1, 2, 0) * 255
         return Image.fromarray(image.to(torch.uint8).cpu().numpy())
 
+    def _move_generation_input_to_device(self, generation_input: dict[str, Any]) -> dict[str, Any]:
+        for k, v in generation_input.items():
+            if torch.is_tensor(v):
+                generation_input[k] = v.to(self.device)
+        return generation_input
+
+    def _decode_generated_text(self, token_ids: torch.Tensor) -> str:
+        decoded = self.tokenizer.decode(token_ids[:, 0].tolist())
+        text = decoded.split("<|im_end|>")[0]
+        if "<|im_start|>" in text:
+            text = text.split("<|im_start|>")[-1]
+        return text
+
+    @staticmethod
+    def _force_visible_answer(text: str) -> str:
+        text = (text or "").strip()
+        if not text:
+            return ""
+        if "<think>" in text and "</think>" in text:
+            before_end, after_end = text.split("</think>", 1)
+            inner = before_end.split("<think>", 1)[-1].strip()
+            rest = after_end.strip()
+            return rest or inner
+        return text.replace("<think>", "").replace("</think>", "").strip()
+
+    def _update_context_text(
+        self,
+        gen_context: dict[str, Any],
+        text: str,
+    ) -> dict[str, Any]:
+        clean_text = text.removeprefix("<|im_start|>").removesuffix("<|im_end|>")
+        generation_input, newlens, new_rope = self.bagel.prepare_prompts(
+            curr_kvlens=gen_context["kv_lens"],
+            curr_rope=gen_context["ropes"],
+            prompts=[clean_text],
+            tokenizer=self.tokenizer,
+            new_token_ids=self.new_token_ids,
+        )
+        max_tid = int(generation_input["packed_text_ids"].max().item())
+        emb_n = int(self.language_model.vocab_size)
+        if max_tid >= emb_n:
+            raise ValueError(
+                "Tokenizer/model vocab mismatch: max token id "
+                f"{max_tid} >= embed_tokens size {emb_n}. "
+                "This usually means the tokenizer token IDs do not match the checkpoint embeddings."
+            )
+        generation_input = self._move_generation_input_to_device(generation_input)
+        with torch.autocast(
+            device_type=self.device.type,
+            enabled=self.device.type != "cpu",
+            dtype=self.od_config.dtype,
+        ):
+            gen_context["past_key_values"] = self.bagel.forward_cache_update_text(
+                gen_context["past_key_values"], **generation_input
+            )
+        gen_context["kv_lens"] = newlens
+        gen_context["ropes"] = new_rope
+        return gen_context
+
+    def _update_context_image(
+        self,
+        gen_context: dict[str, Any],
+        image: Image.Image,
+        *,
+        vae: bool,
+        vit: bool,
+    ) -> tuple[dict[str, Any], tuple[int, int] | None]:
+        if not (vae or vit):
+            raise ValueError("At least one of vae/vit must be enabled.")
+
+        image_shape: tuple[int, int] | None = None
+        rgb_image = image.convert("RGB") if image.mode != "RGB" else image
+        vae_image = rgb_image
+        if vae:
+            vae_image = self._vae_transform.resize_only(rgb_image)
+            resized_w, resized_h = vae_image.size
+            image_shape = (resized_h, resized_w)
+
+            gen_input_vae, newlens_vae, new_rope_vae = self.bagel.prepare_vae_images(
+                curr_kvlens=gen_context["kv_lens"],
+                curr_rope=gen_context["ropes"],
+                images=[vae_image],
+                transforms=self._vae_transform,
+                new_token_ids=self.new_token_ids,
+            )
+            gen_input_vae = self._move_generation_input_to_device(gen_input_vae)
+            with torch.autocast(
+                device_type=self.device.type,
+                enabled=self.device.type != "cpu",
+                dtype=self.od_config.dtype,
+            ):
+                gen_context["past_key_values"] = self.bagel.forward_cache_update_vae(
+                    self.vae, gen_context["past_key_values"], **gen_input_vae
+                )
+            gen_context["kv_lens"] = newlens_vae
+            gen_context["ropes"] = new_rope_vae
+
+        if vit:
+            # Local force_interleave_inference VAE-resizes image inputs before
+            # calling update_context_image(..., vae=True, vit=True). Preserve
+            # that behavior when both branches are active; pure ViT updates
+            # still use the original RGB image.
+            vit_image = vae_image if vae else rgb_image
+            gen_input_img, newlens_img, new_rope_img = self.bagel.prepare_vit_images(
+                curr_kvlens=gen_context["kv_lens"],
+                curr_rope=gen_context["ropes"],
+                images=[vit_image],
+                transforms=self._vit_transform,
+                new_token_ids=self.new_token_ids,
+            )
+            gen_input_img = self._move_generation_input_to_device(gen_input_img)
+            with torch.autocast(
+                device_type=self.device.type,
+                enabled=self.device.type != "cpu",
+                dtype=self.od_config.dtype,
+            ):
+                gen_context["past_key_values"] = self.bagel.forward_cache_update_vit(
+                    gen_context["past_key_values"], **gen_input_img
+                )
+            gen_context["kv_lens"] = newlens_img
+            gen_context["ropes"] = new_rope_img
+
+        return gen_context, image_shape
+
+    def _decode_generated_text_sequence(self, token_ids: torch.Tensor) -> str:
+        if token_ids.numel() == 0:
+            return ""
+        if token_ids.ndim == 2:
+            ids = token_ids[:, 0].tolist()
+        else:
+            ids = token_ids.tolist()
+        decoded = self.tokenizer.decode(ids)
+        text = decoded.split("<|im_end|>")[0]
+        if "<|im_start|>" in text:
+            text = text.split("<|im_start|>")[-1]
+        return text
+
+    def _empty_context(self, batch_size: int) -> dict[str, Any]:
+        return {
+            "kv_lens": [0] * batch_size,
+            "ropes": [0] * batch_size,
+            "past_key_values": NaiveCache(self.bagel.config.llm_config.num_hidden_layers),
+        }
+
+    def _merge_contexts(self, contexts: list[dict[str, Any]]) -> dict[str, Any]:
+        merged_kv_lens: list[int] = []
+        merged_ropes: list[int] = []
+        caches = []
+        for context in contexts:
+            merged_kv_lens.extend(int(x) for x in context["kv_lens"])
+            merged_ropes.extend(int(x) for x in context["ropes"])
+            caches.append(context["past_key_values"])
+        return {
+            "kv_lens": merged_kv_lens,
+            "ropes": merged_ropes,
+            "past_key_values": self.bagel._merge_naive_caches(caches),
+        }
+
+    def _adopt_generated_text_batch_context(
+        self,
+        target_context: dict[str, Any],
+        generated_context: dict[str, Any],
+        original_kv_lens: list[int],
+        original_ropes: list[int],
+        token_sequences: list[torch.Tensor],
+    ) -> None:
+        """Keep exact batched text-generation KV, trimming finished-row padding.
+
+        `batch_generate_text` must keep every row in the packed cache until all
+        rows finish, so shorter rows receive extra post-finish tokens. Local
+        single-sample force mode continues from the exact generated-token KV,
+        without re-encoding decoded text or adding an EOS prompt token. Trim the
+        packed cache back to each row's real generated length to preserve that
+        contract for the batched Stage 1 path.
+        """
+        generated_lengths = [int(seq.shape[0]) if torch.is_tensor(seq) else len(seq) for seq in token_sequences]
+        if not generated_lengths:
+            target_context["past_key_values"] = generated_context["past_key_values"]
+            target_context["kv_lens"] = list(original_kv_lens)
+            target_context["ropes"] = list(original_ropes)
+            return
+
+        source_cache = generated_context["past_key_values"]
+        total_cache_len = self._cache_seq_len(source_cache)
+        original_total = sum(int(x) for x in original_kv_lens)
+        batch_size = len(original_kv_lens)
+        if batch_size <= 0:
+            return
+
+        # In the common case all rows finish at the same step. If the cache
+        # shape is unavailable, falling back to max length is still consistent.
+        global_steps = max(generated_lengths)
+        if total_cache_len >= original_total:
+            delta = total_cache_len - original_total
+            if delta % batch_size == 0:
+                global_steps = delta // batch_size
+
+        full_lens = [int(kv_len) + global_steps for kv_len in original_kv_lens]
+        keep_lens = [
+            int(kv_len) + int(gen_len)
+            for kv_len, gen_len in zip(original_kv_lens, generated_lengths)
+        ]
+
+        trimmed_cache = NaiveCache(source_cache.num_layers)
+        for layer_idx in range(source_cache.num_layers):
+            key_cache = source_cache.key_cache[layer_idx]
+            value_cache = source_cache.value_cache[layer_idx]
+            if key_cache is None or value_cache is None:
+                continue
+            key_chunks = []
+            value_chunks = []
+            cursor = 0
+            for full_len, keep_len in zip(full_lens, keep_lens):
+                key_chunks.append(key_cache[cursor : cursor + keep_len])
+                value_chunks.append(value_cache[cursor : cursor + keep_len])
+                cursor += full_len
+            trimmed_cache.key_cache[layer_idx] = torch.cat(key_chunks, dim=0)
+            trimmed_cache.value_cache[layer_idx] = torch.cat(value_chunks, dim=0)
+
+        target_context["past_key_values"] = trimmed_cache
+        target_context["kv_lens"] = keep_lens
+        target_context["ropes"] = [
+            int(rope) + int(gen_len)
+            for rope, gen_len in zip(original_ropes, generated_lengths)
+        ]
+
+    @staticmethod
+    def _cache_seq_len(past_key_values: NaiveCache) -> int:
+        key_cache = past_key_values.key_cache
+        values = key_cache.values() if hasattr(key_cache, "values") else key_cache
+        for key_cache in values:
+            if key_cache is not None:
+                return int(key_cache.shape[0])
+        return 0
+
+    @staticmethod
+    def _slice_cache_prefix(past_key_values: NaiveCache, keep_len: int) -> NaiveCache:
+        key_cache = past_key_values.key_cache
+        value_cache = past_key_values.value_cache
+        num_layers = (
+            past_key_values.num_layers
+            if hasattr(past_key_values, "num_layers")
+            else len(key_cache)
+        )
+        sliced = NaiveCache(num_layers)
+        for layer_idx in range(num_layers):
+            k = key_cache[layer_idx]
+            v = value_cache[layer_idx]
+            if k is None or v is None:
+                continue
+            sliced.key_cache[layer_idx] = k[:keep_len].clone()
+            sliced.value_cache[layer_idx] = v[:keep_len].clone()
+        return sliced
+
+    @staticmethod
+    def _first_rope(value: Any, default: int) -> int:
+        if value is None:
+            return int(default)
+        if isinstance(value, (list, tuple)):
+            return int(value[0]) if value else int(default)
+        return int(value)
+
+    def _update_context_text_batch(
+        self,
+        gen_context: dict[str, Any],
+        texts: list[str],
+    ) -> dict[str, Any]:
+        clean_texts = [
+            (text or "").removeprefix("<|im_start|>").removesuffix("<|im_end|>")
+            for text in texts
+        ]
+        generation_input, newlens, new_rope = self.bagel.prepare_prompts(
+            curr_kvlens=gen_context["kv_lens"],
+            curr_rope=gen_context["ropes"],
+            prompts=clean_texts,
+            tokenizer=self.tokenizer,
+            new_token_ids=self.new_token_ids,
+        )
+        if generation_input["packed_text_ids"].numel() > 0:
+            max_tid = int(generation_input["packed_text_ids"].max().item())
+            emb_n = int(self.language_model.vocab_size)
+            if max_tid >= emb_n:
+                raise ValueError(
+                    "Tokenizer/model vocab mismatch: max token id "
+                    f"{max_tid} >= embed_tokens size {emb_n}."
+                )
+        generation_input = self._move_generation_input_to_device(generation_input)
+        with torch.autocast(
+            device_type=self.device.type,
+            enabled=self.device.type != "cpu",
+            dtype=self.od_config.dtype,
+        ):
+            gen_context["past_key_values"] = self.bagel.forward_cache_update_text(
+                gen_context["past_key_values"], **generation_input
+            )
+        gen_context["kv_lens"] = newlens
+        gen_context["ropes"] = new_rope
+        return gen_context
+
+    def _update_context_image_batch(
+        self,
+        gen_context: dict[str, Any],
+        images: list[Image.Image],
+        *,
+        vae: bool,
+        vit: bool,
+    ) -> tuple[dict[str, Any], list[tuple[int, int] | None]]:
+        if not (vae or vit):
+            raise ValueError("At least one of vae/vit must be enabled.")
+
+        rgb_images = [img.convert("RGB") if isinstance(img, Image.Image) else img for img in images]
+        image_shapes: list[tuple[int, int] | None] = [None] * len(rgb_images)
+        vae_images = rgb_images
+
+        if vae:
+            vae_images = [self._vae_transform.resize_only(img) for img in rgb_images]
+            image_shapes = [(img.size[1], img.size[0]) for img in vae_images]
+
+            gen_input_vae, newlens_vae, new_rope_vae = self.bagel.prepare_vae_images(
+                curr_kvlens=gen_context["kv_lens"],
+                curr_rope=gen_context["ropes"],
+                images=vae_images,
+                transforms=self._vae_transform,
+                new_token_ids=self.new_token_ids,
+            )
+            gen_input_vae = self._move_generation_input_to_device(gen_input_vae)
+            with torch.autocast(
+                device_type=self.device.type,
+                enabled=self.device.type != "cpu",
+                dtype=self.od_config.dtype,
+            ):
+                gen_context["past_key_values"] = self.bagel.forward_cache_update_vae(
+                    self.vae, gen_context["past_key_values"], **gen_input_vae
+                )
+            gen_context["kv_lens"] = newlens_vae
+            gen_context["ropes"] = new_rope_vae
+
+        if vit:
+            # Match local force-interleaved context updates: VAE+ViT receives
+            # the VAE-resized image; ViT-only receives the original image.
+            vit_images = vae_images if vae else rgb_images
+            gen_input_img, newlens_img, new_rope_img = self.bagel.prepare_vit_images(
+                curr_kvlens=gen_context["kv_lens"],
+                curr_rope=gen_context["ropes"],
+                images=vit_images,
+                transforms=self._vit_transform,
+                new_token_ids=self.new_token_ids,
+            )
+            gen_input_img = self._move_generation_input_to_device(gen_input_img)
+            with torch.autocast(
+                device_type=self.device.type,
+                enabled=self.device.type != "cpu",
+                dtype=self.od_config.dtype,
+            ):
+                gen_context["past_key_values"] = self.bagel.forward_cache_update_vit(
+                    gen_context["past_key_values"], **gen_input_img
+                )
+            gen_context["kv_lens"] = newlens_img
+            gen_context["ropes"] = new_rope_img
+
+        return gen_context, image_shapes
+
+    def _generate_texts_from_context_batch(
+        self,
+        gen_context: dict[str, Any],
+        *,
+        max_tokens: int,
+        do_sample: bool,
+        text_temperature: float,
+        sampling_generators: list[torch.Generator | None] | None = None,
+        repeat_stop_n: int | None = None,
+        adopt_context: bool = True,
+    ) -> list[str]:
+        with torch.autocast(
+            device_type=self.device.type,
+            enabled=self.device.type != "cpu",
+            dtype=self.od_config.dtype,
+        ):
+            start_input = self.bagel.prepare_start_tokens(
+                gen_context["kv_lens"], gen_context["ropes"], self.new_token_ids
+            )
+            start_input = self._move_generation_input_to_device(start_input)
+            gen_ctx_copy = deepcopy(gen_context)
+            original_kv_lens = list(gen_context["kv_lens"])
+            original_ropes = list(gen_context["ropes"])
+            token_sequences = self.bagel.batch_generate_text(
+                past_key_values=gen_ctx_copy["past_key_values"],
+                max_length=max_tokens,
+                do_sample=do_sample,
+                temperature=text_temperature,
+                end_token_id=self.new_token_ids["eos_token_id"],
+                sampling_generators=sampling_generators,
+                repeat_stop_n=repeat_stop_n,
+                **start_input,
+            )
+        texts = [self._decode_generated_text_sequence(seq) for seq in token_sequences]
+        if adopt_context:
+            self._adopt_generated_text_batch_context(
+                gen_context,
+                gen_ctx_copy,
+                original_kv_lens,
+                original_ropes,
+                token_sequences,
+            )
+        return texts
+
+    def _make_text_sampling_generators(
+        self,
+        reqs: list[OmniDiffusionRequest],
+    ) -> list[torch.Generator | None] | None:
+        if not any(req.sampling_params.seed is not None for req in reqs):
+            return None
+        generators: list[torch.Generator | None] = []
+        for req in reqs:
+            seed = req.sampling_params.seed
+            if seed is None:
+                generators.append(None)
+                continue
+            generator = torch.Generator(device=self.device)
+            generator.manual_seed(int(seed))
+            generators.append(generator)
+        return generators
+
+    def _validate_image_generation_input(
+        self,
+        generation_input: dict[str, Any],
+        image_shapes: list[tuple[int, int]],
+    ) -> None:
+        if generation_input["packed_text_ids"].numel() > 0:
+            max_tid_img = int(generation_input["packed_text_ids"].max().item())
+            emb_n = int(self.language_model.vocab_size)
+            if max_tid_img >= emb_n:
+                raise ValueError(
+                    "Tokenizer/model vocab mismatch (image path): max token id "
+                    f"{max_tid_img} >= embed_tokens size {emb_n}."
+                )
+        min_pid = int(generation_input["packed_position_ids"].min().item())
+        if min_pid < 0:
+            raise ValueError(f"Invalid packed_position_ids: min={min_pid} (must be >= 0)")
+        max_lat_pid = int(generation_input["packed_vae_position_ids"].max().item())
+        max_lat_pid_allowed = int(self.bagel.max_latent_size * self.bagel.max_latent_size) - 1
+        if max_lat_pid > max_lat_pid_allowed:
+            raise ValueError(
+                "Invalid packed_vae_position_ids (latent position embedding OOB): "
+                f"max={max_lat_pid} > allowed_max={max_lat_pid_allowed}. "
+                f"Requested image_shapes={image_shapes}, max_latent_size={self.bagel.max_latent_size}."
+            )
+
+    def _generate_images_from_context_batch(
+        self,
+        reqs: list[OmniDiffusionRequest],
+        gen_context: dict[str, Any],
+        cfg_text_context: dict[str, Any],
+        cfg_img_context: dict[str, Any],
+        image_shapes: list[tuple[int, int]],
+        gen_params: BagelGenParams,
+    ) -> list[Image.Image]:
+        generation_input = self.bagel.prepare_vae_latent(
+            curr_kvlens=gen_context["kv_lens"],
+            curr_rope=gen_context["ropes"],
+            image_sizes=image_shapes,
+            new_token_ids=self.new_token_ids,
+            noise_seeds=[req.sampling_params.seed for req in reqs],
+        )
+        self._validate_image_generation_input(generation_input, image_shapes)
+        generation_input = self._move_generation_input_to_device(generation_input)
+
+        generation_input_cfg_text = self.bagel.prepare_vae_latent_cfg(
+            curr_kvlens=cfg_text_context["kv_lens"],
+            curr_rope=cfg_text_context["ropes"],
+            image_sizes=image_shapes,
+        )
+        generation_input_cfg_img = self.bagel.prepare_vae_latent_cfg(
+            curr_kvlens=cfg_img_context["kv_lens"],
+            curr_rope=cfg_img_context["ropes"],
+            image_sizes=image_shapes,
+        )
+        generation_input_cfg_text = self._move_generation_input_to_device(generation_input_cfg_text)
+        generation_input_cfg_img = self._move_generation_input_to_device(generation_input_cfg_img)
+
+        with torch.autocast(
+            device_type=self.device.type,
+            enabled=self.device.type != "cpu",
+            dtype=self.od_config.dtype,
+        ):
+            latents, _, _, _ = self.bagel.generate_image(
+                past_key_values=gen_context["past_key_values"],
+                cfg_text_past_key_values=cfg_text_context["past_key_values"],
+                cfg_img_past_key_values=cfg_img_context["past_key_values"],
+                num_timesteps=gen_params.num_timesteps,
+                timestep_shift=gen_params.timestep_shift,
+                cfg_text_scale=gen_params.cfg_text_scale,
+                cfg_img_scale=gen_params.cfg_img_scale,
+                cfg_interval=gen_params.cfg_interval,
+                cfg_renorm_min=gen_params.cfg_renorm_min,
+                cfg_renorm_type=gen_params.cfg_renorm_type,
+                **generation_input,
+                cfg_text_packed_position_ids=generation_input_cfg_text["cfg_packed_position_ids"],
+                cfg_text_packed_query_indexes=generation_input_cfg_text["cfg_packed_query_indexes"],
+                cfg_text_key_values_lens=generation_input_cfg_text["cfg_key_values_lens"],
+                cfg_text_packed_key_value_indexes=generation_input_cfg_text["cfg_packed_key_value_indexes"],
+                cfg_img_packed_position_ids=generation_input_cfg_img["cfg_packed_position_ids"],
+                cfg_img_packed_query_indexes=generation_input_cfg_img["cfg_packed_query_indexes"],
+                cfg_img_key_values_lens=generation_input_cfg_img["cfg_key_values_lens"],
+                cfg_img_packed_key_value_indexes=generation_input_cfg_img["cfg_packed_key_value_indexes"],
+                return_trajectory_latents=False,
+                scheduler=self.scheduler,
+                scheduler_kwargs=self.scheduler_kwargs,
+            )
+        return [
+            self._decode_image_from_latent(self.bagel, self.vae, latent, image_shape)
+            for latent, image_shape in zip(latents, image_shapes)
+        ]
+
+    def _generate_text_from_context(
+        self,
+        gen_context: dict[str, Any],
+        *,
+        max_tokens: int,
+        do_sample: bool,
+        text_temperature: float,
+        adopt_context: bool = True,
+        repeat_stop_n: int | None = None,
+    ) -> str:
+        with torch.autocast(
+            device_type=self.device.type,
+            enabled=self.device.type != "cpu",
+            dtype=self.od_config.dtype,
+        ):
+            start_input = self.bagel.prepare_start_tokens(
+                gen_context["kv_lens"], gen_context["ropes"], self.new_token_ids
+            )
+            start_input = self._move_generation_input_to_device(start_input)
+            gen_ctx_copy = deepcopy(gen_context)
+            token_ids = self.bagel.generate_text(
+                past_key_values=gen_ctx_copy["past_key_values"],
+                max_length=max_tokens,
+                do_sample=do_sample,
+                temperature=text_temperature,
+                end_token_id=self.new_token_ids["eos_token_id"],
+                repeat_stop_n=repeat_stop_n,
+                **start_input,
+            )
+        if adopt_context:
+            gen_context["past_key_values"] = gen_ctx_copy["past_key_values"]
+            gen_context["kv_lens"] = [
+                kv_len + token_ids.shape[0] for kv_len in gen_context["kv_lens"]
+            ]
+            gen_context["ropes"] = [
+                rope + token_ids.shape[0] for rope in gen_context["ropes"]
+            ]
+        return self._decode_generated_text(token_ids)
+
+    def _generate_image_from_context(
+        self,
+        req: OmniDiffusionRequest,
+        gen_context: dict[str, Any],
+        cfg_text_context: dict[str, Any],
+        cfg_img_context: dict[str, Any],
+        image_shape: tuple[int, int],
+        gen_params: BagelGenParams,
+    ) -> Image.Image:
+        generation_input = self.bagel.prepare_vae_latent(
+            curr_kvlens=gen_context["kv_lens"],
+            curr_rope=gen_context["ropes"],
+            image_sizes=[image_shape],
+            new_token_ids=self.new_token_ids,
+        )
+        max_tid_img = int(generation_input["packed_text_ids"].max().item())
+        emb_n = int(self.language_model.vocab_size)
+        if max_tid_img >= emb_n:
+            raise ValueError(
+                "Tokenizer/model vocab mismatch (image path): max token id "
+                f"{max_tid_img} >= embed_tokens size {emb_n}."
+            )
+        min_pid = int(generation_input["packed_position_ids"].min().item())
+        if min_pid < 0:
+            raise ValueError(f"Invalid packed_position_ids: min={min_pid} (must be >= 0)")
+        max_lat_pid = int(generation_input["packed_vae_position_ids"].max().item())
+        max_lat_pid_allowed = int(self.bagel.max_latent_size * self.bagel.max_latent_size) - 1
+        if max_lat_pid > max_lat_pid_allowed:
+            raise ValueError(
+                "Invalid packed_vae_position_ids (latent position embedding OOB): "
+                f"max={max_lat_pid} > allowed_max={max_lat_pid_allowed}. "
+                f"Requested image_shape={image_shape}, max_latent_size={self.bagel.max_latent_size}."
+            )
+        generation_input = self._move_generation_input_to_device(generation_input)
+
+        generation_input_cfg_text = self.bagel.prepare_vae_latent_cfg(
+            curr_kvlens=cfg_text_context["kv_lens"],
+            curr_rope=cfg_text_context["ropes"],
+            image_sizes=[image_shape],
+        )
+        generation_input_cfg_img = self.bagel.prepare_vae_latent_cfg(
+            curr_kvlens=cfg_img_context["kv_lens"],
+            curr_rope=cfg_img_context["ropes"],
+            image_sizes=[image_shape],
+        )
+        generation_input_cfg_text = self._move_generation_input_to_device(generation_input_cfg_text)
+        generation_input_cfg_img = self._move_generation_input_to_device(generation_input_cfg_img)
+
+        with torch.autocast(
+            device_type=self.device.type,
+            enabled=self.device.type != "cpu",
+            dtype=self.od_config.dtype,
+        ):
+            latents, _, _, _ = self.bagel.generate_image(
+                past_key_values=gen_context["past_key_values"],
+                cfg_text_past_key_values=cfg_text_context["past_key_values"],
+                cfg_img_past_key_values=cfg_img_context["past_key_values"],
+                num_timesteps=gen_params.num_timesteps,
+                timestep_shift=gen_params.timestep_shift,
+                cfg_text_scale=gen_params.cfg_text_scale,
+                cfg_img_scale=gen_params.cfg_img_scale,
+                cfg_interval=gen_params.cfg_interval,
+                cfg_renorm_min=gen_params.cfg_renorm_min,
+                cfg_renorm_type=gen_params.cfg_renorm_type,
+                **generation_input,
+                cfg_text_packed_position_ids=generation_input_cfg_text["cfg_packed_position_ids"],
+                cfg_text_packed_query_indexes=generation_input_cfg_text["cfg_packed_query_indexes"],
+                cfg_text_key_values_lens=generation_input_cfg_text["cfg_key_values_lens"],
+                cfg_text_packed_key_value_indexes=generation_input_cfg_text["cfg_packed_key_value_indexes"],
+                cfg_img_packed_position_ids=generation_input_cfg_img["cfg_packed_position_ids"],
+                cfg_img_packed_query_indexes=generation_input_cfg_img["cfg_packed_query_indexes"],
+                cfg_img_key_values_lens=generation_input_cfg_img["cfg_key_values_lens"],
+                cfg_img_packed_key_value_indexes=generation_input_cfg_img["cfg_packed_key_value_indexes"],
+                return_trajectory_latents=req.sampling_params.return_trajectory_latents,
+                scheduler=self.scheduler,
+                scheduler_kwargs=self.scheduler_kwargs,
+            )
+        return self._decode_image_from_latent(self.bagel, self.vae, latents[0], image_shape)
+
+    def _force_generation_settings(
+        self,
+        req: OmniDiffusionRequest,
+        extra_args: dict[str, Any],
+    ) -> tuple[BagelGenParams, int, int, bool, bool, float, int | None]:
+        force_params = BagelGenParams(
+            num_timesteps=int(
+                extra_args.get("num_timesteps")
+                or req.sampling_params.num_inference_steps
+                or 50
+            ),
+            timestep_shift=float(extra_args.get("timestep_shift", 3.0)),
+            # Keep force-interleaved defaults aligned with
+            # VLMEvalKit's active bagel_local_force_interleaved config.
+            cfg_text_scale=float(extra_args.get("cfg_text_scale", 4.0)),
+            cfg_img_scale=float(extra_args.get("cfg_img_scale", 2.0)),
+            cfg_interval=tuple(extra_args.get("cfg_interval", (0.0, 1.0))),
+            cfg_renorm_min=float(extra_args.get("cfg_renorm_min", 0.0)),
+            cfg_renorm_type=str(extra_args.get("cfg_renorm_type", "text_channel")),
+        )
+        max_think_tokens = int(
+            extra_args.get("max_think_token_n")
+            or extra_args.get("max_think_tokens")
+            or 4096
+        )
+        max_answer_tokens = int(
+            extra_args.get("max_answer_token_n")
+            or extra_args.get("max_answer_tokens")
+            or 4096
+        )
+        do_sample = _truthy(extra_args.get("do_sample", True))
+        answer_do_sample_raw = extra_args.get("answer_do_sample")
+        answer_do_sample = do_sample if answer_do_sample_raw is None else _truthy(answer_do_sample_raw)
+        text_temperature = float(extra_args.get("text_temperature", 0.3))
+        repeat_stop_n_raw = extra_args.get("text_repeat_stop_n", 64)
+        repeat_stop_n = int(repeat_stop_n_raw) if repeat_stop_n_raw is not None else None
+        return (
+            force_params,
+            max_think_tokens,
+            max_answer_tokens,
+            do_sample,
+            answer_do_sample,
+            text_temperature,
+            repeat_stop_n,
+        )
+
+    def _force_stage1_continue_forward(
+        self,
+        req: OmniDiffusionRequest,
+        gen_context: dict[str, Any],
+        cfg_text_context: dict[str, Any],
+        cfg_img_context: dict[str, Any],
+        image_shape: tuple[int, int],
+        extra_args: dict[str, Any],
+    ) -> DiffusionOutput:
+        if req.sampling_params.seed is not None:
+            torch.manual_seed(req.sampling_params.seed)
+            if self.device.type == "cuda":
+                torch.cuda.manual_seed(req.sampling_params.seed)
+
+        (
+            force_params,
+            max_think_tokens,
+            max_answer_tokens,
+            do_sample,
+            answer_do_sample,
+            text_temperature,
+            repeat_stop_n,
+        ) = self._force_generation_settings(req, extra_args)
+
+        reencode_text = _truthy(extra_args.get("force_reencode_text", False))
+        think_text = self._generate_text_from_context(
+            gen_context,
+            max_tokens=max_think_tokens,
+            do_sample=do_sample,
+            text_temperature=text_temperature,
+            adopt_context=not reencode_text,
+            repeat_stop_n=repeat_stop_n,
+        )
+        if reencode_text:
+            # Mirrors VLMEvalKit's batched force path: decoded think text is
+            # fed back through prepare_prompts before image generation.
+            gen_context = self._update_context_text(gen_context, think_text)
+
+        img = self._generate_image_from_context(
+            req,
+            gen_context,
+            cfg_text_context,
+            cfg_img_context,
+            image_shape,
+            force_params,
+        )
+
+        gen_context, _ = self._update_context_image(
+            gen_context,
+            img,
+            vae=True,
+            vit=True,
+        )
+
+        answer_text = self._generate_text_from_context(
+            gen_context,
+            max_tokens=max_answer_tokens,
+            do_sample=answer_do_sample,
+            text_temperature=text_temperature,
+            repeat_stop_n=repeat_stop_n,
+        )
+        answer_visible = self._force_visible_answer(answer_text)
+        trace_text = "\n".join(
+            part for part in (think_text, "[Generated Image]", answer_visible) if part
+        )
+
+        return DiffusionOutput(
+            output=img,
+            custom_output={
+                "text_output": trace_text,
+                "answer_text": answer_visible,
+                "raw_answer_text": answer_text,
+                "think_text": think_text,
+                "force_interleaved": True,
+                "stage1_continue": True,
+                "stage1_reencode_text": reencode_text,
+                "answer_do_sample": answer_do_sample,
+            },
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
+
+    def _resolve_request_image_shape(self, req: OmniDiffusionRequest) -> tuple[int, int]:
+        max_hw = int(self.bagel.max_latent_size * self.bagel.latent_downsample)
+        if req.sampling_params.height is None and req.sampling_params.width is None:
+            image_shape = (max_hw, max_hw)
+        else:
+            height = int(req.sampling_params.height) if req.sampling_params.height is not None else max_hw
+            width = int(req.sampling_params.width) if req.sampling_params.width is not None else max_hw
+            image_shape = (height, width)
+        if req.sampling_params.kv_metadata and "image_shape" in req.sampling_params.kv_metadata:
+            image_shape = tuple(req.sampling_params.kv_metadata["image_shape"])
+        height, width = image_shape
+        if height > max_hw or width > max_hw:
+            raise ValueError(
+                f"Requested resolution {height}x{width} exceeds Bagel checkpoint limit "
+                f"{max_hw}x{max_hw} (max_latent_size={self.bagel.max_latent_size}, "
+                f"latent_downsample={self.bagel.latent_downsample})."
+            )
+        return int(height), int(width)
+
+    def _force_stage1_contexts_from_request(
+        self,
+        req: OmniDiffusionRequest,
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], tuple[int, int]]:
+        injected_kv = req.sampling_params.past_key_values
+        if injected_kv is None:
+            raise ValueError("force_stage1_continue requires injected KV cache from Stage 0.")
+
+        image_shape = self._resolve_request_image_shape(req)
+        seq_len = self._cache_seq_len(injected_kv)
+        ropes = (
+            req.sampling_params.kv_metadata["ropes"]
+            if req.sampling_params.kv_metadata and "ropes" in req.sampling_params.kv_metadata
+            else seq_len
+        )
+        gen_context = {
+            "kv_lens": [seq_len],
+            "ropes": [self._first_rope(ropes, seq_len)],
+            "past_key_values": injected_kv,
+        }
+
+        cfg_text_context = self._empty_context(1)
+        cfg_img_context = self._empty_context(1)
+
+        branch_kvs = getattr(req.sampling_params, "cfg_branch_past_key_values", None) or {}
+        branch_metadata = getattr(req.sampling_params, "cfg_branch_kv_metadata", None) or {}
+        cfg_text_kv = getattr(req.sampling_params, "cfg_text_past_key_values", None) or branch_kvs.get("cfg_text")
+        cfg_text_metadata = getattr(req.sampling_params, "cfg_text_kv_metadata", None) or branch_metadata.get(
+            "cfg_text"
+        )
+        cfg_img_kv = getattr(req.sampling_params, "cfg_img_past_key_values", None) or branch_kvs.get("cfg_img")
+        cfg_img_metadata = getattr(req.sampling_params, "cfg_img_kv_metadata", None) or branch_metadata.get("cfg_img")
+
+        cfg_text_prefix_len = None
+        cfg_text_prefix_rope = None
+        if req.sampling_params.kv_metadata:
+            cfg_text_prefix_len = req.sampling_params.kv_metadata.get("cfg_text_kv_len")
+            cfg_text_prefix_rope = req.sampling_params.kv_metadata.get("cfg_text_rope")
+
+        if cfg_text_prefix_len:
+            cfg_text_seq_len = int(cfg_text_prefix_len)
+            cfg_text_context = {
+                "kv_lens": [cfg_text_seq_len],
+                "ropes": [self._first_rope(cfg_text_prefix_rope, cfg_text_seq_len)],
+                "past_key_values": self._slice_cache_prefix(injected_kv, cfg_text_seq_len),
+            }
+        elif cfg_text_kv is not None:
+            cfg_text_seq_len = self._cache_seq_len(cfg_text_kv)
+            cfg_text_ropes = (
+                cfg_text_metadata["ropes"] if cfg_text_metadata and "ropes" in cfg_text_metadata else cfg_text_seq_len
+            )
+            cfg_text_context = {
+                "kv_lens": [cfg_text_seq_len],
+                "ropes": [self._first_rope(cfg_text_ropes, cfg_text_seq_len)],
+                "past_key_values": cfg_text_kv,
+            }
+
+        if cfg_img_kv is None:
+            cfg_img_context = {
+                "kv_lens": [seq_len],
+                "ropes": [self._first_rope(ropes, seq_len)],
+                "past_key_values": injected_kv,
+            }
+        else:
+            cfg_img_seq_len = self._cache_seq_len(cfg_img_kv)
+            cfg_img_ropes = (
+                cfg_img_metadata["ropes"] if cfg_img_metadata and "ropes" in cfg_img_metadata else cfg_img_seq_len
+            )
+            cfg_img_context = {
+                "kv_lens": [cfg_img_seq_len],
+                "ropes": [self._first_rope(cfg_img_ropes, cfg_img_seq_len)],
+                "past_key_values": cfg_img_kv,
+            }
+
+        return gen_context, cfg_text_context, cfg_img_context, image_shape
+
+    def _can_batch_force_stage1(self, reqs: list[OmniDiffusionRequest]) -> bool:
+        if not reqs:
+            return False
+        first_extra = getattr(reqs[0].sampling_params, "extra_args", {}) or {}
+        if not _truthy(first_extra.get("force_stage1_continue")):
+            return False
+        try:
+            first_settings = self._force_generation_settings(reqs[0], first_extra)
+        except Exception:
+            return False
+        for req in reqs:
+            extra_args = getattr(req.sampling_params, "extra_args", {}) or {}
+            if not _truthy(extra_args.get("force_stage1_continue")):
+                return False
+            if _truthy(extra_args.get("force_batch_text", False)) != _truthy(
+                first_extra.get("force_batch_text", False)
+            ):
+                return False
+            if req.sampling_params.past_key_values is None:
+                return False
+            if req.sampling_params.return_trajectory_latents or req.sampling_params.return_trajectory_decoded:
+                return False
+            try:
+                if self._force_generation_settings(req, extra_args) != first_settings:
+                    return False
+            except Exception:
+                return False
+        return True
+
+    def _force_stage1_continue_forward_batch(
+        self,
+        reqs: list[OmniDiffusionRequest],
+    ) -> list[DiffusionOutput]:
+        if not self._can_batch_force_stage1(reqs):
+            return [self.forward(req) for req in reqs]
+
+        first_extra = getattr(reqs[0].sampling_params, "extra_args", {}) or {}
+        (
+            force_params,
+            max_think_tokens,
+            max_answer_tokens,
+            do_sample,
+            answer_do_sample,
+            text_temperature,
+            repeat_stop_n,
+        ) = self._force_generation_settings(reqs[0], first_extra)
+
+        contexts = [self._force_stage1_contexts_from_request(req) for req in reqs]
+        image_shapes = [ctx[3] for ctx in contexts]
+
+        batch_text = _truthy(first_extra.get("force_batch_text", False))
+        can_batch_text = batch_text and len(reqs) > 1
+        if can_batch_text:
+            logger.info(
+                "Running BAGEL force_stage1_continue batch size=%d "
+                "(batched text, batched image)",
+                len(reqs),
+            )
+            sampling_generators = self._make_text_sampling_generators(reqs)
+
+            phase_t0 = time.perf_counter()
+            gen_context = self._merge_contexts([ctx[0] for ctx in contexts])
+            cfg_text_context = self._merge_contexts([ctx[1] for ctx in contexts])
+            cfg_img_context = self._merge_contexts([ctx[2] for ctx in contexts])
+            reencode_text = _truthy(first_extra.get("force_reencode_text", False))
+
+            think_texts = self._generate_texts_from_context_batch(
+                gen_context,
+                max_tokens=max_think_tokens,
+                do_sample=do_sample,
+                text_temperature=text_temperature,
+                sampling_generators=sampling_generators,
+                repeat_stop_n=repeat_stop_n,
+                adopt_context=not reencode_text,
+            )
+            if reencode_text:
+                # VLMEvalKit's batched force path decodes think text, then
+                # re-encodes it into the context before image generation.
+                gen_context = self._update_context_text_batch(gen_context, think_texts)
+            logger.info(
+                "BAGEL force_stage1_continue batched think done in %.2fs",
+                time.perf_counter() - phase_t0,
+            )
+            phase_t0 = time.perf_counter()
+            images = self._generate_images_from_context_batch(
+                reqs,
+                gen_context,
+                cfg_text_context,
+                cfg_img_context,
+                image_shapes,
+                force_params,
+            )
+            logger.info(
+                "BAGEL force_stage1_continue batched image done in %.2fs",
+                time.perf_counter() - phase_t0,
+            )
+            phase_t0 = time.perf_counter()
+            gen_context, _ = self._update_context_image_batch(
+                gen_context,
+                images,
+                vae=True,
+                vit=True,
+            )
+            answer_texts = self._generate_texts_from_context_batch(
+                gen_context,
+                max_tokens=max_answer_tokens,
+                do_sample=answer_do_sample,
+                text_temperature=text_temperature,
+                sampling_generators=sampling_generators,
+                repeat_stop_n=repeat_stop_n,
+            )
+            logger.info(
+                "BAGEL force_stage1_continue batched answer done in %.2fs",
+                time.perf_counter() - phase_t0,
+            )
+
+            outputs: list[DiffusionOutput] = []
+            for think_text, img, answer_text in zip(think_texts, images, answer_texts):
+                answer_visible = self._force_visible_answer(answer_text)
+                trace_text = "\n".join(
+                    part for part in (think_text, "[Generated Image]", answer_visible) if part
+                )
+                outputs.append(
+                    DiffusionOutput(
+                        output=img,
+                        custom_output={
+                            "text_output": trace_text,
+                            "answer_text": answer_visible,
+                            "raw_answer_text": answer_text,
+                            "think_text": think_text,
+                            "force_interleaved": True,
+                            "stage1_continue": True,
+                            "stage1_batch_text": True,
+                            "stage1_reencode_text": reencode_text,
+                            "answer_do_sample": answer_do_sample,
+                        },
+                        stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+                    )
+            )
+            return outputs
+
+        logger.info(
+            "Running BAGEL force_stage1_continue batch size=%d "
+            "(per-request text, batched image)",
+            len(reqs),
+        )
+
+        total_t0 = time.perf_counter()
+        think_texts: list[str] = []
+        think_durations: list[float] = []
+        text_rng_states: list[tuple[torch.Tensor, torch.Tensor | None] | None] = []
+        reencode_text = _truthy(first_extra.get("force_reencode_text", False))
+        for req, (gen_context_i, _, _, _) in zip(reqs, contexts):
+            phase_t0 = time.perf_counter()
+            seed = req.sampling_params.seed
+            if seed is not None:
+                torch.manual_seed(seed)
+                if self.device.type == "cuda":
+                    torch.cuda.manual_seed(seed)
+            think_texts.append(
+                self._generate_text_from_context(
+                    gen_context_i,
+                    max_tokens=max_think_tokens,
+                    do_sample=do_sample,
+                    text_temperature=text_temperature,
+                    adopt_context=not reencode_text,
+                    repeat_stop_n=repeat_stop_n,
+                )
+            )
+            think_durations.append(time.perf_counter() - phase_t0)
+            if seed is None:
+                text_rng_states.append(None)
+            else:
+                text_rng_states.append(
+                    (
+                        torch.random.get_rng_state(),
+                        torch.cuda.get_rng_state(self.device)
+                        if self.device.type == "cuda"
+                        else None,
+                    )
+                )
+
+        think_total = sum(think_durations)
+        logger.info(
+            "BAGEL force_stage1_continue per-request think done in %.2fs "
+            "(sum %.2fs, avg %.2fs, max %.2fs)",
+            time.perf_counter() - total_t0,
+            think_total,
+            think_total / max(len(think_durations), 1),
+            max(think_durations, default=0.0),
+        )
+
+        if reencode_text:
+            for think_text, (gen_context_i, _, _, _) in zip(think_texts, contexts):
+                self._update_context_text(gen_context_i, think_text)
+
+        gen_context = self._merge_contexts([ctx[0] for ctx in contexts])
+        cfg_text_context = self._merge_contexts([ctx[1] for ctx in contexts])
+        cfg_img_context = self._merge_contexts([ctx[2] for ctx in contexts])
+
+        image_t0 = time.perf_counter()
+        images = self._generate_images_from_context_batch(
+            reqs,
+            gen_context,
+            cfg_text_context,
+            cfg_img_context,
+            image_shapes,
+            force_params,
+        )
+        image_duration = time.perf_counter() - image_t0
+        logger.info(
+            "BAGEL force_stage1_continue batched image done in %.2fs",
+            image_duration,
+        )
+
+        answer_texts: list[str] = []
+        answer_t0 = time.perf_counter()
+        answer_durations: list[float] = []
+        for (gen_context_i, _, _, _), img, rng_state in zip(contexts, images, text_rng_states):
+            phase_t0 = time.perf_counter()
+            gen_context_i, _ = self._update_context_image(
+                gen_context_i,
+                img,
+                vae=True,
+                vit=True,
+            )
+            if rng_state is not None:
+                cpu_state, cuda_state = rng_state
+                torch.random.set_rng_state(cpu_state)
+                if cuda_state is not None:
+                    torch.cuda.set_rng_state(cuda_state, self.device)
+            answer_texts.append(
+                self._generate_text_from_context(
+                    gen_context_i,
+                    max_tokens=max_answer_tokens,
+                    do_sample=answer_do_sample,
+                    text_temperature=text_temperature,
+                    repeat_stop_n=repeat_stop_n,
+                )
+            )
+            answer_durations.append(time.perf_counter() - phase_t0)
+
+        answer_total = sum(answer_durations)
+        logger.info(
+            "BAGEL force_stage1_continue per-request answer done in %.2fs "
+            "(sum %.2fs, avg %.2fs, max %.2fs)",
+            time.perf_counter() - answer_t0,
+            answer_total,
+            answer_total / max(len(answer_durations), 1),
+            max(answer_durations, default=0.0),
+        )
+        logger.info(
+            "BAGEL force_stage1_continue batch total %.2fs "
+            "(think sum %.2fs, image %.2fs, answer sum %.2fs)",
+            time.perf_counter() - total_t0,
+            think_total,
+            image_duration,
+            answer_total,
+        )
+
+        outputs: list[DiffusionOutput] = []
+        for think_text, img, answer_text in zip(think_texts, images, answer_texts):
+            answer_visible = self._force_visible_answer(answer_text)
+            trace_text = "\n".join(
+                part for part in (think_text, "[Generated Image]", answer_visible) if part
+            )
+            outputs.append(
+                DiffusionOutput(
+                    output=img,
+                    custom_output={
+                        "text_output": trace_text,
+                        "answer_text": answer_visible,
+                        "raw_answer_text": answer_text,
+                        "think_text": think_text,
+                        "force_interleaved": True,
+                        "stage1_continue": True,
+                        "stage1_reencode_text": reencode_text,
+                        "answer_do_sample": answer_do_sample,
+                    },
+                    stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+                )
+            )
+        return outputs
+
+    def _force_interleave_forward(
+        self,
+        req: OmniDiffusionRequest,
+        first_prompt: Any,
+        prompt: str,
+        image_shape: tuple[int, int],
+        extra_args: dict[str, Any],
+    ) -> DiffusionOutput:
+        if req.sampling_params.seed is not None:
+            torch.manual_seed(req.sampling_params.seed)
+            if self.device.type == "cuda":
+                torch.cuda.manual_seed(req.sampling_params.seed)
+
+        (
+            force_params,
+            max_think_tokens,
+            max_answer_tokens,
+            do_sample,
+            answer_do_sample,
+            text_temperature,
+            repeat_stop_n,
+        ) = self._force_generation_settings(req, extra_args)
+
+        gen_context = {
+            "kv_lens": [0],
+            "ropes": [0],
+            "past_key_values": NaiveCache(self.bagel.config.llm_config.num_hidden_layers),
+        }
+        cfg_text_context = deepcopy(gen_context)
+        cfg_img_context = deepcopy(gen_context)
+
+        gen_context = self._update_context_text(gen_context, GEN_THINK_SYSTEM_PROMPT)
+        cfg_img_context = self._update_context_text(cfg_img_context, GEN_THINK_SYSTEM_PROMPT)
+
+        image_input = None
+        if not isinstance(first_prompt, str):
+            image_input = (
+                (first_prompt.get("multi_modal_data") or {}).get("image")
+                or (first_prompt.get("multi_modal_data") or {}).get("img2img")
+            )
+        if image_input and not isinstance(image_input, list):
+            image_input = [image_input]
+        if image_input:
+            image_input = [
+                Image.open(image).convert("RGB") if isinstance(image, str) else image.convert("RGB")
+                for image in image_input
+            ]
+            input_vit = _truthy(
+                extra_args.get(
+                    "force_input_vit",
+                    os.environ.get("BAGEL_FORCE_IMG2IMG_VIT", "1"),
+                )
+            )
+            for image in image_input:
+                gen_context, maybe_shape = self._update_context_image(
+                    gen_context,
+                    image,
+                    vae=True,
+                    vit=input_vit,
+                )
+                if maybe_shape is not None:
+                    image_shape = maybe_shape
+            cfg_text_context = deepcopy(gen_context)
+
+        if prompt:
+            cfg_text_context = deepcopy(gen_context)
+            gen_context = self._update_context_text(gen_context, prompt)
+            cfg_img_context = self._update_context_text(cfg_img_context, prompt)
+
+        think_text = self._generate_text_from_context(
+            gen_context,
+            max_tokens=max_think_tokens,
+            do_sample=do_sample,
+            text_temperature=text_temperature,
+            repeat_stop_n=repeat_stop_n,
+        )
+
+        img = self._generate_image_from_context(
+            req,
+            gen_context,
+            cfg_text_context,
+            cfg_img_context,
+            image_shape,
+            force_params,
+        )
+
+        gen_context, _ = self._update_context_image(
+            gen_context,
+            img,
+            vae=True,
+            vit=True,
+        )
+
+        answer_text = self._generate_text_from_context(
+            gen_context,
+            max_tokens=max_answer_tokens,
+            do_sample=answer_do_sample,
+            text_temperature=text_temperature,
+            repeat_stop_n=repeat_stop_n,
+        )
+        answer_visible = self._force_visible_answer(answer_text)
+        trace_text = "\n".join(
+            part for part in (think_text, "[Generated Image]", answer_visible) if part
+        )
+
+        return DiffusionOutput(
+            output=trace_text,
+            custom_output={
+                "text_output": trace_text,
+                "answer_text": answer_visible,
+                "raw_answer_text": answer_text,
+                "think_text": think_text,
+                "force_interleaved": True,
+                "answer_do_sample": answer_do_sample,
+            },
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
+
+    @torch.inference_mode()
+    def forward_batch(self, reqs: list[OmniDiffusionRequest]) -> list[DiffusionOutput]:
+        if not reqs:
+            return []
+        self._maybe_reseed_after_warmup(reqs)
+        if self._can_batch_force_stage1(reqs):
+            return self._force_stage1_continue_forward_batch(reqs)
+        return [self.forward(req) for req in reqs]
+
     @torch.inference_mode()
     def forward(self, req: OmniDiffusionRequest) -> DiffusionOutput:
+        self._maybe_reseed_after_warmup(req)
         if len(req.prompts) > 1:
             logger.warning(
                 """This model only supports a single prompt, not a batched request.""",
@@ -346,12 +1786,26 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
         image_shape = (height, width)
 
         extra_args = getattr(req.sampling_params, "extra_args", {}) or {}
-        cfg_text_scale = extra_args.get("cfg_text_scale", 4.0)
+        if _truthy(extra_args.get("force_interleaved")):
+            if req.sampling_params.past_key_values is not None:
+                raise ValueError("force_interleaved does not support injected KV cache.")
+            return self._force_interleave_forward(
+                req,
+                first_prompt,
+                prompt,
+                image_shape,
+                extra_args,
+            )
+
+        # Canonical ThinkMorphInterleaved/Bagel.py defaults: cfg_text_scale=3.0,
+        # cfg_renorm_min=1.0. Prior 4.0/0.0 defaults caused image-quality drift
+        # vs the HF baseline.
+        cfg_text_scale = extra_args.get("cfg_text_scale", 3.0)
         cfg_img_scale = extra_args.get("cfg_img_scale", 1.5)
 
         cfg_interval = extra_args.get("cfg_interval", (0.4, 1.0))
         cfg_renorm_type = extra_args.get("cfg_renorm_type", "global")
-        cfg_renorm_min = extra_args.get("cfg_renorm_min", 0.0)
+        cfg_renorm_min = extra_args.get("cfg_renorm_min", 1.0)
 
         gen_params = BagelGenParams(
             num_timesteps=int(req.sampling_params.num_inference_steps or 50),
@@ -409,7 +1863,23 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
                     active_branch,
                 )
 
-            if cfg_text_kv is not None:
+            cfg_text_prefix_len = None
+            cfg_text_prefix_rope = None
+            if req.sampling_params.kv_metadata:
+                cfg_text_prefix_len = req.sampling_params.kv_metadata.get("cfg_text_kv_len")
+                cfg_text_prefix_rope = req.sampling_params.kv_metadata.get("cfg_text_rope")
+
+            if cfg_text_prefix_len:
+                cfg_text_seq_len = int(cfg_text_prefix_len)
+                cfg_text_context["past_key_values"] = self._slice_cache_prefix(
+                    injected_kv,
+                    cfg_text_seq_len,
+                )
+                cfg_text_context["kv_lens"] = [cfg_text_seq_len]
+                cfg_text_context["ropes"] = [
+                    self._first_rope(cfg_text_prefix_rope, cfg_text_seq_len)
+                ]
+            elif cfg_text_kv is not None:
                 cfg_text_seq_len = cfg_text_kv.key_cache[0].shape[0]
                 cfg_text_context["past_key_values"] = cfg_text_kv
                 cfg_text_context["kv_lens"] = [cfg_text_seq_len]
@@ -445,7 +1915,20 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
                 else:
                     cfg_img_context["ropes"] = [cfg_img_seq_len]
 
+            if _truthy(extra_args.get("force_stage1_continue")):
+                return self._force_stage1_continue_forward(
+                    req,
+                    gen_context,
+                    cfg_text_context,
+                    cfg_img_context,
+                    image_shape,
+                    extra_args,
+                )
+
         else:
+            if _truthy(extra_args.get("force_stage1_continue")):
+                raise ValueError("force_stage1_continue requires injected KV cache from Stage 0.")
+
             image_input = (
                 None
                 if isinstance(first_prompt, str)
@@ -461,44 +1944,32 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
 
             if image_input:
                 # If we have an image, we prefill with it
-                if self.image_processor and self.vae:
+                if self.vae:
+                    # Canonical preprocessing: VAE and ViT use *independent*
+                    # MaxLongEdgeMinShortEdgeResize ladders applied to the same
+                    # source image. The prior shared `_resize_to_stride` (with
+                    # stride=latent_downsample=8 and max=max_latent_size*8=512)
+                    # forced ViT to receive 8-aligned dims and capped at 512px,
+                    # diverging from the canonical 14-aligned dynamic ladder.
 
-                    def vit_transforms(img):
-                        return self.image_processor(images=img, return_tensors="pt").pixel_values[0]
+                    vit_transforms = self._vit_transform  # callable: PIL → CHW tensor in [-1,1]
+                    vae_transforms = self._vae_transform  # callable: PIL → CHW tensor in [-1,1]
 
-                    stride = self.bagel.latent_downsample
-                    max_img_size = int(self.bagel.max_latent_size * stride)
-
-                    def _resize_to_stride(img):
-                        if img.mode != "RGB":
-                            img = img.convert("RGB")
-                        w, h = img.size
-                        # Scale down if longest edge exceeds max
-                        scale = min(max_img_size / max(w, h), 1.0)
-                        # Scale up if shortest edge is too small (min 256)
-                        min_img_size = min(256, max_img_size)
-                        scale = max(scale, min_img_size / min(w, h))
-                        new_w = max(stride, int(round(w * scale / stride) * stride))
-                        new_h = max(stride, int(round(h * scale / stride) * stride))
-                        # Clamp to max
-                        new_w = min(new_w, max_img_size)
-                        new_h = min(new_h, max_img_size)
-                        if new_w != w or new_h != h:
-                            img = img.resize((new_w, new_h), Image.BICUBIC)
-                        return img
-
-                    image_input = [_resize_to_stride(img) for img in image_input]
-
-                    resized_w, resized_h = image_input[0].size
+                    image_input_vae_resized = [
+                        self._vae_transform.resize_only(img) for img in image_input
+                    ]
+                    # Local force_interleave_inference passes the VAE-resized
+                    # image into update_context_image(..., vae=True, vit=True),
+                    # so ViT also starts from this resized image.
+                    image_input_vit = list(image_input_vae_resized)
+                    resized_w, resized_h = image_input_vae_resized[0].size
                     image_shape = (resized_h, resized_w)
-                    logger.info(f"img2img: resized image to {resized_w}x{resized_h}")
-
-                    def vae_transforms(img):
-                        if img.mode != "RGB":
-                            img = img.convert("RGB")
-                        # Convert to [-1, 1] tensor (H, W, C) -> (C, H, W)
-                        arr = torch.from_numpy(np.array(img)).float() / 127.5 - 1.0
-                        return arr.permute(2, 0, 1)
+                    logger.info(
+                        "img2img: VAE-resized image to %dx%d (stride 16, max 1024); ViT path follows local force input",
+                        resized_w,
+                        resized_h,
+                    )
+                    image_input = image_input_vae_resized
 
                     # Update gen_context with image (VAE + ViT)
                     gen_input_vae, newlens_vae, new_rope_vae = self.bagel.prepare_vae_images(
@@ -525,7 +1996,7 @@ class BagelPipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipelineProf
                     gen_input_img, newlens_img, new_rope_img = self.bagel.prepare_vit_images(
                         curr_kvlens=gen_context["kv_lens"],
                         curr_rope=gen_context["ropes"],
-                        images=image_input,
+                        images=image_input_vit,
                         transforms=vit_transforms,
                         new_token_ids=self.new_token_ids,
                     )

--- a/vllm_omni/diffusion/request.py
+++ b/vllm_omni/diffusion/request.py
@@ -36,7 +36,13 @@ class OmniDiffusionRequest:
 
         # When neither a generator nor a seed is provided, assign a random seed
         # so that all ranks derive the same generator state.
-        if self.sampling_params.generator is None and self.sampling_params.seed is None:
+        extra_args = getattr(self.sampling_params, "extra_args", None) or {}
+        preserve_none_seed = bool(extra_args.get("preserve_none_seed", False))
+        if (
+            self.sampling_params.generator is None
+            and self.sampling_params.seed is None
+            and not preserve_none_seed
+        ):
             self.sampling_params.seed = random.randint(0, 2**31 - 1)
 
         # Detect whether user explicitly provided guidance_scale.

--- a/vllm_omni/diffusion/sched/base_scheduler.py
+++ b/vllm_omni/diffusion/sched/base_scheduler.py
@@ -128,6 +128,14 @@ class _BaseScheduler(SchedulerInterface):
     def has_requests(self) -> bool:
         return bool(self._waiting or self._running)
 
+    @property
+    def num_waiting(self) -> int:
+        return len(self._waiting)
+
+    @property
+    def num_running(self) -> int:
+        return len(self._running)
+
     def get_request_state(self, request_id: str) -> DiffusionRequestState | None:
         return self._request_states.get(request_id)
 

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -345,6 +345,91 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
 
             return output
 
+    def execute_model_batch(
+        self,
+        reqs: list[OmniDiffusionRequest],
+        sched_req_ids: list[str],
+    ) -> BatchRunnerOutput:
+        """Execute a request-mode batch and return per-request outputs."""
+        assert self.pipeline is not None, "Model not loaded. Call load_model() first."
+        if len(reqs) != len(sched_req_ids):
+            raise ValueError(f"reqs length ({len(reqs)}) does not match sched_req_ids length ({len(sched_req_ids)})")
+        if not reqs:
+            return BatchRunnerOutput.from_list([])
+
+        use_hsdp = self.od_config.parallel_config.use_hsdp
+        grad_context = torch.no_grad() if use_hsdp else torch.inference_mode()
+        with grad_context:
+            for req in reqs:
+                if len(req.prompts) == 0:
+                    raise ValueError("Cannot execute model with empty request list")
+                self.kv_transfer_manager.receive_multi_kv_cache_distributed(
+                    req,
+                    cfg_kv_collect_func=getattr(self.od_config, "cfg_kv_collect_func", None),
+                    target_device=getattr(self.pipeline, "device", None),
+                )
+
+                if req.sampling_params.generator is None and req.sampling_params.seed is not None:
+                    if req.sampling_params.generator_device is not None:
+                        gen_device = req.sampling_params.generator_device
+                    elif self.device.type == "cpu":
+                        gen_device = "cpu"
+                    else:
+                        gen_device = self.device
+                    req.sampling_params.generator = torch.Generator(device=gen_device).manual_seed(
+                        req.sampling_params.seed
+                    )
+
+            if self.cache_backend is not None and self.cache_backend.is_enabled():
+                step_values = {
+                    req.sampling_params.num_inference_steps
+                    for req in reqs
+                    if req.sampling_params.num_inference_steps is not None
+                }
+                if len(step_values) == 1:
+                    self.cache_backend.refresh(self.pipeline, next(iter(step_values)))
+
+            is_primary = not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
+            if is_primary:
+                current_omni_platform.reset_peak_memory_stats()
+
+            with set_forward_context(vllm_config=self.vllm_config, omni_diffusion_config=self.od_config):
+                with record_function("pipeline_forward_batch"):
+                    forward_batch = getattr(self.pipeline, "forward_batch", None)
+                    if callable(forward_batch):
+                        outputs = forward_batch(reqs)
+                    else:
+                        outputs = [self.pipeline.forward(req) for req in reqs]
+
+            if len(outputs) != len(reqs):
+                raise RuntimeError(f"Batched pipeline returned {len(outputs)} outputs for {len(reqs)} requests")
+
+            if is_primary and outputs:
+                self._record_peak_memory(outputs[0])
+                peak_memory_mb = outputs[0].peak_memory_mb
+                for output in outputs[1:]:
+                    output.peak_memory_mb = peak_memory_mb
+
+            if (
+                self.cache_backend is not None
+                and self.cache_backend.is_enabled()
+                and self.od_config.cache_backend == "cache_dit"
+                and self.od_config.enable_cache_dit_summary
+            ):
+                cache_summary(self.pipeline, details=True)
+
+            return BatchRunnerOutput.from_list(
+                [
+                    RunnerOutput(
+                        req_id=sched_req_id,
+                        step_index=None,
+                        finished=True,
+                        result=output,
+                    )
+                    for sched_req_id, output in zip(sched_req_ids, outputs)
+                ]
+            )
+
     # ------------------------------------------------------------------
     # Step-wise execution
     # ------------------------------------------------------------------

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -370,6 +370,26 @@ class DiffusionWorker:
             profiler.step()
         return output
 
+    def execute_model_batch(
+        self,
+        reqs: list[OmniDiffusionRequest],
+        sched_req_ids: list[str],
+        od_config: OmniDiffusionConfig,
+    ) -> BaseRunnerOutput:
+        """Execute a batched request-mode forward pass."""
+        assert self.model_runner is not None, "Model runner not initialized"
+        if self.lora_manager is not None:
+            if any(req.sampling_params.lora_request is not None for req in reqs):
+                raise ValueError("Request-mode batching does not support LoRA yet.")
+            self.lora_manager.set_active_adapter(None)
+        profiler = self._get_profiler()
+        ctx = profiler.annotate_context_manager("diffusion_forward_batch") if profiler else nullcontext()
+        with ctx:
+            output = self.model_runner.execute_model_batch(reqs, sched_req_ids)
+        if profiler:
+            profiler.step()
+        return output
+
     def execute_stepwise(self, scheduler_output: DiffusionSchedulerOutput) -> BaseRunnerOutput:
         """Execute one diffusion step by delegating to the model runner."""
         assert self.model_runner is not None, "Model runner not initialized"
@@ -994,6 +1014,15 @@ class WorkerWrapperBase:
             DiffusionOutput with generated results
         """
         return self.worker.execute_model(reqs, od_config)
+
+    def execute_model_batch(
+        self,
+        reqs: list[OmniDiffusionRequest],
+        sched_req_ids: list[str],
+        od_config: OmniDiffusionConfig,
+    ) -> BaseRunnerOutput:
+        """Execute a batched request-mode forward pass."""
+        return self.worker.execute_model_batch(reqs, sched_req_ids, od_config)
 
     def execute_stepwise(self, scheduler_output: DiffusionSchedulerOutput) -> BaseRunnerOutput:
         """Execute one diffusion step."""

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1120,6 +1120,40 @@ class AsyncOmniEngine:
             return self._initialize_diffusion_replica(plan, stage_init_timeout, stage_launch_lock)
         return self._initialize_llm_replica(plan, stage_init_timeout, stage_launch_lock)
 
+    @staticmethod
+    def _parse_replica_devices(plan: LogicalStageInitPlan) -> set[str]:
+        devices: set[str] = set()
+        for replica in plan.replicas:
+            runtime_cfg = getattr(replica.stage_cfg, "runtime", None)
+            raw_devices = None
+            if runtime_cfg is not None:
+                raw_devices = (
+                    runtime_cfg.get("devices")
+                    if hasattr(runtime_cfg, "get")
+                    else getattr(runtime_cfg, "devices", None)
+                )
+            if raw_devices is None:
+                continue
+            devices.update(d.strip() for d in str(raw_devices).split(",") if d.strip())
+        return devices
+
+    @classmethod
+    def _stage_init_requires_ordering(cls, stage_plans: Sequence[LogicalStageInitPlan]) -> bool:
+        """Return true when stages intentionally share devices.
+
+        Disjoint stages can initialize concurrently. If stages overlap on a
+        physical device, initialize them in logical order so an upstream LLM
+        stage can finish profiling and reserve KV cache before a downstream
+        replica loads onto the same GPU.
+        """
+        seen: set[str] = set()
+        for plan in stage_plans:
+            devices = cls._parse_replica_devices(plan)
+            if devices & seen:
+                return True
+            seen.update(devices)
+        return False
+
     def _initialize_stage_replicas(
         self,
         stage_plans: Sequence[LogicalStageInitPlan],
@@ -1720,8 +1754,9 @@ class AsyncOmniEngine:
         sampling_params_list: list[Any],
     ) -> None:
         """Expand prompt into CFG companions, process through InputProcessor, and enqueue."""
+        expand_params = self._sampling_params_for_prompt_expansion(stage0_params, sampling_params_list)
         try:
-            expanded = self.prompt_expand_func(original_prompt, stage0_params)
+            expanded = self.prompt_expand_func(original_prompt, expand_params)
         except Exception:
             logger.exception("[AsyncOmniEngine] prompt_expand_func failed for req %s", parent_id)
             return
@@ -1765,6 +1800,37 @@ class AsyncOmniEngine:
             parent_id,
             len(expanded),
         )
+
+    @staticmethod
+    def _sampling_params_for_prompt_expansion(stage0_params: Any, sampling_params_list: list[Any]) -> Any:
+        """Expose downstream diffusion extra_args to Stage-0 prompt expansion."""
+        stage0_extra = dict(getattr(stage0_params, "extra_args", None) or {})
+        merged_extra: dict[str, Any] = {}
+        for params in sampling_params_list[1:]:
+            extra = getattr(params, "extra_args", None) or {}
+            if extra:
+                merged_extra.update(extra)
+        merged_extra.update(stage0_extra)
+        if not merged_extra or merged_extra == stage0_extra:
+            return stage0_params
+
+        try:
+            if hasattr(stage0_params, "clone"):
+                expand_params = stage0_params.clone()
+            else:
+                expand_params = copy.copy(stage0_params)
+            setattr(expand_params, "extra_args", merged_extra)
+            return expand_params
+        except Exception:
+            class _ExpansionParamsProxy:
+                def __init__(self, base: Any, extra_args: dict[str, Any]) -> None:
+                    self._base = base
+                    self.extra_args = extra_args
+
+                def __getattr__(self, name: str) -> Any:
+                    return getattr(self._base, name)
+
+            return _ExpansionParamsProxy(stage0_params, merged_extra)
 
     @staticmethod
     def _get_default_cache_config(cache_backend: str | None) -> dict[str, Any] | None:

--- a/vllm_omni/engine/stage_pool.py
+++ b/vllm_omni/engine/stage_pool.py
@@ -93,6 +93,8 @@ class StagePool:
         self._stage_vllm_config = stage_vllm_config
         self._next_replica_id = 0
         self._request_bindings: dict[str, int] = {}
+        self._inflight_bindings: dict[str, int] = {}
+        self._replica_inflight: list[int] = [0 for _ in self.clients]
         self._replica_metrics: list[_ReplicaMetrics] = [_ReplicaMetrics() for _ in self.clients]
 
         # Distributed-mode state. Populated by add_client / remove_client.
@@ -218,6 +220,7 @@ class StagePool:
         replica_id = len(self.clients)
         self.clients.append(client)
         self._addr_to_replica_id[input_addr] = replica_id
+        self._replica_inflight.append(0)
         self._replica_metrics.append(_ReplicaMetrics())
         return replica_id
 
@@ -424,6 +427,7 @@ class StagePool:
 
     def release_binding(self, request_id: str) -> None:
         """Drop the route binding for *request_id* in this stage."""
+        self._mark_request_finished(request_id)
         self._request_bindings.pop(request_id, None)
         self._affinity.pop(request_id, None)
 
@@ -456,10 +460,7 @@ class StagePool:
             if len(live) == 1:
                 chosen = live[0]
             else:
-                # Round-robin over live replicas only.
-                start = self._next_replica_id % len(live)
-                chosen = live[start]
-                self._next_replica_id = (self._next_replica_id + 1) % len(live)
+                chosen = self._select_least_loaded_replica_id()
 
         self._request_bindings[request_id] = chosen
         return chosen
@@ -475,6 +476,32 @@ class StagePool:
         if client is None:
             raise RuntimeError(f"stage {self.stage_id} replica {replica_id} is not attached")
         return cast(StagePoolDiffusionClient, client)
+
+    def _select_least_loaded_replica_id(self) -> int:
+        live = self.live_replica_ids()
+        if not live:
+            raise RuntimeError(f"stage {self.stage_id} has no live replicas")
+        min_load = min(self._replica_inflight[idx] for idx in live)
+        for offset in range(len(live)):
+            candidate = live[(self._next_replica_id + offset) % len(live)]
+            if self._replica_inflight[candidate] == min_load:
+                self._next_replica_id = (offset + 1) % len(live)
+                return candidate
+        return live[0]
+
+    def _mark_request_submitted(self, request_id: str, replica_id: int) -> None:
+        previous = self._inflight_bindings.get(request_id)
+        if previous == replica_id:
+            return
+        if previous is not None:
+            self._replica_inflight[previous] = max(0, self._replica_inflight[previous] - 1)
+        self._inflight_bindings[request_id] = replica_id
+        self._replica_inflight[replica_id] += 1
+
+    def _mark_request_finished(self, request_id: str) -> None:
+        replica_id = self._inflight_bindings.pop(request_id, None)
+        if replica_id is not None:
+            self._replica_inflight[replica_id] = max(0, self._replica_inflight[replica_id] - 1)
 
     # ---- Metrics ----
 
@@ -540,10 +567,15 @@ class StagePool:
                 affinity_request_id=affinity_request_id,
             )
             client = self._diffusion_client(replica_id)
-            if isinstance(request, list):
-                await client.add_batch_request_async(request_id, request, params, **submit_kwargs)
-            else:
-                await client.add_request_async(request_id, request, params, **submit_kwargs)
+            try:
+                if isinstance(request, list):
+                    await client.add_batch_request_async(request_id, request, params, **submit_kwargs)
+                else:
+                    await client.add_request_async(request_id, request, params, **submit_kwargs)
+            except Exception:
+                self.release_binding(request_id)
+                raise
+            self._mark_request_submitted(request_id, replica_id)
             return replica_id
 
         replica_id = await self._pick_or_select(
@@ -581,6 +613,7 @@ class StagePool:
                         rollback_error,
                     )
             raise
+        self._mark_request_submitted(request_id, replica_id)
         return replica_id
 
     async def submit_update(
@@ -615,6 +648,7 @@ class StagePool:
                 queue=None,
             )
             await self._llm_client(replica_id).add_request_async(request)
+        self._mark_request_submitted(request_id, replica_id)
         return replica_id
 
     async def _pick_or_select(
@@ -653,6 +687,9 @@ class StagePool:
             raw_outputs.timestamp,
             None,
         )
+        for output in processed.request_outputs:
+            if getattr(output, "finished", False):
+                self._mark_request_finished(output.request_id)
 
         if processed.reqs_to_abort:
             await client.abort_requests_async(processed.reqs_to_abort)
@@ -695,7 +732,10 @@ class StagePool:
         raw_client = self.clients[replica_id]
         if raw_client is None:
             return None
-        return cast(StagePoolDiffusionClient, raw_client).get_diffusion_output_nowait()
+        output = cast(StagePoolDiffusionClient, raw_client).get_diffusion_output_nowait()
+        if output is not None and getattr(output, "finished", True):
+            self._mark_request_finished(output.request_id)
+        return output
 
     # ---- Stage-local control plane ----
 
@@ -721,6 +761,8 @@ class StagePool:
             if client is None:
                 continue
             await client.abort_requests_async(replica_request_ids)
+            for request_id in replica_request_ids:
+                self._mark_request_finished(request_id)
 
         # Clean up OutputProcessor state (e.g. mm_accumulated tensors) that
         # would otherwise leak — aborted requests never produce a final

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import json
+import os
 import time
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
@@ -110,6 +111,10 @@ from vllm_omni.entrypoints.openai.utils import (
 )
 from vllm_omni.lora.request import LoRARequest
 from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.utils.bagel_vqa import (
+    bagel_vqa_reference_layout_enabled,
+    build_bagel_vqa_reference_prompt_token_ids,
+)
 
 logger = init_logger(__name__)
 
@@ -700,7 +705,78 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 engine_prompt["additional_information"] = {}
             engine_prompt["additional_information"]["instruction"] = instructions.strip()
 
+        self._maybe_apply_bagel_vqa_reference_prompt(
+            request=request,
+            messages=messages,
+            tokenizer=tokenizer,
+            engine_prompt=engine_prompt,
+        )
+
         return conversation, [engine_prompt]
+
+    def _is_bagel_vqa_request(
+        self,
+        request: ChatLikeRequest | ResponsesRequest,
+        engine_prompt: TokPrompt,
+    ) -> bool:
+        """Return True for BAGEL image-understanding chat requests."""
+        hf_config = getattr(self.model_config, "hf_config", None)
+        if type(hf_config).__name__ != "BagelConfig":
+            return False
+
+        req_modalities = getattr(request, "modalities", None)
+        if req_modalities and "text" not in req_modalities:
+            return False
+
+        mm_data = engine_prompt.get("multi_modal_data")
+        if not isinstance(mm_data, dict) or "image" not in mm_data:
+            return False
+
+        # img2img/image-generation requests also carry images, but should stay
+        # on the diffusion-oriented prompt path.
+        if "img2img" in mm_data:
+            return False
+        return True
+
+    def _maybe_apply_bagel_vqa_reference_prompt(
+        self,
+        *,
+        request: ChatLikeRequest | ResponsesRequest,
+        messages: list[ChatCompletionMessageParam],
+        tokenizer: AnyTokenizer,
+        engine_prompt: TokPrompt,
+    ) -> None:
+        """Use BAGEL's reference VQA layout while keeping vLLM serving.
+
+        Reference BAGEL does not run Qwen's chat template. It updates KV cache
+        in this order: think-system text, image block(s), final text containing
+        <img><|image_N|></img> markers, then a bare <|im_start|> decode token.
+        This produces token IDs directly and lets the multimodal processor
+        expand one <|image_pad|> per image into the actual vision block.
+
+        This path is opt-in because vLLM still performs the image block as
+        causal decoder prefill, while reference BAGEL uses non-causal image
+        prefill. In GPU smoke tests, enabling only the token/position layout
+        caused special-token repetition and caption-mode failures.
+        """
+        if not bagel_vqa_reference_layout_enabled():
+            return
+
+        if not self._is_bagel_vqa_request(request, engine_prompt):
+            return
+
+        prompt_token_ids, final_text, image_count = (
+            build_bagel_vqa_reference_prompt_token_ids(messages, tokenizer)
+        )
+        if image_count <= 0:
+            return
+
+        engine_prompt["prompt_token_ids"] = prompt_token_ids
+        engine_prompt["prompt"] = final_text
+        addi = engine_prompt.setdefault("additional_information", {})
+        if isinstance(addi, dict):
+            addi["bagel_vqa_reference_layout"] = [1]
+            addi["bagel_vqa_image_count"] = [image_count]
 
     async def _inject_audio_from_video_urls(
         self,
@@ -3161,6 +3237,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                                 try:
                                     _, b64_data = url.split(",", 1)
                                     images.append(b64_data)
+                                    if bagel_vqa_reference_layout_enabled():
+                                        prompt_parts.append(f"<img><|image_{len(images)}|></img>")
                                 except ValueError:
                                     logger.warning("Invalid data URL format")
                         elif item.get("type") == "video_url":
@@ -3174,6 +3252,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         # Handle {"image": "base64..."} format
                         elif "image" in item:
                             images.append(item["image"])
+                            if bagel_vqa_reference_layout_enabled():
+                                prompt_parts.append(f"<img><|image_{len(images)}|></img>")
                         elif "video" in item and isinstance(item["video"], str):
                             videos.append(item["video"])
                         elif "audio" in item and isinstance(item["audio"], str):

--- a/vllm_omni/model_executor/models/bagel/bagel.py
+++ b/vllm_omni/model_executor/models/bagel/bagel.py
@@ -1,9 +1,13 @@
 from collections.abc import Iterable, Mapping, Sequence
+import logging
+import os
 from math import isqrt
 from typing import Any
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+from PIL import Image
 from transformers import BatchFeature
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
@@ -48,8 +52,126 @@ from vllm_omni.diffusion.models.bagel.autoencoder import (
 from vllm_omni.diffusion.models.bagel.bagel_transformer import (
     PositionEmbedding,
     TimestepEmbedder,
+    get_flattened_position_ids_extrapolate,
+    patchify,
 )
-from vllm_omni.diffusion.models.bagel.pipeline_bagel import default_ae_params
+from vllm_omni.diffusion.models.bagel.pipeline_bagel import (
+    SiglipNaViTWrapper,
+    _ImageTransform,
+    default_ae_params,
+)
+from vllm_omni.utils.bagel_vqa import (
+    bagel_vqa_reference_layout_enabled,
+    bagel_vqa_reference_prefill_enabled,
+    build_bagel_vqa_image_spans,
+    build_bagel_vqa_rope_positions,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _bagel_img2img_vit_separator_enabled() -> bool:
+    return _env_flag("BAGEL_IMG2IMG_VIT_SEPARATOR", False)
+
+
+def _bagel_img2img_local_preprocess_enabled() -> bool:
+    return _env_flag("BAGEL_IMG2IMG_LOCAL_PREPROCESS", False)
+
+
+def _bagel_img2img_local_preprocess_vit_enabled() -> bool:
+    return _env_flag("BAGEL_IMG2IMG_LOCAL_PREPROCESS_VIT", False)
+
+
+def _bagel_img2img_debug_enabled() -> bool:
+    return _env_flag("BAGEL_IMG2IMG_DEBUG", False)
+
+
+def _bagel_force_input_img2img_vit_enabled() -> bool:
+    input_vit = os.environ.get("BAGEL_FORCE_INPUT_IMG2IMG_VIT")
+    if input_vit is not None and input_vit.strip() != "":
+        return _env_flag("BAGEL_FORCE_INPUT_IMG2IMG_VIT", True)
+    return _env_flag("BAGEL_FORCE_IMG2IMG_VIT", True)
+
+
+_BAGEL_IMAGE_MAX_PIXELS = 14 * 14 * 9 * 1024
+_BAGEL_FORCE_VAE_MAX_SIZE = 1024
+_BAGEL_FORCE_VAE_MIN_SIZE = 512
+_BAGEL_FORCE_VIT_MAX_SIZE = 980
+_BAGEL_FORCE_VIT_MIN_SIZE = 224
+_BAGEL_FORCE_VIT_STRIDE = 14
+
+
+def _bagel_make_divisible(value: float, stride: int) -> int:
+    return max(stride, int(round(value / stride) * stride))
+
+
+def _bagel_apply_scale_to_stride(width: int, height: int, scale: float, stride: int) -> tuple[int, int]:
+    return (
+        _bagel_make_divisible(round(width * scale), stride),
+        _bagel_make_divisible(round(height * scale), stride),
+    )
+
+
+def _bagel_reference_resize_hw(
+    height: int,
+    width: int,
+    *,
+    max_size: int,
+    min_size: int,
+    stride: int,
+    max_pixels: int = _BAGEL_IMAGE_MAX_PIXELS,
+    img_num: int = 1,
+) -> tuple[int, int]:
+    """Match BAGEL ImageTransform resize geometry, returning (H, W)."""
+    scale = min(max_size / max(width, height), 1.0)
+    scale = max(scale, min_size / min(width, height))
+    new_width, new_height = _bagel_apply_scale_to_stride(width, height, scale, stride)
+
+    if new_width * new_height > max_pixels / img_num:
+        scale = max_pixels / img_num / (new_width * new_height)
+        new_width, new_height = _bagel_apply_scale_to_stride(new_width, new_height, scale, stride)
+
+    if max(new_width, new_height) > max_size:
+        scale = max_size / max(new_width, new_height)
+        new_width, new_height = _bagel_apply_scale_to_stride(new_width, new_height, scale, stride)
+
+    return int(new_height), int(new_width)
+
+
+def _bagel_force_img2img_vae_hw(
+    height: int,
+    width: int,
+    *,
+    latent_downsample: int,
+    max_latent_size: int,
+) -> tuple[int, int]:
+    max_size = min(_BAGEL_FORCE_VAE_MAX_SIZE, int(max_latent_size * latent_downsample))
+    min_size = min(_BAGEL_FORCE_VAE_MIN_SIZE, max_size)
+    return _bagel_reference_resize_hw(
+        height,
+        width,
+        max_size=max_size,
+        min_size=min_size,
+        stride=latent_downsample,
+    )
+
+
+def _bagel_force_img2img_vit_hw(height: int, width: int) -> tuple[int, int]:
+    return _bagel_reference_resize_hw(
+        height,
+        width,
+        max_size=_BAGEL_FORCE_VIT_MAX_SIZE,
+        min_size=_BAGEL_FORCE_VIT_MIN_SIZE,
+        stride=_BAGEL_FORCE_VIT_STRIDE,
+    )
 
 
 class OmniBagelProcessor(BagelProcessor):
@@ -59,6 +181,50 @@ class OmniBagelProcessor(BagelProcessor):
     # ``self.tokenizer`` on the OmniBagelProcessor instance.
     image_processor_class = "SiglipImageProcessor"
     tokenizer_class = "AutoTokenizer"
+
+    # PATCH (navit-thinker-fix): Canonical aspect-preserving ViT transform for the
+    # VQA / understanding path. Mirrors VLMEvalKit's ImageTransform(980, 224, 14) and
+    # the pipeline_bagel.py DiT path, producing variable-shape ViT input the
+    # checkpoint was trained on (NaViT-style packed sequences). Replaces the prior
+    # fixed-980×980 SigLIP path that destroyed aspect ratio.
+    _vit_transform_cls = _ImageTransform
+    _vit_patch_size = 14
+    _img2img_vae_stride = 16
+
+    def _get_vit_transform(self) -> _ImageTransform:
+        # Cached instance — stride-14 ladder, mean/std = 0.5 (matches canonical).
+        cached = getattr(self, "_cached_vit_transform", None)
+        if cached is None:
+            cached = self._vit_transform_cls(980, 224, self._vit_patch_size)
+            object.__setattr__(self, "_cached_vit_transform", cached)
+        return cached
+
+    def _get_img2img_vae_transform(self) -> _ImageTransform:
+        # Local force_interleave first resizes source images with the VAE ladder,
+        # then feeds that image to both VAE and ViT context updates.
+        cached = getattr(self, "_cached_img2img_vae_transform", None)
+        if cached is None:
+            cached = self._vit_transform_cls(1024, 512, self._img2img_vae_stride)
+            object.__setattr__(self, "_cached_img2img_vae_transform", cached)
+        return cached
+
+    def _get_img2img_vit_transform(self) -> _ImageTransform:
+        cached = getattr(self, "_cached_img2img_vit_transform", None)
+        if cached is None:
+            cached = self._vit_transform_cls(980, 224, self._vit_patch_size)
+            object.__setattr__(self, "_cached_img2img_vit_transform", cached)
+        return cached
+
+    @staticmethod
+    def _to_image_list(images) -> list:
+        if images is None:
+            return []
+        if isinstance(images, Image.Image):
+            return [images]
+        if isinstance(images, (list, tuple)):
+            return list(images)
+        # numpy / tensor inputs unsupported on this path; let parent handle.
+        return list(images) if hasattr(images, "__iter__") else [images]
 
     def __call__(self, text=None, images=None, **kwargs):
         is_img2img = kwargs.pop("is_img2img", False)
@@ -74,17 +240,56 @@ class OmniBagelProcessor(BagelProcessor):
                 tokenizer_init_kwargs=self.tokenizer.init_kwargs,
                 **kwargs,
             )
-            image_kwargs = dict(output_kwargs["images_kwargs"])
-            image_kwargs["do_resize"] = False
-            image_kwargs["do_rescale"] = True
-            image_kwargs.setdefault("return_tensors", "pt")
-            pixel_values = self.image_processor(images, **image_kwargs)
+            image_list = self._to_image_list(images)
+            use_local_preprocess = _bagel_img2img_local_preprocess_enabled()
+            precompute_local_vit = _bagel_img2img_local_preprocess_vit_enabled()
+            pixel_values = None
+            if use_local_preprocess and image_list and all(isinstance(img, Image.Image) for img in image_list):
+                vae_transform = self._get_img2img_vae_transform()
+                vit_transform = self._get_img2img_vit_transform()
+                vae_tensors = []
+                vit_chunks: list[torch.Tensor] = []
+                vit_grid_rows: list[list[int]] = []
+                patch_size = self._vit_patch_size
+                for img in image_list:
+                    img = img.convert("RGB") if img.mode != "RGB" else img
+                    vae_img = vae_transform.resize_only(img)
+                    vae_tensors.append(vae_transform(vae_img))
+
+                    if precompute_local_vit:
+                        vit_tensor = vit_transform(vae_img)
+                        _, vit_h, vit_w = vit_tensor.shape
+                        if vit_h % patch_size != 0 or vit_w % patch_size != 0:
+                            pad_h = (-vit_h) % patch_size
+                            pad_w = (-vit_w) % patch_size
+                            vit_tensor = torch.nn.functional.pad(vit_tensor, (0, pad_w, 0, pad_h))
+                            _, vit_h, vit_w = vit_tensor.shape
+                        vit_chunks.append(patchify(vit_tensor, patch_size))
+                        vit_grid_rows.append([1, vit_h // patch_size, vit_w // patch_size])
+
+                if len({tuple(t.shape) for t in vae_tensors}) == 1:
+                    data = {"pixel_values": torch.stack(vae_tensors, dim=0)}
+                    if precompute_local_vit and vit_chunks:
+                        data["pixel_values_img2img_vit"] = torch.cat(vit_chunks, dim=0)
+                        data["image_grid_thw_img2img_vit"] = torch.tensor(
+                            vit_grid_rows,
+                            dtype=torch.long,
+                        )
+                    pixel_values = BatchFeature(data)
+
+            if pixel_values is None:
+                image_kwargs = dict(output_kwargs["images_kwargs"])
+                image_kwargs["do_resize"] = False
+                image_kwargs["do_rescale"] = True
+                image_kwargs.setdefault("return_tensors", "pt")
+                pixel_values = self.image_processor(images, **image_kwargs)
 
             text_inputs = self.tokenizer(text, **output_kwargs["text_kwargs"]) if text is not None else None
 
             if pixel_values is not None and text_inputs is not None:
                 combined = dict(text_inputs)
-                combined["pixel_values"] = pixel_values["pixel_values"]
+                for key, value in pixel_values.items():
+                    combined[key] = value
                 return BatchFeature(combined)
             elif pixel_values is not None:
                 return pixel_values
@@ -93,12 +298,63 @@ class OmniBagelProcessor(BagelProcessor):
             else:
                 return BatchFeature({})
 
+        # PATCH (navit-thinker-fix): VQA path — apply ImageTransform(980, 224, 14)
+        # + patchify, emit packed pixel_values + image_grid_thw, so the model's
+        # _process_image_input override can run a NaViT-style ViT.
+        image_list = self._to_image_list(images)
+        if image_list:
+            from vllm.transformers_utils.processors.bagel import BagelProcessorKwargs
+
+            output_kwargs = self._merge_kwargs(
+                BagelProcessorKwargs,
+                tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+                **kwargs,
+            )
+
+            vit_transform = self._get_vit_transform()
+            patch_size = self._vit_patch_size
+            packed_chunks: list[torch.Tensor] = []
+            grid_thw_rows: list[list[int]] = []
+            for img in image_list:
+                tensor = vit_transform(img)  # (3, H, W) in [-1, 1]
+                _, H, W = tensor.shape
+                if H % patch_size != 0 or W % patch_size != 0:
+                    # ImageTransform's resize already aligns to stride=14, but
+                    # be defensive: pad to multiple of patch_size if upstream
+                    # ever changes.
+                    pad_h = (-H) % patch_size
+                    pad_w = (-W) % patch_size
+                    tensor = torch.nn.functional.pad(tensor, (0, pad_w, 0, pad_h))
+                    _, H, W = tensor.shape
+                patches = patchify(tensor, patch_size)  # (L, 3 * p²)
+                packed_chunks.append(patches)
+                grid_thw_rows.append([1, H // patch_size, W // patch_size])
+
+            packed_pixel_values = torch.cat(packed_chunks, dim=0)
+            image_grid_thw = torch.tensor(grid_thw_rows, dtype=torch.long)
+
+            text_inputs = (
+                self.tokenizer(text, **output_kwargs["text_kwargs"]) if text is not None else {}
+            )
+            result = dict(text_inputs) if text_inputs else {}
+            result["pixel_values"] = packed_pixel_values
+            result["image_grid_thw"] = image_grid_thw
+            return BatchFeature(result)
+
+        # Text-only / no-image path: defer to parent (tokenizer-only).
         return super().__call__(text, images, **kwargs)
 
 
 class OmniBagelProcessingInfo(BaseProcessingInfo):
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
-        return {"image": 1, "img2img": 1}
+        image_limit = 1
+        raw_limit = os.environ.get("BAGEL_MAX_MULTIMODAL_IMAGE_INPUTS")
+        if raw_limit:
+            try:
+                image_limit = max(1, int(raw_limit))
+            except ValueError:
+                image_limit = 1
+        return {"image": image_limit, "img2img": 1}
 
     def get_hf_processor(self, **kwargs: object):
         return self.ctx.get_hf_processor(OmniBagelProcessor, **kwargs)
@@ -233,10 +489,35 @@ class OmniBagelMultiModalProcessor(BaseMultiModalProcessor[OmniBagelProcessingIn
         return super()._cached_apply_hf_processor(inputs, timing_ctx)
 
     def _get_mm_fields_config(self, hf_inputs, hf_processor_mm_kwargs):
-        return {
-            "pixel_values": MultiModalFieldConfig.batched("image"),
+        # PATCH (navit-thinker-fix): VQA pixel_values now arrive as packed
+        # variable-shape tokens — slice with `flat_from_sizes` keyed off
+        # `image_grid_thw[:, 1] * image_grid_thw[:, 2]`. img2img path still
+        # produces uniform fixed-shape tensors.
+        image_grid_thw = hf_inputs.get("image_grid_thw") if isinstance(hf_inputs, Mapping) else None
+        if image_grid_thw is not None:
+            image_pixel_grid_sizes = image_grid_thw[:, 1] * image_grid_thw[:, 2]
+            pixel_values_cfg = MultiModalFieldConfig.flat_from_sizes("image", image_pixel_grid_sizes)
+        else:
+            # Fallback for warmup / dummy paths that may not populate image_grid_thw.
+            pixel_values_cfg = MultiModalFieldConfig.batched("image")
+        config = {
+            "pixel_values": pixel_values_cfg,
+            "image_grid_thw": MultiModalFieldConfig.batched("image"),
             "pixel_values_img2img": MultiModalFieldConfig.batched("img2img"),
         }
+        img2img_vit_grid_thw = (
+            hf_inputs.get("image_grid_thw_img2img_vit")
+            if isinstance(hf_inputs, Mapping)
+            else None
+        )
+        if img2img_vit_grid_thw is not None:
+            img2img_vit_grid_sizes = img2img_vit_grid_thw[:, 1] * img2img_vit_grid_thw[:, 2]
+            config["pixel_values_img2img_vit"] = MultiModalFieldConfig.flat_from_sizes(
+                "img2img",
+                img2img_vit_grid_sizes,
+            )
+            config["image_grid_thw_img2img_vit"] = MultiModalFieldConfig.batched("img2img")
+        return config
 
     def _call_hf_processor(
         self,
@@ -314,11 +595,32 @@ class OmniBagelMultiModalProcessor(BaseMultiModalProcessor[OmniBagelProcessingIn
         replacements: list[PromptReplacement] = []
 
         image_token_id = tokenizer.get_vocab().get("<|image_pad|>")
+        vision_start_id = tokenizer.get_vocab().get("<|vision_start|>")
+        vision_end_id = tokenizer.get_vocab().get("<|vision_end|>")
+        reference_layout = bagel_vqa_reference_layout_enabled()
         if image_token_id is not None:
-            num_patches = hf_config.vit_max_num_patch_per_side**2
+            # PATCH (navit-thinker-fix): with variable-shape ViT, each image
+            # consumes its own actual patch count (grid_h × grid_w from
+            # image_grid_thw), not the maximum 70×70=4900 slots. Read the
+            # grid from out_mm_kwargs which our HF processor populated.
+            # Pattern mirrors Qwen2-VL (`qwen2_5_vl.py:_get_prompt_updates`).
+            max_num_patches = hf_config.vit_max_num_patch_per_side**2
+
+            def _get_image_patch_count(item_idx: int) -> int:
+                try:
+                    out_item = out_mm_kwargs["image"][item_idx]
+                    grid = out_item["image_grid_thw"].data
+                    return int(grid[1].item()) * int(grid[2].item())
+                except Exception:
+                    return max_num_patches
 
             def get_image_replacement(item_idx: int):
-                return [image_token_id] * num_patches
+                count = _get_image_patch_count(item_idx)
+                if not reference_layout or vision_start_id is None or vision_end_id is None:
+                    return [image_token_id] * count
+
+                full = [vision_start_id] + [image_token_id] * count + [vision_end_id]
+                return PromptUpdateDetails.select_token_id(full, image_token_id)
 
             replacements.append(
                 PromptReplacement(
@@ -330,16 +632,41 @@ class OmniBagelMultiModalProcessor(BaseMultiModalProcessor[OmniBagelProcessingIn
 
         img2img_token_id = tokenizer.get_vocab().get("<|fim_middle|>")
         if img2img_token_id is not None:
+            include_vit = _bagel_force_input_img2img_vit_enabled()
             vit_config = hf_config.vit_config
             image_size = vit_config.image_size
-            num_vit_patches = (image_size // vit_config.patch_size) ** 2
 
             latent_patch_size = getattr(hf_config, "latent_patch_size", 2)
             downsample = hf_config.vae_config.get("downsample", 8)
             latent_downsample = downsample * latent_patch_size
 
+            def get_img2img_processed_item(item_idx: int) -> dict[str, object]:
+                if "img2img" not in out_mm_kwargs:
+                    return {}
+                try:
+                    items = out_mm_kwargs["img2img"]
+                    if item_idx >= len(items) or items[item_idx] is None:
+                        return {}
+                    return items[item_idx].get_data()
+                except Exception:
+                    return {}
+
             def get_img2img_replacement(item_idx: int):
                 h, w = image_size, image_size
+                processed = get_img2img_processed_item(item_idx)
+                processed_vae_hw: tuple[int, int] | None = None
+                processed_vit_tokens: int | None = None
+
+                if _bagel_img2img_local_preprocess_enabled():
+                    pv = processed.get("pixel_values_img2img")
+                    if isinstance(pv, torch.Tensor) and pv.ndim >= 3:
+                        processed_vae_hw = (int(pv.shape[-2]), int(pv.shape[-1]))
+
+                    grid = processed.get("image_grid_thw_img2img_vit")
+                    if isinstance(grid, torch.Tensor) and grid.numel() >= 3:
+                        row = grid.reshape(-1, 3)[0]
+                        processed_vit_tokens = int(row[1].item()) * int(row[2].item()) + 2
+
                 if "img2img" in mm_items:
                     item = mm_items.get_items("img2img", (Img2ImgProcessorItems, ImageEmbeddingItems))
                     if hasattr(item, "get_image_size"):
@@ -347,26 +674,61 @@ class OmniBagelMultiModalProcessor(BaseMultiModalProcessor[OmniBagelProcessingIn
                         h, w = size.height, size.width
 
                 max_latent_size = getattr(hf_config, "max_latent_size", 32)
-                max_img_size = int(max_latent_size * latent_downsample)
-                stride = latent_downsample
-                scale = min(max_img_size / max(h, w), 1.0)
-                min_img_size = min(256, max_img_size)
-                scale = max(scale, min_img_size / min(h, w))
-                new_h = max(stride, int(round(h * scale / stride) * stride))
-                new_w = max(stride, int(round(w * scale / stride) * stride))
-                new_h = min(new_h, max_img_size)
-                new_w = min(new_w, max_img_size)
+                if processed_vae_hw is not None:
+                    vae_h, vae_w = processed_vae_hw
+                else:
+                    vae_h, vae_w = _bagel_force_img2img_vae_hw(
+                        h,
+                        w,
+                        latent_downsample=latent_downsample,
+                        max_latent_size=max_latent_size,
+                    )
+                vit_h, vit_w = _bagel_force_img2img_vit_hw(vae_h, vae_w)
 
-                num_vae_patches = (new_h // latent_downsample) * (new_w // latent_downsample)
+                num_vae_patches = (vae_h // latent_downsample) * (vae_w // latent_downsample)
                 num_vae_total = num_vae_patches + 2
-                num_vit_total = num_vit_patches + 2
-                # +1 separator between VAE and ViT blocks so that
-                # extract_embeds_range() produces two distinct mm_prefix_range
-                # entries, preventing VAE tokens from attending to ViT.
-                total = num_vae_total + 1 + num_vit_total
+                num_vit_total = (
+                    processed_vit_tokens
+                    if processed_vit_tokens is not None
+                    else (vit_h // vit_config.patch_size) * (vit_w // vit_config.patch_size) + 2
+                )
+                if include_vit:
+                    if _bagel_img2img_vit_separator_enabled():
+                        # Historical vLLM-Omni img2img layout: VAE image block,
+                        # one raw <|fim_middle|> separator token, then the ViT
+                        # image block. Local BAGEL's force path performs VAE and
+                        # ViT cache updates back-to-back without this token, so
+                        # keep the separator opt-in for diagnostics only.
+                        total = num_vae_total + 1 + num_vit_total
+                        embed_mask = [True] * num_vae_total + [False] + [True] * num_vit_total
+                    else:
+                        total = num_vae_total + num_vit_total
+                        embed_mask = [True] * total
+                else:
+                    total = num_vae_total
+                    embed_mask = [True] * num_vae_total
                 tokens = [img2img_token_id] * total
 
-                embed_mask = [True] * num_vae_total + [False] + [True] * num_vit_total
+                if _bagel_img2img_debug_enabled():
+                    logger.info(
+                        "BAGEL img2img replacement idx=%d raw_hw=%dx%d vae_hw=%dx%d "
+                        "vit_hw=%dx%d vae_tokens=%d vit_tokens=%d total=%d "
+                        "processed_vae=%s processed_vit=%s sep=%s",
+                        item_idx,
+                        h,
+                        w,
+                        vae_h,
+                        vae_w,
+                        vit_h,
+                        vit_w,
+                        num_vae_total,
+                        num_vit_total if include_vit else 0,
+                        total,
+                        processed_vae_hw is not None,
+                        processed_vit_tokens is not None,
+                        _bagel_img2img_vit_separator_enabled(),
+                    )
+
                 return PromptUpdateDetails(
                     full=tokens,
                     is_embed=lambda _tok, _seq, _m=embed_mask: torch.tensor(_m, dtype=torch.bool),
@@ -404,6 +766,274 @@ class VAEEncoder(nn.Module):
         z = self.reg(self.encoder(x))
         z = self.scale_factor * (z - self.shift_factor)
         return z
+
+
+def _bagel_vqa_layer_attention_metadata(layer_name: str):
+    from vllm.forward_context import get_forward_context
+
+    raw = get_forward_context().attn_metadata
+    if isinstance(raw, dict):
+        return raw.get(layer_name)
+    if isinstance(raw, list):
+        return raw[0].get(layer_name)
+    return raw
+
+
+def _bagel_vqa_recompute_noncausal_image_blocks(
+    qwen_attn,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_output: torch.Tensor,
+) -> torch.Tensor:
+    owner = getattr(qwen_attn, "_bagel_vqa_owner", None)
+    spans = getattr(owner, "_bagel_vqa_image_spans_current", None)
+    if not spans:
+        return attn_output
+    return _bagel_recompute_noncausal_image_blocks_paged(
+        qwen_attn,
+        query,
+        key,
+        value,
+        attn_output,
+        spans,
+    )
+
+
+def _bagel_recompute_noncausal_image_blocks_paged(
+    qwen_attn,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_output: torch.Tensor,
+    spans: list[dict[str, int]],
+) -> torch.Tensor:
+    if not spans:
+        return attn_output
+    attn_layer = qwen_attn.attn
+    backend_name = attn_layer.attn_backend.get_name()
+
+    impl = attn_layer.impl
+    if getattr(impl, "dcp_world_size", 1) > 1:
+        raise RuntimeError("BAGEL reference prefill does not support DCP yet")
+
+    metadata = _bagel_vqa_layer_attention_metadata(attn_layer.layer_name)
+    if metadata is None:
+        return attn_output
+    if getattr(metadata, "use_cascade", False):
+        raise RuntimeError(
+            "BAGEL reference prefill does not support cascade attention; "
+            "disable prefix caching for this mode"
+        )
+
+    if backend_name != "FLASH_ATTN":
+        return _bagel_vqa_recompute_noncausal_image_blocks_direct(
+            qwen_attn,
+            query,
+            key,
+            value,
+            attn_output,
+            spans,
+            backend_name,
+        )
+
+    try:
+        from vllm.v1.attention.backends.fa_utils import (
+            flash_attn_varlen_func,
+            is_flash_attn_varlen_func_available,
+        )
+    except Exception as exc:
+        raise RuntimeError("BAGEL reference prefill requires FlashAttention") from exc
+    if not is_flash_attn_varlen_func_available():
+        raise RuntimeError("BAGEL reference prefill requires flash_attn_varlen_func")
+
+    kv_cache = attn_layer.kv_cache
+    if kv_cache.numel() == 0:
+        return attn_output
+    key_cache, value_cache = kv_cache.unbind(0)
+
+    out = attn_output.clone()
+    block_table = metadata.block_table
+    device = query.device
+    q_descale = None
+
+    for span in spans:
+        q_start = int(span["q_start"])
+        q_end = int(span["q_end"])
+        req_idx = int(span["req_idx"])
+        kv_end = int(span["kv_end"])
+        if q_end <= q_start:
+            continue
+
+        q_len = q_end - q_start
+        q = query[q_start:q_end].view(q_len, attn_layer.num_heads, attn_layer.head_size)
+        block_out = torch.empty(
+            (q_len, attn_layer.num_heads, attn_layer.head_size_v),
+            dtype=out.dtype,
+            device=device,
+        )
+        cu_q = torch.tensor([0, q_len], dtype=torch.int32, device=device)
+        seqused_k = torch.tensor([kv_end], dtype=torch.int32, device=device)
+
+        descale_shape = (1, attn_layer.num_kv_heads)
+        if getattr(impl, "supports_quant_query_input", False):
+            q_descale = attn_layer._q_scale.expand(descale_shape)
+        k_descale = attn_layer._k_scale.expand(descale_shape)
+        v_descale = attn_layer._v_scale.expand(descale_shape)
+        sliding_window = (
+            list(impl.sliding_window)
+            if getattr(impl, "sliding_window", None) is not None
+            else None
+        )
+
+        flash_attn_varlen_func(
+            q=q,
+            k=key_cache,
+            v=value_cache,
+            out=block_out,
+            cu_seqlens_q=cu_q,
+            max_seqlen_q=q_len,
+            seqused_k=seqused_k,
+            max_seqlen_k=max(kv_end, 1),
+            softmax_scale=impl.scale,
+            causal=False,
+            alibi_slopes=impl.alibi_slopes,
+            window_size=sliding_window,
+            block_table=block_table[req_idx : req_idx + 1],
+            softcap=impl.logits_soft_cap,
+            scheduler_metadata=None,
+            fa_version=impl.vllm_flash_attn_version,
+            q_descale=q_descale,
+            k_descale=k_descale,
+            v_descale=v_descale,
+            num_splits=1,
+            s_aux=getattr(impl, "sinks", None),
+        )
+        out[q_start:q_end] = block_out.reshape(q_len, -1)
+
+    return out
+
+
+def _bagel_vqa_recompute_noncausal_image_blocks_direct(
+    qwen_attn,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_output: torch.Tensor,
+    spans: list[dict[str, int]],
+    backend_name: str,
+) -> torch.Tensor:
+    """Backend-independent recompute for full-prefill image blocks.
+
+    Triton paged attention in vLLM 0.20 only exposes causal decoder attention.
+    In reference-prefill mode we disable chunked prefill, so BAGEL VQA image
+    spans are scheduled in the first prompt pass and the current K/V tensors
+    contain all keys needed up to the end of the image block.
+    """
+    attn_layer = qwen_attn.attn
+    impl = attn_layer.impl
+    if getattr(impl, "alibi_slopes", None) is not None:
+        raise RuntimeError(
+            "BAGEL reference prefill direct recompute does not support ALiBi"
+        )
+    if getattr(impl, "sinks", None) is not None:
+        raise RuntimeError(
+            "BAGEL reference prefill direct recompute does not support sinks"
+        )
+
+    sliding_window = getattr(impl, "sliding_window", None)
+    if sliding_window not in (None, (-1, -1), [-1, -1]):
+        raise RuntimeError(
+            "BAGEL reference prefill direct recompute does not support "
+            f"sliding window attention on backend {backend_name}"
+        )
+
+    out = attn_output.clone()
+    q_all = query.view(-1, attn_layer.num_heads, attn_layer.head_size)
+    k_all = key.view(-1, attn_layer.num_kv_heads, attn_layer.head_size)
+    v_all = value.view(-1, attn_layer.num_kv_heads, attn_layer.head_size_v)
+    repeat = attn_layer.num_heads // attn_layer.num_kv_heads
+    softcap = getattr(impl, "logits_soft_cap", 0) or 0
+
+    for span in spans:
+        computed = int(span.get("num_computed_tokens", 0))
+        if computed != 0:
+            raise RuntimeError(
+                "BAGEL reference prefill direct recompute needs the complete "
+                "image prefix in the current scheduled batch; disable chunked "
+                f"prefill or use a paged non-causal backend (got {computed} "
+                "computed tokens)"
+            )
+
+        q_start = int(span["q_start"])
+        q_end = int(span["q_end"])
+        request_start = int(span["request_start"])
+        kv_local_end = int(span["kv_local_end"])
+        kv_end = request_start + kv_local_end
+        if q_end <= q_start or kv_end <= request_start:
+            continue
+
+        q = q_all[q_start:q_end]
+        k = k_all[request_start:kv_end]
+        v = v_all[request_start:kv_end]
+        if repeat != 1:
+            k = k.repeat_interleave(repeat, dim=1)
+            v = v.repeat_interleave(repeat, dim=1)
+
+        if softcap <= 0:
+            q_sdpa = q.transpose(0, 1).unsqueeze(0).to(dtype=v.dtype)
+            k_sdpa = k.transpose(0, 1).unsqueeze(0).to(dtype=v.dtype)
+            v_sdpa = v.transpose(0, 1).unsqueeze(0)
+            block_out = F.scaled_dot_product_attention(
+                q_sdpa,
+                k_sdpa,
+                v_sdpa,
+                dropout_p=0.0,
+                is_causal=False,
+                scale=impl.scale,
+            )
+            block_out = block_out.squeeze(0).transpose(0, 1)
+            out[q_start:q_end] = block_out.reshape(q_end - q_start, -1).to(out.dtype)
+            continue
+
+        scores = torch.einsum("qhd,khd->hqk", q.float(), k.float()) * impl.scale
+        if softcap > 0:
+            scores = torch.tanh(scores / softcap) * softcap
+        probs = torch.softmax(scores, dim=-1).to(v.dtype)
+        block_out = torch.einsum("hqk,khd->qhd", probs, v)
+        out[q_start:q_end] = block_out.reshape(q_end - q_start, -1).to(out.dtype)
+
+    return out
+
+
+def _bagel_vqa_reference_qwen2_attention_forward(
+    self,
+    positions: torch.Tensor,
+    hidden_states: torch.Tensor,
+) -> torch.Tensor:
+    qkv, _ = self.qkv_proj(hidden_states)
+    q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+    if self.qk_norm:
+        total_tokens = q.shape[0]
+        q = q.view(total_tokens, self.num_heads, self.head_dim)
+        k = k.view(total_tokens, self.num_kv_heads, self.head_dim)
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+        q = q.view(total_tokens, self.q_size)
+        k = k.view(total_tokens, self.kv_size)
+
+    q, k = self.rotary_emb(positions, q, k)
+    attn_output = self.attn(q, k, v)
+    attn_output = _bagel_vqa_recompute_noncausal_image_blocks(
+        self,
+        q,
+        k,
+        v,
+        attn_output,
+    )
+    output, _ = self.o_proj(attn_output)
+    return output
 
 
 @MULTIMODAL_REGISTRY.register_processor(
@@ -447,6 +1077,18 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
         config = vllm_config.model_config.hf_config
+
+        # PATCH (navit-thinker-fix): `self.vit_model` (vllm's
+        # SiglipVisionModel) stays untouched so the upstream fixed-shape
+        # `_process_image_input` (used by img2img and warmup) still works.
+        # The NaViT path runs a per-image vllm-encoder loop in
+        # `_process_image_input_navit` (Session 5 winning state). Session 6
+        # tried swapping in HF SiglipVisionModel via SiglipNaViTWrapper —
+        # closed `know` by +16.67 but regressed text-heavy categories
+        # (math/ocr/spat -3 to -9 each), net -3.25 overall. Reverted; helper
+        # `_load_hf_navit_vit` is retained as a known-good loader for
+        # potential future hybrid experiments.
+
         self.latent_patch_size = getattr(config, "latent_patch_size", 2)
         self.downsample = config.vae_config.get("downsample")
         self.latent_downsample = self.downsample * self.latent_patch_size
@@ -460,10 +1102,23 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         self.latent_pos_embed = PositionEmbedding(self.max_latent_size, hidden_size)
         self.time_embedder = TimestepEmbedder(hidden_size)
 
-        self._pending_img2img_info: list[tuple[int, int, int, int]] = []
+        self._pending_img2img_info: list[tuple[int, ...]] = []
+        self._img2img_noncausal_spans_current: list[dict[str, int]] = []
         self._ropes_pending: list[dict[str, Any]] = []
         self._ropes_metadata: dict[str, dict[str, Any]] = {}
-        self._last_img2img_info: tuple[int, int, int, int] | None = None
+        self._last_img2img_info: tuple[int, ...] | None = None
+        self._bagel_vqa_rope_states: dict[str, dict[str, Any]] = {}
+        self._bagel_vqa_rope_positions_current: torch.Tensor | None = None
+        self._bagel_vqa_image_spans_current: list[dict[str, int]] = []
+        self._bagel_runner_num_computed_tokens_current: list[int] = []
+        self._bagel_vqa_reference_prefill_enabled = (
+            bagel_vqa_reference_prefill_enabled()
+        )
+        self._bagel_vqa_logical_rope_enabled = (
+            self._bagel_vqa_reference_prefill_enabled
+            or os.environ.get("BAGEL_VQA_LOGICAL_ROPE", "").lower()
+            in {"1", "true", "yes", "on"}
+        )
 
         from transformers import AutoTokenizer
 
@@ -478,6 +1133,8 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         self._vae_token_mask: torch.Tensor | None = None
         self.device = get_local_device()
         self._install_mot_modules(config)
+        if self._bagel_vqa_reference_prefill_enabled:
+            self._install_vqa_reference_attention()
 
     def _install_mot_modules(self, config):
         """Add generation-mode (MoT) weight modules to each Qwen2 decoder layer.
@@ -527,6 +1184,126 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
             layer.input_layernorm_moe_gen = VllmRMSNorm(hidden_size, eps=rms_eps)
             layer.post_attention_layernorm_moe_gen = VllmRMSNorm(hidden_size, eps=rms_eps)
 
+    def _install_vqa_reference_attention(self) -> None:
+        """Bind BAGEL-only image-block non-causal attention recompute hooks."""
+        qwen2_model = self.language_model.model
+        for layer in qwen2_model.layers:
+            if not isinstance(layer, Qwen2DecoderLayer):
+                continue
+            attn = layer.self_attn
+            if getattr(attn, "_bagel_vqa_reference_attention_installed", False):
+                object.__setattr__(attn, "_bagel_vqa_owner", self)
+                continue
+            object.__setattr__(attn, "_bagel_vqa_owner", self)
+            attn._bagel_vqa_original_forward = attn.forward
+            attn.forward = _bagel_vqa_reference_qwen2_attention_forward.__get__(
+                attn,
+                attn.__class__,
+            )
+            attn._bagel_vqa_reference_attention_installed = True
+
+    def _load_hf_navit_vit(self, device: torch.device, dtype: torch.dtype) -> SiglipNaViTWrapper:
+        """Lazily build a HuggingFace SiglipVisionModel + NaViT wrapper for the
+        VQA path. Loads weights from the BAGEL checkpoint (keys
+        ``vit_model.vision_model.*``) directly — no dependence on vllm's
+        already-loaded ``self.vit_model``. This bypasses vllm's adapted
+        ``SiglipEncoder`` (which lacks ``attention_mask`` support and produces
+        unnormalized output) and matches the reference torch-native bagel_local
+        pipeline exactly.
+
+        PATCH (hf-sigvit): the only forward path that hits this is
+        ``_process_image_input_navit`` (VQA). img2img + warmup still use
+        vllm's ``self.vit_model`` via the parent's ``_process_image_input``.
+        """
+        from pathlib import Path
+
+        from safetensors import safe_open
+        from transformers import SiglipVisionConfig, SiglipVisionModel
+
+        vit_cfg = self.config.vit_config
+        hf_cfg = SiglipVisionConfig(
+            hidden_size=vit_cfg.hidden_size,
+            intermediate_size=vit_cfg.intermediate_size,
+            num_attention_heads=vit_cfg.num_attention_heads,
+            num_hidden_layers=vit_cfg.num_hidden_layers,
+            patch_size=vit_cfg.patch_size,
+            image_size=vit_cfg.image_size,
+            num_channels=vit_cfg.num_channels,
+            attention_dropout=getattr(vit_cfg, "attention_dropout", 0.0),
+            layer_norm_eps=getattr(vit_cfg, "layer_norm_eps", 1e-6),
+            hidden_act=getattr(vit_cfg, "hidden_act", "gelu_pytorch_tanh"),
+            vision_use_head=False,
+        )
+        # `meta` device + later `to_empty` + state_dict load avoids materialising
+        # a full random-init ViT just to overwrite it.
+        with torch.device("meta"):
+            hf_model = SiglipVisionModel(hf_cfg)
+        hf_model = hf_model.to_empty(device=device).to(dtype=dtype)
+
+        ckpt_dir = Path(self._hf_navit_ckpt_path)
+        index_path = ckpt_dir / "model.safetensors.index.json"
+        if not index_path.exists():
+            raise RuntimeError(
+                f"HF NaViT ViT load: missing safetensors index at {index_path}"
+            )
+        import json as _json
+        with open(index_path) as f:
+            weight_map = _json.load(f)["weight_map"]
+
+        # Collect every `vit_model.vision_model.*` key, mapping prefix away.
+        wanted = {k: v for k, v in weight_map.items() if k.startswith("vit_model.vision_model.")}
+        if not wanted:
+            raise RuntimeError("HF NaViT ViT load: no vit_model.vision_model.* keys found")
+
+        # Group by shard for efficient I/O.
+        by_shard: dict[str, list[str]] = {}
+        for k, shard in wanted.items():
+            by_shard.setdefault(shard, []).append(k)
+
+        # Determine prefix handling: transformers >=5.x flattens
+        # SiglipVisionModel (state_dict starts with `embeddings.*`); pre-5.x
+        # kept the inner wrapper (`vision_model.embeddings.*`). Inspect what
+        # the model actually wants.
+        hf_keys = set(hf_model.state_dict().keys())
+        needs_strip = "embeddings.patch_embedding.weight" in hf_keys
+
+        state: dict[str, torch.Tensor] = {}
+        for shard, keys in by_shard.items():
+            with safe_open(str(ckpt_dir / shard), framework="pt") as sf:
+                for k in keys:
+                    # Strip BAGEL's `vit_model.` prefix.
+                    new_key = k[len("vit_model."):]
+                    # Optionally also strip `vision_model.` prefix on
+                    # transformers >=5.x.
+                    if needs_strip:
+                        new_key = new_key[len("vision_model."):]
+                    t = sf.get_tensor(k).to(dtype=dtype)
+                    # BAGEL stores patch_embedding flat as (out, kh*kw*in) with
+                    # inner order (kh, kw, c); HF Conv2d expects (out, in, kh, kw).
+                    is_patch_w = new_key.endswith("embeddings.patch_embedding.weight")
+                    if is_patch_w and t.ndim == 2:
+                        patch_size = vit_cfg.patch_size
+                        in_ch = vit_cfg.num_channels
+                        out_ch = t.shape[0]
+                        t = t.reshape(out_ch, patch_size, patch_size, in_ch).permute(0, 3, 1, 2).contiguous()
+                    state[new_key] = t
+
+        missing, unexpected = hf_model.load_state_dict(state, strict=False)
+        # `head` is added by HF for some configurations and is absent in BAGEL;
+        # filter it out of the unexpected list before warning.
+        unexpected = [u for u in unexpected if "head" not in u]
+        if missing or unexpected:
+            import logging
+            logging.getLogger(__name__).warning(
+                "HF NaViT ViT load: missing=%s unexpected=%s (transformers_strip=%s)",
+                missing[:5], unexpected[:5], needs_strip,
+            )
+
+        hf_model.eval()
+        for p in hf_model.parameters():
+            p.requires_grad_(False)
+        return SiglipNaViTWrapper(hf_model)
+
     def _resize_to_stride(self, pixel_values: torch.Tensor) -> torch.Tensor:
         """Resize pixel values to stride-aligned dimensions
         (matches DiT's ``_resize_images_to_stride``)."""
@@ -555,6 +1332,10 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         self._pending_img2img_info.clear()
         self._last_img2img_info = None
         self._vae_token_mask = None
+        self._bagel_vqa_rope_states.clear()
+        self._bagel_vqa_rope_positions_current = None
+        self._bagel_vqa_image_spans_current = []
+        self._bagel_runner_num_computed_tokens_current = []
 
     def get_kv_transfer_metadata(
         self,
@@ -592,7 +1373,74 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         detection."""
         if inputs_embeds is not None and input_ids is None and input_ids_buffer is not None:
             input_ids = input_ids_buffer
+        self._bagel_vqa_rope_positions_current = self._build_bagel_vqa_rope_positions(
+            input_ids=input_ids,
+            positions=positions,
+            req_ids=req_ids,
+            num_computed_tokens=num_computed_tokens,
+            num_scheduled_tokens=num_scheduled_tokens,
+        )
+        self._bagel_vqa_image_spans_current = self._build_bagel_vqa_image_spans(
+            input_ids=input_ids,
+            req_ids=req_ids,
+            num_computed_tokens=num_computed_tokens,
+            num_scheduled_tokens=num_scheduled_tokens,
+        )
+        self._bagel_runner_num_computed_tokens_current = [
+            int(x) for x in num_computed_tokens
+        ]
         return input_ids, positions
+
+    def _build_bagel_vqa_rope_positions(
+        self,
+        *,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor | None,
+        req_ids: list[str],
+        num_computed_tokens: list[int],
+        num_scheduled_tokens: list[int],
+    ) -> torch.Tensor | None:
+        """Compute BAGEL logical RoPE positions without touching vLLM slots.
+
+        vLLM's `positions` tensor remains the physical paged-KV position used by
+        slot mapping and attention metadata. This side-channel mirrors BAGEL
+        reference's logical rule for VQA: every token in a vision block shares
+        one RoPE position, and text/decode tokens continue from the collapsed
+        logical length. State is per request so chunked prefill and continuous
+        batching can cross image-block boundaries safely.
+        """
+        if not self._bagel_vqa_logical_rope_enabled:
+            return None
+
+        return build_bagel_vqa_rope_positions(
+            input_ids=input_ids,
+            positions=positions,
+            req_ids=req_ids,
+            num_computed_tokens=num_computed_tokens,
+            num_scheduled_tokens=num_scheduled_tokens,
+            rope_states=self._bagel_vqa_rope_states,
+            start_of_image_id=self._start_of_image_id,
+            end_of_image_id=self._end_of_image_id,
+        )
+
+    def _build_bagel_vqa_image_spans(
+        self,
+        *,
+        input_ids: torch.Tensor | None,
+        req_ids: list[str],
+        num_computed_tokens: list[int],
+        num_scheduled_tokens: list[int],
+    ) -> list[dict[str, int]]:
+        if not self._bagel_vqa_reference_prefill_enabled:
+            return []
+        return build_bagel_vqa_image_spans(
+            input_ids=input_ids,
+            req_ids=req_ids,
+            num_computed_tokens=num_computed_tokens,
+            num_scheduled_tokens=num_scheduled_tokens,
+            start_of_image_id=self._start_of_image_id,
+            end_of_image_id=self._end_of_image_id,
+        )
 
     def flush_pending_metadata(self, req_ids: list[str]) -> None:
         """Map pending metadata (batch order) to req_ids after forward().
@@ -618,15 +1466,45 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         mm_input_by_modality = {}
 
         if any(k in kwargs for k in ("pixel_values", "image_embeds")):
-            mm_input_by_modality["img2text"] = self._parse_and_validate_image_input(**kwargs)
+            parsed = self._parse_and_validate_image_input(**kwargs)
+            # PATCH (navit-thinker-fix): propagate image_grid_thw alongside
+            # pixel_values so `_process_img2text_input` can dispatch to the
+            # NaViT branch when present. The parent returns an immutable
+            # ``BagelImagePixelInputs`` TensorSchema, so re-pack into a plain
+            # dict (still subscriptable downstream) before adding extra keys.
+            grid_thw = kwargs.get("image_grid_thw")
+            if parsed is not None and grid_thw is not None:
+                parsed_dict = {
+                    "type": parsed["type"],
+                    "pixel_values": parsed["pixel_values"],
+                    "image_grid_thw": grid_thw,
+                }
+                mm_input_by_modality["img2text"] = parsed_dict
+            else:
+                mm_input_by_modality["img2text"] = parsed
 
-        img2img_keys = {"pixel_values_img2img": "pixel_values", "image_embeds_img2img": "image_embeds"}
+        img2img_keys = {
+            "pixel_values_img2img": "pixel_values",
+            "image_embeds_img2img": "image_embeds",
+            "pixel_values_img2img_vit": "pixel_values_vit",
+            "image_grid_thw_img2img_vit": "image_grid_thw_vit",
+        }
         img2img_kwargs = {img2img_keys[k]: v for k, v in kwargs.items() if k in img2img_keys}
 
         if img2img_kwargs:
             combined_kwargs = kwargs.copy()
             combined_kwargs.update(img2img_kwargs)
-            mm_input_by_modality["img2img"] = self._parse_and_validate_image_input(**combined_kwargs)
+            parsed = self._parse_and_validate_image_input(**combined_kwargs)
+            if parsed is not None:
+                parsed_dict = {
+                    "type": parsed["type"],
+                    "pixel_values": parsed["pixel_values"],
+                }
+                if "pixel_values_vit" in img2img_kwargs:
+                    parsed_dict["pixel_values_vit"] = img2img_kwargs["pixel_values_vit"]
+                if "image_grid_thw_vit" in img2img_kwargs:
+                    parsed_dict["image_grid_thw_vit"] = img2img_kwargs["image_grid_thw_vit"]
+                mm_input_by_modality["img2img"] = parsed_dict
 
         return mm_input_by_modality
 
@@ -654,34 +1532,126 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         return pos_ids
 
     def _process_img2text_input(self, multimodal_input):
+        # PATCH (navit-thinker-fix): when our processor produced packed
+        # variable-shape pixel_values + image_grid_thw, take the NaViT path.
+        # Otherwise fall back to the upstream fixed-shape path (used by
+        # warmup / dummy inputs that pre-date this patch).
+        if "image_grid_thw" in multimodal_input:
+            return self._process_image_input_navit(multimodal_input)
         return self._process_image_input(multimodal_input)
+
+    def _process_image_input_navit(self, multimodal_input) -> tuple[torch.Tensor, ...]:
+        """NaViT-style ViT forward for variable-shape packed pixel_values.
+
+        Per-image vllm-encoder loop (the Session 5 winning configuration).
+        Tried Session 6 HF SigLIP via SiglipNaViTWrapper: improved `know`
+        (+16.67) but regressed `math/ocr/spat` by 3-9pt each, net -3.25
+        overall on full 100 vs this baseline. Reverted because the gain on
+        `know` doesn't compensate the loss on text-heavy categories.
+
+        Sequence: linear patch_embed + pos_embed → vllm SiglipEncoder per
+        image → post_layernorm → connector → vit_pos_embed. post_layernorm
+        IS load-bearing here — removing it broke the path entirely (mean=0.0
+        on smoke).
+        """
+        pixel_values = multimodal_input["pixel_values"]
+        grid_thw = multimodal_input["image_grid_thw"]
+        # `flat_from_sizes` slices into a list of per-image (L_i, ...) tensors;
+        # concatenate back to packed (total_patches, ...) for NaViT.
+        if isinstance(pixel_values, (list, tuple)):
+            pixel_values = torch.cat([t for t in pixel_values], dim=0)
+        if isinstance(grid_thw, (list, tuple)):
+            grid_thw = torch.cat([t.unsqueeze(0) if t.ndim == 1 else t for t in grid_thw], dim=0)
+
+        device = pixel_values.device
+        grid_thw = grid_thw.to(device)
+        patch_counts = grid_thw[:, 1] * grid_thw[:, 2]
+        cu_seqlens = torch.cat([
+            torch.zeros(1, dtype=torch.int32, device=device),
+            patch_counts.cumsum(0).to(torch.int32),
+        ])
+
+        # Shared bits: patch embedding weight and pos table.
+        vit = self.vit_model  # vllm's SiglipVisionModel (unwrapped — see __init__)
+        patch_embed = vit.vision_model.embeddings.patch_embedding
+        patch_embed_weight = patch_embed.weight.view(patch_embed.weight.shape[0], -1)
+        position_embedding = vit.vision_model.embeddings.position_embedding
+        target_dtype = patch_embed.weight.dtype
+        patch_size = self.config.vit_config.patch_size
+        max_per_side = self.config.vit_max_num_patch_per_side
+
+        # Forward each image independently through patch_embed + pos + encoder.
+        per_image_features: list[torch.Tensor] = []
+        per_image_pos_ids: list[torch.Tensor] = []
+        cu_list = cu_seqlens.tolist()
+        for i in range(grid_thw.shape[0]):
+            start, end = cu_list[i], cu_list[i + 1]
+            patches = pixel_values[start:end].to(dtype=target_dtype)
+
+            h_pixels = int(grid_thw[i, 1].item()) * patch_size
+            w_pixels = int(grid_thw[i, 2].item()) * patch_size
+            pos_ids = get_flattened_position_ids_extrapolate(
+                h_pixels, w_pixels, patch_size, max_per_side
+            ).to(device=device, dtype=torch.long)
+            per_image_pos_ids.append(pos_ids)
+
+            x = torch.nn.functional.linear(patches, patch_embed_weight, patch_embed.bias)
+            x = x + position_embedding(pos_ids)
+            x_3d = x.unsqueeze(0)
+
+            encoder_out = vit.vision_model.encoder(
+                inputs_embeds=x_3d, return_all_hidden_states=False
+            )
+            if isinstance(encoder_out, list):
+                encoder_out = encoder_out[-1]
+            post_ln = getattr(vit.vision_model, "post_layernorm", None)
+            if post_ln is not None:
+                encoder_out = post_ln(encoder_out)
+            per_image_features.append(encoder_out.squeeze(0))
+
+        vision_features = torch.cat(per_image_features, dim=0)
+        vision_embeds = self.connector(vision_features)
+        packed_pos_ids = torch.cat(per_image_pos_ids)
+        pos_emb = self.vit_pos_embed(packed_pos_ids.cpu()).to(
+            device=vision_embeds.device, dtype=vision_embeds.dtype
+        )
+        vision_embeds = vision_embeds + pos_emb
+
+        return tuple(
+            vision_embeds[cu_list[i]: cu_list[i + 1]]
+            for i in range(len(cu_list) - 1)
+        )
 
     def _process_img2img_input(self, multimodal_input):
         pixel_values = multimodal_input["pixel_values"]
-        if pixel_values.ndim == 5:
-            b, n, c, h, w = pixel_values.shape
-            pixel_values = pixel_values.reshape(b * n, c, h, w)
+        pixel_value_items: list[torch.Tensor] = []
+        raw_items = pixel_values if isinstance(pixel_values, (list, tuple)) else [pixel_values]
+        for item in raw_items:
+            if item.ndim == 5:
+                b, n, c, h, w = item.shape
+                item = item.reshape(b * n, c, h, w)
+            elif item.ndim == 3:
+                item = item.unsqueeze(0)
+            if item.ndim != 4:
+                raise ValueError(f"Unsupported img2img pixel_values shape: {tuple(item.shape)}")
+            pixel_value_items.extend(item[i : i + 1] for i in range(item.shape[0]))
 
-        num_images = pixel_values.shape[0]
-        image_size = self.config.vit_config.image_size
+        if not pixel_value_items:
+            return ()
+
+        num_images = len(pixel_value_items)
+        pixel_device = pixel_value_items[0].device
+        include_vit = _bagel_force_input_img2img_vit_enabled()
+        use_vit_separator = include_vit and _bagel_img2img_vit_separator_enabled()
         p = self.latent_patch_size
         timestep = 0
 
         if self._ropes_pending:
             self._ropes_pending.clear()
 
-        vit_pixel_values = torch.nn.functional.interpolate(
-            pixel_values,
-            size=(image_size, image_size),
-            mode="bicubic",
-            align_corners=False,
-        )
-
-        vit_embeddings_tuple = self._process_image_input({"pixel_values": vit_pixel_values})
-
         marker_ids = torch.tensor(
             [self._start_of_image_id, self._end_of_image_id],
-            device=pixel_values.device,
+            device=pixel_device,
             dtype=torch.long,
         )
         marker_embeds = self.language_model.model.embed_tokens(marker_ids)
@@ -689,11 +1659,85 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         end_embed = marker_embeds[1:2]
 
         results = []
+        prepared_vae_inputs: list[tuple[torch.Tensor, int, int]] = []
+        vit_patch_chunks: list[torch.Tensor] = []
+        vit_grid_rows: list[list[int]] = []
+        precomputed_vit_pixel_values = multimodal_input.get("pixel_values_vit")
+        precomputed_vit_grid_thw = multimodal_input.get("image_grid_thw_vit")
+        debug_img2img = _bagel_img2img_debug_enabled()
 
-        for i in range(num_images):
-            single_pv = pixel_values[i : i + 1]
-            single_pv = self._resize_to_stride(single_pv)
-            H, W = single_pv.shape[2:]
+        for i, single_pv in enumerate(pixel_value_items):
+            raw_h, raw_w = single_pv.shape[2:]
+            vae_h, vae_w = _bagel_force_img2img_vae_hw(
+                raw_h,
+                raw_w,
+                latent_downsample=self.latent_downsample,
+                max_latent_size=self.max_latent_size,
+            )
+            if (raw_h, raw_w) != (vae_h, vae_w):
+                single_pv = torch.nn.functional.interpolate(
+                    single_pv,
+                    size=(vae_h, vae_w),
+                    mode="bicubic",
+                    align_corners=False,
+            )
+            prepared_vae_inputs.append((single_pv, vae_h, vae_w))
+
+            if include_vit and precomputed_vit_pixel_values is None:
+                vit_h, vit_w = _bagel_force_img2img_vit_hw(vae_h, vae_w)
+                vit_pixel_values = torch.nn.functional.interpolate(
+                    single_pv,
+                    size=(vit_h, vit_w),
+                    mode="bicubic",
+                    align_corners=False,
+                )
+                vit_patch_chunks.append(
+                    patchify(vit_pixel_values[0], self.config.vit_config.patch_size)
+                )
+                vit_grid_rows.append(
+                    [
+                        1,
+                        vit_h // self.config.vit_config.patch_size,
+                        vit_w // self.config.vit_config.patch_size,
+                    ]
+                )
+
+        vit_embeddings_tuple = ()
+        if include_vit:
+            if precomputed_vit_pixel_values is not None and precomputed_vit_grid_thw is not None:
+                vit_pixel_values = precomputed_vit_pixel_values
+                vit_grid_thw = precomputed_vit_grid_thw
+                if isinstance(vit_pixel_values, (list, tuple)):
+                    vit_pixel_values = torch.cat([t for t in vit_pixel_values], dim=0)
+                if isinstance(vit_grid_thw, (list, tuple)):
+                    vit_grid_thw = torch.cat(
+                        [t.unsqueeze(0) if t.ndim == 1 else t for t in vit_grid_thw],
+                        dim=0,
+                    )
+                if vit_grid_thw.ndim == 1:
+                    vit_grid_thw = vit_grid_thw.unsqueeze(0)
+                vit_embeddings_tuple = self._process_image_input_navit(
+                    {
+                        "pixel_values": vit_pixel_values,
+                        "image_grid_thw": vit_grid_thw.to(
+                            device=pixel_device,
+                            dtype=torch.long,
+                        ),
+                    }
+                )
+            elif vit_patch_chunks:
+                vit_embeddings_tuple = self._process_image_input_navit(
+                    {
+                        "pixel_values": torch.cat(vit_patch_chunks, dim=0),
+                        "image_grid_thw": torch.tensor(
+                            vit_grid_rows,
+                            dtype=torch.long,
+                            device=pixel_values.device,
+                        ),
+                    }
+                )
+
+        for i, (single_pv, H, W) in enumerate(prepared_vae_inputs):
 
             padded_latent = self.vae.encode(single_pv)
             h = H // self.latent_downsample
@@ -715,16 +1759,34 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                 timestep_embeds = self.time_embedder(packed_timesteps.to(padded_latent))
             vae_embeds = self.vae2llm(latent) + timestep_embeds + pos_embed
 
-            vit_emb = vit_embeddings_tuple[i] if i < len(vit_embeddings_tuple) else vit_embeddings_tuple[0]
-
             se = start_embed.to(vae_embeds.dtype)
             ee = end_embed.to(vae_embeds.dtype)
-            combined = torch.cat([se, vae_embeds, ee, se, vit_emb, ee], dim=0)
+            if include_vit:
+                vit_emb = vit_embeddings_tuple[i] if i < len(vit_embeddings_tuple) else vit_embeddings_tuple[0]
+                combined = torch.cat([se, vae_embeds, ee, se, vit_emb, ee], dim=0)
+                num_vit = vit_emb.shape[0] + 2 + (1 if use_vit_separator else 0)
+            else:
+                combined = torch.cat([se, vae_embeds, ee], dim=0)
+                num_vit = 0
             results.append(combined)
 
             num_vae = h * w + 2  # +2 for start/end markers
-            num_vit = vit_emb.shape[0] + 2
-            info = (num_vae, num_vit, int(H), int(W))
+            info = (num_vae, num_vit, int(H), int(W), 1 if use_vit_separator else 0)
+            if debug_img2img:
+                logger.info(
+                    "BAGEL img2img embeddings idx=%d raw_hw=%dx%d vae_hw=%dx%d "
+                    "vae_tokens=%d vit_tokens=%d combined=%d precomputed_vit=%s sep=%s",
+                    i,
+                    raw_h,
+                    raw_w,
+                    H,
+                    W,
+                    num_vae,
+                    num_vit,
+                    combined.shape[0],
+                    precomputed_vit_pixel_values is not None,
+                    use_vit_separator,
+                )
             self._pending_img2img_info.append(info)
             self._last_img2img_info = info
 
@@ -747,8 +1809,9 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
 
         elif self._last_img2img_info is not None:
             info = self._last_img2img_info
-            num_vae, num_vit, _, _ = info
-            num_img2img = num_vae + 1 + num_vit
+            num_vae = int(info[0])
+            num_vit = int(info[1])
+            num_img2img = num_vae + num_vit
 
             if seq_len >= num_img2img:
                 self._pending_img2img_info = [info]
@@ -760,7 +1823,15 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
 
         if use_mot:
             return self._mot_forward(input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs)
-        return super().forward(input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs)
+
+        rope_positions = self._bagel_vqa_rope_positions_current
+        self._bagel_vqa_rope_positions_current = None
+        try:
+            if rope_positions is not None and rope_positions.shape == positions.shape:
+                return super().forward(input_ids, rope_positions, intermediate_tensors, inputs_embeds, **kwargs)
+            return super().forward(input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs)
+        finally:
+            self._bagel_vqa_image_spans_current = []
 
     def _adjust_positions_for_img2img(
         self,
@@ -774,7 +1845,6 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
 
             pre_text -> 0 .. M-1
             VAE      -> M       (all share)
-            separator-> M
             ViT      -> M+1     (all share)
             post_text-> M+2, M+3, ...
 
@@ -798,10 +1868,17 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         vae_mask = torch.zeros(len(positions), dtype=torch.bool, device=positions.device)
 
         img2img_idx = 0
+        noncausal_spans: list[dict[str, int]] = []
+        num_computed_tokens = self._bagel_runner_num_computed_tokens_current
         for req_idx in range(num_requests):
             start = boundaries[req_idx]
             end = boundaries[req_idx + 1]
             req_len = end - start
+            num_computed = (
+                int(num_computed_tokens[req_idx])
+                if req_idx < len(num_computed_tokens)
+                else 0
+            )
 
             if img2img_idx < len(info_list):
                 cur_info = info_list[img2img_idx]
@@ -811,8 +1888,13 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                 cur_info = None
 
             if cur_info is not None:
-                num_vae, num_vit, img_H, img_W = cur_info
-                num_img2img = num_vae + 1 + num_vit  # +1 separator
+                if len(cur_info) >= 5:
+                    num_vae, num_vit, img_H, img_W, sep_count = cur_info
+                else:
+                    num_vae, num_vit, img_H, img_W = cur_info
+                    sep_count = 0
+                include_vit = num_vit > 0
+                num_img2img = num_vae + num_vit if include_vit else num_vae
 
                 if req_len >= num_img2img:
                     pre_text_len = 0
@@ -832,15 +1914,17 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                         )
 
                     new_positions[img_start : img_start + num_vae] = M
-                    new_positions[img_start + num_vae] = M  # separator
-                    vit_start = img_start + num_vae + 1
-                    new_positions[vit_start : vit_start + num_vit] = M + 1
+                    if include_vit:
+                        vit_group_start = img_start + num_vae
+                        vit_start = vit_group_start + sep_count
+                        new_positions[vit_group_start : vit_group_start + num_vit] = M + 1
 
                     num_post_text = end - post_text_start
+                    post_text_rope_start = M + 2 if include_vit else M + 1
                     if num_post_text > 0:
                         new_positions[post_text_start:end] = torch.arange(
-                            M + 2,
-                            M + 2 + num_post_text,
+                            post_text_rope_start,
+                            post_text_rope_start + num_post_text,
                             device=positions.device,
                             dtype=positions.dtype,
                         )
@@ -850,14 +1934,53 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                     if vae_patches_end > vae_patches_start:
                         vae_mask[vae_patches_start:vae_patches_end] = True
 
-                    rope = M + 2 + num_post_text
+                    noncausal_spans.append(
+                        {
+                            "req_idx": req_idx,
+                            "q_start": img_start,
+                            "q_end": img_start + num_vae,
+                            "request_start": start,
+                            "num_computed_tokens": num_computed,
+                            "kv_local_end": M + num_vae,
+                            "kv_end": num_computed + M + num_vae,
+                        }
+                    )
+                    if include_vit:
+                        noncausal_spans.append(
+                            {
+                                "req_idx": req_idx,
+                                "q_start": vit_start,
+                                "q_end": img_start + num_vae + num_vit,
+                                "request_start": start,
+                                "num_computed_tokens": num_computed,
+                                "kv_local_end": M + num_vae + num_vit,
+                                "kv_end": num_computed + M + num_vae + num_vit,
+                            }
+                        )
+
+                    rope = post_text_rope_start + num_post_text
                     self._ropes_pending.append(
                         {
                             "ropes": [rope],
                             "image_shape": [img_H, img_W],
                             "prefill_position_count": req_len,
+                            "cfg_text_kv_len": num_img2img + M,
+                            "cfg_text_rope": post_text_rope_start,
                         }
                     )
+                    if _bagel_img2img_debug_enabled():
+                        logger.info(
+                            "BAGEL img2img positions req=%d req_len=%d pre_text=%d "
+                            "img_start=%d num_vae=%d num_vit=%d post_text=%d rope=%d",
+                            req_idx,
+                            req_len,
+                            M,
+                            img_start,
+                            num_vae,
+                            num_vit,
+                            num_post_text,
+                            rope,
+                        )
                     img2img_idx += 1
                     continue
 
@@ -865,7 +1988,32 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
             self._ropes_pending.append({"ropes": [rope]})
 
         self._vae_token_mask = vae_mask if vae_mask.any() else None
+        self._img2img_noncausal_spans_current = noncausal_spans
         return new_positions
+
+    # Session 8 (2026-05-18) attempted to add a VQA-mode counterpart to
+    # _adjust_positions_for_img2img that collapsed <|vision_start|>...<|vision_end|>
+    # tokens to a shared position (mirroring vlmeval reference's bagel.py:340
+    # which assigns ALL vision-block tokens the same packed_position_id and
+    # advances RoPE by only 1 after the whole block).
+    #
+    # Result: NET REGRESSION on full 100-sample MMVet:
+    #   - Smoke 10-sample (concurrency=4): 77.78 (looked great)
+    #   - Full 100 (chunked prefill on, concurrency=16):  61.14 (vs S5 baseline 64.66)
+    #   - Full 100 (chunked prefill off, concurrency=16): 60.22
+    # The smoke's 77.78 was a sample artifact: first-10 indices are all
+    # equation/math problems where collapsed positions happened to help. On
+    # the broader 100-sample set every category regressed (math −4.17,
+    # ocr −4.71, spat −6.94, rec −4.44, know flat).
+    #
+    # Reverted. `_build_bagel_vqa_rope_positions` above keeps the safer
+    # side-channel version available behind BAGEL_VQA_LOGICAL_ROPE=1 for
+    # future experiments, but default VQA serving stays on physical positions.
+    # Token/RoPE layout alone is not enough to match reference BAGEL because
+    # reference image blocks are prefetched with non-causal attention.
+    #
+    # Diff archive: vllm_omni_serving/patches/omni_bagel_vqa_position_remap.patch
+    # Snapshot:     vllm_omni_serving/patches/omni_bagel_thinker_vqa_position_fix.py.patched
 
     # ------------------------------------------------------------------
     # MoT (Mixture-of-Transformers) forward path
@@ -882,7 +2030,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         """Full forward pass with MoT routing for img2img requests.
 
         VAE latent patches are routed through ``*_moe_gen`` weight matrices
-        while all other tokens (markers, ViT, separator, text) use the
+        while all other tokens (markers, ViT, text) use the
         standard understanding-mode weights.
         """
         qwen2_model = self.language_model.model  # Qwen2Model
@@ -1013,6 +2161,31 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         # ---- RoPE + attention (same for all tokens) ----
         q, k = attn.rotary_emb(positions, q, k)
         attn_output = attn.attn(q, k, v)
+        spans = self._img2img_noncausal_spans_current
+        if spans:
+            if _env_flag("BAGEL_IMG2IMG_NONCAUSAL_RECOMPUTE", False):
+                try:
+                    attn_output = _bagel_recompute_noncausal_image_blocks_paged(
+                        attn,
+                        q,
+                        k,
+                        v,
+                        attn_output,
+                        spans,
+                    )
+                except Exception:
+                    # Keep the experiment debuggable on non-paged/mock
+                    # backends; real vLLM prefill should use the paged KV path
+                    # above so image tokens can still see transferred/prefix KV.
+                    attn_output = _bagel_vqa_recompute_noncausal_image_blocks_direct(
+                        attn,
+                        q,
+                        k,
+                        v,
+                        attn_output,
+                        spans,
+                        "img2img",
+                    )
 
         # ---- O projection (split) ----
         output = torch.empty(

--- a/vllm_omni/model_executor/stage_input_processors/bagel.py
+++ b/vllm_omni/model_executor/stage_input_processors/bagel.py
@@ -13,6 +13,7 @@ This module provides model-specific functions referenced by bagel.yaml:
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
@@ -21,6 +22,14 @@ logger = logging.getLogger(__name__)
 
 CFG_TEXT_SUFFIX = "__cfg_text"
 CFG_IMG_SUFFIX = "__cfg_img"
+
+
+def _cfg_text_from_main_prefix_enabled(sampling_params: Any) -> bool:
+    raw = os.environ.get("BAGEL_CFG_TEXT_FROM_MAIN_PREFIX", "0")
+    if raw.strip().lower() not in {"1", "true", "yes", "on"}:
+        return False
+    extra = getattr(sampling_params, "extra_args", None) or {}
+    return bool(extra.get("force_stage1_continue"))
 
 
 @dataclass
@@ -98,50 +107,57 @@ def expand_cfg_prompts(
 
     if "img2img" in modalities:
         IMG2IMG_PLACEHOLDER = "<|fim_middle|>"
+        original_text = prompt.get("prompt", "")
+        parts = original_text.split(IMG2IMG_PLACEHOLDER, 1)
+        system_prefix = parts[0] if len(parts) > 1 else ""
 
         cfg_text_dict: dict[str, Any] = {
-            "prompt": f"{IMG2IMG_PLACEHOLDER}{neg_prompt}",
+            "prompt": f"{system_prefix}{IMG2IMG_PLACEHOLDER}{neg_prompt}",
             "modalities": ["img2img"],
         }
         mm_data = prompt.get("multi_modal_data")
         if mm_data:
             cfg_text_dict["multi_modal_data"] = mm_data
 
-        original_text = prompt.get("prompt", "")
         cfg_img_text = original_text.replace(IMG2IMG_PLACEHOLDER, "")
         cfg_img_dict: dict[str, Any] = {
             "prompt": cfg_img_text,
             "modalities": ["img2img"],
         }
 
-        return [
-            ExpandedPrompt(
-                prompt=cfg_text_dict,
-                role="cfg_text",
-                request_id_suffix=CFG_TEXT_SUFFIX,
-            ),
+        expanded = []
+        if not _cfg_text_from_main_prefix_enabled(sampling_params):
+            expanded.append(
+                ExpandedPrompt(
+                    prompt=cfg_text_dict,
+                    role="cfg_text",
+                    request_id_suffix=CFG_TEXT_SUFFIX,
+                )
+            )
+        expanded.append(
             ExpandedPrompt(
                 prompt=cfg_img_dict,
                 role="cfg_img",
                 request_id_suffix=CFG_IMG_SUFFIX,
-            ),
-        ]
+            )
+        )
+        return expanded
 
     return []
 
 
 GEN_THINK_SYSTEM_PROMPT = (
-    "You should first think about the planning process in the mind "
-    "and then generate the image. \n"
-    "The planning process is enclosed within <think> </think> tags, "
-    "i.e. <think> planning process here </think> image here"
+    "You should first think about the planning process in the mind and then "
+    "generate the image.\n"
+    "The planning process is enclosed within <think> </think> tags, i.e. "
+    "<think> planning process here </think> image here"
 )
 
 VLM_THINK_SYSTEM_PROMPT = (
-    "You should first think about the reasoning process in the mind "
-    "and then provide the user with the answer. \n"
-    "The reasoning process is enclosed within <think> </think> tags, "
-    "i.e. <think> reasoning process here </think> answer here"
+    "You should first think about the reasoning process in the mind and then "
+    "provide the user with the answer.\n"
+    "The reasoning process is enclosed within <think> </think> tags, i.e. "
+    "<think> reasoning process here </think> answer here"
 )
 
 
@@ -207,23 +223,26 @@ def expand_cfg_prompts_think(
             "prompt": cfg_img_text,
             "modalities": ["img2img"],
         }
-        if mm_data:
-            cfg_img_dict["multi_modal_data"] = mm_data
 
-        return [
-            ExpandedPrompt(
-                prompt=cfg_text_dict,
-                role="cfg_text",
-                request_id_suffix=CFG_TEXT_SUFFIX,
-                sampling_params_override=companion_params,
-            ),
+        expanded = []
+        if not _cfg_text_from_main_prefix_enabled(sampling_params):
+            expanded.append(
+                ExpandedPrompt(
+                    prompt=cfg_text_dict,
+                    role="cfg_text",
+                    request_id_suffix=CFG_TEXT_SUFFIX,
+                    sampling_params_override=companion_params,
+                )
+            )
+        expanded.append(
             ExpandedPrompt(
                 prompt=cfg_img_dict,
                 role="cfg_img",
                 request_id_suffix=CFG_IMG_SUFFIX,
                 sampling_params_override=companion_params,
-            ),
-        ]
+            )
+        )
+        return expanded
 
     return []
 

--- a/vllm_omni/utils/bagel_vqa.py
+++ b/vllm_omni/utils/bagel_vqa.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import torch
+
+BAGEL_VLM_THINK_SYSTEM_PROMPT = (
+    "You should first think about the reasoning process in the mind and then "
+    "provide the user with the answer.\n"
+    "The reasoning process is enclosed within <think> </think> tags, i.e. "
+    "<think> reasoning process here </think> answer here"
+)
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def env_flag(name: str) -> bool:
+    return os.environ.get(name, "").lower() in TRUE_VALUES
+
+
+def bagel_vqa_reference_prefill_enabled() -> bool:
+    return env_flag("BAGEL_VQA_REFERENCE_PREFILL")
+
+
+def bagel_vqa_reference_layout_enabled() -> bool:
+    return (
+        bagel_vqa_reference_prefill_enabled()
+        or env_flag("BAGEL_VQA_REFERENCE_LAYOUT")
+    )
+
+
+def bagel_token_id(tokenizer: Any, token: str) -> int:
+    token_id = tokenizer.convert_tokens_to_ids(token)
+    if token_id is None or token_id < 0:
+        raise ValueError(f"BAGEL tokenizer is missing required token {token!r}")
+    return int(token_id)
+
+
+def bagel_encode_text_segment(tokenizer: Any, text: str) -> list[int]:
+    im_start = bagel_token_id(tokenizer, "<|im_start|>")
+    im_end = bagel_token_id(tokenizer, "<|im_end|>")
+    return [im_start] + list(tokenizer.encode(text)) + [im_end]
+
+
+def strip_bagel_think_prompt(text: str) -> str:
+    if text.startswith(BAGEL_VLM_THINK_SYSTEM_PROMPT):
+        return text[len(BAGEL_VLM_THINK_SYSTEM_PROMPT) :].lstrip()
+    return text
+
+
+def messages_to_dicts(messages: list[Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        if hasattr(msg, "model_dump"):
+            out.append(msg.model_dump())
+        elif isinstance(msg, dict):
+            out.append(msg)
+        else:
+            out.append(
+                {
+                    "role": getattr(msg, "role", "user"),
+                    "content": getattr(msg, "content", ""),
+                }
+            )
+    return out
+
+
+def build_bagel_reference_text_and_image_count(
+    messages: list[Any],
+) -> tuple[str, int]:
+    text_parts: list[str] = []
+    image_count = 0
+
+    for message in messages_to_dicts(messages):
+        role = message.get("role")
+        if role is not None and role != "user":
+            continue
+
+        content = message.get("content", "")
+        if isinstance(content, str):
+            stripped = strip_bagel_think_prompt(content)
+            if stripped:
+                text_parts.append(stripped)
+            continue
+
+        if not isinstance(content, list):
+            continue
+
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            part_type = part.get("type")
+            if part_type == "text":
+                text = part.get("text") or ""
+                stripped = strip_bagel_think_prompt(text)
+                if stripped:
+                    text_parts.append(stripped)
+            elif part_type in {"image", "image_url"}:
+                image_count += 1
+                text_parts.append(f"<img><|image_{image_count}|></img>")
+
+    return " ".join(text_parts), image_count
+
+
+def build_bagel_vqa_reference_prompt_token_ids(
+    messages: list[Any],
+    tokenizer: Any,
+) -> tuple[list[int], str, int]:
+    final_text, image_count = build_bagel_reference_text_and_image_count(messages)
+    if image_count <= 0:
+        return [], final_text, image_count
+
+    image_pad = bagel_token_id(tokenizer, "<|image_pad|>")
+    im_start = bagel_token_id(tokenizer, "<|im_start|>")
+
+    prompt_token_ids: list[int] = []
+    prompt_token_ids.extend(
+        bagel_encode_text_segment(tokenizer, BAGEL_VLM_THINK_SYSTEM_PROMPT)
+    )
+    prompt_token_ids.extend([image_pad] * image_count)
+    if final_text:
+        prompt_token_ids.extend(bagel_encode_text_segment(tokenizer, final_text))
+    prompt_token_ids.append(im_start)
+    return prompt_token_ids, final_text, image_count
+
+
+def build_bagel_vqa_rope_positions(
+    *,
+    input_ids: torch.Tensor | None,
+    positions: torch.Tensor | None,
+    req_ids: list[str],
+    num_computed_tokens: list[int],
+    num_scheduled_tokens: list[int],
+    rope_states: dict[str, dict[str, Any]],
+    start_of_image_id: int,
+    end_of_image_id: int,
+) -> torch.Tensor | None:
+    """Compute BAGEL logical RoPE positions without touching vLLM slots."""
+    if input_ids is None or positions is None or not req_ids:
+        return None
+    if positions.ndim != 1:
+        return None
+
+    total_scheduled = sum(int(n) for n in num_scheduled_tokens)
+    if total_scheduled <= 0:
+        return None
+
+    active_req_ids = set(req_ids)
+    for rid in list(rope_states):
+        if rid not in active_req_ids:
+            rope_states.pop(rid, None)
+
+    rope_positions = positions.clone()
+    any_changed = False
+    offset = 0
+
+    for req_idx, req_id in enumerate(req_ids):
+        sched = int(num_scheduled_tokens[req_idx])
+        if sched <= 0:
+            continue
+
+        start = offset
+        end = offset + sched
+        offset = end
+
+        token_slice = input_ids[start:end]
+        if token_slice.numel() == 0:
+            continue
+
+        state = rope_states.get(req_id)
+        has_vision_marker = bool(
+            ((token_slice == start_of_image_id) | (token_slice == end_of_image_id))
+            .any()
+            .item()
+        )
+        if state is None and not has_vision_marker:
+            continue
+
+        if state is None:
+            state = {
+                "enabled": True,
+                "next": int(num_computed_tokens[req_idx]),
+                "in_vision": False,
+                "block": None,
+            }
+        else:
+            state["enabled"] = True
+
+        logical = []
+        next_pos = int(state.get("next", num_computed_tokens[req_idx]))
+        in_vision = bool(state.get("in_vision", False))
+        block_pos = state.get("block")
+        if block_pos is None:
+            block_pos = next_pos
+        block_pos = int(block_pos)
+
+        for tok in token_slice.tolist():
+            tok = int(tok)
+            if tok == start_of_image_id and not in_vision:
+                in_vision = True
+                block_pos = next_pos
+                logical.append(block_pos)
+            elif in_vision:
+                logical.append(block_pos)
+                if tok == end_of_image_id:
+                    in_vision = False
+                    next_pos = block_pos + 1
+            else:
+                logical.append(next_pos)
+                next_pos += 1
+
+        new_vals = torch.tensor(logical, device=positions.device, dtype=positions.dtype)
+        rope_positions[start:end] = new_vals
+        if not torch.equal(new_vals, positions[start:end]):
+            any_changed = True
+
+        state["next"] = next_pos
+        state["in_vision"] = in_vision
+        state["block"] = block_pos if in_vision else None
+        rope_states[req_id] = state
+
+    return rope_positions if any_changed else None
+
+
+def build_bagel_vqa_image_spans(
+    *,
+    input_ids: torch.Tensor | None,
+    req_ids: list[str],
+    num_computed_tokens: list[int],
+    num_scheduled_tokens: list[int],
+    start_of_image_id: int,
+    end_of_image_id: int,
+) -> list[dict[str, int]]:
+    """Find complete BAGEL VQA image blocks in the scheduled token batch.
+
+    Returned offsets are flat query rows for the current vLLM batch. `kv_end`
+    is the per-request sequence length immediately after the image block, which
+    prevents the non-causal image recompute from attending to future text.
+    """
+    if input_ids is None or not req_ids:
+        return []
+    if input_ids.ndim != 1:
+        return []
+
+    spans: list[dict[str, int]] = []
+    offset = 0
+    for req_idx, _req_id in enumerate(req_ids):
+        sched = int(num_scheduled_tokens[req_idx])
+        if sched <= 0:
+            continue
+
+        start = offset
+        end = offset + sched
+        offset = end
+
+        token_slice = input_ids[start:end]
+        block_start: int | None = None
+        for local_idx, tok in enumerate(token_slice.tolist()):
+            tok = int(tok)
+            if tok == start_of_image_id:
+                block_start = local_idx
+            elif tok == end_of_image_id and block_start is not None:
+                block_end = local_idx + 1
+                spans.append(
+                    {
+                        "req_idx": req_idx,
+                        "request_start": start,
+                        "num_computed_tokens": int(num_computed_tokens[req_idx]),
+                        "q_start": start + block_start,
+                        "q_end": start + block_end,
+                        "kv_local_end": block_end,
+                        "kv_end": int(num_computed_tokens[req_idx]) + block_end,
+                    }
+                )
+                block_start = None
+
+    return spans


### PR DESCRIPTION
## Overview

This PR adds a BAGEL force-interleaved two-stage path that is designed to keep vLLM Omni aligned with local VLMEvalKit BAGEL force-interleaved behavior while improving 2-GPU inference throughput.

The main changes are:

- Add BAGEL reference-style VQA helpers for prompt layout, image span tracking, and logical RoPE handling.
- Add BAGEL img2img VAE+ViT preprocessing support, including robust tensor/list pixel batch handling for high-concurrency requests.
- Add non-causal image-block recompute hooks for BAGEL reference-style prefill behavior.
- Add a force-interleaved Stage 1 continuation path that consumes transferred Stage 0 KV and continues through think -> image -> answer in the diffusion pipeline.
- Add CFG branch handling needed by the force path, including optional reuse of the main prefix for CFG text conditioning.
- Add request-mode diffusion batching: scheduler fill wait knobs, worker/model-runner batched execution, and pipeline `forward_batch` support.
- Improve multi-replica StagePool routing with least-loaded replica selection and in-flight accounting.
- Add tests for request-batch fill behavior, StagePool replica routing, and BAGEL VQA reference layout helpers.

## Why

Naive vLLM Omni serving was fast, but it did not reliably match local BAGEL force-interleaved semantics. The accuracy gap came from several behavior differences:

- img2img context could miss the intended VAE+ViT conditioning path,
- image-block cache behavior differed from local BAGEL's non-causal updates,
- CFG text conditioning could diverge from the main prompt prefix,
- async request order could change global RNG consumption,
- Stage 1 text batching changed think/answer generation behavior,
- output formatting could differ from the local force-interleaved judge payload.

This PR keeps speed improvements in the vLLM Omni style, but gates the accuracy-sensitive pieces so the eval path can preserve local BAGEL semantics.

## Current Results

Judged 32-sample alignment probe, same 20-step force config:

| System | Score | Valid | Inference Time |
|---|---:|---:|---:|
| vLLM Omni two-stage force | 71.88 | 32/32 | 504.419s |
| BAGEL local force-interleaved | 59.375 | 32/32 | 1071.252s |

100-sample 2-GPU speed-only comparison, no judge:

| System | Samples | Valid | Generated Images | Inference Time | Throughput |
|---|---:|---:|---:|---:|---:|
| vLLM Omni two-stage force, 20 steps | 100 | 100 | 100 | 1489.254s | 0.067 samples/s |
| BAGEL local force-interleaved | 100 | 100 | - | 3242.676s | 0.03084 samples/s |

Speedup:

```text
3242.676 / 1489.254 = 2.177x
```

The 2x target required vLLM `T_inference <= 1621.338s`; the current run completed in `1489.254s`.

The previous early 2-GPU force comparison was only `1.014x` faster than local (`3197.369s` vs `3242.676s`), so the new result is the meaningful throughput improvement.

## Config Used For The Final Speed Run

```bash
N_SAMPLES=100
CONCURRENCY=64
SKIP_JUDGE=1
MLAUNCH_GPUS=2
BAGEL_CFG_TEXT_FROM_MAIN_PREFIX=1
FORCE_STAGE1_BATCH_TEXT=0
FORCE_STAGE1_REENCODE_TEXT=0
FORCE_NUM_TIMESTEPS=20
FORCE_TWOSTAGE_DIFFUSION_BATCH_SIZE=4
FORCE_TWOSTAGE_DEPLOY_CFG=vllm_omni_serving/bagel_force_twostage_dualgpu_stage1rep2.yaml
```

Accuracy-sensitive defaults kept for alignment:

```text
FORCE_SEED=0
FORCE_SEED_BY_INDEX=1
BAGEL_FORCE_IMG2IMG_VIT=1
BAGEL_IMG2IMG_VIT_SEPARATOR=0
BAGEL_IMG2IMG_NONCAUSAL_RECOMPUTE=1
```

Stage 1 CUDA graph is still disabled in the evaluated config (`enforce_eager: true`). The measured speedup comes from two-stage KV reuse, Stage 1 replica scaling, request concurrency, image batching, and validated 20-step diffusion.

## Validation

Passed:

```bash
git diff --check
python -m py_compile \
  vllm_omni/diffusion/data.py \
  vllm_omni/diffusion/diffusion_engine.py \
  vllm_omni/diffusion/executor/multiproc_executor.py \
  vllm_omni/diffusion/models/bagel/bagel_transformer.py \
  vllm_omni/diffusion/models/bagel/pipeline_bagel.py \
  vllm_omni/diffusion/request.py \
  vllm_omni/diffusion/sched/base_scheduler.py \
  vllm_omni/diffusion/worker/diffusion_model_runner.py \
  vllm_omni/diffusion/worker/diffusion_worker.py \
  vllm_omni/engine/async_omni_engine.py \
  vllm_omni/engine/stage_pool.py \
  vllm_omni/entrypoints/openai/serving_chat.py \
  vllm_omni/model_executor/models/bagel/bagel.py \
  vllm_omni/model_executor/stage_input_processors/bagel.py \
  tests/diffusion/test_diffusion_batch_wait.py \
  tests/engine/test_stage_pool.py \
  tests/model_executor/test_bagel_vqa_reference_layout.py \
  vllm_omni/utils/bagel_vqa.py
```

Attempted but not runnable in the default shell environment:

```bash
pytest -q tests/diffusion/test_diffusion_batch_wait.py \
  tests/engine/test_stage_pool.py \
  tests/model_executor/test_bagel_vqa_reference_layout.py
```

Collection failed before reaching these tests because the default environment is missing the repo dependency `aenum`.
