### PR TITLE
[Bugfix][TTS] Fix MOSS-TTS-Nano offline RequestOutput handling

### DIFF
--- a/examples/offline_inference/text_to_speech/moss_tts_nano/end2end.py
+++ b/examples/offline_inference/text_to_speech/moss_tts_nano/end2end.py
@@ -137,7 +137,10 @@ def main(args) -> None:
     params_list = sampling_params
 
     for stage_outputs in omni.generate(inputs, params_list):
-        for i, req_output in enumerate(stage_outputs.request_output):
+        request_outputs = stage_outputs.request_output
+        if not isinstance(request_outputs, (list, tuple)):
+            request_outputs = [request_outputs]
+        for i, req_output in enumerate(request_outputs):
             for j, out in enumerate(req_output.outputs):
                 mm = out.multimodal_output
                 if mm is None:


### PR DESCRIPTION
  ## Summary                                                       
                                                                   
  - Fix the MOSS-TTS-Nano offline example when                     
  `stage_outputs.request_output` is returned as a single           
  `RequestOutput`.                                                 
  - Normalize the value to a list before iterating so the example
  remains compatible with both single and batched outputs.         
   
  ## Test plan                                                     
                  
  - `python -m py_compile examples/offline_inference/text_to_speech
  /moss_tts_nano/end2end.py`
  - Ran:                                                           
    `python examples/offline_inference/text_to_speech/moss_tts_nano
  /end2end.py --text "你好，这是 MOSS-TTS-Nano 的语音合成测试。"   
  --ref-audio "$HOME/.cache/moss-tts-nano/zh_1.wav"`               
  - Confirmed it generated:                                        
    `/home/mtarch/.cache/moss_tts_nano_output/output_0_0.wav` 