### PR TITLE
fix: cast non-float32 floating tensors to float32 before numpy conversion in _normalize_frames

### DIFF
--- a/vllm_omni/entrypoints/openai/video_api_utils.py
+++ b/vllm_omni/entrypoints/openai/video_api_utils.py
@@ -138,7 +138,8 @@ def _normalize_frames(frames: list[Any]) -> list[np.ndarray]:
     normalized: list[np.ndarray] = []
     for frame in frames:
         if isinstance(frame, torch.Tensor):
-            frame_array = frame.detach().cpu().numpy()
+            frame = frame.detach().cpu()
+            frame_array = frame.float().numpy() if frame.is_floating_point() else frame.numpy()
         elif isinstance(frame, Image.Image):
             frame_array = np.array(frame)
         elif isinstance(frame, np.ndarray):


### PR DESCRIPTION
 

## Purpose

Issue Trigger Scenario
Any diffusion pipeline (e.g., Wan, SANA, CogVideoX) that outputs video as a list[3D torch.Tensor] with bfloat16 or float16 dtype. This is the default inference dtype on modern GPUs. The path: POST /v1/videos or /v1/videos/sync → _encode_video_bytes() → _coerce_video_to_frames() → list branch → _normalize_frames().


Expected Behavior
bf16/fp16 frame tensors are cast to float32 transparently before numpy conversion. The encode pipeline completes and returns valid MP4 bytes.

Root Cause
_normalize_frames() called .numpy() directly on the raw tensor, implicitly assuming the dtype is always float32 or an integer type. NumPy has no bfloat16 dtype, so the call raises a TypeError. 



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
