### PR TITLE
[BugFix] Include Omni CLI fields in startup non-default args logging

### DIFF
--- a/tests/entrypoints/test_async_omni_diffusion_config.py
+++ b/tests/entrypoints/test_async_omni_diffusion_config.py
@@ -258,6 +258,55 @@ def test_serve_cli_accepts_diffusion_pipeline_profiler_flag():
     assert stage_cfg["engine_args"]["enable_diffusion_pipeline_profiler"] is True
 
 
+def test_omni_non_default_args_include_omni_cli_fields(monkeypatch: pytest.MonkeyPatch):
+    """Ensure Omni startup logging diffs against Omni parser defaults."""
+    import vllm.entrypoints.utils as vllm_entrypoint_utils
+    from vllm.entrypoints.openai import api_server as openai_api_server
+
+    parser = TrackingArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    OmniServeCommand().subparser_init(subparsers)
+
+    args = parser.parse_args(
+        [
+            "serve",
+            "/tmp/model",
+            "--omni",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "18001",
+            "--usp",
+            "2",
+            "--ring-degree",
+            "4",
+            "--cfg-parallel-size",
+            "2",
+        ]
+    )
+    args.model = args.model_tag
+
+    logged: list[dict[str, object]] = []
+
+    def _capture(msg: str, payload: dict[str, object]) -> None:
+        assert msg == "non-default args: %s"
+        logged.append(payload)
+
+    monkeypatch.setattr(vllm_entrypoint_utils.logger, "info", _capture)
+    openai_api_server.log_non_default_args(args)
+
+    payload = logged[-1]
+
+    assert payload["model_tag"] == "/tmp/model"
+    assert payload["model"] == "/tmp/model"
+    assert payload["host"] == "127.0.0.1"
+    assert payload["port"] == 18001
+    assert payload["omni"] is True
+    assert payload["ulysses_degree"] == 2
+    assert payload["ring_degree"] == 4
+    assert payload["cfg_parallel_size"] == 2
+
+
 def test_serve_cli_accepts_diffusion_attention_backend():
     """Ensure diffusion serve CLI exposes the shorthand backend flag."""
     parser = TrackingArgumentParser()

--- a/vllm_omni/patch.py
+++ b/vllm_omni/patch.py
@@ -1,9 +1,12 @@
 import logging
 import os
 import sys
+from argparse import Namespace
 from functools import cached_property
 
 import torch
+import vllm.entrypoints.openai.api_server as _vllm_openai_api_server
+import vllm.entrypoints.utils as _vllm_entrypoint_utils
 from aenum import extend_enum
 from vllm.config import ModelConfig as _OriginalModelConfig
 from vllm.inputs import TokensPrompt as _OriginalTokensPrompt
@@ -22,6 +25,7 @@ from vllm_omni.engine import OmniEngineCoreOutput, OmniEngineCoreOutputs, OmniEn
 from vllm_omni.inputs.data import OmniTokensPrompt
 from vllm_omni.model_executor.layers.rotary_embedding import OmniMRotaryEmbedding
 from vllm_omni.request import OmniRequest, OmniStreamingUpdate
+from vllm_omni.utils.tracking_parser import TrackingArgumentParser, TrackingNamespace
 
 _PATCH_LOGGER = logging.getLogger("vllm_omni.patch")
 
@@ -417,3 +421,48 @@ def _patch_fp8_use_quack_fused_bias():
 
 
 _patch_fp8_use_quack_fused_bias()
+
+
+# =============================================================================
+# Patch OpenAI startup non-default args logging for Omni CLI
+# =============================================================================
+# WHY: Omni extends the serve CLI with additional overridable flags, but
+# upstream startup logging diffs against the upstream serve parser defaults
+# only, so omni-only args never appear in `non-default args: {...}`. Rebuild
+# the baseline from Omni's full serve parser to keep the upstream log format
+# while including Omni CLI overrides.
+#
+# REMOVAL: Remove this patch once upstream vLLM supports passing the parser
+# (or parser defaults) into this log path, so the startup diff can be computed
+# against the full Omni-aware CLI schema without patching the OpenAI server.
+_original_openai_log_non_default_args = _vllm_openai_api_server.log_non_default_args
+
+
+def _build_omni_serve_default_namespace() -> TrackingNamespace:
+    """Build the Omni serve parser's default namespace."""
+    from vllm_omni.entrypoints.cli.serve import OmniServeCommand
+
+    parser = TrackingArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    OmniServeCommand().subparser_init(subparsers)
+    return parser.parse_args(["serve"])
+
+
+def _patched_openai_log_non_default_args(args: Namespace) -> None:
+    """Use Omni's parser defaults for --omni startup logging."""
+    if not getattr(args, "omni", False) or not isinstance(args, TrackingNamespace):
+        _original_openai_log_non_default_args(args)
+        return
+
+    default_args = _build_omni_serve_default_namespace()
+    non_default_args: dict[str, object] = {}
+    for arg, default in vars(default_args).items():
+        if not hasattr(args, arg):
+            continue
+        current = getattr(args, arg)
+        if current != default:
+            non_default_args[arg] = current
+    _vllm_entrypoint_utils.logger.info("non-default args: %s", non_default_args)
+
+
+_vllm_openai_api_server.log_non_default_args = _patched_openai_log_non_default_args


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

