### PR TITLE
fix(shm_connector): replace hardcoded `if True` with threshold-based branch selection

### DIFF
--- a/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/shm_connector.py
@@ -53,8 +53,8 @@ class SharedMemoryConnector(OmniConnectorBase):
             payload = self.serialize_obj(data)
             size = len(payload)
 
-            # Currently, we always use SHM.
-            if True:
+            # Use SHM for large payloads; inline transfer for small ones.
+            if size > self.threshold:
                 # Use Shared Memory
                 lock_file = f"/dev/shm/shm_{put_key}_lockfile.lock"
                 with open(lock_file, "wb+") as lockf:


### PR DESCRIPTION
## Problem

`SharedMemoryConnector.put()` contained a hardcoded `if True:` condition that permanently short-circuits the inline transfer path:

```python
# Currently, we always use SHM.
if True:
    # Use Shared Memory — always taken
    ...
else:
    # Inline path — UNREACHABLE, dead code
    metadata = {"inline_bytes": payload, "size": size}
    self._metrics["inline_writes"] += 1
```

This has two concrete consequences:

1. **`self.threshold` is initialized but never consulted.** The constructor reads `shm_threshold_bytes` from config (defaulting to 65536), stores it as `self.threshold`, and then nothing ever reads it. Any operator who tunes `shm_threshold_bytes` in their deploy config gets no effect.

2. **`self._metrics["inline_writes"]` can never increment.** The metric exists in the health report but will always be 0, making it misleading for anyone debugging transfer behavior.

## Fix

Replace the hardcoded condition with the threshold check the code was clearly designed to use:

```python
# Use SHM for large payloads; inline transfer for small ones.
if size > self.threshold:
    # Use Shared Memory
    ...
else:
    # Inline path — now reachable
    metadata = {"inline_bytes": payload, "size": size}
    self._metrics["inline_writes"] += 1
```

This restores the intended semantics:
- Payloads **above** `shm_threshold_bytes` → shared memory (avoids queue serialization overhead for large tensors)
- Payloads **below** `shm_threshold_bytes` → inline bytes in metadata (avoids SHM setup cost for small transfers)

The `get()` method already handles both `"shm"` and `"inline_bytes"` keys in metadata correctly — this fix makes `put()` consistent with what `get()` already expects and supports.

## Impact

- No behavior change for workloads where all payloads exceed the default threshold (65536 bytes), which covers most production tensor transfers
- Enables the inline path for small metadata or control messages, reducing `/dev/shm` pressure
- Makes `shm_threshold_bytes` config key functional for the first time
- `inline_writes` metric now accurately reflects transfer behavior

## Testing

Verified the fix locally by reading the surrounding `get()` implementation, which already handles both `"shm"` and `"inline_bytes"` metadata keys — confirming the `else` branch is safe to activate.

## Related

Part of the cleanup checklist in #4009 (robustness issues):
> `vllm_omni/distributed/omni_connectors/connectors/shm_connector.py` contains `if True`, leaving the inline transfer branch unreachable.
