### PR TITLE
[CI] Save curated TTS audio clips as Buildkite artifacts (RFC)

### DIFF
--- a/.buildkite/test-nightly.yml
+++ b/.buildkite/test-nightly.yml
@@ -487,6 +487,9 @@ steps:
             pytest -s -v tests/dfx/perf/scripts/run_benchmark.py --test-config-file tests/dfx/perf/tests/test_tts.json
             EXIT=$$?
             buildkite-agent artifact upload "tests/dfx/perf/results/*.json"
+            # Audio sample artifacts (FLAC + index.json). See docs/ci/audio_artifacts.md.
+            # Best-effort: never let upload failure mask the real pytest exit code.
+            buildkite-agent artifact upload "tests/dfx/perf/results/audio_samples/**/*" || true
             exit $$EXIT
         agents:
           queue: "mithril-h100-pool"

--- a/docs/ci/audio_artifacts.md
+++ b/docs/ci/audio_artifacts.md
@@ -1,0 +1,103 @@
+# Audio Sample Artifacts in CI
+
+vLLM-Omni's nightly and ready CI already saves benchmark results as JSON
+artifacts so reviewers can diff metrics across runs. This document defines
+the policy for also saving a curated subset of generated **audio clips** so
+reviewers can *listen* to representative outputs without re-running the
+bench.
+
+## Why
+
+- Catching audio regressions from JSON metrics alone is hard. A WER delta
+  of +2% could mean "model is slightly worse" or "ASR misheard a Chinese
+  homophone" — listening resolves it in seconds.
+- TTS perf PRs touching the vocoder, talker, or code2wav stage need a
+  listening pass before merge. Reviewers shouldn't need GPU access to do
+  this.
+
+## What gets saved
+
+Per opt-in bench run, the collector writes to
+`tests/dfx/perf/results/audio_samples/<label>/`:
+
+- `NN_<utterance_id>.flac` — up to `--save-audio-samples N` FLAC clips
+  (lossless, ~50% of raw WAV size). Falls back to `.wav` (PCM_16) if the
+  installed libsndfile lacks FLAC support.
+- `index.json` — manifest with `utterance_id`, `locale`, `ref_text`,
+  `duration_sec`, `sample_rate`, `buffer_index`, `total_buffered`.
+
+The sampler picks first, last, and evenly-spaced middle clips so reviewers
+see both warmup and steady-state regimes.
+
+## Size budget
+
+| Configuration | Per bench | × jobs/day | Annualized |
+|---|---|---|---|
+| 8 clips × 5 s × FLAC | ~1 MB | 8 nightly → 8 MB/night | ~3 GB/year |
+| 8 clips × 10 s × FLAC | ~2 MB | 8 nightly → 16 MB/night | ~6 GB/year |
+| 8 clips × 10 s × Opus 48 kbps | ~0.5 MB | 8 nightly → 4 MB/night | ~1.5 GB/year |
+
+The recommended default (8 FLAC clips) lands the entire nightly fleet at
+**~10–20 MB per run**, well inside Buildkite's artifact tier.
+
+## Policy: when to upload
+
+| CI tier | Policy | Rationale |
+|---|---|---|
+| `test-nightly.yml` | **Always on** for TTS/Omni perf jobs (this PR enables `nightly-tts-performance` as the demonstrator). | Listening post for regressions; everyone hears the same clips across nights. |
+| `test-ready.yml` | **Opt-in (Phase 2)**: failure-only, or behind a `ci/save-audio` PR label, or auto-on for paths touching `code2wav/`, `vocoder/`, `talker.py`. | Avoid wasting per-PR uploads on green runs that nobody listens to. |
+| `test-merge.yml`, `test-weekly.yml` | Inherit nightly policy. | Same listening surface; no extra cost. |
+
+The Phase 2 test-ready hook is intentionally **not** in this PR — proving
+the framework end-to-end on one nightly job first, then expanding once the
+maintainers agree on the policy.
+
+## How to opt a bench in
+
+In the bench JSON (`tests/dfx/perf/tests/test_*.json`):
+
+```jsonc
+{
+  "task": "voice_clone",
+  "dataset_name": "seed-tts",
+  "seed_tts_wer_eval": true,
+  "save_audio_samples": 8,
+  "audio_samples_label": "qwen3_tts_base_voice_clone_quality_en"
+}
+```
+
+The runner translates JSON keys to `--<kebab-case>` CLI flags. Equivalent
+direct invocation:
+
+```bash
+vllm bench serve --omni \
+  --dataset-name seed-tts \
+  --save-audio-samples 8 \
+  --audio-samples-label qwen3_tts_base_voice_clone_quality_en \
+  ...
+```
+
+Env-var equivalents (`SAVE_AUDIO_SAMPLES`, `AUDIO_SAMPLES_DIR`,
+`AUDIO_SAMPLES_LABEL`) work too, for ad-hoc shell runs.
+
+## Caveats
+
+- **Currently active path is `seed_tts_eval`.** Benches that decode audio
+  outside `compute_seed_tts_wer_metrics` (e.g. ttsd, daily-omni audio mode)
+  collect nothing today; expanding coverage means calling
+  `get_collector().add(...)` from those data modules. Tracked as Phase 2.
+- **Reference voice clones.** If a bench uses unreleased reference voices,
+  uploading clones to Buildkite is a leak surface. Reviewers should confirm
+  the dataset license before enabling for a new bench.
+- **Buildkite UI does not auto-stream FLAC.** Clips are downloaded and
+  played locally. If in-browser playback becomes a requirement, switch the
+  helper to write Opus instead of FLAC (one-line change).
+
+## Future work
+
+- Add an HTML index that embeds `<audio>` tags per clip, uploaded as a
+  single browsable artifact.
+- Push clips to a small object store (S3/GCS) and embed signed URLs in the
+  bench JSON for one-click listening from the summary `.xlsx`.
+- Wire the collector into `ttsd`, `daily-omni`, and `random-mm` data modules.
+- Add the test-ready failure-only / label-gated upload pattern.

