### PR TITLE
[FEAT]Fallback Mooncake connector to shared memory

### DIFF
--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -15,6 +15,7 @@ import msgspec
 import torch
 import zmq
 
+from ..utils.exceptions import MooncakeUnavailableError
 from ..utils.logging import get_connector_logger
 from ..utils.memory_pool import BufferAllocator, ManagedBuffer
 from ..utils.serialization import OmniSerializer
@@ -99,7 +100,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
 
     def __init__(self, config: dict[str, Any]):
         if TransferEngine is None:
-            raise ImportError("Mooncake not available")
+            raise MooncakeUnavailableError("Mooncake TransferEngine is not available")
 
         self._closed = False
         self._bind_error: Exception | None = None  # fatal ZMQ bind error from listener thread
@@ -175,12 +176,15 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         self.engine_id = str(uuid.uuid4())
 
         # --- Mooncake Engine Init ---
-        self.engine = TransferEngine()
+        try:
+            self.engine = TransferEngine()
+        except Exception as e:
+            raise MooncakeUnavailableError(f"Failed to create Mooncake TransferEngine: {e}") from e
         # Note: For P2P handshake mode, local_hostname should be just the IP address.
         # Mooncake will auto-assign an RPC port, retrievable via get_rpc_port().
         ret = self.engine.initialize(self.host, "P2PHANDSHAKE", self.protocol, self.device_name)
         if ret != 0:
-            raise RuntimeError(f"Mooncake Engine initialization failed with code {ret}")
+            raise MooncakeUnavailableError(f"Mooncake Engine initialization failed with code {ret}")
 
         self.rpc_port = self.engine.get_rpc_port()
         logger.info(f"MooncakeTransferEngineConnector initialized at {self.host}:{self.rpc_port}")
@@ -198,11 +202,13 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
             # Register the entire pool
             ret = self.engine.register_memory(self.base_ptr, self.pool_size)
             if ret != 0:
-                raise RuntimeError("Failed to register memory pool with Mooncake Engine")
+                raise MooncakeUnavailableError("Failed to register memory pool with Mooncake Engine")
 
         except Exception as e:
             logger.error(f"Failed to allocate/register memory pool: {e}")
-            raise
+            if isinstance(e, MooncakeUnavailableError):
+                raise
+            raise MooncakeUnavailableError(f"Failed to allocate/register Mooncake memory pool: {e}") from e
 
         self.allocator = BufferAllocator(self.pool_size, alignment=4096)  # 4KB alignment for safety
 

--- a/vllm_omni/distributed/omni_connectors/factory.py
+++ b/vllm_omni/distributed/omni_connectors/factory.py
@@ -10,6 +10,7 @@ from .utils.logging import get_connector_logger
 try:
     from .connectors.base import OmniConnectorBase
     from .utils.config import ConnectorSpec
+    from .utils.exceptions import ConnectorUnavailableError, MooncakeUnavailableError
 except ImportError:
     # Fallback for direct execution
     import sys
@@ -17,6 +18,7 @@ except ImportError:
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
     from omni_connectors.connectors.base import OmniConnectorBase
     from omni_connectors.utils.config import ConnectorSpec
+    from omni_connectors.utils.exceptions import ConnectorUnavailableError, MooncakeUnavailableError
 
 logger = get_connector_logger(__name__)
 
@@ -45,6 +47,8 @@ class OmniConnectorFactory:
             connector = constructor(spec.extra)
             logger.info(f"Created connector: {spec.name}")
             return connector
+        except ConnectorUnavailableError:
+            raise
         except Exception as e:
             logger.error(f"Failed to create connector {spec.name}: {e}")
             raise ValueError(f"Failed to create connector {spec.name}: {e}")
@@ -106,11 +110,16 @@ def _create_yuanrong_transfer_engine_connector(config: dict[str, Any]) -> OmniCo
 def _create_mooncake_transfer_engine_connector(config: dict[str, Any]) -> OmniConnectorBase:
     try:
         from .connectors.mooncake_transfer_engine_connector import MooncakeTransferEngineConnector
-    except ImportError:
+    except ImportError as first_exc:
         import sys
 
         sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-        from omni_connectors.connectors.mooncake_transfer_engine_connector import MooncakeTransferEngineConnector
+        try:
+            from omni_connectors.connectors.mooncake_transfer_engine_connector import MooncakeTransferEngineConnector
+        except ImportError as exc:
+            raise MooncakeUnavailableError(
+                f"MooncakeTransferEngineConnector dependencies are unavailable: {first_exc}"
+            ) from exc
     return MooncakeTransferEngineConnector(config)
 
 

--- a/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
+++ b/vllm_omni/distributed/omni_connectors/kv_transfer_manager.py
@@ -17,7 +17,8 @@ from vllm_omni.diffusion.request import OmniDiffusionRequest
 from .factory import OmniConnectorFactory
 from .utils.config import TRANSFER_ENGINE_CONNECTOR_NAMES, ConnectorSpec
 from .utils.env import expand_env_int
