### PR TITLE
[DRAFT] qwen3-omni lora megatron support

### DIFF
--- a/tests/model_executor/models/qwen2_5_omni/test_per_video_audio_mask.py
+++ b/tests/model_executor/models/qwen2_5_omni/test_per_video_audio_mask.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Omni project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.multimodal.processing.processor import PlaceholderFeaturesInfo
+
+from vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_thinker import (
+    Qwen2_5OmniThinkerMultiModalProcessor,
+    _normalize_use_audio_in_video,
+)
+from vllm_omni.model_executor.models.qwen3_omni.qwen3_omni_moe_thinker import (
+    Qwen3OmniMoeThinkerMultiModalProcessor,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+AUDIO_TOKEN_ID = 10
+VIDEO_TOKEN_ID = 20
+
+
+class _Feature:
+    def __init__(self, data: torch.Tensor) -> None:
+        self.data = data
+
+
+def _fake_processor() -> SimpleNamespace:
+    tokenizer = SimpleNamespace(get_vocab=lambda: {"<|audio_pad|>": AUDIO_TOKEN_ID})
+    processor = SimpleNamespace(audio_token="<|audio_pad|>")
+    config = SimpleNamespace(audio_token_id=AUDIO_TOKEN_ID)
+    info = SimpleNamespace(
+        get_hf_config=lambda: config,
+        get_hf_processor=lambda: processor,
+        get_tokenizer=lambda: tokenizer,
+    )
+    return SimpleNamespace(info=info)
+
+
+def test_normalize_use_audio_in_video_accepts_bool_and_per_video_mask():
+    assert _normalize_use_audio_in_video(True, 2) == [True, True]
+    assert _normalize_use_audio_in_video(False, 2) == [False, False]
+    assert _normalize_use_audio_in_video([True, False], 2) == [True, False]
+    assert _normalize_use_audio_in_video(torch.tensor([1, 0]), 2) == [
+        True,
+        False,
+    ]
+
+
+def test_normalize_use_audio_in_video_rejects_wrong_length():
+    with pytest.raises(ValueError, match="one boolean per video"):
+        _normalize_use_audio_in_video([True], 2)
+
+
+def test_get_video_use_audio_in_video_preserves_explicit_false():
+    fake_self = _fake_processor()
+    mm_kwargs = {
+        "video": [
+            {"use_audio_in_video": _Feature(torch.tensor(True))},
+            {"use_audio_in_video": _Feature(torch.tensor(False))},
+        ]
+    }
+
+    result = Qwen2_5OmniThinkerMultiModalProcessor._get_video_use_audio_in_video(
+        fake_self,
+        mm_kwargs,
+        {},
+    )
+
+    assert result == [True, False]
+
+
+def test_get_video_use_audio_in_video_treats_missing_item_as_false_with_explicit_mask():
+    fake_self = _fake_processor()
+    mm_kwargs = {
+        "video": [
+            {"use_audio_in_video": _Feature(torch.tensor(True))},
+            None,
+        ]
+    }
+
+    result = Qwen2_5OmniThinkerMultiModalProcessor._get_video_use_audio_in_video(
+        fake_self,
+        mm_kwargs,
+        {},
+    )
+
+    assert result == [True, False]
+
+
+def test_get_video_use_audio_in_video_falls_back_to_prompt_updates_for_cache_hits():
+    fake_self = _fake_processor()
+    update_with_audio = SimpleNamespace(content=SimpleNamespace(full=[VIDEO_TOKEN_ID, AUDIO_TOKEN_ID]))
+    update_without_audio = SimpleNamespace(content=SimpleNamespace(full=[VIDEO_TOKEN_ID]))
+
+    result = Qwen2_5OmniThinkerMultiModalProcessor._get_video_use_audio_in_video(
+        fake_self,
+        {"video": [None, None]},
+        {"video": [[update_with_audio], [update_without_audio]]},
+    )
+
+    assert result == [True, False]
+
+
+def test_derive_audio_from_video_placeholders_only_pairs_true_videos():
+    fake_self = _fake_processor()
+    video_placeholders = [
+        PlaceholderFeaturesInfo(
+            modality="video",
+            item_idx=0,
+            start_idx=5,
+            tokens=[VIDEO_TOKEN_ID, AUDIO_TOKEN_ID, VIDEO_TOKEN_ID],
+            is_embed=torch.tensor([True, True, True]),
+        ),
+        PlaceholderFeaturesInfo(
+            modality="video",
+            item_idx=1,
+            start_idx=12,
+            tokens=[VIDEO_TOKEN_ID, VIDEO_TOKEN_ID],
+            is_embed=torch.tensor([True, True]),
+        ),
+    ]
+
+    result = Qwen2_5OmniThinkerMultiModalProcessor._derive_audio_from_video_placeholders(
+        fake_self,
+        {"video": video_placeholders},
+        {"audio": [[object()]]},
+        [True, False],
+    )
+
+    assert len(result["audio"]) == 1
+    assert result["audio"][0].item_idx == 0
+    assert result["audio"][0].start_idx == 5
+    assert result["audio"][0].is_embed.tolist() == [False, True, False]
+
+    assert len(result["video"]) == 2
+    assert result["video"][0].item_idx == 0
+    assert result["video"][0].is_embed.tolist() == [True, False, True]
+    assert result["video"][1].item_idx == 1
+    assert result["video"][1].is_embed.tolist() == [True, True]
+
+
+def test_qwen3_processor_inherits_vllm_omni_per_video_helpers():
+    assert issubclass(
+        Qwen3OmniMoeThinkerMultiModalProcessor,
+        Qwen2_5OmniThinkerMultiModalProcessor,
+    )

--- a/tests/models/test_qwen3_omni_lora.py
+++ b/tests/models/test_qwen3_omni_lora.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from pathlib import Path
+
+
+def _qwen3_omni_thinker_class_body() -> dict[str, ast.AST]:
+    source = Path("vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py").read_text()
+    module = ast.parse(source)
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == "Qwen3OmniMoeThinkerForConditionalGeneration":
+            body = {}
+            for statement in node.body:
+                if isinstance(statement, ast.Assign):
+                    for target in statement.targets:
+                        if isinstance(target, ast.Name):
+                            body[target.id] = statement.value
+                elif isinstance(statement, ast.AnnAssign) and isinstance(statement.target, ast.Name):
+                    body[statement.target.id] = statement.value
+            return body
+    raise AssertionError("Qwen3OmniMoeThinkerForConditionalGeneration class not found")
+
+
+class TestQwen3OmniThinkerLoRADeclaration:
+    def test_qwen3_omni_lora_supports_stacked_qkv_and_gate_up(self):
+        body = _qwen3_omni_thinker_class_body()
+        mapping = ast.literal_eval(body["packed_modules_mapping"])
+
+        assert mapping["qkv_proj"] == ["q_proj", "k_proj", "v_proj"]
+        assert mapping["gate_up_proj"] == ["gate_proj", "up_proj"]
+
+    def test_qwen3_omni_lora_metadata_for_3d_moe(self):
+        body = _qwen3_omni_thinker_class_body()
+
+        assert ast.literal_eval(body["is_3d_moe_weight"]) is True
+        assert ast.literal_eval(body["is_non_gated_moe"]) is False
+        assert ast.literal_eval(body["embedding_modules"]) == {
+            "embed_tokens": "input_embeddings",
+            "lm_head": "output_embeddings",
+        }
+        assert ast.literal_eval(body["lora_skip_prefixes"]) == []

--- a/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
+++ b/vllm_omni/model_executor/models/qwen2_5_omni/qwen2_5_omni_thinker.py
@@ -1,6 +1,6 @@
 """Thin Omni wrapper: reuse upstream Qwen2.5-Omni thinker with minimal overrides."""
 
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import Any
 
 import numpy as np
@@ -74,10 +74,136 @@ except (ImportError, ModuleNotFoundError):
 logger = init_logger(__name__)
 
 
+def _normalize_use_audio_in_video(
+    value: object,
+    num_videos: int,
+) -> list[bool]:
+    if isinstance(value, torch.Tensor):
+        if value.numel() == 1:
+            return [bool(value.item())] * num_videos
+        values = value.flatten().tolist()
+    elif isinstance(value, np.ndarray):
+        if value.size == 1:
+            return [bool(value.item())] * num_videos
+        values = value.flatten().tolist()
+    elif isinstance(value, bool):
+        return [value] * num_videos
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        values = list(value)
+    else:
+        return [bool(value)] * num_videos
+
+    if len(values) != num_videos:
+        raise ValueError(
+            "use_audio_in_video must be a boolean or contain one boolean per "
+            f"video, but found {len(values)} values for {num_videos} videos."
+        )
+    return [bool(v) for v in values]
+
+
 class Qwen2_5OmniThinkerMultiModalProcessor(
     _Qwen2_5OmniThinkerMultiModalProcessorBase,
 ):
     """Override to fix use_audio_in_video detection when mm cache returns None."""
+
+    def _get_video_use_audio_in_video(
+        self,
+        mm_kwargs: MultiModalKwargsItems,
+        mm_prompt_updates: MultiModalPromptUpdates,
+    ) -> list[bool]:
+        video_kwargs = mm_kwargs.get("video", [])
+        if not video_kwargs:
+            return []
+
+        audio_token_id = self.info.get_hf_config().audio_token_id
+        video_use_audio_in_video = []
+        has_use_audio_in_video = any(item is not None and "use_audio_in_video" in item for item in video_kwargs)
+        for item_idx, item in enumerate(video_kwargs):
+            if has_use_audio_in_video:
+                if item is None or "use_audio_in_video" not in item:
+                    video_use_audio_in_video.append(False)
+                    continue
+                use_audio_in_video_tensor = item["use_audio_in_video"].data
+                if use_audio_in_video_tensor.numel() > 0:
+                    video_use_audio_in_video.append(bool(use_audio_in_video_tensor.item()))
+                    continue
+                video_use_audio_in_video.append(False)
+                continue
+
+            updates = mm_prompt_updates.get("video", [])
+            update_has_audio = False
+            if item_idx < len(updates):
+                update_has_audio = any(
+                    audio_token_id in update.content.full
+                    for update in updates[item_idx]
+                    if isinstance(update.content.full, list)
+                )
+            video_use_audio_in_video.append(update_has_audio)
+
+        return video_use_audio_in_video
+
+    def _derive_audio_from_video_placeholders(
+        self,
+        placeholders: Mapping[str, list[PlaceholderFeaturesInfo]],
+        mm_prompt_updates: MultiModalPromptUpdates,
+        video_use_audio_in_video: Sequence[bool] | None = None,
+    ) -> Mapping[str, list[PlaceholderFeaturesInfo]]:
+        if "video" not in placeholders:
+            return placeholders
+
+        num_videos = len(placeholders["video"])
+        if video_use_audio_in_video is None:
+            video_use_audio_in_video = [True] * num_videos
+        elif len(video_use_audio_in_video) != num_videos:
+            raise ValueError(
+                "use_audio_in_video must contain one boolean per video, "
+                f"but found {len(video_use_audio_in_video)} values for "
+                f"{num_videos} videos."
+            )
+
+        num_audio_in_video = sum(video_use_audio_in_video)
+        num_audios = len(mm_prompt_updates.get("audio", []))
+        if num_audios != num_audio_in_video:
+            raise ValueError(
+                "use_audio_in_video requires equal number of audio and video "
+                f"items using audio, got {num_audios=}, {num_audio_in_video=}"
+            )
+
+        tokenizer = self.info.get_tokenizer()
+        processor = self.info.get_hf_processor()
+        audio_token_id = tokenizer.get_vocab()[processor.audio_token]
+
+        result_placeholders = dict(placeholders)
+        audio_placeholders = []
+        video_placeholders = []
+
+        audio_idx = 0
+        for video_idx, video_placeholder in enumerate(placeholders["video"]):
+            audio_is_embed = torch.tensor(video_placeholder.tokens) == audio_token_id
+
+            if video_use_audio_in_video[video_idx]:
+                audio_placeholder = PlaceholderFeaturesInfo(
+                    modality="audio",
+                    item_idx=audio_idx,
+                    start_idx=video_placeholder.start_idx,
+                    tokens=video_placeholder.tokens,
+                    is_embed=audio_is_embed,
+                )
+                audio_placeholders.append(audio_placeholder)
+                audio_idx += 1
+
+            video_placeholder_with_mask = PlaceholderFeaturesInfo(
+                modality="video",
+                item_idx=video_idx,
+                start_idx=video_placeholder.start_idx,
+                tokens=video_placeholder.tokens,
+                is_embed=~audio_is_embed,
+            )
+            video_placeholders.append(video_placeholder_with_mask)
+
+        result_placeholders["audio"] = audio_placeholders
+        result_placeholders["video"] = video_placeholders
+        return result_placeholders
 
     def _maybe_apply_prompt_updates(
         self,
@@ -91,24 +217,8 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
         self._validate_mm_kwargs(mm_kwargs, mm_item_counts)
         self._validate_mm_updates(mm_prompt_updates, mm_item_counts)
 
-        # Detect use_audio_in_video from mm_kwargs
-        use_audio_in_video = False
-        if "video" in mm_kwargs:
-            for item in mm_kwargs["video"]:
-                if item and item.get("use_audio_in_video"):
-                    use_audio_in_video_tensor = item["use_audio_in_video"].data
-                    if use_audio_in_video_tensor.numel() > 0:
-                        use_audio_in_video = bool(use_audio_in_video_tensor.item())
-                        break
-            # for mutilmodality cache
-            if any(item is None for item in mm_kwargs["video"]):
-                video_token_id = self.info.get_hf_config().video_token_id
-                audio_token_id = self.info.get_hf_config().audio_token_id
-                video_audio_item_num = sum(id in (video_token_id, audio_token_id) for id in prompt_ids)
-                audio_updates_num = len(mm_prompt_updates.get("audio", []))
-                video_updates_num = len(mm_prompt_updates.get("video", []))
-                if video_audio_item_num != video_updates_num + audio_updates_num:
-                    use_audio_in_video = True
+        video_use_audio_in_video = self._get_video_use_audio_in_video(mm_kwargs, mm_prompt_updates)
+        use_audio_in_video = any(video_use_audio_in_video)
 
         if is_update_applied:
             mm_placeholders = self._find_mm_placeholders(
@@ -126,7 +236,11 @@ class Qwen2_5OmniThinkerMultiModalProcessor(
                     prompt_ids,
                     filtered_updates,
                 )
-                mm_placeholders = self._derive_audio_from_video_placeholders(mm_placeholders, mm_prompt_updates)
+                mm_placeholders = self._derive_audio_from_video_placeholders(
+                    mm_placeholders,
+                    mm_prompt_updates,
+                    video_use_audio_in_video,
+                )
             else:
                 prompt_ids, mm_placeholders = self._apply_prompt_updates(
                     prompt_ids,

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -74,7 +74,6 @@ from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.model_executor.models.qwen2_5_omni_thinker import (
     Qwen2_5OmniAudioFeatureInputs,
     Qwen2_5OmniThinkerDummyInputsBuilder,
-    Qwen2_5OmniThinkerMultiModalProcessor,
     check_interleaved_audio_video,
     merge_interleaved_embeddings,
 )
@@ -120,6 +119,8 @@ from vllm.transformers_utils.processor import cached_processor_from_config
 
 from vllm_omni.model_executor.models.qwen2_5_omni.qwen2_5_omni_thinker import (
     Qwen2_5OmniConditionalGenerationMixin,
+    Qwen2_5OmniThinkerMultiModalProcessor,
+    _normalize_use_audio_in_video,
 )
 from vllm_omni.quantization.component_config import (
     PRE_QUANTIZED_METHODS,
@@ -769,22 +770,8 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
         mm_item_counts = mm_items.get_all_counts()
         self._validate_mm_kwargs(mm_kwargs, mm_item_counts)
 
-        use_audio_in_video = False
-        if "video" in mm_kwargs:
-            for item in mm_kwargs["video"]:
-                if item and item["use_audio_in_video"].data:
-                    use_audio_in_video = True
-                else:
-                    use_audio_in_video = False
-            # for mutilmodality cache
-            if any(item is None for item in mm_kwargs["video"]):
-                video_token_id = self.info.get_hf_config().video_token_id
-                audio_token_id = self.info.get_hf_config().audio_token_id
-                video_audio_item_num = sum(id in (video_token_id, audio_token_id) for id in prompt_ids)
-                audio_updates_num = len(mm_prompt_updates.get("audio", []))
-                video_updates_num = len(mm_prompt_updates.get("video", []))
-                if video_audio_item_num != video_updates_num + audio_updates_num:
-                    use_audio_in_video = True
+        video_use_audio_in_video = self._get_video_use_audio_in_video(mm_kwargs, mm_prompt_updates)
+        use_audio_in_video = any(video_use_audio_in_video)
 
         # normal case with `use_audio_in_video=False`
         if is_update_applied:
@@ -803,7 +790,11 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
                     prompt_ids,
                     filtered_updates,
                 )
-                mm_placeholders = self._derive_audio_from_video_placeholders(mm_placeholders, mm_prompt_updates)
+                mm_placeholders = self._derive_audio_from_video_placeholders(
+                    mm_placeholders,
+                    mm_prompt_updates,
+                    video_use_audio_in_video,
+                )
             else:
                 prompt_ids, mm_placeholders = self._apply_prompt_updates(
                     prompt_ids,
@@ -917,11 +908,19 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
             token_id = image_token_id if modality == "image" else video_token_id
             return [token_id] * (int(grid_thw.prod()) // merge_length)
 
-        use_audio_in_video = hf_processor_mm_kwargs.get("use_audio_in_video", False)
+        num_videos = len(out_mm_data.get("video_grid_thw", []))
+        video_use_audio_in_video = _normalize_use_audio_in_video(
+            hf_processor_mm_kwargs.get("use_audio_in_video", False),
+            num_videos,
+        )
         thinker_config = self.info.get_hf_config()
 
-        def get_replacement_qwen2_use_audio_in_video(item_idx: int):
+        def get_replacement_qwen2_video(item_idx: int):
             nonlocal audio_in_video_item_idx
+
+            if not video_use_audio_in_video[item_idx]:
+                return get_replacement_qwen2_vision(item_idx, modality="video")
+
             audio_num_features = audio_output_lengths[audio_in_video_item_idx]
             video_grid_thw = out_mm_data["video_grid_thw"][item_idx]
 
@@ -941,12 +940,6 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
             )
             return PromptUpdateDetails.select_token_id(placeholder, embed_token_id=video_token_id)
 
-        video_replacement_fn = (
-            get_replacement_qwen2_use_audio_in_video
-            if use_audio_in_video
-            else partial(get_replacement_qwen2_vision, modality="video")
-        )
-
         return [
             PromptReplacement(
                 modality="audio",
@@ -961,7 +954,7 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
             PromptReplacement(
                 modality="video",
                 target=video_token,
-                replacement=video_replacement_fn,
+                replacement=get_replacement_qwen2_video,
             ),
         ]
 
@@ -969,6 +962,7 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
         self,
         placeholders: Mapping[str, list[PlaceholderFeaturesInfo]],
         mm_prompt_updates: MultiModalPromptUpdates,
+        video_use_audio_in_video: Sequence[bool] | None = None,
     ) -> Mapping[str, list[PlaceholderFeaturesInfo]]:
         """
         Helper to derive audio placeholders from video placeholders when
@@ -978,10 +972,21 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
             return placeholders
 
         num_videos = len(placeholders["video"])
-        num_audios = len(mm_prompt_updates.get("audio", []))
-        if num_audios != num_videos:
+        if video_use_audio_in_video is None:
+            video_use_audio_in_video = [True] * num_videos
+        elif len(video_use_audio_in_video) != num_videos:
             raise ValueError(
-                f"use_audio_in_video requires equal number of audio and video items, got {num_audios=}, {num_videos=}"
+                "use_audio_in_video must contain one boolean per video, "
+                f"but found {len(video_use_audio_in_video)} values for "
+                f"{num_videos} videos."
+            )
+
+        num_audio_in_video = sum(video_use_audio_in_video)
+        num_audios = len(mm_prompt_updates.get("audio", []))
+        if num_audios != num_audio_in_video:
+            raise ValueError(
+                "use_audio_in_video requires equal number of audio and video "
+                f"items using audio, got {num_audios=}, {num_audio_in_video=}"
             )
 
         tokenizer = self.info.get_tokenizer()
@@ -990,22 +995,36 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
 
         result_placeholders = dict(placeholders)
         audio_placeholders = []
+        video_placeholders = []
 
-        # Each video is paired with one audio
+        # Each video using audio is paired with one audio
+        audio_idx = 0
         for video_idx, video_placeholder in enumerate(placeholders["video"]):
             # Create is_embed mask selecting only audio tokens
             audio_is_embed = torch.tensor(video_placeholder.tokens) == audio_token_id
 
-            audio_placeholder = PlaceholderFeaturesInfo(
-                modality="audio",
+            if video_use_audio_in_video[video_idx]:
+                audio_placeholder = PlaceholderFeaturesInfo(
+                    modality="audio",
+                    item_idx=audio_idx,
+                    start_idx=video_placeholder.start_idx,
+                    tokens=video_placeholder.tokens,
+                    is_embed=audio_is_embed,
+                )
+                audio_placeholders.append(audio_placeholder)
+                audio_idx += 1
+
+            video_placeholder_with_mask = PlaceholderFeaturesInfo(
+                modality="video",
                 item_idx=video_idx,
                 start_idx=video_placeholder.start_idx,
                 tokens=video_placeholder.tokens,
-                is_embed=audio_is_embed,
+                is_embed=~audio_is_embed,
             )
-            audio_placeholders.append(audio_placeholder)
+            video_placeholders.append(video_placeholder_with_mask)
 
         result_placeholders["audio"] = audio_placeholders
+        result_placeholders["video"] = video_placeholders
         return result_placeholders
 
     def _get_raw_input_ids(

--- a/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
+++ b/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_thinker.py
@@ -1108,6 +1108,13 @@ class Qwen3OmniMoeThinkerForConditionalGeneration(
             "up_proj",
         ],
     }
+    embedding_modules = {
+        "embed_tokens": "input_embeddings",
+        "lm_head": "output_embeddings",
+    }
+    is_3d_moe_weight = True
+    is_non_gated_moe = False
+    lora_skip_prefixes: list[str] = []
 
     supported_languages = ISO639_1_SUPPORTED_LANGS
 


### PR DESCRIPTION
## Summary

Declare Qwen3-Omni thinker LoRA metadata.

## Changes

- Add embedding module metadata for LoRA.
- Mark Qwen3-Omni thinker MoE weights as 3D MoE LoRA weights.
- Declare non-gated MoE behavior and empty LoRA skip prefixes.
- Add a lightweight test for Qwen3-Omni LoRA metadata.

## Tests

Passed locally:

- `pytest -q tests/models/test_qwen3_omni_lora.py`
  - Result: `2 passed`
- `python -m py_compile ...`
  - Result: passed
- `git diff --check`
  - Result: passed

Not run:

- `ruff` was not available in the local environment.

related PRs:
https://github.com/verl-project/verl-omni/pull/169
https://github.com/verl-project/verl/pull/6713
