### PR TITLE
[FEAT]Support sample-wise batched image prompts in step batching

### DIFF
--- a/docs/design/feature/diffusion_continuous_batching.md
+++ b/docs/design/feature/diffusion_continuous_batching.md
@@ -88,8 +88,11 @@ key also covers LoRA identity (`lora_int_id`, `lora_scale`), so requests
 targeting different adapters or scales run in separate batches and the
 worker can activate exactly one adapter per step.
 
-The current batching unit is one `OmniDiffusionRequest`. Requests with
-multiple prompts do not participate in batching today.
+The scheduler admits whole `OmniDiffusionRequest` objects, but capacity is
+accounted in sample rows: `len(prompts) * num_outputs_per_prompt`. This lets a
+single request containing multiple prompts participate in the same step-wise
+batching path as separate single-prompt requests, while still respecting
+`max_num_seqs` as the maximum active sample count.
 
 ## Runner
 
@@ -136,7 +139,9 @@ batch packing.
 - Only native pipelines that already support `step_execution=True`.
 - Request-mode diffusion still clamps `max_num_seqs` back to `1`.
 - Only homogeneous batches keyed by `SamplingParamsKey` are supported.
-- Multi-prompt requests are not batched.
+- Multi-prompt requests are admitted as whole requests and counted by sample
+  rows; the scheduler does not split one multi-prompt request across separate
+  batches.
 - `cache_backend`, KV transfer, and other request-mode extras are not wired
   into the batched step-wise path yet.
 - Future work can relax the current same-shape restriction with richer

--- a/tests/diffusion/test_diffusion_input_batch.py
+++ b/tests/diffusion/test_diffusion_input_batch.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm_omni.diffusion.worker.input_batch import InputBatch
+from vllm_omni.diffusion.worker.utils import DiffusionRequestState
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+
+def _make_state(
+    request_id: str,
+    *,
+    rows: int,
+    prompt_lens: list[int],
+    img_shapes: list,
+) -> DiffusionRequestState:
+    return DiffusionRequestState(
+        request_id=request_id,
+        sampling=OmniDiffusionSamplingParams(),
+        prompts=[f"prompt-{request_id}-{i}" for i in range(rows)],
+        latents=torch.zeros((rows, 4, 8), dtype=torch.float32),
+        timesteps=torch.tensor([1.0, 0.5], dtype=torch.float32),
+        step_index=0,
+        prompt_embeds=torch.ones((rows, 3, 4), dtype=torch.float32),
+        prompt_embeds_mask=torch.tensor(
+            [[idx < prompt_lens[min(row, len(prompt_lens) - 1)] for idx in range(3)] for row in range(rows)],
+            dtype=torch.bool,
+        ),
+        img_shapes=img_shapes,
+        txt_seq_lens=prompt_lens,
+    )
+
+
+def test_input_batch_flattens_multi_prompt_request_metadata() -> None:
+    first = _make_state(
+        "multi",
+        rows=2,
+        prompt_lens=[2, 3],
+        img_shapes=[["shape-a"], ["shape-b"]],
+    )
+    second = _make_state(
+        "single",
+        rows=1,
+        prompt_lens=[1],
+        img_shapes=[["shape-c"]],
+    )
+
+    batch = InputBatch.make_batch([first, second])
+
+    assert batch.latents.shape[0] == 3
+    assert batch.prompt_embeds.shape[0] == 3
+    assert batch.timesteps.tolist() == [1.0, 1.0, 1.0]
+    assert batch.txt_seq_lens == [2, 3, 1]
+    assert batch.img_shapes == [["shape-a"], ["shape-b"], ["shape-c"]]
+
+
+def test_input_batch_repeats_request_metadata_for_multiple_outputs_per_prompt() -> None:
+    state = _make_state(
+        "multi-output",
+        rows=4,
+        prompt_lens=[2, 3],
+        img_shapes=[["shape-a"], ["shape-b"]],
+    )
+    state.prompt_embeds_mask = torch.tensor(
+        [
+            [True, True, False],
+            [True, True, False],
+            [True, True, True],
+            [True, True, True],
+        ],
+        dtype=torch.bool,
+    )
+    state.prompt_embeds = torch.ones((4, 3, 4), dtype=torch.float32)
+
+    batch = InputBatch.make_batch([state])
+
+    assert batch.txt_seq_lens == [2, 2, 3, 3]
+    assert batch.img_shapes == [["shape-a"], ["shape-a"], ["shape-b"], ["shape-b"]]