-from .utils.initialization import KV_RANK_PORT_STRIDE
+from .utils.exceptions import MooncakeUnavailableError
+from .utils.initialization import KV_RANK_PORT_STRIDE, _can_fallback_to_shm, _make_shm_fallback_spec
 from .utils.kv_utils import (
     KVTPTopology,
     build_rank_aware_recv_keys,
@@ -451,6 +452,34 @@ class OmniKVTransferManager:
                         c_extra.get("role", "N/A"),
                     )
                     self._connector = OmniConnectorFactory.create_connector(ConnectorSpec(name=c_type, extra=c_extra))
+                except MooncakeUnavailableError as e:
+                    if c_type != "MooncakeTransferEngineConnector":
+                        logger.exception("Failed to initialize OmniConnector")
+                        self._connector = False
+                        return None
+
+                    allowed, reject_reason = _can_fallback_to_shm(c_extra)
+                    if not allowed:
+                        logger.exception(
+                            "MooncakeTransferEngineConnector unavailable, but SharedMemoryConnector fallback is "
+                            "unsafe: %s",
+                            reject_reason,
+                        )
+                        self._connector = False
+                        return None
+
+                    fallback_spec = _make_shm_fallback_spec(
+                        ConnectorSpec(name=c_type, extra=c_extra),
+                        e,
+                        default_shm_threshold=65536,
+                    )
+                    self.config.connector_config = {"type": fallback_spec.name, **fallback_spec.extra}
+                    logger.warning(
+                        "MooncakeTransferEngineConnector unavailable in KV transfer manager; "
+                        "falling back to SharedMemoryConnector: %s",
+                        e,
+                    )
+                    self._connector = OmniConnectorFactory.create_connector(fallback_spec)
                 except Exception:
                     logger.exception("Failed to initialize OmniConnector")
                     self._connector = False

--- a/vllm_omni/distributed/omni_connectors/utils/exceptions.py
+++ b/vllm_omni/distributed/omni_connectors/utils/exceptions.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Connector-specific exceptions."""
+
+
+class ConnectorUnavailableError(RuntimeError):
+    """Raised when a connector cannot run in the current environment."""
+
+
+class MooncakeUnavailableError(ConnectorUnavailableError):
+    """Raised when Mooncake Transfer Engine support is unavailable."""

--- a/vllm_omni/distributed/omni_connectors/utils/initialization.py
+++ b/vllm_omni/distributed/omni_connectors/utils/initialization.py
@@ -4,7 +4,8 @@
 """Utilities for OmniConnector configuration and validation."""
 
 import json
-import sys
+import os
+import socket
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -12,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 from ..factory import OmniConnectorFactory
 from .config import TRANSFER_ENGINE_CONNECTOR_NAMES, ConnectorSpec, OmniTransferConfig
 from .env import expand_env_int
+from .exceptions import MooncakeUnavailableError
 from .local_rank import get_connector_local_rank
 from .logging import get_connector_logger
 
@@ -39,6 +41,70 @@ KV_RANK_PORT_STRIDE = 16
 # comfortably sized block per replica for TP-rank and stage offsets.
 KV_REPLICA_PORT_STRIDE = 1024
 
+_LOCAL_HOST_VALUES = {"", "auto", "localhost", "127.0.0.1", "::1", "0.0.0.0", "::", "*"}
+_TRANSFER_ENGINE_ONLY_EXTRA_KEYS = {
+    "device_name",
+    "from_stage",
+    "host",
+    "memory_pool_device",
+    "memory_pool_size",
+    "protocol",
+    "role",
+    "sender_host",
+    "sender_zmq_port",
+    "to_stage",
+    "zmq_port",
+}
+
+
+def _local_host_values() -> set[str]:
+    values = set(_LOCAL_HOST_VALUES)
+    for name in {socket.gethostname(), socket.getfqdn()}:
+        if name:
+            values.add(name.lower())
+            try:
+                values.update(addr[4][0].lower() for addr in socket.getaddrinfo(name, None))
+            except OSError:
+                pass
+    return values
+
+
+def _is_local_host(value: Any) -> bool:
+    if value is None:
+        return True
+    host = os.path.expandvars(str(value)).strip().lower()
+    if host in _local_host_values():
+        return True
+    try:
+        return all(addr[4][0].lower() in _local_host_values() for addr in socket.getaddrinfo(host, None))
+    except OSError:
+        return False
+
+
+def _can_fallback_to_shm(extra: dict[str, Any]) -> tuple[bool, str | None]:
+    for key in ("host", "sender_host"):
+        value = extra.get(key)
+        if value is not None and not _is_local_host(value):
+            return False, f"{key}={value!r} is not a local host"
+    return True, None
+
+
+def _make_shm_fallback_spec(
+    original: ConnectorSpec,
+    reason: Exception,
+    default_shm_threshold: int,
+) -> ConnectorSpec:
+    original_extra = dict(original.extra) if original.extra else {}
+    extra = {
+        key: value
+        for key, value in original_extra.items()
+        if key not in _TRANSFER_ENGINE_ONLY_EXTRA_KEYS and key in {"device", "shm_threshold_bytes", "stage_id"}
+    }
+    extra.setdefault("shm_threshold_bytes", default_shm_threshold)
+    extra["fallback_from"] = original.name
+    extra["fallback_reason"] = str(reason)
+    return ConnectorSpec(name="SharedMemoryConnector", extra=extra)
+
 
 def initialize_connectors_from_config(
     config_path: str | Path | None = None,
@@ -65,6 +131,7 @@ def initialize_connectors_from_config(
         purpose=purpose,
         caller_stage_id=caller_stage_id,
         is_sender=is_sender,
+        default_shm_threshold=default_shm_threshold,
     )
     return transfer_config, connectors
 
@@ -74,6 +141,7 @@ def create_connectors_from_config(
     purpose: str = "request_forwarding",
     caller_stage_id: int | str | None = None,
     is_sender: bool | None = None,
+    default_shm_threshold: int = 65536,
 ) -> dict[tuple[str, str], OmniConnectorBase]:
     """
     Create connectors from config.
