### PR TITLE
[Refactor] Move chunk transfer adapter tracking sets to per-request state

### DIFF
--- a/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
+++ b/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
@@ -39,6 +39,9 @@ def _req(req_id: str, status: RequestStatus, external_req_id: str | None = None)
         num_computed_tokens=0,
         num_output_placeholders=0,
         additional_information=None,
+        omni_chunk_finished=False,
+        omni_segment_finished=False,
+        omni_chunk_ready=False,
         is_finished=lambda: status == RequestStatus.FINISHED_STOPPED,
     )
 
@@ -62,10 +65,8 @@ def build_adapter(monkeypatch, mocker: MockerFixture):
         def _fake_base_init(self, config):
             self.config = config
             self._pending_load_reqs = deque()
-            self._finished_load_reqs = set()
             self._cancelled_load_reqs = set()
             self._pending_save_reqs = deque()
-            self._finished_save_reqs = set()
             self.stop_event = threading.Event()
             self._recv_cond = threading.Condition()
             self._save_cond = threading.Condition()
@@ -135,9 +136,33 @@ def test_load_poll(build_adapter):
 
     assert request.additional_information == payload
     assert adapter.get_req_chunk["req-1"] == 1
-    assert "req-1" in adapter._finished_load_reqs
-    assert "req-1" in adapter.finished_requests
+    assert request.omni_chunk_ready
+    assert request.omni_chunk_finished
+    assert not request.omni_segment_finished
     assert "req-1" not in adapter._pending_load_reqs
+
+
+def test_load_poll_segment_finished(build_adapter):
+    """Payload with is_segment_finished=True (but finished=False) must set
+    omni_segment_finished without touching omni_chunk_finished."""
+    adapter, connector = build_adapter(stage_id=2, model_mode="ar")
+    request = _req("req-seg", RequestStatus.WAITING, external_req_id="ext-seg")
+
+    adapter.load_async(request)
+    payload: OmniPayload = {
+        "codes": {"audio": [[1]]},
+        "hidden_states": {"output": torch.tensor([[2.0]])},
+        "meta": {
+            "finished": torch.tensor(False, dtype=torch.bool),
+            "is_segment_finished": torch.tensor(True, dtype=torch.bool),
+        },
+    }
+    connector.get.return_value = (payload, 16)
+    adapter._poll_single_request(request)
+
+    assert request.omni_chunk_ready
+    assert request.omni_segment_finished
+    assert not request.omni_chunk_finished
 
 
 def test_load_poll_generation_tensor_codes_use_placeholder_prompt(build_adapter):
@@ -161,7 +186,7 @@ def test_load_poll_generation_tensor_codes_use_placeholder_prompt(build_adapter)
     assert torch.equal(request.additional_information["codes"]["audio"], codes)
     assert request.additional_information["meta"]["left_context_size"] == 1
     assert "finished" not in request.additional_information["meta"]
-    assert "req-tensor" in adapter._finished_load_reqs
+    assert request.omni_chunk_ready
 
 
 def test_load_poll_generation_empty_nonterminal_chunk_keeps_polling(build_adapter):
