### PR TITLE
[Model][MIMO Audio] Unify sync/async code2wav into single path

### DIFF
--- a/tests/e2e/online_serving/test_mimo_audio_expansion.py
+++ b/tests/e2e/online_serving/test_mimo_audio_expansion.py
@@ -4,6 +4,7 @@
 E2E expansion tests for MiMo-Audio online serving (nightly Omni · Function Test with H100).
 """
 
+import itertools
 import os
 from pathlib import Path
 
@@ -46,15 +47,30 @@ try:
     tokenizer_path = download_tokenizer()
     os.environ["MIMO_AUDIO_TOKENIZER_PATH"] = tokenizer_path
 
-    test_params = [
-        OmniServerParams(
-            model=model,
-            stage_config_path=stage_config,
-            server_args=["--chat-template", CHAT_TEMPLATE_PATH],
+    test_params = list(
+        itertools.chain.from_iterable(
+            [
+                pytest.param(
+                    OmniServerParams(
+                        model=model,
+                        stage_config_path=stage_config,
+                        server_args=["--chat-template", CHAT_TEMPLATE_PATH],
+                    ),
+                    id="async_chunk",
+                ),
+                pytest.param(
+                    OmniServerParams(
+                        model=model,
+                        stage_config_path=stage_config,
+                        server_args=["--chat-template", CHAT_TEMPLATE_PATH, "--no-async-chunk"],
+                    ),
+                    id="no_async_chunk",
+                ),
+            ]
+            for model in models
+            for stage_config in stage_configs
         )
-        for model in models
-        for stage_config in stage_configs
-    ]
+    )
 except Exception as exc:
     pytest.skip(
         f"MiMo-Audio expansion tests skipped: module setup failed ({type(exc).__name__}: {exc})",
@@ -100,7 +116,6 @@ def test_text_to_text_001(omni_server, openai_client) -> None:
 
 @hardware_test(res={"cuda": "H100", "rocm": "MI325"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", test_params, indirect=True)
-@pytest.mark.skip(reason="CI failed 8571")
 def test_audio_to_text_audio_001(omni_server, openai_client) -> None:
     """
     Test audio and text input processing and text/audio output generation via OpenAI API.

--- a/tests/model_executor/models/mimo_audio/test_mimo_audio_code2wav_batch_decode.py
+++ b/tests/model_executor/models/mimo_audio/test_mimo_audio_code2wav_batch_decode.py
@@ -13,6 +13,21 @@ pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 _GROUP = 4
 _AC = 8
 _FTP = 2 * 2 * 240  # frames_per_token from mocked tokenizer.config
+_TOTAL_UPSAMPLE = _FTP * _GROUP
+
+# left_context values:
+#   0 → sync path, no stripping, full waveform returned
+#   1 → partial strip on 2+ group inputs (drop < waveform), full strip on 1-group
+#   5 → full strip on all test inputs (drop >= waveform), output is empty
+left_context_params = pytest.mark.parametrize(
+    "left_context",
+    [0, 1, 5],
+    ids=["sync", "partial_strip", "full_strip"],
+)
+
+
+def _expected_len(num_tokens: int, left_context: int) -> int:
+    return max(0, num_tokens * _FTP - left_context * _TOTAL_UPSAMPLE)
 
 
 @functools.lru_cache(maxsize=1)
@@ -75,6 +90,7 @@ def _minimal_model(mocker: MockerFixture):
     model.config = SimpleNamespace(group_size=_GROUP, audio_channels=_AC)
     model.streamer_config = AudioStreamerConfig(group_size=_GROUP, audio_channels=_AC)
     model.codes = _codes_ns()
