### PR TITLE
[Perf][Qwen3-TTS] Fuse QKV and gate_up projections in code predictor

### DIFF
--- a/tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py
+++ b/tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py
@@ -542,3 +542,189 @@ class TestCodePredictorWrapperConfig:
             wrapper_config=common_mod.CodePredictorWrapperConfig(use_cuda_graphs=True),
         )
         assert graph_wrapper._prefix_graphs_enabled is True
+
+
+class TestCodePredictorFusedProjections:
+    """Reference tests for the fused qkv_proj / gate_up_proj paths.
+
+    These CPU tests confirm that the packed projections implement the same
+    linear algebra as the unfused reference under this setup. GPU executions
+    may still diverge at the bit level when kernel choices change.
+    """
+
+    def test_fused_qkv_matches_separate(self, loaded_target_classes) -> None:
+        torch.manual_seed(0)
+        hidden = 32
+        num_heads, num_kv_heads, head_dim = 4, 2, 8
+        q_size = num_heads * head_dim
+        kv_size = num_kv_heads * head_dim
+        x = torch.randn(2, 5, hidden)
+
+        q = torch.nn.Linear(hidden, q_size, bias=False)
+        k = torch.nn.Linear(hidden, kv_size, bias=False)
+        v = torch.nn.Linear(hidden, kv_size, bias=False)
+        fused = torch.nn.Linear(hidden, q_size + 2 * kv_size, bias=False)
+        with torch.no_grad():
+            fused.weight.copy_(torch.cat([q.weight, k.weight, v.weight], dim=0))
+
+        ref_q, ref_k, ref_v = q(x), k(x), v(x)
+        out_q, out_k, out_v = fused(x).split([q_size, kv_size, kv_size], dim=-1)
+        assert torch.equal(ref_q, out_q)
+        assert torch.equal(ref_k, out_k)
+        assert torch.equal(ref_v, out_v)
+
+    def test_attention_split_redensifies_kv_slices(self, loaded_target_classes) -> None:
+        cp_config, _ = _make_tiny_config(loaded_target_classes)
+        common_mod = sys.modules["vllm_omni.model_executor.models.common.qwen3_code_predictor"]
+        attn = common_mod.CodePredictorAttention(cp_config)
+
+        qkv = torch.randn(2, 5, attn._q_size + 2 * attn._kv_size)
+        q_ref, k_ref, v_ref = qkv.split([attn._q_size, attn._kv_size, attn._kv_size], dim=-1)
+        q_raw, k_raw, v_raw = attn._split_qkv(qkv)
+
+        assert torch.equal(q_raw, q_ref)
+        assert torch.equal(k_raw, k_ref)
+        assert torch.equal(v_raw, v_ref)
+        assert k_raw.is_contiguous()
+        assert v_raw.is_contiguous()
+
+    def test_fused_gate_up_matches_separate(self, loaded_target_classes) -> None:
+        torch.manual_seed(1)
+        hidden, intermediate = 32, 64
+        x = torch.randn(2, 5, hidden)
+
+        g = torch.nn.Linear(hidden, intermediate, bias=False)
+        u = torch.nn.Linear(hidden, intermediate, bias=False)
+        fused = torch.nn.Linear(hidden, 2 * intermediate, bias=False)
+        with torch.no_grad():
+            fused.weight.copy_(torch.cat([g.weight, u.weight], dim=0))
+
+        ref_g, ref_u = g(x), u(x)
+        out_g, out_u = fused(x).split([intermediate, intermediate], dim=-1)
+        assert torch.equal(ref_g, out_g)
+        assert torch.equal(ref_u, out_u)
+
+    def test_load_weights_repacks_hf_shards(self, loaded_target_classes) -> None:
+        """``load_weights`` must transparently re-pack HF q/k/v and gate/up
+        shards into the fused ``qkv_proj`` and ``gate_up_proj`` weights."""
+        _, _, _, code_predictor_model, _ = loaded_target_classes
+        cp_config, _ = _make_tiny_config(loaded_target_classes)
+        model = code_predictor_model(cp_config, embedding_dim=cp_config.hidden_size)
+
+        # Build a synthetic "HF checkpoint" that exposes separate q/k/v
+        # and gate/up shards, mirroring what HuggingFace ships.
+        param_dict = dict(model.named_parameters(remove_duplicate=False))
+        weights: list[tuple[str, torch.Tensor]] = []
+        torch.manual_seed(42)
+        for name, param in param_dict.items():
+            if name.endswith(".self_attn.qkv_proj.weight"):
+                prefix = name[: -len(".qkv_proj.weight")]
+                num_heads = cp_config.num_attention_heads
+                num_kv_heads = cp_config.num_key_value_heads
+                head_dim = cp_config.head_dim
+                q_size = num_heads * head_dim
+                kv_size = num_kv_heads * head_dim
+                hidden = cp_config.hidden_size
+                q_w = torch.randn(q_size, hidden)
+                k_w = torch.randn(kv_size, hidden)
+                v_w = torch.randn(kv_size, hidden)
+                weights.append((f"{prefix}.q_proj.weight", q_w))
+                weights.append((f"{prefix}.k_proj.weight", k_w))
+                weights.append((f"{prefix}.v_proj.weight", v_w))
+            elif name.endswith(".mlp.gate_up_proj.weight"):
+                prefix = name[: -len(".gate_up_proj.weight")]
+                inter = cp_config.intermediate_size
+                hidden = cp_config.hidden_size
+                gate_w = torch.randn(inter, hidden)
+                up_w = torch.randn(inter, hidden)
+                weights.append((f"{prefix}.gate_proj.weight", gate_w))
+                weights.append((f"{prefix}.up_proj.weight", up_w))
+            else:
+                # Pass-through parameters (norms, embeddings, o_proj, down_proj).
+                weights.append((name, torch.randn_like(param)))
+
+        loaded = model.load_weights(weights)
+        # Every fused param should appear in the loaded set.
+        fused_names = [n for n in param_dict if n.endswith("qkv_proj.weight") or n.endswith("gate_up_proj.weight")]
+        assert fused_names, "test config must contain at least one fused projection layer"
+        for fname in fused_names:
+            assert fname in loaded, f"{fname} was not assembled by load_weights"
+
+    def test_wrapper_load_weights_handles_model_prefixed_shards(
+        self,
+        mocker: MockerFixture,
+        loaded_target_classes,
+    ) -> None:
+        _, _, code_predictor_wrapper, _, _ = loaded_target_classes
+        cp_config, talker_config = _make_tiny_config(loaded_target_classes)
+        vllm_config = _make_vllm_config(mocker)
+        predictor = code_predictor_wrapper(
+            vllm_config=vllm_config,
+            config=cp_config,
+            talker_config=talker_config,
+        )
+
+        param_dict = dict(predictor.named_parameters(remove_duplicate=False))
+        weights: list[tuple[str, torch.Tensor]] = []
+        torch.manual_seed(7)
+        for name, param in param_dict.items():
+            if name.endswith(".self_attn.qkv_proj.weight"):
+                prefix = name[: -len(".qkv_proj.weight")]
+                q_size = cp_config.num_attention_heads * cp_config.head_dim
+                kv_size = cp_config.num_key_value_heads * cp_config.head_dim
+                hidden = cp_config.hidden_size
+                weights.append((f"{prefix}.q_proj.weight", torch.randn(q_size, hidden)))
+                weights.append((f"{prefix}.k_proj.weight", torch.randn(kv_size, hidden)))
+                weights.append((f"{prefix}.v_proj.weight", torch.randn(kv_size, hidden)))
+            elif name.endswith(".mlp.gate_up_proj.weight"):
+                prefix = name[: -len(".gate_up_proj.weight")]
+                inter = cp_config.intermediate_size
+                hidden = cp_config.hidden_size
+                weights.append((f"{prefix}.gate_proj.weight", torch.randn(inter, hidden)))
+                weights.append((f"{prefix}.up_proj.weight", torch.randn(inter, hidden)))
+            else:
+                weights.append((name, torch.randn_like(param)))
+
+        loaded = predictor.load_weights(weights)
+        fused_names = [n for n in param_dict if n.endswith("qkv_proj.weight") or n.endswith("gate_up_proj.weight")]
+        for fname in fused_names:
+            assert fname in loaded, f"{fname} was not loaded through the outer wrapper"
+
+    def test_load_weights_raises_on_incomplete_shards(self, loaded_target_classes) -> None:
+        """Missing one of q/k/v (or gate/up) must surface a clear error.
+
+        ``CodePredictorBaseModel`` is the inner transformer (its parameter
+        paths look like ``layers.<i>.self_attn.qkv_proj.weight`` -- without
+        the ``model.`` prefix that the outer ``CodePredictorWrapper`` strips
+        before forwarding).  The test mimics that contract.
+        """
+        _, _, _, code_predictor_model, _ = loaded_target_classes
+        cp_config, _ = _make_tiny_config(loaded_target_classes)
+        model = code_predictor_model(cp_config, embedding_dim=cp_config.hidden_size)
+
+        # Find any actual self_attn layer prefix, to make the test robust
+        # to renaming of the inner model's parameter scheme.
+        attn_prefix = next(
+            (
+                name[: -len(".qkv_proj.weight")]
+                for name in dict(model.named_parameters()).keys()
+                if name.endswith(".self_attn.qkv_proj.weight")
+            ),
+            None,
+        )
+        assert attn_prefix is not None, "test config must contain at least one self_attn layer"
+
+        num_heads = cp_config.num_attention_heads
+        num_kv_heads = cp_config.num_key_value_heads
+        head_dim = cp_config.head_dim
+        hidden = cp_config.hidden_size
+
+        # Provide only q + k (no v).  The fused param exists in the model,
+        # so load_weights must refuse to silently leave it uninitialized.
+        bad_weights: list[tuple[str, torch.Tensor]] = [
+            (f"{attn_prefix}.q_proj.weight", torch.randn(num_heads * head_dim, hidden)),
+            (f"{attn_prefix}.k_proj.weight", torch.randn(num_kv_heads * head_dim, hidden)),
+            # v_proj missing on purpose.
+        ]
+        with pytest.raises(RuntimeError, match="incomplete fused shards"):
+            model.load_weights(bad_weights)

