### PR TITLE
[Frontend] Fix HunyuanImage3 online image edit support

### DIFF
--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1941,6 +1941,7 @@ async def edit_images(
                 extra_body["sys_type"] = sys_type
             if system_prompt is not None:
                 extra_body["system_prompt"] = system_prompt
+            extra_body.setdefault("bot_task", "think")
 
             prompt_text = prompt.get("prompt", "")
             generation_result = await chat_handler.generate_diffusion_images(

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -74,6 +74,7 @@ from vllm.multimodal.inputs import (
 )
 from vllm.multimodal.parse import (
     MultiModalDataItems,
+    MultiModalDataParser,
 )
 from vllm.multimodal.processing import (
     BaseDummyInputsBuilder,
@@ -982,6 +983,21 @@ class HunyuanImage3Processor:
         return image.crop((crop_left, crop_top, crop_left + tw, crop_top + th))
 
 
+class HunyuanImage3DataParser(MultiModalDataParser):
+    """Treat image-edit ``img2img`` input as regular image input."""
+
+    def _get_subparsers(self):
+        parsers = super()._get_subparsers()
+        parsers["img2img"] = self._parse_image_data
+        return parsers
+
+    def parse_mm_data(self, mm_data, **kwargs):
+        normalized = {}
+        for key, value in mm_data.items():
+            normalized["image" if key == "img2img" else key] = value
+        return super().parse_mm_data(normalized, **kwargs)
+
+
 class HunyuanImage3ProcessingInfo(BaseProcessingInfo):
     """Processing information for HunyuanImage3 model."""
 
@@ -995,8 +1011,11 @@ class HunyuanImage3ProcessingInfo(BaseProcessingInfo):
             **kwargs,
         )
 
+    def get_data_parser(self) -> HunyuanImage3DataParser:
+        return HunyuanImage3DataParser()
+
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
-        return {"image": None}
+        return {"image": None, "img2img": 1}
 
 
 class HunyuanImage3DummyInputsBuilder(BaseDummyInputsBuilder[HunyuanImage3ProcessingInfo]):


### PR DESCRIPTION
## Summary

This PR enables HunyuanImage3 to work with the OpenAI-compatible
`/v1/images/edits` endpoint in multi-stage online serving.

## Problem

The image edit endpoint sends a single input image as `img2img` modality.
HunyuanImage3 only advertises `image` support, so requests fail with:

`Unsupported modality: img2img`

After aliasing `img2img` to `image`, requests can pass modality validation
but may still fail prompt replacement if the prompt is not built with the
Hunyuan IT2I template containing `<img>`.

## Changes

- Add `HunyuanImage3DataParser` to normalize `img2img` to `image`.
- Add `get_data_parser()` for HunyuanImage3.
- Advertise `img2img` in `get_supported_mm_limits()`.
- Default image edit multi-stage requests to `bot_task="think"` so Hunyuan
  IT2I prompt construction inserts the required `<img>` placeholder.

## Validation

- `python3 -m py_compile vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py vllm_omni/entrypoints/openai/api_server.py`
- Verified the previous `Unsupported modality: img2img` error is resolved.

## test
```bash
curl -sS -X POST "http://localhost:8091/v1/images/edits" \
  -F 'prompt=新年宠物海报，Q版圆润的可爱标题“新年快乐汪”，副标题“HAPPY NEW YEAR”。 鱼眼镜头，背景是房间门口，近景，上传的主体歪头笑，围着红色围巾，戴着红色毛线帽，高清，绒毛细节，面部特写。 宝丽莱相纸，超现实主义，写实主义，胶片摄影，打印颗粒感肌理。肌理，超写实，复古感。' \
  -F 'url=https://raw.githubusercontent.com/Tencent-Hunyuan/HunyuanImage-3.0/main/assets/demo_instruct_imgs/input_0_0.png' \
  -F 'size=auto' \
  -F 'num_inference_steps=8' \
  -F 'seed=42' \
  -o response.json

jq -r '.data[0].b64_json' response.json | base64 -d > image_edit.png
```

<img width="832" height="1216" alt="image" src="https://github.com/user-attachments/assets/5f57d7bb-dac1-499f-a175-e74d9e15bd93" />
