### PR TITLE
[Quantization] Re-land SenseNova-U1 gen-only FP8 Quantization

### DIFF
--- a/docs/user_guide/quantization/fp8.md
+++ b/docs/user_guide/quantization/fp8.md
@@ -52,6 +52,17 @@ guide. FP8 on Ampere may use a weight-only path where available.
 Audio encoder, vision encoder, talker, and code2wav stay in BF16 unless a
 model-specific guide says otherwise.
 
+### MoT Diffusion Model (SenseNova-U1)
+
+| Model | HF models | Scope | Status | Notes |
+|-------|-----------|-------|--------|-------|
+| SenseNova-U1 | `SenseNova/SenseNova-U1-8B-MoT` | Gen-path only (`*_mot_gen` layers) | Validated | Understanding-path layers stay in BF16; no `ignored_layers` needed |
+
+SenseNova-U1 uses Mixture-of-Tokenizers (MoT) with duplicate weights per
+layer: understanding path (`qkv_proj`, `mlp`) and generation path
+(`qkv_proj_mot_gen`, `mlp_mot_gen`).  When `quantization="fp8"` is set,
+the pipeline automatically applies FP8 only to gen-path GEMMs.
+
 ### Multi-Stage Diffusion Model (BAGEL, GLM-Image)
 
 | Model | Scope | Status | Notes |

--- a/tests/diffusion/quantization/test_quantization_fp8.py
+++ b/tests/diffusion/quantization/test_quantization_fp8.py
@@ -6,11 +6,13 @@ End-to-end tests for the unified quantization framework (PR #1764).
 Validates FP8 quantization works correctly for all supported model types:
   - Single-stage diffusion models (FLUX.1-dev, Qwen-Image, Z-Image-Turbo)
   - Multi-stage models (BAGEL: LLM + Diffusion)
+  - MoT gen-only models (SenseNova-U1: gen-path FP8, und-path BF16)
 
 Tests verify:
   1. FP8 quantization produces valid images
   2. Memory usage is lower than BF16 baseline
   3. Multi-stage models only quantize the diffusion stage (not the LLM stage)
+  4. MoT models only quantize gen-path layers (mot_gen)
 
 Usage:
     # Run all FP8 quantization tests
@@ -436,3 +438,97 @@ def test_single_stage_quantization_config_key():
         quantization_config="fp8",
     )
     assert len(images) >= 1
