### PR TITLE
[WIP] [Metrics] Add OpenTelemetry tracing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,13 @@ quack = [
     "quack-kernels>=0.3.11",
 ]
 
+otel = [
+    "opentelemetry-sdk>=1.26.0",
+    "opentelemetry-api>=1.26.0",
+    "opentelemetry-exporter-otlp>=1.26.0",
+    "opentelemetry-semantic-conventions-ai>=0.4.1",
+]
+
 docs = [
     "mkdocs>=1.5.0",
     "mkdocs-api-autonav",

--- a/tests/tracing/conftest.py
+++ b/tests/tracing/conftest.py
@@ -1,0 +1,133 @@
+import threading
+from collections.abc import Callable, Generator, Iterable
+from concurrent import futures
+from typing import Any, Literal
+
+import grpc
+import pytest
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+    ExportTraceServiceResponse,
+)
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2_grpc import (
+    TraceServiceServicer,
+    add_TraceServiceServicer_to_server,
+)
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+from opentelemetry.sdk.environment_variables import (
+    OTEL_EXPORTER_OTLP_TRACES_INSECURE,
+)
+from vllm.tracing import init_tracer
+
+FAKE_TRACE_SERVER_ADDRESS = "localhost:14317"
+
+FieldName = Literal["bool_value", "string_value", "int_value", "double_value", "array_value"]
+
+
+def decode_value(value: AnyValue):
+    field_decoders: dict[FieldName, Callable] = {
+        "bool_value": (lambda v: v.bool_value),
+        "string_value": (lambda v: v.string_value),
+        "int_value": (lambda v: v.int_value),
+        "double_value": (lambda v: v.double_value),
+        "array_value": (lambda v: [decode_value(item) for item in v.array_value.values]),
+    }
+    for field, decoder in field_decoders.items():
+        if value.HasField(field):
+            return decoder(value)
+    raise ValueError(f"Couldn't decode value: {value}")
+
+
+def decode_attributes(attributes: Iterable[KeyValue]) -> dict[str, Any]:
+    return {kv.key: decode_value(kv.value) for kv in attributes}
+
+
+class FakeTraceService(TraceServiceServicer):
+    def __init__(self):
+        self.requests: list[ExportTraceServiceRequest] = []
+        self.evt = threading.Event()
+        self._lock = threading.Lock()
+
+    def Export(self, request, context):
+        with self._lock:
+            self.requests.append(request)
+        self.evt.set()
+        return ExportTraceServiceResponse()
+
+    def get_all_spans(self) -> list[dict]:
+        spans = []
+        with self._lock:
+            for request in self.requests:
+                for resource_span in request.resource_spans:
+                    for scope_span in resource_span.scope_spans:
+                        for span in scope_span.spans:
+                            spans.append(
+                                {
+                                    "name": span.name,
+                                    "attributes": decode_attributes(span.attributes),
+                                    "trace_id": span.trace_id.hex(),
+                                    "span_id": span.span_id.hex(),
+                                    "parent_span_id": (span.parent_span_id.hex() if span.parent_span_id else None),
+                                    "start_time_unix_nano": span.start_time_unix_nano,
+                                    "end_time_unix_nano": span.end_time_unix_nano,
+                                    "kind": span.kind,
+                                }
+                            )
+        return spans
+
+    def wait_for_spans(self, count: int = 1, timeout: float = 10) -> bool:
+        import time
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if len(self.get_all_spans()) >= count:
+                return True
+            time.sleep(0.1)
+        return False
+
+    def clear(self):
+        with self._lock:
+            self.requests.clear()
+        self.evt.clear()
+
+
+def _wait_for_server_ready(address: str, timeout: float = 5.0) -> bool:
+    import socket
+    import time
+
+    host, port = address.rsplit(":", 1)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, int(port)), timeout=0.5):
+                return True
+        except (OSError, ConnectionRefusedError):
+            time.sleep(0.1)
+    return False
+
+
+@pytest.fixture
+def trace_service() -> Generator[FakeTraceService, None, None]:
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
+    service = FakeTraceService()
+    add_TraceServiceServicer_to_server(service, server)
+    server.add_insecure_port(FAKE_TRACE_SERVER_ADDRESS)
+    server.start()
+
+    if not _wait_for_server_ready(FAKE_TRACE_SERVER_ADDRESS):
+        server.stop(grace=None)
+        raise RuntimeError(f"Fake trace server failed to start on {FAKE_TRACE_SERVER_ADDRESS}")
+
+    yield service
+
+    server.stop(grace=None)
+
+
+@pytest.fixture
+def init_test_tracer(monkeypatch, trace_service):
+    monkeypatch.setenv(OTEL_EXPORTER_OTLP_TRACES_INSECURE, "true")
+    # Clear any stale traceparent from the environment
+    monkeypatch.delenv("traceparent", raising=False)
+    monkeypatch.delenv("TRACEPARENT", raising=False)
+    init_tracer("test.omni", FAKE_TRACE_SERVER_ADDRESS)
+    return trace_service

--- a/tests/tracing/test_tracing.py
+++ b/tests/tracing/test_tracing.py
@@ -12,6 +12,7 @@ from vllm.tracing import (
 )
 from vllm.tracing.otel import is_otel_available
 
+from vllm_omni.metrics.stats import PipelineTimings
 from vllm_omni.tracing import OmniSpanAttributes
 
 from .conftest import FakeTraceService
@@ -250,7 +251,7 @@ class MockOrchestratorRequestState:
     request_id: str = "req-001"
     trace_headers: dict[str, str] | None = None
     trace_start_ns: int = 0
-    pipeline_timings: dict[str, float] = field(default_factory=dict)
+    pipeline_timings: PipelineTimings = field(default_factory=PipelineTimings)
     _omni_span: Any = None
 
 
@@ -299,7 +300,7 @@ class TestOmniRequestSpan:
         orch = self._make_orchestrator()
         req_state = MockOrchestratorRequestState(
             trace_start_ns=int(time.time() * 1e9),
-            pipeline_timings={"stage0_ms": 100.5, "stage1_ms": 200.3},
+            pipeline_timings=PipelineTimings(queue_wait_ms=100.5, preprocess_ms=200.3),
         )
 
         orch._start_omni_request_span(req_state)

