### PR TITLE
LTX-2.3 Image-to-Video + Public Examples/Performance

### DIFF
--- a/docs/user_guide/examples/offline_inference/image_to_video.md
+++ b/docs/user_guide/examples/offline_inference/image_to_video.md
@@ -3,7 +3,9 @@
 Source <https://github.com/vllm-project/vllm-omni/tree/main/examples/offline_inference/image_to_video>.
 
 
-This example demonstrates how to generate videos from images using Wan2.2 Image-to-Video models with vLLM-Omni's offline inference API.
+This example demonstrates how to generate videos from images using Wan2.2,
+LTX-2/LTX-2.3, and HunyuanVideo-1.5 Image-to-Video models with vLLM-Omni's
+offline inference API.
 
 ## Local CLI Usage
 
@@ -51,13 +53,39 @@ python image_to_video.py \
   --output i2v_output.mp4
 ```
 
+### LTX-2.3
+
+```bash
+python image_to_video.py \
+  --model dg845/LTX-2.3-Diffusers \
+  --image cherry_blossom.jpg \
+  --prompt "Cherry blossoms swaying gently in the breeze with synchronized ambient sound" \
+  --negative-prompt "worst quality, inconsistent motion, blurry, jittery, distorted" \
+  --height 384 \
+  --width 512 \
+  --num-frames 25 \
+  --guidance-scale 4.0 \
+  --num-inference-steps 20 \
+  --frame-rate 24 \
+  --fps 24 \
+  --output ltx23_i2v_output.mp4
+```
+
+Use a Diffusers-format checkpoint such as `dg845/LTX-2.3-Diffusers`; the
+upstream `Lightricks/LTX-2.3` raw safetensors repo is not directly loadable by
+this pipeline.
+
 Key arguments:
 
-- `--model`: Model ID (I2V-A14B for MoE, TI2V-5B for unified T2V+I2V).
+- `--model`: Model ID (I2V-A14B for MoE, TI2V-5B for unified T2V+I2V, or
+  LTX-2/LTX-2.3).
 - `--image`: Path to input image (required).
 - `--prompt`: Text description of desired motion/animation.
-- `--height/--width`: Output resolution (auto-calculated from image if not set). Dimensions should be multiples of 16.
-- `--num-frames`: Number of frames (default 81).
+- `--height/--width`: Output resolution (auto-calculated from image if not set).
+  Wan dimensions should be multiples of 16; LTX dimensions should be multiples
+  of 32.
+- `--num-frames`: Number of frames (model-specific default; LTX-style models
+  work best with `8k + 1`).
 - `--guidance-scale` and `--guidance-scale-high`: CFG scale (applied to low/high-noise stages for MoE).
 - `--negative-prompt`: Optional list of artifacts to suppress.
 - `--boundary-ratio`: Boundary split ratio for two-stage MoE models.
@@ -65,6 +93,7 @@ Key arguments:
 - `--sample-solver`: Wan2.2 sampling solver. Use `unipc` for the default multistep solver, or `euler` for Lightning/Distill checkpoints.
 - `--num-inference-steps`: Number of denoising steps (default 50).
 - `--fps`: Frames per second for the saved MP4 (requires `diffusers` export_to_video).
+- `--audio-sample-rate`: fallback audio sample rate for embedded audio.
 - `--output`: Path to save the generated video.
 - `--vae-use-slicing`: Enable VAE slicing for memory optimization.
 - `--vae-use-tiling`: Enable VAE tiling for memory optimization.

--- a/examples/offline_inference/image_to_video/README.md
+++ b/examples/offline_inference/image_to_video/README.md
@@ -1,6 +1,8 @@
 # Image-To-Video
 
-This example demonstrates how to generate videos from images using Wan2.2 Image-to-Video models with vLLM-Omni's offline inference API.
+This example demonstrates how to generate videos from images using Wan2.2,
+LTX-2/LTX-2.3, and HunyuanVideo-1.5 Image-to-Video models with vLLM-Omni's
+offline inference API.
 
 ## Local CLI Usage
 
@@ -48,13 +50,39 @@ python image_to_video.py \
   --output i2v_output.mp4
 ```
 
+### LTX-2.3
+
+```bash
+python image_to_video.py \
+  --model dg845/LTX-2.3-Diffusers \
+  --image cherry_blossom.jpg \
+  --prompt "Cherry blossoms swaying gently in the breeze with synchronized ambient sound" \
+  --negative-prompt "worst quality, inconsistent motion, blurry, jittery, distorted" \
+  --height 384 \
+  --width 512 \
+  --num-frames 25 \
+  --guidance-scale 4.0 \
+  --num-inference-steps 20 \
+  --frame-rate 24 \
+  --fps 24 \
+  --output ltx23_i2v_output.mp4
+```
+
+Use a Diffusers-format checkpoint such as `dg845/LTX-2.3-Diffusers`; the
+upstream `Lightricks/LTX-2.3` raw safetensors repo is not directly loadable by
+this pipeline.
+
 Key arguments:
 
-- `--model`: Model ID (I2V-A14B for MoE, TI2V-5B for unified T2V+I2V).
+- `--model`: Model ID (I2V-A14B for MoE, TI2V-5B for unified T2V+I2V, or
+  LTX-2/LTX-2.3).
 - `--image`: Path to input image (required).
 - `--prompt`: Text description of desired motion/animation.
-- `--height/--width`: Output resolution (auto-calculated from image if not set). Dimensions should be multiples of 16.
-- `--num-frames`: Number of frames (default 81).
+- `--height/--width`: Output resolution (auto-calculated from image if not set).
+  Wan dimensions should be multiples of 16; LTX dimensions should be multiples
+  of 32.
+- `--num-frames`: Number of frames (model-specific default; LTX-style models
+  work best with `8k + 1`).
 - `--guidance-scale` and `--guidance-scale-high`: CFG scale (applied to low/high-noise stages for MoE).
 - `--negative-prompt`: Optional list of artifacts to suppress.
 - `--boundary-ratio`: Boundary split ratio for two-stage MoE models.
@@ -62,6 +90,7 @@ Key arguments:
 - `--sample-solver`: Wan2.2 sampling solver. Use `unipc` for the default multistep solver, or `euler` for Lightning/Distill checkpoints.
 - `--num-inference-steps`: Number of denoising steps (default 50).
 - `--fps`: Frames per second for the saved MP4 (requires `diffusers` export_to_video).
+- `--audio-sample-rate`: fallback audio sample rate for embedded audio.
 - `--output`: Path to save the generated video.
 - `--vae-use-slicing`: Enable VAE slicing for memory optimization.
 - `--vae-use-tiling`: Enable VAE tiling for memory optimization.