+
+
+# ─── SenseNova-U1 gen-only FP8 tests ─────────────────────────────────────────
+
+_SENSENOVA_MODEL = "SenseNova/SenseNova-U1-8B-MoT"
+
+
+def _generate_sensenova_u1_image(
+    quantization: str | None = None,
+    num_inference_steps: int = 20,
+) -> tuple[Any, float]:
+    """Generate an image with SenseNova-U1 (single-stage MoT, gen-only FP8).
+
+    Returns (generated_image, peak_memory_gib).
+    """
+    omni_kwargs: dict[str, Any] = {}
+    if quantization:
+        omni_kwargs["quantization"] = quantization
+
+    with OmniRunner(_SENSENOVA_MODEL, **omni_kwargs) as runner:
+        torch.accelerator.reset_peak_memory_stats()
+
+        sampling_params = OmniDiffusionSamplingParams(
+            height=1024,
+            width=1024,
+            seed=42,
+            num_inference_steps=num_inference_steps,
+            extra_args={
+                "cfg_scale": 4.0,
+                "cfg_norm": "none",
+                "timestep_shift": 3.0,
+            },
+        )
+        omni_outputs = list(
+            runner.omni.generate(
+                prompts={"prompt": "A cat sitting on a windowsill", "modalities": ["image"]},
+                sampling_params_list=sampling_params,
+            )
+        )
+
+        generated_image = None
+        for req_output in omni_outputs:
+            if images := getattr(req_output, "images", None):
+                generated_image = images[0]
+                break
+
+        assert generated_image is not None, "No images generated from SenseNova-U1"
+        assert generated_image.size == (1024, 1024), f"Expected 1024x1024, got {generated_image.size}"
+
+        first_output = omni_outputs[0] if omni_outputs else None
+        peak_mem_mb = getattr(first_output, "peak_memory_mb", None) if first_output else None
+        if peak_mem_mb:
+            peak_mem = float(peak_mem_mb) / 1024.0
+        else:
+            peak_mem = torch.accelerator.max_memory_allocated() / (1024**3)
+
+        return generated_image, peak_mem
+
+
+@hardware_test(res={"cuda": "H100"})
+def test_sensenova_u1_fp8_generates_image():
+    """SenseNova-U1 with gen-only FP8 generates a valid image.
+
+    FP8 is applied only to gen-path (mot_gen) layers; understanding-path
+    layers stay in BF16.
+    """
+    image, _ = _generate_sensenova_u1_image(quantization="fp8")
+    image.save("test_sensenova_u1_fp8.png")
+
+
+@hardware_test(res={"cuda": "H100"})
+def test_sensenova_u1_bf16_generates_image():
+    """SenseNova-U1 without quantization generates a valid image (baseline)."""
+    image, _ = _generate_sensenova_u1_image(quantization=None)
+    image.save("test_sensenova_u1_bf16.png")
+
+
+@hardware_test(res={"cuda": "H100"})
+def test_sensenova_u1_fp8_uses_less_memory():
+    """Gen-only FP8 should use less peak memory than BF16 for SenseNova-U1."""
+    _, mem_bf16 = _generate_sensenova_u1_image(
+        quantization=None,
+        num_inference_steps=10,
+    )
+    torch.accelerator.empty_cache()
+
+    _, mem_fp8 = _generate_sensenova_u1_image(
+        quantization="fp8",
+        num_inference_steps=10,
+    )
+
+    print(f"SenseNova-U1 BF16 peak memory: {mem_bf16:.2f} GiB")
+    print(f"SenseNova-U1 FP8  peak memory: {mem_fp8:.2f} GiB")
+    assert mem_fp8 < mem_bf16, f"FP8 ({mem_fp8:.2f} GiB) should use less memory than BF16 ({mem_bf16:.2f} GiB)"