@@ -138,6 +206,27 @@ def create_connectors_from_config(
                 from_stage,
                 to_stage,
                 type(connector).__name__,
+            )
+        except MooncakeUnavailableError as e:
+            if connector_spec.name != "MooncakeTransferEngineConnector":
+                raise RuntimeError(f"Failed to initialize connector for edge {edge_key}: {e}") from e
+            allowed, reject_reason = _can_fallback_to_shm(connector_spec.extra or {})
+            if not allowed:
+                raise RuntimeError(
+                    f"MooncakeTransferEngineConnector unavailable for edge {from_stage}->{to_stage}: {e}. "
+                    f"SharedMemoryConnector fallback is unsafe: {reject_reason}."
+                ) from e
+
+            fallback_spec = _make_shm_fallback_spec(connector_spec, e, default_shm_threshold)
+            connectors_config[edge_key] = fallback_spec
+            connector = OmniConnectorFactory.create_connector(fallback_spec)
+            connectors[edge_key] = connector
+            logger.warning(
+                "MooncakeTransferEngineConnector unavailable for edge %s -> %s; "
+                "falling back to SharedMemoryConnector: %s",
+                from_stage,
+                to_stage,
+                e,
             )
         except Exception as e:
             raise RuntimeError(f"Failed to initialize connector for edge {edge_key}: {e}") from e
@@ -378,10 +467,7 @@ def initialize_orchestrator_connectors(
     Returns:
         A tuple containing the OmniTransferConfig and a dictionary of connectors.
     """
-    if worker_backend == "ray":
-        default_shm_threshold = sys.maxsize
-    else:
-        default_shm_threshold = max(0, shm_threshold_bytes)
+    default_shm_threshold = max(0, shm_threshold_bytes)
     transfer_config, connectors = initialize_connectors_from_config(
         config_path,
         default_shm_threshold=default_shm_threshold,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

  This PR adds initialization-time fallback from MooncakeTransferEngineConnector to SharedMemoryConnector for local inter-stage transfer.

  When a deploy config selects Mooncake transfer engine but the current environment cannot initialize it, vLLM-Omni now falls back to shared memory instead of failing startup. This improves local usability on machines where Mooncake/RDMA dependencies or runtime support are unavailable.

  Fallback is triggered when:

  - mooncake.engine.TransferEngine is unavailable.
  - Creating TransferEngine() fails.
  - TransferEngine.initialize(...) returns a non-zero error code.
  - Mooncake memory pool allocation or register_memory(...) fails.

  Fallback is not performed when:

  - host points to a non-local address.
  - sender_host points to a non-local address.
  - The unavailable connector is not MooncakeTransferEngineConnector.
  - Mooncake initializes successfully but a later runtime transfer operation fails.

  In those cases, startup or transfer should fail explicitly instead of silently switching transport. This is intentional because SharedMemoryConnector is local-only and cannot safely replace remote transfer paths.

  This PR also keeps Mooncake-specific configuration out of the fallback connector and preserves fallback metadata through fallback_from and fallback_reason for observability.

## Test Plan

Create fake Mooncake packages under /tmp:

```
  # /tmp/mooncake_init_fail/mooncake/engine.py
  class TransferEngine:
      def initialize(self, *args, **kwargs):
          return 7

      def get_rpc_port(self):
          return 12345

  # /tmp/mooncake_register_fail/mooncake/engine.py
  class TransferEngine:
      def initialize(self, *args, **kwargs):
          return 0

      def get_rpc_port(self):
          return 12345

      def register_memory(self, *args, **kwargs):
          return 1

      def unregister_memory(self, *args, **kwargs):
          return 0
```

  Run offline flow with:
```
  PYTHONPATH=/tmp/mooncake_init_fail:$PYTHONPATH
```

  and:
```
  PYTHONPATH=/tmp/mooncake_register_fail:$PYTHONPATH
```
## Test Result
  Expected logs:
```
  MooncakeTransferEngineConnector unavailable
  falling back to SharedMemoryConnector
  Created connector: SharedMemoryConnector
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
