### PR TITLE
[Quant] 2-GPU ModelOpt FP8 DiT serve configs for Flux / Flux2-Klein / Qwen-Image / Z-Image

### DIFF
--- a/vllm_omni/model_executor/stage_configs/flux2_klein_dit_2gpu_fp8.yaml
+++ b/vllm_omni/model_executor/stage_configs/flux2_klein_dit_2gpu_fp8.yaml
@@ -1,0 +1,30 @@
+# Stage config for running FLUX.2-klein DiT with ModelOpt FP8 auto-detect.
+# The following config is for 2 GPUs.
+
+stage_args:
+  - stage_id: 0
+    stage_type: diffusion
+    runtime:
+      devices: "0,1"
+      max_batch_size: 1
+    engine_args:
+      model_stage: dit
+      model_class_name: Flux2KleinPipeline
+      max_num_seqs: 1
+      enforce_eager: true
+      trust_remote_code: true
+      distributed_executor_backend: "mp"
+      parallel_config:
+        tensor_parallel_size: 2
+
+    final_output: true
+    final_output_type: image
+    is_comprehension: false
+    default_sampling_params:
+      seed: 42
+
+runtime:
+  enabled: true
+  defaults:
+    window_size: -1
+    max_inflight: 1

--- a/vllm_omni/model_executor/stage_configs/flux_dit_2gpu_fp8.yaml
+++ b/vllm_omni/model_executor/stage_configs/flux_dit_2gpu_fp8.yaml
@@ -1,0 +1,30 @@
+# Stage config for running FLUX.1 DiT with ModelOpt FP8 auto-detect.
+# The following config is for 2 GPUs.
+
+stage_args:
+  - stage_id: 0
+    stage_type: diffusion
+    runtime:
+      devices: "0,1"
+      max_batch_size: 1
+    engine_args:
+      model_stage: dit
+      model_class_name: FluxPipeline
+      max_num_seqs: 1
+      enforce_eager: true
+      trust_remote_code: true
+      distributed_executor_backend: "mp"
+      parallel_config:
+        tensor_parallel_size: 2
+
+    final_output: true
+    final_output_type: image
+    is_comprehension: false
+    default_sampling_params:
+      seed: 42
+
+runtime:
+  enabled: true
+  defaults:
+    window_size: -1
+    max_inflight: 1

--- a/vllm_omni/model_executor/stage_configs/qwen_image_dit_2gpu_fp8.yaml
+++ b/vllm_omni/model_executor/stage_configs/qwen_image_dit_2gpu_fp8.yaml
@@ -1,0 +1,30 @@
+# Stage config for running Qwen-Image DiT with ModelOpt FP8 auto-detect.
+# The following config is for 2 GPUs.
+
+stage_args:
+  - stage_id: 0
+    stage_type: diffusion
+    runtime:
+      devices: "0,1"
+      max_batch_size: 1
+    engine_args:
+      model_stage: dit
+      model_class_name: QwenImagePipeline
+      max_num_seqs: 1
+      enforce_eager: true
+      trust_remote_code: true
+      distributed_executor_backend: "mp"
+      parallel_config:
+        tensor_parallel_size: 2
+
+    final_output: true
+    final_output_type: image
+    is_comprehension: false
+    default_sampling_params:
+      seed: 42
+
+runtime:
+  enabled: true
+  defaults:
+    window_size: -1
+    max_inflight: 1

--- a/vllm_omni/model_executor/stage_configs/z_image_dit_2gpu_fp8.yaml
+++ b/vllm_omni/model_executor/stage_configs/z_image_dit_2gpu_fp8.yaml
@@ -1,0 +1,30 @@
+# Stage config for running Z-Image DiT with ModelOpt FP8 auto-detect.
+# The following config is for 2 GPUs.
+
+stage_args:
+  - stage_id: 0
+    stage_type: diffusion
+    runtime:
+      devices: "0,1"
+      max_batch_size: 1
+    engine_args:
+      model_stage: dit
+      model_class_name: ZImagePipeline
+      max_num_seqs: 1
+      enforce_eager: true
+      trust_remote_code: true
+      distributed_executor_backend: "mp"
+      parallel_config:
+        tensor_parallel_size: 2
+
+    final_output: true
+    final_output_type: image
+    is_comprehension: false
+    default_sampling_params:
+      seed: 42
+
+runtime:
+  enabled: true
+  defaults:
+    window_size: -1
+    max_inflight: 1


### PR DESCRIPTION
## What

DiT-only **ModelOpt FP8** serve configs (TP=2, 2-GPU) for the image-gen models whose FP8 checkpoint adapter landed in #2913:

- `flux_dit_2gpu_fp8.yaml` (`FluxPipeline`)
- `flux2_klein_dit_2gpu_fp8.yaml` (`Flux2KleinPipeline`)
- `qwen_image_dit_2gpu_fp8.yaml` (`QwenImagePipeline`)
- `z_image_dit_2gpu_fp8.yaml` (`ZImagePipeline`)

Split out of the video-gen calibration PR (#3305) since these are image-gen scope. Each `model_class_name` is verified against main's diffusion registry. Configs only — no code changes.
