### PR TITLE
[CI] Temporarily skip failing Bagel connector tests

### DIFF
--- a/tests/distributed/omni_connectors/test_bagel_mooncake_connector.py
+++ b/tests/distributed/omni_connectors/test_bagel_mooncake_connector.py
@@ -269,6 +269,7 @@ def _load_mooncake_config(host: str, rpc_port: int, http_port: int) -> str:
 @pytest.mark.core_model
 @pytest.mark.advanced_model
 @pytest.mark.diffusion
+@pytest.mark.skip(reason="Skip failed CI issue 3977: https://github.com/vllm-project/vllm-omni/issues/3977")
 @hardware_test(res={"cuda": "H100"}, num_cards=1)
 def test_bagel_text2img_mooncake_connector(run_level):
     """Test Bagel text2img with Mooncake connector for inter-stage communication."""

--- a/tests/distributed/omni_connectors/test_bagel_shared_memory_connector.py
+++ b/tests/distributed/omni_connectors/test_bagel_shared_memory_connector.py
@@ -258,6 +258,7 @@ def _resolve_deploy_config(config_path: str, run_level: str) -> str:
 @pytest.mark.core_model
 @pytest.mark.advanced_model
 @pytest.mark.diffusion
+@pytest.mark.skip(reason="Skip failed CI issue 3977: https://github.com/vllm-project/vllm-omni/issues/3977")
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"})
 def test_bagel_img2img_shared_memory_connector(run_level):
     """Test Bagel img2img with shared memory connector."""
@@ -275,6 +276,7 @@ def test_bagel_img2img_shared_memory_connector(run_level):
 @pytest.mark.core_model
 @pytest.mark.advanced_model
 @pytest.mark.diffusion
+@pytest.mark.skip(reason="Skip failed CI issue 3977: https://github.com/vllm-project/vllm-omni/issues/3977")
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"})
 def test_bagel_text2img_shared_memory_connector(run_level):
     """Test Bagel text2img with shared memory connector."""


### PR DESCRIPTION
## Summary
- Temporarily skips three failing Bagel connector CI tests.
- Adds skip reasons pointing to https://github.com/vllm-project/vllm-omni/issues/3977.

## Tests
- `git diff --check`
- `python -m py_compile tests/distributed/omni_connectors/test_bagel_mooncake_connector.py tests/distributed/omni_connectors/test_bagel_shared_memory_connector.py`

## Not run
- `python -m pytest --collect-only -q ...` could not run locally because this environment is missing `torch` during pytest plugin import.