### PR TITLE
feat: Support dynamic batching for heterogeneous diffusion requests

### DIFF
--- a/docs/design/feature/diffusion_continuous_batching.md
+++ b/docs/design/feature/diffusion_continuous_batching.md
@@ -1,13 +1,21 @@
 # Continuous Batching for Step-Wise Diffusion
 
 !!! warning "Experimental Feature"
-    This feature is experimental. It currently applies only to native
-    diffusion pipelines running with `step_execution=True`.
+    This feature is experimental. It currently applies to native diffusion
+    pipelines running with `step_execution=True`. Heterogeneous dynamic
+    batching is implemented for Qwen-Image first.
 
 This document describes the batching extension built on top of
 [Diffusion Step Execution](diffusion_step_execution.md). The base
-step-execution contract is unchanged. The batching work is mainly in the
-scheduler and runner layers.
+step-execution contract is unchanged: the scheduler admits requests by step,
+the runner owns per-request state, and the pipeline still exposes
+`denoise_step(input_batch)`, `step_scheduler(...)`, and `post_decode(...)`.
+
+The current implementation supports two batching shapes:
+
+- dense step batching, where requests share a dense tensor layout
+- Qwen-Image dynamic heterogeneous batching, where requests may have different
+  image token lengths, text lengths, resolutions, and CFG scalar values
 
 ## Why It Helps
 
@@ -19,27 +27,35 @@ This matters most in low-MFU or bursty serving scenarios:
 
 - one request's denoise step may not fully saturate the GPU
 - several compatible requests can share the same denoise forward pass
-- throughput and device utilization can improve without changing request-local
-  scheduler state
+- throughput and device utilization can improve without changing
+  request-local scheduler state
 
 This is **not** a guaranteed single-request latency win. The main benefit is
-usually higher utilization and better throughput when the workload contains
-multiple in-flight compatible requests.
+higher utilization and better throughput when the workload contains multiple
+in-flight compatible requests.
 
-## Overview
+## Current Support
 
 With continuous batching enabled:
 
 - the scheduler may keep multiple compatible requests active at the same time
-- the runner packs request-local step state into one `InputBatch`
+- the runner packs active request state into one step-local `InputBatch`
 - `denoise_step()` runs on that batch
 - `step_scheduler()` and `post_decode()` still run per request
+- request progress and completion remain independent
 
-The current implementation is conservative:
+For Qwen-Image, the dynamic path additionally supports heterogeneous
+co-batching:
 
-- only compatible requests are batched together
-- request-mode diffusion still runs with `max_num_seqs=1`
-- per-request progress and completion remain independent
+- different image resolutions and latent token lengths
+- different positive and negative text lengths
+- different request-local CFG scalar values, such as `true_cfg_scale`
+- different request arrival times, because cached running requests and newly
+  admitted requests are rebuilt into the same step view
+
+The Qwen-Image dynamic path is padding-free in attention. The runner builds
+varlen `AttentionMetadata` with `padded_tokens=0`, and FlashAttention consumes
+flat packed `[total_tokens, heads, head_dim]` Q/K/V tensors.
 
 ## Enablement
 
@@ -50,10 +66,13 @@ above `1` if you want batching:
 vllm serve Qwen/Qwen-Image --omni \
   --port 8091 \
   --step-execution \
