### PR TITLE
[WIP][benchmark] add new benchmark OmniInteract

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -53,7 +53,7 @@ Accuracy benchmarks for image generation/editing models, adapting external suite
 Omni-specific benchmark datasets currently include:
 
 - `daily-omni` (audio-visual MCQ)
-- `omniinteract` (speech-QA + video)
+- [`omniinteract`](omniinteract/README.md) (streaming speech-QA + video, including AURA streaming and 1QnA)
 - `seed-tts` / `seed-tts-text` / `seed-tts-design` / `ttsd` / `sound-effect`
 
 See `vllm_omni/benchmarks/serve.py` for the `vllm bench serve --omni` runner wrapper and `vllm_omni/benchmarks/metrics/` for Omni metric definitions.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -50,6 +50,12 @@ Accuracy benchmarks for image generation/editing models, adapting external suite
 - **Audio output**: TTFP (time to first audio packet), E2E latency, RTF (real-time factor)
 - **Throughput**: request throughput, output token throughput, total token throughput, audio throughput
 
+Omni-specific benchmark datasets currently include:
+
+- `daily-omni` (audio-visual MCQ)
+- `omniinteract` (speech-QA + video)
+- `seed-tts` / `seed-tts-text` / `seed-tts-design` / `ttsd` / `sound-effect`
+
 See `vllm_omni/benchmarks/serve.py` for the `vllm bench serve --omni` runner wrapper and `vllm_omni/benchmarks/metrics/` for Omni metric definitions.
 
 ## Adding a new benchmark

