### PR TITLE
fix: print video stage metrics in --print-stage output

### DIFF
--- a/vllm_omni/benchmarks/metrics/metrics.py
+++ b/vllm_omni/benchmarks/metrics/metrics.py
@@ -480,6 +480,23 @@ def _print_image_stage_metrics(
     )
 
 
+def _print_video_stage_metrics(
+    selected_percentiles: list[float],
+    sm: StageBenchmarkMetrics,
+) -> None:
+    video_num = getattr(sm, defs.OUTPUT_UNIT_COUNT) if getattr(sm, "output_unit_type") == "video" else 0
+    print("{s:{c}^{n}}".format(s=" Video Result ", n=50, c="="))
+    print("{:<40} {:<10}".format("Total videos generated:", video_num))
+    _print_percentile_metric(
+        "Video Generation",
+        "VIDEO_GENERATION",
+        getattr(sm, defs.STAGE_GEN_TIMES_MS),
+        selected_percentiles,
+        values_are_ms=True,
+        to_ms=True,
+    )
+
+
 def _print_internal_stream_stage_metrics(
     selected_percentile_metrics: list[str],
     selected_percentiles: list[float],
@@ -539,6 +556,7 @@ def print_stage_metrics(
         return
 
     if is_video_stage:
+        _print_video_stage_metrics(selected_percentiles, sm)
         return
 
     _print_stage_timing(sm, selected_percentiles)


### PR DESCRIPTION
 

## Purpose

Issue: 
vllm bench serve --omni --print-stage where any stage has output_unit_type="video" or final_output_type in {"video","videos"}.
--print-stage correctly prints full metrics for all stage types (text, audio, image, internal-stream), but the video stage is the sole exception — only the header line appears, all metrics are silently dropped.

Expected: 
Video stage prints Total videos generated + VIDEO_GENERATION percentile latencies, identical in structure to the image stage output.

Root Cause: 
print_stage_metrics() handled is_video_stage with a bare return — a placeholder that was never implemented, with no TODO comment to indicate it.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
