### PR TITLE
[WIP][4a/5][core]refactor communication layer: PR 4a of 5 Qwen3 Omni in  async mode 

### DIFF
--- a/tests/core/sched/test_omni_ar_scheduler_streaming.py
+++ b/tests/core/sched/test_omni_ar_scheduler_streaming.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from types import SimpleNamespace
 
 import pytest
@@ -13,20 +14,159 @@ import vllm_omni  # noqa: F401 - import for side effects (patch vLLM)
 from vllm.sampling_params import SamplingParams
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
 from vllm_omni.core.sched.omni_ar_scheduler import OmniARScheduler
+from vllm_omni.outputs import OmniConnectorOutput
 
 # isort: on
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
-def _make_scheduler(*, stage_id: int = 0) -> OmniARScheduler:
+def _make_scheduler(
+    *,
+    stage_id: int = 0,
+    async_chunk: bool = False,
+    model_stage: str = "thinker",
+    final_output: bool = False,
+) -> OmniARScheduler:
     sched = OmniARScheduler.__new__(OmniARScheduler)
     sched._new_prompt_len_snapshot = {}
-    sched.vllm_config = SimpleNamespace(model_config=SimpleNamespace(stage_id=stage_id))
+    sched._omni_pending_segment_finished = set()
+    sched.vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            stage_id=stage_id,
+            async_chunk=async_chunk,
+            final_output=final_output,
+            model_arch="Qwen3OmniMoeForConditionalGeneration",
+            model_stage=model_stage,
+        )
+    )
     sched.num_waiting_for_streaming_input = 0
     sched.log_stats = False
     sched.chunk_transfer_adapter = None
     return sched
+
+
+def test_terminal_only_input_coordinator_request_finishes_without_model_run() -> None:
+    sched = _make_scheduler(stage_id=1)
+    sched.requests = {"req-live": object()}
+    sched.input_coordinator = SimpleNamespace(
+        _async_chunk=True,
+        finished_requests={"req-live", "req-stale", "req-ready"},
+        requests_with_ready_chunks={"req-ready"},
+    )
+    finished = []
+
+    def fake_finish_requests(request_ids, status):
+        finished.append((request_ids, status))
+        for request_id in request_ids:
+            sched.requests.pop(request_id, None)
+
+    sched.finish_requests = fake_finish_requests
+
+    sched._finish_input_coordinator_terminal_only_requests()
+
+    assert finished == [(["req-live"], RequestStatus.FINISHED_STOPPED)]
+    assert sched.input_coordinator.finished_requests == {"req-ready"}
+
+
+def test_final_output_terminal_only_request_runs_terminal_flush_step() -> None:
+    sched = _make_scheduler(stage_id=2, final_output=True)
+    sched.requests = {"req-live": object()}
+    sched.input_coordinator = SimpleNamespace(
+        _async_chunk=True,
+        finished_requests={"req-live", "req-stale", "req-ready"},
+        requests_with_ready_chunks={"req-ready"},
+    )
+    finished = []
+
+    def fake_finish_requests(request_ids, status):
+        finished.append((request_ids, status))
+
+    sched.finish_requests = fake_finish_requests
+
+    sched._finish_input_coordinator_terminal_only_requests()
+
+    assert finished == []
+    assert sched.input_coordinator.requests_with_ready_chunks == {"req-live", "req-ready"}
+    assert sched.input_coordinator.finished_requests == {"req-live", "req-ready"}
+
+
+def test_full_payload_input_coordinator_request_is_not_terminal_only() -> None:
+    sched = _make_scheduler(stage_id=1)
+    sched.requests = {"req-live": object()}
+    sched.input_coordinator = SimpleNamespace(
+        _async_chunk=False,
+        finished_requests={"req-live"},
+        requests_with_ready_chunks=set(),
+    )
+    finished = []
+
+    def fake_finish_requests(request_ids, status):
+        finished.append((request_ids, status))
+
+    sched.finish_requests = fake_finish_requests
+
+    sched._finish_input_coordinator_terminal_only_requests()
+
+    assert finished == []
+    assert sched.input_coordinator.finished_requests == {"req-live"}
+
+
+def test_final_output_segment_only_connector_output_wakes_flush_step() -> None:
+    sched = _make_scheduler(stage_id=2, async_chunk=True, final_output=True)
+    sched.requests = {"req-live": object()}
+    sched.waiting = []
+    sched.running = []
+    sched._omni_pending_upstream_segment_finished = set()
+    sched._latest_omni_connector_output = OmniConnectorOutput(
+        chunk_segment_finished_req_ids={"req-live"},
+    )
+    chunk_calls = []
+    full_payload_calls = []
+
+    def process_pending_chunks(waiting, running, chunk_ready_req_ids, chunk_finished_req_ids):
+        chunk_calls.append((set(chunk_ready_req_ids), set(chunk_finished_req_ids)))
+
+    def process_pending_full_payload_inputs(waiting, running, stage_recv_req_ids):
+        full_payload_calls.append(set(stage_recv_req_ids))
+
+    sched.input_coordinator = SimpleNamespace(
+        process_pending_chunks=process_pending_chunks,
+        process_pending_full_payload_inputs=process_pending_full_payload_inputs,
+    )
+
+    sched._consume_pending_connector_output(model_mode="ar")
+
+    assert sched._latest_omni_connector_output is None
+    assert sched._omni_pending_upstream_segment_finished == {"req-live"}
+    assert chunk_calls == [({"req-live"}, set())]
+    assert full_payload_calls == [set()]
+
+
+def test_segment_ready_connector_output_remains_pending_for_flush_step() -> None:
+    sched = _make_scheduler(stage_id=2, async_chunk=True, final_output=True)
+    sched.requests = {"req-live": object()}
+    sched.waiting = []
+    sched.running = []
+    sched._omni_pending_upstream_segment_finished = set()
+    sched._latest_omni_connector_output = OmniConnectorOutput(
+        chunk_ready_req_ids={"req-live"},
+        chunk_segment_finished_req_ids={"req-live"},
+    )
+    chunk_calls = []
+
+    def process_pending_chunks(waiting, running, chunk_ready_req_ids, chunk_finished_req_ids):
+        chunk_calls.append((set(chunk_ready_req_ids), set(chunk_finished_req_ids)))
+
+    sched.input_coordinator = SimpleNamespace(
+        process_pending_chunks=process_pending_chunks,
+        process_pending_full_payload_inputs=lambda waiting, running, stage_recv_req_ids: None,
+    )
+
+    sched._consume_pending_connector_output(model_mode="ar")
+
+    assert sched._omni_pending_upstream_segment_finished == {"req-live"}
+    assert chunk_calls == [({"req-live"}, set())]
 
 
 def _make_request() -> Request:
@@ -48,6 +188,27 @@ def _make_update(prompt_token_ids: list[int] | None = None) -> StreamingUpdate:
         arrival_time=200.0,
         sampling_params=SamplingParams(max_tokens=16),
     )
+
+
+def test_stage0_model_runner_final_commit_emits_segment_terminal() -> None:
+    sched = _make_scheduler(stage_id=0, async_chunk=True, model_stage="thinker")
+    session = _make_request()
+    session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+    session.streaming_queue = deque()
+    sched.requests = {session.request_id: session}
+    finished = []
+
+    def fake_finish_requests(request_ids, status):
+        finished.append((request_ids, status))
+
+    sched.finish_requests = fake_finish_requests
+    final_commit = _make_request()
+
+    sched.add_request(final_commit)
+
+    assert sched._omni_pending_segment_finished == {session.request_id}
+    assert finished == [(session.request_id, RequestStatus.FINISHED_STOPPED)]
+    assert sched.has_requests()
 
 
 def test_stage0_streaming_update_discards_outstanding_async_placeholder_token() -> None:

--- a/tests/core/sched/test_omni_generation_scheduler_update_session.py
+++ b/tests/core/sched/test_omni_generation_scheduler_update_session.py
@@ -9,6 +9,7 @@ update payloads early.
 from __future__ import annotations
 
 from dataclasses import replace
+from types import SimpleNamespace
 
 import pytest
 
@@ -17,10 +18,12 @@ import pytest
 # isort: off
 import vllm_omni  # noqa: F401 - import for side effects (patch vLLM)
 from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.engine import EngineCoreEventType
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
 from vllm_omni.core.sched.omni_generation_scheduler import OmniGenerationScheduler
 from vllm_omni.core.sched.omni_scheduler_mixin import OmniSchedulerMixin
+from vllm_omni.outputs import OmniConnectorOutput
 
 # isort: on
 
@@ -440,3 +443,137 @@ class TestPurgeFinishedFromRunning:
 
         assert held_ref is sched.running
         assert held_ref == [alive]
+
+
+class _FinishOnlyInputCoordinatorStub:
+    def __init__(self) -> None:
+        self.freed: list[str] = []
+        self.finished_requests: set[str] = set()
+        self.requests_with_ready_chunks: set[str] = set()
+        self._completed_chunk_streams: set[str] = set()
+
+    def free_finished_request(self, request_id: str) -> None:
+        self.freed.append(request_id)
+
+    def chunk_stream_completed(self, request_id: str) -> bool:
+        return request_id in self.finished_requests or request_id in self._completed_chunk_streams
+
+
+class _FinishOnlySchedulerStub(OmniGenerationScheduler):
+    def __init__(self, request: Request) -> None:
+        self._async_chunk_coordinator_active = True
+        self._pending_finish_reqs: list[Request] = []
+        self._deferred_terminal_chunk_req_ids: set[str] = set()
+        self._deferred_terminal_request_metadata: dict[str, dict] = {}
+        self._reqs_with_generation_output = {request.request_id}
+        self.requests = {request.request_id: request}
+        self.running = [request]
+        self.waiting = SimpleNamespace(remove_requests=lambda _reqs: None)
+        self.skipped_waiting = SimpleNamespace(remove_requests=lambda _reqs: None)
+        self.input_coordinator = _FinishOnlyInputCoordinatorStub()
+        self.chunk_transfer_adapter = None
+        self.connector = None
+        self.perf_metrics = None
+        self.kv_cache_manager = SimpleNamespace(take_events=lambda: None)
+        self.kv_event_publisher = SimpleNamespace(publish=lambda _batch: None)
+        self.structured_output_manager = SimpleNamespace(should_advance=lambda _req: False)
+        self.recompute_kv_load_failures = False
+        self.finished_req_ids_dict: dict[int, set[str]] = {}
+        self.log_stats = False
+        self.freed: list[str] = []
+
+    def _handle_stopped_request(self, request: Request) -> bool:
+        return True
+
+    def _free_request(self, request: Request, delay_free_blocks: bool = False):
+        self.freed.append(request.request_id)
+        self.requests.pop(request.request_id, None)
+        return None
+
+    def make_stats(self, *args, **kwargs):
+        return None
+
+
+def _empty_scheduler_output() -> SchedulerOutput:
+    return SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens={},
+        total_num_scheduled_tokens=0,
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+
+
+def _finish_only_model_output(request_id: str):
+    return SimpleNamespace(
+        sampled_token_ids=[],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=None,
+        multimodal_outputs=None,
+        num_nans_in_logits=None,
+        kv_connector_output=None,
+        cudagraph_stats=None,
+        req_id_to_index={},
+        routed_experts=None,
+        req_ids=[],
+        omni_connector_output=OmniConnectorOutput(
+            chunk_finished_req_ids={request_id},
+        ),
+    )
+
+
+class TestAsyncChunkFinishOnlyOutput:
+    def test_multimodal_request_finishes_on_connector_only_terminal(self) -> None:
+        request = _make_request(request_id="req-mm-terminal")
+        request.status = RequestStatus.RUNNING
+        request.num_computed_tokens = len(request.prompt_token_ids)
+        sched = _FinishOnlySchedulerStub(request)
+
+        outputs = sched.update_from_output(
+            _empty_scheduler_output(),
+            _finish_only_model_output(request.request_id),
+        )
+
+        client_outputs = outputs[request.client_index].outputs
+        assert len(client_outputs) == 1
+        assert client_outputs[0].request_id == request.request_id
+        assert client_outputs[0].finish_reason.name == "STOP"
+        assert sched.freed == [request.request_id]
+        assert sched.input_coordinator.freed == [request.request_id]
+
+    def test_multimodal_request_finishes_from_stored_coordinator_terminal(self) -> None:
+        request = _make_request(request_id="req-mm-stored-terminal")
+        request.status = RequestStatus.RUNNING
+        request.num_computed_tokens = len(request.prompt_token_ids)
+        sched = _FinishOnlySchedulerStub(request)
+        sched.input_coordinator.finished_requests.add(request.request_id)
+
+        outputs = sched.update_from_output(
+            _empty_scheduler_output(),
+            SimpleNamespace(
+                sampled_token_ids=[],
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=None,
+                multimodal_outputs=None,
+                num_nans_in_logits=None,
+                kv_connector_output=None,
+                cudagraph_stats=None,
+                req_id_to_index={},
+                routed_experts=None,
+                req_ids=[],
+                omni_connector_output=OmniConnectorOutput(),
+            ),
+        )
+
+        client_outputs = outputs[request.client_index].outputs
+        assert len(client_outputs) == 1
+        assert client_outputs[0].request_id == request.request_id
+        assert client_outputs[0].finish_reason.name == "STOP"
+        assert sched.freed == [request.request_id]
+        assert sched.input_coordinator.freed == [request.request_id]

--- a/tests/core/sched/test_omni_scheduling_coordinator.py
+++ b/tests/core/sched/test_omni_scheduling_coordinator.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 import torch
 
 import vllm_omni.core.sched.omni_scheduling_coordinator as coord_mod
 from vllm_omni.core.sched.omni_scheduling_coordinator import (
     OmniSchedulingCoordinator,
+    uses_async_chunk_coordinator,
+    uses_async_chunk_model_runner_transport,
     uses_full_payload_input_coordinator,
 )
 
@@ -205,6 +208,26 @@ class TestChunkCoordinatorStateTransition(unittest.TestCase):
         self.assertEqual(req.status, RequestStatus.WAITING)
         self.assertIn("r1", coord.requests_with_ready_chunks)
 
+    def test_late_ready_before_queue_insertion_is_retained(self):
+        # A chunk can arrive before the request is surfaced into a
+        # queue.  The readiness must be retained (not lost when the connector
+        # output is cleared) so a later cycle still transitions the request.
+        coord = OmniSchedulingCoordinator(scheduler_max_num_seqs=10, stage_id=1, async_chunk=True)
+
+        # Cycle 1: ready for "r1" arrives while no queue holds it yet.
+        coord.process_pending_chunks(MockQueue([]), [], chunk_ready_req_ids={"r1"}, chunk_finished_req_ids=set())
+        self.assertIn("r1", coord.requests_with_ready_chunks, "late ready must be retained")
+
+        # Cycle 2: r1 now appears as a fresh WAITING request, but chunk_ready is
+        # already empty (the connector output was consumed last cycle).  Because
+        # retention recorded r1, it must NOT be parked into WAITING_FOR_CHUNK --
+        # it stays schedulable.  Without the retain it would be wrongly parked.
+        req = _make_request("r1", status=RequestStatus.WAITING)
+        waiting = MockQueue([req])
+        coord.process_pending_chunks(waiting, [], chunk_ready_req_ids=set(), chunk_finished_req_ids=set())
+        self.assertEqual(req.status, RequestStatus.WAITING, "ready-before-insertion must not be parked")
+        self.assertIn(req, waiting, "request must remain schedulable in the waiting queue")
+
     def test_non_ready_stays_waiting_for_chunk(self):
         coord = OmniSchedulingCoordinator(scheduler_max_num_seqs=10, stage_id=1, async_chunk=True)
 
@@ -220,6 +243,24 @@ class TestChunkCoordinatorStateTransition(unittest.TestCase):
         )
 
         self.assertEqual(req.status, RequestStatus.WAITING_FOR_CHUNK)
+
+    def test_finish_only_request_does_not_become_ready(self):
+        coord = OmniSchedulingCoordinator(scheduler_max_num_seqs=10, stage_id=1, async_chunk=True)
+
+        req = _make_request("r1", status=RequestStatus.WAITING_FOR_CHUNK)
+        waiting = MockQueue([req])
+        running: list = []
+
+        coord.process_pending_chunks(
+            waiting,
+            running,
+            chunk_ready_req_ids=set(),
+            chunk_finished_req_ids={"r1"},
+        )
+
+        self.assertEqual(req.status, RequestStatus.WAITING_FOR_CHUNK)
+        self.assertNotIn("r1", coord.requests_with_ready_chunks)
+        self.assertIn("r1", coord.finished_requests)
 
     def test_stage_0_is_noop(self):
         coord = OmniSchedulingCoordinator(scheduler_max_num_seqs=10, stage_id=0)
@@ -275,7 +316,40 @@ class TestChunkCoordinatorFinishedSignal(unittest.TestCase):
             chunk_finished_req_ids={"r1"},
         )
 
-        self.assertIn("r1", coord.finished_requests)
+        self.assertNotIn("r1", coord.finished_requests)
+        self.assertIn("r1", coord._completed_chunk_streams)
+        self.assertTrue(coord.chunk_stream_completed("r1"))
+
+    def test_terminal_ready_request_does_not_wait_for_more_chunks(self):
+        coord = OmniSchedulingCoordinator(scheduler_max_num_seqs=10, stage_id=1, async_chunk=True)
+
+        req = _make_request("r1", status=RequestStatus.WAITING_FOR_CHUNK)
+        waiting = MockQueue([req])
+        running: list = []
+
+        coord.process_pending_chunks(
+            waiting,
+            running,
+            chunk_ready_req_ids={"r1"},
+            chunk_finished_req_ids={"r1"},
+        )
+        coord.postprocess_scheduler_output(
+            SimpleNamespace(scheduled_new_reqs=[], scheduled_cached_reqs=SimpleNamespace(req_ids=["r1"]))
+        )
+
+        req.status = RequestStatus.RUNNING
+        running = [req]
+
+        coord.process_pending_chunks(
+            MockQueue([]),
+            running,
+            chunk_ready_req_ids=set(),
+            chunk_finished_req_ids=set(),
+        )
+
+        self.assertEqual(req.status, RequestStatus.RUNNING)
+        self.assertIn(req, running)
+        self.assertEqual(coord.pending_connector_registrations, [])
 
 
 class TestChunkCoordinatorUpdateRequestMetadata(unittest.TestCase):
@@ -472,7 +546,7 @@ class TestWaitingForInputTransition(unittest.TestCase):
 
         self.assertEqual(req.status, RequestStatus.WAITING_FOR_INPUT)
         self.assertEqual(len(coord._waiting_for_input), 1)
-        self.assertEqual(len(coord.pending_input_registrations), 1)
+        self.assertEqual(len(coord.pending_connector_registrations), 1)
 
     def test_async_chunk_mode_does_not_auto_transition(self):
         """In async_chunk mode, fresh WAITING requests should NOT be
@@ -495,7 +569,7 @@ class TestWaitingForInputTransition(unittest.TestCase):
 
         self.assertEqual(req.status, RequestStatus.WAITING)
 
-    def test_pending_input_registrations(self):
+    def test_pending_connector_registrations(self):
         coord = OmniSchedulingCoordinator(scheduler_max_num_seqs=10, stage_id=1)
 
         req = _make_request("r1", status=RequestStatus.WAITING_FOR_INPUT)
@@ -508,8 +582,8 @@ class TestWaitingForInputTransition(unittest.TestCase):
             stage_recv_req_ids=set(),
         )
 
-        self.assertEqual(len(coord.pending_input_registrations), 1)
-        self.assertEqual(coord.pending_input_registrations[0].request_id, "r1")
+        self.assertEqual(len(coord.pending_connector_registrations), 1)
+        self.assertEqual(coord.pending_connector_registrations[0].request_id, "r1")
 
     def test_idle_cycles_retain_received_marker_before_request_appears(self):
         coord = OmniSchedulingCoordinator(
@@ -534,7 +608,7 @@ class TestWaitingForInputTransition(unittest.TestCase):
         coord.process_pending_full_payload_inputs(waiting, running, stage_recv_req_ids=set())
 
         self.assertEqual(late_req.status, RequestStatus.WAITING)
-        self.assertEqual(coord.pending_input_registrations, [])
+        self.assertEqual(coord.pending_connector_registrations, [])
         self.assertIn("late", coord._full_payload_input_received)
         self.assertIn("late", coord.finished_requests)
 
@@ -641,17 +715,19 @@ class TestTimeoutDetection(unittest.TestCase):
         self.assertEqual(result, set())
 
     def test_collect_timed_out_request_ids_expired(self):
-        """Timed-out IDs are returned and _waiting_since is cleared."""
+        """Timed-out full-payload input waits are returned and cleared."""
         coord = OmniSchedulingCoordinator(
             scheduler_max_num_seqs=10,
             stage_id=1,
         )
-        coord._waiting_since["r1"] = 0.0  # epoch → definitely expired
+        coord._waiting_since["r1"] = 0.0  # epoch -> definitely expired
         coord._waiting_since["r2"] = 0.0
+        coord._waiting_for_input_req_ids.update({"r1", "r2"})
 
         import time
 
         coord._waiting_since["r3"] = time.monotonic() + 9999  # far future
+        coord._waiting_for_input_req_ids.add("r3")
 
         result = coord.collect_timed_out_request_ids(timeout_s=1.0)
 
@@ -659,9 +735,12 @@ class TestTimeoutDetection(unittest.TestCase):
         self.assertNotIn("r1", coord._waiting_since)
         self.assertNotIn("r2", coord._waiting_since)
         self.assertIn("r3", coord._waiting_since)
+        self.assertNotIn("r1", coord._waiting_for_input_req_ids)
+        self.assertNotIn("r2", coord._waiting_for_input_req_ids)
+        self.assertIn("r3", coord._waiting_for_input_req_ids)
 
     def test_collect_removes_from_coordinator_queues(self):
-        """Timed-out requests are defensively removed from internal queues."""
+        """Timed-out full-payload waits are removed from input queues only."""
         coord = OmniSchedulingCoordinator(
             scheduler_max_num_seqs=10,
             stage_id=1,
@@ -672,12 +751,15 @@ class TestTimeoutDetection(unittest.TestCase):
         coord._waiting_for_input.append(r2)
         coord._waiting_since["r1"] = 0.0
         coord._waiting_since["r2"] = 0.0
+        coord._waiting_for_input_req_ids.add("r2")
 
         result = coord.collect_timed_out_request_ids(timeout_s=1.0)
 
-        self.assertEqual(result, {"r1", "r2"})
-        self.assertEqual(len(coord._waiting_for_chunk_waiting), 0)
+        self.assertEqual(result, {"r2"})
+        self.assertEqual(len(coord._waiting_for_chunk_waiting), 1)
         self.assertEqual(len(coord._waiting_for_input), 0)
+        self.assertIn("r1", coord._waiting_since)
+        self.assertNotIn("r2", coord._waiting_since)
 
     def test_free_finished_request_clears_waiting_since(self):
         """free_finished_request clears coordinator lifecycle markers."""
@@ -688,20 +770,15 @@ class TestTimeoutDetection(unittest.TestCase):
         coord._waiting_since["r1"] = 0.0
         coord._full_payload_input_received.add("r1")
         coord.finished_requests.add("r1")
+        coord._completed_chunk_streams.add("r1")
         coord.free_finished_request("r1")
         self.assertNotIn("r1", coord._waiting_since)
         self.assertNotIn("r1", coord._full_payload_input_received)
         self.assertNotIn("r1", coord.finished_requests)
+        self.assertNotIn("r1", coord._completed_chunk_streams)
 
-    def test_timeout_from_running_queue_full_lifecycle(self):
-        """End-to-end: request from running → WAITING_FOR_CHUNK → restore →
-        timeout → removed from running list.
-
-        This is the critical regression case: WAITING_FOR_CHUNK requests
-        that originated from self.running are placed back into self.running
-        by restore_queues(), but their status remains WAITING_FOR_CHUNK.
-        The scheduler must remove from BOTH queues unconditionally.
-        """
+    def test_async_chunk_running_queue_wait_does_not_timeout(self):
+        """Async chunk waits may pause after restore without being timed out."""
         coord = OmniSchedulingCoordinator(
             scheduler_max_num_seqs=10,
             stage_id=1,
@@ -730,23 +807,17 @@ class TestTimeoutDetection(unittest.TestCase):
         self.assertEqual(len(coord._waiting_for_chunk_running), 0)
         self.assertEqual(req.status, RequestStatus.WAITING_FOR_CHUNK)
 
-        # 4) Force timeout by setting _waiting_since to epoch
+        # 4) Async chunk waits may pause without being failed by the coordinator
         coord._waiting_since["r1"] = 0.0
 
         timed_out_ids = coord.collect_timed_out_request_ids(timeout_s=1.0)
-        self.assertEqual(timed_out_ids, {"r1"})
-
-        # 5) Scheduler removes from both queues (simulating the scheduler path)
-        timed_out_id_set = {id(req)}
-        running = [r for r in running if id(r) not in timed_out_id_set]
-        waiting.remove_requests([req])
-
-        self.assertNotIn(req, running)
+        self.assertEqual(timed_out_ids, set())
+        self.assertIn("r1", coord._waiting_since)
+        self.assertIn(req, running)
         self.assertEqual(len(waiting), 0)
 
-    def test_timeout_from_waiting_queue_full_lifecycle(self):
-        """End-to-end: request from waiting → WAITING_FOR_CHUNK → restore →
-        timeout → removed from waiting queue."""
+    def test_async_chunk_waiting_queue_wait_does_not_timeout(self):
+        """Async chunk waits in the waiting queue are not timeout-failed."""
         coord = OmniSchedulingCoordinator(
             scheduler_max_num_seqs=10,
             stage_id=1,
@@ -770,10 +841,9 @@ class TestTimeoutDetection(unittest.TestCase):
 
         coord._waiting_since["r1"] = 0.0
         timed_out_ids = coord.collect_timed_out_request_ids(timeout_s=1.0)
-        self.assertEqual(timed_out_ids, {"r1"})
-
-        waiting.remove_requests([req])
-        self.assertEqual(len(waiting), 0)
+        self.assertEqual(timed_out_ids, set())
+        self.assertIn("r1", coord._waiting_since)
+        self.assertIn(req, waiting)
 
 
 class TestOverflowPreemption(unittest.TestCase):
@@ -860,6 +930,164 @@ class TestOverflowPreemption(unittest.TestCase):
         self.assertEqual(len(waiting), 1)
         for req in waiting:
             self.assertNotEqual(req.status, RequestStatus.RUNNING, "Overflowed request must not keep RUNNING status")
+
+
+class TestAsyncChunkCoordinatorGate(unittest.TestCase):
+    """Async-chunk transport is broader than scheduler receive coordination.
+
+    Qwen3 thinker is a producer-only stage: it sends through the model-runner
+    connector, but it must not enter coordinator WAITING_FOR_CHUNK state.
+    """
+
+    _SM = {"name": "SharedMemoryConnector"}
+    _MOONCAKE = {"name": "MooncakeStoreConnector"}
+    _DEFAULT_CONNECTOR = object()
+
+    def _qwen3(self, stage: str, *, async_chunk: bool = True, connector=_DEFAULT_CONNECTOR):
+        return SimpleNamespace(
+            async_chunk=async_chunk,
+            model_arch="Qwen3OmniMoeForConditionalGeneration",
+            model_stage=stage,
+            stage_connector_config=self._SM if connector is self._DEFAULT_CONNECTOR else connector,
+        )
+
+    def test_qwen3_sharedmemory_transport_matrix(self):
+        with mock.patch.object(
+            coord_mod,
+            "_supports_async_chunk_model_runner_transport_platform",
+            return_value=True,
+        ):
+            thinker = self._qwen3("thinker")
+            talker = self._qwen3("talker")
+            code2wav = self._qwen3("code2wav")
+
+            self.assertTrue(uses_async_chunk_model_runner_transport(thinker))
+            self.assertFalse(uses_async_chunk_coordinator(thinker))
+            self.assertTrue(uses_async_chunk_model_runner_transport(talker))
+            self.assertTrue(uses_async_chunk_coordinator(talker))
+            self.assertTrue(uses_async_chunk_model_runner_transport(code2wav))
+            self.assertTrue(uses_async_chunk_coordinator(code2wav))
+
+            # Missing connector config uses the SharedMemory default on the runner path.
+            self.assertTrue(uses_async_chunk_model_runner_transport(self._qwen3("talker", connector=None)))
+            self.assertTrue(uses_async_chunk_model_runner_transport(self._qwen3("talker", connector={})))
+            self.assertFalse(uses_async_chunk_model_runner_transport(self._qwen3("talker", connector={"name": ""})))
+
+    def test_npu_stays_on_adapter(self):
+        npu_platform = SimpleNamespace(is_npu=lambda: True)
+        with mock.patch.object(coord_mod.omni_platforms, "_current_omni_platform", npu_platform):
+            mc = self._qwen3("talker")
+            self.assertFalse(uses_async_chunk_model_runner_transport(mc))
+            self.assertFalse(uses_async_chunk_coordinator(mc))
+
+    def test_mooncake_stays_on_adapter(self):
+        mc = self._qwen3("talker", connector=self._MOONCAKE)
+        self.assertFalse(uses_async_chunk_model_runner_transport(mc))
+        self.assertFalse(uses_async_chunk_coordinator(mc))
+
+    def test_sync_or_non_allowlisted_does_not_fire(self):
+        sync_talker = self._qwen3("talker", async_chunk=False)
+        self.assertFalse(uses_async_chunk_model_runner_transport(sync_talker))
+        self.assertFalse(uses_async_chunk_coordinator(sync_talker))
+
+        non_allowlisted_arch = SimpleNamespace(
+            async_chunk=True,
+            model_arch="MiMoAudioModel",
+            model_stage="code2wav",
+            stage_connector_config=self._SM,
+        )
+        self.assertFalse(uses_async_chunk_model_runner_transport(non_allowlisted_arch))
+        self.assertFalse(uses_async_chunk_coordinator(non_allowlisted_arch))
+
+        non_allowlisted_stage = self._qwen3("not-a-stage")
+        self.assertFalse(uses_async_chunk_model_runner_transport(non_allowlisted_stage))
+        self.assertFalse(uses_async_chunk_coordinator(non_allowlisted_stage))
+
+
+class TestAsyncChunkRecvRegistration(unittest.TestCase):
+    """Regression coverage: a parked async-chunk
+    request must be registered for bg-thread recv via SchedulerOutput
+    ``pending_connector_registrations``; otherwise the runner never calls
+    register_chunk_recv and the request can wait until timeout. The
+    full-payload pass runs after process_pending_chunks each cycle in
+    async-chunk mode, so it must NOT re-clear the chunk registrations.
+    """
+
+    def test_parked_chunk_request_registered_and_survives_full_payload_pass(self):
+        coord = OmniSchedulingCoordinator(scheduler_max_num_seqs=10, stage_id=1, async_chunk=True)
+        req = _make_request("r1", status=RequestStatus.WAITING)
+        waiting = MockQueue([req])
+        running: list = []
+
+        # No chunk ready yet -> park WAITING_FOR_CHUNK AND register for recv.
+        coord.process_pending_chunks(waiting, running, chunk_ready_req_ids=set(), chunk_finished_req_ids=set())
+        self.assertEqual(req.status, RequestStatus.WAITING_FOR_CHUNK)
+        regs = [h.request_id for h in coord.pending_connector_registrations]
+        self.assertIn("r1", regs, "parked async-chunk request must be registered for bg recv polling")
+
+        # The full-payload pass (runs after, every cycle) must not wipe it.
+        coord.process_pending_full_payload_inputs(waiting, running, stage_recv_req_ids=set())
+        regs_after = [h.request_id for h in coord.pending_connector_registrations]
+        self.assertIn("r1", regs_after, "full-payload pass must not drop async-chunk recv registrations")
+
+    def test_free_finished_request_prunes_parked_requests(self):
+        coord = OmniSchedulingCoordinator(scheduler_max_num_seqs=10, stage_id=1, async_chunk=True)
+        keep_waiting = _make_request("keep-w", status=RequestStatus.WAITING_FOR_CHUNK)
+        keep_running = _make_request("keep-r", status=RequestStatus.WAITING_FOR_CHUNK)
+        keep_input = _make_request("keep-i", status=RequestStatus.WAITING_FOR_INPUT)
+        stale_waiting = _make_request("stale", status=RequestStatus.WAITING_FOR_CHUNK)
+        stale_running = _make_request("stale", status=RequestStatus.WAITING_FOR_CHUNK)
+        stale_input = _make_request("stale", status=RequestStatus.WAITING_FOR_INPUT)
+
+        coord._waiting_for_chunk_waiting.extend([stale_waiting, keep_waiting])
+        coord._waiting_for_chunk_running.extend([stale_running, keep_running])
+        coord._waiting_for_input.extend([stale_input, keep_input])
+        coord._waiting_since["stale"] = 1.0
+        coord._waiting_for_input_req_ids.add("stale")
+
+        coord.free_finished_request("stale")
+
+        waiting = MockQueue()
+        running: list = []
+        coord.restore_queues(waiting, running)
+
+        self.assertEqual([request.request_id for request in waiting._items], ["keep-w", "keep-i"])
+        self.assertEqual([request.request_id for request in running], ["keep-r"])
+        self.assertNotIn("stale", coord._waiting_since)
+        self.assertNotIn("stale", coord._waiting_for_input_req_ids)
+
+    def test_input_timeout_ignores_async_chunk_waits(self):
+        coord = OmniSchedulingCoordinator(scheduler_max_num_seqs=10, stage_id=1, async_chunk=True)
+        req = _make_request("r1", status=RequestStatus.WAITING)
+        waiting = MockQueue([req])
+        running: list = []
+
+        coord.process_pending_chunks(waiting, running, chunk_ready_req_ids=set(), chunk_finished_req_ids=set())
+        self.assertEqual(req.status, RequestStatus.WAITING_FOR_CHUNK)
+        coord._waiting_since["r1"] = 0.0
+
+        with mock.patch.object(coord_mod.time, "monotonic", return_value=10.0):
+            timed_out = coord.collect_timed_out_request_ids(timeout_s=1.0)
+
+        self.assertEqual(timed_out, set())
+        self.assertIn("r1", coord._waiting_since)
+
+    def test_input_timeout_still_collects_full_payload_waits(self):
+        coord = OmniSchedulingCoordinator(scheduler_max_num_seqs=10, stage_id=1, async_chunk=False)
+        req = _make_request("r1", status=RequestStatus.WAITING)
+        waiting = MockQueue([req])
+        running: list = []
+
+        coord.process_pending_full_payload_inputs(waiting, running, stage_recv_req_ids=set())
+        self.assertEqual(req.status, RequestStatus.WAITING_FOR_INPUT)
+        coord._waiting_since["r1"] = 0.0
+
+        with mock.patch.object(coord_mod.time, "monotonic", return_value=10.0):
+            timed_out = coord.collect_timed_out_request_ids(timeout_s=1.0)
+
+        self.assertEqual(timed_out, {"r1"})
+        self.assertNotIn("r1", coord._waiting_since)
+        self.assertNotIn("r1", coord._waiting_for_input_req_ids)
 
 
 if __name__ == "__main__":

--- a/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
+++ b/tests/distributed/omni_connectors/test_chunk_transfer_adapter.py
@@ -242,12 +242,34 @@ def test_send_single_request_struct_without_meta_does_not_crash(build_adapter, m
     assert cleanup_calls == []  # no terminal cleanup; meta.finished is false
 
 
+def test_send_single_request_skips_nonterminal_meta_only_struct(build_adapter, monkeypatch):
+    adapter, connector = build_adapter(stage_id=1)
+    request = _req("req-meta-only", RequestStatus.WAITING, external_req_id="ext-meta-only")
+
+    adapter.custom_process_next_stage_input_func = lambda **kwargs: OmniPayloadStruct(
+        meta=MetaStruct(finished=torch.tensor(False, dtype=torch.bool)),
+    )
+    monkeypatch.setattr(adapter, "cleanup", lambda *a, **kw: None)
+
+    adapter._send_single_request(
+        {
+            "pooling_output": None,
+            "request": request,
+            "is_finished": False,
+            "is_segment_finished": False,
+        }
+    )
+
+    assert not connector.put.called
+    assert adapter.put_req_chunk.get("ext-meta-only", 0) == 0
+
+
 def test_send_single_request_empty_struct_goes_on_wire(build_adapter, monkeypatch):
     """Pin the contract: an explicitly empty ``OmniPayloadStruct()`` passes
     the ``payload_data is None`` check and gets sent. To skip a chunk, the
