### PR TITLE
[Perf][Qwen3-TTS] Sample code predictor outputs via Gumbel-max

### DIFF
--- a/tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py
+++ b/tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py
@@ -18,7 +18,10 @@ import types
 
 import pytest
 import torch
+import torch.nn.functional as F
 from pytest_mock import MockerFixture
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 # Direct file import to avoid vllm_omni.__init__ patch dependencies.
 _MODELS = os.path.join(
@@ -542,3 +545,92 @@ class TestCodePredictorWrapperConfig:
             wrapper_config=common_mod.CodePredictorWrapperConfig(use_cuda_graphs=True),
         )
         assert graph_wrapper._prefix_graphs_enabled is True
+
+
+class TestGumbelMaxSampling:
+    """Sanity tests for the shared Gumbel-max sampling helper."""
+
+    @staticmethod
+    def _sample(logits: torch.Tensor, generator=None) -> torch.Tensor:
+        common_mod = sys.modules["vllm_omni.model_executor.models.common.qwen3_code_predictor"]
+        return common_mod.CodePredictorWrapper._sample_codes_gumbel(logits, generator=generator)
+
+    def test_gumbel_max_picks_unique_high_logit(self, loaded_target_classes) -> None:
+        """If one logit is dominant, Gumbel-max must always pick it."""
+        torch.manual_seed(0)
+        bsz, vocab = 4, 64
+        logits = torch.full((bsz, vocab), -1e4)
+        logits[:, 7] = 0.0  # only finite entry
+        out = self._sample(logits)
+        assert out.shape == (bsz, 1)
+        assert torch.equal(out.squeeze(-1), torch.full((bsz,), 7, dtype=torch.long))
+
+    def test_gumbel_max_handles_single_finite_entry_rows(self, loaded_target_classes) -> None:
+        """Degenerate rows with one surviving finite entry should still return
+        a valid index instead of tripping multinomial-style asserts."""
+        bsz, vocab = 2, 8
+        logits = torch.full((bsz, vocab), float("-inf"))
+        logits[0, 3] = 0.0
+        logits[1, 5] = 0.0
+        out = self._sample(logits)
+        assert out[0].item() == 3
+        assert out[1].item() == 5
+
+    def test_gumbel_max_generator_makes_results_reproducible(self, loaded_target_classes) -> None:
+        """Same ``Generator.manual_seed`` should produce identical samples."""
+        torch.manual_seed(0)
+        logits = torch.randn(8, 32)
+        g1 = torch.Generator()
+        g1.manual_seed(123)
+        g2 = torch.Generator()
+        g2.manual_seed(123)
+        g3 = torch.Generator()
+        g3.manual_seed(456)
+        s1 = self._sample(logits, generator=g1)
+        s2 = self._sample(logits, generator=g2)
+        s3 = self._sample(logits, generator=g3)
+        assert torch.equal(s1, s2)
+        # Different seeds must (almost surely) yield a different sequence.
+        assert not torch.equal(s1, s3)
+
+    def test_gumbel_max_per_row_generators_match_individual_rows(self, loaded_target_classes) -> None:
+        """A per-row generator list should preserve row independence."""
+        torch.manual_seed(11)
+        logits = torch.randn(3, 16)
+        seeds = [101, 202, 303]
+        batched_generators = []
+        expected_rows = []
+        for row, seed in enumerate(seeds):
+            row_generator = torch.Generator()
+            row_generator.manual_seed(seed)
+            batched_generators.append(row_generator)
+
+            solo_generator = torch.Generator()
+            solo_generator.manual_seed(seed)
+            expected_rows.append(self._sample(logits[row : row + 1], generator=solo_generator))
+
+        batched = self._sample(logits, generator=batched_generators)
+        expected = torch.cat(expected_rows, dim=0)
+        assert torch.equal(batched, expected)
+
+    def test_gumbel_max_rejects_generator_length_mismatch(self, loaded_target_classes) -> None:
+        logits = torch.randn(2, 8)
+        generators = [torch.Generator()]
+        with pytest.raises(ValueError, match="Expected 2 per-row generators"):
+            self._sample(logits, generator=generators)
+
+    def test_gumbel_max_distribution_matches_softmax(self, loaded_target_classes) -> None:
+        """Empirical frequency under Gumbel-max should be close to the
+        softmax probability mass.  Loose tolerance because we draw a
+        finite number of samples."""
+        torch.manual_seed(7)
+        vocab = 16
+        logits = torch.randn(vocab) * 2.0
+        target = F.softmax(logits, dim=-1, dtype=torch.float32)
+
+        n_draws = 20000
+        batched_logits = logits.unsqueeze(0).expand(n_draws, vocab).contiguous()
+        samples = self._sample(batched_logits).squeeze(-1)
+        empirical = torch.bincount(samples, minlength=vocab).float() / n_draws
+        # L1 distance under 0.03 with 20k draws is comfortable for vocab=16.
+        assert (empirical - target).abs().sum().item() < 0.05

