### PR TITLE
[Perf][Ming-flash-omni-2] Optimize Talker TTS high-concurrency serving fast paths

### DIFF
--- a/tests/core/sched/test_ming_tts_cohort_hold.py
+++ b/tests/core/sched/test_ming_tts_cohort_hold.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
+
+
+def _request(cohort_id: int, cohort_size: int = 2):
+    return SimpleNamespace(
+        additional_information={
+            "ming_tts_admission_cohort": cohort_id,
+            "ming_tts_admission_cohort_size": cohort_size,
+        }
+    )
+
+
+def _scheduler(*waiting, running=(), max_num_running_reqs: int = 8):
+    scheduler = OmniGenerationScheduler.__new__(OmniGenerationScheduler)
+    scheduler.waiting = list(waiting)
+    scheduler.running = list(running)
+    scheduler.max_num_running_reqs = max_num_running_reqs
+    scheduler._ming_tts_cohort_hold_deadlines = {}
+    scheduler._ming_tts_cohort_hold_s = 0.05
+    return scheduler
+
+
+def test_ming_tts_cohort_hold_waits_for_same_cohort_only():
+    current = _request(1, cohort_size=2)
+    other = _request(2, cohort_size=2)
+    scheduler = _scheduler(current, other)
+
+    assert scheduler._should_hold_ming_tts_batch(current, now=1.0) is True
+
+
+def test_ming_tts_cohort_hold_releases_when_same_cohort_is_ready():
+    current = _request(1, cohort_size=2)
+    peer = _request(1, cohort_size=2)
+    scheduler = _scheduler(current, peer)
+
+    assert scheduler._should_hold_ming_tts_batch(current, now=1.0) is False
+
+
+def test_ming_tts_cohort_hold_respects_available_slots():
+    current = _request(1, cohort_size=8)
+    scheduler = _scheduler(current, running=range(7), max_num_running_reqs=8)
+
+    assert scheduler._should_hold_ming_tts_batch(current, now=1.0) is False

--- a/tests/entrypoints/openai/test_ming_tts_admission_gate.py
+++ b/tests/entrypoints/openai/test_ming_tts_admission_gate.py
@@ -1,0 +1,99 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.entrypoints.openai.serving_speech import MingTTSAdmissionGate, OmniOpenAIServingSpeech
+
+
+@pytest.mark.asyncio
+async def test_ming_tts_admission_gate_releases_full_batch_together():
+    gate = MingTTSAdmissionGate(max_batch_size=2, max_wait_ms=1000)
+
+    async def wait(name):
+        cohort = await gate.wait("same-key")
+        return name, cohort
+
+    first = asyncio.create_task(wait("first"))
+    await asyncio.sleep(0)
+    assert not first.done()
+
+    second = asyncio.create_task(wait("second"))
+    results = await asyncio.wait_for(asyncio.gather(first, second), timeout=1)
+
+    assert results[0][0] == "first"
+    assert results[1][0] == "second"
+    assert results[0][1][0] == results[1][1][0]
+    assert results[0][1][1] == 2
+
+
+@pytest.mark.asyncio
+async def test_ming_tts_admission_gate_yields_after_full_batch_release():
+    gate = MingTTSAdmissionGate(max_batch_size=2, max_wait_ms=1000)
+    resumed = []
+
+    async def wait(name):
+        cohort = await gate.wait("same-key")
+        resumed.append((name, cohort))
+
+    first = asyncio.create_task(wait("first"))
+    await asyncio.sleep(0)
+    assert not first.done()
+
+    second = asyncio.create_task(wait("second"))
+    await asyncio.sleep(0)
+
+    assert resumed == []
+    await asyncio.wait_for(asyncio.gather(first, second), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_ming_tts_admission_gate_separates_keys():
+    gate = MingTTSAdmissionGate(max_batch_size=2, max_wait_ms=20)
+
+    first = asyncio.create_task(gate.wait("a"))
+    second = asyncio.create_task(gate.wait("b"))
+
+    cohorts = await asyncio.wait_for(asyncio.gather(first, second), timeout=1)
+    assert cohorts[0][0] != cohorts[1][0]
+    assert cohorts[0][1] == 1
+    assert cohorts[1][1] == 1
+
+
+@pytest.mark.asyncio
+async def test_ming_tts_admission_gate_cleans_cancelled_waiter():
+    gate = MingTTSAdmissionGate(max_batch_size=2, max_wait_ms=1000)
+
+    waiter = asyncio.create_task(gate.wait("same-key"))
+    await asyncio.sleep(0)
+    assert gate._queues
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    assert gate._queues == {}
+    assert gate._timers == {}
+
+
+def test_ming_tts_admission_config_reads_stage_config():
+    serving = object.__new__(OmniOpenAIServingSpeech)
+    serving._tts_stage = SimpleNamespace(
+        speech_admission_config={
+            "max_batch_size": 4,
+            "max_wait_ms": 25.0,
+        }
+    )
+
+    config = serving._resolve_ming_tts_admission_config()
+
+    assert config == {"max_batch_size": 4, "max_wait_ms": 25.0}
+
+
+def test_ming_tts_admission_config_defaults_without_stage_config():
+    serving = object.__new__(OmniOpenAIServingSpeech)
+    serving._tts_stage = None
+
+    config = serving._resolve_ming_tts_admission_config()
+
+    assert config == {"max_batch_size": 8, "max_wait_ms": 15.0}

--- a/tests/model_executor/models/ming_flash_omni/test_talker_cfm.py
+++ b/tests/model_executor/models/ming_flash_omni/test_talker_cfm.py
@@ -6,12 +6,16 @@ from types import SimpleNamespace
 
 import pytest
 
+import vllm_omni.model_executor.models.ming_flash_omni.talker_module as talker_module
 from vllm_omni.model_executor.models.ming_flash_omni.talker_module import (
     CFM,
     Aggregator,
     CFMGraphExecutor,
     CFMGraphExecutorPool,
     DiT,
+    MingAudioGenerator,
+    MingTalkerBatchPolicy,
+    MingTalkerSlotTable,
 )
 
 torch = pytest.importorskip("torch")
@@ -144,3 +148,433 @@ class TestCFMGraphExecutorPool:
         assert inputs_embeds.shape == (1, 1, _LLM_HIDDEN)
         assert stop_out.shape == (1, 2)
         assert pool.pool.qsize() == 2
+
+
+class TestMingAudioGeneratorBatch:
+    def test_generate_latents_batch_returns_one_latent_list_per_request(self) -> None:
+        config, cfm, aggregator, stop_head, device = _build_pipeline()
+
+        class TinyLLM(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.empty((), device=device, dtype=_DTYPE))
+
+            def forward(self, *, inputs_embeds, **kwargs):
+                return SimpleNamespace(last_hidden_state=inputs_embeds)
+
+        generator = MingAudioGenerator(
+            config=config,
+            llm_config=SimpleNamespace(
+                num_hidden_layers=1, num_attention_heads=1, hidden_size=_LLM_HIDDEN, num_key_value_heads=1
+            ),
+            model=TinyLLM(),
+            cfm=cfm,
+            aggregator=aggregator,
+            stop_head=stop_head,
+            audio_vae=None,
+            patch_size=_PATCH_SIZE,
+            his_patch_size=_HIS_PATCH_SIZE,
+            latent_dim=_LATENT_DIM,
+            cfg_strength=2.0,
+            use_cuda_graphs=True,
+        )
+
+        single = torch.randn(1, 3, _LLM_HIDDEN, device=device, dtype=_DTYPE)
+        single_latents = generator.generate_latents_batch(single, max_steps=2, use_static_cache=False)
+        torch.accelerator.synchronize()
+        assert len(single_latents) == 1
+
+        inputs_embeds = torch.randn(2, 3, _LLM_HIDDEN, device=device, dtype=_DTYPE)
+        latents = generator.generate_latents_batch(inputs_embeds, max_steps=2, use_static_cache=False)
+        torch.accelerator.synchronize()
+
+        assert len(latents) == 2
+        assert all(len(item) == 2 for item in latents)
+        assert all(lat.shape == (1, _PATCH_SIZE, _LATENT_DIM) for item in latents for lat in item)
+
+    def test_generate_latents_batch_compacts_finished_rows(self) -> None:
+        config, cfm, aggregator, stop_head, device = _build_pipeline()
+
+        class TinyLLM(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.empty((), device=device, dtype=_DTYPE))
+
+            def forward(self, *, inputs_embeds, **kwargs):
+                return SimpleNamespace(last_hidden_state=inputs_embeds)
+
+        class StopAfterFirst(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            def forward(self, x):
+                out = torch.zeros(x.shape[0], 2, device=x.device, dtype=x.dtype)
+                out[:, 0] = 1.0
+                if self.calls == 0:
+                    out[0, 1] = 2.0
+                self.calls += 1
+                return out
+
+        generator = MingAudioGenerator(
+            config=config,
+            llm_config=SimpleNamespace(
+                num_hidden_layers=1, num_attention_heads=1, hidden_size=_LLM_HIDDEN, num_key_value_heads=1
+            ),
+            model=TinyLLM(),
+            cfm=cfm,
+            aggregator=aggregator,
+            stop_head=StopAfterFirst(),
+            audio_vae=None,
+            patch_size=_PATCH_SIZE,
+            his_patch_size=_HIS_PATCH_SIZE,
+            latent_dim=_LATENT_DIM,
+            cfg_strength=2.0,
+            use_cuda_graphs=False,
+        )
+
+        inputs_embeds = torch.randn(2, 3, _LLM_HIDDEN, device=device, dtype=_DTYPE)
+        latents = generator.generate_latents_batch(inputs_embeds, max_steps=3, min_new_token=-1, use_static_cache=False)
+        torch.accelerator.synchronize()
+
+        assert len(latents[0]) == 1
+        assert len(latents[1]) == 3
+
+    def test_generate_latents_batch_compacts_finished_rows_with_static_cache(self, monkeypatch) -> None:
+        config, cfm, aggregator, stop_head, device = _build_pipeline()
+
+        class TinyCache:
+            def __init__(self):
+                self.selected = []
+
+            def get_seq_length(self):
+                return 3
+
+            def batch_select_indices(self, indices):
+                self.selected.append(indices.detach().cpu().tolist())
+
+        class TinyLLM(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.empty((), device=device, dtype=_DTYPE))
+
+            def forward(self, *, inputs_embeds, **kwargs):
+                return SimpleNamespace(last_hidden_state=inputs_embeds)
+
+        class StopAfterFirst(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            def forward(self, x):
+                out = torch.zeros(x.shape[0], 2, device=x.device, dtype=x.dtype)
+                out[:, 0] = 1.0
+                if self.calls == 0:
+                    out[0, 1] = 2.0
+                self.calls += 1
+                return out
+
+        generator = MingAudioGenerator(
+            config=config,
+            llm_config=SimpleNamespace(
+                num_hidden_layers=1, num_attention_heads=1, hidden_size=_LLM_HIDDEN, num_key_value_heads=1
+            ),
+            model=TinyLLM(),
+            cfm=cfm,
+            aggregator=aggregator,
+            stop_head=StopAfterFirst(),
+            audio_vae=None,
+            patch_size=_PATCH_SIZE,
+            his_patch_size=_HIS_PATCH_SIZE,
+            latent_dim=_LATENT_DIM,
+            cfg_strength=2.0,
+            use_cuda_graphs=False,
+        )
+        cache = TinyCache()
+        monkeypatch.setattr(generator, "_init_batched_kv_cache", lambda *args, **kwargs: (cache, 2048))
+
+        inputs_embeds = torch.randn(2, 3, _LLM_HIDDEN, device=device, dtype=_DTYPE)
+        latents = generator.generate_latents_batch(inputs_embeds, max_steps=3, min_new_token=-1, use_static_cache=True)
+        torch.accelerator.synchronize()
+
+        assert len(latents[0]) == 1
+        assert len(latents[1]) == 3
+        assert cache.selected == [[1]]
+
+    def test_reusable_static_cache_recreated_after_batch_compaction(self, monkeypatch) -> None:
+        config, cfm, aggregator, stop_head, device = _build_pipeline()
+
+        class DummyLayer:
+            def __init__(self, batch_size: int):
+                self.keys = torch.empty(batch_size, 1, 1, 1, device=device)
+                self.values = torch.empty(batch_size, 1, 1, 1, device=device)
+                self.cumulative_length = torch.zeros(batch_size, device=device, dtype=torch.int32)
+
+        class DummyStaticCache:
+            def __init__(self, *, max_batch_size: int, **kwargs):
+                self.layers = [DummyLayer(max_batch_size)]
+
+        generator = MingAudioGenerator(
+            config=config,
+            llm_config=SimpleNamespace(
+                num_hidden_layers=1, num_attention_heads=1, hidden_size=_LLM_HIDDEN, num_key_value_heads=1
+            ),
+            model=torch.nn.Linear(_LLM_HIDDEN, _LLM_HIDDEN).to(device=device, dtype=_DTYPE),
+            cfm=cfm,
+            aggregator=aggregator,
+            stop_head=stop_head,
+            audio_vae=None,
+            patch_size=_PATCH_SIZE,
+            his_patch_size=_HIS_PATCH_SIZE,
+            latent_dim=_LATENT_DIM,
+            cfg_strength=2.0,
+            use_cuda_graphs=False,
+        )
+        monkeypatch.setattr(talker_module, "StaticCache", DummyStaticCache)
+
+        first = generator._get_reusable_kv_cache(2, device, _DTYPE, 16)
+        first.layers[0].keys = first.layers[0].keys[:1].contiguous()
+        second = generator._get_reusable_kv_cache(2, device, _DTYPE, 16)
+
+        assert second is not first
+        assert second.layers[0].keys.shape[0] == 2
+
+    def test_generate_latents_batch_disables_llm_graph_for_compaction_path(self, monkeypatch) -> None:
+        config, cfm, aggregator, stop_head, device = _build_pipeline()
+
+        class TinyLLM(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.empty((), device=device, dtype=_DTYPE))
+
+            def forward(self, *, inputs_embeds, **kwargs):
+                return SimpleNamespace(last_hidden_state=inputs_embeds)
+
+        generator = MingAudioGenerator(
+            config=config,
+            llm_config=SimpleNamespace(
+                num_hidden_layers=1, num_attention_heads=1, hidden_size=_LLM_HIDDEN, num_key_value_heads=1
+            ),
+            model=TinyLLM(),
+            cfm=cfm,
+            aggregator=aggregator,
+            stop_head=stop_head,
+            audio_vae=None,
+            patch_size=_PATCH_SIZE,
+            his_patch_size=_HIS_PATCH_SIZE,
+            latent_dim=_LATENT_DIM,
+            cfg_strength=2.0,
+            use_cuda_graphs=False,
+        )
+        seen: list[bool] = []
+
+        def fake_init_batched_kv_cache(*args, allow_llm_decode_graph: bool = True, **kwargs):
+            seen.append(allow_llm_decode_graph)
+            return None, 2048
+
+        monkeypatch.setattr(generator, "_init_batched_kv_cache", fake_init_batched_kv_cache)
+
+        inputs_embeds = torch.randn(2, 3, _LLM_HIDDEN, device=device, dtype=_DTYPE)
+        generator.generate_latents_batch(inputs_embeds, max_steps=1, use_static_cache=True)
+        torch.accelerator.synchronize()
+
+        assert seen == [False]
+
+
+class TestMingTalkerBatchPolicy:
+    def test_policy_dispatches_on_full_batch_or_wait_budget(self) -> None:
+        policy = MingTalkerBatchPolicy(max_batch_size=8, max_wait_ms=20.0)
+
+        assert policy.should_dispatch(0, 100.0) is False
+        assert policy.should_dispatch(4, 5.0) is False
+        assert policy.should_dispatch(8, 0.0) is True
+        assert policy.should_dispatch(2, 20.0) is True
+
+    def test_policy_chooses_bucket_without_exceeding_max_batch(self) -> None:
+        policy = MingTalkerBatchPolicy(max_batch_size=8, bucket_sizes=(1, 2, 4, 8, 16))
+
+        assert policy.choose_bucket(0) == 0
+        assert policy.choose_bucket(1) == 1
+        assert policy.choose_bucket(3) == 4
+        assert policy.choose_bucket(9) == 8
+
+
+class TestMingTalkerSlotTable:
+    def test_slot_table_allocates_reuses_and_frees_slots(self) -> None:
+        table = MingTalkerSlotTable(max_slots=2)
+
+        first = table.allocate("r1")
+        assert table.allocate("r1") == first
+        second = table.allocate("r2")
+        assert {first, second} == {0, 1}
+
+        table.free("r1")
+        reused = table.allocate("r3")
+
+        assert reused == first
+        assert set(table.active_request_ids()) == {"r2", "r3"}
+
+    def test_slot_table_reports_compact_active_indices(self) -> None:
+        table = MingTalkerSlotTable(max_slots=4)
+        table.allocate("r1")
+        table.allocate("r2")
+        table.allocate("r3")
+        table.free("r2")
+
+        assert table.active_request_ids() == ["r1", "r3"]
+        assert table.active_slots() == [0, 2]
+
+
+class TestMingTalkerBatchCompatibility:
+    def test_can_batch_additional_info_rejects_mismatched_params(self) -> None:
+        from vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni_talker import (
+            MingFlashOmniTalkerForConditionalGeneration,
+        )
+
+        talker = object.__new__(MingFlashOmniTalkerForConditionalGeneration)
+        compatible = [{"text": "a", "max_decode_steps": 10}, {"text": "b", "max_decode_steps": 10}]
+        incompatible = [{"text": "a", "max_decode_steps": 10}, {"text": "b", "max_decode_steps": 11}]
+
+        assert talker._can_batch_additional_info(compatible) is True
+        assert talker._can_batch_additional_info(incompatible) is False
+
+
+def test_ming_inner_cfm_graph_config_overrides_enforce_eager():
+    from vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni_talker import (
+        _resolve_inner_cfm_graph_enabled,
+    )
+    from vllm_omni.transformers_utils.configs.ming_flash_omni import MingFlashOmniTalkerConfig
+
+    config = MingFlashOmniTalkerConfig(enable_cfm_graph=True)
+
+    assert _resolve_inner_cfm_graph_enabled(config, enforce_eager=True) is True
+
+
+def test_ming_inner_cfm_graph_defaults_to_not_enforce_eager():
+    from vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni_talker import (
+        _resolve_inner_cfm_graph_enabled,
+    )
+    from vllm_omni.transformers_utils.configs.ming_flash_omni import MingFlashOmniTalkerConfig
+
+    config = MingFlashOmniTalkerConfig(enable_cfm_graph=None)
+
+    assert _resolve_inner_cfm_graph_enabled(config, enforce_eager=True) is False
+    assert _resolve_inner_cfm_graph_enabled(config, enforce_eager=False) is True
+
+
+def test_ming_full_vae_decode_config_changes_default_stream_decode():
+    from vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni_talker import (
+        MingFlashOmniTalkerForConditionalGeneration,
+    )
+
+    talker = object.__new__(MingFlashOmniTalkerForConditionalGeneration)
+    talker.cfg_strength = 2.0
+    talker.config = SimpleNamespace(enable_full_vae_decode=True)
+
+    params = talker._resolve_generation_params({})
+
+    assert params.stream_decode is False
+
+
+def test_ming_explicit_stream_decode_overrides_full_vae_decode_config():
+    from vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni_talker import (
+        MingFlashOmniTalkerForConditionalGeneration,
+    )
+
+    talker = object.__new__(MingFlashOmniTalkerForConditionalGeneration)
+    talker.cfg_strength = 2.0
+    talker.config = SimpleNamespace(enable_full_vae_decode=True)
+
+    params = talker._resolve_generation_params({"stream_decode": True})
+
+    assert params.stream_decode is True
+
+
+def test_decode_batch_latents_uses_stream_decode_by_default():
+    from types import SimpleNamespace
+
+    import torch
+
+    from vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni_talker import (
+        MingFlashOmniTalkerForConditionalGeneration,
+    )
+
+    class FakeAudioVAE:
+        config = SimpleNamespace(sample_rate=44100)
+
+        def decode(self, batch_latents, **kwargs):
+            raise AssertionError("stream decode must not use batched full VAE")
+
+    class FakeAudioGenerator:
+        def __init__(self):
+            self.calls = []
+
+        def decode_to_waveform(self, latents, *, stream_decode):
+            self.calls.append((len(latents), stream_decode))
+            return torch.zeros(1, 1, 8)
+
+    talker = object.__new__(MingFlashOmniTalkerForConditionalGeneration)
+    talker.config = SimpleNamespace(batch_vae_min_batch=4)
+    talker.audio_vae = FakeAudioVAE()
+    talker.audio_generator = FakeAudioGenerator()
+    latents = [[torch.zeros(1, 2, 3)] for _ in range(4)]
+
+    audios, sample_rate = talker.decode_batch_latents_for_runner(latents, stream_decode=True)
+
+    assert sample_rate == 44100
+    assert len(audios) == 4
+    assert talker.audio_generator.calls == [(1, True), (1, True), (1, True), (1, True)]
+
+
+def test_decode_batch_latents_transfers_batched_waveform_to_cpu_once():
+    from types import SimpleNamespace
+
+    import torch
+
+    from vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni_talker import (
+        MingFlashOmniTalkerForConditionalGeneration,
+    )
+
+    class FakeWaveform:
+        def __init__(self, tensor, counter):
+            self.tensor = tensor
+            self.counter = counter
+            self.shape = tensor.shape
+
+        def detach(self):
+            return self
+
+        def float(self):
+            return self
+
+        def cpu(self):
+            self.counter["cpu"] += 1
+            return self.tensor.cpu()
+
+        def __getitem__(self, idx):
+            return FakeWaveform(self.tensor[idx], self.counter)
+
+    class FakeAudioGenerator:
+        def trim_trailing_silence(self, waveform):
+            return waveform
+
+    class FakeAudioVAE:
+        def __init__(self):
+            self.config = SimpleNamespace(sample_rate=44100)
+            self.counter = {"cpu": 0}
+
+        def decode(self, batch_latents, **kwargs):
+            waveform = FakeWaveform(torch.zeros(batch_latents.shape[0], 1, 8), self.counter)
+            return waveform, None, None
+
+    talker = object.__new__(MingFlashOmniTalkerForConditionalGeneration)
+    talker.config = SimpleNamespace(batch_vae_min_batch=4)
+    talker.audio_vae = FakeAudioVAE()
+    talker.audio_generator = FakeAudioGenerator()
+    latents = [[torch.zeros(1, 2, 3)] for _ in range(4)]
+
+    audios, sample_rate = talker.decode_batch_latents_for_runner(latents, stream_decode=False)
+
+    assert sample_rate == 44100
+    assert len(audios) == 4
+    assert talker.audio_vae.counter["cpu"] == 1

--- a/tests/model_executor/models/ming_flash_omni/test_talker_modules.py
+++ b/tests/model_executor/models/ming_flash_omni/test_talker_modules.py
@@ -2,9 +2,21 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from __future__ import annotations
 
-import pytest
+from types import SimpleNamespace
 
-from vllm_omni.model_executor.models.ming_flash_omni.talker_module import CFM, Aggregator, DiT
+import pytest
+from transformers import Qwen2Config, Qwen2Model
+from x_transformers.x_transformers import RotaryEmbedding
+
+from vllm_omni.model_executor.models.ming_flash_omni.audio_vae import Decoder
+from vllm_omni.model_executor.models.ming_flash_omni.talker_module import (
+    CFM,
+    Aggregator,
+    Attention,
+    DiT,
+    MingAudioGenerator,
+    pack_qwen2_attention_qkv_projections,
+)
 
 torch = pytest.importorskip("torch")
 pytest.importorskip("x_transformers")
@@ -21,6 +33,73 @@ _AGG_HIDDEN = 32
 _NUM_HEADS = 4
 _DEPTH = 2
 _STEPS = 5
+
+
+def test_ming_cfm_zero_diff_fastpaths_default_on() -> None:
+    dit = _make_dit()
+    aggregator = _make_aggregator()
+    cfm = CFM(dit, steps=_STEPS)
+
+    assert dit.use_precomputed_rope_trig is True
+    assert aggregator.use_precomputed_rope_trig is True
+    assert cfm.use_preembedded_cfg is True
+    assert cfm.use_precomputed_temb is True
+
+
+def test_attention_packed_qkv_matches_separate_projections() -> None:
+    attn = Attention(dim=_DIT_HIDDEN, heads=_NUM_HEADS).eval()
+    x = torch.randn(2, 5, _DIT_HIDDEN)
+
+    with torch.no_grad():
+        separate = attn(x)
+        attn.pack_qkv()
+        packed = attn(x)
+
+    assert attn.to_qkv is not None
+    assert torch.allclose(separate, packed, rtol=1e-5, atol=1e-6)
+
+
+def test_attention_cached_rope_trig_matches_freqs_rope() -> None:
+    attn = Attention(dim=_DIT_HIDDEN, heads=_NUM_HEADS).eval()
+    x = torch.randn(2, 5, _DIT_HIDDEN)
+    rope = RotaryEmbedding(_DIT_HIDDEN // _NUM_HEADS).forward_from_seq_len(x.shape[1])
+    freqs, xpos_scale = rope
+    cached_rope = (
+        freqs.cos(),
+        freqs.sin(),
+        1.0 if xpos_scale is None else xpos_scale,
+        1.0 if xpos_scale is None else xpos_scale**-1.0,
+    )
+
+    with torch.no_grad():
+        original = attn(x, rope=rope)
+        cached = attn(x, rope=cached_rope)
+
+    assert torch.allclose(original, cached, rtol=1e-5, atol=1e-6)
+
+
+def test_qwen2_attention_packed_qkv_matches_separate_projections() -> None:
+    config = Qwen2Config(
+        vocab_size=32,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+        attention_dropout=0.0,
+    )
+    config._attn_implementation = "sdpa"
+    model = Qwen2Model(config).eval()
+    inputs_embeds = torch.randn(2, 5, 32)
+
+    with torch.no_grad():
+        separate = model(inputs_embeds=inputs_embeds, use_cache=False).last_hidden_state
+        packed_count = pack_qwen2_attention_qkv_projections(model)
+        packed = model(inputs_embeds=inputs_embeds, use_cache=False).last_hidden_state
+
+    assert packed_count == 1
+    assert torch.allclose(separate, packed, rtol=1e-5, atol=1e-6)
 
 
 def _make_dit() -> DiT:
@@ -43,6 +122,73 @@ def _make_aggregator() -> Aggregator:
         mlp_ratio=2.0,
         llm_input_dim=_LLM_HIDDEN,
     )
+
+
+def _make_generator() -> MingAudioGenerator:
+    llm_config = Qwen2Config(
+        vocab_size=32,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+        attention_dropout=0.0,
+    )
+    llm_config._attn_implementation = "sdpa"
+    model = Qwen2Model(llm_config).eval()
+    dit = _make_dit()
+    cfm = CFM(dit, steps=_STEPS)
+    aggregator = _make_aggregator()
+    stop_head = torch.nn.Linear(32, 2)
+    return MingAudioGenerator(
+        SimpleNamespace(steps=_STEPS, patch_size=_PATCH_SIZE),
+        llm_config,
+        model,
+        cfm,
+        aggregator,
+        stop_head,
+        audio_vae=None,
+        patch_size=_PATCH_SIZE,
+        his_patch_size=_HIS_PATCH_SIZE,
+        latent_dim=_LATENT_DIM,
+        cfg_strength=2.0,
+        use_cuda_graphs=False,
+    )
+
+
+def test_ming_generator_zero_diff_fastpaths_default_on() -> None:
+    generator = _make_generator()
+
+    assert generator._pack_qkv_enabled is True
+    assert generator._llm_decode_graph_enabled is True
+
+
+def test_ming_generator_stop_logit_decision_default_on() -> None:
+    generator = _make_generator()
+    stop_scores = torch.tensor([[1.0, 2.0], [3.0, 2.0]])
+
+    assert generator._stop_logit_decision_enabled is True
+    assert torch.equal(generator._stop_decision(stop_scores), torch.tensor([True, False]))
+
+
+def test_audio_vae_qwen_graph_default_on() -> None:
+    decoder_args = {
+        "vocab_size": 32,
+        "hidden_size": 32,
+        "intermediate_size": 64,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "max_position_embeddings": 64,
+        "attention_dropout": 0.0,
+    }
+
+    assert Decoder(decoder_args, output_dim=8, latent_dim=4, patch_size=-1)._qwen_decode_graph_enabled is True
+
+
+def test_ming_audio_generator_vae_stream_graph_default_on() -> None:
+    assert _make_generator()._vae_stream_graph_enabled is True
 
 
 class TestDiTDummyForward:
@@ -77,6 +223,29 @@ class TestDiTDummyForward:
         # CFG doubles the batch and trims the output to the patch window.
         assert out.shape == (2 * bsz, _PATCH_SIZE, _LATENT_DIM)
 
+    def test_preembedded_path_applies_final_layer_to_patch_only(self) -> None:
+        dit = _make_dit().eval()
+        bsz = 2
+        x = torch.randn(bsz, _PATCH_SIZE, _LATENT_DIM)
+        c_emb = torch.randn(2 * bsz, 1, _DIT_HIDDEN)
+        latent_history_emb = torch.randn(2 * bsz, _HIS_PATCH_SIZE, _DIT_HIDDEN)
+        t_emb = torch.randn(1, 1, _DIT_HIDDEN)
+        rope = dit._maybe_precompute_rope_trig(dit.rotary_embed.forward_from_seq_len(1 + _HIS_PATCH_SIZE + _PATCH_SIZE))
+        final_layer_input_shapes = []
+        original_final_layer = dit.final_layer.forward
+
+        def recorded_final_layer(x):
+            final_layer_input_shapes.append(tuple(x.shape))
+            return original_final_layer(x)
+
+        dit.final_layer.forward = recorded_final_layer
+
+        with torch.no_grad():
+            out = dit.forward_with_preembedded_cfg_temb(x, t_emb, c_emb, latent_history_emb, rope)
+
+        assert out.shape == (2 * bsz, _PATCH_SIZE, _LATENT_DIM)
+        assert final_layer_input_shapes == [(2 * bsz, _PATCH_SIZE, _DIT_HIDDEN)]
+
 
 class TestAggregatorDummyForward:
     """Aggregator with dummy weights maps latent patch -> LLM hidden."""
@@ -98,6 +267,25 @@ class TestAggregatorDummyForward:
             out = agg(gen_lat)
         assert torch.isfinite(out).all()
 
+    def test_forward_applies_final_layer_to_cls_token_only(self) -> None:
+        agg = _make_aggregator().eval()
+        bsz = 3
+        gen_lat = torch.randn(bsz, _PATCH_SIZE, _LATENT_DIM)
+        final_layer_input_shapes = []
+        original_final_layer = agg.final_layer.forward
+
+        def recorded_final_layer(x):
+            final_layer_input_shapes.append(tuple(x.shape))
+            return original_final_layer(x)
+
+        agg.final_layer.forward = recorded_final_layer
+
+        with torch.no_grad():
+            out = agg(gen_lat)
+
+        assert out.shape == (bsz, 1, _LLM_HIDDEN)
+        assert final_layer_input_shapes == [(bsz, 1, _AGG_HIDDEN)]
+
 
 class TestCFMSampleDummy:
     """CFM.sample drives DiT.forward_with_cfg through the integration loop."""
@@ -118,6 +306,72 @@ class TestCFMSampleDummy:
 
         assert out.shape == y0.shape
         assert torch.isfinite(out).all()
+
+    def test_temperature_zero_allows_skipping_sde_noise(self) -> None:
+        cfm = CFM(_make_dit(), steps=_STEPS, sway_sampling_coef=-1.0).eval()
+        bsz = 1
+        llm_cond = torch.randn(bsz, 1, _LLM_HIDDEN)
+        lat_cond = torch.randn(bsz, _HIS_PATCH_SIZE, _LATENT_DIM)
+        y0 = torch.randn(bsz, _PATCH_SIZE, _LATENT_DIM)
+        t = torch.linspace(0.0, 1.0, _STEPS + 1)
+        sde_args = torch.tensor([2.0, 0.25, 0.0])
+        sde_rnd = torch.randn(_STEPS, bsz, _PATCH_SIZE, _LATENT_DIM)
+
+        with torch.no_grad():
+            with_noise_input = cfm.sample(llm_cond, lat_cond, y0, t, sde_args, sde_rnd)
+            without_noise_input = cfm.sample(llm_cond, lat_cond, y0, t, sde_args, None)
+
+        assert torch.equal(with_noise_input, without_noise_input)
+
+    def test_prepared_timesteps_match_inline_sway(self) -> None:
+        cfm = CFM(_make_dit(), steps=_STEPS, sway_sampling_coef=-1.0).eval()
+        bsz = 1
+        llm_cond = torch.randn(bsz, 1, _LLM_HIDDEN)
+        lat_cond = torch.randn(bsz, _HIS_PATCH_SIZE, _LATENT_DIM)
+        y0 = torch.randn(bsz, _PATCH_SIZE, _LATENT_DIM)
+        t = torch.linspace(0.0, 1.0, _STEPS + 1)
+        sde_args = torch.tensor([2.0, 0.25, 0.0])
+
+        with torch.no_grad():
+            inline = cfm.sample(llm_cond, lat_cond, y0, t, sde_args, None)
+            prepared = cfm.sample(
+                llm_cond,
+                lat_cond,
+                y0,
+                cfm.prepare_timesteps(t),
+                sde_args,
+                None,
+                timesteps_are_swayed=True,
+            )
+
+        assert torch.equal(inline, prepared)
+
+    def test_prepared_cfg_paths_match_original_cfg(self) -> None:
+        cfm = CFM(_make_dit(), steps=_STEPS, sway_sampling_coef=-1.0).eval()
+        cfm.use_prepared_cfg = False
+        cfm.use_preembedded_cfg = False
+        cfm.use_precomputed_temb = False
+        bsz = 2
+        llm_cond = torch.randn(bsz, 1, _LLM_HIDDEN)
+        lat_cond = torch.randn(bsz, _HIS_PATCH_SIZE, _LATENT_DIM)
+        y0 = torch.randn(bsz, _PATCH_SIZE, _LATENT_DIM)
+        t = torch.linspace(0.0, 1.0, _STEPS + 1)
+        sde_args = torch.tensor([2.0, 0.25, 0.0])
+
+        with torch.no_grad():
+            original = cfm.sample(llm_cond, lat_cond, y0, t, sde_args, None)
+            cfm.use_prepared_cfg = True
+            prepared = cfm.sample(llm_cond, lat_cond, y0, t, sde_args, None)
+            cfm.use_prepared_cfg = False
+            cfm.use_preembedded_cfg = True
+            cfm.use_precomputed_temb = False
+            preembedded = cfm.sample(llm_cond, lat_cond, y0, t, sde_args, None)
+            cfm.use_precomputed_temb = True
+            precomputed_temb = cfm.sample(llm_cond, lat_cond, y0, t, sde_args, None)
+
+        assert torch.equal(original, prepared)
+        assert torch.equal(original, preembedded)
+        assert torch.equal(original, precomputed_temb)
 
     def test_sample_zero_cfg_reduces_to_unguided(self) -> None:
         """With cfg=0 the guidance term drops, but output shape is still valid."""

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -1122,6 +1122,24 @@ stages:
         assert deploy.stages[0].compilation_config == {"pass_config": {"fuse_allreduce_rms": False}}
         assert "compilation_config" not in deploy.stages[0].engine_extras
 
+    def test_ming_flash_omni_tts_speech_admission_config_is_stage_extra(self):
+        pipeline = _PIPELINE_REGISTRY["ming_flash_omni_tts"]
+        deploy_path = (
+            Path(__file__).parent.parent / "vllm_omni" / "deploy" / "ming_flash_omni_tts_high_concurrency.yaml"
+        )
+        deploy = load_deploy_config(deploy_path)
+        stages = merge_pipeline_deploy(pipeline, deploy)
+
+        assert deploy.stages[0].speech_admission_config == {
+            "max_batch_size": 8,
+            "max_wait_ms": 15.0,
+        }
+        assert stages[0].yaml_extras["speech_admission_config"] == {
+            "max_batch_size": 8,
+            "max_wait_ms": 15.0,
+        }
+        assert "speech_admission_config" not in stages[0].yaml_engine_args
+
     def test_merge_pipeline_deploy(self):
         pipeline = _PIPELINE_REGISTRY["qwen3_omni_moe"]
         deploy_path = Path(__file__).parent.parent / "vllm_omni" / "deploy" / "qwen3_omni_moe.yaml"

--- a/tests/worker/test_ming_tts_stage_step_runner.py
+++ b/tests/worker/test_ming_tts_stage_step_runner.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+
+from vllm_omni.worker.ming_tts_stage_step_runner import MingTTSStageStepRunner
+
+
+class MingFlashOmniTalkerForConditionalGeneration:
+    pass
+
+
+def test_ming_tts_step_runner_accepts_homogeneous_ming_batch():
+    runner = SimpleNamespace(
+        model=MingFlashOmniTalkerForConditionalGeneration(),
+        vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(model_stage="ming_flash_omni_tts", enforce_eager=True)
+        ),
+    )
+    infos = [
+        {"text": "a", "cfg": 2.0, "sigma": 0.25, "temperature": 0.0, "max_decode_steps": 20},
+        {"text": "b", "cfg": 2.0, "sigma": 0.25, "temperature": 0.0, "max_decode_steps": 20},
+    ]
+
+    step_runner = MingTTSStageStepRunner(max_batch_size=8)
+
+    assert step_runner.supports_batch(runner=runner, runtime_infos=infos, is_graph_capturing=False) is True
+
+
+def test_ming_tts_step_runner_rejects_heterogeneous_params():
+    runner = SimpleNamespace(
+        model=MingFlashOmniTalkerForConditionalGeneration(),
+        vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(model_stage="ming_flash_omni_tts", enforce_eager=True)
+        ),
+    )
+    infos = [
+        {"text": "a", "max_decode_steps": 20},
+        {"text": "b", "max_decode_steps": 21},
+    ]
+
+    step_runner = MingTTSStageStepRunner(max_batch_size=8)
+
+    assert step_runner.supports_batch(runner=runner, runtime_infos=infos, is_graph_capturing=False) is False
+
+
+def test_ming_tts_step_runner_rejects_heterogeneous_prompt_inputs():
+    runner = SimpleNamespace(
+        model=MingFlashOmniTalkerForConditionalGeneration(),
+        vllm_config=SimpleNamespace(model_config=SimpleNamespace(model_stage="ming_tts", enforce_eager=True)),
+    )
+    infos = [
+        {"text": "a", "instruction": "calm", "max_decode_steps": 20},
+        {"text": "b", "instruction": "excited", "max_decode_steps": 20},
+    ]
+
+    step_runner = MingTTSStageStepRunner(max_batch_size=8)
+
+    assert step_runner.supports_batch(runner=runner, runtime_infos=infos, is_graph_capturing=False) is False
+
+
+def test_ming_tts_step_runner_rejects_graph_capture():
+    runner = SimpleNamespace(
+        model=MingFlashOmniTalkerForConditionalGeneration(),
+        vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(model_stage="ming_flash_omni_tts", enforce_eager=True)
+        ),
+    )
+    infos = [{"text": "a"}, {"text": "b"}]
+
+    step_runner = MingTTSStageStepRunner(max_batch_size=8)
+
+    assert step_runner.supports_batch(runner=runner, runtime_infos=infos, is_graph_capturing=True) is False
+
+
+def test_ming_tts_step_runner_run_and_commit_writes_per_request_audio():
+    class AudioGenerator:
+        def __init__(self):
+            self.calls = []
+
+        def generate_latents_batch(self, inputs_embeds, **kwargs):
+            self.calls.append((tuple(inputs_embeds.shape), kwargs))
+            return [[f"lat-{i}"] for i in range(inputs_embeds.shape[0])]
+
+    class Model:
+        def __init__(self):
+            self.audio_generator = AudioGenerator()
+
+        def decode_batch_latents_for_runner(self, latents_by_request, stream_decode=True):
+            return [f"audio-{item[0]}" for item in latents_by_request], 44100
+
+    runner = SimpleNamespace(
+        model=Model(),
+        model_intermediate_buffer={},
+    )
+    step_runner = MingTTSStageStepRunner(max_batch_size=8)
+    runtime_infos = [{"text": "a", "max_decode_steps": 2}, {"text": "b", "max_decode_steps": 2}]
+    inputs_embeds = __import__("torch").zeros(2, 3, 4)
+
+    prepared = step_runner.prepare_step(
+        request_ids=["r1", "r2"], runtime_infos=runtime_infos, inputs_embeds=inputs_embeds
+    )
+    step_runner.run_step(prepared=prepared, runner=runner)
+    step_runner.commit_step(prepared=prepared, runner=runner)
+
+    assert runner.model.audio_generator.calls == [
+        ((2, 3, 4), {"max_steps": 2, "cfg": None, "sigma": 0.25, "temperature": 0.0, "use_static_cache": True})
+    ]
+    assert runner.model_intermediate_buffer["r1"]["audio"]["audio"] == "audio-lat-0"
+    assert runner.model_intermediate_buffer["r2"]["audio"]["audio"] == "audio-lat-1"
+    assert runner.model_intermediate_buffer["r1"]["audio"]["sr"] == 44100

