### PR TITLE
[CI][XPU]Fix sage_attn hard-code import for cuda

### DIFF
--- a/tests/diffusion/attention/test_sage_attn3.py
+++ b/tests/diffusion/attention/test_sage_attn3.py
@@ -7,12 +7,7 @@ import types
 
 import pytest
 import torch
-from vllm.platforms.interface import DeviceCapability
-
-from vllm_omni.diffusion.attention.backends.registry import DiffusionAttentionBackendEnum
-from vllm_omni.diffusion.envs import PACKAGES_CHECKER
-from vllm_omni.platforms.cuda import platform as cuda_platform_module
-from vllm_omni.platforms.cuda.platform import CudaOmniPlatform
+from vllm.platforms import current_platform
 
 SAGE_ATTN3_MODULE = "vllm_omni.diffusion.attention.backends.sage_attn3"
 
@@ -88,7 +83,15 @@ def test_sage_attn3_falls_back_to_sdpa_for_gqa(monkeypatch: pytest.MonkeyPatch):
     assert torch.allclose(output, expected)
 
 
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="sage_attn3 tests require CUDA platform")
 def test_cuda_platform_selects_sage_attn3_alias(monkeypatch: pytest.MonkeyPatch):
+    from vllm.platforms.interface import DeviceCapability
+
+    from vllm_omni.diffusion.attention.backends.registry import DiffusionAttentionBackendEnum
+    from vllm_omni.diffusion.envs import PACKAGES_CHECKER
+    from vllm_omni.platforms.cuda import platform as cuda_platform_module
+    from vllm_omni.platforms.cuda.platform import CudaOmniPlatform
+
     original_import_module = importlib.import_module
 
     monkeypatch.setattr(
@@ -108,7 +111,14 @@ def test_cuda_platform_selects_sage_attn3_alias(monkeypatch: pytest.MonkeyPatch)
     assert backend_path == DiffusionAttentionBackendEnum.SAGE_ATTN_3.get_path()
 
 
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="sage_attn3 tests require CUDA platform")
 def test_cuda_platform_falls_back_when_sage_attn3_gpu_is_unsupported(monkeypatch: pytest.MonkeyPatch):
+    from vllm.platforms.interface import DeviceCapability
+
+    from vllm_omni.diffusion.attention.backends.registry import DiffusionAttentionBackendEnum
+    from vllm_omni.diffusion.envs import PACKAGES_CHECKER
+    from vllm_omni.platforms.cuda.platform import CudaOmniPlatform
+
     monkeypatch.setattr(
         CudaOmniPlatform,
         "get_device_capability",


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

error
```

==================================== ERRORS ====================================
--
  | ________ ERROR collecting tests/diffusion/attention/test_sage_attn3.py _________
  | ImportError while importing test module '/workspace/vllm-omni/tests/diffusion/attention/test_sage_attn3.py'.
  | Hint: make sure your test modules/packages have valid Python names.
  | Traceback:
  | /usr/lib/python3.12/importlib/__init__.py:90: in import_module
  | return _bootstrap._gcd_import(name[level:], package, level)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | tests/diffusion/attention/test_sage_attn3.py:14: in <module>
  | from vllm_omni.platforms.cuda import platform as cuda_platform_module
  | vllm_omni/platforms/cuda/__init__.py:4: in <module>
  | from vllm_omni.platforms.cuda.platform import CudaOmniPlatform
  | vllm_omni/platforms/cuda/platform.py:11: in <module>
  | from vllm.platforms.cuda import CudaPlatformBase
  | /opt/venv/lib/python3.12/site-packages/vllm/platforms/cuda.py:21: in <module>
  | import vllm._C  # noqa
  | ^^^^^^^^^^^^^^
  | E   ModuleNotFoundError: No module named 'vllm._C'


```

Root Cause:

test_sage_attn3.py imported `from vllm_omni.platforms.cuda import platform as cuda_platform_module` in header.

Fix:

Skipped cuda_only test with current_platform check
move cuda_platform_module import to cuda tests

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
