### PR TITLE
[Feature] Add support for PipeFusion and integrate it into Wan 2.2

### DIFF
--- a/docs/design/feature/pipefusion.md
+++ b/docs/design/feature/pipefusion.md
@@ -1,0 +1,315 @@
+# PipeFusion
+
+This section describes how to add PipeFusion to a diffusion pipeline. PipeFusion builds on Pipeline Parallelism (PP) by
+splitting each denoising sequence into patches during the later denoising steps. The patch loop lets PP stages overlap
+communication from one patch with compute from the next patch, reducing pipeline bubbles for supported diffusion
+models.
+
+## Implementation Checklist
+
+Adding PipeFusion support requires:
+
+1. Add pipeline warmup and async patch loop support by placing `PipeFusionPipelineMixin` before `PipelineParallelMixin` in the pipeline class
+2. Implement `prepare_model_kwargs()` to handle `latents=None` on non-first PP stages
+3. Add scheduler patch-cache support with `PipeFusionSchedulerMixin`
+4. Add transformer patch support (RoPE slicing, KV-cache updates, unpatchify) with `PipeFusionTransformerMixin`, `PipeFusionRotaryEmbeddingMixin`, and `PipeFusionSelfAttentionMixin`
+5. Add Conv3d boundary caching for overlapping convolutions with `Conv3dLayer`
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Step-by-Step Implementation](#step-by-step-implementation)
+- [Testing](#testing)
+- [Troubleshooting](#troubleshooting)
+- [Reference Implementations](#reference-implementations)
+
+---
+
+## Overview
+
+### What is PipeFusion?
+
+Pipeline Parallelism splits the denoising transformer by layer across sequential PP ranks. PipeFusion keeps that PP
+layout, but during the async phase it also splits the current latent sequence into `pipeline_parallel_size` patches.
+
+For each timestep after warmup:
+
+1. The first PP rank splits the current latents into patches.
+2. Each patch runs through the normal PP `predict_noise_maybe_with_cfg()` path.
+3. The last PP rank runs the scheduler for each patch and sends updated patch latents back to rank 0.
+4. Rank 0 reassembles the patches after the async timesteps finish.
+
+The first `warmup_steps` use the standard PP denoising loop. This fills attention KV caches and scheduler state
+with full-sequence tensors before the patch loop starts.
+
+### Architecture
+
+PipeFusion is a set of small mixins layered on top of existing PP and CFG abstractions.
+
+| Component                        | Purpose                                                                                               |
+|----------------------------------|-------------------------------------------------------------------------------------------------------|
+| `PipeFusionPipelineMixin`        | Wraps `forward()`, `diffuse()`, and `prepare_model_kwargs()` for warmup plus async patch execution    |
+| `PipeFusionRuntime`              | Tracks patch mode, current patch index, split dimension, token ranges, and communication-buffer reset |
+| `PipeFusionSchedulerMixin`       | Splits scheduler caches by patch and gates shared scheduler state updates                             |
+| `PipeFusionTransformerMixin`     | Provides patch-aware output shape helpers and unpatchify                                              |
+| `PipeFusionRotaryEmbeddingMixin` | Slices full RoPE embeddings to the current patch                                                      |
+| `PipeFusionSelfAttentionMixin`   | Maintains full K/V caches while updating the current patch slice                                      |
+| `PipeFusionConvMixin`            | Caches activations for overlapping Conv3d layers at patch boundaries                                  |
+| `PipelineParallelMixin`          | Provides the inter-stage communication PipeFusion relies on                                           |
+
+### Execution Flow
+
+```mermaid
+flowchart LR
+    request[Request] --> config[Set PipeFusion Run Config]
+    config --> input[Set Input Metadata]
+    input --> warmup[Warmup: Standard PP Denoising]
+    warmup --> asyncPhase[Async Patch Mode]
+    asyncPhase --> split[Split Latents]
+    split --> patchLoop[Per-Patch PP Predict And Scheduler]
+    patchLoop --> sync[Drain PP Sends]
+    sync --> concat[Concatenate Patches]
+```
+
+PipeFusion reuses the standard denoising contract:
+
+- `predict_noise_maybe_with_cfg()` still owns PP forward communication.
+- `scheduler_step_maybe_with_cfg()` still owns last-rank scheduler execution and last-to-first loopback.
+- `PipeFusionPipelineMixin` only changes how often these helpers are called and which communication labels are used.
+
+### Patch Split Dimensions
+
+PipeFusion can split latents along either height or temporal dimensions.
+
+| `split_dim` | Latent split dimension    | Token layout behavior                                                           |
+|-------------|---------------------------|---------------------------------------------------------------------------------|
+| `height`    | `-2` in `[B, C, T, H, W]` | Patch tokens are interleaved by frame and must be written through a 5D K/V view |
+| `temporal`  | `-3` in `[B, C, T, H, W]` | Patch tokens are contiguous in flattened `[frame, height, width]` order         |
+
+The number of patches equals the PP world size. Any remainder is assigned to the last patch.
+
+---
+
+## Step-by-Step Implementation
+
+### Step 1: Add `PipeFusionPipelineMixin`
+
+`PipeFusionPipelineMixin` requires `PipelineParallelMixin` and must appear before it in the class MRO. The mixin enforces
+this when the class is defined.
+
+```python
+from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion import PipeFusionPipelineMixin
+from vllm_omni.diffusion.distributed.pipeline_parallel import PipelineParallelMixin
+
+
+class YourPipeline(
+    nn.Module,
+    PipeFusionPipelineMixin,
+    PipelineParallelMixin,
+    CFGParallelMixin,
+):
+    ...
+```
+
+The order matters because PipeFusion wraps the pipeline boundary, then delegates prediction and scheduler communication
+to the PP-aware methods. The mixin automatically handles the split between warmup and async denoising phases, as well as
+the labeled communication using `inter_comm_ids` and `loopback_comm_id`.
+
+### Step 2: Make `prepare_model_kwargs()` patch-aware
+
+Only the first PP stage consumes latent tensors in patch mode. Later stages receive intermediate tensors from upstream PP
+ranks, so `PipeFusionPipelineMixin` passes `latents=None` to `prepare_model_kwargs()` on non-first stages.
+
+Model-specific implementations should:
+
+- Preserve full original dimensions in `dims` or an equivalent field.
+- Build patch-local latent inputs only when `latents` is not `None`.
+- Keep CFG positive and negative kwargs identical to the non-PipeFusion path.
+
+### Step 3: Add scheduler patch caches
+
+Schedulers that keep state across steps should inherit `PipeFusionSchedulerMixin` and declare which attributes are
+per-patch caches via `_pipefusion_patch_cache_spec`.
+
+```python
+class YourScheduler(PipeFusionSchedulerMixin, BaseScheduler):
+    _pipefusion_patch_cache_spec = [
+        ("model_outputs", "list"),
+        ("last_sample", "tensor"),
+    ]
+```
+
+The mixin automates the transition from full-sequence to patch-based scheduling:
+
+- **Initial State Splitting**: When async mode starts, it takes the tensors from the warmup phase and splits them into per-patch caches.
+- **Automatic State Management**: It swaps the correct patch state into the scheduler before each `step()` and saves the results back into the patch cache after.
+- **Shared State Protection**: Prevents internal scheduler variables (like `_step_index` or step counters) from advancing multiple times per timestep. These values are only allowed to increment after the last patch is processed.
+
+### Step 4: Add transformer patch support
+
+PipeFusion transformer support requires integrating several mixins into the model components.
+
+#### 4.1 Inherit `PipeFusionTransformerMixin`
+
+The transformer model must inherit from `PipeFusionTransformerMixin` and implement the `_unpatchify` abstract method.
+The mixin automatically wraps `_unpatchify` to handle patch-local dimensions during async mode.
+
+```python
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_transformer import PipeFusionTransformerMixin
+
+class YourTransformer(PipeFusionTransformerMixin, YourBaseModel):
+    def _unpatchify(self, hidden_states, dims):
+        # REQUIRED: Implementation that reshapes tokens back to original latent space.
+        # The mixin ensures this is called with patch-local dimensions
+        # during async mode.
+        ...
+```
+
+#### 4.2 Slice RoPE with `PipeFusionRotaryEmbeddingMixin`
+
+The rotary embedding module should inherit from `PipeFusionRotaryEmbeddingMixin`. This API automatically handles
+slicing the full-sequence RoPE embeddings to match the current patch during async mode.
+
+```python
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_transformer import PipeFusionRotaryEmbeddingMixin
+
+class YourRotaryPosEmbed(PipeFusionRotaryEmbeddingMixin, YourBaseRoPE):
+    ...
+```
+
+#### 4.3 Update full K/V caches with `PipeFusionSelfAttentionMixin`
+
+The attention module should inherit from `PipeFusionSelfAttentionMixin`. This API maintains separate full K/V caches
+for conditional and unconditional branches. During the async patch loop, it ensures that each patch's newly computed
+keys and values are written into their correct spatial or temporal position within the full-sequence cache, allowing
+each patch to attend to the entire sequence.
+
+```python
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_transformer import PipeFusionSelfAttentionMixin
+
+class YourSelfAttention(PipeFusionSelfAttentionMixin, YourBaseAttention):
+    ...
+```
+
+### Step 5: Add Conv3d boundary caching
+
+For convolutions with `kernel_size != stride` (overlapping convolutions), use `Conv3dLayer` from
+`vllm_omni.diffusion.distributed.pipefusion.pipefusion_conv`. This layer stores a full activation cache and performs
+sliced convolutions to handle patch boundaries correctly.
+
+When calling the forward pass of these layers during patch mode, you must pass the original full input dimensions.
+
+```python
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_conv import Conv3dLayer
+
+class YourTransformer(nn.Module):
+    def __init__(self):
+        ...
+        self.patch_embedding = Conv3dLayer(...)
+
+    def forward(self, hidden_states, dims=None):
+        # hidden_states is the current patch input [B, C, T_patch, H_patch, W_patch]
+        # dims is the original full input dimensions [B, C, T, H, W]
+        hidden_states = self.patch_embedding(hidden_states, dims=dims)
+        ...
+```
+
+---
+
+## Testing
+
+PipeFusion testing consists of unit tests for the bookkeeping logic and manual inference checks for end-to-end parity.
+
+### PipeFusion unit tests
+
+Most PipeFusion bookkeeping can be tested on CPU:
+
+- runtime patch metadata for height and temporal splits
+- scheduler patch-cache splitting and state restoration
+- RoPE slicing
+- height and temporal K/V cache writes
+- patch-aware unpatchify shape behavior
+- Conv3d activation cache behavior
+- mixin MRO and request config validation
+
+### Manual inference
+
+Use an offline inference script with PP and PipeFusion enabled:
+
+```bash
+python examples/offline_inference/text_to_video/text_to_video.py \
+--model=Wan-AI/Wan2.2-TI2V-5B-Diffusers \
+--width=1280 \
+--height=704 \
+--guidance-scale=5.0 \
+--prompt="Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage" \
+--output=t2v_5B_pp4_pf.mp4 \
+--pipeline-parallel-size=4 \
+--enable-pipefusion \
+--pipefusion-warmup-steps=5 \
+--pipefusion-split-dim=temporal \
+--vae-patch-parallel-size=4
+```
+
+Verify that:
+
+1. The run completes without hangs.
+2. Output quality remains acceptable for the target workload compared with the standard PP baseline.
+3. PP sends are drained before VAE decode.
+4. Both `height` and `temporal` split dimensions work for supported shapes.
+
+---
+
+## Troubleshooting
+
+### Issue: PipeFusion fails with `pipeline_parallel_size=1`
+
+**Cause:** PipeFusion relies on PP communication and patch count equals PP world size.
+
+**Solution:** Set `pipeline_parallel_size > 1` when `enable_pipefusion=True`.
+
+### Issue: Import raises a mixin-order `TypeError`
+
+**Cause:** `PipeFusionPipelineMixin` must be listed before `PipelineParallelMixin`.
+
+**Solution:** Use:
+
+```python
+class YourPipeline(nn.Module, PipeFusionPipelineMixin, PipelineParallelMixin, CFGParallelMixin):
+    ...
+```
+
+### Issue: Missing PipeFusion KV cache during patch mode
+
+**Cause:** Async patch execution started before a warmup pass populated full K/V caches.
+
+**Solution:** Use at least one warmup step. The runtime validates `pipefusion_warmup_steps >= 1`.
+
+### Issue: PP communication hangs in patch mode
+
+**Causes and checks:**
+
+- Sender and receiver ranks are out of sync.
+- A pending async send was not flushed before a later collective.
+- CFG branch count changed unexpectedly.
+
+---
+
+## Reference Implementations
+
+| Component                  | Path                                                                   | Notes                                                    |
+|----------------------------|------------------------------------------------------------------------|----------------------------------------------------------|
+| `PipeFusionPipelineMixin`  | `vllm_omni/diffusion/distributed/pipefusion/pipefusion.py`             | Pipeline wrapping, warmup split, async patch loop        |
+| `PipeFusionRuntime`        | `vllm_omni/diffusion/distributed/pipefusion/pipefusion_runtime.py`     | Patch metadata, split dimension, cache key, buffer reset |
+| `PipeFusionSchedulerMixin` | `vllm_omni/diffusion/distributed/pipefusion/pipefusion_scheduler.py`   | Per-patch scheduler caches and state gating              |
+| Transformer mixins         | `vllm_omni/diffusion/distributed/pipefusion/pipefusion_transformer.py` | RoPE slicing, K/V cache patch updates, unpatchify        |
+| Conv mixin                 | `vllm_omni/diffusion/distributed/pipefusion/pipefusion_conv.py`        | Conv3d activation cache and sliced convolution           |
+| PP mixin                   | `vllm_omni/diffusion/distributed/pipeline_parallel.py`                 | `skip_sync`, `inter_comm_ids`, and `loopback_comm_id`    |
+| PP tests                   | `tests/diffusion/distributed/test_pipeline_parallel.py`                | GPU coverage for labeled PP communication                |
+| PipeFusion tests           | `tests/diffusion/distributed/test_pipefusion.py`                       | CPU coverage for PipeFusion bookkeeping                  |
+| Wan2.2 T2V pipeline        | `vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py`                 | Reference text-to-video integration                      |
+| Wan2.2 I2V pipeline        | `vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py`             | Reference image-to-video integration                     |
+| Wan2.2 transformer         | `vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py`              | Reference transformer integration                        |

--- a/docs/user_guide/diffusion/parallelism/overview.md
+++ b/docs/user_guide/diffusion/parallelism/overview.md
@@ -13,5 +13,6 @@ This guide covers the parallelism methods in vLLM-Omni for speeding up diffusion
 | **[VAE Patch Parallelism](vae_patch_parallel.md)** | Distributes VAE decode spatially across GPUs to reduce peak VAE memory                                              |
 | **[HSDP](hsdp.md)**                                | Shards full model weights via PyTorch FSDP2 to enable large-model inference on memory-constrained GPUs              |
 | **[Expert Parallelism](expert_parallel.md)**       | Shards MoE expert blocks across GPUs for MoE models (e.g. HunyuanImage3.0)                                          |
+| **[PipeFusion](pipefusion.md)**                    | Splits latents into patches and processes them asynchronously to reduce Pipeline Parallel bubbles                   |
 
 See [Supported Models](../../diffusion_features.md#supported-models) for per-model compatibility.

--- a/docs/user_guide/diffusion/parallelism/pipefusion.md
+++ b/docs/user_guide/diffusion/parallelism/pipefusion.md
@@ -174,9 +174,13 @@ that benefits from PipeFusion overlap.
 
 ### When to Use
 
+PipeFusion trades communication bottlenecks for memory bandwidth overhead (due to repeated KV-cache reads).
+Choose PipeFusion when inter-GPU communication is the primary performance cost, and consider alternative distributed
+strategies otherwise.
+
 **Good for:**
 
-- Supported large video diffusion pipelines with Pipeline Parallelism enabled
+- Supported large diffusion pipelines with Pipeline Parallelism enabled
 - Multi-GPU setups where plain PP has noticeable pipeline bubbles
 - Images and shorter videos, where repeated KV-cache reads are less likely to become a memory bottleneck
 - PP combined with CFG-Parallel on supported models

--- a/docs/user_guide/diffusion/parallelism/pipefusion.md
+++ b/docs/user_guide/diffusion/parallelism/pipefusion.md
@@ -1,0 +1,245 @@
+# PipeFusion Guide
+
+## Table of Content
+
+- [Overview](#overview)
+- [Quick Start](#quick-start)
+- [Example Script](#example-script)
+- [Configuration Parameters](#configuration-parameters)
+- [Best Practices](#best-practices)
+- [Troubleshooting](#troubleshooting)
+- [Summary](#summary)
+
+---
+
+## Overview
+
+PipeFusion is a latency-optimized parallelism method that enhances Pipeline Parallelism (PP).
+It reduces pipeline bubbles by splitting the denoising sequence into patches, allowing GPU stages to
+overlap communication for one patch with computation for the next. This approach improves
+throughput and reduces end-to-end latency for large-scale generation tasks.
+
+The first warmup step(s) run with normal Pipeline Parallelism. After warmup, PipeFusion processes
+spatial or temporal patches through the same PP stages with asynchronous communication. This
+reduces PP bubble time for large generations where each denoising step has enough work to overlap.
+PipeFusion is a lossy acceleration method: it is designed to preserve output quality in practice, but it
+is not mathematically equivalent to plain Pipeline Parallelism.
+
+---
+
+## Quick Start
+
+### Basic Usage
+
+Simplest working example:
+
+```python
+from vllm_omni import Omni
+from vllm_omni.diffusion.data import DiffusionParallelConfig
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+omni = Omni(
+    model="Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+    parallel_config=DiffusionParallelConfig(
+        pipeline_parallel_size=4,
+        enable_pipefusion=True,
+        vae_patch_parallel_size=4,
+    ),
+)
+
+outputs = omni.generate(
+    {"prompt": "A cinematic drone shot over snowy mountains"},
+    OmniDiffusionSamplingParams(
+        num_inference_steps=40,
+        num_frames=81,
+        height=704,
+        width=1280,
+        pipefusion_warmup_steps=1,
+        pipefusion_split_dim="height",
+    ),
+)
+```
+
+PipeFusion requires `pipeline_parallel_size > 1`.
+
+---
+
+## Example Script
+
+### Offline Inference
+
+Use python scripts under:
+
+- `examples/offline_inference/text_to_video/text_to_video.py`
+- `examples/offline_inference/image_to_video/image_to_video.py`
+
+Text-to-video example:
+
+```bash
+python examples/offline_inference/text_to_video/text_to_video.py \
+--model=Wan-AI/Wan2.2-TI2V-5B-Diffusers \
+--width=1280 \
+--height=704 \
+--guidance-scale=5.0 \
+--prompt="Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage" \
+--output=t2v_5B_pp4_pf.mp4 \
+--pipeline-parallel-size=4 \
+--enable-pipefusion \
+--pipefusion-warmup-steps=5 \
+--pipefusion-split-dim=temporal \
+--vae-patch-parallel-size=4
+```
+
+PipeFusion can be combined with CFG-Parallel when the model supports both:
+
+```bash
+python examples/offline_inference/text_to_video/text_to_video.py \
+--model=Wan-AI/Wan2.2-TI2V-5B-Diffusers \
+--width=1280 \
+--height=704 \
+--guidance-scale=5.0 \
+--prompt="Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage" \
+--output=t2v_5B_pp2_cfg2_pf.mp4 \
+--pipeline-parallel-size=2 \
+--cfg-parallel-size=2 \
+--enable-pipefusion \
+--pipefusion-warmup-steps=5 \
+--pipefusion-split-dim=temporal \
+--vae-patch-parallel-size=4
+```
+
+### Online Serving
+
+Enable PipeFusion in online serving:
+
+```bash
+vllm serve Wan-AI/Wan2.2-TI2V-5B-Diffusers --omni --port 8091 \
+  --pipeline-parallel-size 4 \
+  --enable-pipefusion \
+  --vae-patch-parallel-size 4
+```
+
+Request-level parameters can be passed through the video generation request:
+
+```bash
+curl http://localhost:8091/v1/videos/generations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+    "prompt": "A cinematic drone shot over snowy mountains",
+    "height": 704,
+    "width": 1280,
+    "num_frames": 81,
+    "pipefusion_warmup_steps": 1,
+    "pipefusion_split_dim": "height"
+  }'
+```
+
+---
+
+## Configuration Parameters
+
+In `DiffusionParallelConfig`
+
+| Parameter                | Type | Default | Description                                                                  |
+|--------------------------|------|---------|------------------------------------------------------------------------------|
+| `pipeline_parallel_size` | int  | 1       | Number of pipeline-parallel stages. Must be greater than 1 for PipeFusion    |
+| `enable_pipefusion`      | bool | `False` | Enables PipeFusion patch-wise async execution on top of Pipeline Parallelism |
+
+In `OmniDiffusionSamplingParams` or video generation requests
+
+| Parameter                 | Type                                | Default | Description                                                                                                       |
+|---------------------------|-------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------|
+| `pipefusion_warmup_steps` | int or `None`                       | `None`  | Number of initial denoising steps to run with standard PP before patch mode. `None` uses the runtime default of 1 |
+| `pipefusion_split_dim`    | `"height"`, `"temporal"`, or `None` | `None`  | Latent dimension to split during patch mode. `None` uses the runtime default of `"height"`                        |
+
+> [!NOTE]
+> Total GPU count is the product of all enabled distributed dimensions, for example
+> `pipeline_parallel_size * cfg_parallel_size * tensor_parallel_size * ulysses_degree * ring_degree`.
+
+### Split Dimension
+
+Use `height` for the default spatial split. Use `temporal` when you want patches to cover groups of frames instead of
+height bands. The best split depends on the model and whether it is a video or image generation task.
+
+### Warmup Steps
+
+PipeFusion requires at least one warmup step. Warmup fills full-sequence attention and scheduler caches before async patch
+execution begins. Increasing warmup steps can improve stability for some workloads but reduces the portion of denoising
+that benefits from PipeFusion overlap.
+
+---
+
+## Best Practices
+
+### When to Use
+
+**Good for:**
+
+- Supported large video diffusion pipelines with Pipeline Parallelism enabled
+- Multi-GPU setups where plain PP has noticeable pipeline bubbles
+- Images and shorter videos, where repeated KV-cache reads are less likely to become a memory bottleneck
+- PP combined with CFG-Parallel on supported models
+
+**Not for:**
+
+- Single GPU setups
+- Models that do not support PipeFusion
+- Large resolutions or long videos where the overhead of repeated KV-cache reads may outweigh the overlap benefits
+- Workloads where the primary goal is only to reduce model memory; plain Pipeline Parallelism may be enough
+
+### PipeFusion vs Pipeline Parallelism
+
+Pipeline Parallelism is a lossless memory-scaling technique: each rank owns only a slice of the transformer. PipeFusion
+keeps that memory benefit and tries to improve utilization by feeding patches through the PP stages during later denoising
+steps, but this patch-wise async schedule is lossy and should be validated against a plain PP baseline for your workload.
+
+Start with plain PP when you only need to fit the model. Add PipeFusion when PP works correctly and you want to reduce
+idle time during denoising.
+
+---
+
+## Troubleshooting
+
+### Common Issue 1: `enable_pipefusion=True` fails with one PP stage
+
+**Symptoms**: Configuration validation raises an error about `pipeline_parallel_size`.
+
+**Solutions**:
+
+1. Set `pipeline_parallel_size` to a value greater than 1.
+
+```python
+parallel_config = DiffusionParallelConfig(
+    pipeline_parallel_size=2,
+    enable_pipefusion=True,
+)
+```
+
+2. If you are on one GPU, disable PipeFusion.
+
+### Common Issue 2: PipeFusion run hangs
+
+**Symptoms**: The process stalls during denoising.
+
+**Solutions**:
+
+- Try plain Pipeline Parallelism first to isolate PP setup issues, as PipeFusion relies on PP for communication.
+
+### Common Issue 3: Temporal split fails or gives unexpected quality
+
+**Symptoms**: `pipefusion_split_dim="temporal"` behaves worse than `height`.
+
+**Solutions**:
+
+1. Verify the frame count is compatible with the model patch size and PP size.
+2. Use the default `height` split unless temporal splitting is known to help your workload.
+
+---
+
+## Summary
+
+1. Enable Pipeline Parallelism with `pipeline_parallel_size > 1`.
+2. Enable PipeFusion with `enable_pipefusion=True`.
+3. Tune `pipefusion_warmup_steps` and `pipefusion_split_dim` per workload.
+4. Use PipeFusion when you want to reduce PP idle time, not just model memory.

--- a/docs/user_guide/diffusion_features.md
+++ b/docs/user_guide/diffusion_features.md
@@ -23,12 +23,13 @@ vLLM-Omni supports various advanced features for diffusion models:
 
 #### Lossy Acceleration
 
-Cache methods trade minimal quality for significant speedup. Quality loss is typically imperceptible with proper tuning.
+Lossy methods trade minimal quality for significant speedup. Quality loss is typically imperceptible with proper tuning.
 
-| Method | Description | Best For |
-|--------|-------------|----------|
-| **[TeaCache](diffusion/cache_acceleration/teacache.md)** | Adaptive caching using modulated inputs | Quick setup, balanced quality/speed on single GPU |
-| **[Cache-DiT](diffusion/cache_acceleration/cache_dit.md)** | Multiple caching techniques: DBCache, TaylorSeer, SCM | Fine-grained control, tunable quality-speed tradeoff |
+| Method                                                     | Description                                                                                       | Best For                                                                                               |
+|------------------------------------------------------------|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| **[TeaCache](diffusion/cache_acceleration/teacache.md)**   | Adaptive caching using modulated inputs                                                           | Quick setup, balanced quality/speed on single GPU                                                      |
+| **[Cache-DiT](diffusion/cache_acceleration/cache_dit.md)** | Multiple caching techniques: DBCache, TaylorSeer, SCM                                             | Fine-grained control, tunable quality-speed tradeoff                                                   |
+| **[PipeFusion](diffusion/parallelism/pipefusion.md)**      | Splits latents into patches and processes them asynchronously to reduce Pipeline Parallel bubbles | Images and shorter videos, where repeated KV-cache reads are less likely to become a memory bottleneck |
 
 
 #### Lossless Acceleration

--- a/examples/offline_inference/image_to_video/image_to_video.py
+++ b/examples/offline_inference/image_to_video/image_to_video.py
@@ -170,6 +170,12 @@ def parse_args() -> argparse.Namespace:
         help="Enable diffusion pipeline profiler to display stage durations.",
     )
     parser.add_argument(
+        "--profiler-config",
+        type=parse_profiler_config,
+        default=None,
+        help='JSON profiler config for torch/cuda profiling, e.g. \'{"profiler":"torch","torch_profiler_dir":"./perf"}\'.',
+    )
+    parser.add_argument(
         "--quantization",
         type=str,
         default=None,
@@ -239,10 +245,22 @@ def parse_args() -> argparse.Namespace:
         help="Number of pipeline parallel stages.",
     )
     parser.add_argument(
-        "--profiler-config",
-        type=parse_profiler_config,
-        default=None,
-        help='JSON profiler config for torch/cuda profiling, e.g. \'{"profiler":"torch","torch_profiler_dir":"./perf"}\'.',
+        "--enable-pipefusion",
+        action="store_true",
+        help="Enable PipeFusion (patch-wise async pipeline parallel). Requires --pipeline-parallel-size > 1.",
+    )
+    parser.add_argument(
+        "--pipefusion-warmup-steps",
+        type=int,
+        default=1,
+        help="Number of warmup (sync) steps before switching to async PipeFusion patch mode (default: 1).",
+    )
+    parser.add_argument(
+        "--pipefusion-split-dim",
+        type=str,
+        default="height",
+        choices=["height", "temporal"],
+        help="Dimension along which to split latents into patches for PipeFusion (default: height).",
     )
     return parser.parse_args()
 
@@ -335,6 +353,7 @@ def main():
         hsdp_shard_size=args.hsdp_shard_size,
         hsdp_replicate_size=args.hsdp_replicate_size,
         pipeline_parallel_size=args.pipeline_parallel_size,
+        enable_pipefusion=args.enable_pipefusion,
     )
     omni_kwargs = dict(
         model=args.model,
@@ -399,6 +418,8 @@ def main():
             num_inference_steps=num_inference_steps,
             num_frames=num_frames,
             frame_rate=frame_rate,
+            pipefusion_warmup_steps=args.pipefusion_warmup_steps,
+            pipefusion_split_dim=args.pipefusion_split_dim,
             extra_args={
                 "sample_solver": args.sample_solver,
                 "flow_shift": args.flow_shift,

--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -213,6 +213,24 @@ def parse_args() -> argparse.Namespace:
         help="Number of pipeline parallel stages.",
     )
     parser.add_argument(
+        "--enable-pipefusion",
+        action="store_true",
+        help="Enable PipeFusion (patch-wise async pipeline parallel). Requires --pipeline-parallel-size > 1.",
+    )
+    parser.add_argument(
+        "--pipefusion-warmup-steps",
+        type=int,
+        default=1,
+        help="Number of warmup (sync) steps before switching to async PipeFusion patch mode (default: 1).",
+    )
+    parser.add_argument(
+        "--pipefusion-split-dim",
+        type=str,
+        default="height",
+        choices=["height", "temporal"],
+        help="Dimension along which to split latents into patches for PipeFusion (default: height).",
+    )
+    parser.add_argument(
         "--enable-expert-parallel",
         action="store_true",
         help="Enable expert parallelism for MoE layers.",
@@ -293,6 +311,7 @@ def main():
         vae_patch_parallel_size=args.vae_patch_parallel_size,
         pipeline_parallel_size=args.pipeline_parallel_size,
         enable_expert_parallel=args.enable_expert_parallel,
+        enable_pipefusion=args.enable_pipefusion,
     )
 
     profiler_enabled = args.profiler_config is not None
@@ -354,6 +373,8 @@ def main():
         guidance_scale=args.guidance_scale,
         num_inference_steps=args.num_inference_steps,
         num_frames=args.num_frames,
+        pipefusion_warmup_steps=args.pipefusion_warmup_steps,
+        pipefusion_split_dim=args.pipefusion_split_dim,
     )
     if args.guidance_scale_high is not None:
         sampling_kwargs["guidance_scale_2"] = args.guidance_scale_high

--- a/examples/online_serving/text_to_video/run_server.sh
+++ b/examples/online_serving/text_to_video/run_server.sh
@@ -28,4 +28,4 @@ vllm serve "$MODEL" --omni \
     --boundary-ratio "$BOUNDARY_RATIO" \
     --flow-shift "$FLOW_SHIFT" \
     $CACHE_BACKEND_FLAG \
-    $(if [ "$ENABLE_CACHE_DIT_SUMMARY" != "0" ]; then echo "--enable-cache-dit-summary"; fi)
+    $(if [ "$ENABLE_CACHE_DIT_SUMMARY" != "0" ]; then echo "--enable-cache-dit-summary"; fi) "$@"

--- a/tests/diffusion/distributed/test_pipefusion.py
+++ b/tests/diffusion/distributed/test_pipefusion.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU unit tests for PipeFusion.
+
+These tests intentionally avoid real distributed process groups. GPU-backed
+communication correctness for the PP labels PipeFusion uses lives in
+test_pipeline_parallel.py.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch.nn import functional as F
+
+import vllm_omni.diffusion.distributed.pipefusion.pipefusion as pf_pipeline
+import vllm_omni.diffusion.distributed.pipefusion.pipefusion_conv as pf_conv
+import vllm_omni.diffusion.distributed.pipefusion.pipefusion_runtime as pf_runtime
+import vllm_omni.diffusion.distributed.pipefusion.pipefusion_scheduler as pf_scheduler
+import vllm_omni.diffusion.distributed.pipefusion.pipefusion_transformer as pf_transformer
+from vllm_omni.diffusion.data import DiffusionParallelConfig
+from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion import PipeFusionPipelineMixin
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_conv import PipeFusionConvMixin
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_runtime import PipeFusionRuntime
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_scheduler import PipeFusionSchedulerMixin
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_transformer import (
+    PipeFusionRotaryEmbeddingMixin,
+    PipeFusionSelfAttentionMixin,
+    PipeFusionTransformerMixin,
+)
+from vllm_omni.diffusion.distributed.pipeline_parallel import PipelineParallelMixin
+
+pytestmark = [pytest.mark.parallel, pytest.mark.cpu]
+
+
+class FakePPGroup:
+    def __init__(self):
+        self.device = torch.device("cpu")
+        self.reset_calls = 0
+        self.dtype = None
+
+    def reset_buffer(self):
+        self.reset_calls += 1
+
+    def set_config(self, dtype: torch.dtype):
+        self.dtype = dtype
+
+
+@pytest.fixture(autouse=True)
+def reset_pipefusion_runtime(monkeypatch):
+    monkeypatch.setattr(pf_runtime, "_PF_RUNTIME", None)
+
+
+def _set_patch_idx(runtime: PipeFusionRuntime, patch_idx: int) -> None:
+    runtime.pipeline_patch_idx = patch_idx
+    runtime.patch_idx_tensor = torch.tensor(patch_idx, dtype=torch.int64)
+
+
+class TestPipeFusionRuntime:
+    def test_set_run_config_validates_warmup_steps(self):
+        runtime = PipeFusionRuntime()
+
+        with pytest.raises(ValueError, match="warmup_steps must be a positive integer"):
+            runtime.set_run_config(warmup_steps=0)
+
+        with pytest.raises(ValueError, match="warmup_steps must be a positive integer"):
+            runtime.set_run_config(warmup_steps=1.5)
+
+        runtime.set_run_config(warmup_steps=3)
+        assert runtime.warmup_steps == 3
+
+    def test_set_run_config_validates_split_dim(self):
+        runtime = PipeFusionRuntime()
+
+        with pytest.raises(ValueError, match="Invalid PipeFusion split_dim"):
+            runtime.set_run_config(split_dim="width")
+
+        runtime.set_run_config(split_dim="temporal")
+        assert runtime.split_dim == "temporal"
+
+    def test_set_cache_key_validates_cfg_branch(self):
+        runtime = PipeFusionRuntime()
+
+        runtime.set_cache_key("inputs_uncond")
+        assert runtime.cache_key == "inputs_uncond"
+
+        with pytest.raises(ValueError, match="Invalid PipeFusion cache key"):
+            runtime.set_cache_key("bad-key")
+
+    def test_height_split_patch_metadata_and_recv_buffer_reset(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.patch_size = (1, 2, 2)
+        runtime.split_dim = "height"
+        pp_group = FakePPGroup()
+
+        monkeypatch.setattr(pf_runtime, "get_pipeline_parallel_world_size", lambda: 3)
+        monkeypatch.setattr(pf_runtime, "get_pp_group", lambda: pp_group)
+
+        latents = torch.zeros(1, 4, 2, 10, 6)
+        runtime.set_input_parameters(latents, torch.float32)
+
+        assert runtime.num_pipeline_patch == 3
+        assert runtime.latent_split_dim == -2
+        assert runtime.pp_patches_post_height == [1, 1, 3]
+        assert runtime.pp_patches_height == [2, 2, 6]
+        assert runtime.pp_patches_start_end_idx == [(0, 2), (2, 4), (4, 10)]
+        assert runtime.pp_patches_token_num == [6, 6, 18]
+        assert runtime.pp_patches_token_start_end_idx == [(0, 6), (6, 12), (12, 30)]
+        assert pp_group.reset_calls == 1
+        assert pp_group.dtype is torch.float32
+        assert runtime.patch_idx_tensor.device.type == "cpu"
+
+    def test_temporal_split_patch_metadata(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.patch_size = (1, 2, 2)
+        runtime.split_dim = "temporal"
+
+        monkeypatch.setattr(pf_runtime, "get_pipeline_parallel_world_size", lambda: 2)
+
+        latents = torch.zeros(1, 4, 5, 6, 4)
+        runtime._calc_patches_metadata(latents)
+
+        assert runtime.latent_split_dim == -3
+        assert runtime.pp_patches_post_frames == [2, 3]
+        assert runtime.pp_patches_height == [2, 3]
+        assert runtime.pp_patches_start_end_idx == [(0, 2), (2, 5)]
+        assert runtime.pp_patches_token_num == [12, 18]
+        assert runtime.pp_patches_token_start_end_idx == [(0, 12), (12, 30)]
+
+    def test_next_patch_wraps_only_in_patch_mode(self):
+        runtime = PipeFusionRuntime()
+        runtime.num_pipeline_patch = 3
+
+        runtime.set_patched_mode(True)
+        assert runtime.pipeline_patch_idx == 0
+
+        runtime.next_patch()
+        assert runtime.pipeline_patch_idx == 1
+        assert runtime.patch_idx_tensor.item() == 1
+
+        runtime.next_patch()
+        assert runtime.pipeline_patch_idx == 2
+
+        runtime.next_patch()
+        assert runtime.pipeline_patch_idx == 0
+
+        runtime.set_patched_mode(False)
+        runtime.pipeline_patch_idx = 2
+        runtime.next_patch()
+        assert runtime.pipeline_patch_idx == 0
+
+
+class DummyScheduler(PipeFusionSchedulerMixin):
+    _pipefusion_patch_cache_spec = [
+        ("model_outputs", "list"),
+        ("last_sample", "tensor"),
+    ]
+
+    def __init__(self):
+        self._init_patch_caches()
+        self.model_outputs = [torch.arange(6, dtype=torch.float32).view(1, 1, 1, 6, 1), None]
+        self.last_sample = torch.arange(100, 106, dtype=torch.float32).view(1, 1, 1, 6, 1)
+        self._step_index = 4
+        self.lower_order_nums = 2
+        self.this_order = 1
+        self.timestep_list = ["warmup"]
+
+
+def _scheduler_step_impl(self: DummyScheduler, sample: torch.Tensor):
+    self.model_outputs[0] = sample + 10
+    self.last_sample = sample + 20
+    self._step_index += 1
+    self.lower_order_nums += 1
+    self.this_order += 1
+    self.timestep_list.append(f"patch-{pf_scheduler.get_pipefusion_runtime().pipeline_patch_idx}")
+    return self.last_sample
+
+
+class TestPipeFusionSchedulerMixin:
+    def test_split_caches_for_patches_splits_list_and_tensor_entries(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.num_pipeline_patch = 2
+        monkeypatch.setattr(pf_scheduler, "get_pipefusion_runtime", lambda: runtime)
+
+        scheduler = DummyScheduler()
+        scheduler.split_caches_for_patches([2, 4], dim=-2)
+
+        assert set(scheduler._pf_patch_caches) == {"model_outputs", "last_sample"}
+        assert scheduler._pf_patch_caches["model_outputs"][0][0].shape[-2] == 2
+        assert scheduler._pf_patch_caches["model_outputs"][1][0].shape[-2] == 4
+        assert scheduler._pf_patch_caches["model_outputs"][0][1] is None
+        assert scheduler._pf_patch_caches["last_sample"][0].shape[-2] == 2
+        assert scheduler._pf_patch_caches["last_sample"][1].shape[-2] == 4
+
+    def test_scheduler_step_restores_shared_and_first_patch_only_state(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.num_pipeline_patch = 2
+        runtime.set_patched_mode(True)
+        monkeypatch.setattr(pf_scheduler, "get_pipefusion_runtime", lambda: runtime)
+
+        scheduler = DummyScheduler()
+        scheduler.split_caches_for_patches([2, 4], dim=-2)
+
+        _set_patch_idx(runtime, 0)
+        first_patch_sample = torch.ones(1, 1, 1, 2, 1)
+        first_result = scheduler._pipefusion_scheduler_step(_scheduler_step_impl, first_patch_sample)
+
+        torch.testing.assert_close(first_result, first_patch_sample + 20)
+        assert scheduler._step_index == 4
+        assert scheduler.lower_order_nums == 2
+        assert scheduler.this_order == 1
+        assert scheduler.timestep_list == ["warmup", "patch-0"]
+        torch.testing.assert_close(scheduler._pf_patch_caches["last_sample"][0], first_patch_sample + 20)
+
+        _set_patch_idx(runtime, 1)
+        second_patch_sample = torch.ones(1, 1, 1, 4, 1) * 2
+        second_result = scheduler._pipefusion_scheduler_step(_scheduler_step_impl, second_patch_sample)
+
+        torch.testing.assert_close(second_result, second_patch_sample + 20)
+        assert scheduler._step_index == 5
+        assert scheduler.lower_order_nums == 3
+        assert scheduler.this_order == 2
+        assert scheduler.timestep_list == ["warmup", "patch-0"]
+        torch.testing.assert_close(scheduler._pf_patch_caches["last_sample"][1], second_patch_sample + 20)
+
+    def test_clear_patch_caches(self):
+        scheduler = DummyScheduler()
+        scheduler._pf_patch_caches = {"last_sample": [torch.ones(1)]}
+
+        scheduler.clear_patch_caches()
+
+        assert scheduler._pf_patch_caches is None
+
+
+class DummyRotary(PipeFusionRotaryEmbeddingMixin):
+    patch_size = (1, 2, 2)
+
+
+class DummyAttention(PipeFusionSelfAttentionMixin):
+    pass
+
+
+class DummyTransformer(PipeFusionTransformerMixin):
+    def __init__(self):
+        self.config = SimpleNamespace(patch_size=(1, 2, 2))
+
+    def _unpatchify(self, hidden_states: torch.Tensor, dims: tuple[int, int, int, int, int]):
+        return hidden_states
+
+
+class TestPipeFusionTransformerHelpers:
+    def test_rotary_embedding_slice_height(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.num_pipeline_patch = 2
+        runtime.split_dim = "height"
+        _set_patch_idx(runtime, 1)
+        monkeypatch.setattr(pf_transformer, "get_pipefusion_runtime", lambda: runtime)
+
+        rotary = DummyRotary()
+        cos = torch.arange(1 * 16 * 1 * 2, dtype=torch.float32).reshape(1, 16, 1, 2)
+        sin = cos + 100
+
+        sliced_cos, sliced_sin = rotary.pipefusion_slice_rotary_emb((cos, sin), 2, 8, 4)
+
+        expected_cos = cos.reshape(2, 4, 2, 2).narrow(1, 2, 2).reshape(1, 8, 1, 2)
+        expected_sin = sin.reshape(2, 4, 2, 2).narrow(1, 2, 2).reshape(1, 8, 1, 2)
+        torch.testing.assert_close(sliced_cos, expected_cos)
+        torch.testing.assert_close(sliced_sin, expected_sin)
+
+    def test_rotary_embedding_slice_temporal(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.num_pipeline_patch = 2
+        runtime.split_dim = "temporal"
+        _set_patch_idx(runtime, 0)
+        monkeypatch.setattr(pf_transformer, "get_pipefusion_runtime", lambda: runtime)
+
+        rotary = DummyRotary()
+        cos = torch.arange(1 * 16 * 1 * 2, dtype=torch.float32).reshape(1, 16, 1, 2)
+        sin = cos + 100
+
+        sliced_cos, sliced_sin = rotary.pipefusion_slice_rotary_emb((cos, sin), 4, 4, 4)
+
+        expected_cos = cos.reshape(4, 2, 2, 2).narrow(0, 0, 2).reshape(1, 8, 1, 2)
+        expected_sin = sin.reshape(4, 2, 2, 2).narrow(0, 0, 2).reshape(1, 8, 1, 2)
+        torch.testing.assert_close(sliced_cos, expected_cos)
+        torch.testing.assert_close(sliced_sin, expected_sin)
+
+    def test_kv_cache_height_patch_update_uses_5d_slice(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.patch_mode = False
+        runtime.cache_key = "inputs"
+        runtime.split_dim = "height"
+        runtime.num_pipeline_patch = 2
+        runtime.ppf = 2
+        runtime.pph = 4
+        runtime.ppw = 2
+        _set_patch_idx(runtime, 1)
+        monkeypatch.setattr(pf_transformer, "get_pipefusion_runtime", lambda: runtime)
+
+        attention = DummyAttention()
+        attention.pipefusion_reset_cache()
+        full_key = torch.arange(16, dtype=torch.float32).reshape(1, 16, 1, 1)
+        full_value = full_key + 100
+        attention._pipefusion_update_kv_cache(full_key.clone(), full_value.clone())
+
+        runtime.patch_mode = True
+        patch_key = torch.full((1, 8, 1, 1), 1000.0)
+        patch_value = torch.full((1, 8, 1, 1), 2000.0)
+        updated_key, updated_value = attention._pipefusion_update_kv_cache(patch_key, patch_value)
+
+        expected_key = full_key.clone().view(1, 2, 4, 2, 1, 1)
+        expected_value = full_value.clone().view(1, 2, 4, 2, 1, 1)
+        expected_key.narrow(2, 2, 2).copy_(patch_key.reshape(1, 2, 2, 2, 1, 1))
+        expected_value.narrow(2, 2, 2).copy_(patch_value.reshape(1, 2, 2, 2, 1, 1))
+        torch.testing.assert_close(updated_key, expected_key.reshape(1, 16, 1, 1))
+        torch.testing.assert_close(updated_value, expected_value.reshape(1, 16, 1, 1))
+
+    def test_kv_cache_temporal_patch_update_uses_contiguous_slice(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.patch_mode = False
+        runtime.cache_key = "inputs_uncond"
+        runtime.split_dim = "temporal"
+        runtime.num_pipeline_patch = 2
+        runtime.ppf = 4
+        runtime.pph = 2
+        runtime.ppw = 2
+        _set_patch_idx(runtime, 1)
+        monkeypatch.setattr(pf_transformer, "get_pipefusion_runtime", lambda: runtime)
+
+        attention = DummyAttention()
+        attention.pipefusion_reset_cache()
+        full_key = torch.arange(16, dtype=torch.float32).reshape(1, 16, 1, 1)
+        full_value = full_key + 100
+        attention._pipefusion_update_kv_cache(full_key.clone(), full_value.clone())
+
+        runtime.patch_mode = True
+        patch_key = torch.full((1, 8, 1, 1), 3000.0)
+        patch_value = torch.full((1, 8, 1, 1), 4000.0)
+        updated_key, updated_value = attention._pipefusion_update_kv_cache(patch_key, patch_value)
+
+        expected_key = full_key.clone()
+        expected_value = full_value.clone()
+        expected_key.narrow(1, 8, 8).copy_(patch_key)
+        expected_value.narrow(1, 8, 8).copy_(patch_value)
+        torch.testing.assert_close(updated_key, expected_key)
+        torch.testing.assert_close(updated_value, expected_value)
+
+    def test_kv_cache_requires_warmup_cache_before_patch_mode(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.patch_mode = True
+        runtime.cache_key = "inputs"
+        monkeypatch.setattr(pf_transformer, "get_pipefusion_runtime", lambda: runtime)
+
+        attention = DummyAttention()
+        attention.pipefusion_reset_cache()
+
+        with pytest.raises(RuntimeError, match="Run at least one warmup step"):
+            attention._pipefusion_update_kv_cache(torch.ones(1, 1, 1, 1), torch.ones(1, 1, 1, 1))
+
+    def test_unpatchify_uses_patch_local_height(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.split_dim = "height"
+        runtime.num_pipeline_patch = 2
+        _set_patch_idx(runtime, 1)
+        monkeypatch.setattr(pf_transformer, "get_pipefusion_runtime", lambda: runtime)
+
+        transformer = DummyTransformer()
+        hidden_states = torch.arange(1 * 8 * 4, dtype=torch.float32).reshape(1, 8, 4)
+        output = transformer.pipefusion_unpatchify(hidden_states, (1, 4, 2, 8, 4))
+
+        assert output.shape == (1, 1, 2, 4, 4)
+
+    def test_unpatchify_uses_patch_local_frames(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.split_dim = "temporal"
+        runtime.num_pipeline_patch = 2
+        _set_patch_idx(runtime, 0)
+        monkeypatch.setattr(pf_transformer, "get_pipefusion_runtime", lambda: runtime)
+
+        transformer = DummyTransformer()
+        hidden_states = torch.arange(1 * 8 * 4, dtype=torch.float32).reshape(1, 8, 4)
+        output = transformer.pipefusion_unpatchify(hidden_states, (1, 4, 4, 4, 4))
+
+        assert output.shape == (1, 1, 2, 4, 4)
+
+
+class DummyConv(PipeFusionConvMixin):
+    def __init__(self):
+        self.kernel_size = (1, 3, 1)
+        self.stride = (1, 1, 1)
+        self.padding = (0, 1, 0)
+        self.dilation = (1, 1, 1)
+        self.groups = 1
+        self.weight = torch.ones(1, 1, 1, 3, 1)
+        self.bias = None
+
+    def orig_forward(self, x: torch.Tensor, dims=None) -> torch.Tensor:
+        return F.conv3d(x, self.weight, self.bias, stride=self.stride, padding=self.padding)
+
+
+class TestPipeFusionConvMixin:
+    def test_conv3d_enabled_only_for_overlapping_patch_mode(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.patch_mode = True
+        runtime.num_pipeline_patch = 2
+        monkeypatch.setattr(pf_conv, "get_pipefusion_runtime", lambda: runtime)
+
+        conv = DummyConv()
+        assert conv.pipefusion_conv3d_enabled() is True
+
+        conv.stride = conv.kernel_size
+        assert conv.pipefusion_conv3d_enabled() is False
+
+        runtime.patch_mode = False
+        conv.stride = (1, 1, 1)
+        assert conv.pipefusion_conv3d_enabled() is False
+
+    def test_conv3d_forward_caches_activations_and_returns_patch_slice(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        runtime.patch_mode = True
+        runtime.num_pipeline_patch = 2
+        runtime.pp_patches_start_end_idx = [(0, 2), (2, 6)]
+        runtime.pp_patches_post_start_end_idx = [(0, 2), (2, 6)]
+        monkeypatch.setattr(pf_conv, "get_pipefusion_runtime", lambda: runtime)
+
+        conv = DummyConv()
+        full_input = torch.arange(6, dtype=torch.float32).view(1, 1, 1, 6, 1)
+
+        runtime.pipeline_patch_idx = 0
+        _ = conv.pipefusion_conv3d_forward(full_input[:, :, :, :2, :], dims=full_input.shape)
+
+        runtime.pipeline_patch_idx = 1
+        patch_output = conv.pipefusion_conv3d_forward(full_input[:, :, :, 2:, :], dims=full_input.shape)
+        full_output = conv.orig_forward(full_input)
+
+        torch.testing.assert_close(patch_output, full_output[:, :, :, 2:6, :])
+        torch.testing.assert_close(conv.activation_cache, full_input)
+
+
+class TestPipeFusionPipelineMixin:
+    def test_pipefusion_pipeline_requires_pipeline_parallel_mixin(self):
+        with pytest.raises(TypeError, match="inherits PipeFusionPipelineMixin but not PipelineParallelMixin"):
+
+            class _MissingPP(PipeFusionPipelineMixin):
+                def prepare_model_kwargs(self, latents, timestep, **extra_kwargs):
+                    return {}, None, False, 1.0
+
+    def test_pipefusion_pipeline_requires_mro_before_pipeline_parallel_mixin(self):
+        with pytest.raises(TypeError, match="must inherit PipeFusionPipelineMixin before PipelineParallelMixin"):
+
+            class _WrongOrder(PipelineParallelMixin, PipeFusionPipelineMixin, CFGParallelMixin):
+                def prepare_model_kwargs(self, latents, timestep, **extra_kwargs):
+                    return {}, None, False, 1.0
+
+    def test_configure_pipefusion_run_reads_sampling_params(self, monkeypatch):
+        runtime = PipeFusionRuntime()
+        monkeypatch.setattr(pf_pipeline, "get_pipefusion_runtime", lambda: runtime)
+        req = SimpleNamespace(
+            sampling_params=SimpleNamespace(
+                pipefusion_warmup_steps=4,
+                pipefusion_split_dim="temporal",
+            )
+        )
+
+        PipeFusionPipelineMixin._configure_pipefusion_run(req)
+
+        assert runtime.warmup_steps == 4
+        assert runtime.split_dim == "temporal"
+
+
+class TestDiffusionParallelConfigPipeFusion:
+    def test_pipefusion_disabled_by_default(self):
+        config = DiffusionParallelConfig()
+
+        assert config.enable_pipefusion is False
+
+    def test_pipefusion_requires_pipeline_parallelism(self):
+        with pytest.raises(ValueError, match="PipeFusion requires pipeline_parallel_size > 1"):
+            DiffusionParallelConfig(enable_pipefusion=True)
+
+    def test_pipefusion_valid_with_pipeline_parallelism(self):
+        config = DiffusionParallelConfig(pipeline_parallel_size=2, enable_pipefusion=True)
+
+        assert config.enable_pipefusion is True
+        assert config.pipeline_parallel_size == 2

--- a/tests/diffusion/distributed/test_pipeline_parallel.py
+++ b/tests/diffusion/distributed/test_pipeline_parallel.py
@@ -367,6 +367,34 @@ def test_pipeline_parallel_requires_mro_before_cfg_mixin():
             pass
 
 
+@pytest.mark.cpu
+def test_predict_noise_validates_inter_comm_ids_length(monkeypatch):
+    """Sequential CFG uses two PP branches, so it requires two inter-stage labels."""
+
+    class _FakePPGroup:
+        is_first_rank = True
+        is_last_rank = False
+
+    class _LabelValidationPP(PipelineParallelMixin, CFGParallelMixin):
+        def predict_noise(self, **_kwargs):
+            return IntermediateTensors({"hidden_states": torch.ones(1, 1)})
+
+    monkeypatch.setattr(pp_module, "get_pipeline_parallel_world_size", lambda: 2)
+    monkeypatch.setattr(pp_module, "get_classifier_free_guidance_world_size", lambda: 1)
+    monkeypatch.setattr(pp_module, "get_pp_group", lambda: _FakePPGroup())
+
+    pipeline = _LabelValidationPP()
+    with pytest.raises(ValueError, match="inter_comm_ids has length 1 but expected 2"):
+        pipeline.predict_noise_maybe_with_cfg(
+            do_true_cfg=True,
+            true_cfg_scale=7.5,
+            positive_kwargs={},
+            negative_kwargs={},
+            cfg_normalize=False,
+            inter_comm_ids=["only-positive"],
+        )
+
+
 # ---------------------------------------------------------------------------
 # Distributed test helpers
 # ---------------------------------------------------------------------------
@@ -390,7 +418,11 @@ def init_dist(local_rank: int, world_size: int, master_port: str) -> torch.devic
 
 
 def make_pipeline_and_inputs(
-    test_config: dict, dtype: torch.dtype, device: torch.device, do_true_cfg: bool = False
+    test_config: dict,
+    dtype: torch.dtype,
+    device: torch.device,
+    do_true_cfg: bool = False,
+    pipeline: "MockPipelineParallel | None" = None,
 ) -> tuple["MockPipelineParallel", dict, dict | None]:
     """Create a MockPipelineParallel and seeded inputs from a test_config dict.
 
@@ -400,13 +432,14 @@ def make_pipeline_and_inputs(
     Returns ``(pipeline, positive_kwargs, negative_kwargs)``.
     ``negative_kwargs`` is ``None`` when ``do_true_cfg=False``.
     """
-    pipeline = MockPipelineParallel(
-        num_layers=test_config["num_layers"],
-        dim=test_config["dim"],
-        seed=test_config["model_seed"],
-        device=device,
-        dtype=dtype,
-    )
+    if pipeline is None:
+        pipeline = MockPipelineParallel(
+            num_layers=test_config["num_layers"],
+            dim=test_config["dim"],
+            seed=test_config["model_seed"],
+            device=device,
+            dtype=dtype,
+        )
 
     torch.manual_seed(test_config["input_seed"])
     if torch.cuda.is_available():
@@ -429,7 +462,7 @@ def make_pipeline_and_inputs(
 # ---------------------------------------------------------------------------
 
 
-def isend_irecv_worker(local_rank: int, world_size: int, master_port: str, result_queue):
+def isend_irecv_worker(local_rank: int, world_size: int, master_port: str, result_queue, comm_id: str | None = None):
     device = init_dist(local_rank, world_size, master_port)
     initialize_model_parallel(pipeline_parallel_size=world_size)
     pp_group = get_pp_group()
@@ -439,12 +472,12 @@ def isend_irecv_worker(local_rank: int, world_size: int, master_port: str, resul
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(77)
         tensor = torch.randn(3, 5, dtype=torch.float32, device=device)
-        handles = pp_group.isend_tensor_dict({"t": tensor})
+        handles = pp_group.isend_tensor_dict({"t": tensor}, comm_id=comm_id)
         for h in handles:
             h.wait()
         result_queue.put(("sent", tensor.cpu()))
     else:
-        received = AsyncIntermediateTensors(*pp_group.irecv_tensor_dict())
+        received = AsyncIntermediateTensors(*pp_group.irecv_tensor_dict(comm_id=comm_id))
         result_queue.put(("received", received["t"].cpu()))
 
     if torch.distributed.is_initialized():
@@ -453,21 +486,88 @@ def isend_irecv_worker(local_rank: int, world_size: int, master_port: str, resul
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(current_omni_platform.get_device_count() < 2, reason="Need at least 2 GPUs")
-@pytest.mark.parametrize("pp_size", [2])
-def test_isend_irecv_tensor_dict(pp_size: int):
+@pytest.mark.parametrize(
+    "pp_size, comm_id",
+    [
+        pytest.param(
+            2,
+            None,
+            marks=pytest.mark.skipif(current_omni_platform.get_device_count() < 2, reason="Need at least 2 GPUs"),
+            id="unlabeled",
+        ),
+        pytest.param(
+            2,
+            "test-comm-id",
+            marks=pytest.mark.skipif(current_omni_platform.get_device_count() < 2, reason="Need at least 2 GPUs"),
+            id="comm_id",
+        ),
+    ],
+)
+def test_isend_irecv_tensor_dict(pp_size: int, comm_id: str | None):
     """isend_tensor_dict / irecv_tensor_dict transfer a tensor dict without loss."""
     mp_context = torch.multiprocessing.get_context("spawn")
     manager = mp_context.Manager()
     q = manager.Queue()
 
     port = _find_free_port()
-    torch.multiprocessing.spawn(isend_irecv_worker, args=(pp_size, port, q), nprocs=pp_size)
+    torch.multiprocessing.spawn(isend_irecv_worker, args=(pp_size, port, q, comm_id), nprocs=pp_size)
 
     results = {label: tensor for label, tensor in [q.get(), q.get()]}
     torch.testing.assert_close(
         results["received"], results["sent"], rtol=0, atol=0, msg="isend/irecv transferred tensor incorrectly"
     )
+
+
+def labeled_shape_drift_worker(local_rank: int, world_size: int, master_port: str, result_queue):
+    device = init_dist(local_rank, world_size, master_port)
+    initialize_model_parallel(pipeline_parallel_size=world_size)
+    pp_group = get_pp_group()
+    comm_id = "test-shape-drift"
+
+    if pp_group.is_first_rank:
+        tensor = torch.randn(3, 5, dtype=torch.float32, device=device)
+        handles = pp_group.isend_tensor_dict({"t": tensor}, comm_id=comm_id)
+        for handle in handles:
+            handle.wait()
+
+        error = None
+        try:
+            pp_group.isend_tensor_dict({"t": torch.randn(4, 5, dtype=torch.float32, device=device)}, comm_id=comm_id)
+        except ValueError as exc:
+            error = str(exc)
+        result_queue.put(("sender_error", error))
+    else:
+        received = AsyncIntermediateTensors(*pp_group.irecv_tensor_dict(comm_id=comm_id))
+        result_queue.put(("received_shape", tuple(received["t"].shape)))
+
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+    destroy_distributed_env()
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "pp_size",
+    [
+        pytest.param(
+            2,
+            marks=pytest.mark.skipif(current_omni_platform.get_device_count() < 2, reason="Need at least 2 GPUs"),
+        ),
+    ],
+)
+def test_labeled_comm_id_rejects_shape_drift(pp_size: int):
+    """Reusing a comm_id with a different tensor structure should fail on the sender."""
+    mp_context = torch.multiprocessing.get_context("spawn")
+    manager = mp_context.Manager()
+    q = manager.Queue()
+
+    port = _find_free_port()
+    torch.multiprocessing.spawn(labeled_shape_drift_worker, args=(pp_size, port, q), nprocs=pp_size)
+
+    results = {label: value for label, value in [q.get(), q.get()]}
+    assert results["received_shape"] == (3, 5)
+    assert results["sender_error"] is not None
+    assert "shape drift on comm_id" in results["sender_error"]
 
 
 # ---------------------------------------------------------------------------
@@ -528,6 +628,9 @@ def predict_noise_worker(
     dtype: torch.dtype,
     test_config: dict,
     result_queue,
+    num_calls: int = 1,
+    skip_sync: bool = False,
+    inter_comm_ids: list[str] | None = None,
 ):
     """Generic predict-noise worker parameterized by PP and CFG topology."""
     device = init_dist(local_rank, world_size, master_port)
@@ -536,28 +639,39 @@ def predict_noise_worker(
     pp_group = get_pp_group()
     cfg_rank = get_classifier_free_guidance_rank()
 
-    pipeline, positive_kwargs, negative_kwargs = make_pipeline_and_inputs(
-        test_config, dtype, device, do_true_cfg=do_true_cfg
-    )
-
+    pipeline = None
+    noise_preds = []
     with torch.inference_mode():
-        noise_pred = pipeline.predict_noise_maybe_with_cfg(
-            do_true_cfg=do_true_cfg,
-            true_cfg_scale=test_config["cfg_scale"],
-            positive_kwargs=positive_kwargs,
-            negative_kwargs=negative_kwargs,
-            cfg_normalize=False,
-        )
+        for call_idx in range(num_calls):
+            pipeline, positive_kwargs, negative_kwargs = make_pipeline_and_inputs(
+                {**test_config, "input_seed": test_config["input_seed"] + call_idx},
+                dtype,
+                device,
+                do_true_cfg=do_true_cfg,
+                pipeline=pipeline,
+            )
+            noise_pred = pipeline.predict_noise_maybe_with_cfg(
+                do_true_cfg=do_true_cfg,
+                true_cfg_scale=test_config["cfg_scale"],
+                positive_kwargs=positive_kwargs,
+                negative_kwargs=negative_kwargs,
+                cfg_normalize=False,
+                skip_sync=skip_sync,
+                inter_comm_ids=inter_comm_ids,
+            )
+            if pp_group.is_last_rank:
+                assert noise_pred is not None
+                if cfg_rank == 0:
+                    noise_preds.append(noise_pred.cpu())
+            else:
+                assert noise_pred is None
+
     # This worker exercises predict_noise_maybe_with_cfg directly, bypassing diffuse().
     # Flush the non-last PP rank's async send before barrier / process teardown.
     pipeline._sync_pp_send()
 
-    if pp_group.is_last_rank:
-        assert noise_pred is not None
-        if cfg_rank == 0:
-            result_queue.put(noise_pred.cpu())
-    else:
-        assert noise_pred is None
+    if pp_group.is_last_rank and cfg_rank == 0:
+        result_queue.put(noise_preds if num_calls > 1 or inter_comm_ids is not None else noise_preds[0])
 
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
@@ -667,13 +781,107 @@ def test_predict_noise(pp_size, cfg_size, do_true_cfg, dtype, num_layers, input_
     )
 
 
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    "pp_size, cfg_size, dtype, do_true_cfg, num_calls, skip_sync, input_seed",
+    [
+        pytest.param(
+            2,
+            1,
+            torch.float32,
+            False,
+            1,
+            False,
+            700,
+            marks=pytest.mark.skipif(current_omni_platform.get_device_count() < 2, reason="Need at least 2 GPUs"),
+            id="pp2-labeled-no_cfg",
+        ),
+        pytest.param(
+            2,
+            1,
+            torch.float32,
+            True,
+            1,
+            False,
+            800,
+            marks=pytest.mark.skipif(current_omni_platform.get_device_count() < 2, reason="Need at least 2 GPUs"),
+            id="pp2-labeled-seq_cfg",
+        ),
+        pytest.param(
+            2,
+            1,
+            torch.float32,
+            False,
+            2,
+            True,
+            900,
+            marks=pytest.mark.skipif(current_omni_platform.get_device_count() < 2, reason="Need at least 2 GPUs"),
+            id="pp2-labeled-skip_sync-overlap",
+        ),
+    ],
+)
+def test_predict_noise_with_labeled_inter_comm_ids(
+    pp_size, cfg_size, dtype, do_true_cfg, num_calls, skip_sync, input_seed
+):
+    """Labeled inter-stage PP communication should match the single-rank baseline."""
+    test_config = {
+        "num_layers": 4,
+        "dim": 64,
+        "batch_size": 2,
+        "cfg_scale": 7.5,
+        "model_seed": 42,
+        "input_seed": input_seed,
+    }
+    baselines = [
+        compute_single_gpu_baseline({**test_config, "input_seed": input_seed + call_idx}, dtype, do_true_cfg)
+        for call_idx in range(num_calls)
+    ]
+
+    mp_context = torch.multiprocessing.get_context("spawn")
+    manager = mp_context.Manager()
+    q = manager.Queue()
+
+    world_size = pp_size * cfg_size
+    n_branches = 2 if do_true_cfg else 1
+    inter_comm_ids = [f"test-it-{branch}" for branch in range(n_branches)]
+    port = _find_free_port()
+    torch.multiprocessing.spawn(
+        predict_noise_worker,
+        args=(
+            world_size,
+            port,
+            pp_size,
+            cfg_size,
+            do_true_cfg,
+            dtype,
+            test_config,
+            q,
+            num_calls,
+            skip_sync,
+            inter_comm_ids,
+        ),
+        nprocs=world_size,
+    )
+
+    pp_outputs = q.get()
+    assert len(pp_outputs) == num_calls
+    for pp_out, baseline in zip(pp_outputs, baselines):
+        torch.testing.assert_close(
+            pp_out,
+            baseline,
+            rtol=1e-5,
+            atol=1e-5,
+            msg="Labeled PP predict_noise output differs from single-rank baseline",
+        )
+
+
 # ---------------------------------------------------------------------------
 # 5.  scheduler_step_maybe_with_cfg
 # ---------------------------------------------------------------------------
 
 
-def compute_scheduler_step_baseline(test_config: dict, do_true_cfg: bool) -> torch.Tensor:
-    """Single-GPU reference: predict_noise + scheduler_step."""
+def compute_scheduler_step_baseline(test_config: dict, do_true_cfg: bool, steps: int = 1) -> torch.Tensor:
+    """Single-GPU reference: predict_noise + scheduler_step (``steps`` times)."""
     device = init_dist(0, 1, _find_free_port())
     initialize_model_parallel(pipeline_parallel_size=1)
 
@@ -691,12 +899,13 @@ def compute_scheduler_step_baseline(test_config: dict, do_true_cfg: bool) -> tor
             negative_kwargs=negative_kwargs,
             cfg_normalize=False,
         )
-        result = pipeline.scheduler_step_maybe_with_cfg(
-            noise_pred=noise_pred, t=t, latents=latents, do_true_cfg=do_true_cfg
-        )
+        for _ in range(steps):
+            latents = pipeline.scheduler_step_maybe_with_cfg(
+                noise_pred=noise_pred, t=t, latents=latents, do_true_cfg=do_true_cfg
+            )
 
     destroy_distributed_env()
-    return result.cpu()
+    return latents.cpu()
 
 
 def scheduler_step_worker(
@@ -708,6 +917,9 @@ def scheduler_step_worker(
     do_true_cfg: bool,
     test_config: dict,
     result_queue,
+    steps: int = 1,
+    loopback_comm_id: str | None = None,
+    seed_pending_send: bool = False,
 ):
     device = init_dist(local_rank, world_size, master_port)
     initialize_model_parallel(pipeline_parallel_size=pp_size, cfg_parallel_size=cfg_size)
@@ -721,6 +933,11 @@ def scheduler_step_worker(
     latents = positive_kwargs["x"]
     t = torch.tensor(500, device=device)
 
+    sentinel = None
+    if seed_pending_send and pp_group.is_last_rank:
+        sentinel = FakeWork()
+        pipeline._pp_send_work = [sentinel]
+
     with torch.inference_mode():
         noise_pred = pipeline.predict_noise_maybe_with_cfg(
             do_true_cfg=do_true_cfg,
@@ -729,16 +946,28 @@ def scheduler_step_worker(
             negative_kwargs=negative_kwargs,
             cfg_normalize=False,
         )
-        latents = pipeline.scheduler_step_maybe_with_cfg(
-            noise_pred=noise_pred, t=t, latents=latents, do_true_cfg=do_true_cfg
-        )
+        for _ in range(steps):
+            latents = pipeline.scheduler_step_maybe_with_cfg(
+                noise_pred=noise_pred,
+                t=t,
+                latents=latents,
+                do_true_cfg=do_true_cfg,
+                loopback_comm_id=loopback_comm_id,
+            )
+
     # This worker exercises scheduler_step_maybe_with_cfg directly, bypassing diffuse().
     # Flush the last PP rank's async latent send before barrier / process teardown.
     pipeline._sync_pp_send()
 
-    if pp_group.is_first_rank and cfg_rank == 0:
+    if seed_pending_send:
+        if pp_group.is_first_rank:
+            resolved = latents.contiguous()
+            result_queue.put(("latents", resolved.cpu()))
+        if pp_group.is_last_rank:
+            result_queue.put(("sentinel_waited", sentinel.waited))
+    elif pp_group.is_first_rank and cfg_rank == 0:
         resolved = latents.contiguous()
-        result_queue.put(resolved.cpu())
+        result_queue.put(("latents", resolved.cpu()))
 
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
@@ -747,13 +976,16 @@ def scheduler_step_worker(
 
 @pytest.mark.gpu
 @pytest.mark.parametrize(
-    "pp_size, cfg_size, do_true_cfg, input_seed",
+    "pp_size, cfg_size, do_true_cfg, input_seed, steps, loopback_comm_id, seed_pending_send",
     [
         pytest.param(
             2,
             1,
             False,
             300,
+            1,
+            None,
+            False,
             marks=pytest.mark.skipif(current_omni_platform.get_device_count() < 2, reason="Need at least 2 GPUs"),
             id="pp2-no_cfg",
         ),
@@ -762,13 +994,38 @@ def scheduler_step_worker(
             2,
             True,
             600,
+            1,
+            None,
+            False,
             marks=pytest.mark.skipif(current_omni_platform.get_device_count() < 4, reason="Need at least 4 GPUs"),
             id="pp2-cfg2-true_cfg",
         ),
+        pytest.param(
+            2,
+            1,
+            False,
+            1000,
+            2,
+            "test-lb",
+            True,
+            marks=pytest.mark.skipif(current_omni_platform.get_device_count() < 2, reason="Need at least 2 GPUs"),
+            id="pp2-labeled_loopback",
+        ),
     ],
 )
-def test_scheduler_step(pp_size, cfg_size, do_true_cfg, input_seed):
-    """Rank 0 latents after scheduler_step match the single-GPU baseline across PP / CFG topologies."""
+def test_scheduler_step(
+    pp_size,
+    cfg_size,
+    do_true_cfg,
+    input_seed,
+    steps,
+    loopback_comm_id,
+    seed_pending_send,
+):
+    """
+    Rank 0 latents after scheduler_step match the single-GPU baseline across PP / CFG topologies.
+    Loopback case also checks pending sends.
+    """
     test_config = {
         "num_layers": 4,
         "dim": 64,
@@ -778,7 +1035,7 @@ def test_scheduler_step(pp_size, cfg_size, do_true_cfg, input_seed):
         "input_seed": input_seed,
     }
 
-    baseline = compute_scheduler_step_baseline(test_config, do_true_cfg)
+    baseline = compute_scheduler_step_baseline(test_config, do_true_cfg, steps=steps)
 
     mp_context = torch.multiprocessing.get_context("spawn")
     manager = mp_context.Manager()
@@ -788,15 +1045,28 @@ def test_scheduler_step(pp_size, cfg_size, do_true_cfg, input_seed):
     world_size = pp_size * cfg_size
     torch.multiprocessing.spawn(
         scheduler_step_worker,
-        args=(world_size, port, pp_size, cfg_size, do_true_cfg, test_config, q),
+        args=(
+            world_size,
+            port,
+            pp_size,
+            cfg_size,
+            do_true_cfg,
+            test_config,
+            q,
+            steps,
+            loopback_comm_id,
+            seed_pending_send,
+        ),
         nprocs=world_size,
     )
 
-    result = q.get()
+    results = dict(q.get() for _ in range(2 if seed_pending_send else 1))
     torch.testing.assert_close(
-        result,
+        results["latents"],
         baseline,
         rtol=0,
         atol=0,
         msg=f"PP={pp_size} CFG={cfg_size} scheduler step latents on rank 0 do not match single-GPU baseline",
     )
+    if seed_pending_send:
+        assert results["sentinel_waited"] is True

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -135,6 +135,9 @@ class DiffusionParallelConfig:
     hsdp_replicate_size: int = 1
     """Number of replica groups for HSDP. Each replica holds a full sharded copy."""
 
+    enable_pipefusion: bool = False
+    """Enable PipeFusion (patch-wise async pipeline parallel). Requires pipeline_parallel_size > 1."""
+
     @model_validator(mode="after")
     def _validate_parallel_config(self) -> Self:
         """Validates the config relationships among the parallel strategies."""
@@ -156,6 +159,9 @@ class DiffusionParallelConfig:
         assert self.ulysses_mode in {"strict", "advanced_uaa"}, (
             f"ulysses_mode must be one of {{'strict','advanced_uaa'}}, but got {self.ulysses_mode!r}."
         )
+
+        if self.enable_pipefusion and self.pipeline_parallel_size <= 1:
+            raise ValueError(f"PipeFusion requires pipeline_parallel_size > 1, but got {self.pipeline_parallel_size}")
 
         # Validate HSDP configuration
         if self.use_hsdp:

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -707,7 +707,7 @@ class DiffusionEngine:
     def _dummy_run(self):
         """A dummy run to warm up the model."""
         # PipeFusion requires two sampling steps: one for the sync branch and one for the async branch.
-        num_inference_steps = 1 if getattr(self.od_config.parallel_config, "enable_pipefusion", False) else 2
+        num_inference_steps = 1 if not getattr(self.od_config.parallel_config, "enable_pipefusion", False) else 2
         height = 512
         width = 512
         prompt: OmniTextPrompt = {"prompt": "dummy run"}

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -706,7 +706,8 @@ class DiffusionEngine:
 
     def _dummy_run(self):
         """A dummy run to warm up the model."""
-        num_inference_steps = 1
+        # PipeFusion requires two sampling steps: one for the sync branch and one for the async branch.
+        num_inference_steps = 1 if getattr(self.od_config.parallel_config, "enable_pipefusion", False) else 2
         height = 512
         width = 512
         prompt: OmniTextPrompt = {"prompt": "dummy run"}

--- a/vllm_omni/diffusion/distributed/group_coordinator.py
+++ b/vllm_omni/diffusion/distributed/group_coordinator.py
@@ -123,6 +123,16 @@ class GroupCoordinator:
 
         self.device = current_omni_platform.get_torch_device(local_rank)
 
+        # Per-comm-id metadata caches for the fast path of
+        # isend_tensor_dict / irecv_tensor_dict. The first call with a given
+        # comm_id performs a full Gloo metadata exchange and stores the
+        # ``metadata_list``; subsequent calls with the same comm_id skip the
+        # Gloo round-trip and only post NCCL P2P. Callers must guarantee
+        # tensor structure is stable across calls with the same comm_id; a
+        # sender-side assert catches drift.
+        self._isend_meta_cache: dict[str, list] = {}
+        self._irecv_meta_cache: dict[str, list] = {}
+
     @property
     def first_rank(self):
         """Return the global rank of the first process in the group"""
@@ -320,7 +330,9 @@ class GroupCoordinator:
         assert dst != self.rank_in_group, "Invalid destination rank. Destination rank is the same as the current rank."
 
         # Serialize object to tensor and get the size as well
-        object_tensor = torch.frombuffer(pickle.dumps(obj), dtype=torch.uint8)
+        # use `bytearray` to avoid:
+        # `UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors`
+        object_tensor = torch.frombuffer(bytearray(pickle.dumps(obj)), dtype=torch.uint8)
 
         size_tensor = torch.tensor([object_tensor.numel()], dtype=torch.long, device="cpu")
 
@@ -433,6 +445,7 @@ class GroupCoordinator:
         self,
         tensor_dict: dict[str, torch.Tensor | Any],
         dst: int | None = None,
+        comm_id: str | None = None,
     ) -> list[torch.distributed.Work]:
         """Non-blocking send of a tensor dictionary.
 
@@ -440,6 +453,13 @@ class GroupCoordinator:
         non-blocking NCCL isend for each GPU tensor.  Returns the list of
         Work handles; the caller must call handle.wait() before the tensors
         can be safely reused or freed.
+
+        If ``comm_id`` is provided, the Gloo metadata exchange is performed
+        only on the first call with that ID; subsequent calls reuse the
+        cached metadata and skip Gloo entirely. Callers must guarantee that
+        every call with the same comm_id sends a tensor_dict with identical
+        structure (keys, shapes, dtypes, devices); a sender-side assert
+        catches drift.
 
         NOTE: `dst` is the group rank of the destination.
         """
@@ -451,7 +471,18 @@ class GroupCoordinator:
         assert dst < self.world_size, f"Invalid dst rank ({dst})"
 
         metadata_list, tensor_list = _split_tensor_dict(tensor_dict)
-        self.send_object(metadata_list, dst=dst)
+
+        if comm_id is not None and comm_id in self._isend_meta_cache:
+            cached = self._isend_meta_cache[comm_id]
+            if metadata_list != cached:
+                raise ValueError(
+                    f"isend_tensor_dict shape drift on comm_id={comm_id!r}: got {metadata_list}, cached {cached}. "
+                    "Cached comm_ids require stable tensor structure across calls."
+                )
+        else:
+            self.send_object(metadata_list, dst=dst)
+            if comm_id is not None:
+                self._isend_meta_cache[comm_id] = metadata_list
 
         handles: list[torch.distributed.Work] = []
         for tensor in tensor_list:
@@ -468,6 +499,7 @@ class GroupCoordinator:
     def irecv_tensor_dict(
         self,
         src: int | None = None,
+        comm_id: str | None = None,
     ) -> tuple[dict[str, torch.Tensor | Any], list[torch.distributed.Work], list]:
         """Non-blocking receive of a tensor dictionary.
 
@@ -475,6 +507,12 @@ class GroupCoordinator:
         non-blocking NCCL irecv for each GPU tensor.  Returns
         ``(tensor_dict, comm_handles, comm_postprocess)`` matching the
         interface expected by ``AsyncIntermediateTensors``.
+
+        If ``comm_id`` is provided, the Gloo metadata exchange is performed
+        only on the first call with that ID; subsequent calls reuse the
+        cached metadata, allocate fresh recv buffers, and post NCCL irecvs
+        directly. This makes pre-posting truly non-blocking on the CPU once
+        the cache is warm.
 
         NOTE: `src` is the group rank of the source.
         """
@@ -485,7 +523,13 @@ class GroupCoordinator:
             src = self.group_prev_rank
         assert src < self.world_size, f"Invalid src rank ({src})"
 
-        recv_metadata_list = self.recv_object(src=src)
+        if comm_id is not None and comm_id in self._irecv_meta_cache:
+            recv_metadata_list = self._irecv_meta_cache[comm_id]
+        else:
+            recv_metadata_list = self.recv_object(src=src)
+            if comm_id is not None:
+                self._irecv_meta_cache[comm_id] = recv_metadata_list
+
         tensor_dict: dict[str, Any] = {}
         handles: list[torch.distributed.Work] = []
 
@@ -689,6 +733,12 @@ class PipelineGroupCoordinator(GroupCoordinator):
 
         self.device = current_omni_platform.get_torch_device(local_rank)
 
+        # Per-comm-id metadata caches for the (i)send/recv_tensor_dict fast
+        # path. See ``GroupCoordinator.__init__`` for details. Re-initialized
+        # here because this subclass overrides __init__ without super().
+        self._isend_meta_cache: dict[str, list] = {}
+        self._irecv_meta_cache: dict[str, list] = {}
+
         self.recv_buffer_set: bool = False
         self.recv_tasks_queue: list[tuple[str, int]] = []
         self.receiving_tasks: list[tuple[torch.distributed.Work, str, int]] = []
@@ -720,6 +770,10 @@ class PipelineGroupCoordinator(GroupCoordinator):
         self.recv_skip_tasks_queue = []
         self.receiving_skip_tasks = []
         self.skip_tensor_recv_buffer = {}
+
+        # comm_id metadata caches are valid only within a single request
+        self._isend_meta_cache = {}
+        self._irecv_meta_cache = {}
 
     def set_config(self, dtype: torch.dtype):
         self.dtype = dtype

--- a/vllm_omni/diffusion/distributed/parallel_state.py
+++ b/vllm_omni/diffusion/distributed/parallel_state.py
@@ -684,6 +684,7 @@ def initialize_model_parallel(
     fully_shard_degree: int = 1,
     hsdp_replicate_size: int = 1,
     enable_expert_parallel: bool = False,
+    enable_pipefusion: bool = False,
     backend: str | None = None,
 ) -> None:
     if backend is None:
@@ -701,6 +702,7 @@ def initialize_model_parallel(
         tensor_parallel_size: number of GPUs used for tensor parallelism.
         pipeline_parallel_size: number of GPUs used for pipeline parallelism.
         fully_shard_degree: number of GPUs used for fully sharded data parallelism (HSDP shard dimension).
+        enable_pipefusion: whether to initialize PipeFusion runtime state for this topology.
         backend: distributed backend of pytorch collective comm.
 
     Let's say we have a total of 16 GPUs denoted by g0 ... g15 and we
@@ -810,6 +812,10 @@ def initialize_model_parallel(
         parallel_mode="pipeline",
     )
     vllm_parallel_state._PP = _PP
+    if enable_pipefusion:  # PipeFusion resides on top of PP
+        from vllm_omni.diffusion.distributed.pipefusion.pipefusion_runtime import initialize_pupefusion_runtime
+
+        initialize_pupefusion_runtime()
 
     global _SP
     assert _SP is None, "sequence parallel group is already initialized"

--- a/vllm_omni/diffusion/distributed/pipefusion/pipefusion.py
+++ b/vllm_omni/diffusion/distributed/pipefusion/pipefusion.py
@@ -65,6 +65,8 @@ class PipeFusionPipelineMixin(ABC):
             )
 
         if is_pipefusion_initialized():
+            runtime = get_pipefusion_runtime()
+
             init = cls.__dict__.get("__init__")
             if callable(init):
 
@@ -72,7 +74,7 @@ class PipeFusionPipelineMixin(ABC):
                 def wrapped_init(self, *args: Any, **kwargs: Any) -> None:
                     init(self, *args, **kwargs)
                     # Initialize the patch size to transformer's patch size
-                    get_pipefusion_runtime().patch_size = self.transformer_config.patch_size
+                    runtime.patch_size = self.transformer_config.patch_size
 
                 cls.__init__ = wrapped_init
 
@@ -101,13 +103,14 @@ class PipeFusionPipelineMixin(ABC):
                     dtype = bound.arguments["dtype"]
 
                     # PipeFusion: set runtime state input parameters and reset caches
-                    get_pipefusion_runtime().set_input_parameters(latents, dtype)
+                    runtime.set_input_parameters(latents, dtype)
                     self.scheduler.clear_patch_caches()
                     self._reset_pipefusion_caches()
 
-                    warmup_steps = get_pipefusion_runtime().warmup_steps
+                    warmup_steps = runtime.warmup_steps
                     warmup_timesteps = timesteps[:warmup_steps]
                     async_timesteps = timesteps[warmup_steps:] if len(timesteps) > warmup_steps else None
+                    runtime.warmup_cache_timestep = warmup_timesteps[-1]
 
                     # Call standard diffuse for warmup steps
                     bound.arguments["timesteps"] = warmup_timesteps
@@ -132,6 +135,19 @@ class PipeFusionPipelineMixin(ABC):
                     return prepare_model_kwargs(self, None, *args, **kwargs)
 
                 cls.prepare_model_kwargs = wrapped_prepare_model_kwargs
+
+            predict_noise_maybe_with_cfg = getattr(cls, "predict_noise_maybe_with_cfg", None)
+            if callable(predict_noise_maybe_with_cfg):
+
+                @wraps(predict_noise_maybe_with_cfg)
+                def wrapped_predict_noise_maybe_with_cfg(self, *args: Any, **kwargs: Any) -> Any:
+                    # Update the KV cache only during the final warmup step
+                    runtime.update_warmup_cache = not runtime.patch_mode and torch.equal(
+                        self._current_timestep, runtime.warmup_cache_timestep
+                    )
+                    return predict_noise_maybe_with_cfg(self, *args, **kwargs)
+
+                cls.predict_noise_maybe_with_cfg = wrapped_predict_noise_maybe_with_cfg
 
     @staticmethod
     def _configure_pipefusion_run(req: "OmniDiffusionRequest") -> None:

--- a/vllm_omni/diffusion/distributed/pipefusion/pipefusion.py
+++ b/vllm_omni/diffusion/distributed/pipefusion/pipefusion.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project and the xDiT authors.
+#
+# This module is adapted from xDiT (https://github.com/xdit-project/xdit)
+
+"""
+PipeFusion mixin for diffusion pipelines.
+
+Provides patch-wise pipeline parallelism for diffusion models.
+The warmup phase uses the standard denoising loop (via PipelineParallelMixin),
+and the async phase splits latents into patches and processes each patch
+through predict_noise_maybe_with_cfg + scheduler_step_maybe_with_cfg.
+"""
+
+import inspect
+from abc import ABC, abstractmethod
+from functools import wraps
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from vllm_omni.diffusion.distributed.parallel_state import (
+    get_classifier_free_guidance_world_size,
+    is_pipeline_first_stage,
+    is_pipeline_last_stage,
+)
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_runtime import (
+    get_pipefusion_runtime,
+    is_pipefusion_initialized,
+)
+from vllm_omni.diffusion.forward_context import set_forward_context_denoise_step_idx
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.request import OmniDiffusionRequest
+
+
+class PipeFusionPipelineMixin(ABC):
+    """
+    Mixin class providing PipeFusion (patch-wise + pipeline parallel) logic
+    for diffusion pipelines.
+
+    Required methods (to be implemented by subclasses):
+        - predict_noise_maybe_with_cfg(): From PipelineParallelMixin.
+        - scheduler_step_maybe_with_cfg(): From PipelineParallelMixin.
+        - prepare_model_kwargs(): Returns (positive_kwargs, negative_kwargs) for the current timestep/patch.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        from vllm_omni.diffusion.distributed.pipeline_parallel import PipelineParallelMixin
+
+        if not issubclass(cls, PipelineParallelMixin):
+            raise TypeError(
+                f"{cls.__name__} inherits PipeFusionPipelineMixin but not PipelineParallelMixin. "
+                "PipeFusion requires PipelineParallelMixin for _sync_pp_send(), "
+                "predict_noise_maybe_with_cfg(), and scheduler_step_maybe_with_cfg(). "
+                "Add PipelineParallelMixin to the base classes of your pipeline."
+            )
+
+        mro = cls.mro()
+        if mro.index(PipeFusionPipelineMixin) > mro.index(PipelineParallelMixin):
+            raise TypeError(
+                f"{cls.__name__} must inherit PipeFusionPipelineMixin before "
+                "PipelineParallelMixin so MRO selects patch-aware predict/scheduler wrappers"
+            )
+
+        if is_pipefusion_initialized():
+            init = cls.__dict__.get("__init__")
+            if callable(init):
+
+                @wraps(init)
+                def wrapped_init(self, *args: Any, **kwargs: Any) -> None:
+                    init(self, *args, **kwargs)
+                    # Initialize the patch size to transformer's patch size
+                    get_pipefusion_runtime().patch_size = self.transformer_config.patch_size
+
+                cls.__init__ = wrapped_init
+
+            forward = cls.__dict__.get("forward")
+            if callable(forward):
+
+                @wraps(forward)
+                def wrapped_forward(self, req: "OmniDiffusionRequest", *args: Any, **kwargs: Any) -> Any:
+                    # capture the number of warm-up steps and split dimension
+                    self._configure_pipefusion_run(req)
+                    return forward(self, req, *args, **kwargs)
+
+                cls.forward = wrapped_forward
+
+            diffuse = cls.__dict__.get("diffuse")
+            if callable(diffuse):
+                sig = inspect.signature(diffuse)
+
+                @wraps(diffuse)
+                def wrapped_diffuse(self, *args: Any, **kwargs: Any) -> Any:
+                    bound = sig.bind(self, *args, **kwargs)
+                    bound.apply_defaults()
+
+                    latents = bound.arguments["latents"]
+                    timesteps = bound.arguments["timesteps"]
+                    dtype = bound.arguments["dtype"]
+
+                    # PipeFusion: set runtime state input parameters and reset caches
+                    get_pipefusion_runtime().set_input_parameters(latents, dtype)
+                    self.scheduler.clear_patch_caches()
+                    self._reset_pipefusion_caches()
+
+                    warmup_steps = get_pipefusion_runtime().warmup_steps
+                    warmup_timesteps = timesteps[:warmup_steps]
+                    async_timesteps = timesteps[warmup_steps:] if len(timesteps) > warmup_steps else None
+
+                    # Call standard diffuse for warmup steps
+                    bound.arguments["timesteps"] = warmup_timesteps
+                    latents = diffuse(*bound.args, **bound.kwargs)
+
+                    if async_timesteps is not None:
+                        with self.progress_bar(total=len(async_timesteps)) as pbar:
+                            latents = self._async_pipeline(timesteps=async_timesteps, latents=latents, pbar=pbar)
+
+                    return latents
+
+                cls.diffuse = wrapped_diffuse
+
+            prepare_model_kwargs = cls.__dict__.get("prepare_model_kwargs")
+            if callable(prepare_model_kwargs):
+
+                @wraps(prepare_model_kwargs)
+                def wrapped_prepare_model_kwargs(self, latents: torch.Tensor, *args: Any, **kwargs: Any) -> Any:
+                    # Only the first PP stage consumes latents; later stages receive intermediate tensors.
+                    if is_pipeline_first_stage():
+                        return prepare_model_kwargs(self, latents, *args, **kwargs)
+                    return prepare_model_kwargs(self, None, *args, **kwargs)
+
+                cls.prepare_model_kwargs = wrapped_prepare_model_kwargs
+
+    @staticmethod
+    def _configure_pipefusion_run(req: "OmniDiffusionRequest") -> None:
+        if sampling_params := getattr(req, "sampling_params", None):
+            get_pipefusion_runtime().set_run_config(
+                warmup_steps=getattr(sampling_params, "pipefusion_warmup_steps", None),
+                split_dim=getattr(sampling_params, "pipefusion_split_dim", None),
+            )
+
+    def _reset_pipefusion_caches(self) -> None:
+        for module in self.modules():
+            if callable(reset_cache := getattr(module, "pipefusion_reset_cache", None)):
+                reset_cache()
+
+    @abstractmethod
+    def prepare_model_kwargs(
+        self,
+        latents: torch.Tensor | None,
+        timestep: torch.Tensor,
+        **extra_kwargs: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any] | None, bool, float]:
+        """
+        Prepare positive and negative kwargs for noise prediction.
+
+        Subclasses MUST implement this to provide model-specific kwargs.
+
+        Args:
+            latents: The input latents for this step/patch.
+            timestep: Current timestep tensor.
+            **extra_kwargs: Additional pipeline-specific arguments.
+
+        Returns:
+            (positive_kwargs, negative_kwargs, do_true_cfg, scale) for predict_noise_maybe_with_cfg.
+        """
+        raise NotImplementedError("Subclasses must implement prepare_model_kwargs")
+
+    def _async_pipeline(self, timesteps: torch.Tensor, latents: torch.Tensor, pbar) -> torch.Tensor | None:
+        """
+        Run the asynchronous (patched) phase of PipeFusion.
+
+        Splits latents into spatial patches and runs the standard
+        predict_noise_maybe_with_cfg + scheduler_step_maybe_with_cfg
+        loop for each patch, using PipelineParallelMixin for all inter-stage
+        communication.
+
+        Args:
+            timesteps: Timestep schedule for this phase.
+            latents: Current latents (from warmup phase).
+
+        Returns:
+            Updated latents on the first pipeline stage, None otherwise.
+        """
+        runtime = get_pipefusion_runtime()
+        runtime.set_patched_mode(patch_mode=True)
+
+        # Split latents into patches
+        split_sizes = runtime.pp_patches_height
+        split_dim = runtime.latent_split_dim
+        patch_latents = list(latents.split(split_sizes, dim=split_dim))
+        if is_pipeline_last_stage():
+            # Split scheduler caches into per-patch versions for async pipeline
+            self.scheduler.split_caches_for_patches(split_sizes, dim=split_dim)
+
+        num_patch = runtime.num_pipeline_patch
+        for i, t in enumerate(timesteps):
+            self._current_timestep = t
+            set_forward_context_denoise_step_idx(runtime.warmup_steps + i)
+
+            self._sync_pp_send()
+
+            for pidx in range(num_patch):
+                positive_kwargs, negative_kwargs, do_true_cfg, scale = self.prepare_model_kwargs(
+                    patch_latents[pidx], t, **self._pipeline_kwargs
+                )
+
+                cfg_parallel_ready = do_true_cfg and get_classifier_free_guidance_world_size() > 1
+                n_branches = 1 if (cfg_parallel_ready or not do_true_cfg) else 2
+
+                noise_pred = self.predict_noise_maybe_with_cfg(
+                    do_true_cfg=do_true_cfg,
+                    true_cfg_scale=scale,
+                    positive_kwargs=positive_kwargs,
+                    negative_kwargs=negative_kwargs,
+                    cfg_normalize=False,
+                    skip_sync=True,
+                    inter_comm_ids=[f"pf-it-{pidx}-{b}" for b in range(n_branches)],
+                )
+
+                updated_latents = self.scheduler_step_maybe_with_cfg(
+                    noise_pred,
+                    t,
+                    patch_latents[pidx],
+                    do_true_cfg,
+                    loopback_comm_id=f"pf-lb-{pidx}",
+                )
+                if updated_latents is not None:
+                    patch_latents[pidx] = updated_latents
+
+                runtime.next_patch()
+
+            pbar.update()
+
+        # Reassemble latents from patches
+        latents = torch.cat(patch_latents, dim=runtime.latent_split_dim)
+
+        # Drain outstanding non-blocking sends before any downstream
+        # consumer (e.g. VAE decode broadcast) reuses the buffers.
+        self._sync_pp_send()
+
+        runtime.set_patched_mode(patch_mode=False)
+        return latents

--- a/vllm_omni/diffusion/distributed/pipefusion/pipefusion_conv.py
+++ b/vllm_omni/diffusion/distributed/pipefusion/pipefusion_conv.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project and the xDiT authors.
+#
+# This module is adapted from xDiT (https://github.com/xdit-project/xdit)
+
+from functools import wraps
+
+import torch
+from torch.nn import functional as F
+from vllm.model_executor.layers.conv import Conv3dLayer as Conv3dLayerVLLM
+
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_runtime import (
+    get_pipefusion_runtime,
+    is_pipefusion_initialized,
+)
+
+
+class PipeFusionConvMixin:
+    """
+    Mixin for Conv layers in PipeFusion.
+
+    In patch mode, maintains an activation cache so that convolution
+    at patch boundaries can access neighboring patches' activations.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        init = getattr(cls, "__init__")
+
+        @wraps(init)
+        def wrapped_init(self, *args, **kwargs):
+            init(self, *args, **kwargs)
+            if is_pipefusion_initialized():
+                self.forward = self.pipefusion_forward
+            else:
+                self.forward = self.orig_forward
+
+        cls.__init__ = wrapped_init
+
+    def pipefusion_conv3d_enabled(self) -> bool:
+        """Whether this conv layer should use PipeFusion patch-wise execution.
+
+        Only needed when kernel != stride (overlapping convolutions that
+        require boundary data from neighbouring patches).  When kernel == stride
+        (e.g. the patch embedding), each output position depends on exactly one
+        non-overlapping input block, so the direct conv on the patch is correct.
+        """
+        runtime = get_pipefusion_runtime()
+        return runtime.patch_mode and runtime.num_pipeline_patch > 1 and self.kernel_size != self.stride
+
+    def pipefusion_reset_cache(self) -> None:
+        self.activation_cache = None
+
+    def pipefusion_conv3d_forward(self, x: torch.Tensor, dims: tuple[int, ...]) -> torch.Tensor:
+        """
+        Forward pass for Conv3d with PipeFusion patch support.
+
+        In patch mode, caches activations and performs sliced convolution
+        to handle boundary conditions correctly. Call only when
+        `pipefusion_conv3d_enabled()` returns True.
+
+        Args:
+            x: Input tensor for the current patch.
+            dims: Original full input dimensions.
+
+        Returns:
+            Convolution output for the current patch.
+        """
+        runtime = get_pipefusion_runtime()
+        if getattr(self, "activation_cache", None) is None:
+            self.activation_cache = torch.zeros(dims, dtype=x.dtype, device=x.device)
+
+        patch_idx = runtime.pipeline_patch_idx
+        start, end = runtime.pp_patches_start_end_idx[patch_idx]
+        out_start, out_end = runtime.pp_patches_post_start_end_idx[patch_idx]
+        self.activation_cache[:, :, :, start:end, :] = x
+        return self._sliced_conv3d_forward(self.activation_cache, out_start, out_end)
+
+    def _sliced_conv3d_forward(self, x: torch.Tensor, out_start: int, out_end: int) -> torch.Tensor:
+        """
+        Compute convolution on a slice of the input that produces output for [out_start:out_end].
+
+        Args:
+            x: Full input tensor with all patches cached.
+            out_start, out_end: Output slice range (post-patch space).
+        """
+        b, c, t, h, w = x.shape
+        pad_t, pad_h, pad_w = self.padding
+        stride_h = self.stride[1] if isinstance(self.stride, tuple) else self.stride
+
+        # Calculate input range needed to produce output [out_start:out_end]
+        # For strided conv: out_pos = (in_pos + pad - kernel_size) // stride + 1
+        # Inverse: in_pos = out_pos * stride - pad (approximately)
+        in_start = out_start * stride_h
+        in_end = (out_end - 1) * stride_h + self.kernel_size[1]  # Need full kernel for last output
+
+        # Expand to include padding context from neighbors
+        h_begin = max(0, in_start - pad_h)
+        h_end = min(h, in_end + pad_h)
+
+        # Determine padding needed at boundaries
+        pad_top = max(0, pad_h - in_start) if h_begin == 0 else 0
+        pad_bottom = max(0, in_end + pad_h - h) if h_end == h else 0
+
+        sliced_input = x[:, :, :, h_begin:h_end, :]
+        padded_input = F.pad(sliced_input, (pad_w, pad_w, pad_top, pad_bottom, pad_t, pad_t), mode="constant")
+
+        output = F.conv3d(
+            padded_input,
+            self.weight,
+            self.bias,
+            stride=self.stride,
+            padding="valid",
+            dilation=self.dilation,
+            groups=self.groups,
+        )
+
+        # Extract only the output rows we need (in case we computed extra)
+        expected_out_height = out_end - out_start
+        if output.shape[3] > expected_out_height:
+            output = output[:, :, :, :expected_out_height, :]
+        return output
+
+
+class Conv3dLayer(Conv3dLayerVLLM, PipeFusionConvMixin):
+    def pipefusion_forward(self, x: torch.Tensor, dims=None) -> torch.Tensor:
+        if self.pipefusion_conv3d_enabled():
+            return self.pipefusion_conv3d_forward(x, dims)
+        return super().forward(x)
+
+    def orig_forward(self, x: torch.Tensor, dims=None) -> torch.Tensor:
+        return super().forward(x)

--- a/vllm_omni/diffusion/distributed/pipefusion/pipefusion_runtime.py
+++ b/vllm_omni/diffusion/distributed/pipefusion/pipefusion_runtime.py
@@ -41,6 +41,8 @@ class PipeFusionRuntime:
         self.split_dim: Literal["height", "temporal"] = "height"
         self.cache_key: Literal["inputs", "inputs_uncond"] = "inputs"
         self.patch_idx_tensor = torch.tensor(0, dtype=torch.int32)
+        self.warmup_cache_timestep: torch.Tensor | None = None
+        self.update_warmup_cache = True
 
     def set_input_parameters(self, latents: torch.Tensor, dtype):
         self._calc_patches_metadata(latents)

--- a/vllm_omni/diffusion/distributed/pipefusion/pipefusion_runtime.py
+++ b/vllm_omni/diffusion/distributed/pipefusion/pipefusion_runtime.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project and the xDiT authors.
+#
+# This module is adapted from xDiT (https://github.com/xdit-project/xdit)
+
+"""
+PipeFusion runtime state management.
+
+Tracks patch metadata (sizes, token ranges, split dimension) and
+provides the per-patch index counter used by the pipeline, scheduler,
+and transformer mixins.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.distributed.parallel_state import get_pipeline_parallel_world_size, get_pp_group
+
+logger = init_logger(__name__)
+
+_PF_RUNTIME: PipeFusionRuntime | None = None
+
+
+class PipeFusionRuntime:
+    patch_mode: bool
+    pipeline_patch_idx: int
+    pp_patches_height: list[int] | None
+    pp_patches_start_end_idx: list[tuple[int, int]] | None
+    pp_patches_token_num: list[int] | None
+    pp_patches_token_start_end_idx: list[tuple[int, int]] | None
+
+    def __init__(self):
+        self.patch_size: tuple[int, int, int] = (1, 2, 2)
+        self.patch_mode = False
+        self.pipeline_patch_idx = 0
+        self.warmup_steps = 1
+        self.split_dim: Literal["height", "temporal"] = "height"
+        self.cache_key: Literal["inputs", "inputs_uncond"] = "inputs"
+        self.patch_idx_tensor = torch.tensor(0, dtype=torch.int32)
+
+    def set_input_parameters(self, latents: torch.Tensor, dtype):
+        self._calc_patches_metadata(latents)
+        self._reset_recv_buffer(dtype)
+
+    def set_cache_key(self, key: Literal["inputs", "inputs_uncond"]) -> None:
+        if key not in ("inputs", "inputs_uncond"):
+            raise ValueError(f"Invalid PipeFusion cache key: {key!r}. Must be 'inputs' or 'inputs_uncond'.")
+        self.cache_key = key
+
+    def set_run_config(self, warmup_steps: int | None = None, split_dim: str | None = None) -> None:
+        if warmup_steps is not None:
+            if not isinstance(warmup_steps, int) or warmup_steps < 1:
+                raise ValueError(f"PipeFusion warmup_steps must be a positive integer, got {warmup_steps!r}.")
+            self.warmup_steps = warmup_steps
+        if split_dim is not None:
+            if split_dim not in ("height", "temporal"):
+                raise ValueError(f"Invalid PipeFusion split_dim: {split_dim!r}. Must be 'height' or 'temporal'.")
+            self.split_dim = split_dim
+
+    def set_patched_mode(self, patch_mode: bool):
+        self.patch_mode = patch_mode
+        self.pipeline_patch_idx = 0
+        if hasattr(self, "patch_idx_tensor"):
+            self.patch_idx_tensor.fill_(0)
+
+    def next_patch(self):
+        if self.patch_mode:
+            self.pipeline_patch_idx += 1
+            if self.pipeline_patch_idx == self.num_pipeline_patch:
+                self.pipeline_patch_idx = 0
+        else:
+            self.pipeline_patch_idx = 0
+        if hasattr(self, "patch_idx_tensor"):
+            self.patch_idx_tensor.fill_(self.pipeline_patch_idx)
+
+    def _calc_patch_metadata(self, seq_length):
+        lengths = [seq_length // self.num_pipeline_patch] * (self.num_pipeline_patch - 1)
+        # Give more tokens to the last patch, if it's the case.
+        lengths.append(seq_length // self.num_pipeline_patch + seq_length % self.num_pipeline_patch)
+        start = 0
+        start_end_idx = []
+        for num in lengths:
+            start_end_idx.append((start, start + num))
+            start += num
+        return lengths, start_end_idx
+
+    def _calc_patches_metadata(self, latents):
+        self.num_pipeline_patch = get_pipeline_parallel_world_size()
+
+        p_t, p_h, p_w = self.patch_size
+        ppf = latents.size(-3) // p_t  # post-patch frames
+        pph = latents.size(-2) // p_h  # post-patch height (full)
+        ppw = latents.size(-1) // p_w  # post-patch width
+
+        # Store post-patch spatial dims for KV cache reshape in attention
+        self.ppf = ppf
+        self.pph = pph
+        self.ppw = ppw
+
+        # Create 1-element tensors for dynamic shape tracking
+        self.ppf_tensor = torch.tensor(ppf, dtype=torch.int64, device=latents.device)
+        self.pph_tensor = torch.tensor(pph, dtype=torch.int64, device=latents.device)
+        self.ppw_tensor = torch.tensor(ppw, dtype=torch.int64, device=latents.device)
+
+        if self.split_dim == "height":
+            # Split along spatial height
+            self.latent_split_dim = -2  # dim in 5D [B,C,T,H,W]
+
+            # Post-patch heights split among patches
+            self.pp_patches_post_height, self.pp_patches_post_start_end_idx = self._calc_patch_metadata(pph)
+            self.pp_patches_post_frames = None  # not split
+
+            # Latent-space heights (multiply by p_h to ensure divisibility)
+            self.pp_patches_height = [h * p_h for h in self.pp_patches_post_height]
+            start = 0
+            self.pp_patches_start_end_idx = []
+            for h in self.pp_patches_height:
+                self.pp_patches_start_end_idx.append((start, start + h))
+                start += h
+
+            # Token count: each patch covers all frames and widths but partial height
+            self.pp_patches_token_num = [h * ppw * ppf for h in self.pp_patches_post_height]
+
+        elif self.split_dim == "temporal":
+            # Split along temporal (frames) dimension
+            self.latent_split_dim = -3  # dim in 5D [B,C,T,H,W]
+
+            # Post-patch frames split among patches
+            self.pp_patches_post_frames, self.pp_patches_post_start_end_idx = self._calc_patch_metadata(ppf)
+            self.pp_patches_post_height = None  # not split
+
+            # Latent-space frames (multiply by p_t to ensure divisibility)
+            self.pp_patches_height = [f * p_t for f in self.pp_patches_post_frames]
+            start = 0
+            self.pp_patches_start_end_idx = []
+            for f in self.pp_patches_height:
+                self.pp_patches_start_end_idx.append((start, start + f))
+                start += f
+
+            # Token count: each patch covers all heights and widths but partial frames
+            self.pp_patches_token_num = [f * pph * ppw for f in self.pp_patches_post_frames]
+
+        else:
+            raise ValueError(f"Unknown split_dim: {self.split_dim}. Use 'height' or 'temporal'.")
+
+        # Calculate start/end indices for each patch's tokens
+        start = 0
+        self.pp_patches_token_start_end_idx = []
+        for num in self.pp_patches_token_num:
+            self.pp_patches_token_start_end_idx.append((start, start + num))
+            start += num
+
+    def _reset_recv_buffer(self, dtype):
+        get_pp_group().reset_buffer()
+        get_pp_group().set_config(dtype)
+        self.patch_idx_tensor = torch.tensor(self.pipeline_patch_idx, dtype=torch.int32, device=get_pp_group().device)
+
+
+def initialize_pupefusion_runtime():
+    global _PF_RUNTIME
+    if _PF_RUNTIME is not None:
+        RuntimeError("PipeFusion runtime is already initialized...")
+    _PF_RUNTIME = PipeFusionRuntime()
+
+
+def is_pipefusion_initialized() -> bool:
+    return _PF_RUNTIME is not None
+
+
+def get_pipefusion_runtime():
+    if _PF_RUNTIME is None:
+        raise RuntimeError("PipeFusion runtime has not been initialized.")
+    return _PF_RUNTIME
+
+
+def set_pipefusion_cache_key_if_initialized(key: Literal["inputs", "inputs_uncond"]) -> None:
+    if _PF_RUNTIME is not None:
+        _PF_RUNTIME.set_cache_key(key)

--- a/vllm_omni/diffusion/distributed/pipefusion/pipefusion_scheduler.py
+++ b/vllm_omni/diffusion/distributed/pipefusion/pipefusion_scheduler.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project and the xDiT authors.
+#
+# This module is adapted from xDiT (https://github.com/xdit-project/xdit)
+
+"""
+PipeFusion scheduler mixin for diffusion models.
+
+Provides patch-wise cache management for schedulers in PipeFusion mode:
+- Splitting scheduler state (model outputs, cached samples) into per-patch versions
+- Swapping per-patch state in/out during each scheduler step
+- Gating step-level state advancement to only the last patch
+"""
+
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, ClassVar
+
+import torch
+
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_runtime import (
+    get_pipefusion_runtime,
+    is_pipefusion_initialized,
+)
+
+
+class PipeFusionSchedulerMixin:
+    """
+    Mixin for schedulers that participate in PipeFusion patch-wise execution.
+
+    In async PipeFusion mode, the scheduler processes multiple spatial patches
+    per timestep. Each patch needs its own copy of certain scheduler state
+    (e.g., cached model outputs, previous samples) while sharing others
+    (e.g., step index, timestep list).
+
+    Subclasses declare per-patch cached attributes via `_pipefusion_patch_cache_spec`
+    and use the provided helpers to manage state during `step()`.
+    """
+
+    # Override in subclass: list of (attr_name, cache_type)
+    #   cache_type "list" = list[Tensor | None], each element split independently
+    #   cache_type "tensor" = single Tensor | None, split directly
+    _pipefusion_patch_cache_spec: ClassVar[list[tuple[str, str]]] = []
+
+    # Shared scheduler state attributes that should only advance/change on the last patch
+    _pipefusion_shared_state_attrs: ClassVar[list[str]] = [
+        "_step_index",
+        "lower_order_nums",
+        "this_order",
+    ]
+
+    # Shared list/tensor attributes that should only be updated on the first patch (patch_idx == 0)
+    _pipefusion_first_patch_only_attrs: ClassVar[list[str]] = ["timestep_list"]
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        if is_pipefusion_initialized():
+            init = cls.__dict__.get("__init__")
+            if callable(init):
+
+                @wraps(init)
+                def wrapped_init(self, *args: Any, **kwargs: Any) -> None:
+                    init(self, *args, **kwargs)
+                    self._init_patch_caches()
+
+                cls.__init__ = wrapped_init
+
+            step = cls.__dict__.get("step")
+            if callable(step):
+
+                @wraps(step)
+                def wrapped_step(self, *args: Any, **kwargs: Any) -> Any:
+                    if not get_pipefusion_runtime().patch_mode:
+                        return step(self, *args, **kwargs)
+                    return self._pipefusion_scheduler_step(step, *args, **kwargs)
+
+                cls.step = wrapped_step
+
+    def _pipefusion_scheduler_step(self, step: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Run a scheduler step with PipeFusion patch-state bookkeeping."""
+        patch_idx, is_last_patch = self._step_begin()
+
+        # Snapshot shared state to restore if not last patch
+        shared_snapshots = {}
+        for attr in getattr(self, "_pipefusion_shared_state_attrs", []):
+            if hasattr(self, attr):
+                val = getattr(self, attr)
+                shared_snapshots[attr] = val.clone() if isinstance(val, torch.Tensor) else val
+
+        # Snapshot first-patch-only state to restore if patch_idx > 0
+        first_patch_snapshots = {}
+        if patch_idx > 0:
+            for attr in getattr(self, "_pipefusion_first_patch_only_attrs", []):
+                if hasattr(self, attr):
+                    val = getattr(self, attr)
+                    if isinstance(val, list):
+                        first_patch_snapshots[attr] = list(val)
+                    elif isinstance(val, torch.Tensor):
+                        first_patch_snapshots[attr] = val.clone()
+                    else:
+                        first_patch_snapshots[attr] = val
+
+        # Run original step
+        res = step(self, *args, **kwargs)
+
+        # Save updated "tensor" caches back to patch storage
+        if self._pf_patch_caches is not None:
+            for attr_name, cache_type in self._pipefusion_patch_cache_spec:
+                if cache_type == "tensor":
+                    self._update_value(attr_name, getattr(self, attr_name))
+
+        # Restore shared state if not the last patch
+        if not is_last_patch:
+            for attr, val in shared_snapshots.items():
+                setattr(self, attr, val)
+
+        # Restore first-patch-only state if patch_idx > 0
+        if patch_idx > 0:
+            for attr, val in first_patch_snapshots.items():
+                setattr(self, attr, val)
+
+        return res
+
+    def _init_patch_caches(self) -> None:
+        """Initialize per-patch cache storage. Call during __init__."""
+        self._pf_patch_caches: dict[str, list[Any]] | None = None
+
+    def split_caches_for_patches(self, patch_sizes: list[int], dim: int = -2) -> None:
+        """
+        Split cached scheduler state into per-patch versions for async pipeline.
+
+        Called when transitioning from sync to async pipeline mode.
+        Each attribute listed in `_pipefusion_patch_cache_spec` is split
+        along the specified dimension.
+
+        Args:
+            patch_sizes: Size of each patch along the split dimension.
+            dim: Dimension along which to split (default -2 for height).
+        """
+        num_patches = get_pipefusion_runtime().num_pipeline_patch
+        self._pf_patch_caches = {}
+
+        for attr_name, cache_type in self._pipefusion_patch_cache_spec:
+            value = getattr(self, attr_name)
+
+            if cache_type == "list":
+                # list[Tensor | None] — split each non-None element
+                per_patch: list[list[torch.Tensor | None]] = []
+                for patch_idx in range(num_patches):
+                    patch_list: list[torch.Tensor | None] = []
+                    for item in value:
+                        if item is not None:
+                            splits = item.split(patch_sizes, dim=dim)
+                            patch_list.append(splits[patch_idx])
+                        else:
+                            patch_list.append(None)
+                    per_patch.append(patch_list)
+                self._pf_patch_caches[attr_name] = per_patch
+
+            elif cache_type == "tensor":
+                # single Tensor | None — split directly
+                if value is not None:
+                    splits = value.split(patch_sizes, dim=dim)
+                    self._pf_patch_caches[attr_name] = list(splits)
+                else:
+                    self._pf_patch_caches[attr_name] = [None] * num_patches
+
+    def clear_patch_caches(self) -> None:
+        """Clear per-patch caches when exiting async pipeline mode."""
+        self._pf_patch_caches = None
+
+    def _step_begin(self) -> tuple[int, bool]:
+        """
+        Begin a scheduler step: get patch context and load per-patch state.
+
+        Combines patch context lookup and state loading into a single call.
+        In patch mode, swaps cached attributes to the current patch's versions.
+
+        Returns:
+            (patch_idx, is_last_patch) tuple:
+            - patch_idx: Current patch index (0 if not in patch mode).
+            - is_last_patch: Whether this is the last patch in the sequence.
+        """
+        runtime_state = get_pipefusion_runtime()
+
+        patch_idx, is_last_patch = 0, True
+        if runtime_state.patch_mode and self._pf_patch_caches is not None:
+            patch_idx = runtime_state.pipeline_patch_idx
+            is_last_patch = patch_idx == runtime_state.num_pipeline_patch - 1
+
+            for attr_name, _ in self._pipefusion_patch_cache_spec:
+                if attr_name in self._pf_patch_caches:
+                    setattr(self, attr_name, self._pf_patch_caches[attr_name][patch_idx])
+
+        return patch_idx, is_last_patch
+
+    def _update_value(self, attr_name: str, value: Any) -> None:
+        """
+        Save a value back to the per-patch cache.
+
+        Needed for "tensor" caches where assignment rebinds the attribute
+        rather than mutating it in-place. "list" caches that are mutated
+        in-place (e.g., shifting elements) are updated automatically since
+        `_step_begin` sets self.attr to the actual list object.
+
+        Args:
+            attr_name: Name of the cached attribute.
+            value: The value to save.
+        """
+        runtime_state = get_pipefusion_runtime()
+
+        if self._pf_patch_caches is not None and attr_name in self._pf_patch_caches:
+            patch_mode = runtime_state.patch_mode
+            patch_idx = runtime_state.pipeline_patch_idx if patch_mode else 0
+            self._pf_patch_caches[attr_name][patch_idx] = value

--- a/vllm_omni/diffusion/distributed/pipefusion/pipefusion_transformer.py
+++ b/vllm_omni/diffusion/distributed/pipefusion/pipefusion_transformer.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project and the xDiT authors.
+#
+# This module is adapted from xDiT (https://github.com/xdit-project/xdit)
+
+from abc import ABC, abstractmethod
+from functools import wraps
+from typing import Literal
+
+import torch
+
+from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_runtime import (
+    get_pipefusion_runtime,
+    is_pipefusion_initialized,
+)
+
+PipeFusionCacheKey = Literal["inputs", "inputs_uncond"]
+
+
+class PipeFusionRotaryEmbeddingMixin(ABC):
+    """
+    Mixin for rotary embedding modules that need PipeFusion patch slicing.
+
+    The owning RoPE module computes and caches full-resolution embeddings;
+    this mixin only slices the returned embedding during PipeFusion patch mode.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        forward = cls.__dict__.get("forward")
+        if callable(forward) and is_pipefusion_initialized():  # if PipeFusion is initialized
+
+            @wraps(forward)
+            def wrapped_forward(self, *args, **kwargs):
+                rotary_emb = forward(self, *args, **kwargs)
+                if not get_pipefusion_runtime().patch_mode:
+                    return rotary_emb
+                return self.pipefusion_slice_rotary_emb(rotary_emb, *args, **kwargs)
+
+            cls.forward = wrapped_forward
+
+    @staticmethod
+    def _slice_rope(
+        re: torch.Tensor,
+        split_dim: int,
+        dim_size: int,
+        num_pipeline_patch: int,
+        patch_idx: torch.Tensor,
+    ) -> torch.Tensor:
+        base_patch_size = dim_size // num_pipeline_patch
+        start = patch_idx * base_patch_size
+        is_last = patch_idx == num_pipeline_patch - 1
+        length = base_patch_size + is_last * (dim_size - start - base_patch_size)
+        re = torch.narrow(re, split_dim, start, length)
+        # Reshape back to [1, seq, 1, dim]
+        return re.reshape(1, -1, 1, re.shape[-1])
+
+    def pipefusion_slice_rotary_emb(
+        self,
+        rotary_emb: tuple[torch.Tensor, torch.Tensor],
+        num_frames: int,
+        height: int,
+        width: int,
+        *args,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Slice RoPE embeddings to match the current PipeFusion patch.
+
+        Only applies when PipeFusion is in patched mode; otherwise returns
+        the embeddings unchanged.
+
+        Returns:
+            Sliced RoPE tuple for the current patch.
+        """
+        runtime = get_pipefusion_runtime()
+
+        cache_key = (runtime.pipeline_patch_idx, num_frames, height, width)
+        if not hasattr(self, "_cached_sliced_rope"):
+            self._cached_sliced_rope = {}
+        if cache_key in self._cached_sliced_rope:
+            return self._cached_sliced_rope[cache_key]
+
+        p_t, p_h, p_w = self.patch_size
+        ppf, pph, ppw = num_frames // p_t, height // p_h, width // p_w
+        num_pipeline_patch = runtime.num_pipeline_patch
+        patch_idx = runtime.patch_idx_tensor
+
+        if runtime.split_dim == "temporal":
+            split_dim = 0
+            dim_size = ppf
+        else:
+            split_dim = 1
+            dim_size = pph
+
+        self._cached_sliced_rope[cache_key] = tuple(
+            # [1, ppf*pph*ppw, 1, dim] -> [ppf, pph, ppw, dim]
+            self._slice_rope(re.reshape(ppf, pph, ppw, -1), split_dim, dim_size, num_pipeline_patch, patch_idx)
+            for re in rotary_emb
+        )
+        return self._cached_sliced_rope[cache_key]
+
+
+class PipeFusionSelfAttentionMixin(ABC):
+    """
+    Mixin for self-attention modules in PipeFusion.
+
+    In patch mode, maintains full K/V caches across patches so that
+    each patch's query can attend to the full sequence.
+
+    Maintains separate KV caches for conditional ("inputs") and
+    unconditional ("inputs_uncond") predictions to prevent CFG
+    negative predictions from contaminating the conditional cache.
+    The active cache is selected from the PipeFusion runtime state so CFG
+    positive and negative branches do not share K/V buffers.
+    """
+
+    _kv_caches: dict[PipeFusionCacheKey, tuple[torch.Tensor, torch.Tensor]]
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        init = cls.__dict__.get("__init__")
+        if is_pipefusion_initialized() and callable(init):
+
+            @wraps(init)
+            def wrapped_init(self, *args, **kwargs):
+                init(self, *args, **kwargs)
+                for module in self.modules():
+                    if isinstance(module, Attention):
+                        self._pipefusion_patch_attention(module)
+
+            cls.__init__ = wrapped_init
+
+    def _pipefusion_patch_attention(self, attention: Attention):
+        original_forward = attention.forward
+
+        def pipefusion_forward(
+            query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, attn_metadata=None
+        ) -> torch.Tensor:
+            key, value = self._pipefusion_update_kv_cache(key, value)
+            return original_forward(query, key, value, attn_metadata)
+
+        attention.forward = pipefusion_forward
+
+    def pipefusion_reset_cache(self) -> None:
+        self._kv_caches = {}
+
+    def _get_kv_cache(self, cache_key: PipeFusionCacheKey) -> tuple[torch.Tensor, torch.Tensor]:
+        if cache_key not in self._kv_caches:
+            raise RuntimeError(
+                f"PipeFusion KV cache for {cache_key!r} is missing. "
+                "Run at least one warmup step before patched execution."
+            )
+        return self._kv_caches[cache_key]
+
+    def _set_kv_cache(self, cache_key: PipeFusionCacheKey, k: torch.Tensor, v: torch.Tensor):
+        """Store the KV cache for the given correction key."""
+        self._kv_caches[cache_key] = (k, v)
+
+    def _pipefusion_update_kv_cache(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Update and return full K/V for the current patch.
+
+        In patch mode, inserts the current patch's K/V into the full cache
+        and returns the full K/V. In non-patch mode, just stores K/V directly.
+
+        Uses the parent transformer's ``cache_key`` to select between
+        separate conditional / unconditional KV caches, preventing the CFG
+        negative prediction from overwriting the conditional cache.
+
+        The token sequence is flattened as [frames, height, width], so
+        height-based patches are NOT contiguous in the flat sequence.
+        We reshape to 5D [B, ppf, pph, ppw, heads, dim] to write
+        at the correct height positions via view-based slicing.
+
+        Args:
+            key: Current patch's key tensor [B, patch_seq, heads, dim].
+            value: Current patch's value tensor [B, patch_seq, heads, dim].
+
+        Returns:
+            (full_key, full_value) for attention computation.
+        """
+        runtime = get_pipefusion_runtime()
+        if runtime.patch_mode:
+            full_k, full_v = self._get_kv_cache(runtime.cache_key)
+            ppf = runtime.ppf
+            pph = runtime.pph
+            ppw = runtime.ppw
+            num_pipeline_patch = runtime.num_pipeline_patch
+            patch_idx = runtime.patch_idx_tensor
+            B, _, heads, dim = key.shape
+
+            if runtime.split_dim == "temporal":
+                base_patch_size = ppf // num_pipeline_patch
+                patch_start = patch_idx * base_patch_size
+                is_last = patch_idx == num_pipeline_patch - 1
+                patch_end = patch_start + base_patch_size + is_last * (ppf - patch_start - base_patch_size)
+
+                # Temporal split: tokens are contiguous in [f, h, w] order
+                # because frames are the outermost dimension.
+                # Patch covers f∈[f_start, f_end), token range is contiguous.
+                tok_start = patch_start * pph * ppw
+                tok_end = patch_end * pph * ppw
+                tok_len = tok_end - tok_start
+                full_k.narrow(1, tok_start, tok_len).copy_(key)
+                full_v.narrow(1, tok_start, tok_len).copy_(value)
+            else:
+                base_patch_size = pph // num_pipeline_patch
+                patch_start = patch_idx * base_patch_size
+                is_last = patch_idx == num_pipeline_patch - 1
+                patch_end = patch_start + base_patch_size + is_last * (pph - patch_start - base_patch_size)
+
+                # Height split: tokens are NON-contiguous (interleaved by frames).
+                # Reshape to 5D [B, ppf, pph, ppw, heads, dim] and slice height.
+                pph_patch = patch_end - patch_start
+                key_5d = key.reshape(B, ppf, pph_patch, ppw, heads, dim)
+                value_5d = value.reshape(B, ppf, pph_patch, ppw, heads, dim)
+                full_k_5d = full_k.view(B, ppf, pph, ppw, heads, dim)
+                full_v_5d = full_v.view(B, ppf, pph, ppw, heads, dim)
+                patch_len = patch_end - patch_start
+                full_k_5d.narrow(2, patch_start, patch_len).copy_(key_5d)
+                full_v_5d.narrow(2, patch_start, patch_len).copy_(value_5d)
+
+            return full_k, full_v
+        else:
+            self._set_kv_cache(runtime.cache_key, key, value)
+            return key, value
+
+
+class PipeFusionTransformerMixin(ABC):
+    """
+    Mixin for transformer models that participate in PipeFusion.
+
+    Provides helper methods for:
+    1. Slicing RoPE embeddings to match the current patch
+    2. Conditional patch embedding (first stage) and output projection (last stage)
+    3. Pipeline-parallel weight loading with block index remapping
+
+    Models using this mixin should call these helpers from their forward() method
+    instead of inlining the PipeFusion logic.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        unpatchify = getattr(cls, "_unpatchify", None)
+        if not callable(unpatchify):
+            raise TypeError(f"{cls.__name__} must define _unpatchify() to use PipeFusionTransformerMixin")
+
+        if is_pipefusion_initialized():
+
+            @wraps(unpatchify)
+            def wrapped_unpatchify(self, hidden_states: torch.Tensor, dims: tuple[int, int, int, int, int]):
+                if not get_pipefusion_runtime().patch_mode:
+                    return unpatchify(self, hidden_states, dims)
+                return self.pipefusion_unpatchify(hidden_states, dims)
+
+            cls._unpatchify = wrapped_unpatchify
+
+    @abstractmethod
+    def _unpatchify(self, hidden_states: torch.Tensor, dims: tuple[int, ...]) -> torch.Tensor:
+        """REQUIRED: Implementation that reshapes tokens back to image/video space."""
+        pass
+
+    @staticmethod
+    def pipefusion_get_post_patch_height(height: int, patch_height: int) -> int:
+        """
+        Get the post-patch height for the current pipeline stage.
+
+        In height-split mode, returns the height of the current patch;
+        in temporal-split mode or non-patch mode, returns the full post-patch height.
+        """
+        runtime = get_pipefusion_runtime()
+        if runtime.split_dim == "height":
+            base_size = height // patch_height
+            num_pipeline_patch = runtime.num_pipeline_patch
+            patch_idx = runtime.patch_idx_tensor
+            p_size = base_size // num_pipeline_patch
+            start = patch_idx * p_size
+            is_last = patch_idx == num_pipeline_patch - 1
+            return p_size + is_last * (base_size - start - p_size)
+        return height // patch_height
+
+    @staticmethod
+    def pipefusion_get_post_patch_num_frames(num_frames: int, patch_frames: int) -> int:
+        """
+        Get the post-patch frame count for the current pipeline stage.
+
+        In temporal-split mode, returns the frame count of the current patch;
+        in height-split mode or non-patch mode, returns the full post-patch frame count.
+        """
+        runtime = get_pipefusion_runtime()
+        if runtime.split_dim == "temporal":
+            base_size = num_frames // patch_frames
+            num_pipeline_patch = runtime.num_pipeline_patch
+            patch_idx = runtime.patch_idx_tensor
+            p_size = base_size // num_pipeline_patch
+            start = patch_idx * p_size
+            is_last = patch_idx == num_pipeline_patch - 1
+            return p_size + is_last * (base_size - start - p_size)
+        return num_frames // patch_frames
+
+    def pipefusion_unpatchify(self, hidden_states: torch.Tensor, dims: tuple[int, int, int, int, int]) -> torch.Tensor:
+        batch_size, _, num_frames, height, width = dims
+        p_t, p_h, p_w = self.config.patch_size
+        hidden_states = hidden_states.reshape(
+            batch_size,
+            self.pipefusion_get_post_patch_num_frames(num_frames, p_t),
+            self.pipefusion_get_post_patch_height(height, p_h),
+            width // p_w,
+            p_t,
+            p_h,
+            p_w,
+            -1,
+        )
+        hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
+        return hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)

--- a/vllm_omni/diffusion/distributed/pipefusion/pipefusion_transformer.py
+++ b/vllm_omni/diffusion/distributed/pipefusion/pipefusion_transformer.py
@@ -230,7 +230,8 @@ class PipeFusionSelfAttentionMixin(ABC):
 
             return full_k, full_v
         else:
-            self._set_kv_cache(runtime.cache_key, key, value)
+            if runtime.update_warmup_cache:
+                self._set_kv_cache(runtime.cache_key, key, value)
             return key, value
 
 

--- a/vllm_omni/diffusion/distributed/pipeline_parallel.py
+++ b/vllm_omni/diffusion/distributed/pipeline_parallel.py
@@ -15,6 +15,7 @@ from vllm_omni.diffusion.distributed.parallel_state import (
     get_pp_group,
     is_pipeline_first_stage,
 )
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_runtime import set_pipefusion_cache_key_if_initialized
 
 
 class AsyncLatents:
@@ -184,6 +185,8 @@ class PipelineParallelMixin:
         negative_kwargs: dict[str, Any] | None,
         cfg_normalize: bool = True,
         output_slice: int | None = None,
+        skip_sync: bool = False,
+        inter_comm_ids: list[str] | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, ...] | None:
         """
         Drop-in replacement for predict_noise_maybe_with_cfg that also handles PP.
@@ -205,34 +208,49 @@ class PipelineParallelMixin:
                 do_true_cfg, true_cfg_scale, positive_kwargs, negative_kwargs, cfg_normalize, output_slice
             )
 
-        self._sync_pp_send()
+        # skip_sync: when processing a sequence in patches, deferring the sync
+        # allows inter-stage sends of one patch to overlap with compute on the next.
+        if not skip_sync:
+            self._sync_pp_send()
 
         pp_group = get_pp_group()
 
         cfg_parallel_ready = do_true_cfg and get_classifier_free_guidance_world_size() > 1
         if cfg_parallel_ready:
             # Each PP pipeline carries exactly one CFG branch determined by cfg_rank.
-            all_kwargs = [positive_kwargs if get_classifier_free_guidance_rank() == 0 else negative_kwargs]
+            cfg_rank = get_classifier_free_guidance_rank()
+            all_kwargs = [positive_kwargs if cfg_rank == 0 else negative_kwargs]
+            # keep the branch name for PipeFusion to cache KV values
+            cache_keys = ["inputs" if cfg_rank == 0 else "inputs_uncond"]
         else:
             # Sequential CFG (or no CFG): this PP pipeline handles all branches.
             all_kwargs = [positive_kwargs] + ([negative_kwargs] if do_true_cfg else [])
+            # keep the branch name for PipeFusion to cache KV values
+            cache_keys = ["inputs"] + (["inputs_uncond"] if do_true_cfg else [])
 
         # Non-first ranks receive intermediate tensors asynchronously
         n = len(all_kwargs)
+        if inter_comm_ids is None:
+            inter_comm_ids = [None] * n
+        if len(inter_comm_ids) != n:
+            raise ValueError(f"inter_comm_ids has length {len(inter_comm_ids)} but expected {n}")
         its: list[AsyncIntermediateTensors | None] = [None] * n
         if not pp_group.is_first_rank:
-            for i in range(n):
-                its[i] = AsyncIntermediateTensors(*pp_group.irecv_tensor_dict())
+            its = [AsyncIntermediateTensors(*pp_group.irecv_tensor_dict(comm_id=inter_comm_ids[i])) for i in range(n)]
 
         if not pp_group.is_last_rank:
             # First / middle rank: run partial forwards and propagate ITs downstream.
-            for kwargs, it in zip(all_kwargs, its):
+            for kwargs, it, cid, cache_key in zip(all_kwargs, its, inter_comm_ids, cache_keys):
+                set_pipefusion_cache_key_if_initialized(cache_key)
                 result = self.predict_noise(**kwargs, intermediate_tensors=it)
-                self._pp_send_work.extend(pp_group.isend_tensor_dict(result.tensors))
+                self._pp_send_work.extend(pp_group.isend_tensor_dict(result.tensors, comm_id=cid))
             return None
 
         # Last rank: run full forward
-        noise_preds = [self.predict_noise(**kwargs, intermediate_tensors=it) for kwargs, it in zip(all_kwargs, its)]
+        noise_preds = []
+        for kwargs, it, cache_key in zip(all_kwargs, its, cache_keys):
+            set_pipefusion_cache_key_if_initialized(cache_key)
+            noise_preds.append(self.predict_noise(**kwargs, intermediate_tensors=it))
 
         if cfg_parallel_ready:
             # All-gather the single-branch prediction across the CFG group and combine
@@ -263,6 +281,7 @@ class PipelineParallelMixin:
         do_true_cfg: bool,
         per_request_scheduler: Any | None = None,
         generator: torch.Generator | None = None,
+        loopback_comm_id: str | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, ...] | AsyncLatents:
         """
         Drop-in replacement for scheduler_step_maybe_with_cfg that also handles PP.
@@ -285,7 +304,7 @@ class PipelineParallelMixin:
             latents = super().scheduler_step_maybe_with_cfg(
                 noise_pred, t, latents, do_true_cfg, per_request_scheduler, generator
             )
-            self._pp_send_work = pp_group.isend_tensor_dict({"latents": latents}, dst=0)
+            self._pp_send_work.extend(pp_group.isend_tensor_dict({"latents": latents}, dst=0, comm_id=loopback_comm_id))
         elif pp_group.is_first_rank:
-            latents = AsyncLatents(*pp_group.irecv_tensor_dict(src=pp_group.world_size - 1))
+            latents = AsyncLatents(*pp_group.irecv_tensor_dict(src=pp_group.world_size - 1, comm_id=loopback_comm_id))
         return latents

--- a/vllm_omni/diffusion/models/schedulers/scheduling_flow_unipc_multistep.py
+++ b/vllm_omni/diffusion/models/schedulers/scheduling_flow_unipc_multistep.py
@@ -14,7 +14,7 @@ providing faster convergence than simple Euler methods while maintaining quality
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import Any, ClassVar
 
 import numpy as np
 import torch
@@ -22,10 +22,11 @@ from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.schedulers.scheduling_utils import KarrasDiffusionSchedulers, SchedulerMixin, SchedulerOutput
 from diffusers.utils import deprecate
 
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_scheduler import PipeFusionSchedulerMixin
 from vllm_omni.diffusion.models.schedulers.base import BaseScheduler
 
 
-class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
+class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, PipeFusionSchedulerMixin, BaseScheduler):
     """
     `FlowUniPCMultistepScheduler` is a training-free framework designed for the fast sampling of
     flow-matching diffusion models.
@@ -66,6 +67,11 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin, BaseScheduler):
             The final `sigma` value for the noise schedule. Either `"zero"` or `"sigma_min"`.
     """
 
+    # PipeFusion: declare which attributes need per-patch caching
+    _pipefusion_patch_cache_spec: ClassVar[list[tuple[str, str]]] = [
+        ("model_outputs", "list"),
+        ("last_sample", "tensor"),
+    ]
     _compatibles = [e.name for e in KarrasDiffusionSchedulers]
     order = 1
 

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -22,6 +22,7 @@ from vllm.sequence import IntermediateTensors
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import DistributedAutoencoderKLWan
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion import PipeFusionPipelineMixin
 from vllm_omni.diffusion.distributed.pipeline_parallel import AsyncLatents, PipelineParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.forward_context import set_forward_context_denoise_step_idx
@@ -257,7 +258,12 @@ def get_wan22_pre_process_func(
 
 
 class Wan22Pipeline(
-    nn.Module, PipelineParallelMixin, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin
+    nn.Module,
+    PipeFusionPipelineMixin,
+    PipelineParallelMixin,
+    CFGParallelMixin,
+    ProgressBarMixin,
+    DiffusionPipelineProfilerMixin,
 ):
     def __init__(
         self,
@@ -445,75 +451,29 @@ class Wan22Pipeline(
     ) -> torch.Tensor | AsyncLatents:
         if attention_kwargs is None:
             attention_kwargs = {}
+
+        self._pipeline_kwargs = dict(
+            original_dims=latents.shape,
+            boundary_timestep=boundary_timestep,
+            latent_condition=latent_condition,
+            first_frame_mask=first_frame_mask,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            attention_kwargs=attention_kwargs,
+            dtype=dtype,
+            guidance_low=guidance_low,
+            guidance_high=guidance_high,
+        )
+
+        # Standard denoising loop
         with self.progress_bar(total=len(timesteps)) as pbar:
             for step_idx, t in enumerate(timesteps):
                 self._current_timestep = t
                 set_forward_context_denoise_step_idx(step_idx)
 
-                # Select model based on timestep and boundary_ratio
-                # High noise stage (t >= boundary_timestep): use transformer
-                # Low noise stage (t < boundary_timestep): use transformer_2
-                if boundary_timestep is not None and t < boundary_timestep:
-                    # Low noise stage - always use guidance_high for this stage
-                    current_guidance_scale = guidance_high
-                    if self.transformer_2 is not None:
-                        current_model = self.transformer_2
-                    elif self.transformer is not None:
-                        # Fallback to transformer if transformer_2 not loaded
-                        current_model = self.transformer
-                    else:
-                        raise RuntimeError("No transformer available for low-noise stage")
-                else:
-                    # High noise stage - always use guidance_low for this stage
-                    current_guidance_scale = guidance_low
-                    if self.transformer is not None:
-                        current_model = self.transformer
-                    elif self.transformer_2 is not None:
-                        # Fallback to transformer_2 if transformer not loaded
-                        current_model = self.transformer_2
-                    else:
-                        raise RuntimeError("No transformer available for high-noise stage")
-
-                if self.expand_timesteps and latent_condition is not None:
-                    # I2V mode: blend condition with latents using mask
-                    latent_model_input = (1 - first_frame_mask) * latent_condition + first_frame_mask * latents
-                    latent_model_input = latent_model_input.to(dtype)
-
-                    # Expand timesteps per patch - use floor division to match patch embedding
-                    patch_size = self.transformer_config.patch_size
-                    patch_height = latents.shape[3] // patch_size[1]
-                    patch_width = latents.shape[4] // patch_size[2]
-
-                    # Create mask at patch resolution (same as hidden states sequence length)
-                    patch_mask = first_frame_mask[:, :, :, :: patch_size[1], :: patch_size[2]]
-                    patch_mask = patch_mask[:, :, :, :patch_height, :patch_width]  # Ensure correct dimensions
-                    temp_ts = (patch_mask[0][0] * t).flatten()
-                    timestep = temp_ts.unsqueeze(0).expand(latents.shape[0], -1)
-                else:
-                    # T2V mode: standard forward
-                    latent_model_input = latents.to(dtype)
-                    timestep = t.expand(latents.shape[0])
-
-                do_true_cfg = current_guidance_scale > 1.0 and negative_prompt_embeds is not None
-                positive_kwargs = {
-                    "hidden_states": latent_model_input,
-                    "timestep": timestep,
-                    "encoder_hidden_states": prompt_embeds,
-                    "attention_kwargs": attention_kwargs,
-                    "return_dict": False,
-                    "current_model": current_model,
-                }
-                if do_true_cfg:
-                    negative_kwargs = {
-                        "hidden_states": latent_model_input,
-                        "timestep": timestep,
-                        "encoder_hidden_states": negative_prompt_embeds,
-                        "attention_kwargs": attention_kwargs,
-                        "return_dict": False,
-                        "current_model": current_model,
-                    }
-                else:
-                    negative_kwargs = None
+                positive_kwargs, negative_kwargs, do_true_cfg, current_guidance_scale = self.prepare_model_kwargs(
+                    latents, t, **self._pipeline_kwargs
+                )
 
                 noise_pred = self.predict_noise_maybe_with_cfg(
                     do_true_cfg=do_true_cfg,
@@ -859,6 +819,82 @@ class Wan22Pipeline(
             current_model = self.transformer
         result = current_model(**kwargs)
         return result if isinstance(result, IntermediateTensors) else result[0]
+
+    def prepare_model_kwargs(
+        self,
+        latents: torch.Tensor | None,
+        t: torch.Tensor,
+        *,
+        original_dims: torch.Size,
+        boundary_timestep: float | None,
+        latent_condition: torch.Tensor | None,
+        first_frame_mask: torch.Tensor | None,
+        prompt_embeds: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor | None,
+        attention_kwargs: dict[str, Any],
+        dtype: torch.dtype,
+        guidance_low: float,
+        guidance_high: float,
+    ) -> tuple[dict[str, Any], dict[str, Any] | None, bool, float]:
+        """Prepare positive and negative kwargs for noise prediction."""
+
+        # Select model based on timestep and boundary_ratio
+        # High noise stage (t >= boundary_timestep): use transformer
+        # Low noise stage (t < boundary_timestep): use transformer_2
+        if boundary_timestep is not None and t < boundary_timestep:
+            # Low noise stage - always use guidance_high for this stage
+            current_guidance_scale = guidance_high
+            current_model = self.transformer_2 if self.transformer_2 is not None else self.transformer
+        else:
+            # High noise stage - always use guidance_low for this stage
+            current_guidance_scale = guidance_low
+            current_model = self.transformer if self.transformer is not None else self.transformer_2
+        if current_model is None:
+            raise ValueError("Both transformer and transformer_2 are None")
+
+        if latents is not None:
+            # I2V mode: only first stage blends condition with latents using mask
+            if self.expand_timesteps and latent_condition is not None:
+                latents = ((1 - first_frame_mask) * latent_condition + first_frame_mask * latents).to(dtype)
+            else:  # T2V mode: standard forward
+                latents = latents.to(dtype)
+
+        if self.expand_timesteps and latent_condition is not None:
+            # Expand timesteps per patch - use floor division to match patch embedding
+            patch_size = self.transformer_config.patch_size
+            patch_height = original_dims[3] // patch_size[1]
+            patch_width = original_dims[4] // patch_size[2]
+
+            # Create mask at patch resolution (same as hidden states sequence length)
+            patch_mask = first_frame_mask[:, :, :, :: patch_size[1], :: patch_size[2]]
+            patch_mask = patch_mask[:, :, :, :patch_height, :patch_width]  # Ensure correct dimensions
+            temp_ts = (patch_mask[0][0] * t).flatten()
+            timestep = temp_ts.unsqueeze(0).expand(original_dims[0], -1)
+        else:
+            timestep = t.expand(original_dims[0])
+
+        do_true_cfg = current_guidance_scale > 1.0 and negative_prompt_embeds is not None
+        positive_kwargs = {
+            "hidden_states": latents,
+            "timestep": timestep,
+            "encoder_hidden_states": prompt_embeds,
+            "attention_kwargs": attention_kwargs,
+            "return_dict": False,
+            "current_model": current_model,
+            "dims": original_dims,
+        }
+        negative_kwargs = None
+        if do_true_cfg:
+            negative_kwargs = {
+                "hidden_states": latents,
+                "timestep": timestep,
+                "encoder_hidden_states": negative_prompt_embeds,
+                "attention_kwargs": attention_kwargs,
+                "return_dict": False,
+                "current_model": current_model,
+                "dims": original_dims,
+            }
+        return positive_kwargs, negative_kwargs, do_true_cfg, current_guidance_scale
 
     def encode_prompt(
         self,

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -22,6 +22,7 @@ from vllm.sequence import IntermediateTensors
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import DistributedAutoencoderKLWan
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion import PipeFusionPipelineMixin
 from vllm_omni.diffusion.distributed.pipeline_parallel import AsyncLatents, PipelineParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.forward_context import set_forward_context_denoise_step_idx
@@ -139,6 +140,7 @@ def get_wan22_i2v_pre_process_func(
 class Wan22I2VPipeline(
     nn.Module,
     SupportImageInput,
+    PipeFusionPipelineMixin,
     PipelineParallelMixin,
     CFGParallelMixin,
     ProgressBarMixin,
@@ -300,6 +302,7 @@ class Wan22I2VPipeline(
         self._guidance_scale_2 = None
         self._num_timesteps = None
         self._current_timestep = None
+
         self.setup_diffusion_pipeline_profiler(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
         )
@@ -337,56 +340,30 @@ class Wan22I2VPipeline(
     ) -> torch.Tensor | AsyncLatents:
         if attention_kwargs is None:
             attention_kwargs = {}
+
+        self._pipeline_kwargs = dict(
+            original_dims=latents.shape,
+            boundary_timestep=boundary_timestep,
+            condition=condition,
+            first_frame_mask=first_frame_mask,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            image_embeds=image_embeds,
+            attention_kwargs=attention_kwargs,
+            dtype=dtype,
+            guidance_low=guidance_low,
+            guidance_high=guidance_high,
+        )
+
+        # Standard denoising loop
         with self.progress_bar(total=len(timesteps)) as pbar:
             for step_idx, t in enumerate(timesteps):
                 self._current_timestep = t
-
-                # Select model and guidance scale based on timestep
-                current_model = self.transformer
-                current_guidance_scale = guidance_low
-                if boundary_timestep is not None and t < boundary_timestep and self.transformer_2 is not None:
-                    current_model = self.transformer_2
-                    current_guidance_scale = guidance_high
-
                 set_forward_context_denoise_step_idx(step_idx)
 
-                # Prepare latent input
-                if self.expand_timesteps:
-                    # TI2V-5B style: blend condition with latents using mask
-                    latent_model_input = (1 - first_frame_mask) * condition + first_frame_mask * latents
-                    latent_model_input = latent_model_input.to(dtype)
-
-                    # Expand timesteps for each patch
-                    temp_ts = (first_frame_mask[0][0][:, ::2, ::2] * t).flatten()
-                    timestep = temp_ts.unsqueeze(0).expand(latents.shape[0], -1)
-                else:
-                    # Wan2.1 style: concatenate condition with latents
-                    latent_model_input = torch.cat([latents, condition], dim=1).to(dtype)
-                    timestep = t.expand(latents.shape[0])
-
-                do_true_cfg = current_guidance_scale > 1.0 and negative_prompt_embeds is not None
-                # Prepare kwargs for positive and negative predictions
-                positive_kwargs = {
-                    "hidden_states": latent_model_input,
-                    "timestep": timestep,
-                    "encoder_hidden_states": prompt_embeds,
-                    "encoder_hidden_states_image": image_embeds,
-                    "attention_kwargs": attention_kwargs,
-                    "return_dict": False,
-                    "current_model": current_model,
-                }
-                if do_true_cfg:
-                    negative_kwargs = {
-                        "hidden_states": latent_model_input,
-                        "timestep": timestep,
-                        "encoder_hidden_states": negative_prompt_embeds,
-                        "encoder_hidden_states_image": image_embeds,
-                        "attention_kwargs": attention_kwargs,
-                        "return_dict": False,
-                        "current_model": current_model,
-                    }
-                else:
-                    negative_kwargs = None
+                positive_kwargs, negative_kwargs, do_true_cfg, current_guidance_scale = self.prepare_model_kwargs(
+                    latents, t, **self._pipeline_kwargs
+                )
 
                 # Predict noise with automatic CFG parallel handling
                 noise_pred = self.predict_noise_maybe_with_cfg(
@@ -736,6 +713,70 @@ class Wan22I2VPipeline(
             current_model = self.transformer
         result = current_model(**kwargs)
         return result if isinstance(result, IntermediateTensors) else result[0]
+
+    def prepare_model_kwargs(
+        self,
+        latents: torch.Tensor | None,
+        t: torch.Tensor,
+        *,
+        original_dims: torch.Size,
+        boundary_timestep: float | None,
+        condition: torch.Tensor,
+        first_frame_mask: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        negative_prompt_embeds: torch.Tensor | None,
+        image_embeds: torch.Tensor | None,
+        attention_kwargs: dict[str, Any],
+        dtype: torch.dtype,
+        guidance_low: float,
+        guidance_high: float,
+    ) -> tuple[dict[str, Any], dict[str, Any] | None, bool, float]:
+        """Prepare positive and negative kwargs for noise prediction."""
+
+        # Select model and guidance scale based on timestep
+        current_model = self.transformer
+        current_guidance_scale = guidance_low
+        if boundary_timestep is not None and t < boundary_timestep and self.transformer_2 is not None:
+            current_model = self.transformer_2
+            current_guidance_scale = guidance_high
+
+        if latents is not None:
+            if self.expand_timesteps:  # TI2V-5B style: only first stage blends condition with latents using mask
+                latents = ((1 - first_frame_mask) * condition + first_frame_mask * latents).to(dtype)
+            else:  # Wan2.1 style: concatenate condition with latents
+                latents = torch.cat([latents, condition], dim=1).to(dtype)
+
+        if self.expand_timesteps:
+            # Expand timesteps for each patch
+            temp_ts = (first_frame_mask[0][0][:, ::2, ::2] * t).flatten()
+            timestep = temp_ts.unsqueeze(0).expand(original_dims[0], -1)
+        else:
+            timestep = t.expand(original_dims[0])
+
+        do_true_cfg = current_guidance_scale > 1.0 and negative_prompt_embeds is not None
+        positive_kwargs = {
+            "hidden_states": latents,
+            "timestep": timestep,
+            "encoder_hidden_states": prompt_embeds,
+            "encoder_hidden_states_image": image_embeds,
+            "attention_kwargs": attention_kwargs,
+            "return_dict": False,
+            "current_model": current_model,
+            "dims": original_dims,
+        }
+        negative_kwargs = None
+        if do_true_cfg:
+            negative_kwargs = {
+                "hidden_states": latents,
+                "timestep": timestep,
+                "encoder_hidden_states": negative_prompt_embeds,
+                "encoder_hidden_states_image": image_embeds,
+                "attention_kwargs": attention_kwargs,
+                "return_dict": False,
+                "current_model": current_model,
+                "dims": original_dims,
+            }
+        return positive_kwargs, negative_kwargs, do_true_cfg, current_guidance_scale
 
     def encode_prompt(
         self,

--- a/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
+++ b/vllm_omni/diffusion/models/wan2_2/wan2_2_transformer.py
@@ -17,7 +17,6 @@ from vllm.distributed import (
     tensor_model_parallel_all_reduce,
 )
 from vllm.logger import init_logger
-from vllm.model_executor.layers.conv import Conv3dLayer
 from vllm.model_executor.layers.linear import ColumnParallelLinear, QKVParallelLinear, RowParallelLinear
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
@@ -35,6 +34,12 @@ from vllm_omni.diffusion.distributed.parallel_state import (
     get_pipeline_parallel_world_size,
     is_pipeline_first_stage,
     is_pipeline_last_stage,
+)
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_conv import Conv3dLayer
+from vllm_omni.diffusion.distributed.pipefusion.pipefusion_transformer import (
+    PipeFusionRotaryEmbeddingMixin,
+    PipeFusionSelfAttentionMixin,
+    PipeFusionTransformerMixin,
 )
 from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelInput,
@@ -159,7 +164,7 @@ class WanFeedForward(nn.Module):
         return hidden_states
 
 
-class WanRotaryPosEmbed(nn.Module):
+class WanRotaryPosEmbed(nn.Module, PipeFusionRotaryEmbeddingMixin):
     """
     Rotary position embeddings for 3D video data (temporal + spatial dimensions).
     """
@@ -176,6 +181,8 @@ class WanRotaryPosEmbed(nn.Module):
         self.attention_head_dim = attention_head_dim
         self.patch_size = patch_size
         self.max_seq_len = max_seq_len
+        self._cached_rope_emb = None
+        self._cached_rope_resolution = None
 
         # Split dimensions for temporal, height, width
         h_dim = w_dim = 2 * (attention_head_dim // 6)
@@ -209,8 +216,18 @@ class WanRotaryPosEmbed(nn.Module):
         freqs_sin = freqs.sin().float().repeat_interleave(2, dim=-1)
         return freqs_cos.float(), freqs_sin.float()
 
-    def forward(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+    def forward(
+        self,
+        num_frames: int,
+        height: int,
+        width: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        current_rope_resolution = (num_frames, height, width)
+        if self._cached_rope_resolution == current_rope_resolution and self._cached_rope_emb is not None:
+            return self._cached_rope_emb
+
         p_t, p_h, p_w = self.patch_size
         ppf, pph, ppw = num_frames // p_t, height // p_h, width // p_w
 
@@ -234,7 +251,13 @@ class WanRotaryPosEmbed(nn.Module):
         freqs_cos = torch.cat([freqs_cos_f, freqs_cos_h, freqs_cos_w], dim=-1).reshape(1, ppf * pph * ppw, 1, -1)
         freqs_sin = torch.cat([freqs_sin_f, freqs_sin_h, freqs_sin_w], dim=-1).reshape(1, ppf * pph * ppw, 1, -1)
 
-        return freqs_cos.to(hidden_states.device), freqs_sin.to(hidden_states.device)
+        rotary_emb = (
+            freqs_cos[..., 0::2].to(device=device, dtype=dtype),
+            freqs_sin[..., 1::2].to(device=device, dtype=dtype),
+        )
+        self._cached_rope_resolution = current_rope_resolution
+        self._cached_rope_emb = rotary_emb
+        return rotary_emb
 
 
 class WanImageEmbedding(nn.Module):
@@ -352,7 +375,7 @@ class OutputScaleShiftPrepare(nn.Module):
         return shift, scale
 
 
-class WanSelfAttention(nn.Module):
+class WanSelfAttention(nn.Module, PipeFusionSelfAttentionMixin):
     """
     Optimized self-attention module using vLLM layers.
     """
@@ -417,6 +440,7 @@ class WanSelfAttention(nn.Module):
             role="self",
             prefix=prefix,
         )
+        self.rotary_embedding = RotaryEmbeddingWan(is_neox_style=False, half_head_dim=True)
 
     def forward(
         self,
@@ -442,7 +466,6 @@ class WanSelfAttention(nn.Module):
 
         # Apply rotary embeddings
         if rotary_emb is not None:
-            self.rotary_embedding = RotaryEmbeddingWan(is_neox_style=False, half_head_dim=True)
             freqs_cos, freqs_sin = rotary_emb
             query = self.rotary_embedding(query, freqs_cos, freqs_sin)
             key = self.rotary_embedding(key, freqs_cos, freqs_sin)
@@ -746,7 +769,7 @@ class WanTransformerBlock(nn.Module):
         return hidden_states
 
 
-class WanTransformer3DModel(nn.Module):
+class WanTransformer3DModel(nn.Module, PipeFusionTransformerMixin):
     """
     Optimized Wan Transformer model for video generation using vLLM layers.
 
@@ -945,14 +968,19 @@ class WanTransformer3DModel(nn.Module):
 
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(["hidden_states"], inner_dim)
 
-        # ROPE helper
-        self._cached_rope_emb = None
-        self._cached_rope_resolution = None
-
     @property
     def dtype(self) -> torch.dtype:
         """Return the dtype of the model parameters."""
         return next(self.parameters()).dtype
+
+    def _unpatchify(self, hidden_states: torch.Tensor, dims: tuple[int, int, int, int, int]) -> torch.Tensor:
+        batch_size, _, num_frames, height, width = dims
+        p_t, p_h, p_w = self.config.patch_size
+        hidden_states = hidden_states.reshape(
+            batch_size, num_frames // p_t, height // p_h, width // p_w, p_t, p_h, p_w, -1
+        )
+        hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
+        return hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
 
     def forward(
         self,
@@ -963,32 +991,23 @@ class WanTransformer3DModel(nn.Module):
         intermediate_tensors: IntermediateTensors | None = None,
         return_dict: bool = True,
         attention_kwargs: dict[str, Any] | None = None,
+        dims: tuple[int, int, int, int, int] | None = None,
     ) -> torch.Tensor | Transformer2DModelOutput | IntermediateTensors:
-        batch_size, num_channels, num_frames, height, width = hidden_states.shape
-        p_t, p_h, p_w = self.config.patch_size
-        post_patch_num_frames = num_frames // p_t
-        post_patch_height = height // p_h
-        post_patch_width = width // p_w
-
-        # Compute RoPE embeddings (sharded by _sp_plan via split_output=True)
-        current_rope_resolution = (post_patch_num_frames, post_patch_height, post_patch_width)
-        if self._cached_rope_resolution == current_rope_resolution and self._cached_rope_emb is not None:
-            rotary_emb = self._cached_rope_emb
-        else:
-            freqs_cos, freqs_sin = self.rope(hidden_states)
-            rotary_emb = (freqs_cos[..., 0::2].to(hidden_states.dtype), freqs_sin[..., 1::2].to(hidden_states.dtype))
-            self._hidden_states_shape = hidden_states.shape
-            self._cached_rope_emb = rotary_emb
+        # hidden_states is 5D on the first PP stage, 3D on others; dims always carries the original shape.
+        batch_size, num_channels, num_frames, height, width = dims
 
         if is_pipeline_first_stage():
             # Patch embedding and flatten to sequence
             # (hidden_states is sharded at blocks.0 input by _sp_plan)
-            hidden_states = self.patch_embedding(hidden_states)
+            hidden_states = self.patch_embedding(hidden_states, dims=dims)
             hidden_states = hidden_states.flatten(2).transpose(1, 2)
         else:
             if intermediate_tensors is None:
                 raise RuntimeError("intermediate_tensors must be provided for non-first PP stages")
             hidden_states = intermediate_tensors["hidden_states"]
+
+        # Compute RoPE embeddings (sharded by _sp_plan via split_output=True)
+        rotary_emb = self.rope(num_frames, height, width, device=hidden_states.device, dtype=hidden_states.dtype)
 
         # Handle timestep shape (2-D for TI2V, 1-D for T2V)
         if timestep.ndim == 2:
@@ -1052,12 +1071,7 @@ class WanTransformer3DModel(nn.Module):
 
         hidden_states = self.norm_out(hidden_states, scale, shift).type_as(hidden_states)
         hidden_states = self.proj_out(hidden_states)
-
-        hidden_states = hidden_states.reshape(
-            batch_size, post_patch_num_frames, post_patch_height, post_patch_width, p_t, p_h, p_w, -1
-        )
-        hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
-        output = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+        output = self._unpatchify(hidden_states, dims)
 
         if not return_dict:
             return (output,)

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -260,6 +260,7 @@ class DiffusionWorker:
                 fully_shard_degree=parallel_config.hsdp_shard_size if parallel_config.use_hsdp else 1,
                 hsdp_replicate_size=parallel_config.hsdp_replicate_size if parallel_config.use_hsdp else 1,
                 enable_expert_parallel=parallel_config.enable_expert_parallel,
+                enable_pipefusion=parallel_config.enable_pipefusion,
             )
             init_workspace_manager(self.device)
 

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1908,6 +1908,7 @@ class AsyncOmniEngine:
             use_hsdp = normalized_kwargs.get("use_hsdp") or False
             hsdp_shard_size = normalized_kwargs.get("hsdp_shard_size") or -1
             hsdp_replicate_size = normalized_kwargs.get("hsdp_replicate_size") or 1
+            enable_pipefusion = normalized_kwargs.get("enable_pipefusion") or False
             if sequence_parallel_size is None:
                 sequence_parallel_size = ulysses_degree * ring_degree
 
@@ -1925,6 +1926,7 @@ class AsyncOmniEngine:
                 use_hsdp=use_hsdp,
                 hsdp_shard_size=hsdp_shard_size,
                 hsdp_replicate_size=hsdp_replicate_size,
+                enable_pipefusion=enable_pipefusion,
             )
 
         num_devices = max(1, int(parallel_config.world_size))

--- a/vllm_omni/entrypoints/cli/serve.py
+++ b/vllm_omni/entrypoints/cli/serve.py
@@ -625,6 +625,13 @@ class OmniServeCommand(CLISubcommand):
             "Distributes VAE decode workload across multiple ranks by splitting the latent spatially. "
             "Equivalent to setting DiffusionParallelConfig.vae_patch_parallel_size.",
         )
+        omni_config_group.add_argument(
+            "--enable-pipefusion",
+            action="store_true",
+            help="Enable PipeFusion (patch-wise async pipeline parallel) for diffusion models. "
+            "Requires --pipeline-parallel-size > 1. "
+            "Equivalent to setting DiffusionParallelConfig.enable_pipefusion.",
+        )
 
         # Default sampling parameters
         omni_config_group.add_argument(

--- a/vllm_omni/entrypoints/openai/protocol/videos.py
+++ b/vllm_omni/entrypoints/openai/protocol/videos.py
@@ -175,6 +175,15 @@ class VideoGenerationRequest(BaseModel):
         gt=0.0,
         description="Duration in seconds for model-generated audio. Defaults to the generated video duration.",
     )
+    pipefusion_warmup_steps: int | None = Field(
+        default=None,
+        ge=1,
+        description="Per-request PipeFusion warmup steps before async patch mode.",
+    )
+    pipefusion_split_dim: Literal["height", "temporal"] | None = Field(
+        default=None,
+        description="Per-request PipeFusion latent split dimension.",
+    )
 
     # vllm-omni extensions for post-generation frame interpolation.
     enable_frame_interpolation: bool = Field(

--- a/vllm_omni/entrypoints/openai/serving_video.py
+++ b/vllm_omni/entrypoints/openai/serving_video.py
@@ -156,6 +156,10 @@ class OmniOpenAIServingVideo:
             gen_params.true_cfg_scale = request.true_cfg_scale
         if "seed" in provided_fields and request.seed is not None:
             gen_params.seed = request.seed
+        if "pipefusion_warmup_steps" in provided_fields:
+            gen_params.pipefusion_warmup_steps = request.pipefusion_warmup_steps
+        if "pipefusion_split_dim" in provided_fields:
+            gen_params.pipefusion_split_dim = request.pipefusion_split_dim
         if "boundary_ratio" in provided_fields and request.boundary_ratio is not None:
             gen_params.boundary_ratio = request.boundary_ratio
 

--- a/vllm_omni/inputs/data.py
+++ b/vllm_omni/inputs/data.py
@@ -1,7 +1,7 @@
 import copy
 import pprint
 from dataclasses import asdict, dataclass, field
-from typing import Any, TypeAlias, TypedDict
+from typing import Any, Literal, TypeAlias, TypedDict
 
 from vllm.inputs import PromptType
 from vllm.sampling_params import SamplingParams
@@ -304,6 +304,10 @@ class OmniDiffusionSamplingParams:
     # VSA parameters
     VSA_sparsity: float = 0.0
     # perf_logger: PerformanceLogger | None = None
+
+    # PipeFusion runtime settings
+    pipefusion_warmup_steps: int | None = None
+    pipefusion_split_dim: Literal["height", "temporal"] | None = None
 
     # stage logging
     # logging_info: PipelineLoggingInfo = field(default_factory=PipelineLoggingInfo)


### PR DESCRIPTION
<!-- markdownlint-disable -->

This PR introduces **PipeFusion** #647, a latency-optimized parallelism method that enhances Pipeline Parallelism (PP) for diffusion models. By splitting the denoising sequence into patches during later denoising steps, PipeFusion allows overlapping communication of one patch with computation of the next, significantly reducing pipeline bubbles and improving end-to-end latency.

## Purpose

The primary goal of this PR is to provide a high-performance parallelism strategy for large-scale diffusion generation where standard Pipeline Parallelism suffers from utilization gaps (bubbles). 

Key features included:
- **`PipeFusionRuntime`**: Central state manager that calculates patch metadata (sizes, token ranges, split dimensions) and tracks the current patch index across the pipeline.
- **`PipeFusionPipelineMixin`**: Orchestrates the transition between standard PP warmup and asynchronous patch-wise execution.
- **`PipeFusionSchedulerMixin`**: Manages per-patch scheduler states and gates shared state updates.
- **`PipeFusionTransformerMixin` & `PipeFusionSelfAttentionMixin`**: Enables patch-aware RoPE slicing and full-sequence KV-cache updates, ensuring each patch can attend to the entire sequence.
- **Reference Implementation**: Full integration with the Wan2.2 (5B) T2V and I2V pipelines.

## Test Plan

The implementation has been validated through a combination of unit tests and end-to-end inference checks.

1.  **Unit Tests**:

```shell
pytest tests/diffusion/distributed/test_pipeline_parallel.py
pytest tests/diffusion/distributed/test_pipefusion.py
```

2.  **Offline Inference**:

```shell
python examples/offline_inference/text_to_video/text_to_video.py \
--model=Wan-AI/Wan2.2-TI2V-5B-Diffusers \
--width=1280 \
--height=704 \
--guidance-scale=5.0 \
--prompt="Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage" \
--output=t2v_5B_pp4_pf.mp4 \
--pipeline-parallel-size=4 \
--enable-pipefusion \
--pipefusion-warmup-steps=5 \
--pipefusion-split-dim=temporal \
--vae-patch-parallel-size=4
```

## Test Result

All unit tests passed successfully. End-to-end inference on Wan2.2-5B demonstrates significant latency reduction compared to plain PP while preserving visual quality.

### Visual Quality Results

|                                          Single Device                                          |                                      PipeFusion with PP=4                                       |
|:-----------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
| <video src="https://github.com/user-attachments/assets/867e77ba-0457-4bdd-96e7-94dcb4a51659" /> | <video src="https://github.com/user-attachments/assets/3c33d8f3-35d8-41da-8a35-8a3f5fbe6a63" /> |

The results above were produced using the prompt specified in the **Offline Inference** section.

### Benchmark Results (H800)

Benchmarks were conducted against Sequence Parallelism on 4 NVIDIA H800 GPUs with 1 warmup step.

| Resolution | Number of Frames | Latent Tokens | Single Device Diffusion Time (s) | SP Diffusion Time (s) | PF Diffusion Time(s) | Single Device Memory (GB) | SP Memory (GB) | PF Memory (GB) |
|------------|:----------------:|:-------------:|:--------------------------------:|:---------------------:|:--------------------:|:-------------------------:|:--------------:|:--------------:|
|  832x480   |        41        |     4290      |               6.50               |         6.41          |         4.07         |           31.9            |      23.7      |      17.9      |
|  832x480   |        81        |     8190      |              13.17               |         6.54          |         5.75         |           31.9            |      24.1      |      20.4      |
|  1280x704  |        41        |     9680      |              16.39               |         11.78         |         6.89         |           44.7            |      25.9      |      23.9      |
|  832x480   |       121        |     12090     |              22.00               |         8.38          |         8.49         |           31.9            |      24.8      |      21.6      |
|  832x480   |       161        |     15990     |              31.35               |         11.11         |        11.66         |           31.9            |      25.9      |      26.5      |
|  1280x704  |        81        |     18480     |              38.24               |         11.10         |        14.04         |           44.8            |      25.7      |      24.6      |
|  1280x704  |       121        |     27280     |              65.10               |         18.59         |        23.41         |           44.8            |      26.7      |      29.1      |
|  1280x704  |       161        |     36080     |              100.09              |         28.18         |        35.55         |           47.5            |      28.7      |      36.0      |

<img width="350" alt="Diffusion Time" src="https://github.com/user-attachments/assets/70ef6d5f-4b81-4eb1-b224-f88daf875878" /><img width="350" alt="Memory Use" src="https://github.com/user-attachments/assets/5307806b-3e00-4901-b5cd-7477c199d375" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
(anything written below this line will be removed by GitHub Actions)