--- a/tools/profiling/ming_tts_cfm_microbench.py
+++ b/tools/profiling/ming_tts_cfm_microbench.py
@@ -1,0 +1,1509 @@
+#!/usr/bin/env python3
+"""Microbenchmark Ming CFM graph variants without torch profiler overhead."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics as stats
+import time
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from types import MethodType
+
+import torch
+from ming_tts_talker_profile import build_inputs, load_talker, run_ar_profile
+
+
+@contextmanager
+def force_original_sde_graph(generator):
+    """Force the pre-optimization graph path for temperature=0 comparisons."""
+    original_get_sampler_pool = generator._get_sampler_pool
+
+    def _get_sampler_pool(batch_size, device, deterministic_sde_noise):
+        return original_get_sampler_pool(batch_size, device, False)
+
+    generator._get_sampler_pool = _get_sampler_pool
+    try:
+        yield
+    finally:
+        generator._get_sampler_pool = original_get_sampler_pool
+
+
+def _cat_latents(latents: list[list[torch.Tensor]]) -> torch.Tensor:
+    return torch.cat(latents[0], dim=1)
+
+
+def _cat_all_latents(latents: list[list[torch.Tensor]]) -> torch.Tensor:
+    return torch.cat([torch.cat(item, dim=1) for item in latents], dim=0)
+
+
+def _waveform_diff(reference: torch.Tensor, candidate: torch.Tensor) -> dict[str, float | int]:
+    ref = reference.detach().float().flatten()
+    cand = candidate.detach().float().flatten()
+    overlap = min(ref.numel(), cand.numel())
+    if overlap == 0:
+        return {
+            "reference_samples": int(ref.numel()),
+            "candidate_samples": int(cand.numel()),
+            "overlap_samples": int(overlap),
+            "max_abs": 0.0,
+            "mean_abs": 0.0,
+            "rmse": 0.0,
+        }
+    diff = (ref[:overlap] - cand[:overlap]).abs()
+    return {
+        "reference_samples": int(ref.numel()),
+        "candidate_samples": int(cand.numel()),
+        "overlap_samples": int(overlap),
+        "max_abs": float(diff.max().item()),
+        "mean_abs": float(diff.mean().item()),
+        "rmse": float(torch.sqrt((diff * diff).mean()).item()),
+    }
+
+
+def _run(generator, inputs, args, *, force_original: bool):
+    ctx = force_original_sde_graph(generator) if force_original else nullcontext()
+    with ctx:
+        return run_ar_profile(
+            generator,
+            inputs,
+            max_steps=args.steps,
+            use_static_cache=True,
+            device=args.device,
+        )
+
+
+def _mean(values: list[float]) -> float:
+    return float(stats.mean(values)) if values else 0.0
+
+
+def _stdev(values: list[float]) -> float:
+    return float(stats.stdev(values)) if len(values) > 1 else 0.0
+
+
+def _summarize_samples(samples: dict[str, dict[str, list[float]]]) -> dict:
+    return {
+        name: {
+            key: {
+                "mean": _mean(values),
+                "stdev": _stdev(values),
+                "samples": values,
+            }
+            for key, values in metric.items()
+        }
+        for name, metric in samples.items()
+    }
+
+
+def _iter_qwen2_mlp_modules(model):
+    for module in model.modules():
+        if all(hasattr(module, name) for name in ("gate_proj", "up_proj", "down_proj", "act_fn")):
+            yield module
+
+
+def _ensure_fused_llm_mlp(model) -> int:
+    """Pack Qwen2 MLP gate/up projections for a profiling-only A/B probe."""
+    count = 0
+    for mlp in _iter_qwen2_mlp_modules(model):
+        if not hasattr(mlp, "_ming_original_forward"):
+            mlp._ming_original_forward = mlp.forward
+
+        if not hasattr(mlp, "_ming_fused_gate_up_proj"):
+            gate_proj = mlp.gate_proj
+            up_proj = mlp.up_proj
+            has_bias = gate_proj.bias is not None or up_proj.bias is not None
+            fused = torch.nn.Linear(
+                gate_proj.in_features,
+                gate_proj.out_features + up_proj.out_features,
+                bias=has_bias,
+                device=gate_proj.weight.device,
+                dtype=gate_proj.weight.dtype,
+            )
+            with torch.no_grad():
+                fused.weight.copy_(torch.cat([gate_proj.weight, up_proj.weight], dim=0))
+                if has_bias:
+                    gate_bias = (
+                        gate_proj.bias
+                        if gate_proj.bias is not None
+                        else torch.zeros(
+                            gate_proj.out_features, device=gate_proj.weight.device, dtype=gate_proj.weight.dtype
+                        )
+                    )
+                    up_bias = (
+                        up_proj.bias
+                        if up_proj.bias is not None
+                        else torch.zeros(up_proj.out_features, device=up_proj.weight.device, dtype=up_proj.weight.dtype)
+                    )
+                    fused.bias.copy_(torch.cat([gate_bias, up_bias], dim=0))
+            fused.requires_grad_(False)
+            mlp.add_module("_ming_fused_gate_up_proj", fused)
+        count += 1
+    return count
+
+
+def _set_fused_llm_mlp_enabled(model, enabled: bool) -> int:
+    count = _ensure_fused_llm_mlp(model)
+
+    def fused_forward(self, x):
+        gate_up = self._ming_fused_gate_up_proj(x)
+        gate, up = gate_up.split((self.gate_proj.out_features, self.up_proj.out_features), dim=-1)
+        return self.down_proj(self.act_fn(gate) * up)
+
+    for mlp in _iter_qwen2_mlp_modules(model):
+        if enabled:
+            mlp.forward = MethodType(fused_forward, mlp)
+        else:
+            mlp.forward = mlp._ming_original_forward
+    return count
+
+
+def _run_full_history_recompute(generator, inputs, args):
+    """Run the AR loop without KV cache by recomputing the full prefix.
+
+    Unlike the existing use_static_cache=False path, this feeds the prompt plus
+    every generated embedding back into the LLM, so it preserves the causal
+    context semantics at the cost of more LLM work.
+    """
+    cfg = generator.cfg_strength
+    dtype = next(generator._model.parameters()).dtype
+    batch_size = inputs.shape[0]
+    device = args.device
+    his_lat = torch.zeros(batch_size, generator.his_patch_size, generator.latent_dim, device=device, dtype=dtype)
+    generated_embeds: list[torch.Tensor] = []
+    latents_by_request: list[list[torch.Tensor]] = [[] for _ in range(batch_size)]
+    llm_s: list[float] = []
+    cfm_s: list[float] = []
+    collect_s: list[float] = []
+
+    with torch.no_grad():
+        for step in range(args.steps):
+            torch.accelerator.synchronize(device)
+            t0 = time.perf_counter()
+            full_inputs = torch.cat([inputs, *generated_embeds], dim=1) if generated_embeds else inputs
+            outputs = generator._model(inputs_embeds=full_inputs, use_cache=False)
+            last_hs = outputs.last_hidden_state[:, -1:, :]
+            torch.accelerator.synchronize(device)
+            t1 = time.perf_counter()
+
+            gen_lat, next_inputs, _stop_out = generator.cfm_sample_step(last_hs, his_lat, cfg=cfg)
+            torch.accelerator.synchronize(device)
+            t2 = time.perf_counter()
+
+            for row in range(batch_size):
+                latents_by_request[row].append(gen_lat[row : row + 1])
+            his_lat = generator._update_his_lat(his_lat, gen_lat)
+            generated_embeds.append(next_inputs)
+            torch.accelerator.synchronize(device)
+            t3 = time.perf_counter()
+
+            if step > 0:
+                llm_s.append(t1 - t0)
+                cfm_s.append(t2 - t1)
+                collect_s.append(t3 - t2)
+
+    return latents_by_request, {
+        "llm_decode_ms": _mean(llm_s) * 1000.0,
+        "cfm_step_ms": _mean(cfm_s) * 1000.0,
+        "collect_ms": _mean(collect_s) * 1000.0,
+    }
+
+
+def run_full_history_recompute_compare(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    generator._pack_qkv_enabled = True
+    generator._qkv_packed = False
+    generator._cfm.use_preembedded_cfg = True
+    generator._sampler_pools.clear()
+    torch.manual_seed(0)
+    _run(generator, inputs, args, force_original=False)
+
+    torch.manual_seed(1234)
+    baseline_latents, baseline_timers = _run(generator, inputs, args, force_original=False)
+
+    samples = {
+        "static_cache": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+        "full_history_recompute": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+    }
+    for idx in range(args.repeats):
+        torch.manual_seed(1000 + idx)
+        _latents, timers = _run(generator, inputs, args, force_original=False)
+        for key in samples["static_cache"]:
+            samples["static_cache"][key].append(float(timers[key]))
+
+    generator._sampler_pools.clear()
+    torch.manual_seed(0)
+    _run_full_history_recompute(generator, inputs, args)
+
+    torch.manual_seed(1234)
+    opt_latents, opt_timers = _run_full_history_recompute(generator, inputs, args)
+    diff = (_cat_latents(baseline_latents) - _cat_latents(opt_latents)).float().abs()
+
+    for idx in range(args.repeats):
+        torch.manual_seed(1000 + idx)
+        _latents, timers = _run_full_history_recompute(generator, inputs, args)
+        for key in samples["full_history_recompute"]:
+            samples["full_history_recompute"][key].append(float(timers[key]))
+
+    return {
+        "mode": "full_history_recompute_compare",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": args.batch_size,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": args.steps,
+            "repeats": args.repeats,
+        },
+        "equivalence": {
+            "max_abs_latent_diff": float(diff.max().item()),
+            "mean_abs_latent_diff": float(diff.mean().item()),
+            "baseline_timers": baseline_timers,
+            "optimized_timers": opt_timers,
+        },
+        "timers": _summarize_samples(samples),
+    }
+
+
+def run_llm_recompute_semantics_probe(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    """Compare StaticCache and full-prefix LLM outputs on the same prefixes."""
+    generator._pack_qkv_enabled = True
+    generator._qkv_packed = False
+    generator._cfm.use_preembedded_cfg = True
+    generator._sampler_pools.clear()
+
+    dtype = next(generator._model.parameters()).dtype
+    batch_size = inputs.shape[0]
+    device = torch.device(args.device)
+
+    torch.manual_seed(1234)
+    his_lat = torch.zeros(batch_size, generator.his_patch_size, generator.latent_dim, device=device, dtype=dtype)
+    past_key_values, max_cache_len = generator._init_batched_kv_cache(batch_size, True, device, dtype)
+    current_inputs = inputs
+    forced_inputs: list[torch.Tensor] = []
+
+    with torch.no_grad():
+        for step in range(min(args.steps, max_cache_len - inputs.shape[1])):
+            last_hs = generator.llm_step(
+                current_inputs,
+                step=step,
+                past_key_values=past_key_values,
+                use_static_cache=True,
+            )
+            gen_lat, next_inputs, _stop_out = generator.cfm_sample_step(last_hs, his_lat, cfg=generator.cfg_strength)
+            forced_inputs.append(next_inputs.detach())
+            his_lat = generator._update_his_lat(his_lat, gen_lat)
+            current_inputs = next_inputs
+
+    generator._sampler_pools.clear()
+    past_key_values, _ = generator._init_batched_kv_cache(batch_size, True, device, dtype)
+    hidden_diffs: list[float] = []
+    hidden_mean_diffs: list[float] = []
+    static_s: list[float] = []
+    full_s: list[float] = []
+
+    with torch.no_grad():
+        for step in range(len(forced_inputs)):
+            current_inputs = inputs if step == 0 else forced_inputs[step - 1]
+            full_inputs = torch.cat([inputs, *forced_inputs[:step]], dim=1) if step > 0 else inputs
+
+            torch.accelerator.synchronize(device)
+            t0 = time.perf_counter()
+            static_hs = generator.llm_step(
+                current_inputs,
+                step=step,
+                past_key_values=past_key_values,
+                use_static_cache=True,
+            )
+            torch.accelerator.synchronize(device)
+            t1 = time.perf_counter()
+
+            full_hs = generator._model(inputs_embeds=full_inputs, use_cache=False).last_hidden_state[:, -1:, :]
+            torch.accelerator.synchronize(device)
+            t2 = time.perf_counter()
+
+            if step > 0:
+                static_s.append(t1 - t0)
+                full_s.append(t2 - t1)
+            diff = (static_hs - full_hs).float().abs()
+            hidden_diffs.append(float(diff.max().item()))
+            hidden_mean_diffs.append(float(diff.mean().item()))
+
+    return {
+        "mode": "llm_recompute_semantics_probe",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": args.batch_size,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": len(forced_inputs),
+        },
+        "equivalence": {
+            "max_abs_hidden_diff": max(hidden_diffs) if hidden_diffs else 0.0,
+            "mean_abs_hidden_diff": _mean(hidden_mean_diffs),
+            "per_step_max_abs_hidden_diff": hidden_diffs,
+            "per_step_mean_abs_hidden_diff": hidden_mean_diffs,
+        },
+        "timers": {
+            "static_cache_llm_decode_ms": {
+                "mean": _mean(static_s) * 1000.0,
+                "stdev": _stdev([v * 1000.0 for v in static_s]),
+                "samples": [v * 1000.0 for v in static_s],
+            },
+            "full_prefix_llm_decode_ms": {
+                "mean": _mean(full_s) * 1000.0,
+                "stdev": _stdev([v * 1000.0 for v in full_s]),
+                "samples": [v * 1000.0 for v in full_s],
+            },
+        },
+    }
+
+
+def _collect_teacher_forced_inputs(generator, inputs, args) -> list[torch.Tensor]:
+    generator._pack_qkv_enabled = True
+    generator._qkv_packed = False
+    generator._cfm.use_preembedded_cfg = True
+    generator._sampler_pools.clear()
+
+    dtype = next(generator._model.parameters()).dtype
+    batch_size = inputs.shape[0]
+    device = torch.device(args.device)
+    his_lat = torch.zeros(batch_size, generator.his_patch_size, generator.latent_dim, device=device, dtype=dtype)
+    past_key_values, max_cache_len = generator._init_batched_kv_cache(batch_size, True, device, dtype)
+    current_inputs = inputs
+    forced_inputs: list[torch.Tensor] = []
+
+    with torch.no_grad():
+        for step in range(min(args.steps, max_cache_len - inputs.shape[1])):
+            last_hs = generator.llm_step(
+                current_inputs,
+                step=step,
+                past_key_values=past_key_values,
+                use_static_cache=True,
+            )
+            gen_lat, next_inputs, _stop_out = generator.cfm_sample_step(last_hs, his_lat, cfg=generator.cfg_strength)
+            forced_inputs.append(next_inputs.detach())
+            his_lat = generator._update_his_lat(his_lat, gen_lat)
+            current_inputs = next_inputs
+    return forced_inputs
+
+
+def _run_static_cache_teacher_forced(generator, inputs, forced_inputs, args):
+    dtype = next(generator._model.parameters()).dtype
+    batch_size = inputs.shape[0]
+    device = torch.device(args.device)
+    past_key_values, _ = generator._init_batched_kv_cache(batch_size, True, device, dtype)
+    hidden_states: list[torch.Tensor] = []
+    times: list[float] = []
+
+    with torch.no_grad():
+        for step in range(len(forced_inputs)):
+            current_inputs = inputs if step == 0 else forced_inputs[step - 1]
+            torch.accelerator.synchronize(device)
+            t0 = time.perf_counter()
+            hidden = generator.llm_step(
+                current_inputs,
+                step=step,
+                past_key_values=past_key_values,
+                use_static_cache=True,
+            )
+            torch.accelerator.synchronize(device)
+            t1 = time.perf_counter()
+            hidden_states.append(hidden.detach().clone())
+            if step > 0:
+                times.append(t1 - t0)
+    return hidden_states, times
+
+
+def _snapshot_static_cache(past_key_values):
+    snapshot = []
+    for layer in getattr(past_key_values, "layers", []):
+        keys = getattr(layer, "keys", None)
+        values = getattr(layer, "values", None)
+        cumulative_length = getattr(layer, "cumulative_length", None)
+        snapshot.append(
+            (
+                keys.detach().clone() if keys is not None else None,
+                values.detach().clone() if values is not None else None,
+                cumulative_length.detach().clone() if cumulative_length is not None else None,
+            )
+        )
+    return snapshot
+
+
+def _restore_static_cache(past_key_values, snapshot) -> None:
+    for layer, (keys, values, cumulative_length) in zip(getattr(past_key_values, "layers", []), snapshot):
+        if keys is not None:
+            layer.keys.copy_(keys)
+        if values is not None:
+            layer.values.copy_(values)
+        if cumulative_length is not None:
+            layer.cumulative_length.copy_(cumulative_length)
+
+
+def _run_llm_decode_graph_teacher_forced(generator, inputs, forced_inputs, args):
+    dtype = next(generator._model.parameters()).dtype
+    batch_size = inputs.shape[0]
+    device = torch.device(args.device)
+    past_key_values, _ = generator._init_batched_kv_cache(batch_size, True, device, dtype)
+    hidden_states: list[torch.Tensor] = []
+    times: list[float] = []
+
+    with torch.no_grad():
+        prefill = generator.llm_step(
+            inputs,
+            step=0,
+            past_key_values=past_key_values,
+            use_static_cache=True,
+        )
+        hidden_states.append(prefill.detach().clone())
+        prompt_cache_snapshot = _snapshot_static_cache(past_key_values)
+
+        if len(forced_inputs) <= 1:
+            return hidden_states, times
+
+        input_ph = torch.empty_like(forced_inputs[0])
+        cache_pos_ph = torch.empty((forced_inputs[0].shape[1],), device=device, dtype=torch.long)
+        input_ph.copy_(forced_inputs[0])
+        cache_pos_ph.copy_(torch.arange(inputs.shape[1], inputs.shape[1] + forced_inputs[0].shape[1], device=device))
+
+        graph_stream = torch.cuda.Stream(device=device)
+        graph_stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.stream(graph_stream):
+            for _ in range(3):
+                graph_outputs = generator._model(
+                    past_key_values=past_key_values,
+                    inputs_embeds=input_ph,
+                    use_cache=True,
+                    cache_position=cache_pos_ph,
+                )
+        torch.cuda.current_stream(device).wait_stream(graph_stream)
+        torch.accelerator.synchronize(device)
+        _restore_static_cache(past_key_values, prompt_cache_snapshot)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            graph_outputs = generator._model(
+                past_key_values=past_key_values,
+                inputs_embeds=input_ph,
+                use_cache=True,
+                cache_position=cache_pos_ph,
+            )
+            graph_hidden = graph_outputs.last_hidden_state[:, -1:, :]
+        torch.accelerator.synchronize(device)
+        _restore_static_cache(past_key_values, prompt_cache_snapshot)
+
+        positions = torch.arange(
+            inputs.shape[1],
+            inputs.shape[1] + len(forced_inputs) * forced_inputs[0].shape[1],
+            device=device,
+            dtype=torch.long,
+        )
+
+        for step in range(1, len(forced_inputs)):
+            input_ph.copy_(forced_inputs[step - 1])
+            start = (step - 1) * forced_inputs[0].shape[1]
+            cache_pos_ph.copy_(positions[start : start + forced_inputs[0].shape[1]])
+            torch.accelerator.synchronize(device)
+            t0 = time.perf_counter()
+            graph.replay()
+            torch.accelerator.synchronize(device)
+            t1 = time.perf_counter()
+            hidden_states.append(graph_hidden.detach().clone())
+            times.append(t1 - t0)
+    return hidden_states, times
+
+
+def run_llm_decode_graph_compare(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    torch.manual_seed(1234)
+    forced_inputs = _collect_teacher_forced_inputs(generator, inputs, args)
+    ref_hidden, ref_times = _run_static_cache_teacher_forced(generator, inputs, forced_inputs, args)
+    graph_hidden, graph_times = _run_llm_decode_graph_teacher_forced(generator, inputs, forced_inputs, args)
+    pair_count = min(len(ref_hidden), len(graph_hidden))
+    diffs = [(ref_hidden[i] - graph_hidden[i]).float().abs() for i in range(pair_count)]
+    return {
+        "mode": "llm_decode_graph_compare",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": args.batch_size,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": len(forced_inputs),
+            "timed_decode_steps": len(graph_times),
+        },
+        "equivalence": {
+            "max_abs_hidden_diff": max((float(d.max().item()) for d in diffs), default=0.0),
+            "mean_abs_hidden_diff": _mean([float(d.mean().item()) for d in diffs]),
+            "per_step_max_abs_hidden_diff": [float(d.max().item()) for d in diffs],
+            "per_step_mean_abs_hidden_diff": [float(d.mean().item()) for d in diffs],
+        },
+        "timers": {
+            "static_cache_llm_decode_ms": {
+                "mean": _mean(ref_times) * 1000.0,
+                "stdev": _stdev([v * 1000.0 for v in ref_times]),
+                "samples": [v * 1000.0 for v in ref_times],
+            },
+            "cuda_graph_llm_decode_ms": {
+                "mean": _mean(graph_times) * 1000.0,
+                "stdev": _stdev([v * 1000.0 for v in graph_times]),
+                "samples": [v * 1000.0 for v in graph_times],
+            },
+        },
+    }
+
+
+def run_llm_decode_graph_ar_compare(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    generator._pack_qkv_enabled = True
+    generator._maybe_pack_qkv_projections()
+    generator._cfm.use_preembedded_cfg = True
+    generator._sampler_pools.clear()
+
+    original_enabled = getattr(generator, "_llm_decode_graph_enabled", False)
+    try:
+        torch.manual_seed(1234)
+        generator._llm_decode_graph_enabled = False
+        generator._llm_decode_graphs.clear()
+        baseline_latents, baseline_timers = _run(generator, inputs, args, force_original=False)
+
+        torch.manual_seed(1234)
+        generator._llm_decode_graph_enabled = True
+        generator._llm_decode_graphs.clear()
+        graph_latents, graph_timers = _run(generator, inputs, args, force_original=False)
+    finally:
+        generator._llm_decode_graph_enabled = original_enabled
+        generator._llm_decode_graphs.clear()
+
+    diff = (_cat_latents(baseline_latents) - _cat_latents(graph_latents)).float().abs()
+    samples = {
+        "static_cache": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+        "llm_decode_graph": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+    }
+    torch.manual_seed(0)
+    generator._llm_decode_graph_enabled = True
+    generator._llm_decode_graphs.clear()
+    _run(generator, inputs, args, force_original=False)
+
+    for idx in range(args.repeats):
+        for name, enabled in (("static_cache", False), ("llm_decode_graph", True)):
+            torch.manual_seed(1000 + idx)
+            generator._llm_decode_graph_enabled = enabled
+            _latents, timers = _run(generator, inputs, args, force_original=False)
+            for key in samples[name]:
+                samples[name][key].append(float(timers[key]))
+
+    generator._llm_decode_graph_enabled = original_enabled
+    generator._llm_decode_graphs.clear()
+    return {
+        "mode": "llm_decode_graph_ar_compare",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": args.batch_size,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": args.steps,
+            "repeats": args.repeats,
+        },
+        "equivalence": {
+            "max_abs_latent_diff": float(diff.max().item()),
+            "mean_abs_latent_diff": float(diff.mean().item()),
+            "baseline_timers": baseline_timers,
+            "optimized_timers": graph_timers,
+        },
+        "timers": _summarize_samples(samples),
+    }
+
+
+def run_vae_stream_full_compare(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    generator._pack_qkv_enabled = True
+    generator._qkv_packed = False
+    generator._cfm.use_preembedded_cfg = True
+    generator._sampler_pools.clear()
+
+    torch.manual_seed(1234)
+    latents_by_request, ar_timers = _run(generator, inputs[:1], args, force_original=False)
+    latents = latents_by_request[0]
+    sr = int(generator._audio_vae.config.sample_rate)
+
+    with torch.no_grad():
+        generator._vae_stream_graph_enabled = False
+        stream_wav = generator.decode_to_waveform(latents, stream_decode=True)
+        generator._vae_stream_graph_enabled = True
+        graph_stream_wav = generator.decode_to_waveform(latents, stream_decode=True)
+        generator._vae_stream_graph_enabled = False
+        full_raw_wav = generator.decode_to_waveform(latents, stream_decode=False)
+        full_trimmed_wav = generator.trim_trailing_silence(full_raw_wav)
+
+    samples = {
+        "stream_decode_ms": [],
+        "graph_stream_decode_ms": [],
+        "full_decode_raw_ms": [],
+        "full_decode_trimmed_ms": [],
+    }
+    for _idx in range(args.repeats):
+        torch.accelerator.synchronize(args.device)
+        t0 = time.perf_counter()
+        with torch.no_grad():
+            generator._vae_stream_graph_enabled = False
+            generator.decode_to_waveform(latents, stream_decode=True)
+        torch.accelerator.synchronize(args.device)
+        t1 = time.perf_counter()
+
+        with torch.no_grad():
+            generator._vae_stream_graph_enabled = True
+            generator.decode_to_waveform(latents, stream_decode=True)
+            generator._vae_stream_graph_enabled = False
+        torch.accelerator.synchronize(args.device)
+        t_graph = time.perf_counter()
+
+        with torch.no_grad():
+            raw = generator.decode_to_waveform(latents, stream_decode=False)
+        torch.accelerator.synchronize(args.device)
+        t2 = time.perf_counter()
+
+        with torch.no_grad():
+            generator.trim_trailing_silence(raw)
+        torch.accelerator.synchronize(args.device)
+        t3 = time.perf_counter()
+
+        samples["stream_decode_ms"].append((t1 - t0) * 1000.0)
+        samples["graph_stream_decode_ms"].append((t_graph - t1) * 1000.0)
+        samples["full_decode_raw_ms"].append((t2 - t_graph) * 1000.0)
+        samples["full_decode_trimmed_ms"].append((t3 - t_graph) * 1000.0)
+
+    return {
+        "mode": "vae_stream_full_compare",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+            "sample_rate": sr,
+        },
+        "workload": {
+            "batch_size": 1,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": len(latents),
+            "latent_frames": int(sum(lat.shape[1] for lat in latents)),
+            "repeats": args.repeats,
+        },
+        "ar_timers": ar_timers,
+        "audio": {
+            "stream_seconds": float(stream_wav.shape[-1]) / sr,
+            "graph_stream_seconds": float(graph_stream_wav.shape[-1]) / sr,
+            "full_raw_seconds": float(full_raw_wav.shape[-1]) / sr,
+            "full_trimmed_seconds": float(full_trimmed_wav.shape[-1]) / sr,
+            "stream_vs_graph_stream": _waveform_diff(stream_wav, graph_stream_wav),
+            "stream_vs_full_raw": _waveform_diff(stream_wav, full_raw_wav),
+            "stream_vs_full_trimmed": _waveform_diff(stream_wav, full_trimmed_wav),
+        },
+        "timers": {
+            name: {
+                "mean": _mean(values),
+                "stdev": _stdev(values),
+                "samples": values,
+            }
+            for name, values in samples.items()
+        },
+    }
+
+
+def run_vae_qwen_graph_compare(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    generator._pack_qkv_enabled = True
+    generator._qkv_packed = False
+    generator._cfm.use_preembedded_cfg = True
+    generator._sampler_pools.clear()
+
+    torch.manual_seed(1234)
+    latents_by_request, ar_timers = _run(generator, inputs[:1], args, force_original=False)
+    latents = latents_by_request[0]
+    sr = int(generator._audio_vae.config.sample_rate)
+    vae_decoder = generator._audio_vae.decoder
+    original_enabled = vae_decoder._qwen_decode_graph_enabled
+
+    try:
+        with torch.no_grad():
+            generator._vae_stream_graph_enabled = False
+            vae_decoder._qwen_decode_graph_enabled = False
+            vae_decoder._qwen_decode_graphs.clear()
+            baseline_wav = generator.decode_to_waveform(latents, stream_decode=True)
+
+            vae_decoder._qwen_decode_graph_enabled = True
+            vae_decoder._qwen_decode_graphs.clear()
+            graph_wav = generator.decode_to_waveform(latents, stream_decode=True)
+
+        samples = {
+            "stream_decode_ms": [],
+            "qwen_graph_stream_decode_ms": [],
+        }
+        graph_shapes = [str(key[0]) for key in vae_decoder._qwen_decode_graphs]
+        for _idx in range(args.repeats):
+            vae_decoder._qwen_decode_graph_enabled = False
+            torch.accelerator.synchronize(args.device)
+            t0 = time.perf_counter()
+            with torch.no_grad():
+                generator.decode_to_waveform(latents, stream_decode=True)
+            torch.accelerator.synchronize(args.device)
+            t1 = time.perf_counter()
+
+            vae_decoder._qwen_decode_graph_enabled = True
+            with torch.no_grad():
+                generator.decode_to_waveform(latents, stream_decode=True)
+            torch.accelerator.synchronize(args.device)
+            t2 = time.perf_counter()
+
+            samples["stream_decode_ms"].append((t1 - t0) * 1000.0)
+            samples["qwen_graph_stream_decode_ms"].append((t2 - t1) * 1000.0)
+    finally:
+        vae_decoder._qwen_decode_graph_enabled = original_enabled
+        vae_decoder._qwen_decode_graphs.clear()
+        generator._vae_stream_graph_enabled = False
+
+    return {
+        "mode": "vae_qwen_graph_compare",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+            "sample_rate": sr,
+        },
+        "workload": {
+            "batch_size": 1,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": len(latents),
+            "latent_frames": int(sum(lat.shape[1] for lat in latents)),
+            "repeats": args.repeats,
+        },
+        "ar_timers": ar_timers,
+        "audio": {
+            "baseline_seconds": float(baseline_wav.shape[-1]) / sr,
+            "qwen_graph_seconds": float(graph_wav.shape[-1]) / sr,
+            "stream_vs_qwen_graph": _waveform_diff(baseline_wav, graph_wav),
+        },
+        "graph_shapes": graph_shapes,
+        "timers": {
+            name: {
+                "mean": _mean(values),
+                "stdev": _stdev(values),
+                "samples": values,
+            }
+            for name, values in samples.items()
+        },
+    }
+
+
+def _vae_qwen_stream_inputs(generator, latents: list[torch.Tensor]) -> list[torch.Tensor]:
+    decoder = generator._audio_vae.decoder
+    decode_pad: torch.Tensor | None = None
+    qwen_inputs: list[torch.Tensor] = []
+
+    with torch.no_grad():
+        for lat in latents:
+            vae_input = torch.cat([decode_pad, lat], dim=1) if decode_pad is not None else lat
+            x = decoder.fc1(vae_input)
+            if decoder.patch_size != -1:
+                x = decoder.upsampling.upsampler(x.transpose(1, 2)).transpose(1, 2)
+            qwen_inputs.append(x)
+            decode_pad = vae_input[:, -generator._vae_decode_pad_frames :, :].detach()
+
+    return qwen_inputs
+
+
+def run_vae_qwen_hidden_graph_probe(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    generator._pack_qkv_enabled = True
+    generator._qkv_packed = False
+    generator._cfm.use_preembedded_cfg = True
+    generator._sampler_pools.clear()
+
+    torch.manual_seed(1234)
+    latents_by_request, ar_timers = _run(generator, inputs[:1], args, force_original=False)
+    latents = latents_by_request[0]
+    vae_decoder = generator._audio_vae.decoder
+    original_enabled = vae_decoder._qwen_decode_graph_enabled
+    original_attn_impl = getattr(vae_decoder.decoder.config, "_attn_implementation", None)
+    effective_attn_impl = args.vae_qwen_attn_impl or original_attn_impl
+
+    rows = []
+    try:
+        if args.vae_qwen_attn_impl:
+            vae_decoder.decoder.config._attn_implementation = args.vae_qwen_attn_impl
+        qwen_inputs = _vae_qwen_stream_inputs(generator, latents)
+        for idx, x in enumerate(qwen_inputs):
+            row = {
+                "idx": idx,
+                "shape": list(x.shape),
+                "stride": list(x.stride()),
+                "is_contiguous": bool(x.is_contiguous()),
+            }
+
+            for label, candidate in (("original_stride", x), ("contiguous", x.contiguous())):
+                vae_decoder._qwen_decode_graph_enabled = False
+                vae_decoder._qwen_decode_graphs.clear()
+                eager = vae_decoder.decoder(inputs_embeds=candidate, use_cache=False).last_hidden_state
+
+                vae_decoder._qwen_decode_graph_enabled = True
+                vae_decoder._qwen_decode_graphs.clear()
+                graph = vae_decoder._execute_qwen_decode_graph(candidate)
+                graph_again = vae_decoder._execute_qwen_decode_graph(candidate)
+
+                eager_graph_diff = (eager - graph).float().abs()
+                graph_self_diff = (graph - graph_again).float().abs()
+                row[f"{label}_eager_graph_max_abs"] = float(eager_graph_diff.max().item())
+                row[f"{label}_eager_graph_mean_abs"] = float(eager_graph_diff.mean().item())
+                row[f"{label}_graph_self_max_abs"] = float(graph_self_diff.max().item())
+                row[f"{label}_graph_self_mean_abs"] = float(graph_self_diff.mean().item())
+            rows.append(row)
+    finally:
+        if original_attn_impl is not None:
+            vae_decoder.decoder.config._attn_implementation = original_attn_impl
+        vae_decoder._qwen_decode_graph_enabled = original_enabled
+        vae_decoder._qwen_decode_graphs.clear()
+
+    return {
+        "mode": "vae_qwen_hidden_graph_probe",
+        "attn_implementation": effective_attn_impl,
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": 1,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": len(latents),
+            "latent_frames": int(sum(lat.shape[1] for lat in latents)),
+        },
+        "ar_timers": ar_timers,
+        "rows": rows,
+        "max_original_stride_eager_graph": max(
+            (row["original_stride_eager_graph_max_abs"] for row in rows), default=0.0
+        ),
+        "max_contiguous_eager_graph": max((row["contiguous_eager_graph_max_abs"] for row in rows), default=0.0),
+        "max_original_stride_graph_self": max((row["original_stride_graph_self_max_abs"] for row in rows), default=0.0),
+        "max_contiguous_graph_self": max((row["contiguous_graph_self_max_abs"] for row in rows), default=0.0),
+    }
+
+
+def run_fused_llm_mlp_compare(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    generator._pack_qkv_enabled = True
+    generator._maybe_pack_qkv_projections()
+    generator._cfm.use_preembedded_cfg = True
+    generator._cfm.use_precomputed_temb = True
+    generator._llm_decode_graph_enabled = True
+    generator._sampler_pools.clear()
+
+    original_graph_enabled = getattr(generator, "_llm_decode_graph_enabled", False)
+    original_graphs = generator._llm_decode_graphs
+    mode_graphs: dict[str, dict] = {"baseline": {}, "fused_llm_mlp": {}}
+    mlp_count = _ensure_fused_llm_mlp(generator._model)
+
+    def run_mode(name: str, enabled: bool, seed: int):
+        _set_fused_llm_mlp_enabled(generator._model, enabled)
+        generator._llm_decode_graphs = mode_graphs[name]
+        torch.manual_seed(seed)
+        return _run(generator, inputs, args, force_original=False)
+
+    try:
+        run_mode("baseline", False, 0)
+        baseline_latents, baseline_timers = run_mode("baseline", False, 1234)
+
+        run_mode("fused_llm_mlp", True, 0)
+        opt_latents, opt_timers = run_mode("fused_llm_mlp", True, 1234)
+        diff = (_cat_all_latents(baseline_latents) - _cat_all_latents(opt_latents)).float().abs()
+
+        samples = {
+            "baseline": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+            "fused_llm_mlp": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+        }
+        order = (
+            (("fused_llm_mlp", True), ("baseline", False))
+            if args.reverse_order
+            else (
+                ("baseline", False),
+                ("fused_llm_mlp", True),
+            )
+        )
+        for idx in range(args.repeats):
+            for name, enabled in order:
+                _latents, timers = run_mode(name, enabled, 1000 + idx)
+                for key in samples[name]:
+                    samples[name][key].append(float(timers[key]))
+    finally:
+        _set_fused_llm_mlp_enabled(generator._model, False)
+        generator._llm_decode_graph_enabled = original_graph_enabled
+        generator._llm_decode_graphs = original_graphs
+        generator._llm_decode_graphs.clear()
+        generator._sampler_pools.clear()
+
+    return {
+        "mode": "fused_llm_mlp_compare_reverse_order" if args.reverse_order else "fused_llm_mlp_compare",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "llm_intermediate": llm_config.intermediate_size,
+            "fused_mlp_modules": mlp_count,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": args.batch_size,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": args.steps,
+            "repeats": args.repeats,
+        },
+        "equivalence": {
+            "max_abs_latent_diff": float(diff.max().item()),
+            "mean_abs_latent_diff": float(diff.mean().item()),
+            "baseline_timers": baseline_timers,
+            "optimized_timers": opt_timers,
+        },
+        "timers": _summarize_samples(samples),
+    }
+
+
+def run_fused_qkv_compare(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    generator._pack_qkv_enabled = False
+    generator._qkv_packed = False
+    generator._sampler_pools.clear()
+    torch.manual_seed(0)
+    _run(generator, inputs, args, force_original=False)
+
+    torch.manual_seed(1234)
+    baseline_latents, baseline_timers = _run(generator, inputs, args, force_original=False)
+
+    samples = {
+        "separate_qkv": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+        "packed_qkv": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+    }
+    for idx in range(args.repeats):
+        torch.manual_seed(1000 + idx)
+        _latents, timers = _run(generator, inputs, args, force_original=False)
+        for key in samples["separate_qkv"]:
+            samples["separate_qkv"][key].append(float(timers[key]))
+
+    generator._sampler_pools.clear()
+    generator._pack_qkv_enabled = True
+    generator._qkv_packed = False
+    torch.manual_seed(0)
+    _run(generator, inputs, args, force_original=False)
+
+    torch.manual_seed(1234)
+    opt_latents, opt_timers = _run(generator, inputs, args, force_original=False)
+    diff = (_cat_latents(baseline_latents) - _cat_latents(opt_latents)).float().abs()
+
+    for idx in range(args.repeats):
+        torch.manual_seed(1000 + idx)
+        _latents, timers = _run(generator, inputs, args, force_original=False)
+        for key in samples["packed_qkv"]:
+            samples["packed_qkv"][key].append(float(timers[key]))
+
+    return {
+        "mode": "fused_qkv_compare",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": args.batch_size,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": args.steps,
+            "repeats": args.repeats,
+        },
+        "equivalence": {
+            "max_abs_latent_diff": float(diff.max().item()),
+            "mean_abs_latent_diff": float(diff.mean().item()),
+            "baseline_timers": baseline_timers,
+            "optimized_timers": opt_timers,
+        },
+        "timers": _summarize_samples(samples),
+    }
+
+
+def run_prepared_cfg_compare(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    generator._pack_qkv_enabled = True
+    generator._qkv_packed = False
+    generator._cfm.use_prepared_cfg = False
+    generator._cfm.use_preembedded_cfg = False
+    generator._sampler_pools.clear()
+    torch.manual_seed(0)
+    _run(generator, inputs, args, force_original=False)
+
+    torch.manual_seed(1234)
+    baseline_latents, baseline_timers = _run(generator, inputs, args, force_original=False)
+
+    samples = {
+        "original_cfg": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+        "prepared_cfg": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+        "preembedded_cfg": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+    }
+    for idx in range(args.repeats):
+        torch.manual_seed(1000 + idx)
+        _latents, timers = _run(generator, inputs, args, force_original=False)
+        for key in samples["original_cfg"]:
+            samples["original_cfg"][key].append(float(timers[key]))
+
+    generator._cfm.use_prepared_cfg = True
+    generator._sampler_pools.clear()
+    torch.manual_seed(0)
+    _run(generator, inputs, args, force_original=False)
+
+    torch.manual_seed(1234)
+    opt_latents, opt_timers = _run(generator, inputs, args, force_original=False)
+    diff = (_cat_latents(baseline_latents) - _cat_latents(opt_latents)).float().abs()
+
+    for idx in range(args.repeats):
+        torch.manual_seed(1000 + idx)
+        _latents, timers = _run(generator, inputs, args, force_original=False)
+        for key in samples["prepared_cfg"]:
+            samples["prepared_cfg"][key].append(float(timers[key]))
+
+    generator._cfm.use_preembedded_cfg = True
+    generator._sampler_pools.clear()
+    torch.manual_seed(0)
+    _run(generator, inputs, args, force_original=False)
+
+    torch.manual_seed(1234)
+    preembed_latents, preembed_timers = _run(generator, inputs, args, force_original=False)
+    preembed_diff = (_cat_latents(baseline_latents) - _cat_latents(preembed_latents)).float().abs()
+
+    for idx in range(args.repeats):
+        torch.manual_seed(1000 + idx)
+        _latents, timers = _run(generator, inputs, args, force_original=False)
+        for key in samples["preembedded_cfg"]:
+            samples["preembedded_cfg"][key].append(float(timers[key]))
+
+    return {
+        "mode": "prepared_cfg_compare",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": args.batch_size,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": args.steps,
+            "repeats": args.repeats,
+        },
+        "equivalence": {
+            "max_abs_latent_diff": float(diff.max().item()),
+            "mean_abs_latent_diff": float(diff.mean().item()),
+            "preembedded_max_abs_latent_diff": float(preembed_diff.max().item()),
+            "preembedded_mean_abs_latent_diff": float(preembed_diff.mean().item()),
+            "baseline_timers": baseline_timers,
+            "optimized_timers": opt_timers,
+            "preembedded_timers": preembed_timers,
+        },
+        "timers": _summarize_samples(samples),
+    }
+
+
+def run_stop_logit_decision_compare(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    generator._pack_qkv_enabled = True
+    generator._qkv_packed = False
+    generator._cfm.use_preembedded_cfg = True
+    generator._cfm.use_precomputed_temb = True
+    original_enabled = generator._stop_logit_decision_enabled
+
+    try:
+        generator._stop_logit_decision_enabled = False
+        generator._sampler_pools.clear()
+        torch.manual_seed(0)
+        _run(generator, inputs, args, force_original=False)
+        torch.manual_seed(1234)
+        baseline_latents, baseline_timers = _run(generator, inputs, args, force_original=False)
+
+        generator._stop_logit_decision_enabled = True
+        generator._sampler_pools.clear()
+        torch.manual_seed(0)
+        _run(generator, inputs, args, force_original=False)
+        torch.manual_seed(1234)
+        opt_latents, opt_timers = _run(generator, inputs, args, force_original=False)
+        diff = (_cat_all_latents(baseline_latents) - _cat_all_latents(opt_latents)).float().abs()
+
+        samples = {
+            "stop_softmax": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+            "stop_logit_decision": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+        }
+        for idx in range(args.repeats):
+            for name, enabled in (("stop_softmax", False), ("stop_logit_decision", True)):
+                generator._stop_logit_decision_enabled = enabled
+                generator._sampler_pools.clear()
+                torch.manual_seed(1000 + idx)
+                _latents, timers = _run(generator, inputs, args, force_original=False)
+                for key in samples[name]:
+                    samples[name][key].append(float(timers[key]))
+    finally:
+        generator._stop_logit_decision_enabled = original_enabled
+        generator._sampler_pools.clear()
+
+    return {
+        "mode": "stop_logit_decision_compare",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": args.batch_size,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": args.steps,
+            "repeats": args.repeats,
+        },
+        "equivalence": {
+            "max_abs_latent_diff": float(diff.max().item()),
+            "mean_abs_latent_diff": float(diff.mean().item()),
+            "baseline_timers": baseline_timers,
+            "optimized_timers": opt_timers,
+        },
+        "timers": _summarize_samples(samples),
+    }
+
+
+def run_rope_trig_compare(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    generator._pack_qkv_enabled = True
+    generator._qkv_packed = False
+    generator._cfm.use_preembedded_cfg = True
+    generator._cfm.use_precomputed_temb = True
+    generator._llm_decode_graph_enabled = True
+
+    generator._cfm.model.use_precomputed_rope_trig = False
+    generator._sampler_pools.clear()
+    torch.manual_seed(0)
+    _run(generator, inputs, args, force_original=False)
+
+    torch.manual_seed(1234)
+    baseline_latents, baseline_timers = _run(generator, inputs, args, force_original=False)
+
+    generator._cfm.model.use_precomputed_rope_trig = True
+    generator._sampler_pools.clear()
+    torch.manual_seed(0)
+    _run(generator, inputs, args, force_original=False)
+
+    torch.manual_seed(1234)
+    opt_latents, opt_timers = _run(generator, inputs, args, force_original=False)
+    diff = (_cat_all_latents(baseline_latents) - _cat_all_latents(opt_latents)).float().abs()
+
+    samples = {
+        "freqs_rope": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+        "cached_trig_rope": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+    }
+    for idx in range(args.repeats):
+        for name, enabled in (("freqs_rope", False), ("cached_trig_rope", True)):
+            generator._cfm.model.use_precomputed_rope_trig = enabled
+            generator._sampler_pools.clear()
+            torch.manual_seed(1000 + idx)
+            _latents, timers = _run(generator, inputs, args, force_original=False)
+            for key in samples[name]:
+                samples[name][key].append(float(timers[key]))
+
+    return {
+        "mode": "rope_trig_compare",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": args.batch_size,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": args.steps,
+            "repeats": args.repeats,
+        },
+        "equivalence": {
+            "max_abs_latent_diff": float(diff.max().item()),
+            "mean_abs_latent_diff": float(diff.mean().item()),
+            "baseline_timers": baseline_timers,
+            "optimized_timers": opt_timers,
+        },
+        "timers": _summarize_samples(samples),
+    }
+
+
+def run_aggregator_rope_trig_compare(generator, inputs, args, llm_config, talker_cfg) -> dict:
+    """Compare Aggregator freqs RoPE with cached trig RoPE."""
+
+    generator._pack_qkv_enabled = True
+    generator._qkv_packed = False
+    generator._cfm.use_preembedded_cfg = True
+    generator._cfm.use_precomputed_temb = True
+    generator._cfm.model.use_precomputed_rope_trig = True
+    generator._llm_decode_graph_enabled = True
+
+    original_enabled = generator._aggregator.use_precomputed_rope_trig
+    try:
+        generator._aggregator.use_precomputed_rope_trig = False
+        generator._sampler_pools.clear()
+        torch.manual_seed(0)
+        _run(generator, inputs, args, force_original=False)
+        torch.manual_seed(1234)
+        baseline_latents, baseline_timers = _run(generator, inputs, args, force_original=False)
+
+        generator._aggregator.use_precomputed_rope_trig = True
+        generator._sampler_pools.clear()
+        torch.manual_seed(0)
+        _run(generator, inputs, args, force_original=False)
+        torch.manual_seed(1234)
+        opt_latents, opt_timers = _run(generator, inputs, args, force_original=False)
+        diff = (_cat_all_latents(baseline_latents) - _cat_all_latents(opt_latents)).float().abs()
+
+        samples = {
+            "aggregator_freqs_rope": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+            "aggregator_cached_trig_rope": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+        }
+        for idx in range(args.repeats):
+            for name, enabled in (("aggregator_freqs_rope", False), ("aggregator_cached_trig_rope", True)):
+                generator._aggregator.use_precomputed_rope_trig = enabled
+                generator._sampler_pools.clear()
+                torch.manual_seed(1000 + idx)
+                _latents, timers = _run(generator, inputs, args, force_original=False)
+                for key in samples[name]:
+                    samples[name][key].append(float(timers[key]))
+    finally:
+        generator._aggregator.use_precomputed_rope_trig = original_enabled
+        generator._sampler_pools.clear()
+
+    return {
+        "mode": "aggregator_rope_trig_compare",
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": args.batch_size,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": args.steps,
+            "repeats": args.repeats,
+        },
+        "equivalence": {
+            "max_abs_latent_diff": float(diff.max().item()),
+            "mean_abs_latent_diff": float(diff.mean().item()),
+            "baseline_timers": baseline_timers,
+            "optimized_timers": opt_timers,
+        },
+        "timers": _summarize_samples(samples),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-path", default="/home/admin/workspace/remote_workspace/models/Ming-flash-omni-2.0")
+    parser.add_argument("--output", default="")
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--steps", type=int, default=20)
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--reverse-order", action="store_true")
+    parser.add_argument("--compare-fused-llm-mlp", action="store_true")
+    parser.add_argument("--compare-fused-qkv", action="store_true")
+    parser.add_argument("--compare-prepared-cfg", action="store_true")
+    parser.add_argument("--compare-full-history-recompute", action="store_true")
+    parser.add_argument("--probe-llm-recompute-semantics", action="store_true")
+    parser.add_argument("--compare-llm-decode-graph", action="store_true")
+    parser.add_argument("--compare-llm-decode-graph-ar", action="store_true")
+    parser.add_argument("--compare-vae-stream-full", action="store_true")
+    parser.add_argument("--compare-vae-qwen-graph", action="store_true")
+    parser.add_argument("--probe-vae-qwen-hidden-graph", action="store_true")
+    parser.add_argument("--vae-qwen-attn-impl", choices=("eager", "sdpa"), default="")
+    parser.add_argument("--compare-stop-logit-decision", action="store_true")
+    parser.add_argument("--compare-rope-trig", action="store_true")
+    parser.add_argument("--compare-aggregator-rope-trig", action="store_true")
+    args = parser.parse_args()
+
+    dtype = torch.bfloat16
+    talker_cfg, llm_config, model, _audio_vae, generator = load_talker(args.model_path, args.device, dtype)
+    inputs = build_inputs(model, args.model_path, args.batch_size, args.device, dtype)
+
+    if args.compare_fused_llm_mlp:
+        summary = run_fused_llm_mlp_compare(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.compare_fused_qkv:
+        summary = run_fused_qkv_compare(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.compare_prepared_cfg:
+        summary = run_prepared_cfg_compare(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.compare_full_history_recompute:
+        summary = run_full_history_recompute_compare(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.probe_llm_recompute_semantics:
+        summary = run_llm_recompute_semantics_probe(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.compare_llm_decode_graph:
+        summary = run_llm_decode_graph_compare(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.compare_llm_decode_graph_ar:
+        summary = run_llm_decode_graph_ar_compare(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.compare_vae_stream_full:
+        summary = run_vae_stream_full_compare(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.compare_vae_qwen_graph:
+        summary = run_vae_qwen_graph_compare(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.probe_vae_qwen_hidden_graph:
+        summary = run_vae_qwen_hidden_graph_probe(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.compare_stop_logit_decision:
+        summary = run_stop_logit_decision_compare(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.compare_rope_trig:
+        summary = run_rope_trig_compare(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    if args.compare_aggregator_rope_trig:
+        summary = run_aggregator_rope_trig_compare(generator, inputs, args, llm_config, talker_cfg)
+        text = json.dumps(summary, indent=2, sort_keys=True)
+        if args.output:
+            Path(args.output).write_text(text)
+        print(text)
+        return
+
+    # Initialize both graph variants before measuring or comparing.
+    torch.manual_seed(0)
+    _run(generator, inputs, args, force_original=True)
+    torch.manual_seed(0)
+    _run(generator, inputs, args, force_original=False)
+
+    torch.manual_seed(1234)
+    baseline_latents, baseline_timers = _run(generator, inputs, args, force_original=True)
+    torch.manual_seed(1234)
+    opt_latents, opt_timers = _run(generator, inputs, args, force_original=False)
+    diff = (_cat_latents(baseline_latents) - _cat_latents(opt_latents)).float().abs()
+
+    samples = {
+        "original_sde_graph": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+        "deterministic_sde_graph": {"llm_decode_ms": [], "cfm_step_ms": [], "collect_ms": []},
+    }
+    for idx in range(args.repeats):
+        for name, force_original in (("original_sde_graph", True), ("deterministic_sde_graph", False)):
+            torch.manual_seed(1000 + idx)
+            _latents, timers = _run(generator, inputs, args, force_original=force_original)
+            for key in samples[name]:
+                samples[name][key].append(float(timers[key]))
+
+    summary = {
+        "model": {
+            "llm_layers": llm_config.num_hidden_layers,
+            "llm_hidden": llm_config.hidden_size,
+            "cfm_steps": talker_cfg["steps"],
+            "dit_depth": talker_cfg["flowmodel"]["depth"],
+            "aggregator_depth": talker_cfg["aggregator"]["depth"],
+        },
+        "workload": {
+            "batch_size": args.batch_size,
+            "input_tokens": inputs.shape[1],
+            "profile_steps": args.steps,
+            "repeats": args.repeats,
+        },
+        "equivalence": {
+            "max_abs_latent_diff": float(diff.max().item()),
+            "mean_abs_latent_diff": float(diff.mean().item()),
+            "baseline_timers": baseline_timers,
+            "optimized_timers": opt_timers,
+        },
+        "timers": _summarize_samples(samples),
+    }
+    text = json.dumps(summary, indent=2, sort_keys=True)
+    if args.output:
+        Path(args.output).write_text(text)
+    print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/profiling/ming_tts_talker_profile.py
+++ b/tools/profiling/ming_tts_talker_profile.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Focused Ming-flash-omni-2.0 Talker profiler for H20 experiments.
+
+This script profiles the Talker path outside the HTTP server so the core
+model stages can be measured without scheduler noise:
+
+    text embeddings -> Talker LLM -> CFM/DiT + Aggregator + StopHead -> VAE
+
+It intentionally keeps CFM steps unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics as stats
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from safetensors.torch import load_file
+from torch.profiler import ProfilerActivity, profile, record_function
+from transformers import AutoTokenizer, Qwen2Config, Qwen2Model
+
+from vllm_omni.model_executor.models.ming_flash_omni.audio_vae import AudioVAE, AudioVAEConfig
+from vllm_omni.model_executor.models.ming_flash_omni.talker_module import (
+    CFM,
+    Aggregator,
+    DiT,
+    MingAudioGenerator,
+)
+
+
+def _sync(device: str) -> None:
+    if torch.cuda.is_available():
+        torch.accelerator.synchronize(device)
+
+
+def _mean_ms(values: list[float]) -> float:
+    return stats.mean(values) * 1000.0 if values else 0.0
+
+
+def load_talker(model_path: str, device: str, dtype: torch.dtype):
+    talker_dir = Path(model_path) / "talker"
+    with open(talker_dir / "config.json") as f:
+        talker_cfg = json.load(f)
+
+    llm_config = Qwen2Config.from_pretrained(talker_dir / "llm")
+    llm_config._attn_implementation = "sdpa"
+    flow_cfg = talker_cfg["flowmodel"]
+    agg_cfg = talker_cfg["aggregator"]
+
+    model = Qwen2Model(llm_config).to(device=device, dtype=dtype).eval()
+    dit = DiT(llm_input_dim=llm_config.hidden_size, **flow_cfg).to(device=device, dtype=dtype).eval()
+    cfm = CFM(dit, steps=talker_cfg["steps"])
+    aggregator = Aggregator(llm_input_dim=llm_config.hidden_size, **agg_cfg).to(device=device, dtype=dtype).eval()
+    stop_head = torch.nn.Linear(llm_config.hidden_size, 2, bias=True).to(device=device, dtype=dtype).eval()
+
+    vae_config = AudioVAEConfig.from_pretrained(talker_dir / "vae")
+    audio_vae = AudioVAE(vae_config).to(device=device, dtype=dtype).eval()
+
+    sd = load_file(str(talker_dir / "model.safetensors"), device=device)
+    model.load_state_dict({k.removeprefix("model."): sd[k] for k in sd if k.startswith("model.")}, strict=False)
+    dit.load_state_dict({k.removeprefix("cfm.model."): sd[k] for k in sd if k.startswith("cfm.model.")}, strict=False)
+    aggregator.load_state_dict(
+        {k.removeprefix("aggregator."): sd[k] for k in sd if k.startswith("aggregator.")},
+        strict=False,
+    )
+    stop_head.load_state_dict(
+        {k.removeprefix("stop_head."): sd[k] for k in sd if k.startswith("stop_head.")},
+        strict=False,
+    )
+
+    vae_sd = load_file(str(talker_dir / "vae" / "model.safetensors"), device=device)
+    audio_vae.load_state_dict(vae_sd, strict=False)
+    del sd, vae_sd
+    torch.accelerator.empty_cache()
+
+    generator = MingAudioGenerator(
+        config=SimpleNamespace(**talker_cfg),
+        llm_config=llm_config,
+        model=model,
+        cfm=cfm,
+        aggregator=aggregator,
+        stop_head=stop_head,
+        audio_vae=audio_vae,
+        patch_size=talker_cfg["patch_size"],
+        his_patch_size=talker_cfg["history_patch_size"],
+        latent_dim=flow_cfg["in_channels"],
+        cfg_strength=talker_cfg["cfg_strength"],
+        use_cuda_graphs=True,
+    )
+    return talker_cfg, llm_config, model, audio_vae, generator
+
+
+def build_inputs(model, model_path: str, batch_size: int, device: str, dtype: torch.dtype) -> torch.Tensor:
+    talker_dir = Path(model_path) / "talker"
+    tokenizer = AutoTokenizer.from_pretrained(talker_dir / "llm", trust_remote_code=True)
+    text = "Hello, this is a Ming flash omni text to speech profiling request."
+    prompt = (
+        "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
+        "<|im_start|>user\nPlease synthesize the following text into speech.\n Text input:\n"
+        + text
+        + "<|im_end|>\n<|im_start|>assistant\n<audio>"
+    )
+    input_ids = torch.tensor([tokenizer.encode(prompt)], device=device)
+    embeds = model.get_input_embeddings()(input_ids).to(dtype=dtype)
+    if batch_size == 1:
+        return embeds
+    return embeds.expand(batch_size, -1, -1).contiguous()
+
+
+def run_ar_profile(
+    generator: MingAudioGenerator,
+    inputs_embeds: torch.Tensor,
+    *,
+    max_steps: int,
+    use_static_cache: bool,
+    device: str,
+) -> tuple[list[list[torch.Tensor]], dict[str, float]]:
+    cfg = generator.cfg_strength
+    dtype = next(generator._model.parameters()).dtype
+    batch_size = inputs_embeds.shape[0]
+    his_lat = torch.zeros(batch_size, generator.his_patch_size, generator.latent_dim, device=device, dtype=dtype)
+    past_key_values, max_cache_len = generator._init_batched_kv_cache(
+        batch_size, use_static_cache, torch.device(device), dtype
+    )
+    current_inputs = inputs_embeds
+    latents_by_request: list[list[torch.Tensor]] = [[] for _ in range(batch_size)]
+    llm_s: list[float] = []
+    cfm_s: list[float] = []
+    collect_s: list[float] = []
+
+    with torch.no_grad():
+        for step in range(min(max_steps, max_cache_len - inputs_embeds.shape[1])):
+            _sync(device)
+            t0 = time.perf_counter()
+            with record_function("ming.llm_step"):
+                last_hs = generator.llm_step(
+                    current_inputs,
+                    step=step,
+                    past_key_values=past_key_values,
+                    use_static_cache=use_static_cache,
+                )
+            _sync(device)
+            t1 = time.perf_counter()
+
+            with record_function("ming.cfm_graph_or_eager_step"):
+                gen_lat, next_inputs, _stop_out = generator.cfm_sample_step(last_hs, his_lat, cfg=cfg)
+            _sync(device)
+            t2 = time.perf_counter()
+
+            with record_function("ming.collect_latents"):
+                for row in range(batch_size):
+                    latents_by_request[row].append(gen_lat[row : row + 1])
+                his_lat = generator._update_his_lat(his_lat, gen_lat)
+                current_inputs = next_inputs
+            _sync(device)
+            t3 = time.perf_counter()
+
+            if step > 0:
+                llm_s.append(t1 - t0)
+                cfm_s.append(t2 - t1)
+                collect_s.append(t3 - t2)
+
+    return latents_by_request, {
+        "llm_decode_ms": _mean_ms(llm_s),
+        "cfm_step_ms": _mean_ms(cfm_s),
+        "collect_ms": _mean_ms(collect_s),
+    }
+
+
+def decode_first(
+    generator: MingAudioGenerator,
+    latents: list[list[torch.Tensor]],
+    device: str,
+    *,
+    stream_decode: bool,
+) -> tuple[float, float]:
+    _sync(device)
+    t0 = time.perf_counter()
+    with torch.no_grad(), record_function("ming.vae_decode_one_request"):
+        wav = generator.decode_to_waveform(latents[0], stream_decode=stream_decode)
+        if not stream_decode:
+            wav = generator.trim_trailing_silence(wav)
+    _sync(device)
+    elapsed = time.perf_counter() - t0
+    sr = int(generator._audio_vae.config.sample_rate)
+    audio_s = float(wav.shape[-1]) / sr if wav is not None else 0.0
+    return elapsed * 1000.0, audio_s
+
+
+def warm_vae_qwen_decode_graph(generator: MingAudioGenerator, steps: int, device: str) -> bool:
+    decoder = generator._audio_vae.decoder if generator._audio_vae is not None else None
+    if decoder is None or not getattr(decoder, "_qwen_decode_graph_enabled", False):
+        return False
+
+    dtype = next(generator._model.parameters()).dtype
+    latents = [
+        torch.zeros(1, generator.patch_size, generator.latent_dim, device=device, dtype=dtype) for _ in range(steps)
+    ]
+    with torch.no_grad():
+        generator.decode_to_waveform(latents, stream_decode=True)
+    _sync(device)
+    return True
+
+
+def static_cache_semantics_probe(
+    generator: MingAudioGenerator, inputs_embeds: torch.Tensor, device: str
+) -> dict[str, float]:
+    """Compare static-cache decode to the current no-cache mode.
+
+    The current no-cache mode feeds only the latest generated embedding after
+    prefill, so it is a performance number for a different computation, not a
+    quality-preserving replacement.
+    """
+    single = inputs_embeds[:1]
+    _sync(device)
+    t0 = time.perf_counter()
+    lats_cache, _ = run_ar_profile(generator, single, max_steps=6, use_static_cache=True, device=device)
+    t1 = time.perf_counter()
+    lats_no_cache, _ = run_ar_profile(generator, single, max_steps=6, use_static_cache=False, device=device)
+    t2 = time.perf_counter()
+    last_cache = torch.cat(lats_cache[0], dim=1)
+    last_no_cache = torch.cat(lats_no_cache[0], dim=1)
+    diff = (last_cache - last_no_cache).float().abs()
+    return {
+        "static_cache_6step_ms": (t1 - t0) * 1000.0,
+        "no_cache_6step_ms": (t2 - t1) * 1000.0,
+        "max_abs_latent_diff": float(diff.max().item()),
+        "mean_abs_latent_diff": float(diff.mean().item()),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-path", default="/home/admin/workspace/remote_workspace/models/Ming-flash-omni-2.0")
+    parser.add_argument("--output-dir", default="/home/admin/workspace/remote_workspace/ming_profiles")
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--steps", type=int, default=20)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--vae-decode-mode", choices=("stream", "full"), default="stream")
+    parser.add_argument("--disable-cfm-graph", action="store_true")
+    args = parser.parse_args()
+
+    dtype = torch.bfloat16
+    Path(args.output_dir).mkdir(parents=True, exist_ok=True)
+    trace_path = Path(args.output_dir) / f"ming_talker_b{args.batch_size}_s{args.steps}.trace.json"
+
+    print("loading model...")
+    talker_cfg, llm_config, model, _audio_vae, generator = load_talker(args.model_path, args.device, dtype)
+    if args.disable_cfm_graph:
+        generator._use_cuda_graphs = False
+    inputs = build_inputs(model, args.model_path, args.batch_size, args.device, dtype)
+    print(
+        json.dumps(
+            {
+                "llm_layers": llm_config.num_hidden_layers,
+                "llm_hidden": llm_config.hidden_size,
+                "cfm_steps": talker_cfg["steps"],
+                "dit_depth": talker_cfg["flowmodel"]["depth"],
+                "aggregator_depth": talker_cfg["aggregator"]["depth"],
+                "input_tokens": inputs.shape[1],
+                "batch_size": args.batch_size,
+                "profile_steps": args.steps,
+            },
+            sort_keys=True,
+        )
+    )
+
+    # Warm graph captures for B=1 and the requested batch, outside profiler.
+    run_ar_profile(generator, inputs[:1], max_steps=2, use_static_cache=True, device=args.device)
+    run_ar_profile(generator, inputs, max_steps=2, use_static_cache=True, device=args.device)
+    vae_qwen_graph_warmed = warm_vae_qwen_decode_graph(generator, args.steps, args.device)
+    _sync(args.device)
+
+    with profile(
+        activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+        record_shapes=True,
+        profile_memory=True,
+        with_stack=False,
+    ) as prof:
+        with record_function("ming.total_ar_profile"):
+            latents, timers = run_ar_profile(
+                generator,
+                inputs,
+                max_steps=args.steps,
+                use_static_cache=True,
+                device=args.device,
+            )
+        vae_ms, audio_s = decode_first(
+            generator,
+            latents,
+            args.device,
+            stream_decode=args.vae_decode_mode == "stream",
+        )
+
+    prof.export_chrome_trace(str(trace_path))
+    print("PROFILE_TABLE_START")
+    print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+    print("PROFILE_TABLE_END")
+
+    kv_probe = static_cache_semantics_probe(generator, inputs, args.device)
+    summary = {
+        "trace_path": str(trace_path),
+        "batch_size": args.batch_size,
+        "steps": args.steps,
+        "vae_decode_mode": args.vae_decode_mode,
+        "input_tokens": inputs.shape[1],
+        "timers": timers,
+        "vae_qwen_graph_warmed": vae_qwen_graph_warmed,
+        "vae_decode_one_request_ms": vae_ms,
+        "audio_s_first_request": audio_s,
+        "kv_probe": kv_probe,
+        "gpu_alloc_gb": torch.cuda.memory_allocated(args.device) / 1e9,
+        "gpu_reserved_gb": torch.cuda.memory_reserved(args.device) / 1e9,
+    }
+    print("SUMMARY_JSON_START")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    print("SUMMARY_JSON_END")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -460,6 +460,7 @@ class StageDeployConfig:
     input_connectors: dict[str, str] | None = None
     default_sampling_params: dict[str, Any] | None = None
     subtalker_sampling_params: dict[str, Any] | None = None
+    speech_admission_config: dict[str, Any] | None = None
 
     # === vLLM EngineArgs fields ===
     # Parallelism and scheduler/memory capacity.
@@ -543,6 +544,7 @@ _STAGE_RESERVED_KEYS = frozenset(
         "output_connectors",
         "input_connectors",
         "default_sampling_params",
+        "speech_admission_config",
         "engine_extras",
         "engine_args",
         "runtime",
@@ -584,11 +586,14 @@ def _parse_stage_deploy(stage_data: dict[str, Any]) -> StageDeployConfig:
     kwargs["output_connectors"] = stage_data.get("output_connectors")
     kwargs["input_connectors"] = stage_data.get("input_connectors")
     kwargs["default_sampling_params"] = stage_data.get("default_sampling_params")
+    kwargs["speech_admission_config"] = stage_data.get("speech_admission_config")
     kwargs["engine_extras"] = flat_args
     return StageDeployConfig(**kwargs)
 
 
-_DEEP_MERGE_KEYS = frozenset({"default_sampling_params", "subtalker_sampling_params", "engine_extras", "engine_args"})
+_DEEP_MERGE_KEYS = frozenset(
+    {"default_sampling_params", "subtalker_sampling_params", "speech_admission_config", "engine_extras", "engine_args"}
+)
 
 
 def _deep_merge_stage(base: dict, overlay: dict) -> dict:
@@ -909,6 +914,8 @@ def _build_extras(
         extras["output_connectors"] = dict(ds.output_connectors)
     if ds is not None and ds.input_connectors:
         extras["input_connectors"] = dict(ds.input_connectors)
+    if ds is not None and ds.speech_admission_config:
+        extras["speech_admission_config"] = dict(ds.speech_admission_config)
     if ps.prompt_expand_func:
         extras["prompt_expand_func"] = ps.prompt_expand_func
     if ps.cfg_kv_collect_func:

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -34,6 +34,7 @@ from vllm_omni.distributed.omni_connectors.transfer_adapter.chunk_transfer_adapt
     OmniChunkTransferAdapter,
 )
 from vllm_omni.engine import OmniEngineCoreOutput
+from vllm_omni.engine.serialization import deserialize_additional_information
 from vllm_omni.outputs import OmniConnectorOutput, OmniModelRunnerOutput
 
 logger = init_logger(__name__)
@@ -55,6 +56,48 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                 async_chunk=False,
             )
         self._latest_omni_connector_output: OmniConnectorOutput | None = None
+        self._ming_tts_cohort_hold_deadlines: dict[int, float] = {}
+        self._ming_tts_cohort_hold_s = 0.05
+
+    @staticmethod
+    def _get_ming_tts_cohort(request: Request) -> tuple[int, int] | None:
+        try:
+            info = deserialize_additional_information(getattr(request, "additional_information", None))
+        except Exception:
+            return None
+        cohort_id = info.get("ming_tts_admission_cohort")
+        cohort_size = info.get("ming_tts_admission_cohort_size", 1)
+        if cohort_id is None:
+            return None
+        try:
+            cohort_id = int(cohort_id)
+            cohort_size = int(cohort_size)
+        except (TypeError, ValueError):
+            return None
+        if cohort_size <= 1:
+            return None
+        return cohort_id, cohort_size
+
+    def _should_hold_ming_tts_batch(self, request: Request, now: float) -> bool:
+        cohort = self._get_ming_tts_cohort(request)
+        if cohort is None:
+            return False
+        cohort_id, cohort_size = cohort
+        available_slots = max(1, self.max_num_running_reqs - len(self.running))
+        target_size = min(cohort_size, available_slots)
+        waiting_in_cohort = 0
+        for waiting_request in self.waiting:
+            waiting_cohort = self._get_ming_tts_cohort(waiting_request)
+            if waiting_cohort is not None and waiting_cohort[0] == cohort_id:
+                waiting_in_cohort += 1
+        if waiting_in_cohort >= target_size:
+            self._ming_tts_cohort_hold_deadlines.pop(cohort_id, None)
+            return False
+        deadline = self._ming_tts_cohort_hold_deadlines.setdefault(cohort_id, now + self._ming_tts_cohort_hold_s)
+        if now < deadline:
+            return True
+        self._ming_tts_cohort_hold_deadlines.pop(cohort_id, None)
+        return False
 
     def schedule(self) -> SchedulerOutput:
         """Diffusion fast path:
@@ -80,6 +123,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         scheduled_encoder_inputs: dict[str, list[int]] = {}
         cached_prompt_token_ids: dict[str, list[int]] = {}
         cached_additional_information: dict[str, dict | None] = {}
+        held_waiting_for_ming_tts_cohort = False
 
         # Temporary queue: preserve waiting order, do not disturb non-diffusion requests
         skipped_waiting_requests = create_request_queue(self.policy)
@@ -172,6 +216,9 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
 
             # Uniformly treat as diffusion. A feature flag can be added later
             # via config or request tag.
+            if not scheduled_new_reqs and self._should_hold_ming_tts_batch(request, scheduled_timestamp):
+                held_waiting_for_ming_tts_cohort = True
+                break
 
             # Allocate all input tokens for the request in one shot
             # (allocate 1 placeholder if zero)
@@ -205,7 +252,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             self.waiting.prepend_requests(skipped_waiting_requests)
 
         # If fast path scheduled none, fall back to the original scheduling
-        if not num_scheduled_tokens:
+        if not num_scheduled_tokens and not held_waiting_for_ming_tts_cohort:
             if self.chunk_transfer_adapter:
                 # Don't fall back: base scheduler doesn't handle async_chunk
                 # requests with empty prompt_token_ids.

--- a/vllm_omni/deploy/ming_flash_omni_tts_high_concurrency.yaml
+++ b/vllm_omni/deploy/ming_flash_omni_tts_high_concurrency.yaml
@@ -1,8 +1,4 @@
-# Ming-flash-omni-2.0 standalone TTS deploy: talker only.
-#
-# Single-stage configuration for direct text -> audio synthesis
-# The talker runs as a generation worker on a single GPU
-# and owns the tokenizer.
+# Ming-flash-omni-2.0 standalone TTS high-concurrency deploy.
 pipeline: ming_flash_omni_tts
 async_chunk: false
 
