### PR TITLE
[Doc] validate Cosmos3-Nano online FP8

### DIFF
--- a/docs/user_guide/quantization/fp8.md
+++ b/docs/user_guide/quantization/fp8.md
@@ -85,6 +85,7 @@ warmup_quack_fp8([(14040, 2048, 6144), (14040, 2048, 2048)])
 | FLUX.2-klein | `black-forest-labs/FLUX.2-klein-4B` | Yes | Yes | All layers | None | |
 | HunyuanImage-3.0 | `tencent/HunyuanImage-3.0`, `tencent/HunyuanImage-3.0-Instruct` | Yes | Yes | All layers; use the Hunyuan stage config for multi-stage runs | None | |
 | HunyuanVideo-1.5 | `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v`, `720p_t2v`, `480p_i2v` | Yes | Yes | All layers | None | |
+| Cosmos3 | `nvidia/Cosmos3-Nano` | Yes | Not validated | All layers | None | |
 
 ### Multi-Stage Omni/TTS Model (Qwen3-Omni, Qwen3-TTS)
 

--- a/recipes/cosmos3/Cosmos3-Nano.md
+++ b/recipes/cosmos3/Cosmos3-Nano.md
@@ -101,7 +101,10 @@ vllm serve nvidia/Cosmos3-Nano \
 To run **without** guardrails (you are responsible for license compliance),
 add `--no-guardrails` (no token/`cosmos-guardrail` needed). For extra GPUs use
 `--ulysses-degree N` (context parallel) or `--tensor-parallel-size N`;
-`--enable-layerwise-offload` reduces VRAM on smaller GPUs. The pipeline
+`--enable-layerwise-offload` reduces VRAM on smaller GPUs;
+`--quantization fp8` (online, no calibration) cuts peak VRAM for 720p video
+generation from ~50 GB to ~36 GB with BF16-level quality (T2V composition can
+shift at the same seed). The pipeline
 auto-resolves from `model_index.json`; pass
 `--model-class-name Cosmos3OmniDiffusersPipeline` to force it explicitly.
 


### PR DESCRIPTION
## Purpose

Validate FP8 (online) quantization for Cosmos3-Nano and document it as supported. Part of #4340.

No code change is needed: `Cosmos3VFMTransformer` already threads `quant_config` into every vLLM linear layer, so `--quantization fp8` works out of the box. This PR adds the validation results to the docs:

- `docs/user_guide/quantization/fp8.md`: add Cosmos3 to the supported diffusion model table (online FP8, all layers, no `ignored_layers`).
- `recipes/cosmos3/Cosmos3-Nano.md`: document `--quantization fp8` as a low-VRAM option with measured memory/latency.

## Test Plan

**vLLM Version:** 0.22.0

**vLLM-Omni Commit:** 3ef912ec

All tests on 1x H100 80GB

**Baseline server:**

```bash
vllm serve nvidia/Cosmos3-Nano --omni --host 0.0.0.0 --port 8000 --no-guardrails --init-timeout 1800
```

**FP8 server:**

```bash
vllm serve nvidia/Cosmos3-Nano --omni --host 0.0.0.0 --port 8000 --no-guardrails --quantization fp8 --init-timeout 1800
```

Run each request below once against each server, saving outputs with `_bf16` / `_fp8` suffixes.

**T2I (1024x1024, 50 steps, guidance 7.0):**

```bash
curl -sS -X POST http://localhost:8000/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{
    "model": "nvidia/Cosmos3-Nano",
    "prompt": "A photorealistic red sports car on a city street at golden hour, cinematic lighting.",
    "negative_prompt": "blurry, distorted, low quality",
    "size": "1024x1024", "n": 1, "response_format": "b64_json",
    "num_inference_steps": 50, "guidance_scale": 7.0, "seed": 42
  }' | python3 -c "import sys,json,base64; open('cosmos3_t2i.png','wb').write(base64.b64decode(json.load(sys.stdin)['data'][0]['b64_json']))"
```

**T2V (1280x720, 189 frames, 35 steps, guidance 6.0 — official params):**

