### PR TITLE
fix: Correct YAML Syntax to Ensure Valid Boolean Stage Configuration in hunyuan moe yaml

### DIFF
--- a/vllm_omni/deploy/hunyuan_image_3_moe.yaml
+++ b/vllm_omni/deploy/hunyuan_image_3_moe.yaml
@@ -62,7 +62,7 @@ stages:
       max_tokens: 8192
       detokenize: true
       skip_special_tokens: false
-      include_stop_str_in_output: true,
+      include_stop_str_in_output: true
 
   - stage_id: 1
     max_num_seqs: 1


### PR DESCRIPTION


## Purpose

Typo in hunyuan_image_3_moe.yaml. Trailing comma include_stop_str_in_output: true,  forces parser to load value as string  'true,'  instead of boolean  True

That may lead that Engine initialization crashes with  ValidationError: Input should be a valid  boolean .

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
(anything written below this line will be removed by GitHub Actions)
