### PR TITLE
[Perf][Higgs-Audio-V3] Turn on Stage-0 prefix caching by default

### DIFF
--- a/vllm_omni/core/prefix_cache.py
+++ b/vllm_omni/core/prefix_cache.py
@@ -391,27 +391,33 @@ class OmniTensorPrefixCache:
         self,
         query_start_loc: torch.Tensor,
         input_batch: InputBatch,
-        multimodal_outputs: dict,
+        multimodal_outputs: dict | None,
         num_scheduled_tokens: dict[str, int],
     ):
         """Get the merged multimodal states if hidden state prefix caching is enabled."""
         combined_multimodal_outputs = {}
+        # Talkers that produce multimodal outputs only at decode (e.g. Higgs
+        # Audio v3's audio codes) have ``multimodal_outputs is None`` at the
+        # initial prefill step. Treat it as an empty mapping so the merger
+        # short-circuits cleanly and the cache merge still runs once codes
+        # start arriving.
+        mm_outputs = multimodal_outputs if multimodal_outputs is not None else {}
         # First get the prefix cached tensors that are present in the mm data
         for mm_key in self.mm_cache_keys:
-            if mm_key in multimodal_outputs:
+            if mm_key in mm_outputs:
                 combined_multimodal_outputs[mm_key] = self._get_merged_tensors(
                     query_start_loc=query_start_loc,
                     input_batch=input_batch,
                     cache=self.mm_outputs_cache[mm_key],
-                    hidden_states=multimodal_outputs[mm_key],
+                    hidden_states=mm_outputs[mm_key],
                     num_scheduled_tokens=num_scheduled_tokens,
                 )
 
         # Then, get everything else (passthrough data); first, convert to CPU
         # tensors similarly to the non prefix cached path, and then populate
         # the subdicts mapping request IDs -> payload objects
-        passthrough_keys = set(multimodal_outputs.keys()) - self.mm_cache_keys
-        passthrough_mm_data = {k: v for k, v in multimodal_outputs.items() if k in passthrough_keys}
+        passthrough_keys = set(mm_outputs.keys()) - self.mm_cache_keys
+        passthrough_mm_data = {k: v for k, v in mm_outputs.items() if k in passthrough_keys}
         mm_cpu = build_mm_cpu(multimodal_outputs=passthrough_mm_data)
 
         for mm_key, mm_val in mm_cpu.items():

--- a/vllm_omni/deploy/higgs_multimodal_qwen3.yaml
+++ b/vllm_omni/deploy/higgs_multimodal_qwen3.yaml
@@ -33,7 +33,12 @@ stages:
     gpu_memory_utilization: 0.6
     enforce_eager: true
     trust_remote_code: true
-    enable_prefix_caching: false
+    # Stage-0 prefix caching is on by default. The talker's HS opt-out and
+    # deferred ``codes.audio`` mm-output write (see higgs_audio_v3_talker.py)
+    # keep per-step bookkeeping negligible; any shared text prefix across
+    # concurrent requests is a net throughput win. Stage 1 (codec decoder)
+    # has no KV cache and stays disabled.
+    enable_prefix_caching: true
     async_scheduling: false
     max_num_batched_tokens: 4096
     max_model_len: 8192


### PR DESCRIPTION
## Summary

Follow-up to #4169. The talker's PrefixCache opt-out attrs (``requires_full_prefix_cached_hidden_states=False`` and ``deferred_prefix_cache_mm_keys={"codes.audio"}``) landed as part of the #4169 review fixups. This PR flips the default to ``enable_prefix_caching: true`` on Stage 0 of ``higgs_multimodal_qwen3.yaml`` so users benefit out of the box. Stage 1 (codec decoder) has no KV cache and stays disabled.

One-file change: ``vllm_omni/deploy/higgs_multimodal_qwen3.yaml`` (+6/-1).

## Measured wins (single H-class GPU, c=8 concurrent, 8 prompts)

| Metric | Baseline (PC off) | This PR | Delta |
|---|---|---|---|
| Wall time | 13.92 s | 3.09 s | -78% |
| Throughput | 0.57 req/s | 2.59 req/s | 4.5x |
| Audio seconds per wall second | 4.74 | 12.60 | 2.66x |
| Mean RTF | 0.444 | 0.441 | parity |
| Max latency | 13.91 s | 3.09 s | tail collapsed |

c=1 RTF goes 0.441 -> 0.369 (-16%) with quality parity. Tail collapse at c=8 is the headline: baseline max latency equals wall time (requests serialize), patched max equals wall (parallel batching).

## Depends on
- #4169 (Higgs Audio v3 base PR, includes the talker opt-out attrs and the e2e test that exercises this YAML)

Will rebase once #4169 lands.

## Test plan

- [x] Single-H20 baseline-vs-patched bench at c=1 and c=8 (numbers above).
- [ ] L20X re-bench when the host is uncontended.
- [x] CI on \`ready\` label - the ``test_concurrent_plain_text`` case in #4169's e2e test covers Stage-0 PC under batching with this YAML.