### PR TITLE
[Model] Add Phoenix TTS support

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -43,6 +43,7 @@ th {
 | `LTX23Pipeline` | LTX-2.3-T2V | `dg845/LTX-2.3-Diffusers` | ✅︎ | ✅︎ | | |
 | `LTX23ImageToVideoPipeline` | LTX-2.3-I2V | `dg845/LTX-2.3-Diffusers` | ✅︎ | ✅︎ | | |
 | `DreamZeroPipeline` | DreamZero-DROID | `GEAR-Dreams/DreamZero-DROID` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
+| `PhoenixTTSTalkerForConditionalGeneration` | Phoenix TTS (zero-shot voice cloning) | `/path/to/Phoenix-TTS-24Hz-CustomVoice-HF-v3` | ✅︎ | | | |
 | `HeliosPipeline`, `HeliosPyramidPipeline` | Helios | `BestWishYsh/Helios-Base`, `BestWishYsh/Helios-Mid`, `BestWishYsh/Helios-Distilled` | ✅︎ | ✅︎ | ✅︎ | |
 | `MagiHumanPipeline` | MagiHuman | `SII-GAIR/daVinci-MagiHuman-Base-1080p` | ✅︎ | ✅︎ | | |
 | `OvisImagePipeline` | Ovis-Image | `OvisAI/Ovis-Image` | ✅︎ | ✅︎ | | ✅︎ |


### PR DESCRIPTION
## Purpose

Add Phoenix TTS support to vLLM-Omni: a zero-shot voice-cloning TTS model running as a two-stage pipeline:

```text
talker AR -> code2wav CFM decoder
```

Integration points:
- Add model classes and registry entries: `PhoenixTTSTalkerForConditionalGeneration` and `PhoenixTTSCode2Wav`
- Add Phoenix pipeline topology and central `pipeline_registry` entry
- Add stage input processor for the talker -> code2wav transition
- Integrate Phoenix TTS with OpenAI-compatible `/v1/audio/speech` serving
- Add `vllm_omni/deploy/phoenix_tts.yaml`
- Add offline and online examples under the consolidated `text_to_speech` hub
- Update user docs and `supported_models.md`
- Add unit/system tests for pipeline wiring, serving validation, prompt sizing, stage transition, and example helpers

Phoenix TTS is a zero-shot voice-cloning model, so every request requires `ref_audio`. Streaming output is not supported by the provided deploy config; requests should use non-streaming final-audio responses.

Implementation note: `load_weights` returns the real loaded parameter set, including mapped flow/vae checkpoint keys, so vLLM's strict missing-weights check is not bypassed.

## Test Plan

CPU/unit tests:

```bash
pytest tests/config/test_pipeline_registry.py
pytest tests/test_config_factory.py::TestPhoenixTTSPipeline
pytest tests/model_executor/stage_input_processors/test_phoenix_tts.py
pytest tests/model_executor/models/phoenix_tts/test_phoenix_tts_talker_prompt_len.py
pytest tests/entrypoints/openai_api/test_serving_speech.py -k phoenix
pytest tests/examples/offline_inference/test_phoenix_tts_end2end.py
```

GPU/manual e2e:

```bash
python examples/offline_inference/text_to_speech/phoenix_tts/end2end.py \
    --model <Phoenix-TTS-24Hz-CustomVoice-HF-v3> \
    --deploy-config vllm_omni/deploy/phoenix_tts.yaml \
    --text "你好，这是 Phoenix TTS 的端到端验证。" \
    --ref-audio <ref.wav> \
    --output out.wav
```

## Test Results

CPU/unit tests passed (24 phoenix-related tests in total):

```text
$ pytest tests/config/test_pipeline_registry.py
======================= 10 passed, 16 warnings in 9.55s ========================

$ pytest tests/test_config_factory.py::TestPhoenixTTSPipeline
tests/test_config_factory.py::TestPhoenixTTSPipeline::test_registered                               PASSED [ 25%]
tests/test_config_factory.py::TestPhoenixTTSPipeline::test_talker_stage                             PASSED [ 50%]
tests/test_config_factory.py::TestPhoenixTTSPipeline::test_code2wav_stage_processor_wiring_resolves PASSED [ 75%]
tests/test_config_factory.py::TestPhoenixTTSPipeline::test_code2wav_stage                           PASSED [100%]
======================== 4 passed, 16 warnings in 4.95s ========================

$ pytest tests/model_executor/stage_input_processors/test_phoenix_tts.py
test_phoenix_talker2code2wav_filters_codec_ids_and_forwards_prompt_condition PASSED
test_phoenix_talker2code2wav_skips_unfinished_outputs                        PASSED
======================== 2 passed ========================

$ pytest tests/model_executor/models/phoenix_tts/test_phoenix_tts_talker_prompt_len.py
test_estimate_prompt_len_fallback_has_safe_floor   PASSED
test_estimate_prompt_len_fallback_scales_with_text PASSED
======================== 2 passed ========================

$ pytest tests/entrypoints/openai_api/test_serving_speech.py -k phoenix
TestTTSMethods::test_validate_phoenix_tts_request_requires_ref_audio                 PASSED
TestTTSMethods::test_validate_phoenix_tts_request_rejects_streaming                  PASSED
TestTTSMethods::test_build_phoenix_tts_prompt_uses_resolved_ref_audio_and_estimator  PASSED
========== 3 passed, 151 deselected, 19 warnings in 72.30s (0:01:12) ===========

$ pytest tests/examples/offline_inference/test_phoenix_tts_end2end.py
test_get_audio_from_multimodal_output_accepts_tensor_audio        PASSED
test_get_audio_from_multimodal_output_falls_back_to_model_outputs PASSED
test_get_audio_from_multimodal_output_requires_audio              PASSED
======================== 3 passed ========================
```

GPU/manual e2e result (run on a single CUDA GPU with `Phoenix-TTS-24Hz-CustomVoice-HF-v3` weights; `gpu_memory_utilization` lowered to keep the memory budget tight: stage0=0.30, stage1=0.20):

```text
[talker]    Loaded 1432 weight entries for PhoenixTTSTalker     (no missing-parameter warnings)
[code2wav]  Loaded 1110 weight entries for PhoenixTTSCode2Wav   (no missing-parameter warnings)

Pipeline ran end-to-end: text + ref_audio -> talker AR semantic tokens
  -> code2wav CFM decode -> waveform.
Generated audio: 3.16 s @ 24000 Hz, voice matches the reference clip.
```

## Documentation

Updated:
- `supported_models.md`
- Offline text-to-speech examples
- Online text-to-speech examples
- User guide generated docs for the text-to-speech hub

Docs sync / preview:

```text
NOT RUN locally; the mkdocs site is built by CI.
```

## Release Notes

User-facing change: adds Phoenix TTS support.

Suggested release note:

```text
Added Phoenix TTS zero-shot voice-cloning support with offline and OpenAI-compatible speech serving examples.
```

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR is described.
- [x] The test plan is provided with test commands.
- [x] The test results are provided.
- [x] Documentation updates are listed.
- [x] Release notes impact is described.

</details>