@@ -11,7 +7,7 @@ enable_prefix_caching: false
 
 stages:
   - stage_id: 0
-    max_num_seqs: 1
+    max_num_seqs: 8
     gpu_memory_utilization: 0.8
     enforce_eager: true
     max_num_batched_tokens: 100000
@@ -19,9 +15,11 @@ stages:
     hf_overrides:
       talker_config:
         enable_cfm_graph: true
+    speech_admission_config:
+      max_batch_size: 8
+      max_wait_ms: 15.0
     default_sampling_params:
       temperature: 0.0
       max_tokens: 1
 
-# Ming-flash-omni-2.0 has only been verified on CUDA devices
 platforms: {}

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -64,6 +64,48 @@ from vllm_omni.utils.speaker_cache import (
 
 logger = init_logger(__name__)
 
+_MING_TTS_ADMISSION_DEFAULT_MAX_BATCH = 8
+_MING_TTS_ADMISSION_DEFAULT_WAIT_MS = 15.0
+
+
+def _coerce_int_config(name: str, value: Any, default: int, *, min_value: int | None = None) -> int:
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %d", name, value, default)
+        return default
+    if min_value is not None:
+        parsed = max(min_value, parsed)
+    return parsed
+
+
+def _coerce_float_config(name: str, value: Any, default: float, *, min_value: float | None = None) -> float:
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %s", name, value, default)
+        return default
+    if min_value is not None:
+        parsed = max(min_value, parsed)
+    return parsed
+
+
+def _as_plain_dict(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    try:
+        return dict(value)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid speech_admission_config=%r", value)
+        return {}
+
+
 # TTS Configuration
 _VOXTRAL_TTS_MODEL_STAGES = {"audio_generation"}
 _QWEN3_TTS_MODEL_STAGES = {"qwen3_tts"}
@@ -253,6 +295,74 @@ def _conditioning_cache_salt(request, tts_params: dict | None = None) -> str:
     return h.hexdigest()[:32]
 
 
+class MingTTSAdmissionGate:
+    def __init__(self, *, max_batch_size: int = 8, max_wait_ms: float = 15.0) -> None:
+        self.max_batch_size = max(1, int(max_batch_size))
+        self.max_wait_s = max(0.0, float(max_wait_ms) / 1000.0)
+        self._queues: dict[tuple, list[asyncio.Future]] = {}
+        self._timers: dict[tuple, asyncio.Task] = {}
+        self._lock = asyncio.Lock()
+        self._next_cohort_id = 0
+
+    async def wait(self, key: tuple | str) -> tuple[int, int]:
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        key = (key,) if isinstance(key, str) else key
+        async with self._lock:
+            queue = self._queues.setdefault(key, [])
+            queue.append(future)
+            if len(queue) >= self.max_batch_size:
+                self._release_locked(key)
+            elif key not in self._timers:
+                self._timers[key] = asyncio.create_task(self._release_after_wait(key))
+        try:
+            cohort_id, cohort_size = await future
+        except asyncio.CancelledError:
+            async with self._lock:
+                self._remove_waiter_locked(key, future)
+            raise
+        await asyncio.sleep(0)
+        return cohort_id, cohort_size
+
+    async def _release_after_wait(self, key: tuple) -> None:
+        try:
+            await asyncio.sleep(self.max_wait_s)
+            async with self._lock:
+                self._release_locked(key)
+        except asyncio.CancelledError:
+            return
+
+    def _remove_waiter_locked(self, key: tuple, future: asyncio.Future) -> None:
+        queue = self._queues.get(key)
+        if not queue:
+            return
+        try:
+            queue.remove(future)
+        except ValueError:
+            return
+        if not queue:
+            self._queues.pop(key, None)
+            timer = self._timers.pop(key, None)
+            if timer is not None and timer is not asyncio.current_task() and not timer.done():
+                timer.cancel()
+
+    def _release_locked(self, key: tuple) -> None:
+        queue = self._queues.pop(key, [])
+        timer = self._timers.pop(key, None)
+        if timer is not None and timer is not asyncio.current_task() and not timer.done():
+            timer.cancel()
+        queue = [future for future in queue if not future.cancelled()]
+        if not queue:
+            return
+        cohort_id = self._next_cohort_id
+        self._next_cohort_id += 1
+        logger.debug("MingTTSAdmissionGate releasing cohort=%d size=%d", cohort_id, len(queue))
+        result = (cohort_id, len(queue))
+        for future in queue:
+            if not future.done():
+                future.set_result(result)
+
+
 class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
     _diffusion_mode: bool = False
     _tts_executor: ThreadPoolExecutor | None = None
@@ -430,6 +540,11 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
 
         # Batch configuration
         self._batch_max_items: int = getattr(self.engine_client, "tts_batch_max_items", 32)
+        ming_admission_config = self._resolve_ming_tts_admission_config()
+        self._ming_tts_admission_gate = MingTTSAdmissionGate(
+            max_batch_size=ming_admission_config["max_batch_size"],
+            max_wait_ms=ming_admission_config["max_wait_ms"],
+        )
 
         # Load speech tokenizer codec parameters for prompt length estimation
         self._codec_frame_rate: float | None = self._load_codec_frame_rate()
@@ -552,6 +667,33 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             if stage.engine_args.model_stage in _TTS_MODEL_STAGES:
                 return stage
         return None
+
+    def _resolve_ming_tts_admission_config(self) -> dict[str, int | float]:
+        """Return Ming TTS admission gate settings from stage config."""
+        raw_config = None
+        if self._tts_stage is not None:
+            raw_config = getattr(self._tts_stage, "speech_admission_config", None)
+            if raw_config is None:
+                yaml_extras = getattr(self._tts_stage, "yaml_extras", None)
+                if isinstance(yaml_extras, dict):
+                    raw_config = yaml_extras.get("speech_admission_config")
+            if raw_config is None and hasattr(self._tts_stage, "get"):
+                raw_config = self._tts_stage.get("speech_admission_config", None)
+        config = _as_plain_dict(raw_config)
+        return {
+            "max_batch_size": _coerce_int_config(
+                "speech_admission_config.max_batch_size",
+                config.get("max_batch_size"),
+                _MING_TTS_ADMISSION_DEFAULT_MAX_BATCH,
+                min_value=1,
+            ),
+            "max_wait_ms": _coerce_float_config(
+                "speech_admission_config.max_wait_ms",
+                config.get("max_wait_ms"),
+                _MING_TTS_ADMISSION_DEFAULT_WAIT_MS,
+                min_value=0.0,
+            ),
+        }
 
     def _detect_tts_model_type(self) -> str | None:
         """Detect TTS model type from the stage's model_stage attribute."""
@@ -2517,6 +2659,13 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             "sigma": 0.25,
             "temperature": 0.0,
         }
+        if request.extra_params:
+            cohort_id = request.extra_params.get("ming_tts_admission_cohort")
+            if cohort_id is not None:
+                additional_information["ming_tts_admission_cohort"] = cohort_id
+                additional_information["ming_tts_admission_cohort_size"] = request.extra_params.get(
+                    "ming_tts_admission_cohort_size", 1
+                )
         if has_spk_emb:
             # Passed as plain float list
             additional_information["spk_emb"] = list(request.speaker_embedding)
@@ -2878,12 +3027,35 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         finally:
             self._discard_ref_audio_artifact_warmup(request_id)
 
+    def _ming_tts_admission_key(self, request: OpenAICreateSpeechRequest) -> tuple | None:
+        if self._tts_model_type != "ming_flash_omni_tts":
+            return None
+        if request.stream or request.ref_audio is not None or request.ref_text is not None:
+            return None
+        if request.voice is not None or request.speaker_embedding is not None:
+            return None
+        return (
+            request.model,
+            request.response_format or "wav",
+            request.instructions or "",
+            request.max_new_tokens or _TTS_MAX_NEW_TOKENS_MAX,
+            request.speed or 1.0,
+        )
+
     async def _generate_audio_bytes(
         self,
         request: OpenAICreateSpeechRequest,
         base64_encode: bool = False,
         request_id: str | None = None,
+        skip_admission: bool = False,
     ) -> tuple[bytes | str, str]:
+        key = None if skip_admission else self._ming_tts_admission_key(request)
+        if key is not None:
+            cohort_id, cohort_size = await self._ming_tts_admission_gate.wait(key)
+            extra_params = dict(request.extra_params or {})
+            extra_params["ming_tts_admission_cohort"] = cohort_id
+            extra_params["ming_tts_admission_cohort_size"] = cohort_size
+            request.extra_params = extra_params
         request_id, generator, _ = await self._prepare_speech_generation(request, request_id=request_id)
         artifact_ready = False
 
@@ -3300,7 +3472,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             if validation_error is not None:
                 return SpeechBatchItemResult(index=idx, status="error", error=validation_error)
             try:
-                audio_data, media_type = await self._generate_audio_bytes(req, base64_encode=True)
+                audio_data, media_type = await self._generate_audio_bytes(req, base64_encode=True, skip_admission=True)
             except Exception as e:
                 logger.exception("Batch item %d failed: %s", idx, e)
                 return SpeechBatchItemResult(index=idx, status="error", error=str(e))

--- a/vllm_omni/model_executor/models/ming_flash_omni/audio_vae.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/audio_vae.py
@@ -6,6 +6,9 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
+from threading import Lock
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -14,6 +17,10 @@ from transformers.utils import is_flash_attn_2_available
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+def _record_function(name: str):
+    return nullcontext()
 
 
 class AudioVAEConfig(PretrainedConfig):
@@ -73,38 +80,44 @@ class ISTFT(nn.Module):
             raise ValueError("Padding must be 'center' or 'same'.")
 
         B, N, T = spec.shape
-        ifft = torch.fft.irfft(spec, self.n_fft, dim=1, norm="backward")
-        ifft = ifft * self.window[None, :, None]
+        with _record_function("ming.vae.istft.irfft"):
+            ifft = torch.fft.irfft(spec, self.n_fft, dim=1, norm="backward")
+        with _record_function("ming.vae.istft.window_mul"):
+            ifft = ifft * self.window[None, :, None]
 
         output_size = (T - 1) * self.hop_length + self.win_length
-        y = torch.nn.functional.fold(
-            ifft,
-            output_size=(1, output_size),
-            kernel_size=(1, self.win_length),
-            stride=(1, self.hop_length),
-        )[:, 0, 0, :]
-
-        y, audio_buffer = self._buffer_process(y, audio_buffer, pad, last_chunk=last_chunk, streaming=streaming)
-
-        window_sq = self.window.square().expand(1, T, -1).transpose(1, 2)
-        window_envelope = (
-            torch.nn.functional.fold(
-                window_sq,
+        with _record_function("ming.vae.istft.fold_audio"):
+            y = torch.nn.functional.fold(
+                ifft,
                 output_size=(1, output_size),
                 kernel_size=(1, self.win_length),
                 stride=(1, self.hop_length),
+            )[:, 0, 0, :]
+
+        y, audio_buffer = self._buffer_process(y, audio_buffer, pad, last_chunk=last_chunk, streaming=streaming)
+
+        with _record_function("ming.vae.istft.window_envelope"):
+            window_sq = self.window.square().expand(1, T, -1).transpose(1, 2)
+            window_envelope = (
+                torch.nn.functional.fold(
+                    window_sq,
+                    output_size=(1, output_size),
+                    kernel_size=(1, self.win_length),
+                    stride=(1, self.hop_length),
+                )
+                .squeeze(0)
+                .squeeze(0)
             )
-            .squeeze(0)
-            .squeeze(0)
-        )
 
         window_envelope, window_buffer = self._buffer_process(
             window_envelope, window_buffer, pad, last_chunk=last_chunk, streaming=streaming
         )
         window_envelope = window_envelope.squeeze()
 
-        assert (window_envelope > 1e-11).all()
-        y = y / window_envelope
+        if not (torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()):
+            assert (window_envelope > 1e-11).all()
+        with _record_function("ming.vae.istft.normalize"):
+            y = y / window_envelope
 
         return y, audio_buffer, window_buffer
 
@@ -117,17 +130,20 @@ class ISTFTHead(nn.Module):
         self.istft = ISTFT(n_fft=n_fft, hop_length=hop_length, win_length=n_fft, padding=padding)
 
     def forward(self, x, audio_buffer=None, window_buffer=None, streaming=False, last_chunk=False):
-        x_pred = self.out(x)
-        x_pred = x_pred.transpose(1, 2)
-        mag, p = x_pred.chunk(2, dim=1)
-        mag = torch.exp(mag)
-        mag = torch.clip(mag, max=1e2)
-        x = torch.cos(p)
-        y = torch.sin(p)
-        S = mag * (x + 1j * y)
-        audio, audio_buffer, window_buffer = self.istft(
-            S, audio_buffer=audio_buffer, window_buffer=window_buffer, streaming=streaming, last_chunk=last_chunk
-        )
+        with _record_function("ming.vae.head.linear"):
+            x_pred = self.out(x)
+        with _record_function("ming.vae.head.polar"):
+            x_pred = x_pred.transpose(1, 2)
+            mag, p = x_pred.chunk(2, dim=1)
+            mag = torch.exp(mag)
+            mag = torch.clip(mag, max=1e2)
+            x = torch.cos(p)
+            y = torch.sin(p)
+            S = mag * (x + 1j * y)
+        with _record_function("ming.vae.head.istft"):
+            audio, audio_buffer, window_buffer = self.istft(
+                S, audio_buffer=audio_buffer, window_buffer=window_buffer, streaming=streaming, last_chunk=last_chunk
+            )
         return audio.unsqueeze(1), x_pred, audio_buffer, window_buffer
 
 
@@ -188,6 +204,52 @@ class StreamingLinearUpsample(nn.Module):
         return final_out, state
 
 
+class QwenDecoderGraphExecutor:
+    """CUDA graph executor for one stateless AudioVAE Qwen decoder shape."""
+
+    def __init__(self, decoder: Qwen2Model) -> None:
+        self.decoder = decoder
+        self.initialized = False
+        self.input_placeholder: torch.Tensor | None = None
+        self.hidden_placeholder: torch.Tensor | None = None
+        self.graph: torch.cuda.CUDAGraph | None = None
+        self.lock = Lock()
+
+    def execute(self, inputs_embeds: torch.Tensor) -> torch.Tensor:
+        with self.lock:
+            if not self.initialized:
+                self._initialize_graph(inputs_embeds)
+
+            assert self.input_placeholder is not None
+            assert self.hidden_placeholder is not None
+            assert self.graph is not None
+            self.input_placeholder.copy_(inputs_embeds)
+            self.graph.replay()
+            hidden_states = torch.empty_like(self.hidden_placeholder)
+            hidden_states.copy_(self.hidden_placeholder)
+            return hidden_states
+
+    def _initialize_graph(self, inputs_embeds: torch.Tensor) -> None:
+        device = inputs_embeds.device
+        self.input_placeholder = torch.empty_like(inputs_embeds)
+        self.input_placeholder.copy_(inputs_embeds)
+        self.graph = torch.cuda.CUDAGraph()
+
+        graph_stream = torch.cuda.Stream(device=device)
+        graph_stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.no_grad(), torch.cuda.stream(graph_stream):
+            for _ in range(3):
+                self.decoder(inputs_embeds=self.input_placeholder, use_cache=False)
+        torch.cuda.current_stream(device).wait_stream(graph_stream)
+        torch.accelerator.synchronize(device)
+
+        with torch.no_grad(), torch.cuda.graph(self.graph):
+            outputs = self.decoder(inputs_embeds=self.input_placeholder, use_cache=False)
+            self.hidden_placeholder = outputs.last_hidden_state
+        torch.accelerator.synchronize(device)
+        self.initialized = True
+
+
 class Decoder(nn.Module):
     def __init__(self, decoder_args, output_dim=320, latent_dim=64, patch_size=-1):
         super().__init__()
@@ -210,19 +272,49 @@ class Decoder(nn.Module):
         self.patch_size = patch_size
         if self.patch_size != -1:
             self.upsampling = StreamingLinearUpsample(scale_factor=patch_size)
+        self._qwen_decode_graph_enabled = True
+        self._qwen_decode_graphs: dict[tuple[tuple[int, ...], torch.device, torch.dtype], QwenDecoderGraphExecutor] = {}
+        self._qwen_decode_graphs_lock = Lock()
+
+    def _can_use_qwen_decode_graph(
+        self,
+        x: torch.Tensor,
+        past_key_values,
+        use_cache: bool,
+    ) -> bool:
+        return (
+            self._qwen_decode_graph_enabled
+            and not self.training
+            and not use_cache
+            and past_key_values is None
+            and x.device.type == "cuda"
+            and not torch.cuda.is_current_stream_capturing()
+        )
+
+    def _execute_qwen_decode_graph(self, x: torch.Tensor) -> torch.Tensor:
+        key = (tuple(x.shape), x.device, x.dtype)
+        with self._qwen_decode_graphs_lock:
+            executor = self._qwen_decode_graphs.get(key)
+            if executor is None:
+                executor = QwenDecoderGraphExecutor(self.decoder)
+                self._qwen_decode_graphs[key] = executor
+        return executor.execute(x)
 
     def low_level_reconstruct(self, x, past_key_values=None, use_cache=False, stream_state=None, last_chunk=False):
         upsample_state, audio_buffer, window_buffer = stream_state
         bsz, device, dtype = x.size(0), x.device, x.dtype
-        x = self.fc1(x)
+        with _record_function("ming.vae.decoder.fc1"):
+            x = self.fc1(x)
         if self.patch_size != -1:
             if use_cache:
-                x, upsample_state = self.upsampling(x, state=upsample_state, is_last=last_chunk)
+                with _record_function("ming.vae.decoder.streaming_upsample"):
+                    x, upsample_state = self.upsampling(x, state=upsample_state, is_last=last_chunk)
                 if x is None:
                     stream_state = (upsample_state, audio_buffer, window_buffer)
                     return torch.empty(bsz, 1, 0, device=device, dtype=dtype), stream_state, past_key_values
             else:
-                x = self.upsampling.upsampler(x.transpose(1, 2)).transpose(1, 2)
+                with _record_function("ming.vae.decoder.full_upsample"):
+                    x = self.upsampling.upsampler(x.transpose(1, 2)).transpose(1, 2)
 
         hidden_states_list = []
 
@@ -248,22 +340,28 @@ class Decoder(nn.Module):
                 past_key_values = outputs.past_key_values
                 x = x[:, fill_len:, :]
 
-        outputs = self.decoder(inputs_embeds=x, past_key_values=past_key_values, use_cache=use_cache)
-        hidden_states_list.append(outputs.last_hidden_state)
-        past_key_values = outputs.past_key_values
+        with _record_function("ming.vae.decoder.qwen"):
+            if self._can_use_qwen_decode_graph(x, past_key_values, use_cache):
+                hidden_states_list.append(self._execute_qwen_decode_graph(x))
+                past_key_values = None
+            else:
+                outputs = self.decoder(inputs_embeds=x, past_key_values=past_key_values, use_cache=use_cache)
+                hidden_states_list.append(outputs.last_hidden_state)
+                past_key_values = outputs.past_key_values
 
         if len(hidden_states_list) > 1:
             full_hidden_state = torch.cat(hidden_states_list, dim=1)
         else:
             full_hidden_state = hidden_states_list[0]
 
-        x_out, _, audio_buffer, window_buffer = self.head(
-            full_hidden_state,
-            streaming=use_cache,
-            audio_buffer=audio_buffer,
-            window_buffer=window_buffer,
-            last_chunk=last_chunk,
-        )
+        with _record_function("ming.vae.decoder.head"):
+            x_out, _, audio_buffer, window_buffer = self.head(
+                full_hidden_state,
+                streaming=use_cache,
+                audio_buffer=audio_buffer,
+                window_buffer=window_buffer,
+                last_chunk=last_chunk,
+            )
 
         stream_state = (upsample_state, audio_buffer, window_buffer)
         return x_out, stream_state, past_key_values

--- a/vllm_omni/model_executor/models/ming_flash_omni/ming_flash_omni_talker.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/ming_flash_omni_talker.py
@@ -38,6 +38,12 @@ from .voice_presets import VoicePresetRegistry
 logger = init_logger(__name__)
 
 
+def _resolve_inner_cfm_graph_enabled(config: MingFlashOmniTalkerConfig, enforce_eager: bool) -> bool:
+    if config.enable_cfm_graph is not None:
+        return bool(config.enable_cfm_graph)
+    return not enforce_eager
+
+
 @dataclass(slots=True)
 class _GenerationParams:
     """Resolved sampling / decoding parameters for one forward call."""
@@ -126,7 +132,7 @@ class MingFlashOmniTalkerForConditionalGeneration(nn.Module, CustomProcessMixin)
         # AudioVAE
         self.audio_vae, self._vae_weight_source = self._init_audio_vae(config, self.talker_dir, model_path)
 
-        self._use_cuda_graphs = not vllm_config.model_config.enforce_eager
+        self._use_cuda_graphs = _resolve_inner_cfm_graph_enabled(config, vllm_config.model_config.enforce_eager)
 
         self.audio_generator = MingAudioGenerator(
             config=self.config,
@@ -309,6 +315,20 @@ class MingFlashOmniTalkerForConditionalGeneration(nn.Module, CustomProcessMixin)
 
         The full autoregressive generation loop is executed inside this method.
         """
+        graph_capturing = torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+        if not graph_capturing and self._can_use_batched_forward(inputs_embeds, runtime_additional_information):
+            return self._forward_batched_embeddings(inputs_embeds, runtime_additional_information)
+        if (
+            kwargs.get("ming_tts_enable_runner_coalescing")
+            and not graph_capturing
+            and inputs_embeds is None
+            and runtime_additional_information
+            and self._can_batch_additional_info(runtime_additional_information)
+        ):
+            batched = self._build_batched_tts_inputs(runtime_additional_information)
+            if batched is not None:
+                return self._forward_batched_embeddings(batched, runtime_additional_information)
+
         additional_info = self._extract_additional_info(runtime_additional_information)
         params = self._resolve_generation_params(additional_info)
         voice = self._resolve_voice(additional_info)
@@ -321,6 +341,96 @@ class MingFlashOmniTalkerForConditionalGeneration(nn.Module, CustomProcessMixin)
             voice=voice,
         )
         return self._decode_to_output(latents, stream_decode=params.stream_decode)
+
+    def _can_batch_additional_info(self, infos: list[dict]) -> bool:
+        if len(infos) <= 1:
+            return False
+        first_params = self._resolve_generation_params(infos[0] or {})
+        for info in infos:
+            info = info or {}
+            if info.get("prompt_wav_lat") is not None or info.get("prompt_wav_emb") is not None:
+                return False
+            if self._resolve_generation_params(info) != first_params:
+                return False
+        return True
+
+    def _can_use_batched_forward(
+        self,
+        inputs_embeds: torch.Tensor | None,
+        runtime_additional_information: list[dict] | None,
+    ) -> bool:
+        if inputs_embeds is None or inputs_embeds.ndim != 3 or inputs_embeds.shape[0] <= 1:
+            return False
+        infos = runtime_additional_information or []
+        if len(infos) != inputs_embeds.shape[0]:
+            return False
+        first = self._resolve_generation_params(infos[0] or {})
+        first_voice = self._resolve_voice(infos[0] or {})
+        if first_voice.prompt_wav_lat is not None or first_voice.prompt_wav_emb is not None:
+            return False
+        for info in infos[1:]:
+            params = self._resolve_generation_params(info or {})
+            voice = self._resolve_voice(info or {})
+            if params != first:
+                return False
+            if voice.prompt_wav_lat is not None or voice.prompt_wav_emb is not None:
+                return False
+        return True
+
+    def _build_batched_tts_inputs(self, infos: list[dict]) -> torch.Tensor | None:
+        params = self._resolve_generation_params(infos[0] or {})
+        embeds = []
+        lengths = []
+        for info in infos:
+            voice = self._resolve_voice(info or {})
+            if voice.prompt_wav_lat is not None or voice.prompt_wav_emb is not None:
+                return None
+            spk_emb = self._project_spk_emb(voice.spk_emb, voice.already_projected, params.use_zero_spk_emb)
+            text = (info or {}).get("text", "")
+            segments = segment_and_normalize(text, max_length=params.max_text_length) if text else []
+            segment = segments[0] if segments else text
+            emb, _ = build_tts_input(
+                tokenizer=self.tokenizer,
+                embed_tokens=self.model.get_input_embeddings(),
+                device=self.device,
+                dtype=torch.bfloat16,
+                text=segment,
+                prompt=params.prompt,
+                spk_emb=spk_emb,
+                instruction=params.instruction,
+                prompt_text=voice.prompt_text,
+                prompt_wav_emb=voice.prompt_wav_emb,
+            )
+            embeds.append(emb[0])
+            lengths.append(emb.shape[1])
+        max_len = max(lengths)
+        padded = []
+        for emb in embeds:
+            if emb.shape[0] < max_len:
+                pad = torch.zeros(max_len - emb.shape[0], emb.shape[1], device=emb.device, dtype=emb.dtype)
+                emb = torch.cat([pad, emb], dim=0)
+            padded.append(emb)
+        return torch.stack(padded, dim=0)
+
+    def _forward_batched_embeddings(
+        self,
+        inputs_embeds: torch.Tensor,
+        runtime_additional_information: list[dict] | None,
+    ) -> OmniOutput:
+        infos = runtime_additional_information or []
+        params = self._resolve_generation_params(infos[0] or {})
+        logger.debug(
+            "Ming batched forward activated: batch_size=%d seq_len=%d", inputs_embeds.shape[0], inputs_embeds.shape[1]
+        )
+        latents_by_request = self.audio_generator.generate_latents_batch(
+            inputs_embeds=inputs_embeds,
+            max_steps=params.max_steps,
+            cfg=params.cfg,
+            sigma=params.sigma,
+            temperature=params.temperature,
+            use_static_cache=params.use_static_cache,
+        )
+        return self._decode_batch_to_output(latents_by_request, stream_decode=params.stream_decode)
 
     @staticmethod
     def _extract_additional_info(
@@ -352,6 +462,8 @@ class MingFlashOmniTalkerForConditionalGeneration(nn.Module, CustomProcessMixin)
             temperature = additional_info.get("temperature", 0.0)
             max_steps = int(additional_info.get("max_steps", additional_info.get("max_decode_steps", 200)))
 
+        default_stream_decode = not bool(self.config.enable_full_vae_decode)
+
         return _GenerationParams(
             prompt=prompt,
             instruction=instruction,
@@ -362,7 +474,7 @@ class MingFlashOmniTalkerForConditionalGeneration(nn.Module, CustomProcessMixin)
             use_zero_spk_emb=use_zero_spk_emb,
             max_text_length=int(additional_info.get("max_text_length", 50)),
             use_static_cache=bool(additional_info.get("use_static_cache", True)),
-            stream_decode=bool(additional_info.get("stream_decode", True)),
+            stream_decode=bool(additional_info.get("stream_decode", default_stream_decode)),
         )
 
     def _resolve_voice(self, additional_info: dict[str, Any]) -> _VoiceContext:
@@ -477,6 +589,53 @@ class MingFlashOmniTalkerForConditionalGeneration(nn.Module, CustomProcessMixin)
                 )
             )
         return all_latents
+
+    def decode_batch_latents_for_runner(
+        self, latents_by_request: list[list[torch.Tensor]], *, stream_decode: bool
+    ) -> tuple[list[Any], int]:
+        sample_rate = int(self.audio_vae.config.sample_rate) if self.audio_vae is not None else 24000
+        batch_vae_min_batch = max(1, int(self.config.batch_vae_min_batch))
+        if self.audio_vae is not None and not stream_decode and len(latents_by_request) >= batch_vae_min_batch:
+            joined = [torch.cat(latents, dim=1) for latents in latents_by_request]
+            if joined and all(x.shape == joined[0].shape for x in joined):
+                batch_latents = torch.cat(joined, dim=0)
+                waveform, _, _ = self.audio_vae.decode(
+                    batch_latents,
+                    use_cache=False,
+                    stream_state=(None, None, None),
+                    last_chunk=True,
+                )
+                waveform_cpu = waveform.detach().float().cpu()
+                return [
+                    self.audio_generator.trim_trailing_silence(waveform_cpu[i : i + 1])
+                    for i in range(waveform_cpu.shape[0])
+                ], sample_rate
+
+        outputs = []
+        for latents in latents_by_request:
+            out = self._decode_to_output(latents, stream_decode=stream_decode).multimodal_outputs
+            outputs.append(out.get("audio", out.get("audio_latents")))
+            sr = out.get("sr")
+            if sr is not None:
+                sample_rate = int(sr.item()) if hasattr(sr, "item") else int(sr)
+        return outputs, sample_rate
+
+    def _decode_batch_to_output(
+        self, latents_by_request: list[list[torch.Tensor]], *, stream_decode: bool
+    ) -> OmniOutput:
+        outputs = []
+        sample_rate = None
+        for latents in latents_by_request:
+            out = self._decode_to_output(latents, stream_decode=stream_decode).multimodal_outputs
+            if "audio" in out:
+                outputs.append(out["audio"])
+                sample_rate = out.get("sr")
+            elif "audio_latents" in out:
+                outputs.append(out["audio_latents"])
+        multimodal_outputs: dict[str, Any] = {"audio": outputs}
+        if sample_rate is not None:
+            multimodal_outputs["sr"] = sample_rate
+        return OmniOutput(text_hidden_states=None, multimodal_outputs=multimodal_outputs)
 
     def _decode_to_output(self, latents: list[torch.Tensor], *, stream_decode: bool) -> OmniOutput:
         multimodal_outputs: dict[str, Any] = {}

--- a/vllm_omni/model_executor/models/ming_flash_omni/talker_module.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/talker_module.py
@@ -21,23 +21,91 @@
 # MAE: https://github.com/facebookresearch/mae/blob/main/models_mae.py
 # --------------------------------------------------------
 import logging
+from contextlib import nullcontext
+from dataclasses import dataclass
 from functools import cached_property
 from queue import Queue
 from threading import Lock
+from types import MethodType
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers import PreTrainedTokenizerBase, Qwen2Config, Qwen2Model, StaticCache
+from transformers.models.qwen2.modeling_qwen2 import (
+    ALL_ATTENTION_FUNCTIONS,
+    Qwen2Attention,
+    eager_attention_forward,
+)
+from transformers.models.qwen2.modeling_qwen2 import (
+    apply_rotary_pos_emb as qwen2_apply_rotary_pos_emb,
+)
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
-from x_transformers.x_transformers import RotaryEmbedding, apply_rotary_pos_emb
+from x_transformers.x_transformers import RotaryEmbedding, apply_rotary_pos_emb, rotate_half
 
 from vllm_omni.model_executor.layers.timestep_embedding import DiTTimestepEmbedding
 
 from .audio_vae import AudioVAE
 
 logger = init_logger(__name__)
+
+
+def _record_function(name: str):
+    return nullcontext()
+
+
+def _apply_rotary_pos_emb_from_trig(
+    t: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    scale: torch.Tensor | float = 1,
+) -> torch.Tensor:
+    rot_dim, seq_len, orig_dtype = cos.shape[-1], t.shape[-2], t.dtype
+
+    cos = cos[:, -seq_len:, :]
+    sin = sin[:, -seq_len:, :]
+    scale = scale[:, -seq_len:, :] if torch.is_tensor(scale) else scale
+
+    if t.ndim == 4 and cos.ndim == 3:
+        cos = cos.unsqueeze(1)
+        sin = sin.unsqueeze(1)
+        if torch.is_tensor(scale):
+            scale = scale.unsqueeze(1)
+
+    t, t_unrotated = t[..., :rot_dim], t[..., rot_dim:]
+    if torch.is_tensor(scale) or scale != 1:
+        t = (t * cos * scale) + (rotate_half(t) * sin * scale)
+    else:
+        t = (t * cos) + (rotate_half(t) * sin)
+    if t_unrotated.shape[-1] > 0:
+        t = torch.cat((t, t_unrotated), dim=-1)
+
+    return t.type(orig_dtype)
+
+
+def _apply_rotary_pos_emb_from_trig_seq_first(
+    t: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    scale: torch.Tensor | float = 1,
+) -> torch.Tensor:
+    rot_dim, seq_len, orig_dtype = cos.shape[-1], t.shape[1], t.dtype
+
+    cos = cos[:, -seq_len:, :].unsqueeze(2)
+    sin = sin[:, -seq_len:, :].unsqueeze(2)
+    if torch.is_tensor(scale):
+        scale = scale[:, -seq_len:, :].unsqueeze(2)
+
+    t, t_unrotated = t[..., :rot_dim], t[..., rot_dim:]
+    if torch.is_tensor(scale) or scale != 1:
+        t = (t * cos * scale) + (rotate_half(t) * sin * scale)
+    else:
+        t = (t * cos) + (rotate_half(t) * sin)
+    if t_unrotated.shape[-1] > 0:
+        t = torch.cat((t, t_unrotated), dim=-1)
+
+    return t.type(orig_dtype)
 
 
 ########################################################################
@@ -47,6 +115,65 @@ logger = init_logger(__name__)
 # Ported from:
 # https://github.com/inclusionAI/Ming/blob/e58533db227031990c5a6864dcf5f08fb53ed0d2/talker_module/dit.py
 ########################################################################
+
+
+@dataclass(slots=True)
+class MingTalkerSlot:
+    req_id: str | None = None
+
+
+class MingTalkerSlotTable:
+    def __init__(self, max_slots: int) -> None:
+        if max_slots <= 0:
+            raise ValueError(f"max_slots must be positive, got {max_slots}")
+        self.slots = [MingTalkerSlot() for _ in range(max_slots)]
+        self.req_to_slot: dict[str, int] = {}
+        self.free_slots = list(range(max_slots - 1, -1, -1))
+
+    def allocate(self, req_id: str) -> int:
+        existing = self.req_to_slot.get(req_id)
+        if existing is not None:
+            return existing
+        if not self.free_slots:
+            raise RuntimeError("Ming Talker slot table exhausted")
+        slot = self.free_slots.pop()
+        self.req_to_slot[req_id] = slot
+        self.slots[slot] = MingTalkerSlot(req_id)
+        return slot
+
+    def free(self, req_id: str) -> None:
+        slot = self.req_to_slot.pop(req_id, None)
+        if slot is None:
+            return
+        self.slots[slot] = MingTalkerSlot()
+        self.free_slots.append(slot)
+
+    def active_slots(self) -> list[int]:
+        return [idx for idx, slot in enumerate(self.slots) if slot.req_id is not None]
+
+    def active_request_ids(self) -> list[str]:
+        return [self.slots[idx].req_id for idx in self.active_slots()]
+
+
+@dataclass(slots=True)
+class MingTalkerBatchPolicy:
+    max_batch_size: int = 8
+    max_wait_ms: float = 20.0
+    bucket_sizes: tuple[int, ...] = (1, 2, 4, 8, 16)
+
+    def choose_bucket(self, queued: int) -> int:
+        if queued <= 0:
+            return 0
+        capped = min(queued, self.max_batch_size)
+        for bucket in self.bucket_sizes:
+            if capped <= bucket:
+                return min(bucket, self.max_batch_size)
+        return self.max_batch_size
+
+    def should_dispatch(self, queued: int, oldest_wait_ms: float) -> bool:
+        if queued <= 0:
+            return False
+        return queued >= self.max_batch_size or oldest_wait_ms >= self.max_wait_ms
 
 
 class RMSNorm(nn.Module):
@@ -75,7 +202,12 @@ class FeedForward(nn.Module):
         self.ff = nn.Sequential(project_in, nn.Dropout(dropout), nn.Linear(inner_dim, dim_out))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.ff(x)
+        with _record_function("ming.feed_forward.in_proj_gelu"):
+            x = self.ff[0](x)
+        with _record_function("ming.feed_forward.dropout"):
+            x = self.ff[1](x)
+        with _record_function("ming.feed_forward.out_proj"):
+            return self.ff[2](x)
 
 
 class Attention(nn.Module):
@@ -98,6 +230,7 @@ class Attention(nn.Module):
         self.to_q = nn.Linear(dim, self.inner_dim)
         self.to_k = nn.Linear(dim, self.inner_dim)
         self.to_v = nn.Linear(dim, self.inner_dim)
+        self.to_qkv: nn.Linear | None = None
         if qk_norm is None:
             self.q_norm = None
             self.k_norm = None
@@ -114,40 +247,104 @@ class Attention(nn.Module):
         self.pe_attn_head = pe_attn_head
         self.attn_mask_enabled = attn_mask_enabled
 
+    def pack_qkv(self) -> None:
+        if self.to_qkv is not None:
+            return
+        if self.to_q.bias is None or self.to_k.bias is None or self.to_v.bias is None:
+            raise ValueError("Ming fused QKV packing expects q/k/v bias tensors")
+        qkv = nn.Linear(
+            self.dim,
+            self.inner_dim * 3,
+            bias=True,
+            device=self.to_q.weight.device,
+            dtype=self.to_q.weight.dtype,
+        )
+        with torch.no_grad():
+            qkv.weight.copy_(torch.cat([self.to_q.weight, self.to_k.weight, self.to_v.weight], dim=0))
+            qkv.bias.copy_(torch.cat([self.to_q.bias, self.to_k.bias, self.to_v.bias], dim=0))
+        qkv.requires_grad_(False)
+        self.to_qkv = qkv
+
     def forward(
         self,
         x: torch.Tensor,
         mask: torch.Tensor | None = None,
-        rope: tuple[torch.Tensor, torch.Tensor | None] | None = None,
+        rope: tuple[torch.Tensor, ...] | None = None,
     ) -> torch.Tensor:
         batch_size = x.shape[0]
 
-        query = self.to_q(x)
-        key = self.to_k(x)
-        value = self.to_v(x)
+        with _record_function("ming.attn.qkv_proj"):
+            if self.to_qkv is None:
+                query = self.to_q(x)
+                key = self.to_k(x)
+                value = self.to_v(x)
+            else:
+                query, key, value = self.to_qkv(x).chunk(3, dim=-1)
 
         inner_dim = key.shape[-1]
         head_dim = inner_dim // self.heads
-        query = query.view(batch_size, -1, self.heads, head_dim).transpose(1, 2)
-        key = key.view(batch_size, -1, self.heads, head_dim).transpose(1, 2)
-        value = value.view(batch_size, -1, self.heads, head_dim).transpose(1, 2)
+        query = query.view(batch_size, -1, self.heads, head_dim)
+        key = key.view(batch_size, -1, self.heads, head_dim)
+        value = value.view(batch_size, -1, self.heads, head_dim)
 
-        if self.q_norm is not None:
-            query = self.q_norm(query)
-        if self.k_norm is not None:
-            key = self.k_norm(key)
+        if rope is not None and len(rope) == 4:
+            with _record_function("ming.attn.qk_norm"):
+                if self.q_norm is not None:
+                    query = self.q_norm(query)
+                if self.k_norm is not None:
+                    key = self.k_norm(key)
 
-        if rope is not None:
-            freqs, xpos_scale = rope
-            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+            with _record_function("ming.attn.rope"):
+                cos, sin, q_xpos_scale, k_xpos_scale = rope
+                if self.pe_attn_head is not None:
+                    on = self.pe_attn_head
+                    query[:, :, :on, :] = _apply_rotary_pos_emb_from_trig_seq_first(
+                        query[:, :, :on, :], cos, sin, q_xpos_scale
+                    )
+                    key[:, :, :on, :] = _apply_rotary_pos_emb_from_trig_seq_first(
+                        key[:, :, :on, :], cos, sin, k_xpos_scale
+                    )
+                else:
+                    query = _apply_rotary_pos_emb_from_trig_seq_first(query, cos, sin, q_xpos_scale)
+                    key = _apply_rotary_pos_emb_from_trig_seq_first(key, cos, sin, k_xpos_scale)
 
-            if self.pe_attn_head is not None:
-                on = self.pe_attn_head
-                query[:, :on, :, :] = apply_rotary_pos_emb(query[:, :on, :, :], freqs, q_xpos_scale)
-                key[:, :on, :, :] = apply_rotary_pos_emb(key[:, :on, :, :], freqs, k_xpos_scale)
-            else:
-                query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
-                key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+            query = query.transpose(1, 2)
+            key = key.transpose(1, 2)
+            value = value.transpose(1, 2)
+        else:
+            query = query.transpose(1, 2)
+            key = key.transpose(1, 2)
+            value = value.transpose(1, 2)
+
+            with _record_function("ming.attn.qk_norm"):
+                if self.q_norm is not None:
+                    query = self.q_norm(query)
+                if self.k_norm is not None:
+                    key = self.k_norm(key)
+
+            with _record_function("ming.attn.rope"):
+                if rope is not None:
+                    if len(rope) == 4:
+                        cos, sin, q_xpos_scale, k_xpos_scale = rope
+
+                        def apply_rope(t: torch.Tensor, scale: torch.Tensor | float) -> torch.Tensor:
+                            return _apply_rotary_pos_emb_from_trig(t, cos, sin, scale)
+                    else:
+                        freqs, xpos_scale = rope
+                        q_xpos_scale, k_xpos_scale = (
+                            (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+                        )
+
+                        def apply_rope(t: torch.Tensor, scale: torch.Tensor | float) -> torch.Tensor:
+                            return apply_rotary_pos_emb(t, freqs, scale)
+
+                    if self.pe_attn_head is not None:
+                        on = self.pe_attn_head
+                        query[:, :on, :, :] = apply_rope(query[:, :on, :, :], q_xpos_scale)
+                        key[:, :on, :, :] = apply_rope(key[:, :on, :, :], k_xpos_scale)
+                    else:
+                        query = apply_rope(query, q_xpos_scale)
+                        key = apply_rope(key, k_xpos_scale)
 
         if self.attn_mask_enabled and mask is not None:
             valid_sample_indices = mask.any(dim=1)
@@ -162,7 +359,8 @@ class Attention(nn.Module):
         else:
             attn_mask = None
 
-        x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        with _record_function("ming.attn.sdpa"):
+            x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
         if self.attn_mask_enabled and mask is not None:
             final_output[valid_sample_indices] = x
             x = final_output
@@ -170,8 +368,9 @@ class Attention(nn.Module):
         x = x.transpose(1, 2).reshape(batch_size, -1, self.heads * head_dim)
         x = x.to(query.dtype)
 
-        x = self.to_out[0](x)
-        x = self.to_out[1](x)
+        with _record_function("ming.attn.out_proj"):
+            x = self.to_out[0](x)
+            x = self.to_out[1](x)
 
         if mask is not None:
             mask = mask.unsqueeze(-1)
@@ -212,10 +411,18 @@ class DiTBlock(nn.Module):
         self,
         x: torch.Tensor,
         mask: torch.Tensor | None,
-        rope: tuple[torch.Tensor, torch.Tensor | None] | None,
+        rope: tuple[torch.Tensor, ...] | None,
     ) -> torch.Tensor:
-        x = x + self.attn(self.norm1(x), mask=mask, rope=rope)
-        x = x + self.mlp(self.norm2(x))
+        with _record_function("ming.dit_block.norm1"):
+            normed = self.norm1(x)
+        with _record_function("ming.dit_block.attn"):
+            attn_out = self.attn(normed, mask=mask, rope=rope)
+            x = x + attn_out if torch.is_grad_enabled() else x.add_(attn_out)
+        with _record_function("ming.dit_block.norm2"):
+            normed = self.norm2(x)
+        with _record_function("ming.dit_block.mlp"):
+            mlp_out = self.mlp(normed)
+            x = x + mlp_out if torch.is_grad_enabled() else x.add_(mlp_out)
         return x
 
 
@@ -228,8 +435,10 @@ class FinalLayer(nn.Module):
         self.linear = nn.Linear(hidden_size, out_channels, bias=True)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.norm_final(x)
-        x = self.linear(x)
+        with _record_function("ming.final_layer.norm"):
+            x = self.norm_final(x)
+        with _record_function("ming.final_layer.linear"):
+            x = self.linear(x)
         return x
 
 
@@ -270,6 +479,7 @@ class DiT(nn.Module):
         else:
             self.spk_embedder = None
         self.hidden_size = hidden_size
+        self.use_precomputed_rope_trig = True
 
         self.rotary_embed = RotaryEmbedding(hidden_size // num_heads)
 
@@ -277,6 +487,13 @@ class DiT(nn.Module):
             [DiTBlock(hidden_size, num_heads, mlp_ratio=mlp_ratio, **kwargs) for _ in range(depth)]
         )
         self.final_layer = FinalLayer(hidden_size, self.out_channels)
+
+    def _maybe_precompute_rope_trig(self, rope: tuple[torch.Tensor, torch.Tensor | None]) -> tuple[torch.Tensor, ...]:
+        if not self.use_precomputed_rope_trig:
+            return rope
+        freqs, xpos_scale = rope
+        q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+        return freqs.cos(), freqs.sin(), q_xpos_scale, k_xpos_scale
 
     def forward(
         self,
@@ -296,7 +513,7 @@ class DiT(nn.Module):
             x = torch.cat([y, x], dim=1)
         else:
             x = torch.cat([self.spk_embedder(spk_emb), y, x], dim=1)
-        rope = self.rotary_embed.forward_from_seq_len(x.shape[1])
+        rope = self._maybe_precompute_rope_trig(self.rotary_embed.forward_from_seq_len(x.shape[1]))
 
         for block in self.blocks:
             x = block(x, None, rope)
@@ -322,6 +539,62 @@ class DiT(nn.Module):
             spk_emb = torch.cat([spk_emb, spk_emb], dim=0)
         model_out = self.forward(x, t, c, latent_history, spk_emb)
         return model_out[:, -x.shape[1] :, :]
+
+    def forward_with_prepared_cfg(
+        self,
+        x: torch.Tensor,
+        t: torch.Tensor,
+        c: torch.Tensor,
+        latent_history: torch.Tensor,
+        spk_emb: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Forward with CFG when step-invariant CFG inputs are pre-expanded."""
+        x = torch.cat([x, x], dim=0)
+        if t.ndim == 0:
+            t = t.repeat(x.shape[0])
+        model_out = self.forward(x, t, c, latent_history, spk_emb)
+        return model_out[:, -x.shape[1] :, :]
+
+    def forward_with_preembedded_cfg(
+        self,
+        x: torch.Tensor,
+        t: torch.Tensor,
+        c_emb: torch.Tensor,
+        latent_history_emb: torch.Tensor,
+        rope: tuple[torch.Tensor, ...],
+    ) -> torch.Tensor:
+        """Forward with CFG and step-invariant embeddings precomputed."""
+        x = torch.cat([x, x], dim=0)
+        patch_len = x.shape[1]
+        x = self.x_embedder(x)
+        if t.ndim == 0:
+            t = t.repeat(x.shape[0])
+        t = self.t_embedder(t).unsqueeze(1)
+        x = torch.cat([t + c_emb, latent_history_emb, x], dim=1)
+
+        for block in self.blocks:
+            x = block(x, None, rope)
+        x = self.final_layer(x[:, -patch_len:, :])
+        return x
+
+    def forward_with_preembedded_cfg_temb(
+        self,
+        x: torch.Tensor,
+        t_emb: torch.Tensor,
+        c_emb: torch.Tensor,
+        latent_history_emb: torch.Tensor,
+        rope: tuple[torch.Tensor, ...],
+    ) -> torch.Tensor:
+        """Forward with CFG and precomputed timestep/condition embeddings."""
+        x = self.x_embedder(x)
+        patch_len = x.shape[1]
+        x = torch.cat([x, x], dim=0)
+        x = torch.cat([t_emb + c_emb, latent_history_emb, x], dim=1)
+
+        for block in self.blocks:
+            x = block(x, None, rope)
+        x = self.final_layer(x[:, -patch_len:, :])
+        return x
 
 
 #########################################################################################
@@ -364,6 +637,14 @@ class CFM(nn.Module):
         self.model = model
         self.steps = steps
         self.sway_sampling_coef = sway_sampling_coef
+        self.use_prepared_cfg = False
+        self.use_preembedded_cfg = True
+        self.use_precomputed_temb = True
+
+    def prepare_timesteps(self, t: torch.Tensor) -> torch.Tensor:
+        if self.sway_sampling_coef is None:
+            return t
+        return t + self.sway_sampling_coef * (torch.cos(torch.pi / 2 * t) - 1 + t)
 
     @torch.no_grad()
     def sample(
@@ -373,7 +654,9 @@ class CFM(nn.Module):
         y0: torch.Tensor,
         t: torch.Tensor,
         sde_args: torch.Tensor,
-        sde_rnd: torch.Tensor,
+        sde_rnd: torch.Tensor | None,
+        *,
+        timesteps_are_swayed: bool = False,
     ):
         """Sample audio latent via ODE/SDE integration with CFG.
 
@@ -386,30 +669,96 @@ class CFM(nn.Module):
             sde_rnd: random noise for SDE steps (steps, B, patch_size, latent_dim)
         """
 
-        def fn(fn_t, x):
-            pred_cfg = self.model.forward_with_cfg(x, fn_t, llm_cond, lat_cond, None)
-            pred, null_pred = torch.chunk(pred_cfg, 2, dim=0)
-            return pred + (pred - null_pred) * sde_args[0]
+        if not timesteps_are_swayed:
+            t = self.prepare_timesteps(t)
 
-        if self.sway_sampling_coef is not None:
-            t = t + self.sway_sampling_coef * (torch.cos(torch.pi / 2 * t) - 1 + t)
+        if self.use_preembedded_cfg:
+            lat_cond_emb = self.model.x_embedder(lat_cond)
+            cfg_lat_cond_emb = torch.cat([lat_cond_emb, lat_cond_emb], dim=0)
+            llm_cond_emb = self.model.c_embedder(llm_cond)
+            null_cond_bias = self.model.c_embedder.cond_embedder.bias
+            if null_cond_bias is None:
+                null_llm_cond_emb = self.model.c_embedder(torch.zeros_like(llm_cond))
+            else:
+                null_llm_cond_emb = null_cond_bias.view(1, 1, -1).expand_as(llm_cond_emb)
+            cfg_llm_cond_emb = torch.cat([llm_cond_emb, null_llm_cond_emb], dim=0)
+            rope = self.model._maybe_precompute_rope_trig(
+                self.model.rotary_embed.forward_from_seq_len(1 + cfg_lat_cond_emb.shape[1] + y0.shape[1])
+            )
+            if self.use_precomputed_temb:
+                t_emb = self.model.t_embedder(t[:-1]).unsqueeze(1)
+
+            def fn(fn_t, x):
+                if self.use_precomputed_temb:
+                    step_t_emb = t_emb[step : step + 1]
+                    return self._guided_prediction_from_cfg(
+                        self.model.forward_with_preembedded_cfg_temb(
+                            x,
+                            step_t_emb,
+                            cfg_llm_cond_emb,
+                            cfg_lat_cond_emb,
+                            rope,
+                        ),
+                        sde_args[0],
+                    )
+                pred_cfg = self.model.forward_with_preembedded_cfg(
+                    x,
+                    fn_t,
+                    cfg_llm_cond_emb,
+                    cfg_lat_cond_emb,
+                    rope,
+                )
+                return self._guided_prediction_from_cfg(pred_cfg, sde_args[0])
+
+        elif self.use_prepared_cfg:
+            cfg_lat_cond = torch.cat([lat_cond, lat_cond], dim=0)
+            cfg_llm_cond = torch.cat([llm_cond, torch.zeros_like(llm_cond)], dim=0)
+
+            def fn(fn_t, x):
+                pred_cfg = self.model.forward_with_prepared_cfg(x, fn_t, cfg_llm_cond, cfg_lat_cond, None)
+                pred, null_pred = torch.chunk(pred_cfg, 2, dim=0)
+                return pred + (pred - null_pred) * sde_args[0]
+
+        else:
+
+            def fn(fn_t, x):
+                pred_cfg = self.model.forward_with_cfg(x, fn_t, llm_cond, lat_cond, None)
+                pred, null_pred = torch.chunk(pred_cfg, 2, dim=0)
+                return pred + (pred - null_pred) * sde_args[0]
 
         for step in range(self.steps):
             dt = t[step + 1] - t[step]
             y0 = y0 + fn(t[step], y0) * dt
-            y0 = y0 + sde_args[1] * (sde_args[2] ** 0.5) * (dt.abs() ** 0.5) * sde_rnd[step]
+            if sde_rnd is not None:
+                y0 = y0 + sde_args[1] * (sde_args[2] ** 0.5) * (dt.abs() ** 0.5) * sde_rnd[step]
 
         return y0
+
+    @staticmethod
+    def _guided_prediction_from_cfg(pred_cfg: torch.Tensor, cfg_strength: torch.Tensor) -> torch.Tensor:
+        pred, null_pred = torch.chunk(pred_cfg, 2, dim=0)
+        return pred + (pred - null_pred) * cfg_strength
 
 
 class CFMGraphExecutor:
     """CUDA graph-accelerated executor for CFM + Aggregator + StopHead pipeline."""
 
-    def __init__(self, config, cfm, aggregator, stop_head: nn.Linear):
+    def __init__(
+        self,
+        config,
+        cfm,
+        aggregator,
+        stop_head: nn.Linear,
+        *,
+        deterministic_sde_noise: bool = False,
+        return_stop_logits: bool = False,
+    ):
         self.config = config
         self.cfm = cfm
         self.aggregator = aggregator
         self.stop_head = stop_head
+        self.deterministic_sde_noise = deterministic_sde_noise
+        self.return_stop_logits = return_stop_logits
         self.initialized = False
 
         self.last_hidden_state_placeholder = None
@@ -431,14 +780,22 @@ class CFMGraphExecutor:
         sigma: float = 0.25,
         temperature: float = 0.0,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self.deterministic_sde_noise and temperature != 0.0:
+            raise ValueError("deterministic CFM graph executor requires temperature=0.0")
         bat_size, his_patch_size, z_dim = his_lat.shape
         randn_tensor = torch.randn(
             (bat_size, self.config.patch_size, z_dim), device=input_tensor.device, dtype=input_tensor.dtype
         )
-        t = get_epss_timesteps(self.config.steps, device=input_tensor.device, dtype=input_tensor.dtype)
-        sde_rnd = torch.randn(
-            (self.config.steps, *randn_tensor.shape), device=input_tensor.device, dtype=input_tensor.dtype
-        )
+        sde_shape = (self.config.steps, *randn_tensor.shape)
+        sde_rnd = None
+        if self.deterministic_sde_noise:
+            # Preserve the RNG stream used by the original temperature=0 path.
+            # The sampled noise is mathematically multiplied by zero, so it is
+            # consumed for determinism but intentionally kept out of the graph.
+            _unused_sde_rnd = torch.randn(sde_shape, device=input_tensor.device, dtype=input_tensor.dtype)
+            del _unused_sde_rnd
+        else:
+            sde_rnd = torch.randn(sde_shape, device=input_tensor.device, dtype=input_tensor.dtype)
 
         if not self.initialized:
             self._initialize_graph(input_tensor, his_lat, randn_tensor, sde_rnd)
@@ -446,11 +803,12 @@ class CFMGraphExecutor:
         self.last_hidden_state_placeholder.copy_(input_tensor)
         self.his_lat_placeholder.copy_(his_lat)
         self.randn_like_placeholder.copy_(randn_tensor)
-        self.t_placeholder.copy_(t)
         self.sde_args_placeholder[0] = cfg_strength
         self.sde_args_placeholder[1] = sigma
         self.sde_args_placeholder[2] = temperature
-        self.sde_rnd_placeholder.copy_(sde_rnd)
+        if self.sde_rnd_placeholder is not None:
+            assert sde_rnd is not None
+            self.sde_rnd_placeholder.copy_(sde_rnd)
 
         self.graph.replay()
 
@@ -470,14 +828,16 @@ class CFMGraphExecutor:
         input_tensor: torch.Tensor,
         his_lat: torch.Tensor,
         randn_tensor: torch.Tensor,
-        sde_rnd: torch.Tensor,
+        sde_rnd: torch.Tensor | None,
     ) -> None:
         self.last_hidden_state_placeholder = torch.empty_like(input_tensor)
         self.his_lat_placeholder = torch.empty_like(his_lat)
         self.randn_like_placeholder = torch.empty_like(randn_tensor)
-        self.t_placeholder = get_epss_timesteps(self.config.steps, device=input_tensor.device, dtype=input_tensor.dtype)
+        self.t_placeholder = self.cfm.prepare_timesteps(
+            get_epss_timesteps(self.config.steps, device=input_tensor.device, dtype=input_tensor.dtype)
+        )
         self.sde_args_placeholder = torch.empty(3, device=input_tensor.device, dtype=input_tensor.dtype)
-        self.sde_rnd_placeholder = torch.empty_like(sde_rnd)
+        self.sde_rnd_placeholder = torch.empty_like(sde_rnd) if sde_rnd is not None else None
 
         self.graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(self.graph, pool=current_platform.get_global_graph_pool()):
@@ -488,9 +848,12 @@ class CFMGraphExecutor:
                 self.t_placeholder,
                 self.sde_args_placeholder,
                 self.sde_rnd_placeholder,
+                timesteps_are_swayed=True,
             )
             self.inputs_embeds_placeholder = self.aggregator(self.gen_lat_placeholder)
-            self.stop_out_placeholder = self.stop_head(self.last_hidden_state_placeholder[:, -1, :]).softmax(dim=-1)
+            self.stop_out_placeholder = self.stop_head(self.last_hidden_state_placeholder[:, -1, :])
+            if not self.return_stop_logits:
+                self.stop_out_placeholder = self.stop_out_placeholder.softmax(dim=-1)
 
         self.initialized = True
 
@@ -498,17 +861,36 @@ class CFMGraphExecutor:
 class CFMGraphExecutorPool:
     """Thread-safe pool of CFMGraphExecutors for concurrent inference."""
 
-    def __init__(self, config, cfm, aggregator, stop_head: nn.Linear, pool_size: int = 1):
+    def __init__(
+        self,
+        config,
+        cfm,
+        aggregator,
+        stop_head: nn.Linear,
+        pool_size: int = 1,
+        *,
+        deterministic_sde_noise: bool = False,
+        return_stop_logits: bool = False,
+    ):
         self.config = config
         self.cfm = cfm
         self.aggregator = aggregator
         self.stop_head = stop_head
         self.pool_size = pool_size
+        self.deterministic_sde_noise = deterministic_sde_noise
+        self.return_stop_logits = return_stop_logits
         self.pool = Queue(maxsize=pool_size)
         self.lock = Lock()
 
         for _ in range(pool_size):
-            executor = CFMGraphExecutor(config, cfm, aggregator, stop_head)
+            executor = CFMGraphExecutor(
+                config,
+                cfm,
+                aggregator,
+                stop_head,
+                deterministic_sde_noise=deterministic_sde_noise,
+                return_stop_logits=return_stop_logits,
+            )
             self.pool.put(executor)
 
     def acquire(self) -> CFMGraphExecutor:
@@ -532,6 +914,59 @@ class CFMGraphExecutorPool:
             )
         finally:
             self.release(executor)