+    model.total_upsample = _TOTAL_UPSAMPLE
 
     decode_vq = mocker.Mock(
         side_effect=lambda audio_codes: torch.ones(
@@ -95,17 +111,19 @@ def _minimal_model(mocker: MockerFixture):
     return model, audio_tok
 
 
-def test_batch_decode_waveforms_empty_input_list(mocker: MockerFixture):
+@left_context_params
+def test_batch_decode_waveforms_empty_input_list(mocker: MockerFixture, left_context: int):
     """Empty input list returns a single zero-length float32 tensor on model device."""
     model, _ = _minimal_model(mocker)
-    out = _mimo_t2w_cls()._batch_decode_waveforms(model, [])
+    out = _mimo_t2w_cls()._batch_chunked_decode_streaming(model, [])
     assert len(out) == 1
     assert out[0].dtype == torch.float32
     assert out[0].numel() == 0
     assert out[0].device == model.device
 
 
-def test_batch_decode_waveforms_single_vs_multiple_decoder_shapes(mocker: MockerFixture):
+@left_context_params
+def test_batch_decode_waveforms_single_vs_multiple_decoder_shapes(mocker: MockerFixture, left_context: int):
     """Single and multi-request batches produce correctly shaped packed hidden states and trimmed waveforms."""
     model, audio_tok = _minimal_model(mocker)
     decoder = audio_tok.decoder
@@ -113,29 +131,39 @@ def test_batch_decode_waveforms_single_vs_multiple_decoder_shapes(mocker: Mocker
     # Single valid request: decoder output rank-3 for double squeeze path
     flat = _make_valid_flat_codes(1)
     decoder.return_value = torch.ones(1, 1, 4 * _FTP + 100, dtype=torch.float32)
-    out1 = _mimo_t2w_cls()._batch_decode_waveforms(model, [flat])
+    out1 = _mimo_t2w_cls()._batch_chunked_decode_streaming(
+        model,
+        [flat],
+        per_req_left_context_frames=[left_context],
+    )
     decoder.assert_called_once()
     packed_hs, input_lengths = decoder.call_args[0]
     assert packed_hs.shape == (4, 7)  # T from decode_vq mock
     assert input_lengths.tolist() == [4]
-    assert out1[0].shape == (4 * _FTP,)
+    assert out1[0].numel() == _expected_len(4, left_context)
     assert out1[0].dtype == torch.float32
 
+    # Multi-request batch
     decoder.reset_mock()
     a = _make_valid_flat_codes(1)
     b = _make_valid_flat_codes(2)
     decoder.return_value = torch.ones(2, 1, 8 * _FTP + 100, dtype=torch.float32)
-    out2 = _mimo_t2w_cls()._batch_decode_waveforms(model, [a, b])
+    out2 = _mimo_t2w_cls()._batch_chunked_decode_streaming(
+        model,
+        [a, b],
+        per_req_left_context_frames=[left_context, left_context],
+    )
     decoder.assert_called_once()
     packed_hs2, input_lengths2 = decoder.call_args[0]
     assert packed_hs2.shape == (4 + 8, 7)  # 1 group -> T=4; 2 groups -> T=8
     assert input_lengths2.tolist() == [4, 8]
     assert len(out2) == 2
-    assert out2[0].shape == (4 * _FTP,)
-    assert out2[1].shape == (8 * _FTP,)
+    assert out2[0].numel() == _expected_len(4, left_context)
+    assert out2[1].numel() == _expected_len(8, left_context)
 
 
-def test_batch_decode_waveforms_mixed_valid_invalid_requests(mocker: MockerFixture):
+@left_context_params
+def test_batch_decode_waveforms_mixed_valid_invalid_requests(mocker: MockerFixture, left_context: int):
     """Mixed valid and invalid requests: invalid slots get empty tensors, valid slots get decoded waveforms."""
     model, audio_tok = _minimal_model(mocker)
     valid_a = _make_valid_flat_codes(1)
@@ -155,58 +183,79 @@ def test_batch_decode_waveforms_mixed_valid_invalid_requests(mocker: MockerFixtu
         valid_a,
         valid_b,
     ]
-    out = _mimo_t2w_cls()._batch_decode_waveforms(model, inputs)
+    out = _mimo_t2w_cls()._batch_chunked_decode_streaming(
+        model,
+        inputs,
+        per_req_left_context_frames=[left_context] * len(inputs),
+    )
 
     assert len(out) == len(inputs)
     for i in range(5):
         assert out[i].numel() == 0, f"index {i} should be empty"
-    assert out[5].shape == (4 * _FTP,)
-    assert out[6].shape == (4 * _FTP,)
+    assert out[5].numel() == _expected_len(4, left_context)
+    assert out[6].numel() == _expected_len(4, left_context)
     audio_tok.decoder.assert_called_once()
     packed_hs, input_lengths = audio_tok.decoder.call_args[0]
     assert packed_hs.shape[0] == 8
     assert input_lengths.tolist() == [4, 4]
 
 
-def test_batch_decode_waveforms_all_invalid_returns_per_request_empty(mocker: MockerFixture):
+@left_context_params
+def test_batch_decode_waveforms_all_invalid_returns_per_request_empty(mocker: MockerFixture, left_context: int):
     """All-invalid batch skips decoder entirely and returns empty tensors for every slot."""
     model, audio_tok = _minimal_model(mocker)
-    out = _mimo_t2w_cls()._batch_decode_waveforms(
+    out = _mimo_t2w_cls()._batch_chunked_decode_streaming(
         model,
         [None, _make_dummy_code_tensor(), torch.tensor([], dtype=torch.long)],
+        per_req_left_context_frames=[left_context] * 3,
     )
     assert len(out) == 3
     assert all(t.numel() == 0 for t in out)
     audio_tok.decoder.assert_not_called()
 
 
-def test_batch_decode_waveforms_output_shape_trim_when_decoder_returns_extra_samples(mocker: MockerFixture):
+@left_context_params
+def test_batch_decode_waveforms_output_shape_trim_when_decoder_returns_extra_samples(
+    mocker: MockerFixture, left_context: int
+):
     """Decoder output longer than valid_len is trimmed to the exact expected waveform length."""
     model, audio_tok = _minimal_model(mocker)
     flat = _make_valid_flat_codes(1)
     # Longer than valid_len so branch wav = wav[:valid_len] runs
     audio_tok.decoder.return_value = torch.ones(1, 1, 10_000, dtype=torch.float32)
-    out = _mimo_t2w_cls()._batch_decode_waveforms(model, [flat])
+    out = _mimo_t2w_cls()._batch_chunked_decode_streaming(
+        model,
+        [flat],
+        per_req_left_context_frames=[left_context],
+    )
     assert out[0].dim() == 1
-    assert out[0].numel() == 4 * _FTP
+    assert out[0].numel() == _expected_len(4, left_context)
     assert out[0].dtype == torch.float32
 
 
-def test_batch_decode_waveforms_multi_request_trims_each_row_when_decoder_returns_extra(mocker: MockerFixture):
+@left_context_params
+def test_batch_decode_waveforms_multi_request_trims_each_row_when_decoder_returns_extra(
+    mocker: MockerFixture, left_context: int
+):
     """Else-branch split: per-request wav[:valid_len] when decoder pads each batch row."""
     model, audio_tok = _minimal_model(mocker)
     a = _make_valid_flat_codes(1)
     b = _make_valid_flat_codes(2)
     audio_tok.decoder.return_value = torch.ones(2, 1, 10_000, dtype=torch.float32)
-    out = _mimo_t2w_cls()._batch_decode_waveforms(model, [a, b])
+    out = _mimo_t2w_cls()._batch_chunked_decode_streaming(
+        model,
+        [a, b],
+        per_req_left_context_frames=[left_context, left_context],
+    )
     assert len(out) == 2
-    assert out[0].shape == (4 * _FTP,)
-    assert out[1].shape == (8 * _FTP,)
+    assert out[0].numel() == _expected_len(4, left_context)
+    assert out[1].numel() == _expected_len(8, left_context)
     assert out[0].dtype == torch.float32
     assert out[1].dtype == torch.float32
 
 
-def test_batch_decode_waveforms_valid_only_at_edges_maps_to_correct_indices(mocker: MockerFixture):
+@left_context_params
+def test_batch_decode_waveforms_valid_only_at_edges_maps_to_correct_indices(mocker: MockerFixture, left_context: int):
     """Tensor packing order must match valid_indices when invalid requests are in the middle."""
     model, audio_tok = _minimal_model(mocker)
     first = _make_valid_flat_codes(1)
@@ -218,27 +267,62 @@ def test_batch_decode_waveforms_valid_only_at_edges_maps_to_correct_indices(mock
         last,
     ]
     audio_tok.decoder.return_value = torch.ones(2, 1, 10_000, dtype=torch.float32)
-    out = _mimo_t2w_cls()._batch_decode_waveforms(model, inputs)
+    out = _mimo_t2w_cls()._batch_chunked_decode_streaming(
+        model,
+        inputs,
+        per_req_left_context_frames=[left_context] * len(inputs),
+    )
     assert len(out) == 4
-    assert out[0].numel() == 4 * _FTP
+    assert out[0].numel() == _expected_len(4, left_context)
     assert out[1].numel() == 0
     assert out[2].numel() == 0
-    assert out[3].numel() == 8 * _FTP
+    assert out[3].numel() == _expected_len(8, left_context)
     packed_hs, input_lengths = audio_tok.decoder.call_args[0]
     assert packed_hs.shape[0] == 12
     assert input_lengths.tolist() == [4, 8]
 
 
-def test_batch_decode_waveforms_output_shapes_1d_float32_for_all_slots(mocker: MockerFixture):
+@left_context_params
+def test_batch_decode_waveforms_output_shapes_1d_float32_for_all_slots(mocker: MockerFixture, left_context: int):
     """Every slot is a 1-D float32 vector (empty or waveform), matching downstream expectations."""
     model, audio_tok = _minimal_model(mocker)
     inputs = [_make_valid_flat_codes(1), None, _make_valid_flat_codes(1)]
     audio_tok.decoder.return_value = torch.ones(2, 1, 5000, dtype=torch.float32)
-    out = _mimo_t2w_cls()._batch_decode_waveforms(model, inputs)
+    out = _mimo_t2w_cls()._batch_chunked_decode_streaming(
+        model,
+        inputs,
+        per_req_left_context_frames=[left_context] * len(inputs),
+    )
     assert len(out) == 3
     for i, t in enumerate(out):
         assert t.dim() == 1, f"slot {i}"
         assert t.dtype == torch.float32, f"slot {i}"
-    assert out[0].numel() == 4 * _FTP
+    assert out[0].numel() == _expected_len(4, left_context)
     assert out[1].numel() == 0
-    assert out[2].numel() == 4 * _FTP
+    assert out[2].numel() == _expected_len(4, left_context)
+
+
+def test_sync_and_streaming_produce_same_valid_len(mocker: MockerFixture):
+    """With left_context=0 (sync), output length matches the full waveform.
+    With left_context>0 (streaming), output is shorter by the stripped overlap."""
+    model, audio_tok = _minimal_model(mocker)
+    flat = _make_valid_flat_codes(2)  # 2 groups = 8 tokens => 8*_FTP waveform
+    wav_len = 8 * _FTP + 100
+    audio_tok.decoder.return_value = torch.ones(1, 1, wav_len, dtype=torch.float32)
+
+    out_sync = _mimo_t2w_cls()._batch_chunked_decode_streaming(
+        model,
+        [flat],
+        per_req_left_context_frames=[0],
+    )
+    audio_tok.decoder.reset_mock()
+    audio_tok.decoder.return_value = torch.ones(1, 1, wav_len, dtype=torch.float32)
+    out_stream = _mimo_t2w_cls()._batch_chunked_decode_streaming(
+        model,
+        [flat],
+        per_req_left_context_frames=[3],
+    )
+
+    assert out_sync[0].numel() == 8 * _FTP
+    assert out_stream[0].numel() == _expected_len(8, 3)
+    assert out_stream[0].numel() < out_sync[0].numel()

--- a/tests/model_executor/stage_input_processors/test_qwen3_omni_streaming_helpers.py
+++ b/tests/model_executor/stage_input_processors/test_qwen3_omni_streaming_helpers.py
@@ -505,6 +505,17 @@ def test_mimo_audio_llm2code2wav_token_only_smoke() -> None:
     assert out[0]["additional_information"] is None
 
 
+def _make_mimo_transfer_manager():
+    """Build a minimal transfer_manager mock for llm2code2wav_full_payload."""
+    from collections import defaultdict
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        connector=None,
+        code_prompt_token_ids=defaultdict(list),
+    )
+
+
 def test_mimo_audio_llm2code2wav_full_payload_smoke() -> None:
     """Smoke: mimo_audio producer-side payload builder reads flat codes.audio + flattens."""
     from types import SimpleNamespace
@@ -520,19 +531,19 @@ def test_mimo_audio_llm2code2wav_full_payload_smoke() -> None:
     audio = torch.arange(2 * 1 * 8 * 4, dtype=torch.long).reshape(2, 1, 8, 4)
     audio = audio.clamp(min=1)  # avoid zero-row drop
     pooling_output = {"codes.audio": audio}
-    req = SimpleNamespace(output_token_ids=[])
-    payload = llm2code2wav_full_payload(None, pooling_output, req)
+    tm = _make_mimo_transfer_manager()
+    req = SimpleNamespace(req_id="test-smoke")
+    payload = llm2code2wav_full_payload(tm, pooling_output, req)
     assert payload is not None
-    assert "codes" in payload and "audio" in payload["codes"]
     # Flattened length = numel + B*4 (per-batch pad_vec prepended by prepend_and_flatten_colmajor)
     batch_size = int(audio.shape[0])
-    assert len(payload["codes"]["audio"]) == audio.numel() + batch_size * 4
+    assert payload.codes.audio.numel() == audio.numel() + batch_size * 4
     # prepend_and_flatten_colmajor: PAD appears at column start in col-major flatten.
     # For shape [B=2, 1, 9, 4], each column has 1 PAD then 8 codec vals → PAD at indices 0, 9, 18, 27.
-    out = payload["codes"]["audio"]
-    assert out[0] == TALKER_CODEC_PAD_TOKEN_ID
-    assert out[9] == TALKER_CODEC_PAD_TOKEN_ID
-    assert payload["meta"]["finished"].item() is True
+    out = payload.codes.audio
+    assert out[0].item() == TALKER_CODEC_PAD_TOKEN_ID
+    assert out[9].item() == TALKER_CODEC_PAD_TOKEN_ID
+    assert payload.meta.finished.item() is True
 
 
 def test_mimo_audio_full_payload_nested_fallback() -> None:
@@ -548,10 +559,11 @@ def test_mimo_audio_full_payload_nested_fallback() -> None:
     audio = torch.arange(1 * 1 * 8 * 4, dtype=torch.long).reshape(1, 1, 8, 4)
     audio = audio.clamp(min=1)
     pooling_output = {"codes": {"audio": audio}}  # nested, not flat
-    req = SimpleNamespace(output_token_ids=[])
-    payload = llm2code2wav_full_payload(None, pooling_output, req)
+    tm = _make_mimo_transfer_manager()
+    req = SimpleNamespace(req_id="test-nested")
+    payload = llm2code2wav_full_payload(tm, pooling_output, req)
     assert payload is not None
-    assert len(payload["codes"]["audio"]) == audio.numel() + int(audio.shape[0]) * 4
+    assert payload.codes.audio.numel() == audio.numel() + int(audio.shape[0]) * 4
 
 
 def test_qwen3_tts_talker2code2wav_token_only_smoke() -> None:

--- a/vllm_omni/model_executor/models/mimo_audio/mimo_audio_code2wav.py
+++ b/vllm_omni/model_executor/models/mimo_audio/mimo_audio_code2wav.py
@@ -638,7 +638,6 @@ class MiMoAudioToken2WavForConditionalGenerationVLLM(nn.Module, SupportsPP):
                 multimodal_outputs={"model_outputs": [empty]},
             )
 
-        is_async_chunk = getattr(self.vllm_config.model_config, "async_chunk", False)
         ids = code_tensor.reshape(-1).to(dtype=torch.long)
         request_ids_list = self._split_flat_codes_for_requests(
             ids, kwargs.get("seq_token_counts"), runtime_additional_information
@@ -652,16 +651,13 @@ class MiMoAudioToken2WavForConditionalGenerationVLLM(nn.Module, SupportsPP):
                 multimodal_outputs={"model_outputs": [empty] * len(request_ids_list)},
             )
 
-        if is_async_chunk:
-            audios = self._batch_chunked_decode_streaming(
-                request_ids_list,
-                default_chunk_size=self._codec_chunk_frames,
-                default_left_context_size=self._codec_left_context_frames,
-                per_req_left_context_frames=per_left,
-                per_req_codec_chunk_frames=per_chunk,
-            )
-        else:
-            audios = self._batch_decode_waveforms(request_ids_list)
+        audios = self._batch_chunked_decode_streaming(
+            request_ids_list,
+            default_chunk_size=self._codec_chunk_frames,
+            default_left_context_size=self._codec_left_context_frames,
+            per_req_left_context_frames=per_left,
+            per_req_codec_chunk_frames=per_chunk,
+        )
 
         return OmniOutput(
             text_hidden_states=None,
@@ -712,107 +708,6 @@ class MiMoAudioToken2WavForConditionalGenerationVLLM(nn.Module, SupportsPP):
             return torch.tensor(flat, dtype=torch.long)
 
         return code_tensor
-
-    @torch.inference_mode()
-    def _batch_decode_waveforms(
-        self,
-        request_codes_list: list[torch.Tensor],
-    ) -> list[torch.Tensor]:
-        """Batch-decode multiple requests' codes in a single decoder forward pass.
-
-        Instead of calling _decode_waveform_from_codes per request (which incurs
-        4 GPU↔CPU round-trips each), this method:
-          1. Extracts audio_codes for all valid requests on CPU (cheap).
-          2. Runs quantizer.decode_vq (embedding lookup) for each on GPU.
-          3. Packs all hidden-states into one tensor and calls
-             decoder(packed_hs, input_lengths) once.
-          4. Splits the output waveforms back to per-request tensors.
-        """
-        empty = torch.zeros((0,), dtype=torch.float32, device=self.device)
-        num_req = len(request_codes_list)
-        if num_req == 0:
-            return [empty]
-
-        tokenizer = self._tokenizer_service.audio_tokenizer
-        group_size = self.streamer_config.group_size
-        audio_channels = self.streamer_config.audio_channels
-
-        cg_wrapper = self._tokenizer_service.cuda_graph_wrapper
-        cg_ready = cg_wrapper is not None and cg_wrapper.is_ready
-
-        extracted: list[tuple[int, torch.Tensor]] = []
-
-        for i, req_codes in enumerate(request_codes_list):
-            if req_codes is None or req_codes.numel() == 0:
-                continue
-            if self._check_dummy_code_tensor(req_codes):
-                continue
-
-            flat_codes = req_codes.detach().to(torch.long).cpu()
-            audio_codes = extract_audio_code_tensor(
-                flat_codes,
-                group_size,
-                audio_channels,
-                self.codes,
-            )
-            if audio_codes is None or audio_codes.numel() == 0:
-                continue
-
-            extracted.append((i, audio_codes))
-
-        if not extracted:
-            return [empty] * num_req
-
-        valid_indices = [t[0] for t in extracted]
-        # CUDA graph decode is single-batch only; avoid duplicate decode_vq for len>1.
-        use_cuda_graph = cg_ready and len(extracted) == 1
-
-        if use_cuda_graph:
-            wav_out = cg_wrapper.decode(extracted[0][1].to(self.device))
-            wav = wav_out.squeeze(0).squeeze(0)
-            cfg = tokenizer.config
-            frames_per_token = cfg.avg_pooler * cfg.stride_size * cfg.hop_length
-            valid_len = extracted[0][1].shape[-1] * frames_per_token
-            if wav.numel() > valid_len:
-                wav = wav[:valid_len]
-            result: list[torch.Tensor] = [empty] * num_req
-            result[valid_indices[0]] = wav.to(dtype=torch.float32).reshape(-1)
-            return result
-
-        hidden_list: list[torch.Tensor] = []
-        lengths: list[int] = []
-        for _, audio_codes in extracted:
-            hs = tokenizer.encoder.decode_vq(audio_codes.to(self.device))
-            hidden_list.append(hs)
-            lengths.append(hs.size(0))
-
-        if len(hidden_list) == 1:
-            packed_hs = hidden_list[0]
-        else:
-            packed_hs = torch.cat(hidden_list, dim=0)
-        input_lengths = torch.tensor(lengths, device=self.device)
-
-        recon_wav = tokenizer.decoder(packed_hs, input_lengths)
-
-        cfg = tokenizer.config
-        frames_per_token = cfg.avg_pooler * cfg.stride_size * cfg.hop_length
-
-        result: list[torch.Tensor] = [empty] * num_req
-        if len(valid_indices) == 1:
-            wav = recon_wav.squeeze(0).squeeze(0)
-            valid_len = lengths[0] * frames_per_token
-            if wav.numel() > valid_len:
-                wav = wav[:valid_len]
-            result[valid_indices[0]] = wav.to(dtype=torch.float32).reshape(-1)
-        else:
-            for j, idx in enumerate(valid_indices):
-                wav = recon_wav[j].squeeze(0)
-                valid_len = lengths[j] * frames_per_token
-                if wav.numel() > valid_len:
-                    wav = wav[:valid_len]
-                result[idx] = wav.to(dtype=torch.float32).reshape(-1)
-
-        return result
 
     @torch.inference_mode()
     def _batch_chunked_decode_streaming(

--- a/vllm_omni/model_executor/models/mimo_audio/mimo_audio_code2wav.py
+++ b/vllm_omni/model_executor/models/mimo_audio/mimo_audio_code2wav.py
@@ -713,8 +713,8 @@ class MiMoAudioToken2WavForConditionalGenerationVLLM(nn.Module, SupportsPP):
     def _batch_chunked_decode_streaming(
         self,
         request_codes_list: list[torch.Tensor],
-        default_chunk_size: int,
-        default_left_context_size: int,
+        default_chunk_size: int = _DEFAULT_CODEC_CHUNK_FRAMES,
+        default_left_context_size: int = _DEFAULT_CODEC_LEFT_CONTEXT_FRAMES,
         *,
         per_req_left_context_frames: list[int | None] | None = None,
         per_req_codec_chunk_frames: list[int | None] | None = None,

--- a/vllm_omni/model_executor/models/mimo_audio/pipeline.py
+++ b/vllm_omni/model_executor/models/mimo_audio/pipeline.py
@@ -39,7 +39,7 @@ MIMO_AUDIO_PIPELINE = PipelineConfig(
             owns_tokenizer=True,
             engine_output_type="latent",
             async_chunk_process_next_stage_input_func=(f"{_PROC}.llm2code2wav_async_chunk"),
-            custom_process_next_stage_input_func=f"{_PROC}.llm2code2wav_full_payload",
+            custom_process_next_stage_input_func=f"{_PROC}.llm2code2wav_async_chunk",
             sampling_constraints={
                 "detokenize": True,
                 # Stop once the speech/text interleaved span ends. Code2Wav

--- a/vllm_omni/model_executor/models/mimo_audio/pipeline.py
+++ b/vllm_omni/model_executor/models/mimo_audio/pipeline.py
@@ -39,7 +39,7 @@ MIMO_AUDIO_PIPELINE = PipelineConfig(
             owns_tokenizer=True,
             engine_output_type="latent",
             async_chunk_process_next_stage_input_func=(f"{_PROC}.llm2code2wav_async_chunk"),
-            custom_process_next_stage_input_func=f"{_PROC}.llm2code2wav_async_chunk",
+            custom_process_next_stage_input_func=f"{_PROC}.llm2code2wav_full_payload",
             sampling_constraints={
                 "detokenize": True,
                 # Stop once the speech/text interleaved span ends. Code2Wav

--- a/vllm_omni/model_executor/stage_input_processors/mimo_audio.py
+++ b/vllm_omni/model_executor/stage_input_processors/mimo_audio.py
@@ -114,18 +114,6 @@ def _flush_remaining_codes(
     )
 
 
-def _is_codes_empty(codes: Any) -> bool:
-    """Check whether code_predictor_codes should be treated as empty / invalid."""
-    if codes is None:
-        return True
-    if isinstance(codes, torch.Tensor):
-        return codes.numel() == 0 or not codes.any()
-    if hasattr(codes, "__len__") and len(codes) == 0:
-        return True
-    t = torch.tensor(codes, dtype=torch.long) if not isinstance(codes, torch.Tensor) else codes
-    return not t.any()
-
-
 def _to_code_tensor(codes: Any) -> torch.Tensor | None:
     """Convert codes to a (B, 1, 8, 4) long tensor, or return None if shape is invalid."""
     code_tensor = codes.to(torch.long) if isinstance(codes, torch.Tensor) else torch.tensor(codes, dtype=torch.long)
@@ -208,6 +196,12 @@ def llm2code2wav_async_chunk(
             return _flush_remaining_codes(transfer_manager, request_id, chunk_size, left_context_size)
         return None
 
+    code_tensor = _filter_zero_codec_rows(code_tensor)
+    if code_tensor.numel() == 0:
+        if is_finished:
+            return _flush_remaining_codes(transfer_manager, request_id, chunk_size, left_context_size)
+        return None
+
     pad_vec = torch.tensor([TALKER_CODEC_PAD_TOKEN_ID] * 4, device=code_tensor.device, dtype=code_tensor.dtype)
     code_list = prepend_and_flatten_colmajor(code_tensor, pad_vec).tolist()
 
@@ -223,15 +217,17 @@ def llm2code2wav_async_chunk(
     context_length = chunk_length if chunk_length != 0 else chunk_size
     end_index = min(length, left_context_size + context_length)
     left_ctx_frames = max(0, min(length - context_length, left_context_size))
-    flat_codes = torch.tensor(transfer_manager.code_prompt_token_ids[request_id][-end_index:]).reshape(-1).tolist()
+    flat_codes = torch.tensor(transfer_manager.code_prompt_token_ids[request_id][-end_index:]).reshape(-1)
+    if flat_codes.numel() > MAX_CODE2WAV_TOKENS:
+        flat_codes = flat_codes[:MAX_CODE2WAV_TOKENS]
 
     return OmniPayloadStruct(
-        codes=CodesStruct(audio=torch.tensor(flat_codes)),
+        codes=CodesStruct(audio=flat_codes),
         meta=MetaStruct(
             left_context_size=left_ctx_frames,
             codec_chunk_frames=chunk_size,
             codec_left_context_frames=left_context_size,
-            code_flat_numel=len(flat_codes),
+            code_flat_numel=int(flat_codes.numel()),
             finished=torch.tensor(is_finished, dtype=torch.bool),
         ),
     )

--- a/vllm_omni/model_executor/stage_input_processors/mimo_audio.py
+++ b/vllm_omni/model_executor/stage_input_processors/mimo_audio.py
@@ -392,3 +392,22 @@ def llm2code2wav_token_only(
             )
         )
     return code2wav_inputs
+
+
+def llm2code2wav_full_payload(
+    transfer_manager: Any,
+    pooling_output: dict,
+    request: Any,
+    is_finished: bool = True,
+) -> OmniPayloadStruct | None:
+    """Non-async-chunk entry point, delegates to llm2code2wav_async_chunk.
+
+    The full-payload mixin passes ``pooling_output=`` while the async-chunk
+    adapter passes ``multimodal_output=``; this wrapper bridges the two.
+    """
+    return llm2code2wav_async_chunk(
+        transfer_manager=transfer_manager,
+        multimodal_output=pooling_output,
+        request=request,
+        is_finished=is_finished,
+    )

--- a/vllm_omni/model_executor/stage_input_processors/mimo_audio.py
+++ b/vllm_omni/model_executor/stage_input_processors/mimo_audio.py
@@ -9,6 +9,7 @@ from vllm_omni.data_entry_keys import (
     MetaStruct,
     OmniPayload,
     OmniPayloadStruct,
+    unflatten_payload,
 )
 from vllm_omni.inputs.data import OmniTokensPrompt
 from vllm_omni.model_executor.models.mimo_audio.config_mimo_audio import TALKER_CODEC_PAD_TOKEN_ID
@@ -139,7 +140,7 @@ def llm2code2wav_async_chunk(
     transfer_manager: Any,
     multimodal_output: OmniPayload | dict[str, Any],
     request: Any,
-    is_finished: bool = False,
+    is_finished: bool = True,
 ) -> OmniPayloadStruct | None:
     """
     Async chunk version: convert stage-0 multimodal_output to code2wav payload (pooling / connector accumulation).
@@ -156,7 +157,7 @@ def llm2code2wav_async_chunk(
             cfg = raw_cfg.get("extra", raw_cfg) if isinstance(raw_cfg, dict) else {}
             chunk_size = int(cfg.get("codec_chunk_frames", 3))
             left_context_size = int(cfg.get("codec_left_context_frames", 3))
-            request_id = getattr(request, "external_req_id", None)
+            request_id = getattr(request, "external_req_id", None) or getattr(request, "req_id", None)
             return _flush_remaining_codes(transfer_manager, request_id, chunk_size, left_context_size)
         return None
     connector = getattr(transfer_manager, "connector", None)
@@ -183,11 +184,17 @@ def llm2code2wav_async_chunk(
         )
         left_context_size = _DEFAULT_CODEC_LEFT_CONTEXT_FRAMES
 
-    request_id = getattr(request, "external_req_id", None)
+    request_id = getattr(request, "external_req_id", None) or getattr(request, "req_id", None)
 
     # Text-only paths (e.g. modalities=["text"]) yield no codec pooling output;
     # stage-0 still drives the chunk transfer adapter, so treat None as "no codes
-    # this step" rather than letting `.get()` raise AttributeError.
+    # this step" rather than letting `.get()` raise AttributeError — an unhandled
+    # error here drops the chunk, starves stage-1 of the finished payload, and
+    # the stage subprocesses die before the final token is emitted.
+    # full_payload accumulator flattens {"codes": {"audio": ...}} to {"codes.audio": ...};
+    # unflatten so this function works with both transport modes.
+    if isinstance(multimodal_output, dict):
+        multimodal_output = unflatten_payload(multimodal_output)
     po_codes = multimodal_output.get("codes", {}) if multimodal_output is not None else {}
     if "audio" not in po_codes:
         if is_finished:
@@ -385,62 +392,3 @@ def llm2code2wav_token_only(
             )
         )
     return code2wav_inputs
-
-
-def llm2code2wav_full_payload(
-    transfer_manager,
-    pooling_output: dict,
-    request,
-) -> dict | None:
-    """Producer-side payload builder for the worker connector data plane.
-
-    AR runner's ``flatten_payload`` converts the per-step model emit
-    ``{"codes": {"audio": ...}}`` to ``pooling_output["codes.audio"]``.
-    The accumulator CONCATs per-step tensors along dim 0, so by flush
-    time this holds the full ``[total_steps, 1, 8, 4]`` codec tensor.
-
-    A back-compat fallback to nested ``pooling_output["codes"]["audio"]``
-    is kept in case a future runtime path bypasses `flatten_payload`.
-    """
-    del transfer_manager
-    rid = getattr(request, "request_id", "?")
-    if not isinstance(pooling_output, dict):
-        logger.warning(
-            "mimo_audio.llm2code2wav_full_payload: pooling_output not a dict "
-            "(type=%s) for req=%s; consumer wait gate may hang.",
-            type(pooling_output).__name__,
-            rid,
-        )
-        return None
-    codec_codes = pooling_output.get("codes.audio")
-    if codec_codes is None:
-        # Back-compat fallback for un-flattened pooler emits.
-        codes = pooling_output.get("codes")
-        if isinstance(codes, dict):
-            codec_codes = codes.get("audio")
-    if not isinstance(codec_codes, torch.Tensor) or codec_codes.numel() == 0:
-        logger.warning(
-            "mimo_audio.llm2code2wav_full_payload: missing/empty codes.audio "
-            "(keys=%s) for req=%s; consumer wait gate may hang.",
-            list(pooling_output.keys()),
-            rid,
-        )
-        return None
-    codec_codes = codec_codes.to(torch.long)
-    codec_codes = _filter_zero_codec_rows(codec_codes)
-    if codec_codes.numel() == 0:
-        logger.warning(
-            "mimo_audio.llm2code2wav_full_payload: codec_codes empty after _filter_zero_codec_rows for req=%s.",
-            rid,
-        )
-        return None
-
-    pad_vec = torch.tensor([TALKER_CODEC_PAD_TOKEN_ID] * 4)
-    code_final = prepend_and_flatten_colmajor(codec_codes, pad_vec).tolist()
-    if len(code_final) > MAX_CODE2WAV_TOKENS:
-        code_final = code_final[:MAX_CODE2WAV_TOKENS]
-
-    return {
-        "codes": {"audio": code_final},
-        "meta": {"finished": torch.tensor(True, dtype=torch.bool)},
-    }


### PR DESCRIPTION
## Purpose

Models with both custom_process_next_stage_input_func and async_chunk_process_next_stage_input_func maintain two separate producer functions and two decoder paths that are ~80% identical. This PR eliminates the duplication for MIMO Audio by routing both sync and async modes through the single async_chunk path.

## Test Plan

**vLLM Version:** 0.23.0

**vLLM-Omni Commit:** d80d796b
```
# Unit tests — stage input processors (15 passed)
pytest tests/model_executor/stage_input_processors/test_mimo_audio_llm2code2wav.py -v
pytest tests/model_executor/stage_input_processors/test_mimo_audio_flush_remaining_codes.py -v

# Unit tests — full streaming helpers suite (40 passed, includes updated full_payload tests)
pytest tests/model_executor/stage_input_processors/test_qwen3_omni_streaming_helpers.py -v

# Unit tests — batch decode (25 passed, sync and streaming parametrized)
pytest tests/model_executor/models/mimo_audio/test_mimo_audio_code2wav_batch_decode.py -v

# E2e — online serving (4 passed, both async_chunk and no_async_chunk)
pytest tests/e2e/online_serving/test_mimo_audio_expansion.py -v
```

## Test Result

PASSED