@@ -185,12 +210,11 @@ def test_load_poll_generation_empty_nonterminal_chunk_keeps_polling(build_adapte
     connector.get.side_effect = [(empty_payload, 16), (ready_payload, 16)]
 
     assert adapter._poll_single_request(request) is False
-    assert request.request_id not in adapter._finished_load_reqs
-    assert request.request_id not in adapter.requests_with_ready_chunks
+    assert not request.omni_chunk_ready
     assert adapter.get_req_chunk[request.request_id] == 1
 
     assert adapter._poll_single_request(request) is True
-    assert request.request_id in adapter._finished_load_reqs
+    assert request.omni_chunk_ready
     assert torch.equal(request.additional_information["codes"]["audio"], ready_payload["codes"]["audio"])
     assert adapter.get_req_chunk[request.request_id] == 2
 
@@ -354,8 +378,9 @@ def test_load_poll_non_ar_merges_into_existing_additional_information(build_adap
     assert request.additional_information["meta"]["finished"].item() is False
     assert request.additional_information["meta"]["phase"] == "decode"
     assert request.additional_information["kv_metadata"] == {"foo": "bar"}
-    assert "req-non-ar" in adapter._finished_load_reqs
-    assert "req-non-ar" in adapter.finished_requests
+    assert request.omni_chunk_ready
+    assert request.omni_chunk_finished
+    assert not request.omni_segment_finished
 
 
 def test_load_poll_ar_request_additional_information_concats_tensors(build_adapter):
@@ -416,7 +441,7 @@ def test_fifo_promotion(build_adapter):
     assert reqs[1].status == RequestStatus.WAITING_FOR_CHUNK
     assert reqs[2].status == RequestStatus.WAITING
 
-    adapter.finished_requests.add("req-1")
+    reqs[0].omni_chunk_finished = True
     # Eviction is deferred to postprocess_scheduler_output in the runtime path
     # (commit c4d95fd9 — otherwise the terminal chunk deadlocks at c=8 K=2).
     # Simulate it here so promotion can pick up the freed slot.
@@ -437,7 +462,8 @@ def test_legacy_k0(build_adapter):
     waiting_queue = DummyWaitingQueue([waiting_req])
     running_queue = [running_req_1, running_req_2]
 
-    adapter.requests_with_ready_chunks.update({"running-1", "running-2"})
+    running_req_1.omni_chunk_ready = True
+    running_req_2.omni_chunk_ready = True
     adapter.process_pending_chunks(waiting_queue, running_queue)
 
     assert waiting_req.status == RequestStatus.WAITING_FOR_CHUNK
@@ -459,7 +485,7 @@ def test_finished_releases_slot(build_adapter):
     assert list(adapter._active_streams) == ["req-1"]
     assert waiting_queue == [req_2]
 
-    adapter.finished_requests.add("req-1")
+    req_1.omni_chunk_finished = True
     # Eviction is deferred to postprocess_scheduler_output in the runtime path
     # (commit c4d95fd9). Simulate it so promotion can pick up the freed slot.
     adapter._evict_finished_active_streams({"req-1"})
@@ -473,20 +499,31 @@ def test_finished_releases_slot(build_adapter):
 
 def test_postprocess_scheduler_output(build_adapter):
     adapter, _ = build_adapter()
-    adapter.requests_with_ready_chunks = {"new-ready", "cached-ready", "leftover"}
+
+    new_ready_req = SimpleNamespace(additional_information=None, omni_chunk_ready=True)
+    cached_ready_req = SimpleNamespace(additional_information={"k": "v"}, omni_chunk_ready=True)
+    leftover_req = SimpleNamespace(additional_information=None, omni_chunk_ready=True)
 
     scheduler_output = SimpleNamespace(
         scheduled_new_reqs=[SimpleNamespace(req_id="new-ready")],
         scheduled_cached_reqs=SimpleNamespace(req_ids=["cached-ready", "missing"]),
     )
-    requests = {"cached-ready": SimpleNamespace(additional_information={"k": "v"})}
+    requests = {
+        "new-ready": new_ready_req,
+        "cached-ready": cached_ready_req,
+        "leftover": leftover_req,
+    }
 
     adapter.postprocess_scheduler_output(scheduler_output, requests)
 
     cached_info = scheduler_output.scheduled_cached_reqs.additional_information
     assert cached_info["cached-ready"] == {"k": "v"}
     assert cached_info["missing"] is None
-    assert adapter.requests_with_ready_chunks == {"leftover"}
+    # Scheduled requests should have omni_chunk_ready cleared
+    assert new_ready_req.omni_chunk_ready is False
+    assert cached_ready_req.omni_chunk_ready is False
+    # Unscheduled request should remain ready
+    assert leftover_req.omni_chunk_ready is True
 
 
 # ---------------------------------------------------------------
@@ -496,13 +533,12 @@ def test_postprocess_scheduler_output(build_adapter):
 
 def _populate_adapter_state(adapter, req_id="req-1", ext_id="ext-1"):
     """Fill every per-request structure so cleanup can be verified."""
-    adapter.finished_requests.add(req_id)
-    adapter._active_streams[req_id] = SimpleNamespace(request_id=req_id)
+    adapter._active_streams[req_id] = SimpleNamespace(
+        request_id=req_id, omni_chunk_finished=True, omni_segment_finished=False
+    )
     adapter.get_req_chunk[req_id] = 3
-    adapter.requests_with_ready_chunks.add(req_id)
     adapter.request_ids_mapping[req_id] = ext_id
     adapter._pending_load_reqs.append(SimpleNamespace(request_id=req_id))
-    adapter._finished_load_reqs.add(req_id)
 
     adapter.put_req_chunk[ext_id] = 5
     adapter.request_payload[ext_id] = {"hidden": [1, 2]}
@@ -517,13 +553,10 @@ def test_cleanup_clears_all_state(build_adapter):
 
     adapter.cleanup(req_id, ext_id)
 
-    assert req_id not in adapter.finished_requests
     assert req_id not in adapter._active_streams
     assert req_id not in adapter.get_req_chunk
-    assert req_id not in adapter.requests_with_ready_chunks
     assert req_id not in adapter.request_ids_mapping
     assert req_id in adapter._cancelled_load_reqs
-    assert req_id not in adapter._finished_load_reqs
 
     assert ext_id not in adapter.put_req_chunk
     assert ext_id not in adapter.request_payload
@@ -570,7 +603,6 @@ def test_cleanup_request_id_reuse_not_polluted(build_adapter):
 
     adapter.cleanup(req_id, ext_id)
 
-    assert req_id not in adapter.finished_requests
     assert req_id not in adapter.get_req_chunk
 
 
@@ -596,7 +628,6 @@ def test_cleanup_only_affects_target_request(build_adapter):
 
     adapter.cleanup("req-a", "ext-a")
 
-    assert "req-b" in adapter.finished_requests
     assert "req-b" in adapter.get_req_chunk
     assert "ext-b" in adapter.put_req_chunk
     assert "ext-b" in adapter.request_payload
@@ -619,13 +650,12 @@ def test_cleanup_after_poll_flow(build_adapter):
     connector.get.return_value = (payload, 8)
     adapter._poll_single_request(request)
 
-    assert "req-flow" in adapter.finished_requests
+    assert request.omni_chunk_finished is True
     assert adapter.get_req_chunk["req-flow"] == 1
     assert "req-flow" in adapter.request_ids_mapping
 
     adapter.cleanup("req-flow", "ext-flow")
 
-    assert "req-flow" not in adapter.finished_requests
     assert "req-flow" not in adapter.get_req_chunk
     assert "req-flow" not in adapter.request_ids_mapping
     assert "ext-flow" not in adapter.request_payload
@@ -656,10 +686,10 @@ def test_finish_requests_removes_zombies_from_chunk_waiting_deques(build_adapter
     adapter, _ = build_adapter(stage_id=1)
     zombie = _req("req-zombie", RequestStatus.WAITING_FOR_CHUNK)
     other = _req("req-live", RequestStatus.WAITING_FOR_CHUNK)
+    zombie.omni_chunk_ready = True
+    zombie.omni_chunk_finished = True
     adapter.waiting_for_chunk_waiting_requests = deque([zombie, other])
     adapter.waiting_for_chunk_running_requests = deque([other, zombie])
-    adapter.requests_with_ready_chunks.add("req-zombie")
-    adapter.finished_requests.add("req-zombie")
     requests_map = {
         "req-zombie": zombie,
         "req-live": other,
@@ -673,8 +703,6 @@ def test_finish_requests_removes_zombies_from_chunk_waiting_deques(build_adapter
 
     assert [req.request_id for req in adapter.waiting_for_chunk_waiting_requests] == ["req-live"]
     assert [req.request_id for req in adapter.waiting_for_chunk_running_requests] == ["req-live"]
-    assert "req-zombie" not in adapter.requests_with_ready_chunks
-    assert "req-zombie" not in adapter.finished_requests
 
 
 def test_restore_queues_skips_requests_missing_from_scheduler_requests(build_adapter):
@@ -718,7 +746,6 @@ def test_generation_scheduler_calls_cleanup_on_finished(monkeypatch, mocker: Moc
     cleanup_calls = []
 
     adapter_mock = mocker.MagicMock()
-    adapter_mock.finished_requests = {"req-s1"}
     adapter_mock.cleanup = lambda *a, **kw: cleanup_calls.append((a, kw))
 
     from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
@@ -755,6 +782,9 @@ def test_generation_scheduler_calls_cleanup_on_finished(monkeypatch, mocker: Moc
         take_prefill_stats=lambda: None,
         num_nans_in_logits=0,
         get_finished_reason=lambda: "stop",
+        omni_chunk_finished=True,
+        omni_segment_finished=False,
+        omni_chunk_ready=False,
     )
     scheduler.requests = {"req-s1": request}
 
@@ -838,6 +868,9 @@ def test_ar_scheduler_defers_cleanup_and_queues_save_on_finished(mocker: MockerF
         take_prefill_stats=lambda: None,
         num_nans_in_logits=0,
         get_finished_reason=lambda: "stop",
+        omni_chunk_finished=False,
+        omni_segment_finished=False,
+        omni_chunk_ready=False,
     )
     scheduler.requests = {"req-ar": request}
 
@@ -954,7 +987,6 @@ def test_wire_round_trip_struct_to_dict_contract():
 def _build_deferred_finish_scheduler(mocker, *, running, pending_finish_reqs):
     """Build a mock scheduler with requests queued for deferred finish."""
     adapter_mock = mocker.MagicMock()
-    adapter_mock.finished_requests = {r.request_id for r in pending_finish_reqs}
     cleanup_calls = []
     adapter_mock.cleanup = lambda *a, **kw: cleanup_calls.append((a, kw))
 
@@ -1023,6 +1055,9 @@ def test_deferred_finish_emits_finished_output(mocker: MockerFixture):
         take_prefill_stats=lambda: None,
         num_nans_in_logits=0,
         get_finished_reason=lambda: "stop",
+        omni_chunk_finished=True,
+        omni_segment_finished=False,
+        omni_chunk_ready=False,
     )
     scheduler, sched_out, model_out, cleanup_calls = _build_deferred_finish_scheduler(
         mocker,
@@ -1071,6 +1106,9 @@ def test_deferred_finish_empty_prompt(mocker: MockerFixture):
         take_prefill_stats=lambda: None,
         num_nans_in_logits=0,
         get_finished_reason=lambda: "stop",
+        omni_chunk_finished=True,
+        omni_segment_finished=False,
+        omni_chunk_ready=False,
     )
     scheduler, sched_out, model_out, cleanup_calls = _build_deferred_finish_scheduler(
         mocker,
@@ -1113,6 +1151,9 @@ def test_deferred_finish_skips_already_finished(mocker: MockerFixture):
         take_prefill_stats=lambda: None,
         num_nans_in_logits=0,
         get_finished_reason=lambda: "stop",
+        omni_chunk_finished=True,
+        omni_segment_finished=False,
+        omni_chunk_ready=False,
     )
     scheduler, sched_out, model_out, cleanup_calls = _build_deferred_finish_scheduler(
         mocker,
@@ -1153,6 +1194,9 @@ def test_deferred_finish_not_finished_still_emits_output(mocker: MockerFixture):
         take_prefill_stats=lambda: None,
         num_nans_in_logits=0,
         get_finished_reason=lambda: "stop",
+        omni_chunk_finished=True,
+        omni_segment_finished=False,
+        omni_chunk_ready=False,
     )
     scheduler, sched_out, model_out, cleanup_calls = _build_deferred_finish_scheduler(
         mocker,
@@ -1334,3 +1378,47 @@ def test_purge_is_noop_on_empty_deques(build_adapter):
     adapter.restore_queues(waiting_queue, running_queue, scheduler_requests={})
     assert running_queue == []
     assert waiting_queue == []
+
+
+def test_deferred_finish_via_segment_finished(mocker: MockerFixture):
+    """The done-check is ``omni_chunk_finished or omni_segment_finished``.
+    Verify that segment_finished alone triggers the deferred finish path."""
+    from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
+
+    request = _HashableRequest(
+        request_id="req-df5",
+        external_req_id="ext-df5",
+        status=RequestStatus.RUNNING,
+        is_finished=lambda: False,
+        num_computed_tokens=16,
+        num_prompt_tokens=16,
+        prompt_token_ids=list(range(1, 17)),
+        num_output_placeholders=0,
+        sampling_params=None,
+        pooling_params=None,
+        stop_reason=None,
+        client_index=0,
+        take_events=lambda: [],
+        trace_headers=None,
+        has_encoder_inputs=False,
+        take_prefill_stats=lambda: None,
+        num_nans_in_logits=0,
+        get_finished_reason=lambda: "stop",
+        omni_chunk_finished=False,
+        omni_segment_finished=True,
+        omni_chunk_ready=False,
+    )
+    scheduler, sched_out, model_out, cleanup_calls = _build_deferred_finish_scheduler(
+        mocker,
+        running=[request],
+        pending_finish_reqs=[request],
+    )
+
+    result = OmniGenerationScheduler.update_from_output(scheduler, sched_out, model_out)
+
+    assert request.status == RequestStatus.FINISHED_STOPPED
+    scheduler._handle_stopped_request.assert_called_once_with(request)
+    eco = result[0]
+    assert len(eco.outputs) == 1
+    assert eco.outputs[0].request_id == "req-df5"
+    assert scheduler._pending_finish_reqs == []

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -439,7 +439,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                         if self.vllm_config.model_config.stage_id != 0:
                             # Downstream async-chunk stages receive real payloads from the
                             # connector. This update only resumes polling for the next segment.
-                            self.chunk_transfer_adapter.segment_finished_requests.discard(request.request_id)
+                            request.omni_segment_finished = False
+                            request.omni_chunk_ready = False
                     request.async_tokens_to_discard = 1
                     request.num_output_placeholders = 0
                     request.spec_token_ids = []
@@ -688,7 +689,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             if self.vllm_config.model_config.stage_id != 0:
                 # Downstream async-chunk stages receive real payloads from the
                 # connector. This update only resumes polling for the next segment.
-                self.chunk_transfer_adapter.segment_finished_requests.discard(session.request_id)
+                session.omni_segment_finished = False
+                session.omni_chunk_ready = False
                 # Do not replace prompt/additional_information here; the next
                 # upstream chunk will populate them in chunk transfer adapter.
                 session.arrival_time = update.arrival_time

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -112,8 +112,8 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                 break
             # async_chunk: don't schedule placeholder tokens when no new chunk is available.
             if required_tokens <= 0:
-                if self.chunk_transfer_adapter is not None and self.chunk_transfer_adapter.is_done_receiving_chunks(
-                    request.request_id
+                if self.chunk_transfer_adapter is not None and (
+                    request.omni_chunk_finished or request.omni_segment_finished
                 ):
                     self._pending_finish_reqs.append(request)
                 req_index += 1
@@ -163,7 +163,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
 
             # async_chunk: wait for the first upstream chunk (don't start with placeholders).
             if self.chunk_transfer_adapter is not None and len(request.prompt_token_ids) == 0:
-                if self.chunk_transfer_adapter.is_done_receiving_chunks(request.request_id):
+                if request.omni_chunk_finished or request.omni_segment_finished:
                     self.waiting.pop_request()
                     self._pending_finish_reqs.append(request)
                     continue
@@ -330,7 +330,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             scheduler_output.scheduled_new_reqs = new_list  # type: ignore[assignment]
 
             if self.chunk_transfer_adapter:
-                self.chunk_transfer_adapter.postprocess_scheduler_output(scheduler_output)
+                self.chunk_transfer_adapter.postprocess_scheduler_output(scheduler_output, self.requests)
 
         except Exception:
             # If anything goes wrong, leave the original output unchanged
@@ -510,7 +510,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                 or (self.chunk_transfer_adapter is None and request.num_computed_tokens >= request.num_prompt_tokens)
                 or (
                     self.chunk_transfer_adapter is not None
-                    and self.chunk_transfer_adapter.is_done_receiving_chunks(request.request_id)
+                    and (request.omni_chunk_finished or request.omni_segment_finished)
                     and request.num_computed_tokens >= len(request.prompt_token_ids)
                 )
             ):
@@ -528,7 +528,8 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                 if not finished:
                     # for streaming input request only
                     if self.chunk_transfer_adapter:
-                        self.chunk_transfer_adapter.segment_finished_requests.discard(req_id)
+                        request.omni_segment_finished = False
+                        request.omni_chunk_ready = False
                 if finished:
                     kv_transfer_params = self._free_request(request)
                     if self.chunk_transfer_adapter is not None:
@@ -694,7 +695,8 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         Do not expend prompt id using update.
         """
         if self.chunk_transfer_adapter:
-            self.chunk_transfer_adapter.segment_finished_requests.discard(session.request_id)
+            session.omni_segment_finished = False
+            session.omni_chunk_ready = False
         session._output_token_ids.clear()
         session._all_token_ids.clear()
         new_prompt = update.prompt_token_ids or ()

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/base.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/base.py
@@ -23,14 +23,10 @@ class OmniTransferAdapterBase:
             self.connector = None
         # Requests that are waiting to be polled
         self._pending_load_reqs = deque()
-        # Requests that have successfully retrieved data
-        self._finished_load_reqs = set()
         self._cancelled_load_reqs: set[str] = set()
 
         # Requests that are waiting to be saved
         self._pending_save_reqs = deque()
-        # Requests that have successfully saved data
-        self._finished_save_reqs = set()
 
         self.stop_event = threading.Event()
         self._recv_cond = threading.Condition()
@@ -120,10 +116,6 @@ class OmniTransferAdapterBase:
 
     def save(self, *args, **kwargs):
         """Save data to connector synchronously. To be implemented by subclasses."""
-        raise NotImplementedError
-
-    def get_finished_requests(self):
-        """Get finished loaded or saved requests"""
         raise NotImplementedError
 
     def shutdown(self):

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -68,15 +68,12 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         # mapping for request id and chunk id
         self.put_req_chunk: dict[str, int] = defaultdict(int)
         self.get_req_chunk: dict[str, int] = defaultdict(int)
-        self.finished_requests: set[str] = set()
-        self.segment_finished_requests: set[str] = set()
         self.request_payload = {}
         self.code_prompt_token_ids: dict[str, list[torch.Tensor]] = defaultdict(list)
         self.request_ids_mapping: dict[str, str] = {}
 
         self.waiting_for_chunk_waiting_requests: deque[Any] = deque()
         self.waiting_for_chunk_running_requests: deque[Any] = deque()
-        self.requests_with_ready_chunks = set()
         self.requests_origin_status = {}
         self._active_streams: dict[str, Any] = {}
         # Private hold-queue for non-active running requests. Restored to
@@ -229,16 +226,16 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                     construct_next_stage_streaming_input_prompt(payload_data, request)
 
                 if payload_finished:
-                    self.finished_requests.add(req_id)
+                    request.omni_chunk_finished = True
                     request.resumable = False
                 if payload_segment_finished:
-                    self.segment_finished_requests.add(req_id)
+                    request.omni_segment_finished = True
             else:
                 if payload_finished:
-                    self.finished_requests.add(req_id)
+                    request.omni_chunk_finished = True
                     request.resumable = False
                 if payload_segment_finished:
-                    self.segment_finished_requests.add(req_id)
+                    request.omni_segment_finished = True
 
                 new_ids = payload_data.get("codes", {}).get("audio")
                 has_tensor_codes = isinstance(new_ids, torch.Tensor)
@@ -284,8 +281,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
                     # first DAC frame arrives.
                     return False
 
-            # Mark as finished for consumption
-            self._finished_load_reqs.add(req_id)
+            # Mark as ready for consumption
+            request.omni_chunk_ready = True
             logger.debug(f"[Stage-{stage_id}] Received one chunk for key {connector_get_key}")
             return True
 
@@ -362,15 +359,6 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             if cached_ic is not None:
                 cached_ic.pop(external_req_id, None)
 
-    def is_done_receiving_chunks(self, request_id: str) -> bool:
-        """Return True if the request should stop polling upstream chunks.
-
-        Covers both the whole-request finish marker (``finished_requests``) and
-        the per-segment finish marker (``segment_finished_requests``) used while
-        waiting for the next streaming input slice.
-        """
-        return request_id in self.finished_requests or request_id in self.segment_finished_requests
-
     ########################################################################
     # Cleanup
     ########################################################################
@@ -384,19 +372,12 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
         Idempotent: calling with an already-cleaned or unknown id is safe.
         """
-        if request_id in self.finished_requests:
-            self._evict_finished_active_streams({request_id})
-        else:
-            self._active_streams.pop(request_id, None)
-        self.finished_requests.discard(request_id)
-        self.segment_finished_requests.discard(request_id)
+        self._active_streams.pop(request_id, None)
         self.get_req_chunk.pop(request_id, None)
-        self.requests_with_ready_chunks.discard(request_id)
         self.request_ids_mapping.pop(request_id, None)
         self.requests_origin_status.pop(request_id, None)
 
         self._cancelled_load_reqs.add(request_id)
-        self._finished_load_reqs.discard(request_id)
 
     def cleanup_sender(self, external_req_id: str) -> None:
         """Reclaim sender-side per-request state (keyed by external id).
@@ -476,15 +457,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             self._purge_untracked_chunk_requests(self.waiting_for_chunk_running_requests, scheduler_requests)
 
         if self._active_window <= 0:
-            self._process_chunk_queue_legacy(
-                waiting_queue, self.waiting_for_chunk_waiting_requests, RequestStatus.WAITING, self._finished_load_reqs
-            )
-            self._process_chunk_queue_legacy(
-                running_queue,
-                self.waiting_for_chunk_running_requests,
-                RequestStatus.RUNNING,
-                self._finished_load_reqs,
-            )
+            self._process_chunk_queue(waiting_queue, self.waiting_for_chunk_waiting_requests, RequestStatus.WAITING)
+            self._process_chunk_queue(running_queue, self.waiting_for_chunk_running_requests, RequestStatus.RUNNING)
             while len(running_queue) > self.scheduler_max_num_seqs:
                 request = running_queue.pop()
                 request.status = RequestStatus.PREEMPTED
@@ -493,12 +467,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
         self._promote_active_streams(running_queue)
         self._promote_active_streams(waiting_queue)
-        self._process_chunk_queue(
-            waiting_queue, self.waiting_for_chunk_waiting_requests, RequestStatus.WAITING, self._finished_load_reqs
-        )
-        self._process_chunk_queue(
-            running_queue, self.waiting_for_chunk_running_requests, RequestStatus.RUNNING, self._finished_load_reqs
-        )
+        self._process_chunk_queue(waiting_queue, self.waiting_for_chunk_waiting_requests, RequestStatus.WAITING)
+        self._process_chunk_queue(running_queue, self.waiting_for_chunk_running_requests, RequestStatus.RUNNING)
         self._promote_active_streams(waiting_queue)
         self._preempt_non_active_running(waiting_queue, running_queue)
 
@@ -506,7 +476,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         for request_id in list(self._active_streams):
             if request_ids is not None and request_id not in request_ids:
                 continue
-            if request_id in self.finished_requests:
+            request = self._active_streams[request_id]
+            if request.omni_chunk_finished:
                 self._active_streams.pop(request_id, None)
 
     def _promote_active_streams(self, queue: Any) -> None:
@@ -516,7 +487,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             if len(self._active_streams) >= self._active_window:
                 return
             request_id = request.request_id
-            if request_id in self._active_streams or request_id in self.finished_requests:
+            if request_id in self._active_streams or request.omni_chunk_finished:
                 continue
             # Iterating the existing queue preserves FIFO admission.
             self._active_streams[request_id] = request
@@ -528,7 +499,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         if request_id in self._active_streams:
             self._active_streams[request_id] = request
             return True
-        if request_id in self.finished_requests or len(self._active_streams) >= self._active_window:
+        if request.omni_chunk_finished or len(self._active_streams) >= self._active_window:
             return False
         self._active_streams[request_id] = request
         return True
@@ -552,36 +523,6 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             request = running_queue.pop(index)
             self._held_non_active.append(request)
             index -= 1
-
-    def _process_chunk_queue_legacy(
-        self,
-        queue: Any,
-        waiting_for_chunk_list: deque[Any],
-        target_status: RequestStatus,
-        finished_load_reqs: set[str],
-    ) -> None:
-        queue_snapshot = list(queue)
-        for request in queue_snapshot:
-            if request.status != RequestStatus.WAITING_FOR_CHUNK:
-                if request.request_id in self.requests_with_ready_chunks:
-                    # Requests that have loaded chunk from last round
-                    # of schedule, but have not scheduled
-                    continue
-                if self.is_done_receiving_chunks(request.request_id):
-                    request.additional_information = None
-                    continue
-                # Requests that waiting for chunk
-                self.load_async(request)
-                request.status = RequestStatus.WAITING_FOR_CHUNK
-            else:
-                if request.request_id in finished_load_reqs:
-                    request.status = target_status
-                    finished_load_reqs.remove(request.request_id)
-                    self.requests_with_ready_chunks.add(request.request_id)
-                    continue
-            queue.remove(request)
-            self.requests_origin_status[request.request_id] = target_status
-            waiting_for_chunk_list.append(request)
 
     def _purge_untracked_chunk_requests(
         self,
@@ -666,10 +607,9 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
         if requests is not None:
             self.attach_cached_additional_information(scheduler_output, requests)
+            self._clear_chunk_ready(scheduler_output, requests)
         scheduled_req_ids = self._scheduled_request_ids(scheduler_output)
-        self._clear_chunk_ready(scheduler_output)
         if scheduled_req_ids:
-            # Terminal chunks must stay active until they are scheduled once.
             self._evict_finished_active_streams(scheduled_req_ids)
 
     @staticmethod
@@ -705,43 +645,39 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         queue: Any,
         waiting_for_chunk_list: deque[Any],
         target_status: RequestStatus,
-        finished_load_reqs: set[str],
     ) -> None:
         queue_snapshot = list(queue)
         for request in queue_snapshot:
             if not self._ensure_active_stream(request):
                 continue
             if request.status != RequestStatus.WAITING_FOR_CHUNK:
-                if request.request_id in self.requests_with_ready_chunks:
-                    # Requests that have loaded chunk from last round
-                    # of schedule, but have not scheduled
+                if request.omni_chunk_ready:
                     continue
-                if self.is_done_receiving_chunks(request.request_id):
+                if request.omni_chunk_finished or request.omni_segment_finished:
                     request.additional_information = None
                     continue
-                # Requests that waiting for chunk
                 self.load_async(request)
                 request.status = RequestStatus.WAITING_FOR_CHUNK
             else:
-                if request.request_id in finished_load_reqs:
+                if request.omni_chunk_ready:
                     request.status = target_status
-                    finished_load_reqs.remove(request.request_id)
-                    self.requests_with_ready_chunks.add(request.request_id)
                     continue
             queue.remove(request)
             self.requests_origin_status[request.request_id] = target_status
             waiting_for_chunk_list.append(request)
 
-    def _clear_chunk_ready(self, scheduler_output: Any) -> None:
+    def _clear_chunk_ready(self, scheduler_output: Any, requests: dict[str, Request]) -> None:
         if scheduler_output.scheduled_new_reqs:
             for req_data in scheduler_output.scheduled_new_reqs:
-                if req_data.req_id in self.requests_with_ready_chunks:
-                    self.requests_with_ready_chunks.remove(req_data.req_id)
+                req = requests.get(req_data.req_id)
+                if req is not None:
+                    req.omni_chunk_ready = False
 
         if scheduler_output.scheduled_cached_reqs:
             for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
-                if req_id in self.requests_with_ready_chunks:
-                    self.requests_with_ready_chunks.remove(req_id)
+                req = requests.get(req_id)
+                if req is not None:
+                    req.omni_chunk_ready = False
 
     def finish_requests(
         self, request_ids: Any, finished_status: RequestStatus, requests: dict[str, Request] | None = None
@@ -773,9 +709,6 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         )
 
         for req_id in request_ids:
-            self.requests_with_ready_chunks.discard(req_id)
-            self.finished_requests.discard(req_id)
-            self._finished_load_reqs.discard(req_id)
             self._cancelled_load_reqs.add(req_id)
 
         return []

--- a/vllm_omni/request.py
+++ b/vllm_omni/request.py
@@ -47,6 +47,10 @@ class OmniRequest(Request):
         self.external_req_id: str | None = external_req_id
         # Serialized additional information payload (optional)
         self.additional_information: AdditionalInformationPayload | None = additional_information
+        # Per-request scheduling state (replaces adapter-side tracking sets)
+        self.omni_chunk_finished: bool = False
+        self.omni_segment_finished: bool = False
+        self.omni_chunk_ready: bool = False
 
     @staticmethod
     def _maybe_decode_prompt_embeds(


### PR DESCRIPTION
## Purpose
Replace four adapter-side tracking sets (finished_requests,
segment_finished_requests, requests_with_ready_chunks,
_finished_load_reqs) and two dead base class sets (_finished_load_reqs,
_finished_save_reqs) with three per-request fields on OmniRequest:
- omni_chunk_finished (replaces finished_requests)
- omni_segment_finished (replaces segment_finished_requests)
- omni_chunk_ready (replaces requests_with_ready_chunks/_finished_load_reqs)

Also:
- Remove dead is_done_receiving_chunks() method
- Fix AR scheduler missing segment state reset on streaming segment restart
- Guard _clear_chunk_ready against requests=None


## Test Plan

```shell
pytest tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
pytest tests/e2e/online_serving/test_qwen3_tts_*.py
pytest tests/e2e/offline_inference/test_qwen3_tts_*.py
```

## Test Result

PASSED

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
