### PR TITLE
[Cleanup] Fix pre-commit hook order: check-pickle-imports must precede suggestion (#4009)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,13 @@ repos:
       verbose: true
       stages: [commit-msg]
 
+    - id: check-pickle-imports
+      name: Prevent new pickle/cloudpickle imports
+      entry: python tools/pre_commit/check_pickle_imports.py
+      language: python
+      types: [python]
+      additional_dependencies: [regex]
+
     # Keep `suggestion` last
     - id: suggestion
       name: Suggestion
@@ -61,11 +68,3 @@ repos:
       language: system
       verbose: true
       pass_filenames: false
-    # Insert new entries above the `suggestion` entry
-
-    - id: check-pickle-imports
-      name: Prevent new pickle/cloudpickle imports
-      entry: python tools/pre_commit/check_pickle_imports.py
-      language: python
-      types: [python]
-      additional_dependencies: [regex]


### PR DESCRIPTION
## Purpose

check-pickle-imports was placed after the suggestion hook, violating the comment "Keep suggestion last". Move check-pickle-imports above suggestion to restore correct ordering. Part of codebase cleanup audit #4009.

## Test Plan


uvx pre-commit validate-config .pre-commit-config.yaml
## Test Result


config OK