### PR TITLE
[Perf][Refactor][NPU] Use torch_npu.npu_rotary_mul consistently for NPU RoPE.

### DIFF
--- a/vllm_omni/diffusion/layers/rope.py
+++ b/vllm_omni/diffusion/layers/rope.py
@@ -36,14 +36,14 @@ def apply_rotary_emb_torch(x, cos, sin, interleaved=False):
     )
 
 
-def apply_rotary_emb_mindiesd(
+def apply_rotary_emb_torch_npu(
     x: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
     interleaved: bool = False,
     half_head_dim: bool = True,  # if true, size of sin and cos is (B, S, D/2), otherwise (B, S, D)
 ) -> torch.Tensor:
-    from mindiesd import rotary_position_embedding
+    import torch_npu
 
     if cos.dim() == 3:
         # (B, S, D/2) -> (S, D/2)
@@ -51,18 +51,16 @@ def apply_rotary_emb_mindiesd(
         sin = sin[0]
 
     if interleaved:
-        # if last dim of sin and cos is D/2, expand to (S, D) to adapt to mindiesd operators
         if half_head_dim:
             seqlen = cos.shape[0]
             sin = sin.unsqueeze(0).unsqueeze(2).unsqueeze(-1).expand(-1, -1, -1, -1, 2).reshape(1, seqlen, 1, -1)
             cos = cos.unsqueeze(0).unsqueeze(2).unsqueeze(-1).expand(-1, -1, -1, -1, 2).reshape(1, seqlen, 1, -1)
-        return rotary_position_embedding(x, cos, sin, rotated_mode="rotated_interleaved", head_first=False, fused=True)
+        return torch_npu.npu_rotary_mul(x, cos, sin, "interleave")
     else:
         if half_head_dim:
-            seqlen = cos.shape[0]
             sin = sin.unsqueeze(0).unsqueeze(2).repeat(1, 1, 1, 2)
             cos = cos.unsqueeze(0).unsqueeze(2).repeat(1, 1, 1, 2)
-        return rotary_position_embedding(x, cos, sin, rotated_mode="rotated_half", head_first=False, fused=True)
+        return torch_npu.npu_rotary_mul(x, cos, sin)
 
 
 def _ensure_batch_dim(x: torch.Tensor) -> tuple[torch.Tensor, bool]:
@@ -160,10 +158,7 @@ class RotaryEmbedding(CustomOp):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> torch.Tensor:
-        if self.has_mindie:
-            return apply_rotary_emb_mindiesd(x, cos, sin, self.interleaved)
-        else:
-            return self.forward_native(x, cos, sin)
+        return apply_rotary_emb_torch_npu(x, cos, sin, self.interleaved)
 
     def forward_xpu(
         self,
@@ -251,13 +246,10 @@ class RotaryEmbeddingWan(RotaryEmbedding):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> torch.Tensor:
-        if self.has_mindie:
-            if cos.dim() > 2:
-                cos = cos.reshape(-1, cos.shape[-1])
-                sin = sin.reshape(-1, sin.shape[-1])
-            return apply_rotary_emb_mindiesd(x, cos, sin, self.interleaved, self.half_head_dim)
-        else:
-            return self.forward_native(x, cos, sin)
+        if cos.dim() > 2:
+            cos = cos.reshape(-1, cos.shape[-1])
+            sin = sin.reshape(-1, sin.shape[-1])
+        return apply_rotary_emb_torch_npu(x, cos, sin, self.interleaved, self.half_head_dim)
 
     def forward_native(
         self,

--- a/vllm_omni/diffusion/layers/rope.py
+++ b/vllm_omni/diffusion/layers/rope.py
@@ -91,7 +91,6 @@ class RotaryEmbedding(CustomOp):
         self.is_neox_style = is_neox_style
         self.interleaved = not is_neox_style
         self.apply_rotary_emb_flash_attn = None
-        self.has_mindie = False
         # ``find_spec("flash_attn")`` is True as long as *any* package publishes
         # the ``flash_attn`` namespace — including ``flash-attn-4``, which ships
         # only ``flash_attn.cute`` and no ``flash_attn.ops``. Guard the import
@@ -104,8 +103,6 @@ class RotaryEmbedding(CustomOp):
                 self.apply_rotary_emb_flash_attn = apply_rotary
             except ImportError:
                 pass
-        if find_spec("mindiesd") is not None:
-            self.has_mindie = True
 
     def forward_cuda(
         self,


### PR DESCRIPTION

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

Closes https://github.com/vllm-project/vllm-omni/issues/4042
## Purpose

## Test Plan

- quay.io/ascend/vllm-omni:v0.20.0
- 910b

## Test Result
### Rope Performance

| Case(iters: 100)       | Shape               | forward_npu (ms) | forward_native (ms) | npu vs native  | forward_mindie (ms) | npu vs mindie  |
|----------|---------------------|------------------|---------------------|------------|---------------------|---------|
| S=512    | [1, 512, 24, 128]   | 0.2108 ± 0.0196 ms | 0.3978 ± 0.0422 ms  | +88.7%     | 0.2359 ± 0.0349 ms  | +11.9%  |
| S=1024   | [1, 1024, 24, 128]  | 0.2089 ± 0.0406 ms | 0.4025 ± 0.0817 ms  | +92.7%     | 0.2249 ± 0.0156 ms  | +7.7%   |
| S=2048   | [1, 2048, 24, 128]  | 0.2380 ± 0.0297 ms | 0.3853 ± 0.0135 ms  | +61.9%     | 0.2529 ± 0.0276 ms  | +6.3%   |

### Wan 2.2 I2V Acc

```sh
PYTORCH_NPU_ALLOC_CONF='expandable_segments:True' \
TASK_QUEUE_ENABLE=2 \
CPU_AFFINITY_CONF=1 \
TOKENIZERS_PARALLELISM=false \
MULTI_STREAM_MEMORY_REUSE=2 \
MINDIE_SD_FA_TYPE=ascend_laser_attention \
vllm serve /data/models/Wan2.2-I2V-A14B-Diffusers/ \
--omni \
--port 8080 \
--usp 4 \
--use-hsdp \
--enforce-eager \
--log-stats \
--profiler-config '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_with_stack": "False"}' \
--vae-patch-parallel-size 4 \
--vae-use-tiling
```

```sh
curl --location --request POST 'localhost:8080/v1/videos' \
--form 'prompt="'\''Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline'\''s intricate details and the refreshing atmosphere of the seaside.'\''"' \
--form 'input_reference=@"/data/i2v_input.jpg"' \
--form 'size="720x1280"' \
--form 'fps="12"' \
--form 'num_frames="61"' \
--form 'guidance_scale="5.0"' \
--form 'flow_shift="5.0"' \
--form 'num_inference_steps="10"' \
--form 'enable_frame_interpolation="true"' \
--form 'frame_interpolation_exp="1"' \
--form 'frame_interpolation_scale="1.0"' \
--form 'seed="42"'
```
Before(w/ mindie):

https://github.com/user-attachments/assets/a742577a-5718-4c5e-8432-369cd9fdcda1


```sh
(APIServer pid=298561) INFO 06-02 08:44:48 [diffusion_engine.py:210] DiffusionEngine.step breakdown: preprocess=0.82 ms, add_req_and_wait=132549.59 ms, postprocess=18596.14 ms, total=151147.27 ms
(APIServer pid=298561) INFO 06-02 08:44:52 [serving_video.py:257] Video response encoding (MP4 bytes): 4016.64 ms
```

After(w/ torch_npu):


https://github.com/user-attachments/assets/a13e9673-710b-49ba-9d94-278efeb51f1c


```sh
(APIServer pid=271527) INFO 06-02 08:30:22 [diffusion_engine.py:210] DiffusionEngine.step breakdown: preprocess=1.07 ms, add_req_and_wait=132418.91 ms, postprocess=19115.10 ms, total=151535.79 ms
(APIServer pid=271527) INFO 06-02 08:30:26 [serving_video.py:257] Video response encoding (MP4 bytes): 3630.18 ms
```

### Wan 2.2 Performance
```sh
python /vllm-workspace/vllm-omni/benchmarks/diffusion/diffusion_benchmark_serving.py \
--backend v1/videos \
--dataset vbench \
--task i2v \
--num-prompts 10 \
--height 720 \
--width 720 \
--num-frames 61 \
--num-inference-steps 10 \
--seed 42 \
--fps 12 \
--base-url http://localhost:8080
```
Before(w/ mindie):
```sh
================= Serving Benchmark Result =================
Backend:                                 v1/videos      
Model:                                   default        
Dataset:                                 vbench         
Task:                                    i2v            
--------------------------------------------------
Benchmark duration (s):                  489.01         
Request rate:                            inf            
Max request concurrency:                 1              
Successful requests:                     10/10             
--------------------------------------------------
Request throughput (req/s):              0.02           
Latency Mean (s):                        48.9002        
Latency Median (s):                      48.9170        
Latency P99 (s):                         49.2011        
Latency P95 (s):                         49.1321        
--------------------------------------------------
Peak Memory Max (MB):                    32128.00       
Peak Memory Mean (MB):                   32073.00       
Peak Memory Median (MB):                 32069.00       
--------------------------------------------------
Stage Durations Mean (s):
  queue_wait_ms:                         1.0313         
  stage_0_gen_ms:                        45359.6212     

============================================================
```
After(w/ torch_npu):
```sh
================= Serving Benchmark Result =================
Backend:                                 v1/videos      
Model:                                   default        
Dataset:                                 vbench         
Task:                                    i2v            
--------------------------------------------------
Benchmark duration (s):                  490.44         
Request rate:                            inf            
Max request concurrency:                 1              
Successful requests:                     10/10             
--------------------------------------------------
Request throughput (req/s):              0.02           
Latency Mean (s):                        49.0437        
Latency Median (s):                      49.0096        
Latency P99 (s):                         49.5252        
Latency P95 (s):                         49.4424        
--------------------------------------------------
Peak Memory Max (MB):                    32130.00       
Peak Memory Mean (MB):                   32079.00       
Peak Memory Median (MB):                 32079.00       
--------------------------------------------------
Stage Durations Mean (s):
  queue_wait_ms:                         1.0945         
  stage_0_gen_ms:                        45441.1645     

============================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
