### PR TITLE
Add @trackable & .from_engine_args for `AsyncOmni`

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -22,6 +22,7 @@ from vllm_omni.config.model import OmniModelConfig
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.engine.async_omni_engine import AsyncOmniEngine
 from vllm_omni.engine.stage_init_utils import build_engine_args_dict
+from vllm_omni.utils.dataclass_utils import trackable_to_kwargs
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -552,3 +553,10 @@ def test_tensor_parallel_size_none_is_handled():
     )
     assert isinstance(args, dict)
     assert "tensor_parallel_size" not in args
+
+
+def test_trackable_omni_engine_args_can_filter():
+    """Ensure OmniEngineArgs is @trackable."""
+    omni_args = OmniEngineArgs("my-model", stage_id=1)
+    filtered_kwargs = trackable_to_kwargs(omni_args)
+    assert filtered_kwargs == {"model": "my-model", "stage_id": 1}

--- a/tests/entrypoints/test_async_omni.py
+++ b/tests/entrypoints/test_async_omni.py
@@ -12,6 +12,7 @@ from tests.helpers.stage_config import get_deploy_config_path
 from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.outputs import OmniRequestOutput
+from vllm_omni.utils.dataclass_utils import Trackable
 
 pytestmark = [pytest.mark.core_model]
 
@@ -389,6 +390,7 @@ async def test_omni_generate_request_id():
 def test_from_engine_args_forwarding():
     """Ensure from_engine_args correctly forwards explicit positional args or kwargs."""
     args = OmniEngineArgs("my-model", stage_id=1)
+    assert isinstance(args, Trackable)
     with patch.object(AsyncOmni, "__init__", return_value=None) as mock_init:
         AsyncOmni.from_engine_args(args)
         mock_init.assert_called_once_with(model="my-model", stage_id=1)

--- a/tests/entrypoints/test_async_omni.py
+++ b/tests/entrypoints/test_async_omni.py
@@ -1,6 +1,7 @@
 import asyncio
 import re
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from vllm.lora.request import LoRARequest
@@ -8,6 +9,7 @@ from vllm.sampling_params import RequestOutputKind, SamplingParams
 
 from tests.helpers.mark import hardware_test
 from tests.helpers.stage_config import get_deploy_config_path
+from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.entrypoints.async_omni import AsyncOmni
 from vllm_omni.outputs import OmniRequestOutput
 
@@ -381,3 +383,12 @@ async def test_omni_generate_request_id():
             assert output.request_id != ""
     finally:
         engine.shutdown()
+
+
+@pytest.mark.cpu
+def test_from_engine_args_forwarding():
+    """Ensure from_engine_args correctly forwards explicit positional args or kwargs."""
+    args = OmniEngineArgs("my-model", stage_id=1)
+    with patch.object(AsyncOmni, "__init__", return_value=None) as mock_init:
+        AsyncOmni.from_engine_args(args)
+        mock_init.assert_called_once_with(model="my-model", stage_id=1)

--- a/tests/utils/test_dataclass_utils.py
+++ b/tests/utils/test_dataclass_utils.py
@@ -6,6 +6,8 @@ import pytest
 
 from vllm_omni.utils.dataclass_utils import trackable, trackable_to_kwargs
 
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
 
 def test_trackable_args():
     """Ensure we can track classes generically [positional args]."""

--- a/tests/utils/test_dataclass_utils.py
+++ b/tests/utils/test_dataclass_utils.py
@@ -7,8 +7,21 @@ import pytest
 from vllm_omni.utils.dataclass_utils import trackable, trackable_to_kwargs
 
 
+def test_trackable_args():
+    """Ensure we can track classes generically [positional args]."""
+
+    @trackable
+    class NotADataClass:
+        def __init__(self, foo, bar, baz=128, *args, **kwargs):
+            pass
+
+    obj = NotADataClass(32, 64)
+    # Only foo / bar were initially passed
+    assert obj._init_kwargs == {"foo", "bar"}
+
+
 def test_trackable_kwargs():
