### PR TITLE
[Quant][Perf] Default Blackwell FP8 GEMM to quack CuteDSL fused-bias kernel

### DIFF
--- a/docs/user_guide/quantization/fp8.md
+++ b/docs/user_guide/quantization/fp8.md
@@ -28,6 +28,50 @@ in deep DiT blocks.
 Legend: `✅` supported, `❌` unsupported, `⭕` not verified in this
 guide. FP8 on Ampere may use a weight-only path where available.
 
+### Faster FP8 GEMM on Blackwell (quack)
+
+On Blackwell (SM 100+), vLLM runs FP8 linears through the FlashInfer kernel, which
+applies the bias as a separate kernel after the GEMM. On the small GEMMs in video
+DiTs this bias add is a significant overhead. Installing the optional `quack` kernel
+lets vLLM-Omni fuse `alpha * (A @ B) + bias` into a single CuteDSL GEMM, recovering
+that overhead (e.g. HunyuanVideo-1.5 FP8 goes from slower-than-BF16 to faster).
+
+```bash
+# CUDA 12.9
+pip install vllm-omni[quack]
+
+# CUDA 13.x
+pip install 'quack-kernels[cu13]' --extra-index-url https://download.pytorch.org/whl/cu130
+```
+
+It is enabled automatically once installed (no flag needed) and is **Blackwell-only**:
+on Hopper/Ada the CUTLASS FP8 kernel already fuses bias, so quack is not used there.
+Set `VLLM_OMNI_USE_QUACK_FP8=0` to force the FlashInfer path. If `quack-kernels` is
+not installed, FP8 still works — it just keeps the unfused FlashInfer path.
+
+#### Compile cache and warmup
+
+quack JIT-compiles its kernel once per distinct GEMM shape (tens of seconds, longer
+the first time across all autotuned configs). The compiled `.o` files are cached on
+disk and reused on later runs, so this is a one-time cost — **not** per request.
+
+vLLM-Omni points that cache at `~/.cache/vllm_omni/quack` (override with
+`QUACK_CACHE_DIR`) instead of quack's default under `/tmp`, so it survives restarts.
+In containers, set `QUACK_CACHE_DIR` to a mounted/persistent path — or bake it into
+the image — so the first cold start does not recompile. The engine's startup dummy
+run already exercises the kernels, so with a warm cache the first real request is fast.
+
+To pre-warm specific shapes (e.g. at image build time):
+
+```python
+from vllm_omni.quantization.quack_fp8 import warmup_quack_fp8
+# (M, K, N) per linear; M = number of tokens for your resolution/frame count
+warmup_quack_fp8([(14040, 2048, 6144), (14040, 2048, 2048)])
+```
+
+> The PyPI package is `quack-kernels` (imported as `quack`); plain `pip install
+> quack` is an unrelated statistics library. Requires CUDA 12.9+ and Python 3.12.
+
 ## Model Type Support
 
 ### Diffusion Model (Qwen-Image, Wan2.2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,12 @@ minicpmo = [
     "stepaudio2-minicpmo",
 ]
 
