### PR TITLE
model: add HunyuanImage3 AR VAE DP

### DIFF
--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -1465,12 +1465,6 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
     # _vit_encode_dp.
     supports_encoder_tp_data = True
 
-    # Siglip2 ViT supports data-parallel encoding (mm_encoder_tp_mode="data"):
-    # weights are replicated and the image batch is sharded across TP ranks.
-    # Without this flag, vLLM silently falls back to "weights" (TP). See
-    # _vit_encode_dp.
-    supports_encoder_tp_data = True
-
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -1925,16 +1919,23 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
         cfg_factor: int = 1,
         vae_generator_seed: torch.Tensor | None = None,
     ) -> list[torch.Tensor]:
-        def _make_generator(img_idx: int, device: torch.device) -> torch.Generator:
+        def _seed_for_index(img_idx: int) -> int:
             if vae_generator_seed is None or vae_generator_seed.numel() == 0:
-                return torch.Generator(device=device).manual_seed(0)
+                return 0
             seed_values = vae_generator_seed.reshape(-1)
             seed_idx = img_idx if img_idx < seed_values.numel() else 0
-            return torch.Generator(device=device).manual_seed(
-                int(seed_values[seed_idx].item())
-            )
+            return int(seed_values[seed_idx].item())
+
+        def _make_sequential_generator(device: torch.device) -> torch.Generator:
+            return torch.Generator(device=device).manual_seed(_seed_for_index(0))
+
+        def _make_generator(img_idx: int, device: torch.device) -> torch.Generator:
+            return torch.Generator(device=device).manual_seed(_seed_for_index(img_idx))
 
         batch_size = len(vae_pixel_values)
+        if batch_size == 0:
+            return []
+
         if not self._logged_vae_encode_state:
             try:
                 tp_size = get_tensor_model_parallel_world_size()
@@ -1958,16 +1959,13 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
                     batch_size,
                 )
             vae_token_embeddings = []
-            for img_idx, vae_image_i in enumerate(vae_pixel_values):
-                generator = _make_generator(img_idx, vae_image_i.device)
+            generator = _make_sequential_generator(vae_pixel_values[0].device)
+            for vae_image_i in vae_pixel_values:
                 t_i, latents_i = self._vae_encode(vae_image_i.unsqueeze(0), cfg_factor, generator=generator)
                 t_emb = self.time_embed(t_i[0])
                 vae_tokens, _, _ = self.patch_embed(latents_i, t_emb)
                 vae_token_embeddings.append(vae_tokens)
             return vae_token_embeddings
-
-        if batch_size == 0:
-            return []
 
         tp_size = get_tensor_model_parallel_world_size()
         tp_rank = get_tensor_model_parallel_rank()

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -1465,6 +1465,12 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
     # _vit_encode_dp.
     supports_encoder_tp_data = True
 
+    # Siglip2 ViT supports data-parallel encoding (mm_encoder_tp_mode="data"):
+    # weights are replicated and the image batch is sharded across TP ranks.
+    # Without this flag, vLLM silently falls back to "weights" (TP). See
+    # _vit_encode_dp.
+    supports_encoder_tp_data = True
+
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -1531,6 +1537,8 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
 
         # Used when converting VAE-encoded latent space (latents) to token embeddings.
         self.time_embed = TimestepEmbedder(hidden_size=config.hidden_size)
+        self.use_vae_data_parallel = getattr(config, "ar_vae_tp_mode", None) == "data"
+        self._logged_vae_encode_state = False
 
         # vision
         multimodal_config = vllm_config.model_config.multimodal_config
@@ -1746,6 +1754,8 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
         # Handle empty batch (e.g., during profiling with 0 images / T2T mode)
         if vit_pixel_values.numel() == 0 or vae_pixel_values.numel() == 0:
             return None
+        if vae_token_grid_hw.ndim == 1:
+            vae_token_grid_hw = vae_token_grid_hw.unsqueeze(0)
 
         # `vae_pixel_values` arrives as a 1-D concatenation of per-image flat
         # buffers (see `process_image` + `flat_from_sizes`). Reconstruct a
@@ -1908,6 +1918,105 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
         image_embed = tensor_model_parallel_all_gather(image_embed.contiguous(), dim=0)
         return image_embed[:num_images]
 