-    """Ensure we can track classes generically."""
+    """Ensure we can track classes generically [kwargs]."""
 
     @trackable
     class NotADataClass:
@@ -20,34 +33,21 @@ def test_trackable_kwargs():
     assert obj._init_kwargs == {"foo", "bar"}
 
 
-def test_trackable_dataclass():
-    """Ensure we can track classes dataclasses."""
+def test_trackable_args_and_kwargs():
+    """Ensure we can track classes generically [kwargs]."""
 
-    @trackable
-    @dataclass
-    class MyDataClass:
-        foo: int = 0
-        bar: int = 0
-        baz: int = 128
-
-    obj = MyDataClass(foo=32, bar=64)
-    assert obj._init_kwargs == {"foo", "bar"}
-
-
-@pytest.mark.xfail(reason="positional args not yet tracked")
-def test_trackable_positional_args():
     @trackable
     class NotADataClass:
         def __init__(self, foo, bar, baz=128, *args, **kwargs):
             pass
 
-    obj = NotADataClass(32, 64)
-    # Even though they were positional, this should be fine also
+    obj = NotADataClass(32, bar=64)
+    # Only foo / bar were initially passed
     assert obj._init_kwargs == {"foo", "bar"}
 
 
-def test_trackable_to_kwargs():
-    """Ensure a registered trackable can be filtered down to kwargs."""
+def test_trackable_dataclass():
+    """Ensure we can track dataclasses, since is the most useful case."""
 
     @trackable
     @dataclass
@@ -56,7 +56,21 @@ def test_trackable_to_kwargs():
         bar: int = 0
         baz: int = 128
 
-    obj = MyDataClass(foo=32, bar=64)
+    obj = MyDataClass(32, bar=64)
+    assert obj._init_kwargs == {"foo", "bar"}
+
+
+def test_trackable_to_kwargs():
+    """Ensure a registered trackable can be filtered down to set values."""
+
+    @trackable
+    @dataclass
+    class MyDataClass:
+        foo: int = 0
+        bar: int = 0
+        baz: int = 128
+
+    obj = MyDataClass(32, bar=64)
     res = trackable_to_kwargs(obj)
     assert res == {"foo": 32, "bar": 64}
 

--- a/tests/utils/test_dataclass_utils.py
+++ b/tests/utils/test_dataclass_utils.py
@@ -10,46 +10,35 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
 def test_trackable_args():
-    """Ensure we can track classes generically [positional args]."""
+    """Ensure we can track dataclasses created with positional args."""
 
     @trackable
-    class NotADataClass:
-        def __init__(self, foo, bar, baz=128, *args, **kwargs):
-            pass
+    @dataclass
+    class MyDataClass:
+        foo: int = 0
+        bar: int = 0
+        baz: int = 128
 
-    obj = NotADataClass(32, 64)
-    # Only foo / bar were initially passed
+    obj = MyDataClass(32, 64)
     assert obj._init_kwargs == {"foo", "bar"}
 
 
 def test_trackable_kwargs():
-    """Ensure we can track classes generically [kwargs]."""
+    """Ensure we can track dataclasses created with keyword args."""
 
     @trackable
-    class NotADataClass:
-        def __init__(self, foo, bar, baz=128, *args, **kwargs):
-            pass
+    @dataclass
+    class MyDataClass:
+        foo: int = 0
+        bar: int = 0
+        baz: int = 128
 
-    obj = NotADataClass(foo=32, bar=64)
-    # Only foo / bar were initially passed
+    obj = MyDataClass(foo=32, bar=64)
     assert obj._init_kwargs == {"foo", "bar"}
 
 
 def test_trackable_args_and_kwargs():
-    """Ensure we can track classes generically [kwargs]."""
-
-    @trackable
-    class NotADataClass:
-        def __init__(self, foo, bar, baz=128, *args, **kwargs):
-            pass
-
-    obj = NotADataClass(32, bar=64)
-    # Only foo / bar were initially passed
-    assert obj._init_kwargs == {"foo", "bar"}
-
-
-def test_trackable_dataclass():
-    """Ensure we can track dataclasses, since is the most useful case."""
+    """Ensure we can track dataclasses created with positional & keyword args."""
 
     @trackable
     @dataclass
