### PR TITLE
[Feature]: support ERNIE-Image tea_cache

### DIFF
--- a/docs/user_guide/diffusion_features.md
+++ b/docs/user_guide/diffusion_features.md
@@ -132,7 +132,7 @@ The following tables show which models support each feature:
 | **SenseNova-U1**         |     ❌     |     ✅      |           ❌           |       ❌        |         ✅         |          ❌          |   ❌    |             ✅             |          ❌           |       ❌        |        ❌         |
 | **Stable-Diffusion3.5**  |     ❌     |     ✅      |           ❌           |       ✅        |         ✅         |          ❌          |   ❌    |             ✅             |      ✅ (decode)      |       ❌        |        ❌         |
 | **Z-Image**              |     ✅     |     ✅      |           ✅           |       ❓        |   ✅ (TP=2 only)   |          ❌          |   ✅    |             ❌             |      ✅ (decode)      |       ✅        |        ❌         |
-| **ERNIE-Image**          |     ❌     |     ✅      |           ✅           |       ❓        |         ✅         |          ❌          |   ✅    |             ✅             |          ❌           |       ❌        |        ❌         |
+| **ERNIE-Image**          |     ✅     |     ✅      |           ✅           |       ❓        |         ✅         |          ❌          |   ✅    |             ✅             |          ❌           |       ❌        |        ❌         |
 | **Cosmos3**              |     ❌     |     ✅      |           ✅           |       ✅        |         ✅         |          ❌          |   ✅    |             ✅             |      ✅ (decode)      |       ✅        |        ❌         |
 
 > Notes:

--- a/tests/diffusion/cache/test_teacache_extractors.py
+++ b/tests/diffusion/cache/test_teacache_extractors.py
@@ -15,6 +15,7 @@ Currently implemented:
 - TestFlux2KleinExtractor: Flux2Klein model extractor
 - TestFlux2Extractor: Flux2 model extractor
 - TestFluxExtractor: Flux model extractor