There is currently a startup log line from upstream vLLM:

```text
non-default args: {'model_tag': '/home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B', 'host': '127.0.0.1', 'port': 18011, 'model': '/home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B', 'tensor_parallel_size': 2}
```

Its purpose is to print the non-default startup arguments, which is useful for confirming the effective startup inputs and for debugging.

However, under the `--omni` path, this log currently only includes non-default fields known to the **upstream vLLM parser**, and does not include Omni-specific fields that are also allowed to be overridden from CLI. This causes two problems:

- it can mislead users into thinking those Omni CLI overrides were not applied
- it makes debugging harder, especially for deploy config, stage overrides, and parallelism-related settings

For example, Omni CLI flags such as `--deploy-config`, `--omni`, `--usp`, `--ring-degree`, and `--cfg-parallel-size` may be explicitly passed but still not appear in this log.

The root cause is that upstream `log_non_default_args()` / `get_non_default_args()` rebuilds the startup diff against the **upstream serve parser defaults only**, instead of using the actual parser schema used by the caller:

```python
def get_non_default_args(args: Namespace | EngineArgs) -> dict[str, Any]:
    from vllm.entrypoints.openai.cli_args import make_arg_parser

    non_default_args = {}

    # Handle Namespace
    if isinstance(args, Namespace):
        parser = make_arg_parser(FlexibleArgumentParser())
        for arg, default in vars(parser.parse_args([])).items():
            if default != getattr(args, arg):
                non_default_args[arg] = getattr(args, arg)
```

In the Omni path, although we already have our own `TrackingArgumentParser` (which inherits from `FlexibleArgumentParser`) and defines additional Omni CLI fields, this upstream helper does not accept a parser instance or a default snapshot as input. Instead, it always constructs its own parser internally, so it naturally only sees upstream parser fields.

In Omni startup flow, for example:

```python
# OMNI: Pass supported_tasks to build_app (required by upstream vLLM)
app = build_openai_app(args, supported_tasks)
```

the code still eventually goes through this upstream logging path. As a result, if we want this startup log to correctly include Omni CLI non-default fields, the practical solution for now is to add a patch.

This PR adds that patch. The implementation keeps the same strategy as upstream:

- construct a parser
- get its default namespace
- diff it against the current `args`

but under `--omni`, it rebuilds the default baseline from Omni’s full serve CLI schema (`TrackingArgumentParser` / Omni serve parser) instead of the upstream-only parser.

The log format is intentionally preserved:

```text
non-default args: {'model_tag': '/home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B', 'host': '127.0.0.1', 'port': 18011, 'model': '/home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B', 'tensor_parallel_size': 2, 'omni': True, 'deploy_config': '/home/liwenxiao/vllm-omni/tests/.ci_generated/qwen2_5_omni_thinker_only.yaml', 'stage_overrides': '{"0":{"devices":"0,1"}}'}
```

This allows the startup log to cover both:

- non-default fields from upstream vLLM CLI
- non-default Omni-specific CLI override fields

Scope is intentionally narrow:

- only affects the OpenAI server startup `non-default args` log under `--omni`
- keeps non-Omni behavior unchanged
- does not include deploy-YAML-resolved values or derived runtime values

## Test Plan

- Added a unit test that builds the real Omni serve parser, parses explicit Omni CLI flags, and verifies that the patched startup `non-default args` log includes both upstream and Omni CLI fields.
- Ran targeted test:
  - `python -m pytest tests/entrypoints/test_serve.py'`
- Manually validated startup logging and confirmed the startup log now includes Omni CLI overrides in the same `non-default args` line.

**vLLM Version:**
`0.22.0`

**vLLM-Omni Commit:**
`8c9b4d6a`

## Test Result
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
====================================================== 10 passed, 21 warnings in 2.05s =======================================================
```

### Before
```
(vllm-omni) (base) liwenxiao@cdipc03-B360M-D3H:~/vllm-omni$ vllm serve /home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B   --omni   --deploy-config /home/liwenxiao/vllm-omni/tests/.ci_generated/qwen2_5_omni_thinker_only.yaml   --stage-overrides "{\"0\":{\"devices\":\"0,1\"}}"   --tensor-parallel-size 2   --host 127.0.0.1   --port 18011
WARNING 06-11 20:18:21 [config.py:70] Support for Transformers v4 is deprecated. The Transformers v4 codepath will become unmaintained in vLLM v0.22.0 and will be removed in vLLM v0.24.0. Please upgrade to Transformers v5: pip install --upgrade transformers
/home/liwenxiao/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
 --> vLLM-Omni version 0.19.0rc2.dev301+g50145e166
 --> vLLM version 0.22.0
