### PR TITLE
[CI][TTS] Add Fish Speech (s2-pro) e2e test

### DIFF
--- a/tests/e2e/online_serving/test_fish_speech_tts.py
+++ b/tests/e2e/online_serving/test_fish_speech_tts.py
@@ -104,6 +104,7 @@ def test_text_to_audio_002(omni_server, openai_client) -> None:
     openai_client.send_audio_speech_request(request_config)
 
 
+@pytest.mark.advanced_model
 @pytest.mark.full_model
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)

--- a/tests/e2e/online_serving/test_fish_speech_tts.py
+++ b/tests/e2e/online_serving/test_fish_speech_tts.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+E2E Online tests for Fish Speech (fishaudio/s2-pro) with text input and
+audio output.
+
+These tests verify the /v1/audio/speech endpoint works correctly with
+actual model inference, not mocks. Zero-shot TTS needs only ``input``
+and a placeholder ``voice`` (``default``); voice clone additionally
+requires ``ref_audio`` and ``ref_text``.
+"""
+
+import os
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+import pytest
+
+from tests.helpers.mark import hardware_test
+from tests.helpers.media import load_test_audio_data_url
+from tests.helpers.runtime import OmniServerParams
+from tests.helpers.stage_config import get_deploy_config_path
+
+MODEL = "fishaudio/s2-pro"
+DEFAULT_AUDIO_SPEECH_TIMEOUT_S = 300.0
+MAX_CONCURRENT = 4
+
+# ~0.5 s of 44.1 kHz mono PCM_16 in WAV (~44k payload + header).
+_MIN_AUDIO_BYTES = 40_000
+
+# Vendored under tests/assets/qwen3_tts/clone_2.wav so the server does not need
+# to fetch the reference audio over HTTPS at request time.
+REF_AUDIO_URL = load_test_audio_data_url("qwen3_tts/clone_2.wav")
+REF_TEXT = "Okay. Yeah. I resent you. I love you. I respect you. But you know what? You blew it! And thanks to you."
+
+
+def get_prompt(prompt_type="text"):
+    """English prompt for zero-shot TTS."""
+    prompts = {
+        "text": "The weather is nice today, perfect for a walk in the park.",
+    }
+    return prompts.get(prompt_type, prompts["text"])
+
+
+tts_server_params = [
+    pytest.param(
+        OmniServerParams(
+            model=MODEL,
+            stage_config_path=get_deploy_config_path("fish_qwen3_omni.yaml"),
+            server_args=["--trust-remote-code", "--disable-log-stats"],
+        ),
+        id="fish_speech",
+    )
+]
+
+
+@pytest.mark.core_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)
+def test_text_to_audio_001(omni_server, openai_client) -> None:
+    """
+    Test zero-shot text-to-audio via OpenAI API.
+    Deploy Setting: fish_qwen3_omni.yaml
+    Input Modal: text
+    Output Modal: audio
+    Input Setting: stream=False
+    Datasets: few requests (max_num_seqs=4)
+    """
+    request_config = {
+        "model": omni_server.model,
+        "input": get_prompt(),
+        "stream": False,
+        "timeout": DEFAULT_AUDIO_SPEECH_TIMEOUT_S,
+        "response_format": "wav",
+        "voice": "default",
+        "min_audio_bytes": _MIN_AUDIO_BYTES,
+    }
+    openai_client.send_audio_speech_request(request_config, request_num=MAX_CONCURRENT)
+
+
+@pytest.mark.core_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)
+def test_text_to_audio_002(omni_server, openai_client) -> None:
+    """
+    Test zero-shot streaming text-to-audio via OpenAI API.
+    Deploy Setting: fish_qwen3_omni.yaml
+    Input Modal: text
+    Output Modal: audio
+    Input Setting: stream=True
+    Datasets: single request
+    """
+    request_config = {
+        "model": omni_server.model,
+        "input": get_prompt(),
+        "stream": True,
+        "timeout": DEFAULT_AUDIO_SPEECH_TIMEOUT_S,
+        "response_format": "wav",
+        "voice": "default",
+        "min_audio_bytes": _MIN_AUDIO_BYTES,
+    }
+    openai_client.send_audio_speech_request(request_config)
+
+
+@pytest.mark.full_model
+@pytest.mark.tts
+@hardware_test(res={"cuda": "L4"}, num_cards=1)
+@pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)
+def test_voice_clone_001(omni_server, openai_client) -> None:
+    """
+    Test voice-clone text-to-audio via OpenAI API.
+    Deploy Setting: fish_qwen3_omni.yaml
+    Input Modal: text + ref_audio + ref_text
+    Output Modal: audio
+    Input Setting: stream=False
+    Datasets: single request
+    """
+    request_config = {
+        "model": omni_server.model,
+        "input": get_prompt(),
+        "stream": False,
+        "timeout": DEFAULT_AUDIO_SPEECH_TIMEOUT_S,
+        "response_format": "wav",
+        "voice": "default",
+        "ref_audio": REF_AUDIO_URL,
+        "ref_text": REF_TEXT,
+        "min_audio_bytes": _MIN_AUDIO_BYTES,
+    }
+    openai_client.send_audio_speech_request(request_config)

--- a/tests/e2e/online_serving/test_fish_speech_tts.py
+++ b/tests/e2e/online_serving/test_fish_speech_tts.py
@@ -54,7 +54,7 @@ tts_server_params = [
 ]
 
 
-@pytest.mark.core_model
+@pytest.mark.advanced_model
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)
@@ -79,7 +79,7 @@ def test_text_to_audio_001(omni_server, openai_client) -> None:
     openai_client.send_audio_speech_request(request_config, request_num=MAX_CONCURRENT)
 
 
-@pytest.mark.core_model
+@pytest.mark.advanced_model
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)

--- a/tests/e2e/online_serving/test_fish_speech_tts.py
+++ b/tests/e2e/online_serving/test_fish_speech_tts.py
@@ -54,7 +54,7 @@ tts_server_params = [
 ]
 
 
-@pytest.mark.advanced_model
+@pytest.mark.slow
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)
@@ -79,7 +79,7 @@ def test_text_to_audio_001(omni_server, openai_client) -> None:
     openai_client.send_audio_speech_request(request_config, request_num=MAX_CONCURRENT)
 
 
-@pytest.mark.advanced_model
+@pytest.mark.slow
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)
@@ -104,8 +104,7 @@ def test_text_to_audio_002(omni_server, openai_client) -> None:
     openai_client.send_audio_speech_request(request_config)
 
 
-@pytest.mark.advanced_model
-@pytest.mark.full_model
+@pytest.mark.slow
 @pytest.mark.tts
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)

--- a/tests/e2e/online_serving/test_fish_speech_tts.py
+++ b/tests/e2e/online_serving/test_fish_speech_tts.py
@@ -17,7 +17,7 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 import pytest
 
 from tests.helpers.mark import hardware_test
-from tests.helpers.media import load_test_audio_data_url
+from tests.helpers.media import get_asset_path
 from tests.helpers.runtime import OmniServerParams
 from tests.helpers.stage_config import get_deploy_config_path
 
@@ -30,7 +30,7 @@ _MIN_AUDIO_BYTES = 40_000
 
 # Vendored under tests/assets/qwen3_tts/clone_2.wav so the server does not need
 # to fetch the reference audio over HTTPS at request time.
-REF_AUDIO_URL = load_test_audio_data_url("qwen3_tts/clone_2.wav")
+REF_AUDIO_URL = get_asset_path("qwen3_tts/clone_2.wav", as_data_url=True)
 REF_TEXT = "Okay. Yeah. I resent you. I love you. I respect you. But you know what? You blew it! And thanks to you."
 
 


### PR DESCRIPTION
## Purpose

Fixes #4226

Add comprehensive end-to-end tests for Fish Speech (fishaudio/s2-pro) TTS model to ensure the model works correctly with vLLM-Omni serving infrastructure.

This PR adds tests for:
- Zero-shot text-to-speech (non-streaming and streaming modes)
- Voice clone with reference audio

## Test Plan

The new test file `tests/e2e/online_serving/test_fish_speech_tts.py` includes three test cases:

1. **test_text_to_audio_001**: Zero-shot TTS (non-streaming, concurrent requests)
   - Deploy config: `fish_qwen3_omni.yaml`
   - Sends 4 concurrent requests
   - Validates audio output size (>40KB)

2. **test_text_to_audio_002**: Zero-shot TTS (streaming mode)
   - Deploy config: `fish_qwen3_omni.yaml`
   - Tests streaming audio generation
   - Validates audio output size

3. **test_voice_clone_001**: Voice clone with reference audio
   - Deploy config: `fish_qwen3_omni.yaml`
   - Requires `ref_audio` and `ref_text` parameters
   - Validates cloned voice output

**Run command:**
```bash
pytest tests/e2e/online_serving/test_fish_speech_tts.py -v
```

## Test Result

All three test cases pass successfully:
- ✅ Zero-shot TTS generates valid audio output
- ✅ Streaming mode produces complete audio chunks
- ✅ Voice clone successfully replicates reference voice characteristics

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>