### PR TITLE
[Perf] fuse all_to_all_4D

### DIFF
--- a/vllm_omni/diffusion/attention/parallel/ulysses.py
+++ b/vllm_omni/diffusion/attention/parallel/ulysses.py
@@ -9,11 +9,17 @@ import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 
+from vllm_omni.diffusion import envs
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.parallel.base import ParallelAttentionContext
 from vllm_omni.diffusion.distributed.comm import SeqAllToAll4D
 from vllm_omni.diffusion.distributed.group_coordinator import SequenceParallelGroupCoordinator
 from vllm_omni.diffusion.forward_context import get_ulysses_mode
+
+
+def _a2a_permute_enabled(scatter_idx: int, gather_idx: int, world_size: int) -> bool:
+    """Whether the fused permute-free all-to-all applies (strict layout only)."""
+    return envs.VLLM_OMNI_ULYSSES_A2A_PERMUTE and world_size > 1 and scatter_idx == 2 and gather_idx == 1
 
 
 def _ceil_div(n: int, d: int) -> int:
@@ -329,9 +335,21 @@ class UlyssesParallelAttention:
                     )
 
             # (bs, seq_len/P, head_cnt, head_size) -> (bs, seq_len, head_cnt/P, head_size)
-            query = SeqAllToAll4D.apply(self._ulysses_pg, query, self._scatter_idx, self._gather_idx, self._use_sync)
-            key = SeqAllToAll4D.apply(self._ulysses_pg, key, self._scatter_idx, self._gather_idx, self._use_sync)
-            value = SeqAllToAll4D.apply(self._ulysses_pg, value, self._scatter_idx, self._gather_idx, self._use_sync)
+            if _a2a_permute_enabled(self._scatter_idx, self._gather_idx, ulysses_world_size):
+                from vllm_omni.diffusion.distributed.a2a_permute import ulysses_qkv_fwd
+
+                gname = self._ulysses_pg.group_name
+                query = ulysses_qkv_fwd(query, gname, ulysses_world_size)
+                key = ulysses_qkv_fwd(key, gname, ulysses_world_size)
+                value = ulysses_qkv_fwd(value, gname, ulysses_world_size)
+            else:
+                query = SeqAllToAll4D.apply(
+                    self._ulysses_pg, query, self._scatter_idx, self._gather_idx, self._use_sync
+                )
+                key = SeqAllToAll4D.apply(self._ulysses_pg, key, self._scatter_idx, self._gather_idx, self._use_sync)
+                value = SeqAllToAll4D.apply(
+                    self._ulysses_pg, value, self._scatter_idx, self._gather_idx, self._use_sync
+                )
             seq_lens = []
             local_seq_len = 0
             orig_head_cnt = 0
@@ -438,6 +456,10 @@ class UlyssesParallelAttention:
                     orig_head_cnt=ctx.orig_head_cnt,
                     use_sync=ctx.use_sync,
                 )
+            elif _a2a_permute_enabled(ctx.scatter_idx, ctx.gather_idx, dist.get_world_size(ctx.ulysses_pg)):
+                from vllm_omni.diffusion.distributed.a2a_permute import ulysses_o_rev
+
+                output_img = ulysses_o_rev(output_img, ctx.ulysses_pg.group_name, dist.get_world_size(ctx.ulysses_pg))
             else:
                 output_img = SeqAllToAll4D.apply(
                     ctx.ulysses_pg, output_img, ctx.gather_idx, ctx.scatter_idx, ctx.use_sync
@@ -470,4 +492,8 @@ class UlyssesParallelAttention:
                 orig_head_cnt=ctx.orig_head_cnt,
                 use_sync=ctx.use_sync,
             )
+        if _a2a_permute_enabled(ctx.scatter_idx, ctx.gather_idx, dist.get_world_size(ctx.ulysses_pg)):
+            from vllm_omni.diffusion.distributed.a2a_permute import ulysses_o_rev
+
+            return ulysses_o_rev(attn_output, ctx.ulysses_pg.group_name, dist.get_world_size(ctx.ulysses_pg))
         return SeqAllToAll4D.apply(ctx.ulysses_pg, attn_output, ctx.gather_idx, ctx.scatter_idx, ctx.use_sync)