This will likely cause compatibility issues.
  warn_if_misaligned_vllm_version()
WARNING 06-11 20:18:23 [patch.py:169] Monkey-patched unregister_vllm_metrics() to scope drops to non-omni vllm:* collectors. Remove this patch once vLLM adds _STAT_LOGGER_METRIC_NAMES.
INFO 06-11 20:18:25 [main.py:51] Delegating entrypoint handling to vllm-omni
INFO 06-11 20:18:25 [logo.py:52]        █     █     █▄   ▄█       ▄▀▀▀▀▄ █▄   ▄█ █▄    █ ▀█▀ 
INFO 06-11 20:18:25 [logo.py:52]  ▄▄ ▄█ █     █     █ ▀▄▀ █  ▄▄▄  █    █ █ ▀▄▀ █ █ ▀▄  █  █  
INFO 06-11 20:18:25 [logo.py:52]   █▄█▀ █     █     █     █       █    █ █     █ █   ▀▄█  █  
INFO 06-11 20:18:25 [logo.py:52]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀        ▀▀▀▀  ▀     ▀ ▀     ▀ ▀▀▀ 
INFO 06-11 20:18:25 [logo.py:52] 
(APIServer pid=2509765) INFO 06-11 20:18:25 [utils.py:344] vLLM server version 0.22.0, serving model /home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B
(APIServer pid=2509765) INFO 06-11 20:18:25 [utils.py:278] non-default args: {'model_tag': '/home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B', 'host': '127.0.0.1', 'port': 18011, 'model': '/home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B', 'tensor_parallel_size': 2}

```
### After

```
(vllm-omni) (base) liwenxiao@cdipc03-B360M-D3H:~/vllm-omni$ vllm serve /home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B \
  --omni \
  --deploy-config /home/liwenxiao/vllm-omni/tests/.ci_generated/qwen2_5_omni_thinker_only.yaml \
  --stage-overrides "{\"0\":{\"devices\":\"0,1\"}}" \
  --tensor-parallel-size 2 \
  --host 127.0.0.1 \
  --port 18011
WARNING 06-11 20:17:02 [config.py:70] Support for Transformers v4 is deprecated. The Transformers v4 codepath will become unmaintained in vLLM v0.22.0 and will be removed in vLLM v0.24.0. Please upgrade to Transformers v5: pip install --upgrade transformers
/home/liwenxiao/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
 --> vLLM-Omni version 0.19.0rc2.dev301+g50145e166
 --> vLLM version 0.22.0
This will likely cause compatibility issues.
  warn_if_misaligned_vllm_version()
WARNING 06-11 20:17:05 [patch.py:169] Monkey-patched unregister_vllm_metrics() to scope drops to non-omni vllm:* collectors. Remove this patch once vLLM adds _STAT_LOGGER_METRIC_NAMES.
INFO 06-11 20:17:06 [main.py:51] Delegating entrypoint handling to vllm-omni
INFO 06-11 20:17:06 [logo.py:52]        █     █     █▄   ▄█       ▄▀▀▀▀▄ █▄   ▄█ █▄    █ ▀█▀ 
INFO 06-11 20:17:06 [logo.py:52]  ▄▄ ▄█ █     █     █ ▀▄▀ █  ▄▄▄  █    █ █ ▀▄▀ █ █ ▀▄  █  █  
INFO 06-11 20:17:06 [logo.py:52]   █▄█▀ █     █     █     █       █    █ █     █ █   ▀▄█  █  
INFO 06-11 20:17:06 [logo.py:52]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀        ▀▀▀▀  ▀     ▀ ▀     ▀ ▀▀▀ 
INFO 06-11 20:17:06 [logo.py:52] 
(APIServer pid=2509352) INFO 06-11 20:17:06 [utils.py:344] vLLM server version 0.22.0, serving model /home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B
(APIServer pid=2509352) INFO 06-11 20:17:06 [patch.py:236] non-default args: {'model_tag': '/home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B', 'host': '127.0.0.1', 'port': 18011, 'model': '/home/liwenxiao/models/Qwen/Qwen2.5-Omni-3B', 'tensor_parallel_size': 2, 'omni': True, 'deploy_config': '/home/liwenxiao/vllm-omni/tests/.ci_generated/qwen2_5_omni_thinker_only.yaml', 'stage_overrides': '{"0":{"devices":"0,1"}}'}
```
**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