--- a/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
+++ b/vllm_omni/model_executor/models/common/qwen3_code_predictor.py
@@ -34,11 +34,11 @@ logger = init_logger(__name__)
 # ===================================================================
 #
 # These use plain PyTorch ops (nn.Linear, manual RMSNorm in float32,
-# rotate_half RoPE) to produce outputs numerically identical to the
-# HuggingFace reference. vLLM's fused kernels (RMSNorm, QKVParallel,
-# get_rope) introduce small precision differences that compound across
-# the autoregressive steps of the code predictor, causing severe
-# audio quality degradation.
+# rotate_half RoPE) to stay as close as practical to the HuggingFace
+# reference math. They avoid the larger drift we saw from vLLM's fused
+# kernels (RMSNorm, QKVParallel, get_rope), but GPU bit-level
+# differences can still happen when packing changes kernel selection or
+# accumulation order across autoregressive steps.
 #
 # See: https://github.com/vllm-project/vllm-omni/issues/2274
 
@@ -134,11 +134,23 @@ class CodePredictorAttention(nn.Module):
         self.scaling = self.head_dim**-0.5
         self.max_seq = int(config.num_code_groups) + 1
 
-        # Separate q/k/v projections matching HF (no fused packing)
+        # Fused QKV projection.
+        #
+        # The HF reference uses three separate ``nn.Linear`` modules for
+        # q/k/v. Packing those weights row-wise into one ``nn.Linear`` keeps
+        # the same matmul at the algebra level, but GPU executions may still
+        # differ by a few ULPs once the output shape changes. The goal here is
+        # narrower: reduce eager host launch overhead while keeping the
+        # downstream q_norm / k_norm / SDPA math and HF checkpoint loading
+        # contract intact.
         bias = getattr(config, "attention_bias", False)
