### PR TITLE
[Model] Support languages added by fine-tuned Qwen3-TTS checkpoints

### DIFF
--- a/docs/serving/speech_api.md
+++ b/docs/serving/speech_api.md
@@ -116,7 +116,7 @@ Content-Type: application/json
 | `initial_codec_chunk_frames` | integer | null | Per-request initial chunk size override for TTFA tuning. When null, IC is computed dynamically based on server load. |
 | `stream` | bool | false | Stream raw PCM chunks as they are decoded (requires `response_format="pcm"`) |
 
-**Supported languages:** Auto, Chinese, English, Japanese, Korean, German, French, Russian, Portuguese, Spanish, Italian
+**Supported languages:** Only applicable to Qwen3-TTS. Derived from the model configuration (`talker_config.codec_language_id` in the checkpoint's `config.json`), plus `Auto`, which is always accepted. Official Qwen3-TTS checkpoints support: Auto, Chinese, English, Japanese, Korean, German, French, Russian, Portuguese, Spanish, Italian.
 
 #### Voice Clone Parameters (Base task)
 

--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -33,6 +33,7 @@ from vllm_omni.entrypoints.openai.protocol.audio import (
     SpeechBatchItem,
 )
 from vllm_omni.entrypoints.openai.serving_speech import (
+    _TTS_LANGUAGES,
     OmniOpenAIServingSpeech,
     _create_wav_header,
 )
@@ -1256,6 +1257,67 @@ class TestTTSMethods:
 
         # Verify speakers are normalized to lowercase
         assert server.supported_speakers == {"ryan", "vivian", "aiden"}
+
+    def test_load_supported_languages_from_config(self, speech_server):
+        """Languages/dialects from codec_language_id are loaded title-cased; 'Auto' is added."""
+        speech_server._tts_model_type = "qwen3_tts"
+        speech_server.engine_client.model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(
+                talker_config=SimpleNamespace(
+                    codec_language_id={"chinese": 2055, "english": 2050, "beijing_dialect": 2074}
+                )
+            )
+        )
+        assert speech_server._load_supported_languages() == {
+            "Chinese",
+            "English",
+            "Beijing_Dialect",
+            "Auto",
+        }
+
+    def test_load_supported_languages_from_dict_config(self, speech_server):
+        """talker_config provided as a plain dict is handled the same as an object."""
+        speech_server._tts_model_type = "qwen3_tts"
+        speech_server.engine_client.model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(talker_config={"codec_language_id": {"chinese": 2055, "english": 2050}})
+        )
+        assert speech_server._load_supported_languages() == {"Chinese", "English", "Auto"}
+
+    def test_validate_language_custom_dialect_accepted(self, speech_server):
+        """A language present in the model config passes validation, case-insensitively."""
+        speech_server.supported_languages = {"Chinese", "English", "Beijing_Dialect", "Auto"}
+        for language in ("Beijing_Dialect", "beijing_dialect", "English", "english", "Auto", "AUTO"):
+            req = OpenAICreateSpeechRequest(input="Hello", language=language)
+            result = speech_server._validate_tts_request(req)
+            assert result is None or "Invalid language" not in result
+            # Language is normalized to the title-cased config form.
+            assert req.language == language.title()
+
+    def test_validate_language_unknown_rejected(self, speech_server):
+        """A language not in the configured set is rejected."""
+        speech_server.supported_languages = {"Chinese", "English", "Auto"}
+        for language in ("Klingon", "klingon"):
+            req = OpenAICreateSpeechRequest(input="Hello", language=language)
+            assert "Invalid language" in speech_server._validate_tts_request(req)
+
+    def test_load_supported_languages_default_when_no_config(self, speech_server):
+        """Empty/missing codec_language_id on a Qwen3-TTS model falls back to the default list."""
+        speech_server._tts_model_type = "qwen3_tts"
+        speech_server.engine_client.model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(talker_config=SimpleNamespace(codec_language_id={}))
+        )
+        assert speech_server._load_supported_languages() == _TTS_LANGUAGES
+
+    def test_load_supported_languages_default_on_config_error(self, speech_server):
+        """If the model config cannot be read, fall back to the default list."""
+        speech_server._tts_model_type = "qwen3_tts"
+        speech_server.engine_client = SimpleNamespace()  # no model_config -> AttributeError
+        assert speech_server._load_supported_languages() == _TTS_LANGUAGES
+
+    def test_load_supported_languages_empty_for_non_qwen(self, speech_server):
+        """Non-qwen3_tts model types get an empty language set."""
+        speech_server._tts_model_type = None
+        assert speech_server._load_supported_languages() == set()
 
     def test_build_tts_params_with_uploaded_voice(self, speech_server, mocker: MockerFixture):
         """Test _build_tts_params auto-sets ref_audio for uploaded voices (x_vector only)."""

