### PR TITLE
[Bugfix] Register LTX RMSNorm identity weight as buffer

### DIFF
--- a/tests/diffusion/models/ltx2/test_ltx2_transformer.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_transformer.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from torch import nn
+
+from vllm_omni.diffusion.models.ltx2.ltx2_transformer import _make_rms_norm
+
+
+def test_ltx_rms_norm_no_affine_identity_weight_is_non_persistent_buffer():
+    norm = _make_rms_norm(8, eps=1e-6, elementwise_affine=False)
+
+    assert "weight" not in dict(norm.named_parameters())
+    assert "weight" in dict(norm.named_buffers())
+    assert "weight" not in norm.state_dict()
+
+
+def test_ltx_rms_norm_affine_weight_remains_parameter():
+    norm = _make_rms_norm(8, eps=1e-6, elementwise_affine=True)
+
+    assert isinstance(dict(norm.named_parameters())["weight"], nn.Parameter)
+    assert "weight" not in dict(norm.named_buffers())
+    assert "weight" in norm.state_dict()

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -62,7 +62,17 @@ def _make_rms_norm(hidden_size: int, *, eps: float, elementwise_affine: bool) ->
         kwargs["has_weight"] = elementwise_affine
     elif not elementwise_affine:
         raise TypeError("RMSNorm backend does not support disabling affine weights.")
-    return RMSNorm(hidden_size, **kwargs)
+    norm = RMSNorm(hidden_size, **kwargs)
+    weight = getattr(norm, "weight", None)
+    if (
+        not elementwise_affine
+        and isinstance(weight, torch.Tensor)
+        and not isinstance(weight, nn.Parameter)
+        and "weight" not in dict(norm.named_buffers())
+    ):
+        delattr(norm, "weight")
+        norm.register_buffer("weight", weight, persistent=False)
+    return norm
 
 
 def apply_interleaved_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

#4247 

Fix LTX RMSNorm state placement under explicit offload modes.

LTX-2 and LTX-2.3 share `ltx2_transformer.py`. In the current LTX RMSNorm bridge, diffusers' `elementwise_affine=False` path is mapped to vLLM `RMSNorm(has_weight=False)`. However, vLLM RMSNorm can still expose an identity `weight` tensor for its forward path. That identity tensor is not an `nn.Parameter` and was also not registered as a buffer.

This conflicts with the shared offload backends: module-wise and layerwise offload move parameters and buffers, but plain tensor attributes are invisible to those placement routines. As a result, RMSNorm's identity weight can be left unmanaged while the surrounding module is moved between CPU and GPU, which can trigger CUDA illegal memory access during dummy warmup/generation.

The fix keeps vLLM RMSNorm, but registers the no-affine identity weight as a non-persistent buffer:

- affine RMSNorm behavior is unchanged;
- the identity weight now follows `module.to(...)` and offload placement;
- `state_dict` behavior stays clean because the buffer is `persistent=False`;
- LTX-2 and LTX-2.3 both benefit because they share the transformer implementation.

## Behavior Before

- Default non-offload inference can work because the transformer remains resident on GPU.
- `--enable-cpu-offload` and `--enable-layerwise-offload` can fail in LTX2/LTX2.3 during dummy warmup or generation.
- A diagnostic patch replacing vLLM RMSNorm with `torch.nn.RMSNorm` made the offload path pass, which pointed to the vLLM RMSNorm state/placement interaction rather than the LTX pipeline logic itself.

Representative failure:

```text
RuntimeError: Dummy run failed: CUDA error: an illegal memory access was encountered
```

## Behavior After

- vLLM RMSNorm is still used.
- In the no-affine path, the identity `weight` tensor is registered as a non-persistent buffer.
- Offload backends can now move the RMSNorm identity weight together with the rest of the module state.
- Explicit offload paths no longer depend on replacing LTX RMSNorm with `torch.nn.RMSNorm`.

## Validation:

```bash
python examples/offline_inference/text_to_video/text_to_video.py \
  --model LTX-2.3-diffusers \
  --model-class-name LTX23Pipeline \
  --prompt "Floating crystal islands in cosmic starry sky, glowing nebula, soft luminous particles flowing around, slow camera rotation, dreamlike atmosphere, ultra-detailed, surreal fantasy scene" \
  --negative-prompt "low quality, blurry, noise, watermark, text, deformed figures, cartoon style, over-saturated color, frame jump" \
  --width 1024 --height 576 --num-frames 121 \
  --fps 24 --frame-rate 24 --audio-sample-rate 48000 \
  --num-inference-steps 15 --guidance-scale 4.0 --seed 42 \
  --enable-cpu-offload \
  --enforce-eager \
  --output results/ltx23_rmsfix/cpu_offload.mp4
```

```bash
python examples/offline_inference/text_to_video/text_to_video.py \
  --model LTX-2.3-diffusers \
  --model-class-name LTX23Pipeline \
  --prompt "Floating crystal islands in cosmic starry sky, glowing nebula, soft luminous particles flowing around, slow camera rotation, dreamlike atmosphere, ultra-detailed, surreal fantasy scene" \
  --negative-prompt "low quality, blurry, noise, watermark, text, deformed figures, cartoon style, over-saturated color, frame jump" \
  --width 1024 --height 576 --num-frames 121 \
  --fps 24 --frame-rate 24 --audio-sample-rate 48000 \
  --num-inference-steps 15 --guidance-scale 4.0 --seed 42 \
  --enable-layerwise-offload \
  --enforce-eager \
  --output results/ltx23_rmsfix/layerwise_offload.mp4
```

## Result

https://github.com/user-attachments/assets/630eda12-9c9a-4b2f-8bdb-697a2937c6db

https://github.com/user-attachments/assets/80b8aaac-3d98-433d-8009-a67156c11380

Closes #4247 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
