### PR TITLE
[BugFix] Add missing stage_id to MooncakeTransferEngineConnector

### DIFF
--- a/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
+++ b/vllm_omni/distributed/omni_connectors/connectors/mooncake_transfer_engine_connector.py
@@ -133,6 +133,7 @@ class MooncakeTransferEngineConnector(OmniConnectorBase):
         }
 
         self.config = config
+        self.stage_id = config.get("stage_id", -1)
         host_config = config.get("host")
         host_value = "auto" if host_config is None else str(host_config)
         # Default sender/receiver bootstrap to a routable local IP so the


### PR DESCRIPTION
## Purpose

ChunkTransferAdapter accesses self.connector.stage_id but MooncakeTransferEngineConnector never set it, causing an AttributeError when async_chunk is enabled. Add the same config.get("stage_id", -1) pattern used by SharedMemoryConnector.

## Test Plan

Deploy Qwen3-Omni with stage CLI, set async_chunk: true and use the MooncakeTransferEngineConnector.

## Test Result

Runs.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
(anything written below this line will be removed by GitHub Actions)