--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -1314,10 +1314,10 @@ class TestTTSMethods:
         speech_server.engine_client = SimpleNamespace()  # no model_config -> AttributeError
         assert speech_server._load_supported_languages() == _TTS_LANGUAGES
 
-    def test_load_supported_languages_empty_for_non_qwen(self, speech_server):
-        """Non-qwen3_tts model types get an empty language set."""
+    def test_load_supported_languages_default_for_non_qwen(self, speech_server):
+        """Non-qwen3_tts model types get the default language set."""
         speech_server._tts_model_type = None
-        assert speech_server._load_supported_languages() == set()
+        assert speech_server._load_supported_languages() == _TTS_LANGUAGES
 
     def test_build_tts_params_with_uploaded_voice(self, speech_server, mocker: MockerFixture):
         """Test _build_tts_params auto-sets ref_audio for uploaded voices (x_vector only)."""

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -700,7 +700,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
     def _load_supported_languages(self) -> set[str]:
         """Load supported languages (title-cased) from the model configuration"""
         if self._tts_model_type != "qwen3_tts":
-            return set()
+            return _TTS_LANGUAGES
         try:
             config = self.engine_client.model_config.hf_config.talker_config
 
@@ -1447,7 +1447,9 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         if request.language is not None:
             request.language = request.language.title()
             if request.language not in self.supported_languages:
-                return f"Invalid language '{request.language}'. Supported: {', '.join(sorted(self.supported_languages))}"
+                return (
+                    f"Invalid language '{request.language}'. Supported: {', '.join(sorted(self.supported_languages))}"
+                )
 
         # Validate speaker for CustomVoice task
         if task_type == "CustomVoice":

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -9,6 +9,7 @@ import re
 import struct
 import time
 from collections import OrderedDict
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from http import HTTPStatus
 from pathlib import Path
@@ -102,19 +103,21 @@ _SAMPLING_MAX_TOKENS_TTS_MODEL_TYPES = {
     "higgs_audio_v2",
     "higgs_audio_v3",
 }
-_TTS_LANGUAGES: set[str] = {
-    "Auto",
-    "Chinese",
-    "English",
-    "Japanese",
-    "Korean",
-    "German",
-    "French",
-    "Russian",
-    "Portuguese",
-    "Spanish",
-    "Italian",
-}
+_TTS_LANGUAGES: frozenset[str] = frozenset(
+    {
+        "Auto",
+        "Chinese",
+        "English",
+        "Japanese",
+        "Korean",
+        "German",
+        "French",
+        "Russian",
+        "Portuguese",
+        "Spanish",
+        "Italian",
+    }
+)
 _REF_AUDIO_MIN_DURATION = 1.0  # seconds
 _REF_AUDIO_MAX_DURATION = 30.0  # seconds
 _REF_AUDIO_RESOLVE_CACHE_MAX_ENTRIES = 256
@@ -435,7 +438,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         self.supported_speakers |= self._load_supported_speakers()
         self.supported_speakers |= set(self.precomputed_speakers)
 
-        self.supported_languages: set[str] = self._load_supported_languages()
+        self.supported_languages: frozenset[str] = self._load_supported_languages()
 
         self._tts_tokenizer = None
         self._voxcpm2_tokenizer = None
@@ -697,7 +700,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
 
         return set()
 
-    def _load_supported_languages(self) -> set[str]:
+    def _load_supported_languages(self) -> frozenset[str]:
         """Load supported languages (title-cased) from the model configuration"""
         if self._tts_model_type != "qwen3_tts":
             return _TTS_LANGUAGES
@@ -709,8 +712,8 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             else:
                 codec_language_id = getattr(config, "codec_language_id", None)
 
-            if codec_language_id and isinstance(codec_language_id, dict):
-                return {str(language).title() for language in codec_language_id} | {"Auto"}
+            if codec_language_id and isinstance(codec_language_id, Mapping):
+                return frozenset(str(language).title() for language in codec_language_id) | {"Auto"}
 
             logger.warning("No codec_language_id found in talker_config; falling back to default languages")
         except Exception as e:

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -434,6 +434,9 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         # Merge built-in speakers into the set initialized by _init_speaker_storage.
         self.supported_speakers |= self._load_supported_speakers()
         self.supported_speakers |= set(self.precomputed_speakers)