--- a/examples/offline_inference/image_to_video/image_to_video.py
+++ b/examples/offline_inference/image_to_video/image_to_video.py
@@ -2,7 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 """
-Image-to-Video generation example using Wan2.2 I2V/TI2V models, LTX2, or HunyuanVideo-1.5.
+Image-to-Video generation example using Wan2.2 I2V/TI2V models, LTX2/LTX-2.3,
+or HunyuanVideo-1.5.
 
 Supports:
 - Wan2.2-I2V-A14B-Diffusers: MoE model with CLIP image encoder
@@ -26,6 +27,12 @@ Usage:
         --num-frames 121 --num-inference-steps 40 --guidance-scale 4.0 \
         --frame-rate 24 --fps 24 --output ltx2_i2v.mp4
 
+    # LTX-2.3 image-to-video
+    python image_to_video.py --model dg845/LTX-2.3-Diffusers \
+        --image input.jpg --prompt "A cinematic dolly shot of a boat" \
+        --height 384 --width 512 --num-frames 25 --num-inference-steps 20 \
+        --frame-rate 24 --fps 24 --output ltx23_i2v.mp4
+
     # HunyuanVideo-1.5 I2V (480p)
     python image_to_video.py --model hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_i2v \
         --image input.jpg --prompt "A cat playing with yarn" \
@@ -42,6 +49,11 @@ import numpy as np
 import PIL.Image
 import torch
 
+from examples.offline_inference.video_model_defaults import (
+    default_image_to_video_class_name,
+    is_ltx2_model,
+    is_ltx23_model,
+)
 from vllm_omni.diffusion.data import DiffusionParallelConfig
 from vllm_omni.entrypoints.omni import Omni
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
@@ -60,22 +72,24 @@ def parse_profiler_config(value: str) -> dict[str, Any]:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Generate a video from an image (Wan2.2, LTX2, HunyuanVideo-1.5).")
+    parser = argparse.ArgumentParser(
+        description="Generate a video from an image (Wan2.2, LTX2/LTX-2.3, HunyuanVideo-1.5)."
+    )
     parser.add_argument(
         "--model",
         default="Wan-AI/Wan2.2-I2V-A14B-Diffusers",
-        help="Diffusers I2V model ID or local path (Wan2.2 or HunyuanVideo-1.5).",
+        help="Diffusers I2V model ID or local path (Wan2.2, LTX2/LTX-2.3, or HunyuanVideo-1.5).",
     )
     parser.add_argument(
         "--model-class-name",
         default=None,
-        help="Override model class name (e.g., LTX2ImageToVideoPipeline).",
+        help="Override model class name (e.g., LTX2ImageToVideoPipeline or LTX23ImageToVideoPipeline).",
     )
     parser.add_argument("--image", required=True, help="Path to input image.")
     parser.add_argument("--prompt", default="", help="Text prompt describing the desired motion.")
     parser.add_argument("--negative-prompt", default="", help="Negative prompt.")
     parser.add_argument("--seed", type=int, default=42, help="Random seed.")
-    parser.add_argument("--guidance-scale", type=float, default=5.0, help="CFG scale.")
+    parser.add_argument("--guidance-scale", type=float, default=None, help="CFG scale. Default: model-specific.")
     parser.add_argument(
         "--guidance-scale-high", type=float, default=None, help="Optional separate CFG for high-noise (MoE only)."
     )
@@ -83,8 +97,13 @@ def parse_args() -> argparse.Namespace:
         "--height", type=int, default=None, help="Video height (auto-calculated from image if not set)."
     )
     parser.add_argument("--width", type=int, default=None, help="Video width (auto-calculated from image if not set).")
-    parser.add_argument("--num-frames", type=int, default=81, help="Number of frames.")
-    parser.add_argument("--num-inference-steps", type=int, default=50, help="Sampling steps.")
+    parser.add_argument("--num-frames", type=int, default=None, help="Number of frames. Default: model-specific.")
+    parser.add_argument(
+        "--num-inference-steps",
+        type=int,
+        default=None,
+        help="Sampling steps. Default: model-specific.",
+    )
     parser.add_argument("--boundary-ratio", type=float, default=0.875, help="Boundary split ratio for MoE models.")
     parser.add_argument(
         "--frame-rate",
@@ -265,10 +284,9 @@ def main():
     args = parse_args()
     generator = torch.Generator(device=current_omni_platform.device_type).manual_seed(args.seed)
     model_name = str(args.model).lower() if args.model is not None else ""
-    model_class_name = args.model_class_name
-    is_ltx2 = "ltx2" in model_name or (model_class_name and "ltx2" in model_class_name.lower())
-    if model_class_name is None and is_ltx2:
-        model_class_name = "LTX2ImageToVideoPipeline"
+    model_class_name = default_image_to_video_class_name(args.model, args.model_class_name)
+    is_ltx2 = is_ltx2_model(model_name, model_class_name)
+    is_ltx23 = is_ltx23_model(model_name, model_class_name)
 
     # Load input image
     image = PIL.Image.open(args.image).convert("RGB")
@@ -276,8 +294,12 @@ def main():
     fps = args.fps if args.fps is not None else (24 if is_ltx2 else 16)
     frame_rate = args.frame_rate if args.frame_rate is not None else float(fps)
     guidance_scale = args.guidance_scale if args.guidance_scale is not None else (4.0 if is_ltx2 else 5.0)
-    num_frames = args.num_frames if args.num_frames is not None else (121 if is_ltx2 else 81)
-    num_inference_steps = args.num_inference_steps if args.num_inference_steps is not None else (40 if is_ltx2 else 50)
+    default_ltx_frames = 25 if is_ltx23 else 121
+    default_ltx_steps = 20 if is_ltx23 else 40
+    num_frames = args.num_frames if args.num_frames is not None else (default_ltx_frames if is_ltx2 else 81)
+    num_inference_steps = (
+        args.num_inference_steps if args.num_inference_steps is not None else (default_ltx_steps if is_ltx2 else 50)
+    )
 
     # Calculate dimensions if not provided
     height = args.height
@@ -367,8 +389,8 @@ def main():
     print(f"\n{'=' * 60}")
     print("Generation Configuration:")
     print(f"  Model: {args.model}")
-    print(f"  Inference steps: {args.num_inference_steps}")
-    print(f"  Frames: {args.num_frames}")
+    print(f"  Inference steps: {num_inference_steps}")
+    print(f"  Frames: {num_frames}")
     print(f"  Solver: {args.sample_solver}")
     print(f"  diffusion_kv_cache_dtype(config): {args.diffusion_kv_cache_dtype}")
     print(f"  diffusion_kv_cache_skip_steps(config): {args.diffusion_kv_cache_skip_steps}")
@@ -378,7 +400,7 @@ def main():
         f" tensor_parallel_size={args.tensor_parallel_size}, vae_patch_parallel_size={args.vae_patch_parallel_size},"
         f" pipeline_parallel_size={args.pipeline_parallel_size}"
     )
-    print(f"  Video size: {args.width}x{args.height}")
+    print(f"  Video size: {width}x{height}")
     print(f"{'=' * 60}\n")
 
     generation_start = time.perf_counter()
@@ -412,6 +434,7 @@ def main():
     print(f"Total generation time: {generation_time:.4f} seconds ({generation_time * 1000:.2f} ms)")
 
     audio = None
+    audio_sample_rate = args.audio_sample_rate
     if isinstance(frames, list):
         frames = frames[0] if frames else None
 
@@ -422,11 +445,13 @@ def main():
             )
         if frames.multimodal_output and "audio" in frames.multimodal_output:
             audio = frames.multimodal_output["audio"]
+            audio_sample_rate = frames.multimodal_output.get("audio_sample_rate", audio_sample_rate)
         if frames.is_pipeline_output and frames.request_output is not None:
             inner_output = frames.request_output
             if isinstance(inner_output, OmniRequestOutput):
                 if inner_output.multimodal_output and "audio" in inner_output.multimodal_output:
                     audio = inner_output.multimodal_output["audio"]
+                    audio_sample_rate = inner_output.multimodal_output.get("audio_sample_rate", audio_sample_rate)
                 frames = inner_output
         if isinstance(frames, OmniRequestOutput):
             if frames.images:
@@ -434,6 +459,7 @@ def main():
                     frames, audio = frames.images[0]
                 elif len(frames.images) == 1 and isinstance(frames.images[0], dict):
                     audio = frames.images[0].get("audio")
+                    audio_sample_rate = frames.images[0].get("audio_sample_rate", audio_sample_rate)
                     frames = frames.images[0].get("frames") or frames.images[0].get("video")
                 else:
                     frames = frames.images
@@ -446,6 +472,7 @@ def main():
             frames, audio = first_item
         elif isinstance(first_item, dict):
             audio = first_item.get("audio")
+            audio_sample_rate = first_item.get("audio_sample_rate", audio_sample_rate)
             frames = first_item.get("frames") or first_item.get("video")
         elif isinstance(first_item, list):
             frames = first_item
@@ -454,6 +481,7 @@ def main():
         frames, audio = frames
     elif isinstance(frames, dict):
         audio = frames.get("audio")
+        audio_sample_rate = frames.get("audio_sample_rate", audio_sample_rate)
         frames = frames.get("frames") or frames.get("video")
 
     if frames is None:
@@ -572,7 +600,7 @@ def main():
             frames_u8,
             audio_np,
             fps=float(fps),
-            audio_sample_rate=args.audio_sample_rate,
+            audio_sample_rate=audio_sample_rate,
         )
         with open(str(output_path), "wb") as f:
             f.write(video_bytes)

--- a/examples/offline_inference/video_model_defaults.py
+++ b/examples/offline_inference/video_model_defaults.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+_LTX23_RAW_CHECKPOINT_MODEL_IDS = {
+    "lightricks/ltx-2.3",
+}
+
+
+def _normalize_model_name(value: str | None) -> str:
+    return (value or "").lower().replace("-", "").replace("_", "").replace(".", "")
+
+
+def _is_unsupported_ltx23_raw_checkpoint_model(model: str | None) -> bool:
+    return model is not None and model.lower() in _LTX23_RAW_CHECKPOINT_MODEL_IDS
+
+
+def is_ltx23_model(model: str | None, model_class_name: str | None = None) -> bool:
+    if _is_unsupported_ltx23_raw_checkpoint_model(model) and model_class_name is None:
+        return False
+    model_key = _normalize_model_name(model)
+    class_key = _normalize_model_name(model_class_name)
+    return "ltx23" in model_key or "ltx23" in class_key
+
+
+def is_ltx2_model(model: str | None, model_class_name: str | None = None) -> bool:
+    if _is_unsupported_ltx23_raw_checkpoint_model(model) and model_class_name is None:
+        return False
+    model_key = _normalize_model_name(model)
+    class_key = _normalize_model_name(model_class_name)
+    return is_ltx23_model(model, model_class_name) or "ltx2" in model_key or "ltx2" in class_key
+
+
+def default_image_to_video_class_name(model: str | None, model_class_name: str | None = None) -> str | None:
+    if model_class_name is not None:
+        return model_class_name
+    if is_ltx23_model(model):
+        return "LTX23ImageToVideoPipeline"
+    if is_ltx2_model(model):
+        return "LTX2ImageToVideoPipeline"
+    return None

--- a/recipes/LTX/LTX-2.3.md
+++ b/recipes/LTX/LTX-2.3.md
@@ -6,21 +6,23 @@
 
 - Vendor: Lightricks
 - Model: `dg845/LTX-2.3-Diffusers`
-- Task: Text-to-video with synchronized audio generation
+- Task: Text-to-video and image-to-video with synchronized audio generation
 - Mode: Online serving (pure diffusion)
 - Maintainer: @oglok
 
 ## When to use this recipe
 
-Use this recipe when you want to serve LTX-2.3 for text-to-video generation
-with audio. The model generates videos up to 20+ seconds at 768x512 resolution
-with 48kHz audio, all from a single text prompt. Requires a GPU with at least
-96GB VRAM due to the 22B parameter transformer (~44GB weights) plus text
+Use this recipe when you want to serve LTX-2.3 for text-to-video or
+image-to-video generation with audio. The model generates videos up to 20+
+seconds at 768x512 resolution with 48kHz audio from text prompts, and can
+condition video generation on an initial image. Start with a 96GB-class GPU for
+validation because the model combines a 22B parameter transformer with text
 encoder, VAE, and vocoder components.
 
 ## References
 
-- Model: <https://huggingface.co/dg845/LTX-2.3-Diffusers>
+- Upstream raw checkpoints: <https://huggingface.co/Lightricks/LTX-2.3>
+- Diffusers-format checkpoint: <https://huggingface.co/dg845/LTX-2.3-Diffusers>
 - Requires `diffusers >= 0.38.0` (install from git: `pip install git+https://github.com/huggingface/diffusers.git`)
 
 ## Serving
@@ -34,7 +36,16 @@ vllm serve dg845/LTX-2.3-Diffusers \
   --stage-init-timeout 600
 ```
 
-### Verification
+For image-to-video:
+
+```bash
+vllm serve dg845/LTX-2.3-Diffusers \
+  --omni \
+  --model-class-name LTX23ImageToVideoPipeline \
+  --stage-init-timeout 600
+```
+
+### T2V Verification
 
 ```bash
 # Health check
@@ -73,19 +84,48 @@ curl -X POST http://localhost:8000/v1/videos \
   -F "guidance_scale=4.0"
 ```
 
+### I2V Verification
+
+Start the server with `--model-class-name LTX23ImageToVideoPipeline`, then pass
+an image reference. The I2V pipeline requires `input_reference` or
+`image_reference` because the first frame is the conditioning input.
+
+```bash
+curl http://localhost:8000/health
+
+curl -X POST http://localhost:8000/v1/videos/sync \
+  -F "prompt=A plush toy astronaut gently waving while the camera slowly pushes in." \
+  -F "input_reference=@/absolute/path/to/reference.png" \
+  -F "model=dg845/LTX-2.3-Diffusers" \
+  -F "num_frames=81" \
+  -F "fps=24" \
+  -F "size=768x512" \
+  -F "num_inference_steps=30" \
+  -F "guidance_scale=4.0" \
+  -F "seed=42" \
+  -o ltx23_i2v.mp4
+```
+
 ### Notes
 
-- Memory usage: Model loads at ~36 GiB, peaks at ~62 GiB during inference
+- Memory usage: run a latest-head serving smoke or DFX benchmark on the target
+  GPU before publishing load/peak VRAM numbers.
+- Checkpoint format: use a Diffusers-format checkpoint such as
+  `dg845/LTX-2.3-Diffusers`; the upstream `Lightricks/LTX-2.3` repository ships
+  raw safetensors and does not contain the subfolder configs required by this
+  pipeline loader.
 - Key flags:
-  - `--stage-init-timeout 600`: Required for the initial `torch.compile` warmup (~90-140 seconds on first request)
-  - `--model-class-name LTX23Pipeline`: Selects the LTX-2.3 pipeline (not LTX-2)
+  - `--stage-init-timeout 600`: Gives the initial `torch.compile` warmup enough time on large checkpoints
+  - `--model-class-name LTX23Pipeline`: Selects the LTX-2.3 text-to-video pipeline (not LTX-2)
+  - `--model-class-name LTX23ImageToVideoPipeline`: Selects the LTX-2.3 image-to-video pipeline
+  - `input_reference=@...`: Uploads the I2V reference image directly
 - Audio: 48kHz AAC via BWE vocoder, automatically synced with video
 - CPU offloading: Text encoder (Gemma-3-12B), connectors, VAE, audio VAE, and vocoder stay on CPU and are moved to GPU only when needed
 - Supported resolutions: 768x512, 512x384 (must be divisible by 32)
 - Frame rate: 24 fps
 - Duration: Controlled by `num_frames` (frames = duration_seconds * 24 + 1)
 - Known limitations:
-  - No image-to-video support yet (LTX23ImageToVideoPipeline is a placeholder)
+  - LTX-2.3 I2V currently supports first-frame image conditioning, matching the LTX image-conditioning contract.
   - Requires `diffusers >= 0.38.0` (not yet on PyPI, install from git)
 
 ## Hardware Support
@@ -99,13 +139,16 @@ curl -X POST http://localhost:8000/v1/videos \
 - OS: Ubuntu 22.04
 - Python: 3.10+
 - Driver / runtime: CUDA 13.0, Driver 580.126.09
-- vLLM version: 0.19.x
-- vLLM-Omni version: 0.19.x
+- vLLM version: Match the PR or release checkout being validated
+- vLLM-Omni version or commit: Use the commit you are deploying from
 
-### Validated configurations
+### Benchmarking
 
-| Duration | Frames | Resolution | Steps | Guidance | Inference Time | Peak VRAM |
-|----------|--------|------------|-------|----------|----------------|-----------|
-| 3s | 81 | 768x512 | 30 | 4.0 | ~110s | ~62 GB |
-| 10s | 241 | 768x512 | 30 | 4.0 | ~130s | ~62 GB |
-| 20s | 481 | 768x512 | 30 | 4.0 | ~420s | ~62 GB |
+Do not copy latency or VRAM numbers between commits or machines. Record them
+only after running a latest-head sweep on the target hardware.
+
+For formal PR benchmarking, reuse
+`tests/dfx/perf/tests/test_ltx2_3_vllm_omni.json` with
+`tests/dfx/perf/scripts/run_diffusion_benchmark.py`. That config captures the
+single-device eager baseline and CFG-parallel=2 case for a small 384x512,
+25-frame, 20-step workload.

--- a/tests/dfx/perf/tests/test_ltx2_3_vllm_omni.json
+++ b/tests/dfx/perf/tests/test_ltx2_3_vllm_omni.json
@@ -1,0 +1,89 @@
+[
+    {
+        "test_name": "test_ltx2_3_baseline_eager",
+        "description": "LTX-2.3 single-device baseline with enforce-eager",
+        "server_type": "vllm-omni",
+        "server_params": {
+            "model": "dg845/LTX-2.3-Diffusers",
+            "serve_args": {
+                "model-class-name": "LTX23Pipeline",
+                "enforce-eager": true,
+                "enable-diffusion-pipeline-profiler": true
+            }
+        },
+        "benchmark_params": [
+            {
+                "name": "384x512_25f_steps20",
+                "dataset": "random",
+                "task": "t2v",
+                "backend": "v1/videos",
+                "width": 512,
+                "height": 384,
+                "num-frames": 25,
+                "fps": 24,
+                "num-inference-steps": 20,
+                "num-prompts": 3,
+                "max-concurrency": 1,
+                "enable-negative-prompt": true
+            }
+        ]
+    },
+    {
+        "test_name": "test_ltx2_3_cfg2_eager",
+        "description": "LTX-2.3 CFG-parallel=2 with enforce-eager",
+        "server_type": "vllm-omni",
+        "server_params": {
+            "model": "dg845/LTX-2.3-Diffusers",
+            "serve_args": {
+                "model-class-name": "LTX23Pipeline",
+                "cfg-parallel-size": 2,
+                "enforce-eager": true,
+                "enable-diffusion-pipeline-profiler": true
+            }
+        },
+        "benchmark_params": [
+            {
+                "name": "384x512_25f_steps20",
+                "dataset": "random",
+                "task": "t2v",
+                "backend": "v1/videos",
+                "width": 512,
+                "height": 384,
+                "num-frames": 25,
+                "fps": 24,
+                "num-inference-steps": 20,
+                "num-prompts": 3,
+                "max-concurrency": 1,
+                "enable-negative-prompt": true
+            }
+        ]
+    },
+    {
+        "test_name": "test_ltx2_3_compile",
+        "description": "LTX-2.3 torch.compile path",
+        "server_type": "vllm-omni",
+        "server_params": {
+            "model": "dg845/LTX-2.3-Diffusers",
+            "serve_args": {
+                "model-class-name": "LTX23Pipeline",
+                "enable-diffusion-pipeline-profiler": true
+            }
+        },
+        "benchmark_params": [
+            {
+                "name": "384x512_25f_steps20",
+                "dataset": "random",
+                "task": "t2v",
+                "backend": "v1/videos",
+                "width": 512,
+                "height": 384,
+                "num-frames": 25,
+                "fps": 24,
+                "num-inference-steps": 20,
+                "num-prompts": 3,
+                "max-concurrency": 1,
+                "enable-negative-prompt": true
+            }
+        ]
+    }
+]

--- a/tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py
+++ b/tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py
@@ -38,6 +38,155 @@ def _make_ltx23_pipeline(sequence_parallel_size: int = 1):
     return pipeline
 
 
+def _make_ltx23_request_pipe(cls):
+    pipe = object.__new__(cls)
+    torch.nn.Module.__init__(pipe)
+    pipe.device = torch.device("cpu")
+    pipe.tokenizer_max_length = 99
+    return pipe
+
+
+def _resolve_request_inputs_for_test(pipe, req):
+    return pipe._resolve_request_inputs(
+        req,
+        prompt=None,
+        negative_prompt=None,
+        height=None,
+        width=None,
+        num_frames=None,
+        frame_rate=None,
+        num_inference_steps=None,
+        timesteps=None,
+        guidance_scale=4.0,
+        num_videos_per_prompt=1,
+        generator=None,
+        latents=None,
+        audio_latents=None,
+        prompt_embeds=None,
+        negative_prompt_embeds=None,
+        prompt_attention_mask=None,
+        negative_prompt_attention_mask=None,
+        decode_timestep=0.0,
+        decode_noise_scale=None,
+        output_type="np",
+        max_sequence_length=None,
+    )
+
+
+class TestLTX23RequestParsing:
+    def test_t2v_and_i2v_share_request_input_resolution(self):
+        from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import LTX23ImageToVideoPipeline, LTX23Pipeline
+        from vllm_omni.diffusion.request import OmniDiffusionRequest
+        from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+        prompt_embeds = torch.tensor([[1.0, 2.0]])
+        negative_prompt_embeds = torch.tensor([[3.0, 4.0]])
+        prompt_attention_mask = torch.tensor([True, False])
+        negative_attention_mask = torch.tensor([False, True])
+        video_latents = torch.ones(1, 2, 3)
+        audio_latents = torch.zeros(1, 2, 3)
+
+        req = OmniDiffusionRequest(
+            prompts=[
+                {
+                    "prompt": "shared prompt",
+                    "negative_prompt": "shared negative",
+                    "additional_information": {
+                        "prompt_embeds": prompt_embeds,
+                        "negative_prompt_embeds": negative_prompt_embeds,
+                        "attention_mask": prompt_attention_mask,
+                        "negative_attention_mask": negative_attention_mask,
+                    },
+                }
+            ],
+            sampling_params=OmniDiffusionSamplingParams(
+                height=384,
+                width=512,
+                num_frames=25,
+                frame_rate=12.5,
+                num_inference_steps=1,
+                num_outputs_per_prompt=2,
+                guidance_scale=6.0,
+                seed=123,
+                latents=video_latents,
+                extra_args={"audio_latents": audio_latents},
+                decode_timestep=[0.1],
+                decode_noise_scale=[0.2],
+                output_type="latent",
+                max_sequence_length=17,
+            ),
+            request_id="ltx23-shared-request-inputs",
+        )
+
+        resolved_t2v = _resolve_request_inputs_for_test(
+            _make_ltx23_request_pipe(LTX23Pipeline),
+            req,
+        )
+        resolved_i2v = _resolve_request_inputs_for_test(
+            _make_ltx23_request_pipe(LTX23ImageToVideoPipeline),
+            req,
+        )
+
+        assert resolved_i2v.prompt == resolved_t2v.prompt == ["shared prompt"]
+        assert resolved_i2v.negative_prompt == resolved_t2v.negative_prompt == ["shared negative"]
+        assert resolved_i2v.height == resolved_t2v.height == 384
+        assert resolved_i2v.width == resolved_t2v.width == 512
+        assert resolved_i2v.num_frames == resolved_t2v.num_frames == 25
+        assert resolved_i2v.frame_rate == resolved_t2v.frame_rate == 12.5
+        assert resolved_i2v.num_inference_steps == resolved_t2v.num_inference_steps == 2
+        assert resolved_i2v.guidance_scale == resolved_t2v.guidance_scale == 6.0
+        assert resolved_i2v.num_videos_per_prompt == resolved_t2v.num_videos_per_prompt == 2
+        assert resolved_i2v.generator.initial_seed() == resolved_t2v.generator.initial_seed() == 123
+        assert resolved_i2v.decode_timestep == resolved_t2v.decode_timestep == [0.1]
+        assert resolved_i2v.decode_noise_scale == resolved_t2v.decode_noise_scale == [0.2]
+        assert resolved_i2v.output_type == resolved_t2v.output_type == "latent"
+        assert resolved_i2v.max_sequence_length == resolved_t2v.max_sequence_length == 17
+        torch.testing.assert_close(resolved_i2v.latents, video_latents)
+        torch.testing.assert_close(resolved_t2v.latents, video_latents)
+        torch.testing.assert_close(resolved_i2v.audio_latents, audio_latents)
+        torch.testing.assert_close(resolved_t2v.audio_latents, audio_latents)
+        torch.testing.assert_close(resolved_i2v.prompt_embeds, torch.stack([prompt_embeds]))
+        torch.testing.assert_close(resolved_t2v.prompt_embeds, torch.stack([prompt_embeds]))
+        torch.testing.assert_close(resolved_i2v.negative_prompt_embeds, torch.stack([negative_prompt_embeds]))
+        torch.testing.assert_close(resolved_t2v.negative_prompt_embeds, torch.stack([negative_prompt_embeds]))
+        torch.testing.assert_close(resolved_i2v.prompt_attention_mask, torch.stack([prompt_attention_mask]))
+        torch.testing.assert_close(resolved_t2v.prompt_attention_mask, torch.stack([prompt_attention_mask]))
+        torch.testing.assert_close(
+            resolved_i2v.negative_prompt_attention_mask,
+            torch.stack([negative_attention_mask]),
+        )
+        torch.testing.assert_close(
+            resolved_t2v.negative_prompt_attention_mask,
+            torch.stack([negative_attention_mask]),
+        )
+
+    def test_request_input_resolution_rejects_mixed_precomputed_prompt_fields(self):
+        from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import LTX23Pipeline
+        from vllm_omni.diffusion.request import OmniDiffusionRequest
+        from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+        pipe = _make_ltx23_request_pipe(LTX23Pipeline)
+        req = OmniDiffusionRequest(
+            prompts=[
+                {
+                    "prompt": "with embeds",
+                    "additional_information": {"prompt_embeds": torch.tensor([[1.0]])},
+                },
+                {"prompt": "without embeds"},
+            ],
+            sampling_params=OmniDiffusionSamplingParams(
+                height=384,
+                width=512,
+                num_frames=25,
+                num_inference_steps=2,
+            ),
+            request_id="ltx23-mixed-precomputed-fields",
+        )
+
+        with pytest.raises(ValueError, match="prompt_embeds.*every prompt"):
+            _resolve_request_inputs_for_test(pipe, req)
+
+
 class TestPipelineIndependence:
     """Verify LTX23Pipeline is fully independent from LTX2Pipeline."""
 
@@ -103,6 +252,133 @@ class TestPipelineIndependence:
         from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 
         assert issubclass(LTX23Pipeline, DiffusionPipelineProfilerMixin)
+
+
+class TestLTX23ImageToVideoPipeline:
+    def test_ltx23_i2v_pipeline_reuses_ltx23_semantics(self):
+        from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import LTX23ImageToVideoPipeline, LTX23Pipeline
+
+        assert issubclass(LTX23ImageToVideoPipeline, LTX23Pipeline)
+        assert LTX23ImageToVideoPipeline.support_image_input is True
+
+    def test_ltx23_i2v_rejects_multi_image_prompt_list(self):
+        from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import LTX23ImageToVideoPipeline
+
+        image = object()
+
+        assert LTX23ImageToVideoPipeline._resolve_single_prompt_image([image]) is image
+        with pytest.raises(ValueError, match="exactly one image per prompt"):
+            LTX23ImageToVideoPipeline._resolve_single_prompt_image([object(), object()])
+
+    def test_ltx23_i2v_additional_image_resolution_is_tensor_safe(self):
+        from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import LTX23ImageToVideoPipeline
+
+        image = torch.zeros(1, 3, 4, 4)
+        additional = {
+            "preprocessed_image": None,
+            "pixel_values": image,
+            "image": torch.ones_like(image),
+        }
+
+        assert LTX23ImageToVideoPipeline._resolve_additional_image(additional) is image
+
+    def test_ltx23_i2v_packed_latents_noise_preserves_conditioning_frame(self, monkeypatch):
+        import vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 as ltx23
+        from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import LTX23ImageToVideoPipeline
+
+        pipe = object.__new__(LTX23ImageToVideoPipeline)
+        torch.nn.Module.__init__(pipe)
+        pipe.vae_spatial_compression_ratio = 1
+        pipe.vae_temporal_compression_ratio = 1
+        pipe.transformer_spatial_patch_size = 1
+        pipe.transformer_temporal_patch_size = 1
+
+        def fake_randn_tensor(shape, generator=None, device=None, dtype=None):
+            return torch.ones(shape, device=device, dtype=dtype)
+
+        monkeypatch.setattr(ltx23, "randn_tensor", fake_randn_tensor)
+
+        latents = torch.tensor([[[10.0, 11.0], [20.0, 21.0], [30.0, 31.0]]])
+
+        out, conditioning_mask = pipe.prepare_latents(
+            image=None,
+            batch_size=1,
+            num_channels_latents=2,
+            height=1,
+            width=1,
+            num_frames=3,
+            noise_scale=1.0,
+            dtype=torch.float32,
+            device=torch.device("cpu"),
+            latents=latents,
+        )
+
+        torch.testing.assert_close(conditioning_mask, torch.tensor([[1.0, 0.0, 0.0]]))
+        torch.testing.assert_close(out[:, :1], latents[:, :1])
+        torch.testing.assert_close(out[:, 1:], torch.ones_like(out[:, 1:]))
+
+    def test_ltx23_i2v_video_step_preserves_conditioning_frame(self):
+        from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import LTX23ImageToVideoPipeline
+
+        pipe = object.__new__(LTX23ImageToVideoPipeline)
+        torch.nn.Module.__init__(pipe)
+        pipe.transformer_spatial_patch_size = 1
+        pipe.transformer_temporal_patch_size = 1
+
+        class FakeScheduler:
+            def step(self, noise_pred, t, latents, return_dict=False):
+                return (latents + noise_pred + t,)
+
+        pipe.scheduler = FakeScheduler()
+        latents = torch.tensor([[[1.0], [2.0], [3.0]]])
+        noise_pred = torch.full_like(latents, 10.0)
+
+        out = pipe._step_video_latents_i2v(
+            noise_pred,
+            latents,
+            torch.tensor(0.5),
+            latent_num_frames=3,
+            latent_height=1,
+            latent_width=1,
+        )
+
+        torch.testing.assert_close(out[:, :1], latents[:, :1])
+        torch.testing.assert_close(out[:, 1:], latents[:, 1:] + noise_pred[:, 1:] + 0.5)
+
+
+class TestLTX23DecodeConditioning:
+    def test_decode_conditioning_expands_per_prompt_values_to_effective_batch(self):
+        from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import _expand_per_prompt_decode_value
+
+        assert _expand_per_prompt_decode_value(
+            [0.1, 0.2],
+            prompt_batch_size=2,
+            effective_batch_size=4,
+            field_name="decode_timestep",
+        ) == [0.1, 0.1, 0.2, 0.2]
+        assert _expand_per_prompt_decode_value(
+            [0.3],
+            prompt_batch_size=2,
+            effective_batch_size=4,
+            field_name="decode_timestep",
+        ) == [0.3, 0.3, 0.3, 0.3]
+        assert _expand_per_prompt_decode_value(
+            [0.1, 0.2, 0.3, 0.4],
+            prompt_batch_size=2,
+            effective_batch_size=4,
+            field_name="decode_timestep",
+        ) == [0.1, 0.2, 0.3, 0.4]
+
+    def test_decode_conditioning_rejects_ambiguous_lengths(self):
+        from vllm_omni.diffusion.models.ltx2.pipeline_ltx2_3 import _expand_per_prompt_decode_value
+
+        with pytest.raises(ValueError, match="decode_timestep"):
+            _expand_per_prompt_decode_value(
+                [0.1, 0.2, 0.3],
+                prompt_batch_size=2,
+                effective_batch_size=4,
+                field_name="decode_timestep",
+            )
 
 
 class TestLTX23VaeDecodeParallel:

--- a/tests/examples/offline_inference/test_ltx2_3_video_defaults.py
+++ b/tests/examples/offline_inference/test_ltx2_3_video_defaults.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from examples.offline_inference.video_model_defaults import (
+    default_image_to_video_class_name,
+    is_ltx2_model,
+    is_ltx23_model,
+)
+
+
+def test_ltx23_model_name_detection_accepts_hyphenated_model_ids():
+    assert is_ltx23_model("dg845/LTX-2.3-Diffusers")
+    assert is_ltx23_model("/models/ltx23-local")
+    assert not is_ltx23_model("Lightricks/LTX-2.3")
+    assert not is_ltx2_model("Lightricks/LTX-2.3")
+
+
+def test_ltx23_image_to_video_defaults_select_i2v_pipeline():
+    assert default_image_to_video_class_name("dg845/LTX-2.3-Diffusers") == "LTX23ImageToVideoPipeline"
+    assert default_image_to_video_class_name("Lightricks/LTX-2.3") is None
+    assert default_image_to_video_class_name("Lightricks/LTX-2") == "LTX2ImageToVideoPipeline"

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
@@ -19,14 +19,17 @@ import json
 import os
 from collections.abc import Iterable
 from contextlib import nullcontext
+from dataclasses import dataclass
 from typing import Any, ClassVar
 
 import numpy as np
+import PIL.Image
 import torch
 from diffusers import AutoencoderKLLTX2Audio, FlowMatchEulerDiscreteScheduler
 from diffusers.pipelines.ltx2 import LTX2TextConnectors
 from diffusers.pipelines.ltx2.vocoder import LTX2Vocoder
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import retrieve_timesteps
+from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion_img2img import retrieve_latents
 from diffusers.utils.torch_utils import randn_tensor
 from diffusers.video_processor import VideoProcessor
 from huggingface_hub import hf_hub_download
@@ -59,6 +62,7 @@ from .pipeline_ltx2 import (
     create_transformer_from_config,
     load_transformer_config,
 )
+from .pipeline_ltx2_image2video import LTX2ImageToVideoPipeline, _I2VVideoAudioScheduler
 
 logger = init_logger(__name__)
 
@@ -67,6 +71,56 @@ try:
     from diffusers.pipelines.ltx2.vocoder import LTX2VocoderWithBWE
 except ImportError:
     LTX2VocoderWithBWE = None
+
+
+@dataclass
+class _LTX23RequestInputs:
+    prompt: str | list[str] | None
+    negative_prompt: str | list[str] | None
+    height: int
+    width: int
+    num_frames: int
+    frame_rate: float
+    num_inference_steps: int
+    guidance_scale: float
+    num_videos_per_prompt: int
+    generator: torch.Generator | list[torch.Generator] | None
+    latents: torch.Tensor | None
+    audio_latents: torch.Tensor | None
+    prompt_embeds: torch.Tensor | None
+    negative_prompt_embeds: torch.Tensor | None
+    prompt_attention_mask: torch.Tensor | None
+    negative_prompt_attention_mask: torch.Tensor | None
+    decode_timestep: float | list[float]
+    decode_noise_scale: float | list[float] | None
+    output_type: str
+    max_sequence_length: int
+
+
+@dataclass
+class _LTX23PromptContext:
+    batch_size: int
+    connector_prompt_embeds: torch.Tensor
+    connector_audio_prompt_embeds: torch.Tensor
+    connector_attention_mask: torch.Tensor
+    positive_connector_prompt_embeds: torch.Tensor
+    positive_connector_audio_prompt_embeds: torch.Tensor
+    positive_connector_attention_mask: torch.Tensor
+    negative_connector_prompt_embeds: torch.Tensor | None
+    negative_connector_audio_prompt_embeds: torch.Tensor | None
+    negative_connector_attention_mask: torch.Tensor | None
+
+
+def _stack_prompt_field_if_present(values: list[Any], field_name: str) -> torch.Tensor | None:
+    if not any(value is not None for value in values):
+        return None
+    missing_indices = [idx for idx, value in enumerate(values) if value is None]
+    if missing_indices:
+        raise ValueError(
+            f"`{field_name}` must be provided for every prompt when provided "
+            f"for any prompt. Missing prompt indices: {missing_indices}."
+        )
+    return torch.stack(values)
 
 
 def _detect_vocoder_output_sample_rate(model: str) -> int | None:
@@ -113,6 +167,58 @@ def get_ltx2_post_process_func(od_config: OmniDiffusionConfig):
         return output
 
     return post_process_func
+
+
+def _expand_per_prompt_decode_value(
+    value: float | list[float],
+    *,
+    prompt_batch_size: int,
+    effective_batch_size: int,
+    field_name: str,
+) -> list[float]:
+    if not isinstance(value, list):
+        return [value] * effective_batch_size
+    if len(value) == 1:
+        return value * effective_batch_size
+    if len(value) == effective_batch_size:
+        return value
+    if prompt_batch_size > 0 and len(value) == prompt_batch_size and effective_batch_size % prompt_batch_size == 0:
+        repeats = effective_batch_size // prompt_batch_size
+        return [item for item in value for _ in range(repeats)]
+    raise ValueError(
+        f"`{field_name}` must have length 1, prompt batch size ({prompt_batch_size}), or effective batch size"
+        f" ({effective_batch_size}); got {len(value)}."
+    )
+
+
+def _prepare_decode_timestep_conditioning(
+    *,
+    decode_timestep: float | list[float],
+    decode_noise_scale: float | list[float] | None,
+    prompt_batch_size: int,
+    effective_batch_size: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    decode_timestep_values = _expand_per_prompt_decode_value(
+        decode_timestep,
+        prompt_batch_size=prompt_batch_size,
+        effective_batch_size=effective_batch_size,
+        field_name="decode_timestep",
+    )
+    if decode_noise_scale is None:
+        decode_noise_scale_values = decode_timestep_values
+    else:
+        decode_noise_scale_values = _expand_per_prompt_decode_value(
+            decode_noise_scale,
+            prompt_batch_size=prompt_batch_size,
+            effective_batch_size=effective_batch_size,
+            field_name="decode_noise_scale",
+        )
+    return (
+        torch.tensor(decode_timestep_values, device=device, dtype=dtype),
+        torch.tensor(decode_noise_scale_values, device=device, dtype=dtype)[:, None, None, None, None],
+    )
 
 
 class LTX23Pipeline(
@@ -823,6 +929,212 @@ class LTX23Pipeline(
             torch.cuda.current_stream(device).synchronize()
         return latents
 
+    def _resolve_request_inputs(
+        self,
+        req: OmniDiffusionRequest,
+        *,
+        prompt: str | list[str] | None,
+        negative_prompt: str | list[str] | None,
+        height: int | None,
+        width: int | None,
+        num_frames: int | None,
+        frame_rate: float | None,
+        num_inference_steps: int | None,
+        timesteps: list[int] | None,
+        guidance_scale: float,
+        num_videos_per_prompt: int | None,
+        generator: torch.Generator | list[torch.Generator] | None,
+        latents: torch.Tensor | None,
+        audio_latents: torch.Tensor | None,
+        prompt_embeds: torch.Tensor | None,
+        negative_prompt_embeds: torch.Tensor | None,
+        prompt_attention_mask: torch.Tensor | None,
+        negative_prompt_attention_mask: torch.Tensor | None,
+        decode_timestep: float | list[float],
+        decode_noise_scale: float | list[float] | None,
+        output_type: str,
+        max_sequence_length: int | None,
+    ) -> _LTX23RequestInputs:
+        prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts] or prompt
+        if all(isinstance(p, str) or p.get("negative_prompt") is None for p in req.prompts):
+            negative_prompt = None
+        elif req.prompts:
+            negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in req.prompts]
+
+        height = req.sampling_params.height or height or 512
+        width = req.sampling_params.width or width or 768
+        num_frames = req.sampling_params.num_frames or num_frames or 121
+        frame_rate = req.sampling_params.resolved_frame_rate or frame_rate or 24.0
+        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps or 40
+        if timesteps is None:
+            num_inference_steps = max(int(num_inference_steps), 2)
+        elif len(timesteps) < 2:
+            raise ValueError("`timesteps` must contain at least 2 values for FlowMatchEulerDiscreteScheduler.")
+
+        num_videos_per_prompt = (
+            req.sampling_params.num_outputs_per_prompt
+            if req.sampling_params.num_outputs_per_prompt > 0
+            else num_videos_per_prompt or 1
+        )
+        max_sequence_length = (
+            req.sampling_params.max_sequence_length or max_sequence_length or self.tokenizer_max_length
+        )
+
+        if req.sampling_params.guidance_scale_provided:
+            guidance_scale = req.sampling_params.guidance_scale
+
+        if generator is None:
+            generator = req.sampling_params.generator
+        if generator is None and req.sampling_params.seed is not None:
+            generator = torch.Generator(device=self.device).manual_seed(req.sampling_params.seed)
+
+        latents = req.sampling_params.latents if req.sampling_params.latents is not None else latents
+        audio_latents = (
+            req.sampling_params.audio_latents
+            if req.sampling_params.audio_latents is not None
+            else req.sampling_params.extra_args.get("audio_latents", audio_latents)
+        )
+
+        req_prompt_embeds = [_get_prompt_field(p, "prompt_embeds") for p in req.prompts]
+        stacked_prompt_embeds = _stack_prompt_field_if_present(req_prompt_embeds, "prompt_embeds")
+        if stacked_prompt_embeds is not None:
+            prompt_embeds = stacked_prompt_embeds
+            prompt = None
+
+        req_negative_prompt_embeds = [_get_prompt_field(p, "negative_prompt_embeds") for p in req.prompts]
+        stacked_negative_prompt_embeds = _stack_prompt_field_if_present(
+            req_negative_prompt_embeds, "negative_prompt_embeds"
+        )
+        if stacked_negative_prompt_embeds is not None:
+            negative_prompt_embeds = stacked_negative_prompt_embeds
+            negative_prompt = None
+
+        req_prompt_attention_masks = []
+        for prompt_item in req.prompts:
+            mask = _get_prompt_field(prompt_item, "prompt_attention_mask")
+            if mask is None:
+                mask = _get_prompt_field(prompt_item, "attention_mask")
+            req_prompt_attention_masks.append(mask)
+        stacked_prompt_attention_mask = _stack_prompt_field_if_present(
+            req_prompt_attention_masks, "prompt_attention_mask"
+        )
+        if stacked_prompt_attention_mask is not None:
+            prompt_attention_mask = stacked_prompt_attention_mask
+
+        req_negative_attention_masks = []
+        for prompt_item in req.prompts:
+            mask = _get_prompt_field(prompt_item, "negative_prompt_attention_mask")
+            if mask is None:
+                mask = _get_prompt_field(prompt_item, "negative_attention_mask")
+            req_negative_attention_masks.append(mask)
+        stacked_negative_prompt_attention_mask = _stack_prompt_field_if_present(
+            req_negative_attention_masks, "negative_prompt_attention_mask"
+        )
+        if stacked_negative_prompt_attention_mask is not None:
+            negative_prompt_attention_mask = stacked_negative_prompt_attention_mask
+
+        if req.sampling_params.decode_timestep is not None:
+            decode_timestep = req.sampling_params.decode_timestep
+        if req.sampling_params.decode_noise_scale is not None:
+            decode_noise_scale = req.sampling_params.decode_noise_scale
+        if req.sampling_params.output_type is not None:
+            output_type = req.sampling_params.output_type
+
+        return _LTX23RequestInputs(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            height=int(height),
+            width=int(width),
+            num_frames=int(num_frames),
+            frame_rate=float(frame_rate),
+            num_inference_steps=int(num_inference_steps),
+            guidance_scale=guidance_scale,
+            num_videos_per_prompt=int(num_videos_per_prompt),
+            generator=generator,
+            latents=latents,
+            audio_latents=audio_latents,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            prompt_attention_mask=prompt_attention_mask,
+            negative_prompt_attention_mask=negative_prompt_attention_mask,
+            decode_timestep=decode_timestep,
+            decode_noise_scale=decode_noise_scale,
+            output_type=output_type,
+            max_sequence_length=int(max_sequence_length),
+        )
+
+    def _prepare_prompt_context(
+        self,
+        *,
+        prompt: str | list[str] | None,
+        negative_prompt: str | list[str] | None,
+        prompt_embeds: torch.Tensor | None,
+        negative_prompt_embeds: torch.Tensor | None,
+        prompt_attention_mask: torch.Tensor | None,
+        negative_prompt_attention_mask: torch.Tensor | None,
+        num_videos_per_prompt: int,
+        max_sequence_length: int,
+    ) -> _LTX23PromptContext:
+        if prompt is not None and isinstance(prompt, str):
+            batch_size = 1
+        elif prompt is not None and isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            batch_size = prompt_embeds.shape[0]
+
+        prompt_embeds, prompt_attention_mask, negative_prompt_embeds, negative_prompt_attention_mask = (
+            self.encode_prompt(
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                do_classifier_free_guidance=self.do_classifier_free_guidance,
+                num_videos_per_prompt=num_videos_per_prompt,
+                prompt_embeds=prompt_embeds,
+                negative_prompt_embeds=negative_prompt_embeds,
+                prompt_attention_mask=prompt_attention_mask,
+                negative_prompt_attention_mask=negative_prompt_attention_mask,
+                max_sequence_length=max_sequence_length,
+                device=self.device,
+            )
+        )
+
+        if self.do_classifier_free_guidance:
+            prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+            prompt_attention_mask = torch.cat([negative_prompt_attention_mask, prompt_attention_mask], dim=0)
+
+        connector_prompt_embeds, connector_audio_prompt_embeds, connector_attention_mask = self.connectors(
+            prompt_embeds,
+            prompt_attention_mask,
+            padding_side=getattr(self.tokenizer, "padding_side", "left"),
+        )
+
+        positive_connector_prompt_embeds = connector_prompt_embeds
+        positive_connector_audio_prompt_embeds = connector_audio_prompt_embeds
+        positive_connector_attention_mask = connector_attention_mask
+        negative_connector_prompt_embeds = None
+        negative_connector_audio_prompt_embeds = None
+        negative_connector_attention_mask = None
+        if self.do_classifier_free_guidance:
+            split_batch = batch_size * num_videos_per_prompt
+            negative_connector_prompt_embeds = connector_prompt_embeds[:split_batch]
+            positive_connector_prompt_embeds = connector_prompt_embeds[split_batch:]
+            negative_connector_audio_prompt_embeds = connector_audio_prompt_embeds[:split_batch]
+            positive_connector_audio_prompt_embeds = connector_audio_prompt_embeds[split_batch:]
+            negative_connector_attention_mask = connector_attention_mask[:split_batch]
+            positive_connector_attention_mask = connector_attention_mask[split_batch:]
+
+        return _LTX23PromptContext(
+            batch_size=batch_size,
+            connector_prompt_embeds=connector_prompt_embeds,
+            connector_audio_prompt_embeds=connector_audio_prompt_embeds,
+            connector_attention_mask=connector_attention_mask,
+            positive_connector_prompt_embeds=positive_connector_prompt_embeds,
+            positive_connector_audio_prompt_embeds=positive_connector_audio_prompt_embeds,
+            positive_connector_attention_mask=positive_connector_attention_mask,
+            negative_connector_prompt_embeds=negative_connector_prompt_embeds,
+            negative_connector_audio_prompt_embeds=negative_connector_audio_prompt_embeds,
+            negative_connector_attention_mask=negative_connector_attention_mask,
+        )
+
     # ------------------------------------------------------------------
     # Forward pass
     # ------------------------------------------------------------------
@@ -857,75 +1169,50 @@ class LTX23Pipeline(
         attention_kwargs: dict[str, Any] | None = None,
         max_sequence_length: int | None = None,
     ) -> DiffusionOutput:
-        # ---- Extract from request ----
-        prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts] or prompt
-        if all(isinstance(p, str) or p.get("negative_prompt") is None for p in req.prompts):
-            negative_prompt = None
-        elif req.prompts:
-            negative_prompt = ["" if isinstance(p, str) else (p.get("negative_prompt") or "") for p in req.prompts]
-
-        height = req.sampling_params.height or height or 512
-        width = req.sampling_params.width or width or 768
-        num_frames = req.sampling_params.num_frames or num_frames or 121
-        frame_rate = req.sampling_params.resolved_frame_rate or frame_rate or 24.0
-        num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps or 40
-        # Enforce minimum of 2 timesteps for flow matching scheduler
-        if timesteps is None:
-            num_inference_steps = max(int(num_inference_steps), 2)
-        elif len(timesteps) < 2:
-            raise ValueError("`timesteps` must contain at least 2 values for FlowMatchEulerDiscreteScheduler.")
-        num_videos_per_prompt = (
-            req.sampling_params.num_outputs_per_prompt
-            if req.sampling_params.num_outputs_per_prompt > 0
-            else num_videos_per_prompt or 1
+        request_inputs = self._resolve_request_inputs(
+            req,
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            frame_rate=frame_rate,
+            num_inference_steps=num_inference_steps,
+            timesteps=timesteps,
+            guidance_scale=guidance_scale,
+            num_videos_per_prompt=num_videos_per_prompt,
+            generator=generator,
+            latents=latents,
+            audio_latents=audio_latents,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            prompt_attention_mask=prompt_attention_mask,
+            negative_prompt_attention_mask=negative_prompt_attention_mask,
+            decode_timestep=decode_timestep,
+            decode_noise_scale=decode_noise_scale,
+            output_type=output_type,
+            max_sequence_length=max_sequence_length,
         )
-        max_sequence_length = (
-            req.sampling_params.max_sequence_length or max_sequence_length or self.tokenizer_max_length
-        )
-
-        if req.sampling_params.guidance_scale_provided:
-            guidance_scale = req.sampling_params.guidance_scale
-
-        if generator is None:
-            generator = req.sampling_params.generator
-        if generator is None and req.sampling_params.seed is not None:
-            generator = torch.Generator(device=self.device).manual_seed(req.sampling_params.seed)
-
-        latents = req.sampling_params.latents if req.sampling_params.latents is not None else latents
-        audio_latents = (
-            req.sampling_params.audio_latents
-            if req.sampling_params.audio_latents is not None
-            else req.sampling_params.extra_args.get("audio_latents", audio_latents)
-        )
-
-        # Override with pre-computed embeddings if provided in request
-        req_prompt_embeds = [_get_prompt_field(p, "prompt_embeds") for p in req.prompts]
-        if any(p is not None for p in req_prompt_embeds):
-            prompt_embeds = torch.stack(req_prompt_embeds)
-
-        req_negative_prompt_embeds = [_get_prompt_field(p, "negative_prompt_embeds") for p in req.prompts]
-        if any(p is not None for p in req_negative_prompt_embeds):
-            negative_prompt_embeds = torch.stack(req_negative_prompt_embeds)
-
-        req_prompt_attention_masks = [
-            _get_prompt_field(p, "prompt_attention_mask") or _get_prompt_field(p, "attention_mask") for p in req.prompts
-        ]
-        if any(m is not None for m in req_prompt_attention_masks):
-            prompt_attention_mask = torch.stack(req_prompt_attention_masks)
-
-        req_negative_attention_masks = [
-            _get_prompt_field(p, "negative_prompt_attention_mask") or _get_prompt_field(p, "negative_attention_mask")
-            for p in req.prompts
-        ]
-        if any(m is not None for m in req_negative_attention_masks):
-            negative_prompt_attention_mask = torch.stack(req_negative_attention_masks)
-
-        if req.sampling_params.decode_timestep is not None:
-            decode_timestep = req.sampling_params.decode_timestep
-        if req.sampling_params.decode_noise_scale is not None:
-            decode_noise_scale = req.sampling_params.decode_noise_scale
-        if req.sampling_params.output_type is not None:
-            output_type = req.sampling_params.output_type
+        prompt = request_inputs.prompt
+        negative_prompt = request_inputs.negative_prompt
+        height = request_inputs.height
+        width = request_inputs.width
+        num_frames = request_inputs.num_frames
+        frame_rate = request_inputs.frame_rate
+        num_inference_steps = request_inputs.num_inference_steps
+        guidance_scale = request_inputs.guidance_scale
+        num_videos_per_prompt = request_inputs.num_videos_per_prompt
+        generator = request_inputs.generator
+        latents = request_inputs.latents
+        audio_latents = request_inputs.audio_latents
+        prompt_embeds = request_inputs.prompt_embeds
+        negative_prompt_embeds = request_inputs.negative_prompt_embeds
+        prompt_attention_mask = request_inputs.prompt_attention_mask
+        negative_prompt_attention_mask = request_inputs.negative_prompt_attention_mask
+        decode_timestep = request_inputs.decode_timestep
+        decode_noise_scale = request_inputs.decode_noise_scale
+        output_type = request_inputs.output_type
+        max_sequence_length = request_inputs.max_sequence_length
 
         self.check_inputs(
             prompt=prompt,
@@ -948,61 +1235,27 @@ class LTX23Pipeline(
             )
         cfg_parallel_ready = self.do_classifier_free_guidance and cfg_world_size > 1
 
-        if prompt is not None and isinstance(prompt, str):
-            batch_size = 1
-        elif prompt is not None and isinstance(prompt, list):
-            batch_size = len(prompt)
-        else:
-            batch_size = prompt_embeds.shape[0]
-
         device = self.device
-
-        # ---- Encode prompts ----
-        (
-            prompt_embeds,
-            prompt_attention_mask,
-            negative_prompt_embeds,
-            negative_prompt_attention_mask,
-        ) = self.encode_prompt(
+        prompt_context = self._prepare_prompt_context(
             prompt=prompt,
             negative_prompt=negative_prompt,
-            do_classifier_free_guidance=self.do_classifier_free_guidance,
-            num_videos_per_prompt=num_videos_per_prompt,
             prompt_embeds=prompt_embeds,
             negative_prompt_embeds=negative_prompt_embeds,
             prompt_attention_mask=prompt_attention_mask,
             negative_prompt_attention_mask=negative_prompt_attention_mask,
+            num_videos_per_prompt=num_videos_per_prompt,
             max_sequence_length=max_sequence_length,
-            device=device,
         )
-
-        # ---- Connectors (LTX-2.3: padding_side API) ----
-        # Concatenate negative + positive embeddings BEFORE connector call,
-        # matching diffusers which calls connectors once with batch=2.
-        # This ensures batch-dependent operations produce identical results.
-        if self.do_classifier_free_guidance:
-            prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
-            prompt_attention_mask = torch.cat([negative_prompt_attention_mask, prompt_attention_mask], dim=0)
-
-        tokenizer_padding_side = getattr(self.tokenizer, "padding_side", "left")
-        connector_prompt_embeds, connector_audio_prompt_embeds, connector_attention_mask = self.connectors(
-            prompt_embeds, prompt_attention_mask, padding_side=tokenizer_padding_side
-        )
-
-        positive_connector_prompt_embeds = connector_prompt_embeds
-        positive_connector_audio_prompt_embeds = connector_audio_prompt_embeds
-        positive_connector_attention_mask = connector_attention_mask
-        negative_connector_prompt_embeds = None
-        negative_connector_audio_prompt_embeds = None
-        negative_connector_attention_mask = None
-        if self.do_classifier_free_guidance:
-            split_batch = batch_size * num_videos_per_prompt
-            negative_connector_prompt_embeds = connector_prompt_embeds[:split_batch]
-            positive_connector_prompt_embeds = connector_prompt_embeds[split_batch:]
-            negative_connector_audio_prompt_embeds = connector_audio_prompt_embeds[:split_batch]
-            positive_connector_audio_prompt_embeds = connector_audio_prompt_embeds[split_batch:]
-            negative_connector_attention_mask = connector_attention_mask[:split_batch]
-            positive_connector_attention_mask = connector_attention_mask[split_batch:]
+        batch_size = prompt_context.batch_size
+        connector_prompt_embeds = prompt_context.connector_prompt_embeds
+        connector_audio_prompt_embeds = prompt_context.connector_audio_prompt_embeds
+        connector_attention_mask = prompt_context.connector_attention_mask
+        positive_connector_prompt_embeds = prompt_context.positive_connector_prompt_embeds
+        positive_connector_audio_prompt_embeds = prompt_context.positive_connector_audio_prompt_embeds
+        positive_connector_attention_mask = prompt_context.positive_connector_attention_mask
+        negative_connector_prompt_embeds = prompt_context.negative_connector_prompt_embeds
+        negative_connector_audio_prompt_embeds = prompt_context.negative_connector_audio_prompt_embeds
+        negative_connector_attention_mask = prompt_context.negative_connector_attention_mask
 
         # ---- Prepare latents ----
         latent_num_frames = (num_frames - 1) // self.vae_temporal_compression_ratio + 1
@@ -1251,16 +1504,14 @@ class LTX23Pipeline(
                 timestep_decode = None
             else:
                 noise = randn_tensor(latents.shape, generator=generator, device=device, dtype=latents.dtype)
-                if not isinstance(decode_timestep, list):
-                    decode_timestep = [decode_timestep] * batch_size
-                if decode_noise_scale is None:
-                    decode_noise_scale = decode_timestep
-                elif not isinstance(decode_noise_scale, list):
-                    decode_noise_scale = [decode_noise_scale] * batch_size
-                timestep_decode = torch.tensor(decode_timestep, device=device, dtype=latents.dtype)
-                decode_noise_scale_t = torch.tensor(decode_noise_scale, device=device, dtype=latents.dtype)[
-                    :, None, None, None, None
-                ]
+                timestep_decode, decode_noise_scale_t = _prepare_decode_timestep_conditioning(
+                    decode_timestep=decode_timestep,
+                    decode_noise_scale=decode_noise_scale,
+                    prompt_batch_size=batch_size,
+                    effective_batch_size=latents.shape[0],
+                    device=device,
+                    dtype=latents.dtype,
+                )
                 latents = (1 - decode_noise_scale_t) * latents + decode_noise_scale_t * noise
 
             latents = latents.to(self.vae.dtype)
@@ -1283,12 +1534,615 @@ class LTX23Pipeline(
         return loader.load_weights(weights)
 
 
-class LTX23ImageToVideoPipeline(nn.Module):
-    """LTX-2.3 image-to-video pipeline placeholder."""
+class LTX23ImageToVideoPipeline(LTX23Pipeline):
+    """LTX-2.3 image-to-video pipeline.
+
+    This keeps the LTX-2.3 prompt connector, x0-space CFG, sigma prompt
+    modulation, and audio branch semantics from ``LTX23Pipeline`` while
+    reusing the existing LTX image-conditioning contract: the first video
+    latent frame is encoded from the input image and remains fixed during
+    denoising.
+    """
 
     def __init__(self, *, od_config: OmniDiffusionConfig, prefix: str = ""):
-        super().__init__()
-        raise NotImplementedError(
-            "LTX23ImageToVideoPipeline is not yet implemented. "
-            "Use LTX23Pipeline for single-stage text-to-video generation."
+        super().__init__(od_config=od_config, prefix=prefix)
+        self.video_processor = VideoProcessor(vae_scale_factor=self.vae_spatial_compression_ratio, resample="bilinear")
+
+    support_image_input = True
+
+    _normalize_latents = staticmethod(LTX2ImageToVideoPipeline._normalize_latents)
+
+    @staticmethod
+    def _resolve_single_prompt_image(raw_image: Any) -> Any:
+        if isinstance(raw_image, list):
+            if len(raw_image) != 1:
+                raise ValueError(
+                    "LTX-2.3 I2V prompt dictionaries support exactly one image per prompt. "
+                    "Pass one image per prompt for batched I2V requests."
+                )
+            return raw_image[0]
+        return raw_image
+
+    @staticmethod
+    def _resolve_additional_image(additional: dict[str, Any]) -> Any:
+        raw_image = additional.get("preprocessed_image")
+        if raw_image is None:
+            raw_image = additional.get("pixel_values")
+        if raw_image is None:
+            raw_image = additional.get("image")
+        return raw_image
+
+    def prepare_latents(
+        self,
+        image: torch.Tensor | None = None,
+        batch_size: int = 1,
+        num_channels_latents: int = 128,
+        height: int = 512,
+        width: int = 768,
+        num_frames: int = 121,
+        noise_scale: float = 0.0,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Prepare I2V latents and the first-frame conditioning mask.
+
+        If caller-provided latents are used without an image, the latents must
+        already represent the full video state including the conditioning first
+        frame. Packed 3D latents are assumed to be in transformer token layout.
+        """
+        height = height // self.vae_spatial_compression_ratio
+        width = width // self.vae_spatial_compression_ratio
+        num_frames = (num_frames - 1) // self.vae_temporal_compression_ratio + 1
+
+        shape = (batch_size, num_channels_latents, num_frames, height, width)
+        mask_shape = (batch_size, 1, num_frames, height, width)
+
+        if latents is not None:
+            if latents.ndim == 5:
+                batch_size, _, num_frames, height, width = latents.shape
+                mask_shape = (batch_size, 1, num_frames, height, width)
+                conditioning_mask = latents.new_zeros(mask_shape)
+                conditioning_mask[:, :, 0] = 1.0
+
+                latents = self._normalize_latents(
+                    latents,
+                    self.vae.latents_mean,
+                    self.vae.latents_std,
+                    self.vae.config.scaling_factor,
+                )
+                latents = self._create_noised_state(latents, noise_scale * (1 - conditioning_mask), generator)
+                latents = self._pack_latents(
+                    latents,
+                    self.transformer_spatial_patch_size,
+                    self.transformer_temporal_patch_size,
+                )
+            else:
+                conditioning_mask = latents.new_zeros(mask_shape)
+                conditioning_mask[:, :, 0] = 1.0
+
+            conditioning_mask = self._pack_latents(
+                conditioning_mask,
+                self.transformer_spatial_patch_size,
+                self.transformer_temporal_patch_size,
+            ).squeeze(-1)
+            if latents.ndim != 3 or latents.shape[:2] != conditioning_mask.shape:
+                raise ValueError(
+                    "Provided `latents` tensor has shape"
+                    f" {latents.shape}, but the expected shape is {conditioning_mask.shape + (num_channels_latents,)}."
+                )
+            if noise_scale != 0:
+                noise = randn_tensor(latents.shape, generator=generator, device=latents.device, dtype=latents.dtype)
+                noise_scale_t = noise_scale * (1 - conditioning_mask).unsqueeze(-1)
+                latents = (1 - noise_scale_t) * latents + noise_scale_t * noise
+            return latents.to(device=device, dtype=dtype), conditioning_mask
+
+        if image is None:
+            raise ValueError("`image` must be provided when `latents` is None.")
+
+        image_batch_size = image.shape[0]
+        if image_batch_size == 0:
+            raise ValueError("`image` batch is empty.")
+        if batch_size % image_batch_size != 0:
+            raise ValueError(
+                f"`batch_size` ({batch_size}) must be divisible by image batch size ({image_batch_size}) "
+                "for image-to-video outputs."
+            )
+        num_videos_per_prompt = batch_size // image_batch_size
+
+        if isinstance(generator, list):
+            if len(generator) != batch_size:
+                raise ValueError(
+                    f"You have passed a list of generators of length {len(generator)}, but requested an effective"
+                    f" batch size of {batch_size}. Make sure the batch size matches the length of the generators."
+                )
+            image_generators = [generator[i * num_videos_per_prompt] for i in range(image_batch_size)]
+            init_latents = [
+                retrieve_latents(self.vae.encode(image[i].unsqueeze(0).unsqueeze(2)), image_generators[i], "argmax")
+                for i in range(image_batch_size)
+            ]
+        else:
+            init_latents = [
+                retrieve_latents(self.vae.encode(img.unsqueeze(0).unsqueeze(2)), generator, "argmax") for img in image
+            ]
+
+        init_latents = torch.cat(init_latents, dim=0).to(dtype)
+        if num_videos_per_prompt > 1:
+            init_latents = init_latents.repeat_interleave(num_videos_per_prompt, dim=0)
+        init_latents = self._normalize_latents(
+            init_latents,
+            self.vae.latents_mean,
+            self.vae.latents_std,
+            self.vae.config.scaling_factor,
+        )
+        init_latents = init_latents.repeat(1, 1, num_frames, 1, 1)
+
+        conditioning_mask = torch.zeros(mask_shape, device=device, dtype=dtype)
+        conditioning_mask[:, :, 0] = 1.0
+
+        noise = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+        latents = init_latents * conditioning_mask + noise * (1 - conditioning_mask)
+
+        conditioning_mask = self._pack_latents(
+            conditioning_mask,
+            self.transformer_spatial_patch_size,
+            self.transformer_temporal_patch_size,
+        ).squeeze(-1)
+        latents = self._pack_latents(latents, self.transformer_spatial_patch_size, self.transformer_temporal_patch_size)
+
+        return latents, conditioning_mask
+
+    def check_inputs(
+        self,
+        image,
+        height,
+        width,
+        prompt,
+        latents=None,
+        prompt_embeds=None,
+        negative_prompt_embeds=None,
+        prompt_attention_mask=None,
+        negative_prompt_attention_mask=None,
+    ):
+        if image is None and latents is None:
+            raise ValueError("Provide either `image` or `latents`. Cannot leave both undefined.")
+        super().check_inputs(
+            prompt=prompt,
+            height=height,
+            width=width,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            prompt_attention_mask=prompt_attention_mask,
+            negative_prompt_attention_mask=negative_prompt_attention_mask,
+        )
+
+    _step_video_latents_i2v = LTX2ImageToVideoPipeline._step_video_latents_i2v
+
+    @torch.no_grad()
+    def forward(
+        self,
+        req: OmniDiffusionRequest,
+        image: PIL.Image.Image | torch.Tensor | list[PIL.Image.Image | torch.Tensor] | None = None,
+        prompt: str | list[str] | None = None,
+        negative_prompt: str | list[str] | None = None,
+        height: int | None = None,
+        width: int | None = None,
+        num_frames: int | None = None,
+        frame_rate: float | None = None,
+        num_inference_steps: int | None = None,
+        sigmas: list[float] | None = None,
+        timesteps: list[int] | None = None,
+        guidance_scale: float = 4.0,
+        noise_scale: float = 0.0,
+        num_videos_per_prompt: int | None = 1,
+        generator: torch.Generator | list[torch.Generator] | None = None,
+        latents: torch.Tensor | None = None,
+        audio_latents: torch.Tensor | None = None,
+        prompt_embeds: torch.Tensor | None = None,
+        negative_prompt_embeds: torch.Tensor | None = None,
+        prompt_attention_mask: torch.Tensor | None = None,
+        negative_prompt_attention_mask: torch.Tensor | None = None,
+        decode_timestep: float | list[float] = 0.0,
+        decode_noise_scale: float | list[float] | None = None,
+        output_type: str = "np",
+        return_dict: bool = True,
+        attention_kwargs: dict[str, Any] | None = None,
+        max_sequence_length: int | None = None,
+    ) -> DiffusionOutput:
+        request_inputs = self._resolve_request_inputs(
+            req,
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            frame_rate=frame_rate,
+            num_inference_steps=num_inference_steps,
+            timesteps=timesteps,
+            guidance_scale=guidance_scale,
+            num_videos_per_prompt=num_videos_per_prompt,
+            generator=generator,
+            latents=latents,
+            audio_latents=audio_latents,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            prompt_attention_mask=prompt_attention_mask,
+            negative_prompt_attention_mask=negative_prompt_attention_mask,
+            decode_timestep=decode_timestep,
+            decode_noise_scale=decode_noise_scale,
+            output_type=output_type,
+            max_sequence_length=max_sequence_length,
+        )
+        prompt = request_inputs.prompt
+        negative_prompt = request_inputs.negative_prompt
+        height = request_inputs.height
+        width = request_inputs.width
+        num_frames = request_inputs.num_frames
+        frame_rate = request_inputs.frame_rate
+        num_inference_steps = request_inputs.num_inference_steps
+        guidance_scale = request_inputs.guidance_scale
+        num_videos_per_prompt = request_inputs.num_videos_per_prompt
+        generator = request_inputs.generator
+        latents = request_inputs.latents
+        audio_latents = request_inputs.audio_latents
+        prompt_embeds = request_inputs.prompt_embeds
+        negative_prompt_embeds = request_inputs.negative_prompt_embeds
+        prompt_attention_mask = request_inputs.prompt_attention_mask
+        negative_prompt_attention_mask = request_inputs.negative_prompt_attention_mask
+        decode_timestep = request_inputs.decode_timestep
+        decode_noise_scale = request_inputs.decode_noise_scale
+        output_type = request_inputs.output_type
+        max_sequence_length = request_inputs.max_sequence_length
+
+        if image is None and req.prompts:
+            raw_images = []
+            for prompt_item in req.prompts:
+                if isinstance(prompt_item, str):
+                    raw_image = None
+                else:
+                    multi_modal_data = prompt_item.get("multi_modal_data") or {}
+                    raw_image = multi_modal_data.get("image")
+                    if raw_image is None:
+                        additional = prompt_item.get("additional_information") or {}
+                        raw_image = self._resolve_additional_image(additional)
+                raw_image = self._resolve_single_prompt_image(raw_image)
+                if isinstance(raw_image, str):
+                    raw_image = PIL.Image.open(raw_image).convert("RGB")
+                raw_images.append(raw_image)
+
+            if any(img is None for img in raw_images):
+                if latents is None:
+                    raise ValueError("Image is required for LTX-2.3 I2V generation.")
+            if len(raw_images) == 1:
+                image = raw_images[0]
+            elif raw_images:
+                image = raw_images
+
+        self.check_inputs(
+            image=image,
+            height=height,
+            width=width,
+            prompt=prompt,
+            latents=latents,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            prompt_attention_mask=prompt_attention_mask,
+            negative_prompt_attention_mask=negative_prompt_attention_mask,
+        )
+
+        self._guidance_scale = guidance_scale
+        self._attention_kwargs = attention_kwargs
+        self._interrupt = False
+        self._current_timestep = None
+        cfg_world_size = get_classifier_free_guidance_world_size()
+        if self.do_classifier_free_guidance and cfg_world_size not in (1, 2):
+            raise ValueError(
+                f"LTX23Pipeline supports CFG parallelism with cfg_parallel_size 1 or 2, but got {cfg_world_size}."
+            )
+        cfg_parallel_ready = self.do_classifier_free_guidance and cfg_world_size > 1
+
+        device = self.device
+        prompt_context = self._prepare_prompt_context(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            prompt_attention_mask=prompt_attention_mask,
+            negative_prompt_attention_mask=negative_prompt_attention_mask,
+            num_videos_per_prompt=num_videos_per_prompt,
+            max_sequence_length=max_sequence_length,
+        )
+        batch_size = prompt_context.batch_size
+        connector_prompt_embeds = prompt_context.connector_prompt_embeds
+        connector_audio_prompt_embeds = prompt_context.connector_audio_prompt_embeds
+        connector_attention_mask = prompt_context.connector_attention_mask
+        positive_connector_prompt_embeds = prompt_context.positive_connector_prompt_embeds
+        positive_connector_audio_prompt_embeds = prompt_context.positive_connector_audio_prompt_embeds
+        positive_connector_attention_mask = prompt_context.positive_connector_attention_mask
+        negative_connector_prompt_embeds = prompt_context.negative_connector_prompt_embeds
+        negative_connector_audio_prompt_embeds = prompt_context.negative_connector_audio_prompt_embeds
+        negative_connector_attention_mask = prompt_context.negative_connector_attention_mask
+
+        latent_num_frames = (num_frames - 1) // self.vae_temporal_compression_ratio + 1
+        latent_height = height // self.vae_spatial_compression_ratio
+        latent_width = width // self.vae_spatial_compression_ratio
+        if latents is not None:
+            if latents.ndim == 5:
+                _, _, latent_num_frames, latent_height, latent_width = latents.shape
+            elif latents.ndim != 3:
+                raise ValueError(
+                    f"Provided `latents` tensor has shape {latents.shape}, but the expected shape is either "
+                    "[batch_size, seq_len, num_features] or "
+                    "[batch_size, latent_dim, latent_frames, latent_height, latent_width]."
+                )
+
+        if latents is None:
+            if isinstance(image, torch.Tensor):
+                if image.ndim == 3:
+                    image = image.unsqueeze(0)
+            elif isinstance(image, list) and image and isinstance(image[0], torch.Tensor):
+                image = torch.stack(image, dim=0)
+            else:
+                image = self.video_processor.preprocess(image, height=height, width=width)
+            image = image.to(device=device, dtype=positive_connector_prompt_embeds.dtype)
+
+        num_channels_latents = self.transformer.config.in_channels
+        latents, conditioning_mask = self.prepare_latents(
+            image,
+            batch_size * num_videos_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            num_frames,
+            noise_scale,
+            torch.float32,
+            device,
+            generator,
+            latents,
+        )
+
+        duration_s = num_frames / frame_rate
+        audio_latents_per_second = (
+            self.audio_sampling_rate / self.audio_hop_length / float(self.audio_vae_temporal_compression_ratio)
+        )
+        audio_num_frames = round(duration_s * audio_latents_per_second)
+        audio_num_frames = self._resolve_audio_latent_length(audio_num_frames, audio_latents)
+
+        num_mel_bins = self.audio_vae.config.mel_bins if self.audio_vae is not None else 64
+        latent_mel_bins = num_mel_bins // self.audio_vae_mel_compression_ratio
+        num_channels_latents_audio = self.audio_vae.config.latent_channels if self.audio_vae is not None else 8
+        audio_latents, original_audio_num_frames, padded_audio_num_frames = self.prepare_audio_latents(
+            batch_size * num_videos_per_prompt,
+            num_channels_latents=num_channels_latents_audio,
+            audio_latent_length=audio_num_frames,
+            num_mel_bins=num_mel_bins,
+            noise_scale=noise_scale,
+            dtype=torch.float32,
+            device=device,
+            generator=generator,
+            latents=audio_latents,
+        )
+
+        sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps) if sigmas is None else sigmas
+        mu = calculate_shift(
+            self.scheduler.config.get("max_image_seq_len", 4096),
+            self.scheduler.config.get("base_image_seq_len", 1024),
+            self.scheduler.config.get("max_image_seq_len", 4096),
+            self.scheduler.config.get("base_shift", 0.95),
+            self.scheduler.config.get("max_shift", 2.05),
+        )
+        audio_scheduler = copy.deepcopy(self.scheduler)
+        video_audio_scheduler = _I2VVideoAudioScheduler(
+            self,
+            audio_scheduler,
+            latent_num_frames,
+            latent_height,
+            latent_width,
+        )
+        _ = retrieve_timesteps(audio_scheduler, num_inference_steps, device, timesteps, sigmas=sigmas, mu=mu)
+        timesteps, num_inference_steps = retrieve_timesteps(
+            self.scheduler,
+            num_inference_steps,
+            device,
+            timesteps,
+            sigmas=sigmas,
+            mu=mu,
+        )
+        self._num_timesteps = len(timesteps)
+
+        video_coords = self.transformer.rope.prepare_video_coords(
+            latents.shape[0],
+            latent_num_frames,
+            latent_height,
+            latent_width,
+            latents.device,
+            fps=frame_rate,
+        )
+        audio_coords = self.transformer.audio_rope.prepare_audio_coords(
+            audio_latents.shape[0],
+            padded_audio_num_frames,
+            audio_latents.device,
+        )
+
+        if self.do_classifier_free_guidance and not cfg_parallel_ready:
+            video_coords = video_coords.repeat((2,) + (1,) * (video_coords.ndim - 1))
+            audio_coords = audio_coords.repeat((2,) + (1,) * (audio_coords.ndim - 1))
+            conditioning_mask_for_model = torch.cat([conditioning_mask, conditioning_mask])
+        else:
+            conditioning_mask_for_model = conditioning_mask
+
+        with self.progress_bar(total=len(timesteps)) as pbar:
+            for i, t in enumerate(timesteps):
+                if self.interrupt:
+                    continue
+
+                self._current_timestep = t
+
+                if cfg_parallel_ready:
+                    latent_model_input = latents.to(positive_connector_prompt_embeds.dtype)
+                    audio_latent_model_input = audio_latents.to(positive_connector_prompt_embeds.dtype)
+                    ts = t.expand(latent_model_input.shape[0])
+                    video_ts = ts.unsqueeze(-1) * (1 - conditioning_mask)
+                    positive_kwargs = {
+                        "hidden_states": latent_model_input,
+                        "audio_hidden_states": audio_latent_model_input,
+                        "encoder_hidden_states": positive_connector_prompt_embeds,
+                        "audio_encoder_hidden_states": positive_connector_audio_prompt_embeds,
+                        "timestep": video_ts,
+                        "audio_timestep": ts,
+                        "sigma": ts,
+                        "encoder_attention_mask": positive_connector_attention_mask,
+                        "audio_encoder_attention_mask": positive_connector_attention_mask,
+                        "num_frames": latent_num_frames,
+                        "height": latent_height,
+                        "width": latent_width,
+                        "fps": frame_rate,
+                        "audio_num_frames": padded_audio_num_frames,
+                        "video_coords": video_coords,
+                        "audio_coords": audio_coords,
+                        "attention_kwargs": attention_kwargs,
+                        "return_dict": False,
+                    }
+                    negative_kwargs = {
+                        **positive_kwargs,
+                        "encoder_hidden_states": negative_connector_prompt_embeds,
+                        "audio_encoder_hidden_states": negative_connector_audio_prompt_embeds,
+                        "encoder_attention_mask": negative_connector_attention_mask,
+                        "audio_encoder_attention_mask": negative_connector_attention_mask,
+                    }
+                    noise_pred_video, noise_pred_audio = self.predict_noise_with_parallel_cfg(
+                        true_cfg_scale=guidance_scale,
+                        positive_kwargs=positive_kwargs,
+                        negative_kwargs=negative_kwargs,
+                        cfg_normalize=False,
+                        video_latents=latents,
+                        audio_latents=audio_latents,
+                        video_sigma=self.scheduler.sigmas[i],
+                        audio_sigma=audio_scheduler.sigmas[i],
+                    )
+                else:
+                    latent_model_input = torch.cat([latents] * 2) if self.do_classifier_free_guidance else latents
+                    latent_model_input = latent_model_input.to(connector_prompt_embeds.dtype)
+                    audio_latent_model_input = (
+                        torch.cat([audio_latents] * 2) if self.do_classifier_free_guidance else audio_latents
+                    )
+                    audio_latent_model_input = audio_latent_model_input.to(connector_prompt_embeds.dtype)
+                    ts = t.expand(latent_model_input.shape[0])
+                    video_ts = ts.unsqueeze(-1) * (1 - conditioning_mask_for_model)
+
+                    with self._transformer_cache_context("cond_uncond"):
+                        noise_pred_video, noise_pred_audio = self.transformer(
+                            hidden_states=latent_model_input,
+                            audio_hidden_states=audio_latent_model_input,
+                            encoder_hidden_states=connector_prompt_embeds,
+                            audio_encoder_hidden_states=connector_audio_prompt_embeds,
+                            timestep=video_ts,
+                            audio_timestep=ts,
+                            sigma=ts,
+                            encoder_attention_mask=connector_attention_mask,
+                            audio_encoder_attention_mask=connector_attention_mask,
+                            num_frames=latent_num_frames,
+                            height=latent_height,
+                            width=latent_width,
+                            fps=frame_rate,
+                            audio_num_frames=padded_audio_num_frames,
+                            video_coords=video_coords,
+                            audio_coords=audio_coords,
+                            attention_kwargs=attention_kwargs,
+                            return_dict=False,
+                        )
+
+                    noise_pred_video = noise_pred_video.float()
+                    noise_pred_audio = noise_pred_audio.float()
+                    if self.do_classifier_free_guidance:
+                        noise_pred_video_uncond, noise_pred_video_cond = noise_pred_video.chunk(2)
+                        noise_pred_video = self._combine_x0_space_cfg(
+                            latents,
+                            noise_pred_video_cond,
+                            noise_pred_video_uncond,
+                            self.scheduler.sigmas[i],
+                            guidance_scale,
+                        )
+
+                        noise_pred_audio_uncond, noise_pred_audio_cond = noise_pred_audio.chunk(2)
+                        noise_pred_audio = self._combine_x0_space_cfg(
+                            audio_latents,
+                            noise_pred_audio_cond,
+                            noise_pred_audio_uncond,
+                            audio_scheduler.sigmas[i],
+                            guidance_scale,
+                        )
+
+                latents, audio_latents = self.scheduler_step_maybe_with_cfg(
+                    (noise_pred_video, noise_pred_audio),
+                    (t, t),
+                    (latents, audio_latents),
+                    do_true_cfg=self.do_classifier_free_guidance,
+                    per_request_scheduler=video_audio_scheduler,
+                )
+                latents, audio_latents = self._synchronize_cfg_parallel_step_output(
+                    (latents, audio_latents),
+                    do_true_cfg=self.do_classifier_free_guidance,
+                )
+                pbar.update()
+
+        latents = self._unpack_latents(
+            latents,
+            latent_num_frames,
+            latent_height,
+            latent_width,
+            self.transformer_spatial_patch_size,
+            self.transformer_temporal_patch_size,
+        )
+        latents = self._denormalize_latents(
+            latents,
+            self.vae.latents_mean,
+            self.vae.latents_std,
+            self.vae.config.scaling_factor,
+        )
+
+        audio_latents = self._unpad_audio_latents(audio_latents, original_audio_num_frames)
+        audio_latents = self._denormalize_audio_latents(
+            audio_latents,
+            self.audio_vae.latents_mean,
+            self.audio_vae.latents_std,
+        )
+        audio_latents = self._unpack_audio_latents(
+            audio_latents,
+            original_audio_num_frames,
+            num_mel_bins=latent_mel_bins,
+        )
+
+        if output_type == "latent":
+            video = latents
+            audio = audio_latents
+        else:
+            latents = latents.to(connector_prompt_embeds.dtype)
+            if not self.vae.config.timestep_conditioning:
+                timestep_decode = None
+            else:
+                noise = randn_tensor(latents.shape, generator=generator, device=device, dtype=latents.dtype)
+                timestep_decode, decode_noise_scale_t = _prepare_decode_timestep_conditioning(
+                    decode_timestep=decode_timestep,
+                    decode_noise_scale=decode_noise_scale,
+                    prompt_batch_size=batch_size,
+                    effective_batch_size=latents.shape[0],
+                    device=device,
+                    dtype=latents.dtype,
+                )
+                latents = (1 - decode_noise_scale_t) * latents + decode_noise_scale_t * noise
+
+            latents = latents.to(self.vae.dtype)
+            video = self.vae.decode(latents, timestep_decode, return_dict=False)[0]
+            if video.numel() > 0:
+                video = self.video_processor.postprocess_video(video, output_type=output_type)
+
+            audio_latents = audio_latents.to(self.audio_vae.dtype)
+            generated_mel_spectrograms = self.audio_vae.decode(audio_latents, return_dict=False)[0]
+            audio = self.vocoder(generated_mel_spectrograms)
+
+        return DiffusionOutput(
+            output=(video, audio),
+            stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None,
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Main already contains LTX-2.3 text-to-video support. This PR fills the remaining LTX-2.3 image-to-video and public-coverage gaps:

- Replace the registered `LTX23ImageToVideoPipeline` placeholder with a real first-frame-conditioned I2V path.
- Reuse the existing Omni LTX architecture instead of adding a new stack:
  - LTX-2.3 prompt/audio semantics, Gemma hidden-state flattening, connector call order, sigma prompt modulation, and x0-space CFG remain owned by `LTX23Pipeline`.
  - Existing LTX image-conditioning behavior is reused for I2V, including keeping the first video latent frame fixed during denoising.
  - T2V and I2V share request parsing and prompt connector preparation to avoid field/default drift.
- Add offline image-to-video defaults so Diffusers-format `dg845/LTX-2.3-Diffusers` and local `ltx23` paths auto-select `LTX23ImageToVideoPipeline`; the raw upstream `Lightricks/LTX-2.3` checkpoint is intentionally not auto-routed to this loader.
- Update I2V docs/recipe coverage and add a reusable LTX-2.3 DFX perf config for follow-up serving sweeps.

## Test Plan

**vLLM Version:**

- Validation environment with `vllm 0.22.0` and `diffusers 0.38.0`.

**vLLM-Omni Commit:**

- PR head: `fc39c50f4a49af137ee5cd58f0b73ac1c6fbdbbb`

**Latest-head validation:**

- Static and syntax checks for touched Python files.
- Offline I2V example default-selection unit coverage.
- LTX-2.3 pipeline unit coverage for:
  - shared T2V/I2V request parsing,
  - all-or-none precomputed prompt tensors,
  - I2V image resolution without tensor truthiness fallback,
  - first-frame conditioning preservation,
  - decode-conditioning batch expansion.
- Perf config JSON validation.
- Scope gate against `origin/main`.

**Historical performance reference:**

- Baseline: HF Diffusers `LTX2Pipeline`.
- Omni: `LTX23Pipeline` served through `/v1/videos/sync`.
- Workload: 384x512, 25 frames, 20 denoising steps, guidance 4.0, fps 24.
- Timing scope: model initialization excluded; one warmup run followed by three measured end-to-end runs.
- Baseline scope: HF pipeline call plus MP4 export.
- Omni scope: client-observed sync HTTP request/response, including server generation and returned MP4 bytes.

**Pending before marking ready:**

- Latest-head remote checkpoint smoke for `LTX23ImageToVideoPipeline`.
- Latest-head formal serving/perf sweep if the PR should publish fresh speedup numbers.

## Test Result

- `python -m ruff check examples/offline_inference/video_model_defaults.py examples/offline_inference/image_to_video/image_to_video.py tests/examples/offline_inference/test_ltx2_3_video_defaults.py tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py` passed.
- `python -m ruff format --check --diff ...` passed.
- `python -m py_compile examples/offline_inference/video_model_defaults.py examples/offline_inference/image_to_video/image_to_video.py tests/examples/offline_inference/test_ltx2_3_video_defaults.py tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py` passed.
- `python -m pytest -q -c NUL --confcutdir=tests/examples/offline_inference tests/examples/offline_inference/test_ltx2_3_video_defaults.py` passed: `2 passed`.
- `python -m json.tool tests/dfx/perf/tests/test_ltx2_3_vllm_omni.json` passed.
- `git diff --check` passed.
- Scope gate passed with the repo scope ledger.

Historical end-to-end performance reference:

| Runtime | Scope | Mean latency | Min latency | Max latency | vs HF baseline |
| --- | --- | ---: | ---: | ---: | ---: |
| HF Diffusers `LTX2Pipeline` | pipeline + MP4 export | 4.515s | 4.464s | 4.566s | 1.00x |
| vLLM-Omni `LTX23Pipeline` | `/v1/videos/sync` client E2E | 4.421s | 4.378s | 4.492s | 1.02x |

The historical Omni serving path reduced measured end-to-end latency by 2.1% on this workload. Treat this as reference data until the latest-head sweep is rerun.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
