### PR TITLE
[XPU] update Dreamzero to support any HW

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -42,7 +42,7 @@ th {
 | `LTX2ImageToVideoTwoStagesPipeline` | LTX-2-I2V | `rootonchair/LTX-2-19b-distilled` | ✅︎ | ✅︎ | | |
 | `LTX23Pipeline` | LTX-2.3-T2V | `dg845/LTX-2.3-Diffusers` | ✅︎ | ✅︎ | | |
 | `LTX23ImageToVideoPipeline` | LTX-2.3-I2V | `dg845/LTX-2.3-Diffusers` | ✅︎ | ✅︎ | | |
-| `DreamZeroPipeline` | DreamZero-DROID | `GEAR-Dreams/DreamZero-DROID` | ✅︎ | | | |
+| `DreamZeroPipeline` | DreamZero-DROID | `GEAR-Dreams/DreamZero-DROID` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `HeliosPipeline`, `HeliosPyramidPipeline` | Helios | `BestWishYsh/Helios-Base`, `BestWishYsh/Helios-Mid`, `BestWishYsh/Helios-Distilled` | ✅︎ | ✅︎ | ✅︎ | |
 | `MagiHumanPipeline` | MagiHuman | `SII-GAIR/daVinci-MagiHuman-Base-1080p` | ✅︎ | ✅︎ | | |
 | `OvisImagePipeline` | Ovis-Image | `OvisAI/Ovis-Image` | ✅︎ | ✅︎ | | ✅︎ |

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -617,6 +617,8 @@ class CausalWanModel(nn.Module):
     Architecture (14B): 40 layers, dim=5120, heads=40, ffn=13824
     """
 
+    _layerwise_offload_blocks_attrs = ["blocks"]
+
     def __init__(
         self,
         model_type: str = "t2v",

--- a/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
@@ -49,6 +49,7 @@ from vllm_omni.diffusion.models.dreamzero.utils import (
 )
 from vllm_omni.diffusion.models.schedulers.scheduling_flow_unipc_multistep import FlowUniPCMultistepScheduler
 from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.platforms import current_omni_platform
 
 logger = logging.getLogger(__name__)
 MAX_DREAMZERO_SESSIONS = 64
@@ -363,12 +364,10 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         latents: tuple[torch.Tensor, torch.Tensor],
         do_true_cfg: bool,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Post-step sync: .contiguous() + cuda.synchronize()"""
+        """Post-step sync: .contiguous() + platform synchronize."""
         latents = tuple(t.contiguous() for t in latents)
         if do_true_cfg and get_classifier_free_guidance_world_size() > 1:
-            device = next((t.device for t in latents if t.is_cuda), None)
-            if device is not None:
-                torch.cuda.current_stream(device).synchronize()
+            current_omni_platform.synchronize()
         return latents
 
     # -----------------------------------------------------------------------


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

update Dreamzero to support any HW

## Test Plan

  python examples/offline_inference/dreamzero/export_prediction_video.py \
      --deploy-config vllm_omni/deploy/dreamzero_tp1_layerwise.yaml \
      --save-input-video --save-gif --save-actions

dreamzero_tp1_layerwise.yaml

```
pipeline: dreamzero
async_chunk: false
distributed_executor_backend: mp
dtype: bfloat16

stages:
  - stage_id: 0
    devices: "0"
    max_num_seqs: 1
    enforce_eager: true
    enable_layerwise_offload: true
    model_class_name: DreamZeroPipeline
    model_config:
      default_robot_embodiment: roboarena
      policy_server_config:
        image_resolution: [180, 320]
        n_external_cameras: 2
        needs_wrist_camera: true
        needs_stereo_camera: false
        needs_session_id: true
        action_space: joint_position
```

source assets from:
https://huggingface.co/datasets/YangshenDeng/vllm-omni-dreamzero-assets

## Test Result

input

<img width="640" height="360" alt="dreamzero_prediction_input" src="https://github.com/user-attachments/assets/a27a664c-9933-4d29-a513-dfc7de4a616e" />



prediction

Visually inpected, the robot arm is trying to pick up / get closer to the target

<img width="640" height="352" alt="dreamzero_prediction" src="https://github.com/user-attachments/assets/9338dc61-31a7-4569-b7dd-da0bc3f364db" />



**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