-  --max-num-seqs 8
+  --max-num-seqs 2 \
+  --enforce-eager \
+  --cache-backend none
 ```
 
-`--max-num-seqs 1` keeps the step-wise path without enabling batching.
+`--max-num-seqs 1` keeps the step-wise path without enabling multi-request
+batching.
 
 For a reproducible replay flow using the bundled serving benchmark, see the
 Qwen-Image replay commands in
@@ -61,87 +80,252 @@ Qwen-Image replay commands in
 and
 [`benchmarks/diffusion/performance_dashboard/qwen_image_serving_performance.md`](gh-file:benchmarks/diffusion/performance_dashboard/qwen_image_serving_performance.md).
 
-## Scheduler
+## Scheduler Admission
 
-The scheduler derives its batch capacity from `max_num_seqs` through
+The scheduler derives batch capacity from `max_num_seqs` through
 `max_num_running_reqs`.
 
 Batch admission is gated by
-[`SamplingParamsKey`](gh-file:vllm_omni/diffusion/sched/interface.py),
-which is built from shape-sensitive and CFG-sensitive sampling fields. This is
-the core correctness rule for batching: requests are only co-batched when they
-share the same denoise tensor contract.
+[`SamplingParamsKey`](gh-file:vllm_omni/diffusion/sched/interface.py). The key
+is intentionally narrow:
 
-There are two important details:
+- `do_classifier_free_guidance`
+- `lora_int_id`
+- `lora_scale`
+
+Spatial shape, temporal shape, text length, and CFG scalar values are not
+ordinary scheduler compatibility dimensions. They are request-local state that
+the runner interprets when it builds the current execution view.
+
+For Qwen-Image dynamic batching, `do_classifier_free_guidance` is derived from
+the actual Qwen CFG execution shape:
+
+- `true_cfg_scale > 1`
+- a negative prompt is present
+
+This keeps `true_cfg_scale=1` out of CFG batches even when a negative prompt is
+present. Requests with `true_cfg_scale=2` and `true_cfg_scale=7` can share a
+batch because they have the same CFG execution shape; their scalar values are
+applied per request after positive and negative noise predictions are computed.
+
+Important scheduler details:
 
 - `num_inference_steps` is not part of the key, so requests with different
   total step counts can still share a batch
-- requests also do not need to be at the same current denoise progress; active
-  requests can continue batching even when their current step indices diverge
-- admission is still FIFO, so an incompatible request at the head of the
+- active requests do not need the same current denoise progress
+- FIFO admission is preserved, so an incompatible request at the head of the
   waiting queue blocks later compatible requests
+- LoRA remains a hard key because the worker activates one adapter identity and
+  scale for a step batch
+- multi-prompt requests do not participate in batching today
 
-Today that compatibility rule is still shape-sensitive. `height`, `width`,
-`num_frames`, and CFG-related fields remain part of the key, so different
-resolutions or incompatible guidance settings do **not** co-batch yet. The
-key also covers LoRA identity (`lora_int_id`, `lora_scale`), so requests
-targeting different adapters or scales run in separate batches and the
-worker can activate exactly one adapter per step.
+Shape removal from the scheduler key does not mean every model can execute
+mixed shapes. The current heterogeneous runner path is Qwen-Image-specific.
+Models without a dynamic execution view still need dense-compatible tensors or
+must run with `max_num_seqs=1`.
 
-The current batching unit is one `OmniDiffusionRequest`. Requests with
-multiple prompts do not participate in batching today.
-
-## Runner
+## Runner State
 
 The runner keeps persistent per-request execution state in
-[`DiffusionRequestState`](gh-file:vllm_omni/diffusion/worker/utils.py),
-while the scheduler owns a separate lightweight request state for queueing and
-lifecycle tracking.
+[`DiffusionRequestState`](gh-file:vllm_omni/diffusion/worker/utils.py). The
+scheduler owns a separate lightweight request state for queueing and lifecycle
+tracking.
 
-For each step, the runner builds an
-[`InputBatch`](gh-file:vllm_omni/diffusion/worker/input_batch.py) from the
-active request states:
+For each step, the runner builds or refreshes an
+[`InputBatch`](gh-file:vllm_omni/diffusion/worker/input_batch.py) from active
+request states.
 
-- prompt embeddings and masks are normalized and padded
-- dynamic tensors such as `latents` and `timesteps` are gathered each step
-- buffers are reused when batch composition stays the same
+The dense view exposes:
+
+- gathered `latents`
+- gathered `timesteps`
+- padded prompt embeddings and masks
+- dense `img_shapes` and text length metadata
+
+The Qwen-Image dynamic view exposes:
+
+- `packed_latents`, a padding-free `[total_image_tokens, channels]` tensor
+- `img_seq_lens`, one image-token count per request
+- `request_spans`, separating request boundaries from segment boundaries
+- `txt_seq_lens` and `negative_txt_seq_lens`
+- `img_shapes` for request-local RoPE reconstruction
+- `true_cfg_scales` and `cfg_normalize_flags`
+- `latents=None`, so the dynamic path cannot accidentally use dense latent
+  assumptions
+
+`InputBatch.make_batch(..., allow_dynamic=True)` selects the dynamic view when
+Qwen-Image can use it and the batch needs request-local layout. Mixed latent
+lengths, mixed text lengths, mixed negative text lengths, or mixed CFG scalars
+all force the dynamic view. A single request also uses the dynamic view when
+enabled, so dynamic-single and dynamic-multi share the same code path.
+
+The current dynamic implementation supports one output row per request.
+Dynamic image editing with `image_latents` is rejected for now.
+
+## Attention Metadata
+
+The attention execution contract is
+[`AttentionMetadata`](gh-file:vllm_omni/diffusion/attention/backends/abstract.py).
+It now carries the varlen fields consumed by attention backends:
+
+- `q_cu_seqlens`
+- `kv_cu_seqlens`
+- `max_q_len`
+- `max_kv_len`
+- `q_segments`
+- `kv_segments`
+- `position`
+- `padded_tokens`
+
+[`AttentionSegment`](gh-file:vllm_omni/diffusion/attention/backends/abstract.py)
+describes request-local semantic spans, such as `text`, `negative_text`, and
+`image`. It is not a cache layout and does not describe LoRA or MoE routing.
+
+For Qwen-Image, the runner builds one metadata entry per attention id:
+
+- `qwen_image.joint.positive`
+- `qwen_image.joint.negative`, only when true CFG is active
+
+Each entry contains its own text lengths, image lengths, request order,
+segments, and RoPE position plan. The metadata is valid only for the current
+step batch composition.
+
+## FlashAttention Varlen
+
+[`FlashAttentionImpl`](gh-file:vllm_omni/diffusion/attention/backends/flash_attn.py)
+has a flat varlen branch for packed dynamic Q/K/V tensors:
+
+```text
+query/key/value: [total_tokens, heads, head_dim]
+metadata: q_cu_seqlens, kv_cu_seqlens, max_q_len, max_kv_len
+```
+
+The flat varlen branch rejects attention masks and requires
+`padded_tokens=0`. Dense and masked paths remain available for existing dense
+execution.
+
+## Qwen-Image Dynamic Path
+
+Qwen-Image consumes the dynamic `InputBatch` inside
+[`QwenImagePipeline.denoise_step()`](gh-file:vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py).
+
+The pipeline runs:
+
+1. positive branch prediction using `qwen_image.joint.positive`
+2. negative branch prediction using `qwen_image.joint.negative`, if true CFG is
+   active
+3. per-request CFG combine:
+
+   ```python
+   negative + true_cfg_scale * (positive - negative)
+   ```
+
+4. optional per-request CFG normalization
+5. request-local scheduler step and decode
+
+The transformer dynamic path is implemented in
+[`QwenImageTransformer2DModel._forward_dynamic()`](gh-file:vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py).
+It keeps model-specific work in the model boundary:
+
+- packed image projection
+- packed text projection
+- deterministic RoPE reconstruction from `img_shapes` and text lengths
+- per-request timestep embedding with token-to-request modulation
+- packed norm/FFN/output projection
+- packed joint varlen attention over text and image streams
+- packed noise output, split by `img_seq_lens` at the runner boundary
+
+This preserves the dense Qwen-Image path for dense tensor inputs.
+
+When pure Ulysses sequence parallelism is enabled (`sequence_parallel_size > 1`
+and `ring_degree=1`), the packed Qwen-Image path shards flat text/image tokens
+before the DiT blocks. Its attention path all-to-alls flat local source-order
+Q/K/V into global joint varlen order, runs FlashAttention with the same
+padding-free metadata, then all-to-alls the output back to local text/image
+tokens. The final packed noise tensor is gathered before returning to the
+pipeline contract.
+
+## Guardrails
+
+The runner fails fast when a dynamic Qwen-Image batch is requested under an
+unsupported engine profile:
+
+- not `QwenImagePipeline`
+- `step_execution=False`
+- `max_num_seqs <= 1`
+- `enforce_eager=False`
+- diffusion cache backend enabled
+- ring attention enabled
+- CFG parallelism enabled
+- HSDP enabled
+- attention backend is not FlashAttention
+- dynamic image editing `image_latents` are present
+
+These are engine/profile constraints, not scheduler batch keys. They are
+checked at the runner boundary before the dynamic forward runs.
+
+## Execution Flow
 
 The step-wise batched path is:
 
 1. Run `prepare_encode()` for newly admitted requests.
 2. Build or refresh `InputBatch`.
-3. Run one batched `denoise_step(input_batch)`.
-4. Slice the batched `noise_pred` back per request.
-5. Run per-request `step_scheduler()`.
-6. Run `post_decode()` only for requests that finished denoising.
-7. Scatter updated latents back into persistent request state with
-   [`scatter_latents()`](gh-file:vllm_omni/diffusion/worker/input_batch.py).
+3. Build `dict[attention_id, AttentionMetadata]`.
+4. Enter forward context with the metadata map.
+5. Run one `denoise_step(input_batch)`.
+6. Split dynamic noise predictions by request, or slice dense noise by row.
+7. Run per-request `step_scheduler()`.
+8. Run `post_decode()` only for completed requests.
+9. Remove completed request state from the runner cache.
 
-This keeps the shared work limited to the denoise forward pass while preserving
-request-local scheduler state and outputs.
+Dense batches still scatter updated latent tensors back through
+[`scatter_latents()`](gh-file:vllm_omni/diffusion/worker/input_batch.py).
+Dynamic batches update request-local latents directly through each request's
+`step_scheduler()`.
 
-## Engine
+## Validation
 
-[`DiffusionEngine`](gh-file:vllm_omni/diffusion/diffusion_engine.py) provides
-the background loop and async add-request path needed for multiple requests to
-accumulate in the scheduler.
+The current test coverage includes:
 
-This is supporting infrastructure, not the main design point. The batching
-behavior is defined by scheduler-side compatibility gating and runner-side
-batch packing.
+- scheduler key tests for LoRA, CFG shape, resolution removal, and CFG scalar
+  removal
+- request and segment boundary tests for Qwen-Image metadata
+- FlashAttention flat varlen numerical comparison against per-request
+  attention
+- Qwen-Image transformer dynamic-vs-dense tests
+- a deterministic DiT mock-attention test proving dense single, dynamic
+  single, and dynamic multi use the same model semantics
+- runner stepwise tests for request-local latents, CFG scales, and shape
+  metadata
+- a 2-GPU packed SP smoke for flat Ulysses attention and a 1-layer Qwen-Image
+  dynamic transformer
+- an online serving e2e test covering:
+  - `512x512 + 512x512`
+  - `512x512 + 768x768`
+  - `512x512 + 1024x1024`
+  - staggered arrival
+  - different request-local `true_cfg_scale` values
+  - dynamic single, dynamic multi, and execute-model reference comparison
+- an online serving e2e performance benchmark for the hard acceptance cases:
+  - `single`, `tp2`, and pure Ulysses `usp2`
+  - `serial` vs staggered `batching` on the same stepwise server profile
+  - speedup gates: `512x512 + 512x512 >= 1.10x`, `512x512 + 768x768 >= 1.00x`,
+    and `512x512 + 1024x1024 >= 1.00x`
 
 ## Current Limitations
 
 - Experimental feature; use `max_num_seqs=1` for the older conservative path.
-- Only native pipelines that already support `step_execution=True`.
+- Heterogeneous dynamic execution is implemented for Qwen-Image first.
 - Request-mode diffusion still clamps `max_num_seqs` back to `1`.
-- Only homogeneous batches keyed by `SamplingParamsKey` are supported.
+- Dynamic batches currently support one output row per request.
 - Multi-prompt requests are not batched.
-- `cache_backend`, KV transfer, and other request-mode extras are not wired
-  into the batched step-wise path yet.
-- Future work can relax the current same-shape restriction with richer
-  heterogeneous batching policies such as bucketing or padded execution for
-  different resolutions.
+- Qwen-Image edit/image-latent dynamic batching is not supported yet.
+- Diffusion cache, CFG parallel, ring, HSDP, and CUDA graph dynamic execution
+  are not supported yet.
+- Sequence parallel support is limited to pure Ulysses (`ring_degree=1`) for
+  Qwen-Image packed dynamic batching.
+- Non-Qwen models need their own runner/model dynamic view before they can
+  safely execute mixed shapes.
 
 ## Related Files
 
@@ -155,5 +339,15 @@ batch packing.
   [`vllm_omni/diffusion/worker/diffusion_model_runner.py`](gh-file:vllm_omni/diffusion/worker/diffusion_model_runner.py)
 - Input batch:
   [`vllm_omni/diffusion/worker/input_batch.py`](gh-file:vllm_omni/diffusion/worker/input_batch.py)
-- Tests:
+- Attention metadata:
+  [`vllm_omni/diffusion/attention/backends/abstract.py`](gh-file:vllm_omni/diffusion/attention/backends/abstract.py)
+- FlashAttention backend:
+  [`vllm_omni/diffusion/attention/backends/flash_attn.py`](gh-file:vllm_omni/diffusion/attention/backends/flash_attn.py)
+- Qwen-Image pipeline:
+  [`vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py`](gh-file:vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py)
+- Qwen-Image transformer:
+  [`vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py`](gh-file:vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py)
+- Scheduler tests:
   [`tests/diffusion/test_diffusion_scheduler.py`](gh-file:tests/diffusion/test_diffusion_scheduler.py)
+- Dynamic Qwen-Image tests:
+  [`tests/diffusion/test_qwen_image_dynamic_step_batching.py`](gh-file:tests/diffusion/test_qwen_image_dynamic_step_batching.py)

--- a/tests/diffusion/test_diffusion_engine_rpc_routing.py
+++ b/tests/diffusion/test_diffusion_engine_rpc_routing.py
@@ -122,7 +122,13 @@ def _make_request(tag: str):
     return SimpleNamespace(
         request_id=tag,
         prompts=[f"prompt_{tag}"],
-        sampling_params=SimpleNamespace(num_inference_steps=1, **_SAMPLING_KEY_DEFAULTS),
+        sampling_params=SimpleNamespace(
+            num_inference_steps=1,
+            timesteps=None,
+            sigmas=None,
+            step_index=None,
+            **_SAMPLING_KEY_DEFAULTS,
+        ),
     )
 
 

--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -194,6 +194,82 @@ class TestGetSamplingParamsKey:
         b = get_sampling_params_key(self._make(lora_int_id=1, lora_scale=0.5))
         assert a == b
 
+    @staticmethod
+    def _qwen_config() -> SimpleNamespace:
+        return SimpleNamespace(
+            step_execution=True,
+            max_num_seqs=2,
+            model_class_name="QwenImagePipeline",
+            model="Qwen/Qwen-Image",
+        )
+
+    @staticmethod
+    def _make_qwen(
+        *,
+        request_id: str,
+        height: int = 512,
+        width: int = 512,
+        negative_prompt: str | None = "low quality",
+        true_cfg_scale: float = 4.0,
+        lora_int_id: int | None = None,
+    ) -> OmniDiffusionRequest:
+        from vllm_omni.lora.request import LoRARequest
+
+        sp = OmniDiffusionSamplingParams(
+            num_inference_steps=2,
+            height=height,
+            width=width,
+            true_cfg_scale=true_cfg_scale,
+        )
+        if lora_int_id is not None:
+            sp.lora_request = LoRARequest(
+                lora_name=f"adapter-{lora_int_id}",
+                lora_int_id=lora_int_id,
+                lora_path=f"/tmp/lora-{lora_int_id}",
+            )
+        prompt = {"prompt": f"prompt-{request_id}"}
+        if negative_prompt is not None:
+            prompt["negative_prompt"] = negative_prompt
+        return OmniDiffusionRequest(
+            prompts=[prompt],
+            sampling_params=sp,
+            request_id=request_id,
+        )
+
+    def test_qwen_dynamic_admission_ignores_resolution_and_cfg_scalar(self) -> None:
+        from vllm_omni.diffusion.sched.base_scheduler import get_sampling_params_key
+
+        config = self._qwen_config()
+        a = get_sampling_params_key(
+            self._make_qwen(request_id="a", height=512, width=512, true_cfg_scale=4.0),
+            config,
+        )
+        b = get_sampling_params_key(
+            self._make_qwen(request_id="b", height=1024, width=1024, true_cfg_scale=7.0),
+            config,
+        )
+        assert a == b
+
+    def test_qwen_dynamic_admission_keeps_cfg_shape_and_lora(self) -> None:
+        from vllm_omni.diffusion.sched.base_scheduler import get_sampling_params_key
+
+        config = self._qwen_config()
+        cfg = get_sampling_params_key(self._make_qwen(request_id="cfg"), config)
+        no_cfg = get_sampling_params_key(
+            self._make_qwen(request_id="no-cfg", negative_prompt=None),
+            config,
+        )
+        scale_one = get_sampling_params_key(
+            self._make_qwen(request_id="scale-one", true_cfg_scale=1.0),
+            config,
+        )
+        lora_1 = get_sampling_params_key(self._make_qwen(request_id="lora-1", lora_int_id=1), config)
+        lora_2 = get_sampling_params_key(self._make_qwen(request_id="lora-2", lora_int_id=2), config)
+
+        assert cfg != no_cfg
+        assert cfg != scale_one
+        assert lora_1 != lora_2
+
 
 class TestRequestScheduler:
     def setup_method(self) -> None:
@@ -276,6 +352,54 @@ class TestRequestScheduler:
         assert sched_output.num_running_reqs == 2
         assert sched_output.num_waiting_reqs == 0
 
+    def test_qwen_dynamic_batches_different_resolution_and_cfg_scale(self) -> None:
+        scheduler = RequestScheduler()
+        scheduler.initialize(TestGetSamplingParamsKey._qwen_config())
+
+        req_a = scheduler.add_request(
+            TestGetSamplingParamsKey._make_qwen(
+                request_id="a",
+                height=512,
+                width=512,
+                true_cfg_scale=4.0,
+            )
+        )
+        req_b = scheduler.add_request(
+            TestGetSamplingParamsKey._make_qwen(
+                request_id="b",
+                height=1024,
+                width=1024,
+                true_cfg_scale=7.0,
+            )
+        )
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == [req_a, req_b]
+        assert sched_output.num_running_reqs == 2
+        assert sched_output.num_waiting_reqs == 0
+
+    def test_qwen_dynamic_does_not_mix_cfg_disabled_scale_one(self) -> None:
+        scheduler = RequestScheduler()
+        scheduler.initialize(
+            SimpleNamespace(
+                step_execution=True,
+                max_num_seqs=3,
+                model_class_name="QwenImagePipeline",
+                model="Qwen/Qwen-Image",
+            )
+        )
+
+        req_a = scheduler.add_request(TestGetSamplingParamsKey._make_qwen(request_id="a", true_cfg_scale=4.0))
+        scheduler.add_request(TestGetSamplingParamsKey._make_qwen(request_id="b", true_cfg_scale=1.0))
+        scheduler.add_request(TestGetSamplingParamsKey._make_qwen(request_id="c", true_cfg_scale=7.0))
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == [req_a]
+        assert sched_output.num_running_reqs == 1
+        assert sched_output.num_waiting_reqs == 2
+
     def test_incompatible_waiting_head_blocks_later_compatible_request(self) -> None:
         scheduler = RequestScheduler()
         scheduler.initialize(SimpleNamespace(max_num_seqs=3))
@@ -284,7 +408,7 @@ class TestRequestScheduler:
         req_id_b = scheduler.add_request(
             OmniDiffusionRequest(
                 prompts=["prompt_b"],
-                sampling_params=OmniDiffusionSamplingParams(width=768),
+                sampling_params=OmniDiffusionSamplingParams(do_classifier_free_guidance=True),
                 request_id="b",
             )
         )
@@ -829,7 +953,7 @@ class TestStepScheduler:
             _make_step_request(
                 "b",
                 sampling_params=OmniDiffusionSamplingParams(
-                    height=768,
+                    do_classifier_free_guidance=True,
                     num_inference_steps=4,
                 ),
             )

--- a/tests/diffusion/test_qwen_image_dynamic_step_batching.py
+++ b/tests/diffusion/test_qwen_image_dynamic_step_batching.py
@@ -1,0 +1,1347 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+import socket
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.data import DiffusionOutput
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.diffusion.sched.interface import (
+    CachedRequestData,
+    DiffusionSchedulerOutput,
+    NewRequestData,
+)
+from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+from vllm_omni.diffusion.worker.input_batch import InputBatch
+from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+def _state(
+    request_id: str,
+    *,
+    image_len: int,
+    txt_len: int,
+    negative_txt_len: int | None = None,
+    true_cfg_scale: float | None = None,
+    img_shape: list[tuple[int, int, int]] | None = None,
+) -> DiffusionRequestState:
+    sampling = OmniDiffusionSamplingParams(num_inference_steps=1)
+    sampling.true_cfg_scale = true_cfg_scale
+    state = DiffusionRequestState(request_id=request_id, sampling=sampling, prompts=["prompt"])
+    state.latents = torch.zeros((1, image_len, 2), dtype=torch.float32)
+    state.timesteps = torch.tensor([1.0])
+    state.prompt_embeds = torch.ones((1, txt_len, 3), dtype=torch.float32)
+    state.prompt_embeds_mask = torch.ones((1, txt_len), dtype=torch.bool)
+    state.img_shapes = [img_shape or [(1, 1, image_len)]]
+    state.txt_seq_lens = [txt_len]
+    if negative_txt_len is not None:
+        state.do_true_cfg = True
+        state.negative_prompt_embeds = torch.full((1, negative_txt_len, 3), 2.0, dtype=torch.float32)
+        state.negative_prompt_embeds_mask = torch.ones((1, negative_txt_len), dtype=torch.bool)
+        state.negative_txt_seq_lens = [negative_txt_len]
+    return state
+
+
+def test_qwen_image_metadata_separates_request_and_segment_boundaries() -> None:
+    states = [
+        _state("req-1", image_len=4, txt_len=5),
+        _state("req-2", image_len=9, txt_len=3),
+    ]
+
+    input_batch = InputBatch.make_batch(states, allow_dynamic=True)
+    metadata = DiffusionModelRunner._make_qwen_image_metadata(
+        object.__new__(DiffusionModelRunner),
+        input_batch,
+        branch="positive",
+    )
+
+    assert input_batch.is_dynamic is True
+    assert input_batch.request_spans[0].token_start == 0
+    assert input_batch.request_spans[0].token_count == 4
+    assert input_batch.request_spans[1].token_start == 4
+    assert input_batch.request_spans[1].token_count == 9
+
+    assert metadata.padded_tokens == 0
+    assert metadata.q_cu_seqlens.tolist() == [0, 9, 21]
+    assert metadata.kv_cu_seqlens.tolist() == [0, 9, 21]
+
+    segments = metadata.q_segments
+    assert segments is not None
+    assert [(s.request_id, s.role, s.packed_start, s.length, s.request_start) for s in segments] == [
+        ("req-1", "text", 0, 5, 0),
+        ("req-1", "image", 5, 4, 0),
+        ("req-2", "text", 9, 3, 0),
+        ("req-2", "image", 12, 9, 0),
+    ]
+    assert input_batch.request_spans[1].token_start != segments[2].packed_start
+
+
+def test_qwen_image_single_request_keeps_dense_view_when_dynamic_enabled() -> None:
+    input_batch = InputBatch.make_batch(
+        [_state("req-1", image_len=4, txt_len=5)],
+        allow_dynamic=True,
+    )
+
+    assert input_batch.is_dynamic is False
+    assert input_batch.latents is not None
+    assert input_batch.latents.shape == (1, 4, 2)
+    assert input_batch.packed_latents is None
+    assert input_batch.img_seq_lens is None
+
+
+def test_qwen_image_single_request_can_force_dynamic_request_view_for_ring_sp() -> None:
+    input_batch = InputBatch.make_batch(
+        [_state("req-1", image_len=4, txt_len=5)],
+        allow_dynamic=True,
+        force_dynamic_request_view=True,
+    )
+
+    assert input_batch.is_dynamic is True
+    assert input_batch.latents is None
+    assert input_batch.packed_latents is not None
+    assert input_batch.packed_latents.shape == (4, 2)
+    assert input_batch.img_seq_lens == [4]
+
+
+def test_qwen_image_prompt_batch_keeps_padded_width_when_mask_is_shorter() -> None:
+    states = [
+        _state("req-1", image_len=4, txt_len=18),
+        _state("req-2", image_len=16, txt_len=18),
+    ]
+    states[0].prompt_embeds = torch.ones((1, 19, 3), dtype=torch.float32)
+    states[0].prompt_embeds_mask = torch.zeros((1, 19), dtype=torch.bool)
+    states[0].prompt_embeds_mask[:, :18] = True
+    states[0].txt_seq_lens = [18]
+
+    input_batch = InputBatch.make_batch(states, allow_dynamic=True)
+
+    assert input_batch.prompt_embeds.shape == (2, 19, 3)
+    assert input_batch.prompt_embeds_mask is not None
+    assert input_batch.prompt_embeds_mask.shape == (2, 19)
+    assert input_batch.txt_seq_lens == [18, 18]
+
+
+def test_qwen_image_dynamic_metadata_keeps_shape_and_cfg_request_local() -> None:
+    states = [
+        _state(
+            "req-1",
+            image_len=4,
+            txt_len=5,
+            negative_txt_len=6,
+            true_cfg_scale=2.0,
+            img_shape=[(1, 2, 2)],
+        ),
+        _state(
+            "req-2",
+            image_len=9,
+            txt_len=3,
+            negative_txt_len=4,
+            true_cfg_scale=7.0,
+            img_shape=[(1, 3, 3)],
+        ),
+    ]
+
+    input_batch = InputBatch.make_batch(states, allow_dynamic=True)
+    positive = DiffusionModelRunner._make_qwen_image_metadata(
+        object.__new__(DiffusionModelRunner),
+        input_batch,
+        branch="positive",
+    )
+    negative = DiffusionModelRunner._make_qwen_image_metadata(
+        object.__new__(DiffusionModelRunner),
+        input_batch,
+        branch="negative",
+    )
+
+    assert input_batch.is_dynamic is True
+    assert input_batch.do_true_cfg is True
+    assert input_batch.true_cfg_scales == [2.0, 7.0]
+    assert input_batch.img_shapes == [[(1, 2, 2)], [(1, 3, 3)]]
+
+    assert positive.position["img_shapes"] == [[(1, 2, 2)], [(1, 3, 3)]]
+    assert positive.position["txt_seq_lens"] == [5, 3]
+    assert positive.q_cu_seqlens.tolist() == [0, 9, 21]
+    assert negative.position["img_shapes"] == [[(1, 2, 2)], [(1, 3, 3)]]
+    assert negative.position["txt_seq_lens"] == [6, 4]
+    assert negative.q_cu_seqlens.tolist() == [0, 10, 23]
+
+    negative_segments = negative.q_segments
+    assert negative_segments is not None
+    assert [
+        (segment.request_id, segment.role, segment.packed_start, segment.length) for segment in negative_segments
+    ] == [
+        ("req-1", "negative_text", 0, 6),
+        ("req-1", "image", 6, 4),
+        ("req-2", "negative_text", 10, 4),
+        ("req-2", "image", 14, 9),
+    ]
+
+
+def test_qwen_image_same_shape_request_local_cfg_uses_dynamic_view() -> None:
+    states = [
+        _state("req-1", image_len=4, txt_len=5, negative_txt_len=6, true_cfg_scale=2.0),
+        _state("req-2", image_len=4, txt_len=5, negative_txt_len=6, true_cfg_scale=7.0),
+    ]
+
+    input_batch = InputBatch.make_batch(states, allow_dynamic=True)
+
+    assert input_batch.is_dynamic is True
+    assert input_batch.latents is None
+    assert input_batch.packed_latents is not None
+    assert input_batch.packed_latents.shape == (8, 2)
+    assert input_batch.img_seq_lens == [4, 4]
+    assert input_batch.true_cfg_scales == [2.0, 7.0]
+
+
+def test_dense_batch_rejects_mixed_cfg_scalars() -> None:
+    states = [
+        _state("req-1", image_len=4, txt_len=5, negative_txt_len=6, true_cfg_scale=2.0),
+        _state("req-2", image_len=4, txt_len=5, negative_txt_len=6, true_cfg_scale=7.0),
+    ]
+
+    with pytest.raises(ValueError, match="Mixed true_cfg_scale"):
+        InputBatch.make_batch(states, allow_dynamic=False)
+
+
+def test_qwen_image_same_shape_different_text_lengths_uses_dynamic_view() -> None:
+    states = [
+        _state("req-1", image_len=4, txt_len=5, negative_txt_len=6, true_cfg_scale=2.0),
+        _state("req-2", image_len=4, txt_len=7, negative_txt_len=8, true_cfg_scale=7.0),
+    ]
+
+    input_batch = InputBatch.make_batch(states, allow_dynamic=True)
+
+    assert input_batch.is_dynamic is True
+    assert input_batch.latents is None
+    assert input_batch.packed_latents is not None
+    assert input_batch.packed_latents.shape == (8, 2)
+    assert input_batch.prompt_embeds.shape == (2, 7, 3)
+    assert input_batch.negative_prompt_embeds is not None
+    assert input_batch.negative_prompt_embeds.shape == (2, 8, 3)
+    assert input_batch.txt_seq_lens == [5, 7]
+    assert input_batch.negative_txt_seq_lens == [6, 8]
+
+
+def test_qwen_image_dense_cfg_combine_uses_request_local_scales() -> None:
+    from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import QwenImagePipeline
+
+    states = [
+        _state("req-1", image_len=4, txt_len=5, negative_txt_len=6, true_cfg_scale=2.0),
+        _state("req-2", image_len=4, txt_len=5, negative_txt_len=6, true_cfg_scale=7.0),
+    ]
+    input_batch = InputBatch.make_batch(states, allow_dynamic=True)
+    pipeline = object.__new__(QwenImagePipeline)
+    positive = torch.ones((2, 4, 2), dtype=torch.float32)
+    negative = torch.zeros_like(positive)
+
+    actual = QwenImagePipeline._combine_dense_cfg(pipeline, positive, negative, input_batch)
+
+    torch.testing.assert_close(actual[0], torch.full((4, 2), 2.0))
+    torch.testing.assert_close(actual[1], torch.full((4, 2), 7.0))
+
+
+def test_qwen_image_dynamic_cfg_combine_uses_request_local_scales_for_mixed_lengths() -> None:
+    from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import QwenImagePipeline
+
+    pipeline = object.__new__(QwenImagePipeline)
+    positive = torch.ones((13, 2), dtype=torch.float32)
+    negative = torch.zeros_like(positive)
+
+    actual = QwenImagePipeline._combine_dynamic_cfg(
+        pipeline,
+        positive,
+        negative,
+        [4, 9],
+        [2.0, 7.0],
+        [False, False],
+    )
+
+    torch.testing.assert_close(actual[:4], torch.full((4, 2), 2.0))
+    torch.testing.assert_close(actual[4:], torch.full((9, 2), 7.0))
+
+
+@pytest.mark.parametrize(
+    ("parallel_config", "expected_attention_ids"),
+    [
+        (
+            SimpleNamespace(sequence_parallel_size=1, ring_degree=1),
+            ["qwen_image.joint.positive", "qwen_image.joint.negative"],
+        ),
+        (
+            SimpleNamespace(sequence_parallel_size=2, ring_degree=2),
+            ["qwen_image.joint.positive", "qwen_image.joint.negative"],
+        ),
+    ],
+)
+def test_qwen_image_dynamic_cfg_uses_packed_positive_negative_paths_for_ring_sp(
+    parallel_config: SimpleNamespace,
+    expected_attention_ids: list[str],
+) -> None:
+    from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import QwenImagePipeline
+
+    class _DynamicCfgPipeline(QwenImagePipeline):
+        def __init__(self) -> None:
+            torch.nn.Module.__init__(self)
+            self.parallel_config = parallel_config
+            self._attention_kwargs = {}
+            self.attention_ids: list[str] = []
+
+        def predict_noise(self, **kwargs) -> torch.Tensor:
+            self.attention_ids.append(kwargs["attention_kwargs"]["attention_id"])
+            return torch.zeros(
+                (sum(int(value) for value in kwargs["img_seq_lens"]), 2),
+                dtype=kwargs["hidden_states"].dtype,
+                device=kwargs["hidden_states"].device,
+            )
+
+        @staticmethod
+        def cfg_normalize_function(positive: torch.Tensor, noise: torch.Tensor) -> torch.Tensor:
+            del positive
+            return noise
+
+    states = [
+        _state("req-1", image_len=4, txt_len=5, negative_txt_len=6, true_cfg_scale=2.0),
+        _state("req-2", image_len=9, txt_len=3, negative_txt_len=4, true_cfg_scale=7.0),
+    ]
+    input_batch = InputBatch.make_batch(states, allow_dynamic=True)
+    pipeline = _DynamicCfgPipeline()
+
+    output = pipeline._denoise_step_dynamic_batch(input_batch)
+
+    assert pipeline.attention_ids == expected_attention_ids
+    assert output.shape == (13, 2)
+
+
+def test_qwen_image_post_decode_batch_keeps_final_vae_decode_request_local() -> None:
+    from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image import QwenImagePipeline
+
+    pipeline = object.__new__(QwenImagePipeline)
+    torch.nn.Module.__init__(pipeline)
+    pipeline._current_timestep = object()
+    pipeline.default_sample_size = 64
+    pipeline.vae_scale_factor = 8
+    calls: list[str] = []
+
+    def post_decode(state, **kwargs):
+        calls.append(state.request_id)
+        return DiffusionOutput(output=state.latents + len(calls))
+
+    pipeline.post_decode = post_decode
+    states = [
+        _state("req-1", image_len=4, txt_len=5),
+        _state("req-2", image_len=4, txt_len=5),
+    ]
+
+    outputs = QwenImagePipeline.post_decode_batch(pipeline, states, output_type="pil")
+
+    assert calls == ["req-1", "req-2"]
+    assert set(outputs) == {"req-1", "req-2"}
+    assert torch.equal(outputs["req-1"].output, states[0].latents + 1)
+    assert torch.equal(outputs["req-2"].output, states[1].latents + 2)
+    assert pipeline._current_timestep is None
+
+
+def test_qwen_image_dense_ring_attention_does_not_fall_through_to_joint_attention() -> None:
+    from vllm_omni.diffusion.forward_context import set_forward_context
+    from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import QwenImageCrossAttention
+
+    class _FakeQKV:
+        def __call__(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+            q = torch.ones((*x.shape[:2], 2), dtype=x.dtype)
+            k = torch.full_like(q, 2.0)
+            v = torch.full_like(q, 3.0)
+            return torch.cat([q, k, v], dim=-1), None
+
+    class _IdentityRope:
+        def __call__(
+            self,
+            x: torch.Tensor,
+            cos: torch.Tensor,
+            sin: torch.Tensor,
+        ) -> torch.Tensor:
+            del cos, sin
+            return x
+
+    class _FakeAttention:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def __call__(
+            self,
+            query: torch.Tensor,
+            key: torch.Tensor,
+            value: torch.Tensor,
+            metadata,
+        ) -> torch.Tensor:
+            del key, value
+            self.calls.append((query.shape, metadata))
+            prefix_len = int(metadata.joint_query.shape[1]) if metadata is not None else 0
+            return query.new_zeros((query.shape[0], prefix_len + query.shape[1], query.shape[2], query.shape[3]))
+
+    attn = object.__new__(QwenImageCrossAttention)
+    torch.nn.Module.__init__(attn)
+    attn.query_num_heads = 1
+    attn.kv_num_heads = 1
+    attn.add_query_num_heads = 1
+    attn.add_kv_num_heads = 1
+    attn.head_dim = 2
+    attn.to_qkv = _FakeQKV()
+    attn.add_kv_proj = _FakeQKV()
+    attn.norm_q = torch.nn.Identity()
+    attn.norm_k = torch.nn.Identity()
+    attn.norm_added_q = torch.nn.Identity()
+    attn.norm_added_k = torch.nn.Identity()
+    attn.rope = _IdentityRope()
+    fake_attention = _FakeAttention()
+    attn.attn = fake_attention
+    attn.to_out = torch.nn.Identity()
+    attn.to_add_out = torch.nn.Identity()
+    parallel_config = SimpleNamespace(sequence_parallel_size=2, ring_degree=2)
+    attn.parallel_config = parallel_config
+
+    hidden_states = torch.zeros((1, 4, 2), dtype=torch.float32)
+    encoder_hidden_states = torch.zeros((1, 3, 2), dtype=torch.float32)
+    vid_freqs = torch.ones((1, 4, 1, 2), dtype=torch.complex64)
+    txt_freqs = torch.ones((1, 3, 1, 2), dtype=torch.complex64)
+
+    with set_forward_context(omni_diffusion_config=SimpleNamespace(parallel_config=parallel_config)):
+        img_out, txt_out = QwenImageCrossAttention.forward(
+            attn,
+            hidden_states,
+            encoder_hidden_states,
+            vid_freqs,
+            txt_freqs,
+        )
+
+    assert img_out.shape == (1, 4, 2)
+    assert txt_out.shape == (1, 3, 2)
+    assert len(fake_attention.calls) == 1
+    query_shape, metadata = fake_attention.calls[0]
+    assert query_shape == (1, 4, 1, 2)
+    assert metadata.joint_strategy == "front"
+    assert metadata.joint_query.shape == (1, 3, 1, 2)
+
+
+@pytest.mark.parametrize("tensor_parallel_size", [1, 2])
+def test_qwen_image_dynamic_forward_keeps_packed_linear_for_tp(
+    tensor_parallel_size: int,
+) -> None:
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+    from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+    from vllm_omni.diffusion.forward_context import set_forward_context
+    from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import QwenImageTransformer2DModel
+
+    class _Identity(torch.nn.Module):
+        def forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+            del args, kwargs
+            return x
+
+    class _FakePosEmbed(torch.nn.Module):
+        def forward(
+            self,
+            img_shapes: list[tuple[int, int, int]],
+            txt_seq_lens: list[int],
+            device: torch.device,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            image_len = sum(depth * height * width for depth, height, width in img_shapes)
+            return (
+                torch.ones((image_len, 1), dtype=torch.complex64, device=device),
+                torch.ones((txt_seq_lens[0], 1), dtype=torch.complex64, device=device),
+            )
+
+    class _FakeTimeEmbed(torch.nn.Module):
+        def forward(self, timestep: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+            del args, kwargs
+            return torch.ones((int(timestep.shape[0]), 4), dtype=timestep.dtype, device=timestep.device)
+
+    class _FakeNormOut(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = self
+
+        def silu(self, x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        def norm(self, x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return torch.zeros((int(x.shape[0]), 8), dtype=x.dtype, device=x.device)
+
+    class _CaptureBlock(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.packed_indices: dict[str, object] | None = None
+
+        def forward_dynamic(
+            self,
+            hidden_states: torch.Tensor,
+            encoder_hidden_states: torch.Tensor,
+            temb: torch.Tensor,
+            temb_silu: torch.Tensor,
+            image_rotary_emb: tuple[torch.Tensor, torch.Tensor],
+            attn_metadata: AttentionMetadata,
+            packed_indices: dict[str, object],
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            del temb, temb_silu, image_rotary_emb, attn_metadata
+            self.packed_indices = packed_indices
+            return encoder_hidden_states, hidden_states
+
+    model = object.__new__(QwenImageTransformer2DModel)
+    torch.nn.Module.__init__(model)
+    model.zero_cond_t = False
+    model.parallel_config = SimpleNamespace(tensor_parallel_size=tensor_parallel_size)
+    model.img_in = _Identity()
+    model.txt_norm = _Identity()
+    model.txt_in = _Identity()
+    model.pos_embed = _FakePosEmbed()
+    model.time_text_embed = _FakeTimeEmbed()
+    capture_block = _CaptureBlock()
+    model.transformer_blocks = torch.nn.ModuleList([capture_block])
+    model.norm_out = _FakeNormOut()
+    model.proj_out = _Identity()
+
+    image_lens = [4, 5]
+    text_lens = [3, 6]
+    hidden_states = torch.zeros((sum(image_lens), 4), dtype=torch.float32)
+    encoder_hidden_states = torch.ones((2, max(text_lens), 4), dtype=torch.float32)
+    timestep = torch.tensor([1.0, 1.0], dtype=torch.float32)
+    cu_seqlens = torch.tensor([0, 7, 18], dtype=torch.int32)
+    attn_metadata = AttentionMetadata(
+        q_cu_seqlens=cu_seqlens,
+        kv_cu_seqlens=cu_seqlens,
+        max_q_len=11,
+        max_kv_len=11,
+        padded_tokens=0,
+    )
+    od_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(sequence_parallel_size=1, ring_degree=1),
+    )
+
+    with set_forward_context(
+        omni_diffusion_config=od_config,
+        attn_metadata={"qwen_image.joint.positive": attn_metadata},
+    ):
+        output = QwenImageTransformer2DModel._forward_dynamic(
+            model,
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_hidden_states_mask=None,
+            timestep=timestep,
+            img_shapes=[[(1, 2, 2)], [(1, 1, 5)]],
+            img_seq_lens=image_lens,
+            txt_seq_lens=text_lens,
+            guidance=None,
+            attention_kwargs={"attention_id": "qwen_image.joint.positive"},
+        )
+
+    assert isinstance(output, Transformer2DModelOutput)
+    assert output.sample.shape == hidden_states.shape
+    assert capture_block.packed_indices is not None
+    assert "request_local_gemm" not in capture_block.packed_indices
+    assert capture_block.packed_indices["image_lens"] == image_lens
+    assert capture_block.packed_indices["text_lens"] == text_lens
+
+
+@pytest.mark.cuda
+def test_flash_attention_flat_varlen_matches_per_request_attention() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for FlashAttention varlen comparison.")
+    from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+    from vllm_omni.diffusion.attention.backends.flash_attn import FlashAttentionImpl
+    from vllm_omni.diffusion.attention.backends.utils.fa import HAS_FLASH_ATTN
+
+    if not HAS_FLASH_ATTN:
+        pytest.skip("FlashAttention is not installed.")
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    lengths = [3, 5]
+    num_heads = 2
+    head_dim = 64
+    total_tokens = sum(lengths)
+    query = torch.randn(total_tokens, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    cu_seqlens = torch.tensor([0, lengths[0], total_tokens], device=device, dtype=torch.int32)
+    metadata = AttentionMetadata(
+        q_cu_seqlens=cu_seqlens,
+        kv_cu_seqlens=cu_seqlens,
+        max_q_len=max(lengths),
+        max_kv_len=max(lengths),
+        padded_tokens=0,
+    )
+
+    impl = FlashAttentionImpl(
+        num_heads=num_heads,
+        head_size=head_dim,
+        softmax_scale=head_dim**-0.5,
+        causal=False,
+        num_kv_heads=num_heads,
+    )
+    actual = impl.forward_cuda(query, key, value, metadata)
+
+    expected_parts: list[torch.Tensor] = []
+    offset = 0
+    for length in lengths:
+        q = query[offset : offset + length].float()
+        k = key[offset : offset + length].float()
+        v = value[offset : offset + length].float()
+        scores = torch.einsum("qhd,khd->hqk", q, k) * (head_dim**-0.5)
+        probs = torch.softmax(scores, dim=-1)
+        expected_parts.append(torch.einsum("hqk,khd->qhd", probs, v).to(actual.dtype))
+        offset += length
+
+    assert metadata.padded_tokens == 0
+    torch.testing.assert_close(actual, torch.cat(expected_parts, dim=0), rtol=2e-2, atol=2e-2)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class _DeterministicAttention(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.q_cu_seqlens_by_call: list[list[int] | None] = []
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata=None,
+    ) -> torch.Tensor:
+        if attn_metadata is None:
+            self.q_cu_seqlens_by_call.append(None)
+        else:
+            assert attn_metadata.padded_tokens == 0
+            assert attn_metadata.q_cu_seqlens is not None
+            self.q_cu_seqlens_by_call.append(attn_metadata.q_cu_seqlens.detach().cpu().tolist())
+        return query + key + value
+
+
+def _qwen_image_dynamic_metadata(
+    *,
+    image_lens: list[int],
+    txt_lens: list[int],
+    device: torch.device,
+):
+    from vllm_omni.diffusion.attention.backends.abstract import (
+        AttentionMetadata,
+        AttentionSegment,
+    )
+
+    cu_values = [0]
+    segments: list[AttentionSegment] = []
+    for request_index, (image_len, txt_len) in enumerate(zip(image_lens, txt_lens, strict=True)):
+        packed_start = cu_values[-1]
+        segments.append(
+            AttentionSegment(
+                request_id=f"req-{request_index}",
+                request_index=request_index,
+                role="text",
+                packed_start=packed_start,
+                length=txt_len,
+                request_start=0,
+            )
+        )
+        segments.append(
+            AttentionSegment(
+                request_id=f"req-{request_index}",
+                request_index=request_index,
+                role="image",
+                packed_start=packed_start + txt_len,
+                length=image_len,
+                request_start=0,
+            )
+        )
+        cu_values.append(packed_start + txt_len + image_len)
+
+    cu_seqlens = torch.tensor(cu_values, device=device, dtype=torch.int32)
+    max_seq_len = max(txt_len + image_len for txt_len, image_len in zip(txt_lens, image_lens, strict=True))
+    return AttentionMetadata(
+        q_cu_seqlens=cu_seqlens,
+        kv_cu_seqlens=cu_seqlens,
+        max_q_len=max_seq_len,
+        max_kv_len=max_seq_len,
+        q_segments=segments,
+        kv_segments=segments,
+        padded_tokens=0,
+    )
+
+
+@pytest.mark.cuda
+def test_qwen_image_dit_dynamic_mock_attention_is_exact_across_batch_shapes() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for Qwen-Image DiT RoPE execution.")
+
+    from vllm.config import CompilationConfig, DeviceConfig, VllmConfig, set_current_vllm_config
+    from vllm.distributed.parallel_state import (
+        cleanup_dist_env_and_memory,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    from vllm_omni.diffusion.forward_context import set_forward_context
+    from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import QwenImageTransformer2DModel
+
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ["MASTER_PORT"] = str(_free_port())
+
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(),
+        device_config=DeviceConfig(device="cuda"),
+    )
+    parallel_config = SimpleNamespace(
+        use_hsdp=False,
+        sequence_parallel_size=1,
+        ring_degree=1,
+        cfg_parallel_size=1,
+    )
+    od_config = SimpleNamespace(
+        parallel_config=parallel_config,
+        quantization_config=None,
+    )
+
+    with set_current_vllm_config(vllm_config):
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            distributed_init_method="env://",
+        )
+        initialize_model_parallel()
+        try:
+            torch.manual_seed(7)
+            model = QwenImageTransformer2DModel(
+                od_config=od_config,
+                patch_size=1,
+                in_channels=4,
+                out_channels=4,
+                num_layers=1,
+                attention_head_dim=8,
+                num_attention_heads=2,
+                joint_attention_dim=8,
+                axes_dims_rope=(2, 2, 4),
+            ).to(device="cuda", dtype=torch.float32)
+            for param in model.parameters():
+                torch.nn.init.uniform_(param, -0.02, 0.02)
+            model.eval()
+
+            attention_modules: list[_DeterministicAttention] = []
+            for block in model.transformer_blocks:
+                attention = _DeterministicAttention()
+                block.attn.attn = attention
+                attention_modules.append(attention)
+
+            image_lens = [4, 9]
+            txt_lens = [3, 5]
+            img_shapes = [[(1, 2, 2)], [(1, 3, 3)]]
+            generator = torch.Generator(device="cpu").manual_seed(11)
+            hidden_states = [
+                torch.randn((1, image_len, 4), generator=generator, dtype=torch.float32).to("cuda")
+                for image_len in image_lens
+            ]
+            encoder_states = [
+                torch.randn((1, txt_len, 8), generator=generator, dtype=torch.float32).to("cuda")
+                for txt_len in txt_lens
+            ]
+            timestep = torch.tensor([0.9, 0.7], device="cuda", dtype=torch.float32)
+
+            with torch.inference_mode():
+                dense_outputs = []
+                for index, txt_len in enumerate(txt_lens):
+                    dense_outputs.append(
+                        model(
+                            hidden_states=hidden_states[index],
+                            encoder_hidden_states=encoder_states[index],
+                            encoder_hidden_states_mask=torch.ones(
+                                (1, txt_len),
+                                device="cuda",
+                                dtype=torch.bool,
+                            ),
+                            timestep=timestep[index : index + 1],
+                            img_shapes=[img_shapes[index]],
+                            txt_seq_lens=[txt_len],
+                            guidance=None,
+                        ).sample
+                    )
+
+                max_txt_len = max(txt_lens)
+                batched_encoder = torch.zeros((2, max_txt_len, 8), device="cuda")
+                batched_mask = torch.zeros((2, max_txt_len), device="cuda", dtype=torch.bool)
+                for index, txt_len in enumerate(txt_lens):
+                    batched_encoder[index, :txt_len].copy_(encoder_states[index][0])
+                    batched_mask[index, :txt_len] = True
+
+                attention_id = "qwen_image.joint.positive"
+                packed_hidden_states = torch.cat([tensor.squeeze(0) for tensor in hidden_states], dim=0)
+                multi_metadata = _qwen_image_dynamic_metadata(
+                    image_lens=image_lens,
+                    txt_lens=txt_lens,
+                    device=torch.device("cuda"),
+                )
+                with set_forward_context(
+                    vllm_config=vllm_config,
+                    omni_diffusion_config=od_config,
+                    attn_metadata={attention_id: multi_metadata},
+                ):
+                    dynamic_multi_packed = model(
+                        hidden_states=packed_hidden_states,
+                        encoder_hidden_states=batched_encoder,
+                        encoder_hidden_states_mask=batched_mask,
+                        timestep=timestep,
+                        img_shapes=img_shapes,
+                        img_seq_lens=image_lens,
+                        txt_seq_lens=txt_lens,
+                        guidance=None,
+                        attention_kwargs={"attention_id": attention_id},
+                    ).sample
+                    dynamic_multi_outputs = [
+                        part.unsqueeze(0) for part in torch.split(dynamic_multi_packed, image_lens, dim=0)
+                    ]
+
+                dynamic_single_outputs = []
+                for index, txt_len in enumerate(txt_lens):
+                    single_metadata = _qwen_image_dynamic_metadata(
+                        image_lens=[image_lens[index]],
+                        txt_lens=[txt_len],
+                        device=torch.device("cuda"),
+                    )
+                    with set_forward_context(
+                        vllm_config=vllm_config,
+                        omni_diffusion_config=od_config,
+                        attn_metadata={attention_id: single_metadata},
+                    ):
+                        dynamic_single_outputs.append(
+                            model(
+                                hidden_states=hidden_states[index].squeeze(0),
+                                encoder_hidden_states=encoder_states[index],
+                                encoder_hidden_states_mask=torch.ones(
+                                    (1, txt_len),
+                                    device="cuda",
+                                    dtype=torch.bool,
+                                ),
+                                timestep=timestep[index : index + 1],
+                                img_shapes=[img_shapes[index]],
+                                img_seq_lens=[image_lens[index]],
+                                txt_seq_lens=[txt_len],
+                                guidance=None,
+                                attention_kwargs={"attention_id": attention_id},
+                            ).sample.unsqueeze(0)
+                        )
+
+            torch.accelerator.synchronize()
+            for dense, dynamic_single, dynamic_multi in zip(
+                dense_outputs,
+                dynamic_single_outputs,
+                dynamic_multi_outputs,
+                strict=True,
+            ):
+                torch.testing.assert_close(dynamic_single, dense, rtol=0, atol=0)
+                torch.testing.assert_close(dynamic_multi, dense, rtol=0, atol=0)
+                torch.testing.assert_close(dynamic_multi, dynamic_single, rtol=0, atol=0)
+
+            assert attention_modules[0].q_cu_seqlens_by_call == [
+                None,
+                None,
+                [0, 7, 21],
+                [0, 7],
+                [0, 14],
+            ]
+        finally:
+            cleanup_dist_env_and_memory()
+
+
+@pytest.mark.cuda
+def test_qwen_image_transformer_dynamic_batch_matches_dense_serial() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for Qwen-Image dynamic transformer comparison.")
+
+    from vllm.config import CompilationConfig, DeviceConfig, VllmConfig, set_current_vllm_config
+    from vllm.distributed.parallel_state import (
+        cleanup_dist_env_and_memory,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+    from vllm_omni.diffusion.attention.backends.utils.fa import HAS_FLASH_ATTN
+    from vllm_omni.diffusion.forward_context import set_forward_context
+    from vllm_omni.diffusion.models.qwen_image.qwen_image_transformer import QwenImageTransformer2DModel
+
+    if not HAS_FLASH_ATTN:
+        pytest.skip("FlashAttention is not installed.")
+
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ["MASTER_PORT"] = str(_free_port())
+
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(),
+        device_config=DeviceConfig(device="cuda"),
+    )
+    parallel_config = SimpleNamespace(
+        use_hsdp=False,
+        sequence_parallel_size=1,
+        ring_degree=1,
+        cfg_parallel_size=1,
+    )
+    od_config = SimpleNamespace(
+        parallel_config=parallel_config,
+        quantization_config=None,
+    )
+
+    with set_current_vllm_config(vllm_config):
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            distributed_init_method="env://",
+        )
+        initialize_model_parallel()
+        try:
+            torch.manual_seed(1234)
+            model = QwenImageTransformer2DModel(
+                od_config=od_config,
+                patch_size=2,
+                in_channels=4,
+                out_channels=4,
+                num_layers=1,
+                attention_head_dim=64,
+                num_attention_heads=2,
+                joint_attention_dim=8,
+                axes_dims_rope=(4, 4, 4),
+            ).to(device="cuda", dtype=torch.bfloat16)
+            for param in model.parameters():
+                torch.nn.init.uniform_(param, -0.02, 0.02)
+            model.eval()
+
+            image_lens = [16, 64]
+            txt_lens = [5, 7]
+            img_shapes = [[(1, 4, 4)], [(1, 8, 8)]]
+            generator = torch.Generator(device="cpu").manual_seed(5)
+            hidden_states = [
+                torch.randn((1, image_len, 4), generator=generator, dtype=torch.float32).to(
+                    device="cuda",
+                    dtype=torch.bfloat16,
+                )
+                for image_len in image_lens
+            ]
+            encoder_states = [
+                torch.randn((1, txt_len, 8), generator=generator, dtype=torch.float32).to(
+                    device="cuda",
+                    dtype=torch.bfloat16,
+                )
+                for txt_len in txt_lens
+            ]
+            timestep = torch.tensor([0.9, 0.7], device="cuda", dtype=torch.bfloat16)
+
+            with torch.inference_mode():
+                dense_outputs = []
+                for index, txt_len in enumerate(txt_lens):
+                    dense_outputs.append(
+                        model(
+                            hidden_states=hidden_states[index],
+                            encoder_hidden_states=encoder_states[index],
+                            encoder_hidden_states_mask=torch.ones(
+                                (1, txt_len),
+                                device="cuda",
+                                dtype=torch.bool,
+                            ),
+                            timestep=timestep[index : index + 1],
+                            img_shapes=[img_shapes[index]],
+                            txt_seq_lens=[txt_len],
+                            guidance=None,
+                        ).sample
+                    )
+
+                cu_values = [0]
+                for txt_len, image_len in zip(txt_lens, image_lens, strict=True):
+                    cu_values.append(cu_values[-1] + txt_len + image_len)
+                cu_seqlens = torch.tensor(cu_values, device="cuda", dtype=torch.int32)
+                attn_metadata = AttentionMetadata(
+                    q_cu_seqlens=cu_seqlens,
+                    kv_cu_seqlens=cu_seqlens,
+                    max_q_len=max(txt_len + image_len for txt_len, image_len in zip(txt_lens, image_lens, strict=True)),
+                    max_kv_len=max(
+                        txt_len + image_len for txt_len, image_len in zip(txt_lens, image_lens, strict=True)
+                    ),
+                    padded_tokens=0,
+                )
+
+                max_txt_len = max(txt_lens)
+                batched_encoder = torch.zeros((2, max_txt_len, 8), device="cuda", dtype=torch.bfloat16)
+                batched_mask = torch.zeros((2, max_txt_len), device="cuda", dtype=torch.bool)
+                for index, txt_len in enumerate(txt_lens):
+                    batched_encoder[index, :txt_len].copy_(encoder_states[index][0])
+                    batched_mask[index, :txt_len] = True
+
+                packed_hidden_states = torch.cat([tensor.squeeze(0) for tensor in hidden_states], dim=0)
+                with set_forward_context(
+                    vllm_config=vllm_config,
+                    omni_diffusion_config=od_config,
+                    attn_metadata={"qwen_image.joint.positive": attn_metadata},
+                ):
+                    dynamic_packed = model(
+                        hidden_states=packed_hidden_states,
+                        encoder_hidden_states=batched_encoder,
+                        encoder_hidden_states_mask=batched_mask,
+                        timestep=timestep,
+                        img_shapes=img_shapes,
+                        img_seq_lens=image_lens,
+                        txt_seq_lens=txt_lens,
+                        guidance=None,
+                        attention_kwargs={"attention_id": "qwen_image.joint.positive"},
+                    ).sample
+                    dynamic_outputs = [part.unsqueeze(0) for part in torch.split(dynamic_packed, image_lens, dim=0)]
+
+                single_cu_seqlens = torch.tensor(
+                    [0, txt_lens[0] + image_lens[0]],
+                    device="cuda",
+                    dtype=torch.int32,
+                )
+                single_attn_metadata = AttentionMetadata(
+                    q_cu_seqlens=single_cu_seqlens,
+                    kv_cu_seqlens=single_cu_seqlens,
+                    max_q_len=txt_lens[0] + image_lens[0],
+                    max_kv_len=txt_lens[0] + image_lens[0],
+                    padded_tokens=0,
+                )
+                with set_forward_context(
+                    vllm_config=vllm_config,
+                    omni_diffusion_config=od_config,
+                    attn_metadata={"qwen_image.joint.positive": single_attn_metadata},
+                ):
+                    dynamic_single_output = model(
+                        hidden_states=hidden_states[0].squeeze(0),
+                        encoder_hidden_states=encoder_states[0],
+                        encoder_hidden_states_mask=torch.ones(
+                            (1, txt_lens[0]),
+                            device="cuda",
+                            dtype=torch.bool,
+                        ),
+                        timestep=timestep[:1],
+                        img_shapes=[img_shapes[0]],
+                        img_seq_lens=[image_lens[0]],
+                        txt_seq_lens=[txt_lens[0]],
+                        guidance=None,
+                        attention_kwargs={"attention_id": "qwen_image.joint.positive"},
+                    ).sample.unsqueeze(0)
+
+            for dense, dynamic in zip(dense_outputs, dynamic_outputs, strict=True):
+                torch.testing.assert_close(dynamic, dense, rtol=0, atol=1e-3)
+            torch.testing.assert_close(dynamic_outputs[0], dynamic_single_output, rtol=0, atol=1e-3)
+        finally:
+            cleanup_dist_env_and_memory()
+
+
+class _FakeDynamicQwenImagePipeline(torch.nn.Module):
+    supports_step_execution = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.prepare_calls = 0
+        self.denoise_calls = 0
+        self.scheduler_calls = 0
+        self.decode_calls = 0
+        self.batch_decode_calls = 0
+        self.seen_input_batch: InputBatch | None = None
+        self.seen_attn_metadata = None
+
+    @property
+    def interrupt(self) -> bool:
+        return False
+
+    def prepare_encode(self, state: DiffusionRequestState, **kwargs) -> DiffusionRequestState:
+        del kwargs
+        self.prepare_calls += 1
+        image_len = int(state.sampling.extra_args["image_len"])
+        txt_len = int(state.sampling.extra_args["txt_len"])
+        negative_txt_len = state.sampling.extra_args.get("negative_txt_len")
+        img_shape = state.sampling.extra_args.get("img_shape", [(1, 1, image_len)])
+        state.timesteps = torch.tensor([1.0])
+        state.latents = torch.zeros((1, image_len, 2), dtype=torch.float32)
+        state.prompt_embeds = torch.ones((1, txt_len, 3), dtype=torch.float32)
+        state.prompt_embeds_mask = torch.ones((1, txt_len), dtype=torch.bool)
+        state.img_shapes = [img_shape]
+        state.txt_seq_lens = [txt_len]
+        if negative_txt_len is not None:
+            negative_txt_len = int(negative_txt_len)
+            state.do_true_cfg = True
+            state.negative_prompt_embeds = torch.full((1, negative_txt_len, 3), 2.0, dtype=torch.float32)
+            state.negative_prompt_embeds_mask = torch.ones((1, negative_txt_len), dtype=torch.bool)
+            state.negative_txt_seq_lens = [negative_txt_len]
+        return state
+
+    def denoise_step(self, input_batch: InputBatch, **kwargs) -> torch.Tensor:
+        del kwargs
+        from vllm_omni.diffusion.forward_context import get_forward_context
+
+        self.denoise_calls += 1
+        self.seen_input_batch = input_batch
+        self.seen_attn_metadata = get_forward_context().attn_metadata
+        assert input_batch.is_dynamic is True
+        assert input_batch.packed_latents is not None
+        assert input_batch.img_seq_lens is not None
+        fill_values = (
+            input_batch.true_cfg_scales
+            if input_batch.do_true_cfg
+            else [float(index + 1) for index in range(len(input_batch.img_seq_lens))]
+        )
+        return torch.cat(
+            [
+                torch.full(
+                    (seq_len, input_batch.packed_latents.shape[-1]),
+                    fill_value=float(fill_value),
+                    dtype=input_batch.packed_latents.dtype,
+                    device=input_batch.packed_latents.device,
+                )
+                for seq_len, fill_value in zip(input_batch.img_seq_lens, fill_values, strict=True)
+            ],
+            dim=0,
+        )
+
+    def step_scheduler(self, state: DiffusionRequestState, noise_pred: torch.Tensor, **kwargs) -> None:
+        del kwargs
+        self.scheduler_calls += 1
+        state.latents = state.latents + noise_pred
+        state.step_index += 1
+
+    def post_decode(self, state: DiffusionRequestState, **kwargs) -> DiffusionOutput:
+        del kwargs
+        self.decode_calls += 1
+        return DiffusionOutput(output=state.latents.clone())
+
+    def post_decode_batch(self, states: list[DiffusionRequestState], **kwargs) -> dict[str, DiffusionOutput]:
+        del kwargs
+        self.batch_decode_calls += 1
+        return {state.request_id: DiffusionOutput(output=state.latents.clone()) for state in states}
+
+
+QwenImagePipeline = type(
+    "QwenImagePipeline",
+    (_FakeDynamicQwenImagePipeline,),
+    {"__module__": "vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image"},
+)
+
+
+def _runner() -> DiffusionModelRunner:
+    runner = object.__new__(DiffusionModelRunner)
+    runner.vllm_config = None
+    runner.od_config = SimpleNamespace(
+        cache_backend="none",
+        enforce_eager=True,
+        step_execution=True,
+        max_num_seqs=2,
+        parallel_config=SimpleNamespace(
+            use_hsdp=False,
+            sequence_parallel_size=1,
+            ring_degree=1,
+            cfg_parallel_size=1,
+        ),
+    )
+    runner.device = torch.device("cpu")
+    runner.pipeline = QwenImagePipeline()
+    runner.state_cache = {}
+    runner.kv_transfer_manager = SimpleNamespace(
+        receive_multi_kv_cache_distributed=lambda req, cfg_kv_collect_func=None, target_device=None: None
+    )
+    return runner
+
+
+def _request(
+    request_id: str,
+    *,
+    image_len: int,
+    txt_len: int,
+    negative_txt_len: int | None = None,
+    true_cfg_scale: float | None = None,
+    img_shape: list[tuple[int, int, int]] | None = None,
+) -> OmniDiffusionRequest:
+    extra_args = {"image_len": image_len, "txt_len": txt_len}
+    if negative_txt_len is not None:
+        extra_args["negative_txt_len"] = negative_txt_len
+    if img_shape is not None:
+        extra_args["img_shape"] = img_shape
+    return OmniDiffusionRequest(
+        prompts=[f"prompt-{request_id}"],
+        sampling_params=OmniDiffusionSamplingParams(
+            num_inference_steps=1,
+            true_cfg_scale=true_cfg_scale,
+            extra_args=extra_args,
+        ),
+        request_id=request_id,
+    )
+
+
+def test_qwen_image_dynamic_stepwise_updates_request_local_latents() -> None:
+    runner = _runner()
+    requests = [
+        _request("req-1", image_len=4, txt_len=5),
+        _request("req-2", image_len=9, txt_len=3),
+    ]
+    scheduler_output = DiffusionSchedulerOutput(
+        step_id=0,
+        scheduled_new_reqs=[NewRequestData(request_id=req.request_id, req=req) for req in requests],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        finished_req_ids=set(),
+        num_running_reqs=2,
+        num_waiting_reqs=0,
+    )
+
+    result = DiffusionModelRunner.execute_stepwise(runner, scheduler_output)
+
+    first = result.get_request_output("req-1")
+    second = result.get_request_output("req-2")
+    assert first is not None and first.finished is True and first.result is not None
+    assert second is not None and second.finished is True and second.result is not None
+    torch.testing.assert_close(first.result.output, torch.ones((1, 4, 2)))
+    torch.testing.assert_close(second.result.output, torch.full((1, 9, 2), 2.0))
+
+    pipeline = runner.pipeline
+    assert pipeline.prepare_calls == 2
+    assert pipeline.denoise_calls == 1
+    assert pipeline.scheduler_calls == 2
+    assert pipeline.decode_calls == 0
+    assert pipeline.batch_decode_calls == 1
+    assert pipeline.seen_input_batch is not None
+    assert pipeline.seen_input_batch.latents is None
+    assert pipeline.seen_input_batch.packed_latents is not None
+    assert pipeline.seen_input_batch.img_seq_lens == [4, 9]
+    assert "req-1" not in runner.state_cache
+    assert "req-2" not in runner.state_cache
+
+
+def test_qwen_image_dynamic_stepwise_uses_request_local_cfg_and_shape_metadata() -> None:
+    runner = _runner()
+    requests = [
+        _request(
+            "req-1",
+            image_len=4,
+            txt_len=5,
+            negative_txt_len=6,
+            true_cfg_scale=2.0,
+            img_shape=[(1, 2, 2)],
+        ),
+        _request(
+            "req-2",
+            image_len=9,
+            txt_len=3,
+            negative_txt_len=4,
+            true_cfg_scale=7.0,
+            img_shape=[(1, 3, 3)],
+        ),
+    ]
+    scheduler_output = DiffusionSchedulerOutput(
+        step_id=0,
+        scheduled_new_reqs=[NewRequestData(request_id=req.request_id, req=req) for req in requests],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        finished_req_ids=set(),
+        num_running_reqs=2,
+        num_waiting_reqs=0,
+    )
+
+    result = DiffusionModelRunner.execute_stepwise(runner, scheduler_output)
+
+    first = result.get_request_output("req-1")
+    second = result.get_request_output("req-2")
+    assert first is not None and first.finished is True and first.result is not None
+    assert second is not None and second.finished is True and second.result is not None
+    torch.testing.assert_close(first.result.output, torch.full((1, 4, 2), 2.0))
+    torch.testing.assert_close(second.result.output, torch.full((1, 9, 2), 7.0))
+
+    pipeline = runner.pipeline
+    assert pipeline.seen_input_batch is not None
+    assert pipeline.seen_input_batch.true_cfg_scales == [2.0, 7.0]
+    assert pipeline.seen_input_batch.img_shapes == [[(1, 2, 2)], [(1, 3, 3)]]
+    assert pipeline.seen_attn_metadata is not None
+
+    assert set(pipeline.seen_attn_metadata) == {
+        "qwen_image.joint.positive",
+        "qwen_image.joint.negative",
+    }
+    positive = pipeline.seen_attn_metadata["qwen_image.joint.positive"]
+    negative = pipeline.seen_attn_metadata["qwen_image.joint.negative"]
+    assert positive.position["img_shapes"] == [[(1, 2, 2)], [(1, 3, 3)]]
+    assert positive.position["txt_seq_lens"] == [5, 3]
+    assert positive.q_cu_seqlens.tolist() == [0, 9, 21]
+    assert negative.position["img_shapes"] == [[(1, 2, 2)], [(1, 3, 3)]]
+    assert negative.position["txt_seq_lens"] == [6, 4]
+    assert negative.q_cu_seqlens.tolist() == [0, 10, 23]
+
+
+def test_qwen_image_dynamic_stepwise_ring_sp_uses_packed_cfg_metadata(monkeypatch) -> None:
+    runner = _runner()
+    runner.od_config.parallel_config.sequence_parallel_size = 2
+    runner.od_config.parallel_config.ulysses_degree = 1
+    runner.od_config.parallel_config.ring_degree = 2
+    monkeypatch.setattr(
+        "vllm_omni.diffusion.distributed.parallel_state.get_sp_group",
+        lambda: SimpleNamespace(
+            ring_group=object(),
+            ring_world_size=2,
+            ring_rank=0,
+            ulysses_group=object(),
+            ulysses_world_size=1,
+            ulysses_rank=0,
+        ),
+    )
+    requests = [
+        _request(
+            "req-1",
+            image_len=4,
+            txt_len=5,
+            negative_txt_len=6,
+            true_cfg_scale=2.0,
+            img_shape=[(1, 2, 2)],
+        ),
+        _request(
+            "req-2",
+            image_len=9,
+            txt_len=3,
+            negative_txt_len=4,
+            true_cfg_scale=7.0,
+            img_shape=[(1, 3, 3)],
+        ),
+    ]
+    scheduler_output = DiffusionSchedulerOutput(
+        step_id=0,
+        scheduled_new_reqs=[NewRequestData(request_id=req.request_id, req=req) for req in requests],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        finished_req_ids=set(),
+        num_running_reqs=2,
+        num_waiting_reqs=0,
+    )
+
+    result = DiffusionModelRunner.execute_stepwise(runner, scheduler_output)
+
+    first = result.get_request_output("req-1")
+    second = result.get_request_output("req-2")
+    assert first is not None and first.finished is True and first.result is not None
+    assert second is not None and second.finished is True and second.result is not None
+
+    pipeline = runner.pipeline
+    assert pipeline.seen_attn_metadata is not None
+    assert set(pipeline.seen_attn_metadata) == {
+        "qwen_image.joint.positive",
+        "qwen_image.joint.negative",
+    }
+    positive = pipeline.seen_attn_metadata["qwen_image.joint.positive"]
+    negative = pipeline.seen_attn_metadata["qwen_image.joint.negative"]
+    assert positive.position["img_shapes"] == [[(1, 2, 2)], [(1, 3, 3)]]
+    assert positive.position["txt_seq_lens"] == [5, 3]
+    assert positive.q_cu_seqlens.tolist() == [0, 9, 21]
+    assert negative.position["img_shapes"] == [[(1, 2, 2)], [(1, 3, 3)]]
+    assert negative.position["txt_seq_lens"] == [6, 4]
+    assert negative.q_cu_seqlens.tolist() == [0, 10, 23]

--- a/vllm_omni/diffusion/attention/backends/abstract.py
+++ b/vllm_omni/diffusion/attention/backends/abstract.py
@@ -10,6 +10,32 @@ import torch
 from vllm_omni.platforms import current_omni_platform
 
 
+@dataclass(frozen=True)
+class AttentionSegment:
+    """Request-local semantic span used to split/gather dynamic attention.
+
+    This describes model semantics, not cache layout. Cache-specific block
+    tables and slot mappings stay on ``AttentionMetadata``.
+    """
+
+    request_id: str
+    request_index: int
+    role: str
+    packed_start: int
+    length: int
+    request_start: int = 0
+    branch: str = "positive"
+    position_id: str | None = None
+
+    @property
+    def packed_end(self) -> int:
+        return self.packed_start + self.length
+
+    @property
+    def request_end(self) -> int:
+        return self.request_start + self.length
+
+
 class AttentionBackend(ABC):
     """Abstract class for diffusion attention backends."""
 
@@ -53,6 +79,21 @@ class AttentionBackend(ABC):
 
 @dataclass
 class AttentionMetadata:
+    # Varlen execution contract. These fields are direct because attention
+    # backends consume them on the hot path.
+    q_cu_seqlens: torch.Tensor | None = None
+    kv_cu_seqlens: torch.Tensor | None = None
+    max_q_len: int | None = None
+    max_kv_len: int | None = None
+    q_segments: list[AttentionSegment] | None = None
+    kv_segments: list[AttentionSegment] | None = None
+    position: Any | None = None
+    padded_tokens: int = 0
+
+    # Future cache layout hooks, kept separate from AttentionSegment.
+    # block_table: torch.Tensor | None = None
+    # slot_mapping: torch.Tensor | None = None
+
     attn_mask: torch.Tensor | None = None
     joint_attn_mask: torch.Tensor | None = None
     # a joint mask for the joint query, key, and value, depends the joint_strategy
@@ -75,6 +116,10 @@ class AttentionMetadata:
     # Piecewise attention metadata (mixed causal/full masks).
     # full_attn_spans: per-sample [start, end) spans in global coordinates using full attention.
     full_attn_spans: list[list[tuple[int, int]]] | None = None
+
+    @property
+    def is_varlen(self) -> bool:
+        return self.q_cu_seqlens is not None or self.kv_cu_seqlens is not None
 
 
 T = TypeVar("T", bound=AttentionMetadata)
@@ -109,6 +154,11 @@ class AttentionImpl(ABC, Generic[T]):
         if kv_cache_dtype is None:
             return True
         return kv_cache_dtype in cls._supported_kv_cache_dtypes.get(platform_key, set())
+
+    def get_kv_cache_spec(self, *args: Any, **kwargs: Any) -> None:
+        # TODO(kv-cache): attention implementations do not register cache specs
+        # for diffusion dynamic attention yet.
+        return None
 
     def forward(
         self,

--- a/vllm_omni/diffusion/attention/backends/flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/flash_attn.py
@@ -160,6 +160,42 @@ class FlashAttentionImpl(AttentionImpl):
         # (b s) h d -> b s h d
         return out.reshape(batch_size, q_len, *out.shape[1:])
 
+    def _forward_varlen_flat(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+    ) -> torch.Tensor:
+        """Run padding-free FlashAttention over flat packed dynamic Q/K/V."""
+        from vllm_omni.diffusion.attention.backends.utils.fa import (
+            flash_attn_varlen_func,
+        )
+
+        if query.ndim != 3 or key.ndim != 3 or value.ndim != 3:
+            raise ValueError("Flat varlen FlashAttention expects [total_tokens, heads, head_dim] Q/K/V.")
+        if attn_metadata.attn_mask is not None or attn_metadata.joint_attn_mask is not None:
+            raise ValueError("Flat varlen FlashAttention does not accept attention masks.")
+        if attn_metadata.padded_tokens != 0:
+            raise ValueError("Flat varlen FlashAttention requires padded_tokens=0.")
+        if attn_metadata.q_cu_seqlens is None or attn_metadata.kv_cu_seqlens is None:
+            raise ValueError("Flat varlen FlashAttention requires q_cu_seqlens and kv_cu_seqlens.")
+        if attn_metadata.max_q_len is None or attn_metadata.max_kv_len is None:
+            raise ValueError("Flat varlen FlashAttention requires max_q_len and max_kv_len.")
+
+        out = flash_attn_varlen_func(
+            q=query,
+            k=key,
+            v=value,
+            cu_seqlens_q=attn_metadata.q_cu_seqlens,
+            cu_seqlens_k=attn_metadata.kv_cu_seqlens,
+            max_seqlen_q=attn_metadata.max_q_len,
+            max_seqlen_k=attn_metadata.max_kv_len,
+            causal=self.causal,
+            softmax_scale=self.softmax_scale,
+        )
+        return self._unwrap_flash_output(out)
+
     def forward_cuda(
         self,
         query: torch.Tensor,
@@ -182,6 +218,9 @@ class FlashAttentionImpl(AttentionImpl):
 
         attention_mask = attn_metadata.attn_mask if attn_metadata is not None else None
         full_attn_spans = attn_metadata.full_attn_spans if attn_metadata is not None else None
+
+        if attn_metadata is not None and attn_metadata.is_varlen:
+            return self._forward_varlen_flat(query, key, value, attn_metadata)
 
         # Try piecewise attention
         if full_attn_spans is not None:
@@ -244,6 +283,9 @@ class FlashAttentionImpl(AttentionImpl):
             )
 
         attention_mask = attn_metadata.attn_mask if attn_metadata is not None else None
+
+        if attn_metadata is not None and attn_metadata.is_varlen:
+            return self._forward_varlen_flat(query, key, value, attn_metadata)
 
         if attention_mask is not None and torch.any(~attention_mask):
             return self._forward_varlen_masked(

--- a/vllm_omni/diffusion/attention/backends/ring_flash_attn.py
+++ b/vllm_omni/diffusion/attention/backends/ring_flash_attn.py
@@ -3,10 +3,13 @@
 # Adapted from https://github.com/feifeibear/long-context-attention
 
 
+from typing import Any
+
 import torch
+import torch.distributed as dist
 
 from vllm_omni.diffusion.attention.backends.ring.ring_selector import AttnType, select_flash_attn_impl
-from vllm_omni.diffusion.attention.backends.ring.ring_utils import update_out_and_lse
+from vllm_omni.diffusion.attention.backends.ring.ring_utils import flatten_varlen_lse, update_out_and_lse
 from vllm_omni.diffusion.distributed.comm import RingComm
 
 
@@ -106,6 +109,293 @@ def ring_flash_attn_forward(
     if attn_type != AttnType.SPARSE_SAGE:
         lse = lse.squeeze(dim=-1).transpose(1, 2)
     return out, lse
+
+
+def _ring_varlen_cu_seqlens(lengths: list[int], device: torch.device) -> tuple[torch.Tensor, int]:
+    cu_values = [0]
+    max_len = 0
+    for length in lengths:
+        length = int(length)
+        cu_values.append(cu_values[-1] + length)
+        max_len = max(max_len, length)
+    return torch.tensor(cu_values, dtype=torch.int32, device=device), max_len
+
+
+def _ring_varlen_replicated_prefix_indices(
+    suffix_lens: list[int],
+    prefix_lens: list[int],
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    total_prefix = sum(prefix_lens)
+    prefix_offset = 0
+    suffix_offset = 0
+    packed_offset = 0
+    gather_indices: list[torch.Tensor] = []
+    prefix_restore_indices: list[torch.Tensor] = []
+    suffix_restore_indices: list[torch.Tensor] = []
+    for prefix_len, suffix_len in zip(prefix_lens, suffix_lens, strict=True):
+        gather_indices.append(torch.arange(prefix_offset, prefix_offset + prefix_len, dtype=torch.long, device=device))
+        prefix_restore_indices.append(
+            torch.arange(packed_offset, packed_offset + prefix_len, dtype=torch.long, device=device)
+        )
+        packed_offset += prefix_len
+        gather_indices.append(
+            torch.arange(
+                total_prefix + suffix_offset,
+                total_prefix + suffix_offset + suffix_len,
+                dtype=torch.long,
+                device=device,
+            )
+        )
+        suffix_restore_indices.append(
+            torch.arange(packed_offset, packed_offset + suffix_len, dtype=torch.long, device=device)
+        )
+        packed_offset += suffix_len
+        prefix_offset += prefix_len
+        suffix_offset += suffix_len
+    return torch.cat(gather_indices, dim=0), torch.cat([*prefix_restore_indices, *suffix_restore_indices], dim=0)
+
+
+def ring_flash_attn_varlen_replicated_prefix_plan(
+    *,
+    prefix_lens: list[int],
+    suffix_lens_by_rank: list[list[int]],
+    rank: int,
+    device: torch.device,
+) -> dict[str, Any]:
+    local_suffix_lens = suffix_lens_by_rank[rank]
+    q_gather_idx, q_restore_idx = _ring_varlen_replicated_prefix_indices(
+        local_suffix_lens,
+        prefix_lens,
+        device,
+    )
+    q_lens = [prefix_len + suffix_len for prefix_len, suffix_len in zip(prefix_lens, local_suffix_lens, strict=True)]
+    q_cu_seqlens, max_q_len = _ring_varlen_cu_seqlens(q_lens, device)
+
+    kv_cu_seqlens_by_owner: list[torch.Tensor] = []
+    max_kv_len_by_owner: list[int] = []
+    for owner, suffix_lens in enumerate(suffix_lens_by_rank):
+        if owner == rank:
+            kv_cu_seqlens_by_owner.append(q_cu_seqlens)
+            max_kv_len_by_owner.append(max_q_len)
+        else:
+            kv_cu_seqlens, max_kv_len = _ring_varlen_cu_seqlens(suffix_lens, device)
+            kv_cu_seqlens_by_owner.append(kv_cu_seqlens)
+            max_kv_len_by_owner.append(max_kv_len)
+
+    return {
+        "q_gather_idx": q_gather_idx,
+        "q_restore_idx": q_restore_idx,
+        "q_cu_seqlens": q_cu_seqlens,
+        "max_q_len": max_q_len,
+        "kv_cu_seqlens_by_owner": kv_cu_seqlens_by_owner,
+        "max_kv_len_by_owner": max_kv_len_by_owner,
+    }
+
+
+def _normalize_varlen_lse(
+    lse: torch.Tensor,
+    q_cu_seqlens: torch.Tensor,
+    query: torch.Tensor,
+) -> torch.Tensor:
+    query_len = int(query.shape[0])
+    head_count = int(query.shape[1])
+    if lse.ndim == 2:
+        if int(lse.shape[0]) == head_count and int(lse.shape[1]) == query_len:
+            return lse.contiguous()
+        if int(lse.shape[0]) == query_len and int(lse.shape[1]) == head_count:
+            return lse.transpose(0, 1).contiguous()
+    if lse.ndim == 3:
+        if int(lse.shape[1]) == head_count:
+            return flatten_varlen_lse(lse, q_cu_seqlens).contiguous()
+        if int(lse.shape[0]) == head_count:
+            pieces = []
+            for i in range(int(q_cu_seqlens.numel()) - 1):
+                start = int(q_cu_seqlens[i].item())
+                end = int(q_cu_seqlens[i + 1].item())
+                pieces.append(lse[:, i, : end - start])
+            return torch.cat(pieces, dim=1).contiguous()
+    raise ValueError(f"Unsupported varlen LSE shape {tuple(lse.shape)} for query shape {tuple(query.shape)}.")
+
+
+def _flash_varlen_with_lse(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    q_cu_seqlens: torch.Tensor,
+    kv_cu_seqlens: torch.Tensor,
+    max_q_len: int,
+    max_kv_len: int,
+    softmax_scale: float | None,
+    causal: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from vllm_omni.diffusion.attention.backends.utils.fa import flash_attn_varlen_func
+
+    if flash_attn_varlen_func is None:
+        raise ImportError("Ring varlen attention requires flash_attn_varlen_func.")
+
+    kwargs = {
+        "q": query,
+        "k": key,
+        "v": value,
+        "cu_seqlens_q": q_cu_seqlens,
+        "cu_seqlens_k": kv_cu_seqlens,
+        "max_seqlen_q": max_q_len,
+        "max_seqlen_k": max_kv_len,
+        "causal": causal,
+        "softmax_scale": softmax_scale,
+    }
+    try:
+        result = flash_attn_varlen_func(**kwargs, return_softmax_lse=True)
+    except TypeError:
+        result = flash_attn_varlen_func(**kwargs, return_attn_probs=True)
+    if not isinstance(result, tuple) or len(result) < 2:
+        raise RuntimeError("flash_attn_varlen_func did not return softmax_lse.")
+
+    out, lse = result[0], result[1]
+    return out, _normalize_varlen_lse(lse, q_cu_seqlens, query)
+
+
+def _update_flat_varlen_out_and_lse(
+    out: torch.Tensor | None,
+    lse: torch.Tensor | None,
+    block_out: torch.Tensor,
+    block_lse: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    block_out = block_out.to(torch.float32)
+    block_lse = block_lse.transpose(0, 1).unsqueeze(-1).to(torch.float32)
+    if out is None or lse is None:
+        return block_out, block_lse
+
+    out = out - torch.sigmoid(block_lse - lse) * (out - block_out)
+    lse = lse - torch.nn.functional.logsigmoid(lse - block_lse)
+    return out, lse
+
+
+def ring_flash_attn_varlen_with_replicated_prefix_func(
+    prefix_query: torch.Tensor,
+    prefix_key: torch.Tensor,
+    prefix_value: torch.Tensor,
+    suffix_query: torch.Tensor,
+    suffix_key: torch.Tensor,
+    suffix_value: torch.Tensor,
+    *,
+    prefix_lens: list[int],
+    suffix_lens_by_rank: list[list[int]],
+    rank: int | None = None,
+    dropout_p: float = 0.0,
+    softmax_scale: float | None = None,
+    causal: bool = False,
+    group: dist.ProcessGroup | None = None,
+    return_attn_probs: bool = False,
+    varlen_plan: dict[str, Any] | None = None,
+) -> tuple[torch.Tensor, torch.Tensor] | tuple[tuple[torch.Tensor, torch.Tensor], torch.Tensor, None]:
+    """Ring varlen attention for flat requests with a replicated prefix.
+
+    Query tokens are packed per request as ``[prefix, local suffix]``.  K/V
+    suffix shards rotate around the ring; the replicated prefix K/V is visible
+    only on the local step, matching the dense Ring joint-prefix path.
+    """
+    if dropout_p != 0.0:
+        raise ValueError("Ring varlen attention is inference-only and requires dropout_p=0.")
+    if softmax_scale is None:
+        softmax_scale = prefix_query.shape[-1] ** (-0.5)
+
+    world_size = dist.get_world_size(group)
+    if rank is None:
+        rank = dist.get_rank(group)
+
+    if varlen_plan is None:
+        varlen_plan = ring_flash_attn_varlen_replicated_prefix_plan(
+            prefix_lens=prefix_lens,
+            suffix_lens_by_rank=suffix_lens_by_rank,
+            rank=rank,
+            device=prefix_query.device,
+        )
+    source_query = torch.cat([prefix_query, suffix_query], dim=0)
+    q_gather_idx = varlen_plan["q_gather_idx"]
+    q_restore_idx = varlen_plan["q_restore_idx"]
+    query = source_query.index_select(0, q_gather_idx)
+    q_cu_seqlens = varlen_plan["q_cu_seqlens"]
+    max_q_len = int(varlen_plan["max_q_len"])
+
+    if world_size == 1:
+        source_key = torch.cat([prefix_key, suffix_key], dim=0)
+        source_value = torch.cat([prefix_value, suffix_value], dim=0)
+        key = source_key.index_select(0, q_gather_idx)
+        value = source_value.index_select(0, q_gather_idx)
+        joint_out, joint_lse = _flash_varlen_with_lse(
+            query,
+            key,
+            value,
+            q_cu_seqlens=q_cu_seqlens,
+            kv_cu_seqlens=q_cu_seqlens,
+            max_q_len=max_q_len,
+            max_kv_len=max_q_len,
+            softmax_scale=softmax_scale,
+            causal=causal,
+        )
+        source_out = joint_out.index_select(0, q_restore_idx)
+        prefix_len = int(prefix_query.shape[0])
+        output = (source_out[:prefix_len], source_out[prefix_len:])
+        return output if not return_attn_probs else (output, joint_lse, None)
+
+    comm = RingComm(group)
+    current_owner = rank
+    current_key = suffix_key.contiguous()
+    current_value = suffix_value.contiguous()
+    out: torch.Tensor | None = None
+    lse: torch.Tensor | None = None
+
+    for step in range(world_size):
+        if step + 1 != world_size:
+            recv_owner = (current_owner - 1) % world_size
+            recv_len = sum(suffix_lens_by_rank[recv_owner])
+            next_key = current_key.new_empty((recv_len, *current_key.shape[1:]))
+            next_value = current_value.new_empty((recv_len, *current_value.shape[1:]))
+            next_key = comm.send_recv(current_key, recv_tensor=next_key)
+            next_value = comm.send_recv(current_value, recv_tensor=next_value)
+            comm.commit()
+
+        if step == 0:
+            source_key = torch.cat([prefix_key, current_key], dim=0)
+            source_value = torch.cat([prefix_value, current_value], dim=0)
+            key = source_key.index_select(0, q_gather_idx)
+            value = source_value.index_select(0, q_gather_idx)
+        else:
+            key = current_key
+            value = current_value
+
+        kv_cu_seqlens = varlen_plan["kv_cu_seqlens_by_owner"][current_owner]
+        max_kv_len = int(varlen_plan["max_kv_len_by_owner"][current_owner])
+        block_out, block_lse = _flash_varlen_with_lse(
+            query,
+            key,
+            value,
+            q_cu_seqlens=q_cu_seqlens,
+            kv_cu_seqlens=kv_cu_seqlens,
+            max_q_len=max_q_len,
+            max_kv_len=max_kv_len,
+            softmax_scale=softmax_scale,
+            causal=causal and step == 0,
+        )
+        out, lse = _update_flat_varlen_out_and_lse(out, lse, block_out, block_lse)
+
+        if step + 1 != world_size:
+            comm.wait()
+            current_key = next_key
+            current_value = next_value
+            current_owner = (current_owner - 1) % world_size
+
+    if out is None or lse is None:
+        raise RuntimeError("Ring varlen attention produced no output.")
+
+    source_out = out.to(query.dtype).index_select(0, q_restore_idx)
+    prefix_len = int(prefix_query.shape[0])
+    output = (source_out[:prefix_len], source_out[prefix_len:])
+    softmax_lse = lse.squeeze(-1).transpose(0, 1)
+    return output if not return_attn_probs else (output, softmax_lse, None)
 
 
 class RingFlashAttnFunc(torch.autograd.Function):

--- a/vllm_omni/diffusion/attention/builder.py
+++ b/vllm_omni/diffusion/attention/builder.py
@@ -1,0 +1,370 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen-Image attention metadata builders.
+
+This module keeps Qwen-Image's step-local layout construction out of the
+transformer forward path. ``InputBatch`` owns the packed image tokens for the
+current denoise step; this builder derives the varlen joint-attention contract
+that attention layers consume.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from vllm_omni.diffusion.attention.backends.abstract import (
+    AttentionMetadata,
+    AttentionSegment,
+)
+from vllm_omni.diffusion.attention.backends.ring_flash_attn import (
+    ring_flash_attn_varlen_replicated_prefix_plan,
+)
+from vllm_omni.diffusion.worker.input_batch import InputBatch
+
+
+def qwen_image_token_to_req(lengths: list[int], device: torch.device) -> torch.Tensor:
+    return torch.repeat_interleave(
+        torch.arange(len(lengths), dtype=torch.long, device=device),
+        torch.tensor(lengths, dtype=torch.long, device=device),
+    )
+
+
+def qwen_image_packed_indices(
+    image_lens: list[int],
+    text_lens: list[int],
+    device: torch.device,
+) -> dict[str, torch.Tensor]:
+    total_text = sum(text_lens)
+    text_offset = 0
+    image_offset = 0
+    joint_offset = 0
+    gather_indices: list[torch.Tensor] = []
+    text_indices: list[torch.Tensor] = []
+    image_indices: list[torch.Tensor] = []
+    for text_len, image_len in zip(text_lens, image_lens, strict=True):
+        gather_indices.append(torch.arange(text_offset, text_offset + text_len, dtype=torch.long, device=device))
+        gather_indices.append(
+            torch.arange(
+                total_text + image_offset,
+                total_text + image_offset + image_len,
+                dtype=torch.long,
+                device=device,
+            )
+        )
+        text_indices.append(torch.arange(joint_offset, joint_offset + text_len, dtype=torch.long, device=device))
+        image_indices.append(
+            torch.arange(
+                joint_offset + text_len,
+                joint_offset + text_len + image_len,
+                dtype=torch.long,
+                device=device,
+            )
+        )
+        text_offset += text_len
+        image_offset += image_len
+        joint_offset += text_len + image_len
+
+    return {
+        "image_token_to_req": qwen_image_token_to_req(image_lens, device),
+        "text_token_to_req": qwen_image_token_to_req(text_lens, device),
+        "joint_gather_idx": torch.cat(gather_indices, dim=0),
+        "joint_text_idx": torch.cat(text_indices, dim=0),
+        "joint_image_idx": torch.cat(image_indices, dim=0),
+    }
+
+
+def qwen_image_balanced_ranges(total_len: int, parts: int) -> list[tuple[int, int]]:
+    base, remainder = divmod(int(total_len), int(parts))
+    ranges: list[tuple[int, int]] = []
+    start = 0
+    for rank in range(parts):
+        length = base + (1 if rank < remainder else 0)
+        end = start + length
+        ranges.append((start, end))
+        start = end
+    return ranges
+
+
+def qwen_image_rank_local_indices(
+    lengths: list[int],
+    *,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, list[int]]:
+    pieces: list[torch.Tensor] = []
+    local_lens: list[int] = []
+    offset = 0
+    for length in lengths:
+        ranges = qwen_image_balanced_ranges(int(length), world_size)
+        start, end = ranges[rank]
+        local_lens.append(end - start)
+        if end > start:
+            pieces.append(torch.arange(offset + start, offset + end, dtype=torch.long, device=device))
+        offset += int(length)
+    if not pieces:
+        return torch.empty(0, dtype=torch.long, device=device), local_lens
+    return torch.cat(pieces, dim=0), local_lens
+
+
+def qwen_image_cu_seqlens(lengths: list[int], device: torch.device) -> tuple[torch.Tensor, int]:
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(lengths, dtype=torch.int32).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device=device,
+    )
+    return cu_seqlens, max(lengths) if lengths else 0
+
+
+def qwen_image_sp_replicated_text_source_order_indices(
+    *,
+    text_lens: list[int],
+    image_lens: list[int],
+    world_size: int,
+    joint_gather_idx: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    total_text = sum(text_lens)
+    total_image = sum(image_lens)
+    image_source_pieces: list[torch.Tensor] = []
+    for rank in range(world_size):
+        image_indices, _ = qwen_image_rank_local_indices(
+            image_lens,
+            rank=rank,
+            world_size=world_size,
+            device=device,
+        )
+        image_source_pieces.append(image_indices)
+
+    image_source_order = torch.cat(image_source_pieces, dim=0)
+    source_order = torch.cat(
+        [
+            torch.arange(total_text, dtype=torch.long, device=device),
+            total_text + image_source_order,
+        ],
+        dim=0,
+    )
+    concat_to_source = torch.empty(total_text + total_image, dtype=torch.long, device=device)
+    concat_to_source.scatter_(0, source_order, torch.arange(source_order.numel(), dtype=torch.long, device=device))
+    source_to_joint = concat_to_source.index_select(0, joint_gather_idx)
+    joint_to_source = torch.empty_like(source_to_joint)
+    joint_to_source.scatter_(0, source_to_joint, torch.arange(source_to_joint.numel(), dtype=torch.long, device=device))
+
+    image_packed_to_source = torch.empty(total_image, dtype=torch.long, device=device)
+    image_packed_to_source.scatter_(
+        0,
+        image_source_order,
+        torch.arange(image_source_order.numel(), dtype=torch.long, device=device),
+    )
+    return source_to_joint, joint_to_source, image_packed_to_source
+
+
+class QwenImageJointMetadataBuilder:
+    """Build Qwen-Image packed joint-attention metadata from ``InputBatch``."""
+
+    def __init__(self, transformer: Any | None = None, parallel_config: Any | None = None) -> None:
+        self.transformer = transformer
+        self.parallel_config = parallel_config
+
+    def build(self, input_batch: InputBatch, *, branch: str) -> AttentionMetadata:
+        device, image_lens = self._image_lens(input_batch)
+        row_requests = self._row_requests(input_batch)
+        text_lens = self._text_lens(input_batch, branch=branch, row_count=len(row_requests))
+
+        lengths: list[int] = []
+        segments: list[AttentionSegment] = []
+        offset = 0
+        for (request_id, request_index, row_in_request), text_len, image_len in zip(
+            row_requests, text_lens, image_lens, strict=True
+        ):
+            text_len = int(text_len)
+            image_len = int(image_len)
+            position_suffix = f"{request_id}:{row_in_request}"
+            if text_len:
+                segments.append(
+                    AttentionSegment(
+                        request_id=request_id,
+                        request_index=request_index,
+                        branch=branch,
+                        role="text" if branch == "positive" else "negative_text",
+                        packed_start=offset,
+                        length=text_len,
+                        request_start=0,
+                        position_id=f"{position_suffix}:{branch}:text",
+                    )
+                )
+            if image_len:
+                segments.append(
+                    AttentionSegment(
+                        request_id=request_id,
+                        request_index=request_index,
+                        branch=branch,
+                        role="image",
+                        packed_start=offset + text_len,
+                        length=image_len,
+                        request_start=0,
+                        position_id=f"{position_suffix}:{branch}:image",
+                    )
+                )
+            total_len = text_len + image_len
+            lengths.append(total_len)
+            offset += total_len
+
+        cu_seqlens, max_len = qwen_image_cu_seqlens(lengths, device)
+        packed_indices = qwen_image_packed_indices(image_lens, text_lens, device)
+        extra: dict[str, Any] = {
+            "attention_id": f"qwen_image.joint.{branch}",
+            "qwen_image_dynamic": input_batch.is_dynamic,
+            "request_ids": tuple(input_batch.request_ids),
+            "lengths": tuple(lengths),
+            "num_rows": len(row_requests),
+            "image_lens": image_lens,
+            "text_lens": text_lens,
+            "token_to_req": packed_indices["image_token_to_req"],
+            **packed_indices,
+        }
+        extra.update(self._sequence_parallel_plan(image_lens, text_lens, packed_indices, device))
+
+        return AttentionMetadata(
+            q_cu_seqlens=cu_seqlens,
+            kv_cu_seqlens=cu_seqlens,
+            max_q_len=max_len,
+            max_kv_len=max_len,
+            q_segments=segments,
+            kv_segments=segments,
+            position=self._rope_plan(input_batch, text_lens=text_lens, branch=branch),
+            padded_tokens=0,
+            extra=extra,
+        )
+
+    def _image_lens(self, input_batch: InputBatch) -> tuple[torch.device, list[int]]:
+        if input_batch.packed_latents is not None:
+            return input_batch.packed_latents.device, [int(value) for value in input_batch.img_seq_lens]
+        return input_batch.latents.device, [int(input_batch.latents.shape[1])] * int(input_batch.latents.shape[0])
+
+    @staticmethod
+    def _row_requests(input_batch: InputBatch) -> list[tuple[str, int, int]]:
+        row_requests: list[tuple[str, int, int]] = []
+        for span in input_batch.request_spans:
+            for row_in_request in range(span.row_count):
+                row_requests.append((span.request_id, span.request_index, row_in_request))
+        return row_requests
+
+    @staticmethod
+    def _text_lens(input_batch: InputBatch, *, branch: str, row_count: int) -> list[int]:
+        if branch == "negative":
+            text_lens = input_batch.negative_txt_seq_lens
+            embeds = input_batch.negative_prompt_embeds
+        else:
+            text_lens = input_batch.txt_seq_lens
+            embeds = input_batch.prompt_embeds
+
+        if text_lens is None:
+            text_lens = [int(embeds.shape[1])] * row_count
+        elif len(text_lens) == input_batch.num_reqs and row_count != input_batch.num_reqs:
+            text_lens = [
+                int(text_lens[span.request_index]) for span in input_batch.request_spans for _ in range(span.row_count)
+            ]
+        return [int(value) for value in text_lens]
+
+    def _rope_plan(
+        self,
+        input_batch: InputBatch,
+        *,
+        text_lens: list[int],
+        branch: str,
+    ) -> dict[str, Any]:
+        """Per-request RoPE layout; the transformer recomputes the frequencies."""
+        return {
+            "kind": "qwen_image_rope_plan",
+            "branch": branch,
+            "img_shapes": input_batch.img_shapes,
+            "txt_seq_lens": text_lens,
+        }
+
+    def _sp_context(self) -> tuple[str, dist.ProcessGroup, int, int] | None:
+        parallel_config = self.parallel_config
+        if parallel_config is None:
+            return None
+        sp_size = int(getattr(parallel_config, "sequence_parallel_size", 1) or 1)
+        if sp_size <= 1:
+            return None
+        ulysses_degree = int(getattr(parallel_config, "ulysses_degree", 1) or 1)
+        ring_degree = int(getattr(parallel_config, "ring_degree", 1) or 1)
+        if ulysses_degree > 1 and ring_degree > 1:
+            raise ValueError("Qwen-Image packed dynamic batching does not support hybrid Ulysses+Ring SP yet.")
+
+        from vllm_omni.diffusion.distributed.parallel_state import get_sp_group
+
+        sp_group = get_sp_group()
+        if ring_degree > 1:
+            return "ring", sp_group.ring_group, int(sp_group.ring_world_size), int(sp_group.ring_rank)
+        return "ulysses", sp_group.ulysses_group, int(sp_group.ulysses_world_size), int(sp_group.ulysses_rank)
+
+    def _sequence_parallel_plan(
+        self,
+        image_lens: list[int],
+        text_lens: list[int],
+        packed_indices: dict[str, torch.Tensor],
+        device: torch.device,
+    ) -> dict[str, Any]:
+        sp_context = self._sp_context()
+        if sp_context is None:
+            return {}
+        sp_mode, sp_group, sp_world_size, sp_rank = sp_context
+        image_local_idx, image_local_lens = qwen_image_rank_local_indices(
+            image_lens,
+            rank=sp_rank,
+            world_size=sp_world_size,
+            device=device,
+        )
+        source_to_joint_idx, joint_to_source_idx, image_packed_to_source_idx = (
+            qwen_image_sp_replicated_text_source_order_indices(
+                text_lens=text_lens,
+                image_lens=image_lens,
+                world_size=sp_world_size,
+                joint_gather_idx=packed_indices["joint_gather_idx"],
+                device=device,
+            )
+        )
+        image_lens_by_rank = [
+            qwen_image_rank_local_indices(
+                image_lens,
+                rank=rank,
+                world_size=sp_world_size,
+                device=device,
+            )[1]
+            for rank in range(sp_world_size)
+        ]
+        return {
+            "image_token_to_req": qwen_image_token_to_req(image_local_lens, device),
+            "text_token_to_req": qwen_image_token_to_req(text_lens, device),
+            "sp_group": sp_group,
+            "sp_source_to_joint_idx": source_to_joint_idx,
+            "sp_joint_to_source_idx": joint_to_source_idx,
+            "sp_image_packed_to_source_idx": image_packed_to_source_idx,
+            "sp_image_local_idx": image_local_idx,
+            "sp_mode": sp_mode,
+            "sp_rank": sp_rank,
+            "sp_replicated_text": True,
+            "sp_local_text_len": sum(text_lens),
+            "sp_local_image_len": int(image_local_idx.numel()),
+            "sp_image_lens": image_local_lens,
+            "sp_image_lens_by_rank": image_lens_by_rank,
+            "sp_text_lens": text_lens,
+            "sp_ring_varlen_plan": (
+                ring_flash_attn_varlen_replicated_prefix_plan(
+                    prefix_lens=text_lens,
+                    suffix_lens_by_rank=image_lens_by_rank,
+                    rank=sp_rank,
+                    device=device,
+                )
+                if sp_mode == "ring"
+                else None
+            ),
+            "image_lens": None,
+            "text_lens": None,
+        }

--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -242,6 +242,8 @@ class Attention(nn.Module):
         attn_metadata = self._with_kv_cache_dtype(attn_metadata)
 
         # 2. Kernel Execution (Computation)
+        if attn_metadata is not None and attn_metadata.is_varlen and self.use_ring:
+            raise ValueError("Dynamic varlen diffusion attention does not support ring attention yet.")
         if self.use_ring and strategy is not self._no_parallel_strategy:
             out = self._run_ring_attention(query, key, value, attn_metadata)
         else:
@@ -255,6 +257,10 @@ class Attention(nn.Module):
 
     def _run_local_attention(self, query, key, value, attn_metadata):
         if query.dtype == torch.float32:
+            if attn_metadata is not None and attn_metadata.is_varlen:
+                raise ValueError(
+                    "Dynamic varlen diffusion attention requires FlashAttention, not SDPA float32 fallback."
+                )
             logger.warning_once(
                 f"Only SDPA supports float32. Overriding user config {type(self.attention)} "
                 f"attention_backend='{self.backend_pref}' to 'sdpa' for dtype={query.dtype}."

--- a/vllm_omni/diffusion/attention/parallel/ulysses.py
+++ b/vllm_omni/diffusion/attention/parallel/ulysses.py
@@ -146,6 +146,185 @@ def _ulysses_all_to_all_any_o(
     return out
 
 
+def ulysses_flat_varlen_attention(
+    pg: dist.ProcessGroup,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_metadata: AttentionMetadata,
+    *,
+    source_to_joint_idx: torch.Tensor,
+    joint_to_source_idx: torch.Tensor,
+    local_seq_len: int,
+    attention_fn,
+    use_sync: bool = False,
+) -> torch.Tensor:
+    """Run Ulysses all-to-all for flat packed varlen attention.
+
+    Input/output sequence order is caller-defined "source" order for this rank.
+    The helper reshards local source-order tokens to global source-order tokens
+    with local heads, reorders to varlen joint order for FlashAttention, then
+    restores local source order after the reverse all-to-all.
+    """
+    world_size = dist.get_world_size(pg)
+    if world_size == 1:
+        joint_query = query.index_select(0, source_to_joint_idx)
+        joint_key = key.index_select(0, source_to_joint_idx)
+        joint_value = value.index_select(0, source_to_joint_idx)
+        joint_out = attention_fn(joint_query, joint_key, joint_value, attn_metadata)
+        return joint_out.index_select(0, joint_to_source_idx)
+
+    if query.ndim != 3 or key.ndim != 3 or value.ndim != 3:
+        raise ValueError("Flat Ulysses varlen attention expects [local_tokens, heads, head_dim] Q/K/V.")
+    if attn_metadata.padded_tokens != 0:
+        raise ValueError("Flat Ulysses varlen attention expects padding-free metadata.")
+
+    seq_lens = _all_gather_int(pg, int(local_seq_len), device=query.device)
+    query_4d = query.unsqueeze(0)
+    key_4d = key.unsqueeze(0)
+    value_4d = value.unsqueeze(0)
+
+    query_4d, orig_head_cnt = _ulysses_all_to_all_any_qkv(
+        pg,
+        query_4d,
+        seq_lens=seq_lens,
+        use_sync=use_sync,
+    )
+    key_4d, _ = _ulysses_all_to_all_any_qkv(
+        pg,
+        key_4d,
+        seq_lens=seq_lens,
+        use_sync=use_sync,
+    )
+    value_4d, _ = _ulysses_all_to_all_any_qkv(
+        pg,
+        value_4d,
+        seq_lens=seq_lens,
+        use_sync=use_sync,
+    )
+
+    query = query_4d.squeeze(0).index_select(0, source_to_joint_idx)
+    key = key_4d.squeeze(0).index_select(0, source_to_joint_idx)
+    value = value_4d.squeeze(0).index_select(0, source_to_joint_idx)
+    joint_out = attention_fn(query, key, value, attn_metadata)
+
+    source_out = joint_out.index_select(0, joint_to_source_idx).unsqueeze(0)
+    local_out = _ulysses_all_to_all_any_o(
+        pg,
+        source_out,
+        seq_lens=seq_lens,
+        local_seq_len=int(local_seq_len),
+        orig_head_cnt=orig_head_cnt,
+        use_sync=use_sync,
+    )
+    return local_out.squeeze(0)
+
+
+def ulysses_flat_varlen_attention_with_replicated_prefix(
+    pg: dist.ProcessGroup,
+    prefix_query: torch.Tensor,
+    prefix_key: torch.Tensor,
+    prefix_value: torch.Tensor,
+    suffix_query: torch.Tensor,
+    suffix_key: torch.Tensor,
+    suffix_value: torch.Tensor,
+    attn_metadata: AttentionMetadata,
+    *,
+    source_to_joint_idx: torch.Tensor,
+    joint_to_source_idx: torch.Tensor,
+    local_suffix_len: int,
+    attention_fn,
+    use_sync: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run flat varlen Ulysses with replicated prefix tokens.
+
+    The prefix stream is present on every rank and is sharded only by heads.
+    The suffix stream is sequence-sharded and uses Ulysses all-to-all. This
+    matches the dense dual-stream Qwen-Image SP path, where text is replicated
+    and image tokens are sequence-sharded.
+    """
+    world_size = dist.get_world_size(pg)
+    if world_size == 1:
+        query = torch.cat([prefix_query, suffix_query], dim=0)
+        key = torch.cat([prefix_key, suffix_key], dim=0)
+        value = torch.cat([prefix_value, suffix_value], dim=0)
+        joint_query = query.index_select(0, source_to_joint_idx)
+        joint_key = key.index_select(0, source_to_joint_idx)
+        joint_value = value.index_select(0, source_to_joint_idx)
+        source_out = attention_fn(joint_query, joint_key, joint_value, attn_metadata).index_select(
+            0, joint_to_source_idx
+        )
+        prefix_len = int(prefix_query.shape[0])
+        return source_out[:prefix_len], source_out[prefix_len:]
+
+    tensors = (prefix_query, prefix_key, prefix_value, suffix_query, suffix_key, suffix_value)
+    if any(tensor.ndim != 3 for tensor in tensors):
+        raise ValueError("Flat replicated-prefix Ulysses expects [tokens, heads, head_dim] Q/K/V.")
+    if attn_metadata.padded_tokens != 0:
+        raise ValueError("Flat replicated-prefix Ulysses expects padding-free metadata.")
+
+    seq_lens = _all_gather_int(pg, int(local_suffix_len), device=suffix_query.device)
+    suffix_query_4d, orig_head_cnt = _ulysses_all_to_all_any_qkv(
+        pg,
+        suffix_query.unsqueeze(0),
+        seq_lens=seq_lens,
+        use_sync=use_sync,
+    )
+    suffix_key_4d, _ = _ulysses_all_to_all_any_qkv(
+        pg,
+        suffix_key.unsqueeze(0),
+        seq_lens=seq_lens,
+        use_sync=use_sync,
+    )
+    suffix_value_4d, _ = _ulysses_all_to_all_any_qkv(
+        pg,
+        suffix_value.unsqueeze(0),
+        seq_lens=seq_lens,
+        use_sync=use_sync,
+    )
+
+    def _slice_prefix_heads(x: torch.Tensor) -> torch.Tensor:
+        head_cnt = int(x.shape[-2])
+        padded_head_cnt = _ceil_div(head_cnt, world_size) * world_size
+        if padded_head_cnt != head_cnt:
+            x = F.pad(x, (0, 0, 0, padded_head_cnt - head_cnt))
+        heads_per_rank = padded_head_cnt // world_size
+        rank = dist.get_rank(pg)
+        return x[:, heads_per_rank * rank : heads_per_rank * (rank + 1), :].contiguous()
+
+    prefix_query = _slice_prefix_heads(prefix_query)
+    prefix_key = _slice_prefix_heads(prefix_key)
+    prefix_value = _slice_prefix_heads(prefix_value)
+
+    query = torch.cat([prefix_query, suffix_query_4d.squeeze(0)], dim=0)
+    key = torch.cat([prefix_key, suffix_key_4d.squeeze(0)], dim=0)
+    value = torch.cat([prefix_value, suffix_value_4d.squeeze(0)], dim=0)
+    joint_query = query.index_select(0, source_to_joint_idx)
+    joint_key = key.index_select(0, source_to_joint_idx)
+    joint_value = value.index_select(0, source_to_joint_idx)
+    joint_out = attention_fn(joint_query, joint_key, joint_value, attn_metadata)
+
+    source_out = joint_out.index_select(0, joint_to_source_idx)
+    prefix_len = int(prefix_query.shape[0])
+    prefix_out = source_out[:prefix_len].contiguous()
+    suffix_out = source_out[prefix_len:].unsqueeze(0)
+    suffix_out = _ulysses_all_to_all_any_o(
+        pg,
+        suffix_out,
+        seq_lens=seq_lens,
+        local_seq_len=int(local_suffix_len),
+        orig_head_cnt=orig_head_cnt,
+        use_sync=use_sync,
+    ).squeeze(0)
+
+    gathered_prefix = [torch.zeros_like(prefix_out) for _ in range(world_size)]
+    dist.all_gather(gathered_prefix, prefix_out, group=pg)
+    prefix_out = torch.cat(gathered_prefix, dim=1)
+    if prefix_out.shape[1] != orig_head_cnt:
+        prefix_out = prefix_out[:, :orig_head_cnt, :].contiguous()
+    return prefix_out, suffix_out
+
+
 @dataclass(frozen=True, slots=True)
 class _UlyssesCtx(ParallelAttentionContext):
     """Per-forward context for Ulysses sequence-parallel attention."""

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -891,6 +891,181 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
             stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
         )
 
+    def _build_dynamic_denoise_kwargs(
+        self,
+        input_batch: "InputBatch",
+        *,
+        branch: str,
+    ) -> dict[str, Any]:
+        if input_batch.packed_latents is None or input_batch.img_seq_lens is None:
+            raise ValueError("Dynamic Qwen-Image denoise requires packed latents.")
+
+        latents = input_batch.packed_latents
+        device = latents.device
+        dtype = latents.dtype
+        timestep = input_batch.timesteps.to(device=device, dtype=dtype).reshape(input_batch.num_reqs) / 1000
+        guidance = None if input_batch.guidance is None else input_batch.guidance.to(device=device, dtype=dtype)
+
+        if branch == "negative":
+            encoder_hidden_states = input_batch.negative_prompt_embeds
+            encoder_hidden_states_mask = input_batch.negative_prompt_embeds_mask
+            txt_seq_lens = input_batch.negative_txt_seq_lens
+        else:
+            encoder_hidden_states = input_batch.prompt_embeds
+            encoder_hidden_states_mask = input_batch.prompt_embeds_mask
+            txt_seq_lens = input_batch.txt_seq_lens
+
+        if encoder_hidden_states is None:
+            raise ValueError(f"Dynamic Qwen-Image {branch} branch is missing prompt embeddings.")
+
+        attention_kwargs = dict(self.attention_kwargs)
+        attention_kwargs["attention_id"] = f"qwen_image.joint.{branch}"
+
+        return {
+            "hidden_states": latents,
+            "timestep": timestep,
+            "guidance": guidance,
+            "encoder_hidden_states": encoder_hidden_states,
+            "encoder_hidden_states_mask": encoder_hidden_states_mask,
+            "img_shapes": input_batch.img_shapes,
+            "img_seq_lens": input_batch.img_seq_lens,
+            "txt_seq_lens": txt_seq_lens,
+            "attention_kwargs": attention_kwargs,
+            "return_dict": False,
+        }
+
+    @staticmethod
+    def _expect_dynamic_noise(
+        noise_pred: Any,
+        *,
+        branch: str,
+        img_seq_lens: list[int],
+    ) -> torch.Tensor:
+        if not torch.is_tensor(noise_pred):
+            raise ValueError(f"Dynamic Qwen-Image {branch} branch must return a tensor.")
+        if noise_pred.ndim != 2:
+            raise ValueError(f"Dynamic Qwen-Image {branch} branch must return packed tensor.")
+        return noise_pred
+
+    def combine_cfg(
+        self,
+        positive_noise_pred: torch.Tensor,
+        negative_noise_pred: torch.Tensor,
+        input_batch: "InputBatch",
+    ) -> torch.Tensor:
+        """Combine packed positive/negative noise with request-local CFG.
+
+        vLLM-style stage helper for the Qwen-Image packed dynamic path: reads
+        per-request ``img_seq_lens`` / ``true_cfg_scales`` / ``cfg_normalize_flags``
+        from ``input_batch`` and applies a request-local scale via ``token_to_req``.
+        Numerically identical to the historical ``_combine_dynamic_cfg``.
+        """
+        return self._combine_dynamic_cfg(
+            positive_noise_pred,
+            negative_noise_pred,
+            input_batch.img_seq_lens,
+            input_batch.true_cfg_scales,
+            input_batch.cfg_normalize_flags,
+        )
+
+    def _combine_dynamic_cfg(
+        self,
+        positive_noise_pred: torch.Tensor,
+        negative_noise_pred: torch.Tensor,
+        img_seq_lens: list[int],
+        true_cfg_scales: list[float],
+        cfg_normalize_flags: list[bool],
+    ) -> torch.Tensor:
+        if positive_noise_pred.shape != negative_noise_pred.shape:
+            raise ValueError("Dynamic Qwen-Image CFG branch outputs have different shapes.")
+        if len(true_cfg_scales) != len(img_seq_lens):
+            raise ValueError("Dynamic Qwen-Image CFG scales do not match request count.")
+
+        token_to_req = torch.repeat_interleave(
+            torch.arange(len(img_seq_lens), dtype=torch.long, device=positive_noise_pred.device),
+            torch.tensor(img_seq_lens, dtype=torch.long, device=positive_noise_pred.device),
+        )
+        scales = torch.tensor(true_cfg_scales, dtype=positive_noise_pred.dtype, device=positive_noise_pred.device)
+        noise_pred = negative_noise_pred + scales.index_select(0, token_to_req).unsqueeze(-1) * (
+            positive_noise_pred - negative_noise_pred
+        )
+        if not any(cfg_normalize_flags):
+            return noise_pred
+
+        positive_parts = torch.split(positive_noise_pred, img_seq_lens, dim=0)
+        noise_parts = torch.split(noise_pred, img_seq_lens, dim=0)
+        combined_parts = []
+        for positive, noise, normalize in zip(positive_parts, noise_parts, cfg_normalize_flags, strict=True):
+            if normalize:
+                noise = self.cfg_normalize_function(positive, noise)
+            combined_parts.append(noise)
+        return torch.cat(combined_parts, dim=0)
+
+    def _combine_dense_cfg(
+        self,
+        positive_noise_pred: torch.Tensor,
+        negative_noise_pred: torch.Tensor,
+        input_batch: "InputBatch",
+    ) -> torch.Tensor:
+        if positive_noise_pred.shape != negative_noise_pred.shape:
+            raise ValueError("Dense Qwen-Image CFG branch outputs have different shapes.")
+
+        row_to_req = torch.repeat_interleave(
+            torch.arange(input_batch.num_reqs, dtype=torch.long, device=positive_noise_pred.device),
+            torch.tensor(
+                [span.row_count for span in input_batch.request_spans],
+                dtype=torch.long,
+                device=positive_noise_pred.device,
+            ),
+        )
+        scales = torch.tensor(
+            input_batch.true_cfg_scales,
+            dtype=positive_noise_pred.dtype,
+            device=positive_noise_pred.device,
+        ).index_select(0, row_to_req)
+        noise_pred = negative_noise_pred + scales.reshape(-1, *([1] * (positive_noise_pred.ndim - 1))) * (
+            positive_noise_pred - negative_noise_pred
+        )
+        if not any(input_batch.cfg_normalize_flags):
+            return noise_pred
+
+        flags = torch.tensor(input_batch.cfg_normalize_flags, dtype=torch.bool, device=positive_noise_pred.device)
+        normalize_rows = flags.index_select(0, row_to_req)
+        if bool(normalize_rows.all()):
+            return self.cfg_normalize_function(positive_noise_pred, noise_pred)
+
+        normalized = self.cfg_normalize_function(positive_noise_pred, noise_pred)
+        return torch.where(normalize_rows.reshape(-1, *([1] * (noise_pred.ndim - 1))), normalized, noise_pred)
+
+    def _uses_ring_sp(self) -> bool:
+        parallel_config = getattr(self, "parallel_config", None)
+        return (
+            parallel_config is not None
+            and int(getattr(parallel_config, "sequence_parallel_size", 1) or 1) > 1
+            and int(getattr(parallel_config, "ring_degree", 1) or 1) > 1
+        )
+
+    def forward_branch(self, input_batch: "InputBatch", *, branch: str) -> torch.Tensor:
+        """Run one packed transformer branch (positive/negative) for a step.
+
+        vLLM-style stage helper (≈ ``model.forward``): builds the single packed
+        denoise kwargs for ``branch`` and returns the packed ``[num_img_tokens, C]``
+        noise. Attention metadata is threaded through the active forward context
+        (keyed by ``attention_id`` = ``qwen_image.joint.{branch}``).
+        """
+        return self._expect_dynamic_noise(
+            self.predict_noise(**self._build_dynamic_denoise_kwargs(input_batch, branch=branch)),
+            branch=branch,
+            img_seq_lens=input_batch.img_seq_lens,
+        )
+
+    def _denoise_step_dynamic_batch(self, input_batch: "InputBatch") -> torch.Tensor:
+        positive_noise_pred = self.forward_branch(input_batch, branch="positive")
+        if input_batch.do_true_cfg:
+            negative_noise_pred = self.forward_branch(input_batch, branch="negative")
+            return self.combine_cfg(positive_noise_pred, negative_noise_pred, input_batch)
+        return positive_noise_pred
+
     def denoise_step(
         self,
         input_batch: "InputBatch",
@@ -910,6 +1085,9 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         self._current_timestep = t
         self.transformer.do_true_cfg = input_batch.do_true_cfg
 
+        if input_batch.is_dynamic:
+            return self._denoise_step_dynamic_batch(input_batch)
+
         positive_kwargs, negative_kwargs, output_slice = self._build_denoise_kwargs(
             latents=input_batch.latents,
             timestep=t,
@@ -928,6 +1106,19 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
                 "return_dict": False,
             },
         )
+
+        has_mixed_request_cfg = (
+            input_batch.do_true_cfg
+            and negative_kwargs is not None
+            and (len(set(input_batch.true_cfg_scales)) > 1 or len(set(input_batch.cfg_normalize_flags)) > 1)
+        )
+        if has_mixed_request_cfg:
+            positive_noise_pred = self.predict_noise(**positive_kwargs)
+            negative_noise_pred = self.predict_noise(**negative_kwargs)
+            if output_slice is not None:
+                positive_noise_pred = positive_noise_pred[:, :output_slice]
+                negative_noise_pred = negative_noise_pred[:, :output_slice]
+            return self._combine_dense_cfg(positive_noise_pred, negative_noise_pred, input_batch)
 
         return self.predict_noise_maybe_with_cfg(
             input_batch.do_true_cfg,
@@ -971,7 +1162,20 @@ class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineP
         width = state.sampling.width or self.default_sample_size * self.vae_scale_factor
         output_type = kwargs.get("output_type", "pil")
 
-        return self._decode_latents(state.latents, height, width, output_type)
+        output = self._decode_latents(state.latents, height, width, output_type)
+        return output
+
+    def post_decode_batch(
+        self,
+        states: list["DiffusionRequestState"],
+        **kwargs: Any,
+    ) -> dict[str, DiffusionOutput]:
+        self._current_timestep = None
+
+        output_type = kwargs.get("output_type", "pil")
+        # Decode final VAE outputs one at a time so stepwise batching matches
+        # the serial decode kernel path exactly; denoising remains batched.
+        return {state.request_id: self.post_decode(state, output_type=output_type) for state in states}
 
     def forward(
         self,

--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -9,6 +9,7 @@ from math import prod
 from typing import TYPE_CHECKING, Any
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -33,7 +34,15 @@ if TYPE_CHECKING:
 from vllm_omni.diffusion.attention.backends.abstract import (
     AttentionMetadata,
 )
+from vllm_omni.diffusion.attention.backends.ring_flash_attn import (
+    ring_flash_attn_varlen_replicated_prefix_plan,
+    ring_flash_attn_varlen_with_replicated_prefix_func,
+)
 from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.attention.parallel.ulysses import (
+    ulysses_flat_varlen_attention,
+    ulysses_flat_varlen_attention_with_replicated_prefix,
+)
 from vllm_omni.diffusion.cache.base import CachedTransformer
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.hsdp_utils import is_transformer_block_module
@@ -41,7 +50,7 @@ from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelInput,
     SequenceParallelOutput,
 )
-from vllm_omni.diffusion.forward_context import get_forward_context
+from vllm_omni.diffusion.forward_context import get_forward_context, is_forward_context_available
 from vllm_omni.diffusion.layers.adalayernorm import AdaLayerNorm
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
 
@@ -50,6 +59,375 @@ logger = init_logger(__name__)
 
 def _join_prefix(prefix: str, suffix: str) -> str:
     return f"{prefix}.{suffix}" if prefix else suffix
+
+
+def _get_qwen_image_attention_metadata(attention_id: str | None) -> AttentionMetadata | None:
+    if attention_id is None or not is_forward_context_available():
+        return None
+    metadata = get_forward_context().attn_metadata
+    if isinstance(metadata, dict):
+        return metadata.get(attention_id)
+    return None
+
+
+def _qwen_image_token_to_req(lengths: list[int], device: torch.device) -> torch.Tensor:
+    return torch.repeat_interleave(
+        torch.arange(len(lengths), dtype=torch.long, device=device),
+        torch.tensor(lengths, dtype=torch.long, device=device),
+    )
+
+
+def _qwen_image_packed_indices(
+    image_lens: list[int],
+    text_lens: list[int],
+    device: torch.device,
+) -> dict[str, torch.Tensor]:
+    total_text = sum(text_lens)
+    text_offset = 0
+    image_offset = 0
+    joint_offset = 0
+    gather_indices: list[torch.Tensor] = []
+    text_indices: list[torch.Tensor] = []
+    image_indices: list[torch.Tensor] = []
+    for text_len, image_len in zip(text_lens, image_lens, strict=True):
+        gather_indices.append(torch.arange(text_offset, text_offset + text_len, dtype=torch.long, device=device))
+        gather_indices.append(
+            torch.arange(
+                total_text + image_offset,
+                total_text + image_offset + image_len,
+                dtype=torch.long,
+                device=device,
+            )
+        )
+        text_indices.append(torch.arange(joint_offset, joint_offset + text_len, dtype=torch.long, device=device))
+        image_indices.append(
+            torch.arange(
+                joint_offset + text_len,
+                joint_offset + text_len + image_len,
+                dtype=torch.long,
+                device=device,
+            )
+        )
+        text_offset += text_len
+        image_offset += image_len
+        joint_offset += text_len + image_len
+
+    return {
+        "image_token_to_req": _qwen_image_token_to_req(image_lens, device),
+        "text_token_to_req": _qwen_image_token_to_req(text_lens, device),
+        "joint_gather_idx": torch.cat(gather_indices, dim=0),
+        "joint_text_idx": torch.cat(text_indices, dim=0),
+        "joint_image_idx": torch.cat(image_indices, dim=0),
+    }
+
+
+def _qwen_image_sp_context() -> tuple[dist.ProcessGroup, int, int] | None:
+    if not is_forward_context_available():
+        return None
+    cfg = get_forward_context().omni_diffusion_config
+    if cfg is None:
+        return None
+    sp_size = int(getattr(cfg.parallel_config, "sequence_parallel_size", 1) or 1)
+    if sp_size <= 1:
+        return None
+    if int(getattr(cfg.parallel_config, "ring_degree", 1) or 1) != 1:
+        raise ValueError("Qwen-Image packed dynamic batching only supports pure Ulysses SP (ring_degree=1).")
+    from vllm_omni.diffusion.distributed.parallel_state import get_sp_group
+
+    sp_group = get_sp_group()
+    return sp_group.ulysses_group, int(sp_group.ulysses_world_size), int(sp_group.ulysses_rank)
+
+
+def _qwen_image_dynamic_sp_context() -> tuple[str, dist.ProcessGroup, int, int] | None:
+    if not is_forward_context_available():
+        return None
+    cfg = get_forward_context().omni_diffusion_config
+    if cfg is None:
+        return None
+    parallel_config = cfg.parallel_config
+    sp_size = int(getattr(parallel_config, "sequence_parallel_size", 1) or 1)
+    if sp_size <= 1:
+        return None
+    ulysses_degree = int(getattr(parallel_config, "ulysses_degree", 1) or 1)
+    ring_degree = int(getattr(parallel_config, "ring_degree", 1) or 1)
+    if ulysses_degree > 1 and ring_degree > 1:
+        raise ValueError("Qwen-Image packed dynamic batching does not support hybrid Ulysses+Ring SP yet.")
+
+    from vllm_omni.diffusion.distributed.parallel_state import get_sp_group
+
+    sp_group = get_sp_group()
+    if ring_degree > 1:
+        return "ring", sp_group.ring_group, int(sp_group.ring_world_size), int(sp_group.ring_rank)
+    return "ulysses", sp_group.ulysses_group, int(sp_group.ulysses_world_size), int(sp_group.ulysses_rank)
+
+
+def _qwen_image_balanced_ranges(total_len: int, parts: int) -> list[tuple[int, int]]:
+    base, remainder = divmod(int(total_len), int(parts))
+    ranges: list[tuple[int, int]] = []
+    start = 0
+    for rank in range(parts):
+        length = base + (1 if rank < remainder else 0)
+        end = start + length
+        ranges.append((start, end))
+        start = end
+    return ranges
+
+
+def _qwen_image_source_order_indices(
+    *,
+    total_text: int,
+    total_image: int,
+    text_ranges: list[tuple[int, int]],
+    image_ranges: list[tuple[int, int]],
+    joint_gather_idx: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    concat_to_source = torch.empty(total_text + total_image, dtype=torch.long, device=device)
+    source_offset = 0
+    for text_range, image_range in zip(text_ranges, image_ranges, strict=True):
+        text_start, text_end = text_range
+        text_len = text_end - text_start
+        if text_len:
+            concat_to_source[text_start:text_end] = torch.arange(
+                source_offset,
+                source_offset + text_len,
+                dtype=torch.long,
+                device=device,
+            )
+        source_offset += text_len
+
+        image_start, image_end = image_range
+        image_len = image_end - image_start
+        if image_len:
+            concat_start = total_text + image_start
+            concat_to_source[concat_start : concat_start + image_len] = torch.arange(
+                source_offset,
+                source_offset + image_len,
+                dtype=torch.long,
+                device=device,
+            )
+        source_offset += image_len
+
+    source_to_joint = concat_to_source.index_select(0, joint_gather_idx)
+    joint_to_source = torch.empty_like(source_to_joint)
+    joint_to_source.scatter_(0, source_to_joint, torch.arange(source_to_joint.numel(), dtype=torch.long, device=device))
+    return source_to_joint, joint_to_source
+
+
+def _qwen_image_rank_local_indices(
+    lengths: list[int],
+    *,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, list[int]]:
+    pieces: list[torch.Tensor] = []
+    local_lens: list[int] = []
+    offset = 0
+    for length in lengths:
+        ranges = _qwen_image_balanced_ranges(int(length), world_size)
+        start, end = ranges[rank]
+        local_lens.append(end - start)
+        if end > start:
+            pieces.append(torch.arange(offset + start, offset + end, dtype=torch.long, device=device))
+        offset += int(length)
+    if not pieces:
+        return torch.empty(0, dtype=torch.long, device=device), local_lens
+    return torch.cat(pieces, dim=0), local_lens
+
+
+def _qwen_image_cu_seqlens(lengths: list[int], device: torch.device) -> tuple[torch.Tensor, int]:
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(lengths, dtype=torch.int32).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device=device,
+    )
+    return cu_seqlens, max(lengths) if lengths else 0
+
+
+def _qwen_image_ring_flat_varlen_attention_with_replicated_prefix(
+    pg: dist.ProcessGroup,
+    prefix_query: torch.Tensor,
+    prefix_key: torch.Tensor,
+    prefix_value: torch.Tensor,
+    suffix_query: torch.Tensor,
+    suffix_key: torch.Tensor,
+    suffix_value: torch.Tensor,
+    *,
+    text_lens: list[int],
+    suffix_lens_by_rank: list[list[int]],
+    rank: int,
+    softmax_scale: float | None,
+    varlen_plan: dict[str, Any] | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return ring_flash_attn_varlen_with_replicated_prefix_func(
+        prefix_query,
+        prefix_key,
+        prefix_value,
+        suffix_query,
+        suffix_key,
+        suffix_value,
+        prefix_lens=text_lens,
+        suffix_lens_by_rank=suffix_lens_by_rank,
+        rank=rank,
+        softmax_scale=softmax_scale,
+        causal=False,
+        group=pg,
+        varlen_plan=varlen_plan,
+    )
+
+
+def _qwen_image_sp_source_order_indices(
+    *,
+    text_lens: list[int],
+    image_lens: list[int],
+    world_size: int,
+    joint_gather_idx: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    total_text = sum(text_lens)
+    total_image = sum(image_lens)
+    source_pieces: list[torch.Tensor] = []
+    image_source_pieces: list[torch.Tensor] = []
+    for rank in range(world_size):
+        text_indices, _ = _qwen_image_rank_local_indices(
+            text_lens,
+            rank=rank,
+            world_size=world_size,
+            device=device,
+        )
+        image_indices, _ = _qwen_image_rank_local_indices(
+            image_lens,
+            rank=rank,
+            world_size=world_size,
+            device=device,
+        )
+        source_pieces.append(text_indices)
+        source_pieces.append(total_text + image_indices)
+        image_source_pieces.append(image_indices)
+
+    source_order = torch.cat(source_pieces, dim=0)
+    concat_to_source = torch.empty(total_text + total_image, dtype=torch.long, device=device)
+    concat_to_source.scatter_(0, source_order, torch.arange(source_order.numel(), dtype=torch.long, device=device))
+    source_to_joint = concat_to_source.index_select(0, joint_gather_idx)
+    joint_to_source = torch.empty_like(source_to_joint)
+    joint_to_source.scatter_(0, source_to_joint, torch.arange(source_to_joint.numel(), dtype=torch.long, device=device))
+
+    image_source_order = torch.cat(image_source_pieces, dim=0)
+    image_packed_to_source = torch.empty(total_image, dtype=torch.long, device=device)
+    image_packed_to_source.scatter_(
+        0,
+        image_source_order,
+        torch.arange(image_source_order.numel(), dtype=torch.long, device=device),
+    )
+    return source_to_joint, joint_to_source, image_packed_to_source
+
+
+def _qwen_image_sp_replicated_text_source_order_indices(
+    *,
+    text_lens: list[int],
+    image_lens: list[int],
+    world_size: int,
+    joint_gather_idx: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    total_text = sum(text_lens)
+    total_image = sum(image_lens)
+    image_source_pieces: list[torch.Tensor] = []
+    for rank in range(world_size):
+        image_indices, _ = _qwen_image_rank_local_indices(
+            image_lens,
+            rank=rank,
+            world_size=world_size,
+            device=device,
+        )
+        image_source_pieces.append(image_indices)
+
+    image_source_order = torch.cat(image_source_pieces, dim=0)
+    source_order = torch.cat(
+        [
+            torch.arange(total_text, dtype=torch.long, device=device),
+            total_text + image_source_order,
+        ],
+        dim=0,
+    )
+    concat_to_source = torch.empty(total_text + total_image, dtype=torch.long, device=device)
+    concat_to_source.scatter_(0, source_order, torch.arange(source_order.numel(), dtype=torch.long, device=device))
+    source_to_joint = concat_to_source.index_select(0, joint_gather_idx)
+    joint_to_source = torch.empty_like(source_to_joint)
+    joint_to_source.scatter_(0, source_to_joint, torch.arange(source_to_joint.numel(), dtype=torch.long, device=device))
+
+    image_packed_to_source = torch.empty(total_image, dtype=torch.long, device=device)
+    image_packed_to_source.scatter_(
+        0,
+        image_source_order,
+        torch.arange(image_source_order.numel(), dtype=torch.long, device=device),
+    )
+    return source_to_joint, joint_to_source, image_packed_to_source
+
+
+def _qwen_image_all_gather_varlen(x: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:
+    world_size = dist.get_world_size(group)
+    if world_size == 1:
+        return x
+
+    local_len = torch.tensor([int(x.shape[0])], dtype=torch.int64, device=x.device)
+    gathered_lens = [torch.empty_like(local_len) for _ in range(world_size)]
+    dist.all_gather(gathered_lens, local_len, group=group)
+    lengths = [int(length.item()) for length in gathered_lens]
+    max_len = max(lengths)
+
+    if int(x.shape[0]) < max_len:
+        pad_shape = (max_len - int(x.shape[0]), *x.shape[1:])
+        x = torch.cat([x, torch.zeros(pad_shape, dtype=x.dtype, device=x.device)], dim=0)
+
+    gathered = [torch.empty_like(x) for _ in range(world_size)]
+    dist.all_gather(gathered, x.contiguous(), group=group)
+    return torch.cat([part[:length] for part, length in zip(gathered, lengths, strict=True)], dim=0)
+
+
+def _qwen_image_unwrap_module_output(output: torch.Tensor | tuple[torch.Tensor, Any]) -> torch.Tensor:
+    return output[0] if isinstance(output, tuple) else output
+
+
+def _qwen_image_joint_cat(
+    text: torch.Tensor,
+    image: torch.Tensor,
+    text_lens: list[int],
+    image_lens: list[int],
+) -> torch.Tensor:
+    if len(text_lens) == 1:
+        return torch.cat([text, image], dim=0)
+
+    pieces: list[torch.Tensor] = []
+    text_offset = 0
+    image_offset = 0
+    for text_len, image_len in zip(text_lens, image_lens, strict=True):
+        pieces.append(text[text_offset : text_offset + text_len])
+        pieces.append(image[image_offset : image_offset + image_len])
+        text_offset += text_len
+        image_offset += image_len
+    return torch.cat(pieces, dim=0)
+
+
+def _qwen_image_split_joint(
+    joint: torch.Tensor,
+    text_lens: list[int],
+    image_lens: list[int],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if len(text_lens) == 1:
+        text_len = int(text_lens[0])
+        return joint[:text_len], joint[text_len:]
+
+    text_parts: list[torch.Tensor] = []
+    image_parts: list[torch.Tensor] = []
+    offset = 0
+    for text_len, image_len in zip(text_lens, image_lens, strict=True):
+        text_parts.append(joint[offset : offset + text_len])
+        offset += text_len
+        image_parts.append(joint[offset : offset + image_len])
+        offset += image_len
+    return torch.cat(text_parts, dim=0), torch.cat(image_parts, dim=0)
 
 
 class ImageRopePrepare(nn.Module):
@@ -172,9 +550,6 @@ class QwenTimestepProjEmbeddings(nn.Module):
 
         self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0, scale=1000)
         self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=embedding_dim)
-        # Time embedding MLP is kept full precision (quant_config=None) —
-        # small layers that feed per-block modulation; precision-sensitive
-        # (see #2728).
         self.timestep_embedder.linear_1 = ReplicatedLinear(
             256,
             embedding_dim,
@@ -640,11 +1015,17 @@ class QwenImageCrossAttention(nn.Module):
         joint_key = torch.cat([txt_key, img_key], dim=1)
         joint_value = torch.cat([txt_value, img_value], dim=1)
 
-        if (
-            self.parallel_config is not None
-            and self.parallel_config.sequence_parallel_size > 1
+        parallel_config = self.parallel_config
+        if parallel_config is None and is_forward_context_available():
+            diffusion_config = get_forward_context().omni_diffusion_config
+            parallel_config = None if diffusion_config is None else diffusion_config.parallel_config
+        use_dense_ring_sp = (
+            parallel_config is not None
+            and int(getattr(parallel_config, "sequence_parallel_size", 1) or 1) > 1
+            and int(getattr(parallel_config, "ring_degree", 1) or 1) > 1
             and not get_forward_context().split_text_embed_in_sp
-        ):
+        )
+        if use_dense_ring_sp:
             attn_metadata = AttentionMetadata(
                 joint_query=txt_query,
                 joint_key=txt_key,
@@ -658,33 +1039,103 @@ class QwenImageCrossAttention(nn.Module):
 
             joint_hidden_states = self.attn(img_query, img_key, img_value, attn_metadata)
         else:
-            attn_metadata = None
-            if hidden_states_mask is not None or encoder_hidden_states_mask is not None:
-                mask_list: list[torch.Tensor] = []
-                if encoder_hidden_states_mask is not None:
-                    mask_list.append(encoder_hidden_states_mask)
-                else:
-                    mask_list.append(
-                        torch.ones(
-                            encoder_hidden_states.shape[:2],
-                            dtype=torch.bool,
-                            device=encoder_hidden_states.device,
-                        )
+            sp_context = _qwen_image_sp_context()
+            if sp_context is not None and not get_forward_context().split_text_embed_in_sp:
+                if hidden_states_mask is None and encoder_hidden_states_mask is None:
+                    sp_group, sp_world_size, _ = sp_context
+                    batch_size = int(hidden_states.shape[0])
+                    image_len = int(hidden_states.shape[1]) * sp_world_size
+                    text_len = int(encoder_hidden_states.shape[1])
+                    image_lens = [image_len] * batch_size
+                    text_lens = [text_len] * batch_size
+                    flat_indices = _qwen_image_packed_indices(image_lens, text_lens, hidden_states.device)
+                    source_to_joint_idx, joint_to_source_idx, _ = _qwen_image_sp_replicated_text_source_order_indices(
+                        text_lens=text_lens,
+                        image_lens=image_lens,
+                        world_size=sp_world_size,
+                        joint_gather_idx=flat_indices["joint_gather_idx"],
+                        device=hidden_states.device,
                     )
-                if hidden_states_mask is not None:
-                    mask_list.append(hidden_states_mask)
-                else:
-                    mask_list.append(
-                        torch.ones(
-                            hidden_states.shape[:2],
-                            dtype=torch.bool,
-                            device=hidden_states.device,
-                        )
+                    joint_lens = [text_len + image_len] * batch_size
+                    cu_seqlens = torch.tensor(
+                        [0, *torch.tensor(joint_lens, dtype=torch.int32).cumsum(0).tolist()],
+                        dtype=torch.int32,
+                        device=hidden_states.device,
                     )
-                joint_mask = torch.cat(mask_list, dim=1) if len(mask_list) > 1 else mask_list[0]
-                attn_metadata = AttentionMetadata(attn_mask=joint_mask)
+                    attn_metadata = AttentionMetadata(
+                        q_cu_seqlens=cu_seqlens,
+                        kv_cu_seqlens=cu_seqlens,
+                        max_q_len=text_len + image_len,
+                        max_kv_len=text_len + image_len,
+                        padded_tokens=0,
+                    )
 
-            joint_hidden_states = self.attn(joint_query, joint_key, joint_value, attn_metadata)
+                    def _attention_fn(query, key, value, metadata):
+                        metadata = self.attn._with_kv_cache_dtype(metadata)
+                        return self.attn._run_local_attention(query, key, value, metadata)
+
+                    txt_hidden_states, img_hidden_states = ulysses_flat_varlen_attention_with_replicated_prefix(
+                        sp_group,
+                        txt_query.flatten(0, 1).contiguous(),
+                        txt_key.flatten(0, 1).contiguous(),
+                        txt_value.flatten(0, 1).contiguous(),
+                        img_query.flatten(0, 1).contiguous(),
+                        img_key.flatten(0, 1).contiguous(),
+                        img_value.flatten(0, 1).contiguous(),
+                        attn_metadata,
+                        source_to_joint_idx=source_to_joint_idx,
+                        joint_to_source_idx=joint_to_source_idx,
+                        local_suffix_len=int(img_query.shape[0] * img_query.shape[1]),
+                        attention_fn=_attention_fn,
+                    )
+                    joint_hidden_states = torch.cat(
+                        [
+                            txt_hidden_states.unflatten(0, (batch_size, text_len)),
+                            img_hidden_states.unflatten(0, (batch_size, int(hidden_states.shape[1]))),
+                        ],
+                        dim=1,
+                    )
+                else:
+                    attn_metadata = AttentionMetadata(
+                        joint_query=txt_query,
+                        joint_key=txt_key,
+                        joint_value=txt_value,
+                        joint_strategy="front",
+                    )
+                    if hidden_states_mask is not None:
+                        attn_metadata.attn_mask = hidden_states_mask
+                    if encoder_hidden_states_mask is not None:
+                        attn_metadata.joint_attn_mask = encoder_hidden_states_mask
+
+                    joint_hidden_states = self.attn(img_query, img_key, img_value, attn_metadata)
+            else:
+                attn_metadata = None
+                if hidden_states_mask is not None or encoder_hidden_states_mask is not None:
+                    mask_list: list[torch.Tensor] = []
+                    if encoder_hidden_states_mask is not None:
+                        mask_list.append(encoder_hidden_states_mask)
+                    else:
+                        mask_list.append(
+                            torch.ones(
+                                encoder_hidden_states.shape[:2],
+                                dtype=torch.bool,
+                                device=encoder_hidden_states.device,
+                            )
+                        )
+                    if hidden_states_mask is not None:
+                        mask_list.append(hidden_states_mask)
+                    else:
+                        mask_list.append(
+                            torch.ones(
+                                hidden_states.shape[:2],
+                                dtype=torch.bool,
+                                device=hidden_states.device,
+                            )
+                        )
+                    joint_mask = torch.cat(mask_list, dim=1) if len(mask_list) > 1 else mask_list[0]
+                    attn_metadata = AttentionMetadata(attn_mask=joint_mask)
+
+                joint_hidden_states = self.attn(joint_query, joint_key, joint_value, attn_metadata)
 
         joint_hidden_states = joint_hidden_states.flatten(2, 3).to(joint_query.dtype)
         txt_attn_output = joint_hidden_states[:, :seq_len_txt, :]
@@ -694,6 +1145,127 @@ class QwenImageCrossAttention(nn.Module):
         txt_attn_output = self.to_add_out(txt_attn_output)
 
         return img_attn_output, txt_attn_output
+
+    def forward_dynamic(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        vid_freqs: torch.Tensor,
+        txt_freqs: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        packed_indices: dict[str, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        q_size = self.query_num_heads * self.head_dim
+        kv_size = self.kv_num_heads * self.head_dim
+        add_q_size = self.add_query_num_heads * self.head_dim
+        add_kv_size = self.add_kv_num_heads * self.head_dim
+        sp_group = packed_indices.get("sp_group")
+
+        img_qkv = _qwen_image_unwrap_module_output(self.to_qkv(hidden_states))
+        img_query, img_key, img_value = img_qkv.split([q_size, kv_size, kv_size], dim=-1)
+
+        txt_qkv = _qwen_image_unwrap_module_output(self.add_kv_proj(encoder_hidden_states))
+        txt_query, txt_key, txt_value = txt_qkv.split([add_q_size, add_kv_size, add_kv_size], dim=-1)
+
+        img_query = img_query.unflatten(-1, (self.query_num_heads, self.head_dim))
+        img_key = img_key.unflatten(-1, (self.kv_num_heads, self.head_dim))
+        img_value = img_value.unflatten(-1, (self.kv_num_heads, self.head_dim))
+
+        txt_query = txt_query.unflatten(-1, (self.add_query_num_heads, self.head_dim))
+        txt_key = txt_key.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
+        txt_value = txt_value.unflatten(-1, (self.add_kv_num_heads, self.head_dim))
+
+        img_query = self.norm_q(img_query)
+        img_key = self.norm_k(img_key)
+        txt_query = self.norm_added_q(txt_query)
+        txt_key = self.norm_added_k(txt_key)
+
+        img_cos = vid_freqs.real.to(img_query.dtype)
+        img_sin = vid_freqs.imag.to(img_query.dtype)
+        txt_cos = txt_freqs.real.to(txt_query.dtype)
+        txt_sin = txt_freqs.imag.to(txt_query.dtype)
+
+        img_query = self.rope(img_query, img_cos, img_sin)
+        img_key = self.rope(img_key, img_cos, img_sin)
+        txt_query = self.rope(txt_query, txt_cos, txt_sin)
+        txt_key = self.rope(txt_key, txt_cos, txt_sin)
+
+        if sp_group is not None:
+            sp_mode = packed_indices.get("sp_mode", "ulysses")
+            if sp_mode == "ring":
+                txt_hidden_states, img_hidden_states = _qwen_image_ring_flat_varlen_attention_with_replicated_prefix(
+                    sp_group,
+                    txt_query,
+                    txt_key,
+                    txt_value,
+                    img_query,
+                    img_key,
+                    img_value,
+                    text_lens=packed_indices["sp_text_lens"],
+                    suffix_lens_by_rank=packed_indices["sp_image_lens_by_rank"],
+                    rank=int(packed_indices["sp_rank"]),
+                    softmax_scale=self.attn.softmax_scale,
+                    varlen_plan=packed_indices.get("sp_ring_varlen_plan"),
+                )
+                txt_attn_output = txt_hidden_states.flatten(1, 2).to(txt_query.dtype)
+                img_attn_output = img_hidden_states.flatten(1, 2).to(img_query.dtype)
+                return self.to_out(img_attn_output), self.to_add_out(txt_attn_output)
+
+            def _attention_fn(query, key, value, metadata):
+                metadata = self.attn._with_kv_cache_dtype(metadata)
+                return self.attn._run_local_attention(query, key, value, metadata)
+
+            if packed_indices.get("sp_replicated_text", False):
+                txt_hidden_states, img_hidden_states = ulysses_flat_varlen_attention_with_replicated_prefix(
+                    sp_group,
+                    txt_query,
+                    txt_key,
+                    txt_value,
+                    img_query,
+                    img_key,
+                    img_value,
+                    attn_metadata,
+                    source_to_joint_idx=packed_indices["sp_source_to_joint_idx"],
+                    joint_to_source_idx=packed_indices["sp_joint_to_source_idx"],
+                    local_suffix_len=int(img_query.shape[0]),
+                    attention_fn=_attention_fn,
+                    use_sync=bool(packed_indices.get("sp_use_sync", False)),
+                )
+                txt_attn_output = txt_hidden_states.flatten(1, 2).to(txt_query.dtype)
+                img_attn_output = img_hidden_states.flatten(1, 2).to(img_query.dtype)
+            else:
+                local_query = torch.cat([txt_query, img_query], dim=0).contiguous()
+                local_key = torch.cat([txt_key, img_key], dim=0).contiguous()
+                local_value = torch.cat([txt_value, img_value], dim=0).contiguous()
+                local_hidden_states = ulysses_flat_varlen_attention(
+                    sp_group,
+                    local_query,
+                    local_key,
+                    local_value,
+                    attn_metadata,
+                    source_to_joint_idx=packed_indices["sp_source_to_joint_idx"],
+                    joint_to_source_idx=packed_indices["sp_joint_to_source_idx"],
+                    local_seq_len=int(local_query.shape[0]),
+                    attention_fn=_attention_fn,
+                    use_sync=bool(packed_indices.get("sp_use_sync", False)),
+                )
+                local_hidden_states = local_hidden_states.flatten(1, 2).to(local_query.dtype)
+                text_len = int(packed_indices["sp_local_text_len"])
+                txt_attn_output = local_hidden_states[:text_len]
+                img_attn_output = local_hidden_states[text_len:]
+            return self.to_out(img_attn_output), self.to_add_out(txt_attn_output)
+
+        text_lens = packed_indices["text_lens"]
+        image_lens = packed_indices["image_lens"]
+        joint_query = _qwen_image_joint_cat(txt_query, img_query, text_lens, image_lens)
+        joint_key = _qwen_image_joint_cat(txt_key, img_key, text_lens, image_lens)
+        joint_value = _qwen_image_joint_cat(txt_value, img_value, text_lens, image_lens)
+
+        joint_hidden_states = self.attn(joint_query, joint_key, joint_value, attn_metadata)
+        joint_hidden_states = joint_hidden_states.flatten(1, 2).to(joint_query.dtype)
+
+        txt_attn_output, img_attn_output = _qwen_image_split_joint(joint_hidden_states, text_lens, image_lens)
+        return self.to_out(img_attn_output), self.to_add_out(txt_attn_output)
 
 
 class QwenImageTransformerBlock(nn.Module):
@@ -715,10 +1287,6 @@ class QwenImageTransformerBlock(nn.Module):
         self.attention_head_dim = attention_head_dim
 
         # Image processing modules.
-        # Modulation linear is kept unquantized (quant_config=None) — it
-        # produces shift/scale/gate values that are precision-sensitive
-        # (see #2728). Use column TP with gather_output=True so weights are
-        # sharded while downstream modulation still receives full [B, 6 * dim].
         self.img_mod = nn.Sequential(
             nn.SiLU(),
             ColumnParallelLinear(
@@ -810,6 +1378,20 @@ class QwenImageTransformerBlock(nn.Module):
 
         return scale_result, shift_result, gate_result
 
+    @staticmethod
+    def _modulate_packed(mod_params: torch.Tensor, token_to_req: torch.Tensor):
+        shift, scale, gate = mod_params.chunk(3, dim=-1)
+        return (
+            scale.index_select(0, token_to_req),
+            shift.index_select(0, token_to_req),
+            gate.index_select(0, token_to_req),
+        )
+
+    @staticmethod
+    def _modulate_shared(mod_params: torch.Tensor):
+        shift, scale, gate = mod_params.chunk(3, dim=-1)
+        return scale, shift, gate
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -878,6 +1460,65 @@ class QwenImageTransformerBlock(nn.Module):
         encoder_hidden_states = encoder_hidden_states + txt_gate2 * txt_mlp_output
 
         # Clip to prevent overflow for fp16
+        if encoder_hidden_states.dtype == torch.float16:
+            encoder_hidden_states = encoder_hidden_states.clip(-65504, 65504)
+        if hidden_states.dtype == torch.float16:
+            hidden_states = hidden_states.clip(-65504, 65504)
+
+        return encoder_hidden_states, hidden_states
+
+    def forward_dynamic(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        temb_silu: torch.Tensor,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor],
+        attn_metadata: AttentionMetadata,
+        packed_indices: dict[str, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.zero_cond_t:
+            raise ValueError("Qwen-Image dynamic step batching does not support zero_cond_t/edit blocks yet.")
+
+        image_token_to_req = packed_indices["image_token_to_req"]
+        text_token_to_req = packed_indices["text_token_to_req"]
+        shared_temb = bool(packed_indices.get("shared_temb", False))
+        img_mod1, img_mod2 = _qwen_image_unwrap_module_output(self.img_mod[1](temb_silu)).chunk(2, dim=-1)
+        txt_mod1, txt_mod2 = _qwen_image_unwrap_module_output(self.txt_mod[1](temb_silu)).chunk(2, dim=-1)
+        if shared_temb:
+            img_scale1, img_shift1, img_gate1 = self._modulate_shared(img_mod1)
+            txt_scale1, txt_shift1, txt_gate1 = self._modulate_shared(txt_mod1)
+        else:
+            img_scale1, img_shift1, img_gate1 = self._modulate_packed(img_mod1, image_token_to_req)
+            txt_scale1, txt_shift1, txt_gate1 = self._modulate_packed(txt_mod1, text_token_to_req)
+        img_modulated = self.img_norm1(hidden_states, img_scale1, img_shift1)
+        txt_modulated = self.txt_norm1(encoder_hidden_states, txt_scale1, txt_shift1)
+
+        img_attn_output, txt_attn_output = self.attn.forward_dynamic(
+            hidden_states=img_modulated,
+            encoder_hidden_states=txt_modulated,
+            vid_freqs=image_rotary_emb[0],
+            txt_freqs=image_rotary_emb[1],
+            attn_metadata=attn_metadata,
+            packed_indices=packed_indices,
+        )
+
+        hidden_states = hidden_states + img_gate1 * img_attn_output
+        encoder_hidden_states = encoder_hidden_states + txt_gate1 * txt_attn_output
+
+        if shared_temb:
+            img_scale2, img_shift2, img_gate2 = self._modulate_shared(img_mod2)
+            txt_scale2, txt_shift2, txt_gate2 = self._modulate_shared(txt_mod2)
+        else:
+            img_scale2, img_shift2, img_gate2 = self._modulate_packed(img_mod2, image_token_to_req)
+            txt_scale2, txt_shift2, txt_gate2 = self._modulate_packed(txt_mod2, text_token_to_req)
+        img_mlp_input = self.img_norm2(hidden_states, img_scale2, img_shift2)
+        txt_mlp_input = self.txt_norm2(encoder_hidden_states, txt_scale2, txt_shift2)
+        img_mlp_output = self.img_mlp(img_mlp_input)
+        txt_mlp_output = self.txt_mlp(txt_mlp_input)
+        hidden_states = hidden_states + img_gate2 * img_mlp_output
+        encoder_hidden_states = encoder_hidden_states + txt_gate2 * txt_mlp_output
+
         if encoder_hidden_states.dtype == torch.float16:
             encoder_hidden_states = encoder_hidden_states.clip(-65504, 65504)
         if hidden_states.dtype == torch.float16:
@@ -993,8 +1634,6 @@ class QwenImageTransformer2DModel(CachedTransformer):
 
         self.txt_norm = nn.RMSNorm(joint_attention_dim, eps=1e-6)
 
-        # Entry projections (image/text) are kept full precision —
-        # small sensitive layers at the network boundary (see #2728).
         self.img_in = ReplicatedLinear(
             in_channels,
             self.inner_dim,
@@ -1026,9 +1665,6 @@ class QwenImageTransformer2DModel(CachedTransformer):
             ]
         )
 
-        # Final modulation and output projection are kept full precision —
-        # they produce the output latent and are precision-sensitive
-        # (see #2728).
         self.norm_out = AdaLayerNormContinuous(self.inner_dim, self.inner_dim, elementwise_affine=False, eps=1e-6)
         self.norm_out.linear = ReplicatedLinear(
             self.inner_dim,
@@ -1059,6 +1695,231 @@ class QwenImageTransformer2DModel(CachedTransformer):
         # Only active when zero_cond_t=True (image editing models)
         self.modulate_index_prepare = ModulateIndexPrepare(zero_cond_t=zero_cond_t)
 
+    def _forward_dynamic(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states_mask: torch.Tensor | None,
+        timestep: torch.LongTensor,
+        img_shapes: list[tuple[int, int, int]] | None,
+        img_seq_lens: list[int] | None,
+        txt_seq_lens: list[int] | None,
+        guidance: torch.Tensor | None,
+        attention_kwargs: dict[str, Any] | None,
+        additional_t_cond=None,
+    ) -> Transformer2DModelOutput:
+        if self.zero_cond_t:
+            raise ValueError("Qwen-Image dynamic step batching does not support zero_cond_t/edit mode yet.")
+
+        attention_id = None if attention_kwargs is None else attention_kwargs.get("attention_id")
+        attn_metadata = _get_qwen_image_attention_metadata(attention_id)
+        if attn_metadata is None or not attn_metadata.is_varlen:
+            raise ValueError("Qwen-Image dynamic forward requires varlen AttentionMetadata.")
+        if attn_metadata.padded_tokens != 0:
+            raise ValueError("Qwen-Image dynamic forward requires padded_tokens=0.")
+        if encoder_hidden_states is None:
+            raise ValueError("Qwen-Image dynamic forward requires encoder_hidden_states.")
+        if timestep is None:
+            raise ValueError("Qwen-Image dynamic forward requires timestep.")
+
+        if not torch.is_tensor(hidden_states) or hidden_states.ndim != 2:
+            raise ValueError("Packed dynamic Qwen-Image hidden states must be [total_image_tokens, channels].")
+        if img_seq_lens is None:
+            if img_shapes is None:
+                position = attn_metadata.position if isinstance(attn_metadata.position, dict) else {}
+                img_shapes = position.get("img_shapes")
+            if img_shapes is None:
+                raise ValueError("Packed dynamic Qwen-Image forward requires img_seq_lens or img_shapes.")
+            img_seq_lens = [sum(prod(shape) for shape in image_shape) for image_shape in img_shapes]
+        batch_size = len(img_seq_lens)
+        if batch_size == 0:
+            raise ValueError("Qwen-Image dynamic forward received an empty batch.")
+        if txt_seq_lens is None:
+            if encoder_hidden_states_mask is None:
+                if not torch.is_tensor(encoder_hidden_states):
+                    raise ValueError("txt_seq_lens is required when dynamic text embeddings are provided as a list.")
+                txt_seq_lens = [int(encoder_hidden_states.shape[1])] * batch_size
+            else:
+                txt_seq_lens = encoder_hidden_states_mask.sum(dim=1, dtype=torch.int32).tolist()
+        if len(txt_seq_lens) != batch_size:
+            raise ValueError(f"Expected {batch_size} text sequence lengths, got {len(txt_seq_lens)}.")
+
+        if img_shapes is None:
+            position = attn_metadata.position if isinstance(attn_metadata.position, dict) else {}
+            img_shapes = position.get("img_shapes")
+        if img_shapes is None or len(img_shapes) != batch_size:
+            raise ValueError(f"Expected {batch_size} image shape entries for dynamic Qwen-Image forward.")
+
+        device = hidden_states.device
+        dtype = hidden_states.dtype
+        image_lens = [int(value) for value in img_seq_lens]
+        if sum(image_lens) != int(hidden_states.shape[0]):
+            raise ValueError(
+                f"Packed dynamic Qwen-Image hidden token count {hidden_states.shape[0]} "
+                f"does not match img_seq_lens sum {sum(image_lens)}."
+            )
+        packed_hidden_states = hidden_states.contiguous()
+        image_states = _qwen_image_unwrap_module_output(self.img_in(packed_hidden_states))
+        image_freqs: list[torch.Tensor] = []
+        text_freqs: list[torch.Tensor] = []
+        for image_len, image_shape, txt_len in zip(image_lens, img_shapes, txt_seq_lens, strict=True):
+            vid_freq, txt_freq = self.pos_embed(image_shape, [int(txt_len)], device=image_states.device)
+            if int(vid_freq.shape[0]) != image_len:
+                raise ValueError(
+                    f"Qwen-Image dynamic RoPE image length {vid_freq.shape[0]} "
+                    f"does not match hidden length {image_len}."
+                )
+            image_freqs.append(vid_freq)
+            text_freqs.append(txt_freq[: int(txt_len)])
+        image_freqs_packed = torch.cat(image_freqs, dim=0).contiguous()
+        text_freqs_packed = torch.cat(text_freqs, dim=0).contiguous()
+
+        text_values: list[torch.Tensor] = []
+        if not torch.is_tensor(encoder_hidden_states) or encoder_hidden_states.shape[0] != batch_size:
+            got = "non-tensor" if not torch.is_tensor(encoder_hidden_states) else int(encoder_hidden_states.shape[0])
+            raise ValueError(f"Expected packed dynamic encoder tensor with {batch_size} rows, got {got}.")
+        for index, txt_len in enumerate(txt_seq_lens):
+            text_values.append(encoder_hidden_states[index : index + 1, : int(txt_len)])
+        text_states = torch.cat([tensor.squeeze(0) for tensor in text_values], dim=0).contiguous()
+        text_states = self.txt_norm(text_states)
+        text_states = _qwen_image_unwrap_module_output(self.txt_in(text_states))
+
+        timestep = timestep.to(device=device, dtype=dtype)
+        if timestep.ndim == 0:
+            timestep = timestep.reshape(1).expand(batch_size)
+        elif int(timestep.numel()) != batch_size:
+            raise ValueError(f"Expected {batch_size} timesteps, got {int(timestep.numel())}.")
+        timestep = timestep.reshape(batch_size)
+
+        if guidance is not None:
+            guidance = guidance.to(device=device, dtype=dtype) * 1000
+
+        tensor_parallel_size = int(getattr(self.parallel_config, "tensor_parallel_size", 1) or 1)
+        shared_temb = (
+            tensor_parallel_size == 1
+            and guidance is None
+            and additional_t_cond is None
+            and bool(torch.equal(timestep, timestep[:1].expand_as(timestep)))
+        )
+        if shared_temb:
+            temb = self.time_text_embed(timestep[:1], image_states, None)
+        else:
+            temb = (
+                self.time_text_embed(timestep, image_states, additional_t_cond)
+                if guidance is None
+                else self.time_text_embed(timestep, guidance, image_states, additional_t_cond)
+            )
+
+        text_lens = [int(value) for value in txt_seq_lens]
+        packed_indices = _qwen_image_packed_indices(image_lens, text_lens, device)
+        packed_indices.update(
+            {
+                "image_lens": image_lens,
+                "text_lens": text_lens,
+                "shared_temb": shared_temb,
+            }
+        )
+        sp_group: dist.ProcessGroup | None = None
+        sp_context = _qwen_image_dynamic_sp_context()
+        if sp_context is not None:
+            sp_mode, sp_group, sp_world_size, sp_rank = sp_context
+            total_image = int(image_states.shape[0])
+            total_text = int(text_states.shape[0])
+            image_local_idx, image_local_lens = _qwen_image_rank_local_indices(
+                image_lens,
+                rank=sp_rank,
+                world_size=sp_world_size,
+                device=device,
+            )
+            source_to_joint_idx, joint_to_source_idx, image_packed_to_source_idx = (
+                _qwen_image_sp_replicated_text_source_order_indices(
+                    text_lens=text_lens,
+                    image_lens=image_lens,
+                    world_size=sp_world_size,
+                    joint_gather_idx=packed_indices["joint_gather_idx"],
+                    device=device,
+                )
+            )
+            if int(total_image) != sum(image_lens) or int(total_text) != sum(text_lens):
+                raise ValueError(
+                    "Qwen-Image SP dynamic token count mismatch: "
+                    f"image={total_image}/{sum(image_lens)}, text={total_text}/{sum(text_lens)}."
+                )
+            image_token_to_req = _qwen_image_token_to_req(image_local_lens, device)
+            text_token_to_req = _qwen_image_token_to_req(text_lens, device)
+            sp_image_lens_by_rank = [
+                _qwen_image_rank_local_indices(
+                    image_lens,
+                    rank=rank,
+                    world_size=sp_world_size,
+                    device=device,
+                )[1]
+                for rank in range(sp_world_size)
+            ]
+            packed_indices = dict(packed_indices)
+            packed_indices.update(
+                {
+                    "image_token_to_req": image_token_to_req,
+                    "text_token_to_req": text_token_to_req,
+                    "sp_group": sp_group,
+                    "sp_source_to_joint_idx": source_to_joint_idx,
+                    "sp_joint_to_source_idx": joint_to_source_idx,
+                    "sp_image_packed_to_source_idx": image_packed_to_source_idx,
+                    "sp_mode": sp_mode,
+                    "sp_rank": sp_rank,
+                    "sp_replicated_text": True,
+                    "sp_local_text_len": int(total_text),
+                    "sp_local_image_len": int(image_local_idx.numel()),
+                    "sp_image_lens": image_local_lens,
+                    "sp_image_lens_by_rank": sp_image_lens_by_rank,
+                    "sp_text_lens": text_lens,
+                    "sp_ring_varlen_plan": (
+                        ring_flash_attn_varlen_replicated_prefix_plan(
+                            prefix_lens=text_lens,
+                            suffix_lens_by_rank=sp_image_lens_by_rank,
+                            rank=sp_rank,
+                            device=device,
+                        )
+                        if sp_mode == "ring"
+                        else None
+                    ),
+                    "image_lens": None,
+                    "text_lens": None,
+                }
+            )
+
+            image_states = image_states.index_select(0, image_local_idx).contiguous()
+            image_freqs_packed = image_freqs_packed.index_select(0, image_local_idx).contiguous()
+
+        image_rotary_emb = (image_freqs_packed, text_freqs_packed)
+        temb_silu = F.silu(temb)
+        for block in self.transformer_blocks:
+            text_states, image_states = block.forward_dynamic(
+                hidden_states=image_states,
+                encoder_hidden_states=text_states,
+                temb=temb,
+                temb_silu=temb_silu,
+                image_rotary_emb=image_rotary_emb,
+                attn_metadata=attn_metadata,
+                packed_indices=packed_indices,
+            )
+
+        norm_out_input = self.norm_out.silu(temb).to(image_states.dtype)
+        emb = _qwen_image_unwrap_module_output(self.norm_out.linear(norm_out_input))
+        scale, shift = torch.chunk(emb, 2, dim=1)
+        image_token_to_req = packed_indices["image_token_to_req"]
+        if shared_temb:
+            image_states = self.norm_out.norm(image_states) * (1 + scale) + shift
+        else:
+            image_states = self.norm_out.norm(image_states) * (
+                1 + scale.index_select(0, image_token_to_req)
+            ) + shift.index_select(0, image_token_to_req)
+        sample = _qwen_image_unwrap_module_output(self.proj_out(image_states))
+        if sp_group is not None:
+            sample = _qwen_image_all_gather_varlen(sample, sp_group)
+            sample = sample.index_select(0, packed_indices["sp_image_packed_to_source_idx"]).contiguous()
+        return Transformer2DModelOutput(sample=sample)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -1066,6 +1927,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
         encoder_hidden_states_mask: torch.Tensor = None,
         timestep: torch.LongTensor = None,
         img_shapes: list[tuple[int, int, int]] | None = None,
+        img_seq_lens: list[int] | None = None,
         txt_seq_lens: list[int] | None = None,
         guidance: torch.Tensor = None,  # TODO: this should probably be removed
         attention_kwargs: dict[str, Any] | None = None,
@@ -1101,6 +1963,21 @@ class QwenImageTransformer2DModel(CachedTransformer):
         #     lora_scale = attention_kwargs.pop("scale", 1.0)
         # else:
         #     lora_scale = 1.0
+
+        dynamic_attention_id = None if attention_kwargs is None else attention_kwargs.get("attention_id")
+        if torch.is_tensor(hidden_states) and hidden_states.ndim == 2 and dynamic_attention_id is not None:
+            return self._forward_dynamic(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_hidden_states_mask=encoder_hidden_states_mask,
+                timestep=timestep,
+                img_shapes=img_shapes,
+                img_seq_lens=img_seq_lens,
+                txt_seq_lens=txt_seq_lens,
+                guidance=guidance,
+                attention_kwargs=attention_kwargs,
+                additional_t_cond=additional_t_cond,
+            )
 
         # Set split_text_embed_in_sp = False for dual-stream attention
         # QwenImage uses *dual-stream* (text + image) and runs a *joint attention*.

--- a/vllm_omni/diffusion/sched/base_scheduler.py
+++ b/vllm_omni/diffusion/sched/base_scheduler.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from collections import deque
-from dataclasses import fields
 
 from vllm.logger import init_logger
 
@@ -22,21 +21,35 @@ from vllm_omni.diffusion.sched.interface import (
 
 logger = init_logger(__name__)
 
-# LoRA identity is derived from `sampling.lora_request`, not a same-named field
-# on sampling params, so it must be resolved separately from the bulk lookup.
-_KEY_FIELD_NAMES = frozenset(f.name for f in fields(SamplingParamsKey)) - {"lora_int_id"}
 
-
-def get_sampling_params_key(request: OmniDiffusionRequest) -> SamplingParamsKey | None:
+def get_sampling_params_key(
+    request: OmniDiffusionRequest,
+    od_config: OmniDiffusionConfig | None = None,
+) -> SamplingParamsKey | None:
     """Build a batch-compatibility key from the request's sampling params."""
     if len(request.prompts) != 1:
         return None
 
     sampling = request.sampling_params
     lora_request = getattr(sampling, "lora_request", None)
+    do_classifier_free_guidance = getattr(sampling, "do_classifier_free_guidance", False)
+
+    if (
+        od_config is not None
+        and getattr(od_config, "step_execution", False)
+        and getattr(od_config, "model_class_name", None) == "QwenImagePipeline"
+    ):
+        true_cfg_scale = getattr(sampling, "true_cfg_scale", None)
+        true_cfg_scale = 4.0 if true_cfg_scale is None else true_cfg_scale
+        has_negative_prompt = any(
+            not isinstance(prompt, str) and prompt.get("negative_prompt") is not None for prompt in request.prompts
+        )
+        do_classifier_free_guidance = true_cfg_scale > 1 and has_negative_prompt
+
     return SamplingParamsKey(
+        do_classifier_free_guidance=do_classifier_free_guidance,
         lora_int_id=lora_request.lora_int_id if lora_request is not None else None,
-        **{name: getattr(sampling, name) for name in _KEY_FIELD_NAMES},
+        lora_scale=getattr(sampling, "lora_scale", 1.0),
     )
 
 
@@ -230,7 +243,7 @@ class _BaseScheduler(SchedulerInterface):
         return DiffusionRequestState(
             request_id=request_id,
             req=request,
-            sampling_params_key=get_sampling_params_key(request),
+            sampling_params_key=get_sampling_params_key(request, self.od_config),
         )
 
     def _can_schedule_waiting(self, state: DiffusionRequestState) -> bool:

--- a/vllm_omni/diffusion/sched/interface.py
+++ b/vllm_omni/diffusion/sched/interface.py
@@ -42,23 +42,10 @@ class SamplingParamsKey:
     participate in the current homogeneous batching policy.
     """
 
-    # Spatial / temporal shape.
-    height: int | None = None
-    width: int | None = None
-    num_frames: int = 1
-    resolution: int | str | None = None
-    fps: int | None = None
-    frame_rate: float | None = None
-    boundary_ratio: float | None = None
+    # Spatial / temporal shape can be deleted
 
-    # CFG / guidance.
+    # CFG / guidance can be deleted
     do_classifier_free_guidance: bool = False
-    guidance_scale: float = 0.0
-    guidance_scale_provided: bool = False
-    guidance_scale_2: float | None = None
-    guidance_rescale: float = 0.0
-    true_cfg_scale: float | None = None
-    cfg_normalize: bool = False
 
     # LoRA identity. Requests with different adapters or scales must run in
     # separate batches so the worker can activate exactly one adapter per step.

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -14,7 +14,6 @@ import copy
 import time
 from collections.abc import Iterable
 from contextlib import nullcontext
-from typing import Any
 
 import torch
 from torch.profiler import record_function
@@ -22,6 +21,7 @@ from vllm.config import LoadConfig
 from vllm.logger import init_logger
 from vllm.utils.mem_utils import DeviceMemoryProfiler, GiB_bytes
 
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.cache.cache_dit_backend import cache_summary
 from vllm_omni.diffusion.cache.prompt_embed_cache import (
     install_prompt_embed_cache,
@@ -37,7 +37,7 @@ from vllm_omni.diffusion.offloader import get_offload_backend
 from vllm_omni.diffusion.registry import _NO_CACHE_ACCELERATION
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.sched.interface import DiffusionSchedulerOutput
-from vllm_omni.diffusion.worker.input_batch import InputBatch, scatter_latents
+from vllm_omni.diffusion.worker.input_batch import InputBatch, scatter_latents, split_packed_noise
 from vllm_omni.diffusion.worker.utils import BatchRunnerOutput, DiffusionRequestState, RunnerOutput
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import OmniKVTransferManager
 from vllm_omni.platforms import current_omni_platform
@@ -352,6 +352,14 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         """Return whether current pipeline supports step execution."""
         return self.pipeline is not None and supports_step_execution(self.pipeline)
 
+    def _supports_qwen_image_dynamic_step_batching(self) -> bool:
+        if self.pipeline is None:
+            return False
+        if not getattr(self.od_config, "step_execution", False):
+            return False
+        cls = self.pipeline.__class__
+        return cls.__name__ == "QwenImagePipeline" and "qwen_image" in cls.__module__
+
     def _update_states(
         self, scheduler_output: DiffusionSchedulerOutput
     ) -> tuple[list[DiffusionRequestState], list[str]]:
@@ -416,6 +424,9 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         input_batch = InputBatch.make_batch(
             states,
             cached_batch=getattr(self, "input_batch", None),
+            allow_dynamic=self._supports_qwen_image_dynamic_step_batching(),
+            force_dynamic_request_view=self._supports_qwen_image_dynamic_step_batching(),
+            require_prompt_embeds=self._supports_qwen_image_dynamic_step_batching(),
         )
         self.input_batch = input_batch
         return input_batch
@@ -427,6 +438,13 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         interrupted: bool = False,
     ):
         """Step-after update: clear cached state for completed request."""
+        if input_batch.is_dynamic:
+            self.input_batch = input_batch
+            for state in states:
+                if interrupted or state.denoise_completed:
+                    self.state_cache.pop(state.request_id, None)
+            return
+
         gathered_latents = torch.cat([state.latents for state in states], dim=0)
         if (
             input_batch.latents.size() == gathered_latents.size()
@@ -444,14 +462,71 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             if interrupted or state.denoise_completed:
                 self.state_cache.pop(state.request_id, None)
 
-    def _prepare_attn_metadata(self, input_batch: InputBatch) -> Any:
+    def _make_qwen_image_metadata(
+        self,
+        input_batch: InputBatch,
+        *,
+        branch: str,
+    ) -> AttentionMetadata:
+        from vllm_omni.diffusion.attention.builder import QwenImageJointMetadataBuilder
+
+        builder = QwenImageJointMetadataBuilder(
+            transformer=getattr(getattr(self, "pipeline", None), "transformer", None),
+            parallel_config=getattr(getattr(self, "od_config", None), "parallel_config", None),
+        )
+        metadata = builder.build(input_batch, branch=branch)
+        return metadata
+
+    def _prepare_attn_metadata(self, input_batch: InputBatch) -> dict[str, AttentionMetadata]:
+        if self._supports_qwen_image_dynamic_step_batching():
+            metadata = {
+                "qwen_image.joint.positive": self._make_qwen_image_metadata(
+                    input_batch,
+                    branch="positive",
+                )
+            }
+            if input_batch.do_true_cfg:
+                metadata["qwen_image.joint.negative"] = self._make_qwen_image_metadata(
+                    input_batch,
+                    branch="negative",
+                )
+            return metadata
+
         model_state = getattr(self, "model_state", None)
         if model_state is None:
             return {}
         prepare_attn = getattr(model_state, "prepare_attn", None)
         if not callable(prepare_attn):
             return {}
-        return prepare_attn(input_batch)
+        metadata = prepare_attn(input_batch)
+        return metadata if isinstance(metadata, dict) else {}
+
+    def _prepare_inputs(
+        self, scheduler_output: DiffusionSchedulerOutput
+    ) -> tuple[list[DiffusionRequestState], list[str], InputBatch, dict[str, AttentionMetadata]]:
+        """Host-side input preparation for one stepwise denoise step.
+
+        vLLM-style separation (≈ ``GPUModelRunner.prepare_inputs``): resolve
+        per-request states, build the step-local ``InputBatch``, and derive the
+        packed joint attention metadata (positive/negative branches) — all before
+        the forward pass runs in ``execute_stepwise``.
+        """
+        states, new_request_ids = self._update_states(scheduler_output)
+        input_batch = self._prepare_batch_inputs(states, new_request_ids)
+        attn_metadata = self._prepare_attn_metadata(input_batch)
+        return states, new_request_ids, input_batch, attn_metadata
+
+    def _post_decode_completed_states(
+        self,
+        states: list[DiffusionRequestState],
+    ) -> dict[str, DiffusionOutput]:
+        post_decode_batch = getattr(self.pipeline, "post_decode_batch", None)
+        if callable(post_decode_batch) and len(states) > 1:
+            results = post_decode_batch(states)
+            if set(results) == {state.request_id for state in states}:
+                return results
+
+        return {state.request_id: self.pipeline.post_decode(state) for state in states}
 
     def execute_stepwise(self, scheduler_output: DiffusionSchedulerOutput) -> BatchRunnerOutput:
         """Execute one step for one scheduled request and return runner output."""
@@ -467,9 +542,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         use_hsdp = self.od_config.parallel_config.use_hsdp
         grad_context = torch.no_grad() if use_hsdp else torch.inference_mode()
         with grad_context:
-            states, new_request_ids = self._update_states(scheduler_output)
-            input_batch = self._prepare_batch_inputs(states, new_request_ids)
-            attn_metadata = self._prepare_attn_metadata(input_batch)
+            states, new_request_ids, input_batch, attn_metadata = self._prepare_inputs(scheduler_output)
 
             with set_forward_context(
                 vllm_config=self.vllm_config,
@@ -493,26 +566,50 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
 
                 else:
                     offset = 0
-                    for req in states:
-                        row_num = req.latents.shape[0]
-                        self.pipeline.step_scheduler(
-                            req, noise_pred[offset : offset + row_num] if noise_pred is not None else None
-                        )
-                        offset = offset + row_num
-                        if req.denoise_completed:
-                            result = self.pipeline.post_decode(req)
+                    if input_batch.is_dynamic and noise_pred is not None:
+                        if not torch.is_tensor(noise_pred):
+                            raise ValueError("Dynamic stepwise denoise must return packed noise tensor.")
+                        if input_batch.img_query_start_loc_np is None:
+                            raise ValueError("Dynamic stepwise denoise requires img_query_start_loc.")
+                        # vLLM idiom: slice packed noise by image-token cu_seqlens.
+                        dynamic_noise_pred = split_packed_noise(noise_pred, input_batch.img_query_start_loc_np)
+                        if len(dynamic_noise_pred) != len(states):
+                            raise ValueError("Dynamic stepwise denoise split did not match request count.")
+                    else:
+                        dynamic_noise_pred = None
+
+                    completed_states: list[DiffusionRequestState] = []
+                    output_by_request_id: dict[str, RunnerOutput] = {}
+                    for req_idx, req in enumerate(states):
+                        if input_batch.is_dynamic:
+                            req_noise_pred = None if dynamic_noise_pred is None else dynamic_noise_pred[req_idx]
                         else:
-                            result = None
-                        runner_output_list.append(
-                            RunnerOutput(
+                            row_num = req.latents.shape[0]
+                            req_noise_pred = noise_pred[offset : offset + row_num] if noise_pred is not None else None
+                            offset = offset + row_num
+                        self.pipeline.step_scheduler(req, req_noise_pred)
+                        if req.denoise_completed:
+                            completed_states.append(req)
+                        else:
+                            output_by_request_id[req.request_id] = RunnerOutput(
                                 request_id=req.request_id,
                                 step_index=req.step_index,
-                                finished=req.denoise_completed,
-                                result=result,
+                                finished=False,
+                                result=None,
                             )
+
+                    decoded_results = self._post_decode_completed_states(completed_states) if completed_states else {}
+                    for req in completed_states:
+                        output_by_request_id[req.request_id] = RunnerOutput(
+                            request_id=req.request_id,
+                            step_index=req.step_index,
+                            finished=True,
+                            result=decoded_results[req.request_id],
                         )
 
-                    if noise_pred is not None and offset != noise_pred.shape[0]:
+                    runner_output_list.extend(output_by_request_id[req.request_id] for req in states)
+
+                    if not input_batch.is_dynamic and noise_pred is not None and offset != noise_pred.shape[0]:
                         raise ValueError(
                             f"Stepwise noise_pred consumed {offset} rows, "
                             f"but batched noise_pred has {noise_pred.shape[0]} rows."

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import torch
 import zmq
+from vllm import envs
 from vllm.config import CompilationConfig, DeviceConfig, VllmConfig, set_current_vllm_config
 from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
 from vllm.logger import init_logger
@@ -233,6 +234,17 @@ class DiffusionWorker:
         self.device = current_omni_platform.get_torch_device(rank)
         current_omni_platform.set_device(self.device)
 
+        parallel_config = self.od_config.parallel_config
+        qwen_image_dynamic_step = (
+            getattr(self.od_config, "step_execution", False)
+            and getattr(self.od_config, "model_class_name", None) == "QwenImagePipeline"
+        )
+        if qwen_image_dynamic_step or (
+            getattr(self.od_config, "step_execution", False) and int(parallel_config.tensor_parallel_size) > 1
+        ):
+            os.environ["VLLM_BATCH_INVARIANT"] = "1"
+            envs.disable_envs_cache()
+
         # Create vllm_config for parallel configuration. Pass explicit device_config
         # so DeviceConfig does not rely on current_platform in worker subprocesses.
         vllm_config = _create_diffusion_worker_vllm_config(self.device, self.od_config)
@@ -258,7 +270,6 @@ class DiffusionWorker:
             init_distributed_environment(world_size=world_size, rank=rank)
             logger.info(f"Worker {self.rank}: Initialized device and distributed environment.")
 
-            parallel_config = self.od_config.parallel_config
             initialize_model_parallel(
                 data_parallel_size=parallel_config.data_parallel_size,
                 cfg_parallel_size=parallel_config.cfg_parallel_size,

--- a/vllm_omni/diffusion/worker/input_batch.py
+++ b/vllm_omni/diffusion/worker/input_batch.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Diffusion input-batch structures following the MRV2-style vLLM layout.
+"""Step-local diffusion input batches.
 
-Request states remain the only persistent source of truth. Static tensors are
-normalized/padded onto the request state once, while :class:`InputBatch`
-assembles an ephemeral step-local view. Dynamic tensors are re-gathered every
-step, and step outputs are scattered back into request states by
-``scatter_latents()`` using ``idx_mapping``.
+``DiffusionRequestState`` remains the durable source of truth. ``InputBatch``
+is a per-step view that either exposes the existing dense tensors or, for
+Qwen-Image step batching, a packed step-local view with no latent/text padding
+in attention.
 """
 
 from __future__ import annotations
@@ -20,100 +19,47 @@ import torch
 from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
 
-def _normalize_prompt_embeds(x: torch.Tensor) -> torch.Tensor:
-    if x.ndim == 2:
-        return x.unsqueeze(0)
-    if x.ndim == 3:
-        return x
-    raise ValueError(f"prompt_embeds must be 2D or 3D, got shape={tuple(x.shape)}")
+@dataclass(frozen=True)
+class RequestSpan:
+    request_id: str
+    request_index: int
+    row_start: int
+    row_count: int
+    token_start: int
+    token_count: int
+
+    @property
+    def row_end(self) -> int:
+        return self.row_start + self.row_count
 
 
-def _normalize_mask(x: torch.Tensor) -> torch.Tensor:
-    if x.ndim == 1:
-        x = x.unsqueeze(0)
-    elif x.ndim != 2:
-        raise ValueError(f"prompt mask must be 1D or 2D, got shape={tuple(x.shape)}")
-    if x.dtype != torch.bool:
-        x = x != 0
-    return x
+@dataclass(frozen=True)
+class PromptBatch:
+    embeds: torch.Tensor | None
+    mask: torch.Tensor | None
+    seq_lens: list[int] | None
 
 
-def _pad_prompt_embeds(x: torch.Tensor, target_seq_len: int) -> torch.Tensor:
-    x = _normalize_prompt_embeds(x)
-    bsz, seq_len, hidden = x.shape
-    if seq_len == target_seq_len:
-        return x
-    out = x.new_zeros((bsz, target_seq_len, hidden))
-    out[:, :seq_len] = x
-    return out
+def _normalize_embeds(value: torch.Tensor) -> torch.Tensor:
+    if value.ndim == 2:
+        return value.unsqueeze(0)
+    if value.ndim == 3:
+        return value
+    raise ValueError(f"prompt_embeds must be 2D or 3D, got shape={tuple(value.shape)}")
 
 
-def _pad_mask(x: torch.Tensor, target_seq_len: int) -> torch.Tensor:
-    x = _normalize_mask(x)
-    bsz, seq_len = x.shape
-    if seq_len == target_seq_len:
-        return x
-    out = torch.zeros((bsz, target_seq_len), dtype=torch.bool, device=x.device)
-    out[:, :seq_len] = x
-    return out
+def _normalize_mask(value: torch.Tensor) -> torch.Tensor:
+    if value.ndim == 1:
+        value = value.unsqueeze(0)
+    elif value.ndim != 2:
+        raise ValueError(f"prompt mask must be 1D or 2D, got shape={tuple(value.shape)}")
+    return value if value.dtype == torch.bool else value != 0
 
 
-def _select_states(
-    states: Sequence[DiffusionRequestState],
-    idx_mapping: torch.Tensor | None,
-) -> tuple[list[DiffusionRequestState], torch.Tensor, np.ndarray]:
-    if not states:
-        raise ValueError("Cannot build InputBatch from empty states.")
-
-    if idx_mapping is None:
-        device = states[0].latents.device if states[0].latents is not None else None
-        idx_mapping = torch.arange(len(states), dtype=torch.int32, device=device)
-    else:
-        if idx_mapping.ndim != 1:
-            raise ValueError("idx_mapping must be a 1D tensor.")
-        idx_mapping = idx_mapping.to(dtype=torch.int32)
-
-    selected_states: list[DiffusionRequestState] = []
-    for batch_idx, state_idx in enumerate(idx_mapping.tolist()):
-        if state_idx < 0 or state_idx >= len(states):
-            raise ValueError(f"idx_mapping[{batch_idx}]={state_idx} is out of range for states.")
-        selected_states.append(states[state_idx])
-    return selected_states, idx_mapping, idx_mapping.detach().cpu().numpy()
-
-
-def _prepare_request_ids(states: Sequence[DiffusionRequestState]) -> list[str]:
-    return [state.request_id for state in states]
-
-
-def _prepare_prompt_field_on_state(
-    state: DiffusionRequestState,
-    *,
-    embeds_attr: str,
-    mask_attr: str,
-) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-    embeds = getattr(state, embeds_attr)
-    if embeds is None:
-        return None, None
-
-    normalized_embeds = _normalize_prompt_embeds(embeds)
-    if normalized_embeds is not embeds:
-        setattr(state, embeds_attr, normalized_embeds)
-    embeds = normalized_embeds
-
-    mask = getattr(state, mask_attr)
-    if mask is None:
-        return embeds, None
-
-    normalized_mask = _normalize_mask(mask)
-    if normalized_mask is not mask:
-        setattr(state, mask_attr, normalized_mask)
-    return embeds, normalized_mask
-
-
-def _prepare_reused_buffer(
+def _buffer_like(
     current: torch.Tensor | None,
-    *,
     shape: tuple[int, ...],
+    *,
     dtype: torch.dtype,
     device: torch.device,
 ) -> torch.Tensor:
@@ -122,452 +68,381 @@ def _prepare_reused_buffer(
     return torch.empty(shape, dtype=dtype, device=device)
 
 
-def _validate_gather_tensors(
-    values: Sequence[torch.Tensor],
-    *,
-    field_name: str,
-) -> tuple[torch.dtype, torch.device, tuple[int, ...], int]:
-    if not values:
-        raise ValueError(f"Cannot gather empty tensor list for {field_name}.")
+def _select_states(
+    states: Sequence[DiffusionRequestState],
+    idx_mapping: torch.Tensor | None,
+) -> tuple[list[DiffusionRequestState], torch.Tensor, np.ndarray]:
+    if not states:
+        raise ValueError("Cannot build InputBatch from empty states.")
+    if idx_mapping is None:
+        latents = states[0].latents
+        device = latents.device if latents is not None else None
+        idx_mapping = torch.arange(len(states), dtype=torch.int32, device=device)
+    elif idx_mapping.ndim != 1:
+        raise ValueError("idx_mapping must be a 1D tensor.")
+    else:
+        idx_mapping = idx_mapping.to(dtype=torch.int32)
 
-    first = values[0]
-    dtype = first.dtype
-    device = first.device
-    suffix_shape = tuple(first.shape[1:])
-    total_rows = 0
-
-    for value in values:
-        if value.dtype != dtype:
-            raise ValueError(f"Mixed dtypes in {field_name} batch.")
-        if value.device != device:
-            raise ValueError(f"Mixed devices in {field_name} batch.")
-        if tuple(value.shape[1:]) != suffix_shape:
-            raise ValueError(
-                f"Mixed trailing shapes in {field_name} batch: expected {suffix_shape}, got {tuple(value.shape[1:])}."
-            )
-        total_rows += int(value.shape[0])
-
-    return dtype, device, suffix_shape, total_rows
+    selected: list[DiffusionRequestState] = []
+    for batch_idx, state_idx in enumerate(idx_mapping.tolist()):
+        if state_idx < 0 or state_idx >= len(states):
+            raise ValueError(f"idx_mapping[{batch_idx}]={state_idx} is out of range for states.")
+        selected.append(states[state_idx])
+    return selected, idx_mapping, idx_mapping.detach().cpu().numpy()
 
 
-def _gather_tensor_rows(
+def _state_latents(state: DiffusionRequestState) -> torch.Tensor:
+    if state.latents is None:
+        raise ValueError(f"Request {state.request_id} has no latents.")
+    return state.latents
+
+
+def _gather_rows(
     values: Sequence[torch.Tensor],
     *,
     field_name: str,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    dtype, device, suffix_shape, total_rows = _validate_gather_tensors(
-        values,
-        field_name=field_name,
-    )
-    gathered = _prepare_reused_buffer(
-        out,
-        shape=(total_rows, *suffix_shape),
-        dtype=dtype,
-        device=device,
-    )
-
-    row_offset = 0
+    if not values:
+        raise ValueError(f"Cannot gather empty tensor list for {field_name}.")
+    dtype = values[0].dtype
+    device = values[0].device
+    suffix = tuple(values[0].shape[1:])
+    total_rows = 0
     for value in values:
-        next_row_offset = row_offset + int(value.shape[0])
-        gathered[row_offset:next_row_offset].copy_(value)
-        row_offset = next_row_offset
-    return gathered
+        if value.dtype != dtype:
+            raise ValueError(f"Mixed dtypes in {field_name} batch.")
+        if value.device != device:
+            raise ValueError(f"Mixed devices in {field_name} batch.")
+        if tuple(value.shape[1:]) != suffix:
+            raise ValueError(
+                f"Mixed trailing shapes in {field_name} batch: expected {suffix}, got {tuple(value.shape[1:])}."
+            )
+        total_rows += int(value.shape[0])
+
+    output = _buffer_like(out, (total_rows, *suffix), dtype=dtype, device=device)
+    offset = 0
+    for value in values:
+        next_offset = offset + int(value.shape[0])
+        output[offset:next_offset].copy_(value)
+        offset = next_offset
+    return output
 
 
-def _get_seq_lens_from_mask(mask: torch.Tensor) -> list[int]:
-    return mask.sum(dim=1, dtype=torch.int32).tolist()
+def _expand_rows(value: torch.Tensor, row_count: int, *, field_name: str) -> torch.Tensor:
+    if value.ndim == 0:
+        return value.reshape(1).expand(row_count)
+    if value.ndim != 1:
+        raise ValueError(f"{field_name} must be scalar or 1D, got ndim={value.ndim}.")
+    if value.shape[0] == row_count:
+        return value
+    if value.shape[0] == 1:
+        return value.expand(row_count)
+    raise ValueError(f"{field_name} must have either 1 or {row_count} elements, got {value.shape[0]}.")
 
 
-def _get_request_prompt_seq_lens(
+def _prompt_field(
+    state: DiffusionRequestState,
+    *,
+    embeds_attr: str,
+    mask_attr: str,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    embeds = getattr(state, embeds_attr)
+    if embeds is None:
+        return None, None
+    embeds = _normalize_embeds(embeds)
+    setattr(state, embeds_attr, embeds)
+
+    mask = getattr(state, mask_attr)
+    if mask is None:
+        return embeds, None
+    mask = _normalize_mask(mask)
+    setattr(state, mask_attr, mask)
+    if mask.shape[0] != embeds.shape[0]:
+        raise ValueError(f"{mask_attr} batch dimension does not match {embeds_attr} for request {state.request_id}.")
+    return embeds, mask
+
+
+def _seq_lens(
     state: DiffusionRequestState,
     *,
     embeds_attr: str,
     mask_attr: str,
     seq_lens_attr: str,
 ) -> list[int]:
-    embeds, mask = _prepare_prompt_field_on_state(
-        state,
-        embeds_attr=embeds_attr,
-        mask_attr=mask_attr,
-    )
+    embeds, mask = _prompt_field(state, embeds_attr=embeds_attr, mask_attr=mask_attr)
     if embeds is None:
         raise ValueError(f"{embeds_attr} is not initialized on request {state.request_id}.")
-
     if mask is not None:
-        if mask.shape[0] != embeds.shape[0]:
-            raise ValueError(
-                f"{mask_attr} batch dimension does not match {embeds_attr} for request {state.request_id}."
-            )
-        return _get_seq_lens_from_mask(mask)
-
+        return mask.sum(dim=1, dtype=torch.int32).tolist()
     seq_lens = getattr(state, seq_lens_attr)
     if seq_lens is not None:
         return [int(value) for value in seq_lens]
-
     return [int(embeds.shape[1])] * int(embeds.shape[0])
 
 
-def _prepare_request_prompt_field(
-    state: DiffusionRequestState,
-    *,
-    embeds_attr: str,
-    mask_attr: str,
-    seq_lens_attr: str,
-    target_seq_len: int,
-) -> tuple[torch.Tensor, torch.Tensor | None]:
-    embeds, mask = _prepare_prompt_field_on_state(
-        state,
-        embeds_attr=embeds_attr,
-        mask_attr=mask_attr,
-    )
-    if embeds is None:
-        raise ValueError(f"{embeds_attr} is not initialized on request {state.request_id}.")
-
-    actual_seq_lens = _get_request_prompt_seq_lens(
-        state,
-        embeds_attr=embeds_attr,
-        mask_attr=mask_attr,
-        seq_lens_attr=seq_lens_attr,
-    )
-    max_actual_seq_len = max(actual_seq_lens) if actual_seq_lens else 0
-
-    if mask is None and max_actual_seq_len != target_seq_len:
-        raise ValueError(
-            f"Variable-length {embeds_attr} in batch but {mask_attr} is None. "
-            f"Provide masks or ensure {embeds_attr} have the same seq_len."
-        )
-
-    current_seq_len = int(embeds.shape[1])
-    if current_seq_len < target_seq_len:
-        embeds = _pad_prompt_embeds(embeds, target_seq_len)
-        setattr(state, embeds_attr, embeds)
-        if mask is not None:
-            mask = _pad_mask(mask, target_seq_len)
-            setattr(state, mask_attr, mask)
-        current_seq_len = target_seq_len
-
-    if current_seq_len > target_seq_len:
-        if max_actual_seq_len > target_seq_len:
-            raise ValueError(
-                f"{embeds_attr} for request {state.request_id} requires seq_len "
-                f"{max_actual_seq_len}, got target {target_seq_len}."
-            )
-        return embeds[:, :target_seq_len], None if mask is None else mask[:, :target_seq_len]
-
-    return embeds, mask
+def _pad_prompt(value: torch.Tensor, target_len: int) -> torch.Tensor:
+    value = _normalize_embeds(value)
+    if value.shape[1] == target_len:
+        return value
+    out = value.new_zeros((value.shape[0], target_len, value.shape[2]))
+    out[:, : value.shape[1]].copy_(value)
+    return out
 
 
-def _prepare_padded_prompt_fields(
+def _pad_mask(value: torch.Tensor, target_len: int) -> torch.Tensor:
+    value = _normalize_mask(value)
+    if value.shape[1] == target_len:
+        return value
+    out = torch.zeros((value.shape[0], target_len), dtype=torch.bool, device=value.device)
+    out[:, : value.shape[1]].copy_(value)
+    return out
+
+
+def _build_prompt_batch(
     states: Sequence[DiffusionRequestState],
     *,
     embeds_attr: str,
     mask_attr: str,
     seq_lens_attr: str,
+    required: bool,
     embeds_out: torch.Tensor | None = None,
     mask_out: torch.Tensor | None = None,
-) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-    prepared_fields = [
-        _prepare_prompt_field_on_state(
-            state,
-            embeds_attr=embeds_attr,
-            mask_attr=mask_attr,
-        )
-        for state in states
-    ]
-    embeds_values = [embeds for embeds, _ in prepared_fields]
-    if not any(embeds is not None for embeds in embeds_values):
-        return None, None
-    if not all(embeds is not None for embeds in embeds_values):
+) -> PromptBatch:
+    fields = [_prompt_field(state, embeds_attr=embeds_attr, mask_attr=mask_attr) for state in states]
+    if not any(embeds is not None for embeds, _ in fields):
+        if required:
+            raise ValueError(f"All requests must have `{embeds_attr}` initialized.")
+        return PromptBatch(None, None, None)
+    if not all(embeds is not None for embeds, _ in fields):
         raise ValueError(f"Mixed {embeds_attr} in batch.")
 
-    mask_values = [mask for _, mask in prepared_fields]
-    if any(mask is None for mask in mask_values):
-        if any(mask is not None for mask in mask_values):
-            raise ValueError(f"Mixed {mask_attr} in batch.")
+    seq_lens_by_state = [
+        _seq_lens(state, embeds_attr=embeds_attr, mask_attr=mask_attr, seq_lens_attr=seq_lens_attr) for state in states
+    ]
+    target_len = max(max(lengths) for lengths in seq_lens_by_state)
+    for embeds, mask in fields:
+        assert embeds is not None
+        target_len = max(target_len, int(embeds.shape[1]))
+        if mask is not None:
+            target_len = max(target_len, int(mask.shape[1]))
 
-    target_seq_len = max(
-        max(
-            _get_request_prompt_seq_lens(
-                state,
-                embeds_attr=embeds_attr,
-                mask_attr=mask_attr,
-                seq_lens_attr=seq_lens_attr,
+    embeds_values: list[torch.Tensor] = []
+    mask_values: list[torch.Tensor] = []
+    any_mask = any(mask is not None for _, mask in fields)
+    if any_mask and not all(mask is not None for _, mask in fields):
+        raise ValueError(f"Mixed {mask_attr} in batch.")
+
+    for state, (embeds, mask), lengths in zip(states, fields, seq_lens_by_state, strict=True):
+        assert embeds is not None
+        if mask is None and max(lengths) != target_len:
+            raise ValueError(
+                f"Variable-length {embeds_attr} in batch but {mask_attr} is None for request {state.request_id}."
             )
-        )
-        for state in states
-    )
+        embeds = _pad_prompt(embeds, target_len)
+        setattr(state, embeds_attr, embeds)
+        embeds_values.append(embeds)
+        if mask is not None:
+            mask = _pad_mask(mask, target_len)
+            setattr(state, mask_attr, mask)
+            mask_values.append(mask)
 
-    request_embeds: list[torch.Tensor] = []
-    request_masks: list[torch.Tensor] = []
-    for state in states:
-        prepared_embeds, prepared_mask = _prepare_request_prompt_field(
-            state,
-            embeds_attr=embeds_attr,
-            mask_attr=mask_attr,
-            seq_lens_attr=seq_lens_attr,
-            target_seq_len=target_seq_len,
-        )
-        request_embeds.append(prepared_embeds)
-        if prepared_mask is not None:
-            request_masks.append(prepared_mask)
-
-    gathered_embeds = _gather_tensor_rows(
-        request_embeds,
-        field_name=embeds_attr,
-        out=embeds_out,
-    )
-
-    if not request_masks:
-        return gathered_embeds, None
-
-    gathered_masks = _gather_tensor_rows(
-        request_masks,
-        field_name=mask_attr,
-        out=mask_out,
-    )
-    return gathered_embeds, gathered_masks
-
-
-def _prepare_latents(
-    states: Sequence[DiffusionRequestState],
-    *,
-    out: torch.Tensor | None = None,
-) -> torch.Tensor:
-    latents_values = [state.latents for state in states]
-    if any(latents is None for latents in latents_values):
-        raise ValueError("All requests must have `latents` initialized.")
-    return _gather_tensor_rows(
-        [latents for latents in latents_values if latents is not None],
-        field_name="latents",
-        out=out,
+    embeds = _gather_rows(embeds_values, field_name=embeds_attr, out=embeds_out)
+    mask = _gather_rows(mask_values, field_name=mask_attr, out=mask_out) if mask_values else None
+    return PromptBatch(
+        embeds,
+        mask,
+        [int(length) for lengths in seq_lens_by_state for length in lengths],
     )
 
 
-def _require_state_latents(
-    state: DiffusionRequestState,
-    *,
-    for_field: str,
-) -> torch.Tensor:
-    latents = state.latents
-    if latents is None:
-        raise ValueError(f"Request {state.request_id} has no latents while preparing {for_field}.")
-    return latents
-
-
-def _expand_scalar_or_vector(
-    value: torch.Tensor,
-    *,
-    num_rows: int,
-    field_name: str,
-) -> torch.Tensor:
-    if value.ndim == 0:
-        return value.reshape(1).expand(num_rows)
-    if value.ndim != 1:
-        raise ValueError(f"{field_name} must be scalar or 1D, got ndim={value.ndim}.")
-    if value.shape[0] == num_rows:
-        return value
-    if value.shape[0] == 1:
-        return value.expand(num_rows)
-    raise ValueError(
-        f"Per-request {field_name} must have either 1 element or {num_rows} elements; got {value.shape[0]}."
-    )
-
-
-def _prepare_timesteps(
-    states: Sequence[DiffusionRequestState],
-    *,
-    out: torch.Tensor | None = None,
-) -> torch.Tensor:
-    timestep_values: list[torch.Tensor] = []
-    for state in states:
-        timestep = state.current_timestep
-        if timestep is None:
-            raise ValueError("All requests must have a current timestep initialized.")
-        if not torch.is_tensor(timestep):
-            raise ValueError("InputBatch expects tensor timesteps; normalize them before batching.")
-        latents = _require_state_latents(state, for_field="timesteps")
-        timestep_values.append(
-            _expand_scalar_or_vector(
-                timestep,
-                num_rows=int(latents.shape[0]),
-                field_name="timestep tensor",
-            )
-        )
-
-    return _gather_tensor_rows(
-        timestep_values,
-        field_name="timesteps",
-        out=out,
-    )
-
-
-def _prepare_cfg_scalars(
-    states: Sequence[DiffusionRequestState],
-) -> tuple[bool, float, bool]:
-    def _cfg_scalars(state: DiffusionRequestState) -> tuple[bool, float, bool]:
-        true_cfg_scale = getattr(state.sampling, "true_cfg_scale", None) or 4.0
-        cfg_normalize = bool(getattr(state.sampling, "cfg_normalize", False))
-        return state.do_true_cfg, true_cfg_scale, cfg_normalize
-
-    scalars = _cfg_scalars(states[0])
-    for state in states[1:]:
-        if _cfg_scalars(state) != scalars:
-            raise ValueError("Mixed CFG settings in one diffusion batch are not supported.")
-    return scalars
-
-
-def _prepare_guidance(
-    states: Sequence[DiffusionRequestState],
-    *,
-    out: torch.Tensor | None = None,
-) -> torch.Tensor | None:
-    guidance_values = [state.guidance for state in states]
-    if all(guidance is None for guidance in guidance_values):
-        return None
-    if any(guidance is None for guidance in guidance_values):
-        raise ValueError("Mixed guidance in one diffusion batch are not supported.")
-
-    gathered_guidance: list[torch.Tensor] = []
-    for state in states:
-        latents = _require_state_latents(state, for_field="guidance")
-        guidance = state.guidance
-        assert guidance is not None
-        guidance_tensor = torch.as_tensor(
-            guidance,
-            device=latents.device,
-            dtype=latents.dtype,
-        )
-        gathered_guidance.append(
-            _expand_scalar_or_vector(
-                guidance_tensor,
-                num_rows=int(latents.shape[0]),
-                field_name="guidance tensor",
-            )
-        )
-
-    return _gather_tensor_rows(
-        gathered_guidance,
-        field_name="guidance",
-        out=out,
-    )
-
-
-def _prepare_image_latents(
-    states: Sequence[DiffusionRequestState],
-    *,
-    out: torch.Tensor | None = None,
-) -> torch.Tensor | None:
-    image_latents = [getattr(state.sampling, "image_latent", None) for state in states]
-    if all(image_latent is None for image_latent in image_latents):
-        return None
-    if any(image_latent is None for image_latent in image_latents):
-        raise ValueError("Mixed image_latent presence in one diffusion batch is not supported.")
-    return _gather_tensor_rows(
-        [image_latent for image_latent in image_latents if image_latent is not None],
-        field_name="image_latents",
-        out=out,
-    )
-
-
-def _prepare_seq_lens(
-    states: Sequence[DiffusionRequestState],
-    attr_name: str,
-) -> list[int] | None:
+def _metadata_list(states: Sequence[DiffusionRequestState], attr_name: str) -> list | None:
     values = [getattr(state, attr_name) for state in states]
     if all(value is None for value in values):
         return None
     if any(value is None for value in values):
         raise ValueError(f"Mixed {attr_name} in batch.")
-    return [int(value[0]) for value in values if value is not None]
+    if attr_name == "img_shapes":
+        return [value[0] if value else [] for value in values]
+    return [int(value[0]) for value in values]
 
 
-def _prepare_img_shapes(states: Sequence[DiffusionRequestState]) -> list | None:
-    values = [state.img_shapes for state in states]
+def _cfg_values(states: Sequence[DiffusionRequestState]) -> tuple[bool, float, bool, list[float], list[bool]]:
+    do_cfg = bool(states[0].do_true_cfg)
+    scales: list[float] = []
+    normalizes: list[bool] = []
+    for state in states:
+        if bool(state.do_true_cfg) != do_cfg:
+            raise ValueError("Mixed CFG execution shapes in one diffusion batch are not supported.")
+        scale = getattr(state.sampling, "true_cfg_scale", None)
+        scales.append(4.0 if scale is None else float(scale))
+        normalizes.append(bool(getattr(state.sampling, "cfg_normalize", False)))
+    return do_cfg, scales[0], normalizes[0], scales, normalizes
+
+
+def _validate_dense_cfg_values(cfg_scales: Sequence[float], cfg_normalize: Sequence[bool]) -> None:
+    if len(set(cfg_scales)) > 1:
+        raise ValueError("Mixed true_cfg_scale in dense diffusion batch is not supported.")
+    if len(set(cfg_normalize)) > 1:
+        raise ValueError("Mixed cfg_normalize in dense diffusion batch is not supported.")
+
+
+def _guidance(states: Sequence[DiffusionRequestState], out: torch.Tensor | None = None) -> torch.Tensor | None:
+    values = [state.guidance for state in states]
     if all(value is None for value in values):
         return None
     if any(value is None for value in values):
-        raise ValueError("Mixed img_shapes in batch.")
-    return [value[0] if value else [] for value in values if value is not None]
+        raise ValueError("Mixed guidance in one diffusion batch is not supported.")
+    tensors: list[torch.Tensor] = []
+    for state in states:
+        latents = _state_latents(state)
+        guidance = torch.as_tensor(state.guidance, device=latents.device, dtype=latents.dtype)
+        tensors.append(_expand_rows(guidance, int(latents.shape[0]), field_name="guidance tensor"))
+    return _gather_rows(tensors, field_name="guidance", out=out)
 
 
-def _prepare_prompt_embeds(
-    states: Sequence[DiffusionRequestState],
-    *,
-    embeds_out: torch.Tensor | None = None,
-    mask_out: torch.Tensor | None = None,
-) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-    prompt_embeds, prompt_embeds_mask = _prepare_padded_prompt_fields(
-        states,
-        embeds_attr="prompt_embeds",
-        mask_attr="prompt_embeds_mask",
-        seq_lens_attr="txt_seq_lens",
-        embeds_out=embeds_out,
-        mask_out=mask_out,
-    )
-    return prompt_embeds, prompt_embeds_mask
+def _timesteps(states: Sequence[DiffusionRequestState], out: torch.Tensor | None = None) -> torch.Tensor:
+    tensors: list[torch.Tensor] = []
+    for state in states:
+        timestep = state.current_timestep
+        if timestep is None or not torch.is_tensor(timestep):
+            raise ValueError("All requests must have tensor current timesteps.")
+        tensors.append(_expand_rows(timestep, int(_state_latents(state).shape[0]), field_name="timestep tensor"))
+    return _gather_rows(tensors, field_name="timesteps", out=out)
 
 
-def _prepare_negative_prompt_embeds(
-    states: Sequence[DiffusionRequestState],
-    *,
-    embeds_out: torch.Tensor | None = None,
-    mask_out: torch.Tensor | None = None,
-) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-    return _prepare_padded_prompt_fields(
-        states,
-        embeds_attr="negative_prompt_embeds",
-        mask_attr="negative_prompt_embeds_mask",
-        seq_lens_attr="negative_txt_seq_lens",
-        embeds_out=embeds_out,
-        mask_out=mask_out,
-    )
+def _image_latents(states: Sequence[DiffusionRequestState], out: torch.Tensor | None = None) -> torch.Tensor | None:
+    values = [getattr(state.sampling, "image_latent", None) for state in states]
+    if all(value is None for value in values):
+        return None
+    if any(value is None for value in values):
+        raise ValueError("Mixed image_latent presence in one diffusion batch is not supported.")
+    return _gather_rows([value for value in values if value is not None], field_name="image_latents", out=out)
 
 
-def _same_composition(
-    cached_batch: InputBatch | None,
-    request_ids: list[str],
-    idx_mapping_np: np.ndarray,
-) -> bool:
-    if cached_batch is None:
-        return False
-    if cached_batch.request_ids != request_ids:
-        return False
-    return np.array_equal(cached_batch.idx_mapping_np, idx_mapping_np)
-
-
-def _scatter_batch_tensor_by_mapping(
-    states: Sequence[DiffusionRequestState],
-    idx_mapping_np: np.ndarray,
-    *,
-    attr_name: str,
-    value: torch.Tensor,
-) -> None:
-    row_offset = 0
-    for batch_idx, state_idx in enumerate(idx_mapping_np.tolist()):
-        if state_idx < 0 or state_idx >= len(states):
-            raise ValueError(f"idx_mapping[{batch_idx}]={state_idx} is out of range for states.")
-        state = states[state_idx]
-        state_value = getattr(state, attr_name)
-        num_rows = 1 if state_value is None else int(state_value.shape[0])
-        next_row_offset = row_offset + num_rows
-        value_slice = value[row_offset:next_row_offset]
-        if state_value is None:
-            setattr(state, attr_name, value_slice.clone())
-        elif (
-            tuple(state_value.shape) != tuple(value_slice.shape)
-            or state_value.dtype != value_slice.dtype
-            or state_value.device != value_slice.device
-        ):
-            setattr(state, attr_name, value_slice.clone())
-        else:
-            state_value.copy_(value_slice)
-        row_offset = next_row_offset
-
-    if row_offset != int(value.shape[0]):
-        raise ValueError(
-            f"Scatter for {attr_name} consumed {row_offset} rows, but batch has {int(value.shape[0])} rows."
+def _request_spans(states: Sequence[DiffusionRequestState]) -> list[RequestSpan]:
+    spans: list[RequestSpan] = []
+    row_start = 0
+    token_start = 0
+    for request_index, state in enumerate(states):
+        latents = _state_latents(state)
+        row_count = int(latents.shape[0])
+        token_count = int(latents.shape[1])
+        spans.append(
+            RequestSpan(
+                request_id=state.request_id,
+                request_index=request_index,
+                row_start=row_start,
+                row_count=row_count,
+                token_start=token_start,
+                token_count=token_count,
+            )
         )
+        row_start += row_count
+        token_start += token_count
+    return spans
+
+
+def _dense_latents(
+    states: Sequence[DiffusionRequestState],
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return _gather_rows([_state_latents(state) for state in states], field_name="latents", out=out)
+
+
+def _packed_latents(
+    states: Sequence[DiffusionRequestState],
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    values = [_state_latents(state).squeeze(0) for state in states]
+    return _gather_rows(values, field_name="packed_latents", out=out)
+
+
+def _img_seq_lens(states: Sequence[DiffusionRequestState]) -> list[int]:
+    return [int(_state_latents(state).shape[1]) for state in states]
+
+
+def build_img_query_start_loc(img_seq_lens: Sequence[int]) -> np.ndarray:
+    """Build the packed image-token cu_seqlens (``query_start_loc``).
+
+    Host-side ``[num_reqs + 1]`` int32 prefix sum over per-request image token
+    counts, mirroring vLLM's ``InputBatch.query_start_loc_np``. ``out[i]:out[i+1]``
+    is request ``i``'s slice in the packed ``[sum(img_seq_lens), C]`` tensor.
+    """
+    out = np.zeros(len(img_seq_lens) + 1, dtype=np.int32)
+    if img_seq_lens:
+        np.cumsum(np.asarray(img_seq_lens, dtype=np.int32), out=out[1:])
+    return out
+
+
+def split_packed_noise(
+    noise: torch.Tensor,
+    img_query_start_loc_np: np.ndarray,
+) -> list[torch.Tensor]:
+    """Split packed ``[num_img_tokens, C]`` noise into per-request row views.
+
+    Uses ``img_query_start_loc`` (cu_seqlens) slicing — the vLLM idiom — instead
+    of ``torch.split(..., img_seq_lens)``. Each slice is unsqueezed back to the
+    per-request ``[1, seq, C]`` layout that ``step_scheduler`` consumes.
+    """
+    qsl = img_query_start_loc_np
+    return [noise[int(qsl[i]) : int(qsl[i + 1])].unsqueeze(0) for i in range(len(qsl) - 1)]
+
+
+def _needs_dynamic_batch(
+    states: Sequence[DiffusionRequestState],
+    *,
+    positive_lens: list[int] | None,
+    negative_lens: list[int] | None,
+    cfg_scales: list[float],
+    cfg_normalize: list[bool],
+) -> bool:
+    latents = [_state_latents(state) for state in states]
+    latent_shapes = {tuple(value.shape[1:]) for value in latents}
+    row_counts = {int(value.shape[0]) for value in latents}
+    dynamic = False
+    if len(latent_shapes) > 1:
+        if len({value.dtype for value in latents}) > 1 or len({value.device for value in latents}) > 1:
+            raise ValueError("Dynamic latents require matching dtype and device.")
+        if len({tuple(value.shape[2:]) for value in latents}) > 1:
+            raise ValueError("Dynamic latents only support varying sequence length.")
+        dynamic = True
+    if positive_lens is not None and len(set(positive_lens)) > 1:
+        dynamic = True
+    if negative_lens is not None and len(set(negative_lens)) > 1:
+        dynamic = True
+    if dynamic and row_counts != {1}:
+        raise ValueError("Dynamic Qwen-Image batching currently supports one output row per request.")
+    return dynamic
+
+
+def _can_use_dynamic_request_view(
+    states: Sequence[DiffusionRequestState],
+    *,
+    allow_single: bool = False,
+) -> bool:
+    return (len(states) > 1 or allow_single) and {int(_state_latents(state).shape[0]) for state in states} == {1}
+
+
+def _should_use_dynamic_batch(
+    states: Sequence[DiffusionRequestState],
+    *,
+    allow_dynamic: bool,
+    positive_lens: list[int] | None,
+    negative_lens: list[int] | None,
+    cfg_scales: list[float],
+    cfg_normalize: list[bool],
+    force_dynamic_request_view: bool = False,
+) -> bool:
+    if not allow_dynamic:
+        return False
+    return _needs_dynamic_batch(
+        states,
+        positive_lens=positive_lens,
+        negative_lens=negative_lens,
+        cfg_scales=cfg_scales,
+        cfg_normalize=cfg_normalize,
+    ) or _can_use_dynamic_request_view(states, allow_single=force_dynamic_request_view)
 
 
 @dataclass
@@ -591,7 +466,7 @@ class InputBatch:
     idx_mapping: torch.Tensor
     idx_mapping_np: np.ndarray
 
-    latents: torch.Tensor
+    latents: torch.Tensor | None
     timesteps: torch.Tensor
     prompt_embeds: torch.Tensor | None
     prompt_embeds_mask: torch.Tensor | None
@@ -608,70 +483,116 @@ class InputBatch:
     negative_txt_seq_lens: list[int] | None = None
     states: Sequence[DiffusionRequestState] = field(default_factory=tuple)
 
+    is_dynamic: bool = False
+    packed_latents: torch.Tensor | None = None
+    img_seq_lens: list[int] | None = None
+    # vLLM-style packed image-token cu_seqlens (host). Derived from img_seq_lens
+    # for the dynamic path; None for the dense compatibility path.
+    img_query_start_loc_np: np.ndarray | None = None
+    request_spans: list[RequestSpan] = field(default_factory=list)
+    true_cfg_scales: list[float] = field(default_factory=list)
+    cfg_normalize_flags: list[bool] = field(default_factory=list)
+
     def __post_init__(self) -> None:
         if len(self.request_ids) != int(self.idx_mapping.numel()):
             raise ValueError("`request_ids` and `idx_mapping` must have the same length.")
         if self.num_reqs != len(self.request_ids):
-            raise ValueError("`num_reqs` must match the number of request ids.")
+            raise ValueError("`num_reqs` must match request_ids.")
         if self.num_reqs_after_padding < self.num_reqs:
             raise ValueError("`num_reqs_after_padding` must be >= `num_reqs`.")
+        if self.is_dynamic and self.packed_latents is None:
+            raise ValueError("Dynamic InputBatch requires packed_latents.")
+        if self.is_dynamic and not self.img_seq_lens:
+            raise ValueError("Dynamic InputBatch requires img_seq_lens.")
+        if not self.is_dynamic and self.latents is None:
+            raise ValueError("Dense InputBatch requires latents.")
 
-    def _refresh_dynamic_fields(
-        self,
-        selected_states: Sequence[DiffusionRequestState],
-    ) -> None:
-        self.latents = _prepare_latents(selected_states, out=self.latents)
-        self.timesteps = _prepare_timesteps(selected_states, out=self.timesteps)
-
-    def _refresh_static_fields(
+    def _refresh(
         self,
         states: Sequence[DiffusionRequestState],
-    ) -> None:
-        self.do_true_cfg, self.true_cfg_scale, self.cfg_normalize = _prepare_cfg_scalars(states)
-        self.guidance = _prepare_guidance(states, out=self.guidance)
-        self.image_latents = _prepare_image_latents(states, out=self.image_latents)
-        self.prompt_embeds, self.prompt_embeds_mask = _prepare_prompt_embeds(
-            states,
-            embeds_out=self.prompt_embeds,
-            mask_out=self.prompt_embeds_mask,
-        )
-        (
-            self.negative_prompt_embeds,
-            self.negative_prompt_embeds_mask,
-        ) = _prepare_negative_prompt_embeds(
-            states,
-            embeds_out=self.negative_prompt_embeds,
-            mask_out=self.negative_prompt_embeds_mask,
-        )
-        self.img_shapes = _prepare_img_shapes(states)
-        self.txt_seq_lens = _prepare_seq_lens(states, "txt_seq_lens")
-        self.negative_txt_seq_lens = _prepare_seq_lens(states, "negative_txt_seq_lens")
-
-    def _repack_dynamic_fields(
-        self,
-        selected_states: Sequence[DiffusionRequestState],
-    ) -> None:
-        # Same-composition cache hits reuse static prompt fields; request ids
-        # must keep the same encoded prompt metadata for the batch lifetime.
-        self.states = tuple(selected_states)
-        self._refresh_dynamic_fields(selected_states)
-
-    def _rebuild(
-        self,
-        selected_states: Sequence[DiffusionRequestState],
-        idx_mapping: torch.Tensor,
-        idx_mapping_np: np.ndarray,
-        request_ids: list[str],
+        *,
+        allow_dynamic: bool,
+        force_dynamic_request_view: bool,
+        require_prompt_embeds: bool,
+        static: bool,
     ) -> InputBatch:
-        self.request_ids = request_ids
-        self.num_reqs = len(request_ids)
-        self.num_reqs_after_padding = len(request_ids)
-        self.idx_mapping = idx_mapping
-        self.idx_mapping_np = idx_mapping_np
-        self.states = tuple(selected_states)
-        self.latents = _prepare_latents(selected_states, out=self.latents)
-        self.timesteps = _prepare_timesteps(selected_states, out=self.timesteps)
-        self._refresh_static_fields(selected_states)
+        self.states = tuple(states)
+        timesteps = _timesteps(states, out=self.timesteps)
+        request_spans = _request_spans(states)
+        latents_out = self.latents if not self.is_dynamic else None
+        packed_latents_out = self.packed_latents if self.is_dynamic else None
+
+        prompt = (
+            _build_prompt_batch(
+                states,
+                embeds_attr="prompt_embeds",
+                mask_attr="prompt_embeds_mask",
+                seq_lens_attr="txt_seq_lens",
+                required=require_prompt_embeds,
+                embeds_out=self.prompt_embeds if static else None,
+                mask_out=self.prompt_embeds_mask if static else None,
+            )
+            if static
+            else PromptBatch(self.prompt_embeds, self.prompt_embeds_mask, self.txt_seq_lens)
+        )
+        negative = (
+            _build_prompt_batch(
+                states,
+                embeds_attr="negative_prompt_embeds",
+                mask_attr="negative_prompt_embeds_mask",
+                seq_lens_attr="negative_txt_seq_lens",
+                required=False,
+                embeds_out=self.negative_prompt_embeds if static else None,
+                mask_out=self.negative_prompt_embeds_mask if static else None,
+            )
+            if static
+            else PromptBatch(self.negative_prompt_embeds, self.negative_prompt_embeds_mask, self.negative_txt_seq_lens)
+        )
+        do_cfg, cfg_scale, cfg_norm, cfg_scales, cfg_norms = _cfg_values(states)
+        is_dynamic = _should_use_dynamic_batch(
+            states,
+            allow_dynamic=allow_dynamic,
+            positive_lens=prompt.seq_lens,
+            negative_lens=negative.seq_lens,
+            cfg_scales=cfg_scales,
+            cfg_normalize=cfg_norms,
+            force_dynamic_request_view=force_dynamic_request_view,
+        )
+        if not is_dynamic:
+            _validate_dense_cfg_values(cfg_scales, cfg_norms)
+
+        self.timesteps = timesteps
+        self.request_spans = request_spans
+        self.do_true_cfg = do_cfg
+        self.true_cfg_scale = cfg_scale
+        self.cfg_normalize = cfg_norm
+        self.true_cfg_scales = cfg_scales
+        self.cfg_normalize_flags = cfg_norms
+        self.guidance = _guidance(states, out=self.guidance)
+
+        if static:
+            self.prompt_embeds = prompt.embeds
+            self.prompt_embeds_mask = prompt.mask
+            self.negative_prompt_embeds = negative.embeds
+            self.negative_prompt_embeds_mask = negative.mask
+            self.img_shapes = _metadata_list(states, "img_shapes")
+            self.txt_seq_lens = prompt.seq_lens
+            self.negative_txt_seq_lens = negative.seq_lens
+            self.image_latents = _image_latents(states, out=self.image_latents)
+
+        self.is_dynamic = is_dynamic
+        if is_dynamic:
+            if self.image_latents is not None:
+                raise ValueError("Dynamic Qwen-Image step batching does not support image_latents yet.")
+            self.latents = None
+            self.packed_latents = _packed_latents(states, out=packed_latents_out)
+            self.img_seq_lens = _img_seq_lens(states)
+            self.img_query_start_loc_np = build_img_query_start_loc(self.img_seq_lens)
+        else:
+            self.latents = _dense_latents(states, out=latents_out)
+            self.packed_latents = None
+            self.img_seq_lens = None
+            self.img_query_start_loc_np = None
         self.__post_init__()
         return self
 
@@ -681,70 +602,110 @@ class InputBatch:
         states: Sequence[DiffusionRequestState],
         idx_mapping: torch.Tensor | None = None,
         cached_batch: InputBatch | None = None,
+        allow_dynamic: bool = False,
+        force_dynamic_request_view: bool = False,
+        require_prompt_embeds: bool = False,
     ) -> InputBatch:
-        """Build a temporary step-local batch view from request states."""
-        selected_states, idx_mapping, idx_mapping_np = _select_states(states, idx_mapping)
-        request_ids = _prepare_request_ids(selected_states)
+        selected, idx_mapping, idx_mapping_np = _select_states(states, idx_mapping)
+        request_ids = [state.request_id for state in selected]
 
-        if _same_composition(cached_batch, request_ids, idx_mapping_np):
+        same = (
+            cached_batch is not None
+            and cached_batch.request_ids == request_ids
+            and np.array_equal(cached_batch.idx_mapping_np, idx_mapping_np)
+        )
+        if same:
             assert cached_batch is not None
-            cached_batch._repack_dynamic_fields(selected_states)
-            return cached_batch
-
-        if cached_batch is not None:
-            return cached_batch._rebuild(
-                selected_states,
-                idx_mapping,
-                idx_mapping_np,
-                request_ids,
+            return cached_batch._refresh(
+                selected,
+                allow_dynamic=allow_dynamic,
+                force_dynamic_request_view=force_dynamic_request_view,
+                require_prompt_embeds=require_prompt_embeds,
+                static=False,
             )
 
-        prompt_embeds, prompt_embeds_mask = _prepare_prompt_embeds(selected_states)
-        negative_prompt_embeds, negative_prompt_embeds_mask = _prepare_negative_prompt_embeds(selected_states)
-        do_true_cfg, true_cfg_scale, cfg_normalize = _prepare_cfg_scalars(selected_states)
-        return cls(
+        prompt = _build_prompt_batch(
+            selected,
+            embeds_attr="prompt_embeds",
+            mask_attr="prompt_embeds_mask",
+            seq_lens_attr="txt_seq_lens",
+            required=require_prompt_embeds,
+        )
+        negative = _build_prompt_batch(
+            selected,
+            embeds_attr="negative_prompt_embeds",
+            mask_attr="negative_prompt_embeds_mask",
+            seq_lens_attr="negative_txt_seq_lens",
+            required=False,
+        )
+        do_cfg, cfg_scale, cfg_norm, cfg_scales, cfg_norms = _cfg_values(selected)
+        is_dynamic = _should_use_dynamic_batch(
+            selected,
+            allow_dynamic=allow_dynamic,
+            positive_lens=prompt.seq_lens,
+            negative_lens=negative.seq_lens,
+            cfg_scales=cfg_scales,
+            cfg_normalize=cfg_norms,
+            force_dynamic_request_view=force_dynamic_request_view,
+        )
+        if not is_dynamic:
+            _validate_dense_cfg_values(cfg_scales, cfg_norms)
+        image_latents = _image_latents(selected)
+        if is_dynamic and image_latents is not None:
+            raise ValueError("Dynamic Qwen-Image step batching does not support image_latents yet.")
+
+        batch = cls(
             request_ids=request_ids,
-            num_reqs=len(selected_states),
-            num_reqs_after_padding=len(selected_states),
+            num_reqs=len(selected),
+            num_reqs_after_padding=len(selected),
             idx_mapping=idx_mapping,
             idx_mapping_np=idx_mapping_np,
-            latents=_prepare_latents(selected_states),
-            timesteps=_prepare_timesteps(selected_states),
-            guidance=_prepare_guidance(selected_states),
-            do_true_cfg=do_true_cfg,
-            true_cfg_scale=true_cfg_scale,
-            cfg_normalize=cfg_normalize,
-            image_latents=_prepare_image_latents(selected_states),
-            prompt_embeds=prompt_embeds,
-            prompt_embeds_mask=prompt_embeds_mask,
-            negative_prompt_embeds=negative_prompt_embeds,
-            negative_prompt_embeds_mask=negative_prompt_embeds_mask,
-            img_shapes=_prepare_img_shapes(selected_states),
-            txt_seq_lens=_prepare_seq_lens(selected_states, "txt_seq_lens"),
-            negative_txt_seq_lens=_prepare_seq_lens(
-                selected_states,
-                "negative_txt_seq_lens",
-            ),
-            states=tuple(selected_states),
+            latents=None if is_dynamic else _dense_latents(selected),
+            timesteps=_timesteps(selected),
+            guidance=_guidance(selected),
+            do_true_cfg=do_cfg,
+            true_cfg_scale=cfg_scale,
+            cfg_normalize=cfg_norm,
+            image_latents=image_latents,
+            prompt_embeds=prompt.embeds,
+            prompt_embeds_mask=prompt.mask,
+            negative_prompt_embeds=negative.embeds,
+            negative_prompt_embeds_mask=negative.mask,
+            img_shapes=_metadata_list(selected, "img_shapes"),
+            txt_seq_lens=prompt.seq_lens,
+            negative_txt_seq_lens=negative.seq_lens,
+            is_dynamic=is_dynamic,
+            packed_latents=_packed_latents(selected) if is_dynamic else None,
+            img_seq_lens=_img_seq_lens(selected) if is_dynamic else None,
+            img_query_start_loc_np=(build_img_query_start_loc(_img_seq_lens(selected)) if is_dynamic else None),
+            request_spans=_request_spans(selected),
+            true_cfg_scales=cfg_scales,
+            cfg_normalize_flags=cfg_norms,
+            states=tuple(selected),
         )
+        return batch
 
 
-def scatter_latents(
-    states: Sequence[DiffusionRequestState],
-    input_batch: InputBatch,
-) -> None:
-    """Scatter the step-updated latents back into persistent request states.
+def scatter_latents(states: Sequence[DiffusionRequestState], input_batch: InputBatch) -> None:
+    if input_batch.is_dynamic:
+        return
+    if input_batch.latents is None:
+        raise ValueError("Dense scatter requires input_batch.latents.")
 
-    This is the CPU fallback of the vLLM-style post-update path. The mapping is
-    driven entirely by ``input_batch.idx_mapping_np`` so the runner remains free
-    to keep request states in its own persistent storage layout.
-    """
-    _scatter_batch_tensor_by_mapping(
-        states,
-        input_batch.idx_mapping_np,
-        attr_name="latents",
-        value=input_batch.latents,
-    )
+    offset = 0
+    for state_idx in input_batch.idx_mapping_np.tolist():
+        if state_idx < 0 or state_idx >= len(states):
+            raise ValueError(f"idx_mapping contains out-of-range state index {state_idx}.")
+        state = states[state_idx]
+        row_count = int(_state_latents(state).shape[0])
+        value = input_batch.latents[offset : offset + row_count]
+        if tuple(state.latents.shape) == tuple(value.shape) and state.latents.dtype == value.dtype:
+            state.latents.copy_(value)
+        else:
+            state.latents = value.clone()
+        offset += row_count
+    if offset != int(input_batch.latents.shape[0]):
+        raise ValueError(f"Scatter consumed {offset} rows, but batch has {input_batch.latents.shape[0]} rows.")
 
 
 DiffusionInputBatch = InputBatch


### PR DESCRIPTION
<!-- markdownlint-disable -->

## What does this PR do?

**related:**
https://github.com/vllm-project/vllm-omni/issues/874
https://github.com/vllm-project/vllm-omni/issues/3846

**plans:**
- [x] Validate the single-GPU path.
- [x] Add multi-GPU parallelism compatibility.
- [ ] Add compatibility with acceleration features such as CUDA Graph.



This PR adds dynamic batching support for heterogeneous diffusion `execute_stepwise` requests.

It allows diffusion requests with different image resolutions, image token lengths, text lengths, denoise progress, and request-local CFG scalar values to be batched in the same step, as long as they share the same execution mode.

Qwen-Image is used as the first supported model path to validate the metadata contract and execution flow.

## Why is this needed?

diffusion batching is mostly limited by `SamplingParamsKey`. Several request-local fields are treated as hard batching keys, even though they do not change the transformer execution path.

For example, requests with different resolutions or different `true_cfg_scale` values may still be able to share one packed attention forward. However, because these fields are included in the compatibility key, the scheduler splits them into separate batches. This reduces batching opportunities and lowers GPU utilization.

This PR moves shape-related and CFG scalar fields out of the scheduler key and keeps them as request-local runner/model metadata.

## Main changes

This PR:

* Narrows the dynamic diffusion batching key to true execution barriers:

  * `do_classifier_free_guidance`
  * `lora_int_id`
  * `lora_scale`
* Keeps resolution, text length, timestep, scheduler state, RoPE inputs, and CFG scalar values as request-local state.
* Adds attention metadata for:

  * request boundaries
  * text/image/negative-text spans
  * packed token lengths
  * request-local position/RoPE metadata
* Adds a FlashAttention varlen path for packed `[total_tokens, num_heads, head_dim]` Q/K/V tensors.
* Adds a Qwen-Image dynamic path that:

  * rebuilds per-request RoPE
  * runs packed joint attention
  * splits outputs back by request
  * applies CFG combine per request
* Keeps the existing dense homogeneous path unchanged.
* Fails fast for unsupported profiles.

## How batching works

Instead of padding every request to the largest shape, the runner packs only real tokens.

For each step batch:

* image latents remain request-local before packing;
* text lengths are taken from the real prompt mask or request-local metadata;
* image grid shapes stay in `img_shapes`;
* packed spans are recorded in request/segment metadata;
* padded text or image tokens are not allowed to enter the dynamic attention path.

The packed path only changes how tokens are laid out for FlashAttention. It does not change request-local RoPE, attention boundaries, or output restore semantics.

## Correctness model

The dynamic path relies on three metadata layers.

### 1. Request-local state

Each request keeps its own shape, text length, timestep, scheduler state, CFG values, and RoPE inputs.

RoPE is rebuilt from this request-local state. The model does not infer positions from packed global offsets, so a request should get the same RoPE whether it runs alone or inside a mixed batch.

### 2. AttentionMetadata

`AttentionMetadata` describes the varlen execution contract consumed by the attention backend.

It records packed request order, `q_cu_seqlens`, `kv_cu_seqlens`, max lengths, padded token count, and position metadata.

The FlashAttention varlen path consumes these boundaries directly, so tokens from one request cannot attend to tokens from another request even when they are concatenated into one flat tensor.

### 3. AttentionSegment

`AttentionSegment` records semantic split/gather spans inside each request.

It is used to identify text, image, and negative-text spans, and to scatter attention outputs back to the original request-local latent state.

`AttentionSegment` is intentionally separate from cache layout, LoRA routing, and MoE routing.

## CFG behavior

CFG batching is split into two parts:

* execution shape
* request-local scalar math

The scheduler only keeps one CFG execution key: `do_classifier_free_guidance`.

In the first validated Qwen-Image path, a request is treated as CFG-active when:

```text
true_cfg_scale > 1 and negative_prompt is present
```

This prevents CFG-active and non-CFG requests from sharing an incompatible forward shape.

However, different CFG scalar values can still batch together. For example, requests with `true_cfg_scale=2.0` and `true_cfg_scale=7.0` can share the same CFG batch because the scalar does not change the attention layout.

At runner/model time:

* the positive pass uses positive attention metadata;
* the negative pass uses negative attention metadata when true CFG is active;
* positive and negative text spans are represented as separate segments;
* `true_cfg_scale` and `cfg_normalize` remain per-request values;
* CFG combine is applied after per-request split:

```text
negative + true_cfg_scale * (positive - negative)
```

This ensures that different guidance scales can batch together without mixing request semantics.

## Current guardrails

This PR keeps the first dynamic path conservative.

The dynamic path currently fails fast for:

* KV cache / cache-enabled paths
* image editing inputs
* sequence parallel
* ring attention
* CFG parallel
* HSDP
* non-eager graph paths
* non-FlashAttention backends

These are intentionally disabled until their metadata and correctness requirements are handled explicitly.

## Test plan

Focused scheduler and Qwen-Image dynamic batching tests:

```bash
python -m pytest \
  tests/diffusion/test_qwen_image_dynamic_step_batching.py \
  tests/diffusion/test_diffusion_scheduler.py
```

Online serving e2e test:

```bash
python -m pytest \
  tests/e2e/online_serving/test_qwen_image_dynamic_step_batching.py
```

Lint and format checks for changed Python files:

```bash
CHANGED_PY_FILES="$(git diff --name-only origin/main...HEAD -- '*.py')"
.venv/bin/ruff format $CHANGED_PY_FILES
.venv/bin/ruff check $CHANGED_PY_FILES
```

## Test results

Focused scheduler and dynamic batching tests:

```text
57 passed
```

Online serving e2e test:

```text
1 passed
```

The current e2e coverage uses Qwen-Image and compares execute-model, dynamic single-request, and staggered dynamic multi-request paths for:

* `512x512 + 512x512`
* `512x512 + 1024x1024`
* `512x512 + 256x256`

It also covers batching requests with different `true_cfg_scale` values and verifies that the dynamic multi-request path does not materially regress against the dynamic single-request path in the tested cases.

## CC List.

cc
@ZJY0516 @fake0fan @SamitHuang @hsliuustc0106 @fhfuih @wuhang2014 @Semmer2 @wtomin 

