### PR TITLE
[Bugfix] Ming-omni-tts: generalize dict checks to Mapping

### DIFF
--- a/tests/e2e/offline_inference/test_ming_tts.py
+++ b/tests/e2e/offline_inference/test_ming_tts.py
@@ -5,6 +5,8 @@
 
 import asyncio
 import uuid
+from collections.abc import Mapping
+from typing import Any
 
 import numpy as np
 import pytest
@@ -102,8 +104,8 @@ def _flatten_audio(audio) -> torch.Tensor:
     return torch.as_tensor(audio, dtype=torch.float32).reshape(-1).cpu()
 
 
-def _extract_audio(multimodal_output: dict) -> torch.Tensor:
-    assert isinstance(multimodal_output, dict), f"Expected dict, got {type(multimodal_output)}"
+def _extract_audio(multimodal_output: Mapping[str, Any]) -> torch.Tensor:
+    assert isinstance(multimodal_output, Mapping), f"Expected Mapping, got {type(multimodal_output)}"
     audio = multimodal_output.get("audio", multimodal_output.get("model_outputs"))
     assert audio is not None, f"No audio output found, keys={list(multimodal_output.keys())}"
     waveform = _flatten_audio(audio)
@@ -112,7 +114,7 @@ def _extract_audio(multimodal_output: dict) -> torch.Tensor:
     return waveform
 
 
-def _extract_sample_rate(multimodal_output: dict) -> int:
+def _extract_sample_rate(multimodal_output: Mapping[str, Any]) -> int:
     sample_rate = multimodal_output.get("sr")
     if sample_rate is None:
         raise RuntimeError("Expected multimodal_output['sr']")
@@ -133,29 +135,29 @@ def _extract_final_audio_outputs(outputs):
         if request_output is None:
             continue
         multimodal_output = getattr(request_output, "multimodal_output", None)
-        if isinstance(multimodal_output, dict):
+        if isinstance(multimodal_output, Mapping):
             final_outputs.append(item)
             continue
         completions = getattr(request_output, "outputs", None) or []
-        if any(isinstance(getattr(completion, "multimodal_output", None), dict) for completion in completions):
+        if any(isinstance(getattr(completion, "multimodal_output", None), Mapping) for completion in completions):
             final_outputs.append(item)
     return final_outputs
 
 
 def _extract_multimodal_output(output) -> dict:
     multimodal_output = getattr(output, "multimodal_output", None)
-    if isinstance(multimodal_output, dict):
+    if isinstance(multimodal_output, Mapping):
         return multimodal_output
 
     request_output = getattr(output, "request_output", None)
     if request_output is not None:
         multimodal_output = getattr(request_output, "multimodal_output", None)
-        if isinstance(multimodal_output, dict):
+        if isinstance(multimodal_output, Mapping):
             return multimodal_output
         completions = getattr(request_output, "outputs", None) or []
         for completion in completions:
             multimodal_output = getattr(completion, "multimodal_output", None)
-            if isinstance(multimodal_output, dict):
+            if isinstance(multimodal_output, Mapping):
                 return multimodal_output
 
     raise AssertionError("No multimodal audio output found in Ming generate results")

--- a/tests/e2e/offline_inference/test_ming_tts.py
+++ b/tests/e2e/offline_inference/test_ming_tts.py
@@ -144,7 +144,7 @@ def _extract_final_audio_outputs(outputs):
     return final_outputs
 
 
-def _extract_multimodal_output(output) -> dict:
+def _extract_multimodal_output(output) -> Mapping[str, Any]:
     multimodal_output = getattr(output, "multimodal_output", None)
     if isinstance(multimodal_output, Mapping):
         return multimodal_output

--- a/vllm_omni/model_executor/stage_input_processors/ming_tts.py
+++ b/vllm_omni/model_executor/stage_input_processors/ming_tts.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import torch
@@ -33,8 +34,8 @@ MING_FINAL_DECODE_STEP_KEY = "ming_final_decode_step"
 MING_STOP_REASON_BY_CODE = {code: reason for reason, code in MING_STOP_REASON_CODES.items()}
 
 
-def _extract_last_patch(pooling_output: dict[str, Any] | None) -> torch.Tensor | None:
-    if not isinstance(pooling_output, dict):
+def _extract_last_patch(pooling_output: Mapping[str, Any] | None) -> torch.Tensor | None:
+    if not isinstance(pooling_output, Mapping):
         return None
     has_patch = pooling_output.get("ming_has_patch")
     patch = pooling_output.get("ming_latent_patch")