+
+
+class VAEStreamDecodeGraphExecutor:
+    """CUDA graph executor for one stateless AudioVAE stream decode shape."""
+
+    def __init__(self, audio_vae: AudioVAE) -> None:
+        self.audio_vae = audio_vae
+        self.initialized = False
+        self.latent_placeholder: torch.Tensor | None = None
+        self.waveform_placeholder: torch.Tensor | None = None
+        self.graph: torch.cuda.CUDAGraph | None = None
+
+    def execute(self, latent: torch.Tensor) -> torch.Tensor:
+        if not self.initialized:
+            self._initialize_graph(latent)
+
+        assert self.latent_placeholder is not None
+        assert self.waveform_placeholder is not None
+        assert self.graph is not None
+        self.latent_placeholder.copy_(latent)
+        self.graph.replay()
+        waveform = torch.empty_like(self.waveform_placeholder)
+        waveform.copy_(self.waveform_placeholder)
+        return waveform
+
+    def _initialize_graph(self, latent: torch.Tensor) -> None:
+        device = latent.device
+        self.latent_placeholder = torch.empty_like(latent)
+        self.graph = torch.cuda.CUDAGraph()
+        self.latent_placeholder.copy_(latent)
+
+        graph_stream = torch.cuda.Stream(device=device)
+        graph_stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.no_grad(), torch.cuda.stream(graph_stream):
+            for _ in range(3):
+                self.audio_vae.decode(
+                    self.latent_placeholder,
+                    use_cache=False,
+                    stream_state=(None, None, None),
+                    last_chunk=True,
+                )
+        torch.cuda.current_stream(device).wait_stream(graph_stream)
+        torch.accelerator.synchronize(device)
+
+        with torch.no_grad(), torch.cuda.graph(self.graph):
+            self.waveform_placeholder, _, _ = self.audio_vae.decode(
+                self.latent_placeholder,
+                use_cache=False,
+                stream_state=(None, None, None),
+                last_chunk=True,
+            )
+        torch.accelerator.synchronize(device)
+        self.initialized = True
 
 
 ########################################################################
