### PR TITLE
[BugFix] Support ModelOpt FP8 under batched diffusion serving

### DIFF
--- a/vllm_omni/patch.py
+++ b/vllm_omni/patch.py
@@ -188,3 +188,32 @@ def _patch_chat_template_registry():
 
 
 _patch_chat_template_registry()
+
+
+def _patch_scaled_mm_fp8_contiguous_activation():
+    """Support batched diffusion activations on the ModelOpt FP8 (ScaledMM) path.
+
+    The FP8 ScaledMM linear flattens its activation with ``x.view(-1, ...)``, which
+    needs a contiguous tensor. Under step-execution batching (``--max-num-seqs > 1``)
+    the sequence-packed diffusion activations can be non-contiguous, so we make the
+    activation contiguous before the GEMM (no-op when it already is). Mixed FP8/NVFP4
+    routes through the CUTLASS NVFP4 path and is unaffected.
+    """
+    try:
+        from vllm.model_executor.kernels.linear.scaled_mm.ScaledMMLinearKernel import (
+            ScaledMMLinearKernel,
+        )
+    except ImportError:
+        return
+
+    _original_apply_weights = ScaledMMLinearKernel.apply_weights
+
+    def _patched_apply_weights(self, layer, x, bias=None):
+        if not x.is_contiguous():
+            x = x.contiguous()
+        return _original_apply_weights(self, layer, x, bias)
+
+    ScaledMMLinearKernel.apply_weights = _patched_apply_weights
+
+
+_patch_scaled_mm_fp8_contiguous_activation()


### PR DESCRIPTION
## What

The FP8 ScaledMM linear flattens its activation with `x.view(-1, x.shape[-1])`, which requires a contiguous tensor. Under step-execution batching (`--max-num-seqs > 1`) the diffusion activations are sequence-packed and can be non-contiguous, so a ModelOpt FP8 checkpoint fails once more than one sequence is batched. Single-request serving (`--max-num-seqs 1`) is contiguous and already works.

## Fix

Add a `vllm_omni/patch.py` override that materializes a contiguous activation before the FP8 GEMM (no-op when the input is already contiguous), completing ModelOpt FP8 support for batched diffusion serving. Mixed FP8/NVFP4 is unaffected — it routes through the CUTLASS NVFP4 path, not ScaledMM.

## Test

Qwen-Image-2512 ModelOpt FP8, 2× B300 (TP=2), `--step-execution --max-num-seqs 8`: batches cleanly at concurrency 1 / 4 / 8 with 0 errors, reaching 1.218 img/s at concurrency 8.