-    producer must return ``None``, not an empty struct. (Filtering empty
-    structs at the adapter would require introspecting all struct fields on
-    every send and was rejected for cost vs. value.)
+    producer must return ``None``, not an empty struct. The adapter only filters
+    metadata-only non-terminal placeholders because they carry no consumable
+    downstream payload.
     """
     adapter, connector = build_adapter(stage_id=1)
     request = _req("req-empty", RequestStatus.WAITING, external_req_id="ext-empty")

--- a/tests/entrypoints/test_stream_finish_reason.py
+++ b/tests/entrypoints/test_stream_finish_reason.py
@@ -118,6 +118,20 @@ def _make_audio_omni_output(
     )
 
 
+def _make_empty_audio_omni_output(
+    request_id: str = "test-req",
+    finish_reason: str | None = "stop",
+    index: int = 0,
+) -> OmniRequestOutput:
+    omni_res = _make_audio_omni_output(request_id=request_id, index=index)
+    output = omni_res.request_output.outputs[0]
+    output.finish_reason = finish_reason
+    output.multimodal_output = {"audio": []}
+    omni_res.request_output.finished = finish_reason is not None
+    omni_res.finished = finish_reason is not None
+    return omni_res
+
+
 def _mock_audio_choices(index: int = 0, role: str = "assistant"):
     return [
         ChatCompletionResponseStreamChoice(
@@ -129,7 +143,7 @@ def _mock_audio_choices(index: int = 0, role: str = "assistant"):
     ]
 
 
-def _build_serving_chat():
+def _build_serving_chat(mock_audio_choice: bool = True):
     """Create a minimal OmniOpenAIServingChat for testing."""
     mock_engine = MagicMock()
     mock_engine.errored = False
@@ -149,12 +163,13 @@ def _build_serving_chat():
         chat_template=None,
         chat_template_content_format="auto",
     )
-    instance._create_audio_choice = MagicMock(
-        side_effect=lambda omni_res, role, request, stream=False: _mock_audio_choices(
-            index=omni_res.request_output.outputs[0].index,
-            role=role,
+    if mock_audio_choice:
+        instance._create_audio_choice = MagicMock(
+            side_effect=lambda omni_res, role, request, stream=False: _mock_audio_choices(
+                index=omni_res.request_output.outputs[0].index,
+                role=role,
+            )
         )
-    )
     return instance
 
 
@@ -367,6 +382,47 @@ async def test_declared_modality_not_produced_emits_fallback_stop():
     # chunk must appear at end.
     assert finish_reasons.count("stop") == 1, f"Expected 1 stop, got {finish_reasons}"
     assert finish_reasons[-1] == "stop"
+
+
+@pytest.mark.asyncio
+async def test_empty_terminal_audio_stream_emits_stop_choice():
+    serving_chat = _build_serving_chat(mock_audio_choice=False)
+    request = _make_request(modalities=["audio"])
+
+    async def result_generator():
+        yield _make_empty_audio_omni_output(finish_reason="stop")
+
+    raw_lines = await _collect_stream(
+        serving_chat.chat_completion_stream_generator(
+            request=request,
+            result_generator=result_generator(),
+            request_id="test-req",
+            model_name="test-model",
+            conversation=[],
+            tokenizer=MagicMock(),
+            request_metadata=MagicMock(),
+        )
+    )
+
+    chunks = _parse_sse_chunks(raw_lines)
+    assert not any("error" in chunk for chunk in chunks)
+    choices = [choice for chunk in chunks for choice in chunk.get("choices", [])]
+    assert [choice["finish_reason"] for choice in choices] == ["stop"]
+    assert choices[0]["delta"] == {}
+
+
+def test_empty_nonterminal_audio_stream_is_skipped():
+    serving_chat = _build_serving_chat(mock_audio_choice=False)
+    request = _make_request(modalities=["audio"])
+
+    choices = serving_chat._create_audio_choice(
+        _make_empty_audio_omni_output(finish_reason=None),
+        "assistant",
+        request,
+        stream=True,
+    )
+
+    assert choices == []
 
 
 @pytest.mark.asyncio

--- a/tests/model_executor/models/qwen3_omni/test_qwen3_omni_talker_decode.py
+++ b/tests/model_executor/models/qwen3_omni/test_qwen3_omni_talker_decode.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.models.qwen3_omni.qwen3_omni import (
+    Qwen3OmniMoeForConditionalGeneration,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _make_minimal_omni() -> Qwen3OmniMoeForConditionalGeneration:
+    model = Qwen3OmniMoeForConditionalGeneration.__new__(Qwen3OmniMoeForConditionalGeneration)
+    model.talker = SimpleNamespace(text_projection=lambda x: x + 10)
+    model.tts_pad_embed = torch.full((2,), -1.0)
+    model.tts_eos_embed = torch.full((2,), -2.0)
+    return model
+
+
+def test_async_chunk_decode_consumes_cached_handoff_decode() -> None:
+    model = _make_minimal_omni()
+    payload = {
+        "embed": {
+            "cached_decode": torch.tensor(
+                [
+                    [1.0, 2.0],
+                    [3.0, 4.0],
+                ]
+            )
+        },
+        "meta": {
+            "num_processed_tokens": 1,
+            "prefill_consumed_text_tokens": 1,
+        },
+    }
+    update: dict = {}
+
+    out = model._thinker_decode_to_talker_decode(payload, torch.device("cpu"), update)
+
+    assert torch.equal(out, torch.tensor([11.0, 12.0]))
+    assert update["_advance_num_processed_tokens"] is True
+
+
+def test_async_chunk_decode_appends_current_decode_after_cached_prefix() -> None:
+    model = _make_minimal_omni()
+    payload = {
+        "embed": {
+            "cached_decode": torch.tensor(
+                [
+                    [1.0, 2.0],
+                    [3.0, 4.0],
+                ]
+            ),
+            "decode": torch.tensor([[5.0, 6.0]]),
+        },
+        "meta": {
+            "num_processed_tokens": 3,
+            "prefill_consumed_text_tokens": 1,
+        },
+    }
+    update: dict = {}
+
+    out = model._thinker_decode_to_talker_decode(payload, torch.device("cpu"), update)
+
+    assert torch.equal(out, torch.tensor([15.0, 16.0]))
+    assert update["_advance_num_processed_tokens"] is True
+
+
+def test_async_chunk_decode_uses_accumulated_decode_when_cache_is_prefix() -> None:
+    model = _make_minimal_omni()
+    payload = {
+        "embed": {
+            "cached_decode": torch.tensor([[1.0, 2.0]]),
+            "decode": torch.tensor(
+                [
+                    [1.0, 2.0],
+                    [3.0, 4.0],
+                ]
+            ),
+        },
+        "meta": {
+            "num_processed_tokens": 2,
+            "prefill_consumed_text_tokens": 1,
+        },
+    }
+    update: dict = {}
+
+    out = model._thinker_decode_to_talker_decode(payload, torch.device("cpu"), update)
+
+    assert torch.equal(out, torch.tensor([13.0, 14.0]))
+    assert update["_advance_num_processed_tokens"] is True
+
+
+def test_async_chunk_decode_clears_prior_eos_when_new_decode_arrives() -> None:
+    model = _make_minimal_omni()
+    payload = {
+        "embed": {"decode": torch.tensor([[7.0, 8.0]])},
+        "meta": {
+            "num_processed_tokens": 1,
+            "prefill_consumed_text_tokens": 1,
+            "eos_emitted": True,
+        },
+    }
+    update: dict = {}
+
+    out = model._thinker_decode_to_talker_decode(payload, torch.device("cpu"), update)
+
+    assert torch.equal(out, torch.tensor([17.0, 18.0]))
+    assert update["_advance_num_processed_tokens"] is True
+    assert update["meta"]["eos_emitted"] is False

--- a/tests/model_executor/models/test_qwen3_omni_code2wav.py
+++ b/tests/model_executor/models/test_qwen3_omni_code2wav.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm_omni.model_executor.models.qwen3_omni.qwen3_omni import (
+    Qwen3OmniMoeForConditionalGeneration,
+    _reshape_code2wav_input_ids,
+)
+from vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_code2wav import (
+    Qwen3OmniMoeCode2Wav,
+)
+
+
+class _Decoder:
+    chunked_decode = Qwen3OmniMoeCode2Wav.chunked_decode
+    chunked_decode_streaming = Qwen3OmniMoeCode2Wav.chunked_decode_streaming
+
+    def __init__(self) -> None:
+        self._cudagraph_enabled = False
+        self._cudagraph_wrapper = None
+        self.config = SimpleNamespace(num_quantizers=16)
+        self.total_upsample = 2
+
+    def __call__(self, codes: torch.Tensor) -> torch.Tensor:
+        batch_size = codes.shape[0]
+        wav_len = codes.shape[-1] * self.total_upsample
+        return torch.arange(
+            batch_size * wav_len,
+            dtype=torch.float32,
+        ).reshape(batch_size, 1, wav_len)
+
+
+def test_chunked_decode_ignores_stale_multi_request_metadata() -> None:
+    decoder = _Decoder()
+    codes = torch.zeros((1, 16, 3), dtype=torch.long)
+
+    wavs = decoder.chunked_decode(
+        codes,
+        chunk_size=8,
+        left_context_size=0,
+        seq_token_counts=[16, 32],
+    )
+
+    expected = torch.arange(6, dtype=torch.float32).reshape(1, 6)
+    assert len(wavs) == 1
+    torch.testing.assert_close(wavs[0], expected)
+
+
+def test_chunked_decode_streaming_ignores_stale_multi_request_metadata() -> None:
+    decoder = _Decoder()
+    codes = torch.zeros((1, 16, 3), dtype=torch.long)
+
+    wavs = decoder.chunked_decode_streaming(
+        codes,
+        left_context_size=[0, 1],
+        seq_token_counts=[16, 32],
+    )
+
+    expected = torch.arange(6, dtype=torch.float32).reshape(1, 6)
+    assert len(wavs) == 1
+    torch.testing.assert_close(wavs[0], expected)
+
+
+def test_code2wav_forward_returns_request_aligned_empty_audio_for_stale_counts() -> None:
+    model = object.__new__(Qwen3OmniMoeForConditionalGeneration)
+    model.model_stage = "code2wav"
+
+    def raise_if_called(*args: object, **kwargs: object) -> list[torch.Tensor]:
+        raise AssertionError("generate_audio should not run for stale scheduler counts")
+
+    model.generate_audio = raise_if_called
+
+    audio_tensors = Qwen3OmniMoeForConditionalGeneration.forward(
+        model,
+        input_ids=torch.arange(16, dtype=torch.long),
+        positions=torch.empty(0, dtype=torch.long),
+        seq_token_counts=[16, 32],
+    )
+
+    assert len(audio_tensors) == 2
+    for audio_tensor in audio_tensors:
+        assert audio_tensor.shape == (1, 0)
+        assert audio_tensor.dtype == torch.float32
+
+
+def test_code2wav_forward_pads_partial_scheduler_frames_per_request() -> None:
+    model = object.__new__(Qwen3OmniMoeForConditionalGeneration)
+    model.model_stage = "code2wav"
+    captured: dict[str, object] = {}
+
+    def fake_generate_audio(
+        codes: torch.Tensor,
+        left_context_size: list[int],
+        seq_token_counts: list[int],
+    ) -> list[torch.Tensor]:
+        captured["codes"] = codes
+        captured["left_context_size"] = left_context_size
+        captured["seq_token_counts"] = seq_token_counts
+        return [torch.empty((1, seq_len // 16), dtype=torch.float32) for seq_len in seq_token_counts]
+
+    model.generate_audio = fake_generate_audio
+
+    audio_tensors = Qwen3OmniMoeForConditionalGeneration.forward(
+        model,
+        input_ids=torch.arange(65, dtype=torch.long),
+        positions=torch.empty(0, dtype=torch.long),
+        seq_token_counts=[16, 17, 32],
+    )
+
+    assert [audio_tensor.shape for audio_tensor in audio_tensors] == [(1, 1), (1, 1), (1, 2)]
+    assert captured["seq_token_counts"] == [16, 17, 32]
+    assert captured["left_context_size"] == [0, 0, 0]
+    codes = captured["codes"]
+    assert isinstance(codes, torch.Tensor)
+    assert codes.shape == (3, 16, 2)
+    padded_second_request = codes[1].reshape(-1)
+    torch.testing.assert_close(
+        padded_second_request[:17],
+        torch.arange(16, 33, dtype=torch.long),
+    )
+    torch.testing.assert_close(padded_second_request[17:], torch.zeros(15, dtype=torch.long))
+
+
+def test_code2wav_input_reshape_preserves_aligned_request_boundaries() -> None:
+    input_ids = torch.arange(48, dtype=torch.long)
+
+    codes = _reshape_code2wav_input_ids(input_ids, [16, 32])
+
+    expected_first = torch.arange(16, dtype=torch.long).reshape(16, 1)
+    expected_second = torch.arange(16, 48, dtype=torch.long).reshape(16, 2)
+
+    assert codes.shape == (2, 16, 2)
+    torch.testing.assert_close(codes[0, :, :1], expected_first)
+    torch.testing.assert_close(codes[0, :, 1], torch.zeros(16, dtype=torch.long))
+    torch.testing.assert_close(codes[1], expected_second)
+
+
+def test_code2wav_forward_normalizes_left_context_per_request() -> None:
+    model = object.__new__(Qwen3OmniMoeForConditionalGeneration)
+    model.model_stage = "code2wav"
+    captured: dict[str, object] = {}
+
+    def fake_generate_audio(
+        codes: torch.Tensor,
+        left_context_size: list[int],
+        seq_token_counts: list[int],
+    ) -> list[torch.Tensor]:
+        captured["codes_shape"] = tuple(codes.shape)
+        captured["left_context_size"] = left_context_size
+        captured["seq_token_counts"] = seq_token_counts
+        return [torch.empty((1, seq_len // 16), dtype=torch.float32) for seq_len in seq_token_counts]
+
+    model.generate_audio = fake_generate_audio
+
+    audio_tensors = Qwen3OmniMoeForConditionalGeneration.forward(
+        model,
+        input_ids=torch.arange(64, dtype=torch.long),
+        positions=torch.empty(0, dtype=torch.long),
+        runtime_additional_information=[
+            {"meta": {"left_context_size": 2}},
+            {"meta": {}},
+            {"meta": {"left_context_size": 3}},
+        ],
+        seq_token_counts=[16, 16, 16, 16],
+    )
+
+    assert [audio_tensor.shape for audio_tensor in audio_tensors] == [(1, 1)] * 4
+    assert captured["codes_shape"] == (4, 16, 1)
+    assert captured["seq_token_counts"] == [16, 16, 16, 16]
+    assert captured["left_context_size"] == [2, 0, 3, 0]
+
+
+def test_code2wav_make_output_aligns_zero_token_requests() -> None:
+    model = object.__new__(Qwen3OmniMoeForConditionalGeneration)
+    model.model_stage = "code2wav"
+    model.code2wav_config = SimpleNamespace(sample_rate=24_000)
+    audio = torch.arange(4, dtype=torch.float32).reshape(1, 4)
+
+    output = Qwen3OmniMoeForConditionalGeneration.make_omni_output(
+        model,
+        [audio],
+        seq_token_counts=[0, 16],
+    )
+
+    assert len(output.multimodal_outputs["model_outputs"]) == 2
+    assert output.multimodal_outputs["model_outputs"][0].shape == (1, 0)
+    torch.testing.assert_close(output.multimodal_outputs["model_outputs"][1], audio)
+    assert [sr.item() for sr in output.multimodal_outputs["sr"]] == [24_000, 24_000]
+
+    output = Qwen3OmniMoeForConditionalGeneration.make_omni_output(
+        model,
+        [audio],
+        seq_token_counts=[16, 0],
+    )
+
+    assert len(output.multimodal_outputs["model_outputs"]) == 2
+    torch.testing.assert_close(output.multimodal_outputs["model_outputs"][0], audio)

--- a/tests/model_executor/stage_input_processors/test_qwen3_omni_finish_sentinel.py
+++ b/tests/model_executor/stage_input_processors/test_qwen3_omni_finish_sentinel.py
@@ -1,0 +1,138 @@
+"""code2wav async finish-sentinel terminal flush.
+
+The producer runner sends every in-step codec chunk with ``finished=False`` and
+emits a separate finish sentinel next cycle (empty payload + the
+``ASYNC_FINISH_SENTINEL_KEY`` marker the legacy adapter never sets).  On that
+marker, ``talker2code2wav_async_chunk`` must flush the trailing partial codec
+chunk that the live ``is_finished`` branch would otherwise have flushed, reusing
+the same context math, without re-appending.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm_omni.data_entry_keys import ASYNC_FINISH_SENTINEL_KEY
+from vllm_omni.model_executor.stage_input_processors.qwen3_omni import talker2code2wav_async_chunk
+
+
+def _tm(accumulated, chunk_frames=4, left_frames=25, initial_frames=None):
+    cfg = {"codec_chunk_frames": chunk_frames, "codec_left_context_frames": left_frames}
+    if initial_frames is not None:
+        cfg["initial_codec_chunk_frames"] = initial_frames
+    return SimpleNamespace(
+        code_prompt_token_ids=dict(accumulated),
+        connector=SimpleNamespace(config={"extra": cfg}),
+    )
+
+
+def _sentinel_payload():
+    return {ASYNC_FINISH_SENTINEL_KEY: True}
+
+
+def test_codec_config_can_come_from_runner_model_config():
+    cfg = {
+        "codec_chunk_frames": 25,
+        "codec_left_context_frames": 25,
+        "initial_codec_chunk_frames": 4,
+    }
+    model_config = SimpleNamespace(stage_connector_config={"extra": cfg})
+    tm = SimpleNamespace(
+        code_prompt_token_ids={"r": []},
+        put_req_chunk={"r": 0},
+    )
+    tm._get_model_config = lambda: model_config
+    req = SimpleNamespace(external_req_id="r", sampling_params=None)
+    frame = torch.ones((1, 16), dtype=torch.long)
+
+    for _ in range(3):
+        assert talker2code2wav_async_chunk(tm, {"codes": {"audio": frame}}, req) is None
+    out = talker2code2wav_async_chunk(tm, {"codes": {"audio": frame}}, req)
+
+    assert out is not None
+    assert out.codes.audio.numel() == 64
+    assert out.meta.left_context_size == 0
+
+
+def test_talker2code2wav_async_chunk_accepts_flat_payload():
+    tm = _tm({"r": []}, chunk_frames=1, left_frames=0)
+    tm.put_req_chunk = {"r": 0}
+    req = SimpleNamespace(external_req_id="r", sampling_params=None)
+    frame = torch.arange(1, 17, dtype=torch.long).reshape(1, 16)
+
+    out = talker2code2wav_async_chunk(tm, {"codes.audio": frame}, req)
+
+    assert out is not None
+    assert torch.equal(out.codes.audio, frame.transpose(0, 1).reshape(-1))
+
+
+def test_finish_sentinel_flushes_partial_tail():
+    # 6 frames accumulated, chunk size 4 -> a 2-frame partial tail is still held.
+    tm = _tm({"r": [torch.tensor([[i]]) for i in range(1, 7)]}, chunk_frames=4, left_frames=25)
+    req = SimpleNamespace(external_req_id="r")
+
+    out = talker2code2wav_async_chunk(tm, _sentinel_payload(), req, is_finished=True)
+
+    assert out is not None
+    assert bool(out.meta.finished) is True
+    # context_length = 6 % 4 = 2; left = min(6-2, 25) = 4; end_index = min(6, 4+2) = 6.
+    assert out.meta.left_context_size == 4
+    assert isinstance(out.codes.audio, torch.Tensor)
+    # 6 single-codebook frames -> flattened length 6.
+    assert out.codes.audio.numel() == 6
+
+
+def test_finish_sentinel_on_chunk_boundary_emits_flag_only():
+    # 4 frames, chunk size 4 -> the last full chunk was already sent in-step;
+    # no unsent tail, so the sentinel must NOT re-send codec (flag only).
+    tm = _tm({"r": [torch.tensor([[i]]) for i in range(1, 5)]}, chunk_frames=4)
+    req = SimpleNamespace(external_req_id="r")
+
+    out = talker2code2wav_async_chunk(tm, _sentinel_payload(), req, is_finished=True)
+
+    assert out is not None
+    assert bool(out.meta.finished) is True
+    assert out.codes is None, "boundary finish must not re-send the last full chunk"
+
+
+def test_finish_sentinel_with_no_sent_chunks_emits_flag_only():
+    tm = _tm({}, chunk_frames=4)
+    req = SimpleNamespace(external_req_id="missing")
+
+    out = talker2code2wav_async_chunk(tm, _sentinel_payload(), req, is_finished=True)
+
+    assert out is not None
+    assert bool(out.meta.finished) is True
+    assert out.codes is None
+
+
+def test_non_sentinel_empty_call_is_unchanged():
+    # Without the marker, an empty/codeless call returns None as before -> the
+    # adapter path (which never sets the marker) is byte-identical.
+    tm = _tm({"r": [torch.tensor([[1]]), torch.tensor([[2]])]}, chunk_frames=4)
+    req = SimpleNamespace(external_req_id="r")
+
+    assert talker2code2wav_async_chunk(tm, {"codes": {}}, req, is_finished=True) is None
+    assert talker2code2wav_async_chunk(tm, {}, req, is_finished=True) is None
+
+
+def test_finish_sentinel_on_initial_chunk_boundary_emits_flag_only():
+    tm = _tm({"r": [torch.tensor([[i]]) for i in range(1, 5)]}, chunk_frames=25, initial_frames=4)
+    req = SimpleNamespace(external_req_id="r")
+    out = talker2code2wav_async_chunk(tm, _sentinel_payload(), req, is_finished=True)
+
+    assert out is not None
+    assert bool(out.meta.finished) is True
+    assert out.codes is None, "initial-boundary finish must not re-send the initial chunk"
+
+
+def test_finish_sentinel_flushes_partial_tail_after_initial_chunk():
+    tm = _tm({"r": [torch.tensor([[i]]) for i in range(1, 7)]}, chunk_frames=25, initial_frames=4)
+    req = SimpleNamespace(external_req_id="r")
+    out = talker2code2wav_async_chunk(tm, _sentinel_payload(), req, is_finished=True)
+
+    assert out is not None
+    assert bool(out.meta.finished) is True
+    assert out.meta.left_context_size == 4
+    assert isinstance(out.codes.audio, torch.Tensor)
+    assert out.codes.audio.numel() == 6

