### PR TITLE
Fix: incorrect attention metadata causing wrong outputs on NPU compressed-KV models

### DIFF
--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -509,6 +509,7 @@ class NPUARModelRunner(OmniNPUModelRunner):
                     num_scheduled_tokens=scheduler_output.num_scheduled_tokens,
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+                    num_scheduled_tokens_compressed_list=num_scheduled_tokens_compressed_list,
                 )
 
             (

--- a/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
@@ -272,6 +272,7 @@ class NPUGenerationModelRunner(OmniNPUModelRunner):
                     num_scheduled_tokens=scheduler_output.num_scheduled_tokens,
                     num_scheduled_tokens_np=num_scheduled_tokens_np,
                     cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+                    num_scheduled_tokens_compressed_list=num_scheduled_tokens_compressed_list,
                 )
 
             (


### PR DESCRIPTION
 
## Purpose

Trigger Conditions
NPU platform, AR or generation worker type, model config contains compress_ratios in hf_config (i.e. use_compress=True). Triggered on every real inference call — not a corner case.

Failure Symptom
Model produces garbled / semantically incorrect output with no exception or error log. The inference pipeline runs to completion silently.

Expected Behavior
_build_attention_metadata receives the per-request compressed token counts and computes correct KV cache slot mappings for each attention group.

Root Cause
PR #4130 upgraded _prepare_inputs to return 4 values and correctly unpacked the 4th value (num_scheduled_tokens_compressed_list) into a local variable. 
However, the downstream call to _build_attention_metadata was not updated to forward that variable. The function receives None, falls into the dummy/graph-capture fallback branch, and zeroes out slot_mapping and blk_table_tensor for the entire batch — corrupting all KV cache address lookups.


## Test Plan

## Test Result