--- a/benchmarks/omniinteract/README.md
+++ b/benchmarks/omniinteract/README.md
@@ -1,0 +1,213 @@
+# OmniInteract Benchmark
+
+This benchmark evaluates audio-visual interaction on the
+[OmniInteract](https://github.com/Lucky-Lance/OmniInteract) dataset with
+`vllm bench serve --omni`.
+
+OmniInteract has three subsets:
+
+- `1q1a`: Chinese daily-life QA, including realtime, proactive, and nested slots.
+- `1q1a_math`: English math-reasoning QA.
+- `1qna`: long-horizon monitoring where one spoken instruction leads to many timed answers.
+
+## Dataset Layout
+
+Download and extract `lucky-lance/OmniInteract` so the benchmark root contains:
+
+```text
+data/
+├── 1q1a/
+│   ├── videos/
+│   ├── subvideos/
+│   ├── audios/
+│   ├── annotations/
+│   └── video_json_map.json
+├── 1q1a_math/
+│   ├── videos/
+│   ├── subvideos/
+│   ├── audios/
+│   ├── annotations/
+│   └── video_json_map.json
+└── 1qna/
+    ├── videos_bench/
+    └── annotations/
+```
+
+Pass the extracted `data/` parent or `data/` itself with `--dataset-path`, or use
+`--omniinteract-root` if your run script exposes it.
+
+## Input Modes
+
+### `aura_streaming`
+
+Use this mode for AURA's WebSocket endpoint:
+
+- Backend: `openai-video-stream`
+- Endpoint: `/v1/video/chat/stream`
+- Video input:
+  - `1q1a` / `1q1a_math`: streams sampled frames from `videos/*.mp4`.
+  - `1qna`: streams sampled frames from `videos_bench/**/*.mp4`.
+- Audio input:
+  - `1q1a` / `1q1a_math`: sends `audios/{video}_{qa_idx}.wav` at each annotation `question_time`.
+  - `1qna`: extracts the MP4 audio track with `ffmpeg` and sends it in sync with video frames, matching the original online benchmark protocol.
+- Accuracy metrics are computed from timestamped response chunks and annotation slots.
+
+The recommended default is `--omniinteract-streaming-max-frames 16`, which is
+stable with the current AURA WebSocket server. Larger values increase one-turn
+latency and memory pressure. `0` maps to the server cap and is only intended for
+long-running experiments after a smoke test succeeds.
+
+### `video`
+
+Use this mode for generic OpenAI-compatible chat/video backends. The benchmark
+flattens annotations into independent requests and uses `subvideos/` for
+`1q1a` / `1q1a_math`. For `1qna`, each answer step uses the full
+`videos_bench/**/*.mp4` plus a text prompt containing the instruction and timing
+metadata.
+
+### `aura`
+
+Use this mode for non-streaming AURA chat-style requests. It sends the per-QA
+spoken question as `audio_url` and the per-QA `subvideos/` clip as `video_url`.
+This mode is intended for `1q1a` / `1q1a_math`, where per-QA WAV files exist.
+`1qna` is best evaluated with `aura_streaming`, because its instruction is stored
+inside the full video audio track rather than as per-answer WAV files.
+
+## Metrics
+
+The runner reports standard serving metrics and optional OmniInteract accuracy
+metrics when `--omniinteract-eval` is set.
+
+Performance metrics:
+
+- `ttft`: time to first text token.
+- `tpot`: time per output text token.
+- `itl`: inter-token latency.
+- `e2el`: end-to-end request latency.
+- `audio_ttfp`: time to first audio packet.
+- `audio_rtf`: audio real-time factor.
+- `ttfc`, `tpoc`, `icl`: internal streaming stage latency metrics when stage metrics are available.
+
+OmniInteract accuracy metrics:
+
+- `IA_QTF1`: interaction-aware quality-timeliness F1. It aggregates slot-level
+  true-positive credit, false positives, and false negatives. Streaming mode uses
+  response timestamps against annotation slots.
+- `IDS.NOR`: no-output rate for interrupted slots.
+- `IDS.PAQ`: partial-answer quality for interrupted slots with output.
+- `IDS.CSM_SR`: conditional spillover rate after an interrupted slot's end.
+- `IDS.CSM_AS_seconds`: average spillover seconds for interrupted slots with output.
+- `NCCS`: nested chain completion score, computed over nested inner/outer pairs.
+- `inner_IA_QTF1` / `outer_IA_QTF1`: nested local slot quality by role.
+
+The built-in benchmark scorer uses local soft string matching for content quality.
+For paper-exact semantic scoring, run the official OmniInteract LLM-judge pipeline
+on timestamped model outputs.
+
+## Examples
+
+### Streaming AURA, Full OmniInteract
+
+Start the AURA server first, then run:
+
+```bash
+OMNIINTERACT_EVAL=1 \
+MODEL=/data/models/AURA \
+DATASET_PATH=/data/models/datasets/OmniInteract \
+HOST=127.0.0.1 \
+PORT=8666 \
+NUM_PROMPTS=250 \
+MAX_CONCURRENCY=1 \
+STREAMING_MAX_FRAMES=16 \
+bash /data/yrr/rein_test/omniinteract_bench.sh
+```
+
+Equivalent direct command:
+
+```bash
+vllm bench serve --omni \
+  --host 127.0.0.1 \
+  --port 8666 \
+  --trust-remote-code \
+  --backend openai-video-stream \
+  --endpoint /v1/video/chat/stream \
+  --model /data/models/AURA \
+  --dataset-name omniinteract \
+  --dataset-path /data/models/datasets/OmniInteract \
+  --no-oversample \
+  --num-prompts 16 \
+  --max-concurrency 1 \
+  --omniinteract-subsets 1q1a,1q1a_math,1qna \
+  --omniinteract-input-mode aura_streaming \
+  --omniinteract-streaming-sample-fps 2 \
+  --omniinteract-streaming-send-fps 2 \
+  --omniinteract-streaming-max-frames 16 \
+  --omniinteract-aura-tts-task-type CustomVoice \
+  --omniinteract-aura-tts-language English \
+  --omniinteract-aura-tts-speaker Vivian \
+  --omniinteract-eval \
+  --percentile-metrics ttft,tpot,itl,e2el,audio_ttfp,audio_rtf,audio_duration,ttfc,tpoc,icl \
+  --save-result \
+  --result-dir ./omniinteract_bench \
+  --result-filename omniinteract_streaming.json
+```
+
+### Streaming Smoke Test
+
+```bash
+vllm bench serve --omni \
+  --host 127.0.0.1 \
+  --port 8666 \
+  --backend openai-video-stream \
+  --endpoint /v1/video/chat/stream \
+  --model /data/models/AURA \
+  --dataset-name omniinteract \
+  --dataset-path /data/models/datasets/OmniInteract \
+  --num-prompts 3 \
+  --no-oversample \
+  --omniinteract-subsets 1qna \
+  --omniinteract-input-mode aura_streaming \
+  --omniinteract-streaming-sample-fps 2 \
+  --omniinteract-streaming-send-fps 2 \
+  --omniinteract-streaming-max-frames 16 \
+  --omniinteract-aura-tts-task-type CustomVoice \
+  --omniinteract-aura-tts-language English \
+  --omniinteract-aura-tts-speaker Vivian 
+```
+
+### Non-Streaming AURA on 1Q1A
+
+```bash
+vllm bench serve --omni \
+  --host 127.0.0.1 \
+  --port 8666 \
+  --backend openai-chat-omni \
+  --endpoint /v1/chat/completions \
+  --model /data/models/AURA \
+  --dataset-name omniinteract \
+  --dataset-path /data/models/datasets/OmniInteract \
+  --num-prompts 32 \
+  --omniinteract-subsets 1q1a,1q1a_math \
+  --omniinteract-input-mode aura \
+  --omniinteract-aura-tts-task-type CustomVoice \
+  --omniinteract-aura-tts-language English \
+  --omniinteract-aura-tts-speaker Vivian \
+  --omniinteract-eval
+```
+
+### Generic Non-Streaming Video Backend
+
+```bash
+vllm bench serve --omni \
+  --host 127.0.0.1 \
+  --port 8666 \
+  --backend openai-chat-omni \
+  --endpoint /v1/chat/completions \
+  --model /data/models/AURA \
+  --dataset-name omniinteract \
+  --dataset-path /data/models/datasets/OmniInteract \
+  --num-prompts 32 \
+  --omniinteract-subsets 1q1a,1qna \
+  --omniinteract-input-mode video \
+  --omniinteract-eval
+```

--- a/docs/cli/bench/serve.md
+++ b/docs/cli/bench/serve.md
@@ -2,7 +2,9 @@
 The vllm bench command launches the vLLM-Omni benchmark to evaluate the performance of multimodal models.
 
 ## Notes
-We currently only support using the "openai-chat-omni" and "openai-image-edits-omni" backend.
+The Omni benchmark runner extends the upstream `vllm bench serve` backends with
+Omni-specific adapters such as `openai-chat-omni`, `openai-image-edits-omni`, and
+`openai-video-stream`.
 
 ## Basic Parameter Description
 You can use `vllm bench serve --omni --help=all` to get descriptions of all parameters. The commonly used parameters are described below:
@@ -22,6 +24,8 @@ You can use `vllm bench serve --omni --help=all` to get descriptions of all para
   The name of the dataset used; random-mm indicates generating random multimodal inputs (images, videos, audio).
   Omni dataset extensions include `daily-omni`, `omniinteract`, `seed-tts`,
   `seed-tts-text`, `seed-tts-design`, `ttsd`, and `sound-effect`.
+  For OmniInteract streaming and non-streaming examples, see
+  `benchmarks/omniinteract/README.md`.
 
 - `--num-prompts`
   The total number of requests to send, an integer.

--- a/docs/cli/bench/serve.md
+++ b/docs/cli/bench/serve.md
@@ -20,6 +20,8 @@ You can use `vllm bench serve --omni --help=all` to get descriptions of all para
 
 - `--dataset-name`
   The name of the dataset used; random-mm indicates generating random multimodal inputs (images, videos, audio).
+  Omni dataset extensions include `daily-omni`, `omniinteract`, `seed-tts`,
+  `seed-tts-text`, `seed-tts-design`, `ttsd`, and `sound-effect`.
 
 - `--num-prompts`
   The total number of requests to send, an integer.

--- a/examples/online_serving/aura_omni/run_gradio_demo.sh
+++ b/examples/online_serving/aura_omni/run_gradio_demo.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MODEL="aurateam/AURA"
-SERVER_MODEL="aurateam/AURA"
+MODEL="/data/models/AURA"
+SERVER_MODEL="/data/models/AURA"
 DEPLOY_CONFIG="/data/yrr/vllm-omni/vllm_omni/deploy/aura_omni.yaml"
-SERVER_PORT=8091
+SERVER_PORT=8666
 GRADIO_PORT=7862
 SERVER_HOST="0.0.0.0"
 GRADIO_IP="127.0.0.1"
@@ -33,34 +33,34 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 API_BASE="http://localhost:${SERVER_PORT}/v1"
 LOG_FILE="/tmp/aura_omni_vllm_${SERVER_PORT}.log"
 
-cleanup() {
-  echo "Shutting down..."
-  [[ -n "${SERVER_PID:-}" ]] && kill "$SERVER_PID" 2>/dev/null || true
-  [[ -n "${GRADIO_PID:-}" ]] && kill "$GRADIO_PID" 2>/dev/null || true
-}
-trap cleanup SIGINT SIGTERM EXIT
+# cleanup() {
+#   echo "Shutting down..."
+#   [[ -n "${SERVER_PID:-}" ]] && kill "$SERVER_PID" 2>/dev/null || true
+#   [[ -n "${GRADIO_PID:-}" ]] && kill "$GRADIO_PID" 2>/dev/null || true
+# }
+# trap cleanup SIGINT SIGTERM EXIT
 
-vllm serve "$SERVER_MODEL" \
-  --omni \
-  --host "$SERVER_HOST" \
-  --port "$SERVER_PORT" \
-  --deploy-config "$DEPLOY_CONFIG" \
-  --served-model-name "$MODEL" \
-  --trust-remote-code 2>&1 | tee "$LOG_FILE" &
-SERVER_PID=$!
+# vllm serve "$SERVER_MODEL" \
+#   --omni \
+#   --host "$SERVER_HOST" \
+#   --port "$SERVER_PORT" \
+#   --deploy-config "$DEPLOY_CONFIG" \
+#   --served-model-name "$MODEL" \
+#   --trust-remote-code 2>&1 | tee "$LOG_FILE" &
+# SERVER_PID=$!
 
-echo "Waiting for server startup..."
-for _ in $(seq 1 600); do
-  if grep -q "Application startup complete" "$LOG_FILE" 2>/dev/null; then
-    break
-  fi
-  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
-    echo "vLLM server exited before startup completed"
-    wait "$SERVER_PID" || true
-    exit 1
-  fi
-  sleep 1
-done
+# echo "Waiting for server startup..."
+# for _ in $(seq 1 600); do
+#   if grep -q "Application startup complete" "$LOG_FILE" 2>/dev/null; then
+#     break
+#   fi
+#   if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+#     echo "vLLM server exited before startup completed"
+#     wait "$SERVER_PID" || true
+#     exit 1
+#   fi
+#   sleep 1
+# done
 
 # cd "$SCRIPT_DIR"
 GRADIO_CMD=(python gradio_demo.py --model "$MODEL" --api-base "$API_BASE" --ip "$GRADIO_IP" --port "$GRADIO_PORT")

--- a/tests/benchmarks/patch/test_patch.py
+++ b/tests/benchmarks/patch/test_patch.py
@@ -20,11 +20,12 @@ pytestmark = [pytest.mark.core_model, pytest.mark.benchmark, pytest.mark.cpu]
 class MockResponse:
     """Mock aiohttp response for testing"""
 
-    def __init__(self, status, chunks, delay_between_chunks=0):
+    def __init__(self, status, chunks, delay_between_chunks=0, json_data=None):
         self.status = status
         self.reason = "OK" if status == 200 else "Error"
         self._chunks = chunks
         self._delay = delay_between_chunks
+        self._json_data = json_data
         self.content = self
 
     async def iter_any(self):
@@ -32,6 +33,9 @@ class MockResponse:
             if self._delay > 0:
                 await asyncio.sleep(self._delay)
             yield chunk
+
+    async def json(self):
+        return self._json_data
 
     async def __aenter__(self):
         return self
@@ -43,6 +47,36 @@ class MockResponse:
 def create_sse_chunk(data_dict):
     """Helper to create SSE formatted chunk"""
     return f"data: {json.dumps(data_dict)}\n\n".encode()
+
+
+@pytest.mark.asyncio
+async def test_chat_omni_non_stream_request_parses_json_response(mocker: MockerFixture):
+    request_input = RequestFuncInput(
+        model="test-model",
+        model_name="test-model",
+        prompt="test prompt",
+        api_url="http://test.com/v1/chat/completions",
+        prompt_len=10,
+        output_len=20,
+    )
+    setattr(request_input, "no_stream", True)
+    response_data = {
+        "choices": [{"message": {"content": "final answer"}}],
+        "usage": {"prompt_tokens": 7, "completion_tokens": 3},
+    }
+    mock_response = MockResponse(200, [], json_data=response_data)
+    mock_session = mocker.AsyncMock()
+    mock_session.post = mocker.MagicMock(return_value=mock_response)
+
+    output = await async_request_openai_chat_omni_completions(request_input, mock_session)
+
+    payload = mock_session.post.call_args.kwargs["json"]
+    assert payload["stream"] is False
+    assert "stream_options" not in payload
+    assert output.success is True
+    assert output.generated_text == "final answer"
+    assert output.prompt_len == 7
+    assert output.output_tokens == 3
 
 
 # ============================================================================

--- a/tests/benchmarks/test_omniinteract_dataset.py
+++ b/tests/benchmarks/test_omniinteract_dataset.py
@@ -1,0 +1,425 @@
+"""Unit tests for OmniInteract benchmark data/eval modules."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_DS_MODULE_PATH = _REPO_ROOT / "vllm_omni" / "benchmarks" / "data_modules" / "omniinteract_dataset.py"
+_DS_MODULE_NAME = "vllm_omni.benchmarks.data_modules.omniinteract_dataset"
+if _DS_MODULE_NAME not in sys.modules:
+    _spec = importlib.util.spec_from_file_location(_DS_MODULE_NAME, _DS_MODULE_PATH)
+    _mod = importlib.util.module_from_spec(_spec)
+    sys.modules[_DS_MODULE_NAME] = _mod
+    _spec.loader.exec_module(_mod)
+
+_EVAL_MODULE_PATH = _REPO_ROOT / "vllm_omni" / "benchmarks" / "data_modules" / "omniinteract_eval.py"
+_EVAL_MODULE_NAME = "vllm_omni.benchmarks.data_modules.omniinteract_eval"
+if _EVAL_MODULE_NAME not in sys.modules:
+    _spec = importlib.util.spec_from_file_location(_EVAL_MODULE_NAME, _EVAL_MODULE_PATH)
+    _mod = importlib.util.module_from_spec(_spec)
+    sys.modules[_EVAL_MODULE_NAME] = _mod
+    _spec.loader.exec_module(_mod)
+
+from vllm_omni.benchmarks.data_modules.omniinteract_dataset import (  # noqa: E402
+    OmniInteractDataset,
+    OmniInteractSampleRequest,
+    resolve_omniinteract_root,
+)
+from vllm_omni.benchmarks.data_modules.omniinteract_eval import (  # noqa: E402
+    compute_omniinteract_metrics,
+    print_omniinteract_summary,
+)
+
+
+@pytest.fixture()
+def omniinteract_root(tmp_path: Path) -> Path:
+    root = tmp_path / "data"
+    # 1q1a subset
+    s1 = root / "1q1a"
+    (s1 / "videos").mkdir(parents=True)
+    (s1 / "annotations").mkdir(parents=True)
+    (s1 / "subvideos").mkdir(parents=True)
+    (s1 / "videos" / "0001.mp4").write_bytes(b"fake-mp4")
+    (s1 / "subvideos" / "0001_0.mp4").write_bytes(b"fake-subvideo")
+    (s1 / "annotations" / "0001.json").write_text(
+        json.dumps(
+            [
+                {
+                    "question_time": "00:01",
+                    "question_text": "What color is the cup?",
+                    "answer_time": "00:04",
+                    "answer_text": "red",
+                    "question_type": "realtime",
+                    "is_interrupted": False,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (s1 / "video_json_map.json").write_text(
+        json.dumps(
+            {
+                "total": 1,
+                "entries": [
+                    {
+                        "video": "videos/0001.mp4",
+                        "annotation": "annotations/0001.json",
+                        "scene_type": "multi_turn",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # empty subset dirs to satisfy default subset list
+    (root / "1q1a_math" / "videos").mkdir(parents=True)
+    (root / "1q1a_math" / "annotations").mkdir(parents=True)
+    (root / "1q1a_math" / "video_json_map.json").write_text(json.dumps({"total": 0, "entries": []}), encoding="utf-8")
+    (root / "1qna" / "videos_bench").mkdir(parents=True)
+    (root / "1qna" / "annotations").mkdir(parents=True)
+    return root
+
+
+@pytest.fixture()
+def mock_tokenizer(mocker):
+    tok = mocker.MagicMock()
+    tok.encode = lambda text, **kw: [0] * max(1, len(text.split()))
+    tok.get_vocab.return_value = {"<pad>": 0}
+    tok.all_special_ids = []
+    tok.all_special_tokens = []
+    tok.vocab_size = 1
+    tok.__len__.return_value = 1
+    return tok
+
+
+def _write_minimal_1q1a_tree(root: Path) -> None:
+    s1 = root / "1q1a"
+    (s1 / "videos").mkdir(parents=True)
+    (s1 / "annotations").mkdir(parents=True)
+    (s1 / "subvideos").mkdir(parents=True)
+    (s1 / "videos" / "0001.mp4").write_bytes(b"fake-mp4")
+    (s1 / "subvideos" / "0001_0.mp4").write_bytes(b"fake-subvideo")
+    (s1 / "annotations" / "0001.json").write_text(
+        json.dumps(
+            [
+                {
+                    "question_time": "00:01",
+                    "question_text": "What color is the cup?",
+                    "answer_time": "00:04",
+                    "answer_text": "red",
+                    "question_type": "realtime",
+                    "is_interrupted": False,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (s1 / "video_json_map.json").write_text(
+        json.dumps(
+            {
+                "total": 1,
+                "entries": [
+                    {
+                        "video": "videos/0001.mp4",
+                        "annotation": "annotations/0001.json",
+                        "scene_type": "multi_turn",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_resolve_omniinteract_root_from_local_dataset_path(tmp_path: Path):
+    data_root = tmp_path / "local_dataset"
+    _write_minimal_1q1a_tree(data_root)
+    resolved = resolve_omniinteract_root(str(data_root))
+    assert resolved == data_root.resolve()
+
+
+def test_resolve_omniinteract_root_extracts_local_tarball(tmp_path: Path):
+    data_root = tmp_path / "archive_only"
+    data_root.mkdir()
+    payload = tmp_path / "payload"
+    _write_minimal_1q1a_tree(payload)
+    tar_path = data_root / "data.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tf:
+        for path in payload.rglob("*"):
+            tf.add(path, arcname=path.relative_to(payload))
+    resolved = resolve_omniinteract_root(str(data_root))
+    assert (resolved / "1q1a" / "video_json_map.json").is_file()
+
+
+def test_omniinteract_dataset_builds_chat_requests(omniinteract_root: Path, mock_tokenizer):
+    ds = OmniInteractDataset(
+        dataset_path=str(omniinteract_root),
+        random_seed=0,
+        disable_shuffle=True,
+    )
+    reqs = ds.sample(mock_tokenizer, num_requests=1, no_oversample=True)
+    assert len(reqs) == 1
+    req = reqs[0]
+    assert isinstance(req, OmniInteractSampleRequest)
+    assert req.omniinteract_subset == "1q1a"
+    assert req.omniinteract_gold_answer == "red"
+    assert req.omniinteract_scene_type == "multi_turn"
+    assert req.omniinteract_video == "subvideos/0001_0.mp4"
+    assert req.omni_chat_messages is not None
+    user_msg = req.omni_chat_messages[1]["content"]
+    assert user_msg[0]["type"] == "video_url"
+    assert user_msg[1]["type"] == "text"
+    assert req.omni_extra_body == {"mm_processor_kwargs": {"use_audio_in_video": True}}
+
+
+def test_omniinteract_dataset_aura_mode_sends_audio_and_video(omniinteract_root: Path, mock_tokenizer):
+    audio_dir = omniinteract_root / "1q1a" / "audios"
+    audio_dir.mkdir()
+    (audio_dir / "0001_0.wav").write_bytes(b"fake-wav")
+    ref_audio = omniinteract_root / "ref.wav"
+    ref_audio.write_bytes(b"fake-ref-wav")
+    ds = OmniInteractDataset(
+        dataset_path=str(omniinteract_root),
+        random_seed=0,
+        disable_shuffle=True,
+        input_mode="aura",
+        aura_tts_language="English",
+        aura_tts_ref_audio=str(ref_audio),
+        aura_tts_ref_text="reference transcript",
+    )
+    reqs = ds.sample(mock_tokenizer, num_requests=1, no_oversample=True)
+    assert len(reqs) == 1
+    req = reqs[0]
+    assert req.omni_chat_messages is not None
+    user_msg = req.omni_chat_messages[1]["content"]
+    assert user_msg[0]["type"] == "audio_url"
+    assert user_msg[1]["type"] == "video_url"
+    assert len(user_msg) == 2
+    assert req.omniinteract_video == "subvideos/0001_0.mp4"
+    assert req.omni_extra_body is not None
+    assert req.omni_extra_body["modalities"] == ["text", "audio"]
+    assert req.omni_extra_body["mm_processor_kwargs"] == {"use_audio_in_video": False}
+    assert len(req.omni_extra_body["sampling_params_list"]) == 4
+    assert req.omni_extra_body["additional_information"]["tts_task_type"] == "Base"
+    assert req.omni_extra_body["additional_information"]["tts_language"] == "English"
+    assert req.omni_extra_body["additional_information"]["tts_ref_audio"] == str(ref_audio.resolve())
+    assert req.omni_extra_body["additional_information"]["tts_ref_text"] == "reference transcript"
+
+
+def test_omniinteract_dataset_aura_mode_passes_custom_voice_speaker(omniinteract_root: Path, mock_tokenizer):
+    audio_dir = omniinteract_root / "1q1a" / "audios"
+    audio_dir.mkdir()
+    (audio_dir / "0001_0.wav").write_bytes(b"fake-wav")
+    ds = OmniInteractDataset(
+        dataset_path=str(omniinteract_root),
+        random_seed=0,
+        disable_shuffle=True,
+        input_mode="aura",
+        aura_tts_task_type="CustomVoice",
+        aura_tts_language="English",
+        aura_tts_speaker="Ethan",
+    )
+
+    [req] = ds.sample(mock_tokenizer, num_requests=1, no_oversample=True)
+
+    assert req.omni_extra_body is not None
+    additional_info = req.omni_extra_body["additional_information"]
+    assert additional_info["tts_task_type"] == "CustomVoice"
+    assert additional_info["tts_language"] == "English"
+    assert additional_info["tts_speaker"] == "Ethan"
+    assert "tts_ref_audio" not in additional_info
+    assert "tts_ref_text" not in additional_info
+
+
+def test_omniinteract_dataset_aura_mode_requires_base_tts_refs(omniinteract_root: Path, mock_tokenizer):
+    audio_dir = omniinteract_root / "1q1a" / "audios"
+    audio_dir.mkdir()
+    (audio_dir / "0001_0.wav").write_bytes(b"fake-wav")
+    ds = OmniInteractDataset(
+        dataset_path=str(omniinteract_root),
+        random_seed=0,
+        disable_shuffle=True,
+        input_mode="aura",
+    )
+
+    with pytest.raises(ValueError, match="requires both"):
+        ds.sample(mock_tokenizer, num_requests=1, no_oversample=True)
+
+
+def test_omniinteract_eval_counts_exact_and_soft_match():
+    req = OmniInteractSampleRequest(
+        prompt="q",
+        prompt_len=1,
+        expected_output_len=8,
+        multi_modal_data=None,
+        request_id="r0",
+        omniinteract_gold_answer="red cup",
+        omniinteract_subset="1q1a",
+        omniinteract_question_type="realtime",
+        omniinteract_video="videos/0001.mp4",
+    )
+
+    class _Out:
+        def __init__(self, success: bool, text: str, error: str = "") -> None:
+            self.success = success
+            self.generated_text = text
+            self.error = error
+
+    outputs = [_Out(True, "The answer is red cup.")]
+    m = compute_omniinteract_metrics([req], outputs)
+    assert m is not None
+    assert m["omniinteract_evaluated"] == 1
+    assert m["omniinteract_exact_count"] == 0
+    assert m["omniinteract_soft_count"] == 1
+    assert m["omniinteract_ia_qtf1"] == 1.0
+    assert "omniinteract_ids" in m
+    assert "omniinteract_nccs" in m
+
+
+def test_omniinteract_summary_omits_legacy_match_metrics(capsys):
+    metrics = {
+        "omniinteract_evaluated": 1,
+        "omniinteract_request_failed": 0,
+        "omniinteract_exact_match": 0.0,
+        "omniinteract_soft_match": 0.0,
+        "omniinteract_ia_qtf1": 0.25,
+        "omniinteract_ids": {
+            "NOR": 0.5,
+            "PAQ": 0.75,
+            "CSM_SR": None,
+            "CSM_AS_seconds": None,
+        },
+        "omniinteract_nccs": 0.0,
+        "omniinteract_per_subset_exact": {"1q1a": 0.0},
+        "omniinteract_per_subset": {"1q1a": {"exact": 0, "total": 1}},
+    }
+
+    print_omniinteract_summary(metrics)
+
+    out = capsys.readouterr().out
+    assert "HTTP failed:" not in out
+    assert "Exact Match:" not in out
+    assert "Soft Match (contains):" not in out
+    assert "--- Exact Match by Subset ---" not in out
+    assert "IDS.CSM-SR:" in out
+    assert "IDS.CSM-AS(s):" in out
+
+
+def test_omniinteract_ids_csm_uses_spill_timing_when_available():
+    reqs = [
+        OmniInteractSampleRequest(
+            prompt="q",
+            prompt_len=1,
+            expected_output_len=8,
+            multi_modal_data=None,
+            request_id="r0",
+            omniinteract_gold_answer="red",
+            omniinteract_subset="1q1a",
+            omniinteract_question_type="realtime",
+            omniinteract_video="videos/0001.mp4",
+            omniinteract_is_interrupted=True,
+        ),
+        OmniInteractSampleRequest(
+            prompt="q",
+            prompt_len=1,
+            expected_output_len=8,
+            multi_modal_data=None,
+            request_id="r1",
+            omniinteract_gold_answer="blue",
+            omniinteract_subset="1q1a",
+            omniinteract_question_type="realtime",
+            omniinteract_video="videos/0002.mp4",
+            omniinteract_is_interrupted=True,
+        ),
+    ]
+
+    class _Out:
+        def __init__(self, text: str, spill_seconds: float) -> None:
+            self.success = True
+            self.generated_text = text
+            self.error = ""
+            self.omniinteract_spill_seconds = spill_seconds
+
+    metrics = compute_omniinteract_metrics(
+        reqs,
+        [_Out("red", 1.5), _Out("blue", 0.0)],
+    )
+
+    assert metrics is not None
+    assert metrics["omniinteract_ids"]["CSM_SR"] == 0.5
+    assert metrics["omniinteract_ids"]["CSM_AS_seconds"] == 0.75
+    exp_interruption = metrics["omniinteract_paper_metrics"]["exp_interruption"]
+    assert exp_interruption["interrupted_with_spill_timing_count"] == 2
+
+
+def test_omniinteract_dataset_infers_nested_roles(tmp_path: Path, mock_tokenizer):
+    root = tmp_path / "nested_data"
+    s1 = root / "1q1a"
+    (s1 / "videos").mkdir(parents=True)
+    (s1 / "annotations").mkdir(parents=True)
+    (s1 / "subvideos").mkdir(parents=True)
+    (s1 / "videos" / "0002.mp4").write_bytes(b"fake-mp4")
+    (s1 / "subvideos" / "0002_0.mp4").write_bytes(b"fake-subvideo-0")
+    (s1 / "subvideos" / "0002_1.mp4").write_bytes(b"fake-subvideo-1")
+    (s1 / "annotations" / "0002.json").write_text(
+        json.dumps(
+            [
+                {
+                    "question_time": "00:01",
+                    "question_text": "outer question?",
+                    "answer_time": "00:10",
+                    "answer_text": "outer answer",
+                    "question_type": "proactive",
+                    "is_interrupted": False,
+                },
+                {
+                    "question_time": "00:03",
+                    "question_text": "inner question?",
+                    "answer_time": "00:05",
+                    "answer_text": "inner answer",
+                    "question_type": "realtime",
+                    "is_interrupted": False,
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (s1 / "video_json_map.json").write_text(
+        json.dumps(
+            {
+                "total": 1,
+                "entries": [
+                    {
+                        "video": "videos/0002.mp4",
+                        "annotation": "annotations/0002.json",
+                        "scene_type": "nested",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "1q1a_math" / "videos").mkdir(parents=True)
+    (root / "1q1a_math" / "annotations").mkdir(parents=True)
+    (root / "1q1a_math" / "video_json_map.json").write_text(json.dumps({"total": 0, "entries": []}), encoding="utf-8")
+    (root / "1qna" / "videos_bench").mkdir(parents=True)
+    (root / "1qna" / "annotations").mkdir(parents=True)
+
+    ds = OmniInteractDataset(dataset_path=str(root), random_seed=0, disable_shuffle=True)
+    reqs = ds.sample(mock_tokenizer, num_requests=2, no_oversample=True)
+    assert len(reqs) == 2
+    assert reqs[0].omniinteract_scene_type == "nested"
+    assert reqs[1].omniinteract_scene_type == "nested"
+    roles = {reqs[0].omniinteract_nested_role, reqs[1].omniinteract_nested_role}
+    assert roles == {"outer", "inner"}

--- a/tests/benchmarks/test_omniinteract_dataset.py
+++ b/tests/benchmarks/test_omniinteract_dataset.py
@@ -242,6 +242,104 @@ def test_omniinteract_dataset_aura_mode_passes_custom_voice_speaker(omniinteract
     assert "tts_ref_text" not in additional_info
 
 
+def test_omniinteract_dataset_aura_streaming_carries_media_paths(omniinteract_root: Path, mock_tokenizer):
+    audio_dir = omniinteract_root / "1q1a" / "audios"
+    audio_dir.mkdir()
+    (audio_dir / "0001_0.wav").write_bytes(b"fake-wav")
+    ds = OmniInteractDataset(
+        dataset_path=str(omniinteract_root),
+        random_seed=0,
+        disable_shuffle=True,
+        input_mode="aura_streaming",
+        aura_tts_task_type="CustomVoice",
+        aura_tts_language="English",
+        aura_tts_speaker="Ethan",
+        streaming_sample_fps=4.0,
+        streaming_send_fps=0.0,
+        streaming_max_frames=8,
+    )
+
+    [req] = ds.sample(mock_tokenizer, num_requests=1, no_oversample=True)
+
+    assert req.omni_chat_messages is None
+    assert req.omni_extra_body is None
+    assert req.omniinteract_video == "videos/0001.mp4"
+    assert req.omniinteract_streaming_video_path.endswith("1q1a/videos/0001.mp4")
+    assert req.omniinteract_streaming_audio_path == ""
+    assert req.omniinteract_streaming_audio_schedule is not None
+    assert req.omniinteract_streaming_audio_schedule[0]["at_sec"] == 1.0
+    assert req.omniinteract_streaming_audio_schedule[0]["audio_path"].endswith("1q1a/audios/0001_0.wav")
+    assert req.omniinteract_streaming_slots is not None
+    assert req.omniinteract_streaming_slots[0]["start"] == 1.0
+    assert req.omniinteract_streaming_slots[0]["t_a"] == 4.0
+    assert req.omniinteract_streaming_config is not None
+    assert req.omniinteract_streaming_config["modalities"] == ["text", "audio"]
+    assert req.omniinteract_streaming_config["video_fps"] == 4.0
+    assert req.omniinteract_streaming_config["max_frames_per_round"] == 8
+    assert req.omniinteract_streaming_config["tts_task_type"] == "CustomVoice"
+    assert req.omniinteract_streaming_config["tts_speaker"] == "Ethan"
+
+
+def test_omniinteract_dataset_aura_streaming_supports_1qna_video_audio(tmp_path: Path, mock_tokenizer):
+    root = tmp_path / "data"
+    ann_dir = root / "1qna" / "annotations" / "captaincook4d"
+    video_dir = root / "1qna" / "videos_bench" / "captaincook4d"
+    ann_dir.mkdir(parents=True)
+    video_dir.mkdir(parents=True)
+    (video_dir / "demo.mp4").write_bytes(b"fake-mp4")
+    (ann_dir / "demo.json").write_text(
+        json.dumps(
+            {
+                "question_time": "00:00",
+                "question_text": "Guide me through the task.",
+                "answers": [
+                    {
+                        "answer_time": "00:05",
+                        "answer_text": "stir the pot",
+                        "label": "step",
+                    },
+                    {
+                        "answer_time": "00:08",
+                        "answer_text": "turn off the stove",
+                        "label": "step",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "1q1a" / "videos").mkdir(parents=True)
+    (root / "1q1a" / "annotations").mkdir(parents=True)
+    (root / "1q1a" / "video_json_map.json").write_text(json.dumps({"total": 0, "entries": []}), encoding="utf-8")
+    (root / "1q1a_math" / "videos").mkdir(parents=True)
+    (root / "1q1a_math" / "annotations").mkdir(parents=True)
+    (root / "1q1a_math" / "video_json_map.json").write_text(json.dumps({"total": 0, "entries": []}), encoding="utf-8")
+
+    ds = OmniInteractDataset(
+        dataset_path=str(root),
+        random_seed=0,
+        disable_shuffle=True,
+        subsets=["1qna"],
+        input_mode="aura_streaming",
+        aura_tts_task_type="CustomVoice",
+        aura_tts_language="English",
+        aura_tts_speaker="Ethan",
+    )
+
+    [req] = ds.sample(mock_tokenizer, num_requests=1, no_oversample=True)
+
+    assert req.omniinteract_subset == "1qna"
+    assert req.omniinteract_video == "videos_bench/captaincook4d/demo.mp4"
+    assert req.omniinteract_streaming_audio_from_video is True
+    assert req.omniinteract_streaming_audio_schedule == []
+    assert req.omniinteract_streaming_slots is not None
+    assert [slot["scene_type"] for slot in req.omniinteract_streaming_slots] == ["1QnA", "1QnA"]
+    assert req.omniinteract_streaming_slots[0]["start"] == 0.0
+    assert req.omniinteract_streaming_slots[0]["t_a"] == 5.0
+    assert req.omniinteract_streaming_slots[1]["start"] == 8.0
+    assert req.omniinteract_streaming_slots[1]["t_a"] == 8.0
+
+
 def test_omniinteract_dataset_aura_mode_requires_base_tts_refs(omniinteract_root: Path, mock_tokenizer):
     audio_dir = omniinteract_root / "1q1a" / "audios"
     audio_dir.mkdir()

--- a/vllm_omni/benchmarks/data_modules/omniinteract_dataset.py
+++ b/vllm_omni/benchmarks/data_modules/omniinteract_dataset.py
@@ -1,0 +1,625 @@
+"""OmniInteract dataset loader for ``vllm bench serve --omni``.
+
+OmniInteract is a streaming audio-visual QA benchmark:
+https://huggingface.co/datasets/lucky-lance/OmniInteract
+
+This loader flattens per-QA annotation entries into independent benchmark
+requests. For ``1q1a`` / ``1q1a_math`` each request uses the per-QA
+``subvideos/{video}_{qa_idx}.mp4`` clip together with the matching
+``audios/{video}_{qa_idx}.wav`` when present. The default ``video`` input mode
+sends one ``video_url`` (native audio in the video stream) plus a text question.
+The ``aura`` input mode sends only ``audio_url`` + ``video_url`` so ASR receives
+the spoken question while AURA receives the subvideo clip.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import shutil
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from vllm.benchmarks.datasets import BenchmarkDataset, SampleRequest
+from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers.hf import get_cached_tokenizer
+
+logger = logging.getLogger(__name__)
+
+OmniInteractSubset = Literal["1q1a", "1q1a_math", "1qna"]
+OmniInteractInputMode = Literal["video", "aura"]
+
+DEFAULT_AURA_SYSTEM_PROMPT_FOR_OMNIINTERACT = (
+    "You are answering OmniInteract audio-visual QA tasks. Use the ASR transcript "
+    "of the user's spoken question together with the video frames. Answer the "
+    "question directly and concisely in the same language as the question. "
+    "Do not output '<|silent|>'."
+)
+
+
+def _is_remote_or_data_url(value: str) -> bool:
+    return value.startswith(("http://", "https://", "data:"))
+
+
+@dataclass
+class OmniInteractSampleRequest(SampleRequest):
+    """``SampleRequest`` carrying OmniInteract labels and request fields."""
+
+    omniinteract_gold_answer: str = ""
+    omniinteract_subset: str = ""
+    omniinteract_question_type: str = ""
+    omniinteract_video: str = ""
+    omniinteract_question_time: str = ""
+    omniinteract_answer_time: str = ""
+    omniinteract_is_interrupted: bool | None = None
+    omniinteract_scene_type: str = ""
+    omniinteract_nested_group_id: int | None = None
+    omniinteract_nested_role: str = ""
+    omni_extra_body: dict[str, Any] | None = None
+    omni_chat_messages: list[dict[str, Any]] | None = None
+
+
+@dataclass
+class _OmniInteractEntry:
+    subset: str
+    video_rel: str
+    video_path: Path
+    question_text: str
+    answer_text: str
+    question_time: str
+    answer_time: str
+    question_type: str
+    is_interrupted: bool | None
+    audio_path: Path | None = None
+    scene_type: str = "multi_turn"
+    nested_group_id: int | None = None
+    nested_role: str = ""
+
+
+def aura_sampling_params_list() -> list[dict[str, Any]]:
+    return [
+        {"temperature": 0.0, "top_p": 1.0, "top_k": -1, "max_tokens": 256, "seed": 42},
+        {
+            "temperature": 0.5,
+            "top_p": 1.0,
+            "top_k": -1,
+            "max_tokens": 256,
+            "seed": 42,
+            "repetition_penalty": 1.0,
+        },
+        {
+            "temperature": 0.9,
+            "top_k": 50,
+            "max_tokens": 4096,
+            "seed": 42,
+            "detokenize": False,
+            "repetition_penalty": 1.05,
+            "stop_token_ids": [2150],
+        },
+        {
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "top_k": -1,
+            "max_tokens": 65536,
+            "seed": 42,
+            "repetition_penalty": 1.0,
+        },
+    ]
+
+
+def aura_extra_body(
+    *,
+    tts_task_type: str,
+    tts_language: str,
+    tts_speaker: str | None = None,
+    tts_ref_audio: str | None = None,
+    tts_ref_text: str | None = None,
+) -> dict[str, Any]:
+    additional_information: dict[str, Any] = {
+        "aura_system_prompt": DEFAULT_AURA_SYSTEM_PROMPT_FOR_OMNIINTERACT,
+        "tts_task_type": tts_task_type,
+        "tts_language": tts_language,
+    }
+    if tts_task_type == "Base":
+        if not tts_ref_audio or not tts_ref_text:
+            raise ValueError(
+                "OmniInteract AURA Base TTS requires both --omniinteract-aura-tts-ref-audio "
+                "and --omniinteract-aura-tts-ref-text."
+            )
+        additional_information["tts_ref_audio"] = tts_ref_audio
+        additional_information["tts_ref_text"] = tts_ref_text
+    elif tts_speaker:
+        additional_information["tts_speaker"] = tts_speaker
+    return {
+        "modalities": ["text", "audio"],
+        "mm_processor_kwargs": {"use_audio_in_video": False},
+        "sampling_params_list": aura_sampling_params_list(),
+        "additional_information": additional_information,
+    }
+
+
+def _parse_time_seconds(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not s:
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    parts = s.split(":")
+    if len(parts) not in (2, 3):
+        return None
+    try:
+        nums = [float(x) for x in parts]
+    except ValueError:
+        return None
+    if len(nums) == 2:
+        minutes, seconds = nums
+        return minutes * 60.0 + seconds
+    hours, minutes, seconds = nums
+    return hours * 3600.0 + minutes * 60.0 + seconds
+
+
+def _infer_nested_roles(ann: list[dict[str, Any]]) -> dict[int, tuple[int, str]]:
+    rows: list[tuple[int, float, float]] = []
+    for idx, qa in enumerate(ann):
+        q_time = _parse_time_seconds(qa.get("question_time"))
+        a_time = _parse_time_seconds(qa.get("answer_time"))
+        if q_time is None or a_time is None:
+            continue
+        rows.append((idx, q_time, a_time))
+    rows.sort(key=lambda r: (r[1], r[2], r[0]))
+
+    nested_meta: dict[int, tuple[int, str]] = {}
+    group_id = 1
+    cursor = 0
+    while cursor < len(rows):
+        outer_idx, outer_q, outer_a = rows[cursor]
+        inner_pos: int | None = None
+        for cand_pos in range(cursor + 1, len(rows)):
+            _, cand_q, cand_a = rows[cand_pos]
+            if outer_q < cand_q < outer_a and cand_a <= outer_a:
+                inner_pos = cand_pos
+                break
+        if inner_pos is None:
+            cursor += 1
+            continue
+        inner_idx = rows[inner_pos][0]
+        nested_meta[outer_idx] = (group_id, "outer")
+        nested_meta[inner_idx] = (group_id, "inner")
+        group_id += 1
+        cursor = inner_pos + 1
+    return nested_meta
+
+
+def _hf_cache_root() -> Path:
+    return Path(os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface")).expanduser().resolve()
+
+
+def _tar_fingerprint(tar_path: Path) -> str:
+    st = tar_path.stat()
+    return f"v1:{st.st_size}:{int(st.st_mtime_ns)}"
+
+
+def _resolve_data_dir_under(root: Path) -> Path:
+    """Return the OmniInteract data root that contains 1q1a/1q1a_math/1qna."""
+    probe = root / "1q1a"
+    if probe.is_dir():
+        return root
+    probe = root / "data" / "1q1a"
+    if probe.is_dir():
+        return root / "data"
+    raise FileNotFoundError(f"Could not locate OmniInteract data dir under: {root}")
+
+
+def _extract_tar_archive(tar_path: Path, cache_root: Path) -> Path:
+    """Extract ``data.tar.gz`` under ``cache_root`` and return the data root."""
+    extracted_root = cache_root / "extracted"
+    marker = cache_root / ".extracted"
+    fp = _tar_fingerprint(tar_path)
+    if marker.is_file() and extracted_root.is_dir():
+        try:
+            if marker.read_text(encoding="utf-8").strip() == fp:
+                data_dir = _resolve_data_dir_under(extracted_root)
+                logger.info("Reusing cached OmniInteract media at %s", data_dir)
+                return data_dir
+        except Exception:
+            shutil.rmtree(extracted_root, ignore_errors=True)
+            marker.unlink(missing_ok=True)
+
+    cache_root.mkdir(parents=True, exist_ok=True)
+    shutil.rmtree(extracted_root, ignore_errors=True)
+    extracted_root.mkdir(parents=True, exist_ok=True)
+    logger.info("Extracting OmniInteract archive %s", tar_path)
+    with tarfile.open(tar_path, "r:*") as tf:
+        tf.extractall(path=extracted_root, filter="data")
+    marker.write_text(fp, encoding="utf-8")
+    return _resolve_data_dir_under(extracted_root)
+
+
+def _ensure_extracted_data_dir(root: Path) -> Path:
+    """Resolve a local directory to extracted OmniInteract data (auto-extract if needed)."""
+    try:
+        return _resolve_data_dir_under(root)
+    except FileNotFoundError:
+        pass
+
+    for name in ("data.tar.gz", "data.tar"):
+        tar_path = root / name
+        if tar_path.is_file():
+            cache_root = root / ".vllm_omni_omniinteract_extracted"
+            return _extract_tar_archive(tar_path, cache_root)
+
+    raise FileNotFoundError(
+        f"Could not locate OmniInteract data under {root}. "
+        "Expected extracted 1q1a/ (or data/1q1a/) or data.tar.gz in that directory."
+    )
+
+
+def resolve_omniinteract_root(
+    dataset_path: str | None = None,
+    *,
+    explicit_root: str | Path | None = None,
+) -> Path:
+    """Return OmniInteract data root from a local path or HF dataset repo id.
+
+    Resolution order:
+    1. ``explicit_root`` (--omniinteract-root)
+    2. Local directory ``dataset_path`` (--dataset-path)
+    3. HF dataset repo id via ``dataset_path`` / ``--hf-name``
+    """
+    if explicit_root:
+        root = Path(explicit_root).expanduser().resolve()
+        if not root.is_dir():
+            raise FileNotFoundError(f"--omniinteract-root is not a directory: {root}")
+        return _ensure_extracted_data_dir(root)
+
+    if not dataset_path:
+        raise ValueError("OmniInteract requires --dataset-path (HF repo id or local directory) or --omniinteract-root.")
+
+    p = Path(dataset_path).expanduser()
+    if p.exists() and p.is_dir():
+        return _ensure_extracted_data_dir(p.resolve())
+
+    return ensure_omniinteract_data_dir(dataset_path.strip())
+
+
+def ensure_omniinteract_data_dir(repo_id: str) -> Path:
+    """Download/extract ``data.tar.gz`` from HF and return extracted data root."""
+    rid = (repo_id or "").strip()
+    if not rid:
+        raise ValueError("repo_id is required for OmniInteract HF download")
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as e:
+        raise ImportError(
+            "OmniInteract HF download requires huggingface_hub. "
+            "Install it or pass --omniinteract-root with local extracted data."
+        ) from e
+
+    safe = rid.replace("/", "__").replace("\\", "_")
+    cache_root = _hf_cache_root() / "vllm_omni" / "omniinteract_media" / safe
+
+    tar_path: Path | None = None
+    for name in ("data.tar.gz", "data.tar"):
+        try:
+            tar_path = Path(hf_hub_download(repo_id=rid, filename=name, repo_type="dataset"))
+            break
+        except Exception:
+            continue
+    if tar_path is None or not tar_path.is_file():
+        raise FileNotFoundError(f"Could not download data.tar.gz from dataset repo {rid!r}.")
+
+    return _extract_tar_archive(tar_path, cache_root)
+
+
+class OmniInteractDataset(BenchmarkDataset):
+    """OmniInteract audio+video QA dataset."""
+
+    SUPPORTED_DATASET_PATHS: set[str] = {"lucky-lance/OmniInteract"}
+    DEFAULT_HF_DATASET_ID = "lucky-lance/OmniInteract"
+    DEFAULT_OUTPUT_LEN = 256
+    IS_MULTIMODAL = True
+
+    def __init__(
+        self,
+        dataset_path: str | None = None,
+        random_seed: int = 0,
+        data_root: str | None = None,
+        subsets: list[OmniInteractSubset] | None = None,
+        inline_local_video: bool = False,
+        input_mode: OmniInteractInputMode = "video",
+        aura_tts_task_type: str = "Base",
+        aura_tts_language: str = "Chinese",
+        aura_tts_speaker: str | None = None,
+        aura_tts_ref_audio: str | None = None,
+        aura_tts_ref_text: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.dataset_path = dataset_path or self.DEFAULT_HF_DATASET_ID
+        self.data_root_input = Path(data_root).expanduser().resolve() if data_root else None
+        self.subsets = list(subsets or ["1q1a", "1q1a_math", "1qna"])
+        self.inline_local_video = inline_local_video
+        self.input_mode = input_mode
+        self.aura_tts_task_type = aura_tts_task_type
+        self.aura_tts_language = aura_tts_language
+        self.aura_tts_speaker = aura_tts_speaker
+        self.aura_tts_ref_audio = self._normalize_aura_ref_audio(aura_tts_ref_audio)
+        self.aura_tts_ref_text = aura_tts_ref_text
+        self._data_root: Path | None = None
+        self._entries: list[_OmniInteractEntry] = []
+
+        super().__init__(
+            dataset_path=self.dataset_path,
+            random_seed=random_seed,
+            **kwargs,
+        )
+        self.load_data()
+
+    def _resolve_data_root(self) -> Path:
+        if self._data_root is not None:
+            return self._data_root
+        dataset_ref = None if self.data_root_input is not None else self.dataset_path
+        self._data_root = resolve_omniinteract_root(
+            dataset_ref,
+            explicit_root=self.data_root_input,
+        )
+        return self._data_root
+
+    @staticmethod
+    def _read_json(path: Path) -> Any:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+
+    def _iter_subset_entries(self, data_root: Path, subset: OmniInteractSubset) -> list[_OmniInteractEntry]:
+        entries: list[_OmniInteractEntry] = []
+        subset_root = data_root / subset
+        if not subset_root.is_dir():
+            logger.warning("Subset directory does not exist: %s", subset_root)
+            return entries
+
+        if subset in ("1q1a", "1q1a_math"):
+            map_path = subset_root / "video_json_map.json"
+            map_data = self._read_json(map_path) if map_path.is_file() else {"entries": []}
+            for item in map_data.get("entries", []):
+                video_rel = str(item.get("video") or "").strip()
+                ann_rel = str(item.get("annotation") or "").strip()
+                scene_type = str(item.get("scene_type") or "multi_turn").strip().lower() or "multi_turn"
+                if not video_rel or not ann_rel:
+                    continue
+                ann_path = subset_root / ann_rel
+                if not ann_path.is_file():
+                    continue
+                ann = self._read_json(ann_path)
+                if not isinstance(ann, list):
+                    continue
+                nested_meta = _infer_nested_roles(ann) if scene_type == "nested" else {}
+                video_stem = Path(video_rel).stem
+                for qa_idx, qa in enumerate(ann):
+                    q = str(qa.get("question_text") or "").strip()
+                    a = str(qa.get("answer_text") or "").strip()
+                    if not q or not a:
+                        continue
+                    subvideo_rel = f"subvideos/{video_stem}_{qa_idx}.mp4"
+                    subvideo_path = subset_root / subvideo_rel
+                    if not subvideo_path.is_file():
+                        continue
+                    audio_path = subset_root / "audios" / f"{video_stem}_{qa_idx}.wav"
+                    nested_group_id, nested_role = nested_meta.get(qa_idx, (None, ""))
+                    entries.append(
+                        _OmniInteractEntry(
+                            subset=subset,
+                            video_rel=subvideo_rel,
+                            video_path=subvideo_path,
+                            question_text=q,
+                            answer_text=a,
+                            question_time=str(qa.get("question_time") or "").strip(),
+                            answer_time=str(qa.get("answer_time") or "").strip(),
+                            question_type=str(qa.get("question_type") or "").strip(),
+                            is_interrupted=qa.get("is_interrupted"),
+                            audio_path=audio_path,
+                            scene_type=scene_type,
+                            nested_group_id=nested_group_id,
+                            nested_role=nested_role,
+                        )
+                    )
+            return entries
+
+        ann_root = subset_root / "annotations"
+        video_root = subset_root / "videos_bench"
+        if not ann_root.is_dir() or not video_root.is_dir():
+            return entries
+        for ann_path in sorted(ann_root.rglob("*.json")):
+            rel = ann_path.relative_to(ann_root)
+            video_path = (video_root / rel).with_suffix(".mp4")
+            if not video_path.is_file():
+                continue
+            ann = self._read_json(ann_path)
+            if not isinstance(ann, list):
+                continue
+            video_rel = str(video_path.relative_to(subset_root))
+            for qa_idx, qa in enumerate(ann):
+                q = str(qa.get("question_text") or "").strip()
+                a = str(qa.get("answer_text") or "").strip()
+                if not q or not a:
+                    continue
+                audio_path = subset_root / "audios" / rel.parent / f"{rel.stem}_{qa_idx}.wav"
+                entries.append(
+                    _OmniInteractEntry(
+                        subset=subset,
+                        video_rel=video_rel,
+                        video_path=video_path,
+                        question_text=q,
+                        answer_text=a,
+                        question_time=str(qa.get("question_time") or "").strip(),
+                        answer_time=str(qa.get("answer_time") or "").strip(),
+                        question_type=str(qa.get("question_type") or "").strip(),
+                        is_interrupted=qa.get("is_interrupted"),
+                        audio_path=audio_path,
+                        scene_type="1qna",
+                    )
+                )
+        return entries
+
+    def load_data(self) -> None:
+        root = self._resolve_data_root()
+        all_entries: list[_OmniInteractEntry] = []
+        for subset in self.subsets:
+            all_entries.extend(self._iter_subset_entries(root, subset))
+        if not all_entries:
+            raise ValueError(f"No OmniInteract QA entries found under {root} (subsets={self.subsets})")
+        if not getattr(self, "disable_shuffle", False):
+            import random
+
+            rng = random.Random(self.random_seed)
+            rng.shuffle(all_entries)
+        self._entries = all_entries
+        self.data = self._entries
+        logger.info("Loaded OmniInteract: root=%s subsets=%s rows=%d", root, self.subsets, len(all_entries))
+
+    @staticmethod
+    def _question_prompt(e: _OmniInteractEntry) -> str:
+        return (
+            "You are given a video with its original audio. "
+            "Answer the question concisely based on the observed visual and spoken content.\n"
+            f"Question time: {e.question_time or 'N/A'}\n"
+            f"Expected answer time: {e.answer_time or 'N/A'}\n"
+            f"Question: {e.question_text}\n"
+            "Answer:"
+        )
+
+    def _video_payload(self, video_path: Path) -> dict[str, Any]:
+        p = video_path.expanduser().resolve()
+        if self.inline_local_video:
+            raw = p.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+            return {"type": "video_url", "video_url": {"url": f"data:video/mp4;base64,{b64}"}}
+        return {"type": "video_url", "video_url": {"url": p.as_uri()}}
+
+    def _audio_payload(self, audio_path: Path) -> dict[str, Any]:
+        p = audio_path.expanduser().resolve()
+        if self.inline_local_video:
+            raw = p.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+            return {"type": "audio_url", "audio_url": {"url": f"data:audio/wav;base64,{b64}"}}
+        return {"type": "audio_url", "audio_url": {"url": p.as_uri()}}
+
+    @staticmethod
+    def _normalize_aura_ref_audio(ref_audio: str | None) -> str | None:
+        if ref_audio is None:
+            return None
+        value = ref_audio.strip()
+        if not value:
+            return None
+        if _is_remote_or_data_url(value):
+            return value
+        path = Path(value).expanduser()
+        if not path.is_file():
+            raise ValueError(f"--omniinteract-aura-tts-ref-audio does not exist: {value}")
+        return str(path.resolve())
+
+    def _build_messages(
+        self,
+        e: _OmniInteractEntry,
+        video_payload: dict[str, Any],
+        audio_payload: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        if audio_payload is not None and self.input_mode == "aura":
+            content: list[dict[str, Any]] = [audio_payload, video_payload]
+        else:
+            content = [video_payload, {"type": "text", "text": self._question_prompt(e)}]
+            if audio_payload is not None:
+                content = [audio_payload, *content]
+        return [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "You are a helpful multimodal assistant that understands video and audio.",
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": content,
+            },
+        ]
+
+    def sample(
+        self,
+        tokenizer: TokenizerLike,
+        num_requests: int,
+        output_len: int | None = None,
+        request_id_prefix: str = "",
+        no_oversample: bool = False,
+        **kwargs: Any,
+    ) -> list[SampleRequest]:
+        if output_len is None:
+            output_len = self.DEFAULT_OUTPUT_LEN
+        out: list[SampleRequest] = []
+        tok = get_cached_tokenizer(tokenizer)
+
+        for i, entry in enumerate(self._entries):
+            if len(out) >= num_requests:
+                break
+            if not entry.video_path.is_file():
+                continue
+            if self.input_mode == "aura":
+                prompt = entry.question_text
+            else:
+                prompt = self._question_prompt(entry)
+            payload = self._video_payload(entry.video_path)
+            audio_payload = None
+            extra_body = {"mm_processor_kwargs": {"use_audio_in_video": True}}
+            if self.input_mode == "aura":
+                if entry.audio_path is None or not entry.audio_path.is_file():
+                    logger.warning(
+                        "Skipping OmniInteract row without synthesized audio for AURA mode: subset=%s video=%s audio=%s",
+                        entry.subset,
+                        entry.video_rel,
+                        entry.audio_path,
+                    )
+                    continue
+                audio_payload = self._audio_payload(entry.audio_path)
+                extra_body = aura_extra_body(
+                    tts_task_type=self.aura_tts_task_type,
+                    tts_language=self.aura_tts_language,
+                    tts_speaker=self.aura_tts_speaker,
+                    tts_ref_audio=self.aura_tts_ref_audio,
+                    tts_ref_text=self.aura_tts_ref_text,
+                )
+            messages = self._build_messages(entry, payload, audio_payload)
+            prompt_len = len(tok.encode(prompt))
+            out.append(
+                OmniInteractSampleRequest(
+                    prompt=prompt,
+                    prompt_len=prompt_len,
+                    expected_output_len=output_len,
+                    multi_modal_data=None,
+                    request_id=f"{request_id_prefix}{i}",
+                    omniinteract_gold_answer=entry.answer_text,
+                    omniinteract_subset=entry.subset,
+                    omniinteract_question_type=entry.question_type,
+                    omniinteract_video=entry.video_rel,
+                    omniinteract_question_time=entry.question_time,
+                    omniinteract_answer_time=entry.answer_time,
+                    omniinteract_is_interrupted=entry.is_interrupted,
+                    omniinteract_scene_type=entry.scene_type,
+                    omniinteract_nested_group_id=entry.nested_group_id,
+                    omniinteract_nested_role=entry.nested_role,
+                    omni_extra_body=extra_body,
+                    omni_chat_messages=messages,
+                )
+            )
+
+        self.maybe_oversample_requests(out, num_requests, request_id_prefix, no_oversample)
+        return out

--- a/vllm_omni/benchmarks/data_modules/omniinteract_dataset.py
+++ b/vllm_omni/benchmarks/data_modules/omniinteract_dataset.py
@@ -3,13 +3,17 @@
 OmniInteract is a streaming audio-visual QA benchmark:
 https://huggingface.co/datasets/lucky-lance/OmniInteract
 
-This loader flattens per-QA annotation entries into independent benchmark
-requests. For ``1q1a`` / ``1q1a_math`` each request uses the per-QA
-``subvideos/{video}_{qa_idx}.mp4`` clip together with the matching
+For non-streaming modes this loader flattens per-QA annotation entries into
+independent benchmark requests. For ``1q1a`` / ``1q1a_math`` each request uses
+the per-QA ``subvideos/{video}_{qa_idx}.mp4`` clip together with the matching
 ``audios/{video}_{qa_idx}.wav`` when present. The default ``video`` input mode
 sends one ``video_url`` (native audio in the video stream) plus a text question.
 The ``aura`` input mode sends only ``audio_url`` + ``video_url`` so ASR receives
 the spoken question while AURA receives the subvideo clip.
+
+``aura_streaming`` follows the original OmniInteract online protocol: one
+request streams the full ``videos/*.mp4`` file and injects the per-QA audio
+question at the annotation ``question_time``.
 """
 
 from __future__ import annotations
@@ -31,7 +35,7 @@ from vllm.tokenizers.hf import get_cached_tokenizer
 logger = logging.getLogger(__name__)
 
 OmniInteractSubset = Literal["1q1a", "1q1a_math", "1qna"]
-OmniInteractInputMode = Literal["video", "aura"]
+OmniInteractInputMode = Literal["video", "aura", "aura_streaming"]
 
 DEFAULT_AURA_SYSTEM_PROMPT_FOR_OMNIINTERACT = (
     "You are answering OmniInteract audio-visual QA tasks. Use the ASR transcript "
@@ -61,6 +65,12 @@ class OmniInteractSampleRequest(SampleRequest):
     omniinteract_nested_role: str = ""
     omni_extra_body: dict[str, Any] | None = None
     omni_chat_messages: list[dict[str, Any]] | None = None
+    omniinteract_streaming_video_path: str = ""
+    omniinteract_streaming_audio_path: str = ""
+    omniinteract_streaming_audio_schedule: list[dict[str, Any]] | None = None
+    omniinteract_streaming_audio_from_video: bool = False
+    omniinteract_streaming_slots: list[dict[str, Any]] | None = None
+    omniinteract_streaming_config: dict[str, Any] | None = None
 
 
 @dataclass
@@ -78,6 +88,16 @@ class _OmniInteractEntry:
     scene_type: str = "multi_turn"
     nested_group_id: int | None = None
     nested_role: str = ""
+
+
+@dataclass
+class _OmniInteractStreamingEntry:
+    subset: str
+    video_rel: str
+    video_path: Path
+    annotation_path: Path
+    scene_type: str
+    rows: list[dict[str, Any]]
 
 
 def aura_sampling_params_list() -> list[dict[str, Any]]:
@@ -142,6 +162,49 @@ def aura_extra_body(
     }
 
 
+def aura_streaming_config(
+    *,
+    tts_task_type: str,
+    tts_language: str,
+    tts_speaker: str | None = None,
+    tts_ref_audio: str | None = None,
+    tts_ref_text: str | None = None,
+    sample_fps: float = 2.0,
+    max_frames: int = 16,
+    auto_trigger_min_frames: int = 0,
+    send_fps: float = 0.0,
+    enable_frame_filter: bool = False,
+) -> dict[str, Any]:
+    """Build ``session.config`` fields for AURA WebSocket streaming benchmark."""
+
+    config: dict[str, Any] = {
+        "modalities": ["text", "audio"],
+        "auto_trigger": True,
+        # 0 means the request function chooses a small cadence-based trigger.
+        "auto_trigger_min_frames": int(auto_trigger_min_frames),
+        "max_frames": int(max_frames),
+        "max_frames_per_round": int(max_frames),
+        "video_fps": float(sample_fps),
+        "send_fps": float(send_fps),
+        "enable_frame_filter": bool(enable_frame_filter),
+        "sampling_params_list": aura_sampling_params_list(),
+        "aura_system_prompt": DEFAULT_AURA_SYSTEM_PROMPT_FOR_OMNIINTERACT,
+        "tts_task_type": tts_task_type,
+        "tts_language": tts_language,
+    }
+    if tts_task_type == "Base":
+        if not tts_ref_audio or not tts_ref_text:
+            raise ValueError(
+                "OmniInteract AURA streaming Base TTS requires both "
+                "--omniinteract-aura-tts-ref-audio and --omniinteract-aura-tts-ref-text."
+            )
+        config["tts_ref_audio"] = tts_ref_audio
+        config["tts_ref_text"] = tts_ref_text
+    elif tts_speaker:
+        config["tts_speaker"] = tts_speaker
+    return config
+
+
 def _parse_time_seconds(value: Any) -> float | None:
     if isinstance(value, (int, float)):
         return float(value)
@@ -198,6 +261,197 @@ def _infer_nested_roles(ann: list[dict[str, Any]]) -> dict[int, tuple[int, str]]
         group_id += 1
         cursor = inner_pos + 1
     return nested_meta
+
+
+def _slot_end_for_rows(rows: list[dict[str, Any]], idx: int, *, last_slot_tail_sec: float = 60.0) -> float:
+    q_time = float(rows[idx]["q_time"])
+    a_time = float(rows[idx]["a_time"])
+    if idx + 1 < len(rows):
+        return max(float(rows[idx + 1]["q_time"]), q_time)
+    return max(a_time + float(last_slot_tail_sec), q_time)
+
+
+def _streaming_slots_for_rows(rows: list[dict[str, Any]], scene_type: str) -> list[dict[str, Any]]:
+    """Build enough official OmniInteract slot metadata for benchmark scoring."""
+
+    if scene_type == "1QnA":
+        slots: list[dict[str, Any]] = []
+        q_start = float(rows[0]["q_time"]) if rows else 0.0
+        question_text = str(rows[0].get("question_text") or "") if rows else ""
+        for idx, row in enumerate(rows):
+            t_a = float(row["a_time"])
+            start = q_start if idx == 0 else t_a
+            end = float(rows[idx + 1]["a_time"]) if idx + 1 < len(rows) else t_a + 60.0
+            slots.append(
+                {
+                    "slot_id": idx + 1,
+                    "start": start,
+                    "t_a": t_a,
+                    "end": max(end, start),
+                    "boundary_type": "Soft",
+                    "question_text": question_text,
+                    "gt_answer": row["answer_text"],
+                    "scene_type": "1QnA",
+                    "step_index": idx + 1,
+                    "turn_index": 1,
+                    "question_type": row["question_type"],
+                    "is_interrupted": bool(row["is_interrupted"]),
+                    "label": row.get("label", ""),
+                    "nested_group_id": None,
+                    "nested_role": "",
+                    "inferred_knowledge": row.get("inferred_knowledge", ""),
+                }
+            )
+        return slots
+
+    if scene_type == "nested":
+        slots: list[dict[str, Any]] = []
+        slot_id = 1
+        group_id = 1
+        idx = 0
+        while idx < len(rows):
+            outer = rows[idx]
+            inner_idx = None
+            for cand_idx in range(idx + 1, len(rows)):
+                cand = rows[cand_idx]
+                if outer["q_time"] < cand["q_time"] < outer["a_time"] and cand["a_time"] <= outer["a_time"]:
+                    inner_idx = cand_idx
+                    break
+            if inner_idx is None:
+                idx += 1
+                continue
+            inner = rows[inner_idx]
+            next_outer_q = rows[inner_idx + 1]["q_time"] if inner_idx + 1 < len(rows) else outer["a_time"] + 60.0
+            slots.append(
+                {
+                    "slot_id": slot_id,
+                    "start": float(outer["q_time"]),
+                    "t_a": float(outer["a_time"]),
+                    "end": max(float(next_outer_q), float(outer["a_time"])),
+                    "boundary_type": "Hard",
+                    "question_text": outer["question_text"],
+                    "gt_answer": outer["answer_text"],
+                    "scene_type": "nested",
+                    "turn_index": group_id,
+                    "question_type": outer["question_type"],
+                    "is_interrupted": bool(outer["is_interrupted"]),
+                    "nested_group_id": group_id,
+                    "nested_role": "outer",
+                }
+            )
+            slot_id += 1
+            slots.append(
+                {
+                    "slot_id": slot_id,
+                    "start": float(inner["q_time"]),
+                    "t_a": float(inner["a_time"]),
+                    "end": float(outer["a_time"]),
+                    "boundary_type": "Hard",
+                    "question_text": inner["question_text"],
+                    "gt_answer": inner["answer_text"],
+                    "scene_type": "nested",
+                    "turn_index": group_id,
+                    "question_type": inner["question_type"],
+                    "is_interrupted": bool(inner["is_interrupted"]),
+                    "nested_group_id": group_id,
+                    "nested_role": "inner",
+                }
+            )
+            slot_id += 1
+            group_id += 1
+            idx = inner_idx + 1
+        return slots
+
+    return [
+        {
+            "slot_id": idx + 1,
+            "start": float(row["q_time"]),
+            "t_a": float(row["a_time"]),
+            "end": _slot_end_for_rows(rows, idx),
+            "boundary_type": "Hard",
+            "question_text": row["question_text"],
+            "gt_answer": row["answer_text"],
+            "scene_type": scene_type,
+            "turn_index": idx + 1,
+            "question_type": row["question_type"],
+            "is_interrupted": bool(row["is_interrupted"]),
+            "nested_group_id": None,
+            "nested_role": "",
+        }
+        for idx, row in enumerate(rows)
+    ]
+
+
+def _parse_1qna_rows(ann: Any) -> list[dict[str, Any]]:
+    """Parse OmniInteract 1QnA annotations into answer-step rows."""
+
+    if not isinstance(ann, dict):
+        return []
+    inferred = str(ann.get("inferred_knowledge", "") or "").strip()
+    q_time = _parse_time_seconds(ann.get("question_time"))
+    question_text = str(ann.get("question_text", "") or "").strip()
+    rows: list[dict[str, Any]] = []
+
+    conversations = ann.get("conversations")
+    if isinstance(conversations, list):
+        first_user = next(
+            (
+                item
+                for item in conversations
+                if isinstance(item, dict) and str(item.get("from", "")).strip().lower() == "user"
+            ),
+            None,
+        )
+        if first_user is not None:
+            q_time = _parse_time_seconds(first_user.get("timestamp")) or q_time
+            question_text = str(first_user.get("value", "") or question_text).strip()
+        for idx, item in enumerate(conversations):
+            if not isinstance(item, dict) or str(item.get("from", "")).strip().lower() != "assistant":
+                continue
+            a_time = _parse_time_seconds(item.get("timestamp"))
+            answer = str(item.get("value", "") or "").strip()
+            if a_time is None or not answer:
+                continue
+            rows.append(
+                {
+                    "qa_index": idx,
+                    "q_time": float(q_time or 0.0),
+                    "a_time": float(a_time),
+                    "question_time": str(q_time or 0.0),
+                    "answer_time": str(item.get("timestamp") or "").strip(),
+                    "question_text": question_text,
+                    "answer_text": answer,
+                    "question_type": str(item.get("label", "") or "step").strip().lower() or "step",
+                    "is_interrupted": bool(item.get("interrupted", item.get("is_interrupted", False))),
+                    "label": str(item.get("label", "") or "").strip(),
+                    "inferred_knowledge": inferred,
+                }
+            )
+    elif isinstance(ann.get("answers"), list):
+        for idx, item in enumerate(ann["answers"]):
+            if not isinstance(item, dict):
+                continue
+            a_time = _parse_time_seconds(item.get("answer_time"))
+            answer = str(item.get("answer_text", "") or "").strip()
+            if a_time is None or not answer:
+                continue
+            rows.append(
+                {
+                    "qa_index": idx,
+                    "q_time": float(q_time or 0.0),
+                    "a_time": float(a_time),
+                    "question_time": str(q_time or 0.0),
+                    "answer_time": str(item.get("answer_time") or "").strip(),
+                    "question_text": question_text,
+                    "answer_text": answer,
+                    "question_type": str(item.get("label", "") or "step").strip().lower() or "step",
+                    "is_interrupted": bool(item.get("interrupted", item.get("is_interrupted", False))),
+                    "label": str(item.get("label", "") or "").strip(),
+                    "inferred_knowledge": inferred,
+                }
+            )
+    rows.sort(key=lambda row: (float(row["a_time"]), int(row["qa_index"])))
+    return rows
 
 
 def _hf_cache_root() -> Path:
@@ -342,6 +596,11 @@ class OmniInteractDataset(BenchmarkDataset):
         aura_tts_speaker: str | None = None,
         aura_tts_ref_audio: str | None = None,
         aura_tts_ref_text: str | None = None,
+        streaming_sample_fps: float = 2.0,
+        streaming_send_fps: float = 0.0,
+        streaming_max_frames: int = 16,
+        streaming_auto_trigger_min_frames: int = 0,
+        streaming_enable_frame_filter: bool = False,
         **kwargs: Any,
     ) -> None:
         self.dataset_path = dataset_path or self.DEFAULT_HF_DATASET_ID
@@ -354,8 +613,14 @@ class OmniInteractDataset(BenchmarkDataset):
         self.aura_tts_speaker = aura_tts_speaker
         self.aura_tts_ref_audio = self._normalize_aura_ref_audio(aura_tts_ref_audio)
         self.aura_tts_ref_text = aura_tts_ref_text
+        self.streaming_sample_fps = streaming_sample_fps
+        self.streaming_send_fps = streaming_send_fps
+        self.streaming_max_frames = streaming_max_frames
+        self.streaming_auto_trigger_min_frames = streaming_auto_trigger_min_frames
+        self.streaming_enable_frame_filter = streaming_enable_frame_filter
         self._data_root: Path | None = None
         self._entries: list[_OmniInteractEntry] = []
+        self._streaming_entries: list[_OmniInteractStreamingEntry] = []
 
         super().__init__(
             dataset_path=self.dataset_path,
@@ -443,47 +708,144 @@ class OmniInteractDataset(BenchmarkDataset):
             if not video_path.is_file():
                 continue
             ann = self._read_json(ann_path)
-            if not isinstance(ann, list):
-                continue
             video_rel = str(video_path.relative_to(subset_root))
-            for qa_idx, qa in enumerate(ann):
-                q = str(qa.get("question_text") or "").strip()
-                a = str(qa.get("answer_text") or "").strip()
-                if not q or not a:
-                    continue
-                audio_path = subset_root / "audios" / rel.parent / f"{rel.stem}_{qa_idx}.wav"
+            rows = _parse_1qna_rows(ann)
+            for row in rows:
                 entries.append(
                     _OmniInteractEntry(
                         subset=subset,
                         video_rel=video_rel,
                         video_path=video_path,
-                        question_text=q,
-                        answer_text=a,
-                        question_time=str(qa.get("question_time") or "").strip(),
-                        answer_time=str(qa.get("answer_time") or "").strip(),
-                        question_type=str(qa.get("question_type") or "").strip(),
-                        is_interrupted=qa.get("is_interrupted"),
-                        audio_path=audio_path,
-                        scene_type="1qna",
+                        question_text=str(row.get("question_text") or ""),
+                        answer_text=str(row.get("answer_text") or ""),
+                        question_time=str(row.get("question_time") or "").strip(),
+                        answer_time=str(row.get("answer_time") or "").strip(),
+                        question_type=str(row.get("question_type") or "").strip(),
+                        is_interrupted=bool(row.get("is_interrupted")),
+                        audio_path=None,
+                        scene_type="1QnA",
                     )
                 )
+        return entries
+
+    def _iter_subset_streaming_entries(
+        self,
+        data_root: Path,
+        subset: OmniInteractSubset,
+    ) -> list[_OmniInteractStreamingEntry]:
+        entries: list[_OmniInteractStreamingEntry] = []
+        subset_root = data_root / subset
+        if not subset_root.is_dir():
+            return entries
+        if subset == "1qna":
+            ann_root = subset_root / "annotations"
+            video_root = subset_root / "videos_bench"
+            if not ann_root.is_dir() or not video_root.is_dir():
+                return entries
+            for ann_path in sorted(ann_root.rglob("*.json")):
+                rel = ann_path.relative_to(ann_root)
+                video_path = (video_root / rel).with_suffix(".mp4")
+                if not video_path.is_file():
+                    continue
+                rows = _parse_1qna_rows(self._read_json(ann_path))
+                if not rows:
+                    continue
+                entries.append(
+                    _OmniInteractStreamingEntry(
+                        subset=subset,
+                        video_rel=str(video_path.relative_to(subset_root)),
+                        video_path=video_path,
+                        annotation_path=ann_path,
+                        scene_type="1QnA",
+                        rows=rows,
+                    )
+                )
+            return entries
+
+        if subset not in ("1q1a", "1q1a_math"):
+            return entries
+
+        map_path = subset_root / "video_json_map.json"
+        map_data = self._read_json(map_path) if map_path.is_file() else {"entries": []}
+        for item in map_data.get("entries", []):
+            video_rel = str(item.get("video") or "").strip()
+            ann_rel = str(item.get("annotation") or "").strip()
+            scene_type = str(item.get("scene_type") or "multi_turn").strip().lower() or "multi_turn"
+            if not video_rel or not ann_rel:
+                continue
+            video_path = subset_root / video_rel
+            ann_path = subset_root / ann_rel
+            if not video_path.is_file() or not ann_path.is_file():
+                continue
+            ann = self._read_json(ann_path)
+            if not isinstance(ann, list):
+                continue
+            rows: list[dict[str, Any]] = []
+            video_stem = Path(video_rel).stem
+            nested_meta = _infer_nested_roles(ann) if scene_type == "nested" else {}
+            for qa_idx, qa in enumerate(ann):
+                q_time = _parse_time_seconds(qa.get("question_time"))
+                a_time = _parse_time_seconds(qa.get("answer_time"))
+                q = str(qa.get("question_text") or "").strip()
+                a = str(qa.get("answer_text") or "").strip()
+                audio_path = subset_root / "audios" / f"{video_stem}_{qa_idx}.wav"
+                if q_time is None or a_time is None or not q or not a or not audio_path.is_file():
+                    continue
+                nested_group_id, nested_role = nested_meta.get(qa_idx, (None, ""))
+                rows.append(
+                    {
+                        "qa_index": qa_idx,
+                        "q_time": float(q_time),
+                        "a_time": float(a_time),
+                        "question_time": str(qa.get("question_time") or "").strip(),
+                        "answer_time": str(qa.get("answer_time") or "").strip(),
+                        "question_text": q,
+                        "answer_text": a,
+                        "question_type": str(qa.get("question_type") or "").strip().lower() or "unknown",
+                        "is_interrupted": bool(qa.get("is_interrupted")),
+                        "audio_path": str(audio_path.expanduser().resolve()),
+                        "nested_group_id": nested_group_id,
+                        "nested_role": nested_role,
+                    }
+                )
+            if not rows:
+                continue
+            rows.sort(key=lambda row: (float(row["q_time"]), float(row["a_time"]), int(row["qa_index"])))
+            entries.append(
+                _OmniInteractStreamingEntry(
+                    subset=subset,
+                    video_rel=video_rel,
+                    video_path=video_path,
+                    annotation_path=ann_path,
+                    scene_type="nested" if scene_type == "nested" else "multi_turn",
+                    rows=rows,
+                )
+            )
         return entries
 
     def load_data(self) -> None:
         root = self._resolve_data_root()
         all_entries: list[_OmniInteractEntry] = []
+        all_streaming_entries: list[_OmniInteractStreamingEntry] = []
         for subset in self.subsets:
-            all_entries.extend(self._iter_subset_entries(root, subset))
-        if not all_entries:
+            if self.input_mode == "aura_streaming":
+                all_streaming_entries.extend(self._iter_subset_streaming_entries(root, subset))
+            else:
+                all_entries.extend(self._iter_subset_entries(root, subset))
+        if self.input_mode == "aura_streaming":
+            if not all_streaming_entries:
+                raise ValueError(f"No OmniInteract streaming videos found under {root} (subsets={self.subsets})")
+        elif not all_entries:
             raise ValueError(f"No OmniInteract QA entries found under {root} (subsets={self.subsets})")
         if not getattr(self, "disable_shuffle", False):
             import random
 
             rng = random.Random(self.random_seed)
-            rng.shuffle(all_entries)
+            rng.shuffle(all_streaming_entries if self.input_mode == "aura_streaming" else all_entries)
         self._entries = all_entries
-        self.data = self._entries
-        logger.info("Loaded OmniInteract: root=%s subsets=%s rows=%d", root, self.subsets, len(all_entries))
+        self._streaming_entries = all_streaming_entries
+        self.data = self._streaming_entries if self.input_mode == "aura_streaming" else self._entries
+        logger.info("Loaded OmniInteract: root=%s subsets=%s rows=%d", root, self.subsets, len(self.data))
 
     @staticmethod
     def _question_prompt(e: _OmniInteractEntry) -> str:
@@ -568,19 +930,75 @@ class OmniInteractDataset(BenchmarkDataset):
         out: list[SampleRequest] = []
         tok = get_cached_tokenizer(tokenizer)
 
+        if self.input_mode == "aura_streaming":
+            for i, entry in enumerate(self._streaming_entries):
+                if len(out) >= num_requests:
+                    break
+                slots = _streaming_slots_for_rows(entry.rows, entry.scene_type)
+                if not slots:
+                    continue
+                prompt = "\n".join(row["question_text"] for row in entry.rows)
+                config = aura_streaming_config(
+                    tts_task_type=self.aura_tts_task_type,
+                    tts_language=self.aura_tts_language,
+                    tts_speaker=self.aura_tts_speaker,
+                    tts_ref_audio=self.aura_tts_ref_audio,
+                    tts_ref_text=self.aura_tts_ref_text,
+                    sample_fps=self.streaming_sample_fps,
+                    send_fps=self.streaming_send_fps,
+                    max_frames=self.streaming_max_frames,
+                    auto_trigger_min_frames=self.streaming_auto_trigger_min_frames,
+                    enable_frame_filter=self.streaming_enable_frame_filter,
+                )
+                out.append(
+                    OmniInteractSampleRequest(
+                        prompt=prompt,
+                        prompt_len=len(tok.encode(prompt)),
+                        expected_output_len=output_len,
+                        multi_modal_data=None,
+                        request_id=f"{request_id_prefix}{i}",
+                        omniinteract_gold_answer="\n".join(row["answer_text"] for row in entry.rows),
+                        omniinteract_subset=entry.subset,
+                        omniinteract_question_type="streaming",
+                        omniinteract_video=entry.video_rel,
+                        omniinteract_scene_type=entry.scene_type,
+                        omni_extra_body=None,
+                        omni_chat_messages=None,
+                        omniinteract_streaming_video_path=str(entry.video_path.expanduser().resolve()),
+                        omniinteract_streaming_audio_schedule=[
+                            {
+                                "at_sec": float(row["q_time"]),
+                                "audio_path": row["audio_path"],
+                                "qa_index": int(row["qa_index"]),
+                                "question_text": row["question_text"],
+                            }
+                            for row in entry.rows
+                            if row.get("audio_path")
+                        ],
+                        omniinteract_streaming_audio_from_video=entry.subset == "1qna",
+                        omniinteract_streaming_slots=slots,
+                        omniinteract_streaming_config=config,
+                    )
+                )
+            self.maybe_oversample_requests(out, num_requests, request_id_prefix, no_oversample)
+            return out
+
         for i, entry in enumerate(self._entries):
             if len(out) >= num_requests:
                 break
             if not entry.video_path.is_file():
                 continue
-            if self.input_mode == "aura":
+            if self.input_mode in ("aura", "aura_streaming"):
                 prompt = entry.question_text
             else:
                 prompt = self._question_prompt(entry)
             payload = self._video_payload(entry.video_path)
             audio_payload = None
             extra_body = {"mm_processor_kwargs": {"use_audio_in_video": True}}
-            if self.input_mode == "aura":
+            streaming_config = None
+            streaming_video_path = ""
+            streaming_audio_path = ""
+            if self.input_mode in ("aura", "aura_streaming"):
                 if entry.audio_path is None or not entry.audio_path.is_file():
                     logger.warning(
                         "Skipping OmniInteract row without synthesized audio for AURA mode: subset=%s video=%s audio=%s",
@@ -589,14 +1007,31 @@ class OmniInteractDataset(BenchmarkDataset):
                         entry.audio_path,
                     )
                     continue
-                audio_payload = self._audio_payload(entry.audio_path)
-                extra_body = aura_extra_body(
-                    tts_task_type=self.aura_tts_task_type,
-                    tts_language=self.aura_tts_language,
-                    tts_speaker=self.aura_tts_speaker,
-                    tts_ref_audio=self.aura_tts_ref_audio,
-                    tts_ref_text=self.aura_tts_ref_text,
-                )
+                if self.input_mode == "aura_streaming":
+                    extra_body = None
+                    streaming_video_path = str(entry.video_path.expanduser().resolve())
+                    streaming_audio_path = str(entry.audio_path.expanduser().resolve())
+                    streaming_config = aura_streaming_config(
+                        tts_task_type=self.aura_tts_task_type,
+                        tts_language=self.aura_tts_language,
+                        tts_speaker=self.aura_tts_speaker,
+                        tts_ref_audio=self.aura_tts_ref_audio,
+                        tts_ref_text=self.aura_tts_ref_text,
+                        sample_fps=self.streaming_sample_fps,
+                        send_fps=self.streaming_send_fps,
+                        max_frames=self.streaming_max_frames,
+                        auto_trigger_min_frames=self.streaming_auto_trigger_min_frames,
+                        enable_frame_filter=self.streaming_enable_frame_filter,
+                    )
+                else:
+                    audio_payload = self._audio_payload(entry.audio_path)
+                    extra_body = aura_extra_body(
+                        tts_task_type=self.aura_tts_task_type,
+                        tts_language=self.aura_tts_language,
+                        tts_speaker=self.aura_tts_speaker,
+                        tts_ref_audio=self.aura_tts_ref_audio,
+                        tts_ref_text=self.aura_tts_ref_text,
+                    )
             messages = self._build_messages(entry, payload, audio_payload)
             prompt_len = len(tok.encode(prompt))
             out.append(
@@ -617,7 +1052,10 @@ class OmniInteractDataset(BenchmarkDataset):
                     omniinteract_nested_group_id=entry.nested_group_id,
                     omniinteract_nested_role=entry.nested_role,
                     omni_extra_body=extra_body,
-                    omni_chat_messages=messages,
+                    omni_chat_messages=None if self.input_mode == "aura_streaming" else messages,
+                    omniinteract_streaming_video_path=streaming_video_path,
+                    omniinteract_streaming_audio_path=streaming_audio_path,
+                    omniinteract_streaming_config=streaming_config,
                 )
             )
 

--- a/vllm_omni/benchmarks/data_modules/omniinteract_eval.py
+++ b/vllm_omni/benchmarks/data_modules/omniinteract_eval.py
@@ -65,6 +65,359 @@ def _metric_sub(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
     return _metric_row(tp=max(0.0, tp), fp=max(0.0, fp), fn=max(0.0, fn), num_slots=max(0, slots))
 
 
+def _calculate_decay(time_value: float, peak: float, end: float, alpha: float = 1.0, gamma: float = 1.0) -> float:
+    if end <= peak:
+        return 1.0 if time_value <= peak else 0.0
+    if time_value <= peak:
+        return 1.0
+    if time_value >= end:
+        return 0.0
+    ratio = (time_value - peak) / (end - peak)
+    return max(0.0, min(1.0, 1.0 - alpha * (ratio**gamma)))
+
+
+def _chunk_text(chunks: list[dict[str, Any]]) -> str:
+    return "".join(str(c.get("text", "") or "") for c in chunks).strip()
+
+
+def _chunk_bounds(chunks: list[dict[str, Any]]) -> tuple[float | None, float | None]:
+    if not chunks:
+        return None, None
+    ordered = sorted(chunks, key=lambda c: (float(c.get("start", 0.0)), float(c.get("end", 0.0))))
+    return float(ordered[0].get("start", 0.0)), float(ordered[-1].get("end", 0.0))
+
+
+def _normalize_streaming_output_chunks(out: RequestFuncOutput) -> list[dict[str, Any]]:
+    raw = getattr(out, "omniinteract_streaming_chunks", None) or []
+    chunks: list[dict[str, Any]] = []
+    for idx, item in enumerate(raw):
+        if not isinstance(item, dict):
+            continue
+        ts = item.get("timestamp")
+        if not (isinstance(ts, list) and len(ts) == 2):
+            continue
+        start = _safe_metric(ts[0])
+        end = _safe_metric(ts[1])
+        if start is None or end is None:
+            continue
+        if end < start:
+            start, end = end, start
+        text = str(item.get("text", "") or "")
+        chunks.append(
+            {
+                "chunk_id": item.get("chunk_id", idx),
+                "start": float(start),
+                "end": float(end),
+                "text": text,
+            }
+        )
+    chunks.sort(key=lambda c: (float(c["start"]), float(c["end"])))
+    return chunks
+
+
+def _streaming_match_quality(pred_raw: str, gold_raw: str) -> float:
+    pred = _normalize_text(pred_raw)
+    gold = _normalize_text(gold_raw)
+    if not pred or not gold:
+        return 0.0
+    return 1.0 if pred == gold or pred in gold or gold in pred else 0.0
+
+
+def _assign_chunks_to_slots(
+    slots: list[dict[str, Any]],
+    chunks: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    rows = [{**slot, "all_chunks": [], "early_chunks": [], "core_chunks": []} for slot in slots]
+    unmatched: list[dict[str, Any]] = []
+    for chunk in chunks:
+        start = float(chunk.get("start", 0.0))
+        candidates = [
+            idx
+            for idx, slot in enumerate(rows)
+            if float(slot.get("start", 0.0)) <= start < float(slot.get("end", 0.0))
+        ]
+        if not candidates:
+            unmatched.append(chunk)
+            continue
+        idx = max(candidates, key=lambda i: (float(rows[i].get("start", 0.0)), int(rows[i].get("slot_id", 0))))
+        slot = rows[idx]
+        boundary = float(slot.get("t_a", slot.get("start", 0.0)))
+        tagged = {
+            **chunk,
+            "phase": "early" if start < boundary else "core",
+            "spill": float(chunk.get("end", start)) > float(slot.get("end", boundary)),
+        }
+        slot["all_chunks"].append(tagged)
+        slot["early_chunks" if start < boundary else "core_chunks"].append(tagged)
+    return rows, unmatched
+
+
+def _summarize_streaming_group(acc: dict[str, dict[str, float]]) -> dict[str, Any]:
+    return {
+        key: _metric_row(row["Global_TP"], row["Global_FP"], row["Global_FN"], int(row["num_slots"]))
+        for key, row in sorted(acc.items())
+    }
+
+
+def _add_streaming_metric(
+    acc: dict[str, dict[str, float]],
+    key: str,
+    tp: float,
+    fp: float,
+    fn: float,
+) -> None:
+    row = acc.setdefault(key or "unknown", {"num_slots": 0.0, "Global_TP": 0.0, "Global_FP": 0.0, "Global_FN": 0.0})
+    row["num_slots"] += 1.0
+    row["Global_TP"] += float(tp)
+    row["Global_FP"] += float(fp)
+    row["Global_FN"] += float(fn)
+
+
+def _nested_pair_key(slot: dict[str, Any]) -> tuple[str, int]:
+    return (str(slot.get("video", "") or ""), int(slot.get("nested_group_id") or slot.get("slot_id") or 0))
+
+
+def _compute_streaming_omniinteract_metrics(
+    input_requests: list[Any],
+    outputs: list[RequestFuncOutput],
+    *,
+    include_per_item: bool,
+) -> dict[str, Any]:
+    global_tp = 0.0
+    global_fp = 0.0
+    global_fn = 0.0
+    failed = 0
+    evaluated_slots = 0
+    unmatched_chunks = 0
+    by_scene: dict[str, dict[str, float]] = {}
+    by_qtype: dict[str, dict[str, float]] = {}
+    nested_by_role: dict[str, dict[str, float]] = {}
+    nested_pairs: dict[tuple[str, int], dict[str, float]] = {}
+    nested_pair_times: dict[tuple[str, int], dict[str, float | None]] = {}
+    interrupted_total = 0
+    interrupted_no_output = 0
+    interrupted_output_count = 0
+    interrupted_quality_sum = 0.0
+    interrupted_spill_positive = 0
+    interrupted_spill_seconds = 0.0
+    items: list[dict[str, Any]] = []
+
+    for req, out in zip(input_requests, outputs, strict=True):
+        assert isinstance(req, OmniInteractSampleRequest)
+        slots = list(getattr(out, "omniinteract_streaming_slots", None) or req.omniinteract_streaming_slots or [])
+        if not slots:
+            continue
+        if not out.success:
+            failed += 1
+            for slot in slots:
+                if bool(slot.get("is_interrupted")):
+                    interrupted_total += 1
+                    interrupted_no_output += 1
+                else:
+                    global_fn += 1.0
+                    evaluated_slots += 1
+                    _add_streaming_metric(by_scene, str(slot.get("scene_type") or "unknown"), 0.0, 0.0, 1.0)
+                    _add_streaming_metric(by_qtype, str(slot.get("question_type") or "unknown"), 0.0, 0.0, 1.0)
+            continue
+
+        chunks = _normalize_streaming_output_chunks(out)
+        rows, unmatched = _assign_chunks_to_slots(slots, chunks)
+        unmatched_chunks += len(unmatched)
+        global_fp += float(len(unmatched))
+        for slot in rows:
+            evaluated_slots += 1
+            scene = str(slot.get("scene_type") or "unknown")
+            if scene.lower() == "1qna":
+                scene = "1QnA"
+            qtype = str(slot.get("question_type") or "unknown")
+            is_interrupted = bool(slot.get("is_interrupted"))
+            all_chunks = list(slot.get("all_chunks") or [])
+            early_chunks = list(slot.get("early_chunks") or [])
+            core_chunks = list(slot.get("core_chunks") or [])
+            text_core = _chunk_text(core_chunks)
+            text_all = _chunk_text(all_chunks)
+            quality_core = _streaming_match_quality(text_core, str(slot.get("gt_answer", "") or ""))
+            quality_all = _streaming_match_quality(text_all, str(slot.get("gt_answer", "") or ""))
+            core_start, core_end = _chunk_bounds(core_chunks)
+            early_start, _ = _chunk_bounds(early_chunks)
+            t_a = float(slot.get("t_a", slot.get("start", 0.0)))
+            end = float(slot.get("end", t_a))
+            local_w_ack = 0.2
+            if scene == "1QnA" and int(slot.get("step_index") or slot.get("slot_id") or 1) > 1:
+                local_w_ack = 0.0
+            local_w_core = 1.0 - local_w_ack
+            tp_ack = 0.0
+            if early_chunks and early_start is not None and not is_interrupted:
+                tp_ack = _calculate_decay(early_start, float(slot.get("start", 0.0)), t_a) * local_w_ack
+            tp_core = 0.0
+            if core_chunks and core_start is not None and not is_interrupted and quality_core > 0.0:
+                tp_core = quality_core * _calculate_decay(max(core_start, t_a), t_a, end) * local_w_core
+            spill_seconds = 0.0
+            if all_chunks:
+                max_end = max(float(c.get("end", end)) for c in all_chunks)
+                spill_seconds = max(0.0, max_end - end)
+            fp = 1.0 if core_chunks and not is_interrupted and quality_core <= 0.0 else 0.0
+            if spill_seconds > 0.0:
+                fp += 1.0
+            tp = max(0.0, min(1.0, tp_ack + tp_core))
+            fn = 0.0 if is_interrupted else (0.0 if tp_core > 0.0 else 1.0)
+
+            if is_interrupted:
+                interrupted_total += 1
+                if not all_chunks:
+                    interrupted_no_output += 1
+                else:
+                    interrupted_output_count += 1
+                    interrupted_quality_sum += quality_all
+                    if spill_seconds > 0.0:
+                        interrupted_spill_positive += 1
+                    interrupted_spill_seconds += spill_seconds
+            else:
+                global_tp += tp
+                global_fp += fp
+                global_fn += fn
+                _add_streaming_metric(by_scene, scene, tp, fp, fn)
+                _add_streaming_metric(by_qtype, qtype, tp, fp, fn)
+                role = str(slot.get("nested_role") or "").strip().lower()
+                if scene == "nested" and role in {"inner", "outer"}:
+                    _add_streaming_metric(nested_by_role, role, tp, fp, fn)
+                    pair_key = _nested_pair_key({**slot, "video": req.omniinteract_video})
+                    nested_pairs.setdefault(pair_key, {})[role] = tp_core
+                    nested_pair_times.setdefault(pair_key, {})[role] = core_start
+
+            if include_per_item:
+                items.append(
+                    {
+                        "request_id": req.request_id,
+                        "video": req.omniinteract_video,
+                        "slot_id": slot.get("slot_id"),
+                        "scene_type": scene,
+                        "question_type": qtype,
+                        "nested_group_id": slot.get("nested_group_id"),
+                        "nested_role": slot.get("nested_role"),
+                        "is_interrupted": is_interrupted,
+                        "gt": slot.get("gt_answer", ""),
+                        "predicted_core": text_core,
+                        "predicted_all": text_all,
+                        "Score_core": tp_core,
+                        "TP_n": tp,
+                        "FP_delta": fp,
+                        "FN_delta": fn,
+                        "spill_seconds": spill_seconds,
+                        "num_chunks": len(all_chunks),
+                    }
+                )
+
+    by_scene_metric = _summarize_streaming_group(by_scene)
+    by_qtype_metric = _summarize_streaming_group(by_qtype)
+    nested_by_role_out = _summarize_streaming_group(nested_by_role)
+    realtime_exclusive = _metric_sub(by_qtype_metric.get("realtime", {}), nested_by_role_out.get("inner", {}))
+    proactive_exclusive = _metric_sub(by_qtype_metric.get("proactive", {}), nested_by_role_out.get("outer", {}))
+    nested_metric = by_scene_metric.get("nested", _metric_row(0.0, 0.0, 0.0, 0))
+    one_qna_metric = by_scene_metric.get("1QnA", _metric_row(0.0, 0.0, 0.0, 0))
+    one_q1a_tp = (
+        float(realtime_exclusive.get("Global_TP", 0.0))
+        + float(proactive_exclusive.get("Global_TP", 0.0))
+        + float(nested_metric.get("Global_TP", 0.0))
+    )
+    one_q1a_fp = (
+        float(realtime_exclusive.get("Global_FP", 0.0))
+        + float(proactive_exclusive.get("Global_FP", 0.0))
+        + float(nested_metric.get("Global_FP", 0.0))
+    )
+    one_q1a_fn = (
+        float(realtime_exclusive.get("Global_FN", 0.0))
+        + float(proactive_exclusive.get("Global_FN", 0.0))
+        + float(nested_metric.get("Global_FN", 0.0))
+    )
+    one_q1a_slots = (
+        int(realtime_exclusive.get("num_slots", 0) or 0)
+        + int(proactive_exclusive.get("num_slots", 0) or 0)
+        + int(nested_metric.get("num_slots", 0) or 0)
+    )
+    all_global = _metric_row(global_tp, global_fp, global_fn, evaluated_slots)
+
+    num_pairs = 0
+    success_pairs = 0
+    missing_outer = 0
+    missing_inner = 0
+    order_error = 0
+    ira_sum = 0.0
+    for pair_key, pair in nested_pairs.items():
+        num_pairs += 1
+        q1 = float(pair.get("outer", 0.0))
+        q2 = float(pair.get("inner", 0.0))
+        if q1 <= 0:
+            missing_outer += 1
+        if q2 <= 0:
+            missing_inner += 1
+        q1_time = nested_pair_times.get(pair_key, {}).get("outer")
+        q2_time = nested_pair_times.get(pair_key, {}).get("inner")
+        order_ok = True
+        if q1 > 0 and q2 > 0 and q1_time is not None and q2_time is not None:
+            order_ok = float(q2_time) <= float(q1_time)
+        if q1 > 0 and q2 > 0 and not order_ok:
+            order_error += 1
+        if q1 > 0 and q2 > 0 and order_ok:
+            success_pairs += 1
+            ira_sum += math.sqrt(q1 * q2)
+    nccs = _safe_div(ira_sum, num_pairs)
+    nor = _safe_div(interrupted_no_output, interrupted_total)
+    paq = _safe_div(interrupted_quality_sum, interrupted_output_count)
+    csm_sr = _safe_div(interrupted_spill_positive, interrupted_output_count)
+    csm_as = _safe_div(interrupted_spill_seconds, interrupted_output_count)
+
+    metrics: dict[str, Any] = {
+        "omniinteract_evaluated": evaluated_slots,
+        "omniinteract_request_failed": failed,
+        "omniinteract_unmatched_chunks": unmatched_chunks,
+        "omniinteract_paper_metrics": {
+            "exp_f1": {
+                "realtime": realtime_exclusive,
+                "proactive": proactive_exclusive,
+                "nested": nested_metric,
+                "one_q1a_global": _metric_row(one_q1a_tp, one_q1a_fp, one_q1a_fn, one_q1a_slots),
+                "one_qna": one_qna_metric,
+                "all_global": all_global,
+            },
+            "exp_interruption": {
+                "NOR": nor,
+                "PAQ": paq,
+                "CSM_SR": csm_sr,
+                "CSM_AS_seconds": csm_as,
+                "interrupted_slot_count": interrupted_total,
+                "interrupted_with_output_count": interrupted_output_count,
+            },
+            "exp_nested": {
+                "NCCS": nccs,
+                "inner_IA_QTF1": float(nested_by_role_out.get("inner", {}).get("IA_QTF1", 0.0)),
+                "outer_IA_QTF1": float(nested_by_role_out.get("outer", {}).get("IA_QTF1", 0.0)),
+                "missed_outer": missing_outer,
+                "missed_inner": missing_inner,
+                "order_error": order_error,
+                "num_pairs": num_pairs,
+                "success_pairs": success_pairs,
+            },
+        },
+        "omniinteract_ia_qtf1": float(all_global["IA_QTF1"]),
+        "omniinteract_ids": {
+            "NOR": nor,
+            "PAQ": paq,
+            "CSM_SR": csm_sr,
+            "CSM_AS_seconds": csm_as,
+        },
+        "omniinteract_nccs": nccs,
+        "omniinteract_metric_note": (
+            "Streaming IA-QTF1/IDS/NCCS are computed from annotation slots and "
+            "timestamped response chunks. Text quality uses the benchmark's local "
+            "soft string match; plug in the official LLM judge output for semantic scoring."
+        ),
+    }
+    if include_per_item:
+        metrics["omniinteract_eval_items"] = items
+    return metrics
+
+
 def compute_omniinteract_metrics(
     input_requests: list[Any],
     outputs: list[RequestFuncOutput],
@@ -75,6 +428,12 @@ def compute_omniinteract_metrics(
         return None
     if not all(isinstance(r, OmniInteractSampleRequest) for r in input_requests):
         return None
+    if any(getattr(r, "omniinteract_streaming_slots", None) for r in input_requests):
+        return _compute_streaming_omniinteract_metrics(
+            input_requests,
+            outputs,
+            include_per_item=include_per_item,
+        )
 
     exact = 0
     soft = 0
@@ -354,7 +713,7 @@ def print_omniinteract_summary(metrics: dict[str, Any]) -> None:
     print("{s:{c}^{n}}".format(s=" OmniInteract QA metrics ", n=50, c="="))
     print("{:<40} {:<10}".format("Evaluated:", metrics.get("omniinteract_evaluated", 0)))
     if metrics.get("omniinteract_ia_qtf1") is not None:
-        print("{:<40} {:<10.4f}".format("IA-QTF1 (estimated):", float(metrics.get("omniinteract_ia_qtf1"))))
+        print("{:<40} {:<10.4f}".format("IA-QTF1:", float(metrics.get("omniinteract_ia_qtf1"))))
     ids = metrics.get("omniinteract_ids") or {}
     if ids:
         print("{:<40} {:<10.4f}".format("IDS.NOR:", float(ids.get("NOR", 0.0))))
@@ -370,5 +729,5 @@ def print_omniinteract_summary(metrics: dict[str, Any]) -> None:
         else:
             print("{:<40} {:<10.4f}".format("IDS.CSM-AS(s):", float(csm_as)))
     if metrics.get("omniinteract_nccs") is not None:
-        print("{:<40} {:<10.4f}".format("NCCS (estimated):", float(metrics.get("omniinteract_nccs"))))
+        print("{:<40} {:<10.4f}".format("NCCS:", float(metrics.get("omniinteract_nccs"))))
     print("=" * 50)

--- a/vllm_omni/benchmarks/data_modules/omniinteract_eval.py
+++ b/vllm_omni/benchmarks/data_modules/omniinteract_eval.py
@@ -1,0 +1,374 @@
+"""OmniInteract benchmark metrics (IA-QTF1 / IDS / NCCS) for vLLM bench."""
+
+from __future__ import annotations
+
+import math
+import re
+import string
+from typing import Any
+
+from vllm.benchmarks.lib.endpoint_request_func import RequestFuncOutput
+
+from vllm_omni.benchmarks.data_modules.omniinteract_dataset import OmniInteractSampleRequest
+
+_CJK_PUNCT = "，。！？；：（）【】《》“”‘’、"
+
+
+def _normalize_text(text: str | None) -> str:
+    t = (text or "").strip().lower()
+    if not t:
+        return ""
+    table = str.maketrans("", "", string.punctuation + _CJK_PUNCT)
+    t = t.translate(table)
+    t = re.sub(r"\s+", "", t)
+    return t
+
+
+def _safe_ratio(num: int, den: int) -> float | None:
+    return (num / den) if den else None
+
+
+def _safe_div(num: float, den: float) -> float:
+    return (num / den) if den else 0.0
+
+
+def _safe_metric(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _f1(precision: float, recall: float) -> float:
+    return _safe_div(2.0 * precision * recall, precision + recall)
+
+
+def _metric_row(tp: float, fp: float, fn: float, num_slots: int) -> dict[str, Any]:
+    precision = _safe_div(tp, tp + fp)
+    recall = _safe_div(tp, tp + fn)
+    return {
+        "num_slots": num_slots,
+        "Global_TP": tp,
+        "Global_FP": fp,
+        "Global_FN": fn,
+        "Precision": precision,
+        "Recall": recall,
+        "IA_QTF1": _f1(precision, recall),
+    }
+
+
+def _metric_sub(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
+    tp = float(a.get("Global_TP", 0.0)) - float(b.get("Global_TP", 0.0))
+    fp = float(a.get("Global_FP", 0.0)) - float(b.get("Global_FP", 0.0))
+    fn = float(a.get("Global_FN", 0.0)) - float(b.get("Global_FN", 0.0))
+    slots = int(a.get("num_slots", 0) or 0) - int(b.get("num_slots", 0) or 0)
+    return _metric_row(tp=max(0.0, tp), fp=max(0.0, fp), fn=max(0.0, fn), num_slots=max(0, slots))
+
+
+def compute_omniinteract_metrics(
+    input_requests: list[Any],
+    outputs: list[RequestFuncOutput],
+    *,
+    include_per_item: bool = False,
+) -> dict[str, Any] | None:
+    if not input_requests or len(input_requests) != len(outputs):
+        return None
+    if not all(isinstance(r, OmniInteractSampleRequest) for r in input_requests):
+        return None
+
+    exact = 0
+    soft = 0
+    evaluated = 0
+    failed = 0
+    per_subset: dict[str, dict[str, int]] = {}
+    per_qtype: dict[str, dict[str, int]] = {}
+    global_tp = 0.0
+    global_fp = 0.0
+    global_fn = 0.0
+    by_scene: dict[str, dict[str, float]] = {}
+    by_qtype_metric: dict[str, dict[str, float]] = {}
+    nested_by_role: dict[str, dict[str, float]] = {}
+    nested_pairs: dict[tuple[str, int], dict[str, float]] = {}
+    interrupted_total = 0
+    interrupted_no_output = 0
+    interrupted_output_quality_sum = 0.0
+    interrupted_output_count = 0
+    interrupted_spill_timed_count = 0
+    interrupted_spill_positive_count = 0
+    interrupted_spill_seconds = 0.0
+    items: list[dict[str, Any]] = []
+
+    def _accumulate(store: dict[str, dict[str, float]], key: str, tp: float, fp: float, fn: float) -> None:
+        row = store.setdefault(key, {"num_slots": 0.0, "Global_TP": 0.0, "Global_FP": 0.0, "Global_FN": 0.0})
+        row["num_slots"] += 1.0
+        row["Global_TP"] += tp
+        row["Global_FP"] += fp
+        row["Global_FN"] += fn
+
+    for req, out in zip(input_requests, outputs, strict=True):
+        assert isinstance(req, OmniInteractSampleRequest)
+        subset = (req.omniinteract_subset or "unknown").strip() or "unknown"
+        qtype = (req.omniinteract_question_type or "unknown").strip() or "unknown"
+        scene = (req.omniinteract_scene_type or "").strip().lower() or ("1qna" if subset == "1qna" else "multi_turn")
+        scene = "1qna" if scene in {"1qna", "1qna_long"} else scene
+        per_subset.setdefault(subset, {"exact": 0, "soft": 0, "total": 0})
+        per_qtype.setdefault(qtype, {"exact": 0, "soft": 0, "total": 0})
+
+        if not out.success:
+            failed += 1
+            if req.omniinteract_is_interrupted:
+                interrupted_total += 1
+                interrupted_no_output += 1
+            elif qtype:
+                global_fn += 1.0
+                _accumulate(by_scene, scene, 0.0, 0.0, 1.0)
+                _accumulate(by_qtype_metric, qtype, 0.0, 0.0, 1.0)
+            if include_per_item:
+                items.append(
+                    {
+                        "request_id": req.request_id,
+                        "subset": subset,
+                        "question_type": qtype,
+                        "video": req.omniinteract_video,
+                        "scene_type": scene,
+                        "nested_group_id": req.omniinteract_nested_group_id,
+                        "nested_role": req.omniinteract_nested_role,
+                        "error": (out.error or "")[:500],
+                        "correct_exact": False,
+                        "correct_soft": False,
+                        "quality_score": 0.0,
+                        "has_output": False,
+                    }
+                )
+            continue
+
+        pred_raw = out.generated_text or ""
+        gold_raw = req.omniinteract_gold_answer or ""
+        pred = _normalize_text(pred_raw)
+        gold = _normalize_text(gold_raw)
+        if not gold:
+            continue
+
+        evaluated += 1
+        per_subset[subset]["total"] += 1
+        per_qtype[qtype]["total"] += 1
+        is_exact = pred == gold
+        is_soft = bool(pred and gold and (pred in gold or gold in pred))
+        quality_score = 1.0 if is_soft else 0.0
+        has_output = bool(pred_raw.strip())
+        if is_exact:
+            exact += 1
+            per_subset[subset]["exact"] += 1
+            per_qtype[qtype]["exact"] += 1
+        if is_soft:
+            soft += 1
+            per_subset[subset]["soft"] += 1
+            per_qtype[qtype]["soft"] += 1
+
+        if req.omniinteract_is_interrupted:
+            interrupted_total += 1
+            if not has_output:
+                interrupted_no_output += 1
+            else:
+                interrupted_output_count += 1
+                interrupted_output_quality_sum += quality_score
+                spill_seconds = _safe_metric(getattr(out, "omniinteract_spill_seconds", None))
+                if spill_seconds is None:
+                    spill_seconds = _safe_metric(getattr(out, "spill_seconds", None))
+                if spill_seconds is not None:
+                    interrupted_spill_timed_count += 1
+                    interrupted_spill_seconds += max(0.0, spill_seconds)
+                    if spill_seconds > 0:
+                        interrupted_spill_positive_count += 1
+        else:
+            fp = 1.0 if quality_score <= 0 else 0.0
+            fn = 1.0 if quality_score <= 0 else 0.0
+            global_tp += quality_score
+            global_fp += fp
+            global_fn += fn
+            _accumulate(by_scene, scene, quality_score, fp, fn)
+            _accumulate(by_qtype_metric, qtype, quality_score, fp, fn)
+            role = (req.omniinteract_nested_role or "").strip().lower()
+            if scene == "nested" and role in {"outer", "inner"}:
+                _accumulate(nested_by_role, role, quality_score, fp, fn)
+                if req.omniinteract_nested_group_id is not None:
+                    pair_key = (req.omniinteract_video or "", int(req.omniinteract_nested_group_id))
+                    nested_pairs.setdefault(pair_key, {})[role] = quality_score
+
+        if include_per_item:
+            items.append(
+                {
+                    "request_id": req.request_id,
+                    "subset": subset,
+                    "scene_type": scene,
+                    "question_type": qtype,
+                    "video": req.omniinteract_video,
+                    "nested_group_id": req.omniinteract_nested_group_id,
+                    "nested_role": req.omniinteract_nested_role,
+                    "question_time": req.omniinteract_question_time,
+                    "answer_time": req.omniinteract_answer_time,
+                    "gold": gold_raw,
+                    "predicted": pred_raw,
+                    "gold_normalized": gold,
+                    "predicted_normalized": pred,
+                    "correct_exact": is_exact,
+                    "correct_soft": is_soft,
+                    "quality_score": quality_score,
+                    "has_output": has_output,
+                }
+            )
+
+    by_scene_metric = {
+        name: _metric_row(v["Global_TP"], v["Global_FP"], v["Global_FN"], int(v["num_slots"]))
+        for name, v in by_scene.items()
+    }
+    by_qtype_metric_out = {
+        name: _metric_row(v["Global_TP"], v["Global_FP"], v["Global_FN"], int(v["num_slots"]))
+        for name, v in by_qtype_metric.items()
+    }
+    nested_by_role_out = {
+        name: _metric_row(v["Global_TP"], v["Global_FP"], v["Global_FN"], int(v["num_slots"]))
+        for name, v in nested_by_role.items()
+    }
+
+    realtime_exclusive = _metric_sub(by_qtype_metric_out.get("realtime", {}), nested_by_role_out.get("inner", {}))
+    proactive_exclusive = _metric_sub(by_qtype_metric_out.get("proactive", {}), nested_by_role_out.get("outer", {}))
+    nested_metric = by_scene_metric.get("nested", _metric_row(0.0, 0.0, 0.0, 0))
+    one_qna_metric = by_scene_metric.get("1qna", _metric_row(0.0, 0.0, 0.0, 0))
+    one_q1a_tp = (
+        float(realtime_exclusive.get("Global_TP", 0.0))
+        + float(proactive_exclusive.get("Global_TP", 0.0))
+        + float(nested_metric.get("Global_TP", 0.0))
+    )
+    one_q1a_fp = (
+        float(realtime_exclusive.get("Global_FP", 0.0))
+        + float(proactive_exclusive.get("Global_FP", 0.0))
+        + float(nested_metric.get("Global_FP", 0.0))
+    )
+    one_q1a_fn = (
+        float(realtime_exclusive.get("Global_FN", 0.0))
+        + float(proactive_exclusive.get("Global_FN", 0.0))
+        + float(nested_metric.get("Global_FN", 0.0))
+    )
+    one_q1a_slots = (
+        int(realtime_exclusive.get("num_slots", 0) or 0)
+        + int(proactive_exclusive.get("num_slots", 0) or 0)
+        + int(nested_metric.get("num_slots", 0) or 0)
+    )
+    all_global = _metric_row(global_tp, global_fp, global_fn, int(one_q1a_slots + one_qna_metric.get("num_slots", 0)))
+
+    num_pairs = 0
+    success_pairs = 0
+    missing_outer = 0
+    ira_sum = 0.0
+    for pair in nested_pairs.values():
+        num_pairs += 1
+        q1 = float(pair.get("outer", 0.0))
+        q2 = float(pair.get("inner", 0.0))
+        if q1 <= 0:
+            missing_outer += 1
+        if q1 > 0 and q2 > 0:
+            success_pairs += 1
+            ira_sum += math.sqrt(q1 * q2)
+    nccs = _safe_div(ira_sum, num_pairs)
+
+    nor = _safe_div(interrupted_no_output, interrupted_total)
+    paq = _safe_div(interrupted_output_quality_sum, interrupted_output_count)
+    csm_sr = (
+        _safe_div(interrupted_spill_positive_count, interrupted_spill_timed_count)
+        if interrupted_spill_timed_count
+        else None
+    )
+    csm_as = (
+        _safe_div(interrupted_spill_seconds, interrupted_spill_timed_count) if interrupted_spill_timed_count else None
+    )
+
+    out: dict[str, Any] = {
+        "omniinteract_evaluated": evaluated,
+        "omniinteract_request_failed": failed,
+        "omniinteract_exact_match": _safe_ratio(exact, evaluated),
+        "omniinteract_soft_match": _safe_ratio(soft, evaluated),
+        "omniinteract_exact_count": exact,
+        "omniinteract_soft_count": soft,
+        "omniinteract_per_subset": per_subset,
+        "omniinteract_per_question_type": per_qtype,
+        "omniinteract_paper_metrics": {
+            "exp_f1": {
+                "realtime": realtime_exclusive,
+                "proactive": proactive_exclusive,
+                "nested": nested_metric,
+                "one_q1a_global": _metric_row(one_q1a_tp, one_q1a_fp, one_q1a_fn, one_q1a_slots),
+                "one_qna": one_qna_metric,
+                "all_global": all_global,
+            },
+            "exp_interruption": {
+                "NOR": nor,
+                "PAQ": paq,
+                "CSM_SR": csm_sr,
+                "CSM_AS_seconds": csm_as,
+                "interrupted_slot_count": interrupted_total,
+                "interrupted_with_output_count": interrupted_output_count,
+                "interrupted_with_spill_timing_count": interrupted_spill_timed_count,
+            },
+            "exp_nested": {
+                "NCCS": nccs,
+                "inner_IA_QTF1": float(nested_by_role_out.get("inner", {}).get("IA_QTF1", 0.0)),
+                "outer_IA_QTF1": float(nested_by_role_out.get("outer", {}).get("IA_QTF1", 0.0)),
+                "missed_outer": missing_outer,
+                "num_pairs": num_pairs,
+                "success_pairs": success_pairs,
+            },
+        },
+        "omniinteract_ia_qtf1": float(all_global["IA_QTF1"]),
+        "omniinteract_ids": {
+            "NOR": nor,
+            "PAQ": paq,
+            "CSM_SR": csm_sr,
+            "CSM_AS_seconds": csm_as,
+        },
+        "omniinteract_nccs": nccs,
+        "omniinteract_metric_note": (
+            "IA-QTF1/IDS/NCCS are estimated from per-request benchmark outputs. "
+            "IDS CSM_SR/CSM_AS require continuous-turn spill timing; they are N/A "
+            "unless outputs provide omniinteract_spill_seconds/spill_seconds."
+        ),
+    }
+
+    out["omniinteract_per_subset_exact"] = {
+        name: _safe_ratio(vals["exact"], vals["total"]) for name, vals in per_subset.items()
+    }
+    out["omniinteract_per_question_type_exact"] = {
+        name: _safe_ratio(vals["exact"], vals["total"]) for name, vals in per_qtype.items()
+    }
+    if include_per_item:
+        out["omniinteract_eval_items"] = items
+    return out
+
+
+def print_omniinteract_summary(metrics: dict[str, Any]) -> None:
+    if (
+        int(metrics.get("omniinteract_evaluated", 0) or 0) == 0
+        and int(metrics.get("omniinteract_request_failed", 0) or 0) == 0
+    ):
+        return
+    print("{s:{c}^{n}}".format(s=" OmniInteract QA metrics ", n=50, c="="))
+    print("{:<40} {:<10}".format("Evaluated:", metrics.get("omniinteract_evaluated", 0)))
+    if metrics.get("omniinteract_ia_qtf1") is not None:
+        print("{:<40} {:<10.4f}".format("IA-QTF1 (estimated):", float(metrics.get("omniinteract_ia_qtf1"))))
+    ids = metrics.get("omniinteract_ids") or {}
+    if ids:
+        print("{:<40} {:<10.4f}".format("IDS.NOR:", float(ids.get("NOR", 0.0))))
+        print("{:<40} {:<10.4f}".format("IDS.PAQ:", float(ids.get("PAQ", 0.0))))
+        csm_sr = ids.get("CSM_SR")
+        csm_as = ids.get("CSM_AS_seconds")
+        if csm_sr is None:
+            print("{:<40} {:<10}".format("IDS.CSM-SR:", "N/A"))
+        else:
+            print("{:<40} {:<10.4f}".format("IDS.CSM-SR:", float(csm_sr)))
+        if csm_as is None:
+            print("{:<40} {:<10}".format("IDS.CSM-AS(s):", "N/A"))
+        else:
+            print("{:<40} {:<10.4f}".format("IDS.CSM-AS(s):", float(csm_as)))
+    if metrics.get("omniinteract_nccs") is not None:
+        print("{:<40} {:<10.4f}".format("NCCS (estimated):", float(metrics.get("omniinteract_nccs"))))
+    print("=" * 50)

--- a/vllm_omni/benchmarks/metrics/metrics.py
+++ b/vllm_omni/benchmarks/metrics/metrics.py
@@ -249,7 +249,9 @@ def print_text_metrics(task_type, selected_percentile_metrics, metrics: MultiMod
 
 def _has_audio_output(metrics: MultiModalsBenchmarkMetrics) -> bool:
     return bool(
-        getattr(metrics, defs.TOTAL_AUDIO_DURATION_S, 0.0) > 0 or getattr(metrics, defs.TOTAL_AUDIO_FRAMES, 0) > 0
+        getattr(metrics, defs.TOTAL_AUDIO_DURATION_S, 0.0) > 0
+        or getattr(metrics, defs.TOTAL_AUDIO_FRAMES, 0) > 0
+        or getattr(metrics, defs.MEAN_AUDIO_TTFP_MS, 0.0) > 0
     )
 
 

--- a/vllm_omni/benchmarks/patch/patch.py
+++ b/vllm_omni/benchmarks/patch/patch.py
@@ -6,6 +6,7 @@ import mimetypes
 import os
 import random
 import ssl
+import subprocess
 import sys
 import time
 import traceback
@@ -221,6 +222,17 @@ def _attach_omniinteract_to_request_func_input(sample: SampleRequest, rfi: Reque
     rfi.extra_body = _merge_extra_body_mm_kwargs(rfi.extra_body, sample.omni_extra_body)
     if sample.omni_chat_messages is not None:
         setattr(rfi, "omni_chat_messages", sample.omni_chat_messages)
+    if sample.omniinteract_streaming_video_path:
+        setattr(rfi, "omniinteract_streaming_video_path", sample.omniinteract_streaming_video_path)
+    if sample.omniinteract_streaming_audio_path:
+        setattr(rfi, "omniinteract_streaming_audio_path", sample.omniinteract_streaming_audio_path)
+    if sample.omniinteract_streaming_audio_schedule is not None:
+        setattr(rfi, "omniinteract_streaming_audio_schedule", sample.omniinteract_streaming_audio_schedule)
+    setattr(rfi, "omniinteract_streaming_audio_from_video", sample.omniinteract_streaming_audio_from_video)
+    if sample.omniinteract_streaming_slots is not None:
+        setattr(rfi, "omniinteract_streaming_slots", sample.omniinteract_streaming_slots)
+    if sample.omniinteract_streaming_config is not None:
+        setattr(rfi, "omniinteract_streaming_config", sample.omniinteract_streaming_config)
 #         audio_urls, video_urls = _omniinteract_media_urls(sample.omni_chat_messages)
 #         logger.info(
 #             "OmniInteract request media: request_id=%s video=%s audio=%s",
@@ -308,7 +320,7 @@ def get_samples(args, tokenizer):
     )
 
     # Check if we need to handle omni-related backends/datasets
-    is_omni_backend = args.backend in ["openai-chat-omni", "openai-audio-speech", "daily-omni"]
+    is_omni_backend = args.backend in ["openai-chat-omni", "openai-audio-speech", "daily-omni", "openai-video-stream"]
     is_omni_dataset = is_daily_omni or is_omniinteract or is_seed_tts or args.dataset_name == "random-mm"
 
     if not is_omni_backend and not is_omni_dataset:
@@ -449,10 +461,10 @@ def get_samples(args, tokenizer):
         )
 
     if is_omniinteract:
-        if args.backend not in ["openai-chat-omni", "daily-omni"]:
+        if args.backend not in ["openai-chat-omni", "daily-omni", "openai-video-stream"]:
             raise ValueError(
                 "OmniInteract requires a multimodal backend that supports video/audio. "
-                f"Got backend={args.backend!r}; use --backend openai-chat-omni."
+                f"Got backend={args.backend!r}; use --backend openai-chat-omni or openai-video-stream."
             )
 
         dataset_path = getattr(args, "dataset_path", None) or getattr(args, "hf_name", None)
@@ -489,6 +501,11 @@ def get_samples(args, tokenizer):
             aura_tts_speaker=getattr(args, "omniinteract_aura_tts_speaker", None),
             aura_tts_ref_audio=getattr(args, "omniinteract_aura_tts_ref_audio", None),
             aura_tts_ref_text=getattr(args, "omniinteract_aura_tts_ref_text", None),
+            streaming_sample_fps=getattr(args, "omniinteract_streaming_sample_fps", 2.0),
+            streaming_send_fps=getattr(args, "omniinteract_streaming_send_fps", 0.0),
+            streaming_max_frames=getattr(args, "omniinteract_streaming_max_frames", 16),
+            streaming_auto_trigger_min_frames=getattr(args, "omniinteract_streaming_auto_trigger_min_frames", 0),
+            streaming_enable_frame_filter=getattr(args, "omniinteract_streaming_enable_frame_filter", False),
             disable_shuffle=getattr(args, "disable_shuffle", False),
         )
         out_len = getattr(args, "output_len", None)
@@ -804,6 +821,429 @@ def _decode_audio_bytes_for_benchmark(audio_bytes: bytes, response_format: str) 
     except Exception as ex:
         logger.warning("Failed to decode accumulated audio bytes: %s", ex)
         return 0.0, 0
+
+
+def _api_url_to_ws_url(api_url: str) -> str:
+    if api_url.startswith("https://"):
+        return "wss://" + api_url[len("https://") :]
+    if api_url.startswith("http://"):
+        return "ws://" + api_url[len("http://") :]
+    return api_url
+
+
+def _load_pcm16_16k_mono(path: str) -> bytes:
+    """Load WAV/raw PCM as 16 kHz mono int16 bytes for ``audio.chunk``."""
+
+    with open(path, "rb") as f:
+        raw = f.read()
+    if raw[:4] != b"RIFF":
+        return raw
+
+    import soundfile as sf
+
+    audio, sr = sf.read(path, dtype="float32", always_2d=True)
+    if audio.shape[1] > 1:
+        audio = audio.mean(axis=1)
+    else:
+        audio = audio[:, 0]
+    if sr != 16000 and len(audio) > 0:
+        n_out = int(round(len(audio) * 16000 / sr))
+        if n_out > 0:
+            old_x = np.arange(len(audio), dtype=np.float64)
+            new_x = np.linspace(0, len(audio) - 1, n_out)
+            audio = np.interp(new_x, old_x, audio).astype(np.float32)
+    return (np.clip(audio, -1.0, 1.0) * 32767.0).astype(np.int16).tobytes()
+
+
+def _load_video_audio_pcm16_16k_mono(path: str) -> bytes:
+    """Extract a video's audio track as 16 kHz mono int16 PCM bytes."""
+
+    cmd = [
+        "ffmpeg",
+        "-loglevel",
+        "error",
+        "-i",
+        path,
+        "-vn",
+        "-f",
+        "s16le",
+        "-acodec",
+        "pcm_s16le",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-",
+    ]
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError("openai-video-stream benchmark requires ffmpeg for MP4 audio extraction.") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode("utf-8", errors="replace") if exc.stderr else ""
+        raise RuntimeError(f"Failed to extract audio from video with ffmpeg: {stderr}") from exc
+    return result.stdout
+
+
+def _pcm_schedule_from_video_audio(path: str, *, chunk_duration_s: float = 0.1) -> list[dict[str, Any]]:
+    pcm = _load_video_audio_pcm16_16k_mono(path)
+    bytes_per_second = 16000 * 2
+    chunk_size = max(2, int(round(bytes_per_second * chunk_duration_s)))
+    if chunk_size % 2:
+        chunk_size += 1
+    return [
+        {
+            "at_sec": offset / bytes_per_second,
+            "pcm": pcm[offset : offset + chunk_size],
+            "sent": False,
+            "source": "video_audio",
+            "audio_path": path,
+        }
+        for offset in range(0, len(pcm), chunk_size)
+        if pcm[offset : offset + chunk_size]
+    ]
+
+
+def _load_video_jpeg_frames(path: str, *, sample_fps: float, max_frames: int) -> list[tuple[float, bytes]]:
+    """Extract ``(source_time_sec, jpeg_bytes)`` frames from a local video file."""
+
+    try:
+        import cv2
+    except ImportError as exc:
+        raise RuntimeError("openai-video-stream benchmark requires opencv-python to read MP4 files.") from exc
+
+    cap = cv2.VideoCapture(path)
+    if not cap.isOpened():
+        raise RuntimeError(f"Cannot open video for streaming benchmark: {path}")
+    src_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    step = max(1, int(round(src_fps / max(float(sample_fps), 0.1))))
+    frames: list[tuple[float, bytes]] = []
+    idx = 0
+    try:
+        while max_frames <= 0 or len(frames) < max_frames:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            if idx % step == 0:
+                encoded, buf = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 80])
+                if encoded:
+                    frames.append((float(idx) / float(src_fps), buf.tobytes()))
+            idx += 1
+    finally:
+        cap.release()
+    if not frames:
+        raise RuntimeError(f"No frames extracted from video: {path}")
+    return frames
+
+
+def _video_time_from_wall(
+    *,
+    now: float,
+    start_wall: float,
+    send_fps: float,
+    sample_fps: float,
+) -> float:
+    elapsed = max(now - start_wall, 0.0)
+    if send_fps > 0:
+        return elapsed * (sample_fps / send_fps)
+    return elapsed
+
+
+def _normalize_streaming_chunks(responses: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    chunks: list[dict[str, Any]] = []
+    for idx, response in enumerate(responses):
+        text = str(response.get("text") or "").strip()
+        if not text:
+            continue
+        start = float(response.get("start", 0.0) or 0.0)
+        end = float(response.get("end", start) or start)
+        if end < start:
+            start, end = end, start
+        chunks.append(
+            {
+                "timestamp": [start, end],
+                "text": text,
+                "response_index": idx,
+                "chunk_id": idx,
+            }
+        )
+    return chunks
+
+
+async def async_request_openai_video_stream(
+    request_func_input: RequestFuncInput,
+    session: aiohttp.ClientSession,
+    pbar: tqdm | None = None,
+) -> MixRequestFuncOutput:
+    """Benchmark AURA ``/v1/video/chat/stream`` WebSocket input."""
+
+    output = MixRequestFuncOutput()
+    output.prompt_len = request_func_input.prompt_len
+    output.itl = []
+    output.stage_metrics = {}
+    output.output_tokens = 0
+    output.generated_text = ""
+
+    video_path = getattr(request_func_input, "omniinteract_streaming_video_path", "")
+    legacy_audio_path = getattr(request_func_input, "omniinteract_streaming_audio_path", "")
+    audio_schedule = list(getattr(request_func_input, "omniinteract_streaming_audio_schedule", None) or [])
+    audio_from_video = bool(getattr(request_func_input, "omniinteract_streaming_audio_from_video", False))
+    streaming_slots = list(getattr(request_func_input, "omniinteract_streaming_slots", None) or [])
+    config = dict(getattr(request_func_input, "omniinteract_streaming_config", None) or {})
+    if legacy_audio_path and not audio_schedule:
+        audio_schedule = [{"at_sec": 0.0, "audio_path": legacy_audio_path}]
+    if not video_path or (not audio_schedule and not audio_from_video) or not config:
+        output.success = False
+        output.error = "openai-video-stream requires OmniInteract aura_streaming samples."
+        if pbar:
+            pbar.update(1)
+        return output
+
+    try:
+        max_frames_value = config.get("max_frames_per_round", config.get("max_frames", 16))
+        max_frames = 256 if max_frames_value is None or int(max_frames_value) <= 0 else min(int(max_frames_value), 256)
+        sample_fps = float(config.get("video_fps") or 2.0)
+        send_fps = float(config.pop("send_fps", 0.0) or 0.0)
+        frames = _load_video_jpeg_frames(video_path, sample_fps=sample_fps, max_frames=max_frames)
+        if audio_from_video:
+            scheduled_audio = _pcm_schedule_from_video_audio(video_path)
+        else:
+            scheduled_audio = [
+                {
+                    **item,
+                    "at_sec": float(item.get("at_sec", 0.0) or 0.0),
+                    "pcm": _load_pcm16_16k_mono(str(item.get("audio_path") or "")),
+                    "sent": False,
+                }
+                for item in sorted(audio_schedule, key=lambda x: float(x.get("at_sec", 0.0) or 0.0))
+            ]
+        audio_budget = 3_500_000
+        budgeted_audio: list[dict[str, Any]] = []
+        total_audio_bytes = 0
+        for item in scheduled_audio:
+            pcm = item.get("pcm", b"")
+            if total_audio_bytes + len(pcm) > audio_budget:
+                logger.warning(
+                    "OmniInteract streaming audio truncated before overflow: video=%s kept_audio=%d/%d bytes",
+                    video_path,
+                    total_audio_bytes,
+                    sum(len(x.get("pcm", b"")) for x in scheduled_audio),
+                )
+                break
+            total_audio_bytes += len(pcm)
+            budgeted_audio.append(item)
+        scheduled_audio = budgeted_audio
+    except Exception:
+        frames_for_log = locals().get("frames", [])
+        audio_for_log = locals().get("scheduled_audio", [])
+        logger.exception(
+            "OmniInteract streaming request failed: video=%s frames=%d audio_items=%d audio_bytes=%d",
+            video_path,
+            len(frames_for_log),
+            len(audio_for_log),
+            sum(len(item.get("pcm", b"")) for item in audio_for_log),
+        )
+        output.success = False
+        output.error = traceback.format_exc()
+        if pbar:
+            pbar.update(1)
+        return output
+
+    model_name = request_func_input.model_name if request_func_input.model_name else request_func_input.model
+    config["type"] = "session.config"
+    config["model"] = model_name
+    if _PRINT_STAGE:
+        config[RETURN_STAGE_METRICS_FIELD] = True
+    trigger = int(config.get("auto_trigger_min_frames") or 0)
+    if trigger <= 0:
+        trigger = len(frames)
+    config["auto_trigger_min_frames"] = max(1, min(trigger, len(frames)))
+    config["max_frames"] = max(1, min(max(int(config.get("max_frames") or 0), len(frames)), 256))
+    config["max_frames_per_round"] = max(2, min(max(int(config.get("max_frames_per_round") or 0), len(frames)), 256))
+    logger.info(
+        "OmniInteract streaming request: video=%s frames=%d sample_fps=%.2f send_fps=%.2f audio_items=%d audio_bytes=%d config=%s",
+        video_path,
+        len(frames),
+        sample_fps,
+        send_fps,
+        len(scheduled_audio),
+        sum(len(item.get("pcm", b"")) for item in scheduled_audio),
+        {k: v for k, v in config.items() if k != "sampling_params_list"},
+    )
+
+    ws_url = _api_url_to_ws_url(request_func_input.api_url)
+    wav_pcm_buffer = bytearray()
+    wav_audio_params: tuple[int, int, int] | None = None
+    generated_parts: list[str] = []
+    responses: list[dict[str, Any]] = []
+    current_response: dict[str, Any] | None = None
+    st = time.perf_counter()
+    timestamp = st
+    output.start_time = st
+    audio_generate_time = 0.0
+    try:
+        async with session.ws_connect(ws_url, max_msg_size=32 * 1024 * 1024) as ws:
+            await ws.send_str(json.dumps(config))
+
+            chunk_size = 16000 * 2
+            frame_interval_s = (1.0 / send_fps) if send_fps > 0 else 0.0
+            stream_wall_start = time.perf_counter()
+            for source_time, frame in frames:
+                for item in scheduled_audio:
+                    if item["sent"] or float(item["at_sec"]) > source_time:
+                        continue
+                    pcm = item["pcm"]
+                    for offset in range(0, len(pcm), chunk_size):
+                        await ws.send_str(
+                            json.dumps(
+                                {
+                                    "type": "audio.chunk",
+                                    "data": base64.b64encode(pcm[offset : offset + chunk_size]).decode("ascii"),
+                                }
+                            )
+                        )
+                    item["sent"] = True
+                await ws.send_str(
+                    json.dumps(
+                        {
+                            "type": "video.frame",
+                            "data": base64.b64encode(frame).decode("ascii"),
+                        }
+                    )
+                )
+                if frame_interval_s > 0:
+                    await asyncio.sleep(frame_interval_s)
+
+            await ws.send_str(json.dumps({"type": "video.done"}))
+
+            async for msg in ws:
+                timestamp = time.perf_counter()
+                video_time = _video_time_from_wall(
+                    now=timestamp,
+                    start_wall=stream_wall_start,
+                    send_fps=send_fps,
+                    sample_fps=sample_fps,
+                )
+                if msg.type == aiohttp.WSMsgType.ERROR:
+                    raise RuntimeError(f"WebSocket error: {ws.exception()}")
+                if msg.type not in (aiohttp.WSMsgType.TEXT, aiohttp.WSMsgType.BINARY):
+                    continue
+                data = json.loads(msg.data.decode("utf-8") if isinstance(msg.data, bytes) else msg.data)
+                _update_output_stage_metrics_from_payload(output, data)
+                msg_type = data.get("type")
+                if msg_type == "response.start":
+                    current_response = {"start": video_time, "end": video_time, "text_parts": []}
+                elif msg_type == "response.text.delta":
+                    delta = data.get("delta") or ""
+                    if delta:
+                        if output.ttft == 0.0:
+                            output.ttft = timestamp - st
+                        else:
+                            output.itl.append(max(timestamp - (st + output.text_latency), 0.0))
+                        generated_parts.append(delta)
+                        if current_response is None:
+                            current_response = {"start": video_time, "end": video_time, "text_parts": []}
+                        current_response.setdefault("text_parts", []).append(delta)
+                        current_response["end"] = video_time
+                        output.text_latency = timestamp - st
+                elif msg_type == "response.text.done":
+                    response_parts = []
+                    if current_response is not None:
+                        response_parts = list(current_response.get("text_parts", []) or [])
+                    text = data.get("text") or "".join(response_parts) or "".join(generated_parts)
+                    if text and not generated_parts:
+                        output.ttft = output.ttft or (timestamp - st)
+                        output.text_latency = timestamp - st
+                    output.generated_text = text
+                    if current_response is None:
+                        current_response = {"start": video_time, "end": video_time, "text_parts": []}
+                    current_response["text"] = text
+                    current_response["end"] = video_time
+                    responses.append(current_response)
+                    current_response = None
+                elif msg_type == "response.audio.delta":
+                    if output.audio_ttfp == 0.0:
+                        output.audio_ttfp = timestamp - st
+                    audio_generate_time = timestamp - st
+                    audio_b64 = data.get("data") or ""
+                    if audio_b64:
+                        audio_bytes = base64.b64decode(audio_b64)
+                        try:
+                            with wave.open(io.BytesIO(audio_bytes), "rb") as wav_reader:
+                                params = (
+                                    wav_reader.getnchannels(),
+                                    wav_reader.getsampwidth(),
+                                    wav_reader.getframerate(),
+                                )
+                                if wav_audio_params is None:
+                                    wav_audio_params = params
+                                if wav_audio_params == params:
+                                    wav_pcm_buffer.extend(wav_reader.readframes(wav_reader.getnframes()))
+                        except Exception as ex:
+                            logger.warning("Failed to parse streaming video wav chunk: %s", ex)
+                elif msg_type == "error":
+                    output.success = False
+                    output.error = data.get("message") or "streaming video request failed"
+                    break
+                elif msg_type == "session.done":
+                    if current_response is not None:
+                        current_response["text"] = "".join(current_response.get("text_parts", []) or [])
+                        current_response["end"] = video_time
+                        responses.append(current_response)
+                        current_response = None
+                    output.success = True
+                    break
+
+        output.latency = timestamp - st
+        streaming_chunks = _normalize_streaming_chunks(responses)
+        response_texts = [str(chunk.get("text") or "") for chunk in streaming_chunks if str(chunk.get("text") or "")]
+        output.generated_text = "\n".join(response_texts) if response_texts else "".join(generated_parts)
+        setattr(output, "omniinteract_streaming_chunks", streaming_chunks)
+        setattr(output, "omniinteract_streaming_slots", streaming_slots)
+        setattr(
+            output,
+            "omniinteract_streaming_model_json",
+            {
+                "chunks": streaming_chunks,
+                "responses": responses,
+                "meta": {
+                    "video_path": video_path,
+                    "sample_fps": sample_fps,
+                    "send_fps": send_fps,
+                    "audio_from_video": audio_from_video,
+                    "audio_schedule": (
+                        [
+                            {
+                                "source": "video_audio",
+                                "audio_path": video_path,
+                                "num_chunks": len(scheduled_audio),
+                                "chunk_duration_s": 0.1,
+                            }
+                        ]
+                        if audio_from_video
+                        else [
+                            {k: v for k, v in item.items() if k not in {"pcm", "sent"}}
+                            for item in scheduled_audio
+                        ]
+                    ),
+                },
+            },
+        )
+        if wav_pcm_buffer and wav_audio_params is not None:
+            channels, sample_width, frame_rate = wav_audio_params
+            frame_width = channels * sample_width
+            audio_frames = len(wav_pcm_buffer) // frame_width if frame_width > 0 else 0
+            output.audio_frames = audio_frames
+            output.audio_duration = audio_frames / frame_rate if frame_rate > 0 else 0.0
+            output.audio_rtf = audio_generate_time / output.audio_duration if output.audio_duration > 0 else 0.0
+    except Exception:
+        logger.exception("OmniInteract streaming request failed during websocket exchange: video=%s", video_path)
+        output.success = False
+        output.error = traceback.format_exc()
+
+    if pbar:
+        pbar.update(1)
+    return output
 
 
 def _image_generation_ms_from_content(content: Any) -> float:
@@ -1465,6 +1905,10 @@ if "openai-audio-speech" not in OPENAI_COMPATIBLE_BACKENDS:
 ASYNC_REQUEST_FUNCS["openai-image-edits-omni"] = async_request_openai_image_edits_omni
 if "openai-image-edits-omni" not in OPENAI_COMPATIBLE_BACKENDS:
     OPENAI_COMPATIBLE_BACKENDS.append("openai-image-edits-omni")
+
+ASYNC_REQUEST_FUNCS["openai-video-stream"] = async_request_openai_video_stream
+if "openai-video-stream" not in OPENAI_COMPATIBLE_BACKENDS:
+    OPENAI_COMPATIBLE_BACKENDS.append("openai-video-stream")
 
 # Daily-Omni backend for audio-visual reasoning benchmark
 # Reuses openai-chat-omni completions for video+text understanding

--- a/vllm_omni/benchmarks/patch/patch.py
+++ b/vllm_omni/benchmarks/patch/patch.py
@@ -13,6 +13,7 @@ import wave
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Literal
 
 import aiohttp
@@ -39,6 +40,10 @@ logger = init_logger(__name__)
 
 from vllm_omni.benchmarks.audio_continuity import compute_continuity_stats
 from vllm_omni.benchmarks.data_modules.daily_omni_dataset import DailyOmniDataset, DailyOmniSampleRequest
+from vllm_omni.benchmarks.data_modules.omniinteract_dataset import (
+    OmniInteractDataset,
+    OmniInteractSampleRequest,
+)
 from vllm_omni.benchmarks.data_modules.random_multi_modal_dataset import OmniRandomMultiModalDataset
 from vllm_omni.benchmarks.data_modules.seed_tts_dataset import (
     SEED_TTS_DEFAULT_OMNI_SYSTEM_PROMPT,
@@ -57,6 +62,7 @@ _AUDIO_CHANNELS_ENV = "VLLM_OMNI_BENCH_AUDIO_CHANNELS"
 RETURN_STAGE_METRICS_FIELD = "return_stage_metrics"
 _IMAGE_STAGE_METRICS_BACKENDS = frozenset({"openai-image-edits-omni"})
 _PRINT_STAGE = False
+_BENCH_NO_STREAM = False
 
 
 def maybe_enable_stage_metrics(extra_body: dict[str, Any] | None, *, enabled: bool) -> dict[str, Any] | None:
@@ -140,6 +146,7 @@ def _audio_pcm_format() -> tuple[int, int]:
 get_samples_old = datasets.get_samples
 
 _DEFAULT_DAILY_OMNI_REPO = "liarliar/Daily-Omni"
+_DEFAULT_OMNIINTERACT_REPO = "lucky-lance/OmniInteract"
 
 
 def _seed_tts_capture_pcm_for_wer() -> bool:
@@ -207,6 +214,43 @@ def _attach_seed_tts_to_request_func_input(sample: SampleRequest, rfi: RequestFu
     rfi.extra_body = base
 
 
+def _attach_omniinteract_to_request_func_input(sample: SampleRequest, rfi: RequestFuncInput) -> None:
+    """Apply per-request OpenAI fields for OmniInteract."""
+    if not isinstance(sample, OmniInteractSampleRequest):
+        return
+    rfi.extra_body = _merge_extra_body_mm_kwargs(rfi.extra_body, sample.omni_extra_body)
+    if sample.omni_chat_messages is not None:
+        setattr(rfi, "omni_chat_messages", sample.omni_chat_messages)
+#         audio_urls, video_urls = _omniinteract_media_urls(sample.omni_chat_messages)
+#         logger.info(
+#             "OmniInteract request media: request_id=%s video=%s audio=%s",
+#             getattr(rfi, "request_id", None) or getattr(sample, "request_id", None),
+#             ",".join(video_urls) if video_urls else "None",
+#             ",".join(audio_urls) if audio_urls else "None",
+#         )
+
+
+# def _omniinteract_media_urls(messages: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+#     audio_urls: list[str] = []
+#     video_urls: list[str] = []
+#     for message in messages:
+#         content = message.get("content") if isinstance(message, dict) else None
+#         if not isinstance(content, list):
+#             continue
+#         for part in content:
+#             if not isinstance(part, dict):
+#                 continue
+#             if part.get("type") == "audio_url":
+#                 audio = part.get("audio_url")
+#                 if isinstance(audio, dict) and audio.get("url"):
+#                     audio_urls.append(str(audio["url"]))
+#             elif part.get("type") == "video_url":
+#                 video = part.get("video_url")
+#                 if isinstance(video, dict) and video.get("url"):
+#                     video_urls.append(str(video["url"]))
+#     return audio_urls, video_urls
+
+
 def _daily_omni_repo_from_args(args) -> str | None:
     """Resolve HuggingFace repo id for Daily-Omni from CLI args.
 
@@ -224,10 +268,36 @@ def _daily_omni_repo_from_args(args) -> str | None:
     return None
 
 
+def _omniinteract_repo_from_args(args) -> str | None:
+    dp = getattr(args, "dataset_path", None)
+    hn = getattr(args, "hf_name", None)
+    if dp in OmniInteractDataset.SUPPORTED_DATASET_PATHS:
+        return dp
+    if hn in OmniInteractDataset.SUPPORTED_DATASET_PATHS:
+        return hn
+    return None
+
+
+def _is_local_omniinteract_path(path: str | None) -> bool:
+    if not path:
+        return False
+    p = Path(path).expanduser()
+    return p.exists() and p.is_dir()
+
+
 def get_samples(args, tokenizer):
+    global _BENCH_NO_STREAM
+    _BENCH_NO_STREAM = bool(getattr(args, "no_stream", False))
+
     # Daily-Omni: explicit dataset name, or hf + matching path/hf-name
     is_daily_omni = args.dataset_name == "daily-omni" or (
         args.dataset_name == "hf" and _daily_omni_repo_from_args(args) is not None
+    )
+    is_omniinteract = (
+        args.dataset_name == "omniinteract"
+        or _is_local_omniinteract_path(getattr(args, "dataset_path", None))
+        or _is_local_omniinteract_path(getattr(args, "omniinteract_root", None))
+        or (args.dataset_name == "hf" and _omniinteract_repo_from_args(args) is not None)
     )
     is_seed_tts = args.dataset_name in (
         "seed-tts",
@@ -239,7 +309,7 @@ def get_samples(args, tokenizer):
 
     # Check if we need to handle omni-related backends/datasets
     is_omni_backend = args.backend in ["openai-chat-omni", "openai-audio-speech", "daily-omni"]
-    is_omni_dataset = is_daily_omni or is_seed_tts or args.dataset_name == "random-mm"
+    is_omni_dataset = is_daily_omni or is_omniinteract or is_seed_tts or args.dataset_name == "random-mm"
 
     if not is_omni_backend and not is_omni_dataset:
         # Not an omni-related request, delegate to original implementation
@@ -370,6 +440,62 @@ def get_samples(args, tokenizer):
             out_len = getattr(args, "hf_output_len", None)
         if out_len is None:
             out_len = SeedTTSDataset.DEFAULT_OUTPUT_LEN
+        return dataset.sample(
+            tokenizer=tokenizer,
+            num_requests=args.num_prompts,
+            output_len=out_len,
+            request_id_prefix=args.request_id_prefix,
+            no_oversample=args.no_oversample,
+        )
+
+    if is_omniinteract:
+        if args.backend not in ["openai-chat-omni", "daily-omni"]:
+            raise ValueError(
+                "OmniInteract requires a multimodal backend that supports video/audio. "
+                f"Got backend={args.backend!r}; use --backend openai-chat-omni."
+            )
+
+        dataset_path = getattr(args, "dataset_path", None) or getattr(args, "hf_name", None)
+        omniinteract_root = getattr(args, "omniinteract_root", None)
+        if args.dataset_name == "omniinteract" and not dataset_path and not omniinteract_root:
+            dataset_path = _DEFAULT_OMNIINTERACT_REPO
+        if not dataset_path and not omniinteract_root:
+            raise ValueError(
+                "OmniInteract requires --dataset-path (HF repo id or local directory) "
+                f"or --omniinteract-root (local directory). Default HF repo: {_DEFAULT_OMNIINTERACT_REPO}."
+            )
+
+        subsets_arg = str(getattr(args, "omniinteract_subsets", "1q1a,1q1a_math,1qna"))
+        subsets = [x.strip() for x in subsets_arg.split(",") if x.strip()]
+        if not subsets:
+            subsets = ["1q1a", "1q1a_math", "1qna"]
+
+        logger.info(
+            "Loading OmniInteract dataset: dataset_path=%s, omniinteract_root=%s, subsets=%s",
+            dataset_path,
+            omniinteract_root,
+            subsets,
+        )
+
+        dataset = OmniInteractDataset(
+            dataset_path=dataset_path,
+            data_root=omniinteract_root,
+            random_seed=args.seed,
+            subsets=subsets,
+            inline_local_video=getattr(args, "omniinteract_inline_local_video", False),
+            input_mode=getattr(args, "omniinteract_input_mode", "video"),
+            aura_tts_task_type=getattr(args, "omniinteract_aura_tts_task_type", "Base"),
+            aura_tts_language=getattr(args, "omniinteract_aura_tts_language", "Chinese"),
+            aura_tts_speaker=getattr(args, "omniinteract_aura_tts_speaker", None),
+            aura_tts_ref_audio=getattr(args, "omniinteract_aura_tts_ref_audio", None),
+            aura_tts_ref_text=getattr(args, "omniinteract_aura_tts_ref_text", None),
+            disable_shuffle=getattr(args, "disable_shuffle", False),
+        )
+        out_len = getattr(args, "output_len", None)
+        if out_len is None:
+            out_len = getattr(args, "hf_output_len", None)
+        if out_len is None:
+            out_len = OmniInteractDataset.DEFAULT_OUTPUT_LEN
         return dataset.sample(
             tokenizer=tokenizer,
             num_requests=args.num_prompts,
@@ -655,6 +781,31 @@ def _image_metrics_from_stage_metrics(metrics: dict[str, Any] | None) -> tuple[i
     return image_count, image_generation_ms, image_pixels, denoise_step_latency_ms
 
 
+def _decode_audio_bytes_for_benchmark(audio_bytes: bytes, response_format: str) -> tuple[float, int]:
+    if not audio_bytes:
+        return 0.0, 0
+    try:
+        if response_format == "wav":
+            with wave.open(io.BytesIO(audio_bytes), "rb") as wav_reader:
+                frames = wav_reader.getnframes()
+                frame_rate = wav_reader.getframerate()
+                return (frames / frame_rate if frame_rate > 0 else 0.0), int(frames)
+
+        from vllm.multimodal.audio import get_audio_duration
+        from vllm.multimodal.media.audio import load_audio
+
+        waveform, sr = load_audio(
+            io.BytesIO(audio_bytes),
+            sr=None,
+            mono=False,
+        )
+        duration_sec = get_audio_duration(y=waveform, sr=sr)
+        return duration_sec, int(duration_sec * sr)
+    except Exception as ex:
+        logger.warning("Failed to decode accumulated audio bytes: %s", ex)
+        return 0.0, 0
+
+
 def _image_generation_ms_from_content(content: Any) -> float:
     if not isinstance(content, list):
         return 0.0
@@ -691,6 +842,7 @@ async def async_request_openai_chat_omni_completions(
         content = _get_chat_content(request_func_input, mm_position=effective_mm_position)
         messages_payload = [{"role": "user", "content": content}]
 
+    stream = not bool(getattr(request_func_input, "no_stream", False))
     payload = {
         "model": request_func_input.model_name if request_func_input.model_name else request_func_input.model,
         "messages": messages_payload,
@@ -709,7 +861,16 @@ async def async_request_openai_chat_omni_completions(
             "continuous_usage_stats": True,
         },
     }
+    if stream:
+        payload["stream_options"] = {
+            "include_usage": True,
+        }
     _update_payload_common(payload, request_func_input)
+    payload["stream"] = stream
+    if stream:
+        payload.setdefault("stream_options", {"include_usage": True})
+    else:
+        payload.pop("stream_options", None)
     # Seed-TTS via chat: voice-clone fields live on the body; ensure audio is streamed.
     if getattr(request_func_input, "seed_tts_row", False):
         if payload.get("modalities") is None:
@@ -771,6 +932,62 @@ async def async_request_openai_chat_omni_completions(
         try:
             async with session.post(url=api_url, json=payload, headers=headers) as response:
                 if response.status == 200:
+                    if not stream:
+                        timestamp = time.perf_counter()
+                        data = await response.json()
+                        text_parts: list[str] = []
+                        nonstream_audio_bytes = bytearray()
+
+                        for choice in data.get("choices") or []:
+                            message = choice.get("message") or {}
+                            content = message.get("content")
+                            if isinstance(content, str) and content:
+                                text_parts.append(content)
+                            audio = message.get("audio")
+                            if isinstance(audio, dict) and audio.get("data"):
+                                try:
+                                    nonstream_audio_bytes.extend(base64.b64decode(audio["data"]))
+                                except Exception as ex:
+                                    logger.warning("Failed to decode non-stream audio payload: %s", ex)
+
+                        output.latency = timestamp - st
+                        output.generated_text = "\n".join(text_parts)
+                        if text_parts:
+                            output.ttft = output.latency
+                            output.text_latency = output.latency
+                        if nonstream_audio_bytes:
+                            output.audio_ttfp = output.latency
+                            audio_generate_time = output.latency
+                            audio_duration_sec, audio_frames = _decode_audio_bytes_for_benchmark(
+                                bytes(nonstream_audio_bytes),
+                                response_format,
+                            )
+                            output.audio_duration = audio_duration_sec
+                            output.audio_frames = audio_frames
+                            output.audio_rtf = (
+                                audio_generate_time / audio_duration_sec if audio_duration_sec > 0 else 0.0
+                            )
+
+                        _update_output_stage_metrics_from_payload(output, data)
+                        (
+                            metrics_image_count,
+                            metrics_image_ms,
+                            metrics_image_pixels,
+                            metrics_denoise_step_ms,
+                        ) = _image_metrics_from_stage_metrics(data.get("metrics"))
+                        output.image_count = max(output.image_count, metrics_image_count)
+                        output.image_generation_time_ms = max(output.image_generation_time_ms, metrics_image_ms)
+                        output.image_pixels = max(output.image_pixels, metrics_image_pixels)
+                        output.denoise_step_latency_ms = max(output.denoise_step_latency_ms, metrics_denoise_step_ms)
+
+                        if usage := data.get("usage"):
+                            if (pt := usage.get("prompt_tokens")) is not None:
+                                output.prompt_len = pt
+                            if output.output_tokens == 0 and (ct := usage.get("completion_tokens")) is not None:
+                                output.output_tokens = ct
+                        output.success = True
+                        break
+
                     handler = StreamedResponseHandler()
                     async for chunk_bytes in response.content.iter_any():
                         # NOTE: Do NOT strip() here; TCP may fragment the SSE messages,
@@ -1351,8 +1568,10 @@ async def benchmark(
         extra_headers=extra_headers,
         extra_body=extra_body,
     )
+    setattr(test_input, "no_stream", _BENCH_NO_STREAM)
     _attach_daily_omni_to_request_func_input(input_requests[0], test_input)
     _attach_seed_tts_to_request_func_input(input_requests[0], test_input)
+    _attach_omniinteract_to_request_func_input(input_requests[0], test_input)
 
     if ready_check_timeout_sec > 0:
         test_output = await wait_for_endpoint(
@@ -1415,8 +1634,10 @@ async def benchmark(
             extra_headers=extra_headers,
             extra_body=extra_body,
         )
+        setattr(profile_input, "no_stream", _BENCH_NO_STREAM)
         _attach_daily_omni_to_request_func_input(input_requests[0], profile_input)
         _attach_seed_tts_to_request_func_input(input_requests[0], profile_input)
+        _attach_omniinteract_to_request_func_input(input_requests[0], profile_input)
         profile_output = await request_func(request_func_input=profile_input, session=session)
         if profile_output.success:
             print("Profiler started")
@@ -1498,8 +1719,10 @@ async def benchmark(
             extra_body=extra_body,
             request_id=request_id,
         )
+        setattr(request_func_input, "no_stream", _BENCH_NO_STREAM)
         _attach_daily_omni_to_request_func_input(request, request_func_input)
         _attach_seed_tts_to_request_func_input(request, request_func_input)
+        _attach_omniinteract_to_request_func_input(request, request_func_input)
         tasks.append(
             asyncio.create_task(limited_request_func(request_func_input=request_func_input, session=session, pbar=pbar))
         )
@@ -1588,6 +1811,31 @@ async def benchmark(
         result.update(_daily_acc)
         print_daily_omni_accuracy_summary(_daily_acc)
 
+    from vllm_omni.benchmarks.data_modules.omniinteract_eval import (
+        compute_omniinteract_metrics,
+        print_omniinteract_summary,
+    )
+
+    _omniinteract_eval = os.environ.get("OMNIINTERACT_EVAL", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    if _omniinteract_eval:
+        _save_omniinteract_items = os.environ.get("OMNIINTERACT_SAVE_EVAL_ITEMS", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        _omniinteract_metrics = compute_omniinteract_metrics(
+            input_requests,
+            outputs,
+            include_per_item=_save_omniinteract_items,
+        )
+        if _omniinteract_metrics is not None:
+            result.update(_omniinteract_metrics)
+            print_omniinteract_summary(_omniinteract_metrics)
+
     if _seed_tts_capture_pcm_for_wer():
         from vllm_omni.benchmarks.data_modules.seed_tts_eval import (
             compute_seed_tts_wer_metrics,
@@ -1669,6 +1917,7 @@ async def benchmark(
             output_len=test_output_len,
             logprobs=logprobs,
         )
+        setattr(profile_input, "no_stream", _BENCH_NO_STREAM)
         profile_output = await request_func(request_func_input=profile_input, session=session)
         if profile_output.success:
             print("Profiler stopped")

--- a/vllm_omni/engine/stage_pool.py
+++ b/vllm_omni/engine/stage_pool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time as _time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
@@ -655,20 +656,39 @@ class StagePool:
     def _has_audio_output(self, request_outputs: list[Any]) -> bool:
         for ro in request_outputs:
             for mm_output in self._iter_multimodal_outputs(ro):
-                if isinstance(mm_output, dict) and mm_output.get("audio") is not None:
+                if self._extract_audio_payload(mm_output) is not None:
                     return True
         return False
+
+    @staticmethod
+    def _normalize_multimodal_dict(mm_output: Any) -> dict[str, Any] | None:
+        if mm_output is None:
+            return None
+        if isinstance(mm_output, dict):
+            return mm_output or None
+        to_dict = getattr(mm_output, "to_dict", None)
+        if callable(to_dict):
+            normalized = to_dict()
+            return normalized or None
+        if isinstance(mm_output, Mapping):
+            return dict(mm_output) or None
+        return None
+
+    @staticmethod
+    def _extract_audio_payload(mm_output: dict[str, Any]) -> Any | None:
+        audio = mm_output.get("audio")
+        if audio is not None:
+            return audio
+        return mm_output.get("model_outputs")
 
     def _collect_audio_metrics(self, request_outputs: list[Any]) -> tuple[int, int, float]:
         total_frames = 0
         sample_rate = 0
         for ro in request_outputs:
             for mm_output in self._iter_multimodal_outputs(ro):
-                if not isinstance(mm_output, dict):
-                    continue
                 if sample_rate <= 0:
                     sample_rate = self._infer_audio_sample_rate(mm_output)
-                audio_output = mm_output.get("audio")
+                audio_output = self._extract_audio_payload(mm_output)
                 if audio_output is None:
                     continue
                 items = audio_output if isinstance(audio_output, list) else [audio_output]
@@ -888,12 +908,12 @@ class StagePool:
 
     def _iter_multimodal_outputs(self, request_output: Any) -> list[dict[str, Any]]:
         multimodal_outputs: list[dict[str, Any]] = []
-        outer_mm = getattr(request_output, "multimodal_output", None)
-        if isinstance(outer_mm, dict) and outer_mm:
+        outer_mm = self._normalize_multimodal_dict(getattr(request_output, "multimodal_output", None))
+        if outer_mm is not None:
             multimodal_outputs.append(outer_mm)
         for output in getattr(request_output, "outputs", None) or []:
-            inner_mm = getattr(output, "multimodal_output", None)
-            if isinstance(inner_mm, dict) and inner_mm:
+            inner_mm = self._normalize_multimodal_dict(getattr(output, "multimodal_output", None))
+            if inner_mm is not None:
                 multimodal_outputs.append(inner_mm)
         return multimodal_outputs
 

--- a/vllm_omni/entrypoints/cli/benchmark/serve.py
+++ b/vllm_omni/entrypoints/cli/benchmark/serve.py
@@ -156,14 +156,51 @@ def add_omniinteract_cli_args(parser: argparse.ArgumentParser) -> None:
     g.add_argument(
         "--omniinteract-input-mode",
         type=str,
-        choices=["video", "aura"],
+        choices=["video", "aura", "aura_streaming"],
         default="video",
         help=(
             "OmniInteract request protocol. 'video' sends subvideo_url + text question with "
             "mm_processor_kwargs.use_audio_in_video=true. 'aura' sends paired audio_url + "
             "subvideo_url and AURA/TTS extra_body fields for the ASR -> AURA -> TTS pipeline. "
+            "'aura_streaming' streams paired local audio/video over /v1/video/chat/stream. "
             "Generate subvideos/ and audios/ under 1q1a before benchmarking."
         ),
+    )
+    g.add_argument(
+        "--omniinteract-streaming-sample-fps",
+        type=float,
+        default=2.0,
+        help="For aura_streaming: frames extracted per source-video second.",
+    )
+    g.add_argument(
+        "--omniinteract-streaming-send-fps",
+        type=float,
+        default=0.0,
+        help="For aura_streaming: WebSocket frame send rate. 0 sends frames as fast as possible.",
+    )
+    g.add_argument(
+        "--omniinteract-streaming-max-frames",
+        type=int,
+        default=16,
+        help=(
+            "For aura_streaming: max sampled frames sent per OmniInteract request. "
+            "Use 16 for stable smoke/perf runs; 0 maps to the server cap and can be slow."
+        ),
+    )
+    g.add_argument(
+        "--omniinteract-streaming-auto-trigger-min-frames",
+        type=int,
+        default=0,
+        help=(
+            "For aura_streaming: AURA auto-trigger threshold. 0 means use all sampled frames "
+            "for a single-turn clip request."
+        ),
+    )
+    g.add_argument(
+        "--omniinteract-streaming-enable-frame-filter",
+        action="store_true",
+        default=False,
+        help="For aura_streaming: enable server-side frame similarity filtering.",
     )
     g.add_argument(
         "--omniinteract-aura-tts-task-type",
@@ -304,7 +341,7 @@ class OmniBenchmarkServingSubcommand(OmniBenchmarkSubcommandBase):
                 if extra:
                     action.choices = list(action.choices) + extra
             if action.dest == "backend" and action.choices is not None:
-                extra = [c for c in ("openai-image-edits-omni",) if c not in action.choices]
+                extra = [c for c in ("openai-image-edits-omni", "openai-video-stream") if c not in action.choices]
                 if extra:
                     action.choices = list(action.choices) + extra
         _extend_omni_dataset_name_choices(parser)

--- a/vllm_omni/entrypoints/cli/benchmark/serve.py
+++ b/vllm_omni/entrypoints/cli/benchmark/serve.py
@@ -131,6 +131,90 @@ def add_seed_tts_cli_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_omniinteract_cli_args(parser: argparse.ArgumentParser) -> None:
+    g = parser.add_argument_group("OmniInteract Dataset Options")
+    g.add_argument(
+        "--omniinteract-root",
+        type=str,
+        default=None,
+        help="Local OmniInteract extracted data root (contains 1q1a/1q1a_math/1qna, or a parent with data/). "
+        "If omitted, benchmark downloads data.tar.gz from --dataset-path/--hf-name (default lucky-lance/OmniInteract).",
+    )
+    g.add_argument(
+        "--omniinteract-subsets",
+        type=str,
+        default="1q1a,1q1a_math,1qna",
+        help="Comma-separated subsets to evaluate, e.g. '1q1a,1q1a_math' or '1qna'.",
+    )
+    g.add_argument(
+        "--omniinteract-inline-local-video",
+        action="store_true",
+        default=False,
+        help="Embed local MP4 as data:video URLs instead of file://. Useful when server lacks "
+        "--allowed-local-media-path; increases request body size.",
+    )
+    g.add_argument(
+        "--omniinteract-input-mode",
+        type=str,
+        choices=["video", "aura"],
+        default="video",
+        help=(
+            "OmniInteract request protocol. 'video' sends subvideo_url + text question with "
+            "mm_processor_kwargs.use_audio_in_video=true. 'aura' sends paired audio_url + "
+            "subvideo_url and AURA/TTS extra_body fields for the ASR -> AURA -> TTS pipeline. "
+            "Generate subvideos/ and audios/ under 1q1a before benchmarking."
+        ),
+    )
+    g.add_argument(
+        "--omniinteract-aura-tts-task-type",
+        type=str,
+        choices=["Base", "CustomVoice"],
+        default="Base",
+        help=(
+            "TTS task type for OmniInteract AURA mode. Base requires "
+            "--omniinteract-aura-tts-ref-audio and --omniinteract-aura-tts-ref-text."
+        ),
+    )
+    g.add_argument(
+        "--omniinteract-aura-tts-language",
+        type=str,
+        default="Chinese",
+        help="TTS language passed to OmniInteract AURA TTS.",
+    )
+    g.add_argument(
+        "--omniinteract-aura-tts-speaker",
+        type=str,
+        default=None,
+        help="TTS speaker passed to OmniInteract AURA CustomVoice mode.",
+    )
+    g.add_argument(
+        "--omniinteract-aura-tts-ref-audio",
+        type=str,
+        default=None,
+        help="Reference audio path/URL for OmniInteract AURA Base TTS mode.",
+    )
+    g.add_argument(
+        "--omniinteract-aura-tts-ref-text",
+        type=str,
+        default=None,
+        help="Reference text transcript for OmniInteract AURA Base TTS mode.",
+    )
+    g.add_argument(
+        "--omniinteract-eval",
+        action="store_true",
+        default=False,
+        help="Compute OmniInteract QA metrics (IA-QTF1/IDS/NCCS). Disabled by default; "
+        "use for accuracy runs. Perf-only runs collect serving metrics only.",
+    )
+    g.add_argument(
+        "--omniinteract-save-eval-items",
+        action="store_true",
+        default=False,
+        help="When --omniinteract-eval is set, include per-request OmniInteract eval rows in "
+        "result JSON as omniinteract_eval_items. Alternatively set OMNIINTERACT_SAVE_EVAL_ITEMS=1.",
+    )
+
+
 def add_omni_benchmark_cli_args(parser: argparse.ArgumentParser) -> None:
     """Add vLLM-Omni specific serving benchmark options."""
     group = parser.add_argument_group("vLLM-Omni Multi-stage Benchmark Options")
@@ -158,6 +242,7 @@ def add_omni_benchmark_cli_args(parser: argparse.ArgumentParser) -> None:
 
 _OMNI_BENCH_DATASET_CHOICES = (
     "daily-omni",
+    "omniinteract",
     "seed-tts",
     "seed-tts-text",
     "seed-tts-design",
@@ -197,6 +282,7 @@ class OmniBenchmarkServingSubcommand(OmniBenchmarkSubcommandBase):
 
         # Add Daily-Omni specific arguments
         add_daily_omni_cli_args(parser)
+        add_omniinteract_cli_args(parser)
         add_seed_tts_cli_args(parser)
         add_omni_benchmark_cli_args(parser)
 
@@ -206,6 +292,7 @@ class OmniBenchmarkServingSubcommand(OmniBenchmarkSubcommandBase):
                     c
                     for c in (
                         "daily-omni",
+                        "omniinteract",
                         "seed-tts",
                         "seed-tts-text",
                         "seed-tts-design",
@@ -260,6 +347,10 @@ class OmniBenchmarkServingSubcommand(OmniBenchmarkSubcommandBase):
     def cmd(args: argparse.Namespace) -> None:
         if getattr(args, "daily_omni_save_eval_items", False):
             os.environ["DAILY_OMNI_SAVE_EVAL_ITEMS"] = "1"
+        if getattr(args, "omniinteract_eval", False):
+            os.environ["OMNIINTERACT_EVAL"] = "1"
+        if getattr(args, "omniinteract_save_eval_items", False):
+            os.environ["OMNIINTERACT_SAVE_EVAL_ITEMS"] = "1"
         if getattr(args, "seed_tts_wer_eval", False):
             os.environ["SEED_TTS_WER_EVAL"] = "1"
         if getattr(args, "seed_tts_wer_save_items", False):

--- a/vllm_omni/entrypoints/openai/serving_video_stream.py
+++ b/vllm_omni/entrypoints/openai/serving_video_stream.py
@@ -133,6 +133,618 @@ class QwenOmniStreamingVideoHandler(OmniStreamingVideoHandlerBase):
     _build_messages = build_engine_prompt
 
 
+class AuraStreamingVideoSessionConfig(StreamingVideoSessionConfig):
+    """Session config for AURA streaming video."""
+
+    auto_trigger: bool = Field(default=True, description="Auto-start a turn after enough frames.")
+    auto_trigger_min_frames: int = Field(default=2, ge=1, description="Minimum buffered frames to auto-trigger.")
+    max_frames_per_round: int = Field(default=16, ge=2, description="Max frames per video_tuple.")
+    pruning_enabled: bool = Field(default=True, description="Enable SessionHistory pruning.")
+    max_rounds: int = Field(default=45, ge=1, description="Sliding-window round limit before pruning.")
+    num_rounds_keep: int = Field(default=30, ge=1, description="Rounds to keep in sliding window after pruning.")
+    max_context_qas: int = Field(default=10, ge=1, description="Max QAs in compressed context history.")
+    max_1qna_rounds: int = Field(default=4, ge=1, description="Max rounds per 1QNA context-history QA.")
+    aura_system_prompt: str | None = Field(default=None, description="Override AURA system prompt.")
+    video_fps: float = Field(default=2.0, gt=0.0, description="FPS metadata for video_tuple.")
+    cross_turn_penalty: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Cross-turn repetition penalty strength (0=disabled, 2.0–3.0 recommended).",
+    )
+    cross_turn_lookback: int = Field(
+        default=2,
+        ge=1,
+        description="Number of recent assistant responses for cross-turn penalty window.",
+    )
+    cross_turn_ngram_sizes: list[int] = Field(
+        default_factory=lambda: [3, 4, 5],
+        description="N-gram sizes for bad_words hard blocking in cross-turn penalty.",
+    )
+    tts_task_type: str = Field(default="Base", description="Qwen3-TTS task type: Base or CustomVoice.")
+    tts_language: str = Field(default="English", description="Qwen3-TTS language.")
+    tts_instruct: str = Field(default="", description="Optional Qwen3-TTS style instruct.")
+    tts_ref_audio: str = Field(
+        default_factory=_default_qwen3_tts_ref_audio_path,
+        description="Base-mode reference audio path (server-visible).",
+    )
+    tts_ref_text: str = Field(
+        default_factory=_default_qwen3_tts_ref_text,
+        description="Base-mode reference audio transcript.",
+    )
+    tts_speaker: str = Field(default="Vivian", description="CustomVoice-mode speaker name.")
+    tts_x_vector_only_mode: bool = Field(
+        default=False,
+        description="Base mode: speaker embedding only (no ICL ref_text conditioning).",
+    )
+    tts_pass_token_ids: bool = Field(
+        default=False,
+        description="Pass AURA assistant token ids to Qwen3-TTS instead of decoded text.",
+    )
+    stream_text_deltas: bool = Field(
+        default=False,
+        description=(
+            "When false (default), accumulate assistant text server-side and only "
+            "emit response.text.done to the client. Audio streaming is unaffected."
+        ),
+    )
+
+
+@dataclass
+class AuraSessionState:
+    """Per-WebSocket session state for AURA streaming."""
+
+    history: SessionHistory
+    turn_frame_arrays: list[np.ndarray]
+    session_id: str = ""
+    cross_turn_penalty: CrossTurnPenalty | None = None
+    pending_turn_video: dict[str, Any] | None = None  # deferred_multi_modal_data for next turn
+
+
+class AuraStreamingVideoHandler(OmniStreamingVideoHandlerBase):
+    """AURA pipeline: frame-only auto trigger (no ``video.query`` / interrupt)."""
+
+    def supports_manual_query_turn(self) -> bool:
+        return False
+
+    def supports_query_interrupt(self) -> bool:
+        return False
+
+    @staticmethod
+    def _tts_additional_information(config: AuraStreamingVideoSessionConfig) -> dict[str, Any]:
+        if "audio" not in config.modalities:
+            return {}
+        info: dict[str, Any] = {
+            "tts_task_type": config.tts_task_type,
+            "tts_language": config.tts_language,
+            "tts_instruct": config.tts_instruct,
+            "tts_x_vector_only_mode": config.tts_x_vector_only_mode,
+            "tts_pass_token_ids": config.tts_pass_token_ids,
+        }
+        if config.tts_task_type == "Base":
+            info["tts_ref_audio"] = config.tts_ref_audio
+            info["tts_ref_text"] = config.tts_ref_text
+        elif config.tts_task_type == "CustomVoice":
+            info["tts_speaker"] = config.tts_speaker
+        return info
+
+    def releases_turn_after_text_done(self) -> bool:
+        return True
+
+    def create_message_history(self, config: StreamingVideoSessionConfig) -> AuraSessionState:
+        aura_config = self._as_aura_config(config)
+        history = SessionHistory(
+            max_rounds=aura_config.max_rounds,
+            num_rounds_keep=aura_config.num_rounds_keep,
+            pruning_enabled=aura_config.pruning_enabled,
+            max_context_qas=aura_config.max_context_qas,
+            max_1qna_rounds=aura_config.max_1qna_rounds,
+            system_prompt=aura_config.aura_system_prompt or DEFAULT_AURA_SYSTEM_PROMPT,
+        )
+        session_id = create_session_id()
+        register_session(session_id, history)
+        return AuraSessionState(history=history, turn_frame_arrays=[], session_id=session_id)
+
+    def on_session_end(self, message_history: Any) -> None:
+        if isinstance(message_history, AuraSessionState) and message_history.session_id:
+            unregister_session(message_history.session_id)
+
+    def should_trigger_turn(self, trigger: VideoStreamTurnTrigger) -> bool:
+        config = self._as_aura_config(trigger.config)
+        if not config.auto_trigger:
+            return False
+        return trigger.frame_count >= config.auto_trigger_min_frames and not trigger.is_turn_locked
+
+    def auto_trigger_frame_count(
+        self,
+        frame_buffer: list[str],
+        message_history: Any,
+    ) -> int:
+        del frame_buffer
+        if isinstance(message_history, AuraSessionState):
+            return len(message_history.turn_frame_arrays)
+        return 0
+
+    def on_frame_buffered(
+        self,
+        raw_bytes: bytes,
+        frame_b64: str,
+        message_history: Any,
+        config: StreamingVideoSessionConfig,
+    ) -> None:
+        del frame_b64, config
+        if not isinstance(message_history, AuraSessionState):
+            return
+        frame = _decode_frame_bytes(raw_bytes)
+        message_history.turn_frame_arrays.append(np.asarray(frame))
+
+    def build_engine_prompt(
+        self,
+        config: StreamingVideoSessionConfig,
+        frame_buffer: list[str],
+        audio_buffer: bytearray,
+        message_history: Any,
+        query_text: str,
+        prewarmed_frames: dict[str, tuple[Any, str]],
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        del frame_buffer, prewarmed_frames
+        aura_config = self._as_aura_config(config)
+        if not isinstance(message_history, AuraSessionState):
+            raise TypeError("AURA streaming requires AuraSessionState message history")
+
+        frames = list(message_history.turn_frame_arrays)
+        video_array, metadata = self._frames_to_video_tuple(
+            frames,
+            fps=aura_config.video_fps,
+            max_frames=aura_config.max_frames_per_round,
+        )
+
+        user_content: list[dict[str, Any]] = []
+        if len(audio_buffer) > 0:
+            wav_b64 = self._pcm_to_wav_b64(bytes(audio_buffer))
+            user_content.append(
+                {
+                    "type": "input_audio",
+                    "input_audio": {
+                        "data": wav_b64,
+                        "format": "wav",
+                    },
+                }
+            )
+        if query_text:
+            user_content.append({"type": "text", "text": query_text})
+
+        user_message: dict[str, Any] = {"role": "user", "content": user_content}
+        messages = [user_message]
+
+        system_prompt = aura_config.aura_system_prompt or DEFAULT_AURA_SYSTEM_PROMPT
+        additional_information: dict[str, Any] = {
+            "aura_session_id": message_history.session_id,
+            "deferred_multi_modal_data": {
+                "video": [(video_array, metadata)],
+            },
+            "aura_system_prompt": [system_prompt],
+            "omni_skip_stages": [0] if len(audio_buffer) == 0 else [],
+        }
+        additional_information.update(self._tts_additional_information(aura_config))
+        user_message[_AURA_ADDITIONAL_INFO_KEY] = additional_information
+
+        return messages, user_message
+
+    def on_turn_complete(
+        self,
+        message_history: Any,
+        user_message: dict[str, Any],
+        response_text: str,
+        request_id: str | None = None,
+    ) -> None:
+        del user_message
+        if not isinstance(message_history, AuraSessionState):
+            return
+
+        from vllm_omni.model_executor.stage_input_processors.aura_omni import (
+            pop_turn_transcript,
+            video_tuple_from_deferred_multi_modal,
+        )
+
+        transcript = pop_turn_transcript(request_id)
+        video_tuple = video_tuple_from_deferred_multi_modal(message_history.pending_turn_video)
+        if video_tuple is None and message_history.turn_frame_arrays:
+            video_tuple = self._frames_to_video_tuple(
+                list(message_history.turn_frame_arrays),
+                fps=2.0,
+                max_frames=16,
+            )
+        if video_tuple is not None or transcript:
+            message_history.history.add_user_message(transcript, video_tuple=video_tuple)
+
+        message_history.pending_turn_video = None
+        normalized = normalize_assistant_text(response_text)
+        message_history.history.add_assistant_message(normalized)
+        message_history.turn_frame_arrays.clear()
+        if message_history.cross_turn_penalty is not None:
+            if is_effectively_silent(response_text):
+                message_history.cross_turn_penalty.record(None)
+            else:
+                message_history.cross_turn_penalty.record(response_text)
+
+    @staticmethod
+    def _merge_penalty_sampling_params(
+        sampling_params_list: list[dict[str, Any]] | None,
+        penalty_kwargs: dict[str, Any],
+        *,
+        stage_index: int = 1,
+        num_stages: int = 4,
+    ) -> list[dict[str, Any]]:
+        if not penalty_kwargs:
+            return list(sampling_params_list or [])
+        params = [dict(stage) for stage in (sampling_params_list or [])]
+        while len(params) < num_stages:
+            params.append({})
+        stage_params = dict(params[stage_index])
+        if "logit_bias" in penalty_kwargs:
+            merged_bias = dict(stage_params.get("logit_bias") or {})
+            merged_bias.update(penalty_kwargs["logit_bias"])
+            stage_params["logit_bias"] = merged_bias
+        if "bad_words" in penalty_kwargs:
+            merged_bad = list(stage_params.get("bad_words") or [])
+            merged_bad.extend(penalty_kwargs["bad_words"])
+            stage_params["bad_words"] = merged_bad
+        params[stage_index] = stage_params
+        return params
+
+    async def _ensure_cross_turn_penalty(
+        self,
+        config: AuraStreamingVideoSessionConfig,
+        message_history: AuraSessionState,
+    ) -> CrossTurnPenalty | None:
+        if message_history.cross_turn_penalty is not None:
+            return message_history.cross_turn_penalty
+        if config.cross_turn_penalty <= 0 or self._engine_client is None:
+            return None
+        try:
+            tokenizer = await self._engine_client.get_tokenizer()
+        except Exception:
+            return None
+        message_history.cross_turn_penalty = CrossTurnPenalty(
+            tokenizer,
+            window=config.cross_turn_lookback,
+            logit_penalty=config.cross_turn_penalty,
+            ngram_sizes=config.cross_turn_ngram_sizes,
+        )
+        return message_history.cross_turn_penalty
+
+    async def _receive_config(self, websocket) -> StreamingVideoSessionConfig | None:
+        import asyncio
+        import json
+
+        from pydantic import ValidationError
+
+        try:
+            raw = await asyncio.wait_for(websocket.receive_text(), timeout=self._config_timeout)
+        except asyncio.TimeoutError:
+            await self._send_error(websocket, "Timeout waiting for session.config")
+            return None
+
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            await self._send_error(websocket, "Invalid JSON in session.config")
+            return None
+
+        if not isinstance(msg, dict) or msg.get("type") != "session.config":
+            await self._send_error(
+                websocket,
+                f"Expected session.config, got: {msg.get('type') if isinstance(msg, dict) else type(msg).__name__}",
+            )
+            return None
+
+        config_data = {k: v for k, v in msg.items() if k != "type"}
+        alias_map = {
+            "num_sample_frames": "num_frames",
+            "evs_enabled": "enable_frame_filter",
+            "evs_threshold": "frame_filter_threshold",
+        }
+        for old_key, new_key in alias_map.items():
+            if old_key in config_data and new_key not in config_data:
+                config_data[new_key] = config_data[old_key]
+
+        try:
+            return AuraStreamingVideoSessionConfig(**config_data)
+        except ValidationError as e:
+            await self._send_error(websocket, f"Invalid session config: {e}")
+            return None
+
+    async def _process_query_engine(
+        self,
+        websocket,
+        config: StreamingVideoSessionConfig,
+        frame_buffer: list[str],
+        audio_buffer: bytearray,
+        message_history: list[dict[str, Any]],
+        query_text: str,
+        request_id: str,
+        interrupt_event,
+        prewarmed_frames: dict[str, tuple[Any, str]],
+        release_turn_lock=None,
+    ) -> None:
+        from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+
+        if self._engine_client is None:
+            await self._send_error(websocket, "Streaming video requires an engine client")
+            return
+
+        messages, user_message = self.build_engine_prompt(
+            config,
+            frame_buffer,
+            audio_buffer,
+            message_history,
+            query_text,
+            prewarmed_frames,
+        )
+        additional_information = user_message.pop(_AURA_ADDITIONAL_INFO_KEY, None)
+
+        if isinstance(message_history, AuraSessionState) and isinstance(additional_information, dict):
+            deferred = additional_information.get("deferred_multi_modal_data")
+            message_history.pending_turn_video = deferred if isinstance(deferred, dict) else None
+
+        aura_config = self._as_aura_config(config)
+        penalty_kwargs: dict[str, Any] = {}
+        if isinstance(message_history, AuraSessionState):
+            penalty = await self._ensure_cross_turn_penalty(aura_config, message_history)
+            if penalty is not None:
+                penalty_kwargs = penalty.build_sampling_kwargs()
+
+        request_kwargs: dict[str, Any] = {
+            "model": config.model or "default",
+            "messages": messages,
+            "stream": True,
+            "modalities": config.modalities,
+            "add_generation_prompt": True,
+            "continue_final_message": False,
+            "add_special_tokens": False,
+        }
+        if config.sampling_params_list or penalty_kwargs:
+            request_kwargs["sampling_params_list"] = self._merge_penalty_sampling_params(
+                config.sampling_params_list,
+                penalty_kwargs,
+            )
+
+        try:
+            chat_request = ChatCompletionRequest(**request_kwargs)
+        except Exception as e:
+            await self._send_error(websocket, f"Failed to build request: {e}")
+            return
+
+        if isinstance(additional_information, dict):
+            chat_request.additional_information = additional_information  # type: ignore[attr-defined]
+
+        try:
+            engine_prompt = await self._preprocess_to_engine_prompt(chat_request)
+        except Exception as e:
+            await self._send_error(websocket, f"Preprocess failed: {e}")
+            return
+
+        await self._run_engine_generation(
+            websocket,
+            config,
+            message_history,
+            user_message,
+            request_id,
+            interrupt_event,
+            engine_prompt,
+            release_turn_lock=release_turn_lock,
+        )
+
+    async def _run_engine_generation(
+        self,
+        websocket,
+        config: StreamingVideoSessionConfig,
+        message_history: Any,
+        user_message: dict[str, Any],
+        request_id: str,
+        interrupt_event,
+        engine_prompt: Any,
+        release_turn_lock=None,
+    ) -> None:
+        """Stream engine outputs; release turn lock after assistant text when configured."""
+        import time as _time
+
+        from vllm_omni.entrypoints.openai import video_stream_envs
+        from vllm_omni.outputs import OmniRequestOutput
+
+        await websocket.send_json({"type": "response.start"})
+        text_parts: list[str] = []
+        text_done_sent = False
+        turn_lock_released = False
+        audio_chunk_count = 0
+        audio_chunks_drained = 0
+        previous_text = ""
+        interrupted = False
+        t_start = _time.monotonic()
+        t_first_text = None
+        t_first_audio = None
+
+        async_chunk_mode = video_stream_envs.VLLM_VIDEO_ASYNC_CHUNK
+        streaming = async_chunk_mode == "on"
+        aura_config = self._as_aura_config(config)
+        stream_text_deltas = aura_config.stream_text_deltas
+        audio_tail_tensors: list[Any] = []
+        last_text_metrics: dict[str, Any] | None = None
+        last_audio_metrics: dict[str, Any] | None = None
+
+        def _event_metrics(output: OmniRequestOutput | None) -> dict[str, Any] | None:
+            if not getattr(config, "return_stage_metrics", False) or output is None:
+                return None
+            metrics = getattr(output, "metrics", None)
+            return metrics if isinstance(metrics, dict) else None
+
+        def _with_metrics(payload: dict[str, Any], metrics: dict[str, Any] | None) -> dict[str, Any]:
+            if metrics:
+                payload["metrics"] = metrics
+            return payload
+
+        async def _try_release_turn_lock(full_text: str) -> None:
+            nonlocal turn_lock_released
+            if release_turn_lock is None or turn_lock_released:
+                return
+            turn_lock_released = True
+            await release_turn_lock(
+                message_history=message_history,
+                user_message=user_message,
+                response_text=full_text,
+                request_id=request_id,
+            )
+
+        try:
+            result_gen = self._engine_client.generate(
+                prompt=engine_prompt,
+                request_id=request_id,
+                output_modalities=config.modalities,
+            )
+
+            async for output in result_gen:
+                if interrupt_event.is_set():
+                    if not interrupted:
+                        interrupted = True
+                    continue
+
+                if not isinstance(output, OmniRequestOutput):
+                    continue
+
+                out_type = getattr(output, "final_output_type", "text")
+                metrics = _event_metrics(output)
+
+                if out_type == "audio":
+                    if streaming and not text_done_sent:
+                        full_text = "".join(text_parts)
+                        await websocket.send_json(
+                            _with_metrics({"type": "response.text.done", "text": full_text}, last_text_metrics)
+                        )
+                        text_done_sent = True
+                        await _try_release_turn_lock(full_text)
+
+                    if t_first_audio is None:
+                        t_first_audio = _time.monotonic()
+                    audio_chunk_count += 1
+                    last_audio_metrics = metrics or last_audio_metrics
+                    if streaming:
+                        b64, audio_chunks_drained = self._extract_audio_delta_b64(
+                            output,
+                            audio_chunks_drained,
+                        )
+                        if b64:
+                            await websocket.send_json(
+                                _with_metrics(
+                                    {
+                                        "type": "response.audio.delta",
+                                        "data": b64,
+                                        "format": "wav",
+                                    },
+                                    metrics,
+                                )
+                            )
+                    else:
+                        audio_data = self._get_audio_data(output)
+                        if audio_data is not None:
+                            audio_tail_tensors = list(audio_data) if isinstance(audio_data, list) else [audio_data]
+                else:
+                    last_text_metrics = metrics or last_text_metrics
+                    delta_text, previous_text = self._extract_text_delta(output, previous_text)
+                    if delta_text:
+                        if t_first_text is None:
+                            t_first_text = _time.monotonic()
+                        text_parts.append(delta_text)
+                        if streaming and stream_text_deltas:
+                            await websocket.send_json(
+                                _with_metrics({"type": "response.text.delta", "delta": delta_text}, metrics)
+                            )
+
+            if not text_done_sent:
+                full_text = "".join(text_parts)
+                await websocket.send_json(
+                    _with_metrics({"type": "response.text.done", "text": full_text}, last_text_metrics)
+                )
+                text_done_sent = True
+                await _try_release_turn_lock(full_text)
+
+            if not streaming and audio_tail_tensors:
+                import torch
+
+                try:
+                    coalesced = (
+                        audio_tail_tensors[0] if len(audio_tail_tensors) == 1 else torch.cat(audio_tail_tensors, dim=-1)
+                    )
+                    tail_np = self._tensor_to_1d_np(coalesced)
+                    b64, _ = self._encode_tail(tail_np, 0, new_drained=len(audio_tail_tensors), is_first=True)
+                    if b64:
+                        await websocket.send_json(
+                            _with_metrics(
+                                {
+                                    "type": "response.audio.delta",
+                                    "data": b64,
+                                    "format": "wav",
+                                },
+                                last_audio_metrics,
+                            )
+                        )
+                except Exception:
+                    pass
+
+            if audio_chunk_count > 0:
+                await websocket.send_json(_with_metrics({"type": "response.audio.done"}, last_audio_metrics))
+
+            if release_turn_lock is None and not turn_lock_released:
+                response_text = "".join(text_parts)
+                self.on_turn_complete(message_history, user_message, response_text, request_id)
+
+            t_end = _time.monotonic()
+            del t_start, t_first_text, t_first_audio, t_end
+
+        except Exception:
+            await self._send_error(websocket, "Query processing failed")
+
+        if not text_done_sent:
+            full_text = "".join(text_parts)
+            await websocket.send_json(_with_metrics({"type": "response.text.done", "text": full_text}, last_text_metrics))
+
+    @staticmethod
+    def _as_aura_config(config: StreamingVideoSessionConfig) -> AuraStreamingVideoSessionConfig:
+        if isinstance(config, AuraStreamingVideoSessionConfig):
+            return config
+        return AuraStreamingVideoSessionConfig(**config.model_dump())
+
+    @staticmethod
+    def _frames_to_video_tuple(
+        frames: list[np.ndarray],
+        *,
+        fps: float,
+        max_frames: int,
+    ) -> tuple[np.ndarray, dict[str, Any]]:
+        if not frames:
+            raise ValueError("At least one frame is required to build video_tuple")
+
+        selected = list(frames[-max_frames:])
+        if len(selected) == 1:
+            all_frames = np.stack([selected[0], selected[0]], axis=0)
+        else:
+            all_frames = np.stack(selected, axis=0)
+
+        if all_frames.shape[0] < 2:
+            all_frames = np.concatenate([all_frames, all_frames], axis=0)[:2]
+        elif all_frames.shape[0] > max_frames:
+            all_frames = all_frames[-max_frames:]
+
+        metadata = {
+            "fps": fps,
+            "duration": all_frames.shape[0] / fps,
+            "total_num_frames": int(all_frames.shape[0]),
+            "frames_indices": list(range(all_frames.shape[0])),
+            "video_backend": "opencv",
+            "do_sample_frames": False,
+        }
+        return all_frames, metadata
+
+
 def create_streaming_video_handler(
     chat_service: Any,
     idle_timeout: float = _DEFAULT_IDLE_TIMEOUT,

--- a/vllm_omni/entrypoints/openai/video_stream_base.py
+++ b/vllm_omni/entrypoints/openai/video_stream_base.py
@@ -141,6 +141,10 @@ class StreamingVideoSessionConfig(BaseModel):
         default=True,
         description="EVS pixel-similarity pre-filter to drop near-duplicate frames.",
     )
+    return_stage_metrics: bool = Field(
+        default=False,
+        description="Include per-stage engine metrics in WebSocket response events.",
+    )
     frame_filter_threshold: float = Field(
         default=0.95,
         ge=0.0,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Add support for https://github.com/Lucky-Lance/OmniInteract  

OmniInteract is a benchmark for evaluating real-time omnimodal LLMs through online streaming inference over continuous audio-visual streams. The benchmark is built on an interaction slot formulation, where each slot defines a trigger (response opportunity), a valid response window, and a target answer.

The dataset contains 250 videos with 1,430 temporally grounded response slots: 
- 1Q1A : split (1,062 slots across 210 videos) covers real-time (explicit user queries), proactive (event-driven responses), and nested (inserted queries within ongoing interactions) scenarios.
- 1QnA:  split (368 slots across 40 videos) evaluates continuous task monitoring where a single instruction requires multiple temporally grounded responses. 

Key evaluation metrics:
- Interaction-Aware Quality-Timeliness F1 (IA-QTF1): jointly measures response correctness, timing, and flow-breaking behaviors (e.g., hallucinations, spillover).
- Interruption Diagnostic Suite (IDS):  assesses no-output rate, partial answer quality, and conditional spill during interruptions.
- Nested Chain Completion Score (NCCS): measures a model's ability to answer an inner query and then resume the outer query. 

## Test Plan
con=1/32reqs
each reqs: ~20s video clips+2s audio questions

## Test Result
<img width="702" height="1256" alt="1975762cb103fac05a366eb42c7319d5" src="https://github.com/user-attachments/assets/59ef3fc5-780a-4851-9d54-fa188ae04c69" />
<img width="728" height="1720" alt="30794098c12f4947cd9d83c89717712d" src="https://github.com/user-attachments/assets/b37ab572-d986-47d4-9b1e-584da2cc330a" />
<img width="692" height="504" alt="680a902f771f24509e4e97f64577debb" src="https://github.com/user-attachments/assets/7c1e60a7-5fb2-401a-9d75-aa934e0bf106" />




**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