+- TestErnieImageExtractor: ERNIE-Image model extractor
 """
 
 from abc import ABC, abstractmethod
@@ -25,9 +26,13 @@ import torch
 
 from tests.helpers.mark import hardware_test
 from vllm_omni.diffusion.cache.teacache.extractors import (
+    extract_ernie_image_context,
     extract_flux2_context,
     extract_flux2_klein_context,
     extract_flux_context,
+)
+from vllm_omni.diffusion.models.ernie_image.ernie_image_transformer import (
+    ErnieImageTransformer2DModel,
 )
 from vllm_omni.diffusion.models.flux.flux_transformer import FluxTransformer2DModel
 from vllm_omni.diffusion.models.flux2_klein.flux2_klein_transformer import (
@@ -423,3 +428,172 @@ class TestFluxExtractor(BaseExtractorTest):
                 img_ids=torch.randint(0, 64, (1, 16, 3)),
                 txt_ids=torch.randint(0, 64, (1, 8, 3)),
             )
+
+
+@pytest.mark.cpu
+class TestErnieImageExtractor(BaseExtractorTest):
+    """Test extract_ernie_image_context function."""
+
+    @pytest.fixture(autouse=True)
+    def cpu_vllm_config(self):
+        """Force CPU custom-op dispatch for this test class."""
+        from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+
+        with set_current_vllm_config(VllmConfig(device_config=DeviceConfig(device="cpu"))):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def mock_ernie_image_attention_backend(self):
+        """Use the SDPA backend so ERNIE-Image can be instantiated in CPU tests."""
+        from vllm_omni.diffusion.attention.backends.sdpa import SDPABackend
+
+        with patch(
+            "vllm_omni.diffusion.attention.layer.get_attn_backend_for_role",
+            return_value=(SDPABackend, None),
+        ):
+            yield
+
+    def get_extractor(self):
+        return extract_ernie_image_context
+
+    @pytest.fixture
+    def ernie_image_module(self):
+        """Create a minimal ErnieImageTransformer2DModel for testing."""
+        return ErnieImageTransformer2DModel(
+            patch_size=1,
+            in_channels=64,
+            out_channels=64,
+            num_layers=2,
+            num_attention_heads=4,
+            ffn_hidden_size=256,
+            hidden_size=128,
+            text_in_dim=128,  # Same as hidden_size to skip text_proj
+            rope_theta=256,
+            rope_axes_dim=(16, 16, 16),
+        )
+
+    def get_module(self, ernie_image_module):
+        return ernie_image_module
+
+    @pytest.fixture
+    def sample_inputs(self):
+        """Create sample input tensors for ERNIE-Image.
+
+        ERNIE-Image expects:
+        - hidden_states: [B, C, H, W] - image latents
+        - timestep: scalar or [B] tensor
+        - text_bth: [B, Tmax, text_in_dim] - text embeddings
+        - text_lens: [B] - text sequence lengths
+        """
+        batch_size = 1
+        height, width = 8, 8
+        in_channels = 64
+        text_seq_len = 16
+        text_in_dim = 128
+
+        return {
+            "hidden_states": torch.randn(batch_size, in_channels, height, width),
+            "timestep": torch.tensor([500]),
+            "text_bth": torch.randn(batch_size, text_seq_len, text_in_dim),
+            "text_lens": torch.tensor([text_seq_len]),
+        }
+
+    def get_sample_inputs(self, sample_inputs):
+        return sample_inputs
+
+    def test_modulated_input_shape(self, ernie_image_module, sample_inputs):
+        """Test that modulated_input has correct shape.
+
+        ERNIE-Image uses single-stream architecture where image and text tokens
+        are concatenated. Shape is [S, B, hidden_size] where S = N_img + Tmax.
+        """
+        context = extract_ernie_image_context(ernie_image_module, **sample_inputs)
+
+        B, C, H, W = sample_inputs["hidden_states"].shape
+        N_img = H * W  # patch_size = 1
+        Tmax = sample_inputs["text_bth"].shape[1]
+        hidden_size = ernie_image_module.hidden_size
+
+        # ERNIE-Image uses [S, B, dim] format (sequence first)
+        assert context.modulated_input.shape == (N_img + Tmax, B, hidden_size)
+
+    def test_hidden_states_shape(self, ernie_image_module, sample_inputs):
+        """Test that hidden_states has correct shape after preprocessing."""
+        context = extract_ernie_image_context(ernie_image_module, **sample_inputs)
+
+        B, C, H, W = sample_inputs["hidden_states"].shape
+        N_img = H * W
+        Tmax = sample_inputs["text_bth"].shape[1]
+        hidden_size = ernie_image_module.hidden_size
+
+        assert context.hidden_states.shape == (N_img + Tmax, B, hidden_size)
+
+    def test_encoder_hidden_states_is_none(self, ernie_image_module, sample_inputs):
+        """Test that encoder_hidden_states is None for single-stream model."""
+        context = extract_ernie_image_context(ernie_image_module, **sample_inputs)
+
+        # ERNIE-Image is single-stream, so no separate encoder states
+        assert context.encoder_hidden_states is None
+
+    def test_run_transformer_blocks_callable(self, ernie_image_module, sample_inputs):
+        """Test that run_transformer_blocks is callable."""
+        context = extract_ernie_image_context(ernie_image_module, **sample_inputs)
+        assert callable(context.run_transformer_blocks)
+
+    def test_postprocess_callable(self, ernie_image_module, sample_inputs):
+        """Test that postprocess is callable."""
+        context = extract_ernie_image_context(ernie_image_module, **sample_inputs)
+        assert callable(context.postprocess)
+
+    def test_postprocess_output_shape(self, ernie_image_module, sample_inputs):
+        """Test that postprocess produces correct output shape."""
+        context = extract_ernie_image_context(ernie_image_module, **sample_inputs)
+        output = context.postprocess(context.hidden_states)
+
+        # Output should match input image latent shape [B, C, H, W]
+        assert output.sample.shape == sample_inputs["hidden_states"].shape
+
+    def test_postprocess_return_tuple_when_return_dict_false(self, ernie_image_module, sample_inputs):
+        """Test that postprocess honors return_dict=False."""
+        context = extract_ernie_image_context(ernie_image_module, **sample_inputs, return_dict=False)
+        output = context.postprocess(context.hidden_states)
+
+        assert isinstance(output, tuple)
+        assert len(output) == 1
+        assert output[0].shape == sample_inputs["hidden_states"].shape
+
+    def test_temb_shape(self, ernie_image_module, sample_inputs):
+        """Test that temb has correct shape."""
+        context = extract_ernie_image_context(ernie_image_module, **sample_inputs)
+
+        # temb (c) should be [B, hidden_size]
+        assert context.temb.shape == (1, ernie_image_module.hidden_size)
+
+    def test_invalid_module_raises_error(self):
+        """Test that invalid module without layers raises ValueError."""
+        invalid_module = Mock()
+        invalid_module.layers = []
+
+        with pytest.raises(ValueError, match="Module must have layers"):
+            extract_ernie_image_context(
+                invalid_module,
+                hidden_states=torch.randn(1, 64, 8, 8),
+                timestep=torch.tensor([500]),
+                text_bth=torch.randn(1, 16, 128),
+                text_lens=torch.tensor([16]),
+            )
+
+    def test_different_text_lengths(self, ernie_image_module, sample_inputs):
+        """Test context extraction with varying text lengths."""
+        # Test with shorter text
+        inputs = sample_inputs.copy()
+        inputs["text_bth"] = torch.randn(1, 8, 128)
+        inputs["text_lens"] = torch.tensor([8])
+
+        context = extract_ernie_image_context(ernie_image_module, **inputs)
+
+        B, C, H, W = inputs["hidden_states"].shape
+        N_img = H * W
+        hidden_size = ernie_image_module.hidden_size
+
+        assert context.modulated_input.shape == (N_img + 8, B, hidden_size)

--- a/vllm_omni/diffusion/cache/teacache/config.py
+++ b/vllm_omni/diffusion/cache/teacache/config.py
@@ -75,6 +75,16 @@ _MODEL_COEFFICIENTS = {
     ],
     # LongCat Image transformer coefficients
     "LongCatImageTransformer2DModel": [652.5980, -424.1615, 84.5526, -4.5923, 0.1694],
+    # ERNIE-Image transformer coefficients
+    # Using Qwen-Image coefficients as initial default (single-stream AdaLN DiT architecture)
+    # TODO: Tune specifically for ERNIE-Image using coefficient estimator
+    "ErnieImageTransformer2DModel": [
+        -4.50000000e02,
+        2.80000000e02,
+        -4.50000000e01,
+        3.20000000e00,
+        -2.00000000e-02,
+    ],
 }
 
 

--- a/vllm_omni/diffusion/cache/teacache/extractors.py
+++ b/vllm_omni/diffusion/cache/teacache/extractors.py
@@ -1187,6 +1187,114 @@ def extract_flux_context(
     )
 
 
+def extract_ernie_image_context(
+    module: nn.Module,
+    hidden_states: torch.Tensor,
+    timestep: torch.Tensor,
+    text_bth: torch.Tensor,
+    text_lens: torch.Tensor,
+    return_dict: bool = True,
+    **kwargs: Any,
+) -> CacheContext:
+    """
+    Extract cache context for ErnieImageTransformer2DModel.
+
+    ERNIE-Image uses a single-stream architecture where image and text tokens
+    are concatenated and processed together through shared transformer layers.
+
+    Args:
+        module: ErnieImageTransformer2DModel instance
+        hidden_states: Input image latents [B, C, H, W]
+        timestep: Current diffusion timestep
+        text_bth: Text embeddings [B, Tmax, text_in_dim]
+        text_lens: Text sequence lengths [B]
+        return_dict: Whether to return a Transformer2DModelOutput
+        **kwargs: Additional keyword arguments
+
+    Returns:
+        CacheContext with all information needed for generic caching
+    """
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+    if not hasattr(module, "layers") or len(module.layers) == 0:
+        raise ValueError("Module must have layers attribute with at least one block")
+
+    # ============================================================================
+    # PREPROCESSING (ERNIE-Image specific)
+    # ============================================================================
+    dtype = hidden_states.dtype
+    B, C, H, W = hidden_states.shape
+    p = module.patch_size
+    Hp, Wp = H // p, W // p
+    N_img = Hp * Wp
+
+    # Prepare hidden_states, RoPE embeddings, and attention mask
+    hidden_states, freqs_cos, freqs_sin, attention_mask = module.unified_prepare(hidden_states, text_bth, text_lens)
+    attention_mask = module._slice_attention_mask_for_ring(attention_mask)
+    rotary_pos_emb = (freqs_cos, freqs_sin)
+    S = hidden_states.shape[0]
+
+    # Timestep embedding
+    sample = module.time_proj(timestep)
+    sample = sample.to(dtype=dtype)
+    c = module.time_embedding(sample)
+
+    # AdaLN modulation parameters (6 params per block)
+    shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = [
+        t.unsqueeze(0).expand(S, -1, -1).contiguous() for t in module.adaLN_modulation(c).chunk(6, dim=-1)
+    ]
+
+    # ============================================================================
+    # EXTRACT MODULATED INPUT (for cache decision)
+    # ============================================================================
+    # Use the first transformer block to extract modulated input
+    # The block applies RMSNorm + AdaLN modulation before attention
+    first_block = module.layers[0]
+    modulated_input = first_block.adaLN_sa_ln(hidden_states)
+    modulated_input = (modulated_input.float() * (1 + scale_msa.float()) + shift_msa.float()).to(modulated_input.dtype)
+
+    # ============================================================================
+    # DEFINE TRANSFORMER EXECUTION (ERNIE-Image specific)
+    # ============================================================================
+    def run_transformer_blocks() -> tuple[torch.Tensor]:
+        """Execute all ERNIE-Image transformer blocks."""
+        h = hidden_states
+        temb = [shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp]
+
+        for layer in module.layers:
+            h = layer(h, rotary_pos_emb, temb, attention_mask)
+        return (h,)
+
+    # ============================================================================
+    # DEFINE POSTPROCESSING (ERNIE-Image specific)
+    # ============================================================================
+    def postprocess(h: torch.Tensor) -> Any:
+        """Apply ERNIE-Image specific output postprocessing."""
+        h = module.final_norm(h, c).type_as(h)
+        patches = module.final_linear(h)[:N_img].transpose(0, 1).contiguous()
+        output = (
+            patches.view(B, Hp, Wp, p, p, module.out_channels)
+            .permute(0, 5, 1, 3, 2, 4)
+            .contiguous()
+            .view(B, module.out_channels, H, W)
+        )
+        if not return_dict:
+            return (output,)
+        return Transformer2DModelOutput(sample=output)
+
+    # ============================================================================
+    # RETURN CONTEXT
+    # ============================================================================
+    return CacheContext(
+        modulated_input=modulated_input,
+        hidden_states=hidden_states,
+        encoder_hidden_states=None,  # Single-stream: no separate encoder states
+        temb=c,
+        run_transformer_blocks=run_transformer_blocks,
+        postprocess=postprocess,
+    )
+
+
 # Registry for model-specific extractors
 # Key: Transformer class name
 # Value: extractor function with signature (module, *args, **kwargs) -> CacheContext
@@ -1202,6 +1310,7 @@ EXTRACTOR_REGISTRY: dict[str, Callable] = {
     "Flux2Transformer2DModel": extract_flux2_context,
     "LongCatImageTransformer2DModel": extract_longcat_context,
     "FluxTransformer2DModel": extract_flux_context,
+    "ErnieImageTransformer2DModel": extract_ernie_image_context,
     # Future models:
     # "CogVideoXTransformer3DModel": extract_cogvideox_context,
 }


### PR DESCRIPTION

## Purpose

Part of #1217

## Example Outputs


```
python examples/offline_inference/text_to_image/text_to_image.py \
  --model baidu/ERNIE-Image \
 --prompt "a cup of coffee on the table" \
 --output coffee.png
```

```
python examples/offline_inference/text_to_image/text_to_image.py \
  --model baidu/ERNIE-Image \
  --cache-backend tea_cache \
  --prompt "a cup of coffee on the table" \
  --output coffee.png
```

| Platform | Config | time |  Peak Memory |Total Memory | generated image | 
| --- | --- | --- | --- |  --- | --- |
| NVIDIA RTX PRO 6000 * 1 (96GB) | without teacache | 34.3398  | 35485 | 97887 |  <img width="1024" height="1024" alt="without_teacache_pro6000" src="https://github.com/user-attachments/assets/c736573d-e216-4d24-951a-3aa025cec608" /> |
| NVIDIA RTX PRO 6000 * 1 (96GB) | with teacache | 16.8516  | 35905 |97887 | <img width="1024" height="1024" alt="with_teacache_pro6000" src="https://github.com/user-attachments/assets/16dbafc3-5087-4096-9e87-9b1bfdb6a56d" />|

## UT Test
```
pytest  tests/diffusion/cache/test_teacache_extractors.py::TestErnieImageExtractor -v
```
## UT Test Result
<img width="1556" height="664" alt="test_result" src="https://github.com/user-attachments/assets/b777e948-9b6c-497b-be3f-a620d8d62905" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
