### PR TITLE
[CI/Build] Move check-pickle-imports before suggestion hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,13 @@ repos:
       verbose: true
       stages: [commit-msg]
 
+    - id: check-pickle-imports
+      name: Prevent new pickle/cloudpickle imports
+      entry: python tools/pre_commit/check_pickle_imports.py
+      language: python
+      types: [python]
+      additional_dependencies: [regex]
+
     # Keep `suggestion` last
     - id: suggestion
       name: Suggestion
@@ -62,10 +69,3 @@ repos:
       verbose: true
       pass_filenames: false
     # Insert new entries above the `suggestion` entry
-
-    - id: check-pickle-imports
-      name: Prevent new pickle/cloudpickle imports
-      entry: python tools/pre_commit/check_pickle_imports.py
-      language: python
-      types: [python]
-      additional_dependencies: [regex]


### PR DESCRIPTION
## Summary
`.pre-commit-config.yaml` has a comment saying `suggestion` hook must stay last, 
but `check-pickle-imports` was placed after it. This PR moves `check-pickle-imports` 
above `suggestion`.

Fixes #4009