@@ -54,8 +55,8 @@ def _extract_last_patch(pooling_output: dict[str, Any] | None) -> torch.Tensor |
     return patch.to(torch.float32).cpu()
 
 
-def _extract_all_patches(pooling_output: dict[str, Any] | None) -> torch.Tensor | None:
-    if not isinstance(pooling_output, dict):
+def _extract_all_patches(pooling_output: Mapping[str, Any] | None) -> torch.Tensor | None:
+    if not isinstance(pooling_output, Mapping):
         return None
     has_patch = pooling_output.get("ming_has_patch")
     patch = pooling_output.get("ming_latent_patch")
@@ -78,8 +79,8 @@ def _extract_all_patches(pooling_output: dict[str, Any] | None) -> torch.Tensor 
     return patch.to(torch.float32).cpu()
 
 
-def _extract_last_value(pooling_output: dict[str, Any] | None, key: str) -> Any:
-    if not isinstance(pooling_output, dict):
+def _extract_last_value(pooling_output: Mapping[str, Any] | None, key: str) -> Any:
+    if not isinstance(pooling_output, Mapping):
         return None
     value = pooling_output.get(key)
     if value is None:
@@ -118,7 +119,7 @@ def _decode_stop_reason(value: Any) -> str | None:
 def _get_async_chunk_config(transfer_manager: Any) -> tuple[int, int]:
     connector = getattr(transfer_manager, "connector", None)
     raw_cfg = getattr(connector, "config", {}) or {}
