### PR TITLE
[Bugfix][NPU] Fix NPU diffusion worker VllmConfig initialization

### DIFF
--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -144,14 +144,16 @@ def _create_diffusion_worker_vllm_config(device: torch.device, od_config: OmniDi
         config_kwargs["additional_config"] = od_config.additional_config
 
     try:
-        return VllmConfig(**config_kwargs)
+        with current_omni_platform.diffusion_worker_vllm_config_context():
+            return VllmConfig(**config_kwargs)
     except TypeError as exc:
         if not _is_unexpected_additional_config_type_error(exc):
             raise
 
         logger.debug("Worker-local VllmConfig does not accept additional_config in constructor: %s", exc)
         config_kwargs.pop("additional_config", None)
-        vllm_config = VllmConfig(**config_kwargs)
+        with current_omni_platform.diffusion_worker_vllm_config_context():
+            vllm_config = VllmConfig(**config_kwargs)
         try:
             setattr(vllm_config, "additional_config", dict(od_config.additional_config))
         except Exception as set_exc:  # pragma: no cover - defensive for older vLLM builds

--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -137,6 +137,11 @@ class OmniPlatform(Platform):
         return "vllm_omni.diffusion.worker.diffusion_model_runner.DiffusionModelRunner"
 
     @classmethod
+    def diffusion_worker_vllm_config_context(cls):
+        """Context for constructing worker-local diffusion VllmConfig objects."""
+        return nullcontext()
+
+    @classmethod
     def get_torch_device(cls, local_rank: int | None = None) -> torch.device:
         raise NotImplementedError
 

--- a/vllm_omni/platforms/npu/platform.py
+++ b/vllm_omni/platforms/npu/platform.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from typing import Any
 
 import torch
@@ -167,6 +167,18 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
         from vllm_ascend.compilation.acl_graph import ACLGraphWrapper
 
         return ACLGraphWrapper
+
+    @classmethod
+    @contextmanager
+    def diffusion_worker_vllm_config_context(cls):
+        import vllm_ascend.platform as ascend_platform
+
+        original_refresh_block_size = ascend_platform.refresh_block_size
+        ascend_platform.refresh_block_size = lambda vllm_config: None
+        try:
+            yield
+        finally:
+            ascend_platform.refresh_block_size = original_refresh_block_size
 
     @classmethod
     def set_forward_context(


### PR DESCRIPTION
## Why

Diffusion workers create a worker-local `VllmConfig` before the diffusion-specific model config is attached. During `VllmConfig` construction, vLLM calls `current_platform.check_and_update_config(vllm_config)`.

On NPU, this enters vLLM-Ascend platform initialization. Most of that initialization is still required, because it initializes Ascend-specific config from `additional_config`. However, `refresh_block_size(vllm_config)` can run before Omni attaches its diffusion `_DiffusionVllmModelConfig`, so it may observe `vllm_config.model_config is None` and fail when accessing model fields such as `hf_config`.

Passing Omni's `_DiffusionVllmModelConfig` directly into `VllmConfig(model_config=...)` is not viable because vLLM validates that field as a native `ModelConfig` dataclass. Therefore, the fix needs to preserve the existing post-construction attachment flow.

## What changed

This PR adds a platform hook, `diffusion_worker_vllm_config_context()`, for constructing worker-local diffusion `VllmConfig` objects.

The default implementation is a no-op. The NPU implementation temporarily skips only vLLM-Ascend's block-size refresh while the worker-local `VllmConfig` is being constructed. Other Ascend platform initialization still runs normally.

This keeps Ascend-specific handling under `vllm_omni.platforms.npu` instead of hard-coding vLLM-Ascend logic in the generic diffusion worker.

## Testing

- `python -m py_compile vllm_omni/diffusion/worker/diffusion_worker.py vllm_omni/platforms/interface.py vllm_omni/platforms/npu/platform.py`
- `git diff --check`