### PR TITLE
[Perf]: Eliminate Redundant torch.cat in MRoPE Position

### DIFF
--- a/vllm_omni/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm_omni/model_executor/layers/rotary_embedding/mrope.py
@@ -470,7 +470,7 @@ class OmniMRotaryEmbedding(MRotaryEmbedding):
             idx += len(new_src_item) - new_src_item_len
 
         llm_positions = torch.cat(llm_pos_ids_list, dim=1)
-        mrope_position_delta = torch.cat(llm_pos_ids_list, dim=1).max() + 1 - len(src_item)
+        mrope_position_delta = llm_positions.max() + 1 - len(src_item)
         llm_positions = llm_positions[:, context_len:seq_len]
 
         return llm_positions, mrope_position_delta


### PR DESCRIPTION
## Problem

In `_omni_get_input_positions_tensor` (`mrope.py`), `torch.cat(llm_pos_ids_list, dim=1)` is executed twice consecutively on the same input list:

```python
llm_positions = torch.cat(llm_pos_ids_list, dim=1)
mrope_position_delta = torch.cat(llm_pos_ids_list, dim=1).max() + 1 - len(src_item)
```

The second concatenation is redundant. The result has already been computed and stored in `llm_positions`, and the tensor has not been modified or sliced before being reused.

## Impact

`llm_pos_ids_list` can grow large depending on the input modality:

* One tensor per text token
* One tensor per audio segment
* In `use_audio_in_video` mode, one `(3, 1)` tensor per video-frame column via `.split(1, dim=1)`

For long audio-in-video requests, the list may contain thousands of tensors.

Since `torch.cat` must iterate over the entire list, allocate a new output tensor, and copy all inputs into the result, executing it twice doubles the cost of the most expensive operation in this section of the function.

This adds unnecessary CPU work during prefill scheduling and increases TTFT

## Solution

Reuse the already-computed `llm_positions` tensor when calculating `mrope_position_delta`:

```python
llm_positions = torch.cat(llm_pos_ids_list, dim=1)
mrope_position_delta = llm_positions.max() + 1 - len(src_item)
```

At this point, `llm_positions` still contains the complete concatenated result. The subsequent slice:

```python
llm_positions[:, context_len:seq_len]
```

occurs afterward, making the reuse safe and functionally equivalent.