--- a/tests/diffusion/test_diffusion_model_runner.py
+++ b/tests/diffusion/test_diffusion_model_runner.py
@@ -66,6 +66,21 @@ def _make_runner(cache_backend, cache_backend_name: str, enable_cache_dit_summar
     return runner
 
 
+@pytest.mark.cpu
+def test_set_seeded_generator_accepts_seed_sequence():
+    runner = _make_runner(cache_backend=None, cache_backend_name="none")
+    sampling_params = SimpleNamespace(
+        generator=None,
+        seed=(200, 201),
+        generator_device="cpu",
+    )
+
+    DiffusionModelRunner._set_seeded_generator(runner, sampling_params)
+
+    assert isinstance(sampling_params.generator, list)
+    assert [generator.initial_seed() for generator in sampling_params.generator] == [200, 201]
+
+
 @pytest.mark.core_model
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 def test_execute_model_skips_cache_summary_without_active_cache_backend(monkeypatch):

--- a/tests/diffusion/test_diffusion_scheduler.py
+++ b/tests/diffusion/test_diffusion_scheduler.py
@@ -65,9 +65,10 @@ def _make_step_request(
     num_inference_steps: int = 4,
     step_index: int | None = None,
     sampling_params: OmniDiffusionSamplingParams | None = None,
+    prompts: list[str] | None = None,
 ) -> OmniDiffusionRequest:
     return OmniDiffusionRequest(
-        prompts=[f"prompt_{req_id}"],
+        prompts=prompts if prompts is not None else [f"prompt_{req_id}"],
         sampling_params=sampling_params
         or OmniDiffusionSamplingParams(
             num_inference_steps=num_inference_steps,
@@ -194,6 +195,29 @@ class TestGetSamplingParamsKey:
         a = get_sampling_params_key(self._make(lora_int_id=1, lora_scale=0.5))
         b = get_sampling_params_key(self._make(lora_int_id=1, lora_scale=0.5))
         assert a == b
+
+    def test_multi_prompt_request_keeps_sampling_key(self) -> None:
+        from vllm_omni.diffusion.sched.base_scheduler import get_sampling_params_key
+
+        single = self._make(lora_int_id=None)
+        multi = OmniDiffusionRequest(
+            prompts=["prompt-a", "prompt-b"],
+            sampling_params=single.sampling_params,
+            request_id="req-multi",
+        )
+
+        assert get_sampling_params_key(multi) == get_sampling_params_key(single)
+
+    def test_sample_count_includes_prompts_and_outputs(self) -> None:
+        from vllm_omni.diffusion.sched.base_scheduler import get_request_sample_count
+
+        req = OmniDiffusionRequest(
+            prompts=["prompt-a", "prompt-b"],
+            sampling_params=OmniDiffusionSamplingParams(num_outputs_per_prompt=3),
+            request_id="req-samples",
+        )
+
+        assert get_request_sample_count(req) == 6
 
 
 class TestRequestScheduler:
@@ -692,6 +716,67 @@ class TestStepScheduler:
 
         assert _new_ids(sched_output) == [req_a, req_b]
         assert sched_output.num_running_reqs == 2
+        assert sched_output.num_waiting_reqs == 0
+
+    def test_step_batch_counts_multi_prompt_request_as_samples(self) -> None:
+        scheduler = StepScheduler()
+        scheduler.initialize(SimpleNamespace(max_num_seqs=3))
+
+        req_multi = scheduler.add_request(
+            _make_step_request(
+                "multi",
+                prompts=["prompt_multi_a", "prompt_multi_b"],
+            )
+        )
+        req_single = scheduler.add_request(_make_step_request("single"))
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == [req_multi, req_single]
+        assert sched_output.num_running_reqs == 2
+        assert sched_output.num_waiting_reqs == 0
+        assert scheduler.get_request_state(req_multi).sample_count == 2
+        assert scheduler.get_request_state(req_single).sample_count == 1
+
+    def test_step_batch_respects_sample_capacity_for_multi_prompt_requests(self) -> None:
+        scheduler = StepScheduler()
+        scheduler.initialize(SimpleNamespace(max_num_seqs=3))
+
+        req_a = scheduler.add_request(
+            _make_step_request(
+                "a",
+                prompts=["prompt_a0", "prompt_a1"],
+            )
+        )
+        req_b = scheduler.add_request(
+            _make_step_request(
+                "b",
+                prompts=["prompt_b0", "prompt_b1"],
+            )
+        )
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == [req_a]
+        assert req_b not in _new_ids(sched_output)
+        assert sched_output.num_running_reqs == 1
+        assert sched_output.num_waiting_reqs == 1
+
+    def test_over_capacity_multi_prompt_request_can_run_alone(self) -> None:
+        scheduler = StepScheduler()
+        scheduler.initialize(SimpleNamespace(max_num_seqs=1))
+
+        req_id = scheduler.add_request(
+            _make_step_request(
+                "oversized",
+                prompts=["prompt_0", "prompt_1"],
+            )
+        )
+
+        sched_output = scheduler.schedule()
+
+        assert _new_ids(sched_output) == [req_id]
+        assert sched_output.num_running_reqs == 1
         assert sched_output.num_waiting_reqs == 0
 
     def test_step_batch_allows_different_num_inference_steps(self) -> None:

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -594,6 +594,7 @@ def test_generate_images_batch_prompts_single_stage(test_client):
         json={
             "prompt": ["a cat", "a dog"],
             "negative_prompt": ["blurry", "low quality"],
+            "seed": [200, 201],
             "n": 2,
             "size": "512x512",
         },
@@ -623,6 +624,7 @@ def test_generate_images_batch_prompts_single_stage(test_client):
     assert engine.captured_sampling_params_list[0].num_outputs_per_prompt == 2
     assert engine.captured_sampling_params_list[0].height == 512
     assert engine.captured_sampling_params_list[0].width == 512
+    assert engine.captured_sampling_params_list[0].seed == (200, 200, 201, 201)
 
 
 def test_generate_images_batch_prompts_rejects_mismatched_negative_prompt(test_client):
@@ -635,6 +637,33 @@ def test_generate_images_batch_prompts_rejects_mismatched_negative_prompt(test_c
     )
     assert response.status_code == 400
     assert "negative_prompt list length" in response.json()["detail"]
+
+
+def test_generate_images_batch_prompts_broadcasts_int_seed(test_client):
+    response = test_client.post(
+        "/v1/images/generations",
+        json={
+            "prompt": ["a cat", "a dog"],
+            "seed": 200,
+        },
+    )
+    assert response.status_code == 200
+
+    engine = test_client.app.state.engine_client
+    assert engine.captured_sampling_params_list[0].seed == (200, 200)
+
+
+def test_generate_images_batch_prompts_rejects_mismatched_seed(test_client):
+    response = test_client.post(
+        "/v1/images/generations",
+        json={
+            "prompt": ["a cat", "a dog"],
+            "seed": [200, 201, 202],
+            "n": 2,
+        },
+    )
+    assert response.status_code == 400
+    assert "seed list length" in response.json()["detail"]
 
 
 def test_generate_images_async_omni_sampling_params(async_omni_test_client):

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -186,7 +186,8 @@ def mock_async_diffusion(mocker: MockerFixture):
             n = kwargs["sampling_params_list"][0].num_outputs_per_prompt
             self.captured_sampling_params_list = kwargs["sampling_params_list"]
             self.captured_prompt = kwargs["prompt"]
-            images = [Image.new("RGB", (64, 64), color="blue") for _ in range(n)]
+            prompt_count = len(kwargs["prompt"]) if isinstance(kwargs["prompt"], list) else 1
+            images = [Image.new("RGB", (64, 64), color="blue") for _ in range(prompt_count * n)]
             yield MockGenerationResult(images)
 
     return MockAsyncDiffusion()
@@ -584,6 +585,56 @@ def test_generate_single_image(test_client):
     img_bytes = base64.b64decode(data["data"][0]["b64_json"])
     img = Image.open(io.BytesIO(img_bytes))
     assert img.size == (64, 64)  # Our mock returns 64x64 images
+
+
+def test_generate_images_batch_prompts_single_stage(test_client):
+    """Single-stage diffusion accepts a list of prompts as one batched request."""
+    response = test_client.post(
+        "/v1/images/generations",
+        json={
+            "prompt": ["a cat", "a dog"],
+            "negative_prompt": ["blurry", "low quality"],
+            "n": 2,
+            "size": "512x512",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data"]) == 4
+
+    engine = test_client.app.state.engine_client
+    assert isinstance(engine.captured_prompt, list)
+    assert engine.captured_prompt == [
+        {
+            "prompt": "a cat",
+            "negative_prompt": "blurry",
+            "mm_processor_kwargs": {"target_h": 512, "target_w": 512},
+            "height": 512,
+            "width": 512,
+        },
+        {
+            "prompt": "a dog",
+            "negative_prompt": "low quality",
+            "mm_processor_kwargs": {"target_h": 512, "target_w": 512},
+            "height": 512,
+            "width": 512,
+        },
+    ]
+    assert engine.captured_sampling_params_list[0].num_outputs_per_prompt == 2
+    assert engine.captured_sampling_params_list[0].height == 512
+    assert engine.captured_sampling_params_list[0].width == 512
+
+
+def test_generate_images_batch_prompts_rejects_mismatched_negative_prompt(test_client):
+    response = test_client.post(
+        "/v1/images/generations",
+        json={
+            "prompt": ["a cat", "a dog"],
+            "negative_prompt": ["blurry"],
+        },
+    )
+    assert response.status_code == 400
+    assert "negative_prompt list length" in response.json()["detail"]
 
 
 def test_generate_images_async_omni_sampling_params(async_omni_test_client):

--- a/vllm_omni/diffusion/sched/base_scheduler.py
+++ b/vllm_omni/diffusion/sched/base_scheduler.py
@@ -29,15 +29,23 @@ _KEY_FIELD_NAMES = frozenset(f.name for f in fields(SamplingParamsKey)) - {"lora
 
 def get_sampling_params_key(request: OmniDiffusionRequest) -> SamplingParamsKey | None:
     """Build a batch-compatibility key from the request's sampling params."""
-    if len(request.prompts) != 1:
-        return None
-
     sampling = request.sampling_params
     lora_request = getattr(sampling, "lora_request", None)
     return SamplingParamsKey(
         lora_int_id=lora_request.lora_int_id if lora_request is not None else None,
         **{name: getattr(sampling, name) for name in _KEY_FIELD_NAMES},
     )
+
+
+def get_request_sample_count(request: OmniDiffusionRequest) -> int:
+    """Return the number of latent rows a request contributes to a step batch."""
+    prompt_count = max(1, len(request.prompts))
+    num_outputs = getattr(request.sampling_params, "num_outputs_per_prompt", 1)
+    try:
+        num_outputs = max(1, int(num_outputs))
+    except (TypeError, ValueError):
+        num_outputs = 1
+    return prompt_count * num_outputs
 
 
 class _BaseScheduler(SchedulerInterface):
@@ -91,13 +99,15 @@ class _BaseScheduler(SchedulerInterface):
                 scheduled_cached_request_ids.append(request_id)
 
         # Second, schedule WAITING requests while capacity remains.
-        while self._waiting and len(self._running) < self.max_num_running_reqs:
+        while self._waiting and self._has_running_capacity():
             request_id = self._waiting[0]
             state = self._request_states.get(request_id)
             if state is None:
                 self._waiting.popleft()
                 continue
             if not self._can_schedule_waiting(state):
+                break
+            if not self._has_capacity_for(state):
                 break
 
             self._waiting.popleft()
@@ -231,6 +241,7 @@ class _BaseScheduler(SchedulerInterface):
             request_id=request_id,
             req=request,
             sampling_params_key=get_sampling_params_key(request),
+            sample_count=get_request_sample_count(request),
         )
 
     def _can_schedule_waiting(self, state: DiffusionRequestState) -> bool:
@@ -239,6 +250,22 @@ class _BaseScheduler(SchedulerInterface):
 
         current_key = self._current_sampling_params_key()
         return current_key is not None and current_key == state.sampling_params_key
+
+    def _running_sample_count(self) -> int:
+        total = 0
+        for request_id in self._running:
+            state = self._request_states.get(request_id)
+            if state is not None and not state.is_finished():
+                total += max(1, int(state.sample_count))
+        return total
+
+    def _has_running_capacity(self) -> bool:
+        return not self._running or self._running_sample_count() < self.max_num_running_reqs
+
+    def _has_capacity_for(self, state: DiffusionRequestState) -> bool:
+        if not self._running:
+            return True
+        return self._running_sample_count() + max(1, int(state.sample_count)) <= self.max_num_running_reqs
 
     def _current_sampling_params_key(self) -> SamplingParamsKey | None:
         if self._running_sampling_params_key is not None or not self._running:

--- a/vllm_omni/diffusion/sched/interface.py
+++ b/vllm_omni/diffusion/sched/interface.py
@@ -73,6 +73,7 @@ class DiffusionRequestState:
     request_id: str
     req: OmniDiffusionRequest
     sampling_params_key: SamplingParamsKey | None = None
+    sample_count: int = 1
     status: DiffusionRequestStatus = DiffusionRequestStatus.WAITING
     error: str | None = None
 

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -83,6 +83,27 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         # Initialize KV cache manager for connector management
         self.kv_transfer_manager = OmniKVTransferManager.from_od_config(od_config)
 
+    def _seeded_generator_device(self, sampling_params) -> torch.device | str:
+        if sampling_params.generator_device is not None:
+            return sampling_params.generator_device
+        if self.device.type == "cpu":
+            return "cpu"
+        return self.device
+
+    def _set_seeded_generator(self, sampling_params) -> None:
+        if sampling_params.generator is not None or sampling_params.seed is None:
+            return
+
+        gen_device = self._seeded_generator_device(sampling_params)
+        seed = sampling_params.seed
+        if isinstance(seed, (list, tuple)):
+            sampling_params.generator = [
+                torch.Generator(device=gen_device).manual_seed(int(item)) for item in seed
+            ]
+            return
+
+        sampling_params.generator = torch.Generator(device=gen_device).manual_seed(seed)
+
     def _compile_transformer(self, attr_name: str) -> None:
         """Compile a transformer attribute on the pipeline with torch.compile."""
         model = getattr(self.pipeline, attr_name, None)
@@ -282,14 +303,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                 target_device=getattr(self.pipeline, "device", None),
             )
 
-            if req.sampling_params.generator is None and req.sampling_params.seed is not None:
-                if req.sampling_params.generator_device is not None:
-                    gen_device = req.sampling_params.generator_device
-                elif self.device.type == "cpu":
-                    gen_device = "cpu"
-                else:
-                    gen_device = self.device
-                req.sampling_params.generator = torch.Generator(device=gen_device).manual_seed(req.sampling_params.seed)
+            self._set_seeded_generator(req.sampling_params)
 
             # Refresh cache context if needed
             if (
@@ -396,14 +410,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         for state in states:
             if state.request_id in new_request_ids:
                 # set generator
-                if state.sampling.generator is None and state.sampling.seed is not None:
-                    if state.sampling.generator_device is not None:
-                        gen_device = state.sampling.generator_device
-                    elif self.device.type == "cpu":
-                        gen_device = "cpu"
-                    else:
-                        gen_device = self.device
-                    state.sampling.generator = torch.Generator(device=gen_device).manual_seed(state.sampling.seed)
+                self._set_seeded_generator(state.sampling)
                 # encode
                 self.pipeline.prepare_encode(state)
 

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -97,9 +97,7 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
         gen_device = self._seeded_generator_device(sampling_params)
         seed = sampling_params.seed
         if isinstance(seed, (list, tuple)):
-            sampling_params.generator = [
-                torch.Generator(device=gen_device).manual_seed(int(item)) for item in seed
-            ]
+            sampling_params.generator = [torch.Generator(device=gen_device).manual_seed(int(item)) for item in seed]
             return
 
         sampling_params.generator = torch.Generator(device=gen_device).manual_seed(seed)

--- a/vllm_omni/diffusion/worker/input_batch.py
+++ b/vllm_omni/diffusion/worker/input_batch.py
@@ -470,6 +470,34 @@ def _prepare_image_latents(
     )
 
 
+def _state_num_rows(state: DiffusionRequestState) -> int:
+    latents = _require_state_latents(state, for_field="row metadata")
+    return int(latents.shape[0])
+
+
+def _expand_state_metadata_rows(
+    state: DiffusionRequestState,
+    values: Sequence,
+    *,
+    attr_name: str,
+) -> list:
+    rows = _state_num_rows(state)
+    if len(values) == 0:
+        if attr_name == "img_shapes":
+            return [[]] * rows
+        raise ValueError(f"{attr_name} for request {state.request_id} is empty.")
+    if len(values) == rows:
+        return list(values)
+    if len(values) == 1:
+        return [values[0]] * rows
+    if rows % len(values) == 0:
+        repeat = rows // len(values)
+        return [value for value in values for _ in range(repeat)]
+    raise ValueError(
+        f"{attr_name} for request {state.request_id} has {len(values)} entries but request contributes {rows} rows."
+    )
+
+
 def _prepare_seq_lens(
     states: Sequence[DiffusionRequestState],
     attr_name: str,
@@ -479,7 +507,19 @@ def _prepare_seq_lens(
         return None
     if any(value is None for value in values):
         raise ValueError(f"Mixed {attr_name} in batch.")
-    return [int(value[0]) for value in values if value is not None]
+
+    seq_lens: list[int] = []
+    for state, value in zip(states, values, strict=True):
+        assert value is not None
+        seq_lens.extend(
+            int(item)
+            for item in _expand_state_metadata_rows(
+                state,
+                value,
+                attr_name=attr_name,
+            )
+        )
+    return seq_lens
 
 
 def _prepare_img_shapes(states: Sequence[DiffusionRequestState]) -> list | None:
@@ -488,7 +528,18 @@ def _prepare_img_shapes(states: Sequence[DiffusionRequestState]) -> list | None:
         return None
     if any(value is None for value in values):
         raise ValueError("Mixed img_shapes in batch.")
-    return [value[0] if value else [] for value in values if value is not None]
+
+    img_shapes: list = []
+    for state, value in zip(states, values, strict=True):
+        assert value is not None
+        img_shapes.extend(
+            _expand_state_metadata_rows(
+                state,
+                value,
+                attr_name="img_shapes",
+            )
+        )
+    return img_shapes
 
 
 def _prepare_prompt_embeds(

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -181,6 +181,7 @@ class OmniEngineArgs(EngineArgs):
     log_stats: bool = False
     custom_pipeline_args: dict[str, Any] | None = None
     has_sampling_extra_args: bool = False
+    step_execution: bool = False
 
     def __post_init__(self) -> None:
         if self.worker_cls is None:
@@ -512,6 +513,7 @@ SHARED_FIELDS: frozenset[str] = frozenset(
         "stage_configs_path",  # orch: load legacy YAML; engine: may reference for validation
         "async_chunk",  # orch: read from CLI, redistribute; engine: per-stage flag
         "tokenizer",  # orch: detect model type; engine: tokenization
+        "step_execution",  # orch: CLI/deploy routing; engine: diffusion scheduler mode
     }
 )
 

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -144,6 +144,66 @@ MAX_UINT32_SEED = 2**32 - 1
 profiler_router = APIRouter()
 
 
+def _normalize_image_generation_prompts(prompt: str | list[str]) -> list[str]:
+    if isinstance(prompt, str):
+        return [prompt]
+    if not prompt:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail="prompt list must contain at least one item.",
+        )
+    return prompt
+
+
+def _normalize_image_generation_negative_prompts(
+    negative_prompt: str | list[str] | None,
+    *,
+    prompt_count: int,
+) -> list[str | None]:
+    if negative_prompt is None:
+        return [None] * prompt_count
+    if isinstance(negative_prompt, str):
+        return [negative_prompt] * prompt_count
+    if len(negative_prompt) != prompt_count:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail=(
+                f"negative_prompt list length must match prompt list length ({len(negative_prompt)} != {prompt_count})."
+            ),
+        )
+    return list(negative_prompt)
+
+
+def _build_image_generation_prompt_payload(
+    request: ImageGenerationRequest,
+    *,
+    width: int | None,
+    height: int | None,
+) -> OmniTextPrompt | list[OmniTextPrompt]:
+    prompt_texts = _normalize_image_generation_prompts(request.prompt)
+    negative_prompts = _normalize_image_generation_negative_prompts(
+        request.negative_prompt,
+        prompt_count=len(prompt_texts),
+    )
+
+    prompts: list[OmniTextPrompt] = []
+    for prompt_text, negative_prompt in zip(prompt_texts, negative_prompts, strict=True):
+        prompt: OmniTextPrompt = {"prompt": prompt_text}
+        if negative_prompt is not None:
+            prompt["negative_prompt"] = negative_prompt
+        if width is not None and height is not None:
+            prompt["mm_processor_kwargs"] = {
+                "target_h": height,
+                "target_w": width,
+            }
+            # Backward-compatible fallback for processors reading top-level fields.
+            prompt["height"] = height
+            prompt["width"] = width
+        prompts.append(prompt)
+
+    return prompts[0] if len(prompts) == 1 else prompts
+
+
 def _load_model_chat_template_json(model: str) -> str | None:
     """Load a model-level chat_template.json from a local path or HF cache.
 
@@ -1579,6 +1639,11 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
         # Unify request construction for any multi-stage pipeline to avoid
         # divergence between /v1/images and /v1/chat/completions.
         if len(stage_configs) > 1:
+            if isinstance(request.prompt, list):
+                raise HTTPException(
+                    status_code=HTTPStatus.BAD_REQUEST.value,
+                    detail="Batched image prompts are only supported for single-stage diffusion pipelines.",
+                )
             chat_handler = getattr(raw_request.app.state, "openai_serving_chat", None)
             if chat_handler is None:
                 logger.warning("openai_serving_chat is not initialized for multi-stage /v1/images/generations")
@@ -1599,7 +1664,11 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
                 _check_max_generated_image_size(app_state_args, width, height)
                 extra_body["size"] = request.size
             if request.negative_prompt is not None:
-                extra_body["negative_prompt"] = request.negative_prompt
+                negative_prompts = _normalize_image_generation_negative_prompts(
+                    request.negative_prompt,
+                    prompt_count=1,
+                )
+                extra_body["negative_prompt"] = negative_prompts[0]
             if request.num_inference_steps is not None:
                 extra_body["num_inference_steps"] = request.num_inference_steps
             if request.guidance_scale is not None:
@@ -1635,10 +1704,6 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
 
             return ImageGenerationResponse(created=int(time.time()), data=image_data)
 
-        # Build params - pass through user values directly
-        prompt: OmniTextPrompt = {"prompt": request.prompt}
-        if request.negative_prompt is not None:
-            prompt["negative_prompt"] = request.negative_prompt
         gen_params = OmniDiffusionSamplingParams(num_outputs_per_prompt=request.n)
         extra_args = {}
         if request.use_system_prompt is not None:
@@ -1662,18 +1727,9 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
         else:
             size_str = "model default"
 
-        # Keep AR stage target grid in sync with requested output size.
-        # GLM-Image consumes target_h/target_w via mm_processor_kwargs.
-        if width is not None and height is not None:
-            prompt["mm_processor_kwargs"] = {
-                "target_h": height,
-                "target_w": width,
-            }
-            # Backward-compatible fallback for processors reading top-level fields.
-            prompt["height"] = height
-            prompt["width"] = width
         app_state_args = getattr(raw_request.app.state, "args", None)
         _check_max_generated_image_size(app_state_args, width, height)
+        prompt = _build_image_generation_prompt_payload(request, width=width, height=height)
 
         _update_if_not_none(gen_params, "width", width)
         _update_if_not_none(gen_params, "height", height)
@@ -1695,9 +1751,15 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
         request_id = f"img_gen-{random_uuid()}"
         raw_request.state.request_metadata = RequestResponseMetadata(request_id=request_id)
 
-        logger.debug(f"Generating {request.n} image(s) {size_str}")
+        prompt_count = len(prompt) if isinstance(prompt, list) else 1
+        logger.debug(
+            "Generating %d image(s) from %d prompt(s) %s",
+            prompt_count * request.n,
+            prompt_count,
+            size_str,
+        )
 
-        # Generate images using AsyncOmni (multi-stage mode)
+        # Generate images using AsyncOmni.
         result = await _generate_with_async_omni(
             engine_client=engine_client,
             gen_params=gen_params,

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -174,6 +174,41 @@ def _normalize_image_generation_negative_prompts(
     return list(negative_prompt)
 
 
+def _normalize_image_generation_seed(
+    seed: int | list[int] | None,
+    *,
+    prompt_count: int,
+    num_outputs_per_prompt: int,
+) -> int | tuple[int, ...] | None:
+    if seed is None:
+        return seed
+
+    sample_count = prompt_count * num_outputs_per_prompt
+    if isinstance(seed, int):
+        if prompt_count == 1:
+            return seed
+        return tuple(seed for _ in range(sample_count))
+
+    if not seed:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail="seed list must contain at least one item.",
+        )
+
+    if len(seed) == prompt_count:
+        return tuple(item for item in seed for _ in range(num_outputs_per_prompt))
+    if len(seed) == sample_count:
+        return tuple(seed)
+
+    raise HTTPException(
+        status_code=HTTPStatus.BAD_REQUEST.value,
+        detail=(
+            "seed list length must match prompt list length "
+            f"or total sample count ({len(seed)} != {prompt_count} or {sample_count})."
+        ),
+    )
+
+
 def _build_image_generation_prompt_payload(
     request: ImageGenerationRequest,
     *,
@@ -1644,6 +1679,11 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
                     status_code=HTTPStatus.BAD_REQUEST.value,
                     detail="Batched image prompts are only supported for single-stage diffusion pipelines.",
                 )
+            if isinstance(request.seed, list):
+                raise HTTPException(
+                    status_code=HTTPStatus.BAD_REQUEST.value,
+                    detail="Batched image seeds are only supported for single-stage diffusion pipelines.",
+                )
             chat_handler = getattr(raw_request.app.state, "openai_serving_chat", None)
             if chat_handler is None:
                 logger.warning("openai_serving_chat is not initialized for multi-stage /v1/images/generations")
@@ -1730,6 +1770,12 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
         app_state_args = getattr(raw_request.app.state, "args", None)
         _check_max_generated_image_size(app_state_args, width, height)
         prompt = _build_image_generation_prompt_payload(request, width=width, height=height)
+        prompt_count = len(prompt) if isinstance(prompt, list) else 1
+        effective_seed = _normalize_image_generation_seed(
+            request.seed,
+            prompt_count=prompt_count,
+            num_outputs_per_prompt=request.n,
+        )
 
         _update_if_not_none(gen_params, "width", width)
         _update_if_not_none(gen_params, "height", height)
@@ -1743,7 +1789,9 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
         # This fixes issues where using the default global generator
         # might produce blurry images in some environments.
         _update_if_not_none(
-            gen_params, "seed", request.seed if request.seed is not None else random.randint(0, MAX_UINT32_SEED)
+            gen_params,
+            "seed",
+            effective_seed if effective_seed is not None else random.randint(0, MAX_UINT32_SEED),
         )
         _update_if_not_none(gen_params, "generator_device", request.generator_device)
         _update_if_not_none(gen_params, "layers", request.layers)
@@ -1751,7 +1799,6 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
         request_id = f"img_gen-{random_uuid()}"
         raw_request.state.request_metadata = RequestResponseMetadata(request_id=request_id)
 
-        prompt_count = len(prompt) if isinstance(prompt, list) else 1
         logger.debug(
             "Generating %d image(s) from %d prompt(s) %s",
             prompt_count * request.n,

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -128,7 +128,13 @@ class ImageGenerationRequest(BaseModel):
         le=20.0,
         description="True CFG scale (model-specific parameter, may be ignored if not supported)",
     )
-    seed: int | None = Field(default=None, description="Random seed for reproducibility")
+    seed: int | list[int] | None = Field(
+        default=None,
+        description=(
+            "Random seed for reproducibility. When prompt is a list, an integer is broadcast "
+            "to each prompt and a list is matched item-by-item."
+        ),
+    )
     generator_device: str | None = Field(
         default=None,
         description="Device for the seeded torch.Generator (e.g. 'cpu', 'cuda'). Defaults to the runner's device.",

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -31,7 +31,7 @@ class ImageGenerationRequest(BaseModel):
     """
 
     # Required fields
-    prompt: str = Field(..., description="Text description of the desired image(s)")
+    prompt: str | list[str] = Field(..., description="Text description(s) of the desired image(s)")
     bot_task: str | None = Field(
         None,
         description="Task mode for the model (e.g., 'cot' enables chain-of-thought generation). "
@@ -85,7 +85,13 @@ class ImageGenerationRequest(BaseModel):
         return validate_layered_layers(v)
 
     # vllm-omni extensions for diffusion control
-    negative_prompt: str | None = Field(default=None, description="Text describing what to avoid in the image")
+    negative_prompt: str | list[str] | None = Field(
+        default=None,
+        description=(
+            "Text describing what to avoid in the image. When prompt is a list, "
+            "a string is shared by all prompts and a list is matched item-by-item."
+        ),
+    )
     system_prompt: str | None = Field(
         default=None, description="Custom system prompt. Used when --use_system_prompt is custom"
     )

--- a/vllm_omni/inputs/data.py
+++ b/vllm_omni/inputs/data.py
@@ -189,7 +189,7 @@ class OmniDiffusionSamplingParams:
 
     # Batch info
     num_outputs_per_prompt: int = 1
-    seed: int | None = None
+    seed: int | tuple[int, ...] | None = None
     generator: torch.Generator | list[torch.Generator] | None = None
     generator_device: str | None = None
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

  Support batched prompts for Qwen-Image /v1/images/generations and make those batched requests compatible with step-wise diffusion batching.

  This PR allows prompt to be either a string or a list of strings. negative_prompt can be a shared string or a list aligned one-to-one with prompt. For single-stage
  diffusion pipelines, multi-prompt image requests are sent as one batched diffusion request.

  It also extends step-wise continuous batching so multi-prompt diffusion requests can participate in batching with other compatible requests. Scheduler capacity is now
  counted by sample rows, len(prompts) * num_outputs_per_prompt, instead of only request count. InputBatch now expands row-level metadata such as img_shapes and prompt
  sequence lengths correctly for multi-prompt requests.

  Multi-stage image pipelines remain unchanged and still reject batched prompts.

## Test Plan

online cmd:
```
  vllm serve Qwen/Qwen-Image \
    --omni \
    --host 0.0.0.0 \
    --port 8091 \
    --tensor-parallel-size 4 \
    --gpu-memory-utilization 0.9 \
    --trust-remote-code \
    --step-execution \
    --max-num-seqs 4
```
Concurrent requests with multi prompts:
```
mkdir -p outputs

for i in 0 1; do
  curl -sS http://127.0.0.1:8091/v1/images/generations \
    -H 'Content-Type: application/json' \
    -d '{
      "model": "/mnt/data1/huggingface/hub/models--Qwen--Qwen-Image/snapshots75e0b4be04f60ec59a75f475837eced720f823b6",
      "prompt": ["a cat sitting on a sofa", "a dog running in a park"],
      "negative_prompt": ["blurry cat, low quality", "blurry dog, low quality"],
      "n": 1,
      "size": "512x512",
      "num_inference_steps": 20,
      "seed": '"$((200 + i))"',
      "response_format": "b64_json"
    }' \
    -o "outputs/batched_concurrent_${i}.json" &
done

wait

jq -r '.data[0].b64_json' outputs/batched_concurrent_0.json | base64 -d > outputsbatched_concurrent_0_image_000.png
jq -r '.data[1].b64_json' outputs/batched_concurrent_0.json | base64 -d > outputsbatched_concurrent_0_image_001.png
jq -r '.data[0].b64_json' outputs/batched_concurrent_1.json | base64 -d > outputsbatched_concurrent_1_image_000.png
jq -r '.data[1].b64_json' outputs/batched_concurrent_1.json | base64 -d > outputsbatched_concurrent_1_image_001.png
```

negative prompt usage:

a negative prompt string could be used for each prompt:
```
  {
    "prompt": ["a cat sitting on a sofa", "a dog running in a park"],
    "negative_prompt": "blurry, low quality"
  }
```
  Or each prompt must match a corresponding negative prompt like:

```
  {
    "prompt": ["a cat sitting on a sofa", "a dog running in a park"],
    "negative_prompt": ["blurry cat, low quality", "blurry dog, low quality"]
  }
```

seed usage:

a seed integer could be broadcast to each prompt with an independent generator:
```
  {
    "prompt": ["a cat sitting on a sofa", "a dog running in a park"],
    "seed": 200
  }
```
Or each prompt can match a corresponding seed like:
```
  {
    "prompt": ["a cat sitting on a sofa", "a dog running in a park"],
    "seed": [200, 201]
  }
```

### Benchmark Result: step-wise vs sample-wise batching in verl-omni

 | Mode | total images | timing_s/gen (20 steps) | speedup vs serial |
  | --- | ---: | ---: | ---: |
  | serial baseline | 16 | 46.355s | baseline |
  | step-wise | 16 | 33.816s | 27.1% faster |
  | sample-wise | 16 | 33.559s | 27.6% faster |

  | Metric | step-wise | sample-wise | delta |
  | --- | ---: | ---: | ---: |
  | normalized timing_s/gen (20 steps) | 33.816s | 33.559s | sample-wise faster by 0.257s / 0.76% |

  #### Summary

  Sample-wise batching improves the rollout/generation phase in verl-omni.

  - Rollout generation time is reduced from `71.026s` to `60.823s`.
  - Rollout throughput improves from `0.4505 img/s` to `0.5262 img/s`.
  - This is a `16.8%` rollout throughput improvement, or about `1.17x` speedup.
  - End-to-end training step time improves from `162.612s` to `155.679s`.
  - This is a `4.3%` end-to-end step-time improvement.

## Test Result

  <table>
    <thead>
      <tr>
        <th>Sample</th>
        <th>Batched request</th>
        <th>Single-prompt request</th>
      </tr>
    </thead>
    <tbody>
      <tr>
        <td>Cat_seed200</td>
        <td><img width="128" height="128" alt="batched cat seed 200" src="https://github.com/user-attachments/assets/515e7f86-e5be-4836-bb7b-fb54b32eedc1" /></td>
        <td><img width="128" height="128" alt="single cat seed 200" src="https://github.com/user-attachments/assets/8ac59f06-e6b4-43a0-8b50-c3cf34f07761" /></td>
      </tr>
      <tr>
        <td>Dog_seed200</td>
        <td><img width="128" height="128" alt="batched dog seed 200" src="https://github.com/user-attachments/assets/b6737fd4-48a0-443e-94c5-65a5156d530a" /></td>
        <td><img width="128" height="128" alt="single dog seed 200" src="https://github.com/user-attachments/assets/5cc19a1b-1689-4fe7-8d23-478495113ebb" /></td>
      </tr>
      <tr>
        <td>Cat_seed201</td>
        <td><img width="128" height="128" alt="batched_concurrent_1_image_000" src="https://github.com/user-attachments/assets/d5d8b5fd-8485-40bb-869b-d8d0442ae151" /></td>
        <td>
<img width="128" height="128" alt="single_cat_seed201" src="https://github.com/user-attachments/assets/9e5aa420-d865-40bb-9109-c3b7ec1f9017" />
</td>
      </tr>
      <tr>
        <td>Dog_seed201</td>
        <td>
<img width="128" height="128" alt="batched_concurrent_1_image_001" src="https://github.com/user-attachments/assets/eda1745d-4b14-407a-8c02-ae3ac8005715" />
</td>
        <td>
<img width="128" height="128" alt="single_dog_seed201" src="https://github.com/user-attachments/assets/85610f37-9df9-4ce1-aa9f-60cebd75f793" />
</td>
      </tr>
    </tbody>
  </table>


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
