### PR TITLE
fix: prevent CLI startup crash in HunyuanImage TP2 performance benchmark

### DIFF
--- a/tests/dfx/perf/tests/test_hunyuan_image_tp2_cfgp2.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp2_cfgp2.json
@@ -6,7 +6,7 @@
         "server_params": {
             "model": "tencent/HunyuanImage-3.0-Instruct",
             "serve_args": {
-                "deploy_config": "../vllm_omni/deploy/hunyuan_image3_dit.yaml",
+                "deploy-config": "../vllm_omni/deploy/hunyuan_image3_dit.yaml",
                 "tensor-parallel-size": 2,
                 "cfg-parallel-size": 2,
                 "enable-diffusion-pipeline-profiler": true


### PR DESCRIPTION


## Purpose

fix typo issue for PR https://github.com/vllm-project/vllm-omni/pull/3996

CLI service startup crash due to unknown argument  --deploy_config

Root Cause: test_hunyuan_image_tp2_cfgp2.json specified  "deploy_config"  with underscore.
run_diffusion_benchmark.py concatenated it  directly into CLI command without replacing underscore, whereas serve.py only registered hyphenated  --deploy-config
  
  
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