--- a/tests/tracing/test_tracing.py
+++ b/tests/tracing/test_tracing.py
@@ -1,0 +1,426 @@
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from vllm.tracing import (
+    SpanKind,
+    extract_trace_context,
+    instrument,
+    instrument_manual,
+)
+from vllm.tracing.otel import is_otel_available
+
+from vllm_omni.tracing import OmniSpanAttributes
+
+from .conftest import FakeTraceService
+
+pytestmark = pytest.mark.skipif(not is_otel_available(), reason="OTel packages required")
+
+FAKE_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736"
+FAKE_PARENT_ID = "00f067aa0be902b7"
+
+
+class TestOmniSpanAttributes:
+    def test_attribute_constants_are_namespaced(self):
+        assert OmniSpanAttributes.ENGINE_IDX == "vllm_omni.engine.idx"
+        assert OmniSpanAttributes.STAGE_ID == "vllm_omni.stage.id"
+        assert OmniSpanAttributes.STAGE_NAME == "vllm_omni.stage.name"
+        assert OmniSpanAttributes.STAGE_REPLICA_ID == "vllm_omni.stage.replica_id"
+        assert OmniSpanAttributes.PIPELINE_TIMINGS == "vllm_omni.pipeline.timings"
+
+    def test_diffusion_attributes_are_namespaced(self):
+        assert OmniSpanAttributes.DIFFUSION_PREPROCESS_MS == "vllm_omni.diffusion.preprocess_ms"
+        assert OmniSpanAttributes.DIFFUSION_EXEC_MS == "vllm_omni.diffusion.exec_ms"
+        assert OmniSpanAttributes.DIFFUSION_POSTPROCESS_MS == "vllm_omni.diffusion.postprocess_ms"
+        assert OmniSpanAttributes.DIFFUSION_TOTAL_MS == "vllm_omni.diffusion.total_ms"
+
+
+class TestInstrumentDecorator:
+    @pytest.fixture(autouse=True)
+    def _setup(self, init_test_tracer):
+        self.trace_service: FakeTraceService = init_test_tracer
+
+    def test_sync_function_creates_span(self):
+        @instrument(span_name="sync_op")
+        def sync_op():
+            return 42
+
+        result = sync_op()
+        assert result == 42
+        assert self.trace_service.wait_for_spans(count=1)
+        spans = self.trace_service.get_all_spans()
+        assert any(s["name"] == "sync_op" for s in spans)
+
+    def test_async_function_creates_span(self):
+        @instrument(span_name="async_op")
+        async def async_op():
+            return 99
+
+        result = asyncio.run(async_op())
+        assert result == 99
+        assert self.trace_service.wait_for_spans(count=1)
+        spans = self.trace_service.get_all_spans()
+        assert any(s["name"] == "async_op" for s in spans)
+
+    def test_nested_spans_have_parent_child_relationship(self):
+        @instrument(span_name="child_fn")
+        def child_fn():
+            pass
+
+        @instrument(span_name="parent_fn")
+        def parent_fn():
+            child_fn()
+
+        parent_fn()
+        assert self.trace_service.wait_for_spans(count=2)
+        spans = self.trace_service.get_all_spans()
+        parent = next(s for s in spans if s["name"] == "parent_fn")
+        child = next(s for s in spans if s["name"] == "child_fn")
+        assert child["parent_span_id"] == parent["span_id"]
+        assert child["trace_id"] == parent["trace_id"]
+
+    def test_span_has_valid_timestamps(self):
+        @instrument(span_name="timed_fn")
+        def timed_fn():
+            pass
+
+        timed_fn()
+        assert self.trace_service.wait_for_spans(count=1)
+        span = self.trace_service.get_all_spans()[0]
+        assert span["start_time_unix_nano"] > 0
+        assert span["end_time_unix_nano"] >= span["start_time_unix_nano"]
+
+
+class TestInstrumentManual:
+    @pytest.fixture(autouse=True)
+    def _setup(self, init_test_tracer):
+        self.trace_service: FakeTraceService = init_test_tracer
+
+    def test_creates_span_with_explicit_timestamps(self):
+        start_ns = int(time.time() * 1e9)
+        end_ns = start_ns + 500_000_000
+
+        instrument_manual(
+            span_name="manual_span",
+            start_time=start_ns,
+            end_time=end_ns,
+            attributes={"test.key": "test_value"},
+        )
+
+        assert self.trace_service.wait_for_spans(count=1)
+        span = self.trace_service.get_all_spans()[0]
+        assert span["name"] == "manual_span"
+        assert span["start_time_unix_nano"] == start_ns
+        assert span["end_time_unix_nano"] == end_ns
+        assert span["attributes"]["test.key"] == "test_value"
+
+    def test_span_with_no_end_time_ends_immediately(self):
+        start_ns = int(time.time() * 1e9)
+
+        instrument_manual(
+            span_name="auto_end",
+            start_time=start_ns,
+        )
+
+        assert self.trace_service.wait_for_spans(count=1)
+        span = self.trace_service.get_all_spans()[0]
+        assert span["name"] == "auto_end"
+        assert span["end_time_unix_nano"] >= span["start_time_unix_nano"]
+
+    def test_span_respects_parent_context(self):
+        traceparent = f"00-{FAKE_TRACE_ID}-{FAKE_PARENT_ID}-01"
+        ctx = extract_trace_context({"traceparent": traceparent})
+
+        instrument_manual(
+            span_name="child_manual",
+            start_time=int(time.time() * 1e9),
+            context=ctx,
+        )
+
+        assert self.trace_service.wait_for_spans(count=1)
+        span = self.trace_service.get_all_spans()[0]
+        assert span["trace_id"] == FAKE_TRACE_ID
+        assert span["parent_span_id"] == FAKE_PARENT_ID
+
+    def test_span_kind_is_propagated(self):
+        instrument_manual(
+            span_name="server_span",
+            start_time=int(time.time() * 1e9),
+            kind=SpanKind.SERVER,
+        )
+
+        assert self.trace_service.wait_for_spans(count=1)
+        span = self.trace_service.get_all_spans()[0]
+        # SPAN_KIND_SERVER = 2 in the protobuf enum
+        assert span["kind"] == 2
+
+    def test_multiple_attributes_types(self):
+        instrument_manual(
+            span_name="typed_attrs",
+            start_time=int(time.time() * 1e9),
+            attributes={
+                "str_attr": "hello",
+                "int_attr": 42,
+                "float_attr": 3.14,
+                "bool_attr": True,
+            },
+        )
+
+        assert self.trace_service.wait_for_spans(count=1)
+        attrs = self.trace_service.get_all_spans()[0]["attributes"]
+        assert attrs["str_attr"] == "hello"
+        assert attrs["int_attr"] == 42
+        assert abs(attrs["float_attr"] - 3.14) < 0.001
+        assert attrs["bool_attr"] is True
+
+
+class TestTraceContextPropagation:
+    @pytest.fixture(autouse=True)
+    def _setup(self, init_test_tracer):
+        self.trace_service: FakeTraceService = init_test_tracer
+
+    def test_extract_from_traceparent_header(self):
+        traceparent = f"00-{FAKE_TRACE_ID}-{FAKE_PARENT_ID}-01"
+        ctx = extract_trace_context({"traceparent": traceparent})
+        assert ctx is not None
+
+        @instrument(span_name="with_parent")
+        def traced():
+            pass
+
+        from opentelemetry import context
+
+        token = context.attach(ctx)
+        try:
+            traced()
+        finally:
+            context.detach(token)
+
+        assert self.trace_service.wait_for_spans(count=1)
+        span = self.trace_service.get_all_spans()[0]
+        assert span["trace_id"] == FAKE_TRACE_ID
+        assert span["parent_span_id"] == FAKE_PARENT_ID
+
+    def test_extract_from_none_returns_none(self):
+        ctx = extract_trace_context(None)
+        assert ctx is None
+
+    def test_extract_from_empty_dict_returns_none(self):
+        ctx = extract_trace_context({})
+        assert ctx is None
+
+    def test_header_injection_round_trip(self):
+        from opentelemetry import trace as otel_trace
+        from opentelemetry.context import Context
+        from opentelemetry.trace.propagation import set_span_in_context
+        from opentelemetry.trace.propagation.tracecontext import (
+            TraceContextTextMapPropagator,
+        )
+
+        tracer = otel_trace.get_tracer("test.roundtrip")
+        span = tracer.start_span("origin")
+        ctx: Context = set_span_in_context(span)
+
+        carrier: dict[str, str] = {}
+        TraceContextTextMapPropagator().inject(carrier, context=ctx)
+        assert "traceparent" in carrier
+
+        extracted = extract_trace_context(carrier)
+        assert extracted is not None
+
+        instrument_manual(
+            span_name="downstream",
+            start_time=int(time.time() * 1e9),
+            context=extracted,
+        )
+        span.end()
+
+        assert self.trace_service.wait_for_spans(count=2)
+        spans = self.trace_service.get_all_spans()
+        origin = next(s for s in spans if s["name"] == "origin")
+        downstream = next(s for s in spans if s["name"] == "downstream")
+        assert downstream["trace_id"] == origin["trace_id"]
+        assert downstream["parent_span_id"] == origin["span_id"]
+
+
+@dataclass
+class MockOrchestratorRequestState:
+    request_id: str = "req-001"
+    trace_headers: dict[str, str] | None = None
+    trace_start_ns: int = 0
+    pipeline_timings: dict[str, float] = field(default_factory=dict)
+    _omni_span: Any = None
+
+
+class TestOmniRequestSpan:
+    @pytest.fixture(autouse=True)
+    def _setup(self, init_test_tracer):
+        self.trace_service: FakeTraceService = init_test_tracer
+
+    def _make_orchestrator(self):
+        from vllm_omni.engine.orchestrator import Orchestrator
+
+        orch = object.__new__(Orchestrator)
+        orch._tracing_enabled = True
+        return orch
+
+    def test_start_span_sets_omni_span(self):
+        orch = self._make_orchestrator()
+        req_state = MockOrchestratorRequestState(
+            trace_start_ns=int(time.time() * 1e9),
+        )
+
+        orch._start_omni_request_span(req_state)
+
+        assert req_state._omni_span is not None
+        assert req_state.trace_headers is not None
+        assert "traceparent" in req_state.trace_headers
+
+    def test_start_span_inherits_parent_trace(self):
+        orch = self._make_orchestrator()
+        traceparent = f"00-{FAKE_TRACE_ID}-{FAKE_PARENT_ID}-01"
+        req_state = MockOrchestratorRequestState(
+            trace_headers={"traceparent": traceparent},
+            trace_start_ns=int(time.time() * 1e9),
+        )
+
+        orch._start_omni_request_span(req_state)
+        req_state._omni_span.end()
+
+        assert self.trace_service.wait_for_spans(count=1)
+        span = self.trace_service.get_all_spans()[0]
+        assert span["name"] == "omni_request"
+        assert span["trace_id"] == FAKE_TRACE_ID
+        assert span["parent_span_id"] == FAKE_PARENT_ID
+
+    def test_end_span_sets_attributes(self):
+        orch = self._make_orchestrator()
+        req_state = MockOrchestratorRequestState(
+            trace_start_ns=int(time.time() * 1e9),
+            pipeline_timings={"stage0_ms": 100.5, "stage1_ms": 200.3},
+        )
+
+        orch._start_omni_request_span(req_state)
+        orch._end_omni_request_span("req-001", req_state)
+
+        assert self.trace_service.wait_for_spans(count=1)
+        span = self.trace_service.get_all_spans()[0]
+        assert span["name"] == "omni_request"
+        assert span["attributes"]["gen_ai.request.id"] == "req-001"
+        assert "vllm_omni.pipeline.timings" in span["attributes"]
+
+    def test_end_span_without_start_is_noop(self):
+        orch = self._make_orchestrator()
+        req_state = MockOrchestratorRequestState()
+        # _omni_span is None, should not raise
+        orch._end_omni_request_span("req-001", req_state)
+
+
+class TestLlmRequestSpan:
+    @pytest.fixture(autouse=True)
+    def _setup(self, init_test_tracer):
+        self.trace_service: FakeTraceService = init_test_tracer
+
+    def test_llm_request_span_attributes(self):
+        from vllm.tracing import SpanAttributes
+
+        now = time.time()
+        arrival_time_ns = int(now * 1e9)
+        traceparent = f"00-{FAKE_TRACE_ID}-{FAKE_PARENT_ID}-01"
+        trace_context = extract_trace_context({"traceparent": traceparent})
+
+        attributes = {
+            SpanAttributes.GEN_AI_LATENCY_TIME_TO_FIRST_TOKEN: 0.05,
+            SpanAttributes.GEN_AI_LATENCY_E2E: 1.5,
+            SpanAttributes.GEN_AI_LATENCY_TIME_IN_QUEUE: 0.01,
+            SpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS: 10,
+            SpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS: 50,
+            SpanAttributes.GEN_AI_REQUEST_ID: "req-llm-001",
+            OmniSpanAttributes.ENGINE_IDX: 0,
+            OmniSpanAttributes.STAGE_ID: 0,
+            OmniSpanAttributes.STAGE_REPLICA_ID: 0,
+            OmniSpanAttributes.STAGE_NAME: "thinker",
+        }
+
+        instrument_manual(
+            span_name="llm_request",
+            start_time=arrival_time_ns,
+            attributes=attributes,
+            context=trace_context,
+            kind=SpanKind.INTERNAL,
+        )
+
+        assert self.trace_service.wait_for_spans(count=1)
+        span = self.trace_service.get_all_spans()[0]
+        assert span["name"] == "llm_request"
+        assert span["trace_id"] == FAKE_TRACE_ID
+        assert span["attributes"]["gen_ai.request.id"] == "req-llm-001"
+        assert span["attributes"]["gen_ai.usage.prompt_tokens"] == 10
+        assert span["attributes"]["gen_ai.usage.completion_tokens"] == 50
+        assert span["attributes"][OmniSpanAttributes.STAGE_NAME] == "thinker"
+        assert span["attributes"][OmniSpanAttributes.ENGINE_IDX] == 0
+
+
+class TestDiffusionRequestSpan:
+    @pytest.fixture(autouse=True)
+    def _setup(self, init_test_tracer):
+        self.trace_service: FakeTraceService = init_test_tracer
+
+    def test_diffusion_span_with_timing_attributes(self):
+        now = time.time()
+        start_ns = int(now * 1e9)
+        total_ms = 2500.0
+        end_ns = int((now + total_ms / 1000) * 1e9)
+
+        attributes = {
+            OmniSpanAttributes.STAGE_ID: 0,
+            OmniSpanAttributes.STAGE_NAME: "diffusion",
+            OmniSpanAttributes.STAGE_REPLICA_ID: 0,
+            OmniSpanAttributes.ENGINE_IDX: 0,
+            OmniSpanAttributes.DIFFUSION_PREPROCESS_MS: 50.0,
+            OmniSpanAttributes.DIFFUSION_EXEC_MS: 2300.0,
+            OmniSpanAttributes.DIFFUSION_POSTPROCESS_MS: 150.0,
+            OmniSpanAttributes.DIFFUSION_TOTAL_MS: total_ms,
+        }
+
+        instrument_manual(
+            span_name="diffusion_request",
+            start_time=start_ns,
+            end_time=end_ns,
+            attributes=attributes,
+            kind=SpanKind.INTERNAL,
+        )
+
+        assert self.trace_service.wait_for_spans(count=1)
+        span = self.trace_service.get_all_spans()[0]
+        assert span["name"] == "diffusion_request"
+        attrs = span["attributes"]
+        assert attrs[OmniSpanAttributes.STAGE_NAME] == "diffusion"
+        assert abs(attrs[OmniSpanAttributes.DIFFUSION_PREPROCESS_MS] - 50.0) < 0.01
+        assert abs(attrs[OmniSpanAttributes.DIFFUSION_EXEC_MS] - 2300.0) < 0.01
+        assert abs(attrs[OmniSpanAttributes.DIFFUSION_POSTPROCESS_MS] - 150.0) < 0.01
+        assert abs(attrs[OmniSpanAttributes.DIFFUSION_TOTAL_MS] - total_ms) < 0.01
+        assert span["start_time_unix_nano"] == start_ns
+        assert span["end_time_unix_nano"] == end_ns
+
+    def test_diffusion_span_inherits_trace_context(self):
+        traceparent = f"00-{FAKE_TRACE_ID}-{FAKE_PARENT_ID}-01"
+        ctx = extract_trace_context({"traceparent": traceparent})
+
+        instrument_manual(
+            span_name="diffusion_request",
+            start_time=int(time.time() * 1e9),
+            attributes={
+                OmniSpanAttributes.STAGE_ID: 0,
+                OmniSpanAttributes.STAGE_NAME: "diffusion",
+            },
+            context=ctx,
+            kind=SpanKind.INTERNAL,
+        )
+
+        assert self.trace_service.wait_for_spans(count=1)
+        span = self.trace_service.get_all_spans()[0]
+        assert span["trace_id"] == FAKE_TRACE_ID
+        assert span["parent_span_id"] == FAKE_PARENT_ID

