### PR TITLE
[Bugfix] qwen3-tts prefix cache: drop per-key size cap that corrupted…

### DIFF
--- a/vllm_omni/core/prefix_cache.py
+++ b/vllm_omni/core/prefix_cache.py
@@ -10,9 +10,6 @@ from vllm_omni.utils.mm_outputs import build_mm_cpu, to_payload_element
 
 logger = init_logger(__name__)
 
-# Skip oversized per-key caches; otherwise hidden_states.layer_N can OOM on big models.
-_MAX_MM_CACHE_BYTES_PER_KEY = 512 * 1024 * 1024
-
 
 class OmniTensorPrefixCache:
     """Prefix cache for hidden states (model outputs) and model specific
@@ -49,7 +46,6 @@ class OmniTensorPrefixCache:
         # actually see mm output tensors dependent on num tokens.
         self.mm_outputs_cache = {}
         self.mm_cache_keys = set()
-        self._mm_oversized_keys: set[str] = set()
         self._new_req_cache_hit_ids: set[str] = set()
         self._deferred_mm_outputs: dict[str, dict[str, list[tuple[int, torch.Tensor]]]] = {}
 
@@ -79,17 +75,6 @@ class OmniTensorPrefixCache:
                 and key not in self.mm_cache_keys
             ):
                 feat_dim = val.shape[-1]
-                # Bound per-key cache to avoid OOM on wide per-token features.
-                key_bytes = self.num_blocks * self.block_size * feat_dim * val.element_size()
-                if key_bytes > _MAX_MM_CACHE_BYTES_PER_KEY:
-                    logger.warning_once(
-                        "Skipping mm prefix cache key '%s': %.1f MiB > %.1f MiB cap.",
-                        key,
-                        key_bytes / 2**20,
-                        _MAX_MM_CACHE_BYTES_PER_KEY / 2**20,
-                    )
-                    self._mm_oversized_keys.add(key)
-                    continue
                 self.mm_outputs_cache[key] = self._get_cache_tensor(
                     dtype=val.dtype,
                     hidden_size=feat_dim,
@@ -432,18 +417,7 @@ class OmniTensorPrefixCache:
         # tensors similarly to the non prefix cached path, and then populate
         # the subdicts mapping request IDs -> payload objects
         passthrough_keys = set(mm_outputs.keys()) - self.mm_cache_keys
-        total_scheduled_tokens = sum(int(num_scheduled_tokens[r]) for r in input_batch.req_ids)
-        passthrough_mm_data: dict[str, object] = {}
-        for k in passthrough_keys:
-            v = mm_outputs[k]
-            if (
-                k in self._mm_oversized_keys
-                and isinstance(v, torch.Tensor)
-                and v.dim() >= 2
-                and v.shape[0] >= total_scheduled_tokens
-            ):
-                v = v[:total_scheduled_tokens]
-            passthrough_mm_data[k] = v
+        passthrough_mm_data = {k: v for k, v in mm_outputs.items() if k in passthrough_keys}
         mm_cpu = build_mm_cpu(multimodal_outputs=passthrough_mm_data)
 
         for mm_key, mm_val in mm_cpu.items():


### PR DESCRIPTION
<!-- markdownlint-disable -->
**Before submitting:** run the precheck-pr skill with code agent for a self-check against project conventions — catches dead code, missing benchmarks, and title format issues.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Solves the issue introduced in: https://github.com/vllm-project/vllm-omni/pull/3689

and also being tracked in: https://github.com/vllm-project/vllm-omni/pull/4308


Fixes the audio-quality regression reported in #4308 (Seed-TTS Mean WER 0.2374 on Qwen3-Omni-30B-A3B).

Root cause is the `512 MiB per-key prefix-cache cap` i introduced in in #3689. When a per-token feature key exceeds the cap, `maybe_init_missing_mm_cache_keys` does `continue`, the key is never added to `mm_cache_keys` and no cache tensor is allocated. It then falls the *passthrough* branch of `get_merged_multimodal_states`, which hands each only its newly-scheduled tokens.


On a prefix-cache **hit** the model only computes the new tokens and the cached prefix is expected to be glued back on by `_get_merged_tensors` (`cat([cached_prefix, new])`). For a skipped (oversized) key that reconstruction never happens, the prefix hidden states were never stored, so the downstream stage receives truncated/misaligned conditioning (in other words, corrupted audio for any request that hits the cache on that key).

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
(anything written below this line will be removed by GitHub Actions)
