### PR TITLE
[Model][ACE-Step] Add ACE-Step 1.5 text-to-music pipeline

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -55,6 +55,7 @@ th {
 | `FluxPipeline` | FLUX.1-schnell | `black-forest-labs/FLUX.1-schnell` | ✅︎ | ✅︎ | | ✅︎ |
 | `OmniGen2Pipeline` | OmniGen2 | `OmniGen2/OmniGen2` | ✅︎ | ✅︎ | | ✅︎ |
 | `StableAudioPipeline` | Stable-Audio-Open | `stabilityai/stable-audio-open-1.0` | ✅︎ | ✅︎ | | ✅︎ |
+| `AceStepPipeline` | ACE-Step 1.5 (text-to-music) | `ACE-Step/Ace-Step1.5` (requires diffusers PR #13095 converter) | ✅︎ | | | |
 | `AudioXPipeline` | AudioX | `zhangj1an/AudioX` | ✅︎ | ✅︎ | | |
 | `Qwen3TTSForConditionalGeneration` | Qwen3-TTS-12Hz-1.7B-CustomVoice | `Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `Qwen3TTSForConditionalGeneration` | Qwen3-TTS-12Hz-1.7B-VoiceDesign | `Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |

--- a/examples/offline_inference/ace_step/README.md
+++ b/examples/offline_inference/ace_step/README.md
@@ -1,0 +1,50 @@
+# ACE-Step 1.5 — Text to Music
+
+Offline example for generating music with the ACE-Step 1.5 model.
+
+## Requirements
+
+- A diffusers-format ACE-Step checkpoint. The original repo at
+  [`ACE-Step/Ace-Step1.5`](https://huggingface.co/ACE-Step/Ace-Step1.5) is **not** in
+  diffusers format. Until the converted checkpoint is hosted publicly, run the
+  conversion script that ships with diffusers PR
+  [`huggingface/diffusers#13095`](https://github.com/huggingface/diffusers/pull/13095)
+  against the original repo and point `--model` at the converted directory.
+- `soundfile` or `scipy` (for writing the WAV output).
+
+## Quick start
+
+```bash
+python text_to_music.py \
+    --model /path/to/ace-step-v15-turbo-diffusers \
+    --prompt "An upbeat jazz piano piece with a walking bass line."
+```
+
+Outputs a WAV file at 48 kHz stereo.
+
+## Defaults match the turbo recipe
+
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `--num-inference-steps` | `8` | Turbo is designed for 8 steps. |
+| `--shift` | `3.0` | Flow-matching timestep shift; choose from `{1, 2, 3}`. |
+| `--guidance-scale` | `1.0` | Turbo distills guidance — values >1 are coerced back to 1 with a warning. |
+| `--audio-duration` | `30.0` s | |
+
+## Known limitation — flash + sliding window
+
+ACE-Step's DiT uses sliding-window self-attention. vLLM-Omni's flash backend
+(`vllm_omni/diffusion/attention/backends/flash_attn.py`) does not currently
+expose a `window_size` parameter, so flash silently drops the window constraint
+and the model produces noise output. As a workaround, `AceStepAttention`
+hard-pins SDPA for sliding-window self-attention sites at construction time
+(cross-attention and full self-attention sites keep using flash). This is
+automatic — no user flag required. Once `window_size` plumbing lands in
+`flash_attn.py` in a follow-up PR, the hard-pin will be removed.
+
+## Out of scope (first PR)
+
+Cover / repaint / extract / lego / complete tasks and their dependencies
+(audio tokenizer / detokenizer, reference-audio timbre conditioning,
+APG-normalised guidance) are not wired up yet. Track future work in
+[issue #1252](https://github.com/vllm-project/vllm-omni/issues/1252).

--- a/examples/offline_inference/ace_step/text_to_music.py
+++ b/examples/offline_inference/ace_step/text_to_music.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Example script for text-to-music generation using ACE-Step 1.5.
+
+Usage:
+    python text_to_music.py --prompt "An upbeat jazz piano piece"
+    python text_to_music.py \\
+        --prompt "Soft piano ballad with strings" \\
+        --lyrics "[verse]\\nQuiet evenings\\n[chorus]\\nFading light" \\
+        --audio-duration 30.0
+
+Until a diffusers-format ACE-Step checkpoint is hosted publicly, run
+PR #13095's conversion script against
+https://huggingface.co/ACE-Step/Ace-Step1.5 and point ``--model`` at the
+converted directory.
+
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from vllm_omni.diffusion.data import DiffusionParallelConfig
+from vllm_omni.entrypoints.omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.platforms import current_omni_platform
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate music with ACE-Step 1.5.")
+    parser.add_argument(
+        "--model",
+        default="ACE-Step/Ace-Step1.5",
+        help="ACE-Step diffusers-format checkpoint path (see PR #13095 conversion script).",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="An upbeat jazz piano piece with a walking bass line.",
+        help="Text caption describing the music style / instruments.",
+    )
+    parser.add_argument(
+        "--lyrics",
+        default="",
+        help='Lyrics text. Supports structured tags like "[verse]" / "[chorus]".',
+    )
+    parser.add_argument(
+        "--vocal-language",
+        default="en",
+        help="Language code for lyrics (e.g. 'en', 'zh', 'ja').",
+    )
+    parser.add_argument(
+        "--audio-duration",
+        type=float,
+        default=30.0,
+        help="Duration of generated music in seconds.",
+    )
+    parser.add_argument(
+        "--num-inference-steps",
+        type=int,
+        default=8,
+        help="Number of denoising steps. Turbo model is designed for 8.",
+    )
+    parser.add_argument(
+        "--guidance-scale",
+        type=float,
+        default=1.0,
+        help="CFG scale. Turbo distills guidance into the weights — keep at 1.0.",
+    )
+    parser.add_argument(
+        "--shift",
+        type=float,
+        default=3.0,
+        choices=[1.0, 2.0, 3.0],
+        help="Flow-matching timestep shift (turbo schedules ship for 1, 2, 3).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for deterministic results.",
+    )
+    parser.add_argument(
+        "--num-waveforms",
+        type=int,
+        default=1,
+        help="Number of audio waveforms to generate for the given prompt.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="ace_step_output.wav",
+        help="Path to save the generated audio (WAV format).",
+    )
+    parser.add_argument(
+        "--sample-rate",
+        type=int,
+        default=48000,
+        help="Sample rate for output audio (ACE-Step uses 48000 Hz).",
+    )
+    parser.add_argument(
+        "--enable-diffusion-pipeline-profiler",
+        action="store_true",
+        help="Enable diffusion pipeline profiler to display stage durations.",
+    )
+    parser.add_argument(
+        "--enable-cpu-offload",
+        action="store_true",
+        help="Enable ModelWise CPU offloading to save GPU memory.",
+    )
+    parser.add_argument(
+        "--enable-layerwise-offload",
+        action="store_true",
+        help="Enable LayerWise CPU offloading to save GPU memory.",
+    )
+    parser.add_argument(
+        "--use-hsdp",
+        action="store_true",
+        help="Enable HSDP for ACE-Step DiT weight sharding.",
+    )
+    parser.add_argument(
+        "--hsdp-shard-size",
+        type=int,
+        default=1,
+        help="Number of GPUs to shard ACE-Step DiT weights across when HSDP is enabled.",
+    )
+    parser.add_argument(
+        "--hsdp-replicate-size",
+        type=int,
+        default=1,
+        help="Number of HSDP replica groups. Default 1 means pure sharding.",
+    )
+    return parser.parse_args()
+
+
+def save_audio(audio_data: np.ndarray, output_path: str, sample_rate: int = 48000):
+    """Save audio data to a WAV file."""
+    try:
+        import soundfile as sf
+
+        sf.write(output_path, audio_data, sample_rate)
+    except ImportError:
+        try:
+            import scipy.io.wavfile as wav
+
+            if audio_data.dtype == np.float32 or audio_data.dtype == np.float64:
+                audio_data = np.clip(audio_data, -1.0, 1.0)
+                audio_data = (audio_data * 32767).astype(np.int16)
+            wav.write(output_path, sample_rate, audio_data)
+        except ImportError:
+            raise ImportError(
+                "Either 'soundfile' or 'scipy' is required to save audio files. "
+                "Install with: pip install soundfile or pip install scipy"
+            )
+
+
+def main():
+    args = parse_args()
+    generator = torch.Generator(device=current_omni_platform.device_type).manual_seed(args.seed)
+
+    print(f"\n{'=' * 60}")
+    print("ACE-Step 1.5 - Text-to-Music Generation")
+    print(f"{'=' * 60}")
+    print(f"  Model: {args.model}")
+    print(f"  Prompt: {args.prompt}")
+    if args.lyrics:
+        first_line = args.lyrics.splitlines()[0] if args.lyrics else ""
+        print(f"  Lyrics (first line): {first_line}")
+    print(f"  Vocal language: {args.vocal_language}")
+    print(f"  Audio duration: {args.audio_duration}s")
+    print(f"  Inference steps: {args.num_inference_steps}")
+    print(f"  Shift: {args.shift}")
+    print(f"  Guidance scale: {args.guidance_scale}")
+    print(f"  ModelWise Offload: {'Enabled' if args.enable_cpu_offload else 'None'}")
+    print(f"  LayerWise Offload: {'Enabled' if args.enable_layerwise_offload else 'None'}")
+    if args.use_hsdp:
+        print(f"  HSDP: enabled (shard_size={args.hsdp_shard_size}, replicate_size={args.hsdp_replicate_size})")
+    else:
+        print("  HSDP: disabled")
+    print(f"  Seed: {args.seed}")
+    print(f"{'=' * 60}\n")
+
+    parallel_config = DiffusionParallelConfig(
+        use_hsdp=args.use_hsdp,
+        hsdp_shard_size=args.hsdp_shard_size,
+        hsdp_replicate_size=args.hsdp_replicate_size,
+    )
+
+    omni = Omni(
+        model=args.model,
+        parallel_config=parallel_config,
+        enable_diffusion_pipeline_profiler=args.enable_diffusion_pipeline_profiler,
+        enable_cpu_offload=args.enable_cpu_offload,
+        enable_layerwise_offload=args.enable_layerwise_offload,
+    )
+
+    generation_start = time.perf_counter()
+
+    outputs = omni.generate(
+        {
+            "prompt": args.prompt,
+        },
+        OmniDiffusionSamplingParams(
+            generator=generator,
+            guidance_scale=args.guidance_scale,
+            num_inference_steps=args.num_inference_steps,
+            num_outputs_per_prompt=args.num_waveforms,
+            extra_args={
+                "lyrics": args.lyrics,
+                "vocal_language": args.vocal_language,
+                "audio_duration": args.audio_duration,
+                "shift": args.shift,
+            },
+        ),
+    )
+
+    generation_time = time.perf_counter() - generation_start
+    print(f"Total generation time: {generation_time:.2f} seconds")
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    suffix = output_path.suffix or ".wav"
+    stem = output_path.stem or "ace_step_output"
+
+    if not outputs:
+        raise ValueError("No output generated from omni.generate()")
+
+    output = outputs[0]
+    if not hasattr(output, "request_output") or not output.request_output:
+        raise ValueError("No request_output found in OmniRequestOutput")
+    request_output = output.request_output
+    if not hasattr(request_output, "multimodal_output"):
+        raise ValueError("No multimodal_output found in request_output")
+
+    audio = request_output.multimodal_output.get("audio")
+    if audio is None:
+        raise ValueError("No audio output found in request_output")
+
+    if isinstance(audio, torch.Tensor):
+        audio = audio.cpu().float().numpy()
+
+    # Audio shape is typically [batch, channels, samples] or [channels, samples].
+    if audio.ndim == 3:
+        if args.num_waveforms <= 1:
+            audio_data = audio[0].T
+            save_audio(audio_data, str(output_path), args.sample_rate)
+            print(f"Saved generated audio to {output_path}")
+        else:
+            for idx in range(audio.shape[0]):
+                audio_data = audio[idx].T
+                save_path = output_path.parent / f"{stem}_{idx}{suffix}"
+                save_audio(audio_data, str(save_path), args.sample_rate)
+                print(f"Saved generated audio to {save_path}")
+    elif audio.ndim == 2:
+        audio_data = audio.T
+        save_audio(audio_data, str(output_path), args.sample_rate)
+        print(f"Saved generated audio to {output_path}")
+    else:
+        save_audio(audio, str(output_path), args.sample_rate)
+        print(f"Saved generated audio to {output_path}")
+
+    print(f"\nGenerated {args.audio_duration}s of music at {args.sample_rate} Hz")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_inference/ace_step/validate_audio.py
+++ b/examples/offline_inference/ace_step/validate_audio.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Level-2 validation for ACE-Step generated audio.
+
+Checks whether a WAV file produced by ``text_to_music.py`` is *plausibly
+music-shaped*: right duration, right sample rate, stereo, non-silent, has
+frequency content, has dynamic range, has stereo correlation but not pure
+mono dupe.
+
+Does NOT check whether the audio matches the prompt (that requires listening
+or perceptual metrics out of scope for a smoke test).
+
+Usage:
+    python validate_audio.py ace_step_output.wav --expected-duration 30.0
+
+Exit status: 0 if all checks pass, 1 if any fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    detail: str
+
+
+def _check(name: str, passed: bool, detail: str) -> CheckResult:
+    return CheckResult(name=name, passed=passed, detail=detail)
+
+
+def load_audio(path: str) -> tuple[np.ndarray, int]:
+    """Load a WAV file as float64 in [-1, 1]. Returns (audio[T, C], sample_rate)."""
+    try:
+        import soundfile as sf
+
+        audio, sample_rate = sf.read(path, always_2d=True)
+        return np.asarray(audio, dtype=np.float64), int(sample_rate)
+    except ImportError:
+        import scipy.io.wavfile as wav
+
+        sample_rate, audio = wav.read(path)
+        if audio.ndim == 1:
+            audio = audio[:, None]
+        if np.issubdtype(audio.dtype, np.integer):
+            max_val = float(np.iinfo(audio.dtype).max)
+            audio = audio.astype(np.float64) / max_val
+        else:
+            audio = audio.astype(np.float64)
+        return audio, int(sample_rate)
+
+
+def check_duration(audio: np.ndarray, sr: int, expected_s: float, tol_s: float) -> CheckResult:
+    actual_s = audio.shape[0] / sr
+    passed = abs(actual_s - expected_s) <= tol_s
+    return _check(
+        "duration_matches_request",
+        passed,
+        f"actual={actual_s:.2f}s, expected={expected_s:.2f}s, tol=±{tol_s}s",
+    )
+
+
+def check_sample_rate(sr: int, expected: int) -> CheckResult:
+    return _check(
+        "sample_rate_is_48000",
+        sr == expected,
+        f"actual={sr} Hz, expected={expected} Hz",
+    )
+
+
+def check_stereo(audio: np.ndarray) -> CheckResult:
+    return _check(
+        "is_stereo",
+        audio.shape[1] == 2,
+        f"channels={audio.shape[1]}",
+    )
+
+
+def check_not_silent(audio: np.ndarray, threshold: float = 0.01) -> CheckResult:
+    peak = float(np.max(np.abs(audio)))
+    return _check(
+        "not_silent",
+        peak >= threshold,
+        f"peak={peak:.4f} (need >= {threshold})",
+    )
+
+
+def check_has_frequency_content(audio: np.ndarray, sr: int) -> CheckResult:
+    """The FFT should have energy above 100 Hz (not just DC offset)."""
+    mono = audio.mean(axis=1)
+    spectrum = np.abs(np.fft.rfft(mono))
+    freqs = np.fft.rfftfreq(len(mono), d=1.0 / sr)
+
+    above_100hz = spectrum[freqs >= 100.0]
+    below_100hz = spectrum[freqs < 100.0]
+    if len(above_100hz) == 0 or below_100hz.sum() == 0:
+        return _check("has_frequency_content_above_100hz", False, "no FFT bins above 100 Hz")
+    ratio = float(above_100hz.sum() / (below_100hz.sum() + 1e-12))
+    return _check(
+        "has_frequency_content_above_100hz",
+        ratio >= 0.1,
+        f"ratio(above100Hz/below100Hz)={ratio:.3f} (need >= 0.1)",
+    )
+
+
+def check_has_dynamic_range(audio: np.ndarray) -> CheckResult:
+    """Audio should not be near-DC and not 100% clipped to one value."""
+    std = float(np.std(audio))
+    return _check(
+        "has_dynamic_range",
+        std >= 0.01,
+        f"std={std:.4f} (need >= 0.01)",
+    )
+
+
+def check_not_clipped(audio: np.ndarray, clip_fraction_threshold: float = 0.05) -> CheckResult:
+    """No more than 5% of samples should be at ±1.0 (full-scale clipping)."""
+    clipped = np.sum(np.abs(audio) >= 0.999) / audio.size
+    return _check(
+        "not_severely_clipped",
+        clipped <= clip_fraction_threshold,
+        f"clipped_fraction={clipped:.4f} (need <= {clip_fraction_threshold})",
+    )
+
+
+def check_stereo_correlation(audio: np.ndarray) -> CheckResult:
+    """Two channels should be related (real stereo) but not identical (mono dupe).
+
+    Acceptable range: correlation in [0.1, 0.999].
+    Below 0.1: channels look uncorrelated (bug in stereo handling).
+    At ~1.0: probably duplicated mono (real audio is never exactly identical L/R).
+    """
+    if audio.shape[1] < 2:
+        return _check("stereo_correlation_sane", True, "(mono, skipped)")
+    left = audio[:, 0]
+    right = audio[:, 1]
+    if np.std(left) < 1e-8 or np.std(right) < 1e-8:
+        return _check("stereo_correlation_sane", False, "one channel is silent")
+    corr = float(np.corrcoef(left, right)[0, 1])
+    passed = 0.1 <= corr <= 0.999
+    return _check(
+        "stereo_correlation_sane",
+        passed,
+        f"corr(L, R)={corr:.4f} (need 0.1 <= corr <= 0.999)",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate ACE-Step generated audio.")
+    parser.add_argument("wav_path", help="Path to the WAV file to validate.")
+    parser.add_argument(
+        "--expected-duration",
+        type=float,
+        default=30.0,
+        help="Expected audio duration in seconds (default: 30.0).",
+    )
+    parser.add_argument(
+        "--duration-tolerance",
+        type=float,
+        default=1.0,
+        help="Allowed deviation from expected duration in seconds.",
+    )
+    parser.add_argument(
+        "--expected-sample-rate",
+        type=int,
+        default=48000,
+        help="Expected sample rate (default: 48000).",
+    )
+    args = parser.parse_args()
+
+    print(f"Loading {args.wav_path}...")
+    audio, sr = load_audio(args.wav_path)
+    print(f"Shape: {audio.shape} (samples, channels), sample_rate={sr} Hz")
+    print()
+
+    checks: list[Callable[[], CheckResult]] = [
+        lambda: check_duration(audio, sr, args.expected_duration, args.duration_tolerance),
+        lambda: check_sample_rate(sr, args.expected_sample_rate),
+        lambda: check_stereo(audio),
+        lambda: check_not_silent(audio),
+        lambda: check_has_frequency_content(audio, sr),
+        lambda: check_has_dynamic_range(audio),
+        lambda: check_not_clipped(audio),
+        lambda: check_stereo_correlation(audio),
+    ]
+
+    results = [c() for c in checks]
+    passed = sum(r.passed for r in results)
+    failed = len(results) - passed
+
+    print("Level-2 audio-shape checks:")
+    for r in results:
+        marker = "PASS" if r.passed else "FAIL"
+        print(f"  [{marker}]  {r.name:<40}  {r.detail}")
+    print()
+    print(f"Summary: {passed}/{len(results)} checks passed.")
+
+    if failed == 0:
+        print("Verdict: Audio is plausibly music-shaped.")
+        return 0
+    else:
+        print("Verdict: Audio failed structural checks. Listen to confirm and debug.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/diffusion/models/ace_step/test_ace_step_pipeline.py
+++ b/tests/diffusion/models/ace_step/test_ace_step_pipeline.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Tier 2 integration smoke test for ``AceStepPipeline``.
+
+Instantiates the pipeline via ``object.__new__`` to bypass the heavy
+``__init__`` (which calls ``from_pretrained`` on tokenizer / text_encoder /
+vae / scheduler — all real-checkpoint paths), then attaches:
+
+  * tiny real ``AceStepTransformer1DModel`` and ``AceStepConditionEncoder``
+    (random init) for the actual ACE-Step math,
+  * mock tokenizer / text encoder / VAE for the I/O surface,
+  * a real ``FlowMatchEulerDiscreteScheduler`` (lightweight, no checkpoint).
+
+Runs ``forward`` end-to-end with a minimal ``OmniDiffusionRequest`` so all
+eight pipeline steps execute on CPU in a few seconds. Catches wiring bugs
+that would otherwise cost GPU hours: shape mismatches between components,
+scheduler misuse, request unpacking errors, missing methods.
+
+What this DOES verify:
+    - All 8 forward steps run without crashing
+    - Component-to-component shapes line up
+    - Scheduler config consumed correctly
+    - OmniDiffusionRequest unpacking works
+    - Output is a populated DiffusionOutput with the right rank/shape
+
+What this does NOT verify:
+    - Audio quality (mock VAE returns randn; tiny DiT/condition encoder
+      have random init weights — output is junk by design).
+    - Real text encoder behaviour (mock embeds a fake vocab).
+    - Numerical stability of the real model at full scale.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+
+from vllm_omni.diffusion.models.ace_step.ace_step_transformer import (
+    AceStepTransformer1DModel,
+)
+from vllm_omni.diffusion.models.ace_step.modeling_ace_step import (
+    AceStepConditionEncoder,
+)
+from vllm_omni.diffusion.models.ace_step.pipeline_ace_step import AceStepPipeline
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+# --------------------------------------------------------------------------- #
+#                           single-process TP init                              #
+# --------------------------------------------------------------------------- #
+# Mirrors test_ace_step_transformer.py — ReplicatedLinear inside the tiny
+# transformer / condition encoder needs the TP group set up before construction.
+
+
+@pytest.fixture(scope="module")
+def _init_single_process_tp():
+    import os
+
+    from vllm.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    if not torch.distributed.is_initialized():
+        os.environ.setdefault("MASTER_ADDR", "localhost")
+        os.environ.setdefault("MASTER_PORT", "29504")
+        os.environ.setdefault("RANK", "0")
+        os.environ.setdefault("WORLD_SIZE", "1")
+        init_distributed_environment(world_size=1, rank=0, local_rank=0)
+        initialize_model_parallel(tensor_model_parallel_size=1)
+    yield
+
+
+# --------------------------------------------------------------------------- #
+#                              I/O mocks                                       #
+# --------------------------------------------------------------------------- #
+
+
+class _MockTokenizerOutput:
+    """Mimics the ``transformers.BatchEncoding`` surface our pipeline uses."""
+
+    def __init__(self, input_ids: torch.Tensor, attention_mask: torch.Tensor):
+        self.input_ids = input_ids
+        self.attention_mask = attention_mask
+
+
+class _MockTokenizer:
+    """Returns fixed-length input_ids / all-ones attention_mask of length 8."""
+
+    def __call__(
+        self,
+        strs,
+        padding=None,
+        truncation=None,
+        max_length=None,
+        return_tensors=None,
+    ):
+        batch_size = len(strs)
+        seq_len = 8
+        input_ids = torch.zeros(batch_size, seq_len, dtype=torch.long)
+        attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+        return _MockTokenizerOutput(input_ids, attention_mask)
+
+
+class _MockTextEncoderOutput:
+    def __init__(self, last_hidden_state: torch.Tensor):
+        self.last_hidden_state = last_hidden_state
+
+
+class _MockTextEncoder(nn.Module):
+    """Stub Qwen3-Embedding: an Embedding layer that doubles as ``get_input_embeddings``."""
+
+    def __init__(self, vocab_size: int = 100, hidden_dim: int = 32):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_dim)
+
+    def forward(self, input_ids=None):
+        hidden = self.embed_tokens(input_ids)
+        return _MockTextEncoderOutput(last_hidden_state=hidden)
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+
+class _MockVAEDecodeOutput:
+    def __init__(self, sample: torch.Tensor):
+        self.sample = sample
+
+
+class _MockVAE(nn.Module):
+    """Stub ``AutoencoderOobleck``: ``decode`` upsamples by ``hop_length``."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int = 2,
+        hop_length: int = 4,
+        sampling_rate: int = 20,
+    ):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.hop_length = hop_length
+        self.config = SimpleNamespace(sampling_rate=sampling_rate)
+        self.dtype = torch.float32
+
+    def decode(self, x: torch.Tensor) -> _MockVAEDecodeOutput:
+        batch_size, _, latent_len = x.shape
+        audio = torch.randn(batch_size, self.out_channels, latent_len * self.hop_length)
+        return _MockVAEDecodeOutput(sample=audio)
+
+
+# --------------------------------------------------------------------------- #
+#                             tiny model configs                               #
+# --------------------------------------------------------------------------- #
+# Same proportions as the existing forward-shape tests; the DiT and condition
+# encoder are real ACE-Step modules, just with small dimensions so the test
+# finishes in seconds on CPU.
+
+
+_TINY_DIT_KWARGS = dict(
+    hidden_size=64,
+    intermediate_size=64,
+    num_hidden_layers=2,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=16,
+    in_channels=24,
+    audio_acoustic_hidden_dim=8,
+    patch_size=2,
+    sliding_window=4,
+)
+
+
+_TINY_COND_KWARGS = dict(
+    hidden_size=64,
+    intermediate_size=64,
+    text_hidden_dim=32,
+    # ``timbre_hidden_dim`` must equal the DiT's ``audio_acoustic_hidden_dim``
+    # in production (the converter writes silence_latent at that width and the
+    # pipeline slices it directly into the ``src_latents`` half of
+    # ``context_latents``). Keep them aligned here so the tiny test exercises
+    # the real wiring.
+    timbre_hidden_dim=_TINY_DIT_KWARGS["audio_acoustic_hidden_dim"],
+    num_lyric_encoder_hidden_layers=2,
+    num_timbre_encoder_hidden_layers=2,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=16,
+    sliding_window=4,
+)
+
+
+# --------------------------------------------------------------------------- #
+#                           the integration test                                #
+# --------------------------------------------------------------------------- #
+
+
+def _build_pipeline_with_mocks() -> AceStepPipeline:
+    """Construct a pipeline whose __init__ would normally call from_pretrained.
+
+    Uses object.__new__ + manual attribute assignment so we never touch a real
+    checkpoint. Mirrors the parallelism-contract tests' use of object.__new__.
+    """
+    pipeline = object.__new__(AceStepPipeline)
+    nn.Module.__init__(pipeline)
+
+    pipeline.device = torch.device("cpu")
+    pipeline.od_config = SimpleNamespace(
+        dtype=torch.float32,
+        enable_diffusion_pipeline_profiler=False,
+    )
+
+    pipeline._guidance_scale = None
+    pipeline._num_timesteps = None
+    pipeline._current_timestep = None
+    pipeline.is_turbo = True
+    # 5 latent frames per second → timbre_fix_frame = ceil(30 * 5) = 150, fits
+    # well inside the condition encoder's silence_latent buffer (15000 frames).
+    pipeline.latents_per_second = 5.0
+
+    pipeline.transformer = AceStepTransformer1DModel(**_TINY_DIT_KWARGS).eval()
+    pipeline.condition_encoder = AceStepConditionEncoder(**_TINY_COND_KWARGS).eval()
+
+    pipeline.tokenizer = _MockTokenizer()
+    pipeline.text_encoder = _MockTextEncoder(
+        vocab_size=100,
+        hidden_dim=_TINY_COND_KWARGS["text_hidden_dim"],
+    )
+    pipeline.vae = _MockVAE(
+        in_channels=_TINY_DIT_KWARGS["audio_acoustic_hidden_dim"],
+        out_channels=2,
+        hop_length=4,
+        sampling_rate=20,
+    )
+
+    # FlowMatchEulerDiscreteScheduler instantiated standalone — no checkpoint
+    # needed since the pipeline supplies its own sigmas via set_timesteps.
+    pipeline.scheduler = FlowMatchEulerDiscreteScheduler(num_train_timesteps=1, shift=1.0)
+
+    return pipeline
+
+
+def test_pipeline_forward_runs_end_to_end_on_cpu(_init_single_process_tp):
+    """All 8 forward steps execute and the output has the expected shape."""
+    torch.manual_seed(0)
+
+    pipeline = _build_pipeline_with_mocks()
+
+    sampling_params = OmniDiffusionSamplingParams(
+        num_inference_steps=2,
+        seed=0,
+        extra_args={
+            "audio_duration": 2.0,
+            "lyrics": "",
+            "vocal_language": "en",
+            "shift": 3.0,
+        },
+    )
+    req = OmniDiffusionRequest(
+        prompts=["test prompt for ace-step pipeline smoke test"],
+        sampling_params=sampling_params,
+        request_id="ace-step-smoke-test-0",
+    )
+
+    with torch.no_grad():
+        output = pipeline.forward(req)
+
+    audio = output.output
+
+    # Expected derived shape:
+    #   latent_length = ceil(audio_duration * latents_per_second)
+    #                 = ceil(2.0 * 5.0) = 10
+    #   audio_length  = latent_length * vae.hop_length = 10 * 4 = 40
+    expected_batch = 1
+    expected_channels = 2  # MockVAE outputs stereo
+    expected_min_samples = 30  # ~40, allow slack for any boundary handling
+
+    assert audio is not None, "forward returned a DiffusionOutput with no audio payload"
+    assert audio.ndim == 3, f"expected [B, C, T] audio, got rank {audio.ndim}"
+    assert audio.shape[0] == expected_batch, f"expected batch {expected_batch}, got {audio.shape[0]}"
+    assert audio.shape[1] == expected_channels, f"expected {expected_channels} audio channels, got {audio.shape[1]}"
+    assert audio.shape[2] >= expected_min_samples, (
+        f"expected at least {expected_min_samples} samples, got {audio.shape[2]}"
+    )
+
+
+def test_pipeline_forward_returns_latent_when_requested(_init_single_process_tp):
+    """``output_type='latent'`` short-circuits the VAE decode + normalization."""
+    torch.manual_seed(0)
+
+    pipeline = _build_pipeline_with_mocks()
+
+    sampling_params = OmniDiffusionSamplingParams(
+        num_inference_steps=2,
+        seed=0,
+        extra_args={
+            "audio_duration": 2.0,
+            "lyrics": "",
+            "vocal_language": "en",
+            "shift": 3.0,
+        },
+    )
+    req = OmniDiffusionRequest(
+        prompts=["another test prompt"],
+        sampling_params=sampling_params,
+        request_id="ace-step-smoke-test-1",
+    )
+
+    with torch.no_grad():
+        output = pipeline.forward(req, output_type="latent")
+
+    latents = output.output
+
+    # Expected: [B, latent_length, audio_acoustic_hidden_dim]
+    #         = [1, 10, 8]
+    assert latents is not None
+    assert latents.ndim == 3, f"expected [B, T, C] latents, got rank {latents.ndim}"
+    assert latents.shape[0] == 1
+    assert latents.shape[1] == 10  # ceil(2.0 * 5.0)
+    assert latents.shape[2] == _TINY_DIT_KWARGS["audio_acoustic_hidden_dim"]

--- a/tests/diffusion/models/ace_step/test_ace_step_transformer.py
+++ b/tests/diffusion/models/ace_step/test_ace_step_transformer.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import inspect
+import os
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm_omni.diffusion.models.ace_step.ace_step_transformer import (
+    AceStepTransformer1DModel,
+)
+from vllm_omni.diffusion.models.ace_step.modeling_ace_step import (
+    AceStepConditionEncoder,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+@pytest.fixture(scope="module")
+def _init_single_process_tp():
+    """Set up a single-process tensor-model-parallel group so the forward-shape
+    tests can instantiate modules that use ``ReplicatedLinear`` (which calls
+    ``get_tensor_model_parallel_rank`` in its ``__init__``).
+    """
+    from vllm.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    if not torch.distributed.is_initialized():
+        os.environ.setdefault("MASTER_ADDR", "localhost")
+        os.environ.setdefault("MASTER_PORT", "29503")
+        os.environ.setdefault("RANK", "0")
+        os.environ.setdefault("WORLD_SIZE", "1")
+        init_distributed_environment(world_size=1, rank=0, local_rank=0)
+        initialize_model_parallel(tensor_model_parallel_size=1)
+    yield
+
+
+# --------------------------------------------------------------------------- #
+#                         parallelism / acceleration contract                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_ace_step_exposes_hsdp_shard_conditions_for_transformer_blocks():
+    """``_hsdp_shard_conditions`` must select every block in ``self.layers`` so
+    FSDP2 shards weights per-block. Mirrors the stable_audio HSDP contract.
+    """
+    model = object.__new__(AceStepTransformer1DModel)
+    nn.Module.__init__(model)
+    model.layers = nn.ModuleList([nn.Linear(4, 4) for _ in range(3)])
+    model.proj_out_conv = nn.Linear(4, 4)
+
+    conditions = getattr(model, "_hsdp_shard_conditions", None)
+    assert conditions is not None
+    assert len(conditions) == 1
+
+    matched = []
+    for name, module in model.named_modules():
+        if any(cond(name, module) for cond in conditions):
+            matched.append(name)
+
+    assert matched == ["layers.0", "layers.1", "layers.2"]
+
+
+def test_ace_step_repeated_blocks_lists_block_class_name():
+    """``_repeated_blocks`` is used by torch.compile to compile a single block
+    type once and reuse the artifact across the stack.
+    """
+    assert AceStepTransformer1DModel._repeated_blocks == ["AceStepTransformerBlock"]
+
+
+def test_ace_step_layerwise_offload_attr_points_at_block_list():
+    """``_layerwise_offload_blocks_attrs`` tells the CPU-offload backend the
+    attribute name of the ``nn.ModuleList`` to offload per layer.
+    """
+    assert AceStepTransformer1DModel._layerwise_offload_blocks_attrs == ["layers"]
+
+
+# --------------------------------------------------------------------------- #
+#         default __init__ kwargs match the official v15-turbo config         #
+# --------------------------------------------------------------------------- #
+# Source of truth:
+#   https://huggingface.co/ACE-Step/Ace-Step1.5/blob/main/acestep-v15-turbo/config.json
+# If these drift, the model will silently load with wrong dimensions and
+# weight loading will fail with cryptic shape mismatches at runtime.
+
+
+_OFFICIAL_TURBO_DIT_CONFIG = {
+    "hidden_size": 2048,
+    "intermediate_size": 6144,
+    "num_hidden_layers": 24,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 8,
+    "head_dim": 128,
+    "in_channels": 192,
+    "audio_acoustic_hidden_dim": 64,
+    "patch_size": 2,
+    "rope_theta": 1000000.0,
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "rms_norm_eps": 1e-6,
+    "sliding_window": 128,
+}
+
+_OFFICIAL_TURBO_COND_ENCODER_CONFIG = {
+    "hidden_size": 2048,
+    "intermediate_size": 6144,
+    "text_hidden_dim": 1024,
+    "timbre_hidden_dim": 64,
+    "num_lyric_encoder_hidden_layers": 8,
+    "num_timbre_encoder_hidden_layers": 4,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 8,
+    "head_dim": 128,
+    "rope_theta": 1000000.0,
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "rms_norm_eps": 1e-6,
+    "sliding_window": 128,
+}
+
+
+@pytest.mark.parametrize("key,expected", list(_OFFICIAL_TURBO_DIT_CONFIG.items()))
+def test_transformer_default_matches_official_turbo_config(key, expected):
+    sig = inspect.signature(AceStepTransformer1DModel.__init__)
+    assert sig.parameters[key].default == expected, (
+        f"AceStepTransformer1DModel default for {key!r} = "
+        f"{sig.parameters[key].default!r} but ACE-Step 1.5 turbo expects {expected!r}"
+    )
+
+
+@pytest.mark.parametrize("key,expected", list(_OFFICIAL_TURBO_COND_ENCODER_CONFIG.items()))
+def test_condition_encoder_default_matches_official_turbo_config(key, expected):
+    sig = inspect.signature(AceStepConditionEncoder.__init__)
+    assert sig.parameters[key].default == expected, (
+        f"AceStepConditionEncoder default for {key!r} = "
+        f"{sig.parameters[key].default!r} but ACE-Step 1.5 turbo expects {expected!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+#                         forward shape checks (tiny config)                   #
+# --------------------------------------------------------------------------- #
+# These instantiate a SMALL model so the test runs in seconds on CPU. The
+# proportions match the real model (GQA factor 2, patch_size 2, channel split
+# context+acoustic) so any reshape / projection bug would still surface.
+
+
+_TINY_DIT_KWARGS = dict(
+    hidden_size=64,
+    intermediate_size=64,
+    num_hidden_layers=2,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=16,
+    in_channels=24,
+    audio_acoustic_hidden_dim=8,
+    patch_size=2,
+    sliding_window=4,
+)
+
+_TINY_COND_ENCODER_KWARGS = dict(
+    hidden_size=64,
+    intermediate_size=64,
+    text_hidden_dim=32,
+    timbre_hidden_dim=16,
+    num_lyric_encoder_hidden_layers=2,
+    num_timbre_encoder_hidden_layers=2,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=16,
+    sliding_window=4,
+)
+
+
+def test_transformer_forward_returns_expected_shape(_init_single_process_tp):
+    """End-to-end shape check: `hidden_states` enters as
+    [B, T, audio_acoustic_hidden_dim], goes through channel-concat + Conv1d
+    patchify (stride=patch_size) -> stack of blocks -> ConvTranspose1d
+    de-patchify -> slice back to original seq_len, and must exit at
+    [B, T, audio_acoustic_hidden_dim].
+    """
+    torch.manual_seed(0)
+    model = AceStepTransformer1DModel(**_TINY_DIT_KWARGS).eval()
+
+    batch_size, seq_len = 1, 8
+    audio_dim = _TINY_DIT_KWARGS["audio_acoustic_hidden_dim"]
+    context_dim = _TINY_DIT_KWARGS["in_channels"] - audio_dim
+    encoder_seq_len = 6
+    encoder_hidden_size = _TINY_DIT_KWARGS["hidden_size"]
+
+    hidden_states = torch.randn(batch_size, seq_len, audio_dim)
+    timestep = torch.tensor([0.5])
+    timestep_r = torch.tensor([0.5])
+    encoder_hidden_states = torch.randn(batch_size, encoder_seq_len, encoder_hidden_size)
+    context_latents = torch.randn(batch_size, seq_len, context_dim)
+
+    with torch.no_grad():
+        output = model(
+            hidden_states=hidden_states,
+            timestep=timestep,
+            timestep_r=timestep_r,
+            encoder_hidden_states=encoder_hidden_states,
+            context_latents=context_latents,
+            return_dict=False,
+        )
+
+    assert isinstance(output, tuple)
+    sample = output[0]
+    assert sample.shape == (batch_size, seq_len, audio_dim), (
+        f"DiT forward returned shape {tuple(sample.shape)}; expected ({batch_size}, {seq_len}, {audio_dim})"
+    )
+
+
+def test_condition_encoder_forward_returns_expected_shape(_init_single_process_tp):
+    """Packed-sequence shape check: lyric (L) + timbre (1 token after CLS pool)
+    + text (T) get concatenated and stable-sorted, so the encoder output must
+    be [B, L + 1 + T, hidden_size] with a matching mask.
+    """
+    torch.manual_seed(0)
+    encoder = AceStepConditionEncoder(**_TINY_COND_ENCODER_KWARGS).eval()
+
+    batch_size = 1
+    text_seq_len = 4
+    lyric_seq_len = 8
+    timbre_k = 4  # per-sample timbre token count before CLS pool
+    text_hidden_dim = _TINY_COND_ENCODER_KWARGS["text_hidden_dim"]
+    timbre_hidden_dim = _TINY_COND_ENCODER_KWARGS["timbre_hidden_dim"]
+    hidden_size = _TINY_COND_ENCODER_KWARGS["hidden_size"]
+
+    text_hidden_states = torch.randn(batch_size, text_seq_len, text_hidden_dim)
+    text_attention_mask = torch.ones(batch_size, text_seq_len, dtype=torch.long)
+    lyric_hidden_states = torch.randn(batch_size, lyric_seq_len, text_hidden_dim)
+    lyric_attention_mask = torch.ones(batch_size, lyric_seq_len, dtype=torch.long)
+    refer_audio_acoustic = torch.randn(batch_size, timbre_k, timbre_hidden_dim)
+    # One timbre sample, assigned to batch 0.
+    refer_audio_order_mask = torch.zeros(batch_size, dtype=torch.long)
+
+    with torch.no_grad():
+        encoder_hidden_states, encoder_attention_mask = encoder(
+            text_hidden_states=text_hidden_states,
+            text_attention_mask=text_attention_mask,
+            lyric_hidden_states=lyric_hidden_states,
+            lyric_attention_mask=lyric_attention_mask,
+            refer_audio_acoustic_hidden_states_packed=refer_audio_acoustic,
+            refer_audio_order_mask=refer_audio_order_mask,
+        )
+
+    # After packing: lyric (L) + timbre (1 CLS token) + text (T) = L + 1 + T.
+    expected_seq_len = lyric_seq_len + 1 + text_seq_len
+    assert encoder_hidden_states.shape == (batch_size, expected_seq_len, hidden_size), (
+        f"Condition encoder returned shape {tuple(encoder_hidden_states.shape)}; "
+        f"expected ({batch_size}, {expected_seq_len}, {hidden_size})"
+    )
+    assert encoder_attention_mask.shape == (batch_size, expected_seq_len), (
+        f"Condition encoder mask shape {tuple(encoder_attention_mask.shape)}; "
+        f"expected ({batch_size}, {expected_seq_len})"
+    )

--- a/vllm_omni/diffusion/models/ace_step/__init__.py
+++ b/vllm_omni/diffusion/models/ace_step/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm_omni.diffusion.models.ace_step.ace_step_transformer import (
+    AceStepTransformer1DModel,
+)
+from vllm_omni.diffusion.models.ace_step.modeling_ace_step import (
+    AceStepConditionEncoder,
+)
+
+__all__ = [
+    "AceStepConditionEncoder",
+    "AceStepTransformer1DModel",
+]

--- a/vllm_omni/diffusion/models/ace_step/ace_step_transformer.py
+++ b/vllm_omni/diffusion/models/ace_step/ace_step_transformer.py
@@ -1,0 +1,638 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+ACE-Step 1.5 DiT Model for vLLM-Omni.
+
+Ported from diffusers PR #13095:
+src/diffusers/models/transformers/ace_step_transformer.py
+
+Known limitation (tracked separately):
+    The DiT uses sliding-window self-attention. vllm-omni's flash backend has no
+    ``window_size`` plumbing today, so flash silently drops the window
+    constraint and the model produces noise. ``AceStepAttention`` hard-pins
+    SDPA for sliding-window self-attention sites at construction time
+    (cross-attention and full self-attention sites keep flash). The pin is
+    automatic — no user flag required — and will be removed in a follow-up PR
+    once ``window_size`` plumbing lands in
+    ``vllm_omni/diffusion/attention/backends/flash_attn.py``.
+"""
+
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from diffusers.models.embeddings import (
+    Timesteps,
+    apply_rotary_emb,
+    get_1d_rotary_pos_embed,
+)
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+from diffusers.models.normalization import RMSNorm
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.data import OmniDiffusionConfig
+
+logger = init_logger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+#                                attention-mask                                #
+# --------------------------------------------------------------------------- #
+
+
+def _create_4d_mask(
+    seq_len: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    attention_mask: torch.Tensor | None = None,
+    sliding_window: int | None = None,
+    is_sliding_window: bool = False,
+    is_causal: bool = True,
+) -> torch.Tensor:
+    """Build a `[B, 1, seq_len, seq_len]` additive mask (0.0 kept, -inf masked).
+
+    Mirrors the mask construction in the original ACE-Step DiT so the model sees
+    identical attention coverage regardless of the attention backend selected.
+    """
+    indices = torch.arange(seq_len, device=device)
+    diff = indices.unsqueeze(1) - indices.unsqueeze(0)
+    valid_mask = torch.ones((seq_len, seq_len), device=device, dtype=torch.bool)
+
+    if is_causal:
+        valid_mask = valid_mask & (diff >= 0)
+
+    if is_sliding_window and sliding_window is not None:
+        if is_causal:
+            valid_mask = valid_mask & (diff <= sliding_window)
+        else:
+            valid_mask = valid_mask & (torch.abs(diff) <= sliding_window)
+
+    valid_mask = valid_mask.unsqueeze(0).unsqueeze(0)
+
+    if attention_mask is not None:
+        padding_mask_4d = attention_mask.view(attention_mask.shape[0], 1, 1, seq_len).to(torch.bool)
+        valid_mask = valid_mask & padding_mask_4d
+
+    min_dtype = torch.finfo(dtype).min
+    mask_tensor = torch.full(valid_mask.shape, min_dtype, dtype=dtype, device=device)
+    mask_tensor.masked_fill_(valid_mask, 0.0)
+    return mask_tensor
+
+
+# --------------------------------------------------------------------------- #
+#                                 RoPE helpers                                 #
+# --------------------------------------------------------------------------- #
+
+
+def _ace_step_rotary_freqs(
+    seq_len: int,
+    head_dim: int,
+    theta: float,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build (cos, sin) freqs for ACE-Step RoPE.
+
+    ACE-Step reuses Qwen3's rotary layout: ``freqs = cat([freq_half, freq_half], dim=-1)``
+    (not interleaved). That matches ``get_1d_rotary_pos_embed(..., use_real=True,
+    repeat_interleave_real=False)`` combined with ``apply_rotary_emb(..., use_real_unbind_dim=-2)``.
+    """
+    positions = torch.arange(seq_len, device=device, dtype=torch.float32)
+    cos, sin = get_1d_rotary_pos_embed(head_dim, positions, theta=theta, use_real=True, repeat_interleave_real=False)
+    return cos.to(dtype=dtype), sin.to(dtype=dtype)
+
+
+# --------------------------------------------------------------------------- #
+#                                building blocks                               #
+# --------------------------------------------------------------------------- #
+
+
+class AceStepMLP(nn.Module):
+    """SwiGLU MLP used in ACE-Step transformer blocks."""
+
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class AceStepTimestepEmbedding(nn.Module):
+    """Sinusoidal timestep embedding + 2-layer MLP + 6-way AdaLN scale/shift projection.
+
+    Matches the original ACE-Step checkpoint layout (``linear_1``, ``linear_2``, ``time_proj``).
+    """
+
+    def __init__(self, in_channels: int = 256, time_embed_dim: int = 2048, scale: float = 1000.0):
+        super().__init__()
+        self.in_channels = in_channels
+        self.scale = scale
+        self.time_sinusoid = Timesteps(num_channels=in_channels, flip_sin_to_cos=True, downscale_freq_shift=0)
+        self.linear_1 = nn.Linear(in_channels, time_embed_dim, bias=True)
+        self.act1 = nn.SiLU()
+        self.linear_2 = nn.Linear(time_embed_dim, time_embed_dim, bias=True)
+        self.act2 = nn.SiLU()
+        self.time_proj = nn.Linear(time_embed_dim, time_embed_dim * 6)
+
+    def forward(self, t: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        t_freq = self.time_sinusoid(t * self.scale)
+        temb = self.linear_1(t_freq.to(t.dtype))
+        temb = self.act1(temb)
+        temb = self.linear_2(temb)
+        timestep_proj = self.time_proj(self.act2(temb)).unflatten(1, (6, -1))
+        return temb, timestep_proj
+
+
+class AceStepAttention(nn.Module):
+    """GQA attention with RMSNorm on query/key for ACE-Step 1.5.
+
+    Self-attention applies RoPE on query/key; cross-attention reads K/V from
+    ``encoder_hidden_states`` and does not apply RoPE. GQA is implemented by
+    manually expanding K/V heads to match Q heads (vllm-omni's Attention layer
+    expects matched head counts), mirroring the stable_audio pattern.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        bias: bool = False,
+        dropout: float = 0.0,
+        eps: float = 1e-6,
+        sliding_window: int | None = None,
+        is_cross_attention: bool = False,
+        role: str = "self",
+    ):
+        super().__init__()
+        self.heads = num_attention_heads
+        self.kv_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.dropout = dropout
+        self.sliding_window = sliding_window
+        self.is_cross_attention = is_cross_attention
+        self.role = role
+        self.num_kv_groups = num_attention_heads // num_key_value_heads
+
+        q_dim = num_attention_heads * head_dim
+        kv_dim = num_key_value_heads * head_dim
+
+        self.to_q = ReplicatedLinear(hidden_size, q_dim, bias=bias)
+        self.to_k = ReplicatedLinear(hidden_size, kv_dim, bias=bias)
+        self.to_v = ReplicatedLinear(hidden_size, kv_dim, bias=bias)
+        self.to_out = nn.ModuleList(
+            [
+                ReplicatedLinear(q_dim, hidden_size, bias=bias),
+                nn.Dropout(dropout),
+            ]
+        )
+        self.norm_q = RMSNorm(head_dim, eps=eps)
+        self.norm_k = RMSNorm(head_dim, eps=eps)
+
+        # vllm-omni Attention; K/V are expanded to match Q heads before dispatch,
+        # so num_kv_heads equals num_heads here.
+        self.attn = Attention(
+            num_heads=num_attention_heads,
+            head_size=head_dim,
+            softmax_scale=head_dim**-0.5,
+            causal=False,
+            num_kv_heads=num_attention_heads,
+            role=role,
+        )
+
+        # Mask-shape compatibility per backend (mirrors the branching the
+        # diffusers source did inside its AceStepAttnProcessor2_0):
+        #
+        #   - SDPA / NPU / others accept the 4D additive mask we build via
+        #     ``_create_4d_mask``. Sliding window is enforced by the mask.
+        #   - Flash attention (vllm-omni's variant) only accepts a 2D padding
+        #     mask and has NO ``window_size`` kwarg, so sliding-window cannot
+        #     be enforced with flash on this codebase. For sliding-window
+        #     self-attention layers we hard-pin the wrapper's inner backend to
+        #     SDPA (via the existing ``sdpa_fallback`` instance) — verified
+        #     empirically that without this the model produces noise on
+        #     alternating layers. Flash is still used for cross-attention and
+        #     full self-attention layers.
+        backend_name = self.attn.attn_backend.get_name().upper()
+        self._uses_flash = "FLASH" in backend_name
+        if self._uses_flash and sliding_window is not None and not is_cross_attention:
+            self.attn.attention = self.attn.sdpa_fallback
+            self._uses_flash = False
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        is_cross = self.is_cross_attention and encoder_hidden_states is not None
+        kv_input = encoder_hidden_states if is_cross else hidden_states
+
+        batch_size, seq_len, _ = hidden_states.shape
+        kv_seq_len = kv_input.shape[1]
+
+        # Project. Q has ``heads * head_dim``; K/V have ``kv_heads * head_dim``.
+        query, _ = self.to_q(hidden_states)
+        key, _ = self.to_k(kv_input)
+        value, _ = self.to_v(kv_input)
+
+        query = query.view(batch_size, seq_len, self.heads, self.head_dim)
+        key = key.view(batch_size, kv_seq_len, self.kv_heads, self.head_dim)
+        value = value.view(batch_size, kv_seq_len, self.kv_heads, self.head_dim)
+
+        # Per-head RMSNorm on Q/K before RoPE.
+        query = self.norm_q(query)
+        key = self.norm_k(key)
+
+        # RoPE on self-attention only.
+        if not is_cross and image_rotary_emb is not None:
+            query = apply_rotary_emb(query, image_rotary_emb, use_real=True, use_real_unbind_dim=-2, sequence_dim=1)
+            key = apply_rotary_emb(key, image_rotary_emb, use_real=True, use_real_unbind_dim=-2, sequence_dim=1)
+
+        # GQA expansion: [B, S, kv_heads, D] -> [B, S, heads, D].
+        if self.num_kv_groups > 1:
+            key = key.unsqueeze(3).expand(-1, -1, -1, self.num_kv_groups, -1)
+            key = key.reshape(batch_size, kv_seq_len, self.heads, self.head_dim)
+            value = value.unsqueeze(3).expand(-1, -1, -1, self.num_kv_groups, -1)
+            value = value.reshape(batch_size, kv_seq_len, self.heads, self.head_dim)
+
+        # Backend-specific mask shape:
+        #   - flash: 2D padding mask `[B, S_kv]` (any positive value = keep).
+        #     ``_create_4d_mask`` produces `[B, 1, S_q, S_kv]` with `0.0` for
+        #     keep and `-inf` for mask; collapse along the query and singleton
+        #     dims with ``any`` to recover the padding axis.
+        #   - others: pass the 4D additive mask through unchanged.
+        # When the model code passes ``None`` (full-attention layers / cross-attn)
+        # we pass ``attn_metadata=None`` so the backend takes its unmasked fast path.
+        dispatch_mask = attention_mask
+        if dispatch_mask is not None and self._uses_flash and dispatch_mask.ndim == 4:
+            keep_mask = dispatch_mask if dispatch_mask.dtype == torch.bool else (dispatch_mask == 0)
+            dispatch_mask = keep_mask.any(dim=(1, 2))
+
+        if dispatch_mask is not None:
+            attn_metadata = AttentionMetadata(attn_mask=dispatch_mask)
+            hidden_states = self.attn(query, key, value, attn_metadata=attn_metadata)
+        else:
+            hidden_states = self.attn(query, key, value)
+
+        hidden_states = hidden_states.reshape(batch_size, seq_len, -1)
+        hidden_states, _ = self.to_out[0](hidden_states)
+        hidden_states = self.to_out[1](hidden_states)
+        return hidden_states
+
+
+class AceStepTransformerBlock(nn.Module):
+    """ACE-Step DiT block: self-attn (AdaLN) → cross-attn → MLP (AdaLN).
+
+    AdaLN parameters come from ``scale_shift_table + temb`` chunked into 6
+    (3 for self-attn + 3 for MLP).
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        intermediate_size: int,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        rms_norm_eps: float = 1e-6,
+        sliding_window: int | None = None,
+        use_cross_attention: bool = True,
+    ):
+        super().__init__()
+        self.self_attn_norm = RMSNorm(hidden_size, eps=rms_norm_eps)
+        self.self_attn = AceStepAttention(
+            hidden_size=hidden_size,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            bias=attention_bias,
+            dropout=attention_dropout,
+            eps=rms_norm_eps,
+            sliding_window=sliding_window,
+            is_cross_attention=False,
+            role="self",
+        )
+
+        self.use_cross_attention = use_cross_attention
+        if self.use_cross_attention:
+            self.cross_attn_norm = RMSNorm(hidden_size, eps=rms_norm_eps)
+            self.cross_attn = AceStepAttention(
+                hidden_size=hidden_size,
+                num_attention_heads=num_attention_heads,
+                num_key_value_heads=num_key_value_heads,
+                head_dim=head_dim,
+                bias=attention_bias,
+                dropout=attention_dropout,
+                eps=rms_norm_eps,
+                is_cross_attention=True,
+                role="cross",
+            )
+
+        self.mlp_norm = RMSNorm(hidden_size, eps=rms_norm_eps)
+        self.mlp = AceStepMLP(hidden_size, intermediate_size)
+
+        self.scale_shift_table = nn.Parameter(torch.randn(1, 6, hidden_size) / hidden_size**0.5)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        temb: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        encoder_hidden_states: torch.Tensor | None = None,
+        encoder_attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (self.scale_shift_table + temb).chunk(
+            6, dim=1
+        )
+
+        # Self-attention with AdaLN.
+        norm_hidden_states = (self.self_attn_norm(hidden_states) * (1 + scale_msa) + shift_msa).type_as(hidden_states)
+        attn_output = self.self_attn(
+            hidden_states=norm_hidden_states,
+            image_rotary_emb=position_embeddings,
+            attention_mask=attention_mask,
+        )
+        hidden_states = (hidden_states + attn_output * gate_msa).type_as(hidden_states)
+
+        # Cross-attention (no AdaLN, plain residual).
+        if self.use_cross_attention and encoder_hidden_states is not None:
+            norm_hidden_states = self.cross_attn_norm(hidden_states).type_as(hidden_states)
+            attn_output = self.cross_attn(
+                hidden_states=norm_hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                attention_mask=encoder_attention_mask,
+            )
+            hidden_states = hidden_states + attn_output
+
+        # MLP with AdaLN.
+        norm_hidden_states = (self.mlp_norm(hidden_states) * (1 + c_scale_msa) + c_shift_msa).type_as(hidden_states)
+        ff_output = self.mlp(norm_hidden_states)
+        hidden_states = (hidden_states + ff_output * c_gate_msa).type_as(hidden_states)
+        return hidden_states
+
+
+# --------------------------------------------------------------------------- #
+#                                 main DiT model                               #
+# --------------------------------------------------------------------------- #
+
+
+class AceStepTransformer1DModel(nn.Module):
+    """Diffusion Transformer for ACE-Step 1.5 music generation.
+
+    Generates audio latents conditioned on text, lyrics, and timbre. Uses 1D
+    patch embedding (``Conv1d`` with stride ``patch_size``) followed by a stack
+    of ``AceStepTransformerBlock`` with alternating sliding-window / full
+    attention on the self-attention branch. Cross-attention consumes the packed
+    ``encoder_hidden_states`` produced by ``AceStepConditionEncoder``.
+    """
+
+    _repeated_blocks = ["AceStepTransformerBlock"]
+    _layerwise_offload_blocks_attrs = ["layers"]
+
+    @staticmethod
+    def _is_ace_step_layer(name: str, module: object) -> bool:
+        """HSDP shard predicate.
+
+        ACE-Step's DiT calls its transformer block list ``layers`` (mirroring
+        the diffusers source — renaming would require remapping every weight
+        name in the checkpoint). The shared ``is_transformer_block_module``
+        helper hardcodes ``transformer_blocks``, so we provide a model-local
+        predicate that matches ``layers.<int>`` instead.
+        """
+        return "layers" in name and name.split(".")[-1].isdigit()
+
+    _hsdp_shard_conditions = [_is_ace_step_layer]
+
+    def __init__(
+        self,
+        od_config: OmniDiffusionConfig | None = None,
+        hidden_size: int = 2048,
+        intermediate_size: int = 6144,
+        num_hidden_layers: int = 24,
+        num_attention_heads: int = 16,
+        num_key_value_heads: int = 8,
+        head_dim: int = 128,
+        in_channels: int = 192,
+        audio_acoustic_hidden_dim: int = 64,
+        patch_size: int = 2,
+        rope_theta: float = 1000000.0,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        rms_norm_eps: float = 1e-6,
+        sliding_window: int = 128,
+        layer_types: list | None = None,
+        # Equal to ``hidden_size`` on base/turbo models; the XL turbo has a
+        # smaller condition encoder feeding a wider DiT, so we project up.
+        encoder_hidden_size: int | None = None,
+        # Variant metadata. Turbo models distill guidance into the weights and
+        # run without CFG; base/SFT models require CFG with the learned
+        # ``AceStepConditionEncoder.null_condition_emb``.
+        is_turbo: bool = False,
+        model_version: str | None = None,
+    ):
+        super().__init__()
+        self.od_config = od_config
+        self.parallel_config = od_config.parallel_config if od_config is not None else None
+
+        if encoder_hidden_size is None:
+            encoder_hidden_size = hidden_size
+        self.patch_size = patch_size
+        self.head_dim = head_dim
+        self.rope_theta = rope_theta
+
+        if layer_types is None:
+            layer_types = [
+                "sliding_attention" if bool((i + 1) % 2) else "full_attention" for i in range(num_hidden_layers)
+            ]
+        self.layer_types = list(layer_types)
+
+        # Stash config so the pipeline can introspect it (mirrors stable_audio).
+        self.config = type(
+            "Config",
+            (),
+            {
+                "hidden_size": hidden_size,
+                "intermediate_size": intermediate_size,
+                "num_hidden_layers": num_hidden_layers,
+                "num_attention_heads": num_attention_heads,
+                "num_key_value_heads": num_key_value_heads,
+                "head_dim": head_dim,
+                "in_channels": in_channels,
+                "audio_acoustic_hidden_dim": audio_acoustic_hidden_dim,
+                "patch_size": patch_size,
+                "rope_theta": rope_theta,
+                "sliding_window": sliding_window,
+                "encoder_hidden_size": encoder_hidden_size,
+                "is_turbo": is_turbo,
+                "model_version": model_version,
+            },
+        )()
+
+        self.layers = nn.ModuleList(
+            [
+                AceStepTransformerBlock(
+                    hidden_size=hidden_size,
+                    num_attention_heads=num_attention_heads,
+                    num_key_value_heads=num_key_value_heads,
+                    head_dim=head_dim,
+                    intermediate_size=intermediate_size,
+                    attention_bias=attention_bias,
+                    attention_dropout=attention_dropout,
+                    rms_norm_eps=rms_norm_eps,
+                    sliding_window=sliding_window if layer_types[i] == "sliding_attention" else None,
+                    use_cross_attention=True,
+                )
+                for i in range(num_hidden_layers)
+            ]
+        )
+
+        # Patchify: Conv1d(stride=patch_size) lifts (B, T, in_channels) ->
+        # (B, T/patch_size, hidden_size). The input is `cat(context_latents, hidden_states)`
+        # along the channel dim.
+        self.proj_in_conv = nn.Conv1d(
+            in_channels=in_channels,
+            out_channels=hidden_size,
+            kernel_size=patch_size,
+            stride=patch_size,
+            padding=0,
+        )
+
+        # Dual-timestep conditioning: one path for ``t``, one for ``(t - r)``.
+        self.time_embed = AceStepTimestepEmbedding(in_channels=256, time_embed_dim=hidden_size)
+        self.time_embed_r = AceStepTimestepEmbedding(in_channels=256, time_embed_dim=hidden_size)
+
+        self.condition_embedder = nn.Linear(encoder_hidden_size, hidden_size, bias=True)
+
+        self.norm_out = RMSNorm(hidden_size, eps=rms_norm_eps)
+        self.proj_out_conv = nn.ConvTranspose1d(
+            in_channels=hidden_size,
+            out_channels=audio_acoustic_hidden_dim,
+            kernel_size=patch_size,
+            stride=patch_size,
+            padding=0,
+        )
+        self.scale_shift_table = nn.Parameter(torch.randn(1, 2, hidden_size) / hidden_size**0.5)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(self.parameters()).dtype
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        timestep_r: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        context_latents: torch.Tensor,
+        return_dict: bool = True,
+    ) -> torch.Tensor | Transformer2DModelOutput:
+        """The [`AceStepTransformer1DModel`] forward method.
+
+        Args:
+            hidden_states: Noisy latent input `(batch, seq_len, channels)`.
+            timestep: Current diffusion timestep `t` `(batch,)`.
+            timestep_r: Reference timestep `r` `(batch,)` (set equal to `t`
+                for standard inference).
+            encoder_hidden_states: Conditioning embeddings from the condition
+                encoder (text + lyrics + timbre), shape
+                `(batch, encoder_seq_len, encoder_hidden_size)`.
+            context_latents: Context latents (source latents concatenated with
+                chunk masks) — fed alongside ``hidden_states`` to the patchify
+                conv, shape `(batch, seq_len, context_dim)`.
+            return_dict: Whether to return ``Transformer2DModelOutput`` or a tuple.
+
+        Returns:
+            Predicted velocity field (flow matching).
+        """
+        # Dual timestep embedding: t and (t - r). Sum the AdaLN projections.
+        temb_t, timestep_proj_t = self.time_embed(timestep)
+        temb_r, timestep_proj_r = self.time_embed_r(timestep - timestep_r)
+        temb = temb_t + temb_r
+        timestep_proj = timestep_proj_t + timestep_proj_r
+
+        # Concat context latents on the channel dim, pad to patch boundary, patchify.
+        hidden_states = torch.cat([context_latents, hidden_states], dim=-1)
+        original_seq_len = hidden_states.shape[1]
+        if hidden_states.shape[1] % self.patch_size != 0:
+            pad_length = self.patch_size - (hidden_states.shape[1] % self.patch_size)
+            hidden_states = F.pad(hidden_states, (0, 0, 0, pad_length), mode="constant", value=0)
+        hidden_states = self.proj_in_conv(hidden_states.transpose(1, 2)).transpose(1, 2)
+        encoder_hidden_states = self.condition_embedder(encoder_hidden_states)
+
+        seq_len = hidden_states.shape[1]
+        dtype = hidden_states.dtype
+        device = hidden_states.device
+
+        cos, sin = _ace_step_rotary_freqs(seq_len, self.head_dim, self.rope_theta, device, dtype)
+        position_embeddings = (cos, sin)
+
+        # Sliding-window self-attention mask. Only the sliding-attention layers
+        # use it; full-attention layers see no mask. Cross-attention is unmasked.
+        sliding_attn_mask = _create_4d_mask(
+            seq_len=seq_len,
+            dtype=dtype,
+            device=device,
+            sliding_window=self.config.sliding_window,
+            is_sliding_window=True,
+            is_causal=False,
+        )
+
+        for i, layer_module in enumerate(self.layers):
+            layer_attn_mask = sliding_attn_mask if self.layer_types[i] == "sliding_attention" else None
+            hidden_states = layer_module(
+                hidden_states=hidden_states,
+                position_embeddings=position_embeddings,
+                temb=timestep_proj,
+                attention_mask=layer_attn_mask,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=None,
+            )
+
+        # Adaptive output norm + de-patchify back to original sequence length.
+        shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
+        hidden_states = (self.norm_out(hidden_states) * (1 + scale) + shift).type_as(hidden_states)
+        hidden_states = self.proj_out_conv(hidden_states.transpose(1, 2)).transpose(1, 2)
+        hidden_states = hidden_states[:, :original_seq_len, :]
+
+        if not return_dict:
+            return (hidden_states,)
+        return Transformer2DModelOutput(sample=hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load weights from a diffusers checkpoint.
+
+        Diffusers uses ``layers.N.self_attn.processor.*`` for processor state
+        (we no longer have a separate processor here) but the parameter names
+        on the AceStepAttention / MLP modules match ours 1:1.
+        """
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            if name in params_dict:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                try:
+                    weight_loader(param, loaded_weight)
+                except AssertionError as err:
+                    raise AssertionError(f"Failed to load ACE-Step weight {name!r}") from err
+                loaded_params.add(name)
+            else:
+                logger.debug("Skipping weight %s - not found in model", name)
+
+        return loaded_params

--- a/vllm_omni/diffusion/models/ace_step/modeling_ace_step.py
+++ b/vllm_omni/diffusion/models/ace_step/modeling_ace_step.py
@@ -1,0 +1,482 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+ACE-Step 1.5 condition encoder for vLLM-Omni (text2music task).
+
+Ported from diffusers PR #13095:
+src/diffusers/pipelines/ace_step/modeling_ace_step.py
+
+Holds the condition encoder (lyric + timbre + text packing) and the encoder
+layer used by the lyric / timbre encoders. The DiT reuses the RoPE helper,
+``AceStepAttention``, and ``_create_4d_mask`` from ``ace_step_transformer``.
+
+Audio-tokenizer / audio-token-detokenizer / FSQ / AttentionPooler classes
+(needed only for cover / lego / extract / complete tasks) are intentionally
+omitted from this port — first PR targets text2music only.
+"""
+
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from diffusers.models.normalization import RMSNorm
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+from vllm_omni.diffusion.models.ace_step.ace_step_transformer import (
+    AceStepAttention,
+    AceStepMLP,
+    _ace_step_rotary_freqs,
+    _create_4d_mask,
+)
+
+logger = init_logger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+#                        helpers used only by condition encoder                #
+# --------------------------------------------------------------------------- #
+
+
+def _pack_sequences(
+    hidden1: torch.Tensor,
+    hidden2: torch.Tensor,
+    mask1: torch.Tensor,
+    mask2: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pack two masked sequences into one with all valid tokens first.
+
+    Concatenates ``hidden1`` + ``hidden2`` along the sequence dim, then stably
+    sorts each batch so mask=1 tokens come before mask=0 tokens. Returns the
+    packed hidden states plus a fresh contiguous mask.
+    """
+    hidden_cat = torch.cat([hidden1, hidden2], dim=1)
+    mask_cat = torch.cat([mask1, mask2], dim=1)
+
+    B, L, D = hidden_cat.shape
+    sort_idx = mask_cat.argsort(dim=1, descending=True, stable=True)
+    hidden_left = torch.gather(hidden_cat, 1, sort_idx.unsqueeze(-1).expand(B, L, D))
+    lengths = mask_cat.sum(dim=1)
+    new_mask = torch.arange(L, dtype=torch.long, device=hidden_cat.device).unsqueeze(0) < lengths.unsqueeze(1)
+    return hidden_left, new_mask
+
+
+class AceStepEncoderLayer(nn.Module):
+    """Pre-LN transformer block used by the lyric and timbre encoders."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        intermediate_size: int,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        rms_norm_eps: float = 1e-6,
+        sliding_window: int | None = None,
+    ):
+        super().__init__()
+        self.self_attn = AceStepAttention(
+            hidden_size=hidden_size,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            bias=attention_bias,
+            dropout=attention_dropout,
+            eps=rms_norm_eps,
+            sliding_window=sliding_window,
+            is_cross_attention=False,
+            role="self",
+        )
+        self.input_layernorm = RMSNorm(hidden_size, eps=rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(hidden_size, eps=rms_norm_eps)
+        self.mlp = AceStepMLP(hidden_size, intermediate_size)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            image_rotary_emb=position_embeddings,
+            attention_mask=attention_mask,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+# --------------------------------------------------------------------------- #
+#                                  encoders                                    #
+# --------------------------------------------------------------------------- #
+
+
+class AceStepLyricEncoder(nn.Module):
+    """Lyric encoder: projects Qwen3 lyric embeddings and runs a small transformer.
+
+    Output feeds the DiT cross-attention (after packing with text + timbre).
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 2048,
+        intermediate_size: int = 6144,
+        text_hidden_dim: int = 1024,
+        num_lyric_encoder_hidden_layers: int = 8,
+        num_attention_heads: int = 16,
+        num_key_value_heads: int = 8,
+        head_dim: int = 128,
+        rope_theta: float = 1000000.0,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        rms_norm_eps: float = 1e-6,
+        sliding_window: int = 128,
+        layer_types: list | None = None,
+    ):
+        super().__init__()
+
+        if layer_types is None:
+            layer_types = [
+                "sliding_attention" if bool((i + 1) % 2) else "full_attention"
+                for i in range(num_lyric_encoder_hidden_layers)
+            ]
+
+        self.embed_tokens = nn.Linear(text_hidden_dim, hidden_size)
+        self.norm = RMSNorm(hidden_size, eps=rms_norm_eps)
+        self.head_dim = head_dim
+        self.rope_theta = rope_theta
+        self.sliding_window = sliding_window
+
+        self.layers = nn.ModuleList(
+            [
+                AceStepEncoderLayer(
+                    hidden_size=hidden_size,
+                    num_attention_heads=num_attention_heads,
+                    num_key_value_heads=num_key_value_heads,
+                    head_dim=head_dim,
+                    intermediate_size=intermediate_size,
+                    attention_bias=attention_bias,
+                    attention_dropout=attention_dropout,
+                    rms_norm_eps=rms_norm_eps,
+                    sliding_window=sliding_window if layer_types[i] == "sliding_attention" else None,
+                )
+                for i in range(num_lyric_encoder_hidden_layers)
+            ]
+        )
+
+        self._layer_types = layer_types
+
+    def forward(
+        self,
+        inputs_embeds: torch.FloatTensor,
+        attention_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        inputs_embeds = self.embed_tokens(inputs_embeds)
+
+        seq_len = inputs_embeds.shape[1]
+        dtype = inputs_embeds.dtype
+        device = inputs_embeds.device
+
+        cos, sin = _ace_step_rotary_freqs(seq_len, self.head_dim, self.rope_theta, device, dtype)
+        position_embeddings = (cos, sin)
+
+        full_attn_mask = _create_4d_mask(
+            seq_len=seq_len,
+            dtype=dtype,
+            device=device,
+            attention_mask=attention_mask,
+            is_causal=False,
+        )
+        sliding_attn_mask = _create_4d_mask(
+            seq_len=seq_len,
+            dtype=dtype,
+            device=device,
+            attention_mask=attention_mask,
+            sliding_window=self.sliding_window,
+            is_sliding_window=True,
+            is_causal=False,
+        )
+
+        hidden_states = inputs_embeds
+        for i, layer_module in enumerate(self.layers):
+            mask = sliding_attn_mask if self._layer_types[i] == "sliding_attention" else full_attn_mask
+            hidden_states = layer_module(
+                hidden_states=hidden_states,
+                position_embeddings=position_embeddings,
+                attention_mask=mask,
+            )
+        return self.norm(hidden_states)
+
+
+class AceStepTimbreEncoder(nn.Module):
+    """Timbre encoder: consumes VAE-encoded reference-audio latents and returns
+    a pooled per-batch timbre embedding (plus a presence mask).
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 2048,
+        intermediate_size: int = 6144,
+        timbre_hidden_dim: int = 64,
+        num_timbre_encoder_hidden_layers: int = 4,
+        num_attention_heads: int = 16,
+        num_key_value_heads: int = 8,
+        head_dim: int = 128,
+        rope_theta: float = 1000000.0,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        rms_norm_eps: float = 1e-6,
+        sliding_window: int = 128,
+        layer_types: list | None = None,
+    ):
+        super().__init__()
+
+        if layer_types is None:
+            layer_types = [
+                "sliding_attention" if bool((i + 1) % 2) else "full_attention"
+                for i in range(num_timbre_encoder_hidden_layers)
+            ]
+
+        self.embed_tokens = nn.Linear(timbre_hidden_dim, hidden_size)
+        self.norm = RMSNorm(hidden_size, eps=rms_norm_eps)
+        self.special_token = nn.Parameter(torch.randn(1, 1, hidden_size))
+        self.head_dim = head_dim
+        self.rope_theta = rope_theta
+        self.sliding_window = sliding_window
+
+        self.layers = nn.ModuleList(
+            [
+                AceStepEncoderLayer(
+                    hidden_size=hidden_size,
+                    num_attention_heads=num_attention_heads,
+                    num_key_value_heads=num_key_value_heads,
+                    head_dim=head_dim,
+                    intermediate_size=intermediate_size,
+                    attention_bias=attention_bias,
+                    attention_dropout=attention_dropout,
+                    rms_norm_eps=rms_norm_eps,
+                    sliding_window=sliding_window if layer_types[i] == "sliding_attention" else None,
+                )
+                for i in range(num_timbre_encoder_hidden_layers)
+            ]
+        )
+
+        self._layer_types = layer_types
+
+    @staticmethod
+    def unpack_timbre_embeddings(
+        timbre_embs_packed: torch.Tensor,
+        refer_audio_order_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        N, d = timbre_embs_packed.shape
+        device = timbre_embs_packed.device
+        dtype = timbre_embs_packed.dtype
+
+        B = int(refer_audio_order_mask.max().item() + 1)
+        counts = torch.bincount(refer_audio_order_mask, minlength=B)
+        max_count = counts.max().item()
+
+        sorted_indices = torch.argsort(refer_audio_order_mask * N + torch.arange(N, device=device), stable=True)
+        sorted_batch_ids = refer_audio_order_mask[sorted_indices]
+
+        positions = torch.arange(N, device=device)
+        batch_starts = torch.cat([torch.tensor([0], device=device), torch.cumsum(counts, dim=0)[:-1]])
+        positions_in_sorted = positions - batch_starts[sorted_batch_ids]
+
+        inverse_indices = torch.empty_like(sorted_indices)
+        inverse_indices[sorted_indices] = torch.arange(N, device=device)
+        positions_in_batch = positions_in_sorted[inverse_indices]
+
+        indices_2d = refer_audio_order_mask * max_count + positions_in_batch
+        one_hot = F.one_hot(indices_2d, num_classes=B * max_count).to(dtype)
+
+        timbre_embs_flat = one_hot.t() @ timbre_embs_packed
+        timbre_embs_unpack = timbre_embs_flat.reshape(B, max_count, d)
+
+        mask_flat = (one_hot.sum(dim=0) > 0).long()
+        new_mask = mask_flat.reshape(B, max_count)
+        return timbre_embs_unpack, new_mask
+
+    def forward(
+        self,
+        refer_audio_acoustic_hidden_states_packed: torch.FloatTensor,
+        refer_audio_order_mask: torch.LongTensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        inputs_embeds = self.embed_tokens(refer_audio_acoustic_hidden_states_packed)
+
+        seq_len = inputs_embeds.shape[1]
+        dtype = inputs_embeds.dtype
+        device = inputs_embeds.device
+
+        cos, sin = _ace_step_rotary_freqs(seq_len, self.head_dim, self.rope_theta, device, dtype)
+        position_embeddings = (cos, sin)
+
+        sliding_attn_mask = _create_4d_mask(
+            seq_len=seq_len,
+            dtype=dtype,
+            device=device,
+            attention_mask=None,
+            sliding_window=self.sliding_window,
+            is_sliding_window=True,
+            is_causal=False,
+        )
+
+        hidden_states = inputs_embeds
+        for i, layer_module in enumerate(self.layers):
+            # No padding mask on timbre input (pre-packed); full-attention layers see None.
+            mask = sliding_attn_mask if self._layer_types[i] == "sliding_attention" else None
+            hidden_states = layer_module(
+                hidden_states=hidden_states,
+                position_embeddings=position_embeddings,
+                attention_mask=mask,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        # CLS-like pooling: first-token embedding per packed sequence.
+        hidden_states = hidden_states[:, 0, :]
+        timbre_embs_unpack, timbre_embs_mask = self.unpack_timbre_embeddings(hidden_states, refer_audio_order_mask)
+        return timbre_embs_unpack, timbre_embs_mask
+
+
+# --------------------------------------------------------------------------- #
+#                               condition encoder                              #
+# --------------------------------------------------------------------------- #
+
+
+class AceStepConditionEncoder(nn.Module):
+    """Fuses text + lyric + timbre conditioning into the packed sequence used
+    by the DiT's cross-attention.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 2048,
+        intermediate_size: int = 6144,
+        text_hidden_dim: int = 1024,
+        timbre_hidden_dim: int = 64,
+        num_lyric_encoder_hidden_layers: int = 8,
+        num_timbre_encoder_hidden_layers: int = 4,
+        num_attention_heads: int = 16,
+        num_key_value_heads: int = 8,
+        head_dim: int = 128,
+        rope_theta: float = 1000000.0,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        rms_norm_eps: float = 1e-6,
+        sliding_window: int = 128,
+        layer_types: list | None = None,
+    ):
+        super().__init__()
+
+        self.text_projector = nn.Linear(text_hidden_dim, hidden_size, bias=False)
+
+        self.lyric_encoder = AceStepLyricEncoder(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            text_hidden_dim=text_hidden_dim,
+            num_lyric_encoder_hidden_layers=num_lyric_encoder_hidden_layers,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            rope_theta=rope_theta,
+            attention_bias=attention_bias,
+            attention_dropout=attention_dropout,
+            rms_norm_eps=rms_norm_eps,
+            sliding_window=sliding_window,
+            layer_types=layer_types,
+        )
+
+        self.timbre_encoder = AceStepTimbreEncoder(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            timbre_hidden_dim=timbre_hidden_dim,
+            num_timbre_encoder_hidden_layers=num_timbre_encoder_hidden_layers,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            rope_theta=rope_theta,
+            attention_bias=attention_bias,
+            attention_dropout=attention_dropout,
+            rms_norm_eps=rms_norm_eps,
+            sliding_window=sliding_window,
+        )
+
+        # Learned null-condition embedding for classifier-free guidance, trained
+        # with `cfg_ratio=0.15` in the original model. Broadcast along the
+        # sequence dim when used. Turbo variants distill CFG into the weights
+        # and ignore this; base/SFT variants need it.
+        self.null_condition_emb = nn.Parameter(torch.randn(1, 1, hidden_size))
+
+        # VAE-encoded audio silence, stored as `(1, T_long, timbre_hidden_dim)`.
+        # When no reference audio is provided, the pipeline slices
+        # `silence_latent[:, :timbre_fix_frame, :]` and feeds it to the timbre
+        # encoder. Passing zeros instead puts the timbre encoder OOD and
+        # produces drone-like audio. The converter overwrites this with real
+        # encoded silence; placeholder shape just needs to match the timbre
+        # encoder's input dim.
+        self.register_buffer(
+            "silence_latent",
+            torch.zeros(1, 15000, timbre_hidden_dim),
+            persistent=True,
+        )
+
+    def forward(
+        self,
+        text_hidden_states: torch.FloatTensor,
+        text_attention_mask: torch.Tensor,
+        lyric_hidden_states: torch.FloatTensor,
+        lyric_attention_mask: torch.Tensor,
+        refer_audio_acoustic_hidden_states_packed: torch.FloatTensor,
+        refer_audio_order_mask: torch.LongTensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        text_hidden_states = self.text_projector(text_hidden_states)
+
+        lyric_hidden_states = self.lyric_encoder(inputs_embeds=lyric_hidden_states, attention_mask=lyric_attention_mask)
+
+        timbre_embs_unpack, timbre_embs_mask = self.timbre_encoder(
+            refer_audio_acoustic_hidden_states_packed, refer_audio_order_mask
+        )
+
+        encoder_hidden_states, encoder_attention_mask = _pack_sequences(
+            lyric_hidden_states, timbre_embs_unpack, lyric_attention_mask, timbre_embs_mask
+        )
+        encoder_hidden_states, encoder_attention_mask = _pack_sequences(
+            encoder_hidden_states, text_hidden_states, encoder_attention_mask, text_attention_mask
+        )
+
+        return encoder_hidden_states, encoder_attention_mask
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load weights from a diffusers checkpoint."""
+        params_dict = dict(self.named_parameters())
+        # Include buffers so `silence_latent` is loaded.
+        buffers_dict = dict(self.named_buffers())
+        loaded: set[str] = set()
+
+        for name, loaded_weight in weights:
+            if name in params_dict:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                try:
+                    weight_loader(param, loaded_weight)
+                except AssertionError as err:
+                    raise AssertionError(f"Failed to load ACE-Step condition-encoder weight {name!r}") from err
+                loaded.add(name)
+            elif name in buffers_dict:
+                buffers_dict[name].copy_(loaded_weight)
+                loaded.add(name)
+            else:
+                logger.debug("Skipping condition-encoder weight %s - not found", name)
+
+        return loaded

--- a/vllm_omni/diffusion/models/ace_step/pipeline_ace_step.py
+++ b/vllm_omni/diffusion/models/ace_step/pipeline_ace_step.py
@@ -1,0 +1,573 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+ACE-Step 1.5 Pipeline for vLLM-Omni.
+
+Text-to-music generation using ACE-Step 1.5. Ported from diffusers PR #13095
+(``src/diffusers/pipelines/ace_step/pipeline_ace_step.py``), restricted to the
+``text2music`` task — cover / repaint / extract / lego / complete tasks and
+their helpers (``audio_tokenizer`` / ``audio_token_detokenizer``,
+``_build_chunk_mask``, ``prepare_reference_audio_latents``,
+``prepare_src_latents``, APG normalised guidance) are intentionally omitted
+from this first PR.
+
+The turbo checkpoint distills guidance into the weights, so the default config
+runs without CFG (``guidance_scale=1.0``). Sliding-window self-attention
+currently requires the SDPA backend (see ``ace_step_transformer.py`` for the
+flash-backend caveat).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Iterable
+from typing import ClassVar
+
+import torch
+from diffusers import AutoencoderOobleck
+from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+from diffusers.utils.torch_utils import randn_tensor
+from torch import nn
+from transformers import AutoModel, AutoTokenizer
+from vllm.logger import init_logger
+from vllm.model_executor.models.utils import AutoWeightsLoader
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+from vllm_omni.diffusion.models.ace_step.ace_step_transformer import (
+    AceStepTransformer1DModel,
+)
+from vllm_omni.diffusion.models.ace_step.modeling_ace_step import (
+    AceStepConditionEncoder,
+)
+from vllm_omni.diffusion.models.interface import SupportAudioOutput
+from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
+
+logger = init_logger(__name__)
+
+
+# Prompt-template constants copied verbatim from diffusers PR #13095 so the
+# tokenized inputs match what the ACE-Step text encoder was trained on. Changing
+# these strings will silently degrade audio quality.
+_SFT_GEN_PROMPT = "# Instruction\n{}\n\n# Caption\n{}\n\n# Metas\n{}<|endoftext|>\n"
+_DEFAULT_INSTRUCTION = "Fill the audio semantic mask based on the given conditions:"
+
+
+def get_ace_step_post_process_func(
+    od_config: OmniDiffusionConfig,
+):
+    """
+    Create post-processing function for ACE-Step audio output.
+
+    Converts raw audio tensor to numpy array for saving.
+    """
+
+    def post_process_func(
+        audio: torch.Tensor,
+        output_type: str = "np",
+    ):
+        if output_type == "latent":
+            return audio
+        if output_type == "pt":
+            return audio
+        # Convert to numpy
+        audio_np = audio.cpu().float().numpy()
+        return audio_np
+
+    return post_process_func
+
+
+class AceStepPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMixin):
+    """
+    Pipeline for text-to-music generation using ACE-Step 1.5.
+
+    This pipeline generates music from text prompts (and optional lyrics) using
+    the ACE-Step 1.5 model, integrated with vLLM-Omni's diffusion framework.
+
+    Args:
+        od_config: OmniDiffusion configuration object
+        prefix: Weight prefix for loading (default: "")
+    """
+
+    # Picked up by ``supports_audio_output`` in the diffusion engine so the
+    # default stage metadata reports ``final_output_type="audio"`` and the
+    # ``multimodal_output`` payload includes the sample rate (mirrors the
+    # contract introduced for AudioX in #2077).
+    support_audio_output: ClassVar[bool] = True
+    audio_sample_rate: ClassVar[int] = 48000
+
+    def __init__(
+        self,
+        *,
+        od_config: OmniDiffusionConfig,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.od_config = od_config
+
+        self.device = get_local_device()
+        dtype = getattr(od_config, "dtype", torch.bfloat16)
+
+        model = od_config.model
+        local_files_only = os.path.exists(model)
+
+        # Set up weights sources. The DiT and condition encoder both come from the
+        # diffusers-converted ACE-Step checkpoint (see PR #13095's conversion
+        # script). The shared text encoder (Qwen3-Embedding) and VAE
+        # (AutoencoderOobleck) load directly via from_pretrained below.
+        self.weights_sources = [
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
+                subfolder="transformer",
+                revision=None,
+                prefix="transformer.",
+                fall_back_to_pt=True,
+            ),
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=od_config.model,
+                subfolder="condition_encoder",
+                revision=None,
+                prefix="condition_encoder.",
+                fall_back_to_pt=True,
+            ),
+        ]
+
+        # Load tokenizer (Qwen3-Embedding's tokenizer).
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model,
+            subfolder="tokenizer",
+            local_files_only=local_files_only,
+        )
+
+        # Load text encoder (Qwen3-Embedding-0.6B).
+        self.text_encoder = AutoModel.from_pretrained(
+            model,
+            subfolder="text_encoder",
+            torch_dtype=dtype,
+            local_files_only=local_files_only,
+        ).to(self.device)
+
+        # Load VAE (AutoencoderOobleck — same class Stable Audio uses, kept in fp32).
+        self.vae = AutoencoderOobleck.from_pretrained(
+            model,
+            subfolder="vae",
+            torch_dtype=torch.float32,
+            local_files_only=local_files_only,
+        ).to(self.device)
+
+        # Initialize condition encoder from HF config; weights load via
+        # AutoWeightsLoader from the ``condition_encoder/`` subfolder.
+        condition_encoder_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, AceStepConditionEncoder)
+        self.condition_encoder = AceStepConditionEncoder(**condition_encoder_kwargs)
+
+        # Initialize DiT from HF config; weights load via AutoWeightsLoader
+        # from the ``transformer/`` subfolder.
+        transformer_kwargs = get_transformer_config_kwargs(od_config.tf_model_config, AceStepTransformer1DModel)
+        self.transformer = AceStepTransformer1DModel(od_config=od_config, **transformer_kwargs)
+
+        # Load scheduler. ACE-Step trains with flow matching; the pipeline supplies
+        # its own shifted / turbo sigma schedule via ``set_timesteps(sigmas=...)``
+        # in ``forward``, so the scheduler is created with the trivial
+        # ``num_train_timesteps=1, shift=1.0`` config from the checkpoint's
+        # ``scheduler/`` subfolder.
+        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+            model,
+            subfolder="scheduler",
+            local_files_only=local_files_only,
+        )
+
+        # Latent frame rate is fixed by the VAE: each VAE latent frame spans
+        # ``hop_length`` samples. AutoencoderOobleck exposes hop_length as an
+        # attribute (not on its config), so cache it once here.
+        self.latents_per_second = self.vae.config.sampling_rate / self.vae.hop_length
+
+        # Variant flag — drives default CFG behaviour in forward.
+        self.is_turbo = bool(getattr(self.transformer.config, "is_turbo", False))
+
+        # Cache backend (set by worker if needed)
+        self._cache_backend = None
+
+        # Profiler / state used by ``forward``.
+        self._guidance_scale = None
+        self._num_timesteps = None
+        self._current_timestep = None
+        self.setup_diffusion_pipeline_profiler(
+            enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
+        )
+
+    # --------------------------------------------------------------------- #
+    #                              prompt helpers                            #
+    # --------------------------------------------------------------------- #
+
+    @staticmethod
+    def _build_metadata_string(audio_duration: float | None) -> str:
+        """Minimal metadata block matching the original handler.
+
+        First PR exposes only ``audio_duration``; bpm / keyscale / timesignature
+        default to ``N/A`` (the model handles ``N/A`` gracefully — it's what the
+        handler emits when the user does not provide explicit values).
+        """
+        if audio_duration is not None and audio_duration > 0:
+            dur_str = f"{int(audio_duration)} seconds"
+        else:
+            dur_str = "30 seconds"
+        return f"- bpm: N/A\n- timesignature: N/A\n- keyscale: N/A\n- duration: {dur_str}\n"
+
+    def _format_prompt(
+        self,
+        prompt: str,
+        lyrics: str = "",
+        vocal_language: str = "en",
+        audio_duration: float = 60.0,
+        instruction: str | None = None,
+    ) -> tuple[str, str]:
+        """Wrap prompt + lyrics in the ACE-Step SFT templates.
+
+        Text gets the SFT generation template (Instruction / Caption / Metas);
+        lyrics get a separate (Languages / Lyric) block. Both end with
+        ``<|endoftext|>`` to match what the text encoder was trained on.
+        """
+        if instruction is None:
+            instruction = _DEFAULT_INSTRUCTION
+        if not instruction.endswith(":"):
+            instruction = instruction + ":"
+
+        metas_str = self._build_metadata_string(audio_duration)
+        formatted_text = _SFT_GEN_PROMPT.format(instruction, prompt, metas_str)
+        formatted_lyrics = f"# Languages\n{vocal_language}\n\n# Lyric\n{lyrics}<|endoftext|>"
+        return formatted_text, formatted_lyrics
+
+    def encode_prompt(
+        self,
+        prompt: str | list[str],
+        lyrics: str | list[str],
+        device: torch.device,
+        vocal_language: str | list[str] = "en",
+        audio_duration: float = 60.0,
+        instruction: str | None = None,
+        max_text_length: int = 256,
+        max_lyric_length: int = 2048,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Tokenize + encode text prompts and lyrics for the condition encoder.
+
+        Text prompts go through the full Qwen3 text encoder; lyrics use only the
+        embedding layer (token lookup), because contextual encoding for lyrics
+        happens inside ``AceStepLyricEncoder``.
+
+        Returns:
+            A 4-tuple of ``text_hidden_states``, ``text_attention_mask``,
+            ``lyric_hidden_states``, ``lyric_attention_mask``.
+        """
+        if isinstance(prompt, str):
+            prompt = [prompt]
+        if isinstance(lyrics, str):
+            lyrics = [lyrics]
+        if isinstance(vocal_language, str):
+            vocal_language = [vocal_language] * len(prompt)
+
+        batch_size = len(prompt)
+        # Pad lyrics list to batch size (caller may pass one lyric for all).
+        while len(lyrics) < batch_size:
+            lyrics.append(lyrics[-1] if lyrics else "")
+
+        all_text_strs: list[str] = []
+        all_lyric_strs: list[str] = []
+        for i in range(batch_size):
+            text_str, lyric_str = self._format_prompt(
+                prompt=prompt[i],
+                lyrics=lyrics[i],
+                vocal_language=vocal_language[i],
+                audio_duration=audio_duration,
+                instruction=instruction,
+            )
+            all_text_strs.append(text_str)
+            all_lyric_strs.append(lyric_str)
+
+        text_inputs = self.tokenizer(
+            all_text_strs,
+            padding="longest",
+            truncation=True,
+            max_length=max_text_length,
+            return_tensors="pt",
+        )
+        text_input_ids = text_inputs.input_ids.to(device)
+        text_attention_mask = text_inputs.attention_mask.to(device).bool()
+
+        lyric_inputs = self.tokenizer(
+            all_lyric_strs,
+            padding="longest",
+            truncation=True,
+            max_length=max_lyric_length,
+            return_tensors="pt",
+        )
+        lyric_input_ids = lyric_inputs.input_ids.to(device)
+        lyric_attention_mask = lyric_inputs.attention_mask.to(device).bool()
+
+        # Run text through the full encoder (contextual hidden states).
+        text_hidden_states = self.text_encoder(input_ids=text_input_ids).last_hidden_state
+
+        # Lyrics use only the embedding layer; the lyric encoder inside the
+        # condition encoder handles the contextual transformer pass.
+        embed_layer = self.text_encoder.get_input_embeddings()
+        lyric_hidden_states = embed_layer(lyric_input_ids)
+
+        return text_hidden_states, text_attention_mask, lyric_hidden_states, lyric_attention_mask
+
+    # --------------------------------------------------------------------- #
+    #                          latents / timestep helpers                    #
+    # --------------------------------------------------------------------- #
+
+    def prepare_latents(
+        self,
+        batch_size: int,
+        audio_duration: float,
+        dtype: torch.dtype,
+        device: torch.device,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Sample initial noise latents at the DiT's frame rate.
+
+        Returns a tensor of shape ``(batch_size, latent_length, acoustic_dim)``.
+        """
+        latent_length = math.ceil(audio_duration * self.latents_per_second)
+        acoustic_dim = self.transformer.config.audio_acoustic_hidden_dim
+
+        if latents is not None:
+            return latents.to(device=device, dtype=dtype)
+
+        shape = (batch_size, latent_length, acoustic_dim)
+        return randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+
+    def _get_timestep_schedule(
+        self,
+        num_inference_steps: int = 8,
+        shift: float = 3.0,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+        timesteps: list[float] | None = None,
+    ) -> torch.Tensor:
+        """ACE-Step's flow-matching schedule, computed from ``num_inference_steps`` and ``shift``.
+
+        Linear in [1, 0] with N+1 points, drop the terminal t=0, then apply the
+        flow-matching shift transform. Turbo checkpoints use 8 steps with
+        ``shift ∈ {1, 2, 3}`` — those tables are recovered exactly by this
+        formula, so no separate lookup is needed.
+        """
+        if timesteps is not None:
+            return torch.tensor(timesteps, device=device, dtype=dtype)
+
+        t = torch.linspace(1.0, 0.0, num_inference_steps + 1, device=device, dtype=dtype)
+        if shift != 1.0:
+            t = shift * t / (1 + (shift - 1) * t)
+        return t[:-1]
+
+    # --------------------------------------------------------------------- #
+    #                                  forward                               #
+    # --------------------------------------------------------------------- #
+
+    @property
+    def do_classifier_free_guidance(self) -> bool:
+        return self._guidance_scale is not None and self._guidance_scale > 1.0
+
+    @property
+    def guidance_scale(self) -> float | None:
+        return self._guidance_scale
+
+    @property
+    def num_timesteps(self) -> int | None:
+        return self._num_timesteps
+
+    def forward(
+        self,
+        req: OmniDiffusionRequest,
+        prompt: str | list[str] | None = None,
+        lyrics: str | list[str] = "",
+        audio_duration: float = 60.0,
+        vocal_language: str = "en",
+        num_inference_steps: int = 8,
+        guidance_scale: float = 1.0,
+        shift: float = 3.0,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.Tensor | None = None,
+        output_type: str = "pt",
+    ) -> DiffusionOutput:
+        """Generate music from text prompts (text2music task only).
+
+        Args mirror the diffusers ``AceStepPipeline.__call__`` but the engine
+        side feeds ``OmniDiffusionRequest`` instead of raw kwargs; the explicit
+        kwargs are kept for offline / direct-call usage.
+        """
+        # 0. Extract from req.
+        # TODO: mirror the stable_audio dict-vs-str dance once the API layer
+        # settles; for now treat req.prompts as a list of strings.
+        prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts] or prompt
+        if num_inference_steps is None or req.sampling_params.num_inference_steps is not None:
+            num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
+        if req.sampling_params.guidance_scale_provided:
+            guidance_scale = req.sampling_params.guidance_scale
+        extra = req.sampling_params.extra_args
+        lyrics = extra.get("lyrics", lyrics)
+        audio_duration = extra.get("audio_duration", audio_duration)
+        vocal_language = extra.get("vocal_language", vocal_language)
+        shift = extra.get("shift", shift)
+        if generator is None:
+            generator = req.sampling_params.generator
+        if generator is None and req.sampling_params.seed is not None:
+            generator = torch.Generator(device=self.device).manual_seed(req.sampling_params.seed)
+
+        if prompt is None or (isinstance(prompt, list) and not prompt):
+            raise ValueError("Must provide `prompt` as a string or list of strings.")
+
+        if isinstance(prompt, str):
+            batch_size = 1
+        else:
+            batch_size = len(prompt)
+
+        device = self.device
+        dtype = self.transformer.dtype if hasattr(self.transformer, "dtype") else self.od_config.dtype
+        acoustic_dim = self.transformer.config.audio_acoustic_hidden_dim
+
+        # Turbo checkpoints have guidance distilled into the weights; CFG produces
+        # over-guided audio. Warn + coerce so users forwarding base/sft settings
+        # to a turbo pipeline still get sensible output.
+        if self.is_turbo and guidance_scale > 1.0:
+            logger.warning(
+                "Guidance scale %s is ignored for turbo (guidance-distilled) checkpoints.",
+                guidance_scale,
+            )
+            guidance_scale = 1.0
+        self._guidance_scale = guidance_scale
+        self._num_timesteps = num_inference_steps
+
+        # 1. Encode prompts + lyrics.
+        text_hidden_states, text_attention_mask, lyric_hidden_states, lyric_attention_mask = self.encode_prompt(
+            prompt=prompt,
+            lyrics=lyrics,
+            device=device,
+            vocal_language=vocal_language,
+            audio_duration=audio_duration,
+        )
+
+        # 2. Timbre conditioning. text2music has no reference audio: slice the
+        #    learned silence_latent (trained-in fallback) at the canonical
+        #    30-second frame count. Zeros are out-of-distribution for the timbre
+        #    encoder and produce drone-like output.
+        timbre_fix_frame = math.ceil(30 * self.latents_per_second)
+        refer_audio_acoustic = (
+            self.condition_encoder.silence_latent[:, :timbre_fix_frame, :]
+            .to(device=device, dtype=dtype)
+            .expand(batch_size, -1, -1)
+            .contiguous()
+        )
+        refer_audio_order_mask = torch.arange(batch_size, device=device, dtype=torch.long)
+
+        # 3. Run condition encoder once before the denoising loop.
+        encoder_hidden_states, _encoder_attention_mask = self.condition_encoder(
+            text_hidden_states=text_hidden_states,
+            text_attention_mask=text_attention_mask,
+            lyric_hidden_states=lyric_hidden_states,
+            lyric_attention_mask=lyric_attention_mask,
+            refer_audio_acoustic_hidden_states_packed=refer_audio_acoustic,
+            refer_audio_order_mask=refer_audio_order_mask,
+        )
+
+        # 4. Build context latents. text2music has no source audio and no
+        #    repaint window. Diffusers' equivalent (pipeline_ace_step.py
+        #    prepare_src_latents + _build_chunk_mask) for text2music uses:
+        #      * ``src_latents`` = silence_latent tiled to latent_length
+        #      * ``chunk_mask``  = all-ones (generate the entire span)
+        #    Zero-filling here (as a previous revision did) leaves the DiT with
+        #    no positional / acoustic prior and produces noise output. The
+        #    DiT concatenates this with the noisy latents on the channel dim.
+        latent_length = math.ceil(audio_duration * self.latents_per_second)
+        silence_latent = self.condition_encoder.silence_latent.to(device=device, dtype=dtype)
+        if silence_latent.shape[1] >= latent_length:
+            src_latents = silence_latent[:, :latent_length, :]
+        else:
+            repeats = (latent_length + silence_latent.shape[1] - 1) // silence_latent.shape[1]
+            src_latents = silence_latent.repeat(1, repeats, 1)[:, :latent_length, :]
+        src_latents = src_latents.expand(batch_size, -1, -1).contiguous()
+        chunk_mask = torch.ones((batch_size, latent_length, acoustic_dim), device=device, dtype=dtype)
+        context_latents = torch.cat([src_latents, chunk_mask], dim=-1)
+
+        # 5. Sample noise latents.
+        latents = self.prepare_latents(
+            batch_size=batch_size,
+            audio_duration=latent_length / self.latents_per_second,
+            dtype=dtype,
+            device=device,
+            generator=generator,
+            latents=latents,
+        )
+
+        # 6. Configure scheduler with the ACE-Step shifted sigma schedule.
+        t_schedule = self._get_timestep_schedule(
+            num_inference_steps=num_inference_steps,
+            shift=shift,
+            device=device,
+            dtype=torch.float32,
+        )
+        self.scheduler.set_timesteps(sigmas=t_schedule.tolist(), device=device)
+        num_steps = len(self.scheduler.timesteps)
+
+        # 7. Denoising loop. Turbo defaults to no CFG.
+        xt = latents
+        for step_idx, t_sched in enumerate(self.scheduler.timesteps):
+            current_timestep = float(t_sched)
+            self._current_timestep = current_timestep
+            t_curr_tensor = current_timestep * torch.ones((batch_size,), device=device, dtype=dtype)
+
+            model_output = self.transformer(
+                hidden_states=xt,
+                timestep=t_curr_tensor,
+                timestep_r=t_curr_tensor,
+                encoder_hidden_states=encoder_hidden_states,
+                context_latents=context_latents,
+                return_dict=False,
+            )
+            vt = model_output[0]
+
+            xt = self.scheduler.step(vt, t_sched, xt, return_dict=False)[0]
+        self._current_timestep = None
+        _ = num_steps  # progress-bar hook lives here when we wire profiling
+
+        # 8. Decode to audio waveform.
+        if output_type == "latent":
+            return DiffusionOutput(
+                output=xt,
+                stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+            )
+
+        # VAE expects [B, C, T]; latents are [B, T, C].
+        audio_latents = xt.to(dtype=self.vae.dtype).transpose(1, 2)
+        audio = self.vae.decode(audio_latents).sample
+
+        # Two-stage normalization matching the diffusers reference: anti-clip,
+        # then rescale to -1 dBFS for consistent loudness.
+        if audio.dtype != torch.float32:
+            audio = audio.float()
+        peak = audio.abs().amax(dim=[1, 2], keepdim=True)
+        if torch.any(peak > 1.0):
+            audio = audio / peak.clamp(min=1.0)
+        target_amp = 10.0 ** (-1.0 / 20.0)  # -1 dBFS
+        peak = audio.abs().amax(dim=[1, 2], keepdim=True).clamp(min=1e-6)
+        audio = audio * (target_amp / peak)
+
+        if output_type == "np":
+            audio = audio.cpu().float().numpy()
+
+        return DiffusionOutput(
+            output=audio,
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
+        )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load weights using AutoWeightsLoader for vLLM integration."""
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -106,6 +106,11 @@ _DIFFUSION_MODELS = {
         "pipeline_ltx2_3_image2video",
         "LTX23ImageToVideoPipeline",
     ),
+    "AceStepPipeline": (
+        "ace_step",
+        "pipeline_ace_step",
+        "AceStepPipeline",
+    ),
     "StableAudioPipeline": (
         "stable_audio",
         "pipeline_stable_audio",
@@ -463,6 +468,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "LTX2I2VDMD2Pipeline": "get_ltx2_post_process_func",
     "LTX23Pipeline": "get_ltx2_post_process_func",
     "LTX23ImageToVideoPipeline": "get_ltx2_post_process_func",
+    "AceStepPipeline": "get_ace_step_post_process_func",
     "StableAudioPipeline": "get_stable_audio_post_process_func",
     "AudioXPipeline": "get_audiox_post_process_func",
     "WanImageToVideoPipeline": "get_wan22_i2v_post_process_func",


### PR DESCRIPTION
  <!-- markdownlint-disable -->

  ## Purpose

  Ports ACE-Step 1.5 turbo (3.5B flow-matching DiT for music generation) from
  [diffusers PR #13095](https://github.com/huggingface/diffusers/pull/13095) into
  vllm-omni. Scope is `text2music` only — cover / repaint / extract / lego /
  complete tasks and their helpers (audio tokenizer / detokenizer, APG-normalised
  guidance) are intentionally omitted from this first PR.

  ### Components

  - `vllm_omni/diffusion/models/ace_step/` — `AceStepTransformer1DModel` (DiT) and
    `AceStepConditionEncoder` (text + lyric + timbre packing).
  - `pipeline_ace_step.py` — uses `AutoencoderOobleck` VAE and
    `FlowMatchEulerDiscreteScheduler`. Turbo distills guidance, default
    `guidance_scale=1.0`.
  - Registry entry, offline example, doc row, 35 CPU tests.

  ### Known limitation — flash + sliding window

  vllm-omni's flash attention backend (`vllm_omni/diffusion/attention/backends/flash_attn.py`)
  has no `window_size` parameter. The DiT uses sliding-window self-attention on
  half its layers; with flash that constraint silently drops and the model
  produces noise output. `AceStepAttention.__init__` detects this at construction
  time and hard-pins the wrapper's inner backend to SDPA for sliding-window
  self-attention sites only. Cross-attention and full self-attention sites keep
  using flash. Reverting this workaround is a follow-up PR (plumb `window_size`
  through `flash_attn.py`).

  ## Test Plan

  Sample output generated with:

  \`\`\`bash
  python examples/offline_inference/ace_step/text_to_music.py \\
      --model /path/to/ACE-Step-1.5-Diffusers \\
      --prompt "An upbeat jazz piano piece with walking bass" \\
      --audio-duration 10.0 \\
      --num-inference-steps 8 \\
      --seed 42 \\
      --output test_output.wav
  \`\`\`

  Compared against the diffusers PR pipeline on the same converted checkpoint
  with identical settings.

  CPU-only test suite at `tests/diffusion/models/ace_step/` (35 tests, ~5s):
  parallelism contract, parametrized config-default checks against
  `acestep-v15-turbo/config.json`, forward-shape checks, and an end-to-end
  pipeline smoke test with mocks.

  ## Test Result

  DiT bisection cosine similarity (our pipeline vs the diffusers PR pipeline,
  same checkpoint, seed 42, 8 steps):

  | stage           | cosine  |
  | --------------- | ------- |
  | after patchify  | 0.9999  |
  | after block 0   | 0.9999  |
  | after block 23  | 0.9995  |

  Output is musical in listening tests; passes the Level-2 structural checks in
  `examples/offline_inference/ace_step/validate_audio.py` (8/8). Sample WAV
  attached.

  35 CPU tests: 35 passed, 0 failed.

  ---

  - [x] Ports ACE-Step 1.5 turbo; scope is text2music only.
  - [x] The test plan & test commands are provided above.
  - [x] Test results (cosine table + sample WAV attached).

  **BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>**
[test_output_fixed (1).wav](https://github.com/user-attachments/files/28424832/test_output_fixed.1.wav)