--- a/tests/model_executor/stage_input_processors/test_qwen3_omni_streaming_helpers.py
+++ b/tests/model_executor/stage_input_processors/test_qwen3_omni_streaming_helpers.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit tests for Qwen3-Omni streaming thinker→talker / talker→codec helpers (PR #2581)."""
+"""Unit tests for Qwen3-Omni streaming thinker→talker / talker→codec helpers."""
 
 from __future__ import annotations
 
@@ -17,6 +17,11 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 @pytest.fixture(autouse=True)
 def _streaming_context() -> SimpleNamespace:
     return SimpleNamespace(bridge_states={})
+
+
+class _TensorCopySentinel:
+    def detach(self):
+        raise AssertionError("tensor copy should not be reached")
 
 
 def test_get_streaming_talker_tokens_first_segment(_streaming_context: SimpleNamespace) -> None:
@@ -105,6 +110,31 @@ def test_streaming_input_prefill_chunk_is_cached() -> None:
     assert cached["ids"]["prompt"] == request.prompt_token_ids
 
 
+def test_streaming_input_placeholder_chunk_is_not_sent() -> None:
+    transfer_manager = SimpleNamespace(_pending_streaming_prefills={})
+    request = SimpleNamespace(
+        external_req_id="rt-placeholder",
+        output_token_ids=[],
+        all_token_ids=[151644, 872],
+        prompt_token_ids=[151644, 872],
+        resumable=True,
+        additional_information=None,
+    )
+    thinker_emb = _TensorCopySentinel()
+    thinker_hid = _TensorCopySentinel()
+
+    payload = q3._construct_thinker2talker_streaming_input_async_chunk(
+        False,
+        request,
+        thinker_emb,
+        thinker_hid,
+        transfer_manager,
+    )
+
+    assert payload is None
+    assert transfer_manager._pending_streaming_prefills == {}
+
+
 def test_streaming_input_prefill_flushes_with_next_decode_chunk() -> None:
     transfer_manager = SimpleNamespace(
         _pending_streaming_prefills={
@@ -124,7 +154,7 @@ def test_streaming_input_prefill_flushes_with_next_decode_chunk() -> None:
         additional_information=None,
     )
     thinker_emb = torch.full((1, 3), 3.0)
-    thinker_hid = torch.full((1, 3), 4.0)
+    thinker_hid = _TensorCopySentinel()
 
     payload = q3._construct_thinker2talker_streaming_input_async_chunk(
         False,
@@ -135,11 +165,53 @@ def test_streaming_input_prefill_flushes_with_next_decode_chunk() -> None:
     )
 
     assert payload is not None
-    assert payload.embed.prefill.shape == (3, 3)
-    assert payload.hidden_states.output.shape == (3, 3)
+    assert payload.embed.prefill.shape == (2, 3)
+    assert torch.equal(payload.embed.decode, thinker_emb)
+    assert payload.hidden_states.output.shape == (2, 3)
     assert payload.ids.all == [151644, 872, 100]
     assert payload.ids.prompt == [151644, 872]
+    assert payload.ids.output == [101]
     assert "rt-2" not in transfer_manager._pending_streaming_prefills
+
+
+def test_thinker2talker_finish_flushes_cached_first_payload() -> None:
+    cached_prefill = torch.ones(2, 3)
+    cached_hidden = torch.full((2, 3), 2.0)
+    transfer_manager = SimpleNamespace(
+        put_req_chunk={},
+        request_payload={
+            "rt-finish": {
+                "embed": {"prefill": cached_prefill},
+                "hidden_states": {"output": cached_hidden},
+                "ids": {"all": [151644, 872], "prompt": [151644, 872]},
+                "meta": {"finished": torch.tensor(False)},
+            }
+        },
+        _pending_streaming_prefills={},
+    )
+    request = SimpleNamespace(
+        external_req_id="rt-finish",
+        output_token_ids=[],
+        all_token_ids=[151644, 872],
+        prompt_token_ids=[151644, 872],
+        resumable=True,
+        additional_information=None,
+    )
+
+    payload = q3.thinker2talker_async_chunk(
+        transfer_manager,
+        {q3.ASYNC_FINISH_SENTINEL_KEY: True},
+        request,
+        is_finished=True,
+    )
+
+    assert payload is not None
+    assert payload["meta"]["finished"].item() is True
+    assert torch.equal(payload["embed"]["prefill"], cached_prefill)
+    assert torch.equal(payload["hidden_states"]["output"], cached_hidden)
+    assert payload["ids"]["prompt"] == [151644, 872]
+    assert transfer_manager.request_payload == {}
+    assert transfer_manager.put_req_chunk == {}
 
 
 def test_talker2code2wav_full_payload_filters_by_output_token_ids() -> None:
@@ -250,6 +322,50 @@ def test_thinker2talker_full_payload_packs_complete_tensors() -> None:
     assert payload["next_stage_prompt_len"] > 0
     assert payload["embed"]["prefill"].shape[0] == 2
     assert payload["hidden_states"]["output"].shape[0] == 2
+
+
+def test_thinker2talker_async_chunk_accepts_flattened_runner_payload() -> None:
+    transfer_manager = SimpleNamespace(put_req_chunk={}, request_payload={})
+    request = SimpleNamespace(
+        external_req_id="thinker",
+        prompt_token_ids=[151644, 872],
+        output_token_ids=[3],
+        all_token_ids=[151644, 872, 3],
+        resumable=False,
+    )
+    pooling_output = {
+        "hidden_states.layer_0": torch.ones(2, 2),
+        "hidden_states.layer_24": torch.full((2, 2), 2.0),
+        "embed.tts_bos": torch.zeros(1, 2),
+    }
+
+    payload = q3.thinker2talker_async_chunk(transfer_manager, pooling_output, request, is_finished=False)
+
+    assert payload is None
+    assert "thinker" in transfer_manager.request_payload
+    cached = transfer_manager.request_payload["thinker"]
+    assert cached["embed"]["prefill"].shape == (2, 2)
+    assert cached["hidden_states"]["output"].shape == (2, 2)
+
+
+def test_thinker2talker_async_chunk_decode_allows_missing_resumable_attr() -> None:
+    transfer_manager = SimpleNamespace(put_req_chunk={"thinker": 1}, request_payload={})
+    request = SimpleNamespace(
+        external_req_id="thinker",
+        prompt_token_ids=[151644, 872],
+        output_token_ids=[3],
+        all_token_ids=[151644, 872, 3],
+    )
+    pooling_output = {
+        "hidden_states.layer_0": torch.ones(1, 2),
+        "hidden_states.layer_24": torch.full((1, 2), 2.0),
+    }
+
+    payload = q3.thinker2talker_async_chunk(transfer_manager, pooling_output, request, is_finished=False)
+
+    assert payload is not None
+    assert payload.embed.decode.shape == (1, 2)
+    assert payload.meta.finished.item() is False
 
 
 def test_accumulator_replaces_keys_in_replace_set() -> None:

--- a/tests/utils/test_mm_outputs.py
+++ b/tests/utils/test_mm_outputs.py
@@ -1,0 +1,29 @@
+import torch
+
+from vllm_omni.utils.mm_outputs import to_payload_element
+
+
+def test_to_payload_element_clones_request_invariant_tensors_by_default():
+    tensor = torch.tensor([[1.0, 2.0]])
+
+    result = to_payload_element(tensor, idx=0, start=0, end=1, seq_len=2)
+
+    assert torch.equal(result, tensor)
+    assert result.data_ptr() != tensor.data_ptr()
+
+
+def test_to_payload_element_can_reuse_request_invariant_tensors_for_send_only_payloads():
+    tensor = torch.tensor([[1.0, 2.0]])
+
+    result = to_payload_element(tensor, idx=0, start=0, end=1, seq_len=2, clone_tensors=False)
+
+    assert result is tensor
+
+
+def test_to_payload_element_propagates_clone_policy_through_nested_payloads():
+    tensor = torch.tensor([[1.0, 2.0]])
+    payload = {"embed": {"tts_bos": [tensor]}}
+
+    result = to_payload_element(payload, idx=0, start=0, end=1, clone_tensors=False)
+
+    assert result["embed"]["tts_bos"] is tensor

--- a/tests/worker/test_async_chunk_request_adapter.py
+++ b/tests/worker/test_async_chunk_request_adapter.py
@@ -1,0 +1,76 @@
+"""Unit coverage for the runner-side async-chunk request shim.
+
+Covers the pure, GPU-free helpers that the AR runner uses to feed the
+async-chunk stage-input processors from a worker-side ``CachedRequestState``:
+``_strip_trailing_placeholder_tokens`` and ``_AsyncChunkRequestAdapter``.
+
+The actual ``send_chunk`` call is gated by the async-chunk model-runner
+transport predicate and exercised end-to-end by Qwen3 async-chunk tests; that
+gate is covered separately in test_omni_scheduling_coordinator.py.
+"""
+
+from types import SimpleNamespace
+
+from vllm_omni.worker.omni_connector_model_runner_mixin import (
+    _AsyncChunkRequestAdapter,
+    _strip_trailing_placeholder_tokens,
+)
+
+
+def test_strip_trailing_placeholder_tokens():
+    assert _strip_trailing_placeholder_tokens(None) == []
+    assert _strip_trailing_placeholder_tokens([]) == []
+    assert _strip_trailing_placeholder_tokens([1, 2, 3]) == [1, 2, 3]
+    # Only trailing -1 placeholders are dropped; interior values are kept.
+    assert _strip_trailing_placeholder_tokens([1, 2, -1, -1]) == [1, 2]
+    assert _strip_trailing_placeholder_tokens([-1, -1]) == []
+    assert _strip_trailing_placeholder_tokens([5, -1, 6]) == [5, -1, 6]
+
+
+def _cached_state():
+    return SimpleNamespace(
+        req_id="internal-1",
+        prompt_token_ids=[10, 11, 12],
+        output_token_ids=[20, 21, -1],
+        additional_information="add-info-sentinel",
+    )
+
+
+def test_adapter_exposes_request_identity_fields():
+    inner = _cached_state()
+    adapter = _AsyncChunkRequestAdapter(inner, external_req_id="ext-99", finished=False)
+
+    # external id is the passed cross-stage id; request_id/req_id mirror the inner req_id.
+    assert adapter.external_req_id == "ext-99"
+    assert adapter.request_id == "internal-1"
+    assert adapter.req_id == "internal-1"
+
+
+def test_adapter_all_token_ids_strips_placeholder_output():
+    inner = _cached_state()
+    adapter = _AsyncChunkRequestAdapter(inner, external_req_id="ext-99", finished=False)
+
+    # output_token_ids drops the trailing -1; all_token_ids = prompt + stripped output.
+    assert adapter.output_token_ids == [20, 21]
+    assert adapter.prompt_token_ids == [10, 11, 12]
+    assert adapter.all_token_ids == [10, 11, 12, 20, 21]
+
+
+def test_adapter_is_finished_reflects_constructor_flag():
+    inner = _cached_state()
+    assert _AsyncChunkRequestAdapter(inner, external_req_id="e", finished=False).is_finished() is False
+    assert _AsyncChunkRequestAdapter(inner, external_req_id="e", finished=True).is_finished() is True
+
+
+def test_adapter_delegates_unknown_attrs_to_inner():
+    inner = _cached_state()
+    adapter = _AsyncChunkRequestAdapter(inner, external_req_id="e", finished=False)
+    # additional_information (used by speaker/language extractors) is not a
+    # declared property -> must delegate to the wrapped CachedRequestState.
+    assert adapter.additional_information == "add-info-sentinel"
+
+
+def test_adapter_handles_empty_prompt():
+    inner = SimpleNamespace(req_id="r", prompt_token_ids=None, output_token_ids=[7])
+    adapter = _AsyncChunkRequestAdapter(inner, external_req_id="e", finished=False)
+    assert adapter.all_token_ids == [7]

--- a/tests/worker/test_gpu_ar_model_runner.py
+++ b/tests/worker/test_gpu_ar_model_runner.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import numpy as np
@@ -126,6 +127,54 @@ def _make_async_output_runner(engine_output_type: str = "audio"):
         req_id_to_index={"mutated": 0},
     )
     return runner
+
+
+def test_execute_model_registers_pending_connector_registrations(monkeypatch):
+    runner = object.__new__(GPUARModelRunner)
+    runner.execute_model_state = None
+    runner.routed_experts_initialized = False
+    runner._warmup_state_cleared = True
+    runner.model = SimpleNamespace()
+    runner.omni_prefix_cache = None
+    runner.kv_caches = []
+    runner.cache_config = SimpleNamespace(block_size=16, cache_dtype="auto")
+    runner._resolve_global_request_id = lambda req_id: req_id
+    runner.kv_transfer_manager = SimpleNamespace(handle_finished_requests_kv_transfer=lambda **kwargs: [])
+    runner._omni_connector = object()
+    runner.recv_full_payload_inputs = lambda scheduler_output: None
+    runner._pending_full_payload_send = {}
+    runner.requests = {}
+    runner.model_config = SimpleNamespace(async_chunk=False)
+    runner.speculative_config = None
+    runner.synchronize_input_prep = nullcontext
+    runner._update_states = lambda scheduler_output: None
+    runner.parallel_config = SimpleNamespace(distributed_executor_backend="mp", data_parallel_size=1)
+    runner.vllm_config = SimpleNamespace()
+    runner.attach_omni_connector_output = lambda output: output
+    registered = []
+    request = SimpleNamespace(request_id="r1")
+    runner.register_chunk_recv = registered.append
+
+    monkeypatch.setattr("vllm_omni.worker.gpu_ar_model_runner.has_kv_transfer_group", lambda: False)
+    monkeypatch.setattr("vllm_omni.worker.gpu_ar_model_runner.has_ec_transfer", lambda: False)
+    monkeypatch.setattr(
+        "vllm_omni.worker.gpu_ar_model_runner.uses_async_chunk_model_runner_transport",
+        lambda model_config: False,
+    )
+
+    scheduler_output = SimpleNamespace(
+        pending_connector_registrations=[request],
+        finished_requests_needing_kv_transfer={},
+        finished_req_ids=set(),
+        total_num_scheduled_tokens=0,
+        scheduled_spec_decode_tokens={},
+        num_scheduled_tokens={},
+        kv_connector_metadata=None,
+    )
+
+    GPUARModelRunner.execute_model(runner, scheduler_output)
+
+    assert registered == [request]
 
 
 def test_build_omni_output_uses_snapshots_and_connector_after_accumulation(monkeypatch):
@@ -484,3 +533,259 @@ def test_build_omni_output_falls_back_to_mm_cpu_without_prefix_merge(monkeypatch
 
     assert torch.equal(output.multimodal_outputs[0]["codes.audio"], codes[0:1])
     assert torch.equal(output.multimodal_outputs[1]["codes.audio"], codes[1:2])
+
+
+@pytest.mark.parametrize(
+    ("additional_information", "expected"),
+    [
+        ({"omni_final_stage_id": 0}, False),
+        ({"omni_final_stage_id": 2}, True),
+        ({}, True),
+    ],
+)
+def test_request_needs_downstream_stage_payload_respects_final_stage_id(monkeypatch, additional_information, expected):
+    runner = object.__new__(GPUARModelRunner)
+    runner.model_config = SimpleNamespace()
+    runner.model_intermediate_buffer = {}
+    runner.requests = {
+        "r1": SimpleNamespace(additional_information_cpu=additional_information),
+    }
+    runner._downstream_payload_cache = {}
+    runner._custom_process_func = object()
+
+    monkeypatch.setattr(
+        "vllm_omni.worker.gpu_ar_model_runner.uses_async_chunk_model_runner_transport",
+        lambda model_config: True,
+    )
+
+    assert GPUARModelRunner._request_needs_downstream_stage_payload(runner, "r1") is expected
+    assert runner._downstream_payload_cache["r1"] is expected
+
+
+def test_request_needs_downstream_stage_payload_keeps_runner_transport_producer(monkeypatch):
+    runner = object.__new__(GPUARModelRunner)
+    runner.model_config = SimpleNamespace()
+    runner.model_intermediate_buffer = {}
+    runner.requests = {
+        "r1": SimpleNamespace(additional_information_cpu={"omni_final_stage_id": 1}),
+    }
+    runner._downstream_payload_cache = {}
+    runner._custom_process_func = object()
+
+    monkeypatch.setattr(
+        "vllm_omni.worker.gpu_ar_model_runner.uses_async_chunk_model_runner_transport",
+        lambda model_config: True,
+    )
+
+    assert GPUARModelRunner._request_needs_downstream_stage_payload(runner, "r1")
+
+
+def test_finish_sentinel_enqueues_when_first_payload_is_cached():
+    runner = object.__new__(GPUARModelRunner)
+    runner._request_ids_mapping = {"local-1": "ext-1"}
+    runner._put_req_chunk = {}
+    runner._send_side_request_payload = {"ext-1": {"embed": {"prefill": object()}}}
+    runner._pending_streaming_prefills = {}
+    runner._send_side_request_snapshot = {
+        "ext-1": SimpleNamespace(
+            request_id="local-1",
+            req_id="local-1",
+            external_req_id="ext-1",
+            is_finished=lambda: False,
+        )
+    }
+    sent = []
+    runner.enqueue_finish_sentinel = lambda request, ext_id: sent.append((request, ext_id)) or True
+
+    GPUARModelRunner._send_async_chunk_finish_sentinels(runner, {"local-1"})
+
+    assert sent == [(runner._send_side_request_snapshot["ext-1"], "ext-1")]
+    assert runner._send_side_request_snapshot["ext-1"].is_finished() is True
+
+
+def test_finish_sentinel_enqueues_bare_terminal_when_downstream_waits():
+    runner = object.__new__(GPUARModelRunner)
+    runner._request_ids_mapping = {"local-1": "ext-1"}
+    runner._put_req_chunk = {}
+    runner._send_side_request_payload = {}
+    runner._pending_streaming_prefills = {}
+    runner._send_side_request_snapshot = {}
+    runner._downstream_payload_cache = {"local-1": True}
+    runner.model_intermediate_buffer = {}
+    runner.requests = {}
+    sent = []
+
+    def enqueue(request, ext_id):
+        sent.append((request, ext_id, request.is_finished()))
+        return True
+
+    runner.enqueue_finish_sentinel = enqueue
+
+    GPUARModelRunner._send_async_chunk_finish_sentinels(runner, {"local-1"})
+
+    assert len(sent) == 1
+    request, ext_id, is_finished = sent[0]
+    assert ext_id == "ext-1"
+    assert request.request_id == "local-1"
+    assert request.external_req_id == "ext-1"
+    assert is_finished is True
+
+
+def test_segment_terminal_waits_for_talker_eos():
+    runner = object.__new__(GPUARModelRunner)
+    runner.model_config = SimpleNamespace(model_stage="talker")
+    runner.model_intermediate_buffer = {
+        "waiting": {
+            "meta": {
+                "is_segment_finished": torch.tensor(True),
+                "eos_emitted": torch.tensor(False),
+            }
+        },
+        "segment": {
+            "meta": {
+                "is_segment_finished": torch.tensor(True),
+                "eos_emitted": torch.tensor(True),
+                "finished": torch.tensor(False),
+            }
+        },
+    }
+
+    assert not GPUARModelRunner._async_chunk_segment_terminal_ready(runner, "waiting")
+    assert GPUARModelRunner._async_chunk_segment_terminal_ready(runner, "segment")
+
+
+def test_segment_terminal_non_talker_does_not_wait_for_eos():
+    runner = object.__new__(GPUARModelRunner)
+    runner.model_config = SimpleNamespace(model_stage="thinker")
+    runner.model_intermediate_buffer = {
+        "local-1": {
+            "meta": {
+                "is_segment_finished": torch.tensor(True),
+                "eos_emitted": torch.tensor(False),
+            }
+        }
+    }
+
+    assert GPUARModelRunner._async_chunk_segment_terminal_ready(runner, "local-1")
+
+
+def test_segment_terminal_enqueue_is_idempotent():
+    runner = object.__new__(GPUARModelRunner)
+    runner.model_intermediate_buffer = {
+        "local-1": {
+            "meta": {
+                "is_segment_finished": torch.tensor(True),
+                "eos_emitted": torch.tensor(True),
+            }
+        }
+    }
+    runner._request_ids_mapping = {"local-1": "ext-1"}
+    runner._send_side_request_snapshot = {
+        "ext-1": SimpleNamespace(
+            request_id="local-1",
+            req_id="local-1",
+            external_req_id="ext-1",
+            is_finished=lambda: False,
+        )
+    }
+    runner._async_chunk_segment_terminal_sent = set()
+    sent = []
+
+    def enqueue(request, ext_id, *, is_segment_finished=False):
+        sent.append((request, ext_id, is_segment_finished))
+        return True
+
+    runner.enqueue_finish_sentinel = enqueue
+
+    GPUARModelRunner._send_async_chunk_segment_sentinels(runner, {"local-1"})
+    GPUARModelRunner._send_async_chunk_segment_sentinels(runner, {"local-1"})
+
+    assert len(sent) == 1
+    assert sent[0][1:] == ("ext-1", True)
+
+
+def test_segment_terminal_guard_clears_when_new_decode_resets_eos():
+    runner = object.__new__(GPUARModelRunner)
+    runner._async_chunk_segment_terminal_sent = {"ext-1"}
+    runner.model_intermediate_buffer = {"local-1": {"meta": {"eos_emitted": torch.tensor(False)}}}
+
+    assert not GPUARModelRunner._should_skip_async_chunk_payload_after_segment_terminal(runner, "local-1", "ext-1")
+    assert "ext-1" not in runner._async_chunk_segment_terminal_sent
+
+
+def test_build_omni_output_runner_transport_sends_nested_payload(monkeypatch):
+    runner = _make_async_output_runner(engine_output_type="latent")
+    runner._custom_process_func = object()
+    runner.model_config.model_stage = "thinker"
+    runner._request_ids_mapping = {"r1": "ext-r1"}
+    runner._send_side_request_snapshot = {}
+    runner.model_intermediate_buffer = {}
+    runner.requests = {
+        "r1": SimpleNamespace(
+            req_id="r1",
+            external_req_id="ext-r1",
+            prompt_token_ids=[1],
+            output_token_ids=[2],
+            additional_information_cpu={"omni_final_stage_id": 1},
+        )
+    }
+    sent = []
+
+    def send_chunk(request, pooling_output):
+        sent.append((request, pooling_output))
+        return True
+
+    runner.send_chunk = send_chunk
+    runner._snapshot_request_for_send = lambda request, ext_id: SimpleNamespace(
+        request_id=request.request_id,
+        req_id=request.req_id,
+        external_req_id=ext_id,
+        is_finished=request.is_finished,
+    )
+
+    monkeypatch.setattr(
+        "vllm_omni.worker.gpu_ar_model_runner.uses_async_chunk_model_runner_transport",
+        lambda model_config: True,
+    )
+    monkeypatch.setattr(
+        GPUARModelRunner,
+        "_resolve_pooler_payload_req_ids",
+        lambda self, req_ids: ("latent", req_ids),
+    )
+    monkeypatch.setattr(GPUARModelRunner, "_should_accumulate_full_payload_output", lambda self: False)
+    monkeypatch.setattr(GPUARModelRunner, "get_omni_connector_output", lambda self: None)
+    monkeypatch.setattr(GPUARModelRunner, "_process_additional_information_updates", lambda *args, **kwargs: None)
+
+    output = GPUARModelRunner._build_omni_model_runner_output_from_snapshot(
+        runner,
+        scheduler_output=SimpleNamespace(
+            total_num_scheduled_tokens=1,
+            num_scheduled_tokens={"r1": 1},
+        ),
+        hidden_states=torch.tensor([[1.0, 2.0]], dtype=torch.float32),
+        staged_hidden_states_cpu=None,
+        multimodal_outputs={"codes": {"audio": torch.tensor([[7, 8]], dtype=torch.long)}},
+        req_ids_output_copy=["r1"],
+        req_id_to_index_output_copy={"r1": 0},
+        valid_sampled_token_ids=[[]],
+        logprobs_lists=None,
+        prompt_logprobs_dict={},
+        num_nans_in_logits=None,
+        kv_connector_output=None,
+        ec_connector_output=None,
+        cudagraph_stats=None,
+        kv_extracted_req_ids=None,
+        seq_len=1,
+        num_scheduled_tokens_np=np.array([1], dtype=np.int32),
+        query_start_loc_cpu=torch.tensor([0], dtype=torch.long),
+    )
+
+    assert output.multimodal_outputs is None
+    assert len(sent) == 1
+    request, payload = sent[0]
+    assert request.external_req_id == "ext-r1"
+    assert request.is_finished() is False
+    assert torch.equal(payload["hidden"], torch.tensor([[1.0, 2.0]], dtype=torch.float32))
+    assert "codes.audio" not in payload
+    assert torch.equal(payload["codes"]["audio"], torch.tensor([[7, 8]], dtype=torch.long))
+    assert runner._send_side_request_snapshot["ext-r1"].is_finished() is False

--- a/tests/worker/test_gpu_generation_model_runner.py
+++ b/tests/worker/test_gpu_generation_model_runner.py
@@ -17,7 +17,9 @@ class _DummyInputBatch:
         self.vocab_size = 10
 
 
-def _make_runner(multimodal_outputs):
+def _make_runner(multimodal_outputs, req_ids=None, req_id_to_index=None):
+    req_ids = req_ids or ["req-1"]
+    req_id_to_index = req_id_to_index or {"req-1": 0}
     runner = object.__new__(GPUGenerationModelRunner)
     runner.execute_model_state = ExecuteModelState(
         None,
@@ -32,6 +34,8 @@ def _make_runner(multimodal_outputs):
         None,
         multimodal_outputs,
         None,
+        req_ids,
+        req_id_to_index,
     )
     runner.kv_connector_output = None
     runner.input_batch = _DummyInputBatch()
@@ -83,3 +87,26 @@ def test_sample_tokens_dict_output():
     assert "audio" in output.multimodal_outputs[0]
     assert "unused" not in output.multimodal_outputs[0]
     assert output.multimodal_outputs[0]["audio"].shape == (1, 4)
+
+
+def test_sample_tokens_uses_execute_snapshot_when_input_batch_mutates():
+    multimodal_outputs = {
+        "model_outputs": [torch.randn(1, 2)],
+        "sr": [torch.tensor(24_000, dtype=torch.int32)],
+    }
+    runner = _make_runner(
+        multimodal_outputs,
+        req_ids=["req-1"],
+        req_id_to_index={"req-1": 0},
+    )
+    runner.input_batch.req_ids = ["req-1", "req-2", "req-3"]
+    runner.input_batch.req_id_to_index = {"req-1": 0, "req-2": 1, "req-3": 2}
+    runner.input_batch.num_reqs = 3
+
+    output = GPUGenerationModelRunner.sample_tokens(runner)
+
+    assert output.req_ids == ["req-1"]
+    assert output.req_id_to_index == {"req-1": 0}
+    assert len(output.multimodal_outputs) == 1
+    assert output.multimodal_outputs[0]["model_outputs"].shape == (1, 2)
+    assert output.multimodal_outputs[0]["sr"].item() == 24_000

--- a/tests/worker/test_omni_connector_mixin.py
+++ b/tests/worker/test_omni_connector_mixin.py
@@ -20,6 +20,7 @@ import torch
 from vllm_omni.outputs import OmniConnectorOutput
 from vllm_omni.worker.omni_connector_model_runner_mixin import (
     OmniConnectorModelRunnerMixin,
+    _deep_merge_chunk_payload,
 )
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
@@ -142,6 +143,71 @@ class TestMixinAsyncChunkSendRecv(unittest.TestCase):
 
         sender.shutdown_omni_connectors()
 
+    def test_send_chunk_accepts_multimodal_output_hook_arg(self):
+        sender = MixinHost()
+        sender.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=0, async_chunk=True),
+        )
+
+        seen = {}
+
+        def mock_process(transfer_manager, multimodal_output, request, is_finished=False):
+            seen["connector"] = transfer_manager.connector
+            seen["data"] = multimodal_output
+            seen["request"] = request
+            seen["is_finished"] = is_finished
+            return {"data": multimodal_output, "finished": is_finished}
+
+        self.assertTrue(sender._is_connector_payload_builder(mock_process))
+        self.assertEqual(
+            sender._connector_payload_output_arg(mock_process),
+            "multimodal_output",
+        )
+        sender._custom_process_func = mock_process
+        sender._custom_process_output_arg = sender._connector_payload_output_arg(mock_process)
+        sender._custom_process_supports_is_finished = sender._custom_process_supports_is_finished_kwarg()
+
+        request = _make_request("req-1", "ext-req-1")
+        request.is_finished = lambda: True
+        payload = sender._build_custom_process_payload("ext-req-1", request, {"value": 42})
+
+        self.assertEqual(payload, {"data": {"value": 42}, "finished": True})
+        self.assertEqual(seen["data"], {"value": 42})
+        self.assertIs(seen["request"], request)
+        self.assertTrue(seen["is_finished"])
+
+        sender.shutdown_omni_connectors()
+
+    def test_build_custom_payload_reuses_cached_is_finished_signature(self):
+        sender = MixinHost()
+        sender.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=0, async_chunk=True),
+        )
+
+        def mock_process(transfer_manager, pooling_output, request, is_finished=False):
+            return {"data": pooling_output, "finished": is_finished}
+
+        sender._custom_process_func = mock_process
+        sender._custom_process_supports_is_finished = True
+        calls = {"count": 0}
+
+        def fail_if_recomputed():
+            calls["count"] += 1
+            raise AssertionError("signature support should be cached")
+
+        sender._custom_process_supports_is_finished_kwarg = fail_if_recomputed
+        request = _make_request("req-1", "ext-req-1")
+        request.is_finished = lambda: True
+
+        payload = sender._build_custom_process_payload("ext-req-1", request, {"value": 42})
+
+        self.assertEqual(payload, {"data": {"value": 42}, "finished": True})
+        self.assertEqual(calls["count"], 0)
+
+        sender.shutdown_omni_connectors()
+
     def test_send_chunk_does_not_retry_real_type_error(self):
         connector = MockConnector(stage_id=0)
 
@@ -169,6 +235,208 @@ class TestMixinAsyncChunkSendRecv(unittest.TestCase):
         self.assertEqual(seen["calls"], 1)
 
         sender.shutdown_omni_connectors()
+
+    def test_send_chunk_skips_preempted_replay(self):
+        # Keep preemption duplicate-send guard parity with the adapter.
+        connector = MockConnector(stage_id=0)
+        sender = MixinHost()
+        sender.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=0, async_chunk=True),
+        )
+        sender._omni_connector = connector
+        sender._stage_id = 0
+        sender._async_chunk = True
+
+        calls = {"n": 0}
+
+        def proc(transfer_manager, pooling_output, request, is_finished=False):
+            calls["n"] += 1
+            return {"data": pooling_output}
+
+        sender._custom_process_func = proc
+
+        req = _make_request("req-1", "ext-1")
+        req.num_computed_tokens = 10
+        self.assertTrue(sender.send_chunk(req, pooling_output={"v": 1}))
+        self.assertEqual(calls["n"], 1)
+        self.assertEqual(sender._requests_num_chunks_sent["ext-1"], 10)
+        self.assertEqual(sender._put_req_chunk["ext-1"], 1)
+
+        # Preemption: committed-token count regresses below the watermark ->
+        # the replayed span must be skipped (no re-run, no chunk-id advance).
+        req.num_computed_tokens = 5
+        self.assertTrue(sender.send_chunk(req, pooling_output={"v": 2}))
+        self.assertEqual(calls["n"], 1, "preempted replay must not re-run the process func")
+        self.assertEqual(sender._put_req_chunk["ext-1"], 1, "chunk id must not advance on a skipped replay")
+        self.assertEqual(sender._requests_num_chunks_sent["ext-1"], 10, "watermark unchanged on skip")
+
+        # Forward progress past the watermark resumes sending.
+        req.num_computed_tokens = 15
+        self.assertTrue(sender.send_chunk(req, pooling_output={"v": 3}))
+        self.assertEqual(calls["n"], 2)
+        self.assertEqual(sender._put_req_chunk["ext-1"], 2)
+        self.assertEqual(sender._requests_num_chunks_sent["ext-1"], 15)
+
+        sender.shutdown_omni_connectors()
+
+    def test_send_chunk_empty_payload_does_not_mark_first_chunk_sent(self):
+        connector = MockConnector(stage_id=0)
+        sender = MixinHost()
+        sender.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=0, async_chunk=True),
+        )
+        sender._omni_connector = connector
+        sender._stage_id = 0
+        sender._async_chunk = True
+
+        calls = {"n": 0}
+
+        def proc(transfer_manager, pooling_output, request, is_finished=False):
+            calls["n"] += 1
+            _ = transfer_manager.put_req_chunk[request.external_req_id]
+            return None
+
+        sender._custom_process_func = proc
+
+        req = _make_request("req-1", "ext-1")
+        self.assertFalse(sender.send_chunk(req, pooling_output={"v": 1}))
+        self.assertEqual(calls["n"], 1)
+        self.assertNotIn("ext-1", sender._put_req_chunk)
+
+        sender.shutdown_omni_connectors()
+
+    def _quiesce_save_thread(self, sender):
+        # Stop the background save loop so the enqueued sentinel task stays in
+        # _pending_save_reqs for deterministic synchronous inspection.
+        sender._stop_event.set()
+        sender._work_available.set()
+        thread = getattr(sender, "_save_thread", None)
+        if thread is not None:
+            thread.join(timeout=2)
+
+    def _last_enqueued_data(self, sender, request_id):
+        with sender._lock:
+            dq = sender._pending_save_reqs.get(request_id)
+            return dq[-1]["data"] if dq else None
+
+    def test_finish_sentinel_falls_back_to_finished_flag(self):
+        # Empty terminal payloads fall back to a bare finished=True flag so the
+        # downstream stage still terminates.
+        sender = MixinHost()
+        sender.init_omni_connectors(vllm_config=None, model_config=_make_model_config(stage_id=0, async_chunk=True))
+        self._quiesce_save_thread(sender)
+        sender._omni_connector = MockConnector(stage_id=0)
+        sender._stage_id = 0
+        sender._async_chunk = True
+
+        calls = {"n": 0}
+
+        def proc(transfer_manager, pooling_output, request, is_finished=False):
+            calls["n"] += 1
+            return None  # empty terminal -> hook produces nothing
+
+        sender._custom_process_func = proc
+        sender._put_req_chunk["ext-1"] = 3  # already sent 3 data chunks
+
+        req = SimpleNamespace(request_id="req-1", req_id="req-1", external_req_id="ext-1", is_finished=lambda: True)
+        self.assertTrue(sender.enqueue_finish_sentinel(req, "ext-1"))
+        self.assertEqual(calls["n"], 1, "hook must be consulted before the flag fallback")
+        self.assertEqual(sender._put_req_chunk["ext-1"], 4, "sentinel must take the next contiguous chunk id")
+
+        data = self._last_enqueued_data(sender, "ext-1")
+        self.assertIsNotNone(data, "finish sentinel must be enqueued")
+        self.assertIn("meta", data)
+        self.assertTrue(bool(data["meta"]["finished"]))
+
+    def test_finish_sentinel_prefers_hook_terminal_payload(self):
+        # When the hook DOES build a terminal payload (e.g. code2wav trailing
+        # codec flush), that payload is sent, not the bare flag.
+        sender = MixinHost()
+        sender.init_omni_connectors(vllm_config=None, model_config=_make_model_config(stage_id=0, async_chunk=True))
+        self._quiesce_save_thread(sender)
+        sender._omni_connector = MockConnector(stage_id=0)
+        sender._stage_id = 0
+        sender._async_chunk = True
+
+        def proc(transfer_manager, pooling_output, request, is_finished=False):
+            return {"meta": {"finished": True}, "tail": "terminal-codec"}
+
+        sender._custom_process_func = proc
+        sender._put_req_chunk["ext-9"] = 5
+
+        req = SimpleNamespace(request_id="r9", req_id="r9", external_req_id="ext-9", is_finished=lambda: True)
+        self.assertTrue(sender.enqueue_finish_sentinel(req, "ext-9"))
+        self.assertEqual(sender._put_req_chunk["ext-9"], 6)
+
+        data = self._last_enqueued_data(sender, "ext-9")
+        self.assertIsNotNone(data)
+        self.assertEqual(data.get("tail"), "terminal-codec", "hook terminal payload must be preferred over the flag")
+
+    def test_segment_finish_sentinel_enqueues_empty_payload_without_prior_chunk(self):
+        sender = MixinHost()
+        sender.init_omni_connectors(vllm_config=None, model_config=_make_model_config(stage_id=0, async_chunk=True))
+        self._quiesce_save_thread(sender)
+        sender._omni_connector = MockConnector(stage_id=0)
+        sender._stage_id = 0
+        sender._async_chunk = True
+
+        calls = {"n": 0}
+
+        def proc(transfer_manager, pooling_output, request, is_finished=False):
+            calls["n"] += 1
+            return None
+
+        sender._custom_process_func = proc
+
+        req = SimpleNamespace(request_id="req-1", req_id="req-1", external_req_id="ext-1", is_finished=lambda: False)
+        self.assertTrue(sender.enqueue_finish_sentinel(req, "ext-1", is_segment_finished=True))
+        self.assertEqual(calls["n"], 1, "hook must still get a chance to build terminal payload")
+        self.assertEqual(sender._put_req_chunk["ext-1"], 1)
+
+        data = self._last_enqueued_data(sender, "ext-1")
+        self.assertIsNotNone(data)
+        self.assertFalse(bool(data["meta"]["finished"]))
+        self.assertTrue(bool(data["meta"]["is_segment_finished"]))
+
+    def test_segment_finish_sentinel_cleans_segment_state_at_enqueue(self):
+        sender = MixinHost()
+        sender.init_omni_connectors(vllm_config=None, model_config=_make_model_config(stage_id=0, async_chunk=True))
+        self._quiesce_save_thread(sender)
+        sender._omni_connector = MockConnector(stage_id=0)
+        sender._stage_id = 0
+        sender._async_chunk = True
+
+        def proc(transfer_manager, pooling_output, request, is_finished=False):
+            return {"meta": {"finished": torch.tensor(True)}}
+
+        sender._custom_process_func = proc
+        sender._put_req_chunk["ext-1"] = 7
+        sender._requests_num_chunks_sent["ext-1"] = 42
+        sender._code_prompt_token_ids["ext-1"] = [[1, 2, 3]]
+        sender._cached_ic["ext-1"] = 16
+
+        req = SimpleNamespace(request_id="req-1", req_id="req-1", external_req_id="ext-1", is_finished=lambda: False)
+        self.assertTrue(sender.enqueue_finish_sentinel(req, "ext-1", is_segment_finished=True))
+
+        self.assertEqual(sender._put_req_chunk["ext-1"], 8)
+        self.assertNotIn("ext-1", sender._requests_num_chunks_sent)
+        self.assertNotIn("ext-1", sender._code_prompt_token_ids)
+        self.assertNotIn("ext-1", sender._cached_ic)
+
+        with sender._lock:
+            task = sender._pending_save_reqs["ext-1"].popleft()
+
+        sender._requests_num_chunks_sent["ext-1"] = 1
+        sender._code_prompt_token_ids["ext-1"] = [[9]]
+        sender._cached_ic["ext-1"] = 2
+
+        self.assertTrue(sender._send_single_request(task))
+        self.assertEqual(sender._put_req_chunk["ext-1"], 8)
+        self.assertEqual(sender._requests_num_chunks_sent["ext-1"], 1)
+        self.assertEqual(sender._code_prompt_token_ids["ext-1"], [[9]])
+        self.assertEqual(sender._cached_ic["ext-1"], 2)
 
 
 class TestMixinKVCacheTransfer(unittest.TestCase):
@@ -795,6 +1063,42 @@ class TestSendChunkCachesMapping(unittest.TestCase):
         time.sleep(0.1)
         host.shutdown_omni_connectors()
 
+    def test_snapshot_request_for_send_does_not_materialize_token_history(self):
+        """Finish-sentinel snapshots should stay off the per-token hot path."""
+        host = MixinHost()
+        host.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=0, async_chunk=True),
+        )
+
+        class ExpensiveTokenHistory(SimpleNamespace):
+            @property
+            def all_token_ids(self):
+                raise AssertionError("all_token_ids should not be read for a terminal snapshot")
+
+        request = ExpensiveTokenHistory(
+            request_id="internal-1",
+            req_id="internal-1",
+            external_req_id="external-1",
+            prompt_token_ids=list(range(4096)),
+            output_token_ids=list(range(4096)),
+            additional_information="voice-metadata",
+            sampling_params="sampling-metadata",
+            is_finished=lambda: False,
+        )
+
+        snapshot = host._snapshot_request_for_send(request, "external-1")
+
+        self.assertEqual(snapshot.request_id, "internal-1")
+        self.assertEqual(snapshot.req_id, "internal-1")
+        self.assertEqual(snapshot.external_req_id, "external-1")
+        self.assertEqual(snapshot.additional_information, "voice-metadata")
+        self.assertEqual(snapshot.sampling_params, "sampling-metadata")
+        self.assertFalse(hasattr(snapshot, "all_token_ids"))
+        self.assertFalse(snapshot.is_finished())
+
+        host.shutdown_omni_connectors()
+
 
 class TestLocalPayloadCacheLifecycle(unittest.TestCase):
     """Unit tests for the local payload cache API (RFC §2.4)."""
@@ -1033,6 +1337,80 @@ class TestKVTransferLifecycle(unittest.TestCase):
         host.shutdown_omni_connectors()
 
 
+class TestAsyncStagedPayloadMerge(unittest.TestCase):
+    def test_deep_merge_concats_pending_decode_rows(self):
+        existing = {
+            "embed": {
+                "prefill": torch.zeros(2, 2),
+                "decode": torch.tensor([[1.0, 2.0]]),
+            },
+            "meta": {"finished": torch.tensor(False)},
+        }
+        incoming = {
+            "embed": {"decode": torch.tensor([[3.0, 4.0]])},
+            "meta": {"finished": torch.tensor(False)},
+        }
+
+        _deep_merge_chunk_payload(existing, incoming)
+
+        self.assertTrue(torch.equal(existing["embed"]["prefill"], torch.zeros(2, 2)))
+        self.assertTrue(
+            torch.equal(
+                existing["embed"]["decode"],
+                torch.tensor(
+                    [
+                        [1.0, 2.0],
+                        [3.0, 4.0],
+                    ]
+                ),
+            )
+        )
+
+    def test_deep_merge_dedupes_accumulated_decode_prefix(self):
+        existing = {"embed": {"decode": torch.tensor([[1.0, 2.0]])}}
+        incoming = {
+            "embed": {
+                "decode": torch.tensor(
+                    [
+                        [1.0, 2.0],
+                        [3.0, 4.0],
+                    ]
+                )
+            }
+        }
+
+        _deep_merge_chunk_payload(existing, incoming)
+
+        self.assertTrue(
+            torch.equal(
+                existing["embed"]["decode"],
+                torch.tensor(
+                    [
+                        [1.0, 2.0],
+                        [3.0, 4.0],
+                    ]
+                ),
+            )
+        )
+
+    def test_deep_merge_keeps_prefill_hidden_output_when_decode_hidden_arrives(self):
+        prefill_hidden = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+        decode_hidden = torch.tensor([[99.0, 100.0]])
+        existing = {
+            "embed": {"prefill": torch.zeros(3, 2)},
+            "hidden_states": {"output": prefill_hidden.clone()},
+        }
+        incoming = {
+            "embed": {"decode": torch.ones(1, 2)},
+            "hidden_states": {"output": decode_hidden},
+        }
+
+        _deep_merge_chunk_payload(existing, incoming)
+
+        self.assertTrue(torch.equal(existing["hidden_states"]["output"], prefill_hidden))
+        self.assertTrue(torch.equal(existing["embed"]["decode"], torch.ones(1, 2)))
+
+
 class TestAsyncPayloadLifecycle(unittest.TestCase):
     """Regression tests for async payload delivery lifecycle."""
 
@@ -1058,6 +1436,85 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
 
         host.get_omni_connector_output()
         self.assertIn("r1", host._send_side_request_payload)
+        host.shutdown_omni_connectors()
+
+    def test_accumulate_payload_overwrites_scalar_meta(self):
+        host = MixinHost()
+        host.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=1, async_chunk=True, worker_type="ar"),
+        )
+        first = {
+            "embed": {"decode": torch.ones(1, 2)},
+            "meta": {
+                "finished": torch.tensor(False),
+                "is_segment_finished": torch.tensor(False),
+                "next_stage_prompt_len": torch.tensor(4),
+                "num_processed_tokens": torch.tensor(1),
+            },
+        }
+        second = {
+            "embed": {"decode": torch.ones(1, 2)},
+            "meta": {
+                "finished": torch.tensor(False),
+                "is_segment_finished": torch.tensor(True),
+                "next_stage_prompt_len": torch.tensor(7),
+                "num_processed_tokens": torch.tensor(2),
+            },
+        }
+
+        host._accumulate_payload("r1", first)
+        merged = host._accumulate_payload("r1", second)
+
+        self.assertEqual(tuple(merged["embed"]["decode"].shape), (2, 2))
+        self.assertEqual(merged["meta"]["is_segment_finished"].shape, torch.Size([]))
+        self.assertTrue(bool(merged["meta"]["is_segment_finished"].item()))
+        self.assertEqual(int(merged["meta"]["next_stage_prompt_len"].item()), 7)
+        self.assertEqual(int(merged["meta"]["num_processed_tokens"].item()), 2)
+        host.shutdown_omni_connectors()
+
+    def test_segment_finish_is_not_request_finish(self):
+        payload = {
+            "meta": {
+                "finished": torch.tensor(False),
+                "is_segment_finished": torch.tensor(True),
+            }
+        }
+
+        self.assertFalse(MixinHost._payload_finished(payload))
+        self.assertTrue(MixinHost._payload_segment_finished(payload))
+        self.assertFalse(MixinHost._payload_is_consumable(payload))
+
+    def test_poll_segment_finish_wakes_without_closing_stream(self):
+        host = MixinHost()
+        host.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=1, async_chunk=True, worker_type="ar"),
+        )
+        host._omni_connector = MagicMock()
+        host._stage_id = 1
+        host._async_chunk = True
+        host._model_mode = "ar"
+        host._request_ids_mapping["r1"] = "ext-r1"
+        host._get_req_chunk["r1"] = 0
+        host._pending_load_reqs["r1"] = object()
+        host._omni_connector.get.return_value = (
+            {
+                "embed": {"decode": torch.ones(1, 2)},
+                "meta": {
+                    "finished": torch.tensor(False),
+                    "is_segment_finished": torch.tensor(True),
+                },
+            },
+            1,
+        )
+
+        self.assertTrue(host._poll_single_request("r1"))
+
+        self.assertIn("r1", host._finished_load_reqs)
+        self.assertNotIn("r1", host._chunk_finished_req_ids)
+        self.assertNotIn("r1", host._chunk_stream_completed)
+        self.assertIn("r1", host._pending_load_reqs)
         host.shutdown_omni_connectors()
 
     def test_payload_consumable_ignores_token_horizon_only_updates(self):
@@ -1135,6 +1592,136 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
 
         host.shutdown_omni_connectors()
 