@@ -722,26 +1157,226 @@ class Aggregator(nn.Module):
         self.hidden_size = hidden_size
 
         self.rotary_embed = RotaryEmbedding(hidden_size // num_heads)
+        self.use_precomputed_rope_trig = True
 
         self.blocks = nn.ModuleList(
             [DiTBlock(hidden_size, num_heads, mlp_ratio=mlp_ratio, **kwargs) for _ in range(depth)]
         )
         self.final_layer = FinalLayer(hidden_size, llm_input_dim)
 
+    def _maybe_precompute_rope_trig(self, rope: tuple[torch.Tensor, torch.Tensor | None]) -> tuple[torch.Tensor, ...]:
+        if not self.use_precomputed_rope_trig:
+            return rope
+        freqs, xpos_scale = rope
+        q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+        return freqs.cos(), freqs.sin(), q_xpos_scale, k_xpos_scale
+
     def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
         x = self.x_embedder(x)
         cls_embed = self.word_embedder(torch.zeros((x.shape[0], 1), dtype=torch.long, device=x.device))
         x = torch.cat([cls_embed, x], dim=1)
 
-        rope = self.rotary_embed.forward_from_seq_len(x.shape[1])
+        rope = self._maybe_precompute_rope_trig(self.rotary_embed.forward_from_seq_len(x.shape[1]))
         if mask is not None:
             mask_pad = mask.clone().detach()[:, :1]
             mask = torch.cat([mask_pad, mask], dim=-1)
         for block in self.blocks:
             x = block(x, mask, rope)
-        x = self.final_layer(x)
-        x = x[:, :1, :]
+        x = self.final_layer(x[:, :1, :])
         return x
+
+
+def pack_attention_qkv_projections(module: nn.Module) -> int:
+    packed = 0
+    for child in module.modules():
+        if isinstance(child, Attention):
+            child.pack_qkv()
+            packed += 1
+    return packed
+
+
+def _qwen2_attention_forward_with_packed_qkv(
+    self,
+    hidden_states: torch.Tensor,
+    position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    attention_mask: torch.Tensor | None,
+    past_key_values: StaticCache | None = None,
+    cache_position: torch.LongTensor | None = None,
+    **kwargs,
+):
+    input_shape = hidden_states.shape[:-1]
+    hidden_shape = (*input_shape, -1, self.head_dim)
+
+    q_out = self.q_proj.out_features
+    k_out = self.k_proj.out_features
+    v_out = self.v_proj.out_features
+    query_states, key_states, value_states = self.qkv_proj(hidden_states).split((q_out, k_out, v_out), dim=-1)
+    query_states = query_states.view(hidden_shape).transpose(1, 2)
+    key_states = key_states.view(hidden_shape).transpose(1, 2)
+    value_states = value_states.view(hidden_shape).transpose(1, 2)
+
+    cos, sin = position_embeddings
+    query_states, key_states = qwen2_apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+    if past_key_values is not None:
+        cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+        key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+
+    attention_interface = ALL_ATTENTION_FUNCTIONS.get_interface(
+        self.config._attn_implementation,
+        eager_attention_forward,
+    )
+    attn_output, attn_weights = attention_interface(
+        self,
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        dropout=0.0 if not self.training else self.attention_dropout,
+        scaling=self.scaling,
+        sliding_window=self.sliding_window,
+        **kwargs,
+    )
+
+    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+    attn_output = self.o_proj(attn_output)
+    return attn_output, attn_weights
+
+
+def pack_qwen2_attention_qkv_projections(module: nn.Module) -> int:
+    packed = 0
+    for child in module.modules():
+        if not isinstance(child, Qwen2Attention):
+            continue
+        if hasattr(child, "qkv_proj"):
+            continue
+        if child.q_proj.bias is None or child.k_proj.bias is None or child.v_proj.bias is None:
+            raise ValueError("Ming Qwen2 fused QKV packing expects q/k/v bias tensors")
+        qkv = nn.Linear(
+            child.config.hidden_size,
+            child.q_proj.out_features + child.k_proj.out_features + child.v_proj.out_features,
+            bias=True,
+            device=child.q_proj.weight.device,
+            dtype=child.q_proj.weight.dtype,
+        )
+        with torch.no_grad():
+            qkv.weight.copy_(torch.cat([child.q_proj.weight, child.k_proj.weight, child.v_proj.weight], dim=0))
+            qkv.bias.copy_(torch.cat([child.q_proj.bias, child.k_proj.bias, child.v_proj.bias], dim=0))
+        qkv.requires_grad_(False)
+        child.qkv_proj = qkv
+        child.forward = MethodType(_qwen2_attention_forward_with_packed_qkv, child)
+        packed += 1
+    return packed
+
+
+def _snapshot_static_cache(
+    past_key_values: StaticCache,
+) -> list[tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]]:
+    snapshot = []
+    for layer in getattr(past_key_values, "layers", []):
+        keys = getattr(layer, "keys", None)
+        values = getattr(layer, "values", None)
+        cumulative_length = getattr(layer, "cumulative_length", None)
+        snapshot.append(
+            (
+                keys.detach().clone() if keys is not None else None,
+                values.detach().clone() if values is not None else None,
+                cumulative_length.detach().clone() if cumulative_length is not None else None,
+            )
+        )
+    return snapshot
+
+
+def _restore_static_cache(
+    past_key_values: StaticCache,
+    snapshot: list[tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]],
+) -> None:
+    for layer, (keys, values, cumulative_length) in zip(getattr(past_key_values, "layers", []), snapshot):
+        if keys is not None:
+            layer.keys.copy_(keys)
+        if values is not None:
+            layer.values.copy_(values)
+        if cumulative_length is not None:
+            layer.cumulative_length.copy_(cumulative_length)
+
+
+class MingLLMDecodeGraphExecutor:
+    def __init__(
+        self,
+        model: Qwen2Model,
+        past_key_values: StaticCache,
+        sample_inputs_embeds: torch.Tensor,
+        cache_position_start: int,
+    ) -> None:
+        if sample_inputs_embeds.device.type != "cuda":
+            raise ValueError("Ming LLM decode graph requires CUDA tensors")
+        self._model = model
+        self._past_key_values = past_key_values
+        self._input_ph = torch.empty_like(sample_inputs_embeds)
+        self._cache_pos_ph = torch.empty(
+            (sample_inputs_embeds.shape[1],),
+            device=sample_inputs_embeds.device,
+            dtype=torch.long,
+        )
+        self._graph = torch.cuda.CUDAGraph()
+        self._output: torch.Tensor | None = None
+        self._shape = tuple(sample_inputs_embeds.shape)
+        self._capture(sample_inputs_embeds, cache_position_start)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self._shape
+
+    def _set_inputs(self, inputs_embeds: torch.Tensor, cache_position_start: int) -> None:
+        self._input_ph.copy_(inputs_embeds)
+        self._cache_pos_ph.copy_(
+            torch.arange(
+                cache_position_start,
+                cache_position_start + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
+                dtype=torch.long,
+            )
+        )
+
+    def _run_model(self):
+        return self._model(
+            past_key_values=self._past_key_values,
+            inputs_embeds=self._input_ph,
+            use_cache=True,
+            cache_position=self._cache_pos_ph,
+        )
+
+    def _capture(self, sample_inputs_embeds: torch.Tensor, cache_position_start: int) -> None:
+        device = sample_inputs_embeds.device
+        cache_snapshot = _snapshot_static_cache(self._past_key_values)
+        rng_state = torch.cuda.get_rng_state(device)
+        self._set_inputs(sample_inputs_embeds, cache_position_start)
+
+        graph_stream = torch.cuda.Stream(device=device)
+        graph_stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.no_grad(), torch.cuda.stream(graph_stream):
+            for _ in range(3):
+                self._run_model()
+        torch.cuda.current_stream(device).wait_stream(graph_stream)
+        torch.accelerator.synchronize(device)
+        _restore_static_cache(self._past_key_values, cache_snapshot)
+        torch.cuda.set_rng_state(rng_state, device)
+
+        with torch.no_grad(), torch.cuda.graph(self._graph):
+            graph_outputs = self._run_model()
+            self._output = graph_outputs.last_hidden_state[:, -1:, :]
+        torch.accelerator.synchronize(device)
+        _restore_static_cache(self._past_key_values, cache_snapshot)
+        torch.cuda.set_rng_state(rng_state, device)
+
+    def replay(self, inputs_embeds: torch.Tensor, cache_position_start: int) -> torch.Tensor:
+        if tuple(inputs_embeds.shape) != self._shape:
+            raise ValueError(f"LLM decode graph shape mismatch: {tuple(inputs_embeds.shape)} != {self._shape}")
+        self._set_inputs(inputs_embeds, cache_position_start)
+        self._graph.replay()
+        if self._output is None:
+            raise RuntimeError("Ming LLM decode graph output was not captured")
+        return self._output
 
 
 ########################################################################