--- a/vllm_omni/core/sched/omni_ar_scheduler.py
+++ b/vllm_omni/core/sched/omni_ar_scheduler.py
@@ -485,6 +485,7 @@ class OmniARScheduler(OmniSchedulerMixin, VLLMScheduler):
                         num_nans_in_logits=request.num_nans_in_logits,
                         is_segment_finished=is_segment_finished,
                         new_prompt_len_snapshot=self._new_prompt_len_snapshot.get(req_id, None),
+                        first_chunk_received_ts=getattr(request, "first_chunk_received_ts", None),
                     )
                 )
                 if self.chunk_transfer_adapter is not None:

--- a/vllm_omni/core/sched/omni_generation_scheduler.py
+++ b/vllm_omni/core/sched/omni_generation_scheduler.py
@@ -578,6 +578,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                         trace_headers=request.trace_headers,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,
+                        first_chunk_received_ts=getattr(request, "first_chunk_received_ts", None),
                     )
                 )
             else:
@@ -609,6 +610,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                     events=request.take_events(),
                     kv_transfer_params=kv_transfer_params,
                     trace_headers=request.trace_headers,
+                    first_chunk_received_ts=getattr(request, "first_chunk_received_ts", None),
                 )
             )
             stopped_running_reqs.add(request)
@@ -634,6 +636,7 @@ class OmniGenerationScheduler(OmniSchedulerMixin, VLLMScheduler):
                         finish_reason=request.get_finished_reason(),
                         events=request.take_events(),
                         trace_headers=request.trace_headers,
+                        first_chunk_received_ts=getattr(request, "first_chunk_received_ts", None),
                     )
                 )
                 if self.chunk_transfer_adapter is not None:

--- a/vllm_omni/core/sched/omni_scheduler_mixin.py
+++ b/vllm_omni/core/sched/omni_scheduler_mixin.py
@@ -151,6 +151,11 @@ class OmniSchedulerMixin:
             pending_input_registrations=pending_input_registrations,
         )
 
+    def add_request(self, request) -> None:
+        if request.request_id not in self.requests:
+            request.first_chunk_received_ts = time.time()
+        super().add_request(request)
+
     def make_stats(self, *args, **kwargs) -> SchedulerStats | None:
         now = time.monotonic()
         if now - getattr(self, "_last_stats_time", 0.0) < _STATS_INTERVAL_S:

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -189,6 +189,7 @@ class DiffusionEngine:
         await self._check_and_start_background_loop()
 
         diffusion_engine_start_time = time.perf_counter()
+        step_start_ts = time.time()
 
         # Apply pre-processing if available
         preprocess_time = 0.0
@@ -278,7 +279,7 @@ class DiffusionEngine:
             step_total_ms,
         )
 
-        return format_diffusion_outputs(
+        outputs = format_diffusion_outputs(
             request=request,
             od_config=self.od_config,
             diffusion_output=output,
@@ -291,6 +292,11 @@ class DiffusionEngine:
                 total_time_ms=step_total_ms,
             ),
         )
+        # Inject step_start_ts into metrics for tracing
+        for out in outputs:
+            if out.metrics is not None:
+                out.metrics["step_start_ts"] = step_start_ts
+        return outputs
 
     def _busy_loop(self):
         while not self.stop_event.is_set():

--- a/vllm_omni/diffusion/envs.py
+++ b/vllm_omni/diffusion/envs.py
@@ -46,12 +46,18 @@ class PackagesEnvChecker:
 
     def _check_flash_attn(self) -> bool:
         """Check if flash attention is available and compatible."""
-        platform = current_omni_platform
+        try:
+            platform = current_omni_platform
 
-        if platform.get_device_count() == 0:
-            return False
+            if platform.get_device_count() == 0:
+                return False
 
-        return platform.has_flash_attn_package()
+            return platform.has_flash_attn_package()
+        except RuntimeError:
+            # CUDA not available (e.g., running on bastion with old driver before
+            # cloudexe forwards to GPU node). Assume flash_attn is available - the
+            # actual check will happen when code runs on the GPU node.
+            return True
 
     def get_packages_info(self) -> dict:
         """Get the packages info dictionary."""

--- a/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
+++ b/vllm_omni/distributed/omni_connectors/transfer_adapter/chunk_transfer_adapter.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import importlib
+import time as _time
 from collections import defaultdict, deque
 from collections.abc import Callable, Mapping
 from typing import Any
@@ -217,6 +218,8 @@ class OmniChunkTransferAdapter(OmniTransferAdapterBase):
 
         if payload_data:
             # Update connector state
+            if chunk_id == 0:
+                request.first_chunk_received_ts = _time.time()
             self.get_req_chunk[req_id] += 1
 
             meta = payload_data.get("meta", {})

--- a/vllm_omni/engine/__init__.py
+++ b/vllm_omni/engine/__init__.py
@@ -125,6 +125,8 @@ class OmniEngineCoreOutput(EngineCoreOutput):
     is_segment_finished: bool | None = False
     # Streaming update prompt length
     new_prompt_len_snapshot: int | None = None
+    # Wall-clock time when the first KV chunk arrived from upstream
+    first_chunk_received_ts: float | None = None
 
 
 class OmniEngineCoreOutputs(EngineCoreOutputs):

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -30,6 +30,7 @@ from vllm import envs as vllm_envs
 from vllm.engine.arg_utils import EngineArgs
 from vllm.inputs import PromptType
 from vllm.logger import init_logger
