### PR TITLE
[Perf] Use SGLang Triton kernel for LayerNorm.forward_cuda

### DIFF
--- a/benchmarks/diffusion/benchmark_layernorm.py
+++ b/benchmarks/diffusion/benchmark_layernorm.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Micro-benchmark: SGLang Triton LayerNorm kernel vs torch.compile(forward_native).
+
+Run with:
+    python benchmarks/diffusion/benchmark_layernorm.py
+"""
+
+import torch
+
+from vllm_omni.diffusion.layers.norm import LayerNorm
+
+SHAPES = [
+    # (batch, seq_len, hidden_dim)
+    (1, 4096, 1536),  # Wan2.2-1.3B
+    (4, 4096, 1536),
+    (1, 16384, 1536),
+    (1, 4096, 5120),  # Wan2.2-14B
+    (4, 4096, 5120),
+]
+
+WARMUP = 50
+REPEATS = 200
+DTYPE = torch.bfloat16
+DEVICE = "cuda"
+
+
+def bench(fn, warmup=WARMUP, repeats=REPEATS):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(repeats):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / repeats * 1e3
+
+
+def check(ref, out, atol=1e-2, rtol=1e-2):
+    max_diff = (ref.float() - out.float()).abs().max().item()
+    ok = torch.allclose(ref.float(), out.float(), atol=atol, rtol=rtol)
+    return ok, max_diff
+
+
+for B, S, D in SHAPES:
+    print(f"\nShape  batch={B}  seq={S}  dim={D}")
+    print("-" * 56)
+
+    x = torch.randn(B, S, D, dtype=DTYPE, device=DEVICE)
+    ln = LayerNorm(D).to(DEVICE).to(DTYPE)
+
+    compiled_fn = torch.compile(ln.forward_native)
+    ref = compiled_fn(x)
+
+    t_compile = bench(lambda: compiled_fn(x))
+    print(f"  torch.compile (native)  : {t_compile:8.2f} µs")
+
+    t_cuda = bench(lambda: ln.forward_cuda(x))
+    out_cuda = ln.forward_cuda(x)
+    ok, md = check(ref, out_cuda)
+    print(f"  SGLang Triton kernel    : {t_cuda:8.2f} µs  max_diff={md:.2e}  {'OK' if ok else 'FAIL'}")

--- a/tests/diffusion/layers/test_norm.py
+++ b/tests/diffusion/layers/test_norm.py
@@ -451,3 +451,47 @@ def test_rmsnorm_with_single_element_batch():
     out = norm(x)
 
     assert out.shape == (1, 1, hidden_size)
+
+
+# ── CUDA-specific LayerNorm tests (Triton kernel path) ──
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (2, 64),
+        (2, 4, 64),
+        (1, 4096, 1536),
+    ],
+)
+def test_layernorm_forward_cuda_matches_native(dtype, shape):
+    """forward_cuda (Triton kernel) must match forward_native within tolerance."""
+    from vllm_omni.diffusion.layers.norm import LayerNorm
+
+    dim = shape[-1]
+    torch.manual_seed(0)
+    norm = LayerNorm(dim).cuda().to(dtype)
+    x = torch.randn(*shape, dtype=dtype, device="cuda")
+
+    out_cuda = norm.forward_cuda(x)
+    out_native = norm.forward_native(x)
+
+    assert out_cuda.shape == x.shape
+    assert out_cuda.dtype == dtype
+    torch.testing.assert_close(out_cuda, out_native, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_layernorm_forward_cuda_no_weight_falls_back():
+    """forward_cuda falls back to forward_native when elementwise_affine=False."""
+    from vllm_omni.diffusion.layers.norm import LayerNorm
+
+    norm = LayerNorm(64, elementwise_affine=False).cuda()
+    x = torch.randn(2, 4, 64, device="cuda")
+
+    out_cuda = norm.forward_cuda(x)
+    out_native = norm.forward_native(x)
+
+    torch.testing.assert_close(out_cuda, out_native, atol=1e-5, rtol=1e-5)

--- a/vllm_omni/diffusion/layers/norm.py
+++ b/vllm_omni/diffusion/layers/norm.py
@@ -1,11 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from importlib.util import find_spec
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import triton
 from vllm.logger import init_logger
 
 from vllm_omni.diffusion.layers.custom_op import CustomOp
+from vllm_omni.diffusion.layers.sglangnorm import _layer_norm_fwd_1pass_kernel
 
 logger = init_logger(__name__)
 
@@ -17,7 +21,12 @@ class LayerNorm(nn.LayerNorm, CustomOp):
     LayerNorm implementation that inherits from both ``nn.LayerNorm`` and ``CustomOp``.
     NPU:
         Uses ``mindiesd.fast_layernorm(self, x)`` when MindIE-SD is installed.
-    CUDA / HIP / XPU / native:
+    CUDA:
+        Uses a single-pass Triton kernel (adapted from SGLang) that avoids the
+        FP32 cast round-trip and operates natively in bf16/fp16.
+        Falls back to ``forward_native`` for CPU tensors or when
+        ``elementwise_affine=False``.
+    HIP / XPU / native:
         Falls back to FP32 nn.LayerNorm implementation.
     """
 
