### PR TITLE
[Bugfix] Fix Compatibility of Ming-flash-omni-2.0 on transformers 5.X and vllm 0.22

### DIFF
--- a/recipes/inclusionAI/Ming-flash-omni-2.0.md
+++ b/recipes/inclusionAI/Ming-flash-omni-2.0.md
@@ -57,12 +57,6 @@ Adjust `devices` in the YAML to match your hardware.
 
 #### Command
 
-Thinker only (text output):
-
-```bash
-vllm serve Jonathan1909/Ming-flash-omni-2.0 --omni --port 8091
-```
-
 Thinker + talker (text and/or audio output):
 
 ```bash
@@ -70,6 +64,15 @@ vllm serve Jonathan1909/Ming-flash-omni-2.0 \
     --omni \
     --port 8091 \
     --log-stats
+```
+
+Thinker only (text-only output):
+
+```bash
+vllm serve Jonathan1909/Ming-flash-omni-2.0 \
+    --omni \
+    --deploy-config vllm_omni/deploy/ming_flash_omni_thinker_only.yaml \
+    --port 8091
 ```
 
 `--log-stats` is optional but recommended while validating the deployment.

--- a/vllm_omni/model_executor/models/ming_flash_omni/ming_flash_omni_thinker.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/ming_flash_omni_thinker.py
@@ -540,20 +540,24 @@ class MingFlashOmniThinkerMultiModalProcessor(BaseMultiModalProcessor[MingFlashO
         if images is not None:
             image_outputs = hf_processor.image_processor(
                 images=images,
-                videos=None,
                 return_tensors="pt",
             )
             data.update(image_outputs)
 
         videos = mm_data.get("videos", None)
         if videos is not None:
-            # TODO: ``videos=`` on image_processor is deprecated since
-            # transformers v4.57 (removed in v5); migrate to Qwen2VLVideoProcessor.
-            video_outputs = hf_processor.image_processor(
-                images=None,
-                videos=videos,
-                return_tensors="pt",
-            )
+            video_processor = getattr(hf_processor, "video_processor", None)
+            if video_processor is not None:
+                video_outputs = video_processor(
+                    videos=videos,
+                    return_tensors="pt",
+                )
+            else:
+                video_outputs = hf_processor.image_processor(
+                    images=None,
+                    videos=videos,
+                    return_tensors="pt",
+                )
             # Rename keys to distinguish from images
             if "pixel_values" in video_outputs:
                 video_outputs["pixel_values_videos"] = video_outputs.pop("pixel_values")

--- a/vllm_omni/model_executor/models/ming_flash_omni/ming_flash_omni_thinker.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/ming_flash_omni_thinker.py
@@ -72,6 +72,7 @@ from vllm_omni.transformers_utils.processors.ming import (
     PLACEHOLDER_VIDEO_TOKEN_IN_TEXT,
     MingFlashOmniProcessor,
     MingWhisperFeatureExtractor,
+    raise_missing_video_processor,
 )
 
 from .audio_encoder import WhisperAudioEncoder
@@ -553,14 +554,7 @@ class MingFlashOmniThinkerMultiModalProcessor(BaseMultiModalProcessor[MingFlashO
                     return_tensors="pt",
                 )
             else:
-                try:
-                    video_outputs = hf_processor.image_processor(
-                        images=None,
-                        videos=videos,
-                        return_tensors="pt",
-                    )
-                except TypeError as exc:
-                    raise ValueError("Video inputs require `video_processor` with this Transformers version.") from exc
+                raise_missing_video_processor()
             # Rename keys to distinguish from images
             if "pixel_values" in video_outputs:
                 video_outputs["pixel_values_videos"] = video_outputs.pop("pixel_values")

--- a/vllm_omni/model_executor/models/ming_flash_omni/ming_flash_omni_thinker.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/ming_flash_omni_thinker.py
@@ -553,11 +553,14 @@ class MingFlashOmniThinkerMultiModalProcessor(BaseMultiModalProcessor[MingFlashO
                     return_tensors="pt",
                 )
             else:
-                video_outputs = hf_processor.image_processor(
-                    images=None,
-                    videos=videos,
-                    return_tensors="pt",
-                )
+                try:
+                    video_outputs = hf_processor.image_processor(
+                        images=None,
+                        videos=videos,
+                        return_tensors="pt",
+                    )
+                except TypeError as exc:
+                    raise ValueError("Video inputs require `video_processor` with this Transformers version.") from exc
             # Rename keys to distinguish from images
             if "pixel_values" in video_outputs:
                 video_outputs["pixel_values_videos"] = video_outputs.pop("pixel_values")

--- a/vllm_omni/model_executor/models/ming_flash_omni/modeling_bailing_moe_v2.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/modeling_bailing_moe_v2.py
@@ -714,6 +714,9 @@ class BailingMoeV2Model(nn.Module):
     def get_input_embeddings(self):
         return self.word_embeddings
 
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.word_embeddings(input_ids)
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -793,6 +796,9 @@ class BailingMoeV2ForCausalLM(nn.Module, CustomProcessMixin):
         self.logits_processor = LogitsProcessor(config.vocab_size)
         self.sampler = Sampler()
         self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
 
     def forward(
         self,

--- a/vllm_omni/model_executor/models/ming_flash_omni/modeling_bailing_moe_v2.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/modeling_bailing_moe_v2.py
@@ -824,7 +824,7 @@ class BailingMoeV2ForCausalLM(nn.Module, CustomProcessMixin):
         hidden_states: torch.Tensor,
         sampling_metadata,
     ) -> torch.Tensor | None:
-        logits = self.logits_processor(self.lm_head, hidden_states, sampling_metadata)
+        logits = self.logits_processor(self.lm_head, hidden_states)
         return logits
 
     def sample(

--- a/vllm_omni/model_executor/models/ming_flash_omni/modeling_bailing_moe_v2.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/modeling_bailing_moe_v2.py
@@ -714,9 +714,6 @@ class BailingMoeV2Model(nn.Module):
     def get_input_embeddings(self):
         return self.word_embeddings
 
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.word_embeddings(input_ids)
-
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -796,9 +793,6 @@ class BailingMoeV2ForCausalLM(nn.Module, CustomProcessMixin):
         self.logits_processor = LogitsProcessor(config.vocab_size)
         self.sampler = Sampler()
         self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors
-
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.embed_input_ids(input_ids)
 
     def forward(
         self,

--- a/vllm_omni/model_executor/models/ming_flash_omni/talker_module.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/talker_module.py
@@ -1041,7 +1041,7 @@ class MingAudioGenerator:
                 use_cache=True,
             )
         else:
-            past_seen_tokens = past_key_values.get_seq_length()
+            past_seen_tokens = int(past_key_values.get_seq_length())
             cache_position = torch.arange(
                 past_seen_tokens,
                 past_seen_tokens + inputs_embeds.shape[1],

--- a/vllm_omni/model_executor/models/ming_flash_omni/talker_module.py
+++ b/vllm_omni/model_executor/models/ming_flash_omni/talker_module.py
@@ -902,6 +902,7 @@ class MingAudioGenerator:
         if self._audio_vae is None:
             return requested_max_steps
 
+        # Transformers >=5.x may expose these config values as 0-d tensors.
         sample_rate = float(self._audio_vae.config.sample_rate)
         vae_patch_size = float(getattr(self._audio_vae.config, "patch_size", 4))
         hop_size = float(getattr(self._audio_vae.decoder, "hop_length", 320))

--- a/vllm_omni/transformers_utils/configs/ming_flash_omni.py
+++ b/vllm_omni/transformers_utils/configs/ming_flash_omni.py
@@ -352,9 +352,11 @@ class MingFlashOmniTalkerConfig(PretrainedConfig):
         self.campplus_model = campplus_model
 
     def get_text_config(self, decoder: bool = False) -> PretrainedConfig:  # noqa: ARG002
-        if isinstance(self.llm_config, dict):
-            return PretrainedConfig.from_dict(self.llm_config)
-        return self.llm_config
+        llm_config = getattr(self, "llm_config", None)
+        if isinstance(llm_config, dict):
+            return PretrainedConfig.from_dict(llm_config)
+
+        return llm_config
 
 
 class MingFlashOmniConfig(PretrainedConfig):

--- a/vllm_omni/transformers_utils/configs/ming_flash_omni.py
+++ b/vllm_omni/transformers_utils/configs/ming_flash_omni.py
@@ -354,7 +354,7 @@ class MingFlashOmniTalkerConfig(PretrainedConfig):
         self.campplus_model = campplus_model
 
     def get_text_config(self, decoder: bool = False) -> PretrainedConfig:  # noqa: ARG002
-        llm_config = getattr(self, "llm_config", None)
+        llm_config = self.llm_config
         if isinstance(llm_config, dict):
             return PretrainedConfig.from_dict(llm_config)
 

--- a/vllm_omni/transformers_utils/configs/ming_flash_omni.py
+++ b/vllm_omni/transformers_utils/configs/ming_flash_omni.py
@@ -354,7 +354,9 @@ class MingFlashOmniTalkerConfig(PretrainedConfig):
         self.campplus_model = campplus_model
 
     def get_text_config(self, decoder: bool = False) -> PretrainedConfig:  # noqa: ARG002
-        llm_config = self.llm_config
+        # NOTE: transformers v5 runs validators (e.g. validate_token_ids -> get_text_config)
+        # during PretrainedConfig.__init__, before llm_config is assigned
+        llm_config = getattr(self, "llm_config", None)
         if isinstance(llm_config, dict):
             return PretrainedConfig.from_dict(llm_config)
 

--- a/vllm_omni/transformers_utils/configs/ming_flash_omni.py
+++ b/vllm_omni/transformers_utils/configs/ming_flash_omni.py
@@ -27,6 +27,7 @@ logger = logging.get_logger(__name__)
 
 class BailingMoeV2Config(PretrainedConfig):
     model_type = "bailing_moe_v2"
+    ignore_keys_at_rope_validation = {"mrope_section"}
 
     def __init__(
         self,
@@ -237,6 +238,7 @@ class WhisperEncoderConfig(PretrainedConfig):
 
 class BailingMM2Config(PretrainedConfig):
     model_type = "bailingmm_moe_v2_lite"
+    ignore_keys_at_rope_validation = {"mrope_section"}
     is_composition = True
     sub_configs: ClassVar = {"llm_config": AutoConfig}
 

--- a/vllm_omni/transformers_utils/processors/ming.py
+++ b/vllm_omni/transformers_utils/processors/ming.py
@@ -22,6 +22,7 @@ from transformers import AutoFeatureExtractor, AutoProcessor
 from transformers.feature_extraction_utils import BatchFeature, FeatureExtractionMixin
 from transformers.processing_utils import ProcessorMixin
 from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
+from transformers.utils import logging
 
 try:
     from transformers import AutoVideoProcessor
@@ -29,6 +30,13 @@ except ImportError:
     AutoVideoProcessor = None
 
 _HAS_VIDEO_PROCESSOR = AutoVideoProcessor is not None
+
+logger = logging.get_logger(__name__)
+
+
+def raise_missing_video_processor():
+    raise ValueError("Ming Flash Omni video inputs require a Transformers 5.x `video_processor`.")
+
 
 DEFAULT_IMAGE_PATCH_TOKEN = "<imagePatch>"
 DEFAULT_IM_START_TOKEN = "<image>"
@@ -219,7 +227,17 @@ class MingFlashOmniProcessor(ProcessorMixin):
                 )
             except OSError:
                 processor.video_processor = None
+            except (ValueError, KeyError) as exc:
+                logger.warning("Failed to load optional Ming video processor: %s", exc)
+                processor.video_processor = None
         return processor
+
+    def save_pretrained(self, save_directory, push_to_hub: bool = False, **kwargs):
+        output = super().save_pretrained(save_directory, push_to_hub=push_to_hub, **kwargs)
+        video_processor = getattr(self, "video_processor", None)
+        if video_processor is not None:
+            video_processor.save_pretrained(save_directory)
+        return output
 
     def __call__(
         self,
@@ -258,15 +276,7 @@ class MingFlashOmniProcessor(ProcessorMixin):
                     **kwargs.get("videos_kwargs", {}),
                 )
             else:
-                try:
-                    video_outputs = self.image_processor(
-                        images=None,
-                        videos=videos,
-                        return_tensors="pt",
-                        **kwargs.get("videos_kwargs", {}),
-                    )
-                except TypeError as exc:
-                    raise ValueError("Video inputs require `video_processor` with this Transformers version.") from exc
+                raise_missing_video_processor()
             if "pixel_values" in video_outputs:
                 video_outputs["pixel_values_videos"] = video_outputs.pop("pixel_values")
             if "image_grid_thw" in video_outputs:

--- a/vllm_omni/transformers_utils/processors/ming.py
+++ b/vllm_omni/transformers_utils/processors/ming.py
@@ -162,8 +162,6 @@ class MingFlashOmniProcessor(ProcessorMixin):
     """
 
     attributes = ["image_processor", "audio_processor", "tokenizer"]
-    if _HAS_VIDEO_PROCESSOR:
-        attributes = ["image_processor", "video_processor", "audio_processor", "tokenizer"]
     image_processor_class = "AutoImageProcessor"
     if _HAS_VIDEO_PROCESSOR:
         video_processor_class = "AutoVideoProcessor"
@@ -192,14 +190,15 @@ class MingFlashOmniProcessor(ProcessorMixin):
         self.image_token = PLACEHOLDER_IMAGE_TOKEN_IN_TEXT
         self.video_token = PLACEHOLDER_VIDEO_TOKEN_IN_TEXT
         self.audio_token = PLACEHOLDER_AUDIO_TOKEN_IN_TEXT
-        processor_kwargs = dict(
+        if video_processor is not None and not _HAS_VIDEO_PROCESSOR:
+            raise ValueError("`video_processor` requires transformers with `AutoVideoProcessor` support.")
+
+        super().__init__(
             image_processor=image_processor,
             audio_processor=audio_processor,
             tokenizer=tokenizer,
         )
-        if _HAS_VIDEO_PROCESSOR:
-            processor_kwargs["video_processor"] = video_processor
-        super().__init__(**processor_kwargs)
+        self.video_processor = video_processor
 
         # Fall back to the tokenizer's own chat_template.
         if self.chat_template is None:

--- a/vllm_omni/transformers_utils/processors/ming.py
+++ b/vllm_omni/transformers_utils/processors/ming.py
@@ -23,6 +23,13 @@ from transformers.feature_extraction_utils import BatchFeature, FeatureExtractio
 from transformers.processing_utils import ProcessorMixin
 from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
 
+try:
+    from transformers import AutoVideoProcessor
+except ImportError:
+    AutoVideoProcessor = None
+
+_HAS_VIDEO_PROCESSOR = AutoVideoProcessor is not None
+
 DEFAULT_IMAGE_PATCH_TOKEN = "<imagePatch>"
 DEFAULT_IM_START_TOKEN = "<image>"
 DEFAULT_IM_END_TOKEN = "</image>"
@@ -155,13 +162,18 @@ class MingFlashOmniProcessor(ProcessorMixin):
     """
 
     attributes = ["image_processor", "audio_processor", "tokenizer"]
+    if _HAS_VIDEO_PROCESSOR:
+        attributes = ["image_processor", "video_processor", "audio_processor", "tokenizer"]
     image_processor_class = "AutoImageProcessor"
+    if _HAS_VIDEO_PROCESSOR:
+        video_processor_class = "AutoVideoProcessor"
     audio_processor_class = "AutoFeatureExtractor"
     tokenizer_class = "AutoTokenizer"
 
     def __init__(
         self,
         image_processor=None,
+        video_processor=None,
         audio_processor=None,
         tokenizer=None,
         merge_size: int = 2,
@@ -180,11 +192,14 @@ class MingFlashOmniProcessor(ProcessorMixin):
         self.image_token = PLACEHOLDER_IMAGE_TOKEN_IN_TEXT
         self.video_token = PLACEHOLDER_VIDEO_TOKEN_IN_TEXT
         self.audio_token = PLACEHOLDER_AUDIO_TOKEN_IN_TEXT
-        super().__init__(
+        processor_kwargs = dict(
             image_processor=image_processor,
             audio_processor=audio_processor,
             tokenizer=tokenizer,
         )
+        if _HAS_VIDEO_PROCESSOR:
+            processor_kwargs["video_processor"] = video_processor
+        super().__init__(**processor_kwargs)
 
         # Fall back to the tokenizer's own chat_template.
         if self.chat_template is None:
@@ -211,7 +226,6 @@ class MingFlashOmniProcessor(ProcessorMixin):
         if images is not None:
             image_outputs = self.image_processor(
                 images=images,
-                videos=None,
                 return_tensors="pt",
                 **kwargs.get("images_kwargs", {}),
             )
@@ -220,12 +234,20 @@ class MingFlashOmniProcessor(ProcessorMixin):
                 text = self._expand_image_tokens(text, image_outputs["image_grid_thw"])
 
         if videos is not None:
-            video_outputs = self.image_processor(
-                images=None,
-                videos=videos,
-                return_tensors="pt",
-                **kwargs.get("videos_kwargs", {}),
-            )
+            video_processor = getattr(self, "video_processor", None)
+            if video_processor is not None:
+                video_outputs = video_processor(
+                    videos=videos,
+                    return_tensors="pt",
+                    **kwargs.get("videos_kwargs", {}),
+                )
+            else:
+                video_outputs = self.image_processor(
+                    images=None,
+                    videos=videos,
+                    return_tensors="pt",
+                    **kwargs.get("videos_kwargs", {}),
+                )
             if "pixel_values" in video_outputs:
                 video_outputs["pixel_values_videos"] = video_outputs.pop("pixel_values")
             if "image_grid_thw" in video_outputs:
@@ -423,6 +445,9 @@ class MingFlashOmniProcessor(ProcessorMixin):
             + self.image_processor.model_input_names
             + self.audio_processor.model_input_names
         )
+        video_processor = getattr(self, "video_processor", None)
+        if video_processor is not None:
+            names += video_processor.model_input_names
         return list(dict.fromkeys(names))
 
 

--- a/vllm_omni/transformers_utils/processors/ming.py
+++ b/vllm_omni/transformers_utils/processors/ming.py
@@ -171,12 +171,12 @@ class MingFlashOmniProcessor(ProcessorMixin):
     def __init__(
         self,
         image_processor=None,
-        video_processor=None,
         audio_processor=None,
         tokenizer=None,
         merge_size: int = 2,
         **kwargs,
     ):
+        video_processor = kwargs.pop("video_processor", None)
         # Enforce that all sub-processors exist
         # Keep None defaults in the signature for HF ProcessorMixin compatibility
         if image_processor is None:
@@ -203,6 +203,23 @@ class MingFlashOmniProcessor(ProcessorMixin):
         # Fall back to the tokenizer's own chat_template.
         if self.chat_template is None:
             self.chat_template = getattr(tokenizer, "chat_template", None)
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
+        video_processor = kwargs.pop("video_processor", None)
+        processor = super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        if video_processor is not None:
+            processor.video_processor = video_processor
+        elif _HAS_VIDEO_PROCESSOR:
+            try:
+                processor.video_processor = AutoVideoProcessor.from_pretrained(
+                    pretrained_model_name_or_path,
+                    *args,
+                    **kwargs,
+                )
+            except OSError:
+                processor.video_processor = None
+        return processor
 
     def __call__(
         self,
@@ -241,12 +258,15 @@ class MingFlashOmniProcessor(ProcessorMixin):
                     **kwargs.get("videos_kwargs", {}),
                 )
             else:
-                video_outputs = self.image_processor(
-                    images=None,
-                    videos=videos,
-                    return_tensors="pt",
-                    **kwargs.get("videos_kwargs", {}),
-                )
+                try:
+                    video_outputs = self.image_processor(
+                        images=None,
+                        videos=videos,
+                        return_tensors="pt",
+                        **kwargs.get("videos_kwargs", {}),
+                    )
+                except TypeError as exc:
+                    raise ValueError("Video inputs require `video_processor` with this Transformers version.") from exc
             if "pixel_values" in video_outputs:
                 video_outputs["pixel_values_videos"] = video_outputs.pop("pixel_values")
             if "image_grid_thw" in video_outputs:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

This PR fixed `transformers` and `vllm` version compatibility issues on existing Ming-flash-omni-2.0 flows.

cc @akshatvishu , @ZhengWG , @LHXuuu 

## Test Plan

1. Offline and online tests (* with commenting out `_SKIP_NEED_4_H100_NOT_CI` to run online tests)
2. Omni-speech, TTS Recipe running
3. Image-gen 

```bash
pytest -s tests/e2e/offline_inference/test_ming_flash_omni_expansion.py tests/e2e/online_serving/test_ming_flash_omni_expansion.py
```

## Test Result

```text
vllm                                     0.22.0
transformers                             5.5.4
```

unit tests output:
```text
=============================================================================================== 13 passed, 18 warnings in 517.86s (0:08:37)
```

Following Ming-flash-omni-2.0 recipe, Omni-speech and TTS work well now.
For image-gen example, please refer to https://github.com/vllm-project/vllm-omni/pull/4080#issuecomment-4611828401

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