@@ -889,13 +1524,51 @@ class MingAudioGenerator:
         # For FA2, let it see a full-length seq Q
         # trailing latent frames prepended on each decode call
         self._vae_decode_pad_frames = 32
+        self._pack_qkv_enabled = True
+        self._qkv_packed = False
+        self._llm_decode_graph_enabled = True
+        self._llm_decode_graph_batch_compaction_enabled = False
+        self._vae_stream_graph_enabled = True
+        self._stop_logit_decision_enabled = True
+        self._llm_decode_graphs: dict[int, MingLLMDecodeGraphExecutor] = {}
+        self._reusable_kv_caches: dict[tuple[int, str, torch.dtype], StaticCache] = {}
+        self._reusable_kv_cache_lock = Lock()
+        self._vae_stream_decode_graphs: dict[tuple[int, torch.device, torch.dtype], VAEStreamDecodeGraphExecutor] = {}
+
+    def _maybe_pack_qkv_projections(self) -> None:
+        if self._pack_qkv_enabled and not self._qkv_packed:
+            packed_talker = pack_attention_qkv_projections(self._cfm) + pack_attention_qkv_projections(self._aggregator)
+            packed_llm = pack_qwen2_attention_qkv_projections(self._model)
+            logger.info(
+                "Packed Ming Talker fused QKV projections for %d CFM/Aggregator and %d LLM attention modules",
+                packed_talker,
+                packed_llm,
+            )
+            self._qkv_packed = True
 
     @cached_property
-    def _sampler_pool(self) -> CFMGraphExecutorPool | None:
-        device = next(self._model.parameters()).device
-        if self._use_cuda_graphs and device.type == "cuda":
-            return CFMGraphExecutorPool(self._config, self._cfm, self._aggregator, self._stop_head, pool_size=1)
-        return None
+    def _sampler_pools(self) -> dict[tuple[int, bool, bool], CFMGraphExecutorPool]:
+        return {}
+
+    def _get_sampler_pool(
+        self, batch_size: int, device: torch.device, deterministic_sde_noise: bool
+    ) -> CFMGraphExecutorPool | None:
+        if not self._use_cuda_graphs or device.type != "cuda":
+            return None
+        key = (batch_size, deterministic_sde_noise, self._stop_logit_decision_enabled)
+        pool = self._sampler_pools.get(key)
+        if pool is None:
+            pool = CFMGraphExecutorPool(
+                self._config,
+                self._cfm,
+                self._aggregator,
+                self._stop_head,
+                pool_size=1,
+                deterministic_sde_noise=deterministic_sde_noise,
+                return_stop_logits=self._stop_logit_decision_enabled,
+            )
+            self._sampler_pools[key] = pool
+        return pool
 
     def duration_capped_steps(self, text_len: int, requested_max_steps: int) -> int:
         """Apply the original Ming duration heuristic as a cap on decode steps."""