@@ -31,7 +40,73 @@ class LayerNorm(nn.LayerNorm, CustomOp):
         return self._forward_method(x)
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
-        return self.forward_native(x)
+        if not x.is_cuda or self.weight is None:
+            return self.forward_native(x)
+
+        weight = self.weight
+        bias = self.bias
+        has_bias = bias is not None
+        eps = self.eps
+        orig_shape = x.shape
+        x_2d = x.reshape(-1, orig_shape[-1])  # (M, N)
+        M, N = x_2d.shape
+
+        y = torch.empty_like(x_2d)
+        mean = torch.empty(M, dtype=torch.float32, device=x.device)
+        rstd = torch.empty(M, dtype=torch.float32, device=x.device)
+
+        BLOCK_N = triton.next_power_of_2(N)
+        assert BLOCK_N <= 131072, f"hidden_dim {N} too large for single-block kernel"
+
+        bias_ptr = bias if has_bias else weight  # harmless dummy when HAS_BIAS=False
+        grid = (M,)
+        _layer_norm_fwd_1pass_kernel[grid](
+            # data pointers
+            x_2d,
+            y,
+            weight,
+            bias_ptr,
+            # unused optional pointers — pass x_2d as a harmless dummy
+            x_2d,
+            x_2d,
+            weight,
+            bias_ptr,
+            y,
+            x_2d,
+            x_2d,
+            x_2d,
+            x_2d,
+            x_2d,
+            mean,
+            rstd,
+            # strides
+            x_2d.stride(0),
+            y.stride(0),
+            x_2d.stride(0),
+            x_2d.stride(0),
+            x_2d.stride(0),
+            y.stride(0),
+            # scalars
+            M,
+            N,
+            eps,
+            0.0,  # dropout_p
+            False,  # zero_centered_weight
+            # constexprs — only the ones we actually need are True
+            IS_RMS_NORM=False,
+            BLOCK_N=BLOCK_N,
+            HAS_RESIDUAL=False,
+            STORE_RESIDUAL_OUT=False,
+            HAS_WEIGHT=True,
+            HAS_BIAS=has_bias,
+            HAS_DROPOUT=False,
+            STORE_DROPOUT_MASK=False,
+            HAS_ROWSCALE=False,
+            HAS_X1=False,
+            HAS_W1=False,
+            HAS_B1=False,
+        )
+        return y.reshape(orig_shape)
 
     def forward_hip(self, x: torch.Tensor) -> torch.Tensor:
         return self.forward_native(x)