--- a/tests/diffusion/quantization/test_sensenova_u1_fp8.py
+++ b/tests/diffusion/quantization/test_sensenova_u1_fp8.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for SenseNova-U1 gen-only FP8 quantization.
+
+Validates that the ``_GenOnlyQuantConfig`` wrapper correctly routes FP8
+quantization to only the gen-path (``*_mot_gen``) layers while leaving
+understanding-path layers in BF16.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from vllm.distributed import parallel_state
+from vllm.model_executor.layers.linear import LinearBase
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+@pytest.fixture(autouse=True)
+def _fake_tp_group():
+    """Provide a fake TP group so vLLM parallel layers can be instantiated.
+
+    Note: a shared ``init_fake_tp_group`` fixture exists in
+    ``tests/helpers/fixtures/env.py`` but requires pytest-mock.
+    """
+    mock_tp = MagicMock()
+    mock_tp.world_size = 1
+    mock_tp.rank_in_group = 0
+    old = parallel_state._TP
+    parallel_state._TP = mock_tp
+    yield
+    parallel_state._TP = old
+
+
+def _make_minimal_llm_config(num_layers: int = 2) -> SimpleNamespace:
+    """Create a minimal SenseNova-U1 LLM config for unit testing."""
+    return SimpleNamespace(
+        hidden_size=256,
+        intermediate_size=512,
+        num_hidden_layers=num_layers,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=64,
+        hidden_act="silu",
+        rms_norm_eps=1e-6,
+        vocab_size=1024,
+        rope_theta=1000000.0,
+        rope_theta_hw=10000.0,
+        max_position_embeddings=4096,
+        max_position_embeddings_hw=1024,
+        attention_bias=True,
+        layer_types=["full_attention"] * num_layers,
+        tie_word_embeddings=False,
+    )
+
+
+def _build_model_with_gen_only_quant(quant_method: str | None = "fp8"):
+    """Construct SenseNovaU1ForCausalLM with gen-only FP8 wrapping."""
+    from unittest.mock import MagicMock, patch
+
+    from vllm_omni.diffusion.models.sensenova_u1.pipeline_sensenova_u1 import (
+        _GenOnlyQuantConfig,
+    )
+    from vllm_omni.diffusion.models.sensenova_u1.sensenova_u1_transformer import (
+        SenseNovaU1ForCausalLM,
+    )
+    from vllm_omni.quantization import build_quant_config
+
+    inner_config = build_quant_config(quant_method)
+    if inner_config is not None:
+        quant_config = _GenOnlyQuantConfig(inner_config)
+    else:
+        quant_config = None
+
+    llm_cfg = _make_minimal_llm_config(num_layers=2)
+
+    mock_vllm_config = MagicMock()
+    mock_vllm_config.model_config.dtype = torch.bfloat16
+    mock_vllm_config.model_config.quantization = quant_method
+
+    with (
+        torch.device("meta"),
+        patch("vllm.model_executor.layers.quantization.fp8.get_current_vllm_config", return_value=mock_vllm_config),
+    ):
+        model = SenseNovaU1ForCausalLM(
+            llm_cfg,
+            quant_config=quant_config,
+            prefix="language_model",
+        )
+    return model
+
+
+def test_mot_gen_layers_have_fp8_quant_method():
+    """Gen-path (mot_gen) Linear layers should have a real FP8 quant_method."""
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    model = _build_model_with_gen_only_quant("fp8")
+
+    mot_gen_linears = [
+        (name, mod) for name, mod in model.named_modules() if isinstance(mod, LinearBase) and "mot_gen" in name
+    ]
+
+    assert len(mot_gen_linears) > 0, "No mot_gen LinearBase modules found"
+
+    for name, mod in mot_gen_linears:
+        assert mod.quant_method is not None, f"mot_gen layer {name!r} should have quant_method with FP8"
+        assert not isinstance(mod.quant_method, UnquantizedLinearMethod), (
+            f"mot_gen layer {name!r} should NOT use UnquantizedLinearMethod"
+        )
+
+
+def test_und_layers_have_no_quant_method():
+    """Understanding-path Linear layers should use UnquantizedLinearMethod (stay BF16)."""
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    model = _build_model_with_gen_only_quant("fp8")
+
+    und_linears = [
+        (name, mod) for name, mod in model.named_modules() if isinstance(mod, LinearBase) and "mot_gen" not in name
+    ]
+
+    assert len(und_linears) > 0, "No und LinearBase modules found"
+
+    for name, mod in und_linears:
+        assert isinstance(mod.quant_method, UnquantizedLinearMethod), (
+            f"und layer {name!r} should use UnquantizedLinearMethod, got {type(mod.quant_method).__name__}"
+        )
+
+
+def test_no_quant_method_without_quantization():
+    """Without quantization, all layers should use UnquantizedLinearMethod."""
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    model = _build_model_with_gen_only_quant(None)
+
+    for name, mod in model.named_modules():
+        if isinstance(mod, LinearBase):
+            assert isinstance(mod.quant_method, UnquantizedLinearMethod), (
+                f"LinearBase module {name!r} has quant_method="
+                f"{type(mod.quant_method).__name__} "
+                "but no quantization was configured"
+            )
+
+
+def test_und_and_gen_layers_both_present():
+    """Sanity check: the model has both und and gen layers."""
+    model = _build_model_with_gen_only_quant(None)
+
+    layer_names = [name for name, _ in model.named_modules()]
+
+    und_qkv = [n for n in layer_names if "qkv_proj" in n and "mot_gen" not in n]
+    gen_qkv = [n for n in layer_names if "qkv_proj_mot_gen" in n]
+    und_mlp = [n for n in layer_names if ".mlp." in n and "mot_gen" not in n]
+    gen_mlp = [n for n in layer_names if "mlp_mot_gen" in n]
+
+    assert len(und_qkv) > 0, "No und qkv_proj layers found"
+    assert len(gen_qkv) > 0, "No gen qkv_proj_mot_gen layers found"
+    assert len(und_mlp) > 0, "No und mlp layers found"
+    assert len(gen_mlp) > 0, "No gen mlp_mot_gen layers found"
+
+
+def test_gen_only_wrapper_delegates_attributes():
+    """_GenOnlyQuantConfig should delegate attribute access to the inner config."""
+    from vllm_omni.diffusion.models.sensenova_u1.pipeline_sensenova_u1 import (
+        _GenOnlyQuantConfig,
+    )
+    from vllm_omni.quantization import build_quant_config
+
+    inner = build_quant_config("fp8")
+    wrapper = _GenOnlyQuantConfig(inner)
+
+    assert wrapper.get_name() == "fp8"
+    assert wrapper.activation_scheme == inner.activation_scheme