@@ -931,6 +1604,7 @@ class MingAudioGenerator:
             cfg = self.cfg_strength
         device = next(self._model.parameters()).device
         dtype = next(self._model.parameters()).dtype
+        self._maybe_pack_qkv_projections()
 
         his_lat = self._init_his_lat(prompt_wav_lat, device, dtype)
         past_key_values, max_cache_len = self._init_kv_cache(use_static_cache, device, dtype)
@@ -950,9 +1624,10 @@ class MingAudioGenerator:
             his_lat = self._update_his_lat(his_lat, gen_lat)
             all_latents.append(gen_lat)
 
-            stop_prob = stop_out.cpu()[0, 1].item()
+            stop_now = bool(self._stop_decision(stop_out)[0].cpu().item())
 
             if logger.isEnabledFor(logging.DEBUG):
+                stop_prob = self._stop_probability(stop_out)[0].cpu().item()
                 if step % 50 == 0 or step < 5:
                     logger.debug(
                         "step=%d stop_prob=%.4f hs_norm=%.4f lat_norm=%.4f emb_norm=%.4f",
@@ -963,8 +1638,8 @@ class MingAudioGenerator:
                         inputs_embeds.float().norm().item(),
                     )
 
-            if step > min_new_token and stop_prob > 0.5:
-                logger.debug("Stopping at step %d with stop_prob=%.4f", step, stop_prob)
+            if step > min_new_token and stop_now:
+                logger.debug("Stopping at step %d", step)
                 break
 
         return all_latents
@@ -985,8 +1660,11 @@ class MingAudioGenerator:
         if cfg is None:
             cfg = self.cfg_strength
 
-        if self._sampler_pool is not None:
-            return self._sampler_pool.execute(last_hidden_state, his_lat, cfg, sigma, temperature)
+        self._maybe_pack_qkv_projections()
+        deterministic_sde_noise = temperature == 0.0
+        sampler_pool = self._get_sampler_pool(his_lat.shape[0], last_hidden_state.device, deterministic_sde_noise)
+        if sampler_pool is not None:
+            return sampler_pool.execute(last_hidden_state, his_lat, cfg, sigma, temperature)
 
         bat_size, _, z_dim = his_lat.shape
         randn_tensor = torch.randn(
@@ -994,23 +1672,174 @@ class MingAudioGenerator:
             device=last_hidden_state.device,
             dtype=last_hidden_state.dtype,
         )
-        t = get_epss_timesteps(self._config.steps, device=last_hidden_state.device, dtype=last_hidden_state.dtype)
-        sde_rnd = torch.randn(
-            (self._config.steps, *randn_tensor.shape),
-            device=last_hidden_state.device,
-            dtype=last_hidden_state.dtype,
+        t = self._cfm.prepare_timesteps(
+            get_epss_timesteps(self._config.steps, device=last_hidden_state.device, dtype=last_hidden_state.dtype)
         )
+        sde_shape = (self._config.steps, *randn_tensor.shape)
+        sde_rnd = None
+        if deterministic_sde_noise:
+            # Keep the same RNG progression as the original temperature=0 path
+            # while avoiding zero-contribution SDE work in CFM.sample.
+            _unused_sde_rnd = torch.randn(
+                sde_shape,
+                device=last_hidden_state.device,
+                dtype=last_hidden_state.dtype,
+            )
+            del _unused_sde_rnd
+        else:
+            sde_rnd = torch.randn(
+                sde_shape,
+                device=last_hidden_state.device,
+                dtype=last_hidden_state.dtype,
+            )
         sde_args = torch.tensor(
             [cfg, sigma, temperature],
             device=last_hidden_state.device,
             dtype=last_hidden_state.dtype,
         )
 
-        gen_lat = self._cfm.sample(last_hidden_state, his_lat, randn_tensor, t, sde_args, sde_rnd)
+        gen_lat = self._cfm.sample(
+            last_hidden_state,
+            his_lat,
+            randn_tensor,
+            t,
+            sde_args,
+            sde_rnd,
+            timesteps_are_swayed=True,
+        )
         inputs_embeds = self._aggregator(gen_lat)
-        stop_out = self._stop_head(last_hidden_state[:, -1, :]).softmax(dim=-1)
+        stop_out = self._stop_head(last_hidden_state[:, -1, :])
+        if not self._stop_logit_decision_enabled:
+            stop_out = stop_out.softmax(dim=-1)
 
         return gen_lat, inputs_embeds, stop_out
+
+    @torch.no_grad()
+    def generate_latents_batch(
+        self,
+        inputs_embeds: torch.Tensor,
+        *,
+        prompt_wav_lat: torch.Tensor | None = None,
+        min_new_token: int = 10,
+        max_steps: int = 1000,
+        cfg: float | None = None,
+        sigma: float = 0.25,
+        temperature: float = 0.0,
+        use_static_cache: bool = True,
+    ) -> list[list[torch.Tensor]]:
+        if cfg is None:
+            cfg = self.cfg_strength
+        device = next(self._model.parameters()).device
+        dtype = next(self._model.parameters()).dtype
+        batch_size = inputs_embeds.shape[0]
+        self._maybe_pack_qkv_projections()
+
+        if prompt_wav_lat is not None:
+            raise NotImplementedError("batched prompt_wav_lat is not supported yet")
+
+        all_latents: list[list[torch.Tensor]] = [[] for _ in range(batch_size)]
+        active_indices = torch.arange(batch_size, device=device)
+        current_inputs_embeds = inputs_embeds
+        his_lat = torch.zeros(batch_size, self.his_patch_size, self.latent_dim, device=device, dtype=dtype)
+        use_active_compaction = True
+        allow_llm_decode_graph = not (
+            use_active_compaction and batch_size > 1 and not self._llm_decode_graph_batch_compaction_enabled
+        )
+
+        past_key_values, max_cache_len = self._init_batched_kv_cache(
+            batch_size,
+            use_static_cache,
+            device,
+            dtype,
+            allow_llm_decode_graph=allow_llm_decode_graph,
+        )
+        prefill_len = inputs_embeds.shape[1]
+
+        for step in range(min(max_steps, max_cache_len - prefill_len)):
+            last_hs = self.llm_step(
+                current_inputs_embeds,
+                step=step,
+                past_key_values=past_key_values,
+                use_static_cache=use_static_cache,
+                allow_llm_decode_graph=allow_llm_decode_graph,
+            )
+            gen_lat, next_inputs_embeds, stop_out = self.cfm_sample_step(
+                last_hs, his_lat, cfg=cfg, sigma=sigma, temperature=temperature
+            )
+            for row, original_idx in enumerate(active_indices.tolist()):
+                all_latents[original_idx].append(gen_lat[row : row + 1])
+
+            should_stop = self._stop_decision(stop_out)
+            if step <= min_new_token:
+                should_stop = torch.zeros_like(should_stop, dtype=torch.bool)
+            if bool(torch.all(should_stop)):
+                break
+
+            if use_active_compaction and bool(torch.any(should_stop)):
+                keep = ~should_stop
+                active_indices = active_indices[keep]
+                if active_indices.numel() == 0:
+                    break
+                current_inputs_embeds = next_inputs_embeds[keep]
+                his_lat = self._update_his_lat(his_lat, gen_lat)[keep]
+                if past_key_values is not None:
+                    self._select_cache_batch(past_key_values, torch.nonzero(keep, as_tuple=False).flatten())
+            else:
+                current_inputs_embeds = next_inputs_embeds
+                his_lat = self._update_his_lat(his_lat, gen_lat)
+
+        return all_latents
+
+    def _stop_decision(self, stop_out: torch.Tensor) -> torch.Tensor:
+        if self._stop_logit_decision_enabled:
+            return stop_out[:, 1] > stop_out[:, 0]
+        return stop_out[:, 1] > 0.5
+
+    def _stop_probability(self, stop_out: torch.Tensor) -> torch.Tensor:
+        if self._stop_logit_decision_enabled:
+            return torch.sigmoid((stop_out[:, 1] - stop_out[:, 0]).float())
+        return stop_out[:, 1]
+
+    @staticmethod
+    def _select_cache_batch(past_key_values: StaticCache, keep_indices: torch.Tensor) -> None:
+        try:
+            past_key_values.batch_select_indices(keep_indices)
+            return
+        except AttributeError:
+            pass
+
+        for layer in getattr(past_key_values, "layers", []):
+            keys = getattr(layer, "keys", None)
+            values = getattr(layer, "values", None)
+            if keys is not None:
+                layer.keys = keys.index_select(0, keep_indices).contiguous()
+            if values is not None:
+                layer.values = values.index_select(0, keep_indices).contiguous()
+
+    def _init_batched_kv_cache(
+        self,
+        batch_size: int,
+        use_static_cache: bool,
+        device: torch.device,
+        dtype: torch.dtype,
+        *,
+        allow_llm_decode_graph: bool = True,
+    ) -> tuple[StaticCache | None, int]:
+        max_cache_len = 2048
+        if not use_static_cache:
+            return None, max_cache_len
+        if allow_llm_decode_graph and self._llm_decode_graph_enabled and device.type == "cuda":
+            cache = self._get_reusable_kv_cache(batch_size, device, dtype, max_cache_len)
+            self._reset_static_cache(cache)
+            return cache, max_cache_len
+        cache = StaticCache(
+            config=self._llm_config,
+            max_batch_size=batch_size,
+            max_cache_len=max_cache_len,
+            device=device,
+            dtype=dtype,
+        )
+        return cache, max_cache_len
 
     def decode_to_waveform(self, latents: list[torch.Tensor], stream_decode: bool = True) -> torch.Tensor:
         """Decode accumulated latents to waveform via AudioVAE."""
@@ -1033,6 +1862,7 @@ class MingAudioGenerator:
         step: int,
         past_key_values: StaticCache | None,
         use_static_cache: bool,
+        allow_llm_decode_graph: bool = True,
     ) -> torch.Tensor:
         if step == 0 or not use_static_cache:
             outputs = self._model(
@@ -1042,6 +1872,12 @@ class MingAudioGenerator:
             )
         else:
             past_seen_tokens = past_key_values.get_seq_length()
+            if isinstance(past_seen_tokens, torch.Tensor):
+                past_seen_tokens = int(past_seen_tokens.max().item())
+            if allow_llm_decode_graph:
+                graph_hidden = self._llm_decode_graph_step(inputs_embeds, past_key_values, past_seen_tokens)
+                if graph_hidden is not None:
+                    return graph_hidden
             cache_position = torch.arange(
                 past_seen_tokens,
                 past_seen_tokens + inputs_embeds.shape[1],
@@ -1054,6 +1890,35 @@ class MingAudioGenerator:
                 cache_position=cache_position,
             )
         return outputs.last_hidden_state[:, -1:, :]
+
+    def _llm_decode_graph_step(
+        self,
+        inputs_embeds: torch.Tensor,
+        past_key_values: StaticCache,
+        cache_position_start: int,
+    ) -> torch.Tensor | None:
+        if not self._llm_decode_graph_enabled or inputs_embeds.device.type != "cuda":
+            return None
+
+        key = id(past_key_values)
+        graph = self._llm_decode_graphs.get(key)
+        if graph is not None and graph.shape != tuple(inputs_embeds.shape):
+            self._llm_decode_graphs.pop(key, None)
+            return None
+        if graph is None:
+            logger.info(
+                "Capturing Ming Talker LLM decode CUDA graph for shape=%s cache_position_start=%d",
+                tuple(inputs_embeds.shape),
+                cache_position_start,
+            )
+            graph = MingLLMDecodeGraphExecutor(
+                self._model,
+                past_key_values,
+                inputs_embeds,
+                cache_position_start,
+            )
+            self._llm_decode_graphs[key] = graph
+        return graph.replay(inputs_embeds, cache_position_start)
 
     def _init_his_lat(
         self, prompt_wav_lat: torch.Tensor | None, device: torch.device, dtype: torch.dtype
@@ -1073,6 +1938,10 @@ class MingAudioGenerator:
         max_cache_len = 2048
         if not use_static_cache:
             return None, max_cache_len
+        if self._llm_decode_graph_enabled and device.type == "cuda":
+            cache = self._get_reusable_kv_cache(1, device, dtype, max_cache_len)
+            self._reset_static_cache(cache)
+            return cache, max_cache_len
         cache = StaticCache(
             config=self._llm_config,
             max_batch_size=1,
@@ -1082,6 +1951,51 @@ class MingAudioGenerator:
         )
         return cache, max_cache_len
 
+    def _get_reusable_kv_cache(
+        self,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        max_cache_len: int,
+    ) -> StaticCache:
+        key = (batch_size, str(device), dtype)
+        with self._reusable_kv_cache_lock:
+            cache = self._reusable_kv_caches.get(key)
+            if cache is None or self._static_cache_batch_size(cache) != batch_size:
+                cache = StaticCache(
+                    config=self._llm_config,
+                    max_batch_size=batch_size,
+                    max_cache_len=max_cache_len,
+                    device=device,
+                    dtype=dtype,
+                )
+                self._reusable_kv_caches[key] = cache
+            return cache
+
+    @staticmethod
+    def _static_cache_batch_size(cache: StaticCache) -> int | None:
+        for layer in getattr(cache, "layers", []):
+            keys = getattr(layer, "keys", None)
+            if keys is not None:
+                return int(keys.shape[0])
+        return None
+
+    @staticmethod
+    def _reset_static_cache(cache: StaticCache) -> None:
+        if hasattr(cache, "reset"):
+            cache.reset()
+            return
+        for layer in getattr(cache, "layers", []):
+            keys = getattr(layer, "keys", None)
+            values = getattr(layer, "values", None)
+            cumulative_length = getattr(layer, "cumulative_length", None)
+            if keys is not None:
+                keys.zero_()
+            if values is not None:
+                values.zero_()
+            if cumulative_length is not None:
+                cumulative_length.zero_()
+
     def _update_his_lat(self, his_lat: torch.Tensor, gen_lat: torch.Tensor) -> torch.Tensor:
         if self.his_patch_size == self.patch_size:
             return gen_lat
@@ -1090,6 +2004,23 @@ class MingAudioGenerator:
         raise NotImplementedError(f"his_patch_size ({self.his_patch_size}) < patch_size ({self.patch_size})")
 
     # VAE streaming decode
+    def _vae_stream_decode_step(self, vae_input: torch.Tensor) -> torch.Tensor:
+        if not self._vae_stream_graph_enabled or vae_input.device.type != "cuda":
+            speech, _, _ = self._audio_vae.decode(
+                vae_input,
+                use_cache=False,
+                stream_state=(None, None, None),
+                last_chunk=True,
+            )
+            return speech
+
+        key = (vae_input.shape[1], vae_input.device, vae_input.dtype)
+        executor = self._vae_stream_decode_graphs.get(key)
+        if executor is None:
+            executor = VAEStreamDecodeGraphExecutor(self._audio_vae)
+            self._vae_stream_decode_graphs[key] = executor
+        return executor.execute(vae_input)
+
     def _stream_decode(self, latents: list[torch.Tensor]) -> torch.Tensor:
         sr = int(self._audio_vae.config.sample_rate)
         decode_pad: torch.Tensor | None = None
@@ -1107,12 +2038,7 @@ class MingAudioGenerator:
                 pad_frames = 0
 
             # Stateless, no KV cache accum intentionally.
-            speech, _, _ = self._audio_vae.decode(
-                vae_input,
-                use_cache=False,
-                stream_state=(None, None, None),
-                last_chunk=True,
-            )
+            speech = self._vae_stream_decode_step(vae_input)
 
             total_frames = vae_input.shape[1]
             dcs = speech.shape[-1] // total_frames

--- a/vllm_omni/transformers_utils/configs/ming_flash_omni.py
+++ b/vllm_omni/transformers_utils/configs/ming_flash_omni.py
@@ -337,10 +337,13 @@ class MingFlashOmniTalkerConfig(PretrainedConfig):
         cfg_strength: float = 2.0,
         audio_vae_path: str | None = None,
         campplus_model: str | None = None,
+        enable_cfm_graph: bool | None = None,
+        enable_full_vae_decode: bool = False,
+        batch_vae_min_batch: int = 4,
         **kwargs,
     ):
-        super().__init__(**kwargs)
         self.llm_config = llm_config
+        super().__init__(**kwargs)
         self.flowmodel = flowmodel or {}
         self.aggregator = aggregator or {}
         self.steps = steps
@@ -350,6 +353,9 @@ class MingFlashOmniTalkerConfig(PretrainedConfig):
         self.cfg_strength = cfg_strength
         self.audio_vae_path = audio_vae_path
         self.campplus_model = campplus_model
+        self.enable_cfm_graph = enable_cfm_graph
+        self.enable_full_vae_decode = enable_full_vae_decode
+        self.batch_vae_min_batch = batch_vae_min_batch
 
     def get_text_config(self, decoder: bool = False) -> PretrainedConfig:  # noqa: ARG002
         if isinstance(self.llm_config, dict):

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -33,6 +33,7 @@ from vllm_omni.engine.serialization import deserialize_additional_information
 from vllm_omni.model_executor.layers.rotary_embedding.mrope import OmniMRotaryEmbedding as MRotaryEmbedding
 from vllm_omni.model_executor.models.output_templates import OmniOutput
 from vllm_omni.platforms import current_omni_platform
+from vllm_omni.worker.ming_tts_stage_step_runner import MingTTSStageStepRunner
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -1804,6 +1805,45 @@ class OmniGPUModelRunner(GPUModelRunner):
     ):
         """Inject omni-specific kwargs into forward and cache model output"""
         model_kwargs_extra = self._build_model_kwargs_extra()
+        runtime_infos = model_kwargs_extra.get("runtime_additional_information")
+        if isinstance(runtime_infos, list):
+            step_runner = getattr(self, "_ming_tts_step_runner", None)
+            if step_runner is None:
+                step_runner = MingTTSStageStepRunner(max_batch_size=8)
+                self._ming_tts_step_runner = step_runner
+            is_capturing = torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+            if step_runner.supports_batch(runner=self, runtime_infos=runtime_infos, is_graph_capturing=is_capturing):
+                cohorts = [info.get("ming_tts_admission_cohort") for info in runtime_infos if isinstance(info, dict)]
+                logger.debug(
+                    "MingTTSStageStepRunner accepted batch_size=%d cohorts=%s",
+                    len(runtime_infos),
+                    cohorts,
+                )
+                build_inputs = getattr(self.model, "_build_batched_tts_inputs", None)
+                if build_inputs is not None:
+                    batched_inputs = build_inputs(runtime_infos)
+                    if batched_inputs is not None:
+                        prepared = step_runner.prepare_step(
+                            request_ids=list(self.input_batch.req_ids[: len(runtime_infos)]),
+                            runtime_infos=runtime_infos,
+                            inputs_embeds=batched_inputs,
+                        )
+                        step_runner.run_step(prepared=prepared, runner=self)
+                        step_runner.commit_step(prepared=prepared, runner=self)
+                        self._omni_last_model_output = OmniOutput(
+                            text_hidden_states=None,
+                            multimodal_outputs={
+                                "audio": prepared.audios,
+                                "sr": torch.tensor(prepared.sample_rate or 24000),
+                            },
+                        )
+                        return self._omni_last_model_output
+            elif len(runtime_infos) > 1:
+                logger.debug(
+                    "MingTTSStageStepRunner rejected batch_size=%d reason=%s",
+                    len(runtime_infos),
+                    getattr(step_runner, "last_reject_reason", None),
+                )
 
         model_output = super()._model_forward(
             input_ids=input_ids,

--- a/vllm_omni/worker/ming_tts_stage_step_runner.py
+++ b/vllm_omni/worker/ming_tts_stage_step_runner.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+@dataclass(slots=True)
+class MingTTSPreparedStep:
+    request_ids: list[str]
+    runtime_infos: list[dict]
+    inputs_embeds: torch.Tensor
+    latents_by_request: list[list[Any]] | None = None
+    audios: list[Any] | None = None
+    sample_rate: int | None = None
+
+
+@dataclass(slots=True)
+class MingTTSStageStepRunner:
+    max_batch_size: int = 8
+    last_reject_reason: str | None = None
+
+    def _reject(self, reason: str) -> bool:
+        self.last_reject_reason = reason
+        return False
+
+    def supports_batch(self, *, runner: Any, runtime_infos: list[dict], is_graph_capturing: bool) -> bool:
+        if is_graph_capturing:
+            return self._reject("graph_capture")
+        if len(runtime_infos) <= 1 or len(runtime_infos) > self.max_batch_size:
+            return self._reject("batch_size")
+        model_config = getattr(getattr(runner, "vllm_config", None), "model_config", None)
+        stage = getattr(model_config, "model_stage", None)
+        arch = getattr(model_config, "model_arch", None)
+        if stage not in {"ming_tts", "ming_flash_omni_tts"} and arch != "MingFlashOmniTalkerForConditionalGeneration":
+            return self._reject(f"wrong_stage:{stage}:{arch}")
+        model_name = type(getattr(runner, "model", None)).__name__
+        if model_name != "MingFlashOmniTalkerForConditionalGeneration":
+            return self._reject("wrong_model")
+        first = runtime_infos[0] or {}
+        keys = (
+            "ming_task",
+            "prompt",
+            "instruction",
+            "cfg",
+            "sigma",
+            "temperature",
+            "max_steps",
+            "max_decode_steps",
+            "max_text_length",
+            "use_static_cache",
+            "stream_decode",
+            "use_zero_spk_emb",
+        )
+        for info in runtime_infos:
+            info = info or {}
+            if info.get("prompt_wav_lat") is not None or info.get("prompt_wav_emb") is not None:
+                return self._reject("prompt_wav")
+            if info.get("voice_name") is not None or info.get("spk_emb") is not None:
+                return self._reject("voice_or_spk")
+            for key in keys:
+                if info.get(key) != first.get(key):
+                    return self._reject("param_mismatch")
+        self.last_reject_reason = None
+        return True
+
+    def prepare_step(
+        self, *, request_ids: list[str], runtime_infos: list[dict], inputs_embeds: torch.Tensor
+    ) -> MingTTSPreparedStep:
+        return MingTTSPreparedStep(list(request_ids), list(runtime_infos), inputs_embeds)
+
+    def run_step(self, *, prepared: MingTTSPreparedStep, runner: Any) -> None:
+        first = prepared.runtime_infos[0] if prepared.runtime_infos else {}
+        prepared.latents_by_request = runner.model.audio_generator.generate_latents_batch(
+            prepared.inputs_embeds,
+            max_steps=int(first.get("max_steps", first.get("max_decode_steps", 200))),
+            cfg=first.get("cfg"),
+            sigma=float(first.get("sigma", 0.25)),
+            temperature=float(first.get("temperature", 0.0)),
+            use_static_cache=bool(first.get("use_static_cache", True)),
+        )
+        decode = getattr(runner.model, "decode_batch_latents_for_runner", None)
+        if decode is not None:
+            prepared.audios, prepared.sample_rate = decode(
+                prepared.latents_by_request,
+                stream_decode=bool(first.get("stream_decode", True)),
+            )
+
+    def commit_step(self, *, prepared: MingTTSPreparedStep, runner: Any) -> None:
+        if prepared.audios is None:
+            raise RuntimeError("run_step must decode audios before commit_step")
+        sr = prepared.sample_rate or 24000
+        for req_id, audio in zip(prepared.request_ids, prepared.audios, strict=True):
+            req_buffer = runner.model_intermediate_buffer.setdefault(req_id, {})
+            req_buffer["audio"] = {"audio": audio, "sr": sr}


### PR DESCRIPTION
## Purpose

Optimize Ming-flash-omni-2.0 TTS serving throughput on high-concurrency workloads without reducing CFM sampling steps or enabling quality-risky VAE shortcuts by default.

This PR adds the quality-preserving serving fast path built from the Ming TTS profiling work:

- enable inner Ming CFM CUDA graph execution while keeping outer vLLM serving in eager mode;
- add runner-level batched Ming TTS step execution with slot-table management and static-cache compaction;
- add an admission gate for compatible `/v1/audio/speech` requests so cohorts form stable batches;
- add zero-diff model fast paths for precomputed RoPE trig, packed QKV, LLM decode CUDA graph, VAE streaming graph, and stop-logit decisions;
- make Ming TTS serving knobs config-driven (`hf_overrides.talker_config.enable_cfm_graph`, `speech_admission_config`) instead of Ming-specific environment variables;
- remove the experimental Triton fused RoPE path from this PR because it had measurable waveform drift and did not show reliable e2e serving gains;
- add a high-concurrency Ming TTS deploy config and profiling helpers;
- add focused unit coverage for batching, graph execution, admission, deploy config parsing, and zero-diff behavior.

## Test Result

H20 e2e serving benchmark, vLLM 0.22 env, `c=64`, `p=500`, non-stream `/v1/audio/speech`:

| Variant | wall_s | req/s | audio_x | mean latency | p95 latency | ok/fail |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| origin/main + vLLM 0.22 compatibility fixes | 554.38 | 0.90 | 4.25 | 66.50s | 72.01s | 500/0 |
| optimized fast path | 70.03 | 7.14 | 33.37 | 8.46s | 9.03s | 500/0 |

Observed speedup: ~7.9x req/s and ~87% lower wall/latency on this workload.

Quality spot-check on 16 real API WAV outputs (8 English + 8 Chinese), comparing baseline vs optimized:

| Metric | baseline | optimized |
| --- | ---: | ---: |
| DNSMOS overall mean | 3.3684 | 3.3533 |
| DNSMOS P.808 mean | 3.8661 | 3.8718 |
| English WER mean | 0.0354 | 0.0000 |
| Mean duration | 4.8375s | 4.8250s |
| Speaker similarity opt-vs-base mean | N/A | 0.7644 |

Notes:

- full VAE decode remains opt-in and is not enabled by this default path;
- CFM sampling steps are unchanged;
- the removed Triton fused RoPE experiment is not part of the default quality story;
- UTMOS/SQUIM were attempted but the remote environment required additional model/cache setup, so DNSMOS/WER/speaker-sim are reported here as the available quality gate.

Local validation after the env cleanup:

- `ruff format` on changed files: pass
- `ruff check` on changed files: pass
- `git diff --check`: pass
- `py_compile` on changed Python files: pass
- local pytest is blocked in this checkout because `tests.helpers.fixtures.env` imports `vllm`, which is not installed in the local pyenv environment.
