### PR TITLE
Fix BAGEL image layout and attention modeling

### DIFF
--- a/tests/model_executor/test_bagel_vqa_reference_layout.py
+++ b/tests/model_executor/test_bagel_vqa_reference_layout.py
@@ -1,0 +1,142 @@
+import torch
+
+from vllm_omni.utils.bagel_vqa import (
+    BAGEL_VLM_THINK_SYSTEM_PROMPT,
+    bagel_vqa_reference_layout_enabled,
+    build_bagel_vqa_image_spans,
+    build_bagel_vqa_rope_positions,
+    build_bagel_vqa_reference_prompt_token_ids,
+)
+
+
+class FakeTokenizer:
+    vocab = {
+        "<|im_start|>": 100,
+        "<|im_end|>": 101,
+        "<|image_pad|>": 102,
+    }
+
+    def convert_tokens_to_ids(self, token):
+        return self.vocab[token]
+
+    def encode(self, text):
+        return [ord(ch) for ch in text]
+
+
+def test_bagel_vqa_serving_prompt_uses_reference_layout():
+    messages = [
+        {"role": "system", "content": BAGEL_VLM_THINK_SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+                {
+                    "type": "text",
+                    "text": f"{BAGEL_VLM_THINK_SYSTEM_PROMPT}\n\nquestion",
+                },
+                {"type": "text", "text": "briefly"},
+            ],
+        },
+        {"role": "assistant", "content": "<think>\n"},
+    ]
+
+    ids, prompt, image_count = build_bagel_vqa_reference_prompt_token_ids(
+        messages,
+        FakeTokenizer(),
+    )
+
+    assert ids[0] == FakeTokenizer.vocab["<|im_start|>"]
+    assert ids[-1] == FakeTokenizer.vocab["<|im_start|>"]
+    assert FakeTokenizer.vocab["<|image_pad|>"] in ids
+    assert prompt == "<img><|image_1|></img> question briefly"
+    assert image_count == 1
+
+
+def test_bagel_vqa_logical_rope_collapses_vision_block_and_decode_continues():
+    states = {}
+    input_ids = torch.tensor([1, 10, 2, 3, 11, 4])
+    positions = torch.arange(6)
+
+    rope = build_bagel_vqa_rope_positions(
+        input_ids=input_ids,
+        positions=positions,
+        req_ids=["r0"],
+        num_computed_tokens=[0],
+        num_scheduled_tokens=[6],
+        rope_states=states,
+        start_of_image_id=10,
+        end_of_image_id=11,
+    )
+
+    assert rope.tolist() == [0, 1, 1, 1, 1, 2]
+
+    decode_rope = build_bagel_vqa_rope_positions(
+        input_ids=torch.tensor([5]),
+        positions=torch.tensor([6]),
+        req_ids=["r0"],
+        num_computed_tokens=[6],
+        num_scheduled_tokens=[1],
+        rope_states=states,
+        start_of_image_id=10,
+        end_of_image_id=11,
+    )
+
+    assert decode_rope.tolist() == [3]
+
+
+def test_bagel_vqa_logical_rope_survives_chunked_image_prefill():
+    states = {}
+
+    first = build_bagel_vqa_rope_positions(
+        input_ids=torch.tensor([1, 10, 2]),
+        positions=torch.tensor([0, 1, 2]),
+        req_ids=["r0"],
+        num_computed_tokens=[0],
+        num_scheduled_tokens=[3],
+        rope_states=states,
+        start_of_image_id=10,
+        end_of_image_id=11,
+    )
+    second = build_bagel_vqa_rope_positions(
+        input_ids=torch.tensor([3, 11, 4]),
+        positions=torch.tensor([3, 4, 5]),
+        req_ids=["r0"],
+        num_computed_tokens=[3],
+        num_scheduled_tokens=[3],
+        rope_states=states,
+        start_of_image_id=10,
+        end_of_image_id=11,
+    )
+
+    assert first.tolist() == [0, 1, 1]
+    assert second.tolist() == [1, 1, 2]
+
+
+def test_bagel_reference_prefill_implies_reference_layout(monkeypatch):
+    monkeypatch.delenv("BAGEL_VQA_REFERENCE_LAYOUT", raising=False)
+    monkeypatch.setenv("BAGEL_VQA_REFERENCE_PREFILL", "1")
+
+    assert bagel_vqa_reference_layout_enabled()
+
+
+def test_bagel_vqa_image_spans_include_kv_end_before_future_text():
+    spans = build_bagel_vqa_image_spans(
+        input_ids=torch.tensor([1, 10, 2, 3, 11, 4, 5]),
+        req_ids=["r0"],
+        num_computed_tokens=[20],
+        num_scheduled_tokens=[7],
+        start_of_image_id=10,
+        end_of_image_id=11,
+    )
+
+    assert spans == [
+        {
+            "req_idx": 0,
+            "request_start": 0,
+            "num_computed_tokens": 20,
+            "q_start": 1,
+            "q_end": 5,
+            "kv_local_end": 5,
+            "kv_end": 25,
+        }
+    ]