+    def _vae_token_encode(
+        self,
+        vae_pixel_values: list[torch.Tensor],
+        vae_token_grid_hw: torch.Tensor,
+        cfg_factor: int = 1,
+        vae_generator_seed: torch.Tensor | None = None,
+    ) -> list[torch.Tensor]:
+        def _make_generator(img_idx: int, device: torch.device) -> torch.Generator:
+            if vae_generator_seed is None or vae_generator_seed.numel() == 0:
+                return torch.Generator(device=device).manual_seed(0)
+            seed_values = vae_generator_seed.reshape(-1)
+            seed_idx = img_idx if img_idx < seed_values.numel() else 0
+            return torch.Generator(device=device).manual_seed(
+                int(seed_values[seed_idx].item())
+            )
+
+        batch_size = len(vae_pixel_values)
+        if not self._logged_vae_encode_state:
+            try:
+                tp_size = get_tensor_model_parallel_world_size()
+                tp_rank = get_tensor_model_parallel_rank()
+            except Exception:
+                tp_size = -1
+                tp_rank = -1
+            logger.info(
+                "HunyuanImage3 AR VAE encode state: use_data_parallel=%s, tp_rank=%s, tp_size=%s, batch_size=%s",
+                self.use_vae_data_parallel,
+                tp_rank,
+                tp_size,
+                batch_size,
+            )
+            self._logged_vae_encode_state = True
+
+        if not self.use_vae_data_parallel or batch_size <= 1:
+            if self.use_vae_data_parallel and batch_size <= 1:
+                logger.info(
+                    "HunyuanImage3 AR VAE DP skipped: global_batch=%s requires batch_size > 1",
+                    batch_size,
+                )
+            vae_token_embeddings = []
+            for img_idx, vae_image_i in enumerate(vae_pixel_values):
+                generator = _make_generator(img_idx, vae_image_i.device)
+                t_i, latents_i = self._vae_encode(vae_image_i.unsqueeze(0), cfg_factor, generator=generator)
+                t_emb = self.time_embed(t_i[0])
+                vae_tokens, _, _ = self.patch_embed(latents_i, t_emb)
+                vae_token_embeddings.append(vae_tokens)
+            return vae_token_embeddings
+
+        if batch_size == 0:
+            return []
+
+        tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
+        local_batch_size = math.ceil(batch_size / tp_size)
+        local_start = tp_rank * local_batch_size
+        local_end = min(local_start + local_batch_size, batch_size)
+        local_count = max(local_end - local_start, 0)
+        token_counts = (vae_token_grid_hw[:, 0] * vae_token_grid_hw[:, 1]).to(dtype=torch.long)
+        max_token_count = int(token_counts.max().item())
+
+        logger.info(
+            "HunyuanImage3 AR VAE DP shard: tp_rank=%s, tp_size=%s, global_batch=%s, "
+            "local_range=[%s,%s), local_count=%s, local_batch_size=%s, max_token_count=%s",
+            tp_rank,
+            tp_size,
+            batch_size,
+            local_start,
+            local_end,
+            local_count,
+            local_batch_size,
+            max_token_count,
+        )
+
+        patch_param = next(self.patch_embed.parameters())
+        local_token_list: list[torch.Tensor] = []
+        for local_offset in range(local_batch_size):
+            global_idx = local_start + local_offset
+            # Keep padded ranks on the same VAE/patch path before HCCL gather.
+            img_idx = global_idx if global_idx < batch_size else 0
+            vae_image_i = vae_pixel_values[img_idx]
+            generator = _make_generator(img_idx, vae_image_i.device)
+            t_i, latents_i = self._vae_encode(vae_image_i.unsqueeze(0), cfg_factor, generator=generator)
+            t_emb = self.time_embed(t_i[0])
+            vae_tokens, _, _ = self.patch_embed(latents_i, t_emb)
+            if vae_tokens.ndim == 3:
+                vae_tokens = vae_tokens.squeeze(0)
+            if vae_tokens.shape[0] < max_token_count:
+                pad = vae_tokens.new_zeros(max_token_count - vae_tokens.shape[0], vae_tokens.shape[-1])
+                vae_tokens = torch.cat((vae_tokens, pad), dim=0)
+            local_token_list.append(vae_tokens[:max_token_count])
+
+        local_tokens = torch.stack(local_token_list, dim=0).to(dtype=patch_param.dtype)
+
+        gathered_tokens = tensor_model_parallel_all_gather(local_tokens, dim=0)[:batch_size]
+        return [
+            gathered_tokens[img_idx : img_idx + 1, : int(token_counts[img_idx].item()), :]
+            for img_idx in range(batch_size)
+        ]
+
     def _timestep_encode(
         self,
         timestep: torch.Tensor,
@@ -1939,23 +2048,19 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
         vit_spatial_shapes = pixel_values["vit_spatial_shapes"]
         vae_pixel_values = pixel_values["vae_pixel_values"]
         vae_generator_seed = pixel_values.get("vae_generator_seed")
-        vae_generator = None
-        if vae_generator_seed is not None and vae_generator_seed.numel() > 0:
-            vae_generator = torch.Generator(device=vae_pixel_values[0].device).manual_seed(
-                int(vae_generator_seed.reshape(-1)[0].item())
-            )
+        vae_token_grid_hw = pixel_values["vae_token_grid_hw"]
 
         # Perform ViT encoding
         vit_embeddings = self._vit_encode(vit_pixel_values, vit_pixel_attention_mask, vit_spatial_shapes)
 
         # VAE encode + patch_embed per image — each cond image is at its own
         # `reso_group` bucket so shapes are ragged across the image-batch dim.
-        vae_token_embeddings = []
-        for vae_image_i in vae_pixel_values:
-            t_i, latents_i = self._vae_encode(vae_image_i.unsqueeze(0), vae_cfg_factor, generator=vae_generator)
-            t_emb = self.time_embed(t_i[0])
-            vae_tokens, _, _ = self.patch_embed(latents_i, t_emb)
-            vae_token_embeddings.append(vae_tokens)
+        vae_token_embeddings = self._vae_token_encode(
+            vae_pixel_values,
+            vae_token_grid_hw,
+            vae_cfg_factor,
+            vae_generator_seed,
+        )
 
         assert vit_embeddings is not None and vit_embeddings.shape[0] == len(vae_token_embeddings), (
             f"Number of ViT embeddings ({vit_embeddings.shape[0]}) does not match "


### PR DESCRIPTION
## Summary
- Add HunyuanImage3 AR VAE DP to hunyuan_image3.py.


## Test Plan
`python examples/offline_inference/hunyuan_image3/vae_dp_end2end.py     --model /data/weight/HunyuanImage-3.0-Instruct-Distil     --deploy-config vllm_omni/deploy/hunyuan_image_3_moe.yaml    --image-path ./input_0_0.png     --prompts '新年宠物海报，Q版圆润的可爱标题\"新年快乐汪\"，副标题\"HAPPY NEW YEAR\"。 鱼眼镜头，背景是房间门口，近景，上传的主体歪头笑，围着红色围巾，戴着红色毛线帽，高清，绒毛细节，面部特写。 宝丽莱相纸，超现实主义，写实主义，胶片摄影，打印颗粒感肌理。肌理，超写实，复古感。'     --steps 8     --guidance-scale 1.0     --seed 42     --warmup-runs 1     --profile-runs 1     --output ./vae_dp_outputs --batch-size 16`

hunyuan_image_3_moe.yaml
```
# HunyuanImage-3.0-Instruct deploy: AR (stage 0) + DiT (stage 1)
# with AR-to-DiT KV reuse. The base CUDA layout uses 2 GPUs for AR
# and 2 GPUs for DiT.
pipeline: hunyuan_image_3_moe
async_chunk: false
trust_remote_code: true

connectors:
  rdma_connector:
    name: MooncakeTransferEngineConnector
    extra:
      host: "auto"
      zmq_port: 50051
      protocol: "rdma"
      device_name: ""
      memory_pool_size: 4294967296
      memory_pool_device: "cpu"
  yuanrong_te_connector:
    name: YuanrongTransferEngineConnector
    extra:
      host: "auto"
      zmq_port: 50051
      rpc_port: "auto"
      protocol: "ascend"
      device_name: "auto"
      memory_pool_size: 1073741824
      memory_pool_device: "npu"
  shared_memory_connector:
    name: SharedMemoryConnector
    extra:
      shm_threshold_bytes: 1048576

stages:
  - stage_id: 0
    # ``is_comprehension`` in vllm-omni names the tokenizer-owning AR stage
    # (see config/stage_config.py + serving_chat AR-stage lookup), independent
    # of whether the AR's task is comprehension (i2t/t2t) or generation
    # (it2i/t2i). HunyuanImage-3.0's stage-0 owns the tokenizer and emits the
    # cot+ratio token sequence consumed by stage-1, so it must be marked True
    # for the serving path to set AR seed/stop_token_ids on this stage.
    is_comprehension: true
    final_output: true
    final_output_type: text
    max_num_seqs: 16
    gpu_memory_utilization: 0.90
    enforce_eager: true
    max_num_batched_tokens: 65536
    devices: "0,1,2,3"
    tensor_parallel_size: 4
    hf_overrides:
      ar_vae_tp_mode: data
      rope_parameters:
        mrope_section: [0, 32, 32]
        rope_type: default
    omni_kv_config:
      need_send_cache: true
    output_connectors:
      to_stage_1: shared_memory_connector
    default_sampling_params:
      temperature: 0.0
      top_p: 1
      top_k: -1
      max_tokens: 8192
      detokenize: true
      skip_special_tokens: false

  - stage_id: 1
    max_num_seqs: 1
    enforce_eager: true
    devices: "4,5,6,7"
    distributed_executor_backend: "mp"
    omni_kv_config:
      need_recv_cache: true
    parallel_config:
      tensor_parallel_size: 4
      enable_expert_parallel: true
    input_connectors:
      from_stage_0: shared_memory_connector
    default_sampling_params:
      num_inference_steps: 8
      guidance_scale: 1.0

edges:
  - from: 0
    to: 1
    window_size: -1
    max_inflight: 1

platforms:
  npu:
    stages:
      - stage_id: 0
        gpu_memory_utilization: 0.90
        devices: "0,1,2,3"
        tensor_parallel_size: 4
        max_num_batched_tokens: 65536
      - stage_id: 1
        gpu_memory_utilization: 0.8
        devices: "4,5,6,7"
        max_num_batched_tokens: 32784
        parallel_config:
          tensor_parallel_size: 4
          enable_expert_parallel: false
          sequence_parallel_size: 1
          ulysses_degree: 1

  xpu:
    stages:
      - stage_id: 0
        gpu_memory_utilization: 0.95
        devices: "0,1,2,3,4,5,6,7"
        tensor_parallel_size: 8
        max_num_batched_tokens: 32784
        quantization: fp8
        enable_expert_parallel: true
        worker_cls: vllm_omni.platforms.xpu.worker.xpu_ar_worker.XPUARWorker
        default_sampling_params:
          max_tokens: 2048
          seed: 42
          repetition_penalty: 1.1
      - stage_id: 1
        gpu_memory_utilization: 0.9
        devices: "0,1,2,3,4,5,6,7"
        quantization: fp8
        parallel_config:
          pipeline_parallel_size: 1
          data_parallel_size: 1
          tensor_parallel_size: 8
          enable_expert_parallel: true
          sequence_parallel_size: 1
          ulysses_degree: 1
          ring_degree: 1
          cfg_parallel_size: 1
          vae_patch_parallel_size: 1
          use_hsdp: false
          hsdp_shard_size: -1
          hsdp_replicate_size: 1

```

## Benchmark

| Configuration | Request Throughput | Mean TTFT | P50 TTFT | P90 TTFT | P50 TPOT | Mean AR Stage Time | Mean DiT Stage Time | Mean E2E Time | Total Token Throughput |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| VAE-DP enable (ar_vae_tp_mode: data) | batch_size=8 | max_num_seqs=8 | max_num_batched_tokens=65536 | 0.175 req/s | 4806.419 ms | 5274.240 ms | 5466.833 ms | 37.820 ms | 21890.696 ms | 12454.458 ms | 34349.383 ms | 2372.062 tok/s |
| VAE-DP enable (ar_vae_tp_mode: data) | batch_size=16 | max_num_seqs=16 | max_num_batched_tokens=65536 | 0.199 req/s | 13150.020 ms | 9483.025 ms | 31194.147 ms | 54.656 ms | 36142.995 ms | 20085.530 ms | 56236.530 ms | 2692.469 tok/s |
| VAE-DP disable | batch_size=8 | max_num_seqs=8 | max_num_batched_tokens=65536 | 0.157 req/s | 5931.194 ms | 6561.494 ms | 6750.414 ms | 36.988 ms | 25279.708 ms | 14292.329 ms | 39575.900 ms | 2126.420 tok/s |
| VAE-DP disable | batch_size=16 | max_num_seqs=16 | max_num_batched_tokens=65536 | 0.195 req/s | 15108.827 ms | 11886.724 ms | 31517.755 ms | 52.828 ms | 38483.789 ms | 18385.566 ms | 56876.979 ms | 2644.668 tok/s |