```bash
curl -sS -X POST http://localhost:8000/v1/videos/sync \
  -H "Accept: video/mp4" \
  -F "model=nvidia/Cosmos3-Nano" \
  -F "prompt=A robot arm is cleaning a plate in the kitchen" \
  -F "negative_prompt=blurry, distorted, low quality, jittery, deformed" \
  -F "size=1280x720" -F "num_frames=189" -F "fps=24" \
  -F "num_inference_steps=35" -F "guidance_scale=6.0" \
  -F "max_sequence_length=4096" -F "flow_shift=10.0" \
  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false}' \
  -F "seed=123" \
  -o cosmos3_t2v.mp4
```

**I2V (1280x720, 189 frames, 35 steps, model-card asset as reference):**

```bash
curl -sS -X POST http://localhost:8000/v1/videos/sync \
  -H "Accept: video/mp4" \
  -F "model=nvidia/Cosmos3-Nano" \
  -F "prompt=The scene comes to life with smooth, natural motion." \
  -F "negative_prompt=blurry, distorted, low quality" \
  -F "size=1280x720" -F "num_frames=189" -F "fps=24" \
  -F "num_inference_steps=35" -F "guidance_scale=6.0" \
  -F "max_sequence_length=4096" -F "flow_shift=10.0" \
  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false}' \
  -F "seed=1111" \
  -F "input_reference=@Cosmos3-Nano/assets/example_i2v_input.jpg;type=image/jpeg" \
  -o cosmos3_i2v.mp4
```

**Comparison (LPIPS, AlexNet, frame-wise):**

```bash
python compare_videos.py cosmos3_t2v_bf16.mp4 cosmos3_t2v_fp8.mp4 --label1 bf16 --label2 fp8
python compare_videos.py cosmos3_i2v_bf16.mp4 cosmos3_i2v_fp8.mp4 --label1 bf16 --label2 fp8
python compare_videos.py cosmos3_t2i_bf16.png cosmos3_t2i_fp8.png --label1 bf16 --label2 fp8
```

## Test Result

### Memory (1x H100 80GB)

| | BF16 | FP8 | saving |
|---|---|---|---|
| Idle after load | 33.2 GB | **19.7 GB** | -13.5 GB (-41%) |
| Peak during 720p/189f video generation (T2V/I2V) | 50.4 GB | **36.4 GB** | -14.0 GB (-28%) |

### Latency (server-side Total pipeline time)

| Scenario | BF16 | FP8 | speedup |
|---|---|---|---|
| T2I 1024x1024, 50 steps | 2.64s | 2.00s | **1.32x** |
| T2V 1280x720, 189f, 35 steps | 196.1s | 174.4s | **1.12x** |
| I2V 1280x720, 189f, 35 steps | 199.3s | 178.2s | **1.12x** |

### Quality (LPIPS vs BF16, identical seed)

| Scenario | LPIPS mean | LPIPS p95 | MaxAbsDiff (mean/max) |
|---|---|---|---|
| T2I | 0.1438 | — | 244 / 244 |
| I2V | 0.1488 | 0.1756 | 176 / 232 |
| T2V | 0.4737 | 0.4877 | 183 / 201 |

### T2I comparison (1024x1024, seed 42)

| BF16 | FP8 |
|------|-----|
| <img width="1024" height="1024" alt="cosmos3_t2i_bf16" src="https://github.com/user-attachments/assets/7732739e-0f63-46fd-9df0-f5f83adcc666" /> | <img width="1024" height="1024" alt="cosmos3_t2i_fp8" src="https://github.com/user-attachments/assets/05aa75a3-a8d6-4808-9cc7-9f79e06b1337" /> |

### I2V comparison (720p/189f, seed 1111)
cosmos3_i2v_bf16.mp4:
https://github.com/user-attachments/assets/1a5fadef-99e7-4240-8ddd-a4a393dbf204

cosmos3_i2v_fp8.mp4
https://github.com/user-attachments/assets/0aef75ea-dfed-4a28-823d-f54eda54e45e

### T2V comparison (720p/189f, seed 123)

cosmos3_t2v_bf16.mp4:
https://github.com/user-attachments/assets/94040cd6-9f16-45d1-ae1b-4dfa0ec8a191

cosmos3_t2v_fp8.mp4:
https://github.com/user-attachments/assets/9baca22d-2809-4cd1-bb95-a2327dcc2736