@@ -60,6 +49,17 @@ def test_trackable_dataclass():
 
     obj = MyDataClass(32, bar=64)
     assert obj._init_kwargs == {"foo", "bar"}
+
+
+def test_trackable_rejects_non_dataclass():
+    """Ensure @trackable raises TypeError on non-dataclass classes."""
+
+    with pytest.raises(TypeError, match="currently requires classes to be dataclasses"):
+
+        @trackable
+        class NotADataClass:
+            def __init__(self, foo, bar):
+                pass
 
 
 def test_trackable_to_kwargs():

--- a/tests/utils/test_dataclass_utils.py
+++ b/tests/utils/test_dataclass_utils.py
@@ -1,0 +1,75 @@
+"""Tests for dataclass utils / helpers."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from vllm_omni.utils.dataclass_utils import trackable, trackable_to_kwargs
+
+
+def test_trackable_kwargs():
+    """Ensure we can track classes generically."""
+
+    @trackable
+    class NotADataClass:
+        def __init__(self, foo, bar, baz=128, *args, **kwargs):
+            pass
+
+    obj = NotADataClass(foo=32, bar=64)
+    # Only foo / bar were initially passed
+    assert obj._init_kwargs == {"foo", "bar"}
+
+
+def test_trackable_dataclass():
+    """Ensure we can track classes dataclasses."""
+
+    @trackable
+    @dataclass
+    class MyDataClass:
+        foo: int = 0
+        bar: int = 0
+        baz: int = 128
+
+    obj = MyDataClass(foo=32, bar=64)
+    assert obj._init_kwargs == {"foo", "bar"}
+
+
+@pytest.mark.xfail(reason="positional args not yet tracked")
+def test_trackable_positional_args():
+    @trackable
+    class NotADataClass:
+        def __init__(self, foo, bar, baz=128, *args, **kwargs):
+            pass
+
+    obj = NotADataClass(32, 64)
+    # Even though they were positional, this should be fine also
+    assert obj._init_kwargs == {"foo", "bar"}
+
+
+def test_trackable_to_kwargs():
+    """Ensure a registered trackable can be filtered down to kwargs."""
+
+    @trackable
+    @dataclass
+    class MyDataClass:
+        foo: int = 0
+        bar: int = 0
+        baz: int = 128
+
+    obj = MyDataClass(foo=32, bar=64)
+    res = trackable_to_kwargs(obj)
+    assert res == {"foo": 32, "bar": 64}
+
+
+def test_trackable_to_kwargs_raises_with_bad_types():
+    """Ensure a non trackable raises TypeError if we try to filter to kwargs."""
+
+    @dataclass
+    class MyDataClass:
+        foo: int = 0
+        bar: int = 0
+        baz: int = 128
+
+    obj = MyDataClass(foo=32, bar=64)
+    with pytest.raises(TypeError):
+        trackable_to_kwargs(obj)

--- a/tests/utils/test_dataclass_utils.py
+++ b/tests/utils/test_dataclass_utils.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from vllm_omni.utils.dataclass_utils import trackable, trackable_to_kwargs
+from vllm_omni.utils.dataclass_utils import Trackable, trackable, trackable_to_kwargs
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -89,3 +89,24 @@ def test_trackable_to_kwargs_raises_with_bad_types():
     obj = MyDataClass(foo=32, bar=64)
     with pytest.raises(TypeError):
         trackable_to_kwargs(obj)
+
+
+def test_trackable_subclasses_are_nontrackable_by_default():
+    """Ensure that by default, inheriting from a @trackable dataclass is not
+    @trackable, i.e., we just inherit from the dataclass. If the subclass needs
+    to be trackable, it should explicit use the decorator.
+    """
+
+    @trackable
+    @dataclass
+    class MyDataClass:
+        foo: int = 0
+        bar: int = 0
+        baz: int = 128
+
+    @dataclass
+    class NonTrackableSubClass(MyDataClass):
+        baz: int = 256
+
+    obj = NonTrackableSubClass()
+    assert not isinstance(obj, Trackable)

--- a/vllm_omni/engine/arg_utils.py
+++ b/vllm_omni/engine/arg_utils.py
@@ -12,6 +12,7 @@ from vllm_omni.config import OmniModelConfig
 from vllm_omni.outputs.output_modality import OutputModality
 from vllm_omni.platforms import current_omni_platform
 from vllm_omni.plugins import load_omni_general_plugins
+from vllm_omni.utils.dataclass_utils import trackable
 
 logger = init_logger(__name__)
 
@@ -132,6 +133,7 @@ def register_omni_models_to_vllm():
     import vllm_omni.reasoning  # noqa: F401
 
 
+@trackable
 @dataclass
 class OmniEngineArgs(EngineArgs):
     """Engine arguments for omni models, extending base EngineArgs.

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -179,7 +179,7 @@ class AsyncOmni(EngineClient, OmniBase):
     def from_engine_args(
         cls,
         engine_args: OmniEngineArgs,
-    ):
+    ) -> AsyncOmni:
         # Drops non-explicit defaults; this is functionally the same
         # as the way in which TrackingArgumentParser filters omitted
         # kwargs to avoid clobbering config defaults

