### PR TITLE
[DEBUG]Add has_preprocess branch to _dummy_run for models with preprocess stage

### DIFF
--- a/vllm_omni/deploy/qwen3_tts.yaml
+++ b/vllm_omni/deploy/qwen3_tts.yaml
@@ -10,8 +10,7 @@
 #     codec prefill length (Q * num_frames) exceeds the 32k default.
 #   * Stage 0 does not set enforce_eager — talker runs cudagraph by default.
 #     Stage 1 defaults to false so Code2Wav can use its inner cudagraph;
-#     set true to disable that path in eager mode. NPU platform flips stage 0 to true where
-#     cudagraph is not yet verified.
+#     set true to disable that path in eager mode.
 async_chunk: true
 
 connectors:
@@ -93,4 +92,4 @@ platforms:
   npu:
     stages:
       - stage_id: 0
-        enforce_eager: true
+        enforce_eager: false

--- a/vllm_omni/platforms/npu/worker/npu_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_model_runner.py
@@ -219,7 +219,10 @@ class OmniNPUModelRunner(OmniGPUModelRunner, NPUModelRunner):
         ):
             # Make sure padding doesn't exceed max_num_tokens
             assert num_tokens_padded <= self.max_num_tokens
-            if self.supports_mm_inputs and not self.model_config.is_encoder_decoder or self.enable_prompt_embeds:
+            if getattr(getattr(self, "model", None), "has_preprocess", False):
+                input_ids = self.input_ids.gpu[:num_tokens_padded]
+                inputs_embeds = self.inputs_embeds.gpu[:num_tokens_padded]
+            elif self.supports_mm_inputs and not self.model_config.is_encoder_decoder or self.enable_prompt_embeds:
                 input_ids = None
                 inputs_embeds = self.inputs_embeds.gpu[:num_tokens_padded]
             else:


### PR DESCRIPTION
## Summary

NPU `_dummy_run` was missing the `has_preprocess` branch that GPU `_dummy_run` already has (`gpu_model_runner.py:812`). This caused graph capture warmup to set `input_ids=None` while inference provides `input_ids=tensor`, violating `@support_torch_compile`'s "None params must always be None" constraint. The torchair compiled graph then doesn't register `input_ids` as a dynamic input, causing data misalignment during replay and producing noise instead of correct audio output for models with `has_preprocess=True` (qwen3_tts, fish_speech, voxcpm2, mimo_audio, etc.).

## Fix

Add `has_preprocess` check as the **first** branch in NPU `_dummy_run`, matching the GPU implementation's priority order. When `has_preprocess=True`, provide both `input_ids=tensor` and `inputs_embeds=tensor` during warmup, matching the inference signature where `_preprocess` writes into `inputs_embeds` and `input_ids` is also present.

## Impact

- Fixes audio output corruption (noise/static) for TTS models on Ascend NPU with PIECEWISE mode
- Consistent with GPU `_dummy_run` behavior (`gpu_model_runner.py:812`)
- No impact on models without `has_preprocess` (falls through to existing branches)

## Test Plan

1. Start model in **eager mode** (`enforce_eager: true` in yaml):

```
vllm-omni serve /home/h00875519/qwen3_tts_VoiceDesign \
    --omni \
    --host 0.0.0.0 \
    --port 8998
```

2. Start model in **PIECEWISE mode** (`enforce_eager: false` in yaml) with the same command.

3. Run serving benchmark for both modes and verify:
   - Audio output is correct (no noise/static)
   - No request failures

## Test Result

### Eager mode (enforce_eager: true)

```
============ Serving Benchmark Result ============
Successful requests:                     5
Failed requests:                         0
Maximum request concurrency:             1
Benchmark duration (s):                  27.35
Request throughput (req/s):              0.18
Peak concurrent requests:                2.00
----------------End-to End Latency----------------
Mean E2EL (ms):                          5469.58
Median E2EL (ms):                        4687.23
P99 E2EL (ms):                           8145.84
================== Text Result ===================
Total input tokens:                      63
Total generated tokens:                  0
Output token throughput (tok/s):         0.00
Peak output token throughput (tok/s):    1.00
Peak concurrent requests:                2.00
Total Token throughput (tok/s):          2.30
================== Audio Result ===================
Total audio duration generated (s):       22.96
Total audio frames generated:            551040
Audio throughput (audio/s):              0.84
Streaming continuity OK rate:            0.00%
---------------Time to First Packet---------------
Mean AUDIO_TTFP (ms):                    277.02
Median AUDIO_TTFP (ms):                  277.04
P99 AUDIO_TTFP (ms):                     280.42
-----------------Real Time Factor------------------
Mean AUDIO_RTF:                          1.20
Median AUDIO_RTF:                        1.20
P99 AUDIO_RTF:                           1.22
------------------ Audio Duration ------------------
Mean AUDIO_DURATION (s):                 4.59
Median AUDIO_DURATION (s):               3.92
P99 AUDIO_DURATION (s):                  6.96
==================================================
```

### PIECEWISE mode (enforce_eager: false)

```
============ Serving Benchmark Result ============
Successful requests:                     5
Failed requests:                         0
Maximum request concurrency:             1
Benchmark duration (s):                  17.86
Request throughput (req/s):              0.28
Peak concurrent requests:                2.00
----------------End to End Latency----------------
Mean E2EL (ms):                          3571.77
Median E2EL (ms):                        3171.11
P99 E2EL (ms):                           4953.35
================== Text Result ===================
Total input tokens:                      63
Total generated tokens:                  0
Output token throughput (tok/s):         0.00
Peak output token throughput (tok/s):    1.00
Peak concurrent requests:                2.00
Total Token throughput (tok/s):          3.53
================== Audio Result ===================
Total audio duration generated (s):       22.40
Total audio frames generated:            537600
Audio throughput (audio/s):              1.25
Streaming continuity OK rate:            0.00%
---------------Time to First Packet---------------
Mean AUDIO_TTFP (ms):                    223.39
Median AUDIO_TTFP (ms):                  219.33
P99 AUDIO_TTFP (ms):                     232.13
-----------------Real Time Factor------------------
Mean AUDIO_RTF:                          0.80
Median AUDIO_RTF:                        0.80
P99 AUDIO_RTF:                           0.81
------------------ Audio Duration ------------------
Mean AUDIO_DURATION (s):                 4.48
Median AUDIO_DURATION (s):               4.00
P99 AUDIO_DURATION (s):                  6.20
==================================================
```

Both modes produce correct audio output with 0 failed requests. PIECEWISE mode achieves RTF=0.80 (< 1.0 target) with 1.56x faster latency than eager mode.