### PR TITLE
Fix stage engine args mutation

### DIFF
--- a/examples/offline_inference/ming_flash_omni/README.md
+++ b/examples/offline_inference/ming_flash_omni/README.md
@@ -16,7 +16,7 @@ For standalone TTS (talker only), see the [Ming-flash-omni-TTS section in the Te
 
 Please refer to the [stage configuration documentation](https://docs.vllm.ai/projects/vllm-omni/en/latest/configuration/stage_configs/) to configure memory allocation appropriately for your hardware setup.
 
-When no `--deploy-config` is passed, the model registry auto-loads the full thinker+talker `vllm_omni/deploy/ming_flash_omni.yaml` (See [Omni-Speech](#omni-speech-thinker--talker)).
+When no `--deploy-config` is passed, the model registry auto-loads the full thinker+talker `vllm_omni/deploy/ming_flash_omni.yaml` (See [Omni-Speech](#omni-speech-thinker-talker)).
 
 For text-only output without spinning up the talker, pass:
 

--- a/tests/engine/test_async_omni_engine_stage_init.py
+++ b/tests/engine/test_async_omni_engine_stage_init.py
@@ -712,6 +712,32 @@ def test_build_engine_args_keeps_stage_owned_tokenizer_subdir(tmp_path):
     assert engine_args["tokenizer"] == os.path.join(str(tmp_path), "tokenizer")
 
 
+def test_build_engine_args_dict_does_not_mutate_stage_engine_args():
+    from vllm_omni.engine.stage_init_utils import build_engine_args_dict
+
+    engine_args = {
+        "tensor_parallel_size": None,
+        "async_chunk": True,
+    }
+    original_engine_args = dict(engine_args)
+    stage_cfg = types.SimpleNamespace(
+        stage_id=1,
+        stage_type="llm",
+        engine_args=engine_args,
+        default_sampling_params={},
+    )
+
+    engine_args_dict = build_engine_args_dict(
+        stage_cfg,
+        model="dummy-model",
+        stage_connector_spec={"connector": "shared_memory"},
+    )
+
+    assert "tensor_parallel_size" not in engine_args_dict
+    assert engine_args_dict["stage_connector_spec"] == {"connector": "shared_memory"}
+    assert stage_cfg.engine_args == original_engine_args
+
+
 def test_build_stage0_input_processor_uses_omni_input_preprocessor(monkeypatch):
     import vllm_omni.engine.stage_init_utils as init_mod
 

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -712,18 +712,17 @@ def build_engine_args_dict(
     cli_tokenizer: str | None = None,
 ) -> dict[str, Any]:
     """Build the normalized engine args dict for one stage."""
-    engine_args = stage_config.engine_args
+    engine_args_dict = _to_dict(stage_config.engine_args)
     # HACK (Alex) Tensor parallel size should not be passed as None;
     # remove it if this is the case so that we fall back to default
     # creation from vLLM's engine args.
     # NOTE: This will be fixed more generically in ongoing work for engine arg filtering.
-    if "tensor_parallel_size" in engine_args and engine_args["tensor_parallel_size"] is None:
-        del engine_args["tensor_parallel_size"]
+    if "tensor_parallel_size" in engine_args_dict and engine_args_dict["tensor_parallel_size"] is None:
+        del engine_args_dict["tensor_parallel_size"]
 
     stage_type = getattr(stage_config, "stage_type", "llm")
     stage_id = stage_config.stage_id
 
-    engine_args_dict = _to_dict(engine_args)
     stage_defines_tokenizer = (
         engine_args_dict.get("tokenizer") is not None or engine_args_dict.get("tokenizer_subdir") is not None
     )

--- a/vllm_omni/model_executor/models/qwen3_tts/prompt_embeds_builder.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/prompt_embeds_builder.py
@@ -893,12 +893,12 @@ class Qwen3TTSPromptEmbedsBuilder:
 
             * ``talker_prompt``: ``[prompt_len, hidden]`` prefill embedding.
             * ``trailing_text_hidden``: ``[T, hidden]`` queue of text-side
-              embeddings consumed one-per-decode-step (streaming mode) or a
-              single pad row (non-streaming).
+                embeddings consumed one-per-decode-step (streaming mode) or a
+                single pad row (non-streaming).
             * ``ref_code_len``: Number of ref codec frames consumed when the
-              Base task ran in in-context mode (``None`` otherwise).
+                Base task ran in in-context mode (``None`` otherwise).
             * ``ref_code``: The ``[T, Q]`` ref codec tensor used for ICL
-              (``None`` outside Base / ICL).
+                (``None`` outside Base / ICL).
         """
         config = self._config
         talker_config = self._talker_config


### PR DESCRIPTION
## Summary
- copy stage engine args before normalizing them in build_engine_args_dict
- keep tensor_parallel_size=None filtering local to the returned engine args dict
- add a regression test that the original stage config engine_args remains unchanged

## Tests
- python -m pytest tests/engine/test_async_omni_engine_stage_init.py -q
- python -m ruff check vllm_omni/engine/stage_init_utils.py tests/engine/test_async_omni_engine_stage_init.py
- python -m ruff format --check vllm_omni/engine/stage_init_utils.py tests/engine/test_async_omni_engine_stage_init.py

Addresses part of #4009.