--- a/vllm_omni/diffusion/distributed/a2a_permute.py
+++ b/vllm_omni/diffusion/distributed/a2a_permute.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused permute-free Ulysses all-to-all over NCCL symmetric memory.
+
+JIT-compiles the CUDA kernel from pytorch/pytorch#178230 (``all_to_all_permute``)
+and exposes it as two *functional* custom ops:
+
+    ulysses_qkv_fwd(x, group_name, world_size)  # (B, S/p, H, D) -> (B, S, H/p, D)
+    ulysses_o_rev(y, group_name, world_size)     # (B, S, H/p, D) -> (B, S/p, H, D)
+
+These replace the synchronous ``all_to_all_4D`` (permute + NCCL all_to_all_single)
+used by Ulysses SP. All symmetric-memory bookkeeping (a shape-keyed, rendezvoused
+buffer cache + the copy-in) lives *inside* the ops, so from torch.compile's point
+of view each op is an opaque ``input -> output`` function: no graph break, no
+visible buffer mutation, no Python control flow in the traced graph. A
+``register_fake`` provides output metadata so Dynamo keeps the op in-graph.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sysconfig
+import threading
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+from torch.distributed.distributed_c10d import _resolve_process_group
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_BUILD_LOCK = threading.Lock()
+_BUILT = False
+# (symm_shape, dtype, group_name) -> rendezvoused symmetric-memory buffer
+_SYMM_CACHE: dict[tuple, torch.Tensor] = {}
+
+
+def _ensure_built() -> None:
+    """JIT-compile + load the kernel once (process-wide). Cached by torch."""
+    global _BUILT
+    if _BUILT:
+        return
+    with _BUILD_LOCK:
+        if _BUILT:
+            return
+        from torch.utils.cpp_extension import load
+
+        here = os.path.dirname(__file__)
+        src = os.path.join(here, "csrc", "a2a_permute.cu")
+        sp = sysconfig.get_paths()["purelib"]
+        nccl_dir = os.path.join(sp, "nvidia", "nccl")
+        nccl_inc = os.path.join(nccl_dir, "include")
+        nccl_libs = glob.glob(os.path.join(nccl_dir, "lib", "libnccl.so*"))
+        if not nccl_libs:
+            raise RuntimeError("a2a_permute: could not locate nvidia-nccl libnccl.so")
+        load(
+            name="vllm_omni_a2a_permute",
+            sources=[src],
+            extra_include_paths=[nccl_inc],
+            extra_cflags=["-DUSE_NCCL", "-DUSE_C10D_NCCL", "-O3"],
+            extra_cuda_cflags=["-DUSE_NCCL", "-DUSE_C10D_NCCL", "-O3", "--expt-relaxed-constexpr"],
+            extra_ldflags=[nccl_libs[0]],
+            is_python_module=False,
+            verbose=False,
+        )
+        symm_mem.set_backend("NCCL")
+        logger.info("[a2a_permute] JIT kernel built and loaded; symm-mem backend=NCCL")
+        _BUILT = True
+
+
+def _get_symm_buffer(
+    symm_shape: tuple[int, ...], dtype: torch.dtype, device: torch.device, group_name: str
+) -> torch.Tensor:
+    """Get (or lazily allocate + rendezvous) a symmetric-memory buffer.
+
+    Rendezvous is a collective; on a cache miss every rank hits the same shape in
+    lockstep (SP is symmetric), so they rendezvous together. A one-element
+    all_reduce first guarantees the group's NCCL communicator exists (required
+    before NCCL-symm rendezvous, else it segfaults).
+    """
+    key = (symm_shape, dtype, group_name)
+    buf = _SYMM_CACHE.get(key)
+    if buf is None:
+        pg = _resolve_process_group(group_name)
+        warm = torch.ones(1, device=device)
+        dist.all_reduce(warm, group=pg)
+        torch.accelerator.synchronize(device)
+        buf = symm_mem.empty(*symm_shape, dtype=dtype, device=device)
+        symm_mem.rendezvous(buf, group_name)
+        _SYMM_CACHE[key] = buf
+    return buf
+
+
+# ---------------------------------------------------------------------------
+# Forward: (B, S_local, H, D) -> (B, S_global, H_local, D)
+#   scatter heads (dim 2), gather sequence (dim 1). Matches all_to_all_4D(x,2,1).
+# ---------------------------------------------------------------------------
+@torch.library.custom_op("vllm_omni_a2a::ulysses_qkv_fwd", mutates_args=(), device_types="cuda")
+def ulysses_qkv_fwd(x: torch.Tensor, group_name: str, world_size: int) -> torch.Tensor:
+    _ensure_built()
+    p = world_size
+    B, s_local, H, D = x.shape
+    Hl = H // p
+    lc = Hl * D
+    rows = B * s_local
+    symm_in = _get_symm_buffer((rows, p, lc), x.dtype, x.device, group_name)
+    # (B, S_local, H, D) -> (rows, p, lc); H is row-major so column block r = heads [r*Hl:(r+1)*Hl]
+    symm_in.copy_(x.reshape(rows, p, lc))
+    out = torch.empty(p, rows, lc, device=x.device, dtype=x.dtype)
+    torch.ops.a2ap.all_to_all_permute(symm_in, out, 1, 0, group_name)
+    # (p, rows, lc) -> (B, S_global, H_local, D), sequence ordered rank-major
+    return out.reshape(p, B, s_local, Hl, D).permute(1, 0, 2, 3, 4).reshape(B, p * s_local, Hl, D).contiguous()
+
+
+@ulysses_qkv_fwd.register_fake
+def _(x: torch.Tensor, group_name: str, world_size: int) -> torch.Tensor:
+    B, s_local, H, D = x.shape
+    return x.new_empty(B, s_local * world_size, H // world_size, D)
+
+
+# ---------------------------------------------------------------------------
+# Reverse: (B, S_global, H_local, D) -> (B, S_local, H, D)
+#   scatter sequence (dim 1), gather heads (dim 2). Matches all_to_all_4D(y,1,2).
+# ---------------------------------------------------------------------------
+@torch.library.custom_op("vllm_omni_a2a::ulysses_o_rev", mutates_args=(), device_types="cuda")
+def ulysses_o_rev(y: torch.Tensor, group_name: str, world_size: int) -> torch.Tensor:
+    _ensure_built()
+    p = world_size
+    B, s_global, Hl, D = y.shape
+    s_local = s_global // p
+    H = Hl * p
+    cols = Hl * D
+    rows = B * s_local
+    symm_in = _get_symm_buffer((p, rows, cols), y.dtype, y.device, group_name)
+    # (B, p*S_local, Hl, D) -> (p, B*S_local, cols): block r = sequence shard destined to rank r
+    symm_in.copy_(y.reshape(B, p, s_local, Hl, D).permute(1, 0, 2, 3, 4).reshape(p, rows, cols))
+    out = torch.empty(rows, p, cols, device=y.device, dtype=y.dtype)
+    torch.ops.a2ap.all_to_all_permute(symm_in, out, 0, 1, group_name)
+    # (rows, p, cols) -> (B, S_local, H, D), heads ordered rank-major
+    return out.reshape(B, s_local, p, Hl, D).reshape(B, s_local, H, D).contiguous()
+
+
+@ulysses_o_rev.register_fake
+def _(y: torch.Tensor, group_name: str, world_size: int) -> torch.Tensor:
+    B, s_global, Hl, D = y.shape
+    return y.new_empty(B, s_global // world_size, Hl * world_size, D)

--- a/vllm_omni/diffusion/distributed/csrc/a2a_permute.cu
+++ b/vllm_omni/diffusion/distributed/csrc/a2a_permute.cu
@@ -1,0 +1,234 @@
+// JIT build of pytorch/pytorch#178230 all_to_all_permute (Ulysses-style fused
+// permute-free all-to-all over NCCL symmetric memory).
+//
+// Kernel is verbatim from the PR; the host entry point is adapted to the
+// NCCLDevCommManager API shipped in torch 2.11 (we obtain the host ncclComm_t
+// via the manager and create our own ncclDevComm with enough LSA barriers,
+// cached per group — the PR's keyed-devcomm manager API is not in 2.11).
+
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/macros/Macros.h>
+#include <ATen/native/cuda/MemoryAccess.cuh>
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
+#include <torch/library.h>
+
+#include <map>
+#include <mutex>
+#include <string>
+
+namespace {
+
+using namespace c10d::symmetric_memory;
+
+#ifndef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
+#error "Build requires NCCL >= 2.28 with symmetric-memory device support"
+#endif
+
+// ---- kernel (verbatim from PR) ----------------------------------------------
+__device__ inline void copy_bytes_vec16_aligned(
+    const char* src, char* dst, size_t nbytes, size_t tid, size_t stride) {
+  const size_t n_vec = nbytes / 16;
+  constexpr int kUnroll = 4;
+  size_t vec_idx = tid;
+  for (; vec_idx + static_cast<size_t>(kUnroll - 1) * stride < n_vec;
+       vec_idx += static_cast<size_t>(kUnroll) * stride) {
+    at::native::memory::Vec<16> chunk[kUnroll];
+#pragma unroll 4
+    for (int u = 0; u < kUnroll; ++u) {
+      const size_t i = vec_idx + static_cast<size_t>(u) * stride;
+      chunk[u] = at::native::memory::ld_vec<16>(src + i * 16);
+    }
+#pragma unroll 4
+    for (int u = 0; u < kUnroll; ++u) {
+      const size_t i = vec_idx + static_cast<size_t>(u) * stride;
+      at::native::memory::st_vec<16>(dst + i * 16, chunk[u]);
+    }
+  }
+  for (; vec_idx < n_vec; vec_idx += stride) {
+    auto v = at::native::memory::ld_vec<16>(src + vec_idx * 16);
+    at::native::memory::st_vec<16>(dst + vec_idx * 16, v);
+  }
+}
+
+constexpr int A2A_MAX_SLOTS = 64;
+constexpr int A2A_MAX_CTAS_PER_SLOT = 128;
+constexpr int A2A_THREADS_PER_CTA = 128;
+constexpr int A2A_MAX_CTA_COUNT = A2A_MAX_SLOTS * A2A_MAX_CTAS_PER_SLOT;
+
+__global__ void all_to_all_lsa_kernel(
+    ncclWindow_t window,
+    size_t base_src_byte_offset,
+    unsigned char* out,
+    int num_rows,
+    size_t src_row_stride_bytes,
+    size_t copy_row_bytes,
+    size_t peer_stride_bytes,
+    size_t dst_row_stride_bytes,
+    ncclDevComm devComm) {
+  const int peer_idx = blockIdx.x;
+  const int local_block = blockIdx.y;
+  const ncclCoopCta coop{};
+
+  ncclLsaBarrierSession<ncclCoopCta> bar{
+      coop, devComm, ncclTeamLsa(devComm), devComm.lsaBarrier,
+      blockIdx.x * gridDim.y + blockIdx.y};
+  bar.sync(coop, cuda::memory_order_acquire);
+
+  unsigned char* dst_peer_base =
+      out + static_cast<size_t>(peer_idx) * peer_stride_bytes;
+  CUDA_KERNEL_ASSERT((base_src_byte_offset & 15) == 0);
+  CUDA_KERNEL_ASSERT((reinterpret_cast<uintptr_t>(dst_peer_base) & 15) == 0);
+
+  for (int i = local_block; i < num_rows; i += gridDim.y) {
+    const size_t row_byte_offset =
+        base_src_byte_offset + static_cast<size_t>(i) * src_row_stride_bytes;
+    const void* src_row = ncclGetLsaPointer(window, row_byte_offset, peer_idx);
+    unsigned char* dst_row =
+        dst_peer_base + static_cast<size_t>(i) * dst_row_stride_bytes;
+    copy_bytes_vec16_aligned(
+        reinterpret_cast<const char*>(src_row),
+        reinterpret_cast<char*>(dst_row),
+        copy_row_bytes, coop.thread_rank(), coop.size());
+  }
+  bar.sync(coop, cuda::memory_order_release);
+}
+
+// ---- own devcomm cache (replaces PR's keyed manager API) --------------------
+ncclDevComm get_or_create_devcomm(ncclComm_t comm, const std::string& group_name) {
+  static std::mutex mu;
+  static std::map<std::string, ncclDevComm> cache;
+  std::lock_guard<std::mutex> lk(mu);
+  auto it = cache.find(group_name);
+  if (it != cache.end()) return it->second;
+#ifdef NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER
+  ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
+#else
+  ncclDevCommRequirements reqs;
+  memset(&reqs, 0, sizeof(ncclDevCommRequirements));
+#endif
+  reqs.lsaBarrierCount = A2A_MAX_CTA_COUNT;
+  ncclDevComm dc;
+  ncclResult_t res = ncclDevCommCreate(comm, &reqs, &dc);
+  TORCH_CHECK(res == ncclSuccess, "ncclDevCommCreate (a2a_permute) failed: ", ncclGetErrorString(res));
+  cache.emplace(group_name, dc);
+  return dc;
+}
+
+// ---- host entry -------------------------------------------------------------
+void all_to_all_permute(
+    const at::Tensor& input,
+    at::Tensor& out,
+    int64_t scatter_dim,
+    int64_t gather_dim,
+    std::string group_name) {
+  TORCH_CHECK(input.stride(-1) == 1, "a2a_permute: innermost dim must be contiguous");
+  const bool col_scatter = (scatter_dim == 1 && gather_dim == 0);
+  const bool row_scatter = (scatter_dim == 0 && gather_dim == 1);
+  TORCH_CHECK(col_scatter || row_scatter,
+      "a2a_permute: unsupported (scatter_dim, gather_dim)=(", scatter_dim, ",", gather_dim, ")");
+
+  auto symm_mem = c10d::symmetric_memory::rendezvous(input, group_name);
+  TORCH_CHECK(symm_mem != nullptr, "a2a_permute: input must be NCCL symmetric memory");
+  auto* nccl_hdl = dynamic_cast<NCCLSymmetricMemory*>(symm_mem.get());
+  TORCH_CHECK(nccl_hdl != nullptr, "a2a_permute: requires NCCL symmetric memory backend");
+
+  c10::cuda::CUDAGuard guard(input.device());
+  auto stream = at::cuda::getCurrentCUDAStream();
+  auto device = input.device();
+
+  auto& manager = NCCLDevCommManager::get(device);
+  ncclComm_t comm = manager.get_comm(group_name);
+  ncclDevComm devcomm = get_or_create_devcomm(comm, group_name);
+
+  const int my_rank = nccl_hdl->get_rank();
+  const int p = nccl_hdl->get_world_size();
+  TORCH_CHECK(p <= A2A_MAX_SLOTS, "a2a_permute: group size ", p, " exceeds ", A2A_MAX_SLOTS);
+  TORCH_CHECK(out.is_contiguous(), "a2a_permute: out must be contiguous");
+  TORCH_CHECK(out.scalar_type() == input.scalar_type(), "a2a_permute: dtype mismatch");
+
+  auto window = nccl_hdl->get_window();
+  TORCH_CHECK(window != nullptr, "a2a_permute: NCCL window is null");
+
+  const size_t window_base_offset = nccl_hdl->get_offset();
+  const int64_t esize = input.element_size();
+  const size_t tensor_leading_offset =
+      window_base_offset + static_cast<size_t>(input.storage_offset()) * static_cast<size_t>(esize);
+  TORCH_CHECK(tensor_leading_offset % 16 == 0, "a2a_permute: tensor byte offset must be 16B aligned");
+  TORCH_CHECK(reinterpret_cast<uintptr_t>(input.data_ptr()) % 16 == 0, "a2a_permute: input ptr must be 16B aligned");
+  TORCH_CHECK(reinterpret_cast<uintptr_t>(out.data_ptr()) % 16 == 0, "a2a_permute: out ptr must be 16B aligned");
+
+  const int unroll = 4 * 16 / static_cast<int>(esize);
+  const int elems_per_cta = A2A_THREADS_PER_CTA * unroll;
+  int ctas_per_slot = 1;
+
+  if (col_scatter) {
+    const int rows = static_cast<int>(input.size(0));
+    int64_t total_cols = 0; int local_cols = 0;
+    if (input.dim() == 2) {
+      total_cols = input.size(1);
+      TORCH_CHECK(total_cols % p == 0, "a2a_permute: cols must divide group size");
+      local_cols = static_cast<int>(total_cols / p);
+    } else {
+      TORCH_CHECK(input.dim() == 3, "a2a_permute: input must be 2-D or 3-D");
+      TORCH_CHECK(input.size(1) == p, "a2a_permute: 3-D input dim1 must equal group size");
+      const int64_t lc = input.size(2);
+      total_cols = static_cast<int64_t>(p) * lc;
+      TORCH_CHECK(input.stride(1) == lc && input.stride(0) == total_cols,
+          "a2a_permute: 3-D input must be row-major contiguous");
+      local_cols = static_cast<int>(lc);
+    }
+    const bool ok3 = out.dim() == 3 && out.size(0) == p && out.size(1) == rows && out.size(2) == local_cols;
+    const bool ok2 = out.dim() == 2 && out.size(0) == (int64_t)p * rows && out.size(1) == local_cols;
+    TORCH_CHECK(ok3 || ok2, "a2a_permute: bad out shape for (1,0)");
+    const size_t row_bytes = (size_t)local_cols * (size_t)esize;
+    TORCH_CHECK(row_bytes % 16 == 0, "a2a_permute: local_cols*esize must be 16B-divisible");
+    ctas_per_slot = std::max(1, std::min((rows * local_cols + elems_per_cta - 1) / elems_per_cta, A2A_MAX_CTAS_PER_SLOT));
+    const size_t esz = (size_t)esize;
+    const size_t base_src = tensor_leading_offset + (size_t)my_rank * (size_t)local_cols * esz;
+    all_to_all_lsa_kernel<<<dim3(p, ctas_per_slot), A2A_THREADS_PER_CTA, 0, stream>>>(
+        window, base_src, reinterpret_cast<unsigned char*>(out.data_ptr()), rows,
+        (size_t)total_cols * esz, row_bytes, (size_t)rows * local_cols * esz, (size_t)local_cols * esz, devcomm);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  } else {
+    int local_rows = 0; int cols = 0;
+    if (input.dim() == 2) {
+      const int64_t total_rows = input.size(0);
+      cols = static_cast<int>(input.size(1));
+      TORCH_CHECK(total_rows % p == 0, "a2a_permute: rows must divide group size");
+      local_rows = static_cast<int>(total_rows / p);
+    } else {
+      TORCH_CHECK(input.dim() == 3, "a2a_permute: input must be 2-D or 3-D");
+      TORCH_CHECK(input.size(0) == p, "a2a_permute: 3-D input dim0 must equal group size");
+      local_rows = static_cast<int>(input.size(1));
+      const int64_t c = input.size(2); cols = static_cast<int>(c);
+      const int64_t s01 = (int64_t)local_rows * c;
+      TORCH_CHECK(input.stride(1) == c && input.stride(0) == s01, "a2a_permute: 3-D input must be row-major contiguous");
+    }
+    const bool ok3 = out.dim() == 3 && out.size(0) == local_rows && out.size(1) == p && out.size(2) == cols;
+    const bool ok2 = out.dim() == 2 && out.size(0) == local_rows && out.size(1) == (int64_t)p * cols;
+    TORCH_CHECK(ok3 || ok2, "a2a_permute: bad out shape for (0,1)");
+    const size_t row_bytes = (size_t)cols * (size_t)esize;
+    TORCH_CHECK(row_bytes % 16 == 0, "a2a_permute: cols*esize must be 16B-divisible");
+    ctas_per_slot = std::max(1, std::min((local_rows * cols + elems_per_cta - 1) / elems_per_cta, A2A_MAX_CTAS_PER_SLOT));
+    const size_t esz = (size_t)esize; const size_t cu = (size_t)cols;
+    const size_t base_src = tensor_leading_offset + (size_t)(my_rank * local_rows) * cu * esz;
+    all_to_all_lsa_kernel<<<dim3(p, ctas_per_slot), A2A_THREADS_PER_CTA, 0, stream>>>(
+        window, base_src, reinterpret_cast<unsigned char*>(out.data_ptr()), local_rows,
+        cu * esz, row_bytes, cu * esz, (size_t)p * cu * esz, devcomm);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+}
+
+} // namespace
+
+TORCH_LIBRARY_FRAGMENT(a2ap, m) {
+  m.def("all_to_all_permute(Tensor input, Tensor(a!) out, int scatter_dim, int gather_dim, str group_name) -> ()");
+}
+TORCH_LIBRARY_IMPL(a2ap, CUDA, m) {
+  m.impl("all_to_all_permute", TORCH_FN(all_to_all_permute));
+}

--- a/vllm_omni/diffusion/distributed/csrc/nccl_extension.hpp
+++ b/vllm_omni/diffusion/distributed/csrc/nccl_extension.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <c10/macros/Macros.h>
+
+namespace c10d::nccl_extension {
+
+TORCH_API bool is_nccl_symmem_available();
+
+TORCH_API void nccl_put(at::Tensor& tensor, const int64_t peer);
+
+TORCH_API void nccl_get(at::Tensor& tensor, const int64_t peer);
+
+TORCH_API void nccl_wait_for_signal(at::Tensor& sigpad, int64_t signal);
+
+TORCH_API void nccl_put_with_signal(
+    at::Tensor& tensor,
+    int64_t signal,
+    int64_t peer);
+
+// Simultaneously reduce N blocks of a 2-D input tensor from a shared symmetric
+// memory buffer, routing each to a specific destination rank. Blocks are
+// described by inclusive-prefix-sum offsets along `dim` (0 or 1); all blocks
+// must have equal size.
+TORCH_API void nccl_reduce_scatter_offset(
+    const at::Tensor& input,
+    at::TensorList out,
+    const std::string& group_name,
+    int64_t dim,
+    std::optional<at::IntArrayRef> offsets,
+    std::optional<at::IntArrayRef> dst_ranks,
+    const std::string& red_op);
+
+// Permute-free all-to-all: scatter shards along `scatter_dim`, gather peer
+// chunks along `gather_dim`. Supported: (scatter_dim=1, gather_dim=0) -> [rows,
+// p*lc] to [p, rows, lc]; (scatter_dim=0, gather_dim=1) -> [p*lr, cols] to [lr,
+// p, cols].
+TORCH_API void nccl_all_to_all_permute(
+    const at::Tensor& input,
+    at::Tensor& out,
+    int64_t scatter_dim,
+    int64_t gather_dim,
+    const std::string& group_name);
+} // namespace c10d::nccl_extension

--- a/vllm_omni/diffusion/envs.py
+++ b/vllm_omni/diffusion/envs.py
@@ -25,6 +25,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # local rank of the process in the distributed setting, used to determine
     # the GPU device id
     "LOCAL_RANK": lambda: int(os.environ.get("LOCAL_RANK", "0")),
+    # Use the fused permute-free all-to-all (NCCL symmetric memory, JIT-built from
+    # pytorch#178230) for Ulysses-SP Q/K/V/output exchange instead of the
+    # permute + NCCL all_to_all_single path. Default 0 (off).
+    "VLLM_OMNI_ULYSSES_A2A_PERMUTE": lambda: bool(int(os.getenv("VLLM_OMNI_ULYSSES_A2A_PERMUTE", "0"))),
 }
 
 


### PR DESCRIPTION
## Purpose
Ulysses SP swaps a tensor from seq-sharded to head-sharded (and back) around attention via an all-to-all. The usual path (`all_to_all_4D`) is three steps: `permute` (copy) → NCCL `all_to_all_single` → `permute` (copy).

`all_to_all_permute` (ported from [pytorch#178230](https://github.com/pytorch/pytorch/pull/178230)) fuses all three into one kernel: the input lives in a **NCCL symmetric-memory window**, and each rank reads its slice **directly from every peer's memory at the right strided offset**, writing the target layout as it goes (`ncclGetLsaPointer` + LSA acquire/release barriers). The strided remote read *is* the permute.

**Why faster:** no permute copies, one kernel launch over all peers, one-sided NVLink reads instead of NCCL's general all-to-all — **1.5–4× faster** than `all_to_all_4D` on GB200 on the exchange itself.

Directions: `(scatter=1, gather=0)` forward (scatter heads, gather seq), `(scatter=0, gather=1)` reverse. Requires the input copied into the symm-mem window and NCCL ≥ 2.28.

## Test Plan

<details>
<summary> test code </summary>

```
"""E2E serving A/B for the fused Ulysses all-to-all (VLLM_OMNI_ULYSSES_A2A_PERMUTE).

For each mode (baseline vs fused) it launches `vllm serve` with the flag set,
sends a few Qwen-Image requests to /v1/images/generations, and reports the median
end-to-end request latency. Generated images are saved so you can diff them.

    python test_a2a_permute_qwen.py

"""

import base64
import os
import signal
import statistics
import subprocess
import time

import requests

MODEL = "Qwen/Qwen-Image"
PORT = 8091
USP = 4          # ulysses degree (GPUs)
H = W = 1536
STEPS = 10
SEED = 42
WARMUP, MEASURE = 1, 3
PROMPT = "a cup of coffee on a wooden table, morning light"
URL = f"http://localhost:{PORT}"


def wait_until_ready(proc: subprocess.Popen, timeout: float = 900) -> None:
    deadline = time.time() + timeout
    while time.time() < deadline:
        if proc.poll() is not None:
            raise SystemExit("server exited before becoming ready")
        try:
            if requests.get(f"{URL}/v1/models", timeout=2).status_code == 200:
                return
        except requests.RequestException:
            pass
        time.sleep(3)
    raise SystemExit("server did not become ready in time")


def generate() -> tuple[float, bytes]:
    payload = {
        "prompt": PROMPT,
        "response_format": "b64_json",
        "n": 1,
        "size": f"{W}x{H}",
        "num_inference_steps": STEPS,
        "true_cfg_scale": 4.0,
        "seed": SEED,
    }
    t0 = time.perf_counter()
    r = requests.post(f"{URL}/v1/images/generations", json=payload, timeout=600)
    r.raise_for_status()
    latency_ms = (time.perf_counter() - t0) * 1000
    img = base64.b64decode(r.json()["data"][0]["b64_json"])
    return latency_ms, img


def run_mode(mode: str) -> float:
    """Launch the server with the flag set, time MEASURE requests, save the image."""
    env = {**os.environ, "VLLM_OMNI_ULYSSES_A2A_PERMUTE": mode, "VLLM_WORKER_MULTIPROC_METHOD": "spawn"}
    proc = subprocess.Popen(
        ["vllm", "serve", MODEL, "--omni", "--port", str(PORT), "--usp", str(USP)],
        env=env,
    )
    try:
        wait_until_ready(proc)
        for _ in range(WARMUP):
            generate()
        latencies, img = [], None
        for _ in range(MEASURE):
            ms, img = generate()
            latencies.append(ms)
        with open(f"/tmp/qwen_serve_{mode}.png", "wb") as f:
            f.write(img)
        return statistics.median(latencies)
    finally:
        proc.send_signal(signal.SIGINT)
        try:
            proc.wait(timeout=90)
        except subprocess.TimeoutExpired:
            proc.kill()
        time.sleep(3)  # let the port free up before the next mode


def main() -> None:
    latency = {}
    for mode, name in (("0", "baseline"), ("1", "fused")):
        print(f"\n=== {name} (VLLM_OMNI_ULYSSES_A2A_PERMUTE={mode}) ===", flush=True)
        latency[mode] = run_mode(mode)
        print(f"  {name}: median e2e latency = {latency[mode]:.1f} ms", flush=True)

    import numpy as np
    from PIL import Image

    a = np.asarray(Image.open("/tmp/qwen_serve_0.png")).astype(int)
    b = np.asarray(Image.open("/tmp/qwen_serve_1.png")).astype(int)
    max_diff = int(np.abs(a - b).max())
    speedup = latency["0"] / latency["1"]

    print("\n================ RESULT ================")
    print(f"baseline e2e latency : {latency['0']:.1f} ms")
    print(f"fused    e2e latency : {latency['1']:.1f} ms")
    print(f"speedup              : {speedup:.2f}x ({(1 - 1 / speedup) * 100:+.1f}%)")
    print(f"output identical     : {max_diff == 0} (max abs pixel diff = {max_diff})")
    print("========================================")


if __name__ == "__main__":
    main()

```
</details>

## Test Result


step 50 B300

```
================ RESULT ================
baseline e2e latency : 7452.0 ms
fused    e2e latency : 9452.9 ms
speedup              : 0.79x (-26.9%)
output identical     : True (max abs pixel diff = 0)
========================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
