### PR TITLE
[Feature] Support session-level TTS speaker selection in streaming video api

### DIFF
--- a/docs/serving/video_stream_api.md
+++ b/docs/serving/video_stream_api.md
@@ -63,6 +63,7 @@ WebSocket /v1/video/chat/stream
 | `sampling_params_list` | list or null | null | Optional per-stage sampling parameter overrides. |
 | `enable_frame_filter` | bool | `true` | Enable EVS near-duplicate frame filtering. |
 | `frame_filter_threshold` | float, 0.0-1.0 | `0.95` | EVS similarity threshold. Higher keeps more frames; lower drops more near-duplicates. |
+| `speaker` | string or null | null | TTS speaker/voice name (e.g. `ethan`, `chelsie`, `aiden`). Applies to the whole session. Uses the model default when unset; an unsupported name returns an `error` on the first query. |
 
 ### Legacy Aliases
 

--- a/vllm_omni/entrypoints/openai/serving_video_stream.py
+++ b/vllm_omni/entrypoints/openai/serving_video_stream.py
@@ -105,6 +105,12 @@ class StreamingVideoSessionConfig(BaseModel):
         le=1.0,
         description="EVS similarity threshold (higher = keep more frames).",
     )
+    speaker: str | None = Field(
+        default=None,
+        description="TTS speaker/voice name (e.g. ethan, chelsie, aiden). "
+        "Applies to the whole session. Uses the model default when unset; "
+        "an unsupported name yields an error on the first query.",
+    )
 
 
 class OmniStreamingVideoHandler:
@@ -524,6 +530,23 @@ class OmniStreamingVideoHandler:
         except Exception as e:
             await self._send_error(websocket, f"Preprocess failed: {e}")
             return
+
+        # Inject the session-level speaker into additional_information
+        if config.speaker:
+            from vllm_omni.entrypoints.openai.utils import (
+                validate_requested_speaker,
+            )
+
+            supported = self._chat_service._get_supported_speakers()
+            try:
+                normalized = validate_requested_speaker(config.speaker, supported)
+            except ValueError as e:
+                await self._send_error(websocket, str(e))
+                return
+            if normalized is not None:
+                ai = engine_prompt.get("additional_information") or {}
+                ai["speaker"] = [normalized]
+                engine_prompt["additional_information"] = ai
 
         await websocket.send_json({"type": "response.start"})
         text_parts: list[str] = []


### PR DESCRIPTION


<!-- markdownlint-disable -->
**Before submitting:** run the precheck-pr skill with code agent for a self-check against project conventions — catches dead code, missing benchmarks, and title format issues.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

This PR adds **session-level TTS speaker selection** to the streaming video WebSocket
API (`/v1/video/chat/stream`) for Qwen3-Omni.

Previously a streaming video session always used the model's default TTS voice with
no way to choose the speaker. This PR introduces a new optional `speaker` field in
the `session.config` message:

- `speaker` (string, optional): TTS speaker/voice name (e.g. `ethan`, `chelsie`,
  `aiden`). It applies to the whole session.
- When set, the requested speaker is validated against the model's supported
  speakers and injected into the engine prompt's `additional_information` so audio
  responses use the chosen voice.
- When unset, the model default is used (no behavior change).
- An unsupported speaker name returns a recoverable `error` event on the first
  query instead of failing silently.

Docs (`docs/serving/video_stream_api.md`) are updated to document the new field.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
(anything written below this line will be removed by GitHub Actions)
