### PR TITLE
[Quantization] FLUX.1-dev text encoder FP8 online quantization

### DIFF
--- a/docs/user_guide/quantization/fp8.md
+++ b/docs/user_guide/quantization/fp8.md
@@ -37,7 +37,7 @@ guide. FP8 on Ampere may use a weight-only path where available.
 | Qwen-Image | `Qwen/Qwen-Image`, `Qwen/Qwen-Image-2512` | Yes | Yes | Skip sensitive image-stream MLPs when quality regresses | `img_mlp` | |
 | Wan2.2 | Wan2.2 diffusion pipelines | Not validated | Not validated | Validate against BF16 before documenting as supported | TBD | |
 | Z-Image | `Tongyi-MAI/Z-Image-Turbo` | Yes | Yes | All layers | None | ✅︎ |
-| FLUX.1 | `black-forest-labs/FLUX.1-dev`, `black-forest-labs/FLUX.1-schnell` | Yes | Yes | All layers | None | |
+| FLUX.1 | `black-forest-labs/FLUX.1-dev`, `black-forest-labs/FLUX.1-schnell` | Yes | Yes | All layers | None | ✅︎ |
 | FLUX.2-klein | `black-forest-labs/FLUX.2-klein-4B` | Yes | Yes | All layers | None | |
 | HunyuanImage-3.0 | `tencent/HunyuanImage-3.0`, `tencent/HunyuanImage-3.0-Instruct` | Yes | Yes | All layers; use the Hunyuan stage config for multi-stage runs | None | |
 | HunyuanVideo-1.5 | `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v`, `720p_t2v`, `480p_i2v` | Yes | Yes | All layers | None | |

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -177,7 +177,8 @@ class DiffusersPipelineLoader:
             # safetensors file. Using both breaks.
             # Here, we download the `model.safetensors.index.json` and filter
             # any files not found in the index.