--- a/tests/dfx/perf/tests/test_tts.json
+++ b/tests/dfx/perf/tests/test_tts.json
@@ -87,6 +87,8 @@
         ],
         "seed_tts_locale": "en",
         "seed_tts_wer_eval": true,
+        "save_audio_samples": 8,
+        "audio_samples_label": "qwen3_tts_base_voice_clone_quality_en",
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "mean_audio_rtf": [

--- a/vllm_omni/benchmarks/data_modules/seed_tts_eval.py
+++ b/vllm_omni/benchmarks/data_modules/seed_tts_eval.py
@@ -559,6 +559,21 @@ def compute_seed_tts_wer_metrics(
                 )
             continue
 
+        # Audio artifact collector: buffer this clip; flush picks K representatives
+        # at bench end. No-op when SAVE_AUDIO_SAMPLES is unset.
+        try:
+            from vllm_omni.benchmarks.utils import get_collector
+
+            get_collector().add(
+                utterance_id=req.seed_tts_utterance_id,
+                wav_f32=wav_16k,
+                sample_rate=16000,
+                ref_text=ref,
+                locale=locale,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("Audio artifact collector add failed", exc_info=True)
+
         # UTMOS scores synthesized audio only; do not gate on ASR/WER (those can fail independently).
         if utmos_on:
             try:

--- a/vllm_omni/benchmarks/serve.py
+++ b/vllm_omni/benchmarks/serve.py
@@ -14,6 +14,7 @@ from vllm_omni.benchmarks.patch.patch import (
     set_print_stage,
     should_request_stage_metrics,
 )
+from vllm_omni.benchmarks.utils import get_collector, reset_collector
 
 
 def main(args: argparse.Namespace) -> dict[str, Any]:
@@ -23,9 +24,33 @@ def main(args: argparse.Namespace) -> dict[str, Any]:
         os.environ["SEED_TTS_WER_SAVE_ITEMS"] = "1"
     if getattr(args, "daily_omni_save_eval_items", False):
         os.environ["DAILY_OMNI_SAVE_EVAL_ITEMS"] = "1"
+    # Audio sample artifact: collect K representative WAVs per bench for CI review.
+    # See docs/ci/audio_artifacts.md for the policy. Disabled by default; opt in
+    # via `save_audio_samples` in the bench JSON or SAVE_AUDIO_SAMPLES env var.
+    n_audio = int(getattr(args, "save_audio_samples", 0) or 0)
+    if n_audio > 0:
+        os.environ["SAVE_AUDIO_SAMPLES"] = str(n_audio)
+        audio_dir = getattr(args, "audio_samples_dir", None)
+        if audio_dir:
+            os.environ["AUDIO_SAMPLES_DIR"] = str(audio_dir)
+        audio_label = getattr(args, "audio_samples_label", None)
+        if audio_label:
+            os.environ["AUDIO_SAMPLES_LABEL"] = str(audio_label)
     set_print_stage(getattr(args, "print_stage", False))
     args.extra_body = maybe_enable_stage_metrics(
         getattr(args, "extra_body", None),
         enabled=should_request_stage_metrics(args),
     )
-    return asyncio.run(main_async(args))
+    # Drop any prior bench's collector so this run gets its own output dir.
+    reset_collector()
+    try:
+        return asyncio.run(main_async(args))
+    finally:
+        # Best-effort flush at bench end; no-op when SAVE_AUDIO_SAMPLES unset.
+        try:
+            get_collector().flush()
+        except Exception:  # noqa: BLE001
+            # Never let artifact serialization fail the bench result.
+            import logging
+
+            logging.getLogger(__name__).exception("Audio artifact flush failed")

--- a/vllm_omni/benchmarks/utils/__init__.py
+++ b/vllm_omni/benchmarks/utils/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm_omni.benchmarks.utils.audio_artifact import (
+    AudioArtifactCollector,
+    get_collector,
+    reset_collector,
+)
+
+__all__ = [
+    "AudioArtifactCollector",
+    "get_collector",
+    "reset_collector",
+]

--- a/vllm_omni/benchmarks/utils/audio_artifact.py
+++ b/vllm_omni/benchmarks/utils/audio_artifact.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Audio artifact collector for TTS/Omni benchmark runs.
+
+Collects a curated subset of generated audio clips during a benchmark run and
+writes them as compressed audio files plus an `index.json` for offline
+review. Designed so a small CI artifact (typically <10 MB per nightly bench)
+lets reviewers listen to representative outputs without re-running the bench.
+
+Usage:
+    collector = get_collector()  # singleton, no-op when SAVE_AUDIO_SAMPLES unset
+    collector.add(utterance_id="zh_001", wav_f32=arr, sample_rate=16000,
+                  ref_text="hello world")
+    collector.flush()  # called once at end of bench
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_ENV_NUM_SAMPLES = "SAVE_AUDIO_SAMPLES"
+_ENV_OUTPUT_DIR = "AUDIO_SAMPLES_DIR"
+_DEFAULT_OUTPUT_DIR = "tests/dfx/perf/results/audio_samples"
+
+
+@dataclass
+class _Item:
+    utterance_id: str
+    wav_f32: np.ndarray
+    sample_rate: int
+    ref_text: str = ""
+    locale: str = ""
+    duration_sec: float = 0.0
+
+
+@dataclass
+class AudioArtifactCollector:
+    """In-memory buffer for representative audio clips from a bench run.
+
+    The collector keeps every clip the bench adds, and `flush()` picks K
+    representative ones (first, last, plus evenly-spaced middle) to write to
+    disk. This biases samples toward run-start (warmup) and run-end (steady
+    state) so reviewers see both regimes.
+    """
+
+    num_samples: int = 0
+    output_dir: str = _DEFAULT_OUTPUT_DIR
+    label: str = "bench"
+    _buffer: list[_Item] = field(default_factory=list)
+
+    @property
+    def enabled(self) -> bool:
+        return self.num_samples > 0
+
+    def add(
+        self,
+        utterance_id: str,
+        wav_f32: np.ndarray,
+        sample_rate: int,
+        ref_text: str = "",
+        locale: str = "",
+    ) -> None:
+        """Buffer a clip. No-op when collector is disabled."""
+        if not self.enabled:
+            return
+        if wav_f32 is None or len(wav_f32) == 0:
+            return
+        duration = float(len(wav_f32)) / float(max(sample_rate, 1))
+        self._buffer.append(
+            _Item(
+                utterance_id=str(utterance_id),
+                wav_f32=np.asarray(wav_f32, dtype=np.float32),
+                sample_rate=int(sample_rate),
+                ref_text=ref_text,
+                locale=locale,
+                duration_sec=duration,
+            )
+        )
+
+    def _pick_indices(self, n_buffered: int) -> list[int]:
+        """Pick up to `num_samples` representative indices.
+
+        Always include first and last; fill remaining slots evenly spaced.
+        """
+        k = min(self.num_samples, n_buffered)
+        if k <= 0:
+            return []
+        if k == 1:
+            return [0]
+        if k >= n_buffered:
+            return list(range(n_buffered))
+        # Linear spacing across the run, inclusive of both ends.
+        step = (n_buffered - 1) / (k - 1)
+        idxs = sorted({int(round(i * step)) for i in range(k)})
+        # Edge case: dedup may shrink set; pad with random middle indices.
+        while len(idxs) < k and len(idxs) < n_buffered:
+            for candidate in range(n_buffered):
+                if candidate not in idxs:
+                    idxs.append(candidate)
+                    break
+            idxs = sorted(idxs)
+        return idxs[:k]
+
+    def flush(self) -> str | None:
+        """Write picked clips and index.json to `output_dir/label/`.
+
+        Returns the output directory path when files were written, else None.
+        Best-effort: never raises out of the bench loop.
+        """
+        if not self.enabled or not self._buffer:
+            return None
+        try:
+            import soundfile as sf
+        except ImportError:
+            logger.warning(
+                "soundfile not available; skipping audio artifact flush (install with `pip install soundfile`)."
+            )
+            return None
+
+        out_root = Path(self.output_dir) / self.label
+        try:
+            out_root.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            logger.warning("Cannot create audio artifact dir %s: %s", out_root, e)
+            return None
+
+        idxs = self._pick_indices(len(self._buffer))
+        manifest: list[dict] = []
+        written = 0
+        for slot, buf_idx in enumerate(idxs):
+            item = self._buffer[buf_idx]
+            # FLAC: lossless, ~50% of raw WAV, plays in most native players.
+            # Plain wav is fallback if soundfile lacks FLAC support.
+            safe_id = "".join(c if c.isalnum() or c in "-_." else "_" for c in item.utterance_id)
+            stem = f"{slot:02d}_{safe_id}"
+            fname = f"{stem}.flac"
+            target = out_root / fname
+            try:
+                sf.write(str(target), item.wav_f32, item.sample_rate, format="FLAC")
+            except (RuntimeError, ValueError):
+                # FLAC unavailable (rare; libsndfile config), fall back to WAV.
+                fname = f"{stem}.wav"
+                target = out_root / fname
+                try:
+                    sf.write(str(target), item.wav_f32, item.sample_rate, subtype="PCM_16")
+                except Exception:
+                    logger.exception("Failed to write audio sample %s", target)
+                    continue
+            written += 1
+            manifest.append(
+                {
+                    "slot": slot,
+                    "buffer_index": buf_idx,
+                    "total_buffered": len(self._buffer),
+                    "utterance_id": item.utterance_id,
+                    "locale": item.locale,
+                    "ref_text": item.ref_text,
+                    "sample_rate": item.sample_rate,
+                    "duration_sec": round(item.duration_sec, 3),
+                    "file": fname,
+                }
+            )
+
+        if written == 0:
+            logger.warning("Audio artifact flush wrote 0 files to %s", out_root)
+            return None
+
+        index_path = out_root / "index.json"
+        try:
+            with open(index_path, "w", encoding="utf-8") as fh:
+                json.dump(
+                    {"label": self.label, "items": manifest},
+                    fh,
+                    ensure_ascii=False,
+                    indent=2,
+                )
+        except OSError:
+            logger.exception("Failed to write audio index at %s", index_path)
+
+        logger.info(
+            "Audio artifact: wrote %d/%d clips to %s",
+            written,
+            len(self._buffer),
+            out_root,
+        )
+        return str(out_root)
+
+
+# Process-global singleton. Bench code reads env vars on first access; resets
+# happen at the bench boundary via `reset_collector` so multi-bench runs in
+# one process get separate output directories.
+_collector: AudioArtifactCollector | None = None
+
+
+def _label_from_env() -> str:
+    label = os.environ.get("AUDIO_SAMPLES_LABEL", "").strip()
+    if label:
+        return "".join(c if c.isalnum() or c in "-_." else "_" for c in label)
+    return "bench"
+
+
+def get_collector() -> AudioArtifactCollector:
+    """Return the process-wide collector, constructing on first call.
+
+    When `SAVE_AUDIO_SAMPLES` is unset or non-positive, returns a disabled
+    collector whose `add()`/`flush()` are no-ops, so call sites can stay
+    unconditional.
+    """
+    global _collector
+    if _collector is not None:
+        return _collector
+    try:
+        n = int(os.environ.get(_ENV_NUM_SAMPLES, "0"))
+    except ValueError:
+        n = 0
+    n = max(0, n)
+    output_dir = os.environ.get(_ENV_OUTPUT_DIR, _DEFAULT_OUTPUT_DIR)
+    _collector = AudioArtifactCollector(
+        num_samples=n,
+        output_dir=output_dir,
+        label=_label_from_env(),
+    )
+    return _collector
+
+
+def reset_collector() -> None:
+    """Drop the cached collector. Used between bench invocations in one process."""
+    global _collector
+    _collector = None

--- a/vllm_omni/entrypoints/cli/benchmark/serve.py
+++ b/vllm_omni/entrypoints/cli/benchmark/serve.py
@@ -131,6 +131,41 @@ def add_seed_tts_cli_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_audio_artifact_cli_args(parser: argparse.ArgumentParser) -> None:
+    """CLI for the audio sample artifact collector.
+
+    When enabled, the bench buffers every decoded audio clip and writes K
+    representative ones (FLAC) plus an index.json at end of run, so CI can
+    upload them as a Buildkite artifact for reviewers to listen to.
+    See docs/ci/audio_artifacts.md for the policy.
+    """
+    g = parser.add_argument_group("Audio Sample Artifact Options")
+    g.add_argument(
+        "--save-audio-samples",
+        type=int,
+        default=0,
+        help="Save N representative audio clips from this bench run to "
+        "--audio-samples-dir as FLAC + index.json. 0 disables (default). "
+        "Currently active for benches that decode through seed_tts_eval. "
+        "Also enabled by env SAVE_AUDIO_SAMPLES.",
+    )
+    g.add_argument(
+        "--audio-samples-dir",
+        type=str,
+        default=None,
+        help="Directory to write audio artifact bundle into. "
+        "Default tests/dfx/perf/results/audio_samples. Also AUDIO_SAMPLES_DIR.",
+    )
+    g.add_argument(
+        "--audio-samples-label",
+        type=str,
+        default=None,
+        help="Subdirectory label under --audio-samples-dir to keep multiple "
+        "bench runs separated (e.g. qwen3_tts_base_voice_clone_c1). "
+        "Also AUDIO_SAMPLES_LABEL.",
+    )
+
+
 def add_omni_benchmark_cli_args(parser: argparse.ArgumentParser) -> None:
     """Add vLLM-Omni specific serving benchmark options."""
     group = parser.add_argument_group("vLLM-Omni Multi-stage Benchmark Options")
@@ -198,6 +233,7 @@ class OmniBenchmarkServingSubcommand(OmniBenchmarkSubcommandBase):
         # Add Daily-Omni specific arguments
         add_daily_omni_cli_args(parser)
         add_seed_tts_cli_args(parser)
+        add_audio_artifact_cli_args(parser)
         add_omni_benchmark_cli_args(parser)
 
         for action in parser._actions:


### PR DESCRIPTION
## Summary

Adds an opt-in "audio sample artifact" collector so reviewers can **listen** to representative TTS/Omni bench outputs straight from a Buildkite build, without re-running the bench. We already upload `*.json` perf results; this PR proposes also uploading a curated handful of audio clips alongside.

Filed as **draft** to socialize the policy before broad rollout — wired through one nightly job (`nightly-tts-performance`) as a demonstrator. Would love a sanity-check from @khluu and @hsliuustc0106 on whether nightly artifact upload of audio is OK from a CI-infra perspective, and from @yenuo26 / @congw729 on whether the test-ready policy below sounds right.

## Why

Catching audio regressions from JSON metrics alone is hard. A WER delta of +2% could mean "model is worse" or "ASR misheard a homophone" — listening resolves it in seconds. Reviewers shouldn't need GPU access to do a listening pass on a TTS PR.

## What this PR does

- `vllm_omni/benchmarks/utils/audio_artifact.py`: `AudioArtifactCollector` buffers every clip the bench decodes, then `flush()` picks K representative ones (first / last / evenly-spaced middle) and writes them as FLAC + `index.json`. Best-effort, never raises into the bench loop, falls back to PCM_16 WAV if libsndfile lacks FLAC, true no-op when disabled.
- `vllm_omni/entrypoints/cli/benchmark/serve.py`: new CLI group `--save-audio-samples N`, `--audio-samples-dir`, `--audio-samples-label`. Standard kebab-case so the bench JSON runner picks them up via the existing key→`--key` conversion.
- `vllm_omni/benchmarks/serve.py`: forwards CLI flags to env vars and calls `flush()` in a `try/finally` so the artifact lands even if the bench errors.
- `vllm_omni/benchmarks/data_modules/seed_tts_eval.py`: one `collector.add()` call right where `wav_16k` is already decoded for ASR.
- `tests/dfx/perf/tests/test_tts.json`: enables the demonstrator on the **qwen3_tts_base** `quality` phase only (`save_audio_samples: 8`).
- `.buildkite/test-nightly.yml`: `nightly-tts-performance` now also uploads `audio_samples/**/*`. Best-effort upload that **never masks the pytest exit code**.
- `docs/ci/audio_artifacts.md`: policy summary, size budget, opt-in syntax, phase-2 plan.

## Steady-state cost

| Configuration | Per bench | × 8 nightly TTS jobs | Annualized |
|---|---|---|---|
| 8 clips × 5 s × FLAC | ~1 MB | ~8 MB/night | **~3 GB/year** |
| 8 clips × 10 s × FLAC | ~2 MB | ~16 MB/night | ~6 GB/year |
| 8 clips × 10 s × Opus 48 kbps | ~0.5 MB | ~4 MB/night | ~1.5 GB/year |

The recommended default (8 FLAC clips) keeps the entire nightly TTS/Omni fleet at **~10-20 MB per run** — well inside Buildkite's artifact tier.

## Proposed policy

| CI tier | Policy | Rationale |
|---|---|---|
| `test-nightly.yml` | **Always-on** for TTS/Omni perf jobs (this PR enables one as the PoC) | Listening post for regressions; everyone hears the same clips across nights |
| `test-ready.yml` | **Opt-in (Phase 2)**: failure-only, or behind a `ci/save-audio` PR label, or auto-on for paths touching `code2wav/`, `vocoder/`, `talker.py` | Avoid wasting per-PR uploads on green runs nobody listens to |
| `test-merge.yml`, `test-weekly.yml` | Inherit nightly policy | Same listening surface; no extra cost |

The Phase-2 test-ready hook is intentionally **not** in this PR — proving the framework on one nightly job first, then expanding once we agree on the policy.

## Opt-in syntax

In the bench JSON:

```jsonc
{
  "task": "voice_clone",
  "dataset_name": "seed-tts",
  "seed_tts_wer_eval": true,
  "save_audio_samples": 8,
  "audio_samples_label": "qwen3_tts_base_voice_clone_quality_en"
}
```

Direct CLI / env var equivalents in `docs/ci/audio_artifacts.md`.

## Caveats

- **Coverage today** is the `seed_tts_eval` path. `ttsd` / `daily-omni` audio mode / `random-mm` still need their own `get_collector().add()` hooks (phase 2). Benches that don't run through WER eval collect nothing, which is the safe default.
- **Reference voice clones.** If a bench uses unreleased reference voices, uploading clones to Buildkite is a leak surface. Per-bench opt-in keeps that decision explicit. Open to feedback on whether we want an extra gate.
- **Buildkite UI does not auto-stream FLAC**; clips are downloaded and played locally. If in-browser playback becomes a requirement, the helper switches to Opus with a one-line format change.

## Verification

- Helper unit-tested locally: 10 buffered → K=3 picks `[0, 4, 9]`; K=0 no-op; K=1 picks first; FLAC + `index.json` written correctly.
- `ruff check` + `ruff format` clean on touched files.
- `test-nightly.yml` parses as valid YAML; `test_tts.json` parses as valid JSON.
- **A real Buildkite run is required to validate the artifact upload glob and that FLAC ships out of the H100 container.** That's why this is filed as a draft.

## Questions for reviewers

1. Is nightly artifact upload of ~10-20 MB/run of audio acceptable from a Buildkite cost / retention perspective, or should we plan to push to S3 from day one?
2. For test-ready: prefer the **failure-only** trigger, the **PR-label** trigger, or the **path-based** trigger? Or all three OR'd together?
3. Is per-bench JSON opt-in the right granularity, or do we want a single nightly-wide env var that flips it on for every TTS/Omni job at once?
4. Any concern about uploading reference voice clones (Seed-TTS is public, but future benches may not be)?