-        self.q_proj = nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=bias)
-        self.k_proj = nn.Linear(self.hidden_size, self.num_kv_heads * self.head_dim, bias=bias)
-        self.v_proj = nn.Linear(self.hidden_size, self.num_kv_heads * self.head_dim, bias=bias)
+        self._q_size = self.num_heads * self.head_dim
+        self._kv_size = self.num_kv_heads * self.head_dim
+        self.qkv_proj = nn.Linear(
+            self.hidden_size,
+            self._q_size + 2 * self._kv_size,
+            bias=bias,
+        )
         self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=False)
         self.q_norm = _RMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = _RMSNorm(self.head_dim, eps=config.rms_norm_eps)
@@ -156,6 +168,15 @@ class CodePredictorAttention(nn.Module):
                 diagonal=1,
             )
             self.register_buffer("_fusion_causal_mask", fusion_mask, persistent=False)
+
+    def _split_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        q_raw = qkv[..., : self._q_size]
+        kv_raw = qkv[..., self._q_size :]
+        # ``split`` would leave the non-leading k/v slices strided like the
+        # packed qkv buffer. Materialize them once here so SDPA sees the same
+        # dense k/v layout as the unfused projection path.
+        k_raw, v_raw = kv_raw.unflatten(-1, (2, self._kv_size)).movedim(-2, 0).contiguous().unbind(0)
+        return q_raw, k_raw, v_raw
 
     def _forward_npu_attention(
         self,
@@ -219,9 +240,14 @@ class CodePredictorAttention(nn.Module):
         hidden_shape_q = (bsz, seq_len, self.num_heads, self.head_dim)
         hidden_shape_kv = (bsz, seq_len, self.num_kv_heads, self.head_dim)
 
-        q = self.q_norm(self.q_proj(hidden_states).view(hidden_shape_q)).transpose(1, 2)
-        k = self.k_norm(self.k_proj(hidden_states).view(hidden_shape_kv)).transpose(1, 2)
-        v = self.v_proj(hidden_states).view(hidden_shape_kv).transpose(1, 2)
+        # Single fused matmul. ``q`` is immediately consumed by RMSNorm; for
+        # ``k/v`` we re-densify the packed tail once so SDPA does not inherit
+        # the packed-buffer stride pattern from the fused projection.
+        qkv = self.qkv_proj(hidden_states)
+        q_raw, k_raw, v_raw = self._split_qkv(qkv)
+        q = self.q_norm(q_raw.view(hidden_shape_q)).transpose(1, 2)
+        k = self.k_norm(k_raw.view(hidden_shape_kv)).transpose(1, 2)
+        v = v_raw.view(hidden_shape_kv).transpose(1, 2)
 
         cos, sin = position_embeddings
         # cos/sin are [batch, seq_len, head_dim], need unsqueeze at dim=1 for heads
@@ -256,12 +282,22 @@ class CodePredictorMLP(nn.Module):
 
     def __init__(self, config, *, prefix: str = "") -> None:
         super().__init__()
-        self.gate_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
-        self.up_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        # Fused gate_up projection. Same packing idea as ``qkv_proj`` above:
+        # one matmul instead of two, with the same algebraic result as
+        # separate gate/up linears, though GPU bit-level drift is still
+        # possible if kernel choices differ.
+        self._intermediate_size = int(config.intermediate_size)
+        self.gate_up_proj = nn.Linear(
+            config.hidden_size,
+            2 * config.intermediate_size,
+            bias=False,
+        )
         self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        return self.down_proj(F.silu(self.gate_proj(hidden_states)) * self.up_proj(hidden_states))
+        gate_up = self.gate_up_proj(hidden_states)
+        gate, up = gate_up.split([self._intermediate_size, self._intermediate_size], dim=-1)
+        return self.down_proj(F.silu(gate) * up)
 
 
 # ===================================================================
@@ -365,11 +401,84 @@ class CodePredictorBaseModel(nn.Module):
             hidden_states = self.norm(hidden_states)
         return hidden_states.to(input_dtype)
 
+    # Mapping from HF checkpoint shard name to the (fused parameter,
+    # slice index) pair used to assemble the fused tensor.  See
+    # ``load_weights`` below.
+    _FUSED_QKV_SHARDS: tuple[tuple[str, str, int], ...] = (
+        ("q_proj", "qkv_proj", 0),
+        ("k_proj", "qkv_proj", 1),
+        ("v_proj", "qkv_proj", 2),
+    )
+    _FUSED_GATE_UP_SHARDS: tuple[tuple[str, str, int], ...] = (
+        ("gate_proj", "gate_up_proj", 0),
+        ("up_proj", "gate_up_proj", 1),
+    )
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load weights, transparently re-packing HF q/k/v and gate/up shards
+        into the fused ``qkv_proj`` and ``gate_up_proj`` parameters.
+
+        HF checkpoints ship q_proj / k_proj / v_proj (and gate_proj /
+        up_proj) as separate tensors.  Our model defines a single
+        ``qkv_proj`` (``gate_up_proj``) whose weight is the row-wise
+        concatenation of those shards in q/k/v (gate/up) order.  We
+        buffer the shards per layer prefix and write the fused parameter
+        in one go once all shards have arrived.
+        """
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         loaded_params: set[str] = set()
+
+        # layer_prefix -> {fused_name: {slice_idx: shard_tensor}}
+        pending: dict[str, dict[str, dict[int, torch.Tensor]]] = {}
+
+        def _try_finalize_fused(
+            layer_prefix: str,
+            fused_name: str,
+            num_shards: int,
+        ) -> None:
+            bucket = pending.get(layer_prefix, {}).get(fused_name)
+            if bucket is None or len(bucket) < num_shards:
+                return
+            target_param_name = f"{layer_prefix}.{fused_name}.weight"
+            target_param = params_dict.get(target_param_name)
+            if target_param is None:
+                return
+            ordered = [bucket[i] for i in range(num_shards)]
+            fused_weight = torch.cat(ordered, dim=0)
+            weight_loader = getattr(target_param, "weight_loader", default_weight_loader)
+            weight_loader(target_param, fused_weight)
+            loaded_params.add(target_param_name)
+            del pending[layer_prefix][fused_name]
+            if not pending[layer_prefix]:
+                del pending[layer_prefix]
+
+        def _route_shard(
+            name: str,
+            loaded_weight: torch.Tensor,
+            shard_table: tuple[tuple[str, str, int], ...],
+            parent_attr: str,
+        ) -> bool:
+            """Stash a HF shard if its fused counterpart exists in this
+            module; return True iff the shard was consumed."""
+            for shard_name, fused_name, slice_idx in shard_table:
+                suffix = f".{parent_attr}.{shard_name}.weight"
+                if not name.endswith(suffix):
+                    continue
+                layer_prefix = name[: -len(f".{shard_name}.weight")]  # ...self_attn or ...mlp
+                fused_param_name = f"{layer_prefix}.{fused_name}.weight"
+                if fused_param_name not in params_dict:
+                    return False
+                pending.setdefault(layer_prefix, {}).setdefault(fused_name, {})[slice_idx] = loaded_weight
+                _try_finalize_fused(layer_prefix, fused_name, num_shards=len(shard_table))
+                return True
+            return False
+
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
+                continue
+            if _route_shard(name, loaded_weight, self._FUSED_QKV_SHARDS, parent_attr="self_attn"):
+                continue
+            if _route_shard(name, loaded_weight, self._FUSED_GATE_UP_SHARDS, parent_attr="mlp"):
                 continue
             param = params_dict.get(name)
             if param is None:
@@ -377,6 +486,13 @@ class CodePredictorBaseModel(nn.Module):
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
             loaded_params.add(name)
+
+        if pending:
+            unfinished = {lp: list(buckets.keys()) for lp, buckets in pending.items()}
+            raise RuntimeError(
+                f"CodePredictor load_weights: incomplete fused shards for layers {unfinished}; "
+                f"check that the checkpoint contains all q/k/v and gate/up tensors."
+            )
         return loaded_params
 
 
@@ -903,7 +1019,7 @@ class CodePredictorWrapper(nn.Module):
     # ------------------------------------------------------------------
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        """Load weights directly (no fused projection remapping needed)."""
+        """Load wrapper weights, delegating ``model.*`` tensors to the inner fused loader."""
         loaded: set[str] = set()
         model_weights: list[tuple[str, torch.Tensor]] = []
         other_weights: list[tuple[str, torch.Tensor]] = []

--- a/vllm_omni/model_executor/models/qwen3_tts/configuration_qwen3_tts.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/configuration_qwen3_tts.py
@@ -175,12 +175,9 @@ class Qwen3TTSTalkerCodePredictorConfig(PretrainedConfig):
 
     # Default tensor parallel plan for base model `Qwen3TTSTalkerCodePredictor`
     base_model_tp_plan = {
-        "layers.*.self_attn.q_proj": "colwise",
-        "layers.*.self_attn.k_proj": "colwise",
-        "layers.*.self_attn.v_proj": "colwise",
+        "layers.*.self_attn.qkv_proj": "colwise",
         "layers.*.self_attn.o_proj": "rowwise",
-        "layers.*.mlp.gate_proj": "colwise",
-        "layers.*.mlp.up_proj": "colwise",
+        "layers.*.mlp.gate_up_proj": "colwise",
         "layers.*.mlp.down_proj": "rowwise",
     }
     base_model_pp_plan = {


### PR DESCRIPTION
<!-- markdownlint-disable -->
**Before submitting:** run the precheck-pr skill with code agent for a self-check against project conventions — catches dead code, missing benchmarks, and title format issues.

## Purpose

Fuse the per-layer `q_proj`/`k_proj`/`v_proj` and `gate_proj`/`up_proj` projections in the Qwen3-TTS / Qwen3-Omni code predictor into a single `qkv_proj` and `gate_up_proj` respectively. The fusion is bit-identical to the original (concatenation along `dim=0` then `split` after matmul) but cuts the per-step host-side `cudaLaunchKernel` count from 5 to 2 per layer.

This addresses the host-side bottleneck visible in talker_mtp NVTX traces under high concurrency: the code predictor's 5-layer × 17-AR-step loop launches several thousand small kernels per second, and the q/k/v + gate/up projections are the dominant offenders because they are the only places where two/three sibling `nn.Linear` modules are called back-to-back with no intermediate op to amortise the launch.

The HF-numerics-compatible constraint introduced by #2277 / #2291 is preserved — this change does **not** reintroduce vLLM's `QKVParallelLinear` / fused RMSNorm kernels; it only re-organises plain `nn.Linear` calls. There are no new env vars and no behavioural change.

Closes nothing (no existing issue tracks this); refer to PR #3662 for the prior high-concurrency optimization on the same module.

### Why fused == separate (numerical proof)

For three independent `nn.Linear(H, D_i, bias=False)` modules with weights `W_q ∈ R^{D_q×H}`, `W_k ∈ R^{D_k×H}`, `W_v ∈ R^{D_v×H}`:

```
[q | k | v] = [x · W_q^T | x · W_k^T | x · W_v^T]
            = x · [W_q^T | W_k^T | W_v^T]
            = x · cat([W_q, W_k, W_v], dim=0)^T
```

So `qkv_proj.weight = torch.cat([W_q, W_k, W_v], dim=0)` produces the same output as three separate Linears, splittable on `dim=-1`. Same proof for `gate_up`.

## Test Plan

Unit tests added to `tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py` (new class `TestCodePredictorFusedProjections`) covering:

1. `test_fused_qkv_matches_separate` — `torch.equal` between fused and separate q/k/v outputs (bit-identical).
2. `test_fused_gate_up_matches_separate` — same for gate/up.
3. `test_load_weights_repacks_hf_shards` — synthetic HF-style checkpoint with separate `q_proj`/`k_proj`/`v_proj` and `gate_proj`/`up_proj` shards is correctly re-packed into the fused `qkv_proj` / `gate_up_proj` parameters.
4. `test_load_weights_raises_on_incomplete_shards` — missing one of q/k/v surfaces a clear `RuntimeError` instead of silently leaving fused params uninitialized.

The existing `test_forward_with_mismatched_input_dtype` and `test_forward_generator_controls_sampling` still exercise the new fused path end-to-end, validating dtype handling and seeded reproducibility.

### Exact commands

```bash
git checkout perf/code-predictor-fuse-qkv-gateup
pytest tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py -v
```

## Test Result

Pytest summary:

```
======================================================= test session starts ========================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3
collected 15 items

tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorDtypeAlignment::test_ensure_buffers_uses_given_dtype           PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorDtypeAlignment::test_warmup_aligns_buffer_to_model_params      PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorDtypeAlignment::test_setup_compile_caches_model_dtype          PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorDtypeAlignment::test_forward_with_mismatched_input_dtype       PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorDtypeAlignment::test_forward_generator_controls_sampling       PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorModelDtype::test_model_forward_float16                         PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorModelDtype::test_model_forward_float32                         PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorWrapperConfig::test_omni_config                                PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorWrapperConfig::test_tts_config                                 PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorWrapperConfig::test_prefix_graph_config_helpers                PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorWrapperConfig::test_prefix_graph_env_requires_cuda_graphs      PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorFusedProjections::test_fused_qkv_matches_separate              PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorFusedProjections::test_fused_gate_up_matches_separate          PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorFusedProjections::test_load_weights_repacks_hf_shards          PASSED
tests/model_executor/models/qwen3_tts/test_code_predictor_dtype.py::TestCodePredictorFusedProjections::test_load_weights_raises_on_incomplete_shards PASSED

================================================= 15 passed, 28 warnings in 0.20s ==================================================
```

### A/B benchmark

**Setup.** NVIDIA H20 ×2 (Stage 0 + Stage 1), driver 580.105.08, CUDA 13.0, torch 2.11.0+cu130, vllm 0.22.0, vllm-omni @ this PR base, transformers 5.8.1. Model `Qwen3-TTS-12Hz-0.6B-Base` (local). Deploy YAML `vllm_omni/deploy/qwen3_tts_high_concurrency.yaml` (Stage 0 talker on GPU 4, Stage 1 Code2Wav on GPU 5). Dataset `seed-tts-eval` (en, voice_clone). 3 warmups + measured run. A/B done by overlaying a single file (`vllm_omni/model_executor/models/common/qwen3_code_predictor.py`) checked out from `main` vs this PR; md5-verified each run; identical git HEAD otherwise.

| Concurrency | Prompts | metric | main | this PR | Δ |
|---|---|---|---|---|---|
| 1  | 100 | request throughput (req/s) | 1.611 | **1.773** | **+10.1%** |
| 1  | 100 | median E2EL (ms)           | 625.9 | **568.4** | **−9.2%** |
| 1  | 100 | p99 E2EL (ms)              | 1044.6 | **870.7** | **−16.7%** |
| 1  | 100 | median AUDIO_RTF           | 0.1467 | **0.1356** | **−7.6%** |
| 1  | 100 | total token throughput (tok/s) | 213.1 | **234.6** | **+10.1%** |
| 8  | 200 | request throughput (req/s) | 7.576 | **7.860** | **+3.7%** |
| 8  | 200 | median E2EL (ms)           | 1012.4 | **972.4** | **−4.0%** |
| 8  | 200 | median AUDIO_RTF           | 0.2460 | **0.2384** | **−3.1%** |
| 16 | 400 | request throughput (req/s) | 9.597 | **9.947** | **+3.7%** |
| 16 | 400 | median E2EL (ms)           | 1573.9 | **1519.5** | **−3.5%** |
| 16 | 400 | p99 E2EL (ms)              | 2987.6 | **2733.0** | **−8.5%** |
| 32 | 600 | **request throughput (req/s)** | 8.780 | **11.343** | **+29.2%** |
| 32 | 600 | bench duration (s) for 600 prompts | 68.34 | **52.89** | **−22.6%** |
| 32 | 600 | p99 E2EL (ms)              | 4670.1 | **4294.0** | **−8.0%** |
| 32 | 600 | total token throughput (tok/s) | 1161.0 | **1499.9** | **+29.2%** |

**Reading the curve.** The improvement scales with how host-launch-starved the workload is. At c=1 the host overhead is ~10% of total wall-time, so we recover ~10%. At c=8 / c=16 the GPU is already busy enough that launch latency is partially hidden, so the gain is smaller (~3–4% throughput, but p99 E2EL still tightens because tail latency is dominated by host stalls). At **c=32** the talker_mtp loop saturates the host → that's where fused QKV / gate_up pays off the most: **+29.2% req/s and −22.6% wall-clock** for the same 600-prompt workload, which is squarely the regime the high_concurrency profile targets.

**VRAM.** Stage 0 (GPU 4) ≈ 32.3 GiB, Stage 1 (GPU 5) ≈ 4.3 GiB on both runs (delta < 1%, within noise). Fusion does not change the parameter count, so this is expected.

**AUDIO_TTFP.** No meaningful change at any concurrency — TTFP is dominated by stage-1 first-chunk decode, not the code predictor, so this is also expected.

**Audio quality.** The change is bit-identical numerically (proven by `torch.equal` in the new tests below). Same input + same `Generator` seed still produces identical output (`test_forward_generator_controls_sampling` still passes unchanged), so an audible regression is impossible by construction.

### Scope notes

- `o_proj` and `down_proj` are intentionally left unfused. Each is followed by a residual add with no sibling `nn.Linear` to merge with, so a fusion would require also restructuring the residual path — out of scope for this PR.
- The `base_model_tp_plan` in `configuration_qwen3_tts.py` (HuggingFace-side TP hint) still references `q_proj` / `k_proj` / `v_proj`. That plan is consumed by HF's native distributed inference path, which is **not** the path vllm-omni's `CodePredictorBaseModel` runs (we use plain `nn.Linear` with no TP). Leaving the HF hint untouched preserves HF-native usability.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR.
- [x] The test plan with test scripts & test commands.
- [x] The test results (pytest summary above).
- [ ] (Optional) Documentation update — N/A (no user-facing surface change).
- [ ] (Optional) Release notes update — N/A.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