--- a/vllm_omni/diffusion/models/bagel/bagel_transformer.py
+++ b/vllm_omni/diffusion/models/bagel/bagel_transformer.py
@@ -14,6 +14,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 from torch import nn
+from torch.nn.attention.flex_attention import flex_attention
 from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
 from transformers.models.qwen2.modeling_qwen2 import (
     Qwen2PreTrainedModel,
@@ -35,6 +36,7 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.transformers_utils.configs.bagel import BagelConfig
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata as DiffusionAttentionMetadata
+from vllm_omni.diffusion.attention.backends.utils.fa import flash_attn_varlen_func
 from vllm_omni.diffusion.attention.layer import Attention as DiffusionAttention
 from vllm_omni.diffusion.data import DiffusionParallelConfig
 from vllm_omni.diffusion.distributed.parallel_state import (
@@ -103,19 +105,10 @@ class BagelRotaryEmbedding(nn.Module):
 
     Replaces HuggingFace's Qwen2RotaryEmbedding while preserving full
     ``rope_scaling`` support.  When ``config.rope_scaling`` is set (e.g.
-    linear, dynamic-NTK, YaRN, …), we delegate the ``inv_freq`` /
+    linear, dynamic-NTK, YaRN, ...), we delegate the ``inv_freq`` /
     ``attention_scaling`` computation to HF's ``ROPE_INIT_FUNCTIONS`` so
     that the frequency basis and scaling factor are identical to the
-    original checkpoint.
-
-    For Qwen2.5-VL-style multimodal RoPE (``rope_scaling.rope_type == "mrope"``)
-    the ``inv_freq`` basis is the standard default-rope one; the difference
-    is that position ids are 3-D ``(t, h, w)`` per token and the
-    ``mrope_section`` describes how the head dimension is split across axes.
-    This module accepts either 2-D scalar position ids ``(B, S)`` or 3-D
-    multimodal position ids ``(B, 3, S)`` and dispatches accordingly so the
-    same module works for both BAGEL (1-D rope) and Lance (Qwen2.5-VL mrope).
-    This module has no learnable parameters.
+    original checkpoint.  This module has no learnable parameters.
     """
 
     def __init__(self, config):
@@ -129,17 +122,10 @@ class BagelRotaryEmbedding(nn.Module):
         rope_type = (
             rope_scaling.get("rope_type") or rope_scaling.get("type") or rope_parameters.get("rope_type") or "default"
         )
-        # Cache mrope_section for the forward-time section-split.
-        self._mrope_section: list[int] | None = None
-        if rope_type == "mrope":
-            section = rope_scaling.get("mrope_section") or rope_parameters.get("mrope_section")
-            if section is None:
-                raise ValueError("rope_scaling.rope_type == 'mrope' requires 'mrope_section'.")
-            self._mrope_section = list(section)
 
-        if rope_type in ("default", "mrope"):
-            # mrope shares the default sinusoidal frequency basis; the
-            # multimodal split happens at forward time, not at init.
+        if rope_type == "default":
+            # transformers>=5.0 removed the 'default' entry from
+            # ROPE_INIT_FUNCTIONS; use the plain sinusoidal formula.
             rope_theta = (
                 getattr(config, "rope_theta", None)
                 or rope_parameters.get("rope_theta")
@@ -163,36 +149,11 @@ class BagelRotaryEmbedding(nn.Module):
 
         Args:
             x: Input tensor (only used for dtype inference).
-            position_ids: Either 2-D scalar ``(batch_size, seq_len)`` for plain
-                1-D RoPE, or 3-D multimodal ``(batch_size, 3, seq_len)`` for
-                Qwen2.5-VL-style mRoPE.  The latter is auto-detected from
-                ``position_ids.ndim``.
+            position_ids: Position indices, shape (batch_size, seq_len).
 
         Returns:
             cos, sin: Rotary embeddings, each of shape (batch_size, seq_len, dim).
         """
-        if position_ids.ndim == 3 and self._mrope_section is not None:
-            # multimodal path: position_ids is (B, 3, S) with rows = (t, h, w).
-            # Compute per-axis frequencies, then assemble the per-section
-            # rotary basis matching Qwen2-VL's ``apply_multimodal_rotary_pos_emb``.
-            B = position_ids.shape[0]
-            inv_freq_expanded = self.inv_freq[None, None, :, None].float().expand(B, 3, -1, 1)
-            position_ids_expanded = position_ids[:, :, None, :].float()
-            freqs = (inv_freq_expanded @ position_ids_expanded).transpose(2, 3)
-            # ``freqs`` is (B, 3, S, head_dim/2); double along the last axis
-            # to get the full ``head_dim`` rotary basis.
-            emb = torch.cat((freqs, freqs), dim=-1)  # (B, 3, S, head_dim)
-            cos_per_axis = emb.cos() * self.attention_scaling
-            sin_per_axis = emb.sin() * self.attention_scaling
-            # ``mrope_section`` (e.g. [16, 24, 24] for Qwen2.5-VL) sums to
-            # head_dim/2; doubled it sums to head_dim and cycles axis = i % 3.
-            sec_full = self._mrope_section * 2
-            cos_split = cos_per_axis.split(sec_full, dim=-1)
-            sin_split = sin_per_axis.split(sec_full, dim=-1)
-            cos = torch.cat([c[:, i % 3] for i, c in enumerate(cos_split)], dim=-1)
-            sin = torch.cat([s[:, i % 3] for i, s in enumerate(sin_split)], dim=-1)
-            return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
-
         inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
         position_ids_expanded = position_ids[:, None, :].float()
         freqs = (inv_freq_expanded @ position_ids_expanded).transpose(1, 2)
@@ -237,6 +198,11 @@ class BagelMLP(nn.Module):
         x = self.act_fn(gate) * up
         x, _ = self.down_proj(x)
         return x
+
+
+torch._dynamo.config.cache_size_limit = 512
+torch._dynamo.config.accumulated_cache_size_limit = 4096
+flex_attention = torch.compile(flex_attention)
 
 
 class Qwen2MoTConfig(Qwen2Config):
@@ -407,55 +373,45 @@ class PackedAttentionMoT(nn.Module):
 
         self.rotary_op = RotaryEmbedding(is_neox_style=True)
 
-        self.attn_causal = DiffusionAttention(
-            num_heads=self.total_num_heads,
-            head_size=self.head_dim,
-            softmax_scale=1.0 / (self.head_dim**0.5),
-            causal=True,
-            num_kv_heads=self.total_num_kv_heads,
-        )
-        self.attn_noncausal = DiffusionAttention(
-            num_heads=self.total_num_heads,
-            head_size=self.head_dim,
-            softmax_scale=1.0 / (self.head_dim**0.5),
-            causal=False,
-            num_kv_heads=self.total_num_kv_heads,
-        )
+        # SP (Ulysses / Ring) attention for generation mode denoising
+        sp_size = parallel_config.sequence_parallel_size if parallel_config is not None else 1
+        if sp_size is not None and sp_size > 1:
+            self.sp_attn = DiffusionAttention(
+                num_heads=self.total_num_heads,
+                head_size=self.head_dim,
+                softmax_scale=1.0 / (self.head_dim**0.5),
+                causal=False,
+                num_kv_heads=self.total_num_kv_heads,
+            )
+        else:
+            self.sp_attn = None
 
     def _is_sp_active(self) -> bool:
         """Check if SP is active for this attention layer."""
+        if self.sp_attn is None:
+            return False
         if not is_forward_context_available():
             return False
         return get_forward_context().sp_active
 
-    def _forward_gen(
+    def _forward_sp_gen(
         self,
         packed_query_sequence: torch.Tensor,
         packed_query_position_embeddings: torch.Tensor,
         past_key_values: NaiveCache | None,
         packed_vae_token_indexes: torch.Tensor,
         packed_text_indexes: torch.Tensor,
-        update_past_key_values: bool = False,
     ) -> tuple[torch.Tensor, NaiveCache | None]:
-        """Forward pass for generation mode.
+        """SP-aware attention for gen mode denoising.
 
-        This path does the following:
-
-        1. Apply qkv projection to the text seq & vae seqs
-        2. Reshape both to 3D & apply RMS norms
-        3. Apply RoPE to text / VAE components independently
-        4. Create the full K/V; Bagel currently manages its own KV cache
-           (NaiveCache) independently since it is a diffusion model
-        5. Apply non-causal attention, while taking sequence parallelism into account
-        6. Apply output projections on the split parts
-        7. Merge back into the packed format
-        8. Update the NaiveCache.
-
-        TODO (Alex): it would be best to remove packing from Bagel to simplify the code.
-        Currently we shouldn't need it in the model, and it would be ideal to handle
-        packing/batching etc in a more model agnostic way.
+        Converts packed format to batched (1, S, H, D) and uses the diffusion
+        Attention layer (Ulysses / Ring) with joint mechanism:
+          - Main Q/K/V: VAE tokens (split across SP ranks)
+          - Joint Q: text marker Q (replicated)
+          - Joint K/V: KV cache K/V + text marker K/V (replicated)
         """
         packed_query_sequence = packed_query_sequence.to(torch.bfloat16)
+
         packed_text_query_sequence = packed_query_sequence[packed_text_indexes]
         packed_vae_query_sequence = packed_query_sequence[packed_vae_token_indexes]
 
@@ -484,6 +440,8 @@ class PackedAttentionMoT(nn.Module):
         # Apply RoPE - need to build per-token cos/sin for text and vae separately
         # packed_query_position_embeddings are ordered as the packed sequence
         cos_full, sin_full = [x[..., : self.head_dim // 2] for x in packed_query_position_embeddings]
+
+        # Extract cos/sin for text and vae positions
         text_cos = cos_full[packed_text_indexes]
         text_sin = sin_full[packed_text_indexes]
         vae_cos = cos_full[packed_vae_token_indexes]
@@ -505,35 +463,33 @@ class PackedAttentionMoT(nn.Module):
         if past_key_values is not None and past_key_values.key_cache[self.layer_idx] is not None:
             cache_k = past_key_values.key_cache[self.layer_idx]
             cache_v = past_key_values.value_cache[self.layer_idx]
-            ctx_k = torch.cat([cache_k, text_k], dim=0)
-            ctx_v = torch.cat([cache_v, text_v], dim=0)
+            joint_k = torch.cat([cache_k, text_k], dim=0).unsqueeze(0)
+            joint_v = torch.cat([cache_v, text_v], dim=0).unsqueeze(0)
         else:
-            ctx_k = text_k
-            ctx_v = text_v
+            joint_k = text_k.unsqueeze(0)
+            joint_v = text_v.unsqueeze(0)
 
-        # NOTE: we reshape to batched (1, S, H, D) for diffusion Attention
-        # attn_out should be: (1, text_len + local_vae_len, H, D)
-        if self._is_sp_active():
-            # Joint mechanism keeps text+cache replicated across SP ranks
-            attn_out = self.attn_noncausal(
-                vae_q.unsqueeze(0),
-                vae_k.unsqueeze(0),
-                vae_v.unsqueeze(0),
-                DiffusionAttentionMetadata(
-                    joint_query=text_q.unsqueeze(0),
-                    joint_key=ctx_k.unsqueeze(0),
-                    joint_value=ctx_v.unsqueeze(0),
-                    joint_strategy="front",
-                ),
-            )
-        else:
-            q = torch.cat([text_q, vae_q], dim=0).unsqueeze(0)
-            k = torch.cat([ctx_k, vae_k], dim=0).unsqueeze(0)
-            v = torch.cat([ctx_v, vae_v], dim=0).unsqueeze(0)
-            attn_out = self.attn_noncausal(q, k, v)
+        # Reshape to batched (1, S, H, D) for diffusion Attention
+        vae_q_4d = vae_q.unsqueeze(0)
+        vae_k_4d = vae_k.unsqueeze(0)
+        vae_v_4d = vae_v.unsqueeze(0)
+        text_q_4d = text_q.unsqueeze(0)
 
+        # Call SP-aware attention: VAE as main, text+cache as joint
+        attn_out = self.sp_attn(
+            vae_q_4d,
+            vae_k_4d,
+            vae_v_4d,
+            DiffusionAttentionMetadata(
+                joint_query=text_q_4d,
+                joint_key=joint_k,
+                joint_value=joint_v,
+                joint_strategy="front",
+            ),
+        )
+        # attn_out: (1, text_len + local_vae_len, H, D)
         text_len = text_q.shape[0]
-        attn_out = attn_out.squeeze(0)
+        attn_out = attn_out.squeeze(0)  # (text_len + local_vae_len, H, D)
         text_attn = attn_out[:text_len].reshape(text_len, self.q_size)
         vae_attn = attn_out[text_len:].reshape(-1, self.q_size)
 
@@ -547,148 +503,145 @@ class PackedAttentionMoT(nn.Module):
         full_output[packed_text_indexes] = text_out
         full_output[packed_vae_token_indexes] = vae_out
 
-        if update_past_key_values:
-            new_k = torch.cat([ctx_k, vae_k], dim=0)
-            new_v = torch.cat([ctx_v, vae_v], dim=0)
-            past_key_values.key_cache[self.layer_idx] = new_k
-            past_key_values.value_cache[self.layer_idx] = new_v
-
         return full_output, past_key_values
-
-    def _forward_und(
-        self,
-        packed_query_sequence: torch.Tensor,
-        packed_query_position_embeddings: torch.Tensor,
-        past_key_values: NaiveCache | None,
-        is_causal: bool,
-        update_past_key_values: bool = True,
-    ) -> tuple[torch.Tensor, NaiveCache | None]:
-        """Forward pass for understanding mode.
-
-        This path does the following (not hard to read):
-
-        1. Apply qkv projection to the text seq
-        2. Reshape to 3D & apply RMS norms
-        3. Apply RoPE
-        4. Create the full K/V; Bagel currently manages its own KV cache
-           (NaiveCache) independently since it is a diffusion model
-        5. Apply attention based on causality kwarg
-        6. Apply output projection
-        7. Update the NaiveCache.
-        """
-
-        qkv, _ = self.qkv_proj(packed_query_sequence)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q = q.view(-1, self.num_heads, self.head_dim)
-        k = k.view(-1, self.num_kv_heads, self.head_dim)
-        v = v.view(-1, self.num_kv_heads, self.head_dim)
-        # Pre-merge code cast to float32 before q_norm/k_norm — bf16
-        # RMSNorm accumulation drift compounds across segmented prefill
-        # (x2t builds the cache via 3+ sequential forward_cache_update_*
-        # calls), producing degenerate token repetition in generate_text.
-        q = self.q_norm(q.to(torch.float32))
-        k = self.k_norm(k.to(torch.float32))
-
-        cos, sin = [x[..., : self.head_dim // 2] for x in packed_query_position_embeddings]
-        q = self.rotary_op(q.to(cos.dtype).unsqueeze(0), cos, sin).squeeze(0)
-        k = self.rotary_op(k.to(cos.dtype).unsqueeze(0), cos, sin).squeeze(0)
-
-        q = q.to(torch.bfloat16)
-        k = k.to(torch.bfloat16)
-        v = v.to(torch.bfloat16)
-
-        if past_key_values is not None and past_key_values.key_cache[self.layer_idx] is not None:
-            cache_k = past_key_values.key_cache[self.layer_idx]
-            cache_v = past_key_values.value_cache[self.layer_idx]
-            full_k = torch.cat([cache_k, k], dim=0)
-            full_v = torch.cat([cache_v, v], dim=0)
-            cache_len = cache_k.shape[0]
-        else:
-            full_k = k
-            full_v = v
-            cache_len = 0
-
-        if is_causal and cache_len > 0:
-            # PyTorch SDPA's ``is_causal=True`` with ``Q != K`` uses
-            # ``tril(diagonal=0)`` — top-left aligned, so for Q=1 against a
-            # long cache only ``q_0 -> k_0`` is unmasked (degenerate
-            # generate_text output).  Build the correct bottom-right
-            # aligned mask manually: ``mask[i, j] = -inf if j > cache_len
-            # + i`` so each new query attends to all of ``cache + self
-            # up to i``.  Bypass ``DiffusionAttention`` entirely — its
-            # ``_maybe_reshape_attn_mask`` helper only handles 2-D
-            # ``(B, K)`` shape, not ``(Q, K)``, so the reshape path
-            # silently drops the per-query mask for Q>1.
-            Q_len = q.shape[0]
-            K_len = full_k.shape[0]
-            arange_q = torch.arange(Q_len, device=q.device).unsqueeze(1)
-            arange_k = torch.arange(K_len, device=q.device).unsqueeze(0)
-            mask = arange_k > (cache_len + arange_q)  # (Q, K) bool
-            attn_bias = torch.zeros(Q_len, K_len, dtype=q.dtype, device=q.device)
-            attn_bias.masked_fill_(mask, float("-inf"))
-            # Permute to (B=1, H, S, D) for SDPA.
-            q_4d = q.unsqueeze(0).permute(0, 2, 1, 3)
-            k_4d = full_k.unsqueeze(0).permute(0, 2, 1, 3)
-            v_4d = full_v.unsqueeze(0).permute(0, 2, 1, 3)
-            attn_out_4d = torch.nn.functional.scaled_dot_product_attention(
-                q_4d,
-                k_4d,
-                v_4d,
-                attn_mask=attn_bias.unsqueeze(0).unsqueeze(0),  # (1, 1, Q, K)
-                dropout_p=0.0,
-                is_causal=False,
-                scale=1.0 / (self.head_dim**0.5),
-                enable_gqa=(self.num_heads != self.num_kv_heads),
-            )
-            attn_out = attn_out_4d.permute(0, 2, 1, 3)
-        else:
-            attn = self.attn_causal if is_causal else self.attn_noncausal
-            attn_out = attn(
-                q.unsqueeze(0),
-                full_k.unsqueeze(0),
-                full_v.unsqueeze(0),
-            )
-
-        attn_out = attn_out.squeeze(0).reshape(-1, self.q_size)
-        attn_out, _ = self.o_proj(attn_out)
-
-        if update_past_key_values:
-            past_key_values.key_cache[self.layer_idx] = full_k
-            past_key_values.value_cache[self.layer_idx] = full_v
-
-        return attn_out, past_key_values
 
     def forward(
         self,
         packed_query_sequence: torch.Tensor,
         query_lens: torch.Tensor,
         packed_query_position_embeddings: torch.Tensor,
+        packed_query_indexes: torch.Tensor,
         past_key_values: NaiveCache | None = None,
+        key_values_lens: torch.Tensor | None = None,
+        packed_key_value_indexes: torch.Tensor | None = None,
         update_past_key_values=True,
         is_causal=True,
         mode="und",
         packed_vae_token_indexes=None,
         packed_text_indexes=None,
     ):
-        if mode == "gen":
-            if is_causal:
-                raise ValueError("Generation model for Bagel requires non-causal attention")
-            return self._forward_gen(
+        # SP path for gen-mode denoising (non-causal, no KV update)
+        if (
+            mode == "gen"
+            and not update_past_key_values
+            and not is_causal
+            and self._is_sp_active()
+            and packed_vae_token_indexes is not None
+            and packed_text_indexes is not None
+        ):
+            return self._forward_sp_gen(
                 packed_query_sequence=packed_query_sequence,
                 packed_query_position_embeddings=packed_query_position_embeddings,
                 past_key_values=past_key_values,
                 packed_vae_token_indexes=packed_vae_token_indexes,
                 packed_text_indexes=packed_text_indexes,
-                update_past_key_values=update_past_key_values,
             )
 
-        return self._forward_und(
-            packed_query_sequence=packed_query_sequence,
-            packed_query_position_embeddings=packed_query_position_embeddings,
-            past_key_values=past_key_values,
-            is_causal=is_causal,
-            update_past_key_values=update_past_key_values,
+        if mode == "und":
+            qkv, _ = self.qkv_proj(packed_query_sequence)
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            packed_query_states = q.view(-1, self.num_heads, self.head_dim)
+            packed_key_states = k.view(-1, self.num_kv_heads, self.head_dim)
+            packed_value_states = v.view(-1, self.num_kv_heads, self.head_dim)
+            packed_query_states = self.q_norm(packed_query_states)
+            packed_key_states = self.k_norm(packed_key_states)
+        elif mode == "gen":
+            packed_query_sequence = packed_query_sequence.to(torch.bfloat16)
+
+            packed_text_query_sequence = packed_query_sequence[packed_text_indexes]
+            packed_vae_query_sequence = packed_query_sequence[packed_vae_token_indexes]
+
+            # Project text tokens through base qkv
+            text_qkv, _ = self.qkv_proj(packed_text_query_sequence)
+            text_q, text_k, text_v = text_qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+            # Project vae tokens through moe_gen qkv
+            vae_qkv, _ = self.qkv_proj_moe_gen(packed_vae_query_sequence)
+            vae_q, vae_k, vae_v = vae_qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+            # Merge into packed tensors
+            total_len = packed_query_sequence.shape[0]
+            packed_query_states = packed_query_sequence.new_zeros((total_len, self.q_size))
+            packed_key_states = packed_query_sequence.new_zeros((total_len, self.kv_size))
+            packed_value_states = packed_query_sequence.new_zeros((total_len, self.kv_size))
+
+            packed_query_states[packed_text_indexes] = text_q
+            packed_query_states[packed_vae_token_indexes] = vae_q
+            packed_key_states[packed_text_indexes] = text_k
+            packed_key_states[packed_vae_token_indexes] = vae_k
+            packed_value_states[packed_text_indexes] = text_v
+            packed_value_states[packed_vae_token_indexes] = vae_v
+
+            packed_query_states = packed_query_states.view(-1, self.num_heads, self.head_dim)
+            packed_key_states = packed_key_states.view(-1, self.num_kv_heads, self.head_dim)
+            packed_value_states = packed_value_states.view(-1, self.num_kv_heads, self.head_dim)
+
+            packed_query_states = packed_query_states.to(torch.float32)
+            packed_query_states[packed_text_indexes] = self.q_norm(packed_query_states[packed_text_indexes])
+            packed_query_states[packed_vae_token_indexes] = self.q_norm_moe_gen(
+                packed_query_states[packed_vae_token_indexes]
+            )
+
+            packed_key_states = packed_key_states.to(torch.float32)
+            packed_key_states[packed_text_indexes] = self.k_norm(packed_key_states[packed_text_indexes])
+            packed_key_states[packed_vae_token_indexes] = self.k_norm_moe_gen(
+                packed_key_states[packed_vae_token_indexes]
+            )
+
+        cos, sin = [x[..., : self.head_dim // 2] for x in packed_query_position_embeddings]
+        packed_query_states = self.rotary_op(packed_query_states.to(cos.dtype).unsqueeze(0), cos, sin).squeeze(0)
+        packed_key_states = self.rotary_op(packed_key_states.to(cos.dtype).unsqueeze(0), cos, sin).squeeze(0)
+
+        packed_query_states = packed_query_states.to(torch.bfloat16)
+        packed_key_states = packed_key_states.to(torch.bfloat16)
+        packed_value_states = packed_value_states.to(torch.bfloat16)
+
+        if past_key_values is not None and past_key_values.key_cache[self.layer_idx] is not None:
+            past_key_states = past_key_values.key_cache[self.layer_idx]
+            past_value_states = past_key_values.value_cache[self.layer_idx]
+
+            seqlens = sum(query_lens) + sum(key_values_lens)
+            merged_key_states = past_key_states.new_zeros(size=[seqlens, self.num_kv_heads, self.head_dim])
+            merged_value_states = past_key_states.new_zeros(size=[seqlens, self.num_kv_heads, self.head_dim])
+            merged_key_states[packed_query_indexes] = packed_key_states
+            merged_key_states[packed_key_value_indexes] = past_key_states
+            merged_value_states[packed_query_indexes] = packed_value_states
+            merged_value_states[packed_key_value_indexes] = past_value_states
+            key_values_lens = key_values_lens + query_lens
+        else:
+            merged_key_states = packed_key_states
+            merged_value_states = packed_value_states
+            key_values_lens = query_lens
+
+        cu_seqlens_q = torch.nn.functional.pad(torch.cumsum(query_lens, dim=0), (1, 0))
+        cu_seqlens_k = torch.nn.functional.pad(torch.cumsum(key_values_lens, dim=0), (1, 0))
+
+        packed_attn_output = flash_attn_varlen_func(
+            q=packed_query_states,
+            k=merged_key_states,
+            v=merged_value_states,
+            cu_seqlens_q=cu_seqlens_q.to(torch.int32),
+            cu_seqlens_k=cu_seqlens_k.to(torch.int32),
+            max_seqlen_q=max(query_lens).item(),
+            max_seqlen_k=max(key_values_lens).item(),
+            causal=is_causal,
         )
+        packed_attn_output = packed_attn_output.reshape(-1, self.q_size)
+        if mode == "und":
+            packed_attn_output, _ = self.o_proj(packed_attn_output)
+        elif mode == "gen":
+            text_out, _ = self.o_proj(packed_attn_output[packed_text_indexes])
+            vae_out, _ = self.o_proj_moe_gen(packed_attn_output[packed_vae_token_indexes])
+            full_output = text_out.new_zeros((packed_attn_output.shape[0], self.hidden_size))
+            full_output[packed_text_indexes] = text_out
+            full_output[packed_vae_token_indexes] = vae_out
+            packed_attn_output = full_output
+
+        if update_past_key_values:
+            past_key_values.key_cache[self.layer_idx] = merged_key_states
+            past_key_values.value_cache[self.layer_idx] = merged_value_states
+
+        return packed_attn_output, past_key_values
 
 
 class Qwen2MoTDecoderLayer(nn.Module):
@@ -734,7 +687,10 @@ class Qwen2MoTDecoderLayer(nn.Module):
         packed_query_sequence: torch.Tensor | None = None,
         query_lens: torch.Tensor = None,
         packed_query_position_embeddings: torch.Tensor = None,
+        packed_query_indexes: torch.Tensor = None,
         past_key_values: NaiveCache | None = None,
+        key_values_lens: torch.Tensor | None = None,
+        packed_key_value_indexes: torch.Tensor | None = None,
         update_past_key_values=True,
         is_causal=True,
         mode="und",
@@ -761,7 +717,10 @@ class Qwen2MoTDecoderLayer(nn.Module):
             packed_query_sequence=packed_query_sequence,
             query_lens=query_lens,
             packed_query_position_embeddings=packed_query_position_embeddings,
+            packed_query_indexes=packed_query_indexes,
             past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
             update_past_key_values=update_past_key_values,
             is_causal=is_causal,
             mode=mode,
@@ -842,7 +801,10 @@ class Qwen2MoTModel(Qwen2PreTrainedModel):
         packed_query_sequence: torch.Tensor | None = None,
         query_lens: torch.Tensor | None = None,
         packed_query_position_ids: torch.Tensor | None = None,
+        packed_query_indexes: torch.Tensor | None = None,
         past_key_values: NaiveCache | None = None,
+        key_values_lens: torch.Tensor | None = None,
+        packed_key_value_indexes: torch.Tensor | None = None,
         update_past_key_values=True,
         is_causal=True,
         mode="und",
@@ -880,16 +842,15 @@ class Qwen2MoTModel(Qwen2PreTrainedModel):
                 )
 
         for layer_idx, decoder_layer in enumerate(self.layers):
-            # TODO (Alex): Remove encoder_hidden_states as a kwarg; currently we keep it
-            # for compatibility with the current custom CacheDiT adapter, as we need to be
-            # careful to not break the NaiveCache handling when switching from pattern
-            # 0 -> 4.
             packed_query_sequence, past_key_values = decoder_layer(
                 hidden_states=packed_query_sequence,
                 encoder_hidden_states=None,
                 query_lens=query_lens,
                 packed_query_position_embeddings=packed_query_position_embeddings,
+                packed_query_indexes=packed_query_indexes,
                 past_key_values=past_key_values,
+                key_values_lens=key_values_lens,
+                packed_key_value_indexes=packed_key_value_indexes,
                 update_past_key_values=update_past_key_values,
                 is_causal=is_causal,
                 **extra_inputs,
@@ -957,7 +918,10 @@ class Qwen2MoTForCausalLM(Qwen2PreTrainedModel):
         packed_query_sequence: torch.Tensor | None = None,
         query_lens: torch.Tensor | None = None,
         packed_query_position_ids: torch.Tensor | None = None,
+        packed_query_indexes: torch.Tensor | None = None,
         past_key_values: NaiveCache | None = None,
+        key_values_lens: torch.Tensor | None = None,
+        packed_key_value_indexes: torch.Tensor | None = None,
         update_past_key_values=True,
         is_causal=True,
         mode="und",
@@ -970,7 +934,10 @@ class Qwen2MoTForCausalLM(Qwen2PreTrainedModel):
             packed_query_sequence=packed_query_sequence,
             query_lens=query_lens,
             packed_query_position_ids=packed_query_position_ids,
+            packed_query_indexes=packed_query_indexes,
             past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
             update_past_key_values=update_past_key_values,
             is_causal=is_causal,
             mode=mode,
@@ -1001,7 +968,7 @@ class Qwen2MoTForCausalLM(Qwen2PreTrainedModel):
             (".qkv_proj", ".q_proj", "q"),
             (".qkv_proj", ".k_proj", "k"),
             (".qkv_proj", ".v_proj", "v"),
-            # MLP gate/up projections — fused into MergedColumnParallelLinear.
+            # MLP gate/up projections: fused into MergedColumnParallelLinear.
             # HF checkpoints store separate gate_proj / up_proj weights;
             # these entries remap them to the fused gate_up_proj parameter.
             (".gate_up_proj", ".gate_proj", 0),
@@ -1258,21 +1225,32 @@ class Bagel(nn.Module):
         packed_text_ids = list()
         packed_text_position_ids = list()
         text_token_lens = list()
+        packed_text_indexes = list()
+        packed_key_value_indexes = list()
 
+        curr = 0
         newlens, new_rope = list(), list()
         for prompt, curr_kvlen, curr_position_id in zip(prompts, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
             text_ids = tokenizer.encode(prompt, add_special_tokens=False)
             text_ids = [new_token_ids["bos_token_id"]] + text_ids + [new_token_ids["eos_token_id"]]
             text_token_lens.append(len(text_ids))
             packed_text_ids.extend(text_ids)
             packed_text_position_ids.extend(range(curr_position_id, curr_position_id + len(text_ids)))
+            packed_text_indexes.extend(range(curr, curr + len(text_ids)))
             newlens.append(curr_kvlen + len(text_ids))
             new_rope.append(curr_position_id + len(text_ids))
+            curr += len(text_ids)
 
         generation_input = {
             "text_token_lens": torch.tensor(text_token_lens, dtype=torch.int),
             "packed_text_ids": torch.tensor(packed_text_ids, dtype=torch.long),
             "packed_text_position_ids": torch.tensor(packed_text_position_ids, dtype=torch.long),
+            "packed_text_indexes": torch.tensor(packed_text_indexes, dtype=torch.long),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
         }
 
         return generation_input, newlens, new_rope
@@ -1283,6 +1261,9 @@ class Bagel(nn.Module):
         packed_text_ids: torch.IntTensor,
         packed_text_position_ids: torch.LongTensor,
         text_token_lens: torch.LongTensor,
+        packed_text_indexes: torch.LongTensor,
+        packed_key_value_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
     ):
         extra_inputs = {}
         if self.use_moe:
@@ -1292,7 +1273,10 @@ class Bagel(nn.Module):
             packed_text_ids=packed_text_ids,
             query_lens=text_token_lens,
             packed_query_position_ids=packed_text_position_ids,
+            packed_query_indexes=packed_text_indexes,
             past_key_values=past_key_values,
+            packed_key_value_indexes=packed_key_value_indexes,
+            key_values_lens=key_values_lens,
             update_past_key_values=True,
             is_causal=True,
             **extra_inputs,
@@ -1305,14 +1289,20 @@ class Bagel(nn.Module):
         patchified_vae_latent_shapes, packed_vae_position_ids = list(), list()
         packed_vae_token_indexes = list()
         packed_text_ids, packed_text_indexes = list(), list()
-        packed_seqlens, packed_position_ids = list(), list()
+        packed_seqlens, packed_position_ids, packed_indexes = list(), list(), list()
+        packed_key_value_indexes = list()
 
-        _curr = 0
+        _curr = curr = 0
         vae_image_tensors = list()
         newlens, new_rope = list(), list()
         for image, curr_kvlen, curr_position_id in zip(images, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
             packed_text_ids.append(new_token_ids["start_of_image"])
             packed_text_indexes.append(_curr)
+            packed_indexes.append(curr)
+            curr += 1
             _curr += 1
 
             image_tensor = transforms(image)
@@ -1331,10 +1321,14 @@ class Bagel(nn.Module):
 
             num_img_tokens = w * h
             packed_vae_token_indexes.extend(range(_curr, _curr + num_img_tokens))
+            packed_indexes.extend(range(curr, curr + num_img_tokens))
+            curr += num_img_tokens
             _curr += num_img_tokens
 
             packed_text_ids.append(new_token_ids["end_of_image"])
             packed_text_indexes.append(_curr)
+            packed_indexes.append(curr)
+            curr += 1
             _curr += 1
 
             packed_position_ids.extend([curr_position_id] * (num_img_tokens + 2))
@@ -1358,6 +1352,9 @@ class Bagel(nn.Module):
             "packed_text_indexes": torch.tensor(packed_text_indexes, dtype=torch.long),
             "packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
             "packed_seqlens": torch.tensor(packed_seqlens, dtype=torch.int),
+            "packed_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
         }
 
         return generation_input, newlens, new_rope
@@ -1375,7 +1372,21 @@ class Bagel(nn.Module):
         packed_text_indexes: torch.LongTensor,
         packed_position_ids: torch.LongTensor,
         packed_seqlens: torch.IntTensor,
+        packed_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
+        packed_key_value_indexes: torch.Tensor,
     ):
+        packed_text_embedding = self.language_model.forward(
+            packed_text_ids=packed_text_ids,
+            return_embeddings_only=True,
+        ).packed_query_sequence
+        packed_sequence = packed_text_embedding.new_zeros((sum(packed_seqlens), self.hidden_size))
+        packed_sequence[packed_text_indexes] = packed_text_embedding
+
+        padded_images = padded_images.to(
+            device=packed_text_embedding.device,
+            dtype=torch.bfloat16,
+        )
         padded_latent = vae_model.encode(padded_images)
 
         p = self.latent_patch_size
@@ -1388,15 +1399,6 @@ class Bagel(nn.Module):
         packed_pos_embed = self.latent_pos_embed(packed_vae_position_ids)
         packed_timestep_embeds = self.time_embedder(packed_timesteps)
         packed_latent = self.vae2llm(packed_latent) + packed_timestep_embeds + packed_pos_embed
-
-        # Mirror forward_cache_update_vit: build a full packed_sequence so MoE gen-mode
-        # indexes (packed_text_indexes / packed_vae_token_indexes) match tensor length.
-        packed_text_embedding = self.language_model.forward(
-            packed_text_ids=packed_text_ids,
-            return_embeddings_only=True,
-        ).packed_query_sequence
-        packed_sequence = packed_text_embedding.new_zeros((sum(packed_seqlens), self.hidden_size))
-        packed_sequence[packed_text_indexes] = packed_text_embedding
         if packed_latent.dtype != packed_sequence.dtype:
             packed_latent = packed_latent.to(packed_sequence.dtype)
         packed_sequence[packed_vae_token_indexes] = packed_latent
@@ -1413,7 +1415,10 @@ class Bagel(nn.Module):
             packed_query_sequence=packed_sequence,
             query_lens=packed_seqlens,
             packed_query_position_ids=packed_position_ids,
+            packed_query_indexes=packed_indexes,
             past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
             update_past_key_values=True,
             is_causal=False,
             **extra_inputs,
@@ -1426,13 +1431,19 @@ class Bagel(nn.Module):
         packed_vit_token_indexes = list()
         vit_token_seqlens, packed_vit_tokens, packed_vit_position_ids = list(), list(), list()
         packed_text_ids, packed_text_indexes = list(), list()
-        packed_seqlens, packed_position_ids = list(), list()
+        packed_seqlens, packed_position_ids, packed_indexes = list(), list(), list()
+        packed_key_value_indexes = list()
 
-        _curr = 0
+        _curr = curr = 0
         newlens, new_rope = list(), list()
         for image, curr_kvlen, curr_position_id in zip(images, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
             packed_text_ids.append(new_token_ids["start_of_image"])
             packed_text_indexes.append(_curr)
+            packed_indexes.append(curr)
+            curr += 1
             _curr += 1
 
             image_tensor = transforms(image)
@@ -1448,10 +1459,14 @@ class Bagel(nn.Module):
             packed_vit_position_ids.append(vit_position_ids)
             vit_token_seqlens.append(num_img_tokens)
             packed_vit_token_indexes.extend(range(_curr, _curr + num_img_tokens))
+            packed_indexes.extend(range(curr, curr + num_img_tokens))
+            curr += num_img_tokens
             _curr += num_img_tokens
 
             packed_text_ids.append(new_token_ids["end_of_image"])
             packed_text_indexes.append(_curr)
+            packed_indexes.append(curr)
+            curr += 1
             _curr += 1
 
             packed_position_ids.extend([curr_position_id] * (num_img_tokens + 2))
@@ -1468,6 +1483,9 @@ class Bagel(nn.Module):
             "packed_vit_token_indexes": torch.tensor(packed_vit_token_indexes, dtype=torch.long),
             "packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
             "packed_seqlens": torch.tensor(packed_seqlens, dtype=torch.int),
+            "packed_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
         }
 
         return generation_input, newlens, new_rope
@@ -1483,6 +1501,9 @@ class Bagel(nn.Module):
         vit_token_seqlens: torch.IntTensor,
         packed_position_ids: torch.LongTensor,
         packed_seqlens: torch.IntTensor,
+        packed_indexes: torch.LongTensor,
+        packed_key_value_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
     ):
         packed_text_embedding = self.language_model.forward(
             packed_text_ids=packed_text_ids,
@@ -1515,7 +1536,10 @@ class Bagel(nn.Module):
             packed_query_sequence=packed_sequence,
             query_lens=packed_seqlens,
             packed_query_position_ids=packed_position_ids,
+            packed_query_indexes=packed_indexes,
             past_key_values=past_key_values,
+            packed_key_value_indexes=packed_key_value_indexes,
+            key_values_lens=key_values_lens,
             update_past_key_values=True,
             is_causal=False,
             **extra_inputs,
@@ -1524,15 +1548,22 @@ class Bagel(nn.Module):
 
         return past_key_values
 
-    def prepare_input(self, curr_kvlens, curr_rope, image_sizes, new_token_ids=None):
+    def prepare_input(self, curr_kvlens, curr_rope, image_sizes, new_token_ids=None, noise_seeds=None):
         packed_text_ids, packed_text_indexes = list(), list()
         packed_vae_position_ids, packed_vae_token_indexes, packed_init_noises = list(), list(), list()
-        packed_position_ids, packed_seqlens = list(), list()
+        packed_position_ids, packed_seqlens, packed_indexes = list(), list(), list()
+        packed_key_value_indexes = list()
 
-        query_curr = 0
-        for (H, W), curr_kvlen, curr_position_id in zip(image_sizes, curr_kvlens, curr_rope):
+        query_curr = curr = 0
+        for sample_idx, ((H, W), curr_kvlen, curr_position_id) in enumerate(zip(image_sizes, curr_kvlens, curr_rope)):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
             packed_text_ids.append(new_token_ids["start_of_image"])
             packed_text_indexes.append(query_curr)
+
+            packed_indexes.append(curr)
+            curr += 1
             query_curr += 1
 
             vae_position_ids = self.get_flattened_position_ids(
@@ -1543,13 +1574,28 @@ class Bagel(nn.Module):
             h, w = H // self.latent_downsample, W // self.latent_downsample
             num_image_tokens = h * w
 
-            packed_init_noises.append(torch.randn(num_image_tokens, self.latent_channel * self.latent_patch_size**2))
+            generator = None
+            if noise_seeds is not None and noise_seeds[sample_idx] is not None:
+                generator = torch.Generator(device="cpu").manual_seed(int(noise_seeds[sample_idx]))
+            packed_init_noises.append(
+                torch.randn(
+                    num_image_tokens,
+                    self.latent_channel * self.latent_patch_size**2,
+                    generator=generator,
+                )
+            )
             packed_vae_token_indexes.extend(range(query_curr, query_curr + num_image_tokens))
             packed_seqlens.append(num_image_tokens + 2)
+
+            packed_indexes.extend(range(curr, curr + num_image_tokens))
+            curr += num_image_tokens
             query_curr += num_image_tokens
 
             packed_text_ids.append(new_token_ids["end_of_image"])
             packed_text_indexes.append(query_curr)
+
+            packed_indexes.append(curr)
+            curr += 1
             query_curr += 1
 
             packed_position_ids.extend([curr_position_id] * (num_image_tokens + 2))
@@ -1563,41 +1609,86 @@ class Bagel(nn.Module):
             "packed_vae_token_indexes": torch.tensor(packed_vae_token_indexes, dtype=torch.long),
             "packed_seqlens": torch.tensor(packed_seqlens, dtype=torch.int),
             "packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+            "packed_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
         }
 
         return generation_input
 
-    def prepare_vae_latent(self, curr_kvlens, curr_rope, image_sizes, new_token_ids):
-        return self.prepare_input(curr_kvlens, curr_rope, image_sizes, new_token_ids)
+    def prepare_vae_latent(self, curr_kvlens, curr_rope, image_sizes, new_token_ids, noise_seeds=None):
+        return self.prepare_input(curr_kvlens, curr_rope, image_sizes, new_token_ids, noise_seeds=noise_seeds)
 
     def prepare_vae_latent_cfg(self, curr_kvlens, curr_rope, image_sizes):
-        packed_position_ids = list()
+        packed_position_ids, packed_indexes, packed_key_value_indexes = list(), list(), list()
 
+        query_curr = curr = 0
         for (H, W), curr_kvlen, curr_position_id in zip(image_sizes, curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
+            curr += curr_kvlen
+
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
             h, w = H // self.latent_downsample, W // self.latent_downsample
             num_image_tokens = h * w
+            packed_indexes.extend(range(curr, curr + num_image_tokens))
+            curr += num_image_tokens
+            query_curr += num_image_tokens
+
+            packed_indexes.append(curr)
+            curr += 1
+            query_curr += 1
+
             packed_position_ids.extend([curr_position_id] * (num_image_tokens + 2))
 
         generation_input = {
             "cfg_packed_position_ids": torch.tensor(packed_position_ids, dtype=torch.long),
+            "cfg_key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+            "cfg_packed_query_indexes": torch.tensor(packed_indexes, dtype=torch.long),
+            "cfg_packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
         }
 
         return generation_input
+
+    @staticmethod
+    def _merge_naive_caches(caches: list) -> NaiveCache:
+        """Merge multiple NaiveCache objects by concatenating KV tensors per layer."""
+        if not caches:
+            # Handle empty list case gracefully if desired,
+            # though original code also crashed on this.
+            return NaiveCache(0)
+
+        num_layers = len(caches[0].key_cache)
+        merged = NaiveCache(num_layers)
+        for layer_idx in range(num_layers):
+            key_parts = [c.key_cache[layer_idx] for c in caches if c.key_cache[layer_idx] is not None]
+            val_parts = [c.value_cache[layer_idx] for c in caches if c.value_cache[layer_idx] is not None]
+            merged.key_cache[layer_idx] = torch.cat(key_parts, dim=0) if key_parts else None
+            merged.value_cache[layer_idx] = torch.cat(val_parts, dim=0) if val_parts else None
+        return merged
 
     def prepare_start_tokens(self, curr_kvlens, curr_rope, new_token_ids):
         """Prepare start tokens for autoregressive text generation.
 
         Ported from the original BAGEL ``Bagel.prepare_start_tokens``.
         """
-        packed_start_tokens = list()
+        packed_start_tokens, packed_key_value_indexes = list(), list()
         packed_query_position_ids = list()
 
+        curr = 0
         for curr_kvlen, curr_position_id in zip(curr_kvlens, curr_rope):
+            packed_key_value_indexes.extend(range(curr, curr + curr_kvlen))
             packed_start_tokens.append(new_token_ids["bos_token_id"])
             packed_query_position_ids.append(curr_position_id)
+            curr += curr_kvlen
+
         generation_input = {
             "packed_start_tokens": torch.tensor(packed_start_tokens, dtype=torch.long),
             "packed_query_position_ids": torch.tensor(packed_query_position_ids, dtype=torch.long),
+            "key_values_lens": torch.tensor(curr_kvlens, dtype=torch.int),
+            "packed_key_value_indexes": torch.tensor(packed_key_value_indexes, dtype=torch.long),
         }
         return generation_input
 
@@ -1605,12 +1696,15 @@ class Bagel(nn.Module):
     def generate_text(
         self,
         past_key_values: NaiveCache,
+        packed_key_value_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
         packed_start_tokens: torch.LongTensor,
         packed_query_position_ids: torch.LongTensor,
         max_length: int,
         do_sample: bool = False,
         temperature: float = 1.0,
         end_token_id: int | None = None,
+        repeat_stop_n: int | None = None,
     ):
         """Autoregressive text generation (ported from original BAGEL).
 
@@ -1619,16 +1713,33 @@ class Bagel(nn.Module):
         """
         step = 0
         generated_sequence = []
+        repeat_limit = int(repeat_stop_n or 0)
+        repeat_count = 1
         curr_tokens = packed_start_tokens
         while step < max_length:
+            prev_tokens = curr_tokens.clone()
             generated_sequence.append(curr_tokens)
             query_lens = torch.ones_like(curr_tokens)
+            packed_query_indexes = torch.cumsum(key_values_lens, dim=0) + torch.arange(
+                0,
+                len(key_values_lens),
+                device=key_values_lens.device,
+                dtype=key_values_lens.dtype,
+            )
+
+            uppacked = list(packed_key_value_indexes.split(key_values_lens.tolist(), dim=0))
+            for i in range(len(uppacked)):
+                uppacked[i] += i
+            packed_key_value_indexes = torch.cat(uppacked, dim=0)
 
             output = self.language_model(
                 packed_text_ids=curr_tokens,
                 query_lens=query_lens,
                 packed_query_position_ids=packed_query_position_ids,
+                packed_query_indexes=packed_query_indexes,
                 past_key_values=past_key_values,
+                key_values_lens=key_values_lens,
+                packed_key_value_indexes=packed_key_value_indexes,
                 update_past_key_values=True,
                 is_causal=True,
                 mode="und",
@@ -1643,14 +1754,160 @@ class Bagel(nn.Module):
             else:
                 curr_tokens = torch.argmax(pred_logits, dim=-1)
 
+            uppacked = list(packed_key_value_indexes.split(key_values_lens.tolist(), dim=0))
+            for i in range(len(uppacked)):
+                uppacked[i] = torch.cat(
+                    [uppacked[i], torch.tensor([uppacked[i][-1] + 1], device=uppacked[i].device)], dim=0
+                )
+            packed_key_value_indexes = torch.cat(uppacked, dim=0)
+            key_values_lens = key_values_lens + 1
             packed_query_position_ids = packed_query_position_ids + 1
             step += 1
 
             if end_token_id is not None and curr_tokens[0] == end_token_id:
                 break
+            if repeat_limit > 0:
+                if bool((curr_tokens == prev_tokens).all()):
+                    repeat_count += 1
+                else:
+                    repeat_count = 1
+                if repeat_count >= repeat_limit:
+                    break
 
         output_device = generated_sequence[0].device
         return torch.stack([i.to(output_device) for i in generated_sequence], dim=0)
+
+    @torch.no_grad()
+    def batch_generate_text(
+        self,
+        past_key_values: NaiveCache,
+        packed_key_value_indexes: torch.LongTensor,
+        key_values_lens: torch.IntTensor,
+        packed_start_tokens: torch.LongTensor,
+        packed_query_position_ids: torch.LongTensor,
+        max_length: int,
+        do_sample: bool = False,
+        temperature: float = 1.0,
+        end_token_id: int | None = None,
+        sampling_generators: list[torch.Generator | None] | None = None,
+        repeat_stop_n: int | None = None,
+    ) -> list[torch.Tensor]:
+        """Autoregressive batched text generation with per-row EOS tracking."""
+        device = None
+        for layer_idx in range(past_key_values.num_layers):
+            if past_key_values.key_cache[layer_idx] is not None:
+                device = past_key_values.key_cache[layer_idx].device
+                break
+        if device is None:
+            device = packed_start_tokens.device
+
+        packed_key_value_indexes = packed_key_value_indexes.to(device)
+        key_values_lens = key_values_lens.to(device)
+        packed_start_tokens = packed_start_tokens.to(device)
+        packed_query_position_ids = packed_query_position_ids.to(device)
+
+        batch_size = int(key_values_lens.numel())
+        generated_sequences: list[list[torch.Tensor]] = [[] for _ in range(batch_size)]
+        finished = torch.zeros(batch_size, dtype=torch.bool, device=device)
+        repeat_limit = int(repeat_stop_n or 0)
+        repeat_counts = torch.ones(batch_size, dtype=torch.int, device=device)
+        curr_tokens = packed_start_tokens.clone()
+
+        step = 0
+        while step < max_length:
+            prev_tokens = curr_tokens.clone()
+            active_before_sample = ~finished
+            for row_idx in range(batch_size):
+                if not bool(finished[row_idx]):
+                    generated_sequences[row_idx].append(curr_tokens[row_idx].clone())
+
+            query_lens = torch.ones_like(curr_tokens)
+            packed_query_indexes = torch.cumsum(key_values_lens, dim=0) + torch.arange(
+                0,
+                len(key_values_lens),
+                device=key_values_lens.device,
+                dtype=key_values_lens.dtype,
+            )
+
+            uppacked = list(packed_key_value_indexes.split(key_values_lens.tolist(), dim=0))
+            for row_idx in range(len(uppacked)):
+                uppacked[row_idx] += row_idx
+            packed_key_value_indexes = torch.cat(uppacked, dim=0)
+
+            output = self.language_model(
+                packed_text_ids=curr_tokens,
+                query_lens=query_lens,
+                packed_query_position_ids=packed_query_position_ids,
+                packed_query_indexes=packed_query_indexes,
+                past_key_values=past_key_values,
+                key_values_lens=key_values_lens,
+                packed_key_value_indexes=packed_key_value_indexes,
+                update_past_key_values=True,
+                is_causal=True,
+                mode="und",
+            )
+            past_key_values = output.past_key_values
+            pred_logits = self.language_model.lm_head(output.packed_query_sequence)
+
+            if do_sample:
+                probs = nn.functional.softmax(pred_logits / temperature, dim=-1)
+                if sampling_generators is not None:
+                    sampled_tokens = []
+                    for row_idx in range(batch_size):
+                        if bool(finished[row_idx]):
+                            sampled_tokens.append(curr_tokens[row_idx : row_idx + 1])
+                            continue
+                        generator = (
+                            sampling_generators[row_idx]
+                            if row_idx < len(sampling_generators)
+                            else None
+                        )
+                        sampled_tokens.append(
+                            torch.multinomial(
+                                probs[row_idx : row_idx + 1],
+                                num_samples=1,
+                                generator=generator,
+                            ).squeeze(0)
+                        )
+                    curr_tokens = torch.stack(sampled_tokens, dim=0).squeeze(1)
+                else:
+                    curr_tokens = torch.multinomial(probs, num_samples=1).squeeze(1)
+            else:
+                curr_tokens = torch.argmax(pred_logits, dim=-1)
+
+            if end_token_id is not None:
+                finished = finished | (curr_tokens == end_token_id)
+
+            if repeat_limit > 0:
+                repeated = (curr_tokens == prev_tokens) & active_before_sample
+                repeat_counts = torch.where(
+                    repeated,
+                    repeat_counts + 1,
+                    torch.ones_like(repeat_counts),
+                )
+                finished = finished | (repeat_counts >= repeat_limit)
+
+            uppacked = list(packed_key_value_indexes.split(key_values_lens.tolist(), dim=0))
+            for row_idx in range(len(uppacked)):
+                uppacked[row_idx] = torch.cat(
+                    [
+                        uppacked[row_idx],
+                        torch.tensor([uppacked[row_idx][-1] + 1], device=uppacked[row_idx].device),
+                    ],
+                    dim=0,
+                )
+            packed_key_value_indexes = torch.cat(uppacked, dim=0)
+            key_values_lens = key_values_lens + 1
+            packed_query_position_ids = packed_query_position_ids + 1
+            step += 1
+
+            if bool(finished.all()):
+                break
+
+        return [
+            torch.stack(seq, dim=0) if seq else torch.empty(0, dtype=torch.long, device=device)
+            for seq in generated_sequences
+        ]
 
     def generate_image(
         self,
@@ -1661,7 +1918,10 @@ class Bagel(nn.Module):
         packed_vae_token_indexes: torch.LongTensor,
         packed_seqlens: torch.IntTensor,
         packed_position_ids: torch.LongTensor,
+        packed_indexes: torch.LongTensor,
         past_key_values: NaiveCache,
+        key_values_lens: torch.IntTensor,
+        packed_key_value_indexes: torch.LongTensor,
         num_timesteps: int = 24,
         timestep_shift: float = 1.0,
         cfg_renorm_min: float = 0.0,
@@ -1669,35 +1929,25 @@ class Bagel(nn.Module):
         cfg_interval: tuple[float, float] = [0, 1],
         # cfg_text
         cfg_text_scale: float = 1.0,
+        cfg_text_packed_query_indexes: torch.LongTensor | None = None,
         cfg_text_packed_position_ids: torch.LongTensor | None = None,
         cfg_text_past_key_values: NaiveCache | None = None,
+        cfg_text_key_values_lens: torch.IntTensor | None = None,
+        cfg_text_packed_key_value_indexes: torch.LongTensor | None = None,
         # cfg_img
         cfg_img_scale: float = 1.0,
+        cfg_img_packed_query_indexes: torch.LongTensor | None = None,
         cfg_img_packed_position_ids: torch.LongTensor | None = None,
         cfg_img_past_key_values: NaiveCache | None = None,
+        cfg_img_key_values_lens: torch.IntTensor | None = None,
+        cfg_img_packed_key_value_indexes: torch.LongTensor | None = None,
         return_trajectory_latents: bool = False,
         scheduler: object | None = None,
         scheduler_kwargs: dict | None = None,
-        # Lance i2v: tokens to freeze at their initial (encoded-image)
-        # value throughout the denoise loop.  Matches upstream's
-        # ``mse_loss_indexes``-exclusion behaviour from PR #33: cond
-        # positions are never updated and get ``timestep=0``.
-        frame_condition_token_indexes: torch.LongTensor | None = None,
     ):
         x_t = packed_init_noises
-        # Snapshot the pinned subtensor BEFORE the denoise loop touches
-        # x_t; the cond positions in packed_init_noises hold the
-        # VAE-encoded conditioning latent that must be preserved verbatim.
-        pinned_x_t = None
-        if frame_condition_token_indexes is not None:
-            frame_condition_token_indexes = frame_condition_token_indexes.to(x_t.device).long()
-            pinned_x_t = x_t[frame_condition_token_indexes].clone()
 
-        # Use num_timesteps + 1 sample points so we get `num_timesteps` denoise
-        # steps after dropping the terminal t=0 (which has no dt).  Upstream
-        # Lance / BAGEL both use this convention; without the +1 we silently
-        # run one fewer denoise iteration than the user asked for.
-        timesteps = torch.linspace(1, 0, num_timesteps + 1, device=x_t.device)
+        timesteps = torch.linspace(1, 0, num_timesteps, device=x_t.device)
         timesteps = timestep_shift * timesteps / (1 + (timestep_shift - 1) * timesteps)
         dts = timesteps[:-1] - timesteps[1:]
         timesteps = timesteps[:-1]
@@ -1713,7 +1963,7 @@ class Bagel(nn.Module):
         use_cfg_text = cfg_text_scale > 1.0
         use_cfg_img = cfg_img_scale > 1.0
 
-        # ── Detect CFG parallel mode ──
+        # -- Detect CFG parallel mode --
         cfg_parallel_ready = use_cfg_text and get_classifier_free_guidance_world_size() > 1
 
         if cfg_parallel_ready:
@@ -1727,34 +1977,37 @@ class Bagel(nn.Module):
                 packed_vae_token_indexes=packed_vae_token_indexes,
                 packed_seqlens=packed_seqlens,
                 packed_position_ids=packed_position_ids,
+                packed_indexes=packed_indexes,
                 past_key_values=past_key_values,
+                key_values_lens=key_values_lens,
+                packed_key_value_indexes=packed_key_value_indexes,
                 cfg_renorm_min=cfg_renorm_min,
                 cfg_renorm_type=cfg_renorm_type,
                 cfg_interval=cfg_interval,
                 cfg_text_scale=cfg_text_scale,
+                cfg_text_packed_query_indexes=cfg_text_packed_query_indexes,
                 cfg_text_packed_position_ids=cfg_text_packed_position_ids,
                 cfg_text_past_key_values=cfg_text_past_key_values,
+                cfg_text_key_values_lens=cfg_text_key_values_lens,
+                cfg_text_packed_key_value_indexes=cfg_text_packed_key_value_indexes,
                 cfg_img_scale=cfg_img_scale,
+                cfg_img_packed_query_indexes=cfg_img_packed_query_indexes,
                 cfg_img_packed_position_ids=cfg_img_packed_position_ids,
                 cfg_img_past_key_values=cfg_img_past_key_values,
+                cfg_img_key_values_lens=cfg_img_key_values_lens,
+                cfg_img_packed_key_value_indexes=cfg_img_packed_key_value_indexes,
                 return_trajectory_latents=return_trajectory_latents,
                 scheduler=scheduler,
                 scheduler_kwargs=scheduler_kwargs,
             )
 
-        # ── SP + CFG: sequential single-branch forwards ──
+        # -- SP + CFG: sequential single-branch forwards --
         use_sp = self._sp_size > 1
         if use_sp and use_cfg_text:
             if return_trajectory_latents and len(timesteps) > 0:
                 trajectory_latents.append(x_t.clone())
-            for i, t in enumerate(timesteps.tolist()):  # host floats; a 0-d tensor t would sync each step
+            for i, t in enumerate(timesteps):
                 timestep = torch.tensor([t] * x_t.shape[0], device=x_t.device)
-                if frame_condition_token_indexes is not None:
-                    # Cond positions stay at t=0 (clean signal).  Matches upstream
-                    # PR #33 lance.py line 1605:
-                    #     timestep[current_vae_mse_indexes_local_in_vae] = t
-                    # (cond positions remain at the ``torch.zeros`` init value).
-                    timestep[frame_condition_token_indexes] = 0.0
                 in_cfg_window = t > cfg_interval[0] and t <= cfg_interval[1]
                 cfg_text_scale_ = cfg_text_scale if in_cfg_window else 1.0
                 cfg_img_scale_ = cfg_img_scale if in_cfg_window else 1.0
@@ -1771,22 +2024,31 @@ class Bagel(nn.Module):
 
                 v_t = self.forward_single_branch(
                     **common,
+                    packed_indexes=packed_indexes,
                     packed_position_ids=packed_position_ids,
+                    key_values_lens=key_values_lens,
                     past_key_values=past_key_values,
+                    packed_key_value_indexes=packed_key_value_indexes,
                 )
 
                 if cfg_text_scale_ > 1.0:
                     cfg_text_v_t = self.forward_single_branch(
                         **common,
+                        packed_indexes=cfg_text_packed_query_indexes,
                         packed_position_ids=cfg_text_packed_position_ids,
+                        key_values_lens=cfg_text_key_values_lens,
                         past_key_values=cfg_text_past_key_values,
+                        packed_key_value_indexes=cfg_text_packed_key_value_indexes,
                     )
                     cfg_img_v_t = None
                     if cfg_img_scale_ > 1.0:
                         cfg_img_v_t = self.forward_single_branch(
                             **common,
+                            packed_indexes=cfg_img_packed_query_indexes,
                             packed_position_ids=cfg_img_packed_position_ids,
+                            key_values_lens=cfg_img_key_values_lens,
                             past_key_values=cfg_img_past_key_values,
+                            packed_key_value_indexes=cfg_img_packed_key_value_indexes,
                         )
                     v_t = self._combine_cfg(
                         v_t,
@@ -1812,18 +2074,12 @@ class Bagel(nn.Module):
             unpacked_latent = x_t.split((packed_seqlens - 2).tolist())
             return unpacked_latent, trajectory_latents, trajectory_timesteps, trajectory_log_probs
 
-        # ── SP without CFG: direct single-branch loop ──
+        # -- SP without CFG: direct single-branch loop --
         if use_sp:
             if return_trajectory_latents and len(timesteps) > 0:
                 trajectory_latents.append(x_t.clone())
-            for i, t in enumerate(timesteps.tolist()):  # host floats; a 0-d tensor t would sync each step
+            for i, t in enumerate(timesteps):
                 timestep = torch.tensor([t] * x_t.shape[0], device=x_t.device)
-                if frame_condition_token_indexes is not None:
-                    # Cond positions stay at t=0 (clean signal).  Matches upstream
-                    # PR #33 lance.py line 1605:
-                    #     timestep[current_vae_mse_indexes_local_in_vae] = t
-                    # (cond positions remain at the ``torch.zeros`` init value).
-                    timestep[frame_condition_token_indexes] = 0.0
                 v_t = self.forward_single_branch(
                     x_t=x_t,
                     timestep=timestep,
@@ -1831,9 +2087,12 @@ class Bagel(nn.Module):
                     packed_vae_position_ids=packed_vae_position_ids,
                     packed_text_ids=packed_text_ids,
                     packed_text_indexes=packed_text_indexes,
+                    packed_indexes=packed_indexes,
                     packed_position_ids=packed_position_ids,
                     packed_seqlens=packed_seqlens,
+                    key_values_lens=key_values_lens,
                     past_key_values=past_key_values,
+                    packed_key_value_indexes=packed_key_value_indexes,
                 )
                 if scheduler is not None:
                     out = scheduler.step(v_t.to(x_t.device), timesteps[i], x_t, dts[i], **_sched_kw)
@@ -1850,31 +2109,67 @@ class Bagel(nn.Module):
             unpacked_latent = x_t.split((packed_seqlens - 2).tolist())
             return unpacked_latent, trajectory_latents, trajectory_timesteps, trajectory_log_probs
 
-        # ── Sequential CFG mode (cfg_parallel_size=1, no SP) ──
-        # Each CFG branch runs its own LLM forward; we just need the
-        # per-branch packed_position_ids and past_key_values for
-        # ``Bagel.forward`` to dispatch through.
-        cfg_branches: dict | None = None
+        # -- Batched CFG mode (cfg_parallel_size=1, no SP) --
+        cfg_batched = None
 
         if use_cfg_text:
-            branches_pid = [packed_position_ids, cfg_text_packed_position_ids]
-            branches_cache = [past_key_values, cfg_text_past_key_values]
+            seq_len = int(packed_seqlens.sum())
+
+            # Branch 0: main (gen_context), always present
+            branches_qi = [packed_indexes]
+            branches_kvi = [packed_key_value_indexes]
+            branches_kvl = [key_values_lens]
+            branches_pid = [packed_position_ids]
+            branches_cache = [past_key_values]
+
+            # Branch 1: cfg_text (unconditional text), always present when use_cfg_text
+            branches_qi.append(cfg_text_packed_query_indexes)
+            branches_kvi.append(cfg_text_packed_key_value_indexes)
+            branches_kvl.append(cfg_text_key_values_lens)
+            branches_pid.append(cfg_text_packed_position_ids)
+            branches_cache.append(cfg_text_past_key_values)
+
+            # Branch 2: cfg_img (text-only, no image), optional
             if use_cfg_img:
+                branches_qi.append(cfg_img_packed_query_indexes)
+                branches_kvi.append(cfg_img_packed_key_value_indexes)
+                branches_kvl.append(cfg_img_key_values_lens)
                 branches_pid.append(cfg_img_packed_position_ids)
                 branches_cache.append(cfg_img_past_key_values)
-            cfg_branches = {"pids": branches_pid, "caches": branches_cache}
+
+            num_branches = len(branches_cache)
+
+            # Compute per-branch offsets in the merged KV+Q attention tensor
+            merged_offsets = [0]
+            for b_idx in range(num_branches):
+                merged_offsets.append(merged_offsets[-1] + int(branches_kvl[b_idx].sum()) + seq_len)
+
+            cfg_batched = {
+                "num_branches": num_branches,
+                "seq_len": seq_len,
+                "batched_query_lens": packed_seqlens.repeat(num_branches),
+                "batched_position_ids": torch.cat(branches_pid),
+                "batched_kv_lens": torch.cat(branches_kvl),
+                "batched_query_indexes": torch.cat(
+                    [qi + merged_offsets[b_idx] for b_idx, qi in enumerate(branches_qi)]
+                ),
+                "batched_kv_indexes": torch.cat(
+                    [kvi + merged_offsets[b_idx] for b_idx, kvi in enumerate(branches_kvi)]
+                ),
+                "batched_text_indexes": torch.cat(
+                    [packed_text_indexes + b_idx * seq_len for b_idx in range(num_branches)]
+                ),
+                "batched_vae_indexes": torch.cat(
+                    [packed_vae_token_indexes + b_idx * seq_len for b_idx in range(num_branches)]
+                ),
+                "merged_cache": self._merge_naive_caches(branches_cache),
+            }
 
         if return_trajectory_latents and len(timesteps) > 0:
             trajectory_latents.append(x_t.clone())
 
-        for i, t in enumerate(timesteps.tolist()):  # host floats; a 0-d tensor t would sync each step
+        for i, t in enumerate(timesteps):
             timestep = torch.tensor([t] * x_t.shape[0], device=x_t.device)
-            if frame_condition_token_indexes is not None:
-                # Cond positions stay at t=0 (clean signal).  Matches upstream
-                # PR #33 lance.py line 1605:
-                #     timestep[current_vae_mse_indexes_local_in_vae] = t
-                # (cond positions remain at the ``torch.zeros`` init value).
-                timestep[frame_condition_token_indexes] = 0.0
             if t > cfg_interval[0] and t <= cfg_interval[1]:
                 cfg_text_scale_ = cfg_text_scale
                 cfg_img_scale_ = cfg_img_scale
@@ -1889,13 +2184,16 @@ class Bagel(nn.Module):
                 packed_text_ids=packed_text_ids,
                 packed_text_indexes=packed_text_indexes,
                 packed_position_ids=packed_position_ids,
+                packed_indexes=packed_indexes,
                 packed_seqlens=packed_seqlens,
+                key_values_lens=key_values_lens,
                 past_key_values=past_key_values,
+                packed_key_value_indexes=packed_key_value_indexes,
                 cfg_renorm_min=cfg_renorm_min,
                 cfg_renorm_type=cfg_renorm_type,
                 cfg_text_scale=cfg_text_scale_,
                 cfg_img_scale=cfg_img_scale_,
-                cfg_branches=cfg_branches,
+                cfg_batched=cfg_batched,
             )
 
             if scheduler is not None:
@@ -1905,12 +2203,6 @@ class Bagel(nn.Module):
                     trajectory_log_probs.append(out.log_prob)
             else:
                 x_t = x_t - v_t.to(x_t.device) * dts[i]  # velocity pointing from data to noise
-                if pinned_x_t is not None:
-                    # i2v: restore cond positions to their encoded-image
-                    # latent.  Matches upstream PR #33 lance.py line 1712:
-                    #     x_t[mse_indexes] = x_t[mse_indexes] - v_t[mse_indexes] * dts[i]
-                    # (cond positions are excluded from the update).
-                    x_t[frame_condition_token_indexes] = pinned_x_t
             if return_trajectory_latents:
                 trajectory_latents.append(x_t.clone())
                 trajectory_timesteps.append(timesteps[i])
@@ -1929,44 +2221,53 @@ class Bagel(nn.Module):
         packed_vae_token_indexes: torch.LongTensor,
         packed_seqlens: torch.IntTensor,
         packed_position_ids: torch.LongTensor,
+        packed_indexes: torch.LongTensor,
         past_key_values: NaiveCache,
+        key_values_lens: torch.IntTensor,
+        packed_key_value_indexes: torch.LongTensor,
         cfg_renorm_min: float,
         cfg_renorm_type: str,
         cfg_interval: tuple[float, float],
         cfg_text_scale: float,
+        cfg_text_packed_query_indexes: torch.LongTensor | None,
         cfg_text_packed_position_ids: torch.LongTensor | None,
         cfg_text_past_key_values: NaiveCache | None,
+        cfg_text_key_values_lens: torch.IntTensor | None,
+        cfg_text_packed_key_value_indexes: torch.LongTensor | None,
         cfg_img_scale: float,
+        cfg_img_packed_query_indexes: torch.LongTensor | None,
         cfg_img_packed_position_ids: torch.LongTensor | None,
         cfg_img_past_key_values: NaiveCache | None,
+        cfg_img_key_values_lens: torch.IntTensor | None,
+        cfg_img_packed_key_value_indexes: torch.LongTensor | None,
         return_trajectory_latents: bool = False,
         scheduler: object | None = None,
         scheduler_kwargs: dict | None = None,
-        frame_condition_token_indexes: torch.LongTensor | None = None,
     ):
-        """CFG parallel denoising loop: each rank computes one CFG branch.
+        """CFG parallel denoising loop.
 
-        Rank 0: gen branch (full conditioning)
-        Rank 1: text_cfg branch (unconditional text)
-        Rank 2: img_cfg branch (no image condition), only when cfg_img_scale > 1.0
+        cfg_parallel_size=2:
+            Rank 0 computes gen and, when enabled, img_cfg.
+            Rank 1 computes text_cfg.
+        cfg_parallel_size=3:
+            Rank 0 computes gen, rank 1 computes text_cfg, rank 2 computes img_cfg.
         """
         cfg_group = get_cfg_group()
         cfg_rank = get_classifier_free_guidance_rank()
         cfg_world_size = get_classifier_free_guidance_world_size()
         use_cfg_img = cfg_img_scale > 1.0
 
-        # Validate cfg_parallel_size vs cfg_img_scale consistency
+        # Validate cfg_parallel_size vs cfg_img_scale consistency.
+        if cfg_world_size not in (2, 3):
+            raise ValueError(
+                f"BAGEL CFG parallel supports cfg_parallel_size=2 or 3, "
+                f"but got cfg_parallel_size={cfg_world_size}."
+            )
         if cfg_world_size == 3 and not use_cfg_img:
             raise ValueError(
                 f"cfg_parallel_size=3 requires cfg_img_scale > 1.0, "
                 f"but got cfg_img_scale={cfg_img_scale}. "
                 f"Use cfg_parallel_size=2 for text-only CFG parallel(text2img), or set cfg_img_scale > 1.0."
-            )
-        if cfg_world_size == 2 and use_cfg_img:
-            raise ValueError(
-                f"Image CFG (cfg_img_scale={cfg_img_scale}) requires cfg_parallel_size=3, "
-                f"but got cfg_parallel_size=2. "
-                f"Use cfg_parallel_size=3 to enable image CFG in parallel mode."
             )
 
         # Ensure all ranks start with the same x_t (initial noise may differ
@@ -1974,21 +2275,40 @@ class Bagel(nn.Module):
         x_t = x_t.contiguous()
         cfg_group.broadcast(x_t, src=0)
 
-        # Select this rank's branch inputs
+        gen_branch = (
+            packed_position_ids,
+            packed_indexes,
+            past_key_values,
+            key_values_lens,
+            packed_key_value_indexes,
+        )
+        text_branch = (
+            cfg_text_packed_position_ids,
+            cfg_text_packed_query_indexes,
+            cfg_text_past_key_values,
+            cfg_text_key_values_lens,
+            cfg_text_packed_key_value_indexes,
+        )
+        img_branch = (
+            cfg_img_packed_position_ids,
+            cfg_img_packed_query_indexes,
+            cfg_img_past_key_values,
+            cfg_img_key_values_lens,
+            cfg_img_packed_key_value_indexes,
+        )
+
+        # Select this rank's primary branch for all_gather.
         if cfg_rank == 0:
-            # Gen branch: use main inputs directly
-            branch_position_ids = packed_position_ids
-            branch_past_key_values = past_key_values
+            branch = gen_branch
         elif cfg_rank == 1:
-            # Text CFG branch
-            branch_position_ids = cfg_text_packed_position_ids
-            branch_past_key_values = cfg_text_past_key_values
+            branch = text_branch
         elif cfg_rank == 2:
-            # Image CFG branch
-            branch_position_ids = cfg_img_packed_position_ids
-            branch_past_key_values = cfg_img_past_key_values
+            branch = img_branch
         else:
-            raise RuntimeError(f"Unexpected cfg_rank={cfg_rank} for Bagel 3-branch CFG parallel")
+            raise RuntimeError(f"Unexpected cfg_rank={cfg_rank} for BAGEL CFG parallel")
+        branch_position_ids, branch_indexes, branch_past_key_values, branch_key_values_lens, branch_key_value_indexes = (
+            branch
+        )
 
         trajectory_latents: list[torch.Tensor] | None = [] if return_trajectory_latents else None
         trajectory_timesteps: list[torch.Tensor] | None = [] if return_trajectory_latents else None
@@ -2000,18 +2320,12 @@ class Bagel(nn.Module):
         if return_trajectory_latents and len(timesteps) > 0:
             trajectory_latents.append(x_t.clone())
 
-        for i, t in enumerate(timesteps.tolist()):  # host floats; a 0-d tensor t would sync each step
+        for i, t in enumerate(timesteps):
             timestep = torch.tensor([t] * x_t.shape[0], device=x_t.device)
-            if frame_condition_token_indexes is not None:
-                # Cond positions stay at t=0 (clean signal).  Matches upstream
-                # PR #33 lance.py line 1605:
-                #     timestep[current_vae_mse_indexes_local_in_vae] = t
-                # (cond positions remain at the ``torch.zeros`` init value).
-                timestep[frame_condition_token_indexes] = 0.0
             use_cfg_this_step = t > cfg_interval[0] and t <= cfg_interval[1] and cfg_text_scale > 1.0
 
             if use_cfg_this_step:
-                # CFG interval: each rank computes its own branch
+                # CFG interval: each rank computes its primary branch.
                 local_v_t = self.forward_single_branch(
                     x_t=x_t,
                     timestep=timestep,
@@ -2019,16 +2333,47 @@ class Bagel(nn.Module):
                     packed_vae_position_ids=packed_vae_position_ids,
                     packed_text_ids=packed_text_ids,
                     packed_text_indexes=packed_text_indexes,
+                    packed_indexes=branch_indexes,
                     packed_position_ids=branch_position_ids,
                     packed_seqlens=packed_seqlens,
+                    key_values_lens=branch_key_values_lens,
                     past_key_values=branch_past_key_values,
+                    packed_key_value_indexes=branch_key_value_indexes,
                 )
+
+                cfg_img_v_t = None
+                if use_cfg_img and cfg_world_size == 2:
+                    if cfg_rank == 0:
+                        (
+                            img_position_ids,
+                            img_indexes,
+                            img_past_key_values,
+                            img_key_values_lens,
+                            img_key_value_indexes,
+                        ) = img_branch
+                        cfg_img_v_t = self.forward_single_branch(
+                            x_t=x_t,
+                            timestep=timestep,
+                            packed_vae_token_indexes=packed_vae_token_indexes,
+                            packed_vae_position_ids=packed_vae_position_ids,
+                            packed_text_ids=packed_text_ids,
+                            packed_text_indexes=packed_text_indexes,
+                            packed_indexes=img_indexes,
+                            packed_position_ids=img_position_ids,
+                            packed_seqlens=packed_seqlens,
+                            key_values_lens=img_key_values_lens,
+                            past_key_values=img_past_key_values,
+                            packed_key_value_indexes=img_key_value_indexes,
+                        )
+                    else:
+                        cfg_img_v_t = torch.empty_like(local_v_t)
+                    cfg_img_v_t = cfg_group.broadcast(cfg_img_v_t.contiguous(), src=0)
 
                 gathered = cfg_group.all_gather(local_v_t, separate_tensors=True)
                 v_t = self._combine_cfg(
                     gathered[0],
                     gathered[1],
-                    gathered[2] if (use_cfg_img and len(gathered) > 2) else None,
+                    cfg_img_v_t if cfg_world_size == 2 else (gathered[2] if use_cfg_img else None),
                     cfg_text_scale,
                     cfg_img_scale,
                     cfg_renorm_type,
@@ -2043,9 +2388,12 @@ class Bagel(nn.Module):
                     packed_vae_position_ids=packed_vae_position_ids,
                     packed_text_ids=packed_text_ids,
                     packed_text_indexes=packed_text_indexes,
+                    packed_indexes=packed_indexes,
                     packed_position_ids=packed_position_ids,
                     packed_seqlens=packed_seqlens,
+                    key_values_lens=key_values_lens,
                     past_key_values=past_key_values,
+                    packed_key_value_indexes=packed_key_value_indexes,
                 )
 
             if scheduler is not None:
@@ -2123,9 +2471,12 @@ class Bagel(nn.Module):
         packed_vae_position_ids: torch.LongTensor,
         packed_text_ids: torch.LongTensor,
         packed_text_indexes: torch.LongTensor,
+        packed_indexes: torch.LongTensor,
         packed_position_ids: torch.LongTensor,
         packed_seqlens: torch.IntTensor,
+        key_values_lens: torch.IntTensor,
         past_key_values: NaiveCache,
+        packed_key_value_indexes: torch.LongTensor,
     ) -> torch.Tensor:
         """Run a single-branch forward pass (no CFG batching).
 
@@ -2160,7 +2511,7 @@ class Bagel(nn.Module):
             packed_sequence = packed_text_embedding.new_zeros((int(local_seqlens.sum()), self.hidden_size))
             packed_sequence[local_text_indexes] = packed_text_embedding
 
-            # i2v relaxes this: per-token timestep (cond=0, noncond=t) is valid.
+            assert timestep.unique().shape[0] == 1
             packed_pos_embed = self.latent_pos_embed(local_vae_pos_ids)
             local_timestep = timestep[: local_x_t.shape[0]]
             packed_timestep_embeds = self.time_embedder(local_timestep)
@@ -2168,6 +2519,24 @@ class Bagel(nn.Module):
             if x_t_emb.dtype != packed_sequence.dtype:
                 x_t_emb = x_t_emb.to(packed_sequence.dtype)
             packed_sequence[local_vae_indexes] = x_t_emb
+
+            # Build local packed_indexes for KV cache merging.
+            # In the denoising loop packed_indexes is always contiguous
+            # (arange(kv_len, kv_len + total)), so we can safely build
+            # the local slice from scratch.
+            local_total = int(local_seqlens.sum())
+            kv_len = int(key_values_lens.sum())
+            original_total = int(packed_seqlens.sum())
+            assert torch.equal(
+                packed_indexes,
+                torch.arange(kv_len, kv_len + original_total, device=packed_indexes.device, dtype=packed_indexes.dtype),
+            ), "packed_indexes must be contiguous for SP; non-contiguous layout not supported"
+            local_packed_indexes = torch.arange(
+                kv_len,
+                kv_len + local_total,
+                device=packed_indexes.device,
+                dtype=packed_indexes.dtype,
+            )
 
             extra_inputs = {}
             if self.use_moe:
@@ -2179,7 +2548,10 @@ class Bagel(nn.Module):
                 packed_query_sequence=packed_sequence,
                 query_lens=local_seqlens,
                 packed_query_position_ids=local_position_ids,
+                packed_query_indexes=local_packed_indexes,
                 past_key_values=past_key_values,
+                key_values_lens=key_values_lens,
+                packed_key_value_indexes=packed_key_value_indexes,
                 update_past_key_values=False,
                 is_causal=False,
                 **extra_inputs,
@@ -2197,7 +2569,7 @@ class Bagel(nn.Module):
         packed_sequence = packed_text_embedding.new_zeros((sum(packed_seqlens), self.hidden_size))
         packed_sequence[packed_text_indexes] = packed_text_embedding
 
-        # i2v relaxes this: per-token timestep (cond=0, noncond=t) is valid.
+        assert timestep.unique().shape[0] == 1
         packed_pos_embed = self.latent_pos_embed(packed_vae_position_ids)
         packed_timestep_embeds = self.time_embedder(timestep)
         x_t_emb = self.vae2llm(x_t) + packed_timestep_embeds + packed_pos_embed
@@ -2215,7 +2587,10 @@ class Bagel(nn.Module):
             packed_query_sequence=packed_sequence,
             query_lens=packed_seqlens,
             packed_query_position_ids=packed_position_ids,
+            packed_query_indexes=packed_indexes,
             past_key_values=past_key_values,
+            key_values_lens=key_values_lens,
+            packed_key_value_indexes=packed_key_value_indexes,
             update_past_key_values=False,
             is_causal=False,
             **extra_inputs,
@@ -2232,14 +2607,17 @@ class Bagel(nn.Module):
         packed_vae_position_ids: torch.LongTensor,
         packed_text_ids: torch.LongTensor,
         packed_text_indexes: torch.LongTensor,
+        packed_indexes: torch.LongTensor,
         packed_position_ids: torch.LongTensor,
         packed_seqlens: torch.IntTensor,
+        key_values_lens: torch.IntTensor,
         past_key_values: NaiveCache,
+        packed_key_value_indexes: torch.LongTensor,
         cfg_renorm_min: float = 0.0,
         cfg_renorm_type: str = "global",
         cfg_text_scale: float = 1.0,
         cfg_img_scale: float = 1.0,
-        cfg_branches: dict | None = None,
+        cfg_batched: dict | None = None,
     ):
         # Build query sequence (identical for all CFG branches)
         packed_text_embedding = self.language_model.forward(
@@ -2249,7 +2627,7 @@ class Bagel(nn.Module):
         packed_sequence = packed_text_embedding.new_zeros((sum(packed_seqlens), self.hidden_size))
         packed_sequence[packed_text_indexes] = packed_text_embedding
 
-        # i2v relaxes this: per-token timestep (cond=0, noncond=t) is valid.
+        assert timestep.unique().shape[0] == 1
         packed_pos_embed = self.latent_pos_embed(packed_vae_position_ids)
         packed_timestep_embeds = self.time_embedder(timestep)
         x_t = self.vae2llm(x_t) + packed_timestep_embeds + packed_pos_embed
@@ -2260,52 +2638,74 @@ class Bagel(nn.Module):
         extra_inputs = {}
         if self.use_moe:
             extra_inputs["mode"] = "gen"
-            extra_inputs["packed_vae_token_indexes"] = packed_vae_token_indexes
-            extra_inputs["packed_text_indexes"] = packed_text_indexes
 
         use_cfg = cfg_text_scale > 1.0
         cfg_text_v_t = None
         cfg_img_v_t = None
 
-        if use_cfg and cfg_branches is not None:
-            # Sequential per-branch CFG forwards (matches upstream lance.py).
-            # The previous batched path concatenated cond + cfg into one LLM
-            # forward, but the block-diagonal attention mask was lost when
-            # PR #3728 dropped flash_attn_varlen, so branches leaked into
-            # each other.  Running each branch through its own forward is
-            # numerically identical to upstream.
-            def _run_branch(branch_pkv, branch_pids):
-                out = self.language_model.forward(
-                    packed_query_sequence=packed_sequence,
-                    query_lens=packed_seqlens,
-                    packed_query_position_ids=branch_pids,
-                    past_key_values=branch_pkv,
-                    update_past_key_values=False,
-                    is_causal=False,
-                    **extra_inputs,
-                )
-                return self.llm2vae(out.packed_query_sequence)[packed_vae_token_indexes]
+        if use_cfg and cfg_batched is not None:
+            # -- Batched CFG: single LLM forward for all branches --
+            seq_len = cfg_batched["seq_len"]
+            num_branches = cfg_batched["num_branches"]
 
-            branches_pids = cfg_branches["pids"]
-            branches_caches = cfg_branches["caches"]
-            v_t = _run_branch(branches_caches[0], branches_pids[0])
-            cfg_text_v_t = _run_branch(branches_caches[1], branches_pids[1])
-            if cfg_img_scale > 1.0 and len(branches_caches) > 2:
-                cfg_img_v_t = _run_branch(branches_caches[2], branches_pids[2])
-        else:
-            # Single forward (no CFG or outside cfg_interval).
+            batched_sequence = packed_sequence.repeat(num_branches, 1)
+
+            if self.use_moe:
+                extra_inputs["packed_text_indexes"] = cfg_batched["batched_text_indexes"]
+                extra_inputs["packed_vae_token_indexes"] = cfg_batched["batched_vae_indexes"]
+
             output = self.language_model.forward(
-                packed_query_sequence=packed_sequence,
-                query_lens=packed_seqlens,
-                packed_query_position_ids=packed_position_ids,
-                past_key_values=past_key_values,
+                packed_query_sequence=batched_sequence,
+                query_lens=cfg_batched["batched_query_lens"],
+                packed_query_position_ids=cfg_batched["batched_position_ids"],
+                packed_query_indexes=cfg_batched["batched_query_indexes"],
+                past_key_values=cfg_batched["merged_cache"],
+                key_values_lens=cfg_batched["batched_kv_lens"],
+                packed_key_value_indexes=cfg_batched["batched_kv_indexes"],
                 update_past_key_values=False,
                 is_causal=False,
                 **extra_inputs,
             )
-            v_t = self.llm2vae(output.packed_query_sequence)[packed_vae_token_indexes]
 
-        # ── CFG combination ──
+            # Extract per-branch velocities from batched output
+            all_hidden = output.packed_query_sequence
+            assert all_hidden.shape[0] == seq_len * num_branches, (
+                f"Expected packed sequence length {seq_len * num_branches}, but got {all_hidden.shape[0]}"
+            )
+
+            v_t = self.llm2vae(all_hidden[:seq_len])[packed_vae_token_indexes]
+
+            branch_idx = 1
+            cfg_text_v_t = self.llm2vae(all_hidden[branch_idx * seq_len : (branch_idx + 1) * seq_len])[
+                packed_vae_token_indexes
+            ]
+            branch_idx += 1
+            if cfg_img_scale > 1.0:
+                cfg_img_v_t = self.llm2vae(all_hidden[branch_idx * seq_len : (branch_idx + 1) * seq_len])[
+                    packed_vae_token_indexes
+                ]
+        else:
+            # -- Single forward (no CFG or outside cfg_interval) --
+            if self.use_moe:
+                extra_inputs["packed_vae_token_indexes"] = packed_vae_token_indexes
+                extra_inputs["packed_text_indexes"] = packed_text_indexes
+
+            output = self.language_model.forward(
+                packed_query_sequence=packed_sequence,
+                query_lens=packed_seqlens,
+                packed_query_position_ids=packed_position_ids,
+                packed_query_indexes=packed_indexes,
+                past_key_values=past_key_values,
+                key_values_lens=key_values_lens,
+                packed_key_value_indexes=packed_key_value_indexes,
+                update_past_key_values=False,
+                is_causal=False,
+                **extra_inputs,
+            )
+            v_t = self.llm2vae(output.packed_query_sequence)
+            v_t = v_t[packed_vae_token_indexes]
+
+        # -- CFG combination --
         if use_cfg:
             v_t = self._combine_cfg(
                 v_t,

--- a/vllm_omni/model_executor/models/bagel/bagel.py
+++ b/vllm_omni/model_executor/models/bagel/bagel.py
@@ -1,9 +1,13 @@
 from collections.abc import Iterable, Mapping, Sequence
+import logging
+import os
 from math import isqrt
 from typing import Any
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+from PIL import Image
 from transformers import BatchFeature
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
@@ -48,8 +52,123 @@ from vllm_omni.diffusion.models.bagel.autoencoder import (
 from vllm_omni.diffusion.models.bagel.bagel_transformer import (
     PositionEmbedding,
     TimestepEmbedder,
+    get_flattened_position_ids_extrapolate,
+    patchify,
 )
-from vllm_omni.diffusion.models.bagel.pipeline_bagel import default_ae_params
+from vllm_omni.diffusion.models.bagel.pipeline_bagel import (
+    SiglipNaViTWrapper,
+    _ImageTransform,
+    default_ae_params,
+)
+from vllm_omni.utils.bagel_vqa import (
+    bagel_vqa_reference_layout_enabled,
+    bagel_vqa_reference_prefill_enabled,
+    build_bagel_vqa_image_spans,
+    build_bagel_vqa_rope_positions,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _bagel_img2img_vit_separator_enabled() -> bool:
+    return _env_flag("BAGEL_IMG2IMG_VIT_SEPARATOR", False)
+
+
+def _bagel_img2img_local_preprocess_enabled() -> bool:
+    return _env_flag("BAGEL_IMG2IMG_LOCAL_PREPROCESS", False)
+
+
+def _bagel_img2img_local_preprocess_vit_enabled() -> bool:
+    return _env_flag("BAGEL_IMG2IMG_LOCAL_PREPROCESS_VIT", False)
+
+
+def _bagel_img2img_debug_enabled() -> bool:
+    return _env_flag("BAGEL_IMG2IMG_DEBUG", False)
+
+
+def _bagel_img2img_input_vit_enabled() -> bool:
+    return _env_flag("BAGEL_IMG2IMG_INPUT_VIT", True)
+
+
+_BAGEL_IMAGE_MAX_PIXELS = 14 * 14 * 9 * 1024
+_BAGEL_IMG2IMG_VAE_MAX_SIZE = 1024
+_BAGEL_IMG2IMG_VAE_MIN_SIZE = 512
+_BAGEL_IMG2IMG_VIT_MAX_SIZE = 980
+_BAGEL_IMG2IMG_VIT_MIN_SIZE = 224
+_BAGEL_IMG2IMG_VIT_STRIDE = 14
+
+
+def _bagel_make_divisible(value: float, stride: int) -> int:
+    return max(stride, int(round(value / stride) * stride))
+
+
+def _bagel_apply_scale_to_stride(width: int, height: int, scale: float, stride: int) -> tuple[int, int]:
+    return (
+        _bagel_make_divisible(round(width * scale), stride),
+        _bagel_make_divisible(round(height * scale), stride),
+    )
+
+
+def _bagel_reference_resize_hw(
+    height: int,
+    width: int,
+    *,
+    max_size: int,
+    min_size: int,
+    stride: int,
+    max_pixels: int = _BAGEL_IMAGE_MAX_PIXELS,
+    img_num: int = 1,
+) -> tuple[int, int]:
+    """Match BAGEL ImageTransform resize geometry, returning (H, W)."""
+    scale = min(max_size / max(width, height), 1.0)
+    scale = max(scale, min_size / min(width, height))
+    new_width, new_height = _bagel_apply_scale_to_stride(width, height, scale, stride)
+
+    if new_width * new_height > max_pixels / img_num:
+        scale = max_pixels / img_num / (new_width * new_height)
+        new_width, new_height = _bagel_apply_scale_to_stride(new_width, new_height, scale, stride)
+
+    if max(new_width, new_height) > max_size:
+        scale = max_size / max(new_width, new_height)
+        new_width, new_height = _bagel_apply_scale_to_stride(new_width, new_height, scale, stride)
+
+    return int(new_height), int(new_width)
+
+
+def _bagel_img2img_vae_hw(
+    height: int,
+    width: int,
+    *,
+    latent_downsample: int,
+    max_latent_size: int,
+) -> tuple[int, int]:
+    max_size = min(_BAGEL_IMG2IMG_VAE_MAX_SIZE, int(max_latent_size * latent_downsample))
+    min_size = min(_BAGEL_IMG2IMG_VAE_MIN_SIZE, max_size)
+    return _bagel_reference_resize_hw(
+        height,
+        width,
+        max_size=max_size,
+        min_size=min_size,
+        stride=latent_downsample,
+    )
+
+
+def _bagel_img2img_vit_hw(height: int, width: int) -> tuple[int, int]:
+    return _bagel_reference_resize_hw(
+        height,
+        width,
+        max_size=_BAGEL_IMG2IMG_VIT_MAX_SIZE,
+        min_size=_BAGEL_IMG2IMG_VIT_MIN_SIZE,
+        stride=_BAGEL_IMG2IMG_VIT_STRIDE,
+    )
 
 
 class OmniBagelProcessor(BagelProcessor):
@@ -59,6 +178,48 @@ class OmniBagelProcessor(BagelProcessor):
     # ``self.tokenizer`` on the OmniBagelProcessor instance.
     image_processor_class = "SiglipImageProcessor"
     tokenizer_class = "AutoTokenizer"
+
+    # Canonical aspect-preserving ViT transform for the VQA / understanding
+    # path. This mirrors BAGEL's ImageTransform(980, 224, 14), producing the
+    # variable-shape NaViT packed sequence layout the checkpoint expects.
+    _vit_transform_cls = _ImageTransform
+    _vit_patch_size = 14
+    _img2img_vae_stride = 16
+
+    def _get_vit_transform(self) -> _ImageTransform:
+        # Cached instance: stride-14 ladder, mean/std = 0.5.
+        cached = getattr(self, "_cached_vit_transform", None)
+        if cached is None:
+            cached = self._vit_transform_cls(980, 224, self._vit_patch_size)
+            object.__setattr__(self, "_cached_vit_transform", cached)
+        return cached
+
+    def _get_img2img_vae_transform(self) -> _ImageTransform:
+        # BAGEL img2img first resizes source images with the VAE ladder, then
+        # feeds that image to both VAE and ViT context updates.
+        cached = getattr(self, "_cached_img2img_vae_transform", None)
+        if cached is None:
+            cached = self._vit_transform_cls(1024, 512, self._img2img_vae_stride)
+            object.__setattr__(self, "_cached_img2img_vae_transform", cached)
+        return cached
+
+    def _get_img2img_vit_transform(self) -> _ImageTransform:
+        cached = getattr(self, "_cached_img2img_vit_transform", None)
+        if cached is None:
+            cached = self._vit_transform_cls(980, 224, self._vit_patch_size)
+            object.__setattr__(self, "_cached_img2img_vit_transform", cached)
+        return cached
+
+    @staticmethod
+    def _to_image_list(images) -> list:
+        if images is None:
+            return []
+        if isinstance(images, Image.Image):
+            return [images]
+        if isinstance(images, (list, tuple)):
+            return list(images)
+        # numpy / tensor inputs unsupported on this path; let parent handle.
+        return list(images) if hasattr(images, "__iter__") else [images]
 
     def __call__(self, text=None, images=None, **kwargs):
         is_img2img = kwargs.pop("is_img2img", False)
@@ -74,17 +235,56 @@ class OmniBagelProcessor(BagelProcessor):
                 tokenizer_init_kwargs=self.tokenizer.init_kwargs,
                 **kwargs,
             )
-            image_kwargs = dict(output_kwargs["images_kwargs"])
-            image_kwargs["do_resize"] = False
-            image_kwargs["do_rescale"] = True
-            image_kwargs.setdefault("return_tensors", "pt")
-            pixel_values = self.image_processor(images, **image_kwargs)
+            image_list = self._to_image_list(images)
+            use_local_preprocess = _bagel_img2img_local_preprocess_enabled()
+            precompute_local_vit = _bagel_img2img_local_preprocess_vit_enabled()
+            pixel_values = None
+            if use_local_preprocess and image_list and all(isinstance(img, Image.Image) for img in image_list):
+                vae_transform = self._get_img2img_vae_transform()
+                vit_transform = self._get_img2img_vit_transform()
+                vae_tensors = []
+                vit_chunks: list[torch.Tensor] = []
+                vit_grid_rows: list[list[int]] = []
+                patch_size = self._vit_patch_size
+                for img in image_list:
+                    img = img.convert("RGB") if img.mode != "RGB" else img
+                    vae_img = vae_transform.resize_only(img)
+                    vae_tensors.append(vae_transform(vae_img))
+
+                    if precompute_local_vit:
+                        vit_tensor = vit_transform(vae_img)
+                        _, vit_h, vit_w = vit_tensor.shape
+                        if vit_h % patch_size != 0 or vit_w % patch_size != 0:
+                            pad_h = (-vit_h) % patch_size
+                            pad_w = (-vit_w) % patch_size
+                            vit_tensor = torch.nn.functional.pad(vit_tensor, (0, pad_w, 0, pad_h))
+                            _, vit_h, vit_w = vit_tensor.shape
+                        vit_chunks.append(patchify(vit_tensor, patch_size))
+                        vit_grid_rows.append([1, vit_h // patch_size, vit_w // patch_size])
+
+                if len({tuple(t.shape) for t in vae_tensors}) == 1:
+                    data = {"pixel_values": torch.stack(vae_tensors, dim=0)}
+                    if precompute_local_vit and vit_chunks:
+                        data["pixel_values_img2img_vit"] = torch.cat(vit_chunks, dim=0)
+                        data["image_grid_thw_img2img_vit"] = torch.tensor(
+                            vit_grid_rows,
+                            dtype=torch.long,
+                        )
+                    pixel_values = BatchFeature(data)
+
+            if pixel_values is None:
+                image_kwargs = dict(output_kwargs["images_kwargs"])
+                image_kwargs["do_resize"] = False
+                image_kwargs["do_rescale"] = True
+                image_kwargs.setdefault("return_tensors", "pt")
+                pixel_values = self.image_processor(images, **image_kwargs)
 
             text_inputs = self.tokenizer(text, **output_kwargs["text_kwargs"]) if text is not None else None
 
             if pixel_values is not None and text_inputs is not None:
                 combined = dict(text_inputs)
-                combined["pixel_values"] = pixel_values["pixel_values"]
+                for key, value in pixel_values.items():
+                    combined[key] = value
                 return BatchFeature(combined)
             elif pixel_values is not None:
                 return pixel_values
@@ -93,12 +293,62 @@ class OmniBagelProcessor(BagelProcessor):
             else:
                 return BatchFeature({})
 
+        # VQA path: apply ImageTransform(980, 224, 14), patchify, and emit
+        # packed pixel_values + image_grid_thw for the NaViT-style ViT path.
+        image_list = self._to_image_list(images)
+        if image_list:
+            from vllm.transformers_utils.processors.bagel import BagelProcessorKwargs
+
+            output_kwargs = self._merge_kwargs(
+                BagelProcessorKwargs,
+                tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+                **kwargs,
+            )
+
+            vit_transform = self._get_vit_transform()
+            patch_size = self._vit_patch_size
+            packed_chunks: list[torch.Tensor] = []
+            grid_thw_rows: list[list[int]] = []
+            for img in image_list:
+                tensor = vit_transform(img)  # (3, H, W) in [-1, 1]
+                _, H, W = tensor.shape
+                if H % patch_size != 0 or W % patch_size != 0:
+                    # ImageTransform's resize already aligns to stride=14, but
+                    # be defensive: pad to multiple of patch_size if upstream
+                    # ever changes.
+                    pad_h = (-H) % patch_size
+                    pad_w = (-W) % patch_size
+                    tensor = torch.nn.functional.pad(tensor, (0, pad_w, 0, pad_h))
+                    _, H, W = tensor.shape
+                patches = patchify(tensor, patch_size)  # (L, 3 * p^2)
+                packed_chunks.append(patches)
+                grid_thw_rows.append([1, H // patch_size, W // patch_size])
+
+            packed_pixel_values = torch.cat(packed_chunks, dim=0)
+            image_grid_thw = torch.tensor(grid_thw_rows, dtype=torch.long)
+
+            text_inputs = (
+                self.tokenizer(text, **output_kwargs["text_kwargs"]) if text is not None else {}
+            )
+            result = dict(text_inputs) if text_inputs else {}
+            result["pixel_values"] = packed_pixel_values
+            result["image_grid_thw"] = image_grid_thw
+            return BatchFeature(result)
+
+        # Text-only / no-image path: defer to parent (tokenizer-only).
         return super().__call__(text, images, **kwargs)
 
 
 class OmniBagelProcessingInfo(BaseProcessingInfo):
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
-        return {"image": 1, "img2img": 1}
+        image_limit = 1
+        raw_limit = os.environ.get("BAGEL_MAX_MULTIMODAL_IMAGE_INPUTS")
+        if raw_limit:
+            try:
+                image_limit = max(1, int(raw_limit))
+            except ValueError:
+                image_limit = 1
+        return {"image": image_limit, "img2img": 1}
 
     def get_hf_processor(self, **kwargs: object):
         return self.ctx.get_hf_processor(OmniBagelProcessor, **kwargs)
@@ -227,16 +477,39 @@ class OmniBagelMultiModalProcessor(BaseMultiModalProcessor[OmniBagelProcessingIn
 
     def _cached_apply_hf_processor(self, inputs, timing_ctx):
         # img2img: prompt text must be modified based on mm data presence,
-        # so text and mm data cannot be tokenized separately — bypass cache.
+        # so text and mm data cannot be tokenized separately; bypass cache.
         if inputs.mm_data_items.get_all_counts().get("img2img", 0) > 0:
             return self._apply_hf_processor(inputs, timing_ctx)
         return super()._cached_apply_hf_processor(inputs, timing_ctx)
 
     def _get_mm_fields_config(self, hf_inputs, hf_processor_mm_kwargs):
-        return {
-            "pixel_values": MultiModalFieldConfig.batched("image"),
+        # VQA pixel_values arrive as packed variable-shape tokens. Slice with
+        # flat_from_sizes keyed off image_grid_thw; img2img remains batched.
+        image_grid_thw = hf_inputs.get("image_grid_thw") if isinstance(hf_inputs, Mapping) else None
+        if image_grid_thw is not None:
+            image_pixel_grid_sizes = image_grid_thw[:, 1] * image_grid_thw[:, 2]
+            pixel_values_cfg = MultiModalFieldConfig.flat_from_sizes("image", image_pixel_grid_sizes)
+        else:
+            # Fallback for warmup / dummy paths that may not populate image_grid_thw.
+            pixel_values_cfg = MultiModalFieldConfig.batched("image")
+        config = {
+            "pixel_values": pixel_values_cfg,
+            "image_grid_thw": MultiModalFieldConfig.batched("image"),
             "pixel_values_img2img": MultiModalFieldConfig.batched("img2img"),
         }
+        img2img_vit_grid_thw = (
+            hf_inputs.get("image_grid_thw_img2img_vit")
+            if isinstance(hf_inputs, Mapping)
+            else None
+        )
+        if img2img_vit_grid_thw is not None:
+            img2img_vit_grid_sizes = img2img_vit_grid_thw[:, 1] * img2img_vit_grid_thw[:, 2]
+            config["pixel_values_img2img_vit"] = MultiModalFieldConfig.flat_from_sizes(
+                "img2img",
+                img2img_vit_grid_sizes,
+            )
+            config["image_grid_thw_img2img_vit"] = MultiModalFieldConfig.batched("img2img")
+        return config
 
     def _call_hf_processor(
         self,
@@ -314,11 +587,29 @@ class OmniBagelMultiModalProcessor(BaseMultiModalProcessor[OmniBagelProcessingIn
         replacements: list[PromptReplacement] = []
 
         image_token_id = tokenizer.get_vocab().get("<|image_pad|>")
+        vision_start_id = tokenizer.get_vocab().get("<|vision_start|>")
+        vision_end_id = tokenizer.get_vocab().get("<|vision_end|>")
+        reference_layout = bagel_vqa_reference_layout_enabled()
         if image_token_id is not None:
-            num_patches = hf_config.vit_max_num_patch_per_side**2
+            # With variable-shape ViT, each image consumes its actual patch
+            # count from image_grid_thw instead of the maximum slot count.
+            max_num_patches = hf_config.vit_max_num_patch_per_side**2
+
+            def _get_image_patch_count(item_idx: int) -> int:
+                try:
+                    out_item = out_mm_kwargs["image"][item_idx]
+                    grid = out_item["image_grid_thw"].data
+                    return int(grid[1].item()) * int(grid[2].item())
+                except Exception:
+                    return max_num_patches
 
             def get_image_replacement(item_idx: int):
-                return [image_token_id] * num_patches
+                count = _get_image_patch_count(item_idx)
+                if not reference_layout or vision_start_id is None or vision_end_id is None:
+                    return [image_token_id] * count
+
+                full = [vision_start_id] + [image_token_id] * count + [vision_end_id]
+                return PromptUpdateDetails.select_token_id(full, image_token_id)
 
             replacements.append(
                 PromptReplacement(
@@ -330,16 +621,41 @@ class OmniBagelMultiModalProcessor(BaseMultiModalProcessor[OmniBagelProcessingIn
 
         img2img_token_id = tokenizer.get_vocab().get("<|fim_middle|>")
         if img2img_token_id is not None:
+            include_vit = _bagel_img2img_input_vit_enabled()
             vit_config = hf_config.vit_config
             image_size = vit_config.image_size
-            num_vit_patches = (image_size // vit_config.patch_size) ** 2
 
             latent_patch_size = getattr(hf_config, "latent_patch_size", 2)
             downsample = hf_config.vae_config.get("downsample", 8)
             latent_downsample = downsample * latent_patch_size
 
+            def get_img2img_processed_item(item_idx: int) -> dict[str, object]:
+                if "img2img" not in out_mm_kwargs:
+                    return {}
+                try:
+                    items = out_mm_kwargs["img2img"]
+                    if item_idx >= len(items) or items[item_idx] is None:
+                        return {}
+                    return items[item_idx].get_data()
+                except Exception:
+                    return {}
+
             def get_img2img_replacement(item_idx: int):
                 h, w = image_size, image_size
+                processed = get_img2img_processed_item(item_idx)
+                processed_vae_hw: tuple[int, int] | None = None
+                processed_vit_tokens: int | None = None
+
+                if _bagel_img2img_local_preprocess_enabled():
+                    pv = processed.get("pixel_values_img2img")
+                    if isinstance(pv, torch.Tensor) and pv.ndim >= 3:
+                        processed_vae_hw = (int(pv.shape[-2]), int(pv.shape[-1]))
+
+                    grid = processed.get("image_grid_thw_img2img_vit")
+                    if isinstance(grid, torch.Tensor) and grid.numel() >= 3:
+                        row = grid.reshape(-1, 3)[0]
+                        processed_vit_tokens = int(row[1].item()) * int(row[2].item()) + 2
+
                 if "img2img" in mm_items:
                     item = mm_items.get_items("img2img", (Img2ImgProcessorItems, ImageEmbeddingItems))
                     if hasattr(item, "get_image_size"):
@@ -347,26 +663,61 @@ class OmniBagelMultiModalProcessor(BaseMultiModalProcessor[OmniBagelProcessingIn
                         h, w = size.height, size.width
 
                 max_latent_size = getattr(hf_config, "max_latent_size", 32)
-                max_img_size = int(max_latent_size * latent_downsample)
-                stride = latent_downsample
-                scale = min(max_img_size / max(h, w), 1.0)
-                min_img_size = min(256, max_img_size)
-                scale = max(scale, min_img_size / min(h, w))
-                new_h = max(stride, int(round(h * scale / stride) * stride))
-                new_w = max(stride, int(round(w * scale / stride) * stride))
-                new_h = min(new_h, max_img_size)
-                new_w = min(new_w, max_img_size)
+                if processed_vae_hw is not None:
+                    vae_h, vae_w = processed_vae_hw
+                else:
+                    vae_h, vae_w = _bagel_img2img_vae_hw(
+                        h,
+                        w,
+                        latent_downsample=latent_downsample,
+                        max_latent_size=max_latent_size,
+                    )
+                vit_h, vit_w = _bagel_img2img_vit_hw(vae_h, vae_w)
 
-                num_vae_patches = (new_h // latent_downsample) * (new_w // latent_downsample)
+                num_vae_patches = (vae_h // latent_downsample) * (vae_w // latent_downsample)
                 num_vae_total = num_vae_patches + 2
-                num_vit_total = num_vit_patches + 2
-                # +1 separator between VAE and ViT blocks so that
-                # extract_embeds_range() produces two distinct mm_prefix_range
-                # entries, preventing VAE tokens from attending to ViT.
-                total = num_vae_total + 1 + num_vit_total
+                num_vit_total = (
+                    processed_vit_tokens
+                    if processed_vit_tokens is not None
+                    else (vit_h // vit_config.patch_size) * (vit_w // vit_config.patch_size) + 2
+                )
+                if include_vit:
+                    if _bagel_img2img_vit_separator_enabled():
+                        # Historical vLLM-Omni img2img layout: VAE image block,
+                        # one raw <|fim_middle|> separator token, then the ViT
+                        # image block. BAGEL's reference img2img path performs
+                        # VAE and ViT cache updates back-to-back without this
+                        # token, so keep the separator opt-in for diagnostics.
+                        total = num_vae_total + 1 + num_vit_total
+                        embed_mask = [True] * num_vae_total + [False] + [True] * num_vit_total
+                    else:
+                        total = num_vae_total + num_vit_total
+                        embed_mask = [True] * total
+                else:
+                    total = num_vae_total
+                    embed_mask = [True] * num_vae_total
                 tokens = [img2img_token_id] * total
 
-                embed_mask = [True] * num_vae_total + [False] + [True] * num_vit_total
+                if _bagel_img2img_debug_enabled():
+                    logger.info(
+                        "BAGEL img2img replacement idx=%d raw_hw=%dx%d vae_hw=%dx%d "
+                        "vit_hw=%dx%d vae_tokens=%d vit_tokens=%d total=%d "
+                        "processed_vae=%s processed_vit=%s sep=%s",
+                        item_idx,
+                        h,
+                        w,
+                        vae_h,
+                        vae_w,
+                        vit_h,
+                        vit_w,
+                        num_vae_total,
+                        num_vit_total if include_vit else 0,
+                        total,
+                        processed_vae_hw is not None,
+                        processed_vit_tokens is not None,
+                        _bagel_img2img_vit_separator_enabled(),
+                    )
+
                 return PromptUpdateDetails(
                     full=tokens,
                     is_embed=lambda _tok, _seq, _m=embed_mask: torch.tensor(_m, dtype=torch.bool),
@@ -406,6 +757,274 @@ class VAEEncoder(nn.Module):
         return z
 
 
+def _bagel_vqa_layer_attention_metadata(layer_name: str):
+    from vllm.forward_context import get_forward_context
+
+    raw = get_forward_context().attn_metadata
+    if isinstance(raw, dict):
+        return raw.get(layer_name)
+    if isinstance(raw, list):
+        return raw[0].get(layer_name)
+    return raw
+
+
+def _bagel_vqa_recompute_noncausal_image_blocks(
+    qwen_attn,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_output: torch.Tensor,
+) -> torch.Tensor:
+    owner = getattr(qwen_attn, "_bagel_vqa_owner", None)
+    spans = getattr(owner, "_bagel_vqa_image_spans_current", None)
+    if not spans:
+        return attn_output
+    return _bagel_recompute_noncausal_image_blocks_paged(
+        qwen_attn,
+        query,
+        key,
+        value,
+        attn_output,
+        spans,
+    )
+
+
+def _bagel_recompute_noncausal_image_blocks_paged(
+    qwen_attn,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_output: torch.Tensor,
+    spans: list[dict[str, int]],
+) -> torch.Tensor:
+    if not spans:
+        return attn_output
+    attn_layer = qwen_attn.attn
+    backend_name = attn_layer.attn_backend.get_name()
+
+    impl = attn_layer.impl
+    if getattr(impl, "dcp_world_size", 1) > 1:
+        raise RuntimeError("BAGEL reference prefill does not support DCP yet")
+
+    metadata = _bagel_vqa_layer_attention_metadata(attn_layer.layer_name)
+    if metadata is None:
+        return attn_output
+    if getattr(metadata, "use_cascade", False):
+        raise RuntimeError(
+            "BAGEL reference prefill does not support cascade attention; "
+            "disable prefix caching for this mode"
+        )
+
+    if backend_name != "FLASH_ATTN":
+        return _bagel_vqa_recompute_noncausal_image_blocks_direct(
+            qwen_attn,
+            query,
+            key,
+            value,
+            attn_output,
+            spans,
+            backend_name,
+        )
+
+    try:
+        from vllm.v1.attention.backends.fa_utils import (
+            flash_attn_varlen_func,
+            is_flash_attn_varlen_func_available,
+        )
+    except Exception as exc:
+        raise RuntimeError("BAGEL reference prefill requires FlashAttention") from exc
+    if not is_flash_attn_varlen_func_available():
+        raise RuntimeError("BAGEL reference prefill requires flash_attn_varlen_func")
+
+    kv_cache = attn_layer.kv_cache
+    if kv_cache.numel() == 0:
+        return attn_output
+    key_cache, value_cache = kv_cache.unbind(0)
+
+    out = attn_output.clone()
+    block_table = metadata.block_table
+    device = query.device
+    q_descale = None
+
+    for span in spans:
+        q_start = int(span["q_start"])
+        q_end = int(span["q_end"])
+        req_idx = int(span["req_idx"])
+        kv_end = int(span["kv_end"])
+        if q_end <= q_start:
+            continue
+
+        q_len = q_end - q_start
+        q = query[q_start:q_end].view(q_len, attn_layer.num_heads, attn_layer.head_size)
+        block_out = torch.empty(
+            (q_len, attn_layer.num_heads, attn_layer.head_size_v),
+            dtype=out.dtype,
+            device=device,
+        )
+        cu_q = torch.tensor([0, q_len], dtype=torch.int32, device=device)
+        seqused_k = torch.tensor([kv_end], dtype=torch.int32, device=device)
+
+        descale_shape = (1, attn_layer.num_kv_heads)
+        if getattr(impl, "supports_quant_query_input", False):
+            q_descale = attn_layer._q_scale.expand(descale_shape)
+        k_descale = attn_layer._k_scale.expand(descale_shape)
+        v_descale = attn_layer._v_scale.expand(descale_shape)
+        sliding_window = (
+            list(impl.sliding_window)
+            if getattr(impl, "sliding_window", None) is not None
+            else None
+        )
+
+        flash_attn_varlen_func(
+            q=q,
+            k=key_cache,
+            v=value_cache,
+            out=block_out,
+            cu_seqlens_q=cu_q,
+            max_seqlen_q=q_len,
+            seqused_k=seqused_k,
+            max_seqlen_k=max(kv_end, 1),
+            softmax_scale=impl.scale,
+            causal=False,
+            alibi_slopes=impl.alibi_slopes,
+            window_size=sliding_window,
+            block_table=block_table[req_idx : req_idx + 1],
+            softcap=impl.logits_soft_cap,
+            scheduler_metadata=None,
+            fa_version=impl.vllm_flash_attn_version,
+            q_descale=q_descale,
+            k_descale=k_descale,
+            v_descale=v_descale,
+            num_splits=1,
+            s_aux=getattr(impl, "sinks", None),
+        )
+        out[q_start:q_end] = block_out.reshape(q_len, -1)
+
+    return out
+
+
+def _bagel_vqa_recompute_noncausal_image_blocks_direct(
+    qwen_attn,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_output: torch.Tensor,
+    spans: list[dict[str, int]],
+    backend_name: str,
+) -> torch.Tensor:
+    """Backend-independent recompute for full-prefill image blocks.
+
+    Triton paged attention in vLLM 0.20 only exposes causal decoder attention.
+    In reference-prefill mode we disable chunked prefill, so BAGEL VQA image
+    spans are scheduled in the first prompt pass and the current K/V tensors
+    contain all keys needed up to the end of the image block.
+    """
+    attn_layer = qwen_attn.attn
+    impl = attn_layer.impl
+    if getattr(impl, "alibi_slopes", None) is not None:
+        raise RuntimeError(
+            "BAGEL reference prefill direct recompute does not support ALiBi"
+        )
+    if getattr(impl, "sinks", None) is not None:
+        raise RuntimeError(
+            "BAGEL reference prefill direct recompute does not support sinks"
+        )
+
+    sliding_window = getattr(impl, "sliding_window", None)
+    if sliding_window not in (None, (-1, -1), [-1, -1]):
+        raise RuntimeError(
+            "BAGEL reference prefill direct recompute does not support "
+            f"sliding window attention on backend {backend_name}"
+        )
+
+    out = attn_output.clone()
+    q_all = query.view(-1, attn_layer.num_heads, attn_layer.head_size)
+    k_all = key.view(-1, attn_layer.num_kv_heads, attn_layer.head_size)
+    v_all = value.view(-1, attn_layer.num_kv_heads, attn_layer.head_size_v)
+    repeat = attn_layer.num_heads // attn_layer.num_kv_heads
+    softcap = getattr(impl, "logits_soft_cap", 0) or 0
+
+    for span in spans:
+        computed = int(span.get("num_computed_tokens", 0))
+        if computed != 0:
+            raise RuntimeError(
+                "BAGEL reference prefill direct recompute needs the complete "
+                "image prefix in the current scheduled batch; disable chunked "
+                f"prefill or use a paged non-causal backend (got {computed} "
+                "computed tokens)"
+            )
+
+        q_start = int(span["q_start"])
+        q_end = int(span["q_end"])
+        request_start = int(span["request_start"])
+        kv_local_end = int(span["kv_local_end"])
+        kv_end = request_start + kv_local_end
+        if q_end <= q_start or kv_end <= request_start:
+            continue
+
+        q = q_all[q_start:q_end]
+        k = k_all[request_start:kv_end]
+        v = v_all[request_start:kv_end]
+        if repeat != 1:
+            k = k.repeat_interleave(repeat, dim=1)
+            v = v.repeat_interleave(repeat, dim=1)
+
+        if softcap <= 0:
+            q_sdpa = q.transpose(0, 1).unsqueeze(0).to(dtype=v.dtype)
+            k_sdpa = k.transpose(0, 1).unsqueeze(0).to(dtype=v.dtype)
+            v_sdpa = v.transpose(0, 1).unsqueeze(0)
+            block_out = F.scaled_dot_product_attention(
+                q_sdpa,
+                k_sdpa,
+                v_sdpa,
+                dropout_p=0.0,
+                is_causal=False,
+                scale=impl.scale,
+            )
+            block_out = block_out.squeeze(0).transpose(0, 1)
+            out[q_start:q_end] = block_out.reshape(q_end - q_start, -1).to(out.dtype)
+            continue
+
+        scores = torch.einsum("qhd,khd->hqk", q.float(), k.float()) * impl.scale
+        if softcap > 0:
+            scores = torch.tanh(scores / softcap) * softcap
+        probs = torch.softmax(scores, dim=-1).to(v.dtype)
+        block_out = torch.einsum("hqk,khd->qhd", probs, v)
+        out[q_start:q_end] = block_out.reshape(q_end - q_start, -1).to(out.dtype)
+
+    return out
+
+
+def _bagel_vqa_reference_qwen2_attention_forward(
+    self,
+    positions: torch.Tensor,
+    hidden_states: torch.Tensor,
+) -> torch.Tensor:
+    qkv, _ = self.qkv_proj(hidden_states)
+    q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+    if self.qk_norm:
+        total_tokens = q.shape[0]
+        q = q.view(total_tokens, self.num_heads, self.head_dim)
+        k = k.view(total_tokens, self.num_kv_heads, self.head_dim)
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+        q = q.view(total_tokens, self.q_size)
+        k = k.view(total_tokens, self.kv_size)
+
+    q, k = self.rotary_emb(positions, q, k)
+    attn_output = self.attn(q, k, v)
+    attn_output = _bagel_vqa_recompute_noncausal_image_blocks(
+        self,
+        q,
+        k,
+        v,
+        attn_output,
+    )
+    output, _ = self.o_proj(attn_output)
+    return output
+
+
 @MULTIMODAL_REGISTRY.register_processor(
     OmniBagelMultiModalProcessor,
     info=OmniBagelProcessingInfo,
@@ -428,7 +1047,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
     the DiT's denoising loop.
     """
 
-    # LoRA packed→sublayer mapping for both standard Qwen2 projections
+    # LoRA packed-to-sublayer mapping for both standard Qwen2 projections
     # and the MoE generation-mode projections added by _install_mot_modules().
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
@@ -447,6 +1066,10 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
         config = vllm_config.model_config.hf_config
+
+        # Keep vLLM's SiglipVisionModel as the default encoder and add a
+        # NaViT-style path only when the processor supplies image_grid_thw.
+
         self.latent_patch_size = getattr(config, "latent_patch_size", 2)
         self.downsample = config.vae_config.get("downsample")
         self.latent_downsample = self.downsample * self.latent_patch_size
@@ -460,10 +1083,23 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         self.latent_pos_embed = PositionEmbedding(self.max_latent_size, hidden_size)
         self.time_embedder = TimestepEmbedder(hidden_size)
 
-        self._pending_img2img_info: list[tuple[int, int, int, int]] = []
+        self._pending_img2img_info: list[tuple[int, ...]] = []
+        self._img2img_noncausal_spans_current: list[dict[str, int]] = []
         self._ropes_pending: list[dict[str, Any]] = []
         self._ropes_metadata: dict[str, dict[str, Any]] = {}
-        self._last_img2img_info: tuple[int, int, int, int] | None = None
+        self._last_img2img_info: tuple[int, ...] | None = None
+        self._bagel_vqa_rope_states: dict[str, dict[str, Any]] = {}
+        self._bagel_vqa_rope_positions_current: torch.Tensor | None = None
+        self._bagel_vqa_image_spans_current: list[dict[str, int]] = []
+        self._bagel_runner_num_computed_tokens_current: list[int] = []
+        self._bagel_vqa_reference_prefill_enabled = (
+            bagel_vqa_reference_prefill_enabled()
+        )
+        self._bagel_vqa_logical_rope_enabled = (
+            self._bagel_vqa_reference_prefill_enabled
+            or os.environ.get("BAGEL_VQA_LOGICAL_ROPE", "").lower()
+            in {"1", "true", "yes", "on"}
+        )
 
         from transformers import AutoTokenizer
 
@@ -476,13 +1112,10 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         self._end_of_image_id = int(_tok.convert_tokens_to_ids("<|vision_end|>"))
         self._img2img_token_id = int(_tok.convert_tokens_to_ids("<|fim_middle|>"))
         self._vae_token_mask: torch.Tensor | None = None
-        # Whether the current request packs any VAE / non-VAE tokens, refreshed
-        # in _adjust_positions_for_img2img. Cached as plain bools so the per-layer
-        # MoT routing can branch without calling .any() (which forces a device sync).
-        self._has_vae_tokens: bool = False
-        self._has_non_vae_tokens: bool = True
         self.device = get_local_device()
         self._install_mot_modules(config)
+        if self._bagel_vqa_reference_prefill_enabled:
+            self._install_vqa_reference_attention()
 
     def _install_mot_modules(self, config):
         """Add generation-mode (MoT) weight modules to each Qwen2 decoder layer.
@@ -532,6 +1165,125 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
             layer.input_layernorm_moe_gen = VllmRMSNorm(hidden_size, eps=rms_eps)
             layer.post_attention_layernorm_moe_gen = VllmRMSNorm(hidden_size, eps=rms_eps)
 
+    def _install_vqa_reference_attention(self) -> None:
+        """Bind BAGEL-only image-block non-causal attention recompute hooks."""
+        qwen2_model = self.language_model.model
+        for layer in qwen2_model.layers:
+            if not isinstance(layer, Qwen2DecoderLayer):
+                continue
+            attn = layer.self_attn
+            if getattr(attn, "_bagel_vqa_reference_attention_installed", False):
+                object.__setattr__(attn, "_bagel_vqa_owner", self)
+                continue
+            object.__setattr__(attn, "_bagel_vqa_owner", self)
+            attn._bagel_vqa_original_forward = attn.forward
+            attn.forward = _bagel_vqa_reference_qwen2_attention_forward.__get__(
+                attn,
+                attn.__class__,
+            )
+            attn._bagel_vqa_reference_attention_installed = True
+
+    def _load_hf_navit_vit(self, device: torch.device, dtype: torch.dtype) -> SiglipNaViTWrapper:
+        """Lazily build a HuggingFace SiglipVisionModel + NaViT wrapper for the
+        VQA path. Loads weights from the BAGEL checkpoint (keys
+        ``vit_model.vision_model.*``) directly; no dependence on vllm's
+        already-loaded ``self.vit_model``. This bypasses vllm's adapted
+        ``SiglipEncoder`` (which lacks ``attention_mask`` support and produces
+        unnormalized output) and matches the reference torch-native bagel_local
+        pipeline exactly.
+
+        The default VQA path still uses vLLM's SigLIP modules; this helper is
+        retained for checkpoints that require the HuggingFace SigLIP wrapper.
+        """
+        from pathlib import Path
+
+        from safetensors import safe_open
+        from transformers import SiglipVisionConfig, SiglipVisionModel
+
+        vit_cfg = self.config.vit_config
+        hf_cfg = SiglipVisionConfig(
+            hidden_size=vit_cfg.hidden_size,
+            intermediate_size=vit_cfg.intermediate_size,
+            num_attention_heads=vit_cfg.num_attention_heads,
+            num_hidden_layers=vit_cfg.num_hidden_layers,
+            patch_size=vit_cfg.patch_size,
+            image_size=vit_cfg.image_size,
+            num_channels=vit_cfg.num_channels,
+            attention_dropout=getattr(vit_cfg, "attention_dropout", 0.0),
+            layer_norm_eps=getattr(vit_cfg, "layer_norm_eps", 1e-6),
+            hidden_act=getattr(vit_cfg, "hidden_act", "gelu_pytorch_tanh"),
+            vision_use_head=False,
+        )
+        # `meta` device + later `to_empty` + state_dict load avoids materialising
+        # a full random-init ViT just to overwrite it.
+        with torch.device("meta"):
+            hf_model = SiglipVisionModel(hf_cfg)
+        hf_model = hf_model.to_empty(device=device).to(dtype=dtype)
+
+        ckpt_dir = Path(self._hf_navit_ckpt_path)
+        index_path = ckpt_dir / "model.safetensors.index.json"
+        if not index_path.exists():
+            raise RuntimeError(
+                f"HF NaViT ViT load: missing safetensors index at {index_path}"
+            )
+        import json as _json
+        with open(index_path) as f:
+            weight_map = _json.load(f)["weight_map"]
+
+        # Collect every `vit_model.vision_model.*` key, mapping prefix away.
+        wanted = {k: v for k, v in weight_map.items() if k.startswith("vit_model.vision_model.")}
+        if not wanted:
+            raise RuntimeError("HF NaViT ViT load: no vit_model.vision_model.* keys found")
+
+        # Group by shard for efficient I/O.
+        by_shard: dict[str, list[str]] = {}
+        for k, shard in wanted.items():
+            by_shard.setdefault(shard, []).append(k)
+
+        # Determine prefix handling: transformers >=5.x flattens
+        # SiglipVisionModel (state_dict starts with `embeddings.*`); pre-5.x
+        # kept the inner wrapper (`vision_model.embeddings.*`). Inspect what
+        # the model actually wants.
+        hf_keys = set(hf_model.state_dict().keys())
+        needs_strip = "embeddings.patch_embedding.weight" in hf_keys
+
+        state: dict[str, torch.Tensor] = {}
+        for shard, keys in by_shard.items():
+            with safe_open(str(ckpt_dir / shard), framework="pt") as sf:
+                for k in keys:
+                    # Strip BAGEL's `vit_model.` prefix.
+                    new_key = k[len("vit_model."):]
+                    # Optionally also strip `vision_model.` prefix on
+                    # transformers >=5.x.
+                    if needs_strip:
+                        new_key = new_key[len("vision_model."):]
+                    t = sf.get_tensor(k).to(dtype=dtype)
+                    # BAGEL stores patch_embedding flat as (out, kh*kw*in) with
+                    # inner order (kh, kw, c); HF Conv2d expects (out, in, kh, kw).
+                    is_patch_w = new_key.endswith("embeddings.patch_embedding.weight")
+                    if is_patch_w and t.ndim == 2:
+                        patch_size = vit_cfg.patch_size
+                        in_ch = vit_cfg.num_channels
+                        out_ch = t.shape[0]
+                        t = t.reshape(out_ch, patch_size, patch_size, in_ch).permute(0, 3, 1, 2).contiguous()
+                    state[new_key] = t
+
+        missing, unexpected = hf_model.load_state_dict(state, strict=False)
+        # `head` is added by HF for some configurations and is absent in BAGEL;
+        # filter it out of the unexpected list before warning.
+        unexpected = [u for u in unexpected if "head" not in u]
+        if missing or unexpected:
+            import logging
+            logging.getLogger(__name__).warning(
+                "HF NaViT ViT load: missing=%s unexpected=%s (transformers_strip=%s)",
+                missing[:5], unexpected[:5], needs_strip,
+            )
+
+        hf_model.eval()
+        for p in hf_model.parameters():
+            p.requires_grad_(False)
+        return SiglipNaViTWrapper(hf_model)
+
     def _resize_to_stride(self, pixel_values: torch.Tensor) -> torch.Tensor:
         """Resize pixel values to stride-aligned dimensions
         (matches DiT's ``_resize_images_to_stride``)."""
@@ -560,6 +1312,10 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         self._pending_img2img_info.clear()
         self._last_img2img_info = None
         self._vae_token_mask = None
+        self._bagel_vqa_rope_states.clear()
+        self._bagel_vqa_rope_positions_current = None
+        self._bagel_vqa_image_spans_current = []
+        self._bagel_runner_num_computed_tokens_current = []
 
     def get_kv_transfer_metadata(
         self,
@@ -597,7 +1353,74 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         detection."""
         if inputs_embeds is not None and input_ids is None and input_ids_buffer is not None:
             input_ids = input_ids_buffer
+        self._bagel_vqa_rope_positions_current = self._build_bagel_vqa_rope_positions(
+            input_ids=input_ids,
+            positions=positions,
+            req_ids=req_ids,
+            num_computed_tokens=num_computed_tokens,
+            num_scheduled_tokens=num_scheduled_tokens,
+        )
+        self._bagel_vqa_image_spans_current = self._build_bagel_vqa_image_spans(
+            input_ids=input_ids,
+            req_ids=req_ids,
+            num_computed_tokens=num_computed_tokens,
+            num_scheduled_tokens=num_scheduled_tokens,
+        )
+        self._bagel_runner_num_computed_tokens_current = [
+            int(x) for x in num_computed_tokens
+        ]
         return input_ids, positions
+
+    def _build_bagel_vqa_rope_positions(
+        self,
+        *,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor | None,
+        req_ids: list[str],
+        num_computed_tokens: list[int],
+        num_scheduled_tokens: list[int],
+    ) -> torch.Tensor | None:
+        """Compute BAGEL logical RoPE positions without touching vLLM slots.
+
+        vLLM's `positions` tensor remains the physical paged-KV position used by
+        slot mapping and attention metadata. This side-channel mirrors BAGEL
+        reference's logical rule for VQA: every token in a vision block shares
+        one RoPE position, and text/decode tokens continue from the collapsed
+        logical length. State is per request so chunked prefill and continuous
+        batching can cross image-block boundaries safely.
+        """
+        if not self._bagel_vqa_logical_rope_enabled:
+            return None
+
+        return build_bagel_vqa_rope_positions(
+            input_ids=input_ids,
+            positions=positions,
+            req_ids=req_ids,
+            num_computed_tokens=num_computed_tokens,
+            num_scheduled_tokens=num_scheduled_tokens,
+            rope_states=self._bagel_vqa_rope_states,
+            start_of_image_id=self._start_of_image_id,
+            end_of_image_id=self._end_of_image_id,
+        )
+
+    def _build_bagel_vqa_image_spans(
+        self,
+        *,
+        input_ids: torch.Tensor | None,
+        req_ids: list[str],
+        num_computed_tokens: list[int],
+        num_scheduled_tokens: list[int],
+    ) -> list[dict[str, int]]:
+        if not self._bagel_vqa_reference_prefill_enabled:
+            return []
+        return build_bagel_vqa_image_spans(
+            input_ids=input_ids,
+            req_ids=req_ids,
+            num_computed_tokens=num_computed_tokens,
+            num_scheduled_tokens=num_scheduled_tokens,
+            start_of_image_id=self._start_of_image_id,
+            end_of_image_id=self._end_of_image_id,
+        )
 
     def flush_pending_metadata(self, req_ids: list[str]) -> None:
         """Map pending metadata (batch order) to req_ids after forward().
@@ -623,15 +1446,45 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         mm_input_by_modality = {}
 
         if any(k in kwargs for k in ("pixel_values", "image_embeds")):
-            mm_input_by_modality["img2text"] = self._parse_and_validate_image_input(**kwargs)
+            parsed = self._parse_and_validate_image_input(**kwargs)
+            # Propagate image_grid_thw alongside pixel_values so
+            # `_process_img2text_input` can dispatch to the
+            # NaViT branch when present. The parent returns an immutable
+            # ``BagelImagePixelInputs`` TensorSchema, so re-pack into a plain
+            # dict (still subscriptable downstream) before adding extra keys.
+            grid_thw = kwargs.get("image_grid_thw")
+            if parsed is not None and grid_thw is not None:
+                parsed_dict = {
+                    "type": parsed["type"],
+                    "pixel_values": parsed["pixel_values"],
+                    "image_grid_thw": grid_thw,
+                }
+                mm_input_by_modality["img2text"] = parsed_dict
+            else:
+                mm_input_by_modality["img2text"] = parsed
 
-        img2img_keys = {"pixel_values_img2img": "pixel_values", "image_embeds_img2img": "image_embeds"}
+        img2img_keys = {
+            "pixel_values_img2img": "pixel_values",
+            "image_embeds_img2img": "image_embeds",
+            "pixel_values_img2img_vit": "pixel_values_vit",
+            "image_grid_thw_img2img_vit": "image_grid_thw_vit",
+        }
         img2img_kwargs = {img2img_keys[k]: v for k, v in kwargs.items() if k in img2img_keys}
 
         if img2img_kwargs:
             combined_kwargs = kwargs.copy()
             combined_kwargs.update(img2img_kwargs)
-            mm_input_by_modality["img2img"] = self._parse_and_validate_image_input(**combined_kwargs)
+            parsed = self._parse_and_validate_image_input(**combined_kwargs)
+            if parsed is not None:
+                parsed_dict = {
+                    "type": parsed["type"],
+                    "pixel_values": parsed["pixel_values"],
+                }
+                if "pixel_values_vit" in img2img_kwargs:
+                    parsed_dict["pixel_values_vit"] = img2img_kwargs["pixel_values_vit"]
+                if "image_grid_thw_vit" in img2img_kwargs:
+                    parsed_dict["image_grid_thw_vit"] = img2img_kwargs["image_grid_thw_vit"]
+                mm_input_by_modality["img2img"] = parsed_dict
 
         return mm_input_by_modality
 
@@ -659,34 +1512,119 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         return pos_ids
 
     def _process_img2text_input(self, multimodal_input):
+        # When the processor produced packed variable-shape pixel_values plus
+        # image_grid_thw, take the NaViT path. Otherwise fall back to the
+        # fixed-shape path used by dummy inputs and older processors.
+        if "image_grid_thw" in multimodal_input:
+            return self._process_image_input_navit(multimodal_input)
         return self._process_image_input(multimodal_input)
+
+    def _process_image_input_navit(self, multimodal_input) -> tuple[torch.Tensor, ...]:
+        """NaViT-style ViT forward for variable-shape packed pixel_values.
+
+        Sequence: linear patch_embed + SigLIP position embedding, vLLM
+        SiglipEncoder per image, post_layernorm, connector, and BAGEL
+        vit_pos_embed. The post_layernorm is required for parity with the
+        reference ViT path.
+        """
+        pixel_values = multimodal_input["pixel_values"]
+        grid_thw = multimodal_input["image_grid_thw"]
+        # `flat_from_sizes` slices into a list of per-image (L_i, ...) tensors;
+        # concatenate back to packed (total_patches, ...) for NaViT.
+        if isinstance(pixel_values, (list, tuple)):
+            pixel_values = torch.cat([t for t in pixel_values], dim=0)
+        if isinstance(grid_thw, (list, tuple)):
+            grid_thw = torch.cat([t.unsqueeze(0) if t.ndim == 1 else t for t in grid_thw], dim=0)
+
+        device = pixel_values.device
+        grid_thw = grid_thw.to(device)
+        patch_counts = grid_thw[:, 1] * grid_thw[:, 2]
+        cu_seqlens = torch.cat([
+            torch.zeros(1, dtype=torch.int32, device=device),
+            patch_counts.cumsum(0).to(torch.int32),
+        ])
+
+        # Shared bits: patch embedding weight and pos table.
+        vit = self.vit_model  # vllm's SiglipVisionModel, unwrapped.
+        patch_embed = vit.vision_model.embeddings.patch_embedding
+        patch_embed_weight = patch_embed.weight.view(patch_embed.weight.shape[0], -1)
+        position_embedding = vit.vision_model.embeddings.position_embedding
+        target_dtype = patch_embed.weight.dtype
+        patch_size = self.config.vit_config.patch_size
+        max_per_side = self.config.vit_max_num_patch_per_side
+
+        # Forward each image independently through patch_embed + pos + encoder.
+        per_image_features: list[torch.Tensor] = []
+        per_image_pos_ids: list[torch.Tensor] = []
+        cu_list = cu_seqlens.tolist()
+        for i in range(grid_thw.shape[0]):
+            start, end = cu_list[i], cu_list[i + 1]
+            patches = pixel_values[start:end].to(dtype=target_dtype)
+
+            h_pixels = int(grid_thw[i, 1].item()) * patch_size
+            w_pixels = int(grid_thw[i, 2].item()) * patch_size
+            pos_ids = get_flattened_position_ids_extrapolate(
+                h_pixels, w_pixels, patch_size, max_per_side
+            ).to(device=device, dtype=torch.long)
+            per_image_pos_ids.append(pos_ids)
+
+            x = torch.nn.functional.linear(patches, patch_embed_weight, patch_embed.bias)
+            x = x + position_embedding(pos_ids)
+            x_3d = x.unsqueeze(0)
+
+            encoder_out = vit.vision_model.encoder(
+                inputs_embeds=x_3d, return_all_hidden_states=False
+            )
+            if isinstance(encoder_out, list):
+                encoder_out = encoder_out[-1]
+            post_ln = getattr(vit.vision_model, "post_layernorm", None)
+            if post_ln is not None:
+                encoder_out = post_ln(encoder_out)
+            per_image_features.append(encoder_out.squeeze(0))
+
+        vision_features = torch.cat(per_image_features, dim=0)
+        vision_embeds = self.connector(vision_features)
+        packed_pos_ids = torch.cat(per_image_pos_ids)
+        pos_emb = self.vit_pos_embed(packed_pos_ids.cpu()).to(
+            device=vision_embeds.device, dtype=vision_embeds.dtype
+        )
+        vision_embeds = vision_embeds + pos_emb
+
+        return tuple(
+            vision_embeds[cu_list[i]: cu_list[i + 1]]
+            for i in range(len(cu_list) - 1)
+        )
 
     def _process_img2img_input(self, multimodal_input):
         pixel_values = multimodal_input["pixel_values"]
-        if pixel_values.ndim == 5:
-            b, n, c, h, w = pixel_values.shape
-            pixel_values = pixel_values.reshape(b * n, c, h, w)
+        pixel_value_items: list[torch.Tensor] = []
+        raw_items = pixel_values if isinstance(pixel_values, (list, tuple)) else [pixel_values]
+        for item in raw_items:
+            if item.ndim == 5:
+                b, n, c, h, w = item.shape
+                item = item.reshape(b * n, c, h, w)
+            elif item.ndim == 3:
+                item = item.unsqueeze(0)
+            if item.ndim != 4:
+                raise ValueError(f"Unsupported img2img pixel_values shape: {tuple(item.shape)}")
+            pixel_value_items.extend(item[i : i + 1] for i in range(item.shape[0]))
 
-        num_images = pixel_values.shape[0]
-        image_size = self.config.vit_config.image_size
+        if not pixel_value_items:
+            return ()
+
+        num_images = len(pixel_value_items)
+        pixel_device = pixel_value_items[0].device
+        include_vit = _bagel_img2img_input_vit_enabled()
+        use_vit_separator = include_vit and _bagel_img2img_vit_separator_enabled()
         p = self.latent_patch_size
         timestep = 0
 
         if self._ropes_pending:
             self._ropes_pending.clear()
 
-        vit_pixel_values = torch.nn.functional.interpolate(
-            pixel_values,
-            size=(image_size, image_size),
-            mode="bicubic",
-            align_corners=False,
-        )
-
-        vit_embeddings_tuple = self._process_image_input({"pixel_values": vit_pixel_values})
-
         marker_ids = torch.tensor(
             [self._start_of_image_id, self._end_of_image_id],
-            device=pixel_values.device,
+            device=pixel_device,
             dtype=torch.long,
         )
         marker_embeds = self.language_model.model.embed_tokens(marker_ids)
@@ -694,11 +1632,85 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         end_embed = marker_embeds[1:2]
 
         results = []
+        prepared_vae_inputs: list[tuple[torch.Tensor, int, int]] = []
+        vit_patch_chunks: list[torch.Tensor] = []
+        vit_grid_rows: list[list[int]] = []
+        precomputed_vit_pixel_values = multimodal_input.get("pixel_values_vit")
+        precomputed_vit_grid_thw = multimodal_input.get("image_grid_thw_vit")
+        debug_img2img = _bagel_img2img_debug_enabled()
 
-        for i in range(num_images):
-            single_pv = pixel_values[i : i + 1]
-            single_pv = self._resize_to_stride(single_pv)
-            H, W = single_pv.shape[2:]
+        for i, single_pv in enumerate(pixel_value_items):
+            raw_h, raw_w = single_pv.shape[2:]
+            vae_h, vae_w = _bagel_img2img_vae_hw(
+                raw_h,
+                raw_w,
+                latent_downsample=self.latent_downsample,
+                max_latent_size=self.max_latent_size,
+            )
+            if (raw_h, raw_w) != (vae_h, vae_w):
+                single_pv = torch.nn.functional.interpolate(
+                    single_pv,
+                    size=(vae_h, vae_w),
+                    mode="bicubic",
+                    align_corners=False,
+            )
+            prepared_vae_inputs.append((single_pv, vae_h, vae_w))
+
+            if include_vit and precomputed_vit_pixel_values is None:
+                vit_h, vit_w = _bagel_img2img_vit_hw(vae_h, vae_w)
+                vit_pixel_values = torch.nn.functional.interpolate(
+                    single_pv,
+                    size=(vit_h, vit_w),
+                    mode="bicubic",
+                    align_corners=False,
+                )
+                vit_patch_chunks.append(
+                    patchify(vit_pixel_values[0], self.config.vit_config.patch_size)
+                )
+                vit_grid_rows.append(
+                    [
+                        1,
+                        vit_h // self.config.vit_config.patch_size,
+                        vit_w // self.config.vit_config.patch_size,
+                    ]
+                )
+
+        vit_embeddings_tuple = ()
+        if include_vit:
+            if precomputed_vit_pixel_values is not None and precomputed_vit_grid_thw is not None:
+                vit_pixel_values = precomputed_vit_pixel_values
+                vit_grid_thw = precomputed_vit_grid_thw
+                if isinstance(vit_pixel_values, (list, tuple)):
+                    vit_pixel_values = torch.cat([t for t in vit_pixel_values], dim=0)
+                if isinstance(vit_grid_thw, (list, tuple)):
+                    vit_grid_thw = torch.cat(
+                        [t.unsqueeze(0) if t.ndim == 1 else t for t in vit_grid_thw],
+                        dim=0,
+                    )
+                if vit_grid_thw.ndim == 1:
+                    vit_grid_thw = vit_grid_thw.unsqueeze(0)
+                vit_embeddings_tuple = self._process_image_input_navit(
+                    {
+                        "pixel_values": vit_pixel_values,
+                        "image_grid_thw": vit_grid_thw.to(
+                            device=pixel_device,
+                            dtype=torch.long,
+                        ),
+                    }
+                )
+            elif vit_patch_chunks:
+                vit_embeddings_tuple = self._process_image_input_navit(
+                    {
+                        "pixel_values": torch.cat(vit_patch_chunks, dim=0),
+                        "image_grid_thw": torch.tensor(
+                            vit_grid_rows,
+                            dtype=torch.long,
+                            device=pixel_values.device,
+                        ),
+                    }
+                )
+
+        for i, (single_pv, H, W) in enumerate(prepared_vae_inputs):
 
             padded_latent = self.vae.encode(single_pv)
             h = H // self.latent_downsample
@@ -720,16 +1732,34 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                 timestep_embeds = self.time_embedder(packed_timesteps.to(padded_latent))
             vae_embeds = self.vae2llm(latent) + timestep_embeds + pos_embed
 
-            vit_emb = vit_embeddings_tuple[i] if i < len(vit_embeddings_tuple) else vit_embeddings_tuple[0]
-
             se = start_embed.to(vae_embeds.dtype)
             ee = end_embed.to(vae_embeds.dtype)
-            combined = torch.cat([se, vae_embeds, ee, se, vit_emb, ee], dim=0)
+            if include_vit:
+                vit_emb = vit_embeddings_tuple[i] if i < len(vit_embeddings_tuple) else vit_embeddings_tuple[0]
+                combined = torch.cat([se, vae_embeds, ee, se, vit_emb, ee], dim=0)
+                num_vit = vit_emb.shape[0] + 2 + (1 if use_vit_separator else 0)
+            else:
+                combined = torch.cat([se, vae_embeds, ee], dim=0)
+                num_vit = 0
             results.append(combined)
 
             num_vae = h * w + 2  # +2 for start/end markers
-            num_vit = vit_emb.shape[0] + 2
-            info = (num_vae, num_vit, int(H), int(W))
+            info = (num_vae, num_vit, int(H), int(W), 1 if use_vit_separator else 0)
+            if debug_img2img:
+                logger.info(
+                    "BAGEL img2img embeddings idx=%d raw_hw=%dx%d vae_hw=%dx%d "
+                    "vae_tokens=%d vit_tokens=%d combined=%d precomputed_vit=%s sep=%s",
+                    i,
+                    raw_h,
+                    raw_w,
+                    H,
+                    W,
+                    num_vae,
+                    num_vit,
+                    combined.shape[0],
+                    precomputed_vit_pixel_values is not None,
+                    use_vit_separator,
+                )
             self._pending_img2img_info.append(info)
             self._last_img2img_info = info
 
@@ -752,8 +1782,9 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
 
         elif self._last_img2img_info is not None:
             info = self._last_img2img_info
-            num_vae, num_vit, _, _ = info
-            num_img2img = num_vae + 1 + num_vit
+            num_vae = int(info[0])
+            num_vit = int(info[1])
+            num_img2img = num_vae + num_vit
 
             if seq_len >= num_img2img:
                 self._pending_img2img_info = [info]
@@ -765,7 +1796,15 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
 
         if use_mot:
             return self._mot_forward(input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs)
-        return super().forward(input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs)
+
+        rope_positions = self._bagel_vqa_rope_positions_current
+        self._bagel_vqa_rope_positions_current = None
+        try:
+            if rope_positions is not None and rope_positions.shape == positions.shape:
+                return super().forward(input_ids, rope_positions, intermediate_tensors, inputs_embeds, **kwargs)
+            return super().forward(input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs)
+        finally:
+            self._bagel_vqa_image_spans_current = []
 
     def _adjust_positions_for_img2img(
         self,
@@ -779,7 +1818,6 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
 
             pre_text -> 0 .. M-1
             VAE      -> M       (all share)
-            separator-> M
             ViT      -> M+1     (all share)
             post_text-> M+2, M+3, ...
 
@@ -790,28 +1828,30 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
 
         if not info_list:
             self._vae_token_mask = None
-            self._has_vae_tokens = False
-            self._has_non_vae_tokens = True
             return positions
 
         boundaries = [0]
-        # Copy positions to the host once: indexing the CUDA tensor element by
-        # element in the loop below would sync the device on every iteration.
-        pos_list = positions.tolist()
-        for i in range(1, len(pos_list)):
-            if pos_list[i] < pos_list[i - 1]:
+        for i in range(1, len(positions)):
+            if positions[i] < positions[i - 1]:
                 boundaries.append(i)
-        boundaries.append(len(pos_list))
+        boundaries.append(len(positions))
 
         num_requests = len(boundaries) - 1
         new_positions = positions.clone()
         vae_mask = torch.zeros(len(positions), dtype=torch.bool, device=positions.device)
 
         img2img_idx = 0
+        noncausal_spans: list[dict[str, int]] = []
+        num_computed_tokens = self._bagel_runner_num_computed_tokens_current
         for req_idx in range(num_requests):
             start = boundaries[req_idx]
             end = boundaries[req_idx + 1]
             req_len = end - start
+            num_computed = (
+                int(num_computed_tokens[req_idx])
+                if req_idx < len(num_computed_tokens)
+                else 0
+            )
 
             if img2img_idx < len(info_list):
                 cur_info = info_list[img2img_idx]
@@ -821,8 +1861,13 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                 cur_info = None
 
             if cur_info is not None:
-                num_vae, num_vit, img_H, img_W = cur_info
-                num_img2img = num_vae + 1 + num_vit  # +1 separator
+                if len(cur_info) >= 5:
+                    num_vae, num_vit, img_H, img_W, sep_count = cur_info
+                else:
+                    num_vae, num_vit, img_H, img_W = cur_info
+                    sep_count = 0
+                include_vit = num_vit > 0
+                num_img2img = num_vae + num_vit if include_vit else num_vae
 
                 if req_len >= num_img2img:
                     pre_text_len = 0
@@ -842,15 +1887,17 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                         )
 
                     new_positions[img_start : img_start + num_vae] = M
-                    new_positions[img_start + num_vae] = M  # separator
-                    vit_start = img_start + num_vae + 1
-                    new_positions[vit_start : vit_start + num_vit] = M + 1
+                    if include_vit:
+                        vit_group_start = img_start + num_vae
+                        vit_start = vit_group_start + sep_count
+                        new_positions[vit_group_start : vit_group_start + num_vit] = M + 1
 
                     num_post_text = end - post_text_start
+                    post_text_rope_start = M + 2 if include_vit else M + 1
                     if num_post_text > 0:
                         new_positions[post_text_start:end] = torch.arange(
-                            M + 2,
-                            M + 2 + num_post_text,
+                            post_text_rope_start,
+                            post_text_rope_start + num_post_text,
                             device=positions.device,
                             dtype=positions.dtype,
                         )
@@ -860,27 +1907,61 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
                     if vae_patches_end > vae_patches_start:
                         vae_mask[vae_patches_start:vae_patches_end] = True
 
-                    rope = M + 2 + num_post_text
+                    noncausal_spans.append(
+                        {
+                            "req_idx": req_idx,
+                            "q_start": img_start,
+                            "q_end": img_start + num_vae,
+                            "request_start": start,
+                            "num_computed_tokens": num_computed,
+                            "kv_local_end": M + num_vae,
+                            "kv_end": num_computed + M + num_vae,
+                        }
+                    )
+                    if include_vit:
+                        noncausal_spans.append(
+                            {
+                                "req_idx": req_idx,
+                                "q_start": vit_start,
+                                "q_end": img_start + num_vae + num_vit,
+                                "request_start": start,
+                                "num_computed_tokens": num_computed,
+                                "kv_local_end": M + num_vae + num_vit,
+                                "kv_end": num_computed + M + num_vae + num_vit,
+                            }
+                        )
+
+                    rope = post_text_rope_start + num_post_text
                     self._ropes_pending.append(
                         {
                             "ropes": [rope],
                             "image_shape": [img_H, img_W],
                             "prefill_position_count": req_len,
+                            "cfg_text_kv_len": num_img2img + M,
+                            "cfg_text_rope": post_text_rope_start,
                         }
                     )
+                    if _bagel_img2img_debug_enabled():
+                        logger.info(
+                            "BAGEL img2img positions req=%d req_len=%d pre_text=%d "
+                            "img_start=%d num_vae=%d num_vit=%d post_text=%d rope=%d",
+                            req_idx,
+                            req_len,
+                            M,
+                            img_start,
+                            num_vae,
+                            num_vit,
+                            num_post_text,
+                            rope,
+                        )
                     img2img_idx += 1
                     continue
 
             rope = int(new_positions[end - 1].item()) + 1
             self._ropes_pending.append({"ropes": [rope]})
 
-        # Resolve mask occupancy once here (the only .any() syncs on this path)
-        # and cache it; the per-layer routing reads these flags instead of
-        # re-checking the mask on every decoder layer.
-        has_vae = bool(vae_mask.any())
-        self._vae_token_mask = vae_mask if has_vae else None
-        self._has_vae_tokens = has_vae
-        self._has_non_vae_tokens = bool((~vae_mask).any()) if has_vae else True
+        self._vae_token_mask = vae_mask if vae_mask.any() else None
+        self._img2img_noncausal_spans_current = noncausal_spans
         return new_positions
 
     # ------------------------------------------------------------------
@@ -898,7 +1979,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         """Full forward pass with MoT routing for img2img requests.
 
         VAE latent patches are routed through ``*_moe_gen`` weight matrices
-        while all other tokens (markers, ViT, separator, text) use the
+        while all other tokens (markers, ViT, text) use the
         standard understanding-mode weights.
         """
         qwen2_model = self.language_model.model  # Qwen2Model
@@ -926,10 +2007,10 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         # Final norm with MoT routing
         if residual is not None:
             hidden_states = hidden_states + residual
-        if vae_mask is not None and self._has_vae_tokens:
+        if vae_mask is not None and vae_mask.any():
             out = torch.empty_like(hidden_states)
             non_vae = ~vae_mask
-            if self._has_non_vae_tokens:
+            if non_vae.any():
                 out[non_vae] = qwen2_model.norm(hidden_states[non_vae])
             out[vae_mask] = qwen2_model.norm_moe_gen(hidden_states[vae_mask])
             hidden_states = out
@@ -947,7 +2028,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         vae_mask: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Single decoder-layer forward with MoT routing."""
-        if vae_mask is None or not self._has_vae_tokens:
+        if vae_mask is None or not vae_mask.any():
             return layer(positions, hidden_states, residual)
 
         non_vae = ~vae_mask
@@ -957,7 +2038,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
             hidden_states = hidden_states + residual
         residual = hidden_states
         normed = torch.empty_like(hidden_states)
-        if self._has_non_vae_tokens:
+        if non_vae.any():
             normed[non_vae] = layer.input_layernorm(hidden_states[non_vae])
         normed[vae_mask] = layer.input_layernorm_moe_gen(hidden_states[vae_mask])
         hidden_states = normed
@@ -969,14 +2050,14 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         hidden_states = hidden_states + residual
         residual = hidden_states
         normed = torch.empty_like(hidden_states)
-        if self._has_non_vae_tokens:
+        if non_vae.any():
             normed[non_vae] = layer.post_attention_layernorm(hidden_states[non_vae])
         normed[vae_mask] = layer.post_attention_layernorm_moe_gen(hidden_states[vae_mask])
         hidden_states = normed
 
         # ---- MLP (split) ----
         mlp_out = torch.empty_like(hidden_states)
-        if self._has_non_vae_tokens:
+        if non_vae.any():
             mlp_out[non_vae] = layer.mlp(hidden_states[non_vae])
         mlp_out[vae_mask] = layer.mlp_moe_gen(hidden_states[vae_mask])
         hidden_states = mlp_out
@@ -1001,7 +2082,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
             device=hidden_states.device,
             dtype=hidden_states.dtype,
         )
-        if self._has_non_vae_tokens:
+        if non_vae.any():
             qkv_und, _ = attn.qkv_proj(hidden_states[non_vae])
             qkv[non_vae] = qkv_und
         qkv_gen, _ = attn.qkv_proj_moe_gen(hidden_states[vae_mask])
@@ -1017,7 +2098,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
 
             q_out = torch.empty_like(q)
             k_out = torch.empty_like(k)
-            if self._has_non_vae_tokens:
+            if non_vae.any():
                 q_out[non_vae] = attn.q_norm(q[non_vae])
                 k_out[non_vae] = attn.k_norm(k[non_vae])
             q_out[vae_mask] = attn.q_norm_moe_gen(q[vae_mask])
@@ -1029,6 +2110,31 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
         # ---- RoPE + attention (same for all tokens) ----
         q, k = attn.rotary_emb(positions, q, k)
         attn_output = attn.attn(q, k, v)
+        spans = self._img2img_noncausal_spans_current
+        if spans:
+            if _env_flag("BAGEL_IMG2IMG_NONCAUSAL_RECOMPUTE", False):
+                try:
+                    attn_output = _bagel_recompute_noncausal_image_blocks_paged(
+                        attn,
+                        q,
+                        k,
+                        v,
+                        attn_output,
+                        spans,
+                    )
+                except Exception:
+                    # Keep the experiment debuggable on non-paged/mock
+                    # backends; real vLLM prefill should use the paged KV path
+                    # above so image tokens can still see transferred/prefix KV.
+                    attn_output = _bagel_vqa_recompute_noncausal_image_blocks_direct(
+                        attn,
+                        q,
+                        k,
+                        v,
+                        attn_output,
+                        spans,
+                        "img2img",
+                    )
 
         # ---- O projection (split) ----
         output = torch.empty(
@@ -1037,7 +2143,7 @@ class OmniBagelForConditionalGeneration(BagelForConditionalGeneration):
             device=hidden_states.device,
             dtype=hidden_states.dtype,
         )
-        if self._has_non_vae_tokens:
+        if non_vae.any():
             o_und, _ = attn.o_proj(attn_output[non_vae])
             output[non_vae] = o_und
         o_gen, _ = attn.o_proj_moe_gen(attn_output[vae_mask])

--- a/vllm_omni/utils/bagel_vqa.py
+++ b/vllm_omni/utils/bagel_vqa.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import torch
+
+BAGEL_VLM_THINK_SYSTEM_PROMPT = (
+    "You should first think about the reasoning process in the mind and then "
+    "provide the user with the answer.\n"
+    "The reasoning process is enclosed within <think> </think> tags, i.e. "
+    "<think> reasoning process here </think> answer here"
+)
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def env_flag(name: str) -> bool:
+    return os.environ.get(name, "").lower() in TRUE_VALUES
+
+
+def bagel_vqa_reference_prefill_enabled() -> bool:
+    return env_flag("BAGEL_VQA_REFERENCE_PREFILL")
+
+
+def bagel_vqa_reference_layout_enabled() -> bool:
+    return (
+        bagel_vqa_reference_prefill_enabled()
+        or env_flag("BAGEL_VQA_REFERENCE_LAYOUT")
+    )
+
+
+def bagel_token_id(tokenizer: Any, token: str) -> int:
+    token_id = tokenizer.convert_tokens_to_ids(token)
+    if token_id is None or token_id < 0:
+        raise ValueError(f"BAGEL tokenizer is missing required token {token!r}")
+    return int(token_id)
+
+
+def bagel_encode_text_segment(tokenizer: Any, text: str) -> list[int]:
+    im_start = bagel_token_id(tokenizer, "<|im_start|>")
+    im_end = bagel_token_id(tokenizer, "<|im_end|>")
+    return [im_start] + list(tokenizer.encode(text)) + [im_end]
+
+
+def strip_bagel_think_prompt(text: str) -> str:
+    if text.startswith(BAGEL_VLM_THINK_SYSTEM_PROMPT):
+        return text[len(BAGEL_VLM_THINK_SYSTEM_PROMPT) :].lstrip()
+    return text
+
+
+def messages_to_dicts(messages: list[Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        if hasattr(msg, "model_dump"):
+            out.append(msg.model_dump())
+        elif isinstance(msg, dict):
+            out.append(msg)
+        else:
+            out.append(
+                {
+                    "role": getattr(msg, "role", "user"),
+                    "content": getattr(msg, "content", ""),
+                }
+            )
+    return out
+
+
+def build_bagel_reference_text_and_image_count(
+    messages: list[Any],
+) -> tuple[str, int]:
+    text_parts: list[str] = []
+    image_count = 0
+
+    for message in messages_to_dicts(messages):
+        role = message.get("role")
+        if role is not None and role != "user":
+            continue
+
+        content = message.get("content", "")
+        if isinstance(content, str):
+            stripped = strip_bagel_think_prompt(content)
+            if stripped:
+                text_parts.append(stripped)
+            continue
+
+        if not isinstance(content, list):
+            continue
+
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            part_type = part.get("type")
+            if part_type == "text":
+                text = part.get("text") or ""
+                stripped = strip_bagel_think_prompt(text)
+                if stripped:
+                    text_parts.append(stripped)
+            elif part_type in {"image", "image_url"}:
+                image_count += 1
+                text_parts.append(f"<img><|image_{image_count}|></img>")
+
+    return " ".join(text_parts), image_count
+
+
+def build_bagel_vqa_reference_prompt_token_ids(
+    messages: list[Any],
+    tokenizer: Any,
+) -> tuple[list[int], str, int]:
+    final_text, image_count = build_bagel_reference_text_and_image_count(messages)
+    if image_count <= 0:
+        return [], final_text, image_count
+
+    image_pad = bagel_token_id(tokenizer, "<|image_pad|>")
+    im_start = bagel_token_id(tokenizer, "<|im_start|>")
+
+    prompt_token_ids: list[int] = []
+    prompt_token_ids.extend(
+        bagel_encode_text_segment(tokenizer, BAGEL_VLM_THINK_SYSTEM_PROMPT)
+    )
+    prompt_token_ids.extend([image_pad] * image_count)
+    if final_text:
+        prompt_token_ids.extend(bagel_encode_text_segment(tokenizer, final_text))
+    prompt_token_ids.append(im_start)
+    return prompt_token_ids, final_text, image_count
+
+
+def build_bagel_vqa_rope_positions(
+    *,
+    input_ids: torch.Tensor | None,
+    positions: torch.Tensor | None,
+    req_ids: list[str],
+    num_computed_tokens: list[int],
+    num_scheduled_tokens: list[int],
+    rope_states: dict[str, dict[str, Any]],
+    start_of_image_id: int,
+    end_of_image_id: int,
+) -> torch.Tensor | None:
+    """Compute BAGEL logical RoPE positions without touching vLLM slots."""
+    if input_ids is None or positions is None or not req_ids:
+        return None
+    if positions.ndim != 1:
+        return None
+
+    total_scheduled = sum(int(n) for n in num_scheduled_tokens)
+    if total_scheduled <= 0:
+        return None
+
+    active_req_ids = set(req_ids)
+    for rid in list(rope_states):
+        if rid not in active_req_ids:
+            rope_states.pop(rid, None)
+
+    rope_positions = positions.clone()
+    any_changed = False
+    offset = 0
+
+    for req_idx, req_id in enumerate(req_ids):
+        sched = int(num_scheduled_tokens[req_idx])
+        if sched <= 0:
+            continue
+
+        start = offset
+        end = offset + sched
+        offset = end
+
+        token_slice = input_ids[start:end]
+        if token_slice.numel() == 0:
+            continue
+
+        state = rope_states.get(req_id)
+        has_vision_marker = bool(
+            ((token_slice == start_of_image_id) | (token_slice == end_of_image_id))
+            .any()
+            .item()
+        )
+        if state is None and not has_vision_marker:
+            continue
+
+        if state is None:
+            state = {
+                "enabled": True,
+                "next": int(num_computed_tokens[req_idx]),
+                "in_vision": False,
+                "block": None,
+            }
+        else:
+            state["enabled"] = True
+
+        logical = []
+        next_pos = int(state.get("next", num_computed_tokens[req_idx]))
+        in_vision = bool(state.get("in_vision", False))
+        block_pos = state.get("block")
+        if block_pos is None:
+            block_pos = next_pos
+        block_pos = int(block_pos)
+
+        for tok in token_slice.tolist():
+            tok = int(tok)
+            if tok == start_of_image_id and not in_vision:
+                in_vision = True
+                block_pos = next_pos
+                logical.append(block_pos)
+            elif in_vision:
+                logical.append(block_pos)
+                if tok == end_of_image_id:
+                    in_vision = False
+                    next_pos = block_pos + 1
+            else:
+                logical.append(next_pos)
+                next_pos += 1
+
+        new_vals = torch.tensor(logical, device=positions.device, dtype=positions.dtype)
+        rope_positions[start:end] = new_vals
+        if not torch.equal(new_vals, positions[start:end]):
+            any_changed = True
+
+        state["next"] = next_pos
+        state["in_vision"] = in_vision
+        state["block"] = block_pos if in_vision else None
+        rope_states[req_id] = state
+
+    return rope_positions if any_changed else None
+
+
+def build_bagel_vqa_image_spans(
+    *,
+    input_ids: torch.Tensor | None,
+    req_ids: list[str],
+    num_computed_tokens: list[int],
+    num_scheduled_tokens: list[int],
+    start_of_image_id: int,
+    end_of_image_id: int,
+) -> list[dict[str, int]]:
+    """Find complete BAGEL VQA image blocks in the scheduled token batch.
+
+    Returned offsets are flat query rows for the current vLLM batch. `kv_end`
+    is the per-request sequence length immediately after the image block, which
+    prevents the non-causal image recompute from attending to future text.
+    """
+    if input_ids is None or not req_ids:
+        return []
+    if input_ids.ndim != 1:
+        return []
+
+    spans: list[dict[str, int]] = []
+    offset = 0
+    for req_idx, _req_id in enumerate(req_ids):
+        sched = int(num_scheduled_tokens[req_idx])
+        if sched <= 0:
+            continue
+
+        start = offset
+        end = offset + sched
+        offset = end
+
+        token_slice = input_ids[start:end]
+        block_start: int | None = None
+        for local_idx, tok in enumerate(token_slice.tolist()):
+            tok = int(tok)
+            if tok == start_of_image_id:
+                block_start = local_idx
+            elif tok == end_of_image_id and block_start is not None:
+                block_end = local_idx + 1
+                spans.append(
+                    {
+                        "req_idx": req_idx,
+                        "request_start": start,
+                        "num_computed_tokens": int(num_computed_tokens[req_idx]),
+                        "q_start": start + block_start,
+                        "q_end": start + block_end,
+                        "kv_local_end": block_end,
+                        "kv_end": int(num_computed_tokens[req_idx]) + block_end,
+                    }
+                )
+                block_start = None
+
+    return spans


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

This PR fixes BAGEL implementation pipeline parity in vLLM-Omni by aligning image preprocessing, visual token layout, position handling, and image-block attention with the BAGEL reference path.

What changed:

- Use BAGEL's aspect-preserving ImageTransform-style preprocessing for VQA images and pass variable-shape NaViT patches with image_grid_thw.
- Size multimodal placeholder replacements from the actual image patch grid instead of always reserving the maximum ViT grid.
- Add a NaViT-style ViT embedding path that applies patch embedding, SigLIP position embedding, per-image ViT encoding, post-layernorm, connector projection, and BAGEL vit_pos_embed.
- Track logical BAGEL VQA RoPE/image spans separately from vLLM KV slot positions, so chunked/paged execution can preserve correct request slotting while modeling image blocks correctly.
- Recompute complete VQA image blocks with non-causal attention bounded at the image block end, matching BAGEL's bidirectional visual-token prefill while keeping following text causal.
- Fix BAGEL img2img and diffusion-side packed index/KV routing so VAE/ViT/MoT and CFG branches use the right sequence positions and cache indexes.

## Test Plan

- `python -m py_compile vllm_omni/model_executor/models/bagel/bagel.py vllm_omni/diffusion/models/bagel/bagel_transformer.py vllm_omni/utils/bagel_vqa.py`
- Direct BAGEL VQA utility smoke check for logical RoPE and image-span construction.
- Attempted `python -m pytest tests/model_executor/test_bagel_vqa_reference_layout.py -q`; collection is blocked in this local environment because the `vllm` package is not importable.

**vLLM Version:** not available in this local checkout environment

**vLLM-Omni Commit:** upstream/main `3529b8280d755950283c94761c4b9dfce945f7d2` plus this PR commit `3672825a`

## Test Result

- py_compile: passed
- BAGEL VQA utility smoke: passed
- pytest: blocked before test collection by `ModuleNotFoundError: No module named 'vllm'`
