### PR TITLE
[CI] skip MOSS-TTS-Nano E2E tests pending issue#4361

### DIFF
--- a/tests/e2e/offline_inference/test_moss_tts_nano_expansion.py
+++ b/tests/e2e/offline_inference/test_moss_tts_nano_expansion.py
@@ -32,6 +32,7 @@ _OMNI_RUNNER_PARAM = (
 )
 
 pytestmark = [
+    pytest.mark.skip(reason="issue#4361"),
     pytest.mark.full_model,
     pytest.mark.tts,
     pytest.mark.parametrize("omni_runner", [_OMNI_RUNNER_PARAM], indirect=True),

--- a/tests/e2e/online_serving/test_moss_tts_nano_expansion.py
+++ b/tests/e2e/online_serving/test_moss_tts_nano_expansion.py
@@ -25,11 +25,11 @@ from tests.helpers.runtime import OmniServerParams
 from tests.helpers.stage_config import get_deploy_config_path
 
 # ``omni`` for all tests; 001/002 also get ``full_model`` via ``TestMossTtsNanoFull`` (003 is core+advanced only, no full_model).
-pytestmark = [pytest.mark.full_model, pytest.mark.tts]
-
-_SKIP_ISSUE_3168 = pytest.mark.skip(
-    reason="https://github.com/vllm-project/vllm-omni/issues/3168",
-)
+pytestmark = [
+    pytest.mark.skip(reason="issue#4361"),
+    pytest.mark.full_model,
+    pytest.mark.tts,
+]
 
 MODEL = "OpenMOSS-Team/MOSS-TTS-Nano"
 REF_AUDIO_URL = "https://raw.githubusercontent.com/OpenMOSS/MOSS-TTS-Nano/main/assets/audio/zh_1.wav"


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

- Skip MOSS-TTS-Nano offline and online E2E expansion tests while `StageEngineCoreProc` fails during READY on CI (`Orchestrator initialization failed` / server exits before ready).
- Track the regression under issue#4361; remove the module-level `pytest.mark.skip` once fixed.
- Remove unused `_SKIP_ISSUE_3168` marker from the online test file.

## Test Plan

No new tests required — this only adds skips to existing E2E tests.

Verify collection marks tests as skipped:

```bash
pytest tests/e2e/offline_inference/test_moss_tts_nano_expansion.py \
       tests/e2e/online_serving/test_moss_tts_nano_expansion.py \
       --collect-only -q
```

**vLLM Version:** N/A (test-only change)

**vLLM-Omni Commit:** `599a9edc`

## Test Result

- Pending CI (Buildkite merge/ready pipelines that include MOSS-TTS-Nano E2E jobs).
- Expected: 8 tests reported as `SKIPPED (issue#4361)` instead of `ERROR`.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
