### PR TITLE
fix: prevent qwen2_5_omni crash during multimodal M-RoPE position calculation

### DIFF
--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
@@ -425,6 +425,7 @@ class Qwen2_5OmniThinkerForConditionalGeneration(
         self,
         input_tokens: list[int],
         mm_features: list[MultiModalFeatureSpec],
+        **kwargs: object,
     ) -> tuple[torch.Tensor, int]:
         """
         Example:


### PR DESCRIPTION
 

## Purpose

fix: prevent qwen2_5_omni crash during multimodal M-RoPE position calculation

Deploying qwen2_5_omni_thinker.py model for multimodal inference (images, videos, or audio) using gpu_model_runner.py.

Like other thinker models, qwen2_5_omni_thinker.py extracts required parameters internally from  mm_features  and does not use external  runner-level keyword arguments. However, gpu_model_runner.py forces passing these keyword arguments, causing  TypeError  because signature lacks  **kwargs  to accept them.

System crashes immediately with  TypeError: get_mrope_input_positions() got unexpected keyword argument  when
  calculating multimodal position IDs.


```

    class Qwen2_5OmniThinkerForConditionalGeneration(
        nn.Module,
        SupportsMultiModal,
        SupportsPP,
        SupportsLoRA,
        SupportsMRoPE,             # <--- supports_mrope
        Qwen2_5OmniConditionalGenerationMixin,
    ):


  ----- in gpu_model_runner.py 

            if supports_mrope(self.get_model()):
                # Model implements SupportsMRoPE interface
                # Pass all extracted metadata; models use what they need via **kwargs
                ....
                kwargs = dict(
                    mm_features=req_state.mm_features,
                    hf_config=self.model_config.hf_config,
                    image_grid_thw=image_grid_thw,
                    video_grid_thw=video_grid_thw,
                    second_per_grid_ts=second_per_grid_ts,
                    audio_feature_lengths=audio_feature_lengths,
                    use_audio_in_video=use_audio_in_video,
                )
               ...
                req_state.mrope_positions, req_state.mrope_position_delta = self.model.get_mrope_input_positions(
                    req_state.prompt_token_ids,
                    **kwargs,
                )
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