+
+        self.supported_languages: set[str] = self._load_supported_languages()
+
         self._tts_tokenizer = None
         self._voxcpm2_tokenizer = None
         self._voxcpm2_split_map: dict[int, list[int]] = {}
@@ -693,6 +696,26 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             logger.warning("Could not load speakers from model config: %s", e)
 
         return set()
+
+    def _load_supported_languages(self) -> set[str]:
+        """Load supported languages (title-cased) from the model configuration"""
+        if self._tts_model_type != "qwen3_tts":
+            return set()
+        try:
+            config = self.engine_client.model_config.hf_config.talker_config
+
+            if isinstance(config, dict):
+                codec_language_id = config.get("codec_language_id")
+            else:
+                codec_language_id = getattr(config, "codec_language_id", None)
+
+            if codec_language_id and isinstance(codec_language_id, dict):
+                return {str(language).title() for language in codec_language_id} | {"Auto"}
+
+            logger.warning("No codec_language_id found in talker_config; falling back to default languages")
+        except Exception as e:
+            logger.warning("Could not load languages from model config: %s", e)
+        return _TTS_LANGUAGES
 
     def _estimate_ref_code_len(self, ref_audio: object) -> int | None:
         """Estimate ref_code length from ref_audio waveform without running the codec.
@@ -1420,9 +1443,11 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         if not request.input or not request.input.strip():
             return "Input text cannot be empty"
 
-        # Validate language
-        if request.language is not None and request.language not in _TTS_LANGUAGES:
-            return f"Invalid language '{request.language}'. Supported: {', '.join(sorted(_TTS_LANGUAGES))}"
+        # Validate language (case-insensitive; normalized to the title-cased config form)
+        if request.language is not None:
+            request.language = request.language.title()
+            if request.language not in self.supported_languages:
+                return f"Invalid language '{request.language}'. Supported: {', '.join(sorted(self.supported_languages))}"
 
         # Validate speaker for CustomVoice task
         if task_type == "CustomVoice":

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -103,7 +103,7 @@ _SAMPLING_MAX_TOKENS_TTS_MODEL_TYPES = {
     "higgs_audio_v2",
     "higgs_audio_v3",
 }
-_TTS_LANGUAGES: frozenset[str] = frozenset(
+_TTS_LANGUAGES = frozenset(
     {
         "Auto",
         "Chinese",
@@ -438,7 +438,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         self.supported_speakers |= self._load_supported_speakers()
         self.supported_speakers |= set(self.precomputed_speakers)
 
-        self.supported_languages: frozenset[str] = self._load_supported_languages()
+        self.supported_languages = self._load_supported_languages()
 
         self._tts_tokenizer = None
         self._voxcpm2_tokenizer = None


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Closes #4170 

Language validation for Qwen3-TTS was a hardcoded list (`_TTS_LANGUAGES`) of the 10
official languages + `Auto`. Fine-tuned checkpoints that add languages or dialects
to `talker_config.codec_language_id` (e.g. `beijing_dialect`) were rejected at the API
layer with `Invalid language`, even though the model supports them.

This PR derives the supported set from the checkpoint instead:

- At server init, `_load_supported_languages()` reads
`talker_config.codec_language_id`
  from the model config (handles both object and plain-dict `talker_config`),
  title-cases the keys, and always adds `Auto`.
- Request validation is now case-insensitive: the request's `language` is
normalized to
  the title-cased config form (`english` / `ENGLISH` / `English` are equivalent)
before
  matching, so the normalized value is what flows downstream.
- Fallbacks: if `codec_language_id` is missing/empty or the model config can't be
read,
  validation falls back to the previous hardcoded default list (with a warning).
  Non-`qwen3_tts` model types also keep the default list, preserving existing
behavior
  for models that share the fallback validator.

Docs (`docs/serving/speech_api.md`) updated to describe the config-driven behavior.

## Test Plan

Unit tests added in `tests/entrypoints/openai_api/test_serving_speech.py`
(`TestTTSMethods`) covering:

- Loading languages from `codec_language_id` (object and plain-dict `talker_config`),
  including a custom dialect, title-casing, and the implicit `Auto`
- Case-insensitive validation + normalization of `request.language`
- Rejection of languages not in the configured set
- Fallback to the default list: empty `codec_language_id`, unreadable model
  config, and non-`qwen3_tts` model types


## Test Result

pytest tests/entrypoints/openai_api/test_serving_speech.py

```
151 passed, 0 failed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
