### PR TITLE
[NPU][BugFix] Upgrade parts of ModelRunner to v0.22.0

### DIFF
--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -395,6 +395,7 @@ class NPUARModelRunner(OmniNPUModelRunner):
                     logits_indices,
                     spec_decode_metadata,
                     total_num_scheduled_tokens,
+                    num_scheduled_tokens_compressed_list,
                 ) = self._prepare_inputs(
                     scheduler_output,
                     num_scheduled_tokens_np,

--- a/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
@@ -158,6 +158,7 @@ class NPUGenerationModelRunner(OmniNPUModelRunner):
                     logits_indices,
                     spec_decode_metadata,
                     total_num_scheduled_tokens,
+                    num_scheduled_tokens_compressed_list,
                 ) = self._prepare_inputs(
                     scheduler_output,
                     num_scheduled_tokens_np,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
adapt vllm-ascend 0.22.0 model runner
## Test Plan

## Test Result
```
INFO 06-04 11:12:02 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 06-04 11:12:02 [__init__.py:46] - ascend -> vllm_ascend:register
INFO 06-04 11:12:02 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-04 11:12:02 [__init__.py:238] Platform plugin ascend is activated
WARNING 06-04 11:12:07 [patch.py:165] Monkey-patched unregister_vllm_metrics() to scope drops to non-omni vllm:* collectors. Remove this patch once vLLM adds _STAT_LOGGER_METRIC_NAMES.
/usr/local/python3.11.10/lib/python3.11/site-packages/pydub/utils.py:170: RuntimeWarning: Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work
  warn("Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work", RuntimeWarning)
INFO 06-04 11:12:08 [main.py:51] Delegating entrypoint handling to vllm-omni
2026-06-04 11:12:08,737 - 87751 - ServiceProfiler - INFO - VLLM_USE_V1 not set, auto-detected via vLLM 0.22.0+empty: default 1
WARNING 06-04 11:12:08 [registry.py:983] Model architecture DeepseekV4ForCausalLM is already registered, and will be overwritten by the new model class vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM.
WARNING 06-04 11:12:08 [registry.py:983] Model architecture DeepSeekV4MTPModel is already registered, and will be overwritten by the new model class vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP.
INFO 06-04 11:12:08 [__init__.py:115] Registered model loader `<class 'vllm_ascend.model_loader.netloader.netloader.ModelNetLoaderElastic'>` with load format `netloader`
INFO 06-04 11:12:08 [__init__.py:115] Registered model loader `<class 'vllm_ascend.model_loader.rfork.rfork_loader.RForkModelLoader'>` with load format `rfork`
WARNING 06-04 11:12:08 [registry.py:983] Model architecture Qwen2_5OmniForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni:Qwen2_5OmniForConditionalGeneration.
WARNING 06-04 11:12:08 [registry.py:983] Model architecture Qwen3OmniMoeForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_omni.qwen3_omni:Qwen3OmniMoeForConditionalGeneration.
INFO 06-04 11:12:08 [logo.py:52]        █     █     █▄   ▄█       ▄▀▀▀▀▄ █▄   ▄█ █▄    █ ▀█▀ 
INFO 06-04 11:12:08 [logo.py:52]  ▄▄ ▄█ █     █     █ ▀▄▀ █  ▄▄▄  █    █ █ ▀▄▀ █ █ ▀▄  █  █  
INFO 06-04 11:12:08 [logo.py:52]   █▄█▀ █     █     █     █       █    █ █     █ █   ▀▄█  █  
INFO 06-04 11:12:08 [logo.py:52]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀        ▀▀▀▀  ▀     ▀ ▀     ▀ ▀▀▀ 
INFO 06-04 11:12:08 [logo.py:52] 
(APIServer pid=87751) INFO 06-04 11:12:08 [utils.py:344] vLLM server version 0.22.0, serving model /home/Qwen3-TTS-12Hz-1.7B-Base
(APIServer pid=87751) INFO 06-04 11:12:08 [utils.py:278] non-default args: {'model_tag': '/home//Qwen3-TTS-12Hz-1.7B-Base', 'port': 8091, 'model': '/home//Qwen3-TTS-12Hz-1.7B-Base', 'allowed_local_media_path': '/'}
(APIServer pid=87751) INFO 06-04 11:12:08 [omni_base.py:166] [AsyncOmni] Initializing with model /home//Qwen3-TTS-12Hz-1.7B-Base
(APIServer pid=87751) INFO 06-04 11:12:08 [async_omni_engine.py:293] [AsyncOmniEngine] Initializing with model /home//Qwen3-TTS-12Hz-1.7B-Base
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:12:08 [configuration_qwen3_tts.py:487] talker_config is None. Initializing talker model with default values
(APIServer pid=87751) INFO 06-04 11:12:08 [configuration_qwen3_tts.py:490] speaker_encoder_config is None. Initializing talker model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:12:08 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:12:08 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_section', 'interleaved'}
(APIServer pid=87751) Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_section', 'interleaved'}
(APIServer pid=87751) INFO 06-04 11:12:09 [async_omni_engine.py:363] [AsyncOmniEngine] Launching Orchestrator thread with 2 stages
(APIServer pid=87751) INFO 06-04 11:12:09 [initialization.py:364] Loaded OmniTransferConfig with 1 connector configurations
(APIServer pid=87751) WARNING 06-04 11:12:09 [envs.py:2057] Unknown vLLM environment variable detected: VLLM_VERSION
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2_5OmniForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni:Qwen2_5OmniForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2_5OmniThinkerModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_thinker:Qwen2_5OmniThinkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2_5OmniTalkerModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_talker:Qwen2_5OmniTalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2_5OmniToken2WavModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_token2wav:Qwen2_5OmniToken2WavForConditionalGenerationVLLM.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2_5OmniToken2WavDiTModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_token2wav:Qwen2_5OmniToken2WavModel.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2ForCausalLM_old is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_old:Qwen2ForCausalLM.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3OmniMoeForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_omni.qwen3_omni:Qwen3OmniMoeForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3OmniMoeThinkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_moe_thinker:Qwen3OmniMoeThinkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3OmniMoeTalkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_moe_talker:Qwen3OmniMoeTalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3OmniMoeCode2Wav is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_code2wav:Qwen3OmniMoeCode2Wav.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CosyVoice3Model is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.cosyvoice3.cosyvoice3:CosyVoice3Model.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture OmniVoiceModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.omnivoice.omnivoice:OmniVoiceModel.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MammothModa2Qwen2ForCausalLM is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mammoth_moda2.mammoth_moda2:MammothModa2Qwen2ForCausalLM.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MammothModa2ARForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mammoth_moda2.mammoth_moda2:MammothModa2ARForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MammothModa2DiTPipeline is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mammoth_moda2.pipeline_mammothmoda2_dit:MammothModa2DiTPipeline.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MammothModa2ForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mammoth_moda2.mammoth_moda2:MammothModa2ForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Mammothmoda2Model is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mammoth_moda2.mammoth_moda2:MammothModa2ForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3TTSForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_talker:Qwen3TTSTalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3TTSTalkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_talker:Qwen3TTSTalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3TTSCode2Wav is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_code2wav:Qwen3TTSCode2Wav.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture HiggsAudioV2ForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.higgs_audio_v2.higgs_audio_v2_talker:HiggsAudioV2TalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture HiggsAudioV2TalkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.higgs_audio_v2.higgs_audio_v2_talker:HiggsAudioV2TalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture HiggsAudioV2Code2WavForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.higgs_audio_v2.higgs_audio_v2_code2wav:HiggsAudioV2Code2WavForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiMoAudioModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mimo_audio.mimo_audio:MiMoAudioForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiMoV2ASRForCausalLM is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mimo_audio.mimo_audio:MiMoAudioForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiMoAudioLLMModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mimo_audio.mimo_audio_llm:MiMoAudioLLMForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiMoAudioToken2WavModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mimo_audio.mimo_audio_code2wav:MiMoAudioToken2WavForConditionalGenerationVLLM.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture GlmImageForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.glm_image.glm_image_ar:GlmImageForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture GLMTTSForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.glm_tts.glm_tts:GLMTTSForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture OmniBagelForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.bagel.bagel:OmniBagelForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture HunyuanImage3ForCausalMM is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3:HunyuanImage3ForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture FishSpeechSlowARForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.fish_speech.fish_speech_slow_ar:FishSpeechSlowARForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture FishSpeechDACDecoder is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.fish_speech.fish_speech_dac_decoder:FishSpeechDACDecoder.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture VoxCPM2TalkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.voxcpm2.voxcpm2_talker:VoxCPM2TalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture VoxtralTTSForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.voxtral_tts.voxtral_tts:VoxtralTTSForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture VoxtralTTSAudioGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.voxtral_tts.voxtral_tts_audio_generation:VoxtralTTSAudioGenerationForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture VoxtralTTSAudioTokenizer is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.voxtral_tts.voxtral_tts_audio_tokenizer:VoxtralTTSAudioTokenizer.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CovoAudioForCausalLM is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.covo_audio.covo_audio:CovoAudioForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CovoAudioForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.covo_audio.covo_audio:CovoAudioForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CovoAudioModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.covo_audio.covo_audio:CovoAudioForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CovoAudioLLMModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.covo_audio.covo_audio_llm:CovoAudioLLMForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CovoAudioCode2WavModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.covo_audio.covo_audio_code2wav:CovoAudioCode2WavForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MossTTSNanoForCausalLM is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.moss_tts_nano.modeling_moss_tts_nano:MossTTSNanoForGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MossTTSDelayModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker:MossTTSDelayTalkerForGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MossTTSRealtime is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker:MossTTSRealtimeTalkerForGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MossTTSCodecDecoder is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_codec:MossTTSCodecDecoder.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture DyninOmniForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.dynin_omni.dynin_omni:DyninOmniForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MingFlashOmniForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni:MingFlashOmniForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MingFlashOmniThinkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni_thinker:MingFlashOmniThinkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MingFlashOmniTalkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni_talker:MingFlashOmniTalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture BailingMM2NativeForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni:MingFlashOmniForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiniCPMO45OmniForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni:MiniCPMO45OmniForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiniCPMO45OmniLLMForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_llm:MiniCPMO45OmniLLMForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiniCPMO45OmniTTSForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_tts:MiniCPMO45OmniTTSForConditionalGeneration.
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:12:09 [configuration_qwen3_tts.py:487] talker_config is None. Initializing talker model with default values
(APIServer pid=87751) INFO 06-04 11:12:09 [configuration_qwen3_tts.py:490] speaker_encoder_config is None. Initializing talker model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:12:09 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:12:09 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_section', 'interleaved'}
(APIServer pid=87751) Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_section', 'interleaved'}
(APIServer pid=87751) INFO 06-04 11:12:09 [model.py:617] Resolved architecture: Qwen3TTSTalkerForConditionalGeneration
(APIServer pid=87751) INFO 06-04 11:12:09 [model.py:1752] Using max model len 4096
(APIServer pid=87751) INFO 06-04 11:12:09 [scheduler.py:239] Chunked prefill is enabled with max_num_batched_tokens=512.
(APIServer pid=87751) INFO 06-04 11:12:09 [vllm.py:977] Asynchronous scheduling is disabled.
(APIServer pid=87751) WARNING 06-04 11:12:09 [vllm.py:1033] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(APIServer pid=87751) WARNING 06-04 11:12:09 [vllm.py:1058] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(APIServer pid=87751) INFO 06-04 11:12:09 [kernel.py:270] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(APIServer pid=87751) INFO 06-04 11:12:09 [vllm.py:1234] Cudagraph is disabled under eager mode
(APIServer pid=87751) INFO 06-04 11:12:09 [utils.py:169] No quantization signature detected from model files for "/home//Qwen3-TTS-12Hz-1.7B-Base". The model will be loaded as float. To force a quantization method, pass "--quantization <method>" explicitly.
(APIServer pid=87751) WARNING 06-04 11:12:09 [platform.py:840] Parameter '--disable-cascade-attn' is a GPU-specific feature. Resetting to False for Ascend.
(APIServer pid=87751) INFO 06-04 11:12:09 [ascend_config.py:682] Dynamic EPLB is False
(APIServer pid=87751) INFO 06-04 11:12:09 [ascend_config.py:683] The number of redundant experts is 0
(APIServer pid=87751) INFO 06-04 11:12:09 [platform.py:338] Compilation disabled, using eager mode by default
(APIServer pid=87751) INFO 06-04 11:12:09 [utils.py:1338] Block size is set to 128 if prefix cache or chunked prefill is enabled.
(APIServer pid=87751) INFO 06-04 11:12:09 [platform.py:563] Set PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
(APIServer pid=87751) INFO 06-04 11:12:09 [compilation.py:312] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=87751) WARNING 06-04 11:12:09 [envs.py:2057] Unknown vLLM environment variable detected: VLLM_VERSION
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2_5OmniForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni:Qwen2_5OmniForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2_5OmniThinkerModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_thinker:Qwen2_5OmniThinkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2_5OmniTalkerModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_talker:Qwen2_5OmniTalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2_5OmniToken2WavModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_token2wav:Qwen2_5OmniToken2WavForConditionalGenerationVLLM.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2_5OmniToken2WavDiTModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_token2wav:Qwen2_5OmniToken2WavModel.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen2ForCausalLM_old is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_old:Qwen2ForCausalLM.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3OmniMoeForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_omni.qwen3_omni:Qwen3OmniMoeForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3OmniMoeThinkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_moe_thinker:Qwen3OmniMoeThinkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3OmniMoeTalkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_moe_talker:Qwen3OmniMoeTalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3OmniMoeCode2Wav is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_code2wav:Qwen3OmniMoeCode2Wav.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CosyVoice3Model is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.cosyvoice3.cosyvoice3:CosyVoice3Model.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture OmniVoiceModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.omnivoice.omnivoice:OmniVoiceModel.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MammothModa2Qwen2ForCausalLM is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mammoth_moda2.mammoth_moda2:MammothModa2Qwen2ForCausalLM.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MammothModa2ARForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mammoth_moda2.mammoth_moda2:MammothModa2ARForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MammothModa2DiTPipeline is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mammoth_moda2.pipeline_mammothmoda2_dit:MammothModa2DiTPipeline.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MammothModa2ForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mammoth_moda2.mammoth_moda2:MammothModa2ForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Mammothmoda2Model is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mammoth_moda2.mammoth_moda2:MammothModa2ForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3TTSForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_talker:Qwen3TTSTalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3TTSTalkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_talker:Qwen3TTSTalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture Qwen3TTSCode2Wav is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_code2wav:Qwen3TTSCode2Wav.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture HiggsAudioV2ForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.higgs_audio_v2.higgs_audio_v2_talker:HiggsAudioV2TalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture HiggsAudioV2TalkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.higgs_audio_v2.higgs_audio_v2_talker:HiggsAudioV2TalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture HiggsAudioV2Code2WavForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.higgs_audio_v2.higgs_audio_v2_code2wav:HiggsAudioV2Code2WavForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiMoAudioModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mimo_audio.mimo_audio:MiMoAudioForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiMoV2ASRForCausalLM is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mimo_audio.mimo_audio:MiMoAudioForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiMoAudioLLMModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mimo_audio.mimo_audio_llm:MiMoAudioLLMForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiMoAudioToken2WavModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.mimo_audio.mimo_audio_code2wav:MiMoAudioToken2WavForConditionalGenerationVLLM.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture GlmImageForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.glm_image.glm_image_ar:GlmImageForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture GLMTTSForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.glm_tts.glm_tts:GLMTTSForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture OmniBagelForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.bagel.bagel:OmniBagelForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture HunyuanImage3ForCausalMM is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3:HunyuanImage3ForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture FishSpeechSlowARForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.fish_speech.fish_speech_slow_ar:FishSpeechSlowARForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture FishSpeechDACDecoder is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.fish_speech.fish_speech_dac_decoder:FishSpeechDACDecoder.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture VoxCPM2TalkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.voxcpm2.voxcpm2_talker:VoxCPM2TalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture VoxtralTTSForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.voxtral_tts.voxtral_tts:VoxtralTTSForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture VoxtralTTSAudioGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.voxtral_tts.voxtral_tts_audio_generation:VoxtralTTSAudioGenerationForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture VoxtralTTSAudioTokenizer is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.voxtral_tts.voxtral_tts_audio_tokenizer:VoxtralTTSAudioTokenizer.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CovoAudioForCausalLM is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.covo_audio.covo_audio:CovoAudioForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CovoAudioForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.covo_audio.covo_audio:CovoAudioForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CovoAudioModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.covo_audio.covo_audio:CovoAudioForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CovoAudioLLMModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.covo_audio.covo_audio_llm:CovoAudioLLMForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture CovoAudioCode2WavModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.covo_audio.covo_audio_code2wav:CovoAudioCode2WavForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MossTTSNanoForCausalLM is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.moss_tts_nano.modeling_moss_tts_nano:MossTTSNanoForGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MossTTSDelayModel is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker:MossTTSDelayTalkerForGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MossTTSRealtime is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_talker:MossTTSRealtimeTalkerForGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MossTTSCodecDecoder is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.moss_tts.modeling_moss_tts_codec:MossTTSCodecDecoder.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture DyninOmniForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.dynin_omni.dynin_omni:DyninOmniForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MingFlashOmniForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni:MingFlashOmniForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MingFlashOmniThinkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni_thinker:MingFlashOmniThinkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MingFlashOmniTalkerForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni_talker:MingFlashOmniTalkerForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture BailingMM2NativeForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.ming_flash_omni.ming_flash_omni:MingFlashOmniForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiniCPMO45OmniForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni:MiniCPMO45OmniForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiniCPMO45OmniLLMForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_llm:MiniCPMO45OmniLLMForConditionalGeneration.
(APIServer pid=87751) WARNING 06-04 11:12:09 [registry.py:983] Model architecture MiniCPMO45OmniTTSForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.minicpmo_4_5.minicpmo_4_5_omni_tts:MiniCPMO45OmniTTSForConditionalGeneration.
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:12:09 [configuration_qwen3_tts.py:487] talker_config is None. Initializing talker model with default values
(APIServer pid=87751) INFO 06-04 11:12:09 [configuration_qwen3_tts.py:490] speaker_encoder_config is None. Initializing talker model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:12:09 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:12:09 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) INFO 06-04 11:12:20 [model.py:617] Resolved architecture: Qwen3TTSCode2Wav
(APIServer pid=87751) INFO 06-04 11:12:20 [model.py:1752] Using max model len 65536
(APIServer pid=87751) INFO 06-04 11:12:20 [scheduler.py:239] Chunked prefill is enabled with max_num_batched_tokens=65536.
(APIServer pid=87751) WARNING 06-04 11:12:20 [vllm.py:1033] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(APIServer pid=87751) WARNING 06-04 11:12:20 [vllm.py:1058] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(APIServer pid=87751) INFO 06-04 11:12:20 [kernel.py:270] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(APIServer pid=87751) INFO 06-04 11:12:20 [vllm.py:1234] Cudagraph is disabled under eager mode
(APIServer pid=87751) INFO 06-04 11:12:20 [utils.py:169] No quantization signature detected from model files for "/home//Qwen3-TTS-12Hz-1.7B-Base". The model will be loaded as float. To force a quantization method, pass "--quantization <method>" explicitly.
(APIServer pid=87751) WARNING 06-04 11:12:20 [platform.py:840] Parameter '--disable-cascade-attn' is a GPU-specific feature. Resetting to False for Ascend.
(APIServer pid=87751) INFO 06-04 11:12:20 [platform.py:338] Compilation disabled, using eager mode by default
(APIServer pid=87751) INFO 06-04 11:12:20 [utils.py:1338] Block size is set to 128 if prefix cache or chunked prefill is enabled.
(APIServer pid=87751) INFO 06-04 11:12:20 [platform.py:563] Set PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
(APIServer pid=87751) INFO 06-04 11:12:20 [stage_init_utils.py:654] [stage_init] Stage-0 set runtime devices: 0
(APIServer pid=87751) INFO 06-04 11:12:20 [async_omni_engine.py:924] [AsyncOmniEngine] Stage 0 engine launch started
(APIServer pid=87751) INFO 06-04 11:12:20 [stage_init_utils.py:654] [stage_init] Stage-1 set runtime devices: 0
INFO 06-04 11:12:24 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 06-04 11:12:24 [__init__.py:46] - ascend -> vllm_ascend:register
INFO 06-04 11:12:24 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-04 11:12:24 [__init__.py:238] Platform plugin ascend is activated

WARNING 06-04 11:12:28 [patch.py:165] Monkey-patched unregister_vllm_metrics() to scope drops to non-omni vllm:* collectors. Remove this patch once vLLM adds _STAT_LOGGER_METRIC_NAMES.

(StageEngineCoreProc pid=88278) 2026-06-04 11:12:29,448 - 88278 - ServiceProfiler - INFO - VLLM_USE_V1 not set, auto-detected via vLLM 0.22.0+empty: default 1
(StageEngineCoreProc pid=88278) WARNING 06-04 11:12:30 [registry.py:983] Model architecture DeepseekV4ForCausalLM is already registered, and will be overwritten by the new model class vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM.
(StageEngineCoreProc pid=88278) WARNING 06-04 11:12:30 [registry.py:983] Model architecture DeepSeekV4MTPModel is already registered, and will be overwritten by the new model class vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP.
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:30 [__init__.py:115] Registered model loader `<class 'vllm_ascend.model_loader.netloader.netloader.ModelNetLoaderElastic'>` with load format `netloader`
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:30 [__init__.py:115] Registered model loader `<class 'vllm_ascend.model_loader.rfork.rfork_loader.RForkModelLoader'>` with load format `rfork`
(StageEngineCoreProc pid=88278) WARNING 06-04 11:12:30 [registry.py:983] Model architecture Qwen2_5OmniForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni:Qwen2_5OmniForConditionalGeneration.
(StageEngineCoreProc pid=88278) WARNING 06-04 11:12:30 [registry.py:983] Model architecture Qwen3OmniMoeForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_omni.qwen3_omni:Qwen3OmniMoeForConditionalGeneration.
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:30 [core.py:112] Initializing a V1 LLM engine (v0.22.0) with config: model='/home//Qwen3-TTS-12Hz-1.7B-Base', speculative_config=None, tokenizer='/home//Qwen3-TTS-12Hz-1.7B-Base', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=True, quantization=None, quantization_config=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=npu, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=/home//Qwen3-TTS-12Hz-1.7B-Base, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'vllm_ascend.compilation.compiler_interface.AscendCompiler', 'custom_ops': ['all'], 'ir_enable_torch_wrap': False, 'splitting_ops': [], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [512], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto')
(StageEngineCoreProc pid=88278) `Qwen2VLImageProcessorFast` is deprecated. The `Fast` suffix for image processors has been removed; use `Qwen2VLImageProcessor` instead.
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:31 [ascend_config.py:682] Dynamic EPLB is False
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:31 [ascend_config.py:683] The number of redundant experts is 0
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:32 [parallel_state.py:1422] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.4:50077 backend=hccl
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:32 [parallel_state.py:1735] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:32 [model_runner_v1.py:3385] Starting to load model /home//Qwen3-TTS-12Hz-1.7B-Base...
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:33 [qwen3_code_predictor.py:479] code_predictor: prefix CUDA graphs requested but disabled because use_cuda_graphs=True is_npu=True
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:33 [configuration_qwen3_tts_tokenizer_v2.py:156] encoder_config is None. Initializing encoder with default values
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:33 [configuration_qwen3_tts_tokenizer_v2.py:159] decoder_config is None. Initializing decoder with default values
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:33 [speaker_cache.py:242] Speaker cache ready (max_bytes=536870912)
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:33 [weight_utils.py:922] Filesystem type for checkpoints: EXT4. Checkpoint size: 3.59 GiB. Available RAM: 2944.75 GiB.
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:33 [weight_utils.py:945] Auto-prefetch is disabled because the filesystem (EXT4) is not a recognized network FS (NFS/Lustre). If you want to force prefetching, start vLLM with --safetensors-load-strategy=prefetch.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.74it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  1.74it/s]
(StageEngineCoreProc pid=88278) 
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:34 [weight_utils.py:922] Filesystem type for checkpoints: EXT4. Checkpoint size: 0.64 GiB. Available RAM: 2944.71 GiB.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.26it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.26it/s]
(StageEngineCoreProc pid=88278) 
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:34 [weight_utils.py:922] Filesystem type for checkpoints: EXT4. Checkpoint size: 0.64 GiB. Available RAM: 2944.69 GiB.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  6.52it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  6.51it/s]
(StageEngineCoreProc pid=88278) 
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:35 [qwen3_tts_talker.py:993] Loaded 621 weights for Qwen3TTSTalkerForConditionalGeneration
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:35 [default_loader.py:397] Loading weights took 1.57 seconds
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:35 [model_runner_v1.py:3432] Loading model weights took 3.8655 GB
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:37 [worker.py:397] Available KV cache memory: 14.46 GiB
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:37 [kv_cache_utils.py:1733] GPU KV cache size: 135,296 tokens
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:37 [kv_cache_utils.py:1734] Maximum concurrency for 4,096 tokens per request: 33.03x
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:37 [worker.py:561] Free memory on device (60.88/61.27 GiB) on startup. Desired GPU memory utilization is (0.3, 18.38 GiB). Actual usage: 3.87 GiB for weights, 0.04 GiB for peak activation, 0.02 GiB for non-torch memory, 0.0 GiB for NPU graph memory. Replace gpu_memory_utilization with `--kv-cache-memory=15365583872` (14.31 GiB) to fit into requested memory, or `--kv-cache-memory=60993729536` (56.8 GiB) to fully utilize NPU free memory. Current KV cache memory: 14.46 GiB.
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:40 [cpu_binding.py:328] [cpu_bind_mode] mode=global_slice rank=0 visible_npus=[0]
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:40 [cpu_binding.py:388] The CPU allocation plan is as follows:
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:40 [cpu_binding.py:393] NPU0: main=[2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37]  acl=[38]  release=[[39]]
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:40 [cpu_binding.py:415] [migrate] NPU:0 -> NUMA [0]
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [cpu_binding.py:510] NPU0(PCI 0000:9d:00.0): sq_send_trigger_irq IRQ_ID=1749 -> CPU0, cq_update_irq IRQ_ID=1750 -> CPU1
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [core.py:309] init engine (profile, create kv cache, warmup model) took 7.17 s
(StageEngineCoreProc pid=88278) /usr/local/python3.11.10/lib/python3.11/site-packages/transformers/modeling_rope_utils.py:1032: FutureWarning: `rope_config_validation` is deprecated and has been removed. Its functionality has been moved to RotaryEmbeddingConfigMixin.validate_rope method. PreTrainedConfig inherits this class, so please call self.validate_rope() instead. Also, make sure to use the new rope_parameters syntax. You can call self.standardize_rope_params() in the meantime.
(StageEngineCoreProc pid=88278)   warnings.warn(
(StageEngineCoreProc pid=88278) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [configuration_qwen3_tts.py:487] talker_config is None. Initializing talker model with default values
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [configuration_qwen3_tts.py:490] speaker_encoder_config is None. Initializing talker model with default values
(StageEngineCoreProc pid=88278) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(StageEngineCoreProc pid=88278) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(StageEngineCoreProc pid=88278) Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'interleaved', 'mrope_section'}
(StageEngineCoreProc pid=88278) Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'interleaved', 'mrope_section'}
(StageEngineCoreProc pid=88278) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [configuration_qwen3_tts.py:487] talker_config is None. Initializing talker model with default values
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [configuration_qwen3_tts.py:490] speaker_encoder_config is None. Initializing talker model with default values
(StageEngineCoreProc pid=88278) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(StageEngineCoreProc pid=88278) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(StageEngineCoreProc pid=88278) The tokenizer you are loading from '/home//Qwen3-TTS-12Hz-1.7B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(StageEngineCoreProc pid=88278) WARNING 06-04 11:12:43 [scheduler.py:181] Using custom scheduler class vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler. This scheduler interface is not public and compatibility may not be maintained.
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [factory.py:46] Created connector: SharedMemoryConnector
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [vllm.py:977] Asynchronous scheduling is disabled.
(StageEngineCoreProc pid=88278) WARNING 06-04 11:12:43 [vllm.py:1033] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(StageEngineCoreProc pid=88278) WARNING 06-04 11:12:43 [vllm.py:1058] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(APIServer pid=87751) INFO 06-04 11:12:43 [async_omni_engine.py:940] [AsyncOmniEngine] Stage 0 engine startup completed
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [kernel.py:270] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [vllm.py:1234] Cudagraph is disabled under eager mode
(APIServer pid=87751) INFO 06-04 11:12:43 [stage_engine_core_client.py:171] [StageEngineCoreClient] stage-0 [rep-0] initializing EngineCore
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [utils.py:169] No quantization signature detected from model files for "/home//Qwen3-TTS-12Hz-1.7B-Base". The model will be loaded as float. To force a quantization method, pass "--quantization <method>" explicitly.
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [platform.py:338] Compilation disabled, using eager mode by default
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [platform.py:563] Set PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
(StageEngineCoreProc pid=88278) INFO 06-04 11:12:43 [compilation.py:312] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=87751) INFO 06-04 11:12:43 [stage_engine_core_client.py:214] [StageEngineCoreClient] stage-0 [rep-0] EngineCore running
(APIServer pid=87751) INFO 06-04 11:12:43 [async_omni_engine.py:961] [AsyncOmniEngine] Stage 0 initialized
(APIServer pid=87751) INFO 06-04 11:12:43 [async_omni_engine.py:924] [AsyncOmniEngine] Stage 1 engine launch started
INFO 06-04 11:12:48 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 06-04 11:12:48 [__init__.py:46] - ascend -> vllm_ascend:register
INFO 06-04 11:12:48 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-04 11:12:48 [__init__.py:238] Platform plugin ascend is activated
WARNING 06-04 11:12:52 [patch.py:165] Monkey-patched unregister_vllm_metrics() to scope drops to non-omni vllm:* collectors. Remove this patch once vLLM adds _STAT_LOGGER_METRIC_NAMES.
(StageEngineCoreProc pid=89297) 2026-06-04 11:12:53,654 - 89297 - ServiceProfiler - INFO - VLLM_USE_V1 not set, auto-detected via vLLM 0.22.0+empty: default 1
(StageEngineCoreProc pid=89297) WARNING 06-04 11:12:54 [registry.py:983] Model architecture DeepseekV4ForCausalLM is already registered, and will be overwritten by the new model class vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM.
(StageEngineCoreProc pid=89297) WARNING 06-04 11:12:54 [registry.py:983] Model architecture DeepSeekV4MTPModel is already registered, and will be overwritten by the new model class vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP.
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:54 [__init__.py:115] Registered model loader `<class 'vllm_ascend.model_loader.netloader.netloader.ModelNetLoaderElastic'>` with load format `netloader`
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:54 [__init__.py:115] Registered model loader `<class 'vllm_ascend.model_loader.rfork.rfork_loader.RForkModelLoader'>` with load format `rfork`
(StageEngineCoreProc pid=89297) WARNING 06-04 11:12:54 [registry.py:983] Model architecture Qwen2_5OmniForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni:Qwen2_5OmniForConditionalGeneration.
(StageEngineCoreProc pid=89297) WARNING 06-04 11:12:54 [registry.py:983] Model architecture Qwen3OmniMoeForConditionalGeneration is already registered, and will be overwritten by the new model class vllm_omni.model_executor.models.qwen3_omni.qwen3_omni:Qwen3OmniMoeForConditionalGeneration.
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:54 [core.py:112] Initializing a V1 LLM engine (v0.22.0) with config: model='/home//Qwen3-TTS-12Hz-1.7B-Base', speculative_config=None, tokenizer='/home//Qwen3-TTS-12Hz-1.7B-Base', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=65536, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=True, quantization=None, quantization_config=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=npu, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=/home//Qwen3-TTS-12Hz-1.7B-Base, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'vllm_ascend.compilation.compiler_interface.AscendCompiler', 'custom_ops': ['all'], 'ir_enable_torch_wrap': False, 'splitting_ops': [], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [65536], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 0, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto')
(StageEngineCoreProc pid=89297) `Qwen2VLImageProcessorFast` is deprecated. The `Fast` suffix for image processors has been removed; use `Qwen2VLImageProcessor` instead.
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:55 [ascend_config.py:682] Dynamic EPLB is False
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:55 [ascend_config.py:683] The number of redundant experts is 0
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:56 [parallel_state.py:1422] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.4:42561 backend=hccl
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:56 [parallel_state.py:1735] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:57 [model_runner_v1.py:3385] Starting to load model /home//Qwen3-TTS-12Hz-1.7B-Base...
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:57 [configuration_qwen3_tts_tokenizer_v2.py:156] encoder_config is None. Initializing encoder with default values
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:57 [configuration_qwen3_tts_tokenizer_v2.py:159] decoder_config is None. Initializing decoder with default values
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:57 [weight_utils.py:922] Filesystem type for checkpoints: EXT4. Checkpoint size: 3.59 GiB. Available RAM: 2930.61 GiB.
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:57 [weight_utils.py:945] Auto-prefetch is disabled because the filesystem (EXT4) is not a recognized network FS (NFS/Lustre). If you want to force prefetching, start vLLM with --safetensors-load-strategy=prefetch.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00, 61.16it/s]
(StageEngineCoreProc pid=89297) 
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:57 [weight_utils.py:922] Filesystem type for checkpoints: EXT4. Checkpoint size: 0.64 GiB. Available RAM: 2930.61 GiB.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.09it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  2.09it/s]
(StageEngineCoreProc pid=89297) 
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:58 [modeling_qwen3_tts_tokenizer_v2.py:856] Precomputed exp caches for 29 SnakeBeta activations
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:58 [default_loader.py:397] Loading weights took 0.57 seconds
(StageEngineCoreProc pid=89297) INFO 06-04 11:12:59 [model_runner_v1.py:3432] Loading model weights took 0.4261 GB
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:02 [cpu_binding.py:328] [cpu_bind_mode] mode=global_slice rank=0 visible_npus=[0]
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:02 [cpu_binding.py:388] The CPU allocation plan is as follows:
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:02 [cpu_binding.py:393] NPU0: main=[2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37]  acl=[38]  release=[[39]]
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:02 [cpu_binding.py:415] [migrate] NPU:0 -> NUMA [0]
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:05 [cpu_binding.py:510] NPU0(PCI 0000:9d:00.0): sq_send_trigger_irq IRQ_ID=1749 -> CPU0, cq_update_irq IRQ_ID=1750 -> CPU1
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:05 [core.py:309] init engine (profile, create kv cache, warmup model) took 6.35 s
(StageEngineCoreProc pid=89297) /usr/local/python3.11.10/lib/python3.11/site-packages/transformers/modeling_rope_utils.py:1032: FutureWarning: `rope_config_validation` is deprecated and has been removed. Its functionality has been moved to RotaryEmbeddingConfigMixin.validate_rope method. PreTrainedConfig inherits this class, so please call self.validate_rope() instead. Also, make sure to use the new rope_parameters syntax. You can call self.standardize_rope_params() in the meantime.
(StageEngineCoreProc pid=89297)   warnings.warn(
(StageEngineCoreProc pid=89297) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:05 [configuration_qwen3_tts.py:487] talker_config is None. Initializing talker model with default values
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:05 [configuration_qwen3_tts.py:490] speaker_encoder_config is None. Initializing talker model with default values
(StageEngineCoreProc pid=89297) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:05 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(StageEngineCoreProc pid=89297) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:05 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(StageEngineCoreProc pid=89297) Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'interleaved', 'mrope_section'}
(StageEngineCoreProc pid=89297) Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'interleaved', 'mrope_section'}
(StageEngineCoreProc pid=89297) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:05 [configuration_qwen3_tts.py:487] talker_config is None. Initializing talker model with default values
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:05 [configuration_qwen3_tts.py:490] speaker_encoder_config is None. Initializing talker model with default values
(StageEngineCoreProc pid=89297) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:05 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(StageEngineCoreProc pid=89297) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:05 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(StageEngineCoreProc pid=89297) The tokenizer you are loading from '/home//Qwen3-TTS-12Hz-1.7B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(StageEngineCoreProc pid=89297) WARNING 06-04 11:13:05 [scheduler.py:181] Using custom scheduler class vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler. This scheduler interface is not public and compatibility may not be maintained.
(StageEngineCoreProc pid=89297) WARNING 06-04 11:13:05 [core.py:141] Disabling chunked prefill for model without KVCache
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:05 [factory.py:46] Created connector: SharedMemoryConnector
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:06 [vllm.py:977] Asynchronous scheduling is disabled.
(StageEngineCoreProc pid=89297) WARNING 06-04 11:13:06 [vllm.py:1033] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(StageEngineCoreProc pid=89297) WARNING 06-04 11:13:06 [vllm.py:1058] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:06 [kernel.py:270] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(APIServer pid=87751) INFO 06-04 11:13:06 [async_omni_engine.py:940] [AsyncOmniEngine] Stage 1 engine startup completed
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:06 [vllm.py:1234] Cudagraph is disabled under eager mode
(APIServer pid=87751) INFO 06-04 11:13:06 [stage_engine_core_client.py:171] [StageEngineCoreClient] stage-1 [rep-0] initializing EngineCore
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:06 [utils.py:169] No quantization signature detected from model files for "/home//Qwen3-TTS-12Hz-1.7B-Base". The model will be loaded as float. To force a quantization method, pass "--quantization <method>" explicitly.
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:06 [platform.py:338] Compilation disabled, using eager mode by default
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:06 [platform.py:563] Set PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
(StageEngineCoreProc pid=89297) INFO 06-04 11:13:06 [compilation.py:312] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=87751) INFO 06-04 11:13:06 [stage_engine_core_client.py:214] [StageEngineCoreClient] stage-1 [rep-0] EngineCore running
(APIServer pid=87751) INFO 06-04 11:13:06 [async_omni_engine.py:961] [AsyncOmniEngine] Stage 1 initialized
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:13:06 [configuration_qwen3_tts.py:487] talker_config is None. Initializing talker model with default values
(APIServer pid=87751) INFO 06-04 11:13:06 [configuration_qwen3_tts.py:490] speaker_encoder_config is None. Initializing talker model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:13:06 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:13:06 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_section', 'interleaved'}
(APIServer pid=87751) Unrecognized keys in `rope_parameters` for 'rope_type'='default': {'mrope_section', 'interleaved'}
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:13:06 [configuration_qwen3_tts.py:487] talker_config is None. Initializing talker model with default values
(APIServer pid=87751) INFO 06-04 11:13:06 [configuration_qwen3_tts.py:490] speaker_encoder_config is None. Initializing talker model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:13:06 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:13:06 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) The tokenizer you are loading from '/home//Qwen3-TTS-12Hz-1.7B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(APIServer pid=87751) INFO 06-04 11:13:09 [orchestrator.py:299] [Orchestrator] Starting event loop
(APIServer pid=87751) INFO 06-04 11:13:09 [async_omni_engine.py:390] [AsyncOmniEngine] Orchestrator ready with 2 stages
(APIServer pid=87751) INFO 06-04 11:13:09 [omni_base.py:184] [AsyncOmni] AsyncOmniEngine initialized in 60.62 seconds
(APIServer pid=87751) INFO 06-04 11:13:09 [omni_base.py:203] [AsyncOmni] Initialized with 2 stages for model /home//Qwen3-TTS-12Hz-1.7B-Base
(APIServer pid=87751) INFO 06-04 11:13:09 [api_server.py:745] Supported tasks: {'speech', 'generate'}
(APIServer pid=87751) WARNING 06-04 11:13:09 [model.py:1509] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'repetition_penalty': 1.05, 'temperature': 0.9, 'top_k': 50, 'top_p': 1.0, 'max_tokens': 8192}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:13:09 [configuration_qwen3_tts.py:487] talker_config is None. Initializing talker model with default values
(APIServer pid=87751) INFO 06-04 11:13:09 [configuration_qwen3_tts.py:490] speaker_encoder_config is None. Initializing talker model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:13:09 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) `layer_type_validation` is deprecated and will be removed in v5.20. Use `PreTrainedConfig.validate_layer_type` instead
(APIServer pid=87751) INFO 06-04 11:13:09 [configuration_qwen3_tts.py:441] code_predictor_config is None. Initializing code_predictor model with default values
(APIServer pid=87751) The tokenizer you are loading from '/home//Qwen3-TTS-12Hz-1.7B-Base' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
(APIServer pid=87751) INFO 06-04 11:13:10 [hf.py:488] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=87751) INFO 06-04 11:13:10 [speaker_cache.py:242] Speaker cache ready (max_bytes=536870912)
(APIServer pid=87751) INFO 06-04 11:13:10 [serving_speech.py:287] Speaker storage: dir=/root/.cache/vllm-omni/speakers, max_speakers=1000, restored=0
(APIServer pid=87751) WARNING 06-04 11:13:10 [serving_speech.py:686] No speakers found in config (checked spk_id and speaker_id)
(APIServer pid=87751) INFO 06-04 11:13:10 [serving_speech.py:438] Loaded 0 supported speakers: []
(APIServer pid=87751) INFO 06-04 11:13:10 [serving_speech.py:529] Loaded codec frame rate: 12.5 Hz (output_sample_rate=24000, encode_downsample_rate=1920)
(APIServer pid=87751) INFO 06-04 11:13:10 [serving.py:45] OpenAIServingRealtime initialized for task: realtime
(APIServer pid=87751) INFO 06-04 11:13:10 [api_server.py:475] Starting vLLM API server 0 on http://0.0.0.0:8091
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:37] Available routes are:
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/chat/completions/batch, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /generative_scoring, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/audio/speech, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/audio/speech/batch, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/audio/generate, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/audio/voices, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/audio/voices, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/audio/voices/{name}, Methods: DELETE
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/images/generations, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/images/edits, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/videos, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/videos/sync, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/videos, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/videos/{video_id}, Methods: DELETE
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/videos/{video_id}/content, Methods: GET
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/omni/sleep, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:46] Route: /v1/omni/wakeup, Methods: POST
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:57] Route: /v1/audio/speech/stream, Endpoint: streaming_speech
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:57] Route: /v1/video/chat/stream, Endpoint: streaming_video_chat
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:57] Route: /v1/realtime, Endpoint: realtime_websocket
(APIServer pid=87751) INFO 06-04 11:13:10 [launcher.py:57] Route: /v1/realtime/robot/openpi, Endpoint: realtime_robot_openpi
(APIServer pid=87751) INFO:     Started server process [87751]
(APIServer pid=87751) INFO:     Waiting for application startup.
(APIServer pid=87751) INFO:     Application startup complete.
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
