### PR TITLE
[Perf] Avoid HunyuanImage3 timestep mask scalar sync

### DIFF
--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -2009,10 +2009,9 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
         # the bidirectional MM region and biased AR ratio prediction toward
         # the first image's bucket.
         timestep_mask = input_ids == self._timestep_token_id
-        n_timestep = int(timestep_mask.sum().item())
-        if n_timestep > 0:
-            timestep_input = torch.zeros((n_timestep,), device=inputs_embeds.device, dtype=inputs_embeds.dtype)
-            inputs_embeds[timestep_mask] = self._timestep_encode(timestep_input)
+        timestep_input = torch.zeros((1,), device=inputs_embeds.device, dtype=inputs_embeds.dtype)
+        timestep_embed = self._timestep_encode(timestep_input).to(inputs_embeds.dtype)
+        inputs_embeds = torch.where(timestep_mask.unsqueeze(-1), timestep_embed, inputs_embeds)
 
         if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
             return inputs_embeds


### PR DESCRIPTION
## Purpose

Avoid a per-step GPU-to-CPU scalar sync in HunyuanImage3 AR graph decode.

`embed_input_ids()` previously used `timestep_mask.sum().item()` before patching `<timestep>` slots. In the AR graph online trace, that showed up as `aten::item/_local_scalar_dense` on every decode step. This PR keeps the same `timestep_emb(0)` replacement semantics, but performs the replacement with tensor-side `torch.where`.

## Test Plan

- `python -m py_compile vllm_omni\model_executor\models\hunyuan_image3\hunyuan_image3.py`
- `python -m ruff check vllm_omni\model_executor\models\hunyuan_image3\hunyuan_image3.py`
- `python -m ruff format --check --diff vllm_omni\model_executor\models\hunyuan_image3\hunyuan_image3.py`
- Remote online AR graph profiler comparison on `hunyuan_image3_ar`, `enforce_eager: false`, TP=2, `CUDA_VISIBLE_DEVICES=2,3`.
- Remote no-profiler online AR graph benchmark comparison on the same serving path.

## Test Result

- `py_compile`: passed.
- `ruff check`: passed.
- `ruff format --check --diff`: passed.
- Remote profiler artifact: `/tmp/hy3_ar_gap_profile_20260609_064355/`.
  - Output parity: warmup and target requests both generated 294 tokens.
  - `aten::item/_local_scalar_dense`: baseline `~1.60s / 512 calls` on rank0 and `~1.69s / 512 calls` on rank1; not present in the patched key events.
  - Median GPU idle improved from `~1.5ms` to `~50us` in the profiled decode step window.
  - Remaining p90/p99 tail gap is still around CUDA graph replay / `cudaGraphLaunch`; this PR does not claim to solve that tail.
- Remote no-profiler benchmark artifacts:
  - Baseline: `/tmp/hy3_ar_gap_noprofile_baseline_20260609_080810/`
  - Patch: `/tmp/hy3_ar_gap_noprofile_patch_20260609_081248/`
  - Output throughput: `65.65 tok/s -> 68.76 tok/s` (`+4.7%`).
  - Mean TPOT: `14.06ms -> 13.77ms`.
  - Mean ITL: `14.07ms -> 13.77ms`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [x] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING,** please read <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>
(anything written below this line will be removed by GitHub Actions)