--- a/vllm_omni/diffusion/layers/sglangnorm.py
+++ b/vllm_omni/diffusion/layers/sglangnorm.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from SGLang: https://github.com/sgl-project/sglang/blob/main/python/sglang/jit_kernel/diffusion/triton/norm.py
+# ruff: noqa: N803  # Triton kernel convention uses uppercase for pointer/constexpr args
+
+import triton  # type: ignore
+import triton.language as tl  # type: ignore
+
+
+@triton.jit
+def _layer_norm_fwd_1pass_kernel(
+    X,  # pointer to the input
+    Y,  # pointer to the output
+    W,  # pointer to the weights
+    B,  # pointer to the biases
+    RESIDUAL,  # pointer to the residual
+    X1,
+    W1,
+    B1,
+    Y1,
+    RESIDUAL_OUT,  # pointer to the residual
+    ROWSCALE,
+    SEEDS,  # Dropout seeds for each row
+    DROPOUT_MASK,
+    DROPOUT_MASK1,
+    Mean,  # pointer to the mean
+    Rstd,  # pointer to the 1/std
+    stride_x_row,  # how much to increase the pointer when moving by 1 row
+    stride_y_row,
+    stride_res_row,
+    stride_res_out_row,
+    stride_x1_row,
+    stride_y1_row,
+    M,  # number of rows in X
+    N,  # number of columns in X
+    eps,  # epsilon to avoid division by zero
+    dropout_p,  # Dropout probability
+    zero_centered_weight,  # If true, add 1.0 to the weight
+    IS_RMS_NORM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    STORE_RESIDUAL_OUT: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    HAS_DROPOUT: tl.constexpr,
+    STORE_DROPOUT_MASK: tl.constexpr,
+    HAS_ROWSCALE: tl.constexpr,
+    HAS_X1: tl.constexpr,
+    HAS_W1: tl.constexpr,
+    HAS_B1: tl.constexpr,
+):
+    # Map the program id to the row of X and Y it should compute.
+    row = tl.program_id(0)
+    X += row * stride_x_row
+    Y += row * stride_y_row
+    if HAS_RESIDUAL:
+        RESIDUAL += row * stride_res_row
+    if STORE_RESIDUAL_OUT:
+        RESIDUAL_OUT += row * stride_res_out_row
+    if HAS_X1:
+        X1 += row * stride_x1_row
+    if HAS_W1:
+        Y1 += row * stride_y1_row
+    # Compute mean and variance
+    cols = tl.arange(0, BLOCK_N)
+    x = tl.load(X + cols, mask=cols < N, other=0.0).to(tl.float32)
+    if HAS_ROWSCALE:
+        rowscale = tl.load(ROWSCALE + row).to(tl.float32)
+        x *= rowscale
+    if HAS_DROPOUT:
+        # Compute dropout mask
+        # 7 rounds is good enough, and reduces register pressure
+        keep_mask = tl.rand(tl.load(SEEDS + row).to(tl.uint32), cols, n_rounds=7) > dropout_p
+        x = tl.where(keep_mask, x / (1.0 - dropout_p), 0.0)
+        if STORE_DROPOUT_MASK:
+            tl.store(DROPOUT_MASK + row * N + cols, keep_mask, mask=cols < N)
+    if HAS_X1:
+        x1 = tl.load(X1 + cols, mask=cols < N, other=0.0).to(tl.float32)
+        if HAS_ROWSCALE:
+            rowscale = tl.load(ROWSCALE + M + row).to(tl.float32)
+            x1 *= rowscale
+        if HAS_DROPOUT:
+            # Compute dropout mask
+            # 7 rounds is good enough, and reduces register pressure
+            keep_mask = tl.rand(tl.load(SEEDS + M + row).to(tl.uint32), cols, n_rounds=7) > dropout_p
+            x1 = tl.where(keep_mask, x1 / (1.0 - dropout_p), 0.0)
+            if STORE_DROPOUT_MASK:
+                tl.store(DROPOUT_MASK1 + row * N + cols, keep_mask, mask=cols < N)
+        x += x1
+    if HAS_RESIDUAL:
+        residual = tl.load(RESIDUAL + cols, mask=cols < N, other=0.0).to(tl.float32)
+        x += residual
+    if STORE_RESIDUAL_OUT:
+        tl.store(RESIDUAL_OUT + cols, x, mask=cols < N)
+    if not IS_RMS_NORM:
+        mean = tl.sum(x, axis=0) / N
+        tl.store(Mean + row, mean)
+        xbar = tl.where(cols < N, x - mean, 0.0)
+        var = tl.sum(xbar * xbar, axis=0) / N
+    else:
+        mean = 0.0
+        xbar = tl.where(cols < N, x, 0.0)
+        var = tl.sum(xbar * xbar, axis=0) / N
+    rstd = 1 / tl.sqrt(var + eps)
+    tl.store(Rstd + row, rstd)
+    # Normalize and apply linear transformation
+    mask = cols < N
+    if HAS_WEIGHT:
+        w = tl.load(W + cols, mask=mask).to(tl.float32)
+        if zero_centered_weight:
+            w += 1.0
+    if HAS_BIAS:
+        b = tl.load(B + cols, mask=mask).to(tl.float32)
+    x_hat = (x - mean) * rstd if not IS_RMS_NORM else x * rstd
+    if HAS_WEIGHT:
+        y = x_hat * w + b if HAS_BIAS else x_hat * w
+    else:
+        y = x_hat + b if HAS_BIAS else x_hat
+    # Write output
+    tl.store(Y + cols, y, mask=mask)
+    if HAS_W1:
+        w1 = tl.load(W1 + cols, mask=mask).to(tl.float32)
+        if zero_centered_weight:
+            w1 += 1.0
+        if HAS_B1:
+            b1 = tl.load(B1 + cols, mask=mask).to(tl.float32)
+        y1 = x_hat * w1 + b1 if HAS_B1 else x_hat * w1
+        tl.store(Y1 + cols, y1, mask=mask)


