### PR TITLE
[Bugfix] Keep API server alive on single-stage engine death

### DIFF
--- a/tests/dfx/reliability/test_reliability_qwen3_omni.py
+++ b/tests/dfx/reliability/test_reliability_qwen3_omni.py
@@ -319,7 +319,6 @@ QWEN_PARAMS = create_reliability_omni_server_params(RELIABILITY_SCENARIOS, DEPLO
 
 
 @pytest.mark.slow
-@pytest.mark.skip(reason="issue#4285")
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
 @pytest.mark.parametrize("omni_server_function", QWEN_PARAMS, indirect=True)
 def test_reliability_fault_gpu_oom_error_contract_consistent_chat_speech(
@@ -388,7 +387,6 @@ def test_reliability_fault_gpu_oom_error_contract_consistent_chat_speech(
 
 
 @pytest.mark.slow
-@pytest.mark.skip(reason="issue#4285")
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
 @pytest.mark.parametrize("omni_server_function", QWEN_PARAMS, indirect=True)
 def test_reliability_fault_gpu_oom_chat_large_payload_failure(omni_server_function, openai_client_function) -> None:
@@ -431,7 +429,6 @@ def test_reliability_fault_gpu_oom_chat_large_payload_failure(omni_server_functi
 
 
 @pytest.mark.slow
-@pytest.mark.skip(reason="issue#4285")
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
 @pytest.mark.parametrize("omni_server_function", QWEN_PARAMS, indirect=True)
 def test_reliability_fault_gpu_oom_concurrent_pressure_failure(omni_server_function, openai_client_function) -> None:
@@ -774,7 +771,6 @@ def test_reliability_fault_process_kill_tree_with_load_fast_fail_and_cleanup(
 
 
 @pytest.mark.slow
-@pytest.mark.skip(reason="issue#4285")
 @hardware_test(res={"cuda": "H100"}, num_cards=2)
 @pytest.mark.parametrize("omni_server_function", QWEN_PARAMS, indirect=True)
 def test_reliability_fault_gpu_oom_state_converges_after_fault_removed(

--- a/tests/entrypoints/openai_api/test_engine_error_keep_alive.py
+++ b/tests/entrypoints/openai_api/test_engine_error_keep_alive.py
@@ -1,0 +1,75 @@
+# tests/entrypoints/openai/test_engine_error_keep_alive.py
+"""Single-stage engine death must not terminate the API server (issue #4285).
+
+Omni marks ``errored`` when any stage engine dies, but the orchestrator can
+still route requests: subsequent calls fast-fail with ``EngineDeadError`` and
+``/health`` reports 503. These tests pin the termination policy: keep uvicorn
+alive while the orchestrator is alive, defer to upstream
+``terminate_if_errored`` once it is gone.
+"""
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
+
+from vllm_omni.entrypoints.omni_base import OmniEngineDeadError
+from vllm_omni.entrypoints.openai import api_server as api_server_module
+
+
+def _build_app(engine_client) -> FastAPI:
+    app = FastAPI()
+    app.state.args = SimpleNamespace(log_error_stack=False)
+    app.state.engine_client = engine_client
+    app.state.server = SimpleNamespace(should_exit=False)
+    api_server_module._register_omni_exception_handlers(app)
+
+    @app.get("/boom")
+    async def boom(request: Request):
+        request.state.request_metadata = SimpleNamespace(request_id="req-keep-alive-1")
+        raise OmniEngineDeadError("engine dead", error_stage_id=1)
+
+    return app
+
+
+def test_engine_error_keeps_server_alive_when_orchestrator_alive(mocker: MockerFixture):
+    terminate_mock = mocker.patch.object(api_server_module, "terminate_if_errored")
+    app = _build_app(
+        SimpleNamespace(
+            engine=SimpleNamespace(is_alive=lambda: True),
+            errored=True,
+        )
+    )
+
+    response = TestClient(app, raise_server_exceptions=False).get("/boom")
+
+    assert response.status_code == 500
+    assert response.json()["error"]["error_stage_id"] == 1
+    terminate_mock.assert_not_called()
+    assert app.state.server.should_exit is False
+
+
+def test_engine_error_terminates_when_orchestrator_dead(mocker: MockerFixture):
+    terminate_mock = mocker.patch.object(api_server_module, "terminate_if_errored")
+    app = _build_app(
+        SimpleNamespace(
+            engine=SimpleNamespace(is_alive=lambda: False),
+            errored=True,
+        )
+    )
+
+    response = TestClient(app, raise_server_exceptions=False).get("/boom")
+
+    assert response.status_code == 500
+    terminate_mock.assert_called_once()
+
+
+def test_engine_error_falls_back_to_upstream_without_orchestrator_liveness(mocker: MockerFixture):
+    terminate_mock = mocker.patch.object(api_server_module, "terminate_if_errored")
+    app = _build_app(SimpleNamespace(errored=True))
+
+    response = TestClient(app, raise_server_exceptions=False).get("/boom")
+
+    assert response.status_code == 500
+    terminate_mock.assert_called_once()

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -274,7 +274,8 @@ def _register_omni_exception_handlers(app) -> None:
 
     - Log multi-stage diagnostic info (orchestrator liveness, per-stage health)
       when an ``EngineDeadError`` is caught.
-    - Call ``terminate_if_errored``
+    - Terminate the server only when the orchestrator is dead; a single dead
+      stage keeps the API alive so later requests still get the 5xx contract.
     - Return an OpenAI-compatible error JSON response.
     """
 
@@ -331,13 +332,31 @@ def _create_engine_error_json_response(
             error_stage_id,
         )
 
-    terminate_if_errored(
+    _maybe_terminate_on_engine_error(
         server=req.app.state.server,
-        engine=engine,
+        engine_client=engine,
     )
 
     payload, status_code = _build_engine_error_payload(exc, request_id=request_id)
     return JSONResponse(content=payload, status_code=status_code)
+
+
+def _maybe_terminate_on_engine_error(server, engine_client) -> None:
+    """Omni-aware guard around upstream ``terminate_if_errored``.
+
+    Omni marks ``errored`` when *any* stage engine has died (e.g. a CUDA OOM
+    in one stage), but the orchestrator can still route requests: subsequent
+    calls fast-fail with ``EngineDeadError`` and ``/health`` reports 503.
+    Exiting uvicorn in that state would replace the OpenAI error contract
+    with connection-refused for every later request, so fall through to the
+    upstream termination policy only when the orchestrator thread itself is
+    gone (or its liveness cannot be determined).
+    """
+    orchestrator = getattr(engine_client, "engine", None)
+    is_alive = getattr(orchestrator, "is_alive", None)
+    if callable(is_alive) and is_alive():
+        return
+    terminate_if_errored(server=server, engine=engine_client)
 
 
 class _DiffusionServingModels:
@@ -2735,11 +2754,13 @@ async def _run_video_generation_job(
             },
         )
         # Background tasks can't propagate exceptions to FastAPI handlers.
-        # Actively signal shutdown when the engine is dead.
+        # Apply the same orchestrator-gated termination policy as the
+        # request path; the failure is already surfaced to clients via
+        # the video store status.
         if app_state is not None and isinstance(exc, EngineDeadError):
-            terminate_if_errored(
+            _maybe_terminate_on_engine_error(
                 server=app_state.server,
-                engine=app_state.engine_client,
+                engine_client=app_state.engine_client,
             )
     except Exception as exc:
         logger.exception("Video generation failed for id=%s", video_id)


### PR DESCRIPTION

FIX #4285

## Problem

When GPU OOM (or any fatal error) kills a single stage's EngineCore, the API server returns the correct 5xx OpenAI-style error for the failing request — but then exits the whole uvicorn process, so subsequent requests get connection-refused instead of the error contract, and `/health` can no longer report 503.

Root cause: `_create_engine_error_json_response` unconditionally calls upstream `terminate_if_errored`, and vllm-omni's `errored` property is True whenever *any* stage is dead (`omni_base.py`). Upstream's termination policy was written for single-engine vLLM where "engine dead" means nothing is left to serve; in the omni multi-stage architecture the orchestrator can still route requests and produce well-formed error responses.

This is also why `test_reliability_fault_gpu_oom_error_contract_consistent_chat_speech` was flaky rather than consistently red: the server self-exits *deterministically*, but the test's second probe only observes it when it loses the race against uvicorn's graceful shutdown.

## Fix

Gate the upstream termination policy on orchestrator liveness (`_maybe_terminate_on_engine_error`): while the orchestrator thread is alive, single-stage death keeps the server up — new requests already fast-fail with `EngineDeadError` (5xx JSON) and `/health` already returns 503. When the orchestrator is dead or liveness cannot be determined, defer to `terminate_if_errored` exactly as before (including `VLLM_KEEP_ALIVE_ON_ENGINE_DEATH` handling).

Also re-enables the DFX tests that were skip-marked for this issue in #4311.

## Validation

Reproduced on 2× RTX PRO 6000 (96GB, SM120), vllm 0.22.0. Env notes: `VLLM_USE_FLASHINFER_SAMPLER=0` (FlashInfer JIT arch check predates SM120) and `espeak` installed for the test's synthetic audio — both identical across baseline and fix runs.

**Baseline (`main` @ e26f5cb, skip-marker removed):** the OOM-injection test shows the server self-exit — uvicorn `Finished server process` fires in the same second the thinker stage dies, mid-test:

```
ERROR 06-12 13:19:08 [orchestrator.py:723] [Orchestrator] Stage-0 is dead: EngineCore encountered an issue...
INFO  06-12 13:19:08 [orchestrator.py:1626] [Orchestrator] Shutting down all 3 client(s)
INFO:     Shutting down
INFO:     Finished server process [9584]        <-- serve instance exits (issue #4285)
```

**With this fix:** same OOM, same stage death — server stays alive, both probes are answered, shutdown happens only at the test fixture's teardown after PASSED:

```
ERROR 06-12 13:29:24 [api_server.py:327] EngineDeadError: orchestrator_alive=True, errored=True, ...
INFO:     127.0.0.1:55790 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
INFO:     127.0.0.1:48240 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
PASSED
```

- `tests/dfx/reliability/test_reliability_qwen3_omni.py::test_reliability_fault_gpu_oom_error_contract_consistent_chat_speech[omni_server_function0]` → **1 passed** (5m47s)
- New unit tests `tests/entrypoints/openai_api/test_engine_error_keep_alive.py` → 3 passed (orchestrator-alive keeps server up; orchestrator-dead terminates; missing liveness falls back to upstream behavior)
- Existing termination tests unaffected (they stub the orchestrator as dead and exercise the unchanged fall-through path)

## Follow-up (out of scope here)

Request-scoped OOM isolation in the stage busy loop — catching `torch.OutOfMemoryError` per step and failing only the affected request(s) — would let the engine *recover* after pressure is removed (what `test_reliability_fault_gpu_oom_state_converges_after_fault_removed` ultimately wants). That diverges from upstream V1's exceptions-are-fatal semantics, so proposing it separately if maintainers want it.
