### PR TITLE
[platform] fix: set UnspecifiedOmniPlatform device_type to cpu

### DIFF
--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -241,7 +241,7 @@ class OmniPlatform(Platform):
 class UnspecifiedOmniPlatform(OmniPlatform):
     _omni_enum = OmniPlatformEnum.UNSPECIFIED
     _enum = PlatformEnum.UNSPECIFIED
-    device_type = ""
+    device_type = "cpu"
 
     @classmethod
     def get_device_count(cls) -> int:


### PR DESCRIPTION
## Purpose
Set `device_type` of `UnspecifiedOmniPlatform` to `"cpu"` instead of `""`. 
This prevents `RuntimeError: Device string must not be empty` when importing modules with `torch.amp.autocast` on CPU-only/unspecified environments (e.g., CPU CI environments).

## Test Plan
Run `verl-omni`'s CPU unit tests which import `vllm-omni` on a CPU-only environment.

**vLLM Version:**
v0.22.0

**vLLM-Omni Commit:**
85e37338553b81c1ae90b377d8e634b2d76c8b11

## Test Result
CPU unit tests in `verl-omni` now successfully collect and pass.