### PR TITLE
[Bugfix] Fix OpenAI `n` parameter ignored in omni serving

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
+++ b/tests/entrypoints/openai_api/test_serving_chat_sampling_params.py
@@ -102,6 +102,7 @@ def mock_request(mocker: MockerFixture):
     request.stop_token_ids = None
     request.frequency_penalty = None
     request.presence_penalty = None
+    request.n = None
     # Must be real Python objects (not MagicMock) so the code's explicit-field
     # and extra_body checks work correctly.
     request.model_fields_set = set()
@@ -130,6 +131,7 @@ def test_openai_sampling_fields_contains_expected_fields():
         "stop_token_ids",
         "frequency_penalty",
         "presence_penalty",
+        "n",
     }
     assert OmniOpenAIServingChat._OPENAI_SAMPLING_FIELDS == expected_fields
 
@@ -225,6 +227,16 @@ def test_request_presence_penalty_overrides(serving_chat, mock_request):
     result = serving_chat._build_sampling_params_list_from_request(mock_request)
 
     assert result[0].presence_penalty == 0.3
+
+
+def test_request_n_overrides(serving_chat, mock_request):
+    """Test that request n is forwarded to SamplingParams for parallel completions."""
+    mock_request.n = 3
+    mock_request.model_fields_set = {"n"}
+
+    result = serving_chat._build_sampling_params_list_from_request(mock_request)
+
+    assert result[0].n == 3
 
 
 def test_non_comprehension_stages_use_cloned_defaults(serving_chat, mock_request):

--- a/vllm_omni/engine/stage_pool.py
+++ b/vllm_omni/engine/stage_pool.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import time as _time
+from copy import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from vllm.logger import init_logger
 from vllm.v1.engine import EngineCoreOutputs
+from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.metrics.stats import IterationStats
 
 from vllm_omni.distributed.omni_coordinator import (
@@ -969,34 +971,70 @@ class StagePool:
         client = self.clients[replica_id]
         if client is None:
             raise RuntimeError(f"stage {self.stage_id} replica {replica_id} is not attached")
-        try:
-            self.output_processor.add_request(
-                request=request,
-                prompt=prompt_text,
-                parent_req=None,
-                request_index=0,
-                queue=None,
-            )
-        except Exception:
-            self.release_binding(request_id)
-            raise
-
-        try:
-            await self._llm_client(replica_id).add_request_async(request, **submit_kwargs)
-        except Exception:
-            self.release_binding(request_id)
-            rollback = getattr(self.output_processor, "remove_request", None)
-            if callable(rollback):
+        n = getattr(params, "n", 1) or 1
+        if n > 1:
+            parent_request = ParentRequest(request)
+            for idx in range(n):
+                child_req_id, child_params = parent_request.get_child_info(idx)
+                child_request = copy(request)
+                child_request.request_id = child_req_id
+                child_request.sampling_params = child_params
                 try:
-                    rollback(request_id)
-                except Exception as rollback_error:
-                    logger.warning(
-                        "[StagePool] Failed to rollback output processor state for req=%s stage-%s: %s",
-                        request_id,
-                        self.stage_id,
-                        rollback_error,
+                    self.output_processor.add_request(
+                        request=child_request,
+                        prompt=prompt_text,
+                        parent_req=parent_request,
+                        request_index=idx,
+                        queue=None,
                     )
-            raise
+                except Exception:
+                    self.release_binding(request_id)
+                    raise
+                try:
+                    await self._llm_client(replica_id).add_request_async(child_request, **submit_kwargs)
+                except Exception:
+                    self.release_binding(request_id)
+                    rollback = getattr(self.output_processor, "remove_request", None)
+                    if callable(rollback):
+                        try:
+                            rollback(child_request.request_id)
+                        except Exception as rollback_error:
+                            logger.warning(
+                                "[StagePool] Failed to rollback output processor state for req=%s stage-%s: %s",
+                                child_request.request_id,
+                                self.stage_id,
+                                rollback_error,
+                            )
+                    raise
+        else:
+            try:
+                self.output_processor.add_request(
+                    request=request,
+                    prompt=prompt_text,
+                    parent_req=None,
+                    request_index=0,
+                    queue=None,
+                )
+            except Exception:
+                self.release_binding(request_id)
+                raise
+
+            try:
+                await self._llm_client(replica_id).add_request_async(request, **submit_kwargs)
+            except Exception:
+                self.release_binding(request_id)
+                rollback = getattr(self.output_processor, "remove_request", None)
+                if callable(rollback):
+                    try:
+                        rollback(request_id)
+                    except Exception as rollback_error:
+                        logger.warning(
+                            "[StagePool] Failed to rollback output processor state for req=%s stage-%s: %s",
+                            request_id,
+                            self.stage_id,
+                            rollback_error,
+                        )
+                raise
         return replica_id
 
     async def submit_update(

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -1027,6 +1027,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         "stop_token_ids",
         "frequency_penalty",
         "presence_penalty",
+        "n",
     }
 
     def _apply_request_overrides(


### PR DESCRIPTION
## Purpose

Fix #4269: the OpenAI `n` parameter was silently ignored, always returning 1 completion regardless of the requested count.

Two gaps caused this:
1. `"n"` was missing from `_OPENAI_SAMPLING_FIELDS`, so it was never forwarded to `SamplingParams`.
2. `StagePool.submit_initial` always called `output_processor.add_request(parent_req=None)`, so the existing `ParentRequest` fan-out infrastructure was never activated. This PR wires it up, mirroring `vllm/v1/engine/async_llm.py`.

## Test Plan

Unit tests (extended existing file):
```bash
pytest tests/entrypoints/openai_api/test_serving_chat_sampling_params.py -v
```

E2E on 2×H100 with `Qwen/Qwen3-Omni-30B-A3B-Instruct`:
```bash
curl http://localhost:8000/v1/chat/completions \
  -d '{"model":"qwen3-omni","messages":[{"role":"user","content":"Say one word."}],"n":3,"max_tokens":20}'
```

## Test Result

Before: `n=3` returns 1 text completion (`index=0` only).

After:
```json
{"choices": [
  {"index": 0, "message": {"content": "Sunset"}},
  {"index": 1, "message": {"content": "Dream"}},
  {"index": 2, "message": {"content": "Aurora"}},
  {"index": 0, "message": {"content": null}}
]}
```
3 distinct text completions returned, plus 1 audio output from the talker stage.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
(anything written below this line will be removed by GitHub Actions)