--- a/tests/diffusion/quantization/test_sensenova_u1_fp8.py
+++ b/tests/diffusion/quantization/test_sensenova_u1_fp8.py
@@ -162,7 +162,13 @@ def test_und_and_gen_layers_both_present():
 
 
 def test_gen_only_wrapper_delegates_attributes():
-    """_GenOnlyQuantConfig should delegate attribute access to the inner config."""
+    """The wrapper reports a non-uniform name but delegates other attrs.
+
+    - ``get_name()`` -> ``"fp8_gen_only"``: custom, so introspection reflects
+      that FP8 is applied only to the gen path (not a uniform ``"fp8"`` config).
+    - ``activation_scheme``: not customized, so it falls through to the inner
+      FP8 config via ``__getattr__`` unchanged.
+    """
     from vllm_omni.diffusion.models.sensenova_u1.pipeline_sensenova_u1 import (
         _GenOnlyQuantConfig,
     )
@@ -171,5 +177,6 @@ def test_gen_only_wrapper_delegates_attributes():
     inner = build_quant_config("fp8")
     wrapper = _GenOnlyQuantConfig(inner)
 
-    assert wrapper.get_name() == "fp8"
+    assert inner.get_name() == "fp8"
+    assert wrapper.get_name() == "fp8_gen_only"
     assert wrapper.activation_scheme == inner.activation_scheme

--- a/vllm_omni/diffusion/models/sensenova_u1/pipeline_sensenova_u1.py
+++ b/vllm_omni/diffusion/models/sensenova_u1/pipeline_sensenova_u1.py
@@ -31,6 +31,7 @@ import torchvision.transforms as T
 from PIL import Image
 from transformers import AutoTokenizer
 from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization import QuantizationConfig
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
@@ -484,6 +485,39 @@ def _optimized_scale(positive_flat, negative_flat):
 
 
 # ---------------------------------------------------------------------------
+# Gen-only FP8 wrapper
+# ---------------------------------------------------------------------------
+
+
+class _GenOnlyQuantConfig:
+    """Wraps an inner QuantizationConfig so only ``*_mot_gen`` layers are quantized.
+
+    SenseNova-U1 uses Mixture-of-Tokenizers with duplicate weights per layer:
+    understanding path (``qkv_proj``, ``mlp``) and generation path
+    (``qkv_proj_mot_gen``, ``mlp_mot_gen``).  The RFC requires FP8 only on the
+    gen-path GEMMs during denoising; und-path layers stay in BF16.
+
+    This is *not* a full ``QuantizationConfig`` subclass — it only needs to
+    satisfy the duck-typed interface that ``LinearBase.__init__`` uses:
+    ``get_quant_method(layer, prefix)``.  The outer registry and weight-loader
+    still operate on the original config stored in ``od_config.quantization_config``.
+    """
+
+    def __init__(self, inner: QuantizationConfig):
+        self._inner = inner
+
+    def get_quant_method(self, layer, prefix: str = ""):
+        from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+        if "mot_gen" in prefix:
+            return self._inner.get_quant_method(layer, prefix)
+        return UnquantizedLinearMethod()
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+# ---------------------------------------------------------------------------
 # Pipeline
 # ---------------------------------------------------------------------------
 
