### PR TITLE
[BugFix]Fix diffusion profile RPC None results

### DIFF
--- a/tests/diffusion/test_multiproc_engine_concurrency.py
+++ b/tests/diffusion/test_multiproc_engine_concurrency.py
@@ -730,6 +730,39 @@ class TestStageDiffusionClientErrorPropagation:
                 batch_size=1,
             )
 
+    @pytest.mark.asyncio
+    async def test_collective_rpc_async_returns_none_result(self, monkeypatch):
+        client = self._make_client()
+        client._owns_process = False
+        client._proc = None
+        client._encoder.encode.return_value = b"encoded-rpc"
+
+        async def _unexpected_poll(*_, **__):
+            raise AssertionError("collective_rpc_async should not keep polling after a None rpc_result arrives")
+
+        client._response_poller = SimpleNamespace(poll=_unexpected_poll)
+
+        rpc_id = "rpc-none"
+        monkeypatch.setattr(
+            "vllm_omni.diffusion.stage_diffusion_client.uuid.uuid4",
+            lambda: SimpleNamespace(hex=rpc_id),
+        )
+
+        def _drain() -> None:
+            client._rpc_results[rpc_id] = None
+
+        client._drain_responses = _drain
+
+        result = await client.collective_rpc_async(
+            method="profile",
+            timeout=0.01,
+            args=(False, None),
+        )
+
+        assert result is None
+        client._request_socket.send.assert_called_once_with(b"encoded-rpc")
+        assert rpc_id not in client._pending_rpcs
+
 
 # ───────── monitor thread & death sentinel integration tests ─────────
 

--- a/vllm_omni/diffusion/stage_diffusion_client.py
+++ b/vllm_omni/diffusion/stage_diffusion_client.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniPromptType
 
 logger = init_logger(__name__)
+_MISSING_RPC_RESULT = object()
 
 
 def create_diffusion_client(
@@ -506,8 +507,8 @@ class StageDiffusionClient(StageClientBase):
         try:
             while True:
                 self._drain_responses()
-                result = self._rpc_results.pop(rpc_id, None)
-                if result is not None:
+                result = self._rpc_results.pop(rpc_id, _MISSING_RPC_RESULT)
+                if result is not _MISSING_RPC_RESULT:
                     return result
                 proc = self._proc_manager.proc
                 if self._engine_dead or not proc.is_alive():

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -3234,9 +3234,9 @@ async def start_profile(raw_request: Request, request: ProfileRequest | None = N
         stages = request.stages if request else None
         logger.info("Starting profiler for stages: %s", stages if stages else "all")
         engine_client = raw_request.app.state.engine_client
-        result = await engine_client.start_profile(stages=stages)
+        await engine_client.start_profile(stages=stages)
         logger.info("Profiler started.")
-        return JSONResponse(content=result)
+        return JSONResponse(content={"status": "SUCCESS"})
     except Exception as e:
         logger.exception("Failed to start profiler: %s", e)
         raise HTTPException(
@@ -3260,9 +3260,9 @@ async def stop_profile(raw_request: Request, request: ProfileRequest | None = No
         stages = request.stages if request else None
         logger.info("Stopping profiler for stages: %s", stages if stages else "all")
         engine_client = raw_request.app.state.engine_client
-        result = await engine_client.stop_profile(stages=stages)
+        await engine_client.stop_profile(stages=stages)
         logger.info("Profiler stopped.")
-        return JSONResponse(content=result)
+        return JSONResponse(content={"status": "SUCCESS"})
     except Exception as e:
         logger.exception("Failed to stop profiler: %s", e)
         raise HTTPException(


### PR DESCRIPTION
<!-- markdownlint-disable -->

Fixes #4288 

## Purpose

The diffusion client currently uses `None` to mean "RPC result not available yet". Profiling RPCs can also legitimately return `None`, so successful responses are misread as missing and the request keeps waiting forever. This PR switches the missing-result check to a dedicated sentinel value so `/start_profile` and `/stop_profile` can return normally.

## Test Plan

- Manual end-to-end validation on a single-node `8 x H100`
- Reproduced on `tencent/HunyuanImage-3.0-Instruct` with a tuned `4+4` multi-stage config:
    - `max_num_seqs: 1`
    - `max_num_batched_tokens: 6144`
    - `max_tokens: 128`
- Compared:
    - an `unfixed-minimal` control tree where only this sentinel fix was reverted
    - the fixed tree with this patch applied
- Verified both API behavior and profiler output generation on the fixed tree

**vLLM Version:** 0.22.0

**vLLM-Omni Commit:** d6ad4182cc1cf3acae3552708dae6e638847eda0

## Test Result

  - Before this change:
    - the Hunyuan service reached `/health = 200`
    - `POST /start_profile` timed out after about `60s` with `HTTP_CODE=000`
    - `POST /stop_profile` also timed out after about `60s`
    - server logs showed the profiler path was entered, but the request never completed

  - After this change:
    - the Hunyuan service reached `/health = 200`
    - `POST /start_profile` returned `200`
    - `POST /stop_profile` returned `200`
    - server logs showed `Profiler started.`, `Profiler stopped.`, and `200 OK` for both endpoints
    - profiler traces were exported successfully for both stage-0 AR and stage-1 diffusion ranks