+# Optional Blackwell-only fused-bias FP8 GEMM; package is `quack-kernels` (imported
+# as `quack`), not the unrelated `quack`. See docs/user_guide/quantization/fp8.md.
+quack = [
+    "quack-kernels>=0.3.11",
+]
+
 docs = [
     "mkdocs>=1.5.0",
     "mkdocs-api-autonav",

--- a/vllm_omni/patch.py
+++ b/vllm_omni/patch.py
@@ -257,3 +257,15 @@ def _patch_flashinfer_fp8_scaled_mm_output_shape():
 
 
 _patch_flashinfer_fp8_scaled_mm_output_shape()
+
+
+def _patch_fp8_use_quack_fused_bias():
+    try:
+        from vllm_omni.quantization.quack_fp8 import install_quack_fp8_patch
+
+        install_quack_fp8_patch()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+_patch_fp8_use_quack_fused_bias()

--- a/vllm_omni/quantization/quack_fp8.py
+++ b/vllm_omni/quantization/quack_fp8.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""FP8 scaled-MM with a fused bias epilogue, backed by quack's CuteDSL GEMM."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+_gemm_interface = None
+
+
+def _is_blackwell() -> bool:
+    try:
+        if not torch.cuda.is_available():
+            return False
+        return torch.cuda.get_device_capability()[0] >= 10
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def quack_enabled() -> bool:
+    override = os.environ.get("VLLM_OMNI_USE_QUACK_FP8")
+    if override is not None:
+        return override.lower() in _TRUTHY
+    return _is_blackwell()
+
+
+def _set_persistent_cache_dir() -> None:
+    if os.environ.get("QUACK_CACHE_DIR"):
+        return
+    root = (
+        os.environ.get("VLLM_CACHE_ROOT")
+        or os.environ.get("XDG_CACHE_HOME")
+        or os.path.join(os.path.expanduser("~"), ".cache")
+    )
+    os.environ["QUACK_CACHE_DIR"] = os.path.join(root, "vllm_omni", "quack")
+
+
+def _load_quack():
+    global _gemm_interface
+    if _gemm_interface is not None:
+        return _gemm_interface or None
+    try:
+        _set_persistent_cache_dir()
+
+        import cutlass
+        import cutlass.base_dsl
+        import cutlass.base_dsl.arch as arch
+
+        if not hasattr(cutlass.base_dsl, "Arch"):
+            cutlass.base_dsl.Arch = arch.Arch
+
+        import quack.gemm_interface as gemm_interface
+        from quack.cute_dsl_utils import torch2cute_dtype_map
+
+        torch2cute_dtype_map.setdefault(torch.float8_e4m3fn, cutlass.Float8E4M3FN)
+        torch2cute_dtype_map.setdefault(torch.float8_e5m2, cutlass.Float8E5M2)
+
+        _gemm_interface = gemm_interface
+        logger.info("Quack FP8 fused-bias GEMM enabled (CuteDSL).")
+        return gemm_interface
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Quack FP8 unavailable, using FlashInfer: %s", exc)
+        _gemm_interface = False
+        return None
+
+
+def quack_scaled_fp8_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor | None:
+    gemm = _load_quack()
+    if gemm is None:
+        return None
+    out = torch.empty(a.shape[0], b.shape[1], device=a.device, dtype=out_dtype)
+    alpha = scale_a.reshape(1).float() * scale_b.reshape(1).float()
+    gemm.gemm_tuned(a, b, out, bias=bias, alpha=alpha)
+    return out
+
+
+def install_quack_fp8_patch() -> None:
+    if not quack_enabled():
+        return
+    if _load_quack() is None:
+        return
+    try:
+        from vllm.model_executor.kernels.linear.scaled_mm.flashinfer import (
+            FlashInferFP8ScaledMMLinearKernel,
+        )
+    except ImportError:
+        return
+
+    original = FlashInferFP8ScaledMMLinearKernel.apply_scaled_mm
+    if getattr(original, "_omni_quack_patched", False):
+        return
+
+    def apply_scaled_mm(self, *, A, B, out_dtype, As, Bs, bias, output_shape):  # noqa: N803
+        try:
+            out = quack_scaled_fp8_mm(A, B, As, Bs, out_dtype, bias)
+            if out is not None:
+                return out.view(*output_shape)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning_once("Quack FP8 GEMM failed (%s); using FlashInfer.", exc)
+        return original(self, A=A, B=B, out_dtype=out_dtype, As=As, Bs=Bs, bias=bias, output_shape=output_shape)
+
+    apply_scaled_mm._omni_quack_patched = True
+    FlashInferFP8ScaledMMLinearKernel.apply_scaled_mm = apply_scaled_mm
+    logger.info("Patched FlashInfer FP8 ScaledMM to use quack fused-bias GEMM.")
+
+
+def warmup_quack_fp8(
+    shapes: list[tuple[int, int, int]],
+    device: str = "cuda",
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> None:
+    if _load_quack() is None:
+        return
+    scale = torch.ones(1, device=device, dtype=torch.float32)
+    for m, k, n in shapes:
+        a = torch.zeros(m, k, device=device, dtype=torch.float8_e4m3fn)
+        b = torch.zeros(k, n, device=device, dtype=torch.float8_e4m3fn)
+        quack_scaled_fp8_mm(a, b, scale, scale, out_dtype)
+    if torch.cuda.is_available():
+        torch.accelerator.synchronize()


### PR DESCRIPTION
## What this does

On **Blackwell (cc ≥ 100)** vLLM serves FP8 linears through the FlashInfer kernel,
which runs the GEMM and then the **bias as a separate kernel**: FlashInfer's
`bmm_fp8` has no bias argument, so vLLM does the GEMM and then a full-size
`aten::add`. On the small GEMMs in video DiTs that add is expensive — on
HunyuanVideo-1.5 the QKV linear spends **~197 µs** in it, enough to make FP8
**+22% slower per DiT step than BF16** (BF16's `nvjet` kernel fuses bias).

This PR routes that FlashInfer FP8 path through [quack](https://github.com/Dao-AILab/quack)'s
CuteDSL GEMM, which fuses `alpha * (A @ B) + bias` into **one kernel** (no extra
HBM round-trip). Both online and offline FP8 go through the same kernel hook, so
quantization just gets faster automatically with no flag to set.

| HunyuanVideo-1.5 480p, B300 | per DiT step | vs BF16 |
|---|---|---|
| BF16 | ~398 ms | — |
| FP8 (FlashInfer) | ~484 ms | +22% slower |
| **FP8 + quack (this PR)** | **~378 ms** | **−5% faster** |

Verified on B300: matches the reference (rel-err `1e-4`), the separate `aten::add`
is gone from the trace (bias now in the `quackgemm` epilogue), GPU work per QKV
linear drops 430 → 128 µs.

## Why Blackwell only

The bias-add overhead is **specific to the FlashInfer path**, and vLLM only selects
FlashInfer on cc ≥ 100. The kernel chooser (`_POSSIBLE_FP8_KERNELS[CUDA]`) routes by
arch, and the two FP8 paths handle bias differently:

| GPU | vLLM picks | Bias handling | quack needed? |
|---|---|---|---|
| Hopper (sm90) | CUTLASS | **already fused** — `cutlass_scaled_mm(..., bias=bias)` | No |
| Blackwell (sm100/110/120) | FlashInfer | **separate `aten::add`** (~197 µs) | **Yes** |

So this is scoped to Blackwell on purpose — Hopper's CUTLASS kernel already fuses
bias in its epilogue, leaving nothing to remove there.

## How it's enabled

**Automatic, gated, with a safe fallback** — no flag needed:

- **Default on** when running on **Blackwell (cc ≥ 100)** *and* `quack-kernels` is
  importable. Startup logs `Quack FP8 fused-bias GEMM enabled`.
- **Non-Blackwell or quack not installed** → the patch is never installed;
  FlashInfer/CUTLASS run exactly as before (no per-call overhead, no warning spam).
- **Opt out** with `VLLM_OMNI_USE_QUACK_FP8=0` (and `=1` to force it on regardless).
- **Safe fallback**: any runtime error logs once and transparently uses FlashInfer.

## Installation

quack is an **optional extra**, not a core dependency (it pulls the large
`nvidia-cutlass-dsl` libs and only helps on Blackwell):

```bash
# CUDA 12.9
pip install vllm-omni[quack]

# CUDA 13.x — use quack's cu13 wheel directly
pip install 'quack-kernels[cu13]' --extra-index-url https://download.pytorch.org/whl/cu130
```

> The PyPI package is **`quack-kernels`** (imported as `quack`) — plain `pip install
> quack` is an unrelated statistics library.

Then serve / run any FP8 config as usual — quack engages on its own, e.g.:

```bash
vllm-omni serve --config vllm_omni/model_executor/stage_configs/hunyuan_video_15_dit_fp8.yaml
```

## Compile cache & warmup

quack JIT-compiles its kernel once per distinct GEMM shape (tens of seconds; longer
the very first time, across all autotuned configs). The compiled `.o` files are
cached on disk and reused afterward, so this is a **one-time** cost, not per request.

- The cache is pointed at **`~/.cache/vllm_omni/quack`** by default (override with
  `QUACK_CACHE_DIR`) instead of quack's `/tmp` default, so it **survives restarts**.
  In containers, set `QUACK_CACHE_DIR` to a mounted/persistent path or bake it into
  the image, and the one-time compile is paid once per machine — not per cold start.
- The engine's startup **dummy run** already exercises the kernels, so with a warm
  cache the first real request is fast.
- To pre-warm specific shapes at build time:
  ```python
  from vllm_omni.quantization.quack_fp8 import warmup_quack_fp8
  warmup_quack_fp8([(14040, 2048, 6144), (14040, 2048, 2048)])  # (M, K, N) per linear
  ```

## Profiler evidence

PyTorch profiler on the same HV-1.5 480p FP8 run, with and without quack. GPU-side
kernel durations:

| | count | median | max |
|---|---|---|---|
| **FP8 (FlashInfer)** — cutlass GEMM (the matmul) | 5,184 | 41.3 µs | 276.5 µs |
| **FP8 (FlashInfer)** — large elementwise (incl. the separate bias add) | 6,069 | 118.5 µs | 862.8 µs |
| **FP8 + quack** — `quackgemm` (GEMM **+ bias, fused**) | 5,184 | 24.9 µs | 133.6 µs |
| **FP8 + quack** — └ large / QKV-shape band | 1,944 | 124.6 µs | 133.6 µs |

The FlashInfer FP8 path is **two GPU kernels per linear** — a cutlass GEMM plus a
separate full-size elementwise (the bias add, ~197 µs on the QKV span specifically).
quack collapses both into **one** `quackgemm` kernel (~124 µs at the QKV/MLP shapes):
the trace contains **0** `bmm_fp8` calls and the large-elementwise population drops
accordingly. The `bmm_fp8` op on the CPU timeline (~172 µs) is the *operator
envelope*, not the GPU matmul — what quack removes is the separate bias-add kernel
that runs after every FP8 GEMM, plus it runs the matmul in a faster fused kernel.

## Scope

- `vllm_omni/quantization/quack_fp8.py` — kernel wrapper, Blackwell gating, FlashInfer
  patch, persistent cache dir, `warmup_quack_fp8` helper.
- `vllm_omni/patch.py` — installs the patch at import (covers online + offline).
- `pyproject.toml` — `quack` optional extra (`quack-kernels`).
- `docs/user_guide/quantization/fp8.md` — usage, install, cache/warmup.

Carries two one-line shims for the `quack-kernels` 0.3.x / `nvidia-cutlass-dsl` 4.5
version skew (`Arch` alias, fp8 dtype-map registration).

## Follow-up (separate PR)

- Register a first-class `QuackFP8ScaledMMLinearKernel` in `_POSSIBLE_FP8_KERNELS`
  (instead of monkeypatching FlashInfer) so it uses vLLM's native chooser/fallback.
  Still Blackwell-scoped — a code-cleanliness change, not new coverage.

Signed-off-by: lishunyang12 <lishunyang12@163.com>