### PR DESCRIPTION
## Purpose
  Closes #3772
  Replace the no-op `LayerNorm.forward_cuda` (which previously delegated to
  `forward_native` ) with the
  [SGLang single-pass Triton 
  kernel](https://github.com/sgl-project/sglang/blob/main/python/sglang/jit_kernel/diffusion/triton/norm.py).
  
  **Key improvements:**
  - Eliminates the fp32 cast round-trip — kernel runs natively in bf16/fp16
  - Gracefully falls back to `forward_native` when the input is a CPU tensor
    or `elementwise_affine=False`
  - Kernel is vendored in `vllm_omni/diffusion/layers/sglangnorm.py`
    (Apache-2.0, adapted from sgl-project/sglang)

  ## Test Plan
  
  1. Existing CPU unit tests (no GPU required):
  
  uv run python -m pytest tests/diffusion/layers/test_norm.py -v -m cpu

  2. New CUDA-specific tests (numerical correctness + fallback behavior):
  uv run python -m pytest tests/diffusion/layers/test_norm.py -v -k "cuda"
  
  3. Micro-benchmark (kernel vs torch.compile(forward_native)):
  python benchmarks/diffusion/benchmark_layernorm.py
  
  4. End-to-end test on Qwen3-Omni.

  Test Result

  Unit tests

  tests/diffusion/layers/test_norm.py  38/38 passed  (CPU)
  tests/diffusion/layers/test_norm.py   7/7 passed  (CUDA)

 As for micro-bench, the sglang kernel (with a customized wrapper) performs an around 1.5x speed up. The following are micro-bench results:

```
Shape batch=1 seq=4096 dim=1536
torch.compile (native) : 91.34 µs
sglang kernel (Triton) : 59.55 µs

Shape batch=4 seq=4096 dim=1536
torch.compile (native) : 122.86 µs
sglang kernel (Triton) : 67.19 µs 

Shape batch=1 seq=16384 dim=1536
torch.compile (native) : 122.08 µs
sglang kernel (Triton) : 67.45 µs 

Shape batch=1 seq=4096 dim=5120
torch.compile (native) : 105.79 µs
sglang kernel (Triton) : 60.88 µs 

Shape batch=4 seq=4096 dim=5120
torch.compile (native) : 281.59 µs
sglang kernel (Triton) : 219.69 µs
```

For the e2e experiment, I've finished it on Qwen3-omni with the official example vllm-omni/examples/offline_inference/qwen3_omni/run_single_prompt.sh, along with a wrapper timing the e2e time usage of the main() function. It shows significant improvement surpassing the 1% threshold. Following are the e2e experiments results:

```
idx | Native Time (s) | Triton Time (s) | Speed Up Ratio
1 | 107.7637 | 104.1512 | 3.35 
2 | 103.7993 | 100.0336 | 3.63 
3 | 100.8628 | 99.6904  | 1.16
```

