### PR TITLE
[Fix] Update Qwen3 Omni multi-replica perf baselines

### DIFF
--- a/tests/dfx/perf/tests/test_qwen3_omni_multi_replicas.json
+++ b/tests/dfx/perf/tests/test_qwen3_omni_multi_replicas.json
@@ -23,10 +23,10 @@
                 "ignore_eos": true,
                 "percentile-metrics": "ttft,tpot,itl,e2el,audio_rtf,audio_ttfp,audio_duration",
                 "baseline": {
-                    "mean_ttft_ms": [1000, 2000, 3000, 4000],
-                    "mean_tpot_ms": [200, 200, 200, 200],
-                    "mean_audio_ttfp_ms": [10000, 15000, 20000, 25000],
-                    "mean_audio_rtf": [1.5, 1.5, 1.5, 1.5]
+                    "mean_ttft_ms": [203, 283, 470, 869],
+                    "mean_tpot_ms": [28, 36, 41, 45],
+                    "mean_audio_ttfp_ms": [861, 1200, 1528, 2100],
+                    "mean_audio_rtf": [0.24, 0.30, 0.35, 0.39]
                 }
             },
             {
@@ -49,9 +49,9 @@
                 },
                 "percentile-metrics": "ttft,tpot,itl,e2el,audio_rtf,audio_ttfp,audio_duration",
                 "baseline": {
-                    "mean_ttft_ms": [2000],
-                    "mean_audio_ttfp_ms": [2000],
-                    "mean_audio_rtf": [0.25]
+                    "mean_ttft_ms": [377],
+                    "mean_audio_ttfp_ms": [684],
+                    "mean_audio_rtf": [0.14]
                 }
             },
             {
@@ -76,9 +76,9 @@
                 },
                 "percentile-metrics": "ttft,tpot,itl,e2el,audio_rtf,audio_ttfp,audio_duration",
                 "baseline": {
-                    "mean_ttft_ms": [6000],
-                    "mean_audio_ttfp_ms": [6000],
-                    "mean_audio_rtf": [0.7]
+                    "mean_ttft_ms": [228],
+                    "mean_audio_ttfp_ms": [686],
+                    "mean_audio_rtf": [0.16]
                 }
             },
             {
@@ -105,9 +105,9 @@
                 },
                 "percentile-metrics": "ttft,tpot,itl,e2el,audio_rtf,audio_ttfp,audio_duration",
                 "baseline": {
-                    "mean_ttft_ms": [12000],
-                    "mean_audio_ttfp_ms": [12000],
-                    "mean_audio_rtf": [1.0]
+                    "mean_ttft_ms": [522],
+                    "mean_audio_ttfp_ms": [1119],
+                    "mean_audio_rtf": [0.21]
                 }
             }
         ]


### PR DESCRIPTION
## Summary

**Update `qwen3_omni_3gpu_replica2` performance baselines using the latest 7-day historical data from the Qwen3 Omni kanban dashboard.**

## Changes

- Updated the `random` benchmark baselines for `max_concurrency` `[8, 16, 24, 32]`.
- Updated the three `random-mm` benchmark baselines for request rates `0.1`, `0.5`, and `1.0`.
- Replaced the previous loose thresholds with recent 7-day average-based values, rounded conservatively.

## Validation

- Verified JSON syntax with:

```bash
jq empty tests/dfx/perf/tests/test_qwen3_omni_multi_replicas.json
```

@Gaohan123 cc @amy-why-3459 @ZhengWG 
