### PR TITLE
[BugFix]Qwen-Image performance regression by using torch RMSNorm(RMSNorm backend)

### DIFF
--- a/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
+++ b/vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py
@@ -43,7 +43,6 @@ from vllm_omni.diffusion.distributed.sp_plan import (
 )
 from vllm_omni.diffusion.forward_context import get_forward_context
 from vllm_omni.diffusion.layers.adalayernorm import AdaLayerNorm
-from vllm_omni.diffusion.layers.norm import RMSNorm
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
 
 logger = init_logger(__name__)
@@ -538,8 +537,8 @@ class QwenImageCrossAttention(nn.Module):
         self.query_num_heads = self.to_qkv.num_heads
         self.kv_num_heads = self.to_qkv.num_kv_heads
 
-        self.norm_q = RMSNorm(head_dim, eps=eps) if qk_norm else nn.Identity()
-        self.norm_k = RMSNorm(head_dim, eps=eps) if qk_norm else nn.Identity()
+        self.norm_q = nn.RMSNorm(head_dim, eps=eps) if qk_norm else nn.Identity()
+        self.norm_k = nn.RMSNorm(head_dim, eps=eps) if qk_norm else nn.Identity()
 
         self.inner_dim = out_dim if out_dim is not None else head_dim * self.total_num_heads
 
@@ -576,8 +575,8 @@ class QwenImageCrossAttention(nn.Module):
             prefix=_join_prefix(prefix, "to_out"),
         )
 
-        self.norm_added_q = RMSNorm(head_dim, eps=eps)
-        self.norm_added_k = RMSNorm(head_dim, eps=eps)
+        self.norm_added_q = nn.RMSNorm(head_dim, eps=eps)
+        self.norm_added_k = nn.RMSNorm(head_dim, eps=eps)
 
         self.attn = Attention(
             num_heads=self.query_num_heads,
@@ -992,7 +991,7 @@ class QwenImageTransformer2DModel(CachedTransformer):
             quant_config=quant_config,
         )
 
-        self.txt_norm = RMSNorm(joint_attention_dim, eps=1e-6)
+        self.txt_norm = nn.RMSNorm(joint_attention_dim, eps=1e-6)
 
         # Entry projections (image/text) are kept full precision —
         # small sensitive layers at the network boundary (see #2728).


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

**Fix/mitigate the accuracy regression reported in #4029** (`test_qwen_image_matches_diffusers`, SSIM threshold ≥ 0.97): switch Qwen-Image RMSNorm layers to **`torch.nn.RMSNorm`**.

### Background 
- A **Qwen-Image performance regression** investigation (v0.18.0 → v0.20.x), observed via the official serving benchmark (`diffusion_benchmark_serving.py` → `latency_mean`).
- **#3933** switched Qwen-Image RMSNorm from vLLM RMSNorm to **omni RMSNorm** (operator/backend path change).
- Around the same window, **#4029** reported nightly CI **accuracy regression** (SSIM vs diffusers).
- This PR switches to **`torch.nn.RMSNorm`** as a pragmatic fallback: avoid vLLM RMSNorm extension path, and reduce the risk of fused-kernel numerical drift impacting SSIM.

### Change

- **File**: `vllm_omni/diffusion/models/qwen_image/qwen_image_transformer.py`
- **Change**: use `torch.nn.RMSNorm` for Qwen-Image RMSNorm layers
- **Scope**: Qwen-Image diffusion transformer only


## Test Plan
- [x] CI: run `tests/e2e/accuracy/test_qwen_image.py::test_qwen_image_matches_diffusers` (primary goal: confirm #4029 is addressed).
- [x]  `diffusion_benchmark_serving.py` (512×512, 10 steps)  to show `latency_mean` improved compare will applied vllm rmsNorm
- [ ] 0.20.0 compile+warmup A/B version (vLLM RMS_Norm / Torch RMS_Norm) 

## Test Result

#### Accuracy: `test_qwen_image_matches_diffusers` in local test

Note: the rows below are **local** results (L20X + venv). They are not matched nightly CI absolute values, but are useful for comparing relative changes across RMSNorm backends.
## Will be updated once getting CI test result
| Variant (local) | commit | SSIM | PSNR (dB) |
| --- | --- | ---: | ---: |
| baseline (before-#3933 merged) | “Last PASS commit”  `11c4fced` | 0.950571 | 26.75 |
| omni RMSNorm plateau (post-#3933) | `6f4bd3e` | 0.950902 | 26.75 |
| torch RMSNorm (this PR) | `b1e12d1a` | 0.959643 | 28.017508 |

#### Accuracy: `test_qwen_image_matches_diffusers` in CI
| Variant (local) | commit | SSIM | PSNR (dB) |
| --- | --- | ---: | ---: |
| baseline (before-#3933 merged) | “Last PASS commit”  `11c4fced` | 0.972616 | 30.022175 |
| omni RMSNorm plateau (post-#3933) | `6f4bd3e` | 0.941089 | 25.499989  |
| torch RMSNorm (After this PR) | `b1e12d1a` | 0.975093 | 30.727339 |


Workload: 512×512, 10 steps, **500 requests** (+1 warmup), max-concurrency=1.
Baseline table (v0.18.0 as baseline) + torch RMSNorm (this PR):
| Metric | v0.18.0 | v0.20.0 (vLLM RMSNorm) | v0.20.0 (omni RMSNorm) | v0.20.0 (torch RMSNorm, this PR) |
| --- | ---: | ---: | ---: | ---: |
| throughput_qps | 0.843 | 0.742 (−11.9%) | 0.811 (−3.8%) | 0.829 (−1.6%) |
| latency_mean | 1.187 | 1.347 (+13.5%) | 1.233 (+3.9%) | 1.206 (+1.6%) |
| latency_median | 1.181 | 1.317 (+11.5%) | 1.223 (+3.5%) | 1.187 (+0.5%) |
| latency_p99 | 1.269 | 1.647 (+29.8%) | 1.363 (+7.4%) | 1.372 (+8.2%) |
| latency_p95 | 1.234 | 1.459 (+18.2%) | 1.298 (+5.2%) | 1.294 (+4.9%) |



## Compare (vLLM RMS_Norm / Torch RMS_Norm) in profiling

### vLLM RMS_Norm CPU time vs Torch RMS_Norm CPU time 
#### vLLM 
<img width="1895" height="539" alt="vllm_rms_norm" src="https://github.com/user-attachments/assets/d32e1b22-5baa-4ae8-8e19-feb6f71c2147" />
#### Torch 
<img width="1543" height="499" alt="torch_rms_norm" src="https://github.com/user-attachments/assets/bd49a36e-c090-4466-a935-fb9cd7304da0" />
Torch RMS_Norm: ~14us
vLLM RMS_Norm: ~57us

### vLLM RMS_Norm CPU time vs Torch RMS_Norm CUDA time 
#### vLLM 
<img width="1478" height="518" alt="vllm_rms_norm_GPU" src="https://github.com/user-attachments/assets/1f01af71-1616-4107-aed9-28ce3c21002b" />

#### Torch 
<img width="1852" height="539" alt="torch_rms_norm_GPU" src="https://github.com/user-attachments/assets/3ba6a5a9-0bae-4043-804a-fb380c0eebe8" />
Torch RMS_Norm: ~31us
vLLM RMS_Norm: ~62us



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
