### PR TITLE
[ci]skip voxcpm2 pcm hnr test 

### DIFF
--- a/tests/e2e/online_serving/test_voxcpm2_tts_expansion.py
+++ b/tests/e2e/online_serving/test_voxcpm2_tts_expansion.py
@@ -73,6 +73,7 @@ def test_voice_clone_streaming_001(omni_server, openai_client) -> None:
 
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.parametrize("omni_server", tts_server_params, indirect=True)
+@pytest.mark.skip(reason="#4335")
 def test_response_format_001(omni_server, openai_client) -> None:
     """
     Test voice-clone non-stream PCM output via OpenAI API.


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Skip nightly test test_response_format_001. There is a known issue https://github.com/vllm-project/vllm-omni/issues/4335.

Reproduced the issue and saved the audio that HNR < 1db
[.error.wav](https://github.com/user-attachments/files/28870887/default.error.wav)
and the audio that HNR >1 db
[test_voxcpm2_response_format_001.wav](https://github.com/user-attachments/files/28870950/test_voxcpm2_response_format_001.wav)
The audio that HNR < 1db sounds basically fine.
We need to discuss whether the HNR calculation formula is too sensitive for threshold-based pass/fail judgment.

## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