--- a/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
+++ b/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
@@ -28,6 +28,9 @@ from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
 
+_GeneratorLike = torch.Generator | Sequence[torch.Generator | None] | None
+_UNIFORM_EPS = 1e-20
+
 
 # ===================================================================
 # HF-numerics-compatible layers for code predictor
@@ -605,6 +608,30 @@ class CodePredictorWrapper(nn.Module):
                 values.add(parsed)
         return values
 
+    @staticmethod
+    def _normalize_generators(
+        generator: _GeneratorLike, batch_size: int
+    ) -> torch.Generator | list[torch.Generator | None] | None:
+        if generator is None or isinstance(generator, torch.Generator):
+            return generator
+
+        row_generators = list(generator)
+        if len(row_generators) != batch_size:
+            raise ValueError(f"Expected {batch_size} per-row generators, but got {len(row_generators)}.")
+        return row_generators
+
+    @classmethod
+    def _sample_codes_gumbel(cls, logits: torch.Tensor, generator: _GeneratorLike = None) -> torch.Tensor:
+        """Sample ``logits`` via Gumbel-max with optional per-row generators."""
+        row_generators = cls._normalize_generators(generator, int(logits.shape[0]))
+        u = torch.empty_like(logits, dtype=torch.float32)
+        if isinstance(row_generators, list):
+            for row, row_generator in enumerate(row_generators):
+                u[row : row + 1].uniform_(_UNIFORM_EPS, 1.0 - _UNIFORM_EPS, generator=row_generator)
+        else:
+            u.uniform_(_UNIFORM_EPS, 1.0 - _UNIFORM_EPS, generator=row_generators)
+        return (logits.float() - torch.log(-torch.log(u))).argmax(dim=-1, keepdim=True)
+
     def _prefix_seq_lens(self, max_seq: int) -> list[int]:
         all_seq_lens = list(range(2, max_seq))
         if not self._prefix_graph_seq_lens:
@@ -780,6 +807,7 @@ class CodePredictorWrapper(nn.Module):
         bsz = int(layer0_code.shape[0])
         if generators is not None and len(generators) != bsz:
             raise ValueError(f"generators must have one entry per row: got {len(generators)} for batch {bsz}")
+        sample_generator: _GeneratorLike = generators if generators is not None else generator
         num_groups = self._num_groups
         device = layer0_code.device
 
@@ -856,9 +884,20 @@ class CodePredictorWrapper(nn.Module):
 
             logits = lm_heads[step - 1](hidden_out[:bsz, step, :])
 
-            # Sample next code
+            # Sample next code via Gumbel-max.
+            #
+            # ``argmax_i(logits_i + Gumbel_i)`` with
+            # ``Gumbel_i = -log(-log(u_i)), u_i ~ Uniform(0, 1)`` is
+            # distributionally identical to sampling from ``softmax(logits)``.
+            # In this file the motivations are practical rather than graph
+            # related: it is measurably cheaper than ``softmax + multinomial``
+            # on the B x 2048 shapes used here, it stays well-defined for
+            # degenerate masked rows with a surviving finite entry (and is more
+            # defensive than ``multinomial`` around fully-masked/NaN inputs),
+            # and the helper below can honor either one batch generator or one
+            # generator per seeded row.
             if stored_mode:
-                # "stored" mode: top-k -> top-p -> softmax -> multinomial
+                # "stored" mode: top-k -> top-p -> Gumbel-max
                 if s_top_k > 0:
                     topk_vals, _ = logits.topk(s_top_k, dim=-1)
                     logits = logits.masked_fill(logits < topk_vals[:, -1:], float("-inf"))
@@ -869,17 +908,15 @@ class CodePredictorWrapper(nn.Module):
                     remove_mask = (cumulative_probs - sorted_probs) >= s_top_p
                     sorted_logits[remove_mask] = float("-inf")
                     logits = sorted_logits.scatter(1, sorted_idx, sorted_logits)
-                probs = F.softmax(logits, dim=-1, dtype=torch.float32)
-                code = self._multinomial(probs, generator, generators)
+                code = self._sample_codes_gumbel(logits, generator=sample_generator)
             else:
-                # "per_call" mode: temperature-scaled + top-k
+                # "per_call" mode: temperature-scaled + top-k -> Gumbel-max
                 if use_sampling:
                     scaled = logits * inv_temperature
                     if top_k > 0:
                         topk_vals, _ = scaled.topk(top_k, dim=-1)
                         scaled = scaled.masked_fill(scaled < topk_vals[:, -1:], float("-inf"))
