### PR TITLE
[Perf][HunyuanImage] remove sync logic

### DIFF
--- a/tests/e2e/accuracy/test_hunyuan_image3.py
+++ b/tests/e2e/accuracy/test_hunyuan_image3.py
@@ -71,6 +71,7 @@ def _assert_cot_structural_markers(cot_text: str, label: str) -> None:
 
 
 os.environ["DIFFUSION_ATTENTION_BACKEND"] = "TORCH_SDPA"
+os.environ["VLLM_LOGGING_LEVEL"] = "DEBUG"
 
 pytestmark = [pytest.mark.local_model, pytest.mark.diffusion]
 

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -1065,9 +1065,10 @@ class ImageKVCacheManager:
         assert self.image_kv_cache_lens is not None
         if position_ids is not None:
             assert position_ids.shape == (bs, q_len)
-            assert torch.all(position_ids[:, 0] == self.image_kv_cache_lens), (
-                "The first current position must immediately follow each sample's cached prompt KV."
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                assert torch.all(position_ids[:, 0] == self.image_kv_cache_lens.to(position_ids.device)), (
+                    "The first current position must immediately follow each sample's cached prompt KV."
+                )
         new_key = torch.cat([cached_key, key], dim=1)
         new_value = torch.cat([cached_value, value], dim=1)
         return new_key.contiguous(), new_value.contiguous()

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -560,7 +560,7 @@ class HunyuanImage3Pipeline(
         timestep_scatter_src = self.timestep_emb(t.reshape(-1)).reshape(batch_size, -1, n_embd)
         x.scatter_(
             dim=1,
-            index=timestep_scatter_index.unsqueeze(-1).repeat(1, 1, n_embd),
+            index=timestep_scatter_index.to(x.device).unsqueeze(-1).repeat(1, 1, n_embd),
             src=timestep_scatter_src,
         )
 
@@ -943,7 +943,7 @@ class HunyuanImage3Pipeline(
             num_inference_steps=num_inference_steps,
             guidance_scale=guidance_scale,
             image_mask=to_device(output.gen_image_mask, device),
-            gen_timestep_scatter_index=to_device(output.gen_timestep_scatter_index, device),
+            gen_timestep_scatter_index=output.gen_timestep_scatter_index,
             cond_vae_images=to_device(cond_vae_images, device),
             cond_timestep=to_device(cond_timestep, device),
             cond_vae_image_mask=to_device(output.cond_vae_image_mask, device),


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
resolve task in https://github.com/vllm-project/vllm-omni/issues/4367

(1) Move `timestep_scatter_index` from the device side to the CPU side to avoid synchronizing it back to the CPU in `ImageKVCacheManager::_cache_prompt_kv`.

(2) Gate CPU-synchronizing assertions behind debug mode to prevent unnecessary performance overhead in production. Debug mode remains enabled in local accuracy tests to ensure ongoing validation and regression coverage.

### profiling
**Before**
<img width="1094" height="252" alt="image" src="https://github.com/user-attachments/assets/665a096e-a063-4c4d-8340-ccef7ab4af9f" />

**After**
<img width="1554" height="388" alt="image" src="https://github.com/user-attachments/assets/dac5d3c5-3da6-4147-9b5a-43396dbee9da" />


## Test Plan
(1) performance test
`pytest -s -v tests/dfx/perf/scripts/run_diffusion_benchmark.py   --test-config-file tests/dfx/perf/tests/test_hunyuan_image_tp4.json`
(2) accuracy test
`pytest -s -v tests/e2e/accuracy/test_hunyuan_image3.py`

**vLLM Version:**
0.23.0
## Test Result
(1)
| case | Qps | Improve |
|----| ---- | ---- |
| Before | 0.3832 | - |
| After | 0.3999 | 4.3% |

(2)
<img width="1030" height="442" alt="image" src="https://github.com/user-attachments/assets/f9c4afab-8197-48bc-86a6-260d881cec05" />


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