-    cfg = raw_cfg.get("extra", raw_cfg) if isinstance(raw_cfg, dict) else {}
+    cfg = raw_cfg.get("extra", raw_cfg) if isinstance(raw_cfg, Mapping) else {}
     if "latent_chunk_size" not in cfg:
         logger.warning(
             "Ming async chunk config missing latent_chunk_size, using fallback value %s",


### PR DESCRIPTION

## Purpose
fix #4392
## Env

vLLM Version : 0.22.0
vLLM-Omni Version : 0.1.dev1939+g9577ccba5.rocm (git sha: 9577ccb, date: ocm)
<details>
<summary> python collect_env.py </summary>
```bash
==============================
        System Info
==============================
OS                           : Ubuntu 22.04.5 LTS (x86_64)
GCC version                  : (Ubuntu 11.4.0-1ubuntu1~22.04.3) 11.4.0
Clang version                : 22.0.0git (https://github.com/RadeonOpenCompute/llvm-project roc-7.2.2 26084 f58b06dce1f9c15707c5f808fd002e18c2accf7e)
CMake version                : version 3.31.10
Libc version                 : glibc-2.35

==============================
       PyTorch Info
==============================
PyTorch version              : 2.10.0+git8514f05
Is debug build               : False
CUDA used to build PyTorch   : N/A
ROCM used to build PyTorch   : 7.2.53211

==============================
      Python Environment
==============================
Python version               : 3.12.13 (main, Mar  4 2026, 09:23:07) [GCC 11.4.0] (64-bit runtime)
Python platform              : Linux-6.8.0-106-generic-x86_64-with-glibc2.35

==============================
       CUDA / GPU Info
==============================
Is CUDA available            : True
CUDA runtime version         : Could not collect
CUDA_MODULE_LOADING set to   : 
GPU models and configuration :  (gfx942:sramecc+:xnack-)
Nvidia driver version        : Could not collect
cuDNN version                : Could not collect
HIP runtime version          : 7.2.53211
MIOpen runtime version       : 3.5.1
Is XNNPACK available         : True

==============================
          CPU Info
==============================
Architecture:                            x86_64
CPU op-mode(s):                          32-bit, 64-bit
Address sizes:                           46 bits physical, 57 bits virtual
Byte Order:                              Little Endian
CPU(s):                                  20
On-line CPU(s) list:                     0-19
Vendor ID:                               GenuineIntel
Model name:                              INTEL(R) XEON(R) PLATINUM 8568Y+
CPU family:                              6
Model:                                   207
Thread(s) per core:                      1
Core(s) per socket:                      20
Socket(s):                               1
Stepping:                                2
BogoMIPS:                                4600.00
Flags:                                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology cpuid tsc_known_freq pni pclmulqdq dtes64 vmx ssse3 fma cx16 pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves avx_vnni avx512_bf16 wbnoinvd arat vnmi avx512vbmi umip pku ospke waitpkg avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq la57 rdpid bus_lock_detect cldemote movdiri movdir64b fsrm md_clear serialize tsxldtrk avx512_fp16 arch_capabilities
Virtualization:                          VT-x
Hypervisor vendor:                       KVM
Virtualization type:                     full
L1d cache:                               640 KiB (20 instances)
L1i cache:                               640 KiB (20 instances)
L2 cache:                                80 MiB (20 instances)
NUMA node(s):                            1
NUMA node0 CPU(s):                       0-19
Vulnerability Gather data sampling:      Not affected
Vulnerability Indirect target selection: Vulnerable
Vulnerability Itlb multihit:             Not affected
Vulnerability L1tf:                      Not affected
Vulnerability Mds:                       Not affected
Vulnerability Meltdown:                  Not affected
Vulnerability Mmio stale data:           Unknown: No mitigations
Vulnerability Reg file data sampling:    Not affected
Vulnerability Retbleed:                  Not affected
Vulnerability Spec rstack overflow:      Not affected
Vulnerability Spec store bypass:         Mitigation; Speculative Store Bypass disabled via prctl
Vulnerability Spectre v1:                Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:                Mitigation; Enhanced / Automatic IBRS; IBPB conditional; PBRSB-eIBRS SW sequence; BHI SW loop, KVM SW loop
Vulnerability Srbds:                     Not affected
Vulnerability Tsa:                       Not affected
Vulnerability Tsx async abort:           Mitigation; TSX disabled
Vulnerability Vmscape:                   Not affected

==============================
Versions of relevant libraries
==============================
[pip3] conch-triton-kernels==1.2.1
[pip3] mypy==1.11.1
[pip3] mypy_extensions==1.1.0
[pip3] numpy==2.1.3
[pip3] onnx==1.19.0
[pip3] onnx-ir==0.2.1
[pip3] onnxruntime-rocm==1.22.2.post1
[pip3] onnxscript==0.7.0
[pip3] onnxslim==0.1.94
[pip3] pyzmq==27.1.0
[pip3] sentence-transformers==5.5.1
[pip3] torch==2.10.0+git8514f05
[pip3] torch_c_dlpack_ext==0.1.5
[pip3] torch-complex==0.4.4
[pip3] torch-einops-utils==0.1.4
[pip3] torchaudio==2.9.0+eaa9e4e
[pip3] torchcodec==0.14.0
[pip3] torchdiffeq==0.2.5
[pip3] torchmetrics==1.9.0
[pip3] torchsde==0.2.6
[pip3] torchvision==0.24.1+d801a34
[pip3] transformers==5.8.1
[pip3] triton==3.6.0
[pip3] triton_kernels==1.0.0
[pip3] x-transformers==2.20.1
[conda] Could not collect

==============================
         vLLM Info
==============================
ROCM Version                 : 7.2.53211-35e8c7bf89
vLLM Version                 : 0.22.0
vLLM-Omni Version            : 0.1.dev1939+g9577ccba5.rocm (git sha: 9577ccba5, date: ocm)
vLLM Build Flags:
  CUDA Archs: Not Set; ROCm: Disabled
GPU Topology:
  ============================ ROCm System Management Interface ============================
================================ Weight between two GPUs =================================
       GPU0         
GPU0   0            

================================= Hops between two GPUs ==================================
       GPU0         
GPU0   0            

=============================== Link Type between two GPUs ===============================
       GPU0         
GPU0   0            

======================================= Numa Nodes =======================================
GPU[0]          : (Topology) Numa Node: 0
GPU[0]          : (Topology) Numa Affinity: 0
================================== End of ROCm SMI Log ===================================

==============================
     Environment Variables
==============================
VLLM_WORKER_MULTIPROC_METHOD=spawn
VLLM_ROCM_USE_AITER=0
PYTORCH_ROCM_ARCH=gfx942
LD_LIBRARY_PATH=/usr/local/lib/python3.12/dist-packages/cv2/../../lib64:/opt/rocm/lib:/usr/local/lib:
VLLM_LOGGING_LEVEL=DEBUG
PYTORCH_NVML_BASED_CUDA_CHECK=1
TORCHINDUCTOR_COMPILE_THREADS=1
TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_root
</details>



## Test Result

<img width="726" height="55" alt="Image" src="https://github.com/user-attachments/assets/8de005c4-1df0-48b1-abd3-1b7991ee237e" />

<img width="726" height="55" alt="Image" src="https://github.com/user-attachments/assets/8c6b00e3-47cb-4c1c-a51e-3f9eb2e2890c" />

