### PR TITLE
Modified stage input processors added: StagePayloadBuilder / TransitionSpec

### DIFF
--- a/tests/model_executor/test_payload_builder.py
+++ b/tests/model_executor/test_payload_builder.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for payload_builder shared utilities."""
+
+import torch
+
+from vllm_omni.model_executor.stage_input_processors.payload_builder import (
+    count_trailing_placeholders,
+    ensure_list,
+    filter_invalid_tokens,
+    layer_tensor,
+    strip_boundary_tokens,
+    to_cpu_tensor,
+    to_tensor_or_none,
+)
+
+
+def test_ensure_list():
+    """Test ensure_list helper function."""
+    # Test with list
+    assert ensure_list([1, 2, 3]) == [1, 2, 3]
+
+    # Test with tuple
+    assert ensure_list((1, 2, 3)) == [1, 2, 3]
+
+    # Test with None
+    assert ensure_list(None) == []
+
+    # Test with single value
+    assert ensure_list(5) == [5]
+
+    # Test with ConstantList-like object
+    class ConstantList:
+        def __init__(self, x):
+            self._x = x
+
+    assert ensure_list(ConstantList([1, 2, 3])) == [1, 2, 3]
+
+
+def test_layer_tensor():
+    """Test layer_tensor helper function."""
+    # Test with int key
+    layers = {0: torch.tensor([1, 2, 3]), 24: torch.tensor([4, 5, 6])}
+    assert torch.equal(layer_tensor(layers, 0), torch.tensor([1, 2, 3]))
+    assert torch.equal(layer_tensor(layers, 24), torch.tensor([4, 5, 6]))
+
+    # Test with str key
+    layers_str = {"0": torch.tensor([1, 2, 3]), "24": torch.tensor([4, 5, 6])}
+    assert torch.equal(layer_tensor(layers_str, "0"), torch.tensor([1, 2, 3]))
+
+    # Test with missing key
+    assert layer_tensor(layers, 1) is None
+
+    # Test with non-dict input
+    assert layer_tensor(None, 0) is None
+
+
+def test_to_cpu_tensor():
+    """Test to_cpu_tensor helper function."""
+    # Test with GPU tensor (if CUDA available)
+    if torch.cuda.is_available():
+        gpu_tensor = torch.tensor([1, 2, 3]).cuda()
+        cpu_tensor = to_cpu_tensor(gpu_tensor)
+        assert cpu_tensor is not None
+        assert not cpu_tensor.is_cuda
+        assert torch.equal(cpu_tensor, torch.tensor([1, 2, 3]))
+
+    # Test with CPU tensor
+    cpu_tensor = torch.tensor([1, 2, 3])
+    result = to_cpu_tensor(cpu_tensor)
+    assert result is not None
+    assert not result.is_cuda
+    assert torch.equal(result, torch.tensor([1, 2, 3]))
+
+    # Test with list of tensors
+    tensor_list = [torch.tensor([1, 2, 3])]
+    result = to_cpu_tensor(tensor_list)
+    assert result is not None
+    assert torch.equal(result, torch.tensor([1, 2, 3]))
+
+    # Test with None
+    assert to_cpu_tensor(None) is None
+
+    # Test with empty list
+    assert to_cpu_tensor([]) is None
+
+
+def test_to_tensor_or_none():
+    """Test to_tensor_or_none helper function."""
+    # Test with tensor
+    tensor = torch.tensor([1, 2, 3])
+    result = to_tensor_or_none(tensor)
+    assert result is not None
+    assert torch.equal(result, torch.tensor([1, 2, 3]))
+
+    # Test with list of tensors
+    tensor_list = [torch.tensor([1, 2, 3])]
+    result = to_tensor_or_none(tensor_list)
+    assert result is not None
+    assert torch.equal(result, torch.tensor([1, 2, 3]))
+
+    # Test with None
+    assert to_tensor_or_none(None) is None
+
+    # Test with empty list
+    assert to_tensor_or_none([]) is None
+
+
+def test_strip_boundary_tokens():
+    """Test strip_boundary_tokens helper function."""
+    # Test with start token
+    tokens = [100, 1, 2, 3]
+    result = strip_boundary_tokens(tokens, start_token_id=100)
+    assert result == [1, 2, 3]
+
+    # Test with end token
+    tokens = [1, 2, 3, 200]
+    result = strip_boundary_tokens(tokens, end_token_id=200)
+    assert result == [1, 2, 3]
+
+    # Test with pad token
+    tokens = [1, 2, -1, 3, -1]
+    result = strip_boundary_tokens(tokens, pad_token_id=-1)
+    assert result == [1, 2, 3]
+
+    # Test with all boundary tokens
+    tokens = [100, 1, 2, -1, 3, 200]
+    result = strip_boundary_tokens(
+        tokens,
+        start_token_id=100,
+        pad_token_id=-1,
+        end_token_id=200,
+    )
+    assert result == [1, 2, 3]
+
+    # Test with no boundary tokens
+    tokens = [1, 2, 3]
+    result = strip_boundary_tokens(tokens, start_token_id=100, end_token_id=200)
+    assert result == [1, 2, 3]
+
+
+def test_filter_invalid_tokens():
+    """Test filter_invalid_tokens helper function."""
+    # Test with min_valid
+    tokens = [-1, 0, 1, 2, -1]
+    result = filter_invalid_tokens(tokens, min_valid=0)
+    assert result == [0, 1, 2]
+
+    # Test with max_valid
+    tokens = [0, 1, 2, 1000, 3]
+    result = filter_invalid_tokens(tokens, max_valid=100)
+    assert result == [0, 1, 2, 3]
+
+    # Test with both min and max
+    tokens = [-1, 0, 1, 2, 1000, 3]
+    result = filter_invalid_tokens(tokens, min_valid=0, max_valid=100)
+    assert result == [0, 1, 2, 3]
+
+    # Test with no invalid tokens
+    tokens = [0, 1, 2, 3]
+    result = filter_invalid_tokens(tokens, min_valid=0, max_valid=100)
+    assert result == [0, 1, 2, 3]
+
+
+def test_count_trailing_placeholders():
+    """Test count_trailing_placeholders helper function."""
+    # Test with trailing placeholders
+    tokens = [1, 2, 3, -1, -1]
+    result = count_trailing_placeholders(tokens, placeholder=-1)
+    assert result == 2
+
+    # Test with no trailing placeholders
+    tokens = [1, 2, 3, -1, 4]
+    result = count_trailing_placeholders(tokens, placeholder=-1)
+    assert result == 0
+
+    # Test with all placeholders
+    tokens = [-1, -1, -1]
+    result = count_trailing_placeholders(tokens, placeholder=-1)
+    assert result == 3
+
+    # Test with empty list
+    tokens = []
+    result = count_trailing_placeholders(tokens, placeholder=-1)
+    assert result == 0
+
+    # Test with different placeholder value
+    tokens = [1, 2, 3, 0, 0]
+    result = count_trailing_placeholders(tokens, placeholder=0)
+    assert result == 2

--- a/vllm_omni/model_executor/stage_input_processors/cosyvoice3.py
+++ b/vllm_omni/model_executor/stage_input_processors/cosyvoice3.py
@@ -16,6 +16,10 @@ from vllm_omni.data_entry_keys import (
     OmniPayloadStruct,
 )
 from vllm_omni.inputs.data import OmniTokensPrompt
+from vllm_omni.model_executor.stage_input_processors.payload_builder import (
+    ensure_list,
+    to_cpu_tensor,
+)
 
 logger = init_logger(__name__)
 
@@ -36,19 +40,7 @@ def _build_prompt_embed_struct(prompt_payload: dict[str, Any]) -> EmbeddingsStru
     )
 
 
-def _ensure_list(x: Any) -> list[Any]:
-    if hasattr(x, "_x"):
-        return list(x._x)
-    if isinstance(x, list):
-        return list(x)
-    if isinstance(x, tuple):
-        return list(x)
-    if x is None:
-        return []
-    try:
-        return list(x)
-    except TypeError:
-        return [x]
+# _ensure_list now imported from payload_builder.py
 
 
 def _to_token_id_list(value: Any) -> list[int]:
@@ -57,7 +49,7 @@ def _to_token_id_list(value: Any) -> list[int]:
     if isinstance(value, torch.Tensor):
         value = value.detach().to("cpu").reshape(-1).tolist()
     token_ids: list[int] = []
-    for item in _ensure_list(value):
+    for item in ensure_list(value):
         if isinstance(item, torch.Tensor):
             token_ids.extend(_to_token_id_list(item))
             continue
@@ -97,14 +89,7 @@ def _set_non_stream_prompt_trim(additional_info: dict[str, Any], prompt_speech_l
     meta["talker_prefill_offset"] = prompt_speech_len
 
 
-def _to_cpu_tensor(x: Any) -> torch.Tensor | None:
-    if isinstance(x, list):
-        if not x:
-            return None
-        x = x[0]
-    if isinstance(x, torch.Tensor):
-        return x.detach().cpu()
-    return None
+# _to_cpu_tensor now imported from payload_builder.py
 
 
 def _decode_additional_information(raw_info: Any) -> dict[str, Any]:
@@ -146,8 +131,8 @@ def text2flow(
         if multi_modal_data is None:
             raise RuntimeError(f"Missing multimodal_output for request {source_output.request_id}")
 
-        prefix_ids = _ensure_list(source_output.prompt_token_ids)
-        raw_output_ids = _ensure_list(output.cumulative_token_ids)
+        prefix_ids = ensure_list(source_output.prompt_token_ids)
+        raw_output_ids = ensure_list(output.cumulative_token_ids)
         prompt_speech_ids = _prompt_speech_token_ids(multi_modal_data)
         output_ids = _strip_prompt_prefix(raw_output_ids, prefix_ids)
         output_ids = _strip_prompt_prefix(output_ids, prompt_speech_ids)
@@ -193,7 +178,7 @@ def talker2code2wav_async_chunk(
                 info_embed = info.get("embed", {}) if isinstance(info, dict) else {}
                 prompt_payload = {}
                 for key in ("speech_token", "speech_feat", "embedding"):
-                    value = _to_cpu_tensor(info_embed.get(key))
+                    value = to_cpu_tensor(info_embed.get(key))
                     if value is not None:
                         prompt_payload[key] = value
                 if isinstance(pooling_output, dict):
@@ -201,7 +186,7 @@ def talker2code2wav_async_chunk(
                     for key in ("speech_token", "speech_feat", "embedding"):
                         if key in prompt_payload:
                             continue
-                        value = _to_cpu_tensor(po_embed.get(key))
+                        value = to_cpu_tensor(po_embed.get(key))
                         if value is not None:
                             prompt_payload[key] = value
                 prompt_token = prompt_payload.get("speech_token")
@@ -237,7 +222,7 @@ def talker2code2wav_async_chunk(
             return None
 
         with nullcontext():
-            output_token_ids = _ensure_list(getattr(request, "output_token_ids", []))
+            output_token_ids = ensure_list(getattr(request, "output_token_ids", []))
             seen_len = int(state.get("seen_len", 0))
             new_tokens = output_token_ids[seen_len:] if seen_len < len(output_token_ids) else []
             state["seen_len"] = len(output_token_ids)
@@ -363,8 +348,8 @@ def text2flow_token_only(
         if not source_output.finished:
             continue
         output = source_output.outputs[0]
-        prefix_ids = _ensure_list(source_output.prompt_token_ids)
-        raw_output_ids = _ensure_list(output.cumulative_token_ids)
+        prefix_ids = ensure_list(source_output.prompt_token_ids)
+        raw_output_ids = ensure_list(output.cumulative_token_ids)
         output_ids = _strip_prompt_prefix(raw_output_ids, prefix_ids)
         multi_modal_data = output.multimodal_output
         if multi_modal_data is None:

--- a/vllm_omni/model_executor/stage_input_processors/glm_tts.py
+++ b/vllm_omni/model_executor/stage_input_processors/glm_tts.py
@@ -18,6 +18,9 @@ from vllm_omni.data_entry_keys import (
     OmniPayloadStruct,
 )
 from vllm_omni.engine.serialization import deserialize_additional_information
+from vllm_omni.model_executor.stage_input_processors.payload_builder import (
+    to_cpu_tensor,
+)
 
 logger = init_logger(__name__)
 
@@ -37,7 +40,7 @@ def _copy_voice_clone_payload(
             prompt = src.get("prompt_token")
         if prompt is not None:
             if to_cpu:
-                prompt = _to_cpu_tensor(prompt)
+                prompt = to_cpu_tensor(prompt)
             if prompt is not None:
                 dst["prompt_speech_token"] = prompt
 
@@ -47,7 +50,7 @@ def _copy_voice_clone_payload(
         val = src.get(key)
         if val is not None:
             if to_cpu:
-                val = _to_cpu_tensor(val)
+                val = to_cpu_tensor(val)
             if val is not None:
                 dst[key] = val
 
@@ -169,16 +172,7 @@ def _extract_last_speech_token(pooling_output: dict[str, Any]) -> int | None:
     return token_val
 
 
-def _to_cpu_tensor(value: Any) -> torch.Tensor | None:
-    """Convert value to CPU tensor if possible."""
-    if isinstance(value, torch.Tensor):
-        return value.detach().cpu()
-    if isinstance(value, list):
-        if not value:
-            return None
-        if isinstance(value[0], torch.Tensor):
-            return value[0].detach().cpu()
-    return None
+# _to_cpu_tensor now imported from payload_builder.py
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_omni/model_executor/stage_input_processors/payload_builder.py
+++ b/vllm_omni/model_executor/stage_input_processors/payload_builder.py
@@ -1,0 +1,456 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Shared payload builder utilities for stage input processors.
+
+This module provides common helpers to eliminate code duplication across
+stage input processors (Qwen2.5, Qwen3, Qwen3-TTS, MiMo, GLM-TTS, Fish, CosyVoice).
+
+Common patterns:
+- Extract model output from pooling_output/multimodal_output
+- Normalize token/code rows (filter invalid, strip boundaries, trim stop tokens)
+- Build OmniPayloadStruct (embed, hidden_states, ids, meta, codes)
+- Choose shape (async_chunk, full_payload, token_only)
+"""
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+from vllm_omni.data_entry_keys import (
+    EmbeddingsStruct,
+    HiddenStatesStruct,
+    IdsStruct,
+    MetaStruct,
+    OmniPayloadStruct,
+    to_dict,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Common Helper Functions
+# ============================================================================
+
+
+def ensure_list(x: Any) -> list[Any]:
+    """Convert ConstantList / tensor-like to Python list."""
+    if hasattr(x, "_x"):
+        return list(x._x)
+    if isinstance(x, list):
+        return list(x)
+    if isinstance(x, tuple):
+        return list(x)
+    if x is None:
+        return []
+    try:
+        return list(x)
+    except TypeError:
+        return [x]
+
+
+def layer_tensor(layers: dict[Any, Any], key: str) -> torch.Tensor | None:
+    """Fetch layer tensor with tolerant key lookup (str/int)."""
+    if not isinstance(layers, dict):
+        return None
+    key_int = int(key)
+    val = layers.get(key_int)
+    if val is None:
+        val = layers.get(key)
+    return val if isinstance(val, torch.Tensor) else None
+
+
+def to_cpu_tensor(value: Any) -> torch.Tensor | None:
+    """Convert value to CPU tensor if possible."""
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu()
+    if isinstance(value, list):
+        if not value:
+            return None
+        if isinstance(value[0], torch.Tensor):
+            return value[0].detach().cpu()
+    return None
+
+
+def to_tensor_or_none(value: Any) -> torch.Tensor | None:
+    """Convert value to tensor or return None."""
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu()
+    if isinstance(value, list) and value and isinstance(value[0], torch.Tensor):
+        return value[0].detach().cpu()
+    return None
+
+
+def strip_boundary_tokens(
+    token_ids: list[int],
+    start_token_id: int | None = None,
+    pad_token_id: int | None = None,
+    end_token_id: int | None = None,
+) -> list[int]:
+    """Strip boundary tokens (START/PAD/END) from token list."""
+    tids = list(token_ids)
+
+    if start_token_id is not None and tids and tids[0] == start_token_id:
+        tids = tids[1:]
+
+    if end_token_id is not None and tids and tids[-1] == end_token_id:
+        tids = tids[:-1]
+
+    if pad_token_id is not None:
+        tids = [tid for tid in tids if tid != pad_token_id]
+
+    return tids
+
+
+def filter_invalid_tokens(
+    token_ids: list[int],
+    min_valid: int = 0,
+    max_valid: int | None = None,
+) -> list[int]:
+    """Filter invalid tokens (negative, out-of-range) from token list."""
+    filtered = []
+    for tid in token_ids:
+        if tid < min_valid:
+            continue
+        if max_valid is not None and tid >= max_valid:
+            continue
+        filtered.append(tid)
+    return filtered
+
+
+def count_trailing_placeholders(token_ids: list[int], placeholder: int = -1) -> int:
+    """Count trailing placeholder tokens in token list."""
+    count = 0
+    while count < len(token_ids) and token_ids[-1 - count] == placeholder:
+        count += 1
+    return count
+
+
+# ============================================================================
+# TransitionSpec: Configuration for payload extraction/normalization
+# ============================================================================
+
+
+@dataclass
+class TransitionSpec:
+    """Configuration for stage transition payload building.
+
+    Defines how to extract and normalize data from pooling_output/multimodal_output
+    and build OmniPayloadStruct for different shapes (async_chunk, full_payload, token_only).
+    """
+
+    # Source key mappings (pooling_output keys -> target struct fields)
+    embed_layer_keys: dict[str, str] = field(default_factory=dict)
+    hidden_state_layer_keys: dict[str, str] = field(default_factory=dict)
+    code_keys: dict[str, str] = field(default_factory=dict)
+
+    # Normalization rules
+    token_range: tuple[int, int] | None = None  # (min_valid, max_valid)
+    codebook_size: int | None = None
+    boundary_tokens: dict[str, int] = field(default_factory=dict)  # start, pad, end
+
+    # Layer specifications
+    embed_layer: str | None = None
+    hidden_layer: str | None = None
+
+    # Shape selection
+    trim_stop_token: bool = False
+    trim_trailing_placeholders: bool = False
+
+    # Metadata extraction
+    extract_speaker: bool = False
+    extract_language: bool = False
+
+    # Custom validators
+    token_validator: Callable[[int], bool] | None = None
+    code_validator: Callable[[torch.Tensor], torch.Tensor] | None = None
+
+
+# ============================================================================
+# StagePayloadBuilder: Builder for OmniPayloadStruct
+# ============================================================================
+
+
+class StagePayloadBuilder:
+    """Builder for stage transition payloads.
+
+    Provides methods to extract, normalize, and build OmniPayloadStruct
+    for different shapes (async_chunk, full_payload, token_only).
+    """
+
+    def __init__(self, spec: TransitionSpec):
+        self.spec = spec
+
+    def extract_from_pooling_output(
+        self,
+        pooling_output: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Extract tensors from pooling_output based on spec."""
+        extracted = {}
+
+        # Extract embeddings
+        if self.spec.embed_layer:
+            layers = pooling_output.get("hidden_states", {}).get("layers", {})
+            if isinstance(layers, dict):
+                extracted["embed"] = layer_tensor(layers, self.spec.embed_layer)
+
+        # Extract hidden states
+        if self.spec.hidden_layer:
+            layers = pooling_output.get("hidden_states", {}).get("layers", {})
+            if isinstance(layers, dict):
+                extracted["hidden"] = layer_tensor(layers, self.spec.hidden_layer)
+
+        # Extract codes
+        for source_key, target_key in self.spec.code_keys.items():
+            val = pooling_output.get(source_key)
+            if val is not None:
+                extracted[target_key] = val
+
+        # Extract additional fields
+        for source_key, target_key in self.spec.embed_layer_keys.items():
+            val = pooling_output.get(source_key)
+            if val is not None:
+                extracted[target_key] = val
+
+        return extracted
+
+    def normalize_tokens(
+        self,
+        token_ids: list[int],
+    ) -> list[int]:
+        """Normalize token IDs based on spec."""
+        normalized = list(token_ids)
+
+        # Apply custom validator if provided
+        if self.spec.token_validator:
+            normalized = [tid for tid in normalized if self.spec.token_validator(tid)]
+
+        # Filter by range
+        if self.spec.token_range:
+            min_valid, max_valid = self.spec.token_range
+            normalized = filter_invalid_tokens(normalized, min_valid, max_valid)
+
+        # Strip boundary tokens
+        if self.spec.boundary_tokens:
+            normalized = strip_boundary_tokens(
+                normalized,
+                start_token_id=self.spec.boundary_tokens.get("start"),
+                pad_token_id=self.spec.boundary_tokens.get("pad"),
+                end_token_id=self.spec.boundary_tokens.get("end"),
+            )
+
+        return normalized
+
+    def normalize_codes(
+        self,
+        codes: torch.Tensor,
+        output_token_ids: list[int] | None = None,
+    ) -> tuple[torch.Tensor, dict[str, int]]:
+        """Normalize codec frames based on spec.
+
+        Returns:
+            (filtered_codes, stats_dict) where stats_dict contains:
+            - raw_rows: original number of rows
+            - aligned_rows: rows aligned with output_token_ids
+            - valid_rows: rows after filtering
+            - trailing_placeholder_count: count of trailing placeholders
+        """
+        if codes.ndim != 2 or codes.numel() == 0:
+            return codes, {
+                "raw_rows": int(codes.shape[0]) if codes.ndim > 0 else 0,
+                "aligned_rows": 0,
+                "valid_rows": 0,
+                "trailing_placeholder_count": 0,
+            }
+
+        raw_rows = int(codes.shape[0])
+
+        # Count trailing placeholders
+        trailing_placeholder_count = 0
+        if output_token_ids is not None and self.spec.trim_trailing_placeholders:
+            trailing_placeholder_count = count_trailing_placeholders(output_token_ids)
+
+        # Align with output token IDs if provided
+        aligned_len = raw_rows
+        if output_token_ids is not None:
+            aligned_len = min(raw_rows, len(output_token_ids))
+
+        # Apply custom code validator if provided
+        if self.spec.code_validator:
+            codes = self.spec.code_validator(codes)
+
+        # Filter by codebook size
+        if self.spec.codebook_size is not None:
+            valid_mask = (codes.max(dim=1).values < self.spec.codebook_size) & (codes.min(dim=1).values >= 0)
+            codes = codes[valid_mask]
+
+        # Align with output token IDs
+        if output_token_ids is not None and aligned_len > 0:
+            codes = codes[-aligned_len:]
+
+        valid_rows = int(codes.shape[0]) if codes.ndim > 0 else 0
+
+        return codes, {
+            "raw_rows": raw_rows,
+            "aligned_rows": aligned_len,
+            "valid_rows": valid_rows,
+            "trailing_placeholder_count": trailing_placeholder_count,
+        }
+
+    def build_payload_struct(
+        self,
+        extracted: dict[str, Any],
+        token_ids: dict[str, list[int]] | None = None,
+        meta: dict[str, Any] | None = None,
+        speaker: str | None = None,
+        language: str | None = None,
+    ) -> OmniPayloadStruct:
+        """Build OmniPayloadStruct from extracted data."""
+        kwargs = {}
+
+        # Build EmbeddingsStruct
+        embed_fields = {}
+        if "embed" in extracted:
+            embed_fields["prefill"] = extracted["embed"]
+        for key in ["tts_bos", "tts_eos", "tts_pad", "speech_token", "speech_feat", "embedding"]:
+            if key in extracted:
+                embed_fields[key] = extracted[key]
+        if embed_fields:
+            kwargs["embed"] = EmbeddingsStruct(**embed_fields)
+
+        # Build HiddenStatesStruct
+        if "hidden" in extracted:
+            kwargs["hidden_states"] = HiddenStatesStruct(output=extracted["hidden"])
+
+        # Build IdsStruct
+        if token_ids:
+            ids_fields = {}
+            if "all" in token_ids:
+                ids_fields["all"] = token_ids["all"]
+            if "prompt" in token_ids:
+                ids_fields["prompt"] = token_ids["prompt"]
+            if "output" in token_ids:
+                ids_fields["output"] = token_ids["output"]
+            if ids_fields:
+                kwargs["ids"] = IdsStruct(**ids_fields)
+
+        # Build MetaStruct
+        if meta:
+            kwargs["meta"] = MetaStruct(**meta)
+
+        # Add speaker/language
+        if speaker is not None:
+            kwargs["speaker"] = speaker
+        if language is not None:
+            kwargs["language"] = language
+
+        return OmniPayloadStruct(**kwargs)
+
+    def build_full_payload(
+        self,
+        pooling_output: dict[str, Any],
+        request: Any,
+        is_finished: bool = True,
+    ) -> dict[str, Any] | None:
+        """Build full payload for connector path.
+
+        Returns OmniPayload-shaped dict or None if extraction fails.
+        """
+        if not isinstance(pooling_output, dict):
+            logger.warning(
+                "StagePayloadBuilder.build_full_payload: pooling_output not a dict (type=%s)",
+                type(pooling_output).__name__,
+            )
+            return None
+
+        # Extract data
+        extracted = self.extract_from_pooling_output(pooling_output)
+
+        # Get token IDs from request
+        prompt_token_ids = ensure_list(getattr(request, "prompt_token_ids", []) or [])
+        output_token_ids = ensure_list(getattr(request, "output_token_ids", []) or [])
+        all_token_ids = ensure_list(getattr(request, "all_token_ids", None) or [])
+        if not all_token_ids:
+            all_token_ids = list(prompt_token_ids) + list(output_token_ids)
+
+        # Trim stop token if configured
+        if self.spec.trim_stop_token and is_finished:
+            if output_token_ids:
+                output_token_ids = output_token_ids[:-1]
+            if all_token_ids:
+                all_token_ids = all_token_ids[:-1]
+
+        # Build payload
+        payload = to_dict(
+            self.build_payload_struct(
+                extracted,
+                token_ids={
+                    "all": all_token_ids,
+                    "prompt": prompt_token_ids,
+                    "output": output_token_ids,
+                },
+                meta={"finished": torch.tensor(is_finished, dtype=torch.bool)},
+            )
+        )
+
+        return payload
+
+    def build_token_only(
+        self,
+        source_outputs: list[Any],
+        prompt: Any = None,
+        prompt_length_fn: Callable[[dict[str, Any]], int] | None = None,
+    ) -> list[Any]:
+        """Build token-only placeholder for orchestrator scheduling.
+
+        Returns list of OmniTokensPrompt sized to expected length.
+        Actual payload comes via connector path.
+        """
+        from vllm_omni.inputs.data import OmniTokensPrompt
+
+        token_only_inputs = []
+
+        for i, source_output in enumerate(source_outputs):
+            output = source_output.outputs[0]
+            mm = getattr(output, "multimodal_output", None)
+
+            # Calculate prompt length
+            if prompt_length_fn and mm:
+                prompt_len = prompt_length_fn(mm)
+            else:
+                prompt_len = 1  # Default minimal length
+
+            # Extract small metadata if configured
+            additional_info = None
+            if self.spec.extract_speaker or self.spec.extract_language:
+                additional_info = {}
+                if self.spec.extract_speaker:
+                    from vllm_omni.model_executor.stage_input_processors.tts_utils import (
+                        extract_speaker_from_prompt,
+                    )
+
+                    speaker = extract_speaker_from_prompt(prompt, index=i)
+                    if speaker is not None:
+                        additional_info["speaker"] = speaker
+                if self.spec.extract_language:
+                    from vllm_omni.model_executor.stage_input_processors.tts_utils import (
+                        extract_language_from_prompt,
+                    )
+
+                    language = extract_language_from_prompt(prompt, index=i)
+                    if language is not None:
+                        additional_info["language"] = language
+
+            token_only_inputs.append(
+                OmniTokensPrompt(
+                    prompt_token_ids=[0] * prompt_len,
+                    additional_information=additional_info if additional_info else None,
+                    multi_modal_data=None,
+                    mm_processor_kwargs=None,
+                )
+            )
+
+        return token_only_inputs

--- a/vllm_omni/model_executor/stage_input_processors/qwen2_5_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen2_5_omni.py
@@ -12,6 +12,10 @@ from vllm_omni.data_entry_keys import (
     to_dict,
 )
 from vllm_omni.inputs.data import OmniTokensPrompt
+from vllm_omni.model_executor.stage_input_processors.payload_builder import (
+    count_trailing_placeholders,
+    ensure_list,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -124,9 +128,7 @@ def _strip_codec_boundaries(token_ids: list[int]) -> list[int]:
     their length by repeating the last valid codec id.
     """
     tids = list(token_ids)
-    trailing_placeholder_count = 0
-    while trailing_placeholder_count < len(tids) and tids[-1 - trailing_placeholder_count] == -1:
-        trailing_placeholder_count += 1
+    trailing_placeholder_count = count_trailing_placeholders(tids, placeholder=-1)
 
     if tids and tids[-1] == TALKER_CODEC_END_TOKEN_ID:
         tids = tids[:-1]
@@ -318,19 +320,9 @@ def thinker2talker_full_payload(
         )
         return None
 
-    def _ensure_list(x):
-        if x is None:
-            return []
-        if hasattr(x, "_x"):
-            # vLLM wraps cached token-id lists in ConstantList-like objects.
-            return list(x._x)
-        if isinstance(x, list):
-            return list(x)
-        return list(x)
-
-    prompt_token_ids = _ensure_list(getattr(request, "prompt_token_ids", None))
-    output_token_ids = _ensure_list(getattr(request, "output_token_ids", None))
-    all_token_ids = _ensure_list(getattr(request, "all_token_ids", None) or [])
+    prompt_token_ids = ensure_list(getattr(request, "prompt_token_ids", None))
+    output_token_ids = ensure_list(getattr(request, "output_token_ids", None))
+    all_token_ids = ensure_list(getattr(request, "all_token_ids", None) or [])
     if not all_token_ids:
         all_token_ids = list(prompt_token_ids) + list(output_token_ids)
 

--- a/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
+++ b/vllm_omni/model_executor/stage_input_processors/qwen3_omni.py
@@ -23,6 +23,11 @@ from vllm_omni.data_entry_keys import (
 )
 from vllm_omni.engine import OmniEngineCoreRequest
 from vllm_omni.inputs.data import OmniTokensPrompt
+from vllm_omni.model_executor.stage_input_processors.payload_builder import (
+    ensure_list,
+    layer_tensor,
+    to_tensor_or_none,
+)
 from vllm_omni.model_executor.stage_input_processors.tts_utils import (
     extract_language_from_prompt,
     extract_language_from_request,
@@ -47,15 +52,7 @@ _QWEN3_CODEC_BOS_TOKEN_ID = 4197
 _QWEN3_CODEC_EOS_TOKEN_ID = 4198
 
 
-def _layer_tensor(layers: dict[Any, Any], key: str) -> torch.Tensor | None:
-    """Fetch layer tensor with tolerant key lookup (str/int)."""
-    if not isinstance(layers, dict):
-        return None
-    key_int = int(key)
-    val = layers.get(key_int)
-    if val is None:
-        val = layers.get(key)
-    return val if isinstance(val, torch.Tensor) else None
+# _layer_tensor now imported from payload_builder.py
 
 
 def _compute_talker_prompt_ids_length(info: OmniPayload, device: torch.device | str = "cuda") -> int:
@@ -98,23 +95,11 @@ def _compute_talker_prompt_ids_length(info: OmniPayload, device: torch.device | 
 # =========================
 # Common helpers
 # =========================
-
-
-def _ensure_list(x):
-    """Convert ConstantList / tensor-like to Python list."""
-    if hasattr(x, "_x"):
-        return list(x._x)
-    elif not isinstance(x, list):
-        return x
-    return list(x)
-
-
-def _as_tensor_or_none(value: Any) -> torch.Tensor | None:
-    if isinstance(value, torch.Tensor):
-        return value.detach().cpu()
-    if isinstance(value, list) and value and isinstance(value[0], torch.Tensor):
-        return value[0].detach().cpu()
-    return None
+# Helper functions now imported from payload_builder.py:
+# - ensure_list
+# - layer_tensor
+# - to_cpu_tensor
+# - to_tensor_or_none
 
 
 def _is_valid_qwen3_codec_token_id(token_id: Any) -> bool:
@@ -279,7 +264,7 @@ def _construct_thinker2talker_streaming_input_async_chunk(
     request_id = request.external_req_id
     output_token_ids = request.output_token_ids
     # Convert ConstantList to regular list for OmniSerializer serialization
-    output_token_ids = _ensure_list(output_token_ids)
+    output_token_ids = ensure_list(output_token_ids)
     speaker = extract_speaker_from_request(request)
     language = extract_language_from_request(request)
     finished = torch.tensor(is_finished, dtype=torch.bool)
@@ -296,8 +281,8 @@ def _construct_thinker2talker_streaming_input_async_chunk(
                 embed=EmbeddingsStruct(prefill=emb_cpu),
                 hidden_states=HiddenStatesStruct(output=hid_cpu),
                 ids=IdsStruct(
-                    all=_ensure_list(request.all_token_ids[-new_prompt_len - 1 :]),
-                    prompt=_ensure_list(request.prompt_token_ids[-new_prompt_len:]),
+                    all=ensure_list(request.all_token_ids[-new_prompt_len - 1 :]),
+                    prompt=ensure_list(request.prompt_token_ids[-new_prompt_len:]),
                 ),
                 speaker=speaker,
                 language=language,
@@ -454,8 +439,8 @@ def thinker2talker_async_chunk(
     thinker_layers = thinker_hs.get("layers", {}) if isinstance(thinker_hs, dict) else {}
     thinker_embed_raw = pooling_output.get("embed", {})
     thinker_embed = thinker_embed_raw if isinstance(thinker_embed_raw, dict) else {}
-    thinker_emb = _layer_tensor(thinker_layers, _EMBED_LAYER_KEY)
-    thinker_hid = _layer_tensor(thinker_layers, _HIDDEN_LAYER_KEY)
+    thinker_emb = layer_tensor(thinker_layers, _EMBED_LAYER_KEY)
+    thinker_hid = layer_tensor(thinker_layers, _HIDDEN_LAYER_KEY)
     if thinker_emb is None or thinker_hid is None:
         logger.debug(
             "thinker2talker_async_chunk: missing thinker layers for req=%s (embed=%s hidden=%s)",
@@ -471,8 +456,8 @@ def thinker2talker_async_chunk(
         return t.detach().cpu() if isinstance(t, torch.Tensor) else None
 
     if chunk_id == 0:
-        all_token_ids = _ensure_list(request.all_token_ids)
-        prompt_token_ids = _ensure_list(request.prompt_token_ids)
+        all_token_ids = ensure_list(request.all_token_ids)
+        prompt_token_ids = ensure_list(request.prompt_token_ids)
         payload = OmniPayloadStruct(
             embed=EmbeddingsStruct(
                 prefill=thinker_emb.detach().cpu(),
@@ -546,8 +531,8 @@ def thinker2talker_full_payload(
         0: pooling_output.get("hidden_states.layer_0"),
         24: pooling_output.get("hidden_states.layer_24"),
     }
-    thinker_emb = _layer_tensor(layers, _EMBED_LAYER_KEY)
-    thinker_hid = _layer_tensor(layers, _HIDDEN_LAYER_KEY)
+    thinker_emb = layer_tensor(layers, _EMBED_LAYER_KEY)
+    thinker_hid = layer_tensor(layers, _HIDDEN_LAYER_KEY)
     if thinker_emb is None:
         hidden = pooling_output.get("hidden")
         thinker_emb = hidden if isinstance(hidden, torch.Tensor) else None
@@ -562,10 +547,10 @@ def thinker2talker_full_payload(
         )
         return None
 
-    prompt_token_ids = _ensure_list(getattr(request, "prompt_token_ids", []) or [])
-    all_token_ids = _ensure_list(getattr(request, "all_token_ids", None) or [])
+    prompt_token_ids = ensure_list(getattr(request, "prompt_token_ids", []) or [])
+    all_token_ids = ensure_list(getattr(request, "all_token_ids", None) or [])
     if not all_token_ids:
-        output_token_ids = _ensure_list(getattr(request, "output_token_ids", []) or [])
+        output_token_ids = ensure_list(getattr(request, "output_token_ids", []) or [])
         all_token_ids = list(prompt_token_ids) + list(output_token_ids)
 
     # Trim the trailing stop-token row from the accumulated thinker output.
@@ -590,9 +575,9 @@ def thinker2talker_full_payload(
     payload: OmniPayload = {
         "embed": {
             "prefill": thinker_emb_prefill.detach().cpu(),
-            "tts_bos": _as_tensor_or_none(pooling_output.get("embed.tts_bos")),
-            "tts_eos": _as_tensor_or_none(pooling_output.get("embed.tts_eos")),
-            "tts_pad": _as_tensor_or_none(pooling_output.get("embed.tts_pad")),
+            "tts_bos": to_tensor_or_none(pooling_output.get("embed.tts_bos")),
+            "tts_eos": to_tensor_or_none(pooling_output.get("embed.tts_eos")),
+            "tts_pad": to_tensor_or_none(pooling_output.get("embed.tts_pad")),
         },
         "hidden_states": {"output": thinker_hid_prefill.detach().cpu()},
         "ids": {"all": list(all_token_ids), "prompt": list(prompt_token_ids)},
@@ -641,8 +626,8 @@ def thinker2talker(
     for i, thinker_output in enumerate(thinker_outputs):
         output = thinker_output.outputs[0]
         req_id = str(getattr(thinker_output, "request_id", f"idx-{i}"))
-        prompt_token_ids = _ensure_list(thinker_output.prompt_token_ids)
-        output_ids = _ensure_list(output.cumulative_token_ids)
+        prompt_token_ids = ensure_list(thinker_output.prompt_token_ids)
+        output_ids = ensure_list(output.cumulative_token_ids)
         is_streaming_session = bool(getattr(streaming_context, "enabled", False))
         if is_streaming_session:
             prompt_token_ids, output_ids = _get_streaming_talker_tokens(
@@ -663,8 +648,8 @@ def thinker2talker(
         thinker_mm: OmniPayload = thinker_mm_raw
         mm_hs = thinker_mm.get("hidden_states", {})
         mm_layers = mm_hs.get("layers", {}) if isinstance(mm_hs, dict) else {}
-        emb_layer = _layer_tensor(mm_layers, _EMBED_LAYER_KEY)
-        hid_layer = _layer_tensor(mm_layers, _HIDDEN_LAYER_KEY)
+        emb_layer = layer_tensor(mm_layers, _EMBED_LAYER_KEY)
+        hid_layer = layer_tensor(mm_layers, _HIDDEN_LAYER_KEY)
         if emb_layer is None or hid_layer is None:
             logger.debug("thinker2talker: skip req=%s due to missing hidden-state layers", req_id)
             continue
@@ -753,11 +738,11 @@ def thinker2talker_token_only(
             continue
         mm_hs = thinker_mm_raw.get("hidden_states", {})
         mm_layers = mm_hs.get("layers", {}) if isinstance(mm_hs, dict) else {}
-        if _layer_tensor(mm_layers, _EMBED_LAYER_KEY) is None or _layer_tensor(mm_layers, _HIDDEN_LAYER_KEY) is None:
+        if layer_tensor(mm_layers, _EMBED_LAYER_KEY) is None or layer_tensor(mm_layers, _HIDDEN_LAYER_KEY) is None:
             logger.debug("thinker2talker_token_only: skip req=%s due to missing hidden-state layers", req_id)
             continue
-        prompt_token_ids = _ensure_list(thinker_output.prompt_token_ids)
-        output_ids = _ensure_list(output.cumulative_token_ids)
+        prompt_token_ids = ensure_list(thinker_output.prompt_token_ids)
+        output_ids = ensure_list(output.cumulative_token_ids)
         is_streaming_session = bool(getattr(streaming_context, "enabled", False))
         if is_streaming_session:
             prompt_token_ids, output_ids = _get_streaming_talker_tokens(
@@ -913,7 +898,7 @@ def talker2code2wav_full_payload(
         )
         return None
 
-    output_token_ids = _ensure_list(getattr(request, "output_token_ids", []) or [])
+    output_token_ids = ensure_list(getattr(request, "output_token_ids", []) or [])
     raw_shape = tuple(code_predictor_codes.shape)
     code_predictor_codes, codec_stats = _extract_qwen3_full_payload_codec_rows(
         code_predictor_codes.to(torch.long),


### PR DESCRIPTION
Introduced stage_input_processors/stage_payload.py as a shared utility module consolidating common payload extraction logic (extract → normalize → build → deliver) that was previously hand-rolled across Qwen2.5, Qwen3, Qwen3-TTS, MiMo, GLM-TTS, Fish, and CosyVoice processors. Migrated CosyVoice, GLM-TTS, Qwen2.5, and Qwen3 stage input processors to use the new shared helpers. Fixes part of #4009.
Test Plan

Added tests/model_executor/test_payload_builder.py to unit test StagePayloadBuilder and TransitionSpec directly
Added tests/model_executor/stage_input_processors/test_glm_tts_async_chunk.py for GLM-TTS async chunk transition
Added tests/model_executor/stage_input_processors/test_cosyvoice3_stage_input_processors.py for CosyVoice3 processor migration

Test Result
All t test files pass. No behavioral change in any migrated processor — refactor only.