### PR TITLE
[HunyuanImage][Perf] opt prepare_attention_mask for e2e latency 6% reduction

### DIFF
--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -970,11 +970,14 @@ class HunyuanImage3Pipeline(
         # This implementation can handle sequences with text and image modalities, where text tokens use causal
         # attention and image tokens use full attention.
         bsz, seq_len = inputs_tensor.shape
+        device = inputs_tensor.device
         tokenizer_output = model_kwargs["tokenizer_output"]
         batch_image_slices = [
             tokenizer_output.joint_image_slices[i] + tokenizer_output.gen_image_slices[i] for i in range(bsz)
         ]
-        attention_mask = torch.ones(seq_len, seq_len, dtype=torch.bool).tril(diagonal=0).repeat(bsz, 1, 1)
+        attention_mask = (
+            torch.ones(seq_len, seq_len, dtype=torch.bool, device=device).tril(diagonal=0).repeat(bsz, 1, 1)
+        )
         full_attn_spans: list[list[tuple[int, int]]] = [[] for _ in range(bsz)]
         for i in range(bsz):
             for j, image_slice in enumerate(batch_image_slices[i]):


### PR DESCRIPTION
<!-- markdownlint-disable -->
**Before submitting:** run the precheck-pr skill with code agent for a self-check against project conventions — catches dead code, missing benchmarks, and title format issues.

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
For prepare attention mask
### Before:  (1) construct in cpu -> (2) cp to device
<img width="2158" height="1122" alt="image" src="https://github.com/user-attachments/assets/aeaa738e-196d-4118-a2b8-40e9d140e6b8" />

### After: just construct in device
<img width="2386" height="1244" alt="image" src="https://github.com/user-attachments/assets/f5b1ecf1-f6ba-446b-ab47-848cbb833f5a" />


## Test Plan
(1) run perf bench
` pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py   --test-config-file tests/dfx/perf/tests/test_hunyuan_image_tp4.json`

(2) run accuracy test
`pytest -s -v tests/e2e/accuracy/test_hunyuan_image3_pixel_accuracy.py -m full_model --run-level full_model`

## Test Result
(1)
| case | tps | e2e latency | improve |
| -----| -----| ----| ----|
| Before | 0.2115 | 4.7287 s | - |
| After | 0.2248 | 4.4482 s | 6% |

Our expected improve is 2~3%, but we test with 6% improve; the reason is that:
The execution time of the original prepare_attention_mask function on the CPU exhibits substantial variability, ranging from 6 ms to 447 ms in our tests. While our change keep it less than 1ms.


(2)
<img width="1626" height="786" alt="image" src="https://github.com/user-attachments/assets/14d46e62-ea82-40ea-8aaf-233b2f71df40" />




---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
(anything written below this line will be removed by GitHub Actions)