@@ -549,9 +583,15 @@ class SenseNovaU1Pipeline(nn.Module, SupportsComponentDiscovery, DiffusionPipeli
         self.img_context_token_id = self.tokenizer.convert_tokens_to_ids(IMG_CONTEXT_TOKEN)
         self.img_start_token_id = self.tokenizer.convert_tokens_to_ids(IMG_START_TOKEN)
 
-        # Language model (TP-aware)
+        # Language model (TP-aware).
+        # Wrap quant_config so only gen-path (mot_gen) layers are quantized;
+        # understanding-path layers stay in BF16.
+        quant_config = od_config.quantization_config
+        if quant_config is not None:
+            quant_config = _GenOnlyQuantConfig(quant_config)
         self.language_model = SenseNovaU1ForCausalLM(
             self.llm_cfg,
+            quant_config=quant_config,
             prefix="language_model",
         )
 

--- a/vllm_omni/diffusion/models/sensenova_u1/pipeline_sensenova_u1.py
+++ b/vllm_omni/diffusion/models/sensenova_u1/pipeline_sensenova_u1.py
@@ -497,14 +497,27 @@ class _GenOnlyQuantConfig:
     (``qkv_proj_mot_gen``, ``mlp_mot_gen``).  The RFC requires FP8 only on the
     gen-path GEMMs during denoising; und-path layers stay in BF16.
 
-    This is *not* a full ``QuantizationConfig`` subclass — it only needs to
-    satisfy the duck-typed interface that ``LinearBase.__init__`` uses:
-    ``get_quant_method(layer, prefix)``.  The outer registry and weight-loader
-    still operate on the original config stored in ``od_config.quantization_config``.
+    Duck-typed adapter (not a ``QuantizationConfig`` subclass): ``get_name`` and
+    ``get_quant_method`` are custom; everything else delegates to the inner config
+    via ``__getattr__``. It is attached only to this model's ``language_model``
+    and is consumed solely through ``get_quant_method`` by ``LinearBase``; the
+    global weight-loader/registry use the original config in
+    ``od_config.quantization_config``, not this wrapper.
+
+    The quantization is intentionally non-uniform: ``get_quant_method`` is
+    prefix-dependent (inner FP8 only for ``mot_gen`` layers, BF16 elsewhere).
+    ``get_name`` therefore reports ``"fp8_gen_only"`` instead of delegating to the
+    inner ``"fp8"``, so introspection/logging reflect that this is not a uniform
+    FP8 config. This name is a local descriptor only — it is not registered in
+    ``QuantizationMethods``, so do not feed it back into any name-based registry
+    lookup.
     """
 
     def __init__(self, inner: QuantizationConfig):
         self._inner = inner
+
+    def get_name(self) -> str:
+        return "fp8_gen_only"
 
     def get_quant_method(self, layer, prefix: str = ""):
         from vllm.model_executor.layers.linear import UnquantizedLinearMethod


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Re-lands #3943 (reverted in #4196) together with the fix for the CI failure that caused the revert.

## Test Plan
```bash
pytest -sv tests/diffusion/quantization/test_quantization_fp8.py \
  -k "test_sensenova_u1" --run-level full_model
```

## Test Result
```text
INFO 06-06 12:20:15 [diffusers_loader.py:426] Loading weights took 5.45 seconds
INFO 06-06 12:20:16 [diffusion_model_runner.py:149] Model loading took 25.2272 GiB and 8.129822 seconds
INFO 06-06 12:20:16 [diffusion_model_runner.py:154] Model runner: Model loaded successfully.
INFO 06-06 12:20:16 [diffusion_model_runner.py:210] Model runner: Initialization complete.
INFO 06-06 12:20:16 [diffusion_worker.py:307] Worker 0: Process-scoped GPU memory after model loading: 26.30 GiB.
INFO 06-06 12:20:16 [manager.py:96] Initializing DiffusionLoRAManager: device=cuda:0, dtype=torch.bfloat16, max_cached_adapters=1, static_lora_path=None
INFO 06-06 12:20:16 [diffusion_worker.py:208] Worker 0: Initialization complete.
INFO 06-06 12:20:16 [diffusion_worker.py:875] Worker 0: Scheduler loop started.
INFO 06-06 12:20:16 [diffusion_worker.py:767] Worker 0 ready to receive requests via shared memory
INFO 06-06 12:20:16 [diffusion_engine.py:748] dummy run to warm up the model
INFO 06-06 12:20:16 [pipeline_sensenova_u1.py:1320] img2img: 1 input image(s), grid_hw=[[32, 32]]
INFO 06-06 12:20:18 [inline_stage_diffusion_client.py:73] [InlineStageDiffusionClient] stage-0 [rep-0] initialized inline (batch_size=1)
INFO 06-06 12:20:18 [async_omni_engine.py:1098] [AsyncOmniEngine] Stage 0 replica 0 initialized (diffusion, batch_size=1, devices=0)
INFO 06-06 12:20:18 [orchestrator.py:304] [Orchestrator] Starting event loop
INFO 06-06 12:20:18 [async_omni_engine.py:391] [AsyncOmniEngine] Orchestrator ready with 1 stages
INFO 06-06 12:20:18 [omni_base.py:184] [Omni] AsyncOmniEngine initialized in 23.46 seconds
INFO 06-06 12:20:18 [omni_base.py:204] [Omni] Initialized with 1 stages for model SenseNova/SenseNova-U1-8B-MoT

Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s]
Processed prompts: 100%|██████████| 1/1 [00:01<00:00,  1.77s/it]
Processed prompts: 100%|██████████| 1/1 [00:01<00:00,  1.77s/it]
INFO 06-06 12:20:19 [omni_base.py:584] [Omni] Shutting down
INFO 06-06 12:20:19 [async_omni_engine.py:2446] [AsyncOmniEngine] Shutting down Orchestrator
INFO 06-06 12:20:19 [orchestrator.py:435] [Orchestrator] Received shutdown signal
INFO 06-06 12:20:19 [orchestrator.py:1626] [Orchestrator] Shutting down all 1 client(s)
INFO 06-06 12:20:19 [diffusion_worker.py:807] Worker 0: Received shutdown message
INFO 06-06 12:20:19 [diffusion_worker.py:828] event loop terminated.
INFO 06-06 12:20:20 [diffusion_worker.py:898] Worker 0: Shutdown complete.
INFO 06-06 12:20:22 [stage_pool.py:1167] [StagePool] Stage 0 replica 0 shut down
Pre-test GPU status:
[GPU Memory Monitor] Waiting for GPU 0 to free memory, Condition: Memory usage ratio ≤ 5.0%
[GPU Memory Status] Current usage:
  GPU 0: 0.5GiB/79.6GiB (0.6%)
[GPU Memory Freed] Devices 0 meet memory condition
   Condition: Memory usage ratio ≤ 5.0%
   Wait time: 0.0 seconds (0.0 minutes)
Post-test GPU status:

================================================================================
NVIDIA GPU Information (nvidia-smi)
================================================================================
Sat Jun  6 12:20:22 2026       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                  Off |
| N/A   33C    P0            122W /  700W |       4MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+

================================================================================
Detailed GPU Processes (nvidia-smi pmon)
================================================================================
# gpu         pid   type     sm    mem    enc    dec    jpg    ofa    command 
# Idx           #    C/G      %      %      %      %      %      %    name 
    0          -     -      -      -      -      -      -      -    -

================================================================================
System Processes with GPU keywords
================================================================================
SenseNova-U1 BF16 peak memory: 33.60 GiB
SenseNova-U1 FP8  peak memory: 26.06 GiB
PASSED

=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /root/vllm-omni/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

vllm_omni/version.py:55
  /root/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
   --> vLLM-Omni version 0.1.dev1870+g963ba1ab7
   --> vLLM version 0.22.0
  This will likely cause compatibility issues.
    warn_if_misaligned_vllm_version()

tests/diffusion/quantization/test_quantization_fp8.py::test_sensenova_u1_fp8_generates_image
  /root/vllm-omni/.venv/lib/python3.12/site-packages/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py:2060: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    a_major_mode: tcgen05.OperandMajorMode,

tests/diffusion/quantization/test_quantization_fp8.py::test_sensenova_u1_fp8_generates_image
  /root/vllm-omni/.venv/lib/python3.12/site-packages/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py:2062: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    b_major_mode: tcgen05.OperandMajorMode,

tests/diffusion/quantization/test_quantization_fp8.py::test_sensenova_u1_fp8_generates_image
tests/diffusion/quantization/test_quantization_fp8.py::test_sensenova_u1_fp8_generates_image
  /root/vllm-omni/.venv/lib/python3.12/site-packages/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py:99: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
========== 3 passed, 11 deselected, 21 warnings in 117.08s (0:01:57) ===========
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