+    def test_ar_finish_only_terminal_is_not_model_ready(self):
+        host = MixinHost()
+        host.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=1, async_chunk=True, worker_type="ar"),
+        )
+        host._omni_connector = MagicMock()
+        host._stage_id = 1
+        host._async_chunk = True
+        host._model_mode = "ar"
+        host._request_ids_mapping["r1"] = "ext-r1"
+        host._get_req_chunk["r1"] = 0
+        host._pending_load_reqs["r1"] = object()
+        host._omni_connector.get.return_value = (
+            {
+                "meta": {
+                    "finished": torch.tensor(True),
+                },
+            },
+            1,
+        )
+
+        made_progress = host._poll_single_request("r1")
+        output = host.get_omni_connector_output()
+
+        self.assertTrue(made_progress)
+        self.assertEqual(output.chunk_ready_req_ids, set())
+        self.assertEqual(output.chunk_finished_req_ids, {"r1"})
+        self.assertNotIn("r1", host._pending_load_reqs)
+
+        host.shutdown_omni_connectors()
+
+    def test_ar_finish_only_terminal_wakes_existing_staged_payload(self):
+        host = MixinHost()
+        host.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=1, async_chunk=True, worker_type="ar"),
+        )
+        host._stop_event.set()
+        host._omni_connector = MagicMock()
+        host._stage_id = 1
+        host._async_chunk = True
+        host._model_mode = "ar"
+        host._request_ids_mapping["r1"] = "ext-r1"
+        host._get_req_chunk["r1"] = 0
+        host._pending_load_reqs["r1"] = object()
+        host._omni_connector.get.side_effect = [
+            (
+                {
+                    "embed": {"decode": torch.ones(1, 2)},
+                    "meta": {"finished": torch.tensor(False)},
+                },
+                1,
+            ),
+            (
+                {
+                    "meta": {
+                        "finished": torch.tensor(True),
+                    },
+                },
+                1,
+            ),
+        ]
+
+        self.assertTrue(host._poll_single_request("r1"))
+        output1 = host.get_omni_connector_output()
+        self.assertEqual(output1.chunk_ready_req_ids, {"r1"})
+
+        self.assertTrue(host._poll_single_request("r1"))
+        output2 = host.get_omni_connector_output()
+
+        self.assertEqual(output2.chunk_ready_req_ids, {"r1"})
+        self.assertEqual(output2.chunk_finished_req_ids, {"r1"})
+        self.assertNotIn("r1", host._pending_load_reqs)
+
+        host.shutdown_omni_connectors()
+
+    def test_ar_finish_only_terminal_wakes_existing_runtime_payload(self):
+        host = MixinHost()
+        host.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=1, async_chunk=True, worker_type="ar"),
+        )
+        host._stop_event.set()
+        host._omni_connector = MagicMock()
+        host._stage_id = 1
+        host._async_chunk = True
+        host._model_mode = "ar"
+        host._request_ids_mapping["r1"] = "ext-r1"
+        host._get_req_chunk["r1"] = 0
+        host._pending_load_reqs["r1"] = object()
+        host._omni_connector.get.side_effect = [
+            (
+                {
+                    "embed": {"decode": torch.ones(1, 2)},
+                    "meta": {"finished": torch.tensor(False)},
+                },
+                1,
+            ),
+            (
+                {
+                    "meta": {
+                        "finished": torch.tensor(True),
+                    },
+                },
+                1,
+            ),
+        ]
+
+        self.assertTrue(host._poll_single_request("r1"))
+        output1 = host.get_omni_connector_output()
+        self.assertEqual(output1.chunk_ready_req_ids, {"r1"})
+
+        host.model_intermediate_buffer = {
+            "r1": {
+                "embed": {"decode": torch.ones(1, 2)},
+                "meta": {"finished": torch.tensor(False)},
+            }
+        }
+        host._local_stage_payload_cache.pop("r1", None)
+
+        self.assertTrue(host._poll_single_request("r1"))
+        output2 = host.get_omni_connector_output()
+
+        self.assertEqual(output2.chunk_ready_req_ids, {"r1"})
+        self.assertEqual(output2.chunk_finished_req_ids, {"r1"})
+        self.assertNotIn("r1", host._pending_load_reqs)
+
+        host.shutdown_omni_connectors()
+
     def test_non_ar_recv_does_not_overwrite_unconsumed_staged_chunk(self):
         host = MixinHost()
         host.init_omni_connectors(
@@ -1161,6 +1748,24 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
 
         host.shutdown_omni_connectors()
 
+    def test_non_ar_recv_filters_handoff_pending_requests_from_poll_set(self):
+        host = MixinHost()
+        host.init_omni_connectors(
+            vllm_config=None,
+            model_config=_make_model_config(stage_id=2, async_chunk=True, worker_type="gen"),
+        )
+        host._async_chunk = True
+        host._model_mode = "gen"
+        host._pending_load_reqs["blocked"] = object()
+        host._pending_load_reqs["pollable"] = object()
+        host._local_stage_payload_cache["blocked"] = {"codes": {"audio": [1, 2, 3]}}
+
+        with host._lock:
+            pollable = host._filter_pollable_load_req_ids_locked(["blocked", "pollable"])
+
+        self.assertEqual(pollable, ["pollable"])
+        host.shutdown_omni_connectors()
+
     def test_non_ar_recv_waits_for_scheduler_handoff_before_fetching_next_chunk(self):
         host = MixinHost()
         host.init_omni_connectors(
@@ -1185,9 +1790,12 @@ class TestAsyncPayloadLifecycle(unittest.TestCase):
         host._omni_connector.get.assert_not_called()
         self.assertEqual(host._get_req_chunk["r1"], 1)
 
+        host._work_available.clear()
         output = host.get_omni_connector_output()
         self.assertEqual(output.request_metadata["r1"]["code_predictor_codes"], [10, 11, 12])
         self.assertEqual(output.chunk_ready_req_ids, {"r1"})
+        self.assertTrue(host._work_available.is_set())
+        host._work_available.clear()
 
         host._omni_connector.get.return_value = (
             {
@@ -1281,6 +1889,15 @@ class TestAttachOmniConnectorOutput(unittest.TestCase):
 
 
 class TestConnectorConfigValidation(unittest.TestCase):
+    def test_async_chunk_missing_connector_config_defaults_to_shared_memory(self):
+        host = MixinHost()
+        model_config = _make_model_config(stage_id=1, async_chunk=True)
+
+        host.init_omni_connectors(vllm_config=None, model_config=model_config)
+
+        self.assertEqual(type(host._omni_connector).__name__, "SharedMemoryConnector")
+        host.shutdown_omni_connectors()
+
     def test_invalid_connector_name_raises(self):
         host = MixinHost()
         model_config = _make_model_config(stage_id=1)
@@ -1438,6 +2055,105 @@ class TestSendRetry(unittest.TestCase):
         success = sender._send_single_request(requeued)
         self.assertTrue(success)
         sender.shutdown_omni_connectors()
+
+
+class TestDeepMergeChunkPayload(unittest.TestCase):
+    """Regression coverage: the recv cache must DEEP-merge nested dicts so a later
+    decode chunk's embed={decode} does not clobber chunk-0's embed={prefill}
+    (shallow dict.update lost the prefill -> KeyError 'prefill' in
+    talker_preprocess_prefill)."""
+
+    def test_decode_chunk_does_not_clobber_chunk0_prefill(self):
+        existing = {
+            "embed": {"prefill": "P", "tts_bos": "B"},
+            "hidden_states": {"output": "H"},
+            "ids": [1, 2, 3],
+            "meta": {"finished": False, "left_context_size": 1},
+        }
+        incoming = {"embed": {"decode": "D"}, "meta": {"finished": False}}
+        _deep_merge_chunk_payload(existing, incoming)
+
+        # prefill survives AND decode is added.
+        self.assertEqual(existing["embed"], {"prefill": "P", "tts_bos": "B", "decode": "D"})
+        # untouched top-level keys retained.
+        self.assertEqual(existing["hidden_states"], {"output": "H"})
+        self.assertEqual(existing["ids"], [1, 2, 3])
+        # non-finished meta keys retained.
+        self.assertEqual(existing["meta"]["left_context_size"], 1)
+
+    def test_prefill_chunk_replaces_stale_staged_segment_payload(self):
+        old_decode = torch.tensor([[9.0, 9.0]])
+        new_prefill = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        new_decode = torch.tensor([[5.0, 6.0]])
+        new_hidden = new_prefill + 10
+        existing = {
+            "embed": {
+                "decode": old_decode,
+                "cached_decode": old_decode,
+            },
+            "hidden_states": {"output": torch.ones(3, 2)},
+            "ids": {"output": [99]},
+            "meta": {
+                "finished": torch.tensor(False),
+                "is_segment_finished": torch.tensor(True),
+            },
+        }
+        incoming = {
+            "embed": {
+                "prefill": new_prefill,
+                "decode": new_decode,
+            },
+            "hidden_states": {"output": new_hidden},
+            "ids": {"prompt": [1, 2]},
+            "meta": {"finished": torch.tensor(False)},
+        }
+
+        _deep_merge_chunk_payload(existing, incoming)
+
+        self.assertTrue(torch.equal(existing["embed"]["prefill"], new_prefill))
+        self.assertTrue(torch.equal(existing["embed"]["decode"], new_decode))
+        self.assertNotIn("cached_decode", existing["embed"])
+        self.assertTrue(torch.equal(existing["hidden_states"]["output"], new_hidden))
+        self.assertEqual(existing["ids"], {"prompt": [1, 2]})
+        self.assertNotIn("is_segment_finished", existing["meta"])
+
+    def test_latest_decode_embed_wins(self):
+        existing = {"embed": {"prefill": "P", "decode": "D1"}}
+        _deep_merge_chunk_payload(existing, {"embed": {"decode": "D2"}})
+        self.assertEqual(existing["embed"], {"prefill": "P", "decode": "D2"})
+
+    def test_meta_finished_not_overwritten_by_intermediate_chunk(self):
+        existing = {"meta": {"finished": True, "x": 1}}
+        _deep_merge_chunk_payload(existing, {"meta": {"finished": False, "y": 2}})
+        # finished is skipped (mirrors adapter); other meta keys merge.
+        self.assertTrue(existing["meta"]["finished"])
+        self.assertEqual(existing["meta"]["y"], 2)
+
+    def test_meta_finished_true_overwrites_intermediate_false(self):
+        existing = {"meta": {"finished": torch.tensor(False), "x": 1}}
+        _deep_merge_chunk_payload(existing, {"meta": {"finished": torch.tensor(True), "y": 2}})
+
+        self.assertTrue(bool(existing["meta"]["finished"].item()))
+        self.assertEqual(existing["meta"]["x"], 1)
+        self.assertEqual(existing["meta"]["y"], 2)
+
+    def test_terminal_finished_chunk_updates_model_visible_cache(self):
+        existing = {
+            "embed": {"decode": torch.ones(1, 2)},
+            "meta": {"finished": torch.tensor(False)},
+        }
+        incoming = {"meta": {"finished": torch.tensor(True)}}
+
+        _deep_merge_chunk_payload(existing, incoming)
+
+        self.assertTrue(bool(existing["meta"]["finished"].item()))
+
+    def test_non_dict_value_replaced_and_new_key_added(self):
+        existing = {"a": 1, "nested": {"k": "v"}}
+        _deep_merge_chunk_payload(existing, {"a": 2, "b": 3})
+        self.assertEqual(existing["a"], 2)
+        self.assertEqual(existing["b"], 3)
+        self.assertEqual(existing["nested"], {"k": "v"})
 
 
 if __name__ == "__main__":

--- a/tests/worker/test_omni_gpu_model_runner.py
+++ b/tests/worker/test_omni_gpu_model_runner.py
@@ -387,6 +387,197 @@ def test_update_intermediate_buffer_accumulates():
     assert torch.allclose(buf["b"], torch.tensor([2.0]))
 
 
+def test_update_intermediate_buffer_preserves_prefill_hidden_across_decode_update():
+    runner = _make_runner(req_ids=("r1",), hidden_size=4)
+    prefill_hidden = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+    decode_hidden = torch.tensor([[99.0, 100.0]])
+    decode_a = torch.tensor([[1.0, 2.0]])
+    decode_b = torch.tensor([[3.0, 4.0]])
+
+    OmniGPUModelRunner._update_intermediate_buffer(
+        runner,
+        "r1",
+        {
+            "embed": {"prefill": torch.zeros(3, 2)},
+            "hidden_states": {"output": prefill_hidden.clone()},
+        },
+    )
+    OmniGPUModelRunner._update_intermediate_buffer(
+        runner,
+        "r1",
+        {
+            "embed": {"decode": decode_a},
+            "hidden_states": {"output": decode_hidden},
+        },
+    )
+    OmniGPUModelRunner._update_intermediate_buffer(
+        runner,
+        "r1",
+        {"embed": {"decode": torch.cat([decode_a, decode_b], dim=0)}},
+    )
+
+    buf = runner.model_intermediate_buffer["r1"]
+    assert torch.equal(buf["hidden_states"]["output"], prefill_hidden)
+    assert torch.equal(buf["embed"]["decode"], torch.cat([decode_a, decode_b], dim=0))
+
+
+def test_update_intermediate_buffer_resets_previous_segment_prefill_state():
+    runner = _make_runner(req_ids=("r1",), hidden_size=4)
+    old_prefill = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    old_hidden = old_prefill + 100
+    new_prefill = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    new_hidden = new_prefill + 10
+
+    runner.model_intermediate_buffer["r1"] = {
+        "omni_final_stage_id": 2,
+        "embed": {
+            "prefill": old_prefill,
+            "decode": torch.tensor([[9.0, 9.0]]),
+        },
+        "hidden_states": {"output": old_hidden},
+        "ids": {"output": [99]},
+        "meta": {"is_segment_finished": torch.tensor(True)},
+        "model_specific_segment_state": {"stale": True},
+    }
+
+    OmniGPUModelRunner._update_intermediate_buffer(
+        runner,
+        "r1",
+        {
+            "embed": {"prefill": new_prefill},
+            "hidden_states": {"output": new_hidden},
+            "ids": {"prompt": [1, 2]},
+            "meta": {"finished": torch.tensor(False)},
+        },
+    )
+
+    buf = runner.model_intermediate_buffer["r1"]
+    assert buf["omni_final_stage_id"] == 2
+    assert torch.equal(buf["embed"]["prefill"], new_prefill)
+    assert "decode" not in buf["embed"]
+    assert torch.equal(buf["hidden_states"]["output"], new_hidden)
+    assert buf["ids"] == {"prompt": [1, 2]}
+    assert "model_specific_segment_state" not in buf
+    assert buf["meta"]["finished"].item() is False
+
+
+def test_update_intermediate_buffer_replaces_nonprefix_shorter_prefill_state():
+    runner = _make_runner(req_ids=("r1",), hidden_size=4)
+    old_prefill = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    old_hidden = old_prefill + 100
+    new_prefill = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    new_hidden = new_prefill + 10
+
+    OmniGPUModelRunner._update_intermediate_buffer(
+        runner,
+        "r1",
+        {
+            "embed": {"prefill": old_prefill},
+            "hidden_states": {"output": old_hidden},
+        },
+    )
+    OmniGPUModelRunner._update_intermediate_buffer(
+        runner,
+        "r1",
+        {
+            "embed": {"prefill": new_prefill},
+            "hidden_states": {"output": new_hidden},
+        },
+    )
+
+    buf = runner.model_intermediate_buffer["r1"]
+    assert torch.equal(buf["embed"]["prefill"], new_prefill)
+    assert torch.equal(buf["hidden_states"]["output"], new_hidden)
+
+
+def test_streaming_segment_reset_does_not_require_finished_marker():
+    runner = _make_runner(req_ids=("r1",), hidden_size=4)
+    old_decode = torch.tensor([[9.0, 9.0]])
+    old_cached_decode = torch.tensor([[8.0, 8.0]])
+    new_prefill = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    new_decode = torch.tensor([[5.0, 6.0]])
+    new_cached_decode = torch.tensor([[7.0, 8.0]])
+    new_hidden = new_prefill + 10
+
+    runner.model_intermediate_buffer["r1"] = {
+        "omni_final_stage_id": 2,
+        "embed": {
+            "prefill": torch.zeros(2, 2),
+            "decode": old_decode,
+            "cached_decode": old_cached_decode,
+        },
+        "hidden_states": {"output": torch.ones(2, 2)},
+        "ids": {"output": [99]},
+        "meta": {"is_segment_finished": torch.tensor(False)},
+        "model_specific_segment_state": {"stale": True},
+    }
+
+    OmniGPUModelRunner._update_streaming_input_additional_info(runner, "r1")
+    OmniGPUModelRunner._update_intermediate_buffer(
+        runner,
+        "r1",
+        {
+            "embed": {
+                "prefill": new_prefill,
+                "decode": new_decode,
+                "cached_decode": new_cached_decode,
+            },
+            "hidden_states": {"output": new_hidden},
+            "ids": {"prompt": [1, 2]},
+        },
+    )
+
+    buf = runner.model_intermediate_buffer["r1"]
+    assert buf["omni_final_stage_id"] == 2
+    assert torch.equal(buf["embed"]["prefill"], new_prefill)
+    assert torch.equal(buf["embed"]["decode"], new_decode)
+    assert torch.equal(buf["embed"]["cached_decode"], new_cached_decode)
+    assert torch.equal(buf["hidden_states"]["output"], new_hidden)
+    assert buf["ids"] == {"prompt": [1, 2]}
+    assert "model_specific_segment_state" not in buf
+    assert buf["meta"] == {"num_processed_tokens": 0, "resumable": True}
+    assert "r1" not in runner._segment_runtime_reset_req_ids
+
+
+def test_sync_local_stage_payloads_preserves_new_decode_after_segment_reset():
+    runner = _make_runner(req_ids=("r1",), hidden_size=4)
+    old_decode = torch.tensor([[9.0, 9.0]])
+    new_prefill = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    new_decode = torch.tensor([[5.0, 6.0]])
+    new_cached_decode = torch.tensor([[7.0, 8.0]])
+    new_hidden = new_prefill + 10
+
+    runner.model_intermediate_buffer["r1"] = {
+        "omni_final_stage_id": 2,
+        "embed": {"decode": old_decode},
+        "meta": {"is_segment_finished": torch.tensor(False)},
+    }
+    runner._local_stage_payload_cache = {
+        "r1": {
+            "embed": {
+                "prefill": new_prefill,
+                "decode": new_decode,
+                "cached_decode": new_cached_decode,
+            },
+            "hidden_states": {"output": new_hidden},
+        }
+    }
+    runner._full_payload_pending_broadcast_req_ids = set()
+    runner._lock = None
+    runner._work_available = None
+
+    OmniGPUModelRunner._update_streaming_input_additional_info(runner, "r1")
+    OmniGPUModelRunner._sync_local_stage_payloads(runner)
+
+    buf = runner.model_intermediate_buffer["r1"]
+    assert runner._local_stage_payload_cache == {}
+    assert torch.equal(buf["embed"]["prefill"], new_prefill)
+    assert torch.equal(buf["embed"]["decode"], new_decode)
+    assert torch.equal(buf["embed"]["cached_decode"], new_cached_decode)
+    assert torch.equal(buf["hidden_states"]["output"], new_hidden)
+    assert buf["meta"] == {"num_processed_tokens": 0, "resumable": True}
+
+
 def test_update_intermediate_buffer_skips_empty_update():
     """Validate that an empty update dict is a no-op."""
     runner = _make_runner(req_ids=("r1",), hidden_size=4)
@@ -522,9 +713,16 @@ def test_full_payload_output_accumulation_hook_matrix():
     assert _make_full_payload_accumulation_runner(model_stage="thinker")._should_accumulate_full_payload_output()
     assert _make_full_payload_accumulation_runner(model_stage="talker")._should_accumulate_full_payload_output()
 
-    # Terminal stage: even if _load_custom_func derived a builder from
-    # custom_process_input_func, final output stages are not producers.
-    runner = _make_full_payload_accumulation_runner(model_stage="code2wav", final_output=True)
+    # Qwen3 thinker is both a text final-output stage and a downstream
+    # talker producer; the explicit next-stage hook is the producer signal.
+    assert _make_full_payload_accumulation_runner(
+        model_stage="thinker", final_output=True
+    )._should_accumulate_full_payload_output()
+
+    # Terminal stage without an explicit producer hook must not accumulate/send.
+    runner = _make_full_payload_accumulation_runner(
+        model_stage="code2wav", final_output=True, custom_process_next_stage_input_func=None
+    )
     assert not runner._should_accumulate_full_payload_output()
 
     # Input-only consumer stage without an explicit producer hook must not

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from time import time
@@ -22,6 +23,8 @@ from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm_omni.core.sched.omni_scheduler_mixin import OmniSchedulerMixin
 from vllm_omni.core.sched.omni_scheduling_coordinator import (
     OmniSchedulingCoordinator,
+    uses_async_chunk_coordinator,
+    uses_async_chunk_model_runner_transport,
     uses_full_payload_input_coordinator,
 )
 from vllm_omni.core.sched.utils import omni_routed_experts_for_request
@@ -80,19 +83,45 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
         # Cache per-request flag to avoid repeated deserialization of additional_information
         self._omits_kv_transfer_cache: dict[str, bool] = {}
         model_config = self.vllm_config.model_config
+        # Async-chunk receive waiting and model-runner transport ownership are
+        # separate: stage-0 producers do not need recv coordination, but Qwen3
+        # producers still send chunks from the model runner rather than through
+        # the legacy scheduler adapter.
+        _async_coord = uses_async_chunk_coordinator(model_config)
+        _async_model_runner_transport = uses_async_chunk_model_runner_transport(model_config)
         self.chunk_transfer_adapter = None
-        if getattr(model_config, "async_chunk", False):
+        # Coordinator-path segment-finished ids pending emission to the runner
+        # (resumable realtime stops); drained into OmniSchedulerOutput each schedule.
+        self._omni_pending_segment_finished: set[str] = set()
+        self._omni_pending_upstream_segment_finished: set[str] = set()
+        if getattr(model_config, "async_chunk", False) and not _async_model_runner_transport:
             self.chunk_transfer_adapter = OmniChunkTransferAdapter(self.vllm_config)
         self.input_coordinator: OmniSchedulingCoordinator | None = None
-        if uses_full_payload_input_coordinator(model_config):
+        if uses_full_payload_input_coordinator(model_config) or _async_coord:
             self.input_coordinator = OmniSchedulingCoordinator(
                 scheduler_max_num_seqs=self.vllm_config.scheduler_config.max_num_seqs,
                 stage_id=getattr(model_config, "stage_id", 0),
-                async_chunk=False,
+                async_chunk=_async_coord,
             )
         self._latest_omni_connector_output: OmniConnectorOutput | None = None
         # Snapshot prompt length for each streaming input update
         self._new_prompt_len_snapshot: dict[str, int] = {}
+
+    def add_request(self, request: Request) -> None:
+        existing = self.requests.get(request.request_id)
+        if (
+            existing is not None
+            and existing.streaming_queue is not None
+            and existing.status == RequestStatus.WAITING_FOR_STREAMING_REQ
+            and StreamingUpdate.from_request(request) is None
+            and getattr(self.vllm_config.model_config, "stage_id", 0) == 0
+            and uses_async_chunk_model_runner_transport(self.vllm_config.model_config)
+        ):
+            self._omni_pending_segment_finished.add(existing.request_id)
+            self.finish_requests(request.request_id, RequestStatus.FINISHED_STOPPED)
+            return
+
+        super().add_request(request)
 
     def _get_confirmed_num_computed_tokens(self, request: Request) -> int:
         """num_computed_tokens minus async placeholders (KV actually on GPU)."""
@@ -205,6 +234,36 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
         return False
 
+    def _finish_input_coordinator_terminal_only_requests(self) -> None:
+        input_coordinator = getattr(self, "input_coordinator", None)
+        if input_coordinator is None:
+            return
+        if not getattr(input_coordinator, "_async_chunk", False):
+            return
+
+        terminal_only_req_ids = set(input_coordinator.finished_requests) - set(
+            input_coordinator.requests_with_ready_chunks
+        )
+        if not terminal_only_req_ids:
+            return
+
+        final_output_req_ids: set[str] = set()
+        if getattr(self.vllm_config.model_config, "final_output", False):
+            final_output_req_ids = {req_id for req_id in terminal_only_req_ids if req_id in self.requests}
+            input_coordinator.requests_with_ready_chunks.update(final_output_req_ids)
+
+        live_req_ids = [
+            req_id for req_id in terminal_only_req_ids if req_id in self.requests and req_id not in final_output_req_ids
+        ]
+        if live_req_ids:
+            # A connector finish without a ready chunk is a control signal, not
+            # model input. Finish it here so the base scheduler never runs the
+            # request with a metadata-only payload.
+            self.finish_requests(live_req_ids, RequestStatus.FINISHED_STOPPED)
+
+        for req_id in terminal_only_req_ids - final_output_req_ids:
+            input_coordinator.finished_requests.discard(req_id)
+
     def schedule(self) -> SchedulerOutput:  # type: ignore[override]
         # Remove FINISHED_ABORTED requests before the upstream scheduler sees
         # them. Upstream vllm raises RuntimeError on this status; omni allows
@@ -215,6 +274,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 if getattr(req, "status", None) == RequestStatus.FINISHED_ABORTED:
                     queue.remove(req)
         self._consume_pending_connector_output(model_mode="ar")
+        self._finish_input_coordinator_terminal_only_requests()
         self._process_pending_input_timeouts()
 
         if self.chunk_transfer_adapter:
@@ -265,6 +325,13 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             scheduler_output.scheduled_new_reqs = new_list  # type: ignore[assignment]
             if self.chunk_transfer_adapter:
                 self.chunk_transfer_adapter.postprocess_scheduler_output(scheduler_output, self.requests)
+            if self.input_coordinator:
+                # Mirror the adapter postprocess on the coordinator path so the
+                # per-cycle ready-chunk flags (requests_with_ready_chunks) are cleared
+                # after each scheduler step. Without this, a streamed multi-chunk request
+                # stays flagged "ready" after its first chunk and never re-enters the
+                # per-cycle wait/clear cadence the adapter path gets for free.
+                self.input_coordinator.postprocess_scheduler_output(scheduler_output, self.requests)
             # Add information about requests needing KV cache transfer
             finished_reqs = self.get_finished_requests_needing_kv_transfer()
         except Exception:
@@ -410,6 +477,18 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
             if not stopped and self._process_kv_transfer_trigger(request, new_token_ids):
                 stopped = True
 
+            upstream_segment_finished = req_id in self._omni_pending_upstream_segment_finished
+            if (
+                upstream_segment_finished
+                and not stopped
+                and getattr(self.vllm_config.model_config, "final_output", False)
+            ):
+                # Final-output stages must flush each realtime segment locally.
+                # Intermediate stages keep running so they can forward later
+                # segments and emit their own downstream segment sentinels.
+                request.status = RequestStatus.FINISHED_STOPPED
+                stopped = True
+
             if new_token_ids and self.structured_output_manager.should_advance(request):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
@@ -424,6 +503,8 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                     request.resumable = False
                     stopped = True
 
+            self._omni_pending_upstream_segment_finished.discard(req_id)
+
             if stopped:
                 if model_runner_output.routed_experts is not None:
                     routed_experts = omni_routed_experts_for_request(model_runner_output.routed_experts, request)
@@ -434,6 +515,12 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                 is_segment_finished = True
                 finished = self._handle_stopped_request(request)
                 if not finished:
+                    # Coordinator-path stages (talker/code2wav) have no scheduler-side
+                    # save_async(is_segment_finished); record the segment stop so the
+                    # runner emits an is_segment_finished terminal (flushing this
+                    # segment's audio tail) to the downstream stage next cycle.
+                    if self.input_coordinator is not None and not upstream_segment_finished:
+                        self._omni_pending_segment_finished.add(request.request_id)
                     # for streaming input request only
                     if self.chunk_transfer_adapter:
                         if self.vllm_config.model_config.stage_id != 0:
@@ -864,6 +951,13 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
 
     def has_requests(self) -> bool:
         """Check if there are any requests to process, including KV transfers."""
+        if self._omni_pending_segment_finished:
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "async chunk pending segment terminal keeps scheduler active: request_ids=%s",
+                    sorted(self._omni_pending_segment_finished),
+                )
+            return True
         # [Omni] Also check for pending KV transfers
         if self.requests_needing_kv_transfer or self.active_kv_transfers or self.waiting_for_transfer_free:
             return True

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -26,6 +26,7 @@ from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm_omni.core.sched.omni_scheduler_mixin import OmniSchedulerMixin
 from vllm_omni.core.sched.omni_scheduling_coordinator import (
     OmniSchedulingCoordinator,
+    uses_async_chunk_coordinator,
     uses_full_payload_input_coordinator,
 )
 from vllm_omni.core.sched.output import OmniCachedRequestData, OmniNewRequestData
@@ -39,22 +40,41 @@ from vllm_omni.outputs import OmniConnectorOutput, OmniModelRunnerOutput
 logger = init_logger(__name__)
 
 
+def _extend_all_token_ids_if_available(request: Request, padding: int) -> None:
+    if padding <= 0:
+        return
+    all_token_ids = getattr(request, "_all_token_ids", None)
+    if isinstance(all_token_ids, list):
+        all_token_ids.extend([0] * padding)
+
+
 class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         model_config = self.vllm_config.model_config
+        # Allowlisted async-chunk stages use the coordinator + runner mixin;
+        # other stages keep the legacy adapter.
+        _async_coord = uses_async_chunk_coordinator(model_config)
+        # Coordinator stages complete on the terminal chunk signal, not only on
+        # the prompt-length heuristic, so code2wav can drain the final chunk.
+        self._async_chunk_coordinator_active = _async_coord
         self.chunk_transfer_adapter = None
-        if getattr(model_config, "async_chunk", False):
+        if getattr(model_config, "async_chunk", False) and not _async_coord:
             self.chunk_transfer_adapter = OmniChunkTransferAdapter(self.vllm_config)
         self._pending_finish_reqs: list[Request] = []
         self.input_coordinator: OmniSchedulingCoordinator | None = None
-        if uses_full_payload_input_coordinator(model_config):
+        if uses_full_payload_input_coordinator(model_config) or _async_coord:
             self.input_coordinator = OmniSchedulingCoordinator(
                 scheduler_max_num_seqs=self.vllm_config.scheduler_config.max_num_seqs,
                 stage_id=getattr(model_config, "stage_id", 0),
-                async_chunk=False,
+                async_chunk=_async_coord,
             )
         self._latest_omni_connector_output: OmniConnectorOutput | None = None
+        # Async coordinator terminal trackers. Code2wav must finish on the
+        # producer's terminal marker after the request has emitted output.
+        self._deferred_terminal_chunk_req_ids: set[str] = set()
+        self._deferred_terminal_request_metadata: dict[str, dict] = {}
+        self._reqs_with_generation_output: set[str] = set()
 
     def schedule(self) -> SchedulerOutput:
         """Diffusion fast path:
@@ -80,6 +100,25 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         scheduled_encoder_inputs: dict[str, list[int]] = {}
         cached_prompt_token_ids: dict[str, list[int]] = {}
         cached_additional_information: dict[str, dict | None] = {}
+
+        def _ensure_terminal_placeholder(request: Request) -> int:
+            # A terminal-ready coordinator request can still have a connector-
+            # delivered payload queued even when its prompt length has not grown.
+            # Grow by one placeholder so the scheduler runs a drain step instead
+            # of treating required_tokens == 0 as completion.
+            if not isinstance(request.prompt_token_ids, list):
+                request.prompt_token_ids = list(request.prompt_token_ids)
+            current_len = len(request.prompt_token_ids)
+            target_len = max(current_len, request.num_computed_tokens + 1)
+            max_model_len = getattr(self, "max_model_len", None)
+            if isinstance(max_model_len, int) and max_model_len > 0:
+                target_len = min(target_len, max_model_len)
+            missing = target_len - current_len
+            if missing > 0:
+                request.prompt_token_ids.extend([0] * missing)
+                request.num_prompt_tokens = len(request.prompt_token_ids)
+                _extend_all_token_ids_if_available(request, missing)
+            return max(0, len(request.prompt_token_ids) - request.num_computed_tokens)
 
         # Temporary queue: preserve waiting order, do not disturb non-diffusion requests
         skipped_waiting_requests = create_request_queue(self.policy)
@@ -112,12 +151,39 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                 break
             # async_chunk: don't schedule placeholder tokens when no new chunk is available.
             if required_tokens <= 0:
-                if self.chunk_transfer_adapter is not None and self.chunk_transfer_adapter.is_done_receiving_chunks(
-                    request.request_id
-                ):
-                    self._pending_finish_reqs.append(request)
-                req_index += 1
-                continue
+                if self.chunk_transfer_adapter is not None:
+                    # Adapter path (legacy, unchanged): defer the finish to
+                    # update_from_output via _pending_finish_reqs.
+                    if self.chunk_transfer_adapter.is_done_receiving_chunks(request.request_id):
+                        self._pending_finish_reqs.append(request)
+                    req_index += 1
+                    continue
+                if self._async_chunk_coordinator_active and self.input_coordinator is not None:
+                    # A terminal-ready coordinator request may still have queued
+                    # payload. Drain it with a placeholder step; otherwise defer
+                    # finish emission through _pending_finish_reqs, matching the
+                    # adapter path.
+                    if request.request_id in self.input_coordinator.requests_with_ready_chunks:
+                        required_tokens = _ensure_terminal_placeholder(request)
+                        if required_tokens <= 0:
+                            request.stop_reason = (
+                                None if self.input_coordinator.chunk_stream_completed(request.request_id) else "length"
+                            )
+                            self._pending_finish_reqs.append(request)
+                            req_index += 1
+                            continue
+                        # required_tokens > 0: fall through to allocation below so the
+                        # placeholder step actually runs and drains the ready payload.
+                    elif self.input_coordinator.chunk_stream_completed(request.request_id):
+                        self._pending_finish_reqs.append(request)
+                        req_index += 1
+                        continue
+                    else:
+                        req_index += 1
+                        continue
+                else:
+                    req_index += 1
+                    continue
             num_new_tokens = min(required_tokens, token_budget)
             new_blocks = self.kv_cache_manager.allocate_slots(
                 request,
@@ -167,6 +233,28 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                     self.waiting.pop_request()
                     self._pending_finish_reqs.append(request)
                     continue
+                else:
+                    self.waiting.pop_request()
+                    skipped_waiting_requests.prepend_request(request)
+                    continue
+
+            # async-chunk coordinator path: same empty-prompt guard, but a
+            # terminal-ready request still gets a one-token placeholder so the
+            # terminal stage can drain its ready payload before finishing.
+            if (
+                self._async_chunk_coordinator_active
+                and self.input_coordinator is not None
+                and len(request.prompt_token_ids) == 0
+            ):
+                stream_completed = self.input_coordinator.chunk_stream_completed(request.request_id)
+                if stream_completed and request.request_id not in self.input_coordinator.requests_with_ready_chunks:
+                    request = self.waiting.pop_request()
+                    self._pending_finish_reqs.append(request)
+                    continue
+                if stream_completed:
+                    # Terminal chunk arrived but a payload is still queued: grow a
+                    # placeholder and fall through to schedule the drain step.
+                    _ensure_terminal_placeholder(request)
                 else:
                     self.waiting.pop_request()
                     skipped_waiting_requests.prepend_request(request)
@@ -331,6 +419,10 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
 
             if self.chunk_transfer_adapter:
                 self.chunk_transfer_adapter.postprocess_scheduler_output(scheduler_output)
+            if self.input_coordinator:
+                # Mirror the adapter postprocess on the coordinator path so per-cycle
+                # ready-chunk flags are cleared (see omni_ar_scheduler for full rationale).
+                self.input_coordinator.postprocess_scheduler_output(scheduler_output)
 
         except Exception:
             # If anything goes wrong, leave the original output unchanged
@@ -349,6 +441,28 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                 self.input_coordinator.restore_queues(self.waiting, self.running)
 
         return self._wrap_omni_scheduler_output(scheduler_output)
+
+    def _queue_completed_generation_requests(self) -> None:
+        if not self._async_chunk_coordinator_active or self.input_coordinator is None:
+            return
+
+        pending_req_ids = {request.request_id for request in self._pending_finish_reqs}
+        completed_req_ids = set(self.input_coordinator.finished_requests)
+        completed_req_ids.update(getattr(self.input_coordinator, "_completed_chunk_streams", set()))
+        for req_id in completed_req_ids:
+            if req_id in pending_req_ids:
+                continue
+            if req_id in self.input_coordinator.requests_with_ready_chunks:
+                continue
+            request = self.requests.get(req_id)
+            if request is None or request.is_finished():
+                continue
+            if req_id not in self._reqs_with_generation_output:
+                continue
+            if request.num_computed_tokens < len(request.prompt_token_ids):
+                continue
+            self._pending_finish_reqs.append(request)
+            pending_req_ids.add(req_id)
 
     def finish_requests(self, request_ids, finished_status: RequestStatus) -> list[tuple[str, int]]:
         """Handles the finish signal from outside the scheduler.
@@ -389,6 +503,12 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         return finished
 
     def _free_request(self, request: Request, delay_free_blocks: bool = False) -> dict[str, Any] | None:
+        # Drop consumer-side terminal-completeness trackers for the freed
+        # request (no-op outside the async-chunk coordinator path).
+        self._deferred_terminal_chunk_req_ids.discard(request.request_id)
+        self._deferred_terminal_request_metadata.pop(request.request_id, None)
+        self._reqs_with_generation_output.discard(request.request_id)
+
         if self.input_coordinator is None:
             return super()._free_request(request, delay_free_blocks)
 
@@ -423,6 +543,88 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
         mm_outputs = getattr(model_runner_output, "multimodal_outputs", None)
         num_nans_in_logits = model_runner_output.num_nans_in_logits
         kv_connector_output = model_runner_output.kv_connector_output
+
+        # Read this cycle's terminal-chunk signal and producer metadata.
+        # Only consumed on the async-chunk coordinator path; for the adapter /
+        # full-payload paths these stay empty and the blocks below are skipped.
+        omni_output = getattr(model_runner_output, "omni_connector_output", None)
+        chunk_finished_req_ids_now = set(omni_output.chunk_finished_req_ids) if omni_output else set()
+        chunk_ready_req_ids_now = set(omni_output.chunk_ready_req_ids) if omni_output else set()
+        request_metadata_now = (
+            dict(omni_output.request_metadata) if omni_output and omni_output.request_metadata else {}
+        )
+        # Under async scheduling a terminal chunk-finished signal can arrive in an
+        # empty connector-only output one cycle before the final output payload.
+        # Preserve that terminal marker and merge it into the next real model
+        # output for the same request so the last audio frame and terminal state
+        # are evaluated together.  Gated on the async-chunk coordinator path so the
+        # adapter / full-payload deployments are untouched.
+        if (
+            self._async_chunk_coordinator_active
+            and chunk_finished_req_ids_now
+            and not getattr(model_runner_output, "req_ids", None)
+            and not pooler_outputs
+            and not mm_outputs
+        ):
+            handled_finish_only_req_ids: set[str] = set()
+            for req_id in set(chunk_finished_req_ids_now):
+                request = self.requests.get(req_id)
+                if request is None or req_id not in self._reqs_with_generation_output:
+                    continue
+                terminal_prompt_len = len(request.prompt_token_ids)
+                if req_metadata := request_metadata_now.get(req_id):
+                    code_predictor_codes = req_metadata.get("code_predictor_codes")
+                    if code_predictor_codes is not None and len(code_predictor_codes) > 0:
+                        terminal_prompt_len = len(code_predictor_codes)
+                    else:
+                        next_stage_prompt_len = req_metadata.get("next_stage_prompt_len")
+                        if isinstance(next_stage_prompt_len, int) and next_stage_prompt_len > 0:
+                            terminal_prompt_len = next_stage_prompt_len
+                if request.num_computed_tokens < terminal_prompt_len:
+                    continue
+                # If terminal codes arrived with the finish signal, let the next
+                # decode step emit the final payload and finish together.
+                # Finish-only sentinels have no payload to wait for.
+                _co_arrived_codes = request_metadata_now.get(req_id, {}).get("code_predictor_codes")
+                if req_id in chunk_ready_req_ids_now and _co_arrived_codes is not None and len(_co_arrived_codes) > 0:
+                    continue
+                # Emit coordinator-only finishes through the normal scheduler output path.
+                self._pending_finish_reqs.append(request)
+                handled_finish_only_req_ids.add(req_id)
+            remaining_ids = set(chunk_finished_req_ids_now) - handled_finish_only_req_ids
+            if remaining_ids:
+                self._deferred_terminal_chunk_req_ids.update(remaining_ids)
+                for req_id in remaining_ids:
+                    if req_id in request_metadata_now:
+                        self._deferred_terminal_request_metadata[req_id] = dict(request_metadata_now[req_id])
+            chunk_finished_req_ids_now = remaining_ids
+        elif (
+            self._async_chunk_coordinator_active
+            and self._deferred_terminal_chunk_req_ids
+            and getattr(model_runner_output, "req_ids", None)
+        ):
+            carried_req_ids = self._deferred_terminal_chunk_req_ids.intersection(
+                getattr(model_runner_output, "req_ids", None)
+            )
+            if carried_req_ids:
+                chunk_finished_req_ids_now.update(carried_req_ids)
+                for req_id in carried_req_ids:
+                    if req_id not in request_metadata_now:
+                        if (deferred_meta := self._deferred_terminal_request_metadata.get(req_id)) is not None:
+                            request_metadata_now[req_id] = dict(deferred_meta)
+                    self._deferred_terminal_chunk_req_ids.discard(req_id)
+                    self._deferred_terminal_request_metadata.pop(req_id, None)
+
+        # Sweep stale deferred entries for requests no longer tracked, preventing
+        # unbounded growth if a request disappears without being freed.
+        if self._deferred_terminal_chunk_req_ids:
+            stale = self._deferred_terminal_chunk_req_ids - set(self.requests)
+            if stale:
+                self._deferred_terminal_chunk_req_ids -= stale
+                for rid in stale:
+                    self._deferred_terminal_request_metadata.pop(rid, None)
+
+        self._queue_completed_generation_requests()
 
         cudagraph_stats: CUDAGraphStat | None = model_runner_output.cudagraph_stats
         perf_stats: PerfStats | None = None
@@ -500,19 +702,56 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
             kv_transfer_params = None
             pooler_output = pooler_outputs[req_index] if pooler_outputs else None
             mm_output = mm_outputs[req_index] if mm_outputs else None
+            if pooler_output is not None or mm_output is not None:
+                self._reqs_with_generation_output.add(req_id)
             status_before_stop = request.status
             finish_reason = None
             routed_experts = None
 
+            # Terminal-completeness gate (async-chunk coordinator path only).
+            # The true total code length comes from producer metadata -- not the
+            # chunks-arrived-so-far prompt length -- so resolve it before deciding
+            # the request is done.  Defaults to the current prompt length for every
+            # other path (request_metadata_now is empty there).
+            terminal_prompt_len = len(request.prompt_token_ids)
+            if req_metadata := request_metadata_now.get(req_id):
+                code_predictor_codes = req_metadata.get("code_predictor_codes")
+                if code_predictor_codes is not None and len(code_predictor_codes) > 0:
+                    terminal_prompt_len = len(code_predictor_codes)
+                else:
+                    next_stage_prompt_len = req_metadata.get("next_stage_prompt_len")
+                    if isinstance(next_stage_prompt_len, int) and next_stage_prompt_len > 0:
+                        terminal_prompt_len = next_stage_prompt_len
+            reached_terminal_chunk = (
+                self._async_chunk_coordinator_active
+                and req_id in chunk_finished_req_ids_now
+                and pooler_output is not None
+                and request.num_computed_tokens >= terminal_prompt_len
+            )
+
             # Diffusion request: completes in one step; mark finished and free resources
             if (
                 request.status == RequestStatus.FINISHED_STOPPED
-                or (self.chunk_transfer_adapter is None and request.num_computed_tokens >= request.num_prompt_tokens)
+                or (
+                    self.chunk_transfer_adapter is None
+                    and not self._async_chunk_coordinator_active
+                    and request.num_computed_tokens >= request.num_prompt_tokens
+                )
                 or (
                     self.chunk_transfer_adapter is not None
                     and self.chunk_transfer_adapter.is_done_receiving_chunks(request.request_id)
                     and request.num_computed_tokens >= len(request.prompt_token_ids)
                 )
+                or (
+                    # async-chunk coordinator path: complete only when the upstream
+                    # chunk stream is complete, mirroring the legacy-adapter clause
+                    # above instead of the plain-gen heuristic.
+                    self._async_chunk_coordinator_active
+                    and self.input_coordinator is not None
+                    and self.input_coordinator.chunk_stream_completed(request.request_id)
+                    and request.num_computed_tokens >= len(request.prompt_token_ids)
+                )
+                or reached_terminal_chunk
             ):
                 request.status = RequestStatus.FINISHED_STOPPED
                 # Optional: set a stop_reason for front-end clarity
@@ -600,6 +839,10 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                         request.request_id,
                         getattr(request, "external_req_id", None),
                     )
+                # Coordinator path: release the request from the coordinator's
+                # tracking sets too (the adapter path uses cleanup() above).
+                if self._async_chunk_coordinator_active and self.input_coordinator is not None:
+                    self.input_coordinator.free_finished_request(request.request_id)
             outputs[request.client_index].append(
                 OmniEngineCoreOutput(
                     request_id=request.request_id,

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -23,9 +23,9 @@ _STATS_INTERVAL_S = 1.0
 # never arrives.  Override per-deployment via
 # VLLM_OMNI_INPUT_WAIT_TIMEOUT_S; set <=0 to disable the safety net.
 #
-# Scope: this constant only covers the full-payload coordinator path
-# (``input_coordinator``).  The async-chunk path uses
-# ``chunk_transfer_adapter`` and is not affected by this constant.
+# Scope: this constant only covers full-payload ``WAITING_FOR_INPUT`` waits.
+# Async-chunk requests park in ``WAITING_FOR_CHUNK`` and are intentionally not
+# force-failed by this timeout during normal realtime pauses.
 _INPUT_WAIT_TIMEOUT_RAW = os.environ.get("VLLM_OMNI_INPUT_WAIT_TIMEOUT_S", "300")
 try:
     DEFAULT_INPUT_WAIT_TIMEOUT_S: float = float(_INPUT_WAIT_TIMEOUT_RAW)
@@ -62,10 +62,35 @@ class OmniSchedulerMixin:
         input_coordinator = getattr(self, "input_coordinator", None)
         if input_coordinator is None:
             return
+        if connector_output:
+            chunk_ready_req_ids = connector_output.chunk_ready_req_ids
+            chunk_finished_req_ids = connector_output.chunk_finished_req_ids
+        else:
+            chunk_ready_req_ids = set()
+            chunk_finished_req_ids = set()
         if connector_output and connector_output.request_metadata:
             input_coordinator.update_request_metadata(
                 self.requests, connector_output.request_metadata, model_mode=model_mode
             )
+        if connector_output and connector_output.chunk_segment_finished_req_ids:
+            pending_segment_stop = getattr(self, "_omni_pending_upstream_segment_finished", None)
+            model_config = getattr(getattr(self, "vllm_config", None), "model_config", None)
+            if pending_segment_stop is not None and getattr(model_config, "final_output", False):
+                segment_finished_req_ids = set(connector_output.chunk_segment_finished_req_ids)
+                pending_segment_stop.update(segment_finished_req_ids)
+                chunk_ready_req_ids = set(chunk_ready_req_ids)
+                chunk_ready_req_ids.update(segment_finished_req_ids)
+        # Both calls self-guard on the coordinator's async_chunk mode
+        # (process_pending_chunks returns early when async_chunk is False;
+        # process_pending_full_payload_inputs branches internally), so exactly
+        # one path is live per deployment.  With an empty async allowlist the
+        # coordinator is never in async_chunk mode -> the chunk call is a no-op.
+        input_coordinator.process_pending_chunks(
+            self.waiting,
+            self.running,
+            chunk_ready_req_ids,
+            chunk_finished_req_ids,
+        )
         input_coordinator.process_pending_full_payload_inputs(
             self.waiting,
             self.running,
@@ -86,10 +111,9 @@ class OmniSchedulerMixin:
         ``finish_requests`` to mark expired requests FINISHED_ERROR.
         Disabled when ``DEFAULT_INPUT_WAIT_TIMEOUT_S`` is <= 0.
 
-        Scope: only covers ``input_coordinator`` (full-payload path).
-        Async-chunk requests park in ``chunk_transfer_adapter`` instead
-        and are not handled here -- if a similar safety net is needed
-        for the chunk path, it belongs in the chunk adapter.
+        Scope: only covers full-payload ``WAITING_FOR_INPUT`` requests.
+        Async-chunk ``WAITING_FOR_CHUNK`` requests are not handled here, so
+        normal realtime pauses are not bounded by this timeout.
         """
         if DEFAULT_INPUT_WAIT_TIMEOUT_S <= 0:
             return
@@ -133,7 +157,7 @@ class OmniSchedulerMixin:
         base: SchedulerOutput,
         *,
         finished_requests_needing_kv_transfer: dict | None = None,
-        pending_input_registrations: list[OmniChunkRecvHandle] | None = None,
+        pending_connector_registrations: list[OmniChunkRecvHandle] | None = None,
     ) -> OmniSchedulerOutput:
         """Wrap a base ``SchedulerOutput`` in ``OmniSchedulerOutput``.
 
@@ -143,12 +167,24 @@ class OmniSchedulerMixin:
         """
         base_data = {name: getattr(base, name) for name in SchedulerOutput.__dataclass_fields__}
         input_coordinator = getattr(self, "input_coordinator", None)
-        if pending_input_registrations is None:
-            pending_input_registrations = input_coordinator.pending_input_registrations if input_coordinator else []
+        if pending_connector_registrations is None:
+            pending_connector_registrations = (
+                input_coordinator.pending_connector_registrations if input_coordinator else []
+            )
+        # Drain segment-finished ids recorded by update_from_output for resumable
+        # realtime stops (coordinator stages only); the runner emits one
+        # is_segment_finished terminal per id next cycle, mirroring finished_req_ids.
+        pending_segment = getattr(self, "_omni_pending_segment_finished", None)
+        if pending_segment:
+            segment_finished_req_ids = set(pending_segment)
+            pending_segment.clear()
+        else:
+            segment_finished_req_ids = set()
         return OmniSchedulerOutput(
             **base_data,
             finished_requests_needing_kv_transfer=finished_requests_needing_kv_transfer or {},
-            pending_input_registrations=pending_input_registrations,
+            pending_connector_registrations=pending_connector_registrations,
+            segment_finished_req_ids=segment_finished_req_ids,
         )
 
     def make_stats(self, *args, **kwargs) -> SchedulerStats | None:

--- a/vllm_omni/core/sched/omni_scheduling_coordinator.py
+++ b/vllm_omni/core/sched/omni_scheduling_coordinator.py
@@ -19,6 +19,7 @@ from typing import Any
 from vllm.logger import init_logger
 from vllm.v1.request import Request, RequestStatus
 
+import vllm_omni.platforms as omni_platforms
 from vllm_omni.core.sched.output import OmniChunkRecvHandle
 
 logger = init_logger(__name__)
@@ -82,6 +83,73 @@ def uses_full_payload_input_coordinator(model_config: Any) -> bool:
     return key in _FULL_PAYLOAD_INPUT_STAGES
 
 
+# (model_arch, model_stage) whose async-chunk RECEIVE is coordinated by
+# OmniSchedulingCoordinator. Producer-only stages are intentionally absent: they
+# still use the model-runner transport below, but do not need scheduler
+# WAITING_FOR_CHUNK state because they have no upstream chunk producer.
+_ASYNC_CHUNK_COORDINATOR_STAGES: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("Qwen3OmniMoeForConditionalGeneration", "talker"),
+        ("Qwen3OmniMoeForConditionalGeneration", "code2wav"),
+    }
+)
+
+
+# (model_arch, model_stage) pairs whose async-chunk transport is owned by
+# OmniConnectorModelRunnerMixin rather than the legacy scheduler adapter.
+_ASYNC_CHUNK_MODEL_RUNNER_TRANSPORT_STAGES: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("Qwen3OmniMoeForConditionalGeneration", "thinker"),
+        ("Qwen3OmniMoeForConditionalGeneration", "talker"),
+        ("Qwen3OmniMoeForConditionalGeneration", "code2wav"),
+    }
+)
+
+
+def _supports_async_chunk_model_runner_transport_platform() -> bool:
+    # NPU AR runners do not currently inherit OmniConnectorModelRunnerMixin.
+    # Keep them on the legacy transfer adapter until the transport side is wired.
+    platform = omni_platforms.current_omni_platform
+    return not platform.is_npu()
+
+
+def _uses_shared_memory_connector(model_config: Any) -> bool:
+    connector_config = getattr(model_config, "stage_connector_config", None)
+    if connector_config is None:
+        return True
+    if isinstance(connector_config, dict):
+        name = connector_config.get("name", "SharedMemoryConnector")
+    else:
+        name = getattr(connector_config, "name", None)
+    return isinstance(name, str) and name.strip() == "SharedMemoryConnector"
+
+
+def uses_async_chunk_model_runner_transport(model_config: Any) -> bool:
+    """Returns True iff async-chunk put/get is owned by the model runner."""
+    if not getattr(model_config, "async_chunk", False):
+        return False
+    key = (
+        getattr(model_config, "model_arch", None),
+        getattr(model_config, "model_stage", None),
+    )
+    if key not in _ASYNC_CHUNK_MODEL_RUNNER_TRANSPORT_STAGES:
+        return False
+    if not _uses_shared_memory_connector(model_config):
+        return False
+    return _supports_async_chunk_model_runner_transport_platform()
+
+
+def uses_async_chunk_coordinator(model_config: Any) -> bool:
+    """Returns True iff this stage needs scheduler WAITING_FOR_CHUNK state."""
+    key = (
+        getattr(model_config, "model_arch", None),
+        getattr(model_config, "model_stage", None),
+    )
+    if key not in _ASYNC_CHUNK_COORDINATOR_STAGES:
+        return False
+    return uses_async_chunk_model_runner_transport(model_config)
+
+
 class OmniSchedulingCoordinator:
     """Pure-scheduling coordinator for chunk and full_payload input waiting.
 
@@ -98,28 +166,34 @@ class OmniSchedulingCoordinator:
 
         self.finished_requests: set[str] = set()
         self.requests_with_ready_chunks: set[str] = set()
+        self._completed_chunk_streams: set[str] = set()
         self._full_payload_input_received: set[str] = set()
 
         self._waiting_for_chunk_waiting: deque[Any] = deque()
         self._waiting_for_chunk_running: deque[Any] = deque()
 
-        # Request IDs that were newly registered for chunk recv this cycle.
-        # The engine/Model Runner should call register_chunk_recv() for these
-        # so the bg thread starts polling.
-        self.pending_chunk_registrations: list[Any] = []
-
         # Requests waiting for full_payload stage input (WAITING_FOR_INPUT).
         self._waiting_for_input: deque[Any] = deque()
-        # Per-cycle list of minimal handles to ship to the model runner so it
-        # can call register_chunk_recv().  Typed concretely (not list[Any]) so
-        # the surrounding OmniSchedulerOutput stays msgspec-friendly across
-        # default, PD-disagg, and multi-node executor IPC paths.
-        self.pending_input_registrations: list[OmniChunkRecvHandle] = []
+        # Per-cycle list of minimal handles shipped to the model runner so it
+        # can call register_chunk_recv() (so the bg thread starts polling).
+        # Populated by BOTH the async-chunk park (process_pending_chunks) and the
+        # full-payload park (process_pending_full_payload_inputs); carried on
+        # OmniSchedulerOutput by _wrap_omni_scheduler_output.  Typed concretely
+        # (not list[Any]) so the surrounding OmniSchedulerOutput stays
+        # msgspec-friendly across default, PD-disagg, and multi-node executor IPC.
+        self.pending_connector_registrations: list[OmniChunkRecvHandle] = []
 
         # Monotonic timestamp recording when each request first entered
         # WAITING_FOR_CHUNK or WAITING_FOR_INPUT.  Used by
         # collect_timed_out_request_ids() to detect orphaned waits.
         self._waiting_since: dict[str, float] = {}
+        # The input timeout safety net is scoped to full-payload input waits;
+        # async chunk waits may pause without being force-failed here.
+        self._waiting_for_input_req_ids: set[str] = set()
+
+    def chunk_stream_completed(self, request_id: str) -> bool:
+        """Return whether no more async chunks are expected for the request."""
+        return request_id in self.finished_requests or request_id in self._completed_chunk_streams
 
     # ------------------------------------------------------------------ #
     #  Core scheduling methods
@@ -143,9 +217,18 @@ class OmniSchedulingCoordinator:
         if self._stage_id == 0 or not self._async_chunk:
             return
 
+        # Retain readiness for requests not yet surfaced into the waiting/running
+        # queues: a bg recv can complete before the request appears in a queue,
+        # and the connector output clears chunk_ready_req_ids after this cycle.
+        # Without an unconditional retain, that first ready signal is lost during
+        # the queue scan below and the request hangs in WAITING_FOR_CHUNK forever.
+        self.requests_with_ready_chunks.update(chunk_ready_req_ids)
+
         terminal_ready_req_ids = chunk_ready_req_ids.intersection(chunk_finished_req_ids)
         self.finished_requests.update(chunk_finished_req_ids - terminal_ready_req_ids)
-        self.pending_chunk_registrations = []
+        # Reset the carried registration list; the full-payload pass (which runs
+        # after this in async-chunk mode) must NOT re-clear it (see its guard).
+        self.pending_connector_registrations = []
 
         self._process_chunk_queue(
             waiting_queue,
@@ -159,7 +242,7 @@ class OmniSchedulingCoordinator:
             RequestStatus.RUNNING,
             chunk_ready_req_ids,
         )
-        self.finished_requests.update(terminal_ready_req_ids)
+        self._completed_chunk_streams.update(terminal_ready_req_ids)
 
         while len(running_queue) > self._scheduler_max_num_seqs:
             request = running_queue.pop()
@@ -194,13 +277,18 @@ class OmniSchedulingCoordinator:
                 self._stage_id,
                 stage_recv_req_ids,
             )
-        self.pending_input_registrations = []
+        # Only the full-payload path owns this reset.  In async-chunk mode this
+        # method runs AFTER process_pending_chunks (which already reset + filled
+        # the list), so re-clearing here would drop the chunk recv registrations.
+        if not self._async_chunk:
+            self.pending_connector_registrations = []
 
         remaining: deque[Any] = deque()
         for request in self._waiting_for_input:
             if request.request_id in stage_recv_req_ids:
                 request.status = RequestStatus.WAITING
                 self._waiting_since.pop(request.request_id, None)
+                self._waiting_for_input_req_ids.discard(request.request_id)
                 waiting_queue.add_request(request)
             else:
                 remaining.append(request)
@@ -219,9 +307,10 @@ class OmniSchedulingCoordinator:
                         continue
                     request.status = RequestStatus.WAITING_FOR_INPUT
                     self._waiting_since.setdefault(request.request_id, time.monotonic())
+                    self._waiting_for_input_req_ids.add(request.request_id)
                     to_remove.append(request)
                     self._waiting_for_input.append(request)
-                    self.pending_input_registrations.append(
+                    self.pending_connector_registrations.append(
                         OmniChunkRecvHandle(
                             request_id=request.request_id,
                             external_req_id=getattr(request, "external_req_id", None),
@@ -231,10 +320,12 @@ class OmniSchedulingCoordinator:
                     if request.request_id in stage_recv_req_ids:
                         request.status = RequestStatus.WAITING
                         self._waiting_since.pop(request.request_id, None)
+                        self._waiting_for_input_req_ids.discard(request.request_id)
                     else:
                         to_remove.append(request)
+                        self._waiting_for_input_req_ids.add(request.request_id)
                         self._waiting_for_input.append(request)
-                        self.pending_input_registrations.append(
+                        self.pending_connector_registrations.append(
                             OmniChunkRecvHandle(
                                 request_id=request.request_id,
                                 external_req_id=getattr(request, "external_req_id", None),
@@ -259,16 +350,30 @@ class OmniSchedulingCoordinator:
         self._full_payload_input_received.discard(request_id)
         self.finished_requests.discard(request_id)
         self.requests_with_ready_chunks.discard(request_id)
+        self._completed_chunk_streams.discard(request_id)
         self._waiting_since.pop(request_id, None)
+        self._waiting_for_input_req_ids.discard(request_id)
+        for queue_attr in (
+            "_waiting_for_chunk_waiting",
+            "_waiting_for_chunk_running",
+            "_waiting_for_input",
+        ):
+            queue = getattr(self, queue_attr)
+            setattr(
+                self,
+                queue_attr,
+                deque(request for request in queue if request.request_id != request_id),
+            )
 
     def collect_timed_out_request_ids(
         self,
         timeout_s: float,
     ) -> set[str]:
-        """Return IDs of requests that have been waiting longer than *timeout_s*.
+        """Return full-payload input waits older than *timeout_s*.
 
-        Uses ``_waiting_since`` timestamps (always up-to-date) to detect
-        timed-out requests.  This method is safe to call at any point in
+        Uses ``_waiting_since`` timestamps plus ``_waiting_for_input_req_ids``
+        to detect timed-out full-payload input waits.  This method is safe to
+        call at any point in
         the scheduling cycle — it does **not** rely on coordinator internal
         queues (which are empty after ``restore_queues()``).
 
@@ -283,7 +388,7 @@ class OmniSchedulingCoordinator:
         now = time.monotonic()
         timed_out_ids: set[str] = set()
         for req_id, start_time in self._waiting_since.items():
-            if now - start_time > timeout_s:
+            if req_id in self._waiting_for_input_req_ids and now - start_time > timeout_s:
                 timed_out_ids.add(req_id)
         if not timed_out_ids:
             return set()
@@ -304,8 +409,9 @@ class OmniSchedulingCoordinator:
 
         for req_id in timed_out_ids:
             self._waiting_since.pop(req_id, None)
+            self._waiting_for_input_req_ids.discard(req_id)
             logger.warning(
-                "[Coordinator stage-%s] Request %s timed out waiting for chunk/input (waited > %.0fs)",
+                "[Coordinator stage-%s] Request %s timed out waiting for connector input (waited > %.0fs)",
                 self._stage_id,
                 req_id,
                 timeout_s,
@@ -451,16 +557,25 @@ class OmniSchedulingCoordinator:
                     continue
                 if request.request_id in self.finished_requests:
                     continue
+                if request.request_id in self._completed_chunk_streams:
+                    continue
                 if request.status == RequestStatus.WAITING_FOR_INPUT:
                     continue
                 if request.request_id in chunk_ready_req_ids:
                     self.requests_with_ready_chunks.add(request.request_id)
                     continue
-                self.pending_chunk_registrations.append(request)
+                # Register bg-thread chunk recv through SchedulerOutput so the
+                # runner's register_chunk_recv() starts polling.
+                self.pending_connector_registrations.append(
+                    OmniChunkRecvHandle(
+                        request_id=request.request_id,
+                        external_req_id=getattr(request, "external_req_id", None),
+                    )
+                )
                 request.status = RequestStatus.WAITING_FOR_CHUNK
                 self._waiting_since.setdefault(request.request_id, time.monotonic())
             else:
-                if request.request_id in chunk_ready_req_ids:
+                if request.request_id in self.requests_with_ready_chunks:
                     request.status = target_status
                     self.requests_with_ready_chunks.add(request.request_id)
                     self._waiting_since.pop(request.request_id, None)

--- a/vllm_omni/core/sched/output.py
+++ b/vllm_omni/core/sched/output.py
@@ -93,4 +93,5 @@ class OmniSchedulerOutput(SchedulerOutput):
     """Scheduler output with omni-specific transfer metadata."""
 
     finished_requests_needing_kv_transfer: dict[str, dict] = field(default_factory=dict)
-    pending_input_registrations: list[OmniChunkRecvHandle] = field(default_factory=list)
+    pending_connector_registrations: list[OmniChunkRecvHandle] = field(default_factory=list)
+    segment_finished_req_ids: set[str] = field(default_factory=set)

--- a/vllm_omni/data_entry_keys.py
+++ b/vllm_omni/data_entry_keys.py
@@ -22,6 +22,14 @@ if TYPE_CHECKING:
     from vllm_omni.engine import AdditionalInformationEntry, AdditionalInformationPayload
 
 
+# Marker key the runner-level finish sentinel sets on its (otherwise
+# empty) ``pooling_output`` so a model's async-chunk stage-input hook can flush a
+# terminal payload (e.g. code2wav's trailing partial codec).  The legacy
+# scheduler-driven ``OmniChunkTransferAdapter`` never sets it, so adapter-driven
+# hook calls are unaffected.
+ASYNC_FINISH_SENTINEL_KEY = "__async_finish_sentinel__"
+
+
 class HiddenStates(TypedDict, total=False):
     output: torch.Tensor
     trailing_text: torch.Tensor

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -96,6 +96,22 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         return bool(value) if value is not None else False
 
     @staticmethod
+    def _struct_has_non_meta_payload(payload: OmniPayloadStruct) -> bool:
+        for field in payload.__struct_fields__:
+            if field == "meta":
+                continue
+            value = getattr(payload, field, None)
+            if value is None:
+                continue
+            nested_fields = getattr(value, "__struct_fields__", None)
+            if nested_fields is not None:
+                if any(getattr(value, nested_field, None) is not None for nested_field in nested_fields):
+                    return True
+                continue
+            return True
+        return False
+
+    @staticmethod
     def _confirmed_num_computed_tokens(request: Request) -> int:
         # vLLM async scheduling advances num_computed_tokens with output
         # placeholders before the corresponding token is committed. Connector
@@ -167,7 +183,10 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             request: Request object
             is_segment_finished: whether the segment of request is finished
         """
-        is_finished = request.is_finished() and not request.resumable
+        # A final realtime chunk can be both segment-finished and request-finished.
+        # Do not mask request completion just because the session is resumable;
+        # non-final segment stops already report request.is_finished() as False.
+        is_finished = request.is_finished()
 
         confirmed_num_computed_tokens = self._confirmed_num_computed_tokens(request)
 
@@ -292,7 +311,7 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
         return False
 
     def _send_single_request(self, task: dict):
-        raw_mm = task["multimodal_output"]
+        raw_mm = task.get("multimodal_output", task.get("pooling_output"))
         multimodal_output = unflatten_payload(raw_mm) if isinstance(raw_mm, Mapping) else raw_mm
         request = task["request"]
         is_finished = task["is_finished"]
@@ -323,6 +342,18 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
             # Segment/request finish markers must still reach downstream even when
             # the processor has no tensor payload.
             payload_data = OmniPayloadStruct()
+        if (
+            isinstance(payload_data, OmniPayloadStruct)
+            and payload_data.meta is not None
+            and not (is_segment_finished or is_finished)
+            and not self._struct_has_non_meta_payload(payload_data)
+        ):
+            logger.debug(
+                "[Stage-%s] Skip metadata-only non-terminal payload for %s",
+                stage_id,
+                connector_put_key,
+            )
+            return
         if payload_data.meta is None:
             payload_data.meta = MetaStruct()
         payload_data.meta.finished = torch.tensor(is_finished, dtype=torch.bool)

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -1869,29 +1869,12 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     if req_state is not None and req_state_audio_ref is None:
                         req_state_audio_ref = req_state
                     now_ts = time.time()
-                    if req_state is not None and req_state.first_audio_ts is None:
-                        req_state.first_audio_ts = now_ts
-                        stage_pools = getattr(self.engine_client.engine, "stage_pools", None)
-                        # The orchestrator binds requests by their internal id,
-                        # not the user-visible external id, so look up the
-                        # replica with req_state.request_id (internal).
-                        replica_id = (
-                            stage_pools[omni_res.stage_id].get_bound_replica_id(req_state.request_id)
-                            if stage_pools is not None and 0 <= omni_res.stage_id < len(stage_pools)
-                            else None
-                        )
-                        req_state.audio_emit_stage_id = omni_res.stage_id
-                        req_state.audio_emit_replica_id = replica_id
-                        observe_audio_first_packet(
-                            self.engine_client.mod_metrics,
-                            stage_id=omni_res.stage_id,
-                            replica_id=replica_id,
-                            arrival_ts=req_state.request_arrival_ts,
-                            now_ts=now_ts,
-                        )
+                    chunk_bytes = audio_chunk_pcm_bytes(omni_res)
 
                     role = self.get_chat_request_role(request)
                     choices_data = self._create_audio_choice(omni_res, role, request, stream=True)
+                    if not choices_data:
+                        continue
                     # Only emit finish_reason on the last modality to
                     # comply with OpenAI streaming spec.
                     for choice in choices_data:
@@ -1905,9 +1888,28 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                             stop_reason_emitted[choice.index] = True
                     # Record per-chunk PCM byte count + arrival timestamp for
                     # audio_underrun_s / audio_continuity_ok_total at finalize.
-                    if req_state is not None and req_state.request_arrival_ts > 0:
-                        chunk_bytes = audio_chunk_pcm_bytes(omni_res)
-                        if chunk_bytes > 0:
+                    if chunk_bytes > 0:
+                        if req_state is not None and req_state.first_audio_ts is None:
+                            req_state.first_audio_ts = now_ts
+                            stage_pools = getattr(self.engine_client.engine, "stage_pools", None)
+                            # The orchestrator binds requests by their internal id,
+                            # not the user-visible external id, so look up the
+                            # replica with req_state.request_id (internal).
+                            replica_id = (
+                                stage_pools[omni_res.stage_id].get_bound_replica_id(req_state.request_id)
+                                if stage_pools is not None and 0 <= omni_res.stage_id < len(stage_pools)
+                                else None
+                            )
+                            req_state.audio_emit_stage_id = omni_res.stage_id
+                            req_state.audio_emit_replica_id = replica_id
+                            observe_audio_first_packet(
+                                self.engine_client.mod_metrics,
+                                stage_id=omni_res.stage_id,
+                                replica_id=replica_id,
+                                arrival_ts=req_state.request_arrival_ts,
+                                now_ts=now_ts,
+                            )
+                        if req_state is not None and req_state.request_arrival_ts > 0:
                             req_state.audio_chunk_arrivals_s.append(max(now_ts - req_state.request_arrival_ts, 0.0))
                             req_state.audio_chunk_bytes.append(chunk_bytes)
                             if req_state.audio_sample_rate is None:
@@ -2495,6 +2497,19 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         else:
             audio_tensor = audio_data
         if audio_tensor is None:
+            if stream:
+                return [
+                    ChatCompletionResponseStreamChoice(
+                        index=output.index,
+                        delta=DeltaMessage(),
+                        logprobs=None,
+                        finish_reason=output.finish_reason,
+                        stop_reason=output.stop_reason,
+                        token_ids=(as_list(output.token_ids) if request.return_token_ids else None),
+                    )
+                    for output in final_res.outputs
+                    if output.finish_reason is not None
+                ]
             return self._create_error_response("Audio generation completed but no audio was produced.")
         audio_tensor = audio_tensor.detach().cpu().float().numpy()
 

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni.py
@@ -73,6 +73,57 @@ TALKER_CODEC_THINK_EOS_ID = 4205  # Think mode end
 logger = init_logger(__name__)
 
 
+CODE2WAV_NUM_QUANTIZERS = 16
+
+
+def _reshape_code2wav_input_ids(
+    input_ids: torch.Tensor,
+    seq_token_counts: list[int] | None,
+) -> torch.Tensor:
+    input_ids_flatten = input_ids.reshape(-1)
+    if seq_token_counts is None:
+        pad_size = (-input_ids_flatten.shape[0]) % CODE2WAV_NUM_QUANTIZERS
+        if pad_size:
+            input_ids_flatten = torch.cat(
+                [
+                    input_ids_flatten,
+                    input_ids_flatten.new_zeros(pad_size),
+                ]
+            )
+        return input_ids_flatten.reshape(1, CODE2WAV_NUM_QUANTIZERS, -1)
+
+    split_codes = torch.split(input_ids_flatten, seq_token_counts, dim=0)
+    code_seq_lens = [(code.shape[0] + CODE2WAV_NUM_QUANTIZERS - 1) // CODE2WAV_NUM_QUANTIZERS for code in split_codes]
+    max_seq_len = max(code_seq_lens, default=0)
+    codes = torch.zeros(
+        (len(split_codes), CODE2WAV_NUM_QUANTIZERS, max_seq_len),
+        device=input_ids.device,
+        dtype=input_ids.dtype,
+    )
+    for idx, (code, seq_len) in enumerate(zip(split_codes, code_seq_lens)):
+        if seq_len == 0:
+            continue
+        padded_len = seq_len * CODE2WAV_NUM_QUANTIZERS
+        if code.shape[0] < padded_len:
+            code = torch.cat([code, code.new_zeros(padded_len - code.shape[0])])
+        codes[idx, :, :seq_len] = code.reshape(CODE2WAV_NUM_QUANTIZERS, seq_len)
+    return codes
+
+
+def _normalize_code2wav_left_context_sizes(
+    left_context_sizes: list[int | None],
+    seq_token_counts: list[int] | None,
+) -> list[int]:
+    normalized = [0 if value is None else int(value) for value in left_context_sizes]
+    if seq_token_counts is None:
+        return normalized
+
+    expected_len = len(seq_token_counts)
+    if len(normalized) < expected_len:
+        normalized.extend([0] * (expected_len - len(normalized)))
+    return normalized[:expected_len]
+
+
 @MULTIMODAL_REGISTRY.register_processor(
     Qwen3OmniMoeThinkerMultiModalProcessor,
     info=Qwen3OmniMoeThinkerProcessingInfo,
@@ -190,6 +241,10 @@ class Qwen3OmniMoeForConditionalGeneration(
                 ("hidden_states", "last"),
                 ("hidden_states", "trailing_text"),
                 ("embed", "tts_pad_projected"),
+                # async-chunk thinker decode cache is consumed every Talker step;
+                # keep it GPU-resident to avoid per-step CPU->GPU copies.
+                ("embed", "decode"),
+                ("embed", "cached_decode"),
                 # talker MTP codec codes must stay on GPU to avoid a per-step D2H
                 # sync stall; build_mm_cpu handles the eventual D2H at payload time.
                 ("codes", "audio"),
@@ -427,36 +482,23 @@ class Qwen3OmniMoeForConditionalGeneration(
             seq_token_counts: list[int] | None = kwargs.get("seq_token_counts")
 
             # Extract codec codes from input
-            if input_ids.shape[0] % 16 == 0:
-                if seq_token_counts is not None:
-                    max_seq_len = max(seq_token_counts) // 16
-                    batch_size = len(seq_token_counts)
-                    split_codes = torch.split(input_ids, seq_token_counts, dim=0)
-                    codes = torch.zeros((batch_size, 16, max_seq_len), device=input_ids.device, dtype=input_ids.dtype)
-                    for idx, code in enumerate(split_codes):
-                        seq_len = code.shape[0] // 16
-                        codes[idx, :, :seq_len] = code.reshape(16, seq_len)
-                else:
-                    codes = input_ids.reshape(1, 16, -1)
-            else:
-                if seq_token_counts is None:
-                    logger.debug(
-                        "Code2Wav warmup input length %s is not divisible by 16; padding with zeros.",
-                        input_ids.shape[0],
-                    )
-                else:
+            num_input_ids = input_ids.numel()
+
+            if seq_token_counts is not None:
+                if sum(seq_token_counts) != num_input_ids:
                     logger.warning_once(
-                        "Code2Wav input length is not divisible by 16; padding with zeros. "
-                        "This is expected only during cudagraph warmup."
+                        "Code2Wav received scheduler token counts that do not match input_ids; "
+                        "returning request-aligned empty audio for this step."
                     )
-                input_ids_flatten = input_ids.reshape(-1)
-                input_ids_flatten = torch.cat(
-                    [
-                        input_ids_flatten,
-                        torch.zeros(16 - input_ids.shape[0] % 16, dtype=torch.long, device=input_ids.device),
-                    ]
+                    return [torch.empty((1, 0), dtype=torch.float32, device=input_ids.device) for _ in seq_token_counts]
+            elif num_input_ids % CODE2WAV_NUM_QUANTIZERS != 0:
+                logger.debug(
+                    "Code2Wav warmup input length %s is not divisible by %s; padding with zeros.",
+                    num_input_ids,
+                    CODE2WAV_NUM_QUANTIZERS,
                 )
-                codes = input_ids_flatten.reshape(1, 16, -1)
+
+            codes = _reshape_code2wav_input_ids(input_ids, seq_token_counts)
 
             # Generate audio from codec codes
             # Get every request's left_context_size from runtime_additional_information (passed via kwargs)
@@ -464,10 +506,10 @@ class Qwen3OmniMoeForConditionalGeneration(
             if runtime_additional_information is not None:
                 for info in runtime_additional_information:
                     meta = info.get("meta", {})
-                    if "left_context_size" in meta:
-                        left_context_size.append(meta["left_context_size"])
+                    left_context_size.append(meta.get("left_context_size", 0))
             else:
                 logger.debug("No additional_information provided to code2wav stage.")
+            left_context_size = _normalize_code2wav_left_context_sizes(left_context_size, seq_token_counts)
             audio_tensors = self.generate_audio(codes, left_context_size, seq_token_counts)
 
             return audio_tensors
@@ -507,8 +549,8 @@ class Qwen3OmniMoeForConditionalGeneration(
                     embed["tts_bos"] = [bos_eos_pad[0]]
                     embed["tts_eos"] = [bos_eos_pad[1]]
                     embed["tts_pad"] = [bos_eos_pad[2]]
-            except Exception:
-                # Best-effort; absence will be handled by talker with fallbacks
+            except (AttributeError, RuntimeError, TypeError, ValueError):
+                # Best-effort; absence will be handled by talker fallbacks.
                 pass
 
             # Return text-only output (with multimodal sidecar)
@@ -538,6 +580,20 @@ class Qwen3OmniMoeForConditionalGeneration(
             return OmniOutput(text_hidden_states=talker_hidden, multimodal_outputs=multimodal_outputs)
         elif self.model_stage == "code2wav":
             audio_tensors = model_outputs
+            seq_token_counts = kwargs.get("seq_token_counts")
+            if seq_token_counts is not None and len(audio_tensors) != len(seq_token_counts):
+                non_empty_indices = [idx for idx, token_count in enumerate(seq_token_counts) if token_count > 0]
+                if len(audio_tensors) == len(non_empty_indices):
+                    empty_dtype = audio_tensors[0].dtype if audio_tensors else torch.float32
+                    empty_device = audio_tensors[0].device if audio_tensors else torch.device("cpu")
+                    audio_by_index = dict(zip(non_empty_indices, audio_tensors, strict=True))
+                    audio_tensors = [
+                        audio_by_index.get(
+                            idx,
+                            torch.empty((1, 0), dtype=empty_dtype, device=empty_device),
+                        )
+                        for idx in range(len(seq_token_counts))
+                    ]
             sample_rate = defs.resolve_audio_sample_rate(self.code2wav_config)
             # `sr` is the audio sample rate metadata consumed by downstream
             # audio serving and stage-local audio metrics.
@@ -731,7 +787,14 @@ class Qwen3OmniMoeForConditionalGeneration(
             )
             update_dict["mtp_inputs"] = last_talker_hidden, text_step
 
-        update_dict.setdefault("meta", {})["num_processed_tokens"] = meta.get("num_processed_tokens", 0) + span_len
+        # Async-chunk decode: the talker may emit a pad while waiting for the
+        # next thinker decode embed to stream in; in that case it must NOT advance
+        # num_processed_tokens (else the awaited token is skipped). Prefill and the
+        # non-async path leave the flag unset -> default True -> advance as before.
+        advance_num_processed_tokens = update_dict.pop("_advance_num_processed_tokens", True)
+        update_dict.setdefault("meta", {})["num_processed_tokens"] = meta.get("num_processed_tokens", 0) + (
+            span_len if advance_num_processed_tokens else 0
+        )
         return input_ids, input_embeds, update_dict
 
     def talker_mtp(
@@ -1026,33 +1089,53 @@ class Qwen3OmniMoeForConditionalGeneration(
         embed = payload.get("embed", {})
         meta = payload.get("meta", {})
 
-        cached_thinker_decode_embeds = embed.get("cached_decode", None)
-        thinker_decode_embed = embed.get("decode", None)
-        start_index = meta.get("num_processed_tokens", 0)
-
-        if cached_thinker_decode_embeds is not None and start_index < cached_thinker_decode_embeds.shape[0]:
-            cached_thinker_decode_embeds = cached_thinker_decode_embeds.to(device)
-            thinker_embed = cached_thinker_decode_embeds[start_index]
-            if thinker_decode_embed is not None:
-                thinker_decode_embed = thinker_decode_embed.to(device)
-                cached_thinker_decode_embeds = torch.cat([cached_thinker_decode_embeds, thinker_decode_embed], dim=0)
-                update_dict.setdefault("embed", {})["cached_decode"] = cached_thinker_decode_embeds
-
-        elif thinker_decode_embed is not None:
-            thinker_embed = thinker_decode_embed
-            if thinker_embed.device != device:
-                thinker_embed = thinker_embed.to(device)
-
+        cached_decode_embed = embed.get("cached_decode", None)
+        current_decode_embed = embed.get("decode", None)
+        if isinstance(cached_decode_embed, torch.Tensor) and isinstance(current_decode_embed, torch.Tensor):
+            cached_decode_embed = cached_decode_embed.to(
+                device=current_decode_embed.device,
+                dtype=current_decode_embed.dtype,
+            )
+            cached_len = int(cached_decode_embed.shape[0])
+            if current_decode_embed.shape[0] >= cached_len and torch.equal(
+                current_decode_embed[:cached_len], cached_decode_embed
+            ):
+                thinker_decode_embed = current_decode_embed
+            else:
+                thinker_decode_embed = torch.cat([cached_decode_embed, current_decode_embed], dim=0)
+        elif isinstance(cached_decode_embed, torch.Tensor):
+            thinker_decode_embed = cached_decode_embed
         else:
-            # When the tokens output by the thinker are exhausted, an EOS token needs to be appended.
-            # Use the finished_flag to mark that all tokens output by thinker have been consumed.
+            thinker_decode_embed = current_decode_embed
+        start_index = meta.get("num_processed_tokens", 0)
+        # cached_decode is the prefix of the cumulative decode sequence; consume
+        # by absolute index so repeated async syncs cannot drop handoff rows.
+        base = meta.get("prefill_consumed_text_tokens", 0)
+        avail = thinker_decode_embed.shape[0] if isinstance(thinker_decode_embed, torch.Tensor) else 0
+        idx = start_index - base
+
+        if isinstance(thinker_decode_embed, torch.Tensor) and 0 <= idx < avail:
+            thinker_embed = thinker_decode_embed[idx].to(device)
+            update_dict["_advance_num_processed_tokens"] = True
             if meta.get("eos_emitted", False):
+                update_dict.setdefault("meta", {})["eos_emitted"] = False
+            return self.talker.text_projection(thinker_embed).to(device)
+
+        # No (more) thinker decode embed available at this index yet.
+        if bool(meta.get("finished", False)) and idx >= avail:
+            # Thinker finished and the talker consumed everything: emit one EOS
+            # then pad. Do not advance past the terminal token.
+            if meta.get("eos_emitted", False):
+                update_dict["_advance_num_processed_tokens"] = False
                 return self.tts_pad_embed.to(device)
             update_dict.setdefault("meta", {})["eos_emitted"] = True
+            update_dict["_advance_num_processed_tokens"] = False
             return self.tts_eos_embed.to(device)
 
-        update_dict.setdefault("embed", {})["decode"] = None
-        return self.talker.text_projection(thinker_embed).to(device)
+        # Talker outran the thinker stream: emit pad and WAIT (do not advance),
+        # so the not-yet-arrived thinker token is consumed once it lands.
+        update_dict["_advance_num_processed_tokens"] = False
+        return self.tts_pad_embed.to(device)
 
     def talker_preprocess_decode(
         self, input_ids: torch.Tensor, input_embeds: torch.Tensor, update_dict: OmniPayload, payload: OmniPayload

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_code2wav.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_code2wav.py
@@ -262,6 +262,12 @@ class Qwen3OmniMoeCode2Wav(nn.Module):
 
             batch_wav = torch.cat(wavs, dim=-1)
 
+        if seq_token_counts is not None and len(seq_token_counts) != codes.shape[0]:
+            logger.warning_once(
+                "chunked_decode: seq_token_counts length does not match codes batch size; "
+                "falling back to codes.shape[-1]. This is expected during cudagraph warmup."
+            )
+            seq_token_counts = None
         if seq_token_counts is not None:
             code_seq_lens = [seq_len // self.config.num_quantizers for seq_len in seq_token_counts]
         else:
@@ -296,12 +302,16 @@ class Qwen3OmniMoeCode2Wav(nn.Module):
                 codes. For ``batch_size == 1``, this is a list containing a
                 single tensor with shape ``[1, waveform_len]``.
         """
-        if not (left_context_size and seq_token_counts and len(left_context_size) == len(seq_token_counts)):
+        valid_metadata = (
+            left_context_size and seq_token_counts and len(left_context_size) == len(seq_token_counts) == codes.shape[0]
+        )
+        if not valid_metadata:
             logger.warning_once(
                 "chunked_decode_streaming: missing/invalid left_context_size or seq_token_counts; "
-                "defaulting to left_context_size=zeros(len(codes)). This is expected during cudagraph warmup."
+                "defaulting to current codes batch metadata. This is expected during cudagraph warmup."
             )
             left_context_size = [0] * codes.shape[0]
+            seq_token_counts = None
         # Decode chunk
         wavs = []
         if self._cudagraph_enabled and self._cudagraph_wrapper is not None:

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
@@ -13,6 +13,7 @@ from vllm.inputs import TextPrompt
 from vllm.platforms import current_platform
 
 from vllm_omni.data_entry_keys import (
+    ASYNC_FINISH_SENTINEL_KEY,
     CodesStruct,
     EmbeddingsStruct,
     HiddenStatesStruct,
@@ -21,6 +22,7 @@ from vllm_omni.data_entry_keys import (
     OmniPayload,
     OmniPayloadStruct,
     to_dict,
+    unflatten_payload,
 )
 from vllm_omni.engine import OmniEngineCoreRequest
 from vllm_omni.inputs.data import OmniTokensPrompt
@@ -57,6 +59,10 @@ def _layer_tensor(layers: dict[Any, Any], key: str) -> torch.Tensor | None:
     if val is None:
         val = layers.get(key)
     return val if isinstance(val, torch.Tensor) else None
+
+
+def _nested_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    return unflatten_payload(dict(payload)) if any("." in key for key in payload) else payload
 
 
 def _compute_talker_prompt_ids_length(info: OmniPayload, device: torch.device | str = "cuda") -> int:
@@ -272,25 +278,28 @@ def _construct_thinker2talker_streaming_input_async_chunk(
     """Build Thinker -> Talker payloads for realtime streaming input chunks.
 
     A resumable realtime request reuses the same logical request id across
-    audio segments. The first streaming prefill chunk is cached and returns ``None`` so the
-    connector does not emit an incomplete downstream chunk. The following
-    decode chunk flushes that cached prefill together with the current Thinker
-    output, keeping Talker ids and tensor rows aligned.
+    audio segments. The first streaming prefill chunk is cached without
+    sending a payload, so the Talker is not woken before required prefill
+    tensors are available. The following decode chunk flushes the cached
+    prefill and carries the current Thinker output as decode data, keeping
+    Talker ids and tensor rows aligned.
     """
     request_id = request.external_req_id
     output_token_ids = request.output_token_ids
     # Convert ConstantList to regular list for OmniSerializer serialization
     output_token_ids = _ensure_list(output_token_ids)
+    if not output_token_ids and not is_finished:
+        return None
     speaker = extract_speaker_from_request(request)
     language = extract_language_from_request(request)
     finished = torch.tensor(is_finished, dtype=torch.bool)
-    emb_cpu = thinker_emb.detach().cpu()
-    hid_cpu = thinker_hid.detach().cpu()
 
     if output_token_ids:
         if thinker_emb.shape[0] > 1:
             # if thinker_emb.shape[0] > 1, new streaming input segment is added
             # and will transfer prefill embeddings and hidden states to talker.
+            emb_cpu = thinker_emb.detach().cpu()
+            hid_cpu = thinker_hid.detach().cpu()
             new_prompt_len = thinker_emb.shape[0]
             payload = OmniPayloadStruct(
                 meta=MetaStruct(finished=finished),
@@ -311,17 +320,21 @@ def _construct_thinker2talker_streaming_input_async_chunk(
                 saved_prefill = save_payload.get("embed", {}).get("prefill")
                 saved_output = save_payload.get("hidden_states", {}).get("output")
                 if isinstance(saved_prefill, torch.Tensor) and isinstance(saved_output, torch.Tensor):
+                    emb_cpu = thinker_emb.detach().cpu()
                     return OmniPayloadStruct(
                         meta=MetaStruct(finished=finished),
-                        embed=EmbeddingsStruct(prefill=torch.cat((saved_prefill, emb_cpu), dim=0)),
-                        hidden_states=HiddenStatesStruct(output=torch.cat((saved_output, hid_cpu), dim=0)),
+                        embed=EmbeddingsStruct(prefill=saved_prefill, decode=emb_cpu),
+                        hidden_states=HiddenStatesStruct(output=saved_output),
                         ids=IdsStruct(
                             all=save_payload.get("ids", {}).get("all"),
                             prompt=save_payload.get("ids", {}).get("prompt"),
+                            output=output_token_ids,
                         ),
                         speaker=speaker,
                         language=language,
                     )
+            emb_cpu = thinker_emb.detach().cpu()
+            hid_cpu = thinker_hid.detach().cpu()
             return OmniPayloadStruct(
                 meta=MetaStruct(
                     finished=finished,
@@ -333,9 +346,8 @@ def _construct_thinker2talker_streaming_input_async_chunk(
                 language=language,
             )
     else:
-        if not is_finished:
-            # do not send async chunk mode placeholder token or embedding/hidden of the stop token
-            return None
+        emb_cpu = thinker_emb.detach().cpu()
+        hid_cpu = thinker_hid.detach().cpu()
         return OmniPayloadStruct(
             meta=MetaStruct(finished=finished),
             embed=EmbeddingsStruct(decode=emb_cpu),
@@ -343,6 +355,23 @@ def _construct_thinker2talker_streaming_input_async_chunk(
             speaker=speaker,
             language=language,
         )
+
+
+def _flush_cached_thinker2talker_payload(transfer_manager: Any, request_id: str) -> OmniPayload | None:
+    request_payload = getattr(transfer_manager, "request_payload", None)
+    cached_payload = request_payload.pop(request_id, None) if isinstance(request_payload, dict) else None
+    if cached_payload is None:
+        pending_prefills = getattr(transfer_manager, "_pending_streaming_prefills", None)
+        if isinstance(pending_prefills, dict):
+            cached_payload = pending_prefills.pop(request_id, None)
+    if not isinstance(cached_payload, dict):
+        return None
+
+    payload = dict(cached_payload)
+    meta = dict(payload.get("meta") or {})
+    meta["finished"] = torch.tensor(True, dtype=torch.bool)
+    payload["meta"] = meta
+    return payload
 
 
 @dataclass
@@ -437,7 +466,7 @@ def thinker2talker_async_chunk(
     multimodal_output: OmniPayload | dict[str, Any],
     request: OmniEngineCoreRequest,
     is_finished: bool = False,
-) -> OmniPayloadStruct | None:
+) -> OmniPayloadStruct | OmniPayload | None:
     """
     Process thinker outputs to create talker inputs.
     1. thinker's text generation outputs (token IDs + hidden states)
@@ -446,10 +475,14 @@ def thinker2talker_async_chunk(
     """
 
     request_id = request.external_req_id
-    chunk_id = transfer_manager.put_req_chunk[request_id]
     if not isinstance(multimodal_output, Mapping):
         logger.debug("thinker2talker_async_chunk: skip non-dict multimodal_output for req=%s", request_id)
         return None
+    if multimodal_output.get(ASYNC_FINISH_SENTINEL_KEY):
+        return _flush_cached_thinker2talker_payload(transfer_manager, request_id)
+    multimodal_output = _nested_payload(multimodal_output)
+
+    chunk_id = transfer_manager.put_req_chunk.get(request_id, 0)
 
     thinker_hs = multimodal_output.get("hidden_states", {})
     thinker_layers = thinker_hs.get("layers", {}) if isinstance(thinker_hs, dict) else {}
@@ -504,7 +537,7 @@ def thinker2talker_async_chunk(
                 transfer_manager.request_payload[request_id] = to_dict(payload)
                 return None
     else:
-        if request.resumable:
+        if getattr(request, "resumable", False):
             return _construct_thinker2talker_streaming_input_async_chunk(
                 is_finished, request, thinker_emb, thinker_hid, transfer_manager
             )
@@ -569,16 +602,9 @@ def thinker2talker_full_payload(
         output_token_ids = _ensure_list(getattr(request, "output_token_ids", []) or [])
         all_token_ids = list(prompt_token_ids) + list(output_token_ids)
 
-    # Trim the trailing stop-token row from the accumulated thinker output.
-    # The accumulator captures one hidden-state row per executed thinker
-    # forward (prefill + every decode step including the one that emitted
-    # the stop_token), so for a finished request thinker_emb has exactly one
-    # row more than the rows the talker should consume. async_chunk's
-    # chunk-0 path naturally captures only the prefill / non-stop portion,
-    # which is why the [async_chunk] parametrization passes while [default]
-    # over-generates one codec frame on short outputs (e.g.
-    # test_one_word_prompt_001[default]: audio extends "London" with
-    # spurious phonemes).
+    # The full-payload accumulator includes the decode row that emitted the
+    # stop token. The talker consumes only non-stop rows, so trim that trailing
+    # row before handing off finished requests.
     if isinstance(thinker_emb, torch.Tensor) and thinker_emb.shape[0] > 0:
         thinker_emb_prefill = thinker_emb[:-1]
     else:
@@ -732,13 +758,12 @@ def thinker2talker_token_only(
     correct length so the scheduler can allocate KV-cache slots.
 
     Small per-request voice metadata (``speaker`` / ``language``) is forwarded
-    here from the user prompt so the worker's line-408 buffer seed picks it
-    up. The connector-side ``extract_speaker_from_request`` reads the
+    here from the user prompt so the worker buffer seed picks it up. The
+    connector-side ``extract_speaker_from_request`` reads the
     strongly-typed ``request.additional_information.entries["speaker"]`` which
     currently does not always round-trip the user-supplied voice; until that
     plumbing is normalized, providing the small fields directly preserves
-    voice selection (regression discovered on Buildkite 9668:
-    ``test_speaker_002[default]`` lost the preset voice).
+    voice selection.
     """
     talker_inputs: list[OmniTokensPrompt] = []
     for i, thinker_output in enumerate(source_outputs):
@@ -800,6 +825,69 @@ def thinker2talker_token_only(
 # =========================
 
 
+def _code2wav_codec_config(transfer_manager: Any) -> tuple[int, int, int]:
+    connector = getattr(transfer_manager, "connector", None)
+    raw_cfg = getattr(connector, "config", None)
+    cfg = raw_cfg.get("extra", raw_cfg) if isinstance(raw_cfg, dict) else {}
+    if not isinstance(cfg, dict) or "codec_chunk_frames" not in cfg:
+        get_model_config = getattr(transfer_manager, "_get_model_config", None)
+        model_config = (
+            get_model_config() if callable(get_model_config) else getattr(transfer_manager, "model_config", None)
+        )
+        connector_config = getattr(model_config, "stage_connector_config", None)
+        if isinstance(connector_config, dict):
+            cfg = connector_config.get("extra", {})
+        else:
+            cfg = getattr(connector_config, "extra", {})
+        if not isinstance(cfg, dict):
+            cfg = {}
+    return (
+        int(cfg.get("codec_chunk_frames", 25)),
+        int(cfg.get("codec_left_context_frames", 25)),
+        int(cfg.get("initial_codec_chunk_frames") or 0),
+    )
+
+
+def _flush_code2wav_finish_tail(transfer_manager: Any, request: OmniEngineCoreRequest) -> OmniPayloadStruct:
+    """Flush the unsent trailing Code2Wav frames for an async finish sentinel."""
+    chunk_size_config, left_context_size_config, configured_initial_chunk_size = _code2wav_codec_config(
+        transfer_manager
+    )
+    request_id = request.external_req_id
+    length = len(transfer_manager.code_prompt_token_ids.get(request_id, []))
+    chunk_progress_length = length
+    if configured_initial_chunk_size > 0:
+        if length <= configured_initial_chunk_size:
+            chunk_size_config = configured_initial_chunk_size
+        else:
+            chunk_progress_length = length - configured_initial_chunk_size
+
+    chunk_length = chunk_progress_length % chunk_size_config if chunk_size_config else 0
+    finished_flag = torch.tensor(True, dtype=torch.bool)
+    if length == 0 or chunk_length == 0:
+        # Boundary / nothing held: the last full chunk was already sent in-step.
+        return OmniPayloadStruct(meta=MetaStruct(finished=finished_flag))
+
+    context_length = chunk_length
+    if (
+        configured_initial_chunk_size > 0
+        and length > configured_initial_chunk_size
+        and chunk_progress_length <= chunk_size_config
+    ):
+        left_context_size = configured_initial_chunk_size
+        end_index = chunk_progress_length + configured_initial_chunk_size
+    else:
+        left_context_size = max(0, min(chunk_progress_length - context_length, left_context_size_config))
+        end_index = min(chunk_progress_length, left_context_size + context_length)
+    codes = (
+        torch.cat(transfer_manager.code_prompt_token_ids[request_id][-end_index:], dim=0).transpose(0, 1).reshape(-1)
+    )
+    return OmniPayloadStruct(
+        codes=CodesStruct(audio=codes),
+        meta=MetaStruct(left_context_size=left_context_size, finished=finished_flag),
+    )
+
+
 def talker2code2wav_async_chunk(
     transfer_manager: Any,
     multimodal_output: OmniPayload | dict[str, Any],
@@ -811,6 +899,10 @@ def talker2code2wav_async_chunk(
     """
     if not isinstance(multimodal_output, Mapping):
         return None
+    # Runner finish sentinel: flush the held trailing partial codec as the terminal chunk.
+    if multimodal_output.get(ASYNC_FINISH_SENTINEL_KEY):
+        return _flush_code2wav_finish_tail(transfer_manager, request)
+    multimodal_output = _nested_payload(multimodal_output)
     talker_codes = multimodal_output.get("codes", {})
     if not isinstance(talker_codes, dict):
         return None
@@ -824,12 +916,9 @@ def talker2code2wav_async_chunk(
     if not code_predictor_codes.any():
         return None
 
-    connector = getattr(transfer_manager, "connector", None)
-    raw_cfg = getattr(connector, "config", {}) or {}
-    cfg = raw_cfg.get("extra", raw_cfg) if isinstance(raw_cfg, dict) else {}
-    chunk_size_config = int(cfg.get("codec_chunk_frames", 25))
-    left_context_size_config = int(cfg.get("codec_left_context_frames", 25))
-    configured_initial_chunk_size = int(cfg.get("initial_codec_chunk_frames") or 0)
+    chunk_size_config, left_context_size_config, configured_initial_chunk_size = _code2wav_codec_config(
+        transfer_manager
+    )
 
     sampling_params = getattr(request, "sampling_params", None)
     stop_token_ids = set(getattr(sampling_params, "stop_token_ids", None) or [])

--- a/vllm_omni/outputs.py
+++ b/vllm_omni/outputs.py
@@ -19,6 +19,7 @@ class OmniConnectorOutput:
     Attributes:
         chunk_ready_req_ids: Request IDs with newly arrived chunks this cycle.
         chunk_finished_req_ids: Request IDs whose final chunk has arrived.
+        chunk_segment_finished_req_ids: Request IDs whose current realtime segment ended.
         request_metadata: Lightweight scheduling metadata keyed by request ID
             (e.g. next_stage_prompt_len, code_predictor_codes, left_context_size).
             Full payloads are owned by the Model Runner's local cache.
@@ -30,6 +31,7 @@ class OmniConnectorOutput:
 
     chunk_ready_req_ids: set[str] = field(default_factory=set)
     chunk_finished_req_ids: set[str] = field(default_factory=set)
+    chunk_segment_finished_req_ids: set[str] = field(default_factory=set)
     request_metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
     kv_sent_req_ids: list[str] = field(default_factory=list)
     stage_recv_req_ids: set[str] = field(default_factory=set)

--- a/vllm_omni/utils/mm_outputs.py
+++ b/vllm_omni/utils/mm_outputs.py
@@ -57,7 +57,13 @@ def _to_cpu(value):
 
 
 def to_payload_element(
-    element: object, idx: int, start: int, end: int, pass_lists_through: bool = False, seq_len: int | None = None
+    element: object,
+    idx: int,
+    start: int,
+    end: int,
+    pass_lists_through: bool = False,
+    seq_len: int | None = None,
+    clone_tensors: bool = True,
 ):
     """Build an mm payload element corresponding to one request index
     from an element containing 0 or more CPU tensors.
@@ -76,6 +82,10 @@ def to_payload_element(
             sliced per request. The prefix cache passthrough also passes
             the total scheduled token count here so 1D (seq_len,) metadata
             that is intentionally not cached is still split per request.
+        clone_tensors: Whether request-invariant tensor values should be
+            cloned before returning. Keep this enabled for local postprocess
+            paths; send-only connector payloads can disable it because the
+            sender has already frozen a CPU payload for transfer.
     """
     # Cached per-token tensors are merged elsewhere; here a first dim
     # equal to seq_len means a per-request slice is required.
@@ -85,19 +95,27 @@ def to_payload_element(
     # and running a model without prefix caching.
     elif isinstance(element, dict):
         return {
-            sk: to_payload_element(sv, idx, start, end, pass_lists_through=pass_lists_through, seq_len=seq_len)
+            sk: to_payload_element(
+                sv,
+                idx,
+                start,
+                end,
+                pass_lists_through=pass_lists_through,
+                seq_len=seq_len,
+                clone_tensors=clone_tensors,
+            )
             for sk, sv in element.items()
         }
     elif isinstance(element, list):
         # For lists, clone tensors to avoid cross-request aliasing
         if pass_lists_through:
-            return [elem.clone() if isinstance(elem, torch.Tensor) else elem for elem in element]
+            return [elem.clone() if clone_tensors and isinstance(elem, torch.Tensor) else elem for elem in element]
         element = element[idx] if idx < len(element) else element[0]
-        if isinstance(element, torch.Tensor):
+        if clone_tensors and isinstance(element, torch.Tensor):
             element = element.clone()
         return element
     elif isinstance(element, torch.Tensor):
         # List-derived tensor payloads are request-invariant; clone to
         # avoid accidental cross-request aliasing on downstream mutation.
-        return element.clone()
+        return element.clone() if clone_tensors else element
     return element

--- a/vllm_omni/worker/gpu_ar_model_runner.py
+++ b/vllm_omni/worker/gpu_ar_model_runner.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Mapping
 from contextlib import nullcontext
 from copy import copy
 from dataclasses import replace
+from types import SimpleNamespace
 from typing import Any, NamedTuple
 
 import numpy as np
@@ -39,12 +40,18 @@ from vllm.v1.worker.gpu_model_runner import (
 from vllm.v1.worker.ubatch_utils import maybe_create_ubatch_slices
 from vllm.v1.worker.utils import is_residual_scattered_for_sp
 
+from vllm_omni.core.sched.omni_scheduling_coordinator import (
+    uses_async_chunk_model_runner_transport,
+)
 from vllm_omni.data_entry_keys import flatten_payload
 from vllm_omni.distributed.omni_connectors.kv_transfer_manager import OmniKVTransferManager
 from vllm_omni.outputs import OmniModelRunnerOutput
 from vllm_omni.utils.mm_outputs import build_mm_cpu, to_payload_element
 from vllm_omni.worker.gpu_model_runner import OmniGPUModelRunner
-from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
+from vllm_omni.worker.omni_connector_model_runner_mixin import (
+    OmniConnectorModelRunnerMixin,
+    _AsyncChunkRequestAdapter,
+)
 
 logger = init_logger(__name__)
 
@@ -254,6 +261,26 @@ def _ensure_tensor_values(payload: dict[str, object]) -> dict[str, torch.Tensor]
     return result
 
 
+def _set_nested_payload_value(payload: dict[str, object], key: str, value: object) -> None:
+    if "." not in key:
+        payload[key] = value
+        return
+
+    type_key, qualifier = key.split(".", 1)
+    sub_payload = payload.setdefault(type_key, {})
+    if not isinstance(sub_payload, dict):
+        payload[key] = value
+        return
+
+    if type_key == "hidden_states" and qualifier.startswith("layer_"):
+        layers = sub_payload.setdefault("layers", {})
+        if isinstance(layers, dict):
+            layers[int(qualifier.removeprefix("layer_"))] = value
+        return
+
+    sub_payload[qualifier] = value
+
+
 class ExecuteModelState(NamedTuple):
     scheduler_output: SchedulerOutput
     logits: torch.Tensor | None
@@ -312,6 +339,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 kv_transfer_manager=self.kv_transfer_manager,
             )
         self._downstream_payload_cache: dict[str, bool] = {}
+        self._async_chunk_segment_terminal_sent: set[str] = set()
 
     def _make_buffer(self, *size, dtype, numpy=True):
         # Prevent ray from pinning the buffer due to large size
@@ -396,11 +424,94 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         cached = self._downstream_payload_cache.get(req_id)
         if cached is not None:
             return cached
-        # Conservative default: keep payload if marker is missing.
         final_stage_id = self._request_final_stage_id(req_id)
+        if final_stage_id == 0:
+            self._downstream_payload_cache[req_id] = False
+            return False
+        if (
+            uses_async_chunk_model_runner_transport(getattr(self, "model_config", None))
+            and getattr(self, "_custom_process_func", None) is not None
+        ):
+            self._downstream_payload_cache[req_id] = True
+            return True
+        # Conservative default: keep payload if marker is missing.
         needs_payload = final_stage_id is None or final_stage_id > 0
         self._downstream_payload_cache[req_id] = needs_payload
         return needs_payload
+
+    def _resolve_transfer_request_id(self, req_id: str) -> str:
+        mapped = self._request_ids_mapping.get(req_id)
+        if mapped is not None:
+            return mapped
+        req_state = self.requests.get(req_id)
+        if req_state is None:
+            return req_id
+        external_req_id = getattr(req_state, "external_req_id", None)
+        if external_req_id is not None:
+            return str(external_req_id)
+        return req_id
+
+    def _send_async_chunk_finish_sentinels(self, finished_req_ids: set[str]) -> None:
+        for rid in finished_req_ids:
+            ext_id = self._request_ids_mapping.get(rid) or self._resolve_transfer_request_id(rid)
+            has_sent_chunk = ext_id in self._put_req_chunk
+            has_cached_payload = ext_id in self._send_side_request_payload or ext_id in self._pending_streaming_prefills
+            if not has_sent_chunk and not has_cached_payload:
+                if not self._request_needs_downstream_stage_payload(rid):
+                    continue
+            snapshot = self._send_side_request_snapshot.get(ext_id)
+            if snapshot is not None:
+                snapshot.is_finished = lambda: True
+                request: Any = snapshot
+            else:
+                request = SimpleNamespace(request_id=rid, req_id=rid, external_req_id=ext_id, is_finished=lambda: True)
+            self.enqueue_finish_sentinel(request, ext_id)
+
+    def _async_chunk_segment_terminal_ready(self, req_id: str) -> bool:
+        info = self.model_intermediate_buffer.get(req_id)
+        if not isinstance(info, dict):
+            return True
+        meta = info.get("meta")
+        if not isinstance(meta, dict):
+            return True
+        if not self._payload_truthy_scalar(meta.get("is_segment_finished")):
+            return True
+        model_stage = getattr(getattr(self, "model_config", None), "model_stage", None)
+        if model_stage != "talker":
+            return True
+        return self._payload_truthy_scalar(meta.get("eos_emitted"))
+
+    def _async_chunk_segment_terminal_sent_ids(self) -> set[str]:
+        sent = getattr(self, "_async_chunk_segment_terminal_sent", None)
+        if sent is None:
+            sent = self._async_chunk_segment_terminal_sent = set()
+        return sent
+
+    def _should_skip_async_chunk_payload_after_segment_terminal(self, req_id: str, ext_id: str) -> bool:
+        sent = self._async_chunk_segment_terminal_sent_ids()
+        if ext_id not in sent:
+            return False
+        info = self.model_intermediate_buffer.get(req_id)
+        meta = info.get("meta") if isinstance(info, dict) else None
+        if isinstance(meta, dict) and not self._payload_truthy_scalar(meta.get("eos_emitted")):
+            sent.discard(ext_id)
+            return False
+        return True
+
+    def _send_async_chunk_segment_sentinels(self, segment_finished_req_ids: set[str]) -> None:
+        sent = self._async_chunk_segment_terminal_sent_ids()
+        for rid in segment_finished_req_ids:
+            ext_id = self._request_ids_mapping.get(rid) or self._resolve_transfer_request_id(rid)
+            ready = self._async_chunk_segment_terminal_ready(rid)
+            if ext_id in sent or not ready:
+                continue
+            snapshot = self._send_side_request_snapshot.get(ext_id)
+            if snapshot is not None:
+                request: Any = snapshot
+            else:
+                request = SimpleNamespace(request_id=rid, req_id=rid, external_req_id=ext_id, is_finished=lambda: False)
+            if self.enqueue_finish_sentinel(request, ext_id, is_segment_finished=True):
+                sent.add(ext_id)
 
     def _resolve_pooler_payload_req_ids(self, req_ids_output_copy: list[str]) -> tuple[str, list[str]]:
         downstream_req_ids = [rid for rid in req_ids_output_copy if self._request_needs_downstream_stage_payload(rid)]
@@ -504,6 +615,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             self._downstream_payload_cache.clear()
         if hasattr(self, "model_intermediate_buffer"):
             self.model_intermediate_buffer.clear()
+        if hasattr(self, "_async_chunk_segment_terminal_sent"):
+            self._async_chunk_segment_terminal_sent.clear()
 
         # 5. Release all CUDA graphs unconditionally (upstream only does this
         #    on ROCm; on CUDA the graphs are only freed by Python GC during
@@ -750,17 +863,23 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         audio_sparse_output: bool,
         sparse_mm_index: dict[str, int],
         seq_len: int,
+        nested_payload: dict[str, object] | None = None,
+        build_flat_payload: bool = True,
     ) -> dict[str, object]:
         if combined_multimodal_outputs:
-            return self._build_combined_prefix_cache_mm_payload(
+            combined_payload = self._build_combined_prefix_cache_mm_payload(
                 combined_multimodal_outputs,
                 rid=rid,
                 idx=idx,
             )
+            if nested_payload is not None:
+                for mm_key, value in combined_payload.items():
+                    _set_nested_payload_value(nested_payload, mm_key, value)
+            return combined_payload if build_flat_payload else {}
 
-        mm_payload: dict[str, object] = {}
+        mm_payload: dict[str, object] | None = {} if build_flat_payload else None
         if not mm_cpu:
-            return mm_payload
+            return mm_payload or {}
 
         for mm_key, mm_val in mm_cpu.items():
             if mm_key in {"meta.req_id", "meta.sparse_audio"}:
@@ -778,17 +897,28 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                     )
                     continue
                 sparse_val = mm_val[sparse_idx]
-                mm_payload[mm_key] = sparse_val.clone() if isinstance(sparse_val, torch.Tensor) else sparse_val
+                value = (
+                    sparse_val.clone() if build_flat_payload and isinstance(sparse_val, torch.Tensor) else sparse_val
+                )
+                if mm_payload is not None:
+                    mm_payload[mm_key] = value
+                if nested_payload is not None:
+                    _set_nested_payload_value(nested_payload, mm_key, value)
                 continue
-            mm_payload[mm_key] = to_payload_element(
+            value = to_payload_element(
                 element=mm_val,
                 idx=idx,
                 start=start,
                 end=end,
                 pass_lists_through=False,
                 seq_len=seq_len,
+                clone_tensors=build_flat_payload,
             )
-        return mm_payload
+            if mm_payload is not None:
+                mm_payload[mm_key] = value
+            if nested_payload is not None:
+                _set_nested_payload_value(nested_payload, mm_key, value)
+        return mm_payload or {}
 
     def _build_omni_pooler_payload(
         self,
@@ -805,6 +935,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         audio_sparse_output: bool,
         sparse_mm_index: dict[str, int],
         seq_len: int,
+        nested_payload: dict[str, object] | None = None,
+        build_flat_payload: bool = True,
     ) -> dict[str, object]:
         payload: dict[str, object] = {}
         if not audio_sparse_output:
@@ -819,7 +951,10 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                     end,
                 )
             if req_hidden_states is not None:
-                payload["hidden"] = req_hidden_states
+                if build_flat_payload:
+                    payload["hidden"] = req_hidden_states
+                if nested_payload is not None:
+                    nested_payload["hidden"] = req_hidden_states
 
         mm_payload = self._build_omni_mm_payload(
             combined_multimodal_outputs=combined_multimodal_outputs,
@@ -831,6 +966,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             audio_sparse_output=audio_sparse_output,
             sparse_mm_index=sparse_mm_index,
             seq_len=seq_len,
+            nested_payload=nested_payload,
+            build_flat_payload=build_flat_payload,
         )
         payload.update(mm_payload)
         return payload
@@ -892,7 +1029,7 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         )
 
         if hasattr(self, "_omni_connector"):
-            for request in getattr(scheduler_output, "pending_input_registrations", []):
+            for request in getattr(scheduler_output, "pending_connector_registrations", []):
                 self.register_chunk_recv(request)
             self.recv_full_payload_inputs(scheduler_output)
             if self._pending_full_payload_send:
@@ -900,6 +1037,13 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                 flush_ids.update({rid for rid in self._pending_full_payload_send if rid not in self.requests})
                 if flush_ids:
                     self.flush_full_payload_outputs(flush_ids)
+            if uses_async_chunk_model_runner_transport(getattr(self, "model_config", None)):
+                async_finished = set(getattr(scheduler_output, "finished_req_ids", set()))
+                if async_finished:
+                    self._send_async_chunk_finish_sentinels(async_finished)
+                segment_finished = set(getattr(scheduler_output, "segment_finished_req_ids", set()))
+                if segment_finished:
+                    self._send_async_chunk_segment_sentinels(segment_finished)
 
         if self.omni_prefix_cache is not None and scheduler_output.finished_req_ids:
             self.omni_prefix_cache.commit_deferred_mm_outputs(
@@ -1340,6 +1484,19 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             return None
         return [_ensure_tensor_values(payload) if payload else {} for payload in per_req_payloads]
 
+    def _should_build_local_multimodal_outputs(self, *, runner_transport: bool) -> bool:
+        model_config = self.vllm_config.model_config
+        engine_output_type = (getattr(model_config, "engine_output_type", None) or "").lower()
+        if engine_output_type == "text":
+            return False
+        if (
+            runner_transport
+            and engine_output_type == "latent"
+            and getattr(self, "_custom_process_func", None) is not None
+        ):
+            return False
+        return True
+
     def _snapshot_query_start_loc_cpu(self) -> Any:
         query_start_loc_cpu = self.query_start_loc.cpu
         if callable(query_start_loc_cpu):
@@ -1542,14 +1699,22 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
             multimodal_outputs=multimodal_outputs,
         )
 
-        needs_pooler_payload = len(downstream_req_ids) > 0
+        runner_transport = uses_async_chunk_model_runner_transport(getattr(self, "model_config", None))
+        needs_downstream_payload = len(downstream_req_ids) > 0
+        needs_full_payload_accumulation = self._should_accumulate_full_payload_output()
+        needs_pooler_payload = needs_downstream_payload and (
+            needs_full_payload_accumulation
+            or self._should_build_local_multimodal_outputs(runner_transport=runner_transport)
+        )
+        needs_send_payload = needs_downstream_payload and runner_transport
+        needs_payload = needs_pooler_payload or needs_send_payload
         downstream_req_id_set = set(downstream_req_ids)
         hidden_states_cpu = None
         req_hidden_states_cpu: dict[str, torch.Tensor] | None = None
         include_hidden_payload = self._model_omni_pooler_payload_include_hidden()
         needs_scheduled_hidden_payload = (
             include_hidden_payload
-            and needs_pooler_payload
+            and needs_payload
             and (self.omni_prefix_cache is None or not self._model_needs_full_prefix_hidden_states())
         )
         self._stage_deferred_prefix_cache_mm_outputs(
@@ -1581,7 +1746,8 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
         # OmniModelRunnerOutput.pooler_output (which is set to None below).
         # The actual multimodal wire transport uses multimodal_outputs instead.
         pooler_output: list[dict[str, object]] | None = None
-        if needs_pooler_payload:
+        async_chunk_send_payloads: list[dict[str, object]] | None = None
+        if needs_payload:
             mm_cpu = None
             if self.omni_prefix_cache is not None:
                 (
@@ -1615,16 +1781,21 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                         query_start_loc_cpu=query_start_loc_cpu,
                     )
 
-            pooler_output = []
+            pooler_output = [] if needs_pooler_payload else None
+            async_chunk_send_payloads = [] if needs_send_payload else None
             with record_function_or_nullcontext("omni_output_builder:build_pooler_payloads"):
                 for rid in req_ids_output_copy:
                     if rid not in downstream_req_id_set:
-                        pooler_output.append({})
+                        if pooler_output is not None:
+                            pooler_output.append({})
+                        if async_chunk_send_payloads is not None:
+                            async_chunk_send_payloads.append({})
                         continue
                     idx = req_id_to_index_output_copy[rid]
                     start = int(query_start_loc_cpu[idx])
                     sched = int(num_scheduled_tokens_np[idx])
                     end = start + sched
+                    send_payload: dict[str, object] | None = {} if async_chunk_send_payloads is not None else None
                     payload = self._build_omni_pooler_payload(
                         rid=rid,
                         idx=idx,
@@ -1638,18 +1809,59 @@ class GPUARModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
                         audio_sparse_output=audio_sparse_output,
                         sparse_mm_index=sparse_mm_index,
                         seq_len=seq_len,
+                        nested_payload=send_payload,
+                        build_flat_payload=pooler_output is not None,
                     )
-                    pooler_output.append(flatten_payload(payload))
+                    if pooler_output is not None:
+                        pooler_output.append(flatten_payload(payload))
+                    if async_chunk_send_payloads is not None:
+                        async_chunk_send_payloads.append(send_payload or {})
 
-        if pooler_output and self._should_accumulate_full_payload_output():
+        if pooler_output and needs_full_payload_accumulation:
             with record_function_or_nullcontext("omni_output_builder:accumulate_full_payload_output"):
                 for i, rid in enumerate(req_ids_output_copy):
                     req_state = self.requests.get(rid)
                     if req_state is not None and pooler_output[i]:
                         self.accumulate_full_payload_output(rid, pooler_output[i], req_state)
 
+        if async_chunk_send_payloads is not None:
+            with record_function_or_nullcontext("omni_output_builder:send_async_chunks"):
+                for i, rid in enumerate(req_ids_output_copy):
+                    payload = async_chunk_send_payloads[i]
+                    if rid not in downstream_req_id_set or not payload:
+                        continue
+                    req_state = self.requests.get(rid)
+                    if req_state is None:
+                        continue
+                    ext_id = self._resolve_transfer_request_id(rid)
+                    if self._should_skip_async_chunk_payload_after_segment_terminal(rid, ext_id):
+                        continue
+                    wrapped = _AsyncChunkRequestAdapter(req_state, external_req_id=ext_id, finished=False)
+                    if (
+                        self.send_chunk(request=wrapped, pooling_output=payload)
+                        and ext_id not in self._send_side_request_snapshot
+                    ):
+                        self._send_side_request_snapshot[ext_id] = self._snapshot_request_for_send(wrapped, ext_id)
+
         with record_function_or_nullcontext("omni_output_builder:build_multimodal_outputs"):
             multimodal_outputs = self._build_multimodal_outputs(pooler_output)
+
+        if runner_transport and downstream_req_id_set:
+            segment_finished_now: set[str] = set()
+            for rid in downstream_req_id_set:
+                info = self.model_intermediate_buffer.get(rid)
+                if not isinstance(info, dict):
+                    continue
+                meta = info.get("meta")
+                if not isinstance(meta, dict):
+                    continue
+                if self._payload_truthy_scalar(meta.get("is_segment_finished")) and self._payload_truthy_scalar(
+                    meta.get("eos_emitted")
+                ):
+                    segment_finished_now.add(rid)
+                    meta["is_segment_finished"] = False
+            if segment_finished_now:
+                self._send_async_chunk_segment_sentinels(segment_finished_now)
 
         with record_function_or_nullcontext("gpu_model_runner: ModelRunnerOutput"):
             routed_experts_lists = None

--- a/vllm_omni/worker/gpu_generation_model_runner.py
+++ b/vllm_omni/worker/gpu_generation_model_runner.py
@@ -10,6 +10,7 @@ import gc
 import logging
 from collections.abc import Mapping
 from dataclasses import replace
+from typing import Any, NamedTuple
 
 import numpy as np
 import torch
@@ -37,11 +38,28 @@ from vllm.v1.worker.ubatch_utils import maybe_create_ubatch_slices
 from vllm.v1.worker.utils import sanity_check_mm_encoder_outputs
 
 from vllm_omni.outputs import OmniModelRunnerOutput
-from vllm_omni.worker.gpu_ar_model_runner import ExecuteModelState, _ensure_tensor_values
+from vllm_omni.worker.gpu_ar_model_runner import _ensure_tensor_values
 from vllm_omni.worker.gpu_model_runner import OmniGPUModelRunner
 from vllm_omni.worker.omni_connector_model_runner_mixin import OmniConnectorModelRunnerMixin
 
 logger = logging.getLogger(__name__)
+
+
+class ExecuteModelState(NamedTuple):
+    scheduler_output: SchedulerOutput
+    logits: torch.Tensor | None
+    spec_decode_metadata: Any
+    spec_decode_common_attn_metadata: Any
+    hidden_states: torch.Tensor | None
+    hidden_states_cpu: torch.Tensor | None
+    sample_hidden_states: torch.Tensor | None
+    aux_hidden_states: list[torch.Tensor] | None
+    ec_connector_output: Any
+    cudagraph_stats: Any
+    multimodal_outputs: Any
+    slot_mappings: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None = None
+    req_ids: list[str] | None = None
+    req_id_to_index: dict[str, int] | None = None
 
 
 class GPUGenerationModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin):
@@ -112,7 +130,7 @@ class GPUGenerationModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin
             self.routed_experts_capturer.clear_buffer()
 
         if hasattr(self, "_omni_connector"):
-            for request in getattr(scheduler_output, "pending_input_registrations", []):
+            for request in getattr(scheduler_output, "pending_connector_registrations", []):
                 self.register_chunk_recv(request)
             self.recv_full_payload_inputs(scheduler_output)
             if self._pending_full_payload_send:
@@ -187,8 +205,9 @@ class GPUGenerationModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin
                     "logprobs for prompt tokens, tokens, please disable "
                     "it when the requests need prompt logprobs"
                 )
-            num_reqs = self.input_batch.num_reqs
-            req_ids = self.input_batch.req_ids
+            req_ids = self.input_batch.req_ids.copy()
+            req_id_to_index = self.input_batch.req_id_to_index.copy()
+            num_reqs = len(req_ids)
             tokens = [scheduler_output.num_scheduled_tokens[i] for i in req_ids]
             num_scheduled_tokens_np = np.array(tokens, dtype=np.int32)
             max_num_scheduled_tokens = int(num_scheduled_tokens_np.max())
@@ -362,6 +381,8 @@ class GPUGenerationModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin
             cudagraph_stats,
             multimodal_outputs,
             slot_mappings,  # OMNI: pass slot_mappings for upstream v1 API compatibility
+            req_ids,
+            req_id_to_index,
         )
         self.kv_connector_output = kv_connector_output
 
@@ -408,6 +429,8 @@ class GPUGenerationModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin
             cudagraph_stats,
             multimodal_outputs_raw,
             slot_mappings,  # OMNI: unpack slot_mappings for upstream v1 API compatibility
+            req_ids_output_copy,
+            req_id_to_index_output_copy,
         ) = self.execute_model_state
         self.execute_model_state = None
 
@@ -416,15 +439,21 @@ class GPUGenerationModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin
         if self.speculative_config is not None:
             self.finalize_kv_connector()
 
-        # Build per-request multimodal_outputs list (dedicated channel).
-        # pooler_output is no longer used for multimodal data.
+        if req_ids_output_copy is None or req_id_to_index_output_copy is None:
+            req_ids_output_copy = self.input_batch.req_ids.copy()
+            req_id_to_index_output_copy = self.input_batch.req_id_to_index.copy()
+        else:
+            req_ids_output_copy = req_ids_output_copy.copy()
+            req_id_to_index_output_copy = req_id_to_index_output_copy.copy()
+        num_reqs = len(req_ids_output_copy)
+
         multimodal_outputs: list[dict[str, object]] = []
         if isinstance(multimodal_outputs_raw, torch.Tensor):
             assert multimodal_outputs_raw.shape[0] == 1, (
                 "model should return a single tensor, to return multiple tensors, use a dict"
             )
-            assert multimodal_outputs_raw.shape[0] == self.input_batch.num_reqs
-            for i in range(self.input_batch.num_reqs):
+            assert multimodal_outputs_raw.shape[0] == num_reqs
+            for i in range(num_reqs):
                 multimodal_outputs.append({"model_outputs": multimodal_outputs_raw[i].detach().to("cpu").contiguous()})
         elif isinstance(multimodal_outputs_raw, list):
             assert len(multimodal_outputs_raw) == 1, (
@@ -435,7 +464,6 @@ class GPUGenerationModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin
                     {"model_outputs": out.detach().to("cpu").contiguous() if out is not None else None}
                 )
         elif isinstance(multimodal_outputs_raw, Mapping):
-            num_reqs = self.input_batch.num_reqs
             for i in range(num_reqs):
                 mm_payload = {}
                 for key, out in multimodal_outputs_raw.items():
@@ -453,9 +481,6 @@ class GPUGenerationModelRunner(OmniGPUModelRunner, OmniConnectorModelRunnerMixin
                 multimodal_outputs.append(_ensure_tensor_values(mm_payload))
         else:
             raise RuntimeError("Unsupported diffusion output type")
-        # [Omni] Copy req_id mappings to avoid async scheduling mutation.
-        req_ids_output_copy = self.input_batch.req_ids.copy()
-        req_id_to_index_output_copy = self.input_batch.req_id_to_index.copy()
         routed_experts_lists = None
         if self.routed_experts_initialized:
             routed_experts_lists = self._omni_extract_routed_experts(scheduler_output)

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -30,6 +30,7 @@ from vllm.v1.worker.gpu_model_runner import GPUModelRunner, IntermediateTensors,
 from vllm.v1.worker.ubatch_utils import maybe_create_ubatch_slices
 
 from vllm_omni.core.prefix_cache import OmniTensorPrefixCache
+from vllm_omni.core.sched.omni_scheduling_coordinator import uses_async_chunk_coordinator
 from vllm_omni.engine.serialization import deserialize_additional_information
 from vllm_omni.model_executor.layers.rotary_embedding.mrope import OmniMRotaryEmbedding as MRotaryEmbedding
 from vllm_omni.model_executor.models.output_templates import OmniOutput
@@ -74,9 +75,12 @@ def _filter_mrope_kwargs_for_model(model: object, kwargs: dict[str, Any]) -> dic
 
 
 class OmniGPUModelRunner(GPUModelRunner):
+    _SEGMENT_RUNTIME_PRESERVED_KEYS: frozenset[str] = frozenset(("omni_final_stage_id",))
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.model_intermediate_buffer: dict[str, dict[str, Any]] = {}
+        self._segment_runtime_reset_req_ids: set[str] = set()
         self._omni_num_scheduled_tokens_np: np.ndarray | None = None
         self._omni_last_model_output: object | None = None
         # The Omni tensor prefix cache will be allocated
@@ -477,6 +481,9 @@ class OmniGPUModelRunner(GPUModelRunner):
                 self._downstream_payload_cache.pop(req_id, None)
             if hasattr(self, "_talker_mtp_generators"):
                 self._talker_mtp_generators.pop(req_id, None)
+            reset_req_ids = getattr(self, "_segment_runtime_reset_req_ids", None)
+            if reset_req_ids is not None:
+                reset_req_ids.discard(req_id)
             if cleanup_finished_request is not None:
                 cleanup_finished_request(req_id)
 
@@ -1322,6 +1329,10 @@ class OmniGPUModelRunner(GPUModelRunner):
                 cache.pop(req_id, None)
         for req_id, payload in staged.items():
             self._update_intermediate_buffer(req_id, payload)
+        if staged:
+            work_available = getattr(self, "_work_available", None)
+            if work_available is not None:
+                work_available.set()
 
     def _build_model_kwargs_extra(self) -> dict:
         """Build extra keyword arguments passed to the model for this step."""
@@ -1642,6 +1653,16 @@ class OmniGPUModelRunner(GPUModelRunner):
         if hasattr(self.model, "has_preprocess") or hasattr(self.model, "enable_update_additional_information"):
             if self.vllm_config.model_config.async_chunk:
                 self._update_additional_information(scheduler_output)
+                # The coordinator/mixin async-chunk path delivers the heavy
+                # stage payload (e.g. thinker embed.prefill) via the worker-local
+                # _local_stage_payload_cache, NOT via scheduler
+                # additional_information (which _update_additional_information
+                # reads).  Bridge the cache into model_intermediate_buffer the
+                # same way full-payload mode does, before the model's preprocess
+                # reads it.  The legacy adapter async-chunk path still carries the
+                # payload in additional_information, so it needs no extra sync.
+                if uses_async_chunk_coordinator(self.vllm_config.model_config):
+                    self._sync_local_stage_payloads()
             else:
                 # In full-payload (non-async-chunk) mode, connector-delivered
                 # stage payloads must override any earlier engine-level
@@ -1927,6 +1948,63 @@ class OmniGPUModelRunner(GPUModelRunner):
         else:
             dest[key] = value
 
+    @staticmethod
+    def _merge_runtime_tensor_sequence(
+        existing_tensor: torch.Tensor,
+        incoming_tensor: torch.Tensor,
+        *,
+        append: bool,
+        replace_mismatch: bool = False,
+    ) -> torch.Tensor:
+        incoming_tensor = incoming_tensor.to(device=existing_tensor.device, dtype=existing_tensor.dtype)
+        if existing_tensor.ndim != incoming_tensor.ndim or existing_tensor.shape[1:] != incoming_tensor.shape[1:]:
+            return incoming_tensor
+
+        existing_len = int(existing_tensor.shape[0])
+        incoming_len = int(incoming_tensor.shape[0])
+        if not append:
+            if incoming_len >= existing_len and torch.equal(incoming_tensor[:existing_len], existing_tensor):
+                return incoming_tensor
+            if existing_len >= incoming_len and torch.equal(existing_tensor[:incoming_len], incoming_tensor):
+                return existing_tensor
+            if replace_mismatch:
+                return incoming_tensor
+            if existing_len >= incoming_len:
+                return existing_tensor
+            return incoming_tensor
+
+        if incoming_len >= existing_len and torch.equal(incoming_tensor[:existing_len], existing_tensor):
+            return incoming_tensor
+        if existing_len >= incoming_len and torch.equal(existing_tensor[:incoming_len], incoming_tensor):
+            return existing_tensor
+        return torch.cat([existing_tensor, incoming_tensor], dim=0)
+
+    @staticmethod
+    def _truthy_scalar(value: Any) -> bool:
+        if isinstance(value, torch.Tensor):
+            return value.numel() == 1 and bool(value.item())
+        return bool(value)
+
+    @staticmethod
+    def _has_segment_prefill(upd: dict) -> bool:
+        embed = upd.get("embed")
+        return isinstance(embed, dict) and isinstance(embed.get("prefill"), torch.Tensor)
+
+    @classmethod
+    def _should_reset_segment_runtime_buffer(cls, existing: dict, upd: dict, *, reset_pending: bool = False) -> bool:
+        if not cls._has_segment_prefill(upd):
+            return False
+        if reset_pending:
+            return True
+        meta = existing.get("meta")
+        return isinstance(meta, dict) and cls._truthy_scalar(meta.get("is_segment_finished"))
+
+    @classmethod
+    def _reset_segment_runtime_buffer(cls, existing: dict) -> None:
+        for key in tuple(existing):
+            if key not in cls._SEGMENT_RUNTIME_PRESERVED_KEYS:
+                existing.pop(key, None)
+
     def _update_intermediate_buffer(self, req_id: str, upd: dict) -> None:
         if not isinstance(upd, dict) or not upd:
             return
@@ -1938,10 +2016,35 @@ class OmniGPUModelRunner(GPUModelRunner):
         if hasattr(self, "model") and hasattr(self.model, "gpu_resident_buffer_keys"):
             gpu_keys = self.model.gpu_resident_buffer_keys
         existing = self.model_intermediate_buffer.setdefault(req_id, {})
+        reset_req_ids = getattr(self, "_segment_runtime_reset_req_ids", None)
+        reset_pending = reset_req_ids is not None and req_id in reset_req_ids
+        reset_meta = None
+        if reset_pending:
+            meta = existing.get("meta")
+            if isinstance(meta, dict):
+                reset_meta = {k: meta[k] for k in ("num_processed_tokens", "resumable") if k in meta}
+        if self._should_reset_segment_runtime_buffer(existing, upd, reset_pending=reset_pending):
+            self._reset_segment_runtime_buffer(existing)
+            if reset_meta:
+                existing.setdefault("meta", {}).update(reset_meta)
+            if reset_req_ids is not None:
+                reset_req_ids.discard(req_id)
+        has_segment_prefill = self._has_segment_prefill(upd)
         for k, v in upd.items():
             if isinstance(v, dict):
                 existing_sub = existing.setdefault(k, {})
                 for qual, val in v.items():
+                    existing_val = existing_sub.get(qual)
+                    if isinstance(existing_val, torch.Tensor) and isinstance(val, torch.Tensor):
+                        if k == "embed" and qual == "decode":
+                            val = self._merge_runtime_tensor_sequence(existing_val, val, append=True)
+                        elif (k, qual) in {("embed", "prefill"), ("hidden_states", "output")}:
+                            val = self._merge_runtime_tensor_sequence(
+                                existing_val,
+                                val,
+                                append=False,
+                                replace_mismatch=(k == "embed" or has_segment_prefill),
+                            )
                     self._store_value(existing_sub, qual, val, {q for tk, q in gpu_keys if tk == k})
             else:
                 self._store_value(existing, k, v, set())
@@ -1954,10 +2057,13 @@ class OmniGPUModelRunner(GPUModelRunner):
 
     def _update_streaming_input_additional_info(self, req_id):
         # For streaming input prefill case only. Set num processed tokens = 0 for new segment input
-        cached_additional_info = self.model_intermediate_buffer.get(req_id, {})
-        if cached_additional_info:
-            merged_info = dict(cached_additional_info)
-            merged_info.setdefault("meta", {})["num_processed_tokens"] = 0
-            merged_info.setdefault("meta", {})["resumable"] = True
-            self.model_intermediate_buffer[req_id] = merged_info
-            setattr(self.requests[req_id], "additional_information_cpu", merged_info)
+        reset_req_ids = getattr(self, "_segment_runtime_reset_req_ids", None)
+        if reset_req_ids is None:
+            reset_req_ids = set()
+            self._segment_runtime_reset_req_ids = reset_req_ids
+        reset_req_ids.add(req_id)
+
+        cached_additional_info = self.model_intermediate_buffer.setdefault(req_id, {})
+        cached_additional_info.setdefault("meta", {})["num_processed_tokens"] = 0
+        cached_additional_info.setdefault("meta", {})["resumable"] = True
+        setattr(self.requests[req_id], "additional_information_cpu", cached_additional_info)

--- a/vllm_omni/worker/omni_connector_model_runner_mixin.py
+++ b/vllm_omni/worker/omni_connector_model_runner_mixin.py
@@ -24,7 +24,7 @@ import torch
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import init_logger
 
-from vllm_omni.data_entry_keys import OmniPayload
+from vllm_omni.data_entry_keys import ASYNC_FINISH_SENTINEL_KEY, OmniPayload
 from vllm_omni.distributed.omni_connectors.factory import OmniConnectorFactory
 from vllm_omni.distributed.omni_connectors.utils.config import ConnectorSpec
 from vllm_omni.outputs import OmniConnectorOutput
@@ -34,7 +34,15 @@ from vllm_omni.worker.payload_span import (
 )
 
 _EMBED_SPAN_GROUPS: tuple[tuple[str, str, str], ...] = (("decode", "decode_token_start", "decode_token_end"),)
-
+_META_OVERWRITE_KEYS: frozenset[str] = frozenset(
+    (
+        "finished",
+        "is_segment_finished",
+        "stream_finished",
+        "next_stage_prompt_len",
+        "num_processed_tokens",
+    )
+)
 if TYPE_CHECKING:
     from vllm_omni.distributed.omni_connectors.connectors.base import (
         OmniConnectorBase,
@@ -46,20 +54,129 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _strip_trailing_placeholder_tokens(token_ids: list[int] | None) -> list[int]:
+    if not token_ids:
+        return []
+    end = len(token_ids)
+    while end > 0 and int(token_ids[end - 1]) == -1:
+        end -= 1
+    return list(token_ids[:end])
+
+
+class _AsyncChunkRequestAdapter:
+    """Expose request fields expected by async-chunk stage processors."""
+
+    __slots__ = ("_inner", "_external_req_id", "_finished")
+
+    def __init__(self, cached_state: Any, external_req_id: str, finished: bool):
+        self._inner = cached_state
+        self._external_req_id = external_req_id
+        self._finished = finished
+
+    @property
+    def external_req_id(self) -> str:
+        return self._external_req_id
+
+    @property
+    def request_id(self) -> str:
+        return self._inner.req_id
+
+    @property
+    def req_id(self) -> str:
+        return self._inner.req_id
+
+    @property
+    def prompt_token_ids(self) -> list[int] | None:
+        return self._inner.prompt_token_ids
+
+    @property
+    def output_token_ids(self) -> list[int]:
+        return _strip_trailing_placeholder_tokens(self._inner.output_token_ids)
+
+    @property
+    def all_token_ids(self) -> list[int]:
+        prompt = self._inner.prompt_token_ids or []
+        return list(prompt) + self.output_token_ids
+
+    def is_finished(self) -> bool:
+        return self._finished
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+
+def _merge_tensor_sequence(
+    existing_tensor: torch.Tensor, incoming_tensor: torch.Tensor, *, append: bool
+) -> torch.Tensor:
+    incoming_tensor = incoming_tensor.to(device=existing_tensor.device, dtype=existing_tensor.dtype)
+    existing_len = int(existing_tensor.shape[0])
+    incoming_len = int(incoming_tensor.shape[0])
+    if incoming_len >= existing_len and torch.equal(incoming_tensor[:existing_len], existing_tensor):
+        return incoming_tensor
+    if existing_len >= incoming_len and torch.equal(existing_tensor[:incoming_len], incoming_tensor):
+        return existing_tensor
+    if append:
+        return torch.cat([existing_tensor, incoming_tensor], dim=0)
+    if existing_len >= incoming_len:
+        return existing_tensor
+    return incoming_tensor
+
+
+def _deep_merge_chunk_payload(existing: dict, incoming: dict) -> None:
+    """Merge one received async-chunk payload into the cached payload in place.
+
+    Nested dicts are merged key-by-key so decode chunks do not erase prefill
+    fields. Terminal ``meta.finished=True`` is sticky across intermediate
+    ``False`` updates, matching the adapter receive merge.
+    """
+    embed = incoming.get("embed")
+    if isinstance(embed, dict) and "prefill" in embed:
+        existing.clear()
+
+    for key, value in incoming.items():
+        if isinstance(value, dict):
+            sub = existing.get(key)
+            merged = dict(sub) if isinstance(sub, dict) else {}
+            for sub_key, sub_val in value.items():
+                if key == "meta" and sub_key == "finished":
+                    incoming_finished = (
+                        sub_val.numel() == 1 and bool(sub_val.item())
+                        if isinstance(sub_val, torch.Tensor)
+                        else bool(sub_val)
+                    )
+                    existing_val = merged.get(sub_key)
+                    existing_finished = (
+                        existing_val.numel() == 1 and bool(existing_val.item())
+                        if isinstance(existing_val, torch.Tensor)
+                        else bool(existing_val)
+                    )
+                    if existing_finished and not incoming_finished:
+                        continue
+                existing_sub_val = merged.get(sub_key)
+                if isinstance(existing_sub_val, torch.Tensor) and isinstance(sub_val, torch.Tensor):
+                    if key == "embed" and sub_key == "decode":
+                        merged[sub_key] = _merge_tensor_sequence(existing_sub_val, sub_val, append=True)
+                        continue
+                    if (key, sub_key) in {("embed", "prefill"), ("hidden_states", "output")}:
+                        merged[sub_key] = _merge_tensor_sequence(existing_sub_val, sub_val, append=False)
+                        continue
+                merged[sub_key] = sub_val
+            existing[key] = merged
+        else:
+            existing[key] = value
+
+
 def should_accumulate_full_payload_output(model_config, custom_process_func) -> bool:
     """Producer-side structural gate.
 
     Fires iff the stage explicitly declares a downstream full-payload
-    producer hook via ``custom_process_next_stage_input_func``.  Consumer
-    stages may have ``custom_process_input_func`` values that can be
-    mechanically derived to ``*_full_payload`` helper names in the same
-    module; those are intentionally not enough to make the stage a producer.
+    producer hook via ``custom_process_next_stage_input_func``.  Some stages
+    are both user-visible final outputs and downstream payload producers, so
+    ``final_output`` alone is not a terminal-stage signal here.
     """
     if custom_process_func is None:
         return False
     if getattr(model_config, "async_chunk", False):
-        return False
-    if getattr(model_config, "final_output", False):
         return False
     next_stage_func = getattr(model_config, "custom_process_next_stage_input_func", None)
     if not isinstance(next_stage_func, str) or not next_stage_func:
@@ -110,6 +227,11 @@ class OmniConnectorModelRunnerMixin:
 
         self._custom_process_func_path, self._custom_process_func = self._load_custom_func(model_config)
         self._custom_process_supports_is_finished = self._custom_process_supports_is_finished_kwarg()
+        self._custom_process_output_arg = (
+            self._connector_payload_output_arg(self._custom_process_func)
+            if self._custom_process_func is not None
+            else None
+        )
         logger.debug(
             "[Stage-%s] init_omni_connectors: async_chunk=%s, custom_process_func=%s, connector=%s, func_path=%s",
             self._stage_id,
@@ -136,12 +258,22 @@ class OmniConnectorModelRunnerMixin:
         # -- chunk index tracking (ported from OmniChunkTransferAdapter) --
         self._put_req_chunk: dict[str, int] = defaultdict(int)
         self._get_req_chunk: dict[str, int] = defaultdict(int)
+        # Preemption dup-send watermark (parity with the adapter's
+        # ``requests_num_chunks_sent``): committed-token count at the last send
+        # per external req id; a send whose confirmed count regresses below the
+        # watermark is a preempt/replay and is skipped.
+        self._requests_num_chunks_sent: dict[str, int] = defaultdict(int)
         # Send-side async accumulation / staging buffer. Receive-side payload
         # ownership lives in ``_local_stage_payload_cache``.
         self._send_side_request_payload: dict[str, dict[str, Any]] = {}
+        self._pending_streaming_prefills: dict[str, dict[str, Any]] = {}
         self._code_prompt_token_ids: dict[str, list[list[int]]] = defaultdict(list)
         self._cached_ic: dict[str, int] = {}
         self._request_ids_mapping: dict[str, str] = {}
+        # Frozen request snapshot captured at send time so the next-cycle finish
+        # sentinel can rebuild its terminal payload after ``_update_states`` has
+        # freed the live request (keyed by external req id).
+        self._send_side_request_snapshot: dict[str, Any] = {}
 
         # -- async I/O state (shared by chunk + full_payload_mode) --
         self._pending_load_reqs: dict[str, Any] = {}
@@ -152,6 +284,7 @@ class OmniConnectorModelRunnerMixin:
         # -- per-cycle output accumulator --
         self._chunk_ready_req_ids: set[str] = set()
         self._chunk_finished_req_ids: set[str] = set()
+        self._chunk_segment_finished_req_ids: set[str] = set()
         self._stage_recv_req_ids: set[str] = set()
         self._full_payload_pending_broadcast_req_ids: set[str] = set()
         self._async_chunk_updated_req_ids: set[str] = set()
@@ -282,7 +415,10 @@ class OmniConnectorModelRunnerMixin:
                 if k in keys_pending:
                     continue
                 self._put_req_chunk.pop(k, None)
+                self._requests_num_chunks_sent.pop(k, None)
+                self._send_side_request_snapshot.pop(k, None)
                 self._send_side_request_payload.pop(k, None)
+                self._pending_streaming_prefills.pop(k, None)
                 self._code_prompt_token_ids.pop(k, None)
                 self._cached_ic.pop(k, None)
             self._kv_pending_transfers.pop(req_id, None)
@@ -304,8 +440,15 @@ class OmniConnectorModelRunnerMixin:
     def _drop_send_side_payload_state(self, req_id: str, ext_id: str | None) -> None:
         if ext_id is not None:
             self._send_side_request_payload.pop(ext_id, None)
-            self._cached_ic.pop(ext_id, None)
+            self._pending_streaming_prefills.pop(ext_id, None)
+            self._clear_segment_send_state(ext_id)
         self._send_side_request_payload.pop(req_id, None)
+        self._pending_streaming_prefills.pop(req_id, None)
+        self._clear_segment_send_state(req_id)
+
+    def _clear_segment_send_state(self, req_id: str) -> None:
+        self._requests_num_chunks_sent.pop(req_id, None)
+        self._code_prompt_token_ids.pop(req_id, None)
         self._cached_ic.pop(req_id, None)
 
     def _cleanup_recv_delivery_state(self, req_id: str) -> None:
@@ -322,6 +465,7 @@ class OmniConnectorModelRunnerMixin:
         self._finished_load_reqs.discard(req_id)
         self._chunk_ready_req_ids.discard(req_id)
         self._chunk_finished_req_ids.discard(req_id)
+        self._chunk_segment_finished_req_ids.discard(req_id)
         self._chunk_stream_completed.discard(req_id)
         self._stage_recv_req_ids.discard(req_id)
         self._full_payload_pending_broadcast_req_ids.discard(req_id)
@@ -382,6 +526,7 @@ class OmniConnectorModelRunnerMixin:
             "_finished_load_reqs",
             "_chunk_ready_req_ids",
             "_chunk_finished_req_ids",
+            "_chunk_segment_finished_req_ids",
             "_chunk_stream_completed",
             "_stage_recv_req_ids",
             "_full_payload_pending_broadcast_req_ids",
@@ -428,6 +573,22 @@ class OmniConnectorModelRunnerMixin:
         """Retrieve scheduling metadata for a request."""
         return self._local_request_metadata.get(req_id)
 
+    def _async_recv_handoff_pending_locked(self, req_id: str) -> bool:
+        if not (self._async_chunk and self._model_mode != "ar"):
+            return False
+        staged_payload = self._local_stage_payload_cache.get(req_id)
+        return (
+            self._payload_is_consumable(staged_payload)
+            or req_id in self._local_request_metadata
+            or req_id in self._finished_load_reqs
+        )
+
+    def _filter_pollable_load_req_ids_locked(self, req_ids: list[str]) -> list[str]:
+        if not self._async_chunk or self._model_mode == "ar":
+            return req_ids
+
+        return [req_id for req_id in req_ids if not self._async_recv_handoff_pending_locked(req_id)]
+
     # ------------------------------------------------------------------ #
     #  Scheduling metadata extraction
     # ------------------------------------------------------------------ #
@@ -460,6 +621,8 @@ class OmniConnectorModelRunnerMixin:
 
     _NON_CONSUMABLE_PAYLOAD_KEYS: set[tuple[str, str]] = {
         ("meta", "finished"),
+        ("meta", "is_segment_finished"),
+        ("meta", "stream_finished"),
         ("meta", "override_keys"),
         ("meta", "next_stage_prompt_len"),
         ("meta", "left_context_size"),
@@ -479,18 +642,30 @@ class OmniConnectorModelRunnerMixin:
         return True
 
     @staticmethod
+    def _payload_truthy_scalar(flag: Any) -> bool:
+        if isinstance(flag, torch.Tensor):
+            return flag.numel() == 1 and bool(flag.item())
+        return bool(flag)
+
+    @staticmethod
     def _payload_finished(payload: Any) -> bool:
         if not isinstance(payload, dict):
             return False
         if "finished" in payload:
-            logger.warning_once("legacy flat 'finished' key in payload; expected 'meta.finished'")
+            logger.warning_once("legacy flat finished key in payload; expected meta.finished")
         meta = payload.get("meta")
-        if not isinstance(meta, dict) or "finished" not in meta:
+        if not isinstance(meta, dict):
             return False
-        flag = meta["finished"]
-        if isinstance(flag, torch.Tensor):
-            return flag.numel() == 1 and bool(flag.item())
-        return bool(flag)
+        return OmniConnectorModelRunnerMixin._payload_truthy_scalar(meta.get("finished"))
+
+    @staticmethod
+    def _payload_segment_finished(payload: Any) -> bool:
+        if not isinstance(payload, dict):
+            return False
+        meta = payload.get("meta")
+        if not isinstance(meta, dict):
+            return False
+        return OmniConnectorModelRunnerMixin._payload_truthy_scalar(meta.get("is_segment_finished"))
 
     @staticmethod
     def _payload_audio_codes(payload: Any) -> Any:
@@ -598,8 +773,13 @@ class OmniConnectorModelRunnerMixin:
 
     @staticmethod
     def _snapshot_payload(payload: Any) -> Any:
+        """Copy payload containers without cloning tensor storage."""
         if isinstance(payload, dict):
-            return dict(payload)
+            return {key: OmniConnectorModelRunnerMixin._snapshot_payload(value) for key, value in payload.items()}
+        if isinstance(payload, list):
+            return [OmniConnectorModelRunnerMixin._snapshot_payload(value) for value in payload]
+        if isinstance(payload, tuple):
+            return tuple(OmniConnectorModelRunnerMixin._snapshot_payload(value) for value in payload)
         return payload
 
     def _broadcast_tp_payload_packet(self, packet: Any) -> Any:
@@ -639,9 +819,14 @@ class OmniConnectorModelRunnerMixin:
         payload_req_ids = set(self._async_chunk_updated_req_ids)
         payload_req_ids.update(self._finished_load_reqs)
         payload_req_ids.update(self._chunk_finished_req_ids)
+        payload_req_ids.update(self._chunk_segment_finished_req_ids)
         payload_req_ids.update(self._local_request_metadata)
         if not (
-            payload_req_ids or self._finished_load_reqs or self._chunk_finished_req_ids or self._local_request_metadata
+            payload_req_ids
+            or self._finished_load_reqs
+            or self._chunk_finished_req_ids
+            or self._chunk_segment_finished_req_ids
+            or self._local_request_metadata
         ):
             return None
 
@@ -655,12 +840,15 @@ class OmniConnectorModelRunnerMixin:
             "request_metadata": dict(self._local_request_metadata),
             "newly_finished": set(self._finished_load_reqs),
             "chunk_finished": set(self._chunk_finished_req_ids),
+            "chunk_segment_finished": set(self._chunk_segment_finished_req_ids),
         }
 
         self._async_chunk_updated_req_ids.clear()
         self._finished_load_reqs.clear()
         self._chunk_finished_req_ids.clear()
+        self._chunk_segment_finished_req_ids.clear()
         self._local_request_metadata.clear()
+        self._work_available.set()
 
         for req_id in packet["chunk_finished"]:
             if req_id not in self._local_stage_payload_cache:
@@ -752,9 +940,8 @@ class OmniConnectorModelRunnerMixin:
             # In that case the accumulator builds payloads that
             # ``send_full_payload_outputs`` later drops via its own
             # connector-side checks (wasted CPU, not a functional bug).
-            # A topology-aware gate (explicit producer field or pipeline
-            # is_terminal info) would close the gap; that change is out
-            # of scope for this PR.
+            # A topology-aware producer/terminal-stage gate would close the
+            # gap; until then, avoid functional risk and only skip wasted work.
             self._should_accumulate_full_payload_output_cached = False
             return False
         cached = getattr(self, "_should_accumulate_full_payload_output_cached", None)
@@ -1108,6 +1295,13 @@ class OmniConnectorModelRunnerMixin:
         self._chunk_ready_req_ids.update(finished)
         return result
 
+    @staticmethod
+    def _confirmed_num_computed_tokens(request: Any) -> int:
+        """Committed-token watermark for the preemption dup-send guard."""
+        num_computed = int(getattr(request, "num_computed_tokens", 0) or 0)
+        num_placeholders = int(getattr(request, "num_output_placeholders", 0) or 0)
+        return max(0, num_computed - num_placeholders)
+
     def send_chunk(
         self,
         request: Any,
@@ -1131,7 +1325,23 @@ class OmniConnectorModelRunnerMixin:
         # resolve the external ID even after the request is freed.
         if raw_req_id and raw_req_id != request_id:
             self._request_ids_mapping.setdefault(raw_req_id, request_id)
-        chunk_id = self._put_req_chunk[request_id]
+
+        # Skip replayed spans after preemption by comparing committed-token
+        # progress against the last sent watermark.
+        confirmed_num_computed_tokens = self._confirmed_num_computed_tokens(request)
+        if confirmed_num_computed_tokens < self._requests_num_chunks_sent.get(request_id, 0):
+            logger.warning(
+                "[Stage-%s] send_chunk: skip replayed span for req=%s (confirmed=%s < previously_sent=%s)",
+                self._stage_id,
+                request_id,
+                confirmed_num_computed_tokens,
+                self._requests_num_chunks_sent.get(request_id, 0),
+            )
+            return True
+        self._requests_num_chunks_sent[request_id] = confirmed_num_computed_tokens
+
+        had_chunk_entry = request_id in self._put_req_chunk
+        chunk_id = self._put_req_chunk.get(request_id, 0)
 
         payload_data = self._build_custom_process_payload(
             request_id=request_id,
@@ -1139,8 +1349,10 @@ class OmniConnectorModelRunnerMixin:
             pooling_output=pooling_output,
         )
         if payload_data is None:
+            if not had_chunk_entry and self._put_req_chunk.get(request_id) == 0:
+                self._put_req_chunk.pop(request_id, None)
             if chunk_id == 0:
-                logger.warning(
+                logger.debug(
                     "[Stage-%s] send_chunk: payload is None for req=%s chunk=%s (process_func=%s)",
                     self._stage_id,
                     request_id,
@@ -1165,12 +1377,64 @@ class OmniConnectorModelRunnerMixin:
             "stage_id": self._stage_id,
             "next_stage_id": next_stage_id,
             "put_key": connector_put_key,
-            "data": payload_data,
+            "data": self._snapshot_payload(payload_data),
             "request_id": request_id,
         }
         with self._lock:
             self._pending_save_reqs.setdefault(request_id, deque()).append(task)
             self._pending_save_counts[request_id] += 1
+        self._work_available.set()
+        return True
+
+    def enqueue_finish_sentinel(self, request: Any, request_id: str, *, is_segment_finished: bool = False) -> bool:
+        """Enqueue the terminal chunk for a finished async-chunk request.
+
+        The model hook may emit terminal content, such as code2wav tail flushes;
+        otherwise a bare finished flag is sent at the next contiguous chunk id.
+        """
+        if self._omni_connector is None or not self.is_data_transfer_rank():
+            return True
+
+        # The marker lets model hooks distinguish terminal flush calls from
+        # ordinary empty adapter calls.
+        payload_data = self._build_custom_process_payload(
+            request_id=request_id,
+            request=request,
+            pooling_output={ASYNC_FINISH_SENTINEL_KEY: True},
+        )
+        if payload_data is None:
+            payload_data = {
+                "meta": {
+                    "finished": torch.tensor(not is_segment_finished, dtype=torch.bool),
+                    "is_segment_finished": torch.tensor(is_segment_finished, dtype=torch.bool),
+                }
+            }
+        elif is_segment_finished:
+            # Realtime segments flush their tail without finishing the request.
+            _meta = getattr(payload_data, "meta", None)
+            if _meta is not None:
+                _meta.finished = torch.tensor(False, dtype=torch.bool)
+                _meta.is_segment_finished = torch.tensor(True, dtype=torch.bool)
+            elif isinstance(payload_data, dict):
+                _m = payload_data.setdefault("meta", {})
+                _m["finished"] = torch.tensor(False, dtype=torch.bool)
+                _m["is_segment_finished"] = torch.tensor(True, dtype=torch.bool)
+
+        chunk_id = self._put_req_chunk[request_id]
+        self._put_req_chunk[request_id] += 1
+        connector_put_key = f"{request_id}_{self._stage_id}_{chunk_id}"
+        task = {
+            "stage_id": self._stage_id,
+            "next_stage_id": self._next_stage_id,
+            "put_key": connector_put_key,
+            "data": self._snapshot_payload(payload_data),
+            "request_id": request_id,
+        }
+        with self._lock:
+            self._pending_save_reqs.setdefault(request_id, deque()).append(task)
+            self._pending_save_counts[request_id] += 1
+            if is_segment_finished:
+                self._clear_segment_send_state(request_id)
         self._work_available.set()
         return True
 
@@ -1540,12 +1804,14 @@ class OmniConnectorModelRunnerMixin:
             if fanout_packet is None:
                 newly_finished = set()
                 chunk_finished = set()
+                chunk_segment_finished = set()
                 request_metadata = {}
             else:
                 if not self.is_data_transfer_rank():
                     self._apply_async_chunk_fanout_packet(fanout_packet)
                 newly_finished = set(fanout_packet["newly_finished"])
                 chunk_finished = set(fanout_packet["chunk_finished"])
+                chunk_segment_finished = set(fanout_packet.get("chunk_segment_finished", set()))
                 request_metadata = dict(fanout_packet["request_metadata"])
         else:
             with self._lock:
@@ -1553,13 +1819,13 @@ class OmniConnectorModelRunnerMixin:
                 self._finished_load_reqs.clear()
                 chunk_finished = set(self._chunk_finished_req_ids)
                 self._chunk_finished_req_ids.clear()
+                chunk_segment_finished = set(self._chunk_segment_finished_req_ids)
+                self._chunk_segment_finished_req_ids.clear()
                 request_metadata = dict(self._local_request_metadata)
                 self._local_request_metadata.clear()
-                # _send_side_request_payload is the async accumulation buffer for
-                # future recv chunks. Clearing it on every consumable wake-up drops
-                # intermediate
-                # thinker decode spans before the model side can consume them.
-                # Only terminal chunk_finished requests may release that buffer.
+                # Release any send-side accumulated payload only after the
+                # terminal chunk. Ordinary wake-ups may still arrive before the
+                # model side has consumed the staged payload.
                 for req_id in chunk_finished:
                     if req_id not in self._local_stage_payload_cache:
                         continue
@@ -1567,23 +1833,29 @@ class OmniConnectorModelRunnerMixin:
                     self._send_side_request_payload.pop(ext_req_id, None)
                     if ext_req_id != req_id:
                         self._send_side_request_payload.pop(req_id, None)
+                if newly_finished or chunk_finished or chunk_segment_finished or request_metadata:
+                    self._work_available.set()
         self._chunk_ready_req_ids.update(newly_finished)
 
         output = OmniConnectorOutput(
             chunk_ready_req_ids=set(self._chunk_ready_req_ids),
             chunk_finished_req_ids=chunk_finished,
+            chunk_segment_finished_req_ids=chunk_segment_finished,
             request_metadata=request_metadata,
             kv_sent_req_ids=list(self._kv_sent_req_ids),
             stage_recv_req_ids=set(self._stage_recv_req_ids),
             has_pending_kv_work=self.has_pending_kv_work(),
         )
-        if output.stage_recv_req_ids or chunk_finished or newly_finished:
+        if output.stage_recv_req_ids or chunk_finished or chunk_segment_finished or newly_finished or request_metadata:
             logger.debug(
-                "[Stage-%s] get_omni_connector_output: stage_recv=%s, chunk_finished=%s, chunk_ready=%s",
+                "[Stage-%s] get_omni_connector_output: stage_recv=%s, chunk_finished=%s, "
+                "segment_finished=%s, chunk_ready=%s, metadata=%s",
                 self._stage_id,
                 output.stage_recv_req_ids,
                 chunk_finished,
+                chunk_segment_finished,
                 output.chunk_ready_req_ids,
+                sorted(request_metadata.keys()),
             )
         self._chunk_ready_req_ids.clear()
         self._kv_sent_req_ids.clear()
@@ -1595,6 +1867,7 @@ class OmniConnectorModelRunnerMixin:
         return bool(
             output.chunk_ready_req_ids
             or output.chunk_finished_req_ids
+            or output.chunk_segment_finished_req_ids
             or output.request_metadata
             or output.kv_sent_req_ids
             or output.stage_recv_req_ids
@@ -1649,24 +1922,31 @@ class OmniConnectorModelRunnerMixin:
         while not self._stop_event.is_set():
             with self._lock:
                 pending_ids = list(self._pending_load_reqs.keys())
+                pollable_ids = self._filter_pollable_load_req_ids_locked(pending_ids)
 
             if not pending_ids:
                 self._work_available.wait(timeout=0.01)
                 self._work_available.clear()
                 continue
 
+            if not pollable_ids:
+                self._work_available.wait(timeout=0.05)
+                self._work_available.clear()
+                continue
+
             _recv_poll_count += 1
             if _recv_poll_count % 5000 == 1:
                 logger.debug(
-                    "[Stage-%s] _recv_loop: polling %s pending reqs: %s (poll#%s)",
+                    "[Stage-%s] _recv_loop: polling %s/%s pending reqs: %s (poll#%s)",
                     self._stage_id,
+                    len(pollable_ids),
                     len(pending_ids),
-                    pending_ids[:5],
+                    pollable_ids[:5],
                     _recv_poll_count,
                 )
 
             made_progress = False
-            for req_id in pending_ids:
+            for req_id in pollable_ids:
                 if self._stop_event.is_set():
                     break
                 try:
@@ -1748,10 +2028,8 @@ class OmniConnectorModelRunnerMixin:
 
         if self._async_chunk and self._model_mode != "ar":
             with self._lock:
-                staged_payload = self._local_stage_payload_cache.get(req_id)
-                metadata_in_flight = req_id in self._local_request_metadata
-                scheduler_wakeup_pending = req_id in self._finished_load_reqs
-            if self._payload_is_consumable(staged_payload) or metadata_in_flight or scheduler_wakeup_pending:
+                handoff_pending = self._async_recv_handoff_pending_locked(req_id)
+            if handoff_pending:
                 logger.debug(
                     "[Stage-%s] delaying recv for req=%s until staged async payload is handed to scheduler",
                     self._stage_id,
@@ -1785,6 +2063,7 @@ class OmniConnectorModelRunnerMixin:
         payload_data, _size = result
         if not payload_data:
             return False
+
         if isinstance(payload_data, dict):
             logger.debug(
                 "[Stage-%s] recv_chunk_result: req=%s ext=%s key=%s keys=%s finished=%s",
@@ -1800,37 +2079,83 @@ class OmniConnectorModelRunnerMixin:
 
         if self._async_chunk:
             is_finished = self._payload_finished(payload_data)
+            is_segment_finished = self._payload_segment_finished(payload_data)
             incoming_payload_consumable = self._payload_is_consumable(payload_data)
 
             if self._model_mode == "ar":
-                payload_data = self._accumulate_payload(external_req_id, payload_data)
                 payload_consumable = incoming_payload_consumable
             else:
-                new_ids = self._payload_audio_codes(payload_data) or []
-                if not new_ids and not is_finished:
+                # codes.audio may be a multi-element tensor -> use a numel/len
+                # check, never `or []` / `not new_ids` (bool(tensor) raises
+                # "ambiguous truth value" on a >1-element tensor).
+                audio_codes = self._payload_audio_codes(payload_data)
+                if isinstance(audio_codes, torch.Tensor):
+                    has_codes = audio_codes.numel() > 0
+                else:
+                    has_codes = bool(audio_codes)
+                if not has_codes and not (is_finished or is_segment_finished):
+                    payload_keys = (
+                        sorted(payload_data.keys()) if isinstance(payload_data, dict) else type(payload_data).__name__
+                    )
+                    logger.debug(
+                        "[Stage-%s] async recv ignored non-code payload: req=%s key=%s keys=%s "
+                        "finished=%s segment_finished=%s consumable=%s size=%s",
+                        self._stage_id,
+                        req_id,
+                        connector_get_key,
+                        payload_keys,
+                        is_finished,
+                        is_segment_finished,
+                        incoming_payload_consumable,
+                        _size,
+                    )
                     return False
                 payload_consumable = self._payload_is_consumable(payload_data)
+
+            payload_keys = (
+                sorted(payload_data.keys()) if isinstance(payload_data, dict) else type(payload_data).__name__
+            )
+            logger.debug(
+                "[Stage-%s] async recv accepted payload: req=%s key=%s mode=%s keys=%s "
+                "finished=%s segment_finished=%s consumable=%s size=%s",
+                self._stage_id,
+                req_id,
+                connector_get_key,
+                self._model_mode,
+                payload_keys,
+                is_finished,
+                is_segment_finished,
+                payload_consumable,
+                _size,
+            )
 
             with self._lock:
                 if is_finished:
                     self._chunk_finished_req_ids.add(req_id)
                     self._chunk_stream_completed.add(req_id)
-                # Local cache (RFC §2.4) — merge, don't replace, so that
-                # earlier chunk keys (e.g. thinker_prefill_embeddings from
-                # chunk 0) are not overwritten by later chunks.
+                if is_segment_finished:
+                    self._chunk_segment_finished_req_ids.add(req_id)
+                # Nested chunk payloads must be deep-merged so prefill/decode
+                # subkeys survive across chunks.
                 existing = self._local_stage_payload_cache.get(req_id)
                 if existing is not None and isinstance(existing, dict) and isinstance(payload_data, dict):
-                    existing.update(payload_data)
+                    _deep_merge_chunk_payload(existing, payload_data)
                 else:
                     self._local_stage_payload_cache[req_id] = payload_data
                 staged_payload = self._local_stage_payload_cache[req_id]
                 self._async_chunk_updated_req_ids.add(req_id)
                 self.put_local_request_metadata(req_id, self._extract_scheduling_metadata(staged_payload))
-                # A finish-only sentinel still needs one terminal wake-up so
-                # the downstream stage can sync the merged local payload and
-                # flush/finish even when the last recv carries no new
-                # consumable chunk bytes.
-                if payload_consumable or is_finished:
+                wake_model = payload_consumable
+                if is_finished and not wake_model and self._model_mode == "ar":
+                    # A final AR sentinel may only flip meta.finished on a
+                    # payload already owned by the model runner. Wake once so
+                    # the model can consume that final state.
+                    wake_model = self._payload_is_consumable(staged_payload)
+                    if not wake_model:
+                        runtime_payloads = getattr(self, "model_intermediate_buffer", None)
+                        if isinstance(runtime_payloads, dict):
+                            wake_model = self._payload_is_consumable(runtime_payloads.get(req_id))
+                if wake_model:
                     self._finished_load_reqs.add(req_id)
                 if is_finished and not payload_consumable:
                     logger.debug(
@@ -1883,16 +2208,16 @@ class OmniConnectorModelRunnerMixin:
         if self._custom_process_func is None:
             return None
 
+        output_arg = getattr(self, "_custom_process_output_arg", None) or "pooling_output"
         kwargs = {
             "transfer_manager": self,
-            "pooling_output": pooling_output,
             "request": request,
         }
-        supports_is_finished = getattr(
-            self,
-            "_custom_process_supports_is_finished",
-            self._custom_process_supports_is_finished_kwarg(),
-        )
+        kwargs[output_arg] = pooling_output
+        supports_is_finished = getattr(self, "_custom_process_supports_is_finished", None)
+        if supports_is_finished is None:
+            supports_is_finished = self._custom_process_supports_is_finished_kwarg()
+            self._custom_process_supports_is_finished = supports_is_finished
         is_finished_fn = getattr(request, "is_finished", None)
         if callable(is_finished_fn):
             try:
@@ -1967,7 +2292,6 @@ class OmniConnectorModelRunnerMixin:
                 pooling_output=task.get("pooling_output"),
             )
         put_key = task.get("put_key")
-
         success, _size, _metadata = connector.put(
             from_stage=str(task["stage_id"]),
             to_stage=str(task["next_stage_id"]),
@@ -2002,9 +2326,9 @@ class OmniConnectorModelRunnerMixin:
                     cleanup_req_id = request_id
             if cleanup_req_id is not None:
                 self._put_req_chunk.pop(cleanup_req_id, None)
+                self._send_side_request_snapshot.pop(cleanup_req_id, None)
                 self._send_side_request_payload.pop(cleanup_req_id, None)
-                self._code_prompt_token_ids.pop(cleanup_req_id, None)
-                self._cached_ic.pop(cleanup_req_id, None)
+                self._clear_segment_send_state(cleanup_req_id)
 
     # ------------------------------------------------------------------ #
     #  Payload accumulation  (ported from OmniChunkTransferAdapter)
@@ -2044,7 +2368,7 @@ class OmniConnectorModelRunnerMixin:
                 for qual, qval in value.items():
                     if qual in span_handled:
                         continue
-                    if key == "meta" and qual == "finished":
+                    if key == "meta" and qual in _META_OVERWRITE_KEYS:
                         merged_sub[qual] = qval
                         continue
                     if (key, qual) in override_keys:
@@ -2088,54 +2412,40 @@ class OmniConnectorModelRunnerMixin:
     #  Helpers
     # ------------------------------------------------------------------ #
 
-    @staticmethod
-    def _freeze_request_attr(value: Any) -> Any:
-        if isinstance(value, list):
-            return list(value)
-        if isinstance(value, tuple):
-            return list(value)
-        if isinstance(value, torch.Tensor):
-            return value.clone()
-        raw_list = getattr(value, "_x", None)
-        if raw_list is not None:
-            return list(raw_list)
-        return value
-
     def _snapshot_request_for_send(self, request: Any, external_req_id: str) -> Any:
+        """Keep the small request view needed to build a terminal chunk.
+
+        The async send path calls this after successful data chunks so a later
+        finish sentinel can still run after the scheduler frees the live
+        request. Avoid copying token lists or tensors here; normal chunks have
+        already frozen their payload, and Qwen3 terminal hooks only need request
+        identity plus small metadata such as voice settings.
+        """
         finished = bool(getattr(request, "is_finished", lambda: False)())
-        attrs: dict[str, Any] = {}
-        try:
-            attrs.update(vars(request))
-        except TypeError:
-            pass
+        req_id = getattr(request, "req_id", None) or getattr(request, "request_id", None) or external_req_id
+        attrs: dict[str, Any] = {
+            "request_id": getattr(request, "request_id", req_id),
+            "req_id": req_id,
+            "external_req_id": external_req_id,
+            "_frozen_is_finished": finished,
+        }
 
-        for name in (
-            "request_id",
-            "req_id",
-            "external_req_id",
-            "prompt_token_ids",
-            "output_token_ids",
-            "all_token_ids",
-            "additional_information",
-            "sampling_params",
-            "multi_modal_data",
-            "mm_hashes",
-        ):
+        for name in ("additional_information", "sampling_params", "resumable"):
             if hasattr(request, name):
-                attrs[name] = self._freeze_request_attr(getattr(request, name))
+                attrs[name] = getattr(request, name)
 
-        attrs["external_req_id"] = external_req_id
-        attrs["_frozen_is_finished"] = finished
         snapshot = SimpleNamespace(**attrs)
         snapshot.is_finished = lambda: finished
         return snapshot
 
     @staticmethod
     def _create_connector(model_config: Any) -> OmniConnectorBase | None:
-        """Create a connector from model_config, or None if unconfigured."""
+        """Create a connector from model_config, or None when unused."""
         connector_config = getattr(model_config, "stage_connector_config", None)
         if connector_config is None:
-            return None
+            if not getattr(model_config, "async_chunk", False):
+                return None
+            connector_config = {}
 
         if not isinstance(connector_config, dict):
             connector_config = {
@@ -2143,7 +2453,7 @@ class OmniConnectorModelRunnerMixin:
                 "extra": getattr(connector_config, "extra", None),
             }
 
-        name = connector_config.get("name")
+        name = connector_config.get("name", "SharedMemoryConnector")
         if not isinstance(name, str) or not name.strip():
             raise RuntimeError("Invalid stage connector config: missing connector name")
         name = name.strip()
@@ -2214,18 +2524,16 @@ class OmniConnectorModelRunnerMixin:
         return None, None
 
     @staticmethod
-    def _is_connector_payload_builder(func: Any) -> bool:
-        """Whether *func* matches the mixin payload-builder contract."""
+    def _connector_payload_output_arg(func: Any) -> str | None:
         try:
             signature = inspect.signature(func)
         except (TypeError, ValueError):
-            return False
+            return None
 
         params = signature.parameters
         if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()):
-            return True
+            return "pooling_output"
 
-        required = {"transfer_manager", "pooling_output", "request"}
         supported = {
             name
             for name, param in params.items()
@@ -2235,7 +2543,17 @@ class OmniConnectorModelRunnerMixin:
                 inspect.Parameter.KEYWORD_ONLY,
             )
         }
-        return required.issubset(supported)
+        if not {"transfer_manager", "request"}.issubset(supported):
+            return None
+        for output_arg in ("pooling_output", "multimodal_output"):
+            if output_arg in supported:
+                return output_arg
+        return None
+
+    @staticmethod
+    def _is_connector_payload_builder(func: Any) -> bool:
+        """Whether *func* matches the mixin payload-builder contract."""
+        return OmniConnectorModelRunnerMixin._connector_payload_output_arg(func) is not None
 
     def _resolve_external_req_id(self, request: Any, fallback_req_id: str) -> str:
         """Resolve the external request ID consistently.

--- a/vllm_omni/worker/payload_span.py
+++ b/vllm_omni/worker/payload_span.py
@@ -7,15 +7,6 @@ from typing import Any
 
 import torch
 
-THINKER_DECODE_EMBEDDINGS_KEY = "thinker_decode_embeddings"
-THINKER_OUTPUT_TOKEN_IDS_KEY = "thinker_output_token_ids"
-THINKER_DECODE_TOKEN_START_KEY = "thinker_decode_embeddings_token_start"
-THINKER_DECODE_TOKEN_END_KEY = "thinker_decode_embeddings_token_end"
-
-CACHED_THINKER_DECODE_EMBEDDINGS_KEY = "cached_thinker_decode_embeddings"
-CACHED_THINKER_DECODE_TOKEN_START_KEY = "cached_thinker_decode_embeddings_token_start"
-CACHED_THINKER_DECODE_TOKEN_END_KEY = "cached_thinker_decode_embeddings_token_end"
-
 TensorSpan = tuple[torch.Tensor, int, int]
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
For the Refactor of commnication layer, there are going to be 5~6 PRs in total.
4a: Qwen3 Omni only
4b: Other relevant models.
Refer to PR https://github.com/vllm-project/vllm-omni/pull/1555 as the first PR.
PR:https://github.com/vllm-project/vllm-omni/pull/2677 as the second PR.
PR:https://github.com/vllm-project/vllm-omni/pull/3719 as the third PR.

## Architecture
### class diagram


```mermaid
classDiagram
    class OmniSchedulingCoordinator {
        +register downstream input waits
        +collect_timed_out_request_ids()
        +track full-payload wait timing
        +exclude normal async chunk pauses from timeout failure
    }

    class OmniConnectorModelRunnerMixin {
        +send_chunk()
        +enqueue_finish_sentinel()
        +recv_chunk_result()
        +cleanup_finished_request()
        -_send_single_request()
        -_put_req_chunk()
        -_deep_merge_chunk_payload()
        -segment-scoped sender state
        -local stage payload cache
    }

    class GPUARModelRunner {
        +Talker async chunk producer/consumer
        +AR hidden-state and multimodal payload hooks
    }

    class GPUGenerationModelRunner {
        +Code2Wav async chunk producer/consumer
        +per-request multimodal output expansion
    }

    class OmniChunkTransferAdapter {
        +legacy connector path
        +used by thinker and unsupported async platforms
    }

    class Qwen3Code2WavOutput {
        +seq_token_counts
        +audio_tensors
        +zero-token output alignment
        +strict mismatch validation
    }

    GPUARModelRunner --|> OmniConnectorModelRunnerMixin
    GPUGenerationModelRunner --|> OmniConnectorModelRunnerMixin
    OmniConnectorModelRunnerMixin --> OmniSchedulingCoordinator : readiness / waits
    OmniConnectorModelRunnerMixin --> OmniChunkTransferAdapter : fallback / legacy path
    GPUGenerationModelRunner --> Qwen3Code2WavOutput : make_omni_output()
```


### Sequence diagram

```mermaid
sequenceDiagram
    autonumber
    participant Client as Client / realtime segment
    participant TS as Thinker scheduler
    participant AS as Talker scheduler
    participant AC as Talker coordinator
    participant GS as Code2Wav scheduler
    participant GC as Code2Wav coordinator
    participant Thinker as Thinker runner
    participant M0 as Thinker mixin
    participant Conn01 as Connector 0 to 1
    participant Talker as Talker runner
    participant M1 as Talker mixin
    participant Conn12 as Connector 1 to 2
    participant M2 as Code2Wav mixin
    participant C2W as Code2Wav runner
    participant Out as OpenAI serving output

    Client->>TS: submit request or realtime audio segment
    TS->>Thinker: schedule Thinker stage
    Thinker->>M0: send_chunk(request, thinker-to-talker payload)
    M0->>M0: build and freeze Thinker downstream payload
    M0->>Conn01: background put frozen payload for Talker

    AS->>AC: park request waiting for Thinker input
    AC-->>M1: register receive from stage 0
    M1->>Conn01: poll or get payload for request
    Conn01-->>M1: payload visible to Talker side
    M1->>M1: merge Thinker payload into local request cache
    M1-->>AS: connector output says Talker input ready
    AS->>AC: update ready input for request
    AC-->>AS: release request to running queue
    AS->>Talker: schedule Talker with received Thinker payload

    loop Talker / Code2Wav async chunks
        AS->>Talker: schedule Talker AR step
        alt decode handoff has cached prefix
            Talker->>Talker: read embed.cached_decode and accumulated embed.decode
            Talker->>Talker: if decode starts with cached_decode, use decode directly
            Talker->>Talker: consume by processed-token index
        end
        Talker->>Talker: generate Talker hidden state and codec rows
        Talker->>M1: send_chunk(request, talker payload)
        M1->>M1: build per-request payload on model thread
        M1->>M1: freeze SendTask data before enqueue
        M1->>Conn12: background put frozen chunk

        GS->>GC: park request waiting for Talker chunk
        GC-->>M2: register receive from stage 1
        M2->>Conn12: poll or get chunk for request
        Conn12-->>M2: chunk visible to Code2Wav side
        M2->>M2: merge chunk into local request cache
        M2-->>GS: connector output says Code2Wav chunk ready
        GS->>GC: update chunk progress for request id
        GC-->>GS: release request to running queue
        GS->>C2W: schedule Code2Wav step with req ids and seq_token_counts
        M2-->>C2W: provide cached codec payload and runtime metadata
        C2W->>C2W: decode codec rows with token_count > 0
        alt every scheduled request has output
            C2W->>C2W: return already request-aligned audio tensors
        else some scheduled rows have token_count == 0
            C2W->>C2W: scatter non-empty audio to scheduled request positions
            C2W->>C2W: fill zero-token positions with empty audio tensors
        end
        C2W-->>Out: return one output entry per scheduled request
        Out-->>Client: stream audio delta
    end

    alt realtime segment terminal
        Talker->>M1: enqueue_finish_sentinel(is_segment_finished=True)
        M1->>M1: freeze terminal payload / tail-flush marker
        M1->>M1: enqueue frozen terminal send task
        M1->>M1: clear segment-scoped sender state after enqueue
        M1->>Conn12: background put frozen terminal marker
        M2->>Conn12: poll or get terminal marker
        Conn12-->>M2: segment terminal visible
        M2->>M2: merge terminal metadata into local cache
        M2-->>GS: connector output says segment terminal ready
        GS->>GC: mark segment finished without finishing whole request
        GC-->>GS: release request for Code2Wav tail flush
        GS->>C2W: run terminal flush step
        C2W-->>Out: final audio delta for this segment
        Out-->>Client: segment audio complete, request can continue
    else request finished
        Talker->>M1: enqueue request-finished sentinel
        M1->>M1: freeze final terminal payload
        M1->>Conn12: background put final terminal marker
        M2->>Conn12: poll or get final terminal marker
        Conn12-->>M2: final terminal visible
        M2->>M2: terminal finished metadata promotes cached non-terminal metadata
        M2-->>GS: connector output says request terminal ready
        GS->>GC: mark request finished
        GC-->>GS: release request for final Code2Wav step
        GS->>C2W: run final step
        C2W-->>Out: final output / finish metadata
        Out-->>Client: response complete
    end

    Note over AC,GC: Talker and Code2Wav each have their own receive coordinator.
    Note over Conn01,Conn12: Each stage edge has its own connector direction and request keys.
```

### Work flow (overall)
<img width="1820" height="3180" alt="communication_refactor_async_chunk_structure_diagram_en" src="https://github.com/user-attachments/assets/7ea9642a-99e3-4a94-a9f1-bfffbb4fd4f0" />


### Workflow (model runner->mixin->connector)
<img width="1660" height="1180" alt="communication_refactor_async_chunk_hook_flow_en" src="https://github.com/user-attachments/assets/802bbca6-6950-4535-b512-5f99006f1cc3" />


## Test Plan
test-ready, test-merge, test-nightly

## Test Result
(Staled, need to be updated)
<img width="1995" height="981" alt="Screenshot from 2026-06-16 06-03-49" src="https://github.com/user-attachments/assets/b7a801be-f699-4f53-9699-522cfd89e163" />

## Perf

### Scope

- PR commit: `fa4637c7` (`Align Code2Wav outputs for zero-token requests`)
- Baseline commit: `f8340d07`
- Test config: `tests/dfx/perf/tests/test_qwen3_omni_async_chunk.json`

This report covers the full Qwen3-Omni async-chunk perf config: 16 result JSONs.


### Test Summary

- Full perf pytest result: `8 passed, 17 warnings in 2552.88s`
- Result JSONs: `16/16`
- Failed requests: `0` for every case

## Per-Case Delta vs Baseline
| Case | Prompts | Concurrency / Request Rate | Audio | Failed | Request Throughput | Mean E2EL | P99 E2EL | Mean Audio RTF | Audio Throughput |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| random in2500/out900 | 4 | 1 | False | 0 | `+0.39%` | `-0.39%` | `-0.35%` | n/a | n/a |
| random in2500/out900 | 4 | 1 | True | 0 | `+8.57%` | `-7.89%` | `-17.57%` | `-2.69%` | `+0.34%` |
| random in2500/out900 | 16 | 4 | False | 0 | `+0.63%` | `-0.64%` | `-0.07%` | n/a | n/a |
| random in2500/out900 | 16 | 4 | True | 0 | `+4.13%` | `-13.18%` | `-10.31%` | `-27.37%` | `+11.69%` |
| random in2500/out900 | 32 | 8 | False | 0 | `-0.79%` | `+0.80%` | `+0.16%` | n/a | n/a |
| random in2500/out900 | 32 | 8 | True | 0 | `+4.89%` | `-4.49%` | `-4.00%` | `-24.04%` | `+18.76%` |
| random in2500/out900 | 64 | 16 | False | 0 | `-0.51%` | `+0.52%` | `-0.07%` | n/a | n/a |
| random in2500/out900 | 64 | 16 | True | 0 | `+10.98%` | `-10.31%` | `+7.90%` | `-16.03%` | `+5.62%` |
| random in2500/out900 | 128 | 32 | False | 0 | `-0.00%` | `+0.12%` | `-0.03%` | n/a | n/a |
| random in2500/out900 | 128 | 32 | True | 0 | `+2.49%` | `-3.97%` | `+14.47%` | `-9.13%` | `-2.33%` |
| random-mm in100/out100 | 10 | rate=0.1 | False | 0 | `-0.02%` | `+2.52%` | `+4.28%` | n/a | n/a |
| random-mm in100/out100 | 10 | rate=0.1 | True | 0 | `+0.93%` | `+5.58%` | `+0.92%` | `+0.84%` | `+5.32%` |
| random-mm in100/out100 | 40 | rate=0.5 | False | 0 | `+0.01%` | `-0.35%` | `-0.03%` | n/a | n/a |
| random-mm in100/out100 | 40 | rate=0.5 | True | 0 | `+2.21%` | `-11.94%` | `-9.72%` | `-13.03%` | `+3.76%` |
| random-mm in100/out100 | 100 | rate=1.0 | False | 0 | `+0.02%` | `-0.58%` | `-1.70%` | n/a | n/a |
| random-mm in100/out100 | 100 | rate=1.0 | True | 0 | `+0.57%` | `-8.28%` | `+20.60%` | `-8.89%` | `+1.57%` |


## Aggregate Delta

| Metric | Mean Delta | Min Delta | Max Delta | N |
|---|---:|---:|---:|---:|
| request throughput | `+5.55%` | `-11.77%` | `+33.36%` | 16 |
| mean E2EL | `-6.68%` | `-25.35%` | `+13.34%` | 16 |
| p99 E2EL | `-3.49%` | `-17.37%` | `+4.30%` | 16 |
| mean audio RTF | `-20.28%` | `-31.16%` | `-4.47%` | 8 |
| audio throughput | `+13.72%` | `+0.68%` | `+27.09%` | 8 |

## Conclusion

The full Qwen3-Omni async-chunk perf config completed successfully with zero
failed requests. All aggregate metrics in this table improve versus the saved
post-rebase baseline. Per-case tail latency is still mixed, but the largest
positive p99 E2EL delta in the latest 16-case artifact is bounded at
`+4.30%` (`random-mm 100 audio`), followed by `+2.82%`
(`random 32 non-audio`). Audio RTF and audio throughput improve in every audio
case in this run.



## Appendix (Implementation details)
### Finish Sentinel to sending threads
This PR introduces Finish Sentinel marking the end of a request for the sending thread due to the synchronized scheduler <-> model runner scheme.  

```mermaid
sequenceDiagram
    participant MR as Model Runner
    participant SIP as Stage Input Processor
    participant Buf as code_prompt_token_ids
    participant Sched as Scheduler
    participant Send as Send Loop
    participant Down as Downstream Stage

    MR->>SIP: send_chunk(codes.audio, finished=False)
    SIP->>Buf: append codes
    alt enough codec frames
        SIP-->>MR: payload(codes.audio, finished=False)
        MR->>Send: enqueue payload
        Send->>Down: connector.put(payload)
    else partial tail
        SIP-->>MR: None
        Note over Buf: tail remains cached
    end

    Sched-->>MR: finished_req_ids / segment_finished_req_ids
    MR->>SIP: finish sentinel marker
    SIP->>Buf: read cached tail
    SIP-->>MR: terminal payload(codes.audio?, meta.finished)
    MR->>Send: enqueue terminal payload
    Send->>Down: connector.put(terminal payload)
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
