### PR TITLE
[XPU][COSMOS3] removing cuda hardcode and make VLLM_VIDEO_SYNC_TIMEOUT a tunable config

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -33,7 +33,7 @@ th {
 | `ZImagePipeline` | Z-Image | `Tongyi-MAI/Z-Image-Turbo` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `WanPipeline` | Wan2.1-T2V, Wan2.2-T2V, Wan2.2-TI2V | `Wan-AI/Wan2.1-T2V-1.3B-Diffusers`, `Wan-AI/Wan2.1-T2V-14B-Diffusers`, `Wan-AI/Wan2.2-T2V-A14B-Diffusers`, `Wan-AI/Wan2.2-TI2V-5B-Diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `WanImageToVideoPipeline` | Wan2.2-I2V | `Wan-AI/Wan2.2-I2V-A14B-Diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
-| `Cosmos3OmniDiffusersPipeline` | Cosmos3 T2I, T2V, I2V, V2V, T2V with sound, action policy | `nvidia/Cosmos3-Nano` | ✅︎ | | | |
+| `Cosmos3OmniDiffusersPipeline` | Cosmos3 T2I, T2V, I2V, V2V, T2V with sound, action policy | `nvidia/Cosmos3-Nano` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `WanSpeechToVideoPipeline` | Wan2.2-S2V | `Wan-AI/Wan2.2-S2V-14B` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `Wan22VACEPipeline` | Wan2.1-VACE | `Wan-AI/Wan2.1-VACE-1.3B-diffusers`, `Wan-AI/Wan2.1-VACE-14B-diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `LTX2Pipeline` | LTX-2-T2V | `Lightricks/LTX-2` | ✅︎ | ✅︎ | | |

--- a/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
@@ -27,7 +27,6 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
 )
-from vllm.platforms import current_platform
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention as FrameworkAttention
@@ -35,6 +34,7 @@ from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.sp_plan import SequenceParallelInput, SequenceParallelOutput
 from vllm_omni.diffusion.forward_context import get_forward_context, is_forward_context_available
 from vllm_omni.diffusion.layers.norm import RMSNorm
+from vllm_omni.platforms import current_omni_platform
 
 logger = init_logger(__name__)
 
@@ -1420,7 +1420,7 @@ class Cosmos3VFMTransformer(nn.Module):
         # For I2V: only add to noisy tokens, not conditioned ones.
         # Conditioned frames are clean context and should not receive
         # the diffusion timestep signal.
-        with torch.autocast(current_platform.device_type, enabled=False):
+        with torch.autocast(current_omni_platform.device_type, enabled=False):
             time_embed = self.time_embedder((timestep * self.timestep_scale).float())
         time_embed = time_embed.to(hidden_states.dtype)
 

--- a/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
@@ -27,6 +27,7 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
 )
+from vllm.platforms import current_platform
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention as FrameworkAttention
@@ -1419,8 +1420,8 @@ class Cosmos3VFMTransformer(nn.Module):
         # For I2V: only add to noisy tokens, not conditioned ones.
         # Conditioned frames are clean context and should not receive
         # the diffusion timestep signal.
-        with torch.autocast("cuda", enabled=True, dtype=torch.float32):
-            time_embed = self.time_embedder(timestep * self.timestep_scale)
+        with torch.autocast(current_platform.device_type, enabled=False):
+            time_embed = self.time_embedder((timestep * self.timestep_scale).float())
         time_embed = time_embed.to(hidden_states.dtype)
 
         if noisy_frame_mask is not None:

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -2760,7 +2760,7 @@ async def _run_video_generation_job(
         raise
 
 
-VIDEO_SYNC_TIMEOUT_S = 600.0
+VIDEO_SYNC_TIMEOUT_S = float(os.environ.get("VLLM_VIDEO_SYNC_TIMEOUT", 600.0))
 
 
 async def _parse_video_form(

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -2760,7 +2760,7 @@ async def _run_video_generation_job(
         raise
 
 
-VIDEO_SYNC_TIMEOUT_S = float(os.environ.get("VLLM_VIDEO_SYNC_TIMEOUT", 600.0))
+VIDEO_SYNC_TIMEOUT_S = float(os.environ.get("VLLM_OMNI_VIDEO_SYNC_TIMEOUT", 600.0))
 
 
 async def _parse_video_form(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Quick update cosmos by removing cuda hardcode

## Test Plan

```
export VLLM_VIDEO_SYNC_TIMEOUT=1800 \ 
      vllm serve nvidia/Cosmos3-Nano \
      --omni \
      --host 0.0.0.0 --port 8000 \
      --tensor-parallel-size 4 \
      --no-guardrails \
      --vae-use-tiling \
      --init-timeout 1800
```

## Test Result

 T2V-with-sound (720p, 189 frames + audio):
```
  docker exec -i -w /workspace/vllm-omni vllm-omni-dev-dev2 \
    curl -sS --max-time 1200 -X POST http://localhost:8000/v1/videos/sync \
    -H "Accept: video/mp4" \                                    
    -F "model=nvidia/Cosmos3-Nano" \
    -F "prompt=The video opens with a view of a well-lit indoor fruit display..." \
    -F "negative_prompt=blurry, distorted, low quality" \       
    -F "size=1280x720" -F "num_frames=189" -F "fps=24" \
    -F "num_inference_steps=35" -F "guidance_scale=6.0" \
    -F "max_sequence_length=4096" -F "flow_shift=10.0" \
    -F "seed=0" -F "generate_sound=true" -F "sound_duration=7.875" \
    -F 'extra_params={"use_resolution_template":false,"use_duration_template":false}' \
    -o /workspace/vllm-omni/cosmos3_t2v_with_sound.mp4    
```

https://github.com/user-attachments/assets/4b2d5c1e-f732-46e2-b2c9-2bf9a8fa2d5e

Action Policy
```
  Client (policy, 61 frames):
  VIDEO_ID=$(curl -sS -X POST http://localhost:8000/v1/videos \
    -H "Accept: application/json" \
    --form-string "model=nvidia/Cosmos3-Nano" \
    --form-string "prompt=Pick up the banana and place it in the bowl." \
    -F "input_reference=@/workspace/vllm-omni/robot_frame.png;type=image/png" \
    -F "size=640x480" -F "num_frames=61" -F "fps=10" \
    -F "num_inference_steps=30" -F "guidance_scale=1.0" -F "flow_shift=5.0" \
    --form-string
  'extra_params={"action_mode":"policy","domain_name":"bridge_orig_lerobot","raw_action_dim":10,"action_chunk_size":60}' \
    -F "seed=0" | jq -r '.id')

  # Poll until completed
  while true; do
    STATUS=$(curl -sS "http://localhost:8000/v1/videos/$VIDEO_ID" | jq -r '.status')
    [ "$STATUS" = "completed" ] && break
    sleep 5
  done
 
  # Get predicted action trajectory
  curl -sS "http://localhost:8000/v1/videos/$VIDEO_ID" | jq '.action | {shape, dtype, raw_action_dim, domain_id}'
  
  # Download rollout video
  curl -sS -L "http://localhost:8000/v1/videos/$VIDEO_ID/content" -o cosmos3_policy.mp4
```

https://github.com/user-attachments/assets/01a74207-91c0-4293-87f3-d33432a51288

T2I (1024x1024, 50 steps):
```
  docker exec -i -w /workspace/vllm-omni vllm-omni-dev-dev2 \
    curl -sS --max-time 600 -X POST http://localhost:8000/v1/images/generations \
    -H "Content-Type: application/json" \                       
    -d '{                       
      "model": "nvidia/Cosmos3-Nano",
      "prompt": "A photorealistic red sports car on a city street at golden hour, cinematic lighting.",
      "negative_prompt": "blurry, distorted, low quality",      
      "size": "1024x1024", "n": 1, "response_format": "b64_json",
      "num_inference_steps": 50, "guidance_scale": 7.0, "seed": 42
    }' | docker exec -i vllm-omni-dev-dev2 python -c \          
    "import sys,json,base64;    
  open('/workspace/vllm-omni/cosmos3_t2i.png','wb').write(base64.b64decode(json.load(sys.stdin)['data'][0]['b64_json']))"
```

<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/79cb7fb8-20aa-4bc6-86c9-fe1aa018b430" />

T2V (720p, 189 frames): 
```                                     
  docker exec -i -w /workspace/vllm-omni vllm-omni-dev-dev2 \
    curl -sS --max-time 1200 -X POST http://localhost:8000/v1/videos/sync \                                                    
    -H "Accept: video/mp4" \                                    
    -F "model=nvidia/Cosmos3-Nano" \                                                                                           
    -F "prompt=A robot arm is cleaning a plate in the kitchen" \ 
    -F "negative_prompt=blurry, distorted, low quality, jittery, deformed" \
    -F "size=1280x720" -F "num_frames=189" -F "fps=24" \        
    -F "num_inference_steps=35" -F "guidance_scale=6.0" \
    -F "max_sequence_length=4096" -F "flow_shift=10.0" \
    -F 'extra_params={"use_resolution_template":false,"use_duration_template":false}' \
    -F "seed=123" \                                             
    -o /workspace/vllm-omni/cosmos3_t2v_tp4.mp4
```

https://github.com/user-attachments/assets/537d85e3-493e-492c-9c78-b936e07bb8bd



**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