--- a/vllm_omni/entrypoints/async_omni.py
+++ b/vllm_omni/entrypoints/async_omni.py
@@ -27,6 +27,7 @@ from vllm.utils import random_uuid
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from vllm_omni.diffusion.data import CuMemTag, OmniACK, OmniSleepTask, OmniWakeTask
+from vllm_omni.engine.arg_utils import OmniEngineArgs
 from vllm_omni.engine.messages import ErrorMessage, OutputMessage
 from vllm_omni.entrypoints.client_request_state import ClientRequestState
 from vllm_omni.entrypoints.omni_base import (
@@ -38,6 +39,7 @@ from vllm_omni.inputs.data import OmniSamplingParams
 from vllm_omni.metrics.stats import OrchestratorAggregator as OrchestratorMetrics
 from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.platforms import current_omni_platform
+from vllm_omni.utils.dataclass_utils import trackable_to_kwargs
 
 if TYPE_CHECKING:
     from vllm.inputs.preprocess import InputPreprocessor
@@ -172,6 +174,17 @@ class AsyncOmni(EngineClient, OmniBase):
 
                 renderer = renderer_from_config(vllm_config)
             self.io_processor = get_io_processor(vllm_config, renderer, io_processor_plugin)
+
+    @classmethod
+    def from_engine_args(
+        cls,
+        engine_args: OmniEngineArgs,
+    ):
+        # Drops non-explicit defaults; this is functionally the same
+        # as the way in which TrackingArgumentParser filters omitted
+        # kwargs to avoid clobbering config defaults
+        kwargs_dict = trackable_to_kwargs(engine_args)
+        return cls(**kwargs_dict)
 
     def _resolve_transfer_replica(self, stage_id: int, request_id: str) -> int | None:
         """Look up the sticky-routed replica for (stage_id, request_id).

--- a/vllm_omni/utils/dataclass_utils.py
+++ b/vllm_omni/utils/dataclass_utils.py
@@ -25,6 +25,15 @@ def trackable(cls: type[_T]) -> type[_T]:
     NOTE: This decorator preserves the original __init__ signature for
     type checkers while adding runtime tracking of explicitly-passed positional
     and keyword arguments.
+
+    It is also important to consider that @trackable currently needs to be applied
+    above @dataclass, since the consumed class is expected to be a dataclass.
+    You should do this explicitly on any class expected to be @trackable, including
+    the case where you are inheriting from a trackable superclass, otherwise you may
+    see unexpected behaviors due to the way @trackable and @dataclass interact with
+    the initializer. For example, inheriting from a @trackable dataclass and including
+    only @dataclass on the superclass produces a non-trackable subclass unless
+    you explicitly decorate the subclass as @trackable too.
     """
 
     # Currently we explicitly require anything @trackable to be a dataclass

--- a/vllm_omni/utils/dataclass_utils.py
+++ b/vllm_omni/utils/dataclass_utils.py
@@ -4,19 +4,26 @@
 import inspect
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, TypeVar
+from typing import Any, Protocol, TypeVar, runtime_checkable
 
 _T = TypeVar("_T")
+
+
+# Protocol wrapper for static analysis
+@runtime_checkable
+class Trackable(Protocol):
+    _init_kwargs: set[str]
 
 
 def trackable(cls: type[_T]) -> type[_T]:
     """Decorator that wraps __init__ to track which args/kwargs were explicitly
     passed by the caller without special handling. This is useful for a variety
-    of situations, e.g., merge a user's passed sampling params with the default
+    of situations, e.g., merging a user's passed sampling params with the default
     values provided by a pipeline.
 
     NOTE: This decorator preserves the original __init__ signature for
-    type checkers while adding runtime tracking of explicitly-passed kwargs.
+    type checkers while adding runtime tracking of explicitly-passed positional
+    and keyword arguments.
     """
     original_init: Callable[..., None] = cls.__init__
     sig = inspect.signature(original_init)
@@ -29,12 +36,15 @@ def trackable(cls: type[_T]) -> type[_T]:
         bound.arguments.pop("self", None)
         self._init_kwargs: set[str] = set(bound.arguments)  # type: ignore[attr-defined]
 
-    # Replace __init__ - type: ignore needed due to limitations in typing dynamic method replacement
-    cls.__init__ = new_init  # type: ignore[method-assign]
+    cls.__init__ = new_init
     return cls
 
 
-def trackable_to_kwargs(obj):
-    if not hasattr(obj, "_init_kwargs"):
+def trackable_to_kwargs(obj: Trackable) -> dict[str, Any]:
+    """Assuming an object is wrapped as Trackable, return the filterered kwargs.
+    This is analogous to what TrackingArgumentParser does to an argparse namespace,
+    but in application to classes like Dataclasses, etc.
+    """
+    if not isinstance(obj, Trackable):
         raise TypeError(f"Provided object of type {type(obj)} is not registered as trackable")
     return {kwarg: getattr(obj, kwarg) for kwarg in obj._init_kwargs}

--- a/vllm_omni/utils/dataclass_utils.py
+++ b/vllm_omni/utils/dataclass_utils.py
@@ -29,3 +29,9 @@ def trackable(cls: type[_T]) -> type[_T]:
     # Replace __init__ - type: ignore needed due to limitations in typing dynamic method replacement
     cls.__init__ = new_init  # type: ignore[method-assign]
     return cls
+
+
+def trackable_to_kwargs(obj):
+    if not hasattr(obj, "_init_kwargs"):
+        raise TypeError(f"Provided object of type {type(obj)} is not registered as trackable")
+    return {kwarg: getattr(obj, kwarg) for kwarg in obj._init_kwargs}

--- a/vllm_omni/utils/dataclass_utils.py
+++ b/vllm_omni/utils/dataclass_utils.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
+
+
+def trackable(cls: type[_T]) -> type[_T]:
+    """Decorator that wraps __init__ to track which kwargs were explicitly
+    passed by the caller without special handling. This is useful for a variety
+    of situations, e.g., merge a user's passed sampling params with the default
+    values provided by a pipeline.
+
+    NOTE: This decorator preserves the original __init__ signature for
+    type checkers while adding runtime tracking of explicitly-passed kwargs.
+    """
+    original_init: Callable[..., None] = cls.__init__
+
+    @wraps(original_init)
+    def new_init(self: _T, *args: Any, **kwargs: Any) -> None:
+        # Call the original init first (which sets _init_kwargs to empty set)
+        original_init(self, *args, **kwargs)
+        # Then track which keyword arguments were explicitly passed
+        self._init_kwargs: set[str] = set(kwargs.keys())  # type: ignore[attr-defined]
+
+    # Replace __init__ - type: ignore needed due to limitations in typing dynamic method replacement
+    cls.__init__ = new_init  # type: ignore[method-assign]
+    return cls

--- a/vllm_omni/utils/dataclass_utils.py
+++ b/vllm_omni/utils/dataclass_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import inspect
 from collections.abc import Callable
 from functools import wraps
 from typing import Any, TypeVar
@@ -9,7 +10,7 @@ _T = TypeVar("_T")
 
 
 def trackable(cls: type[_T]) -> type[_T]:
-    """Decorator that wraps __init__ to track which kwargs were explicitly
+    """Decorator that wraps __init__ to track which args/kwargs were explicitly
     passed by the caller without special handling. This is useful for a variety
     of situations, e.g., merge a user's passed sampling params with the default
     values provided by a pipeline.
@@ -18,13 +19,15 @@ def trackable(cls: type[_T]) -> type[_T]:
     type checkers while adding runtime tracking of explicitly-passed kwargs.
     """
     original_init: Callable[..., None] = cls.__init__
+    sig = inspect.signature(original_init)
 
     @wraps(original_init)
     def new_init(self: _T, *args: Any, **kwargs: Any) -> None:
-        # Call the original init first (which sets _init_kwargs to empty set)
         original_init(self, *args, **kwargs)
-        # Then track which keyword arguments were explicitly passed
-        self._init_kwargs: set[str] = set(kwargs.keys())  # type: ignore[attr-defined]
+        # Map passed args/kwargs to wrapped initializer.
+        bound = sig.bind(self, *args, **kwargs)
+        bound.arguments.pop("self", None)
+        self._init_kwargs: set[str] = set(bound.arguments)  # type: ignore[attr-defined]
 
     # Replace __init__ - type: ignore needed due to limitations in typing dynamic method replacement
     cls.__init__ = new_init  # type: ignore[method-assign]

--- a/vllm_omni/utils/dataclass_utils.py
+++ b/vllm_omni/utils/dataclass_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import dataclasses
 import inspect
 from collections.abc import Callable
 from functools import wraps
@@ -25,6 +26,12 @@ def trackable(cls: type[_T]) -> type[_T]:
     type checkers while adding runtime tracking of explicitly-passed positional
     and keyword arguments.
     """
+
+    # Currently we explicitly require anything @trackable to be a dataclass
+    # so that we can use .bind on the signature (i.e., don't have to handle
+    # variadic args), since everything we need it on is a dataclass anyway.
+    if not dataclasses.is_dataclass(cls):
+        raise TypeError(f"@trackable currently requires classes to be dataclasses, but {cls.__name__} is not one")
     original_init: Callable[..., None] = cls.__init__
     sig = inspect.signature(original_init)
 
@@ -41,7 +48,7 @@ def trackable(cls: type[_T]) -> type[_T]:
 
 
 def trackable_to_kwargs(obj: Trackable) -> dict[str, Any]:
-    """Assuming an object is wrapped as Trackable, return the filterered kwargs.
+    """Assuming an object is wrapped as Trackable, return the filtered kwargs.
     This is analogous to what TrackingArgumentParser does to an argparse namespace,
     but in application to classes like Dataclasses, etc.
     """


### PR DESCRIPTION
## Purpose
Follow-up for https://github.com/vllm-project/vllm-omni/pull/3369/

This PR adds a `@trackable` decorator that can be used to filter dataclass args/kwargs down to what were explicitly passed in a way that is analogous what the TrackingArgumentParser does for CLI args. This is done by wrapping around `__init__` so that we don't have to worry about the object lineage like we did with the previous `create()` approach. It also adds `from_engine_args` to `AsyncOmni`, to better align with vLLM's `AsyncLLM` API.

`@trackable` will also be useful for things like merging pipeline specific default sampling params user provided values, etc, as its the same situation.

## Test Plan
Added tests for `@trackable` & and a test to ensure omni engine args are now trackable & that things get forwarded through correctly.

## Test Result
Tests pass

@lishunyang12 @xiaohajiayou @wuhang2014 @vraiti  can you PTAL?