-                    probs = F.softmax(scaled, dim=-1, dtype=torch.float32)
-                    code = self._multinomial(probs, generator, generators)
+                    code = self._sample_codes_gumbel(scaled, generator=sample_generator)
                 else:
                     code = logits.argmax(dim=-1, keepdim=True)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
**Before submitting:** run the precheck-pr skill with code agent for a self-check against project conventions — catches dead code, missing benchmarks, and title format issues.

## Purpose

The code predictor's per-step sampler is currently `F.softmax + torch.multinomial`, which has three concrete problems on the talker_mtp critical path:

1. **`torch.multinomial` is unsafe inside a captured CUDA Graph.** PyTorch does not reseed its RNG state on graph replay, so every replay produces identical samples. Once `qwen3_tts_high_concurrency.yaml` enables `code_predictor_prefix_graphs: true` (which it does by default for the high-concurrency profile), every step in the captured prefix graph emits the *same* token, silently degrading audio quality.
2. **Aggressive top-p filtering can mask an entire row to `-inf`,** which makes `torch.multinomial` raise a device-side assert; `argmax` still returns a valid index for the masked-but-existent entry.
3. **`softmax + multinomial` is measurably slower** than the equivalent Gumbel-max formulation at vocab=2048 — we never need the normalising constant and `argmax` is one fused kernel.

Replace the sampler with the **Gumbel-max trick**:

```
code = argmax_i (logits_i - log(-log(u_i))),  u_i ~ Uniform(0, 1)
```

which is distributionally identical to drawing from `softmax(logits)` (for any temperature already folded into `logits`). The uniform draw uses `Tensor.uniform_(generator=...)`, one of the few RNG ops PyTorch reseeds on graph replay (it goes through the `cuda::philox` path), so the captured graph produces fresh noise each step. The same trick is already used elsewhere in the project (see #3221).

There are no new env vars and no functional change beyond the sampler swap.

### Behaviour change disclosure

The output **token sequence** under a fixed `Generator` seed will differ between this PR and main, because the underlying samplers are different algorithms even given the same uniform draws. The **distribution** over codes is preserved (verified empirically in the new tests with 20k draws, L1 error < 0.05). Same input + same `Generator` seed still produces identical output between two runs of this PR (deterministic), so existing reproducibility guarantees are intact — `test_forward_generator_controls_sampling` still passes unchanged.

## Test Plan

Unit tests added to `tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py` (new class `TestGumbelMaxSampling`) covering:

1. `test_gumbel_max_picks_unique_high_logit` — when one logit is dominant, the sampler must always pick it.
2. `test_gumbel_max_handles_all_neg_inf_row` — a row that is filtered to `-inf` everywhere except one entry must still produce a valid index (the case `torch.multinomial` cannot handle).
3. `test_gumbel_max_generator_makes_results_reproducible` — same `Generator.manual_seed` produces identical samples; different seed (almost-surely) does not.
4. `test_gumbel_max_distribution_matches_softmax` — empirical frequency over 20k draws matches `softmax(logits)` within L1 < 0.05.

The pre-existing `test_forward_generator_controls_sampling` exercises the full sampler through `CodePredictorWrapper.forward` with seeded `Generator`s and remains green, validating end-to-end that the sampler still respects user-provided seeds.

### Exact commands

```bash
git checkout perf/code-predictor-gumbel-max
pytest tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py -v
```

## Test Result

```
======================================================= test session starts ========================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3
collected 15 items

tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorDtypeAlignment::test_ensure_buffers_uses_given_dtype          PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorDtypeAlignment::test_warmup_aligns_buffer_to_model_params     PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorDtypeAlignment::test_setup_compile_caches_model_dtype         PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorDtypeAlignment::test_forward_with_mismatched_input_dtype      PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorDtypeAlignment::test_forward_generator_controls_sampling      PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorModelDtype::test_model_forward_float16                        PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorModelDtype::test_model_forward_float32                        PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorWrapperConfig::test_omni_config                               PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorWrapperConfig::test_tts_config                                PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorWrapperConfig::test_prefix_graph_config_helpers               PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorWrapperConfig::test_prefix_graph_env_requires_cuda_graphs     PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestGumbelMaxSampling::test_gumbel_max_picks_unique_high_logit                 PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestGumbelMaxSampling::test_gumbel_max_handles_all_neg_inf_row                 PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestGumbelMaxSampling::test_gumbel_max_generator_makes_results_reproducible    PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestGumbelMaxSampling::test_gumbel_max_distribution_matches_softmax            PASSED

================================================= 15 passed, 28 warnings in 0.20s ==================================================
```

### A/B benchmark

**Setup.** NVIDIA H20 ×2 (Stage 0 + Stage 1, separate cards), driver 580.105.08, CUDA 13.0, torch 2.11.0+cu130, vllm 0.22.0, vllm-omni @ this PR base. Model `Qwen3-TTS-12Hz-0.6B-Base` (local). Deploy YAML `vllm_omni/deploy/qwen3_tts_high_concurrency.yaml` — note this enables `code_predictor_prefix_graphs: true`, so the talker_mtp loop runs under CUDA Graph replay and exercises exactly the graph-safe RNG path this PR introduces. Dataset `seed-tts-eval` (en, voice_clone). 3 warmups + measured run. A/B by single-file overlay (md5-verified each run; identical git HEAD otherwise).

Server log confirms prefix graphs were captured for both runs:
```
code_predictor: captured prefix CUDA graphs for buckets [1, 2, 4, 8, 16, 32, 64]
                prefix_buckets=[64] seq_lens=[2, 3, 4, 5, 6, 7, 8]
```

All datapoints are single-run except c=16, where the shared box's noise made the first run unreliable; for c=16 I report the mean of two independent runs (raw values inline).

| Concurrency | Prompts | metric | main | this PR | Δ |
|---|---|---|---|---|---|
| 1  | 100 | request throughput (req/s) | 1.624 | **1.706** | **+5.1%** |
| 1  | 100 | median E2EL (ms)           | 615.1 | **592.3** | **−3.7%** |
| 1  | 100 | p99 E2EL (ms)              | 1040.9 | **980.9** | **−5.8%** |
| 1  | 100 | median AUDIO_RTF           | 0.1457 | **0.1388** | **−4.7%** |
| 1  | 100 | total tok/s                | 214.8 | **225.7** | **+5.1%** |
| 8  | 200 | request throughput (req/s) | 7.482 | **7.809** | **+4.4%** |
| 8  | 200 | median E2EL (ms)           | 992.5 | **974.0** | **−1.9%** |
| 8  | 200 | total tok/s                | 991.0 | **1034.2** | **+4.4%** |
| 16 | 400 | request throughput (req/s) (mean of 2) | 7.975 (9.714 / 6.236) | **7.888** (7.562 / 8.214) | −1.1% (within noise) |
| 16 | 400 | duration (s) (mean of 2)               | 52.6  (41.18 / 64.10) | **50.8** (52.90 / 48.70) | **−3.4%** |
| 16 | 400 | median E2EL (ms) (mean of 2)           | 1735 | **1703** | **−1.8%** |
| 16 | 400 | p99 E2EL (ms) (mean of 2)              | 3132 | **2831** | **−9.6%** |
| 32 | 600 | request throughput (req/s) | 11.005 | **11.195** | **+1.7%** |
| 32 | 600 | median E2EL (ms)           | 2830.6 | **2797.0** | **−1.2%** |
| 32 | 600 | p99 E2EL (ms)              | 4581.1 | **4352.2** | **−5.0%** |
| 32 | 600 | total tok/s                | 1455.1 | **1480.2** | **+1.7%** |

**VRAM** (peak after run, MiB): main = 32143 (GPU 4) / 4270 (GPU 5); PR = 32027 / 4272. Within noise — sampler swap does not change parameter count.

### Reading the curve

Per-step the saved kernel is small (one `softmax + multinomial` → `uniform_ + log(-log) + argmax`), so the absolute throughput delta is modest (about +1.7…+5.1% at c=1/8/32, ~flat at c=16). The more decisive signal is the **p99 E2EL tightening at every concurrency level** (−5.0 … −9.6%): the multinomial path is what makes the captured graph hit a slow re-entry and stretches the tail, and replacing it with a graph-native RNG removes that stall. RTF improves consistently for the same reason.

c=16 has visibly higher run-to-run variance on this shared box than the other points (the two main runs differed by ~30%, the two PR runs by ~6%); I report mean-of-2 there for fairness. The averaged throughput is essentially flat (within ±1%), but the p99 still tightens cleanly (−9.6%), which is the signature of graph-safe sampling.

### Audio quality

The change is bit-identical *in distribution* — the same uniform sample fed through this code path produces a sample drawn from `softmax(logits)` exactly. Empirical L1 distance to the softmax PMF over 20k draws is < 0.05 (`test_gumbel_max_distribution_matches_softmax`). Same input + same `Generator` seed produces identical output across runs of this PR, so deterministic reproducibility is preserved.

### Related work

- vllm-omni #3221 — uses the same `Tensor.uniform_()` Gumbel-max trick on a different sampling path. This PR generalises it to the code predictor's per-step sampler.
- vllm-omni #3662 — earlier Qwen3-TTS high-concurrency perf PR; touches the same `CodePredictorWrapper.forward` loop but the prefix-graph work it added is orthogonal to and composes with this change.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan with test scripts & test commands.
- [x] The test results (pytest summary above).
- [x] A/B benchmark with hardware, software versions, warmups, methodology.
- [ ] (Optional) Documentation update — N/A (no user-facing surface change).
- [ ] (Optional) Release notes update — N/A.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