+from vllm.tracing import init_tracer, instrument
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.input_processor import InputProcessor
 
@@ -360,6 +361,12 @@ class AsyncOmniEngine:
         self._weak_finalizer: weakref.finalize | None = None
         self._rpc_lock = threading.Lock()
         self._running_counter = OmniRequestCounter()
+        self._otlp_traces_endpoint: str | None = kwargs.get("otlp_traces_endpoint")
+        if self._otlp_traces_endpoint is not None:
+            init_tracer("vllm_omni.engine", self._otlp_traces_endpoint)
+            # Upstream do_tracing asserts req_state.stats is not None, which
+            # requires log_stats=True so RequestStateStats gets created.
+            self._log_stats = True
 
         logger.info(f"[AsyncOmniEngine] Launching Orchestrator thread with {self.num_stages} stages")
 
@@ -1245,7 +1252,12 @@ class AsyncOmniEngine:
             if plan.replicas[0].metadata.stage_type != "diffusion":
                 stage_vllm_config = plan.replicas[0].stage_vllm_config
                 assert stage_vllm_config is not None
-                output_processor = build_llm_stage_output_processor(plan, stage_vllm_config, log_stats=self._log_stats)
+                output_processor = build_llm_stage_output_processor(
+                    plan,
+                    stage_vllm_config,
+                    log_stats=self._log_stats,
+                    tracing_enabled=self._otlp_traces_endpoint is not None,
+                )
 
             stage_pools.append(
                 StagePool(
@@ -1269,6 +1281,7 @@ class AsyncOmniEngine:
         self.stage_metadata = list(stage_metadata_list)
         return stage_pools
 
+    @instrument(span_name="Initialize stages")
     def _initialize_stages(self, stage_init_timeout: int) -> None:
         """Initialize stage clients/processors in orchestrator thread and assign to self.
 
@@ -1398,6 +1411,7 @@ class AsyncOmniEngine:
                 remote_replica_factory=remote_replica_factory,
                 transfer_emitter=self._transfer_emitter,
                 log_stats=self._log_stats,
+                tracing_enabled=self._otlp_traces_endpoint is not None,
             )
             if not startup_future.done():
                 startup_future.set_result(asyncio.get_running_loop())
@@ -1735,6 +1749,7 @@ class AsyncOmniEngine:
             preprocess_ms=_preprocess_ms,
             request_timestamp=request_timestamp,
             enqueue_ts=time.perf_counter(),
+            arrival_time=arrival_time,
         )
 
     def _enqueue_cfg_companions(

--- a/vllm_omni/engine/messages.py
+++ b/vllm_omni/engine/messages.py
@@ -27,6 +27,7 @@ class StageSubmissionMessage(EngineQueueMessage, kw_only=True):
     request_timestamp: float
     enqueue_ts: float
     final_output_stage_ids: list[int] | None = None
+    arrival_time: float | None = None
 
 
 class AddCompanionRequestMessage(EngineQueueMessage, kw_only=True):
@@ -89,6 +90,7 @@ class OutputMessage(EngineQueueMessage, kw_only=True):
     metrics: StageRequestMetrics | None = None
     finished: bool
     stage_submit_ts: float | None = None
+    trace_headers: dict[str, str] | None = None
 
 
 class StageMetricsMessage(EngineQueueMessage, kw_only=True):

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -63,6 +63,7 @@ from vllm_omni.engine.serialization import serialize_additional_information
 from vllm_omni.engine.stage_pool import StagePool
 from vllm_omni.metrics.prometheus import OmniRequestCounter
 from vllm_omni.metrics.stat_logger import OmniPrometheusStatLogger
+from vllm_omni.metrics.stats import PipelineTimings
 from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.tracing import OmniSpanAttributes
 
@@ -152,7 +153,7 @@ class OrchestratorRequestState:
     streaming: StreamingInputState = field(default_factory=lambda: StreamingInputState())
 
     # Per-request pipeline timing accumulator (milliseconds)
-    pipeline_timings: dict[str, float] = field(default_factory=dict)
+    pipeline_timings: PipelineTimings = field(default_factory=PipelineTimings)
 
     # W3C trace context propagated across stages
     trace_headers: dict[str, str] | None = None
@@ -500,7 +501,7 @@ class Orchestrator:
             trace_headers=getattr(prompt, "trace_headers", None),
         )
         if self._tracing_enabled and is_tracing_available():
-            arrival_time = msg.arrival_time or getattr(prompt, "arrival_time", None) or _time.time()
+            arrival_time = msg.arrival_time or _time.time()
             req_state.trace_start_ns = int(arrival_time * 1e9)
             self._start_omni_request_span(req_state)
             if req_state.trace_headers and hasattr(prompt, "trace_headers"):
@@ -512,10 +513,10 @@ class Orchestrator:
         req_state.stage_submit_ts[stage_id] = _time.time()
         enqueue_ts = msg.enqueue_ts
         if enqueue_ts > 0:
-            req_state.pipeline_timings["queue_wait_ms"] = (_time.perf_counter() - enqueue_ts) * 1000.0
+            req_state.pipeline_timings.queue_wait_ms = (_time.perf_counter() - enqueue_ts) * 1000.0
         preprocess_ms = msg.preprocess_ms
         if preprocess_ms > 0:
-            req_state.pipeline_timings["preprocess_ms"] = preprocess_ms
+            req_state.pipeline_timings.preprocess_ms = preprocess_ms
         await self.stage_pools[stage_id].submit_initial(
             request_id,
             req_state,
@@ -820,7 +821,7 @@ class Orchestrator:
                     replica_id=replica_id,
                     sampling_params=req_state.sampling_params_list[stage_id],
                 )
-                stage_metrics.pipeline_timings = dict(req_state.pipeline_timings)
+                stage_metrics.pipeline_timings = req_state.pipeline_timings
 
             await self._route_output(stage_id, replica_id, output, req_state, stage_metrics)
 
@@ -1037,12 +1038,14 @@ class Orchestrator:
         if span is None:
             return
         span.set_attribute(SpanAttributes.GEN_AI_REQUEST_ID, req_id)
-        if req_state.pipeline_timings:
-            import json
+        import dataclasses
+        import json
 
+        pt_dict = dataclasses.asdict(req_state.pipeline_timings)
+        if pt_dict:
             span.set_attribute(
                 OmniSpanAttributes.PIPELINE_TIMINGS,
-                json.dumps(req_state.pipeline_timings),
+                json.dumps(pt_dict),
             )
         span.end(_time.time_ns())
 
@@ -1238,7 +1241,7 @@ class Orchestrator:
                     **_extra_kwargs,
                 )
                 _dt_ar2d = (_time.perf_counter() - _t_ar2d) * 1000
-                req_state.pipeline_timings["ar2diffusion_ms"] = _dt_ar2d
+                req_state.pipeline_timings.ar2diffusion_ms = _dt_ar2d
                 logger.info(
                     "[Orchestrator] ar2diffusion req=%s wall_time=%.3fms stage=%d->%d",
                     req_id,

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -27,6 +27,12 @@ from vllm.config import ModelConfig
 from vllm.logger import init_logger
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
+from vllm.tracing import (
+    SpanAttributes,
+    SpanKind,
+    extract_trace_context,
+    is_tracing_available,
+)
 from vllm.v1.engine import EngineCoreOutputs
 from vllm.v1.engine.exceptions import EngineDeadError
 from vllm.v1.metrics.stats import IterationStats
@@ -58,6 +64,7 @@ from vllm_omni.engine.stage_pool import StagePool
 from vllm_omni.metrics.prometheus import OmniRequestCounter
 from vllm_omni.metrics.stat_logger import OmniPrometheusStatLogger
 from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.tracing import OmniSpanAttributes
 
 # Factory signature for building a head-side stage client for a
 # *dynamically attached* (auto-assigned) remote replica.
@@ -80,6 +87,7 @@ def build_engine_core_request_from_tokens(
     model_config: ModelConfig | None = None,
     resumable: bool = False,
     mm_features: list | None = None,
+    trace_headers: dict[str, str] | None = None,
 ) -> OmniEngineCoreRequest:
     """Build an OmniEngineCoreRequest directly from an OmniTokensPrompt."""
     if arrival_time is None:
@@ -102,7 +110,7 @@ def build_engine_core_request_from_tokens(
         log_prefix=f"build_engine_core_request_from_tokens req={request_id}",
     )
 
-    return OmniEngineCoreRequest(
+    req = OmniEngineCoreRequest(
         request_id=request_id,
         prompt_token_ids=prompt_token_ids,
         mm_features=mm_features,
@@ -116,6 +124,9 @@ def build_engine_core_request_from_tokens(
         resumable=resumable,
         additional_information=additional_info_payload,
     )
+    if trace_headers is not None:
+        req.trace_headers = trace_headers
+    return req
 
 
 @dataclass
@@ -142,6 +153,12 @@ class OrchestratorRequestState:
 
     # Per-request pipeline timing accumulator (milliseconds)
     pipeline_timings: dict[str, float] = field(default_factory=dict)
+
+    # W3C trace context propagated across stages
+    trace_headers: dict[str, str] | None = None
+    trace_start_ns: int = 0
+    # Live omni_request span (opentelemetry.trace.Span), ended on completion
+    _omni_span: Any = None
 
 
 @dataclass
@@ -184,7 +201,9 @@ class Orchestrator:
         remote_replica_factory: RemoteReplicaFactory | None = None,
         transfer_emitter: Any = None,
         log_stats: bool = False,
+        tracing_enabled: bool = False,
     ) -> None:
+        self._tracing_enabled = tracing_enabled
         self.request_async_queue = request_async_queue
         self.output_async_queue = output_async_queue
         self.rpc_async_queue = rpc_async_queue
@@ -478,7 +497,14 @@ class Orchestrator:
             final_output_stage_ids=final_output_stage_ids,
             request_timestamp=float(msg.request_timestamp or _time.time()),
             mm_features=getattr(prompt, "mm_features", None),
+            trace_headers=getattr(prompt, "trace_headers", None),
         )
+        if self._tracing_enabled and is_tracing_available():
+            arrival_time = msg.arrival_time or getattr(prompt, "arrival_time", None) or _time.time()
+            req_state.trace_start_ns = int(arrival_time * 1e9)
+            self._start_omni_request_span(req_state)
+            if req_state.trace_headers and hasattr(prompt, "trace_headers"):
+                prompt.trace_headers = req_state.trace_headers
         self.request_states[request_id] = req_state
         if self._running_counter is not None:
             self._running_counter.increment()
@@ -705,7 +731,7 @@ class Orchestrator:
                             # A second global throttle here would drop stats for
                             # other (stage, replica) pairs in the same 1s window.
                             record_stats = self._stat_logger is not None and raw_outputs.scheduler_stats is not None
-                            iteration_stats = IterationStats() if record_stats else None
+                            iteration_stats = IterationStats() if record_stats or self._tracing_enabled else None
                             raw_output = await pool.process_llm_raw_outputs(
                                 replica_id,
                                 raw_outputs,
@@ -914,6 +940,7 @@ class Orchestrator:
                     metrics=stage_metrics,
                     finished=request_finished,
                     stage_submit_ts=submit_ts,
+                    trace_headers=req_state.trace_headers if self._tracing_enabled else None,
                 )
             )
         elif stage_metrics is not None:
@@ -968,7 +995,56 @@ class Orchestrator:
                     )
 
         if request_finished:
+            if self._tracing_enabled:
+                self._end_omni_request_span(req_id, req_state)
             await self._cleanup_request_ids([req_id, *self._cfg_tracker.cleanup_parent(req_id)])
+
+    def _start_omni_request_span(
+        self,
+        req_state: OrchestratorRequestState,
+    ) -> None:
+        """Start the omni_request span and inject its context into trace_headers."""
+        try:
+            from opentelemetry import trace as otel_trace
+            from opentelemetry.context import Context
+            from opentelemetry.trace.propagation import set_span_in_context
+            from opentelemetry.trace.propagation.tracecontext import (
+                TraceContextTextMapPropagator,
+            )
+
+            tracer = otel_trace.get_tracer("vllm_omni.engine")
+            parent_context = extract_trace_context(req_state.trace_headers)
+            span = tracer.start_span(
+                "omni_request",
+                start_time=req_state.trace_start_ns,
+                kind=SpanKind.SERVER,
+                context=parent_context,
+            )
+            req_state._omni_span = span
+            ctx: Context = set_span_in_context(span)
+            carrier: dict[str, str] = {}
+            TraceContextTextMapPropagator().inject(carrier, context=ctx)
+            req_state.trace_headers = carrier
+        except Exception:
+            pass
+
+    def _end_omni_request_span(
+        self,
+        req_id: str,
+        req_state: OrchestratorRequestState,
+    ) -> None:
+        span = req_state._omni_span
+        if span is None:
+            return
+        span.set_attribute(SpanAttributes.GEN_AI_REQUEST_ID, req_id)
+        if req_state.pipeline_timings:
+            import json
+
+            span.set_attribute(
+                OmniSpanAttributes.PIPELINE_TIMINGS,
+                json.dumps(req_state.pipeline_timings),
+            )
+        span.end(_time.time_ns())
 
     def _next_stage_already_submitted(self, stage_id: int, req_state: OrchestratorRequestState) -> bool:
         return (stage_id + 1) in req_state.stage_submit_ts
@@ -1257,6 +1333,7 @@ class Orchestrator:
                     model_config=next_pool.stage_vllm_config.model_config,
                     mm_features=req_state.mm_features,
                     resumable=next_stage_resumable,
+                    trace_headers=req_state.trace_headers,
                 )
                 request.external_req_id = request.request_id
                 if already_submitted:
@@ -1309,6 +1386,7 @@ class Orchestrator:
                 model_config=next_pool.stage_vllm_config.model_config,
                 mm_features=mm_features,
                 resumable=next_stage_resumable,
+                trace_headers=req_state.trace_headers,
             )
 
             request.external_req_id = request.request_id
@@ -1391,6 +1469,7 @@ class Orchestrator:
                     params=params,
                     model_config=next_pool.stage_vllm_config.model_config,
                     resumable=downstream_resumable,
+                    trace_headers=req_state.trace_headers,
                 )
                 request.external_req_id = request.request_id
                 await next_pool.submit_initial(

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -774,13 +774,8 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
         if first_chunk_ts is None:
             return
 
-        # Use native_text_stats for OmniRequestState (has correct timestamps),
-        # fall back to base stats otherwise
-        metrics = (
-            req_state.native_text_stats
-            if isinstance(req_state, OmniRequestState)
-            else req_state.stats
-        )
+        # Use native_text_stats which tracks the actual timing data
+        metrics = req_state.native_text_stats
         trace_context = extract_trace_context(engine_core_output.trace_headers)
         processing_start_ns = int(first_chunk_ts * 1e9)
 

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -6,13 +6,7 @@ from vllm.logger import init_logger
 from vllm.outputs import CompletionOutput, PoolingRequestOutput, RequestOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.tokenizers import TokenizerLike
-from vllm.tracing import (
-    SpanAttributes,
-    SpanKind,
-    extract_trace_context,
-    instrument_manual,
-)
-from vllm.utils import length_from_prompt_token_ids_or_embeds
+from vllm.tracing import SpanKind, extract_trace_context, instrument_manual
 from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
 from vllm.v1.engine.output_processor import OutputProcessor as VLLMOutputProcessor
 from vllm.v1.engine.output_processor import (
@@ -759,61 +753,40 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
             float(finished_request.mean_time_per_output_token) * 1000.0
         )
 
-    # TODO: deduplicate once upstream do_tracing accepts extra_attributes
     def do_tracing(
         self,
         engine_core_output: EngineCoreOutput,
         req_state: RequestState,
         iteration_stats: IterationStats | None,
     ) -> None:
-        assert req_state.stats is not None
-        assert iteration_stats is not None
-
-        metrics = req_state.stats
-        first_chunk_ts = getattr(engine_core_output, "first_chunk_received_ts", None)
-        if first_chunk_ts is not None:
-            arrival_time_ns = int(first_chunk_ts * 1e9)
-        else:
-            arrival_time_ns = int(metrics.arrival_time * 1e9)
-        trace_context = extract_trace_context(engine_core_output.trace_headers)
-        prompt_length = length_from_prompt_token_ids_or_embeds(req_state.prompt_token_ids, req_state.prompt_embeds)
-
-        e2e_time = iteration_stats.iteration_timestamp - metrics.arrival_time
-        queued_time = metrics.scheduled_ts - metrics.queued_ts
-        prefill_time = metrics.first_token_ts - metrics.scheduled_ts
-        decode_time = metrics.last_token_ts - metrics.first_token_ts
-        inference_time = metrics.last_token_ts - metrics.scheduled_ts
-
-        attributes: dict[str, Any] = {
-            SpanAttributes.GEN_AI_LATENCY_TIME_TO_FIRST_TOKEN: (metrics.first_token_latency),
-            SpanAttributes.GEN_AI_LATENCY_E2E: e2e_time,
-            SpanAttributes.GEN_AI_LATENCY_TIME_IN_QUEUE: queued_time,
-            SpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS: prompt_length,
-            SpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS: (metrics.num_generation_tokens),
-            SpanAttributes.GEN_AI_LATENCY_TIME_IN_MODEL_PREFILL: prefill_time,
-            SpanAttributes.GEN_AI_LATENCY_TIME_IN_MODEL_DECODE: decode_time,
-            SpanAttributes.GEN_AI_LATENCY_TIME_IN_MODEL_INFERENCE: (inference_time),
-            SpanAttributes.GEN_AI_REQUEST_ID: req_state.external_req_id,
+        # Build omni-specific attributes
+        extra_attributes: dict[str, Any] = {
             OmniSpanAttributes.ENGINE_IDX: self._engine_idx,
             OmniSpanAttributes.STAGE_ID: self._stage_id,
             OmniSpanAttributes.STAGE_REPLICA_ID: self._replica_id,
         }
-
         if self._stage_name is not None:
-            attributes[OmniSpanAttributes.STAGE_NAME] = self._stage_name
-        if req_state.top_p:
-            attributes[SpanAttributes.GEN_AI_REQUEST_TOP_P] = req_state.top_p
-        if req_state.max_tokens_param:
-            attributes[SpanAttributes.GEN_AI_REQUEST_MAX_TOKENS] = req_state.max_tokens_param
-        if req_state.temperature:
-            attributes[SpanAttributes.GEN_AI_REQUEST_TEMPERATURE] = req_state.temperature
-        if req_state.n:
-            attributes[SpanAttributes.GEN_AI_REQUEST_N] = req_state.n
+            extra_attributes[OmniSpanAttributes.STAGE_NAME] = self._stage_name
 
-        instrument_manual(
-            span_name="llm_request",
-            start_time=arrival_time_ns,
-            attributes=attributes,
-            context=trace_context,
-            kind=self._span_kind,
+        # Call upstream to create llm_request span (includes queue wait)
+        super().do_tracing(
+            engine_core_output,
+            req_state,
+            iteration_stats,
+            extra_attributes=extra_attributes,
+            span_kind=self._span_kind,
         )
+
+        # Create additional llm_processing span if first_chunk_received_ts available
+        # This span measures pure processing time (scheduler pickup → finish)
+        first_chunk_ts = getattr(engine_core_output, "first_chunk_received_ts", None)
+        if first_chunk_ts is not None:
+            trace_context = extract_trace_context(engine_core_output.trace_headers)
+            processing_start_ns = int(first_chunk_ts * 1e9)
+            instrument_manual(
+                span_name="llm_processing",
+                start_time=processing_start_ns,
+                attributes=extra_attributes,
+                context=trace_context,
+                kind=self._span_kind,
+            )

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -6,6 +6,13 @@ from vllm.logger import init_logger
 from vllm.outputs import CompletionOutput, PoolingRequestOutput, RequestOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.tokenizers import TokenizerLike
+from vllm.tracing import (
+    SpanAttributes,
+    SpanKind,
+    extract_trace_context,
+    instrument_manual,
+)
+from vllm.utils import length_from_prompt_token_ids_or_embeds
 from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
 from vllm.v1.engine.output_processor import OutputProcessor as VLLMOutputProcessor
 from vllm.v1.engine.output_processor import (
@@ -25,6 +32,7 @@ from vllm_omni.engine.output_modality import (
     get_accumulation_strategy,
 )
 from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.tracing import OmniSpanAttributes
 
 logger = init_logger(__name__)
 
@@ -464,6 +472,10 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
         tracing_enabled: bool = False,
         engine_core_output_type: str | None = None,
         output_modality: OutputModality = OutputModality.TEXT,
+        engine_idx: int = -1,
+        stage_id: int = -1,
+        stage_name: str | None = None,
+        replica_id: int = 0,
     ):
         """Initialize the multimodal output processor.
 
@@ -478,6 +490,10 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
             output_modality: Type-safe output modality flag. Used to tag
                 multimodal outputs with the correct modality key when
                 per-output type info is unavailable.
+            engine_idx: Engine index for tracing
+            stage_id: Stage ID for tracing
+            stage_name: Stage name for tracing
+            replica_id: Replica ID for tracing
         """
         super().__init__(
             tokenizer=tokenizer,
@@ -492,6 +508,11 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
             self.output_modality = output_modality
         self.engine_core_output_type = engine_core_output_type
         self._native_text_metrics_by_request: dict[str, dict[str, Any]] = {}
+        self._engine_idx = engine_idx
+        self._stage_id = stage_id
+        self._stage_name = stage_name
+        self._replica_id = replica_id
+        self._span_kind = SpanKind.INTERNAL
 
     def _native_text_metric_record(self, request_id: str) -> dict[str, Any]:
         return self._native_text_metrics_by_request.setdefault(
@@ -736,4 +757,63 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
             return
         self._native_text_metric_record(req_state.external_req_id)["vllm_tpot_ms"] = (
             float(finished_request.mean_time_per_output_token) * 1000.0
+        )
+
+    # TODO: deduplicate once upstream do_tracing accepts extra_attributes
+    def do_tracing(
+        self,
+        engine_core_output: EngineCoreOutput,
+        req_state: RequestState,
+        iteration_stats: IterationStats | None,
+    ) -> None:
+        assert req_state.stats is not None
+        assert iteration_stats is not None
+
+        metrics = req_state.stats
+        first_chunk_ts = getattr(engine_core_output, "first_chunk_received_ts", None)
+        if first_chunk_ts is not None:
+            arrival_time_ns = int(first_chunk_ts * 1e9)
+        else:
+            arrival_time_ns = int(metrics.arrival_time * 1e9)
+        trace_context = extract_trace_context(engine_core_output.trace_headers)
+        prompt_length = length_from_prompt_token_ids_or_embeds(req_state.prompt_token_ids, req_state.prompt_embeds)
+
+        e2e_time = iteration_stats.iteration_timestamp - metrics.arrival_time
+        queued_time = metrics.scheduled_ts - metrics.queued_ts
+        prefill_time = metrics.first_token_ts - metrics.scheduled_ts
+        decode_time = metrics.last_token_ts - metrics.first_token_ts
+        inference_time = metrics.last_token_ts - metrics.scheduled_ts
+
+        attributes: dict[str, Any] = {
+            SpanAttributes.GEN_AI_LATENCY_TIME_TO_FIRST_TOKEN: (metrics.first_token_latency),
+            SpanAttributes.GEN_AI_LATENCY_E2E: e2e_time,
+            SpanAttributes.GEN_AI_LATENCY_TIME_IN_QUEUE: queued_time,
+            SpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS: prompt_length,
+            SpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS: (metrics.num_generation_tokens),
+            SpanAttributes.GEN_AI_LATENCY_TIME_IN_MODEL_PREFILL: prefill_time,
+            SpanAttributes.GEN_AI_LATENCY_TIME_IN_MODEL_DECODE: decode_time,
+            SpanAttributes.GEN_AI_LATENCY_TIME_IN_MODEL_INFERENCE: (inference_time),
+            SpanAttributes.GEN_AI_REQUEST_ID: req_state.external_req_id,
+            OmniSpanAttributes.ENGINE_IDX: self._engine_idx,
+            OmniSpanAttributes.STAGE_ID: self._stage_id,
+            OmniSpanAttributes.STAGE_REPLICA_ID: self._replica_id,
+        }
+
+        if self._stage_name is not None:
+            attributes[OmniSpanAttributes.STAGE_NAME] = self._stage_name
+        if req_state.top_p:
+            attributes[SpanAttributes.GEN_AI_REQUEST_TOP_P] = req_state.top_p
+        if req_state.max_tokens_param:
+            attributes[SpanAttributes.GEN_AI_REQUEST_MAX_TOKENS] = req_state.max_tokens_param
+        if req_state.temperature:
+            attributes[SpanAttributes.GEN_AI_REQUEST_TEMPERATURE] = req_state.temperature
+        if req_state.n:
+            attributes[SpanAttributes.GEN_AI_REQUEST_N] = req_state.n
+
+        instrument_manual(
+            span_name="llm_request",
+            start_time=arrival_time_ns,
+            attributes=attributes,
+            context=trace_context,
+            kind=self._span_kind,
         )

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -779,14 +779,24 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
 
         # Create additional llm_processing span if first_chunk_received_ts available
         # This span measures pure processing time (scheduler pickup → finish)
-        first_chunk_ts = getattr(engine_core_output, "first_chunk_received_ts", None)
-        if first_chunk_ts is not None:
-            trace_context = extract_trace_context(engine_core_output.trace_headers)
-            processing_start_ns = int(first_chunk_ts * 1e9)
-            instrument_manual(
-                span_name="llm_processing",
-                start_time=processing_start_ns,
-                attributes=extra_attributes,
-                context=trace_context,
-                kind=self._span_kind,
-            )
+        first_chunk_ts = engine_core_output.first_chunk_received_ts
+        if first_chunk_ts is None:
+            return
+        
+        metrics = req_state.stats
+        trace_context = extract_trace_context(engine_core_output.trace_headers)
+        processing_start_ns = int(first_chunk_ts * 1e9)
+
+        # Calculate end time: first_chunk_ts + time elapsed from scheduled to last_token
+        # (scheduled_ts and last_token_ts are monotonic, first_chunk_ts is wall-clock)
+        processing_duration_s = metrics.last_token_ts - metrics.scheduled_ts
+        processing_end_ns = int((first_chunk_ts + processing_duration_s) * 1e9)
+
+        instrument_manual(
+            span_name="llm_processing",
+            start_time=processing_start_ns,
+            end_time=processing_end_ns,
+            attributes=extra_attributes,
+            context=trace_context,
+            kind=self._span_kind,
+        )

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -774,7 +774,13 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
         if first_chunk_ts is None:
             return
 
-        metrics = req_state.stats
+        # Use native_text_stats for OmniRequestState (has correct timestamps),
+        # fall back to base stats otherwise
+        metrics = (
+            req_state.native_text_stats
+            if isinstance(req_state, OmniRequestState)
+            else req_state.stats
+        )
         trace_context = extract_trace_context(engine_core_output.trace_headers)
         processing_start_ns = int(first_chunk_ts * 1e9)
 

--- a/vllm_omni/engine/output_processor.py
+++ b/vllm_omni/engine/output_processor.py
@@ -759,22 +759,13 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
         req_state: RequestState,
         iteration_stats: IterationStats | None,
     ) -> None:
-        # Build omni-specific attributes
-        extra_attributes: dict[str, Any] = {
-            OmniSpanAttributes.ENGINE_IDX: self._engine_idx,
-            OmniSpanAttributes.STAGE_ID: self._stage_id,
-            OmniSpanAttributes.STAGE_REPLICA_ID: self._replica_id,
-        }
-        if self._stage_name is not None:
-            extra_attributes[OmniSpanAttributes.STAGE_NAME] = self._stage_name
-
         # Call upstream to create llm_request span (includes queue wait)
+        # TODO: Add omni-specific attributes (ENGINE_IDX, STAGE_ID, STAGE_REPLICA_ID, STAGE_NAME)
+        # once vLLM supports extra_attributes parameter in do_tracing()
         super().do_tracing(
             engine_core_output,
             req_state,
             iteration_stats,
-            extra_attributes=extra_attributes,
-            span_kind=self._span_kind,
         )
 
         # Create additional llm_processing span if first_chunk_received_ts available
@@ -782,7 +773,7 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
         first_chunk_ts = engine_core_output.first_chunk_received_ts
         if first_chunk_ts is None:
             return
-        
+
         metrics = req_state.stats
         trace_context = extract_trace_context(engine_core_output.trace_headers)
         processing_start_ns = int(first_chunk_ts * 1e9)
@@ -792,11 +783,20 @@ class MultimodalOutputProcessor(VLLMOutputProcessor):
         processing_duration_s = metrics.last_token_ts - metrics.scheduled_ts
         processing_end_ns = int((first_chunk_ts + processing_duration_s) * 1e9)
 
+        # Build omni-specific attributes for llm_processing span
+        attributes: dict[str, Any] = {
+            OmniSpanAttributes.ENGINE_IDX: self._engine_idx,
+            OmniSpanAttributes.STAGE_ID: self._stage_id,
+            OmniSpanAttributes.STAGE_REPLICA_ID: self._replica_id,
+        }
+        if self._stage_name is not None:
+            attributes[OmniSpanAttributes.STAGE_NAME] = self._stage_name
+
         instrument_manual(
             span_name="llm_processing",
             start_time=processing_start_ns,
             end_time=processing_end_ns,
-            attributes=extra_attributes,
+            attributes=attributes,
             context=trace_context,
             kind=self._span_kind,
         )

--- a/vllm_omni/engine/stage_engine_core_proc.py
+++ b/vllm_omni/engine/stage_engine_core_proc.py
@@ -17,6 +17,7 @@ import msgspec
 import vllm.v1.engine.core as _vllm_engine_core_module
 import zmq
 from vllm.logger import init_logger
+from vllm.tracing import maybe_init_worker_tracer
 from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value,
 )
@@ -114,8 +115,10 @@ class StageEngineCoreProc(EngineCoreProc):
             # like upstream vLLM.
 
             stage_label = f"stage{omni_stage_id}" if omni_stage_id is not None else "noid"
+            process_title = f"StageEngineCoreProc_{stage_label}_replica{omni_replica_id}_DP{dp_rank}"
             set_death_signal(signal.SIGTERM)
-            set_process_title(f"StageEngineCoreProc_{stage_label}_replica{omni_replica_id}_DP{dp_rank}")
+            set_process_title(process_title)
+            maybe_init_worker_tracer("vllm_omni.stage_core", "stage_core", process_title)
             decorate_logs()
             # Workaround for flashinfer/jit-cache version mismatch in CI.
             # The parent process handles this gracefully via ring_globals.py,

--- a/vllm_omni/engine/stage_init_utils.py
+++ b/vllm_omni/engine/stage_init_utils.py
@@ -849,14 +849,9 @@ def build_llm_stage_output_processor(
     plan: LogicalStageInitPlan,
     stage_vllm_config: Any,
     log_stats: bool = False,
+    tracing_enabled: bool = False,
 ) -> Any | None:
-    """Build one output processor per logical LLM stage.
-
-    ``log_stats`` controls whether the processor populates per-request
-    IterationStats (consumed by the Prometheus wrap). Default False matches
-    the upstream MultimodalOutputProcessor default and respects the
-    --log-stats CLI flag plumbed through AsyncOmniEngine.
-    """
+    """Build one output processor per logical LLM stage."""
 
     metadata = plan.replicas[0].metadata
     if stage_vllm_config.model_config.skip_tokenizer_init:
@@ -868,7 +863,12 @@ def build_llm_stage_output_processor(
     return MultimodalOutputProcessor(
         tokenizer=tokenizer,
         log_stats=log_stats,
+        tracing_enabled=tracing_enabled,
         engine_core_output_type=metadata.engine_output_type,
+        engine_idx=plan.stage_idx,
+        stage_id=metadata.stage_id,
+        stage_name=metadata.model_stage,
+        replica_id=metadata.replica_id,
     )
 
 

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -389,7 +389,7 @@ class AsyncOmni(EngineClient, OmniBase):
                 )
             submit_ts = time.time()
             req_state.metrics.stage_first_ts[0] = submit_ts
-            req_start_ts[request_id] = submit_ts
+            req_start_ts[request_id] = wall_start_ts
 
             # Process results based on mode
             # Both sequential and async_chunk modes read the same message stream
@@ -1046,8 +1046,7 @@ class AsyncOmni(EngineClient, OmniBase):
         return self.input_processor.tokenizer  # type: ignore[return-value]
 
     async def is_tracing_enabled(self) -> bool:
-        """Check if tracing is enabled."""
-        return False
+        return getattr(self.engine, "_otlp_traces_endpoint", None) is not None
 
     async def notify_kv_transfer_request_rejected(
         self,

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -4,10 +4,16 @@ import os
 import time
 import weakref
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import huggingface_hub
 from vllm.logger import init_logger
+from vllm.tracing import (
+    SpanKind,
+    extract_trace_context,
+    instrument_manual,
+    is_tracing_available,
+)
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
 
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
@@ -27,7 +33,11 @@ from vllm_omni.metrics.stats import OrchestratorAggregator
 from vllm_omni.metrics.transfer import OmniTransferMetrics
 from vllm_omni.model_executor.model_loader.weight_utils import download_weights_from_hf_specific
 from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.tracing import OmniSpanAttributes
 from vllm_omni.utils.tracking_parser import TrackingNamespace
+
+if TYPE_CHECKING:
+    pass
 
 logger = init_logger(__name__)
 
@@ -555,6 +565,33 @@ class OmniBase(PDDisaggregationMixin):
         self.prom_metrics.set_running(running)
         self.prom_metrics.set_waiting(max(0, total - running))
 
+        diffusion_metrics = getattr(engine_outputs, "metrics", None)
+        if finished and isinstance(diffusion_metrics, dict) and diffusion_metrics:
+            if is_tracing_available():
+                trace_context = extract_trace_context(getattr(result, "trace_headers", None))
+                step_start = diffusion_metrics.get(
+                    "step_start_ts",
+                    req_start_ts.get(req_id, wall_start_ts),
+                )
+                total_ms = diffusion_metrics.get("diffusion_engine_total_time_ms")
+                step_end_ns = int((step_start + total_ms / 1000) * 1e9) if total_ms is not None else time.time_ns()
+                instrument_manual(
+                    span_name="diffusion_request",
+                    start_time=int(step_start * 1e9),
+                    end_time=step_end_ns,
+                    attributes={
+                        OmniSpanAttributes.STAGE_ID: stage_id,
+                        OmniSpanAttributes.STAGE_NAME: "diffusion",
+                        OmniSpanAttributes.STAGE_REPLICA_ID: result.replica_id,
+                        OmniSpanAttributes.ENGINE_IDX: getattr(result, "engine_idx", stage_id),
+                        OmniSpanAttributes.DIFFUSION_PREPROCESS_MS: diffusion_metrics.get("preprocess_time_ms"),
+                        OmniSpanAttributes.DIFFUSION_EXEC_MS: diffusion_metrics.get("diffusion_engine_exec_time_ms"),
+                        OmniSpanAttributes.DIFFUSION_POSTPROCESS_MS: diffusion_metrics.get("postprocess_time_ms"),
+                        OmniSpanAttributes.DIFFUSION_TOTAL_MS: diffusion_metrics.get("diffusion_engine_total_time_ms"),
+                    },
+                    context=trace_context,
+                    kind=SpanKind.INTERNAL,
+                )
         images = getattr(engine_outputs, "images", []) if output_type == "image" else []
         response_metrics: dict[str, Any] = {}
         stage_metrics: dict[str, dict[str, Any]] = {}

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -4,7 +4,7 @@ import os
 import time
 import weakref
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 import huggingface_hub
 from vllm.logger import init_logger
@@ -35,9 +35,6 @@ from vllm_omni.model_executor.model_loader.weight_utils import download_weights_
 from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.tracing import OmniSpanAttributes
 from vllm_omni.utils.tracking_parser import TrackingNamespace
-
-if TYPE_CHECKING:
-    pass
 
 logger = init_logger(__name__)
 
@@ -490,7 +487,9 @@ class OmniBase(PDDisaggregationMixin):
         # Merge pipeline timings from Orchestrator into stage_durations
         _m = result.metrics
         if _m is not None and hasattr(_m, "pipeline_timings") and _m.pipeline_timings:
-            for key, value in _m.pipeline_timings.items():
+            import dataclasses
+
+            for key, value in dataclasses.asdict(_m.pipeline_timings).items():
                 if key not in stage_durations:
                     stage_durations[key] = value
 

--- a/vllm_omni/metrics/stats.py
+++ b/vllm_omni/metrics/stats.py
@@ -29,6 +29,15 @@ class StageStats:
 
 
 @dataclass
+class PipelineTimings:
+    """Orchestrator-level pipeline timing metrics (all in milliseconds)."""
+
+    queue_wait_ms: float = 0.0
+    preprocess_ms: float = 0.0
+    ar2diffusion_ms: float = 0.0
+
+
+@dataclass
 class StageRequestStats:
     batch_id: int
     batch_size: int
@@ -51,7 +60,7 @@ class StageRequestStats:
     audio_rtf: float = 0.0
     image_pixels: int = 0
     denoise_step_latency_ms: float = 0.0
-    pipeline_timings: dict[str, float] | None = None
+    pipeline_timings: PipelineTimings | None = None
     output_unit_type: str | None = None
     output_unit_count: int = 0
     serving_time_to_first_output_ms: float = 0.0
@@ -738,8 +747,8 @@ class OrchestratorAggregator:
         preprocess_times = []
         for _rid, evts in self.stage_events.items():
             for evt in evts:
-                if evt.pipeline_timings and "preprocess_ms" in evt.pipeline_timings:
-                    preprocess_times.append(evt.pipeline_timings["preprocess_ms"])
+                if evt.pipeline_timings and evt.pipeline_timings.preprocess_ms > 0:
+                    preprocess_times.append(evt.pipeline_timings.preprocess_ms)
                     break  # only once per request
         if preprocess_times:
             overall_summary["input_preprocess_time_ms"] = sum(preprocess_times) / len(preprocess_times)
@@ -795,17 +804,17 @@ class OrchestratorAggregator:
                 self.stage_events.get(rid, []),
                 key=lambda e: e.stage_id if e.stage_id is not None else -1,
             )
-            pt = {}
+            pt = PipelineTimings()
             if stage_evts:
-                pt = stage_evts[-1].pipeline_timings or {}
+                pt = stage_evts[-1].pipeline_timings or PipelineTimings()
             if pt or e2e_evt:
                 parts = [f"req={rid}"]
                 if e2e_evt:
                     parts.append(f"total={e2e_evt.e2e_total_ms / 1000.0:.2f}s")
-                if "preprocess_ms" in pt:
-                    parts.append(f"preprocess={pt['preprocess_ms'] / 1000.0:.2f}s")
+                if pt.preprocess_ms > 0:
+                    parts.append(f"preprocess={pt.preprocess_ms / 1000.0:.2f}s")
                 if e2e_evt:
-                    engine_ms = e2e_evt.e2e_total_ms - pt.get("preprocess_ms", 0.0)
+                    engine_ms = e2e_evt.e2e_total_ms - pt.preprocess_ms
                     parts.append(f"engine={engine_ms / 1000.0:.2f}s")
                 stage_parts = []
                 for evt in stage_evts:
@@ -820,8 +829,8 @@ class OrchestratorAggregator:
                         transfer_parts.append(f"{te.from_stage}->{te.to_stage}={te.tx_time_ms:.2f}ms")
                 if transfer_parts:
                     parts.append(f"transfers=[{','.join(transfer_parts)}]")
-                if "ar2diffusion_ms" in pt:
-                    parts.append(f"ar2diffusion={pt['ar2diffusion_ms']:.2f}ms")
+                if pt.ar2diffusion_ms > 0:
+                    parts.append(f"ar2diffusion={pt.ar2diffusion_ms:.2f}ms")
                 logger.info("[OmniTiming] %s", " ".join(parts))
 
             # === Stage table (columns = stage_id) ===

--- a/vllm_omni/tracing.py
+++ b/vllm_omni/tracing.py
@@ -1,0 +1,10 @@
+class OmniSpanAttributes:
+    ENGINE_IDX = "vllm_omni.engine.idx"
+    STAGE_ID = "vllm_omni.stage.id"
+    STAGE_NAME = "vllm_omni.stage.name"
+    STAGE_REPLICA_ID = "vllm_omni.stage.replica_id"
+    PIPELINE_TIMINGS = "vllm_omni.pipeline.timings"
+    DIFFUSION_PREPROCESS_MS = "vllm_omni.diffusion.preprocess_ms"
+    DIFFUSION_EXEC_MS = "vllm_omni.diffusion.exec_ms"
+    DIFFUSION_POSTPROCESS_MS = "vllm_omni.diffusion.postprocess_ms"
+    DIFFUSION_TOTAL_MS = "vllm_omni.diffusion.total_ms"


### PR DESCRIPTION
<!-- markdownlint-disable -->
Addresses https://github.com/vllm-project/vllm-omni/issues/3995

## Purpose

Add OpenTelemetry tracing to vLLM-Omni's multi-stage pipeline. Each request produces a trace with:

- An **`omni_request`** span (SERVER) covering the full request lifecycle in the orchestrator
- Per-stage **`llm_request`** spans (INTERNAL) for each LLM engine stage, as children of `omni_request`
- A **`diffusion_request`** span (INTERNAL) for diffusion stages, as a child of `omni_request`

All spans share a single trace ID via W3C TraceContext propagation across stages.

Spans include the following attributes:

- `"vllm_omni.engine.idx"`
- `"vllm_omni.stage.id"`
- `"vllm_omni.stage.name"` (e.g. thinker, talker, code2wav)
- `"vllm_omni.stage.replica_id"`
- `"vllm_omni.pipeline.timings"` (fine-grained orchestrator timings)
- `"vllm_omni.diffusion.preprocess_ms"`
- `"vllm_omni.diffusion.exec_ms"`
- `"vllm_omni.diffusion.postprocess_ms"`

Additonally, create a span to capture init events (largely inherited from vLLM: torch compilation, model loading, etc.)

## Test Plan

Tested manually with two model types on 4x A100-40GB, traces collected by a Jaeger sidecar (`--otlp-traces-endpoint localhost:4317`).

**Qwen3-Omni** (3-stage LLM pipeline, `async_chunk: true`)

```bash
vllm-omni serve Qwen/Qwen3-Omni-30B-A3B-Instruct \
  --omni --deploy-config /app/qwen3_omni.yaml \
  --port 8000 --otlp-traces-endpoint localhost:4317

curl -s http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen3-Omni-30B-A3B-Instruct","messages":[{"role":"user","content":"What is 2+2?"}],"max_tokens":32}'
```

**FLUX.2-dev** (single-stage diffusion)

```bash
vllm-omni serve black-forest-labs/FLUX.2-dev \
  --omni --enforce-eager --max-num-seqs 1 --tensor-parallel-size 2 \
  --port 8000 --otlp-traces-endpoint localhost:4317

curl -s http://localhost:8000/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{"model":"black-forest-labs/FLUX.2-dev","prompt":"a red cat sitting on a windowsill","size":"1024x1024"}'
```

**Unit tests** (no GPU required)

```bash
python -m pytest --confcutdir=tests/tracing tests/tracing/ -v
```

22 tests across 7 classes covering `@instrument` decorator, `instrument_manual`, trace context propagation, orchestrator span lifecycle, LLM request spans, and diffusion request spans. Uses an in-process gRPC `FakeTraceService` to collect and assert on exported spans.

## Test Results

### Qwen3-Omni
Init:
<img width="1591" height="515" alt="qwen3-omni-init" src="https://github.com/user-attachments/assets/1b7f0c43-4590-4eb2-8df5-716db8edebdf" />

Request:
<img width="1591" height="515" alt="qwen3-omni-request" src="https://github.com/user-attachments/assets/bb268f21-5d84-43a2-858a-40ab0febb64d" />

### FLUX.2-dev
Init:
<img width="1591" height="515" alt="flux-2-init" src="https://github.com/user-attachments/assets/bae6c819-af8b-4a09-99ac-1e1a2ba34ebe" />

Request:
<img width="1591" height="515" alt="flux-2-request" src="https://github.com/user-attachments/assets/f9bab567-656c-4d94-98bf-bff4578fa11f" />

### Unit tests

```
tests/tracing/test_tracing.py::TestOmniSpanAttributes::test_attribute_constants_are_namespaced PASSED
tests/tracing/test_tracing.py::TestOmniSpanAttributes::test_diffusion_attributes_are_namespaced PASSED
tests/tracing/test_tracing.py::TestInstrumentDecorator::test_sync_function_creates_span PASSED
tests/tracing/test_tracing.py::TestInstrumentDecorator::test_async_function_creates_span PASSED
tests/tracing/test_tracing.py::TestInstrumentDecorator::test_nested_spans_have_parent_child_relationship PASSED
tests/tracing/test_tracing.py::TestInstrumentDecorator::test_span_has_valid_timestamps PASSED
tests/tracing/test_tracing.py::TestInstrumentManual::test_creates_span_with_explicit_timestamps PASSED
tests/tracing/test_tracing.py::TestInstrumentManual::test_span_with_no_end_time_ends_immediately PASSED
tests/tracing/test_tracing.py::TestInstrumentManual::test_span_respects_parent_context PASSED
tests/tracing/test_tracing.py::TestInstrumentManual::test_span_kind_is_propagated PASSED
tests/tracing/test_tracing.py::TestInstrumentManual::test_multiple_attributes_types PASSED
tests/tracing/test_tracing.py::TestTraceContextPropagation::test_extract_from_traceparent_header PASSED
tests/tracing/test_tracing.py::TestTraceContextPropagation::test_extract_from_none_returns_none PASSED
tests/tracing/test_tracing.py::TestTraceContextPropagation::test_extract_from_empty_dict_returns_none PASSED
tests/tracing/test_tracing.py::TestTraceContextPropagation::test_header_injection_round_trip PASSED
tests/tracing/test_tracing.py::TestOmniRequestSpan::test_start_span_sets_omni_span PASSED
tests/tracing/test_tracing.py::TestOmniRequestSpan::test_start_span_inherits_parent_trace PASSED
tests/tracing/test_tracing.py::TestOmniRequestSpan::test_end_span_sets_attributes PASSED
tests/tracing/test_tracing.py::TestOmniRequestSpan::test_end_span_without_start_is_noop PASSED
tests/tracing/test_tracing.py::TestLlmRequestSpan::test_llm_request_span_attributes PASSED
tests/tracing/test_tracing.py::TestDiffusionRequestSpan::test_diffusion_span_with_timing_attributes PASSED
tests/tracing/test_tracing.py::TestDiffusionRequestSpan::test_diffusion_span_inherits_trace_context PASSED

22 passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
(anything written below this line will be removed by GitHub Actions)