-            if not is_local:
+            # Single-file components have no index file; skip the download.
+            if not is_local and index_file:
                 download_safetensors_index_file_from_hf(
                     model_name_or_path,
                     index_file,

--- a/vllm_omni/diffusion/models/flux/pipeline_flux.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux.py
@@ -18,6 +18,7 @@ from diffusers.schedulers.scheduling_flow_match_euler_discrete import (
 from diffusers.utils.torch_utils import randn_tensor
 from torch import nn
 from transformers import AutoConfig, CLIPTextModel, CLIPTokenizer, T5TokenizerFast
+from vllm.model_executor.models.transformers.utils import init_on_device_without_buffers
 from vllm.model_executor.models.utils import AutoWeightsLoader
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
@@ -29,6 +30,7 @@ from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
 from vllm_omni.diffusion.models.flux import FluxTransformer2DModel
 from vllm_omni.diffusion.models.flux.flux_pipeline_mixin import FluxPipelineMixin
 from vllm_omni.diffusion.models.t5_encoder import T5EncoderModel
+from vllm_omni.diffusion.models.utils import init_parameters, recursive_replace_linear
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
@@ -85,6 +87,13 @@ class FluxPipeline(nn.Module, FluxPipelineMixin, CFGParallelMixin, DiffusionPipe
             ),
             DiffusersPipelineLoader.ComponentSource(
                 model_or_path=od_config.model,
+                subfolder="text_encoder",
+                revision=None,
+                prefix="text_encoder.",
+                fall_back_to_pt=True,
+            ),
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
                 subfolder="text_encoder_2",
                 revision=None,
                 prefix="text_encoder_2.",
@@ -100,11 +109,22 @@ class FluxPipeline(nn.Module, FluxPipelineMixin, CFGParallelMixin, DiffusionPipe
         self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
             model, subfolder="scheduler", local_files_only=local_files_only
         )
-        self.text_encoder = CLIPTextModel.from_pretrained(
-            model, subfolder="text_encoder", local_files_only=local_files_only
-        ).to(self.device)
+
+        # CLIP: meta-init + swap to vLLM linears so quant_config applies; loader
+        # streams weights, so no .to() (same as the DiT).
+        clip_config = AutoConfig.from_pretrained(model, subfolder="text_encoder", local_files_only=local_files_only)
+        with init_on_device_without_buffers("meta"):
+            self.text_encoder = CLIPTextModel._from_config(clip_config)
+        recursive_replace_linear(self.text_encoder, od_config)
+        init_parameters(self.text_encoder, dtype=od_config.dtype, device=self.device)
+
+        # T5 already uses vLLM linears; thread quant_config to quantize its GEMMs.
         t5_config = AutoConfig.from_pretrained(model, subfolder="text_encoder_2", local_files_only=local_files_only)
-        self.text_encoder_2 = T5EncoderModel(t5_config, prefix="text_encoder_2").to(self.device)
+        self.text_encoder_2 = T5EncoderModel(
+            t5_config, prefix="text_encoder_2", quant_config=od_config.quantization_config
+        )
+
+        # VAE is precision-sensitive and kept at full precision.
         self.vae = AutoencoderKL.from_pretrained(model, subfolder="vae", local_files_only=local_files_only).to(
             self.device
         )
@@ -665,7 +685,20 @@ class FluxPipeline(nn.Module, FluxPipelineMixin, CFGParallelMixin, DiffusionPipe
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights)
+        return loader.load_weights(self._remap_clip_weights(weights))
+
+    @staticmethod
+    def _remap_clip_weights(
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> Iterable[tuple[str, torch.Tensor]]:
+        # transformers>=5 flattened CLIPTextModel (drops the text_model. prefix);
+        # replicate the from_pretrained remap that meta-init bypasses.
+        legacy_prefix = "text_encoder.text_model."
+        new_prefix = "text_encoder."
+        for name, weight in weights:
+            if name.startswith(legacy_prefix):
+                name = new_prefix + name[len(legacy_prefix) :]
+            yield name, weight
 
 
 class FluxDMD2Pipeline(DMD2PipelineMixin, FluxPipeline):

--- a/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
+++ b/vllm_omni/diffusion/models/t5_encoder/t5_encoder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
@@ -21,6 +22,9 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
 
 class T5SelfAttention(nn.Module):
     def __init__(
@@ -28,6 +32,7 @@ class T5SelfAttention(nn.Module):
         config: T5Config,
         has_relative_attention_bias: bool = False,
         prefix: str = "",
+        quant_config: QuantizationConfig | None = None,
     ):
         super().__init__()
         self.d_model = config.d_model
@@ -51,6 +56,8 @@ class T5SelfAttention(nn.Module):
             total_num_heads=self.n_heads,
             total_num_kv_heads=self.n_heads,  # T5 uses MHA
             bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
         )
 
         # Output projection: all-reduce back to full d_model
@@ -61,6 +68,8 @@ class T5SelfAttention(nn.Module):
             bias=False,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o",
         )
 
         if has_relative_attention_bias:
@@ -166,13 +175,15 @@ class T5SelfAttention(nn.Module):
 
 
 class T5DenseGatedActDense(nn.Module):
-    def __init__(self, config: T5Config, prefix: str = ""):
+    def __init__(self, config: T5Config, prefix: str = "", quant_config: QuantizationConfig | None = None):
         super().__init__()
         self.wi = MergedColumnParallelLinear(
             config.d_model,
             [config.d_ff, config.d_ff],
             bias=False,
             gather_output=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wi",
         )
         self.wo = RowParallelLinear(
             config.d_ff,
@@ -180,6 +191,8 @@ class T5DenseGatedActDense(nn.Module):
             bias=False,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wo",
         )
         self.act = get_act_fn(config.dense_act_fn)
 
@@ -193,7 +206,7 @@ class T5DenseGatedActDense(nn.Module):
 
 
 class T5DenseActDense(nn.Module):
-    def __init__(self, config: T5Config, prefix: str = ""):
+    def __init__(self, config: T5Config, prefix: str = "", quant_config: QuantizationConfig | None = None):
         super().__init__()
         self.wi = ColumnParallelLinear(
             config.d_model,
@@ -201,6 +214,8 @@ class T5DenseActDense(nn.Module):
             bias=False,
             gather_output=False,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wi",
         )
         self.wo = RowParallelLinear(
             config.d_ff,
@@ -208,6 +223,8 @@ class T5DenseActDense(nn.Module):
             bias=False,
             input_is_parallel=True,
             return_bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wo",
         )
         self.act = get_act_fn(config.dense_act_fn)
 
@@ -219,9 +236,20 @@ class T5DenseActDense(nn.Module):
 
 
 class T5LayerSelfAttention(nn.Module):
-    def __init__(self, config: T5Config, has_relative_attention_bias: bool = False, prefix: str = ""):
+    def __init__(
+        self,
+        config: T5Config,
+        has_relative_attention_bias: bool = False,
+        prefix: str = "",
+        quant_config: QuantizationConfig | None = None,
+    ):
         super().__init__()
-        self.SelfAttention = T5SelfAttention(config, has_relative_attention_bias, prefix=f"{prefix}.SelfAttention")
+        self.SelfAttention = T5SelfAttention(
+            config,
+            has_relative_attention_bias,
+            prefix=f"{prefix}.SelfAttention",
+            quant_config=quant_config,
+        )
         self.layer_norm = RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
 
     def forward(
@@ -243,12 +271,14 @@ class T5LayerSelfAttention(nn.Module):
 
 
 class T5LayerFF(nn.Module):
-    def __init__(self, config: T5Config, prefix: str = ""):
+    def __init__(self, config: T5Config, prefix: str = "", quant_config: QuantizationConfig | None = None):
         super().__init__()
         if config.is_gated_act:
-            self.DenseReluDense = T5DenseGatedActDense(config, prefix=f"{prefix}.DenseReluDense")
+            self.DenseReluDense = T5DenseGatedActDense(
+                config, prefix=f"{prefix}.DenseReluDense", quant_config=quant_config
+            )
         else:
-            self.DenseReluDense = T5DenseActDense(config, prefix=f"{prefix}.DenseReluDense")
+            self.DenseReluDense = T5DenseActDense(config, prefix=f"{prefix}.DenseReluDense", quant_config=quant_config)
         self.layer_norm = RMSNorm(config.d_model, eps=config.layer_norm_epsilon)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
@@ -264,12 +294,20 @@ class T5LayerFF(nn.Module):
 
 
 class T5Block(nn.Module):
-    def __init__(self, config: T5Config, has_relative_attention_bias: bool = False, prefix: str = ""):
+    def __init__(
+        self,
+        config: T5Config,
+        has_relative_attention_bias: bool = False,
+        prefix: str = "",
+        quant_config: QuantizationConfig | None = None,
+    ):
         super().__init__()
         self.layer = nn.ModuleList(
             [
-                T5LayerSelfAttention(config, has_relative_attention_bias, prefix=f"{prefix}.layer.0"),
-                T5LayerFF(config, prefix=f"{prefix}.layer.1"),
+                T5LayerSelfAttention(
+                    config, has_relative_attention_bias, prefix=f"{prefix}.layer.0", quant_config=quant_config
+                ),
+                T5LayerFF(config, prefix=f"{prefix}.layer.1", quant_config=quant_config),
             ]
         )
 
@@ -285,12 +323,23 @@ class T5Block(nn.Module):
 
 
 class T5Stack(nn.Module):
-    def __init__(self, config: T5Config, shared: nn.Embedding, prefix: str = ""):
+    def __init__(
+        self,
+        config: T5Config,
+        shared: nn.Embedding,
+        prefix: str = "",
+        quant_config: QuantizationConfig | None = None,
+    ):
         super().__init__()
         self.embed_tokens = shared
         self.block = nn.ModuleList(
             [
-                T5Block(config, has_relative_attention_bias=(i == 0), prefix=f"{prefix}.block.{i}")
+                T5Block(
+                    config,
+                    has_relative_attention_bias=(i == 0),
+                    prefix=f"{prefix}.block.{i}",
+                    quant_config=quant_config,
+                )
                 for i in range(config.num_layers)
             ]
         )
@@ -325,12 +374,12 @@ class T5Stack(nn.Module):
 class T5EncoderModel(nn.Module):
     """T5 encoder model applying upstream vLLM layers"""
 
-    def __init__(self, config: T5Config, prefix: str = ""):
+    def __init__(self, config: T5Config, prefix: str = "", quant_config: QuantizationConfig | None = None):
         super().__init__()
         self.config = config
         self.prefix = prefix
         self.shared = VocabParallelEmbedding(config.vocab_size, config.d_model)
-        self.encoder = T5Stack(config, self.shared, prefix=f"{prefix}.encoder")
+        self.encoder = T5Stack(config, self.shared, prefix=f"{prefix}.encoder", quant_config=quant_config)
 
     @property
     def dtype(self) -> torch.dtype:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Add FP8 online quantization for **FLUX.1-dev** text encoders ([RFC #1854](https://github.com/vllm-project/vllm-omni/issues/1854)).

`--quantization fp8` previously quantized only the DiT; CLIP and T5-XXL stayed BF16. This PR applies `quant_config` to both text encoders (VAE unchanged). Also fix `diffusers_loader` for single-file `model.safetensors` without an index.

## Test Plan

```
python examples/offline_inference/text_to_image/text_to_image.py \
    --model <path to FLUX.1-dev> \
    --width 1024 --height 1024 \
    --quantization fp8 --tensor-parallel-size 2
```

## Test Result
```
INFO 05-30 04:48:08 [diffusers_loader.py:427] Loading weights took 8.12 seconds
INFO 05-30 04:48:08 [diffusion_model_runner.py:149] Model loading took 16.3054 GiB and 10.470250 seconds
INFO 05-30 04:48:08 [diffusion_model_runner.py:154] Model runner: Model loaded successfully.
INFO 05-30 04:48:08 [diffusion_model_runner.py:93] Model runner: transformer compiled with torch.compile.
INFO 05-30 04:48:08 [diffusion_model_runner.py:210] Model runner: Initialization complete.
INFO 05-30 04:48:08 [diffusion_model_runner.py:149] Model loading took 16.3054 GiB and 10.584358 seconds
INFO 05-30 04:48:08 [diffusion_model_runner.py:154] Model runner: Model loaded successfully.
INFO 05-30 04:48:08 [diffusion_model_runner.py:93] Model runner: transformer compiled with torch.compile.
INFO 05-30 04:48:08 [diffusion_model_runner.py:210] Model runner: Initialization complete.
INFO 05-30 04:48:08 [diffusion_worker.py:307] Worker 1: Process-scoped GPU memory after model loading: 0.00 GiB.
INFO 05-30 04:48:08 [manager.py:96] Initializing DiffusionLoRAManager: device=cuda:1, dtype=torch.bfloat16, max_cached_adapters=1, static_lora_path=None
INFO 05-30 04:48:08 [diffusion_worker.py:208] Worker 1: Initialization complete.
INFO 05-30 04:48:08 [diffusion_worker.py:864] Worker 1: Scheduler loop started.
INFO 05-30 04:48:08 [diffusion_worker.py:764] Worker 1 ready to receive requests via shared memory
INFO 05-30 04:48:09 [diffusion_worker.py:307] Worker 0: Process-scoped GPU memory after model loading: 0.00 GiB.
INFO 05-30 04:48:09 [manager.py:96] Initializing DiffusionLoRAManager: device=cuda:0, dtype=torch.bfloat16, max_cached_adapters=1, static_lora_path=None
INFO 05-30 04:48:09 [diffusion_worker.py:208] Worker 0: Initialization complete.
INFO 05-30 04:48:09 [diffusion_worker.py:864] Worker 0: Scheduler loop started.
INFO 05-30 04:48:09 [diffusion_worker.py:764] Worker 0 ready to receive requests via shared memory
INFO 05-30 04:48:09 [diffusion_engine.py:719] dummy run to warm up the model
INFO 05-30 04:48:09 [kv_transfer_manager.py:1306] Rank-aware KV receive: rank 0 independently receiving (from_tp=2, to_tp=2)
INFO 05-30 04:48:09 [kv_transfer_manager.py:1306] Rank-aware KV receive: rank 1 independently receiving (from_tp=2, to_tp=2)
INFO 05-30 04:48:13 [inline_stage_diffusion_client.py:72] [InlineStageDiffusionClient] stage-0 [rep-0] initialized inline (batch_size=1)
INFO 05-30 04:48:13 [async_omni_engine.py:1095] [AsyncOmniEngine] Stage 0 replica 0 initialized (diffusion, batch_size=1, devices=0,1)
INFO 05-30 04:48:13 [orchestrator.py:220] [Orchestrator] Starting event loop
INFO 05-30 04:48:13 [async_omni_engine.py:388] [AsyncOmniEngine] Orchestrator ready with 1 stages
INFO 05-30 04:48:13 [omni_base.py:185] [Omni] AsyncOmniEngine initialized in 26.70 seconds
INFO 05-30 04:48:13 [omni_base.py:202] [Omni] Initialized with 1 stages for model /root/models/FLUX.1-dev

============================================================
Generation Configuration:
  Model: /root/models/FLUX.1-dev
  Inference steps: 50
  Cache backend: None (no acceleration)
  Quantization: fp8
  Parallel configuration: tensor_parallel_size=2, ulysses_degree=None, ulysses_mode=None, ring_degree=None, cfg_parallel_size=None, vae_patch_parallel_size=None, enable_expert_parallel=None.
  CPU offload: False; CPU Layerwise Offload: False
  Image size: 1024x1024
============================================================


Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s]INFO 05-30 04:48:13 [kv_transfer_manager.py:1306] Rank-aware KV receive: rank 1 independently receiving (from_tp=2, to_tp=2)
INFO 05-30 04:48:13 [kv_transfer_manager.py:1306] Rank-aware KV receive: rank 0 independently receiving (from_tp=2, to_tp=2)

Processed prompts: 100%|██████████| 1/1 [00:05<00:00,  5.44s/it]
Processed prompts: 100%|██████████| 1/1 [00:05<00:00,  5.44s/it]
Total generation time: 5.4454 seconds (5445.40 ms)
INFO 05-30 04:48:19 [text_to_image.py:506] Outputs: [OmniRequestOutput(request_id='0_1a58efcd-96ae-45a5-9c70-337d919e8fcf', finished=True, stage_id=0, final_output_type='image', request_output=OmniRequestOutput(request_id='0_1a58efcd-96ae-45a5-9c70-337d919e8fcf', finished=True, stage_id=None, final_output_type='image', request_output=None, images=[1 PIL Images], prompt={'prompt': 'a cup of coffee on the table', 'negative_prompt': None}, latents=None, metrics={'preprocess_time_ms': 0.0, 'diffusion_engine_exec_time_ms': 5361.3277319818735, 'diffusion_engine_total_time_ms': 5439.282173290849, 'image_num': 1, 'resolution': 640, 'postprocess_time_ms': 77.78934855014086}, multimodal_output={}, custom_output={}, stage_durations={'queue_wait_ms': 1.9762739539146423, 'stage_0_gen_ms': 5440.408229827881}, peak_memory_mb=21796.0), images=[1 PIL Images], prompt=None, latents=None, metrics={}, multimodal_output={}, custom_output={}, stage_durations={'queue_wait_ms': 1.9762739539146423, 'stage_0_gen_ms': 5440.408229827881}, peak_memory_mb=21796.0)]
Saved generated image to /root/test_flux_fp8.png
```

| Config (1024×1024, 50 steps, TP=2) | Model-load VRAM / worker | e2e generation |
|------------------------------------|--------------------------|----------------|
| BF16 (baseline)                    | 22.06 GiB                | 5.99 s         |
| FP8 (this PR)                      | 16.31 GiB                | 5.45 s         |

### Sample output (FP8, "a cup of coffee on the table")
<img width="1024" height="1024" alt="test_flux_fp8" src="https://github.com/user-attachments/assets/e27a6296-32ff-454f-97c4-fe136fee3995" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>**
