### PR TITLE
[bugfix] Shim PreTrainedModel._tp_plan to fix MOSS-TTS-Nano load crash

### DIFF
--- a/tests/e2e/offline_inference/test_moss_tts_nano_expansion.py
+++ b/tests/e2e/offline_inference/test_moss_tts_nano_expansion.py
@@ -32,7 +32,6 @@ _OMNI_RUNNER_PARAM = (
 )
 
 pytestmark = [
-    pytest.mark.skip(reason="issue#4361"),
     pytest.mark.full_model,
     pytest.mark.tts,
     pytest.mark.parametrize("omni_runner", [_OMNI_RUNNER_PARAM], indirect=True),

--- a/tests/e2e/online_serving/test_moss_tts_nano_expansion.py
+++ b/tests/e2e/online_serving/test_moss_tts_nano_expansion.py
@@ -26,7 +26,6 @@ from tests.helpers.stage_config import get_deploy_config_path
 
 # ``omni`` for all tests; 001/002 also get ``full_model`` via ``TestMossTtsNanoFull`` (003 is core+advanced only, no full_model).
 pytestmark = [
-    pytest.mark.skip(reason="issue#4361"),
     pytest.mark.full_model,
     pytest.mark.tts,
 ]

--- a/vllm_omni/model_executor/models/moss_tts_nano/modeling_moss_tts_nano.py
+++ b/vllm_omni/model_executor/models/moss_tts_nano/modeling_moss_tts_nano.py
@@ -156,7 +156,11 @@ class MossTTSNanoForGeneration(nn.Module):
             tts_dtype = torch.float32
 
         logger.info("Loading MOSS-TTS-Nano LM from %s (dtype=%s)", self.model_path, tts_dtype)
-        from transformers import AutoModelForCausalLM
+        from transformers import AutoModelForCausalLM, PreTrainedModel
+
+        # Shim _tp_plan to prevent TypeError in transformers when loading remote-code models
+        if getattr(PreTrainedModel, "_tp_plan", None) is None:
+            PreTrainedModel._tp_plan = {}
 
         lm = AutoModelForCausalLM.from_pretrained(
             self.model_path,


### PR DESCRIPTION
fix #4361

MOSS-TTS-Nano fails to load with modern `transformers` releases because its remote-code implementation predates the v4.40.0 initialization changes.

Starting in `transformers` v4.40.0, model loading (`caching_allocator_warmup` / `get_total_byte_count`) accesses `_tp_plan`. Standard models initialize this via `post_init()`, but MOSS-TTS-Nano's remote code does not, leaving `_tp_plan=None` and causing:

```text
TypeError: object of type 'NoneType' has no len()
```

This remains reproducible on current releases (e.g. `transformers==5.8.1`) and affects older `trust_remote_code=True` models that do not call `post_init()`.

### Fix

Initialize `_tp_plan = {}` before `from_pretrained()`.

This follows existing compatibility patterns already used elsewhere in the repository for remote-code models and restores compatibility with `transformers >= 4.40.0`.

