### PR TITLE
[CI/Build] test_speech_speed: assert speed scales duration, not ASR intelligibility

### DIFF
--- a/tests/e2e/online_serving/test_voxtral_tts.py
+++ b/tests/e2e/online_serving/test_voxtral_tts.py
@@ -7,11 +7,13 @@ These tests verify the /v1/audio/speech endpoint works correctly with
 actual model inference, not mocks.
 """
 
+import io
 import os
 
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
 import pytest
+import soundfile as sf
 
 from tests.helpers.mark import hardware_test
 from tests.helpers.runtime import OmniServerParams
@@ -96,20 +98,52 @@ class TestVoxtralTTSFixedVoice:
     @pytest.mark.tts
     @hardware_test(res={"cuda": "H100"}, num_cards=1)
     def test_speech_speed(self, omni_server, openai_client) -> None:
-        """Request with speed parameters"""
-        speeds = [0.5, 1, 1.5, 2, 2.5]
+        """``speed`` time-stretches the output: duration scales ~1/speed.
+
+        ``speed`` is an output-side post-process (phase-vocoder time-stretch),
+        not a model capability, so this asserts the parameter is honored - audio
+        gets shorter as speed rises - rather than ASR intelligibility at extreme
+        rates, where the vocoder (not the model) would dominate the transcript.
+        """
+        text = "The boy was there when the sun rose."
+        speeds = [0.5, 1.0, 1.5, 2.0, 2.5]
+        durations: dict[float, float] = {}
         for speed in speeds:
-            openai_client.send_audio_speech_request(
+            responses = openai_client.send_audio_speech_request(
                 {
                     "model": omni_server.model,
-                    "input": "The boy was there when the sun rose.",
+                    "input": text,
                     "voice": "casual_female",
                     "language": "English",
                     "response_format": "wav",
                     "timeout": 120.0,
                     "speed": speed,
+                    "seed": 1234,
                 }
             )
+            info = sf.info(io.BytesIO(responses[0].audio_bytes))
+            durations[speed] = info.frames / info.samplerate
+            print(f"speed={speed}: duration={durations[speed]:.3f}s ({info.frames} frames @ {info.samplerate} Hz)")
+
+        # ``speed`` sets output samples = round(generated_samples / speed), so
+        # ``duration * speed`` recovers the underlying generation length, which
+        # should be ~constant across requests. Comparing each request's implied
+        # length to the median is robust to the per-request generation-length
+        # jitter that the TTS sampling retains even with a fixed seed; if speed
+        # were ignored the implied lengths would instead spread by ~5x.
+        implied = {speed: durations[speed] * speed for speed in speeds}
+        median_len = sorted(implied.values())[len(implied) // 2]
+        assert median_len > 0, "Generation produced empty audio"
+        for speed in speeds:
+            assert implied[speed] == pytest.approx(median_len, rel=0.4), (
+                f"speed={speed}: duration {durations[speed]:.3f}s implies generation length "
+                f"{implied[speed]:.3f}s, far from median {median_len:.3f}s; speed not applied "
+                f"as ~1/speed: durations={durations}"
+            )
+        # Endpoints are 5x apart in speed; their durations must clearly separate.
+        assert durations[speeds[0]] > durations[speeds[-1]], (
+            f"slowest speed should yield clearly longer audio than fastest: {durations}"
+        )
 
     @pytest.mark.advanced_model
     @pytest.mark.tts

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -24,6 +24,10 @@ _GENDER_PIPELINE = None
 _GENDER_PIPELINE_LOCK = threading.Lock()
 _PCM_SPEECH_SAMPLE_RATE_HZ = 24_000
 _MIN_PCM_SPEECH_HNR_DB = 1.0
+# Speed band within which the time-stretch post-process keeps audio intelligible
+# enough for an ASR transcript to be a meaningful model-correctness signal.
+_ASR_RELIABLE_SPEED_MIN = 0.5
+_ASR_RELIABLE_SPEED_MAX = 1.5
 _PRESET_VOICE_GENDER_MAP: dict[str, str] = {
     "serena": "female",
     "uncle_fu": "male",
@@ -527,7 +531,12 @@ def assert_audio_speech_response(response: Any, request_config: dict[str, Any], 
 
     if run_level in {"advanced_model", "full_model"} and req_fmt != "pcm":
         expected_text = request_config.get("input")
-        if expected_text:
+        # ``speed`` is an optional output-side time-stretch (phase vocoder), not a
+        # model capability. Beyond a moderate band the vocoder degrades
+        # intelligibility enough that an ASR transcript no longer reflects model
+        # correctness, so only gate transcript fidelity where it stays meaningful.
+        speed = request_config.get("speed") or 1.0
+        if expected_text and _ASR_RELIABLE_SPEED_MIN <= speed <= _ASR_RELIABLE_SPEED_MAX:
             transcript = (response.audio_content or "").strip()
             print(f"audio content is: {transcript}")
             print(f"input text is: {expected_text}")
@@ -536,6 +545,8 @@ def assert_audio_speech_response(response: Any, request_config: dict[str, Any], 
             assert similarity > 0.9, (
                 f"Transcript doesn't match input: similarity={similarity:.2f}, transcript='{transcript}'"
             )
+        # The gender check below still runs at any speed (pitch is preserved),
+        # so non-silent real-audio output stays covered outside the ASR band.
         _assert_preset_voice_gender_from_audio(response.audio_bytes, request_config.get("voice"))
 
 


### PR DESCRIPTION
## Summary

`test_speech_speed` (added in #3738) runs the speech endpoint at `speed` up to 2.5x and leans on the shared `assert_audio_speech_response` whisper-similarity gate (`> 0.9`, added in #3539). At 2.5x that gate fails: `speed` is an output-side phase-vocoder time-stretch post-process (#305, refactored to torchaudio in #2273), not a model capability, so transcribing 2.5x-stretched audio tests the vocoder rather than the model, and intelligibility drops below the threshold once the stretch is extreme. The test as written also never verified that `speed` had any effect.

This reworks the test to assert what the parameter is actually for, and makes the shared gate speed-aware so it stops measuring the wrong thing at extreme rates.

## Changes

- **`tests/e2e/online_serving/test_voxtral_tts.py`** — `test_speech_speed` now asserts the parameter's contract: output duration scales as `~1/speed`. Because `duration * speed` recovers the underlying generation length (which should be ~constant across requests), it compares each request's implied length to the median (robust to the per-request TTS generation-length jitter that a fixed seed does not fully remove), plus an endpoint check that the slowest speed yields clearly longer audio than the fastest. No dependency on ASR at extreme speeds.
- **`tests/helpers/assertions.py`** — the ASR transcript-vs-input similarity check only runs within a reliable speed band `[0.5, 1.5]`; outside it, the pitch-preserving gender check still covers real, non-silent audio. This fixes the whole class of problem (any extreme-speed speech test), not just Voxtral.

`audio_utils_mixin._apply_speed_adjustment` is intentionally left unchanged.

## Validation

Run on 1x H20 with real `mistralai/Voxtral-4B-TTS-2603` inference (`--run-level advanced_model`): **1 passed**.

| speed | duration | implied gen length (dur × speed) | ASR similarity |
|------:|---------:|--------------------------------:|---------------|
| 0.5 | 5.920s | 2.96s | 1.000 |
| 1.0 | 2.160s | 2.16s | 1.000 |
| 1.5 | 1.707s | 2.56s | 1.000 |
| 2.0 | 1.520s | 3.04s | skipped (out of band) |
| 2.5 | 1.088s | 2.72s | skipped (out of band) |

Implied lengths cluster around the median (2.72s, all within ±40%); in-band intelligibility is still enforced at 1.000.

cc @clodaghwalsh17 — this edits `test_speech_speed` from #3738; happy to adjust the speed band or the approach if you'd prefer a different shape.
