### PR TITLE
[Core] Add diffusion MFU perf stats bridge

### DIFF
--- a/tests/diffusion/models/flux/test_flux_dit_perf_stats.py
+++ b/tests/diffusion/models/flux/test_flux_dit_perf_stats.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.metrics.perf import FluxDiTForwardStats
+from vllm_omni.diffusion.models.flux.pipeline_flux import FluxPipeline
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _make_flux_pipeline_for_stats(**parallel_overrides):
+    parallel_config = SimpleNamespace(tensor_parallel_size=1)
+    for key, value in parallel_overrides.items():
+        setattr(parallel_config, key, value)
+
+    pipeline = object.__new__(FluxPipeline)
+    pipeline.od_config = SimpleNamespace(parallel_config=parallel_config)
+    pipeline.transformer = SimpleNamespace(
+        inner_dim=8,
+        transformer_blocks=[object(), object()],
+        single_transformer_blocks=[object(), object(), object()],
+    )
+    pipeline._last_dit_forward_stats = None
+    return pipeline
+
+
+def test_flux_records_model_specific_stats_from_runtime_shapes(monkeypatch):
+    import vllm_omni.diffusion.models.flux.pipeline_flux as pipeline_flux_module
+
+    pipeline = _make_flux_pipeline_for_stats(tensor_parallel_size=2)
+    monkeypatch.setattr(pipeline_flux_module, "get_classifier_free_guidance_world_size", lambda: 1)
+
+    pipeline._record_dit_forward_stats(
+        latents=torch.zeros((2, 16, 8)),
+        prompt_embeds=torch.zeros((2, 77, 8)),
+        timesteps=torch.arange(4),
+        do_true_cfg=False,
+    )
+
+    stats = pipeline.get_dit_forward_stats(req=object(), output=object())
+
+    assert stats == FluxDiTForwardStats(
+        batch_size=2,
+        image_seq_len=16,
+        text_seq_len=77,
+        hidden_dim=8,
+        ffn_dim=32,
+        num_double_layers=2,
+        num_single_layers=3,
+        num_steps=4,
+        forwards_per_step_per_gpu=1,
+        tensor_parallel_size=2,
+    )
+
+
+def test_flux_counts_sequential_and_parallel_cfg_forwards(monkeypatch):
+    import vllm_omni.diffusion.models.flux.pipeline_flux as pipeline_flux_module
+
+    pipeline = _make_flux_pipeline_for_stats()
+    monkeypatch.setattr(pipeline_flux_module, "get_classifier_free_guidance_world_size", lambda: 1)
+
+    pipeline._record_dit_forward_stats(
+        latents=torch.zeros((1, 16, 8)),
+        prompt_embeds=torch.zeros((1, 77, 8)),
+        timesteps=torch.arange(4),
+        do_true_cfg=True,
+    )
+    sequential_stats = pipeline.get_dit_forward_stats(req=object(), output=object())
+
+    monkeypatch.setattr(pipeline_flux_module, "get_classifier_free_guidance_world_size", lambda: 2)
+    pipeline._record_dit_forward_stats(
+        latents=torch.zeros((1, 16, 8)),
+        prompt_embeds=torch.zeros((1, 77, 8)),
+        timesteps=torch.arange(4),
+        do_true_cfg=True,
+    )
+    parallel_stats = pipeline.get_dit_forward_stats(req=object(), output=object())
+
+    assert sequential_stats is not None
+    assert sequential_stats.forwards_per_step_per_gpu == 2
+    assert parallel_stats is not None
+    assert parallel_stats.forwards_per_step_per_gpu == 1
+
+
+def test_flux_clears_stale_dit_forward_stats_at_request_start():
+    pipeline = _make_flux_pipeline_for_stats()
+    pipeline._last_dit_forward_stats = object()
+
+    pipeline._clear_dit_forward_stats()
+
+    assert pipeline.get_dit_forward_stats(req=object(), output=object()) is None

--- a/tests/diffusion/models/hunyuan_video/test_hunyuan_video_dit_perf_stats.py
+++ b/tests/diffusion/models/hunyuan_video/test_hunyuan_video_dit_perf_stats.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+HunyuanVideoDiTForwardStats = importlib.import_module("vllm_omni.diffusion.metrics.perf").HunyuanVideoDiTForwardStats
+pipeline_hunyuan_module = importlib.import_module("vllm_omni.diffusion.models.hunyuan_video.pipeline_hunyuan_video_1_5")
+HunyuanVideo15Pipeline = pipeline_hunyuan_module.HunyuanVideo15Pipeline
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _make_parallel_config(**overrides):
+    values = {
+        "tensor_parallel_size": 1,
+        "sequence_parallel_size": 1,
+        "pipeline_parallel_size": 1,
+        "cfg_parallel_size": 1,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _make_hunyuan_pipeline_for_stats(**parallel_overrides):
+    pipeline = object.__new__(HunyuanVideo15Pipeline)
+    pipeline.od_config = SimpleNamespace(parallel_config=_make_parallel_config(**parallel_overrides))
+    pipeline.transformer = SimpleNamespace(
+        inner_dim=8,
+        ffn_dim=32,
+        patch_size_t=1,
+        patch_size=2,
+        transformer_blocks=[object(), object(), object()],
+    )
+    pipeline._last_dit_forward_stats = None
+    return pipeline
+
+
+def test_hunyuan_video_records_model_specific_stats_from_runtime_shapes(monkeypatch):
+    pipeline = _make_hunyuan_pipeline_for_stats(
+        tensor_parallel_size=2,
+        sequence_parallel_size=4,
+        pipeline_parallel_size=2,
+    )
+    monkeypatch.setattr(pipeline_hunyuan_module, "get_classifier_free_guidance_world_size", lambda: 1)
+
+    pipeline._record_dit_forward_stats(
+        latents=torch.zeros((2, 16, 5, 8, 10)),
+        prompt_embeds=torch.zeros((2, 77, 8)),
+        prompt_embeds_mask=torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]]),
+        prompt_embeds_2=torch.zeros((2, 8, 8)),
+        prompt_embeds_mask_2=torch.tensor([[1, 1], [1, 0]]),
+        image_embeds=torch.zeros((2, 6, 8)),
+        image_embeds_mask=torch.tensor([[1, 1, 1], [1, 0, 0]]),
+        timesteps=torch.arange(4),
+        do_true_cfg=False,
+    )
+
+    stats = pipeline.get_dit_forward_stats(req=object(), output=object())
+
+    assert stats is not None
+    assert isinstance(stats, HunyuanVideoDiTForwardStats)
+    assert stats.batch_size == 2
+    assert stats.latent_num_frames == 5
+    assert stats.latent_height == 8
+    assert stats.latent_width == 10
+    assert stats.patch_size_t == 1
+    assert stats.patch_size == 2
+    assert stats.context_len == 3 + 2 + 3
+    assert stats.hidden_dim == 8
+    assert stats.ffn_dim == 32
+    assert stats.num_layers == 3
+    assert stats.num_steps == 4
+    assert stats.tensor_parallel_size == 2
+    assert stats.sequence_parallel_size == 4
+    assert stats.pipeline_parallel_size == 2
+    assert stats.forwards_per_step_per_gpu == 1
+
+
+def test_hunyuan_video_counts_cfg_forwards_per_gpu(monkeypatch):
+    pipeline = _make_hunyuan_pipeline_for_stats()
+    monkeypatch.setattr(pipeline_hunyuan_module, "get_classifier_free_guidance_world_size", lambda: 1)
+
+    pipeline._record_dit_forward_stats(
+        latents=torch.zeros((1, 16, 1, 2, 2)),
+        prompt_embeds=torch.zeros((1, 5, 8)),
+        prompt_embeds_mask=None,
+        prompt_embeds_2=torch.zeros((1, 7, 8)),
+        prompt_embeds_mask_2=None,
+        image_embeds=torch.zeros((1, 0, 8)),
+        image_embeds_mask=None,
+        timesteps=torch.arange(7),
+        do_true_cfg=True,
+    )
+    sequential_stats = pipeline.get_dit_forward_stats(req=object(), output=object())
+
+    monkeypatch.setattr(pipeline_hunyuan_module, "get_classifier_free_guidance_world_size", lambda: 2)
+    pipeline._record_dit_forward_stats(
+        latents=torch.zeros((1, 16, 1, 2, 2)),
+        prompt_embeds=torch.zeros((1, 5, 8)),
+        prompt_embeds_mask=None,
+        prompt_embeds_2=torch.zeros((1, 7, 8)),
+        prompt_embeds_mask_2=None,
+        image_embeds=torch.zeros((1, 0, 8)),
+        image_embeds_mask=None,
+        timesteps=torch.arange(7),
+        do_true_cfg=True,
+    )
+    parallel_stats = pipeline.get_dit_forward_stats(req=object(), output=object())
+
+    assert sequential_stats is not None
+    assert sequential_stats.forwards_per_step_per_gpu == 2
+    assert parallel_stats is not None
+    assert parallel_stats.forwards_per_step_per_gpu == 1
+
+
+def test_hunyuan_video_collects_fail_closed_when_shape_is_incomplete():
+    pipeline = _make_hunyuan_pipeline_for_stats()
+
+    pipeline._record_dit_forward_stats(
+        latents=torch.zeros((1, 16, 1, 2)),
+        prompt_embeds=torch.zeros((1, 5, 8)),
+        prompt_embeds_mask=None,
+        prompt_embeds_2=torch.zeros((1, 7, 8)),
+        prompt_embeds_mask_2=None,
+        image_embeds=torch.zeros((1, 0, 8)),
+        image_embeds_mask=None,
+        timesteps=torch.arange(7),
+        do_true_cfg=False,
+    )
+
+    assert pipeline.get_dit_forward_stats(req=object(), output=object()) is None

--- a/tests/diffusion/models/wan2_2/test_wan_dit_perf_stats.py
+++ b/tests/diffusion/models/wan2_2/test_wan_dit_perf_stats.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+WanDiTForwardStats = importlib.import_module("vllm_omni.diffusion.metrics.perf").WanDiTForwardStats
+pipeline_wan_module = importlib.import_module("vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2")
+Wan22Pipeline = pipeline_wan_module.Wan22Pipeline
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _make_parallel_config(**overrides):
+    values = {
+        "tensor_parallel_size": 1,
+        "sequence_parallel_size": 1,
+        "pipeline_parallel_size": 1,
+        "cfg_parallel_size": 1,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _make_wan_pipeline_for_stats(**parallel_overrides):
+    pipeline = object.__new__(Wan22Pipeline)
+    pipeline.od_config = SimpleNamespace(parallel_config=_make_parallel_config(**parallel_overrides))
+    pipeline.transformer_config = SimpleNamespace(
+        patch_size=(1, 2, 2),
+        num_attention_heads=2,
+        attention_head_dim=4,
+        ffn_dim=32,
+        num_layers=6,
+    )
+    pipeline.transformer = SimpleNamespace(start_layer=1, end_layer=4, config=pipeline.transformer_config)
+    pipeline.transformer_2 = None
+    pipeline._last_dit_forward_stats = None
+    return pipeline
+
+
+def test_wan_records_model_specific_stats_from_latent_runtime_shapes(monkeypatch):
+    pipeline = _make_wan_pipeline_for_stats(tensor_parallel_size=2, sequence_parallel_size=4, pipeline_parallel_size=2)
+    latents = torch.zeros((2, 16, 5, 8, 10))
+    prompt_embeds = torch.zeros((2, 77, 8))
+    timesteps = torch.arange(4)
+
+    monkeypatch.setattr(pipeline_wan_module, "get_classifier_free_guidance_world_size", lambda: 1)
+
+    pipeline._record_dit_forward_stats(
+        latents=latents,
+        prompt_embeds=prompt_embeds,
+        timesteps=timesteps,
+        do_true_cfg=False,
+    )
+
+    stats = pipeline.get_dit_forward_stats(req=object(), output=object())
+
+    assert stats is not None
+    assert isinstance(stats, WanDiTForwardStats)
+    assert stats.batch_size == 2
+    assert stats.latent_num_frames == 5
+    assert stats.latent_height == 8
+    assert stats.latent_width == 10
+    assert stats.patch_size == (1, 2, 2)
+    assert stats.context_len == 77
+    assert stats.hidden_dim == 8
+    assert stats.ffn_dim == 32
+    assert stats.num_layers == 3
+    assert stats.num_steps == 4
+    assert stats.tensor_parallel_size == 2
+    assert stats.sequence_parallel_size == 4
+    assert stats.pipeline_parallel_size == 2
+    assert stats.forwards_per_step_per_gpu == 1
+    assert stats.logical_seq_len == 5 * 4 * 5
+    assert stats.padded_seq_len == 100
+    assert stats.local_seq_len == 25
+
+
+def test_wan_counts_cfg_forwards_per_gpu(monkeypatch):
+    pipeline = _make_wan_pipeline_for_stats()
+    monkeypatch.setattr(pipeline_wan_module, "get_classifier_free_guidance_world_size", lambda: 1)
+
+    pipeline._record_dit_forward_stats(
+        latents=torch.zeros((1, 16, 1, 2, 2)),
+        prompt_embeds=torch.zeros((1, 5, 8)),
+        timesteps=torch.arange(7),
+        do_true_cfg=True,
+    )
+    sequential_stats = pipeline.get_dit_forward_stats(req=object(), output=object())
+
+    monkeypatch.setattr(pipeline_wan_module, "get_classifier_free_guidance_world_size", lambda: 2)
+    pipeline._record_dit_forward_stats(
+        latents=torch.zeros((1, 16, 1, 2, 2)),
+        prompt_embeds=torch.zeros((1, 5, 8)),
+        timesteps=torch.arange(7),
+        do_true_cfg=True,
+    )
+    parallel_stats = pipeline.get_dit_forward_stats(req=object(), output=object())
+
+    assert sequential_stats is not None
+    assert sequential_stats.forwards_per_step_per_gpu == 2
+    assert parallel_stats is not None
+    assert parallel_stats.forwards_per_step_per_gpu == 1
+
+
+def test_wan_counts_mixed_guidance_forwards_by_timestep(monkeypatch):
+    pipeline = _make_wan_pipeline_for_stats()
+    monkeypatch.setattr(pipeline_wan_module, "get_classifier_free_guidance_world_size", lambda: 1)
+
+    pipeline._record_dit_forward_stats(
+        latents=torch.zeros((1, 16, 1, 2, 2)),
+        prompt_embeds=torch.zeros((1, 5, 8)),
+        timesteps=torch.tensor([8.0, 4.0, 2.0]),
+        do_true_cfg=True,
+        guidance_low=1.0,
+        guidance_high=2.0,
+        boundary_timestep=5.0,
+        has_negative_prompt=True,
+    )
+
+    stats = pipeline.get_dit_forward_stats(req=object(), output=object())
+
+    assert stats is not None
+    assert stats.forwards_per_step_per_gpu == 1
+    assert stats.num_forwards_per_gpu == 5
+
+
+def test_wan_collects_fail_closed_when_shape_is_incomplete():
+    pipeline = _make_wan_pipeline_for_stats()
+
+    pipeline._record_dit_forward_stats(
+        latents=torch.zeros((1, 16, 1, 2)),
+        prompt_embeds=torch.zeros((1, 5, 8)),
+        timesteps=torch.arange(7),
+        do_true_cfg=False,
+    )
+
+    assert pipeline.get_dit_forward_stats(req=object(), output=object()) is None

--- a/tests/diffusion/test_diffusion_engine.py
+++ b/tests/diffusion/test_diffusion_engine.py
@@ -11,8 +11,10 @@ from typing import Any
 
 import pytest
 import torch
+from vllm.v1.metrics.perf import PerfStats
 
-from vllm_omni.diffusion.diffusion_engine import _move_tensor_tree_to_cpu
+from vllm_omni.diffusion.data import DiffusionOutput
+from vllm_omni.diffusion.diffusion_engine import DiffusionEngine, _move_tensor_tree_to_cpu
 
 
 @dataclass
@@ -121,6 +123,38 @@ def test_move_tensor_tree_returns_non_tensor_values_unchanged() -> None:
     assert moved is value
 
 
+@pytest.mark.asyncio
+@pytest.mark.core_model
+@pytest.mark.diffusion
+@pytest.mark.cpu
+async def test_step_attaches_batch_perf_stats_to_one_output_for_multi_prompt() -> None:
+    engine = object.__new__(DiffusionEngine)
+
+    async def _check_and_start_background_loop():
+        return None
+
+    engine._check_and_start_background_loop = _check_and_start_background_loop
+    engine.pre_process_func = None
+    engine.post_process_func = None
+    engine._post_process_accepts_sampling_params = False
+    engine.od_config = SimpleNamespace(enable_cpu_offload=False, model_class_name="FluxPipeline")
+    perf_stats = PerfStats(num_flops_per_gpu=123)
+
+    async def _async_add_req_and_wait_for_response(_request):
+        return DiffusionOutput(output=["image-a", "image-b"], perf_stats=perf_stats)
+
+    engine.async_add_req_and_wait_for_response = _async_add_req_and_wait_for_response
+    request = SimpleNamespace(
+        request_id="req",
+        prompts=["prompt-a", "prompt-b"],
+        sampling_params=SimpleNamespace(num_outputs_per_prompt=1, resolution=512),
+    )
+
+    outputs = await DiffusionEngine.step(engine, request)
+
+    assert [out.perf_stats for out in outputs] == [perf_stats, None]
+
+
 @pytest.mark.diffusion
 @pytest.mark.cuda
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
@@ -146,6 +180,7 @@ async def test_async_add_req_and_wait_for_response():
 
     engine = object.__new__(DiffusionEngine)
     engine.scheduler = MockScheduler()
+    engine.od_config = SimpleNamespace(streaming_output=False)
     engine._out_queue = {}
     engine.abort_queue: queue.Queue[str] = queue.Queue()
     engine._rpc_queue = queue.Queue()

--- a/tests/diffusion/test_diffusion_ipc.py
+++ b/tests/diffusion/test_diffusion_ipc.py
@@ -5,6 +5,7 @@ import contextlib
 
 import pytest
 import torch
+from vllm.v1.metrics.perf import PerfStats
 
 from vllm_omni.diffusion.data import DiffusionOutput
 from vllm_omni.diffusion.ipc import (
@@ -105,6 +106,31 @@ def test_rpc_result_envelope_diffusion_output_round_trips_through_shm() -> None:
     assert isinstance(result, DiffusionOutput)
     torch.testing.assert_close(result.output, tensor)
     assert unpacked["rank_statuses"] == [{"rank": 0, "ok": True}]
+
+
+def test_diffusion_output_defaults_perf_stats_to_none() -> None:
+    output = DiffusionOutput(output=torch.tensor([1]))
+
+    assert output.perf_stats is None
+
+
+def test_diffusion_output_to_cpu_preserves_perf_stats() -> None:
+    perf_stats = PerfStats(num_flops_per_gpu=123)
+    output = DiffusionOutput(output=torch.tensor([1]), perf_stats=perf_stats, to_cpu=True)
+
+    assert output.perf_stats is perf_stats
+
+
+def test_diffusion_output_shm_round_trip_preserves_perf_stats() -> None:
+    perf_stats = PerfStats(num_flops_per_gpu=123)
+    tensor = torch.arange(_large_numel(torch.float32), dtype=torch.float32)
+    output = DiffusionOutput(output=tensor, perf_stats=perf_stats)
+
+    pack_diffusion_output_shm(output)
+    unpack_diffusion_output_shm(output)
+
+    torch.testing.assert_close(output.output, tensor)
+    assert output.perf_stats is perf_stats
 
 
 def test_pack_value_keeps_tensor_at_threshold_inline() -> None:

--- a/tests/diffusion/test_diffusion_model_runner.py
+++ b/tests/diffusion/test_diffusion_model_runner.py
@@ -6,10 +6,12 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.v1.metrics.perf import PerfStats
 
 import vllm_omni.diffusion.worker.diffusion_model_runner as model_runner_module
 from tests.helpers.mark import hardware_test
 from vllm_omni.diffusion.data import DiffusionOutput
+from vllm_omni.diffusion.metrics.perf import DiTForwardStats
 from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
 
 pytestmark = [pytest.mark.diffusion]
@@ -118,6 +120,80 @@ def _make_compile_runner(*, use_hsdp: bool):
     return runner
 
 
+def _make_mfu_runner(pipeline, *, enable_mfu_metrics: bool):
+    runner = object.__new__(DiffusionModelRunner)
+    runner.vllm_config = SimpleNamespace(
+        observability_config=SimpleNamespace(enable_mfu_metrics=enable_mfu_metrics),
+    )
+    runner.device = torch.device("cpu")
+    runner.pipeline = pipeline
+    runner.cache_backend = None
+    runner.offload_backend = None
+    runner.prompt_embed_cache = None
+    runner.od_config = SimpleNamespace(
+        cache_backend="none",
+        enable_cache_dit_summary=False,
+        parallel_config=SimpleNamespace(use_hsdp=False),
+    )
+    runner.kv_transfer_manager = SimpleNamespace(
+        receive_multi_kv_cache_distributed=lambda req, cfg_kv_collect_func=None, target_device=None: None,
+    )
+    runner._kv_prefetch_enabled = False
+    return runner
+
+
+def _patch_peak_memory_stats(monkeypatch) -> None:
+    monkeypatch.setattr(
+        model_runner_module,
+        "current_omni_platform",
+        SimpleNamespace(
+            reset_peak_memory_stats=lambda: None,
+            max_memory_reserved=lambda: 0,
+            max_memory_allocated=lambda: 0,
+        ),
+    )
+
+
+class _MfuStatsPipeline:
+    device = torch.device("cpu")
+
+    def __init__(self, output: DiffusionOutput, stats: DiTForwardStats | None):
+        self.output = output
+        self.stats = stats
+        self.collect_flags: list[bool] = []
+        self.get_stats_calls = 0
+
+    def forward(self, req):
+        del req
+        self.collect_flags.append(bool(getattr(self, "collect_dit_mfu_stats", False)))
+        return self.output
+
+    def get_dit_forward_stats(self, req, output):
+        del req, output
+        self.get_stats_calls += 1
+        return self.stats
+
+
+class _NoDitStatsMethodPipeline:
+    device = torch.device("cpu")
+
+    def __init__(self, output: DiffusionOutput):
+        self.output = output
+        self.collect_flags: list[bool] = []
+
+    def forward(self, req):
+        del req
+        self.collect_flags.append(bool(getattr(self, "collect_dit_mfu_stats", False)))
+        return self.output
+
+
+class _FailingDitStatsPipeline(_MfuStatsPipeline):
+    def get_dit_forward_stats(self, req, output):
+        del req, output
+        self.get_stats_calls += 1
+        raise RuntimeError("stats failed")
+
+
 @pytest.mark.core_model
 @pytest.mark.cpu
 @pytest.mark.parametrize("use_hsdp", [False, True])
@@ -158,9 +234,7 @@ def test_execute_stepwise_streaming_returns_chunks_at_boundaries(monkeypatch):
     req.request_id = "req"
 
     monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "reset_peak_memory_stats", lambda: None)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "max_memory_reserved", lambda: 0)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "max_memory_allocated", lambda: 0)
+    _patch_peak_memory_stats(monkeypatch)
     scheduler_output = SimpleNamespace(
         finished_req_ids=set(),
         scheduled_new_reqs=[SimpleNamespace(request_id="req", req=req)],
@@ -195,9 +269,7 @@ def test_execute_model_skips_cache_summary_without_active_cache_backend(monkeypa
     cache_summary_calls = []
 
     monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "reset_peak_memory_stats", lambda: None)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "max_memory_reserved", lambda: 0)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "max_memory_allocated", lambda: 0)
+    _patch_peak_memory_stats(monkeypatch)
     monkeypatch.setattr(
         model_runner_module,
         "cache_summary",
@@ -223,9 +295,7 @@ def test_execute_model_emits_cache_summary_with_active_cache_dit_backend(monkeyp
     cache_summary_calls = []
 
     monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "reset_peak_memory_stats", lambda: None)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "max_memory_reserved", lambda: 0)
-    monkeypatch.setattr(model_runner_module.current_omni_platform, "max_memory_allocated", lambda: 0)
+    _patch_peak_memory_stats(monkeypatch)
     monkeypatch.setattr(
         model_runner_module,
         "cache_summary",
@@ -236,6 +306,167 @@ def test_execute_model_emits_cache_summary_with_active_cache_dit_backend(monkeyp
 
     assert output.output == "ok"
     assert cache_summary_calls == [(runner.pipeline, True)]
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_execute_model_attaches_dit_perf_stats_when_mfu_metrics_enabled(monkeypatch):
+    stats = DiTForwardStats(
+        batch_size=1,
+        seq_len=2,
+        context_len=3,
+        hidden_dim=4,
+        ffn_dim=16,
+        num_layers=5,
+        num_steps=6,
+        forwards_per_step_per_gpu=1,
+    )
+    pipeline = _MfuStatsPipeline(DiffusionOutput(output=torch.tensor([1])), stats)
+    runner = _make_mfu_runner(pipeline, enable_mfu_metrics=True)
+
+    monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+    _patch_peak_memory_stats(monkeypatch)
+
+    output = DiffusionModelRunner.execute_model(runner, _make_request())
+
+    assert pipeline.collect_flags == [True]
+    assert pipeline.get_stats_calls == 1
+    assert output.perf_stats is not None
+    assert output.perf_stats.num_flops_per_gpu > 0
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_execute_model_does_not_collect_dit_stats_when_mfu_metrics_disabled(monkeypatch):
+    stats = DiTForwardStats(
+        batch_size=1,
+        seq_len=2,
+        context_len=3,
+        hidden_dim=4,
+        ffn_dim=16,
+        num_layers=5,
+        num_steps=6,
+        forwards_per_step_per_gpu=1,
+    )
+    pipeline = _MfuStatsPipeline(DiffusionOutput(output=torch.tensor([1])), stats)
+    runner = _make_mfu_runner(pipeline, enable_mfu_metrics=False)
+
+    monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+    _patch_peak_memory_stats(monkeypatch)
+
+    output = DiffusionModelRunner.execute_model(runner, _make_request())
+
+    assert pipeline.collect_flags == [False]
+    assert pipeline.get_stats_calls == 0
+    assert output.perf_stats is None
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_execute_model_leaves_output_unchanged_when_dit_stats_missing(monkeypatch):
+    pipeline = _NoDitStatsMethodPipeline(DiffusionOutput(output=torch.tensor([1])))
+    runner = _make_mfu_runner(pipeline, enable_mfu_metrics=True)
+
+    monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+    _patch_peak_memory_stats(monkeypatch)
+
+    output = DiffusionModelRunner.execute_model(runner, _make_request())
+
+    assert pipeline.collect_flags == [True]
+    assert output.perf_stats is None
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_execute_model_leaves_output_unchanged_when_dit_stats_are_none(monkeypatch):
+    pipeline = _MfuStatsPipeline(DiffusionOutput(output=torch.tensor([1])), None)
+    runner = _make_mfu_runner(pipeline, enable_mfu_metrics=True)
+
+    monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+    _patch_peak_memory_stats(monkeypatch)
+
+    output = DiffusionModelRunner.execute_model(runner, _make_request())
+
+    assert pipeline.collect_flags == [True]
+    assert pipeline.get_stats_calls == 1
+    assert output.perf_stats is None
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_execute_model_leaves_output_unchanged_when_dit_stats_producer_fails(monkeypatch):
+    stats = DiTForwardStats(
+        batch_size=1,
+        seq_len=2,
+        context_len=3,
+        hidden_dim=4,
+        ffn_dim=16,
+        num_layers=5,
+        num_steps=6,
+        forwards_per_step_per_gpu=1,
+    )
+    pipeline = _FailingDitStatsPipeline(DiffusionOutput(output=torch.tensor([1])), stats)
+    runner = _make_mfu_runner(pipeline, enable_mfu_metrics=True)
+
+    monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+    _patch_peak_memory_stats(monkeypatch)
+
+    output = DiffusionModelRunner.execute_model(runner, _make_request())
+
+    assert pipeline.collect_flags == [True]
+    assert pipeline.get_stats_calls == 1
+    assert output.perf_stats is None
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_execute_model_does_not_overwrite_existing_perf_stats(monkeypatch):
+    existing = PerfStats(num_flops_per_gpu=123)
+    stats = DiTForwardStats(
+        batch_size=1,
+        seq_len=2,
+        context_len=3,
+        hidden_dim=4,
+        ffn_dim=16,
+        num_layers=5,
+        num_steps=6,
+        forwards_per_step_per_gpu=1,
+    )
+    pipeline = _MfuStatsPipeline(DiffusionOutput(output=torch.tensor([1]), perf_stats=existing), stats)
+    runner = _make_mfu_runner(pipeline, enable_mfu_metrics=True)
+
+    monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+    _patch_peak_memory_stats(monkeypatch)
+
+    output = DiffusionModelRunner.execute_model(runner, _make_request())
+
+    assert output.perf_stats is existing
+    assert pipeline.get_stats_calls == 0
+
+
+@pytest.mark.core_model
+@pytest.mark.cpu
+def test_execute_model_skips_dit_perf_stats_for_error_output(monkeypatch):
+    stats = DiTForwardStats(
+        batch_size=1,
+        seq_len=2,
+        context_len=3,
+        hidden_dim=4,
+        ffn_dim=16,
+        num_layers=5,
+        num_steps=6,
+        forwards_per_step_per_gpu=1,
+    )
+    pipeline = _MfuStatsPipeline(DiffusionOutput(error="boom"), stats)
+    runner = _make_mfu_runner(pipeline, enable_mfu_metrics=True)
+
+    monkeypatch.setattr(model_runner_module, "set_forward_context", _noop_forward_context)
+    _patch_peak_memory_stats(monkeypatch)
+
+    output = DiffusionModelRunner.execute_model(runner, _make_request())
+
+    assert output.perf_stats is None
+    assert pipeline.get_stats_calls == 0
 
 
 @pytest.mark.core_model

--- a/tests/diffusion/test_dit_mfu_metrics.py
+++ b/tests/diffusion/test_dit_mfu_metrics.py
@@ -6,9 +6,16 @@ import torch
 
 from vllm_omni.diffusion.metrics.perf import (
     DiTForwardStats,
+    FluxDiTForwardStats,
+    HunyuanVideoDiTForwardStats,
+    WanDiTForwardStats,
     collect_flux_dit_forward_stats,
+    estimate_diffusion_forward_flops_per_gpu,
     estimate_dit_flops_per_gpu,
     estimate_dit_perf_stats,
+    estimate_flux_dit_forward_flops_per_gpu,
+    estimate_hunyuan_video_dit_forward_flops_per_gpu,
+    estimate_wan_dit_forward_flops_per_gpu,
     to_perf_stats,
 )
 
@@ -143,15 +150,17 @@ def test_flux_dit_stats_use_runtime_tensors_and_transformer_shape() -> None:
         cfg_parallel_world_size=1,
     )
 
-    assert stats == DiTForwardStats(
+    assert stats == FluxDiTForwardStats(
         batch_size=2,
-        seq_len=9,
-        context_len=5,
+        image_seq_len=9,
+        text_seq_len=5,
         hidden_dim=128,
         ffn_dim=512,
-        num_layers=7,
+        num_double_layers=3,
+        num_single_layers=4,
         num_steps=4,
         forwards_per_step_per_gpu=1,
+        tensor_parallel_size=1,
     )
 
 
@@ -217,6 +226,134 @@ def test_estimate_dit_perf_stats_wraps_estimated_flops_only() -> None:
     assert perf_stats.num_flops_per_gpu == estimate_dit_flops_per_gpu(stats).total_flops_per_gpu
     assert perf_stats.num_read_bytes_per_gpu == 0
     assert perf_stats.num_write_bytes_per_gpu == 0
+
+
+def test_estimate_flux_dit_forward_flops_per_gpu_counts_dual_and_single_blocks() -> None:
+    stats = FluxDiTForwardStats(
+        batch_size=2,
+        image_seq_len=3,
+        text_seq_len=5,
+        hidden_dim=7,
+        ffn_dim=11,
+        num_double_layers=2,
+        num_single_layers=3,
+        num_steps=4,
+        forwards_per_step_per_gpu=2,
+    )
+
+    joint_seq_len = 3 + 5
+    dual_layer_flops = 8 * 7 * 7 * (3 + 5) + 4 * 7 * 11 * (3 + 5) + 4 * joint_seq_len * joint_seq_len * 7
+    single_layer_flops = 8 * 7 * 7 * joint_seq_len + 4 * 7 * 11 * joint_seq_len + 4 * joint_seq_len * joint_seq_len * 7
+    expected = 2 * ((2 * dual_layer_flops) + (3 * single_layer_flops)) * 4 * 2
+
+    assert estimate_flux_dit_forward_flops_per_gpu(stats) == expected
+    assert estimate_diffusion_forward_flops_per_gpu(stats) == expected
+
+
+def test_estimate_wan_dit_forward_flops_per_gpu_uses_post_patch_local_sequence() -> None:
+    stats = WanDiTForwardStats(
+        batch_size=1,
+        latent_num_frames=5,
+        latent_height=8,
+        latent_width=10,
+        patch_size=(1, 2, 5),
+        context_len=6,
+        hidden_dim=4,
+        ffn_dim=8,
+        num_layers=7,
+        num_steps=3,
+        tensor_parallel_size=2,
+        sequence_parallel_size=2,
+    )
+
+    logical_seq_len = 5 * 4 * 2
+    local_seq_len = logical_seq_len // 2
+    per_layer_flops = (
+        8 * 4 * 4 * local_seq_len
+        + (4 * 4 * 4 * local_seq_len + 4 * 4 * 4 * 6)
+        + 4 * 4 * 8 * local_seq_len
+        + 4 * local_seq_len * logical_seq_len * 4
+        + 4 * local_seq_len * 6 * 4
+    )
+    expected = (per_layer_flops // 2) * 7 * 3
+
+    assert stats.logical_seq_len == logical_seq_len
+    assert stats.padded_seq_len == logical_seq_len
+    assert stats.local_seq_len == local_seq_len
+    assert estimate_wan_dit_forward_flops_per_gpu(stats) == expected
+
+
+def test_estimate_wan_dit_forward_flops_per_gpu_can_use_explicit_forward_count() -> None:
+    per_forward = WanDiTForwardStats(
+        batch_size=1,
+        latent_num_frames=1,
+        latent_height=2,
+        latent_width=2,
+        patch_size=(1, 1, 1),
+        context_len=2,
+        hidden_dim=4,
+        ffn_dim=8,
+        num_layers=1,
+        num_steps=1,
+        forwards_per_step_per_gpu=1,
+    )
+    mixed_cfg = WanDiTForwardStats(
+        batch_size=1,
+        latent_num_frames=1,
+        latent_height=2,
+        latent_width=2,
+        patch_size=(1, 1, 1),
+        context_len=2,
+        hidden_dim=4,
+        ffn_dim=8,
+        num_layers=1,
+        num_steps=3,
+        forwards_per_step_per_gpu=2,
+        num_forwards_per_gpu=5,
+    )
+
+    assert estimate_wan_dit_forward_flops_per_gpu(mixed_cfg) == (
+        5 * estimate_wan_dit_forward_flops_per_gpu(per_forward)
+    )
+
+
+def test_estimate_hunyuan_video_dit_forward_flops_per_gpu_uses_effective_context_len() -> None:
+    stats = HunyuanVideoDiTForwardStats(
+        batch_size=1,
+        latent_num_frames=4,
+        latent_height=6,
+        latent_width=8,
+        patch_size_t=2,
+        patch_size=2,
+        context_len=9,
+        hidden_dim=6,
+        ffn_dim=24,
+        num_layers=3,
+        num_steps=5,
+        forwards_per_step_per_gpu=2,
+        sequence_parallel_size=3,
+    )
+
+    assert stats.logical_seq_len == 2 * 3 * 4
+    assert stats.padded_seq_len == 24
+    assert stats.local_seq_len == 8
+    expected = estimate_wan_dit_forward_flops_per_gpu(
+        WanDiTForwardStats(
+            batch_size=1,
+            latent_num_frames=4,
+            latent_height=6,
+            latent_width=8,
+            patch_size=(2, 2, 2),
+            context_len=9,
+            hidden_dim=6,
+            ffn_dim=24,
+            num_layers=3,
+            num_steps=5,
+            forwards_per_step_per_gpu=2,
+            sequence_parallel_size=3,
+        )
+    )
+    assert estimate_hunyuan_video_dit_forward_flops_per_gpu(stats) == expected
 
 
 def test_flux_pipeline_get_dit_forward_stats_returns_cached_stats() -> None:

--- a/tests/diffusion/test_dit_mfu_metrics.py
+++ b/tests/diffusion/test_dit_mfu_metrics.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.metrics.perf import (
+    DiTForwardStats,
+    collect_flux_dit_forward_stats,
+    estimate_dit_flops_per_gpu,
+    estimate_dit_perf_stats,
+    to_perf_stats,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def _stats(**overrides) -> DiTForwardStats:
+    values = {
+        "batch_size": 2,
+        "seq_len": 3,
+        "context_len": 5,
+        "hidden_dim": 7,
+        "ffn_dim": 11,
+        "num_layers": 13,
+        "num_steps": 17,
+        "forwards_per_step_per_gpu": 19,
+    }
+    values.update(overrides)
+    return DiTForwardStats(**values)
+
+
+def test_dit_flops_estimator_matches_hand_computed_terms() -> None:
+    stats = _stats()
+
+    breakdown = estimate_dit_flops_per_gpu(stats)
+
+    qkv_out = 8 * 7 * 7 * 3
+    cross_attn_proj = (4 * 7 * 7 * 3) + (4 * 7 * 7 * 5)
+    mlp = 4 * 7 * 11 * 3
+    self_attn = 4 * 3 * 3 * 7
+    cross_attn = 4 * 3 * 5 * 7
+    per_layer = qkv_out + cross_attn_proj + mlp + self_attn + cross_attn
+    total = 2 * per_layer * 13 * 17 * 19
+
+    assert breakdown.qkv_out_flops == qkv_out
+    assert breakdown.cross_attn_proj_flops == cross_attn_proj
+    assert breakdown.mlp_flops == mlp
+    assert breakdown.self_attn_flops == self_attn
+    assert breakdown.cross_attn_flops == cross_attn
+    assert breakdown.flops_per_layer == per_layer
+    assert breakdown.total_flops_per_gpu == total
+
+
+@pytest.mark.parametrize(
+    ("field", "expected_multiplier"),
+    [
+        ("batch_size", 2),
+        ("num_layers", 2),
+        ("num_steps", 2),
+        ("forwards_per_step_per_gpu", 2),
+    ],
+)
+def test_dit_flops_estimator_scales_linearly_for_request_multipliers(
+    field: str,
+    expected_multiplier: int,
+) -> None:
+    values = {
+        "batch_size": 1,
+        "num_layers": 1,
+        "num_steps": 1,
+        "forwards_per_step_per_gpu": 1,
+    }
+    base = _stats(**values)
+    values[field] = 2
+    doubled = _stats(**values)
+
+    base_flops = estimate_dit_flops_per_gpu(base).total_flops_per_gpu
+    doubled_flops = estimate_dit_flops_per_gpu(doubled).total_flops_per_gpu
+
+    assert doubled_flops == base_flops * expected_multiplier
+
+
+def test_dit_flops_estimator_exposes_self_attention_quadratic_sequence_term() -> None:
+    short = _stats(batch_size=1, seq_len=3, num_layers=1, num_steps=1, forwards_per_step_per_gpu=1)
+    long = _stats(batch_size=1, seq_len=6, num_layers=1, num_steps=1, forwards_per_step_per_gpu=1)
+
+    short_breakdown = estimate_dit_flops_per_gpu(short)
+    long_breakdown = estimate_dit_flops_per_gpu(long)
+
+    assert long_breakdown.self_attn_flops == short_breakdown.self_attn_flops * 4
+
+
+def test_dit_flops_estimator_context_len_does_not_change_self_attention() -> None:
+    short_context = _stats(batch_size=1, context_len=5, num_layers=1, num_steps=1, forwards_per_step_per_gpu=1)
+    long_context = _stats(batch_size=1, context_len=10, num_layers=1, num_steps=1, forwards_per_step_per_gpu=1)
+
+    short_breakdown = estimate_dit_flops_per_gpu(short_context)
+    long_breakdown = estimate_dit_flops_per_gpu(long_context)
+
+    assert long_breakdown.self_attn_flops == short_breakdown.self_attn_flops
+    assert long_breakdown.cross_attn_proj_flops > short_breakdown.cross_attn_proj_flops
+    assert long_breakdown.cross_attn_flops > short_breakdown.cross_attn_flops
+
+
+def test_dit_flops_to_perf_stats_sets_only_flops_counter() -> None:
+    breakdown = estimate_dit_flops_per_gpu(_stats())
+
+    perf_stats = to_perf_stats(breakdown)
+
+    assert perf_stats.num_flops_per_gpu == breakdown.total_flops_per_gpu
+    assert perf_stats.num_read_bytes_per_gpu == 0
+    assert perf_stats.num_write_bytes_per_gpu == 0
+
+
+def test_dit_hardware_mfu_uses_runtime_padded_sequence_length_not_goodput() -> None:
+    useful = _stats(batch_size=1, seq_len=7, num_layers=1, num_steps=1, forwards_per_step_per_gpu=1)
+    padded = _stats(batch_size=1, seq_len=8, num_layers=1, num_steps=1, forwards_per_step_per_gpu=1)
+
+    useful_flops = estimate_dit_flops_per_gpu(useful).total_flops_per_gpu
+    padded_flops = estimate_dit_flops_per_gpu(padded).total_flops_per_gpu
+
+    assert padded_flops > useful_flops
+
+
+class _FakeTransformer:
+    inner_dim = 128
+    transformer_blocks = [object(), object(), object()]
+    single_transformer_blocks = [object(), object(), object(), object()]
+
+
+def test_flux_dit_stats_use_runtime_tensors_and_transformer_shape() -> None:
+    latents = torch.empty(2, 9, 64)
+    prompt_embeds = torch.empty(2, 5, 4096)
+    timesteps = torch.arange(4)
+
+    stats = collect_flux_dit_forward_stats(
+        latents=latents,
+        prompt_embeds=prompt_embeds,
+        timesteps=timesteps,
+        transformer=_FakeTransformer(),
+        do_true_cfg=False,
+        cfg_parallel_world_size=1,
+    )
+
+    assert stats == DiTForwardStats(
+        batch_size=2,
+        seq_len=9,
+        context_len=5,
+        hidden_dim=128,
+        ffn_dim=512,
+        num_layers=7,
+        num_steps=4,
+        forwards_per_step_per_gpu=1,
+    )
+
+
+def test_flux_dit_stats_count_sequential_true_cfg_as_two_forwards() -> None:
+    stats = collect_flux_dit_forward_stats(
+        latents=torch.empty(1, 9, 64),
+        prompt_embeds=torch.empty(1, 5, 4096),
+        timesteps=torch.arange(4),
+        transformer=_FakeTransformer(),
+        do_true_cfg=True,
+        cfg_parallel_world_size=1,
+    )
+
+    assert stats is not None
+    assert stats.forwards_per_step_per_gpu == 2
+
+
+def test_flux_dit_stats_count_cfg_parallel_true_cfg_as_one_forward_per_gpu() -> None:
+    stats = collect_flux_dit_forward_stats(
+        latents=torch.empty(1, 9, 64),
+        prompt_embeds=torch.empty(1, 5, 4096),
+        timesteps=torch.arange(4),
+        transformer=_FakeTransformer(),
+        do_true_cfg=True,
+        cfg_parallel_world_size=2,
+    )
+
+    assert stats is not None
+    assert stats.forwards_per_step_per_gpu == 1
+
+
+def test_flux_dit_stats_return_none_when_required_transformer_shape_is_missing() -> None:
+    stats = collect_flux_dit_forward_stats(
+        latents=torch.empty(1, 9, 64),
+        prompt_embeds=torch.empty(1, 5, 4096),
+        timesteps=torch.arange(4),
+        transformer=object(),
+        do_true_cfg=False,
+        cfg_parallel_world_size=1,
+    )
+
+    assert stats is None
+
+
+def test_flux_dit_stats_return_none_when_cfg_parallel_world_size_is_invalid() -> None:
+    stats = collect_flux_dit_forward_stats(
+        latents=torch.empty(1, 9, 64),
+        prompt_embeds=torch.empty(1, 5, 4096),
+        timesteps=torch.arange(4),
+        transformer=_FakeTransformer(),
+        do_true_cfg=True,
+        cfg_parallel_world_size=0,
+    )
+
+    assert stats is None
+
+
+def test_estimate_dit_perf_stats_wraps_estimated_flops_only() -> None:
+    stats = _stats()
+
+    perf_stats = estimate_dit_perf_stats(stats)
+
+    assert perf_stats.num_flops_per_gpu == estimate_dit_flops_per_gpu(stats).total_flops_per_gpu
+    assert perf_stats.num_read_bytes_per_gpu == 0
+    assert perf_stats.num_write_bytes_per_gpu == 0
+
+
+def test_flux_pipeline_get_dit_forward_stats_returns_cached_stats() -> None:
+    from vllm_omni.diffusion.data import DiffusionOutput
+    from vllm_omni.diffusion.models.flux.pipeline_flux import FluxPipeline
+
+    pipeline = object.__new__(FluxPipeline)
+    stats = _stats()
+    pipeline._last_dit_forward_stats = stats
+
+    assert pipeline.get_dit_forward_stats(req=object(), output=DiffusionOutput(output=None)) is stats

--- a/tests/engine/test_orchestrator.py
+++ b/tests/engine/test_orchestrator.py
@@ -14,6 +14,7 @@ import janus
 import pytest
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import SamplingParams
+from vllm.v1.metrics.perf import PerfStats
 
 from vllm_omni.engine.messages import (
     AbortRequestMessage,
@@ -1179,3 +1180,39 @@ def test_orchestrator_does_not_re_introduce_global_stats_throttle() -> None:
         "raw_outputs.scheduler_stats being non-None — the per-scheduler 1Hz "
         "throttle in OmniSchedulerMixin.make_stats() is the only gate needed."
     )
+
+
+def test_orchestrator_records_diffusion_perf_stats_with_stage_replica_engine_idx() -> None:
+    class _FakeStatLogger:
+        def __init__(self):
+            self.calls = []
+
+        def record_perf_stats(self, perf_stats, engine_idx=0):
+            self.calls.append((perf_stats, engine_idx))
+
+    perf_stats = PerfStats(num_flops_per_gpu=123)
+    output = OmniRequestOutput.from_diffusion(
+        request_id="req-diff",
+        images=[],
+        perf_stats=perf_stats,
+    )
+    orchestrator = Orchestrator.__new__(Orchestrator)
+    orchestrator._stat_logger = _FakeStatLogger()
+    orchestrator._stage_replica_to_engine_idx = {(1, 2): 7}
+
+    Orchestrator._record_diffusion_perf_stats(orchestrator, 1, 2, output)
+
+    assert orchestrator._stat_logger.calls == [(perf_stats, 7)]
+
+
+def test_orchestrator_skips_diffusion_perf_stats_when_output_has_none() -> None:
+    class _FakeStatLogger:
+        def record_perf_stats(self, *_args, **_kwargs):
+            raise AssertionError("diffusion output without perf_stats must not record")
+
+    output = OmniRequestOutput.from_diffusion(request_id="req-diff", images=[])
+    orchestrator = Orchestrator.__new__(Orchestrator)
+    orchestrator._stat_logger = _FakeStatLogger()
+    orchestrator._stage_replica_to_engine_idx = {(1, 2): 7}
+
+    Orchestrator._record_diffusion_perf_stats(orchestrator, 1, 2, output)

--- a/tests/metrics/test_stat_logger.py
+++ b/tests/metrics/test_stat_logger.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from prometheus_client import CollectorRegistry, generate_latest
+from vllm.v1.metrics.perf import PerfStats
 
 from vllm_omni.metrics.stat_logger import (
     _ENGINE_INDEX_MAP,
@@ -366,6 +369,67 @@ class TestOmniPrometheusStatLogger:
 
         assert dict(_ENGINE_INDEX_MAP) == srm
         assert 99 not in _ENGINE_INDEX_MAP  # old entry was cleared
+
+    def test_record_perf_stats_observes_existing_perf_metrics_when_enabled(self):
+        class _FakePerfMetricsProm:
+            def __init__(self):
+                self.calls = []
+
+            def observe(self, perf_stats, engine_idx=0):
+                self.calls.append((perf_stats, engine_idx))
+
+        sl = OmniPrometheusStatLogger.__new__(OmniPrometheusStatLogger)
+        sl.vllm_config = SimpleNamespace(
+            observability_config=SimpleNamespace(enable_mfu_metrics=True),
+        )
+        sl.perf_metrics_prom = _FakePerfMetricsProm()
+        perf_stats = PerfStats(num_flops_per_gpu=123)
+
+        sl.record_perf_stats(perf_stats, engine_idx=2)
+
+        assert sl.perf_metrics_prom.calls == [(perf_stats, 2)]
+
+    def test_record_perf_stats_skips_existing_perf_metrics_when_disabled(self):
+        class _FakePerfMetricsProm:
+            def observe(self, *_args, **_kwargs):
+                raise AssertionError("disabled MFU metrics must not observe perf stats")
+
+        sl = OmniPrometheusStatLogger.__new__(OmniPrometheusStatLogger)
+        sl.vllm_config = SimpleNamespace(
+            observability_config=SimpleNamespace(enable_mfu_metrics=False),
+        )
+        sl.perf_metrics_prom = _FakePerfMetricsProm()
+
+        sl.record_perf_stats(PerfStats(num_flops_per_gpu=123), engine_idx=2)
+
+    def test_record_perf_stats_exports_estimated_flops_with_stage_replica_labels(self, registry):
+        class _RegistryCounter(_RelabelCounter):
+            def __init__(self, *args, **kwargs):
+                kwargs["registry"] = registry
+                super().__init__(*args, **kwargs)
+
+        class _RegistryPerfMetricsProm(_OmniPerfMetricsProm):
+            _counter_cls = _RegistryCounter
+
+        perf_metrics_prom = _RegistryPerfMetricsProm(
+            vllm_config=SimpleNamespace(),
+            labelnames=["model_name", "engine"],
+            per_engine_labelvalues={2: ["flux", "diffusion", "0"]},
+        )
+        sl = OmniPrometheusStatLogger.__new__(OmniPrometheusStatLogger)
+        sl.vllm_config = SimpleNamespace(
+            observability_config=SimpleNamespace(enable_mfu_metrics=True),
+        )
+        sl.perf_metrics_prom = perf_metrics_prom
+
+        sl.record_perf_stats(PerfStats(num_flops_per_gpu=123), engine_idx=2)
+
+        out = generate_latest(registry).decode()
+        assert "vllm:estimated_flops_per_gpu_total" in out
+        assert 'vllm:estimated_flops_per_gpu_total{model_name="flux",replica="0",stage="diffusion"} 123.0' in out
+        assert 'vllm:estimated_read_bytes_per_gpu_total{model_name="flux",replica="0",stage="diffusion"} 0.0' in out
+        assert 'vllm:estimated_write_bytes_per_gpu_total{model_name="flux",replica="0",stage="diffusion"} 0.0' in out
+        assert "engine=" not in out
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -18,6 +18,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
 )
+from vllm.v1.metrics.perf import PerfStats
 
 from vllm_omni.diffusion.model_metadata import get_diffusion_model_metadata
 from vllm_omni.diffusion.utils.network_utils import is_port_available
@@ -1185,6 +1186,9 @@ class DiffusionOutput:
 
     # memory usage info
     peak_memory_mb: float = 0.0
+
+    # Optional upstream vLLM MFU stats produced by diffusion / DiT execution.
+    perf_stats: PerfStats | None = None
 
     # When True, move all tensor fields (including tensors inside
     # ``custom_output``) to CPU at construction time. Useful when the output

--- a/vllm_omni/diffusion/metrics/__init__.py
+++ b/vllm_omni/diffusion/metrics/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_omni/diffusion/metrics/common.py
+++ b/vllm_omni/diffusion/metrics/common.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import math
+from typing import Any, TypeAlias
+
+PatchSize3D: TypeAlias = tuple[int, int, int]
+
+
+def require_non_negative(name: str, value: int) -> None:
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative, got {value}")
+
+
+def require_positive(name: str, value: int) -> None:
+    if value < 1:
+        raise ValueError(f"{name} must be positive, got {value}")
+
+
+def positive_int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        int_value = int(value)
+    except Exception:
+        return None
+    if int_value > 0:
+        return int_value
+    return None
+
+
+def shape_dim(value: Any, index: int) -> int | None:
+    try:
+        shape = getattr(value, "shape", None)
+        if shape is None or len(shape) <= index:
+            return None
+        return positive_int_or_none(shape[index])
+    except Exception:
+        return None
+
+
+def ceil_to_multiple(value: int, divisor: int) -> int:
+    require_non_negative("value", value)
+    require_positive("divisor", divisor)
+    return math.ceil(value / divisor) * divisor if value else 0
+
+
+def divide_flops_for_parallelism(value: int, degree: int) -> int:
+    require_non_negative("value", value)
+    require_positive("degree", degree)
+    return math.ceil(value / degree)
+
+
+def video_patch_seq_len(
+    *,
+    latent_num_frames: int,
+    latent_height: int,
+    latent_width: int,
+    patch_size: PatchSize3D,
+) -> int:
+    for field_name, value in (
+        ("latent_num_frames", latent_num_frames),
+        ("latent_height", latent_height),
+        ("latent_width", latent_width),
+    ):
+        require_non_negative(field_name, value)
+    p_t, p_h, p_w = patch_size
+    for field_name, value in (
+        ("patch_size_t", p_t),
+        ("patch_size_h", p_h),
+        ("patch_size_w", p_w),
+    ):
+        require_positive(field_name, value)
+    return (latent_num_frames // p_t) * (latent_height // p_h) * (latent_width // p_w)
+
+
+def estimate_cross_attention_dit_layer_flops(
+    *,
+    query_seq_len: int,
+    key_seq_len: int,
+    context_len: int,
+    hidden_dim: int,
+    ffn_dim: int,
+    tensor_parallel_size: int,
+) -> int:
+    qkv_out_flops = 8 * hidden_dim * hidden_dim * query_seq_len
+    cross_attn_proj_flops = (4 * hidden_dim * hidden_dim * query_seq_len) + (4 * hidden_dim * hidden_dim * context_len)
+    mlp_flops = 4 * hidden_dim * ffn_dim * query_seq_len
+    self_attn_flops = 4 * query_seq_len * key_seq_len * hidden_dim
+    cross_attn_flops = 4 * query_seq_len * context_len * hidden_dim
+    return divide_flops_for_parallelism(
+        qkv_out_flops + cross_attn_proj_flops + mlp_flops + self_attn_flops + cross_attn_flops,
+        tensor_parallel_size,
+    )

--- a/vllm_omni/diffusion/metrics/estimators/__init__.py
+++ b/vllm_omni/diffusion/metrics/estimators/__init__.py
@@ -1,0 +1,33 @@
+from vllm_omni.diffusion.metrics.estimators.flux import (
+    FluxDiTForwardStats,
+    collect_flux_dit_forward_stats,
+    estimate_flux_dit_forward_flops_per_gpu,
+)
+from vllm_omni.diffusion.metrics.estimators.generic_dit import (
+    DiTFlopsBreakdown,
+    DiTForwardStats,
+    estimate_dit_flops_per_gpu,
+    estimate_dit_forward_flops_per_gpu,
+)
+from vllm_omni.diffusion.metrics.estimators.hunyuan_video import (
+    HunyuanVideoDiTForwardStats,
+    estimate_hunyuan_video_dit_forward_flops_per_gpu,
+)
+from vllm_omni.diffusion.metrics.estimators.wan2_2 import (
+    WanDiTForwardStats,
+    estimate_wan_dit_forward_flops_per_gpu,
+)
+
+__all__ = [
+    "DiTFlopsBreakdown",
+    "DiTForwardStats",
+    "FluxDiTForwardStats",
+    "HunyuanVideoDiTForwardStats",
+    "WanDiTForwardStats",
+    "collect_flux_dit_forward_stats",
+    "estimate_dit_flops_per_gpu",
+    "estimate_dit_forward_flops_per_gpu",
+    "estimate_flux_dit_forward_flops_per_gpu",
+    "estimate_hunyuan_video_dit_forward_flops_per_gpu",
+    "estimate_wan_dit_forward_flops_per_gpu",
+]

--- a/vllm_omni/diffusion/metrics/estimators/flux.py
+++ b/vllm_omni/diffusion/metrics/estimators/flux.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from vllm_omni.diffusion.metrics.common import (
+    divide_flops_for_parallelism,
+    positive_int_or_none,
+    require_non_negative,
+    require_positive,
+    shape_dim,
+)
+
+
+@dataclass(frozen=True)
+class FluxDiTForwardStats:
+    """Runtime shape for Flux-specific estimated/theoretical DiT FLOPs."""
+
+    batch_size: int
+    image_seq_len: int
+    text_seq_len: int
+    hidden_dim: int
+    ffn_dim: int
+    num_double_layers: int
+    num_single_layers: int
+    num_steps: int
+    forwards_per_step_per_gpu: int = 1
+    tensor_parallel_size: int = 1
+
+    def __post_init__(self) -> None:
+        for field_name, value in self.__dict__.items():
+            require_non_negative(field_name, value)
+        require_positive("forwards_per_step_per_gpu", self.forwards_per_step_per_gpu)
+        require_positive("tensor_parallel_size", self.tensor_parallel_size)
+
+
+def estimate_flux_dit_forward_flops_per_gpu(stats: FluxDiTForwardStats) -> int:
+    """Estimate Flux denoiser FLOPs with dual/single block accounting."""
+
+    joint_seq_len = stats.image_seq_len + stats.text_seq_len
+    dual_layer_flops = (
+        8 * stats.hidden_dim * stats.hidden_dim * stats.image_seq_len
+        + 8 * stats.hidden_dim * stats.hidden_dim * stats.text_seq_len
+        + 4 * stats.hidden_dim * stats.ffn_dim * stats.image_seq_len
+        + 4 * stats.hidden_dim * stats.ffn_dim * stats.text_seq_len
+        + 4 * joint_seq_len * joint_seq_len * stats.hidden_dim
+    )
+    single_layer_flops = (
+        8 * stats.hidden_dim * stats.hidden_dim * joint_seq_len
+        + 4 * stats.hidden_dim * stats.ffn_dim * joint_seq_len
+        + 4 * joint_seq_len * joint_seq_len * stats.hidden_dim
+    )
+    per_forward_flops = divide_flops_for_parallelism(
+        stats.num_double_layers * dual_layer_flops + stats.num_single_layers * single_layer_flops,
+        stats.tensor_parallel_size,
+    )
+    return stats.batch_size * per_forward_flops * stats.num_steps * stats.forwards_per_step_per_gpu
+
+
+def collect_flux_dit_forward_stats(
+    *,
+    latents: Any,
+    prompt_embeds: Any,
+    timesteps: Any,
+    transformer: Any,
+    do_true_cfg: bool,
+    cfg_parallel_world_size: int = 1,
+    tensor_parallel_size: int = 1,
+) -> FluxDiTForwardStats | None:
+    """Build Flux-specific DiT estimate input from Flux runtime tensors."""
+
+    batch_size = shape_dim(latents, 0)
+    image_seq_len = shape_dim(latents, 1)
+    text_seq_len = shape_dim(prompt_embeds, 1)
+    hidden_dim = positive_int_or_none(getattr(transformer, "inner_dim", None))
+    if hidden_dim is None:
+        config = getattr(transformer, "config", None)
+        hidden_dim = positive_int_or_none(getattr(config, "hidden_size", None))
+    if hidden_dim is None:
+        return None
+
+    transformer_blocks = getattr(transformer, "transformer_blocks", None)
+    single_transformer_blocks = getattr(transformer, "single_transformer_blocks", None)
+    try:
+        num_double_layers = len(transformer_blocks)
+        num_single_layers = len(single_transformer_blocks)
+    except Exception:
+        return None
+
+    num_double_layers = positive_int_or_none(num_double_layers)
+    num_single_layers = positive_int_or_none(num_single_layers)
+    try:
+        num_steps = len(timesteps)
+    except Exception:
+        return None
+    num_steps = positive_int_or_none(num_steps)
+
+    cfg_parallel_world_size = positive_int_or_none(cfg_parallel_world_size)
+    tensor_parallel_size = positive_int_or_none(tensor_parallel_size)
+    if cfg_parallel_world_size is None or tensor_parallel_size is None:
+        return None
+    forwards_per_step_per_gpu = 1
+    if do_true_cfg and cfg_parallel_world_size == 1:
+        forwards_per_step_per_gpu = 2
+
+    if None in (batch_size, image_seq_len, text_seq_len, num_double_layers, num_single_layers, num_steps):
+        return None
+
+    try:
+        return FluxDiTForwardStats(
+            batch_size=batch_size,
+            image_seq_len=image_seq_len,
+            text_seq_len=text_seq_len,
+            hidden_dim=hidden_dim,
+            ffn_dim=4 * hidden_dim,
+            num_double_layers=num_double_layers,
+            num_single_layers=num_single_layers,
+            num_steps=num_steps,
+            forwards_per_step_per_gpu=forwards_per_step_per_gpu,
+            tensor_parallel_size=tensor_parallel_size,
+        )
+    except (TypeError, ValueError):
+        return None

--- a/vllm_omni/diffusion/metrics/estimators/generic_dit.py
+++ b/vllm_omni/diffusion/metrics/estimators/generic_dit.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DiTForwardStats:
+    """Runtime/model shape inputs for the generic DiT FLOPs estimate."""
+
+    batch_size: int
+    seq_len: int
+    context_len: int
+    hidden_dim: int
+    ffn_dim: int
+    num_layers: int
+    num_steps: int
+    forwards_per_step_per_gpu: int
+
+    def __post_init__(self) -> None:
+        for field_name, value in self.__dict__.items():
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be int, got {type(value)!r}")
+            if value <= 0:
+                raise ValueError(f"{field_name} must be positive, got {value}")
+
+
+@dataclass(frozen=True)
+class DiTFlopsBreakdown:
+    """Componentized per-layer and request-total DiT FLOPs estimate."""
+
+    qkv_out_flops: int
+    cross_attn_proj_flops: int
+    mlp_flops: int
+    self_attn_flops: int
+    cross_attn_flops: int
+    flops_per_layer: int
+    total_flops_per_gpu: int
+
+
+def estimate_dit_flops_per_gpu(stats: DiTForwardStats) -> DiTFlopsBreakdown:
+    """Estimate theoretical forward FLOPs per GPU for a DiT diffusion request.
+
+    The formula intentionally mirrors issue #4077's generic per-layer DiT
+    estimate, then makes diffusion request multipliers explicit: denoising
+    step count and the number of transformer forwards this GPU executes per
+    step, including sequential CFG when applicable.
+    """
+
+    qkv_out_flops = 8 * stats.hidden_dim * stats.hidden_dim * stats.seq_len
+    cross_attn_proj_flops = (
+        4 * stats.hidden_dim * stats.hidden_dim * stats.seq_len
+        + 4 * stats.hidden_dim * stats.hidden_dim * stats.context_len
+    )
+    mlp_flops = 4 * stats.hidden_dim * stats.ffn_dim * stats.seq_len
+    self_attn_flops = 4 * stats.seq_len * stats.seq_len * stats.hidden_dim
+    cross_attn_flops = 4 * stats.seq_len * stats.context_len * stats.hidden_dim
+    flops_per_layer = qkv_out_flops + cross_attn_proj_flops + mlp_flops + self_attn_flops + cross_attn_flops
+    total_flops_per_gpu = (
+        stats.batch_size * flops_per_layer * stats.num_layers * stats.num_steps * stats.forwards_per_step_per_gpu
+    )
+    return DiTFlopsBreakdown(
+        qkv_out_flops=qkv_out_flops,
+        cross_attn_proj_flops=cross_attn_proj_flops,
+        mlp_flops=mlp_flops,
+        self_attn_flops=self_attn_flops,
+        cross_attn_flops=cross_attn_flops,
+        flops_per_layer=flops_per_layer,
+        total_flops_per_gpu=total_flops_per_gpu,
+    )
+
+
+def estimate_dit_forward_flops_per_gpu(stats: DiTForwardStats) -> int:
+    """Estimate theoretical forward FLOPs per GPU as a scalar value."""
+
+    return estimate_dit_flops_per_gpu(stats).total_flops_per_gpu

--- a/vllm_omni/diffusion/metrics/estimators/hunyuan_video.py
+++ b/vllm_omni/diffusion/metrics/estimators/hunyuan_video.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vllm_omni.diffusion.metrics.common import (
+    ceil_to_multiple,
+    estimate_cross_attention_dit_layer_flops,
+    require_non_negative,
+    require_positive,
+    video_patch_seq_len,
+)
+
+
+@dataclass(frozen=True)
+class HunyuanVideoDiTForwardStats:
+    """Runtime shape for HunyuanVideo estimated/theoretical denoiser FLOPs."""
+
+    batch_size: int
+    latent_num_frames: int
+    latent_height: int
+    latent_width: int
+    patch_size_t: int
+    patch_size: int
+    context_len: int
+    hidden_dim: int
+    ffn_dim: int
+    num_layers: int
+    num_steps: int
+    forwards_per_step_per_gpu: int = 1
+    tensor_parallel_size: int = 1
+    sequence_parallel_size: int = 1
+    pipeline_parallel_size: int = 1
+
+    def __post_init__(self) -> None:
+        for field_name, value in self.__dict__.items():
+            require_non_negative(field_name, value)
+        require_positive("patch_size_t", self.patch_size_t)
+        require_positive("patch_size", self.patch_size)
+        require_positive("forwards_per_step_per_gpu", self.forwards_per_step_per_gpu)
+        require_positive("tensor_parallel_size", self.tensor_parallel_size)
+        require_positive("sequence_parallel_size", self.sequence_parallel_size)
+        require_positive("pipeline_parallel_size", self.pipeline_parallel_size)
+
+    @property
+    def logical_seq_len(self) -> int:
+        return video_patch_seq_len(
+            latent_num_frames=self.latent_num_frames,
+            latent_height=self.latent_height,
+            latent_width=self.latent_width,
+            patch_size=(self.patch_size_t, self.patch_size, self.patch_size),
+        )
+
+    @property
+    def padded_seq_len(self) -> int:
+        return ceil_to_multiple(self.logical_seq_len, self.sequence_parallel_size)
+
+    @property
+    def local_seq_len(self) -> int:
+        if self.sequence_parallel_size == 1:
+            return self.padded_seq_len
+        return self.padded_seq_len // self.sequence_parallel_size
+
+
+def estimate_hunyuan_video_dit_forward_flops_per_gpu(stats: HunyuanVideoDiTForwardStats) -> int:
+    """Estimate HunyuanVideo denoiser FLOPs for the current GPU."""
+
+    flops_per_layer = estimate_cross_attention_dit_layer_flops(
+        query_seq_len=stats.local_seq_len,
+        key_seq_len=stats.padded_seq_len,
+        context_len=stats.context_len,
+        hidden_dim=stats.hidden_dim,
+        ffn_dim=stats.ffn_dim,
+        tensor_parallel_size=stats.tensor_parallel_size,
+    )
+    return stats.batch_size * flops_per_layer * stats.num_layers * stats.num_steps * stats.forwards_per_step_per_gpu

--- a/vllm_omni/diffusion/metrics/estimators/wan2_2.py
+++ b/vllm_omni/diffusion/metrics/estimators/wan2_2.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from vllm_omni.diffusion.metrics.common import (
+    PatchSize3D,
+    ceil_to_multiple,
+    estimate_cross_attention_dit_layer_flops,
+    require_non_negative,
+    require_positive,
+    video_patch_seq_len,
+)
+
+
+@dataclass(frozen=True)
+class WanDiTForwardStats:
+    """Runtime shape for Wan2.2 estimated/theoretical denoiser FLOPs.
+
+    ``num_layers`` is the local layer count for the current pipeline-parallel
+    stage. Executed FLOPs use padded sequence length when SP pads tokens before
+    transformer blocks.
+    """
+
+    batch_size: int
+    latent_num_frames: int
+    latent_height: int
+    latent_width: int
+    patch_size: PatchSize3D
+    context_len: int
+    hidden_dim: int
+    ffn_dim: int
+    num_layers: int
+    num_steps: int
+    forwards_per_step_per_gpu: int = 1
+    num_forwards_per_gpu: int | None = None
+    tensor_parallel_size: int = 1
+    sequence_parallel_size: int = 1
+    pipeline_parallel_size: int = 1
+
+    def __post_init__(self) -> None:
+        for field_name, value in (
+            ("batch_size", self.batch_size),
+            ("latent_num_frames", self.latent_num_frames),
+            ("latent_height", self.latent_height),
+            ("latent_width", self.latent_width),
+            ("context_len", self.context_len),
+            ("hidden_dim", self.hidden_dim),
+            ("ffn_dim", self.ffn_dim),
+            ("num_layers", self.num_layers),
+            ("num_steps", self.num_steps),
+        ):
+            require_non_negative(field_name, value)
+        require_positive("forwards_per_step_per_gpu", self.forwards_per_step_per_gpu)
+        if self.num_forwards_per_gpu is not None:
+            require_non_negative("num_forwards_per_gpu", self.num_forwards_per_gpu)
+        require_positive("tensor_parallel_size", self.tensor_parallel_size)
+        require_positive("sequence_parallel_size", self.sequence_parallel_size)
+        require_positive("pipeline_parallel_size", self.pipeline_parallel_size)
+        video_patch_seq_len(
+            latent_num_frames=self.latent_num_frames,
+            latent_height=self.latent_height,
+            latent_width=self.latent_width,
+            patch_size=self.patch_size,
+        )
+
+    @property
+    def logical_seq_len(self) -> int:
+        return video_patch_seq_len(
+            latent_num_frames=self.latent_num_frames,
+            latent_height=self.latent_height,
+            latent_width=self.latent_width,
+            patch_size=self.patch_size,
+        )
+
+    @property
+    def padded_seq_len(self) -> int:
+        return ceil_to_multiple(self.logical_seq_len, self.sequence_parallel_size)
+
+    @property
+    def local_seq_len(self) -> int:
+        if self.sequence_parallel_size == 1:
+            return self.padded_seq_len
+        return self.padded_seq_len // self.sequence_parallel_size
+
+
+def estimate_wan_dit_forward_flops_per_gpu(stats: WanDiTForwardStats) -> int:
+    """Estimate Wan2.2 denoiser FLOPs for the current GPU."""
+
+    flops_per_layer = estimate_cross_attention_dit_layer_flops(
+        query_seq_len=stats.local_seq_len,
+        key_seq_len=stats.padded_seq_len,
+        context_len=stats.context_len,
+        hidden_dim=stats.hidden_dim,
+        ffn_dim=stats.ffn_dim,
+        tensor_parallel_size=stats.tensor_parallel_size,
+    )
+    num_forwards_per_gpu = stats.num_forwards_per_gpu
+    if num_forwards_per_gpu is None:
+        num_forwards_per_gpu = stats.num_steps * stats.forwards_per_step_per_gpu
+    return stats.batch_size * flops_per_layer * stats.num_layers * num_forwards_per_gpu

--- a/vllm_omni/diffusion/metrics/perf.py
+++ b/vllm_omni/diffusion/metrics/perf.py
@@ -1,174 +1,84 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Estimated/theoretical DiT FLOPs helpers for diffusion MFU metrics."""
+from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
+from typing import TypeAlias
 
 from vllm.v1.metrics.perf import PerfStats
 
+from vllm_omni.diffusion.metrics.common import PatchSize3D
+from vllm_omni.diffusion.metrics.estimators import (
+    DiTFlopsBreakdown,
+    DiTForwardStats,
+    FluxDiTForwardStats,
+    HunyuanVideoDiTForwardStats,
+    WanDiTForwardStats,
+    collect_flux_dit_forward_stats,
+    estimate_dit_flops_per_gpu,
+    estimate_dit_forward_flops_per_gpu,
+    estimate_flux_dit_forward_flops_per_gpu,
+    estimate_hunyuan_video_dit_forward_flops_per_gpu,
+    estimate_wan_dit_forward_flops_per_gpu,
+)
 
-@dataclass(frozen=True)
-class DiTForwardStats:
-    """Runtime/model shape inputs for the generic DiT FLOPs estimate."""
-
-    batch_size: int
-    seq_len: int
-    context_len: int
-    hidden_dim: int
-    ffn_dim: int
-    num_layers: int
-    num_steps: int
-    forwards_per_step_per_gpu: int
-
-    def __post_init__(self) -> None:
-        for field_name, value in self.__dict__.items():
-            if not isinstance(value, int):
-                raise TypeError(f"{field_name} must be int, got {type(value)!r}")
-            if value <= 0:
-                raise ValueError(f"{field_name} must be positive, got {value}")
+DiffusionForwardStats: TypeAlias = (
+    DiTForwardStats | FluxDiTForwardStats | WanDiTForwardStats | HunyuanVideoDiTForwardStats
+)
 
 
-@dataclass(frozen=True)
-class DiTFlopsBreakdown:
-    """Componentized per-layer and request-total DiT FLOPs estimate."""
+def estimate_diffusion_forward_flops_per_gpu(stats: DiffusionForwardStats) -> int:
+    """Dispatch estimated/theoretical diffusion FLOPs by stats type."""
 
-    qkv_out_flops: int
-    cross_attn_proj_flops: int
-    mlp_flops: int
-    self_attn_flops: int
-    cross_attn_flops: int
-    flops_per_layer: int
-    total_flops_per_gpu: int
-
-
-def estimate_dit_flops_per_gpu(stats: DiTForwardStats) -> DiTFlopsBreakdown:
-    """Estimate theoretical forward FLOPs per GPU for a DiT diffusion request.
-
-    The formula intentionally mirrors issue #4077's generic per-layer DiT
-    estimate, then makes diffusion request multipliers explicit: denoising
-    step count and the number of transformer forwards this GPU executes per
-    step, including sequential CFG when applicable.
-    """
-
-    qkv_out_flops = 8 * stats.hidden_dim * stats.hidden_dim * stats.seq_len
-    cross_attn_proj_flops = (
-        4 * stats.hidden_dim * stats.hidden_dim * stats.seq_len
-        + 4 * stats.hidden_dim * stats.hidden_dim * stats.context_len
-    )
-    mlp_flops = 4 * stats.hidden_dim * stats.ffn_dim * stats.seq_len
-    self_attn_flops = 4 * stats.seq_len * stats.seq_len * stats.hidden_dim
-    cross_attn_flops = 4 * stats.seq_len * stats.context_len * stats.hidden_dim
-    flops_per_layer = qkv_out_flops + cross_attn_proj_flops + mlp_flops + self_attn_flops + cross_attn_flops
-    total_flops_per_gpu = (
-        stats.batch_size * flops_per_layer * stats.num_layers * stats.num_steps * stats.forwards_per_step_per_gpu
-    )
-    return DiTFlopsBreakdown(
-        qkv_out_flops=qkv_out_flops,
-        cross_attn_proj_flops=cross_attn_proj_flops,
-        mlp_flops=mlp_flops,
-        self_attn_flops=self_attn_flops,
-        cross_attn_flops=cross_attn_flops,
-        flops_per_layer=flops_per_layer,
-        total_flops_per_gpu=total_flops_per_gpu,
-    )
+    if isinstance(stats, DiTForwardStats):
+        return estimate_dit_forward_flops_per_gpu(stats)
+    if isinstance(stats, FluxDiTForwardStats):
+        return estimate_flux_dit_forward_flops_per_gpu(stats)
+    if isinstance(stats, WanDiTForwardStats):
+        return estimate_wan_dit_forward_flops_per_gpu(stats)
+    if isinstance(stats, HunyuanVideoDiTForwardStats):
+        return estimate_hunyuan_video_dit_forward_flops_per_gpu(stats)
+    raise TypeError(f"Unsupported diffusion FLOPs stats type: {type(stats)!r}")
 
 
 def to_perf_stats(breakdown: DiTFlopsBreakdown) -> PerfStats:
-    """Convert the DiT estimate into upstream vLLM PerfStats."""
+    """Convert a generic DiT estimate breakdown into upstream vLLM PerfStats."""
 
     return PerfStats(num_flops_per_gpu=breakdown.total_flops_per_gpu)
 
 
-def estimate_dit_perf_stats(stats: DiTForwardStats) -> PerfStats:
-    """Estimate DiT FLOPs and wrap them in upstream vLLM PerfStats."""
+def estimate_diffusion_perf_stats(stats: DiffusionForwardStats) -> PerfStats:
+    """Convert estimated diffusion FLOPs into upstream vLLM ``PerfStats``."""
 
-    return to_perf_stats(estimate_dit_flops_per_gpu(stats))
-
-
-def _positive_int_or_none(value: Any) -> int | None:
-    if isinstance(value, bool):
-        return None
-    try:
-        int_value = int(value)
-    except Exception:
-        return None
-    if int_value > 0:
-        return int_value
-    return None
+    return PerfStats(
+        num_flops_per_gpu=estimate_diffusion_forward_flops_per_gpu(stats),
+        num_read_bytes_per_gpu=0,
+        num_write_bytes_per_gpu=0,
+    )
 
 
-def _shape_dim(value: Any, index: int) -> int | None:
-    try:
-        shape = getattr(value, "shape", None)
-        if shape is None or len(shape) <= index:
-            return None
-        return _positive_int_or_none(shape[index])
-    except Exception:
-        return None
+def estimate_dit_perf_stats(stats: DiffusionForwardStats) -> PerfStats:
+    """Backward-compatible wrapper for diffusion estimated FLOPs stats."""
+
+    return estimate_diffusion_perf_stats(stats)
 
 
-def collect_flux_dit_forward_stats(
-    *,
-    latents: Any,
-    prompt_embeds: Any,
-    timesteps: Any,
-    transformer: Any,
-    do_true_cfg: bool,
-    cfg_parallel_world_size: int = 1,
-) -> DiTForwardStats | None:
-    """Build the generic DiT estimate input from Flux runtime tensors.
-
-    Flux MVP accounting deliberately uses the packed latent sequence length
-    that the transformer executes. This is hardware-MFU oriented shape
-    accounting, not useful-token goodput accounting.
-    """
-
-    batch_size = _shape_dim(latents, 0)
-    seq_len = _shape_dim(latents, 1)
-    context_len = _shape_dim(prompt_embeds, 1)
-    hidden_dim = _positive_int_or_none(getattr(transformer, "inner_dim", None))
-    if hidden_dim is None:
-        config = getattr(transformer, "config", None)
-        hidden_dim = _positive_int_or_none(getattr(config, "hidden_size", None))
-    if hidden_dim is None:
-        return None
-
-    transformer_blocks = getattr(transformer, "transformer_blocks", None)
-    single_transformer_blocks = getattr(transformer, "single_transformer_blocks", None)
-    try:
-        num_layers = len(transformer_blocks) + len(single_transformer_blocks)
-    except Exception:
-        return None
-    num_layers = _positive_int_or_none(num_layers)
-
-    try:
-        num_steps = len(timesteps)
-    except Exception:
-        return None
-    num_steps = _positive_int_or_none(num_steps)
-
-    cfg_parallel_world_size = _positive_int_or_none(cfg_parallel_world_size)
-    if cfg_parallel_world_size is None:
-        return None
-    forwards_per_step_per_gpu = 1
-    if do_true_cfg and cfg_parallel_world_size == 1:
-        forwards_per_step_per_gpu = 2
-
-    if None in (batch_size, seq_len, context_len, num_layers, num_steps):
-        return None
-
-    try:
-        return DiTForwardStats(
-            batch_size=batch_size,
-            seq_len=seq_len,
-            context_len=context_len,
-            hidden_dim=hidden_dim,
-            ffn_dim=4 * hidden_dim,
-            num_layers=num_layers,
-            num_steps=num_steps,
-            forwards_per_step_per_gpu=forwards_per_step_per_gpu,
-        )
-    except (TypeError, ValueError):
-        return None
+__all__ = [
+    "DiTFlopsBreakdown",
+    "DiTForwardStats",
+    "DiffusionForwardStats",
+    "FluxDiTForwardStats",
+    "HunyuanVideoDiTForwardStats",
+    "PatchSize3D",
+    "WanDiTForwardStats",
+    "collect_flux_dit_forward_stats",
+    "estimate_diffusion_forward_flops_per_gpu",
+    "estimate_diffusion_perf_stats",
+    "estimate_dit_flops_per_gpu",
+    "estimate_dit_forward_flops_per_gpu",
+    "estimate_dit_perf_stats",
+    "estimate_flux_dit_forward_flops_per_gpu",
+    "estimate_hunyuan_video_dit_forward_flops_per_gpu",
+    "estimate_wan_dit_forward_flops_per_gpu",
+    "to_perf_stats",
+]

--- a/vllm_omni/diffusion/metrics/perf.py
+++ b/vllm_omni/diffusion/metrics/perf.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Estimated/theoretical DiT FLOPs helpers for diffusion MFU metrics."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from vllm.v1.metrics.perf import PerfStats
+
+
+@dataclass(frozen=True)
+class DiTForwardStats:
+    """Runtime/model shape inputs for the generic DiT FLOPs estimate."""
+
+    batch_size: int
+    seq_len: int
+    context_len: int
+    hidden_dim: int
+    ffn_dim: int
+    num_layers: int
+    num_steps: int
+    forwards_per_step_per_gpu: int
+
+    def __post_init__(self) -> None:
+        for field_name, value in self.__dict__.items():
+            if not isinstance(value, int):
+                raise TypeError(f"{field_name} must be int, got {type(value)!r}")
+            if value <= 0:
+                raise ValueError(f"{field_name} must be positive, got {value}")
+
+
+@dataclass(frozen=True)
+class DiTFlopsBreakdown:
+    """Componentized per-layer and request-total DiT FLOPs estimate."""
+
+    qkv_out_flops: int
+    cross_attn_proj_flops: int
+    mlp_flops: int
+    self_attn_flops: int
+    cross_attn_flops: int
+    flops_per_layer: int
+    total_flops_per_gpu: int
+
+
+def estimate_dit_flops_per_gpu(stats: DiTForwardStats) -> DiTFlopsBreakdown:
+    """Estimate theoretical forward FLOPs per GPU for a DiT diffusion request.
+
+    The formula intentionally mirrors issue #4077's generic per-layer DiT
+    estimate, then makes diffusion request multipliers explicit: denoising
+    step count and the number of transformer forwards this GPU executes per
+    step, including sequential CFG when applicable.
+    """
+
+    qkv_out_flops = 8 * stats.hidden_dim * stats.hidden_dim * stats.seq_len
+    cross_attn_proj_flops = (
+        4 * stats.hidden_dim * stats.hidden_dim * stats.seq_len
+        + 4 * stats.hidden_dim * stats.hidden_dim * stats.context_len
+    )
+    mlp_flops = 4 * stats.hidden_dim * stats.ffn_dim * stats.seq_len
+    self_attn_flops = 4 * stats.seq_len * stats.seq_len * stats.hidden_dim
+    cross_attn_flops = 4 * stats.seq_len * stats.context_len * stats.hidden_dim
+    flops_per_layer = qkv_out_flops + cross_attn_proj_flops + mlp_flops + self_attn_flops + cross_attn_flops
+    total_flops_per_gpu = (
+        stats.batch_size * flops_per_layer * stats.num_layers * stats.num_steps * stats.forwards_per_step_per_gpu
+    )
+    return DiTFlopsBreakdown(
+        qkv_out_flops=qkv_out_flops,
+        cross_attn_proj_flops=cross_attn_proj_flops,
+        mlp_flops=mlp_flops,
+        self_attn_flops=self_attn_flops,
+        cross_attn_flops=cross_attn_flops,
+        flops_per_layer=flops_per_layer,
+        total_flops_per_gpu=total_flops_per_gpu,
+    )
+
+
+def to_perf_stats(breakdown: DiTFlopsBreakdown) -> PerfStats:
+    """Convert the DiT estimate into upstream vLLM PerfStats."""
+
+    return PerfStats(num_flops_per_gpu=breakdown.total_flops_per_gpu)
+
+
+def estimate_dit_perf_stats(stats: DiTForwardStats) -> PerfStats:
+    """Estimate DiT FLOPs and wrap them in upstream vLLM PerfStats."""
+
+    return to_perf_stats(estimate_dit_flops_per_gpu(stats))
+
+
+def _positive_int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        int_value = int(value)
+    except Exception:
+        return None
+    if int_value > 0:
+        return int_value
+    return None
+
+
+def _shape_dim(value: Any, index: int) -> int | None:
+    try:
+        shape = getattr(value, "shape", None)
+        if shape is None or len(shape) <= index:
+            return None
+        return _positive_int_or_none(shape[index])
+    except Exception:
+        return None
+
+
+def collect_flux_dit_forward_stats(
+    *,
+    latents: Any,
+    prompt_embeds: Any,
+    timesteps: Any,
+    transformer: Any,
+    do_true_cfg: bool,
+    cfg_parallel_world_size: int = 1,
+) -> DiTForwardStats | None:
+    """Build the generic DiT estimate input from Flux runtime tensors.
+
+    Flux MVP accounting deliberately uses the packed latent sequence length
+    that the transformer executes. This is hardware-MFU oriented shape
+    accounting, not useful-token goodput accounting.
+    """
+
+    batch_size = _shape_dim(latents, 0)
+    seq_len = _shape_dim(latents, 1)
+    context_len = _shape_dim(prompt_embeds, 1)
+    hidden_dim = _positive_int_or_none(getattr(transformer, "inner_dim", None))
+    if hidden_dim is None:
+        config = getattr(transformer, "config", None)
+        hidden_dim = _positive_int_or_none(getattr(config, "hidden_size", None))
+    if hidden_dim is None:
+        return None
+
+    transformer_blocks = getattr(transformer, "transformer_blocks", None)
+    single_transformer_blocks = getattr(transformer, "single_transformer_blocks", None)
+    try:
+        num_layers = len(transformer_blocks) + len(single_transformer_blocks)
+    except Exception:
+        return None
+    num_layers = _positive_int_or_none(num_layers)
+
+    try:
+        num_steps = len(timesteps)
+    except Exception:
+        return None
+    num_steps = _positive_int_or_none(num_steps)
+
+    cfg_parallel_world_size = _positive_int_or_none(cfg_parallel_world_size)
+    if cfg_parallel_world_size is None:
+        return None
+    forwards_per_step_per_gpu = 1
+    if do_true_cfg and cfg_parallel_world_size == 1:
+        forwards_per_step_per_gpu = 2
+
+    if None in (batch_size, seq_len, context_len, num_layers, num_steps):
+        return None
+
+    try:
+        return DiTForwardStats(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            context_len=context_len,
+            hidden_dim=hidden_dim,
+            ffn_dim=4 * hidden_dim,
+            num_layers=num_layers,
+            num_steps=num_steps,
+            forwards_per_step_per_gpu=forwards_per_step_per_gpu,
+        )
+    except (TypeError, ValueError):
+        return None

--- a/vllm_omni/diffusion/models/flux/pipeline_flux.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux.py
@@ -24,7 +24,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.parallel_state import get_classifier_free_guidance_world_size
 from vllm_omni.diffusion.distributed.utils import get_local_device
-from vllm_omni.diffusion.metrics.perf import DiTForwardStats, collect_flux_dit_forward_stats
+from vllm_omni.diffusion.metrics.perf import FluxDiTForwardStats, collect_flux_dit_forward_stats
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
 from vllm_omni.diffusion.models.flux import FluxTransformer2DModel
@@ -501,6 +501,29 @@ class FluxPipeline(
             return False
         return True
 
+    def _clear_dit_forward_stats(self) -> None:
+        self._last_dit_forward_stats = None
+
+    def _record_dit_forward_stats(
+        self,
+        *,
+        latents: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        timesteps: torch.Tensor,
+        do_true_cfg: bool,
+    ) -> None:
+        """Record Flux-specific estimated/theoretical DiT FLOPs inputs."""
+
+        self._last_dit_forward_stats = collect_flux_dit_forward_stats(
+            latents=latents,
+            prompt_embeds=prompt_embeds,
+            timesteps=timesteps,
+            transformer=self.transformer,
+            do_true_cfg=do_true_cfg,
+            cfg_parallel_world_size=get_classifier_free_guidance_world_size(),
+            tensor_parallel_size=getattr(self.od_config.parallel_config, "tensor_parallel_size", 1),
+        )
+
     def forward(
         self,
         req: OmniDiffusionRequest,
@@ -528,7 +551,7 @@ class FluxPipeline(
         max_sequence_length: int = 512,
     ):
         """Forward pass for flux."""
-        self._last_dit_forward_stats = None
+        self._clear_dit_forward_stats()
         # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
         # TODO: May be some data formatting operations on the API side. Hack for now.
         prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts] or prompt
@@ -634,13 +657,11 @@ class FluxPipeline(
         self._num_timesteps = len(timesteps)
 
         if getattr(self, "collect_dit_mfu_stats", False):
-            self._last_dit_forward_stats = collect_flux_dit_forward_stats(
+            self._record_dit_forward_stats(
                 latents=latents,
                 prompt_embeds=prompt_embeds,
                 timesteps=timesteps,
-                transformer=self.transformer,
                 do_true_cfg=do_true_cfg,
-                cfg_parallel_world_size=get_classifier_free_guidance_world_size(),
             )
 
         # handle guidance
@@ -682,7 +703,7 @@ class FluxPipeline(
             output=image, stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None
         )
 
-    def get_dit_forward_stats(self, req: OmniDiffusionRequest, output: DiffusionOutput) -> DiTForwardStats | None:
+    def get_dit_forward_stats(self, req: OmniDiffusionRequest, output: DiffusionOutput) -> FluxDiTForwardStats | None:
         """Return cached coarse estimated/theoretical DiT stats for the last forward."""
 
         del req, output

--- a/vllm_omni/diffusion/models/flux/pipeline_flux.py
+++ b/vllm_omni/diffusion/models/flux/pipeline_flux.py
@@ -24,6 +24,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.parallel_state import get_classifier_free_guidance_world_size
 from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.metrics.perf import DiTForwardStats, collect_flux_dit_forward_stats
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
 from vllm_omni.diffusion.models.flux import FluxTransformer2DModel
@@ -527,6 +528,7 @@ class FluxPipeline(
         max_sequence_length: int = 512,
     ):
         """Forward pass for flux."""
+        self._last_dit_forward_stats = None
         # TODO: In online mode, sometimes it receives [{"negative_prompt": None}, {...}], so cannot use .get("...", "")
         # TODO: May be some data formatting operations on the API side. Hack for now.
         prompt = [p if isinstance(p, str) else (p.get("prompt") or "") for p in req.prompts] or prompt
@@ -631,6 +633,16 @@ class FluxPipeline(
         timesteps, num_inference_steps = self.prepare_timesteps(num_inference_steps, sigmas, latents.shape[1])
         self._num_timesteps = len(timesteps)
 
+        if getattr(self, "collect_dit_mfu_stats", False):
+            self._last_dit_forward_stats = collect_flux_dit_forward_stats(
+                latents=latents,
+                prompt_embeds=prompt_embeds,
+                timesteps=timesteps,
+                transformer=self.transformer,
+                do_true_cfg=do_true_cfg,
+                cfg_parallel_world_size=get_classifier_free_guidance_world_size(),
+            )
+
         # handle guidance
         if self.transformer.guidance_embeds:
             guidance = torch.full([1], guidance_scale, dtype=torch.float32)
@@ -669,6 +681,12 @@ class FluxPipeline(
         return DiffusionOutput(
             output=image, stage_durations=self.stage_durations if hasattr(self, "stage_durations") else None
         )
+
+    def get_dit_forward_stats(self, req: OmniDiffusionRequest, output: DiffusionOutput) -> DiTForwardStats | None:
+        """Return cached coarse estimated/theoretical DiT stats for the last forward."""
+
+        del req, output
+        return getattr(self, "_last_dit_forward_stats", None)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)

--- a/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
+++ b/vllm_omni/diffusion/models/hunyuan_video/pipeline_hunyuan_video_1_5.py
@@ -23,7 +23,9 @@ from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_hunyuan_video_1
     DistributedAutoencoderKLHunyuanVideo15,
 )
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
+from vllm_omni.diffusion.distributed.parallel_state import get_classifier_free_guidance_world_size
 from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.metrics.perf import HunyuanVideoDiTForwardStats
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
 from vllm_omni.diffusion.models.hunyuan_video.hunyuan_video_15_transformer import HunyuanVideo15Transformer3DModel
@@ -202,6 +204,7 @@ class HunyuanVideo15Pipeline(
         self._guidance_scale = None
         self._num_timesteps = None
         self._current_timestep = None
+        self._last_dit_forward_stats: HunyuanVideoDiTForwardStats | None = None
 
         self.setup_diffusion_pipeline_profiler(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
@@ -218,6 +221,75 @@ class HunyuanVideo15Pipeline(
     @property
     def current_timestep(self):
         return self._current_timestep
+
+    def _clear_dit_forward_stats(self) -> None:
+        self._last_dit_forward_stats = None
+
+    @staticmethod
+    def _max_valid_tokens(mask: torch.Tensor | None, fallback_len: int) -> int:
+        if mask is None:
+            return int(fallback_len)
+        return int(mask.to(dtype=torch.bool).sum(dim=1).max().item())
+
+    def _record_dit_forward_stats(
+        self,
+        *,
+        latents: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        prompt_embeds_mask: torch.Tensor | None,
+        prompt_embeds_2: torch.Tensor,
+        prompt_embeds_mask_2: torch.Tensor | None,
+        image_embeds: torch.Tensor,
+        image_embeds_mask: torch.Tensor | None,
+        timesteps: torch.Tensor,
+        do_true_cfg: bool,
+    ) -> None:
+        """Record HunyuanVideo estimated/theoretical denoiser FLOPs inputs."""
+
+        try:
+            transformer = self.transformer
+            parallel_config = getattr(self.od_config, "parallel_config", None)
+            cfg_world_size = get_classifier_free_guidance_world_size() if do_true_cfg else 1
+            forwards_per_step_per_gpu = 2 if do_true_cfg and cfg_world_size == 1 else 1
+
+            text_context_len = self._max_valid_tokens(prompt_embeds_mask, int(prompt_embeds.shape[1]))
+            text_context_len_2 = self._max_valid_tokens(prompt_embeds_mask_2, int(prompt_embeds_2.shape[1]))
+            image_context_len = 0
+            if image_embeds_mask is not None:
+                image_context_len = self._max_valid_tokens(image_embeds_mask, int(image_embeds.shape[1]))
+
+            hidden_dim = int(getattr(transformer, "inner_dim"))
+            ffn_dim = int(getattr(transformer, "ffn_dim", 4 * hidden_dim))
+            self._last_dit_forward_stats = HunyuanVideoDiTForwardStats(
+                batch_size=int(latents.shape[0]),
+                latent_num_frames=int(latents.shape[2]),
+                latent_height=int(latents.shape[3]),
+                latent_width=int(latents.shape[4]),
+                patch_size_t=int(getattr(transformer, "patch_size_t")),
+                patch_size=int(getattr(transformer, "patch_size")),
+                context_len=image_context_len + text_context_len_2 + text_context_len,
+                hidden_dim=hidden_dim,
+                ffn_dim=ffn_dim,
+                num_layers=len(transformer.transformer_blocks),
+                num_steps=int(len(timesteps)),
+                forwards_per_step_per_gpu=forwards_per_step_per_gpu,
+                tensor_parallel_size=int(getattr(parallel_config, "tensor_parallel_size", 1)),
+                sequence_parallel_size=int(getattr(parallel_config, "sequence_parallel_size", 1) or 1),
+                pipeline_parallel_size=int(getattr(parallel_config, "pipeline_parallel_size", 1)),
+            )
+        except Exception:
+            self._last_dit_forward_stats = None
+            logger.warning("Failed to collect HunyuanVideo estimated DiT FLOPs inputs.", exc_info=True)
+
+    def get_dit_forward_stats(
+        self,
+        req: OmniDiffusionRequest,
+        output: DiffusionOutput,
+    ) -> HunyuanVideoDiTForwardStats | None:
+        """Return HunyuanVideo estimated/theoretical DiT FLOPs inputs."""
+
+        del req, output
+        return getattr(self, "_last_dit_forward_stats", None)
 
     def _get_mllm_prompt_embeds(
         self,
@@ -404,6 +476,8 @@ class HunyuanVideo15Pipeline(
         generator: torch.Generator | list[torch.Generator] | None = None,
         **kwargs,
     ) -> DiffusionOutput:
+        self._clear_dit_forward_stats()
+
         if len(req.prompts) > 1:
             raise ValueError("This model only supports a single prompt per request.")
         if len(req.prompts) == 1:
@@ -478,6 +552,19 @@ class HunyuanVideo15Pipeline(
         self.scheduler.set_timesteps(sigmas=sigmas, device=device)
         timesteps = self.scheduler.timesteps
         self._num_timesteps = len(timesteps)
+
+        if getattr(self, "collect_dit_mfu_stats", False):
+            self._record_dit_forward_stats(
+                latents=latents,
+                prompt_embeds=prompt_embeds,
+                prompt_embeds_mask=prompt_embeds_mask,
+                prompt_embeds_2=prompt_embeds_2,
+                prompt_embeds_mask_2=prompt_embeds_mask_2,
+                image_embeds=image_embeds,
+                image_embeds_mask=None,
+                timesteps=timesteps,
+                do_true_cfg=do_cfg and negative_prompt_embeds is not None,
+            )
 
         with self.progress_bar(total=len(timesteps)) as pbar:
             for i, t in enumerate(timesteps):

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -22,9 +22,11 @@ from vllm.sequence import IntermediateTensors
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import DistributedAutoencoderKLWan
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
+from vllm_omni.diffusion.distributed.parallel_state import get_classifier_free_guidance_world_size
 from vllm_omni.diffusion.distributed.pipeline_parallel import AsyncLatents, PipelineParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.forward_context import set_forward_context_denoise_step_idx
+from vllm_omni.diffusion.metrics.perf import WanDiTForwardStats
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
 from vllm_omni.diffusion.models.dmd2 import DMD2PipelineMixin
@@ -413,6 +415,7 @@ class Wan22Pipeline(
         self._guidance_scale_2 = None
         self._num_timesteps = None
         self._current_timestep = None
+        self._last_dit_forward_stats: WanDiTForwardStats | None = None
 
         self.setup_diffusion_pipeline_profiler(
             enable_diffusion_pipeline_profiler=self.od_config.enable_diffusion_pipeline_profiler
@@ -438,6 +441,90 @@ class Wan22Pipeline(
     @property
     def current_timestep(self):
         return self._current_timestep
+
+    def _clear_dit_forward_stats(self) -> None:
+        self._last_dit_forward_stats = None
+
+    def _record_dit_forward_stats(
+        self,
+        *,
+        latents: torch.Tensor,
+        prompt_embeds: torch.Tensor,
+        timesteps: torch.Tensor,
+        do_true_cfg: bool,
+        guidance_low: float | None = None,
+        guidance_high: float | None = None,
+        boundary_timestep: float | None = None,
+        has_negative_prompt: bool | None = None,
+    ) -> None:
+        """Record Wan2.2 estimated/theoretical denoiser FLOPs inputs."""
+
+        try:
+            transformer = self.transformer if self.transformer is not None else self.transformer_2
+            if transformer is None:
+                self._last_dit_forward_stats = None
+                return
+
+            config = getattr(transformer, "config", self.transformer_config)
+            patch_size = tuple(int(v) for v in getattr(config, "patch_size"))
+            if len(patch_size) != 3:
+                self._last_dit_forward_stats = None
+                return
+
+            num_heads = int(getattr(config, "num_attention_heads"))
+            head_dim = int(getattr(config, "attention_head_dim"))
+            parallel_config = getattr(self.od_config, "parallel_config", None)
+            cfg_world_size = get_classifier_free_guidance_world_size() if do_true_cfg else 1
+            forwards_per_step_per_gpu = 2 if do_true_cfg and cfg_world_size == 1 else 1
+            num_forwards_per_gpu = None
+            if guidance_low is not None and guidance_high is not None and has_negative_prompt is not None:
+                cfg_world_size = (
+                    get_classifier_free_guidance_world_size()
+                    if has_negative_prompt and (guidance_low > 1.0 or guidance_high > 1.0)
+                    else 1
+                )
+                num_forwards_per_gpu = 0
+                for timestep in timesteps:
+                    timestep_value = float(timestep.item() if hasattr(timestep, "item") else timestep)
+                    current_guidance_scale = (
+                        guidance_high
+                        if (boundary_timestep is not None and timestep_value < boundary_timestep)
+                        else guidance_low
+                    )
+                    step_uses_cfg = current_guidance_scale > 1.0 and has_negative_prompt
+                    num_forwards_per_gpu += 2 if step_uses_cfg and cfg_world_size == 1 else 1
+                forwards_per_step_per_gpu = 1
+
+            self._last_dit_forward_stats = WanDiTForwardStats(
+                batch_size=int(latents.shape[0]),
+                latent_num_frames=int(latents.shape[2]),
+                latent_height=int(latents.shape[3]),
+                latent_width=int(latents.shape[4]),
+                patch_size=patch_size,
+                context_len=int(prompt_embeds.shape[1]),
+                hidden_dim=num_heads * head_dim,
+                ffn_dim=int(getattr(config, "ffn_dim")),
+                num_layers=int(getattr(transformer, "end_layer", 0)) - int(getattr(transformer, "start_layer", 0)),
+                num_steps=int(len(timesteps)),
+                forwards_per_step_per_gpu=forwards_per_step_per_gpu,
+                num_forwards_per_gpu=num_forwards_per_gpu,
+                tensor_parallel_size=int(getattr(parallel_config, "tensor_parallel_size", 1)),
+                sequence_parallel_size=int(getattr(parallel_config, "sequence_parallel_size", 1) or 1),
+                pipeline_parallel_size=int(getattr(parallel_config, "pipeline_parallel_size", 1)),
+            )
+        except Exception:
+            self._last_dit_forward_stats = None
+            logger.warning("Failed to collect Wan2.2 estimated DiT FLOPs inputs.", exc_info=True)
+
+    def get_dit_forward_stats(
+        self,
+        req: OmniDiffusionRequest,
+        output: DiffusionOutput,
+    ) -> WanDiTForwardStats | None:
+        """Return Wan2.2 estimated/theoretical DiT FLOPs inputs."""
+
+        del req, output
+        return getattr(self, "_last_dit_forward_stats", None)
 
     def diffuse(
         self,
@@ -555,6 +642,8 @@ class Wan22Pipeline(
         attention_kwargs: dict | None = None,
         **kwargs,
     ) -> DiffusionOutput:
+        self._clear_dit_forward_stats()
+
         # Get parameters from request or arguments
         if len(req.prompts) > 1:
             raise ValueError(
@@ -777,6 +866,18 @@ class Wan22Pipeline(
 
         if attention_kwargs is None:
             attention_kwargs = {}
+
+        if getattr(self, "collect_dit_mfu_stats", False):
+            self._record_dit_forward_stats(
+                latents=latents,
+                prompt_embeds=prompt_embeds,
+                timesteps=timesteps,
+                do_true_cfg=(guidance_low > 1.0 or guidance_high > 1.0) and negative_prompt_embeds is not None,
+                guidance_low=guidance_low,
+                guidance_high=guidance_high,
+                boundary_timestep=boundary_timestep,
+                has_negative_prompt=negative_prompt_embeds is not None,
+            )
 
         if DEBUG_PERF:
             _t_denoise_start = time.perf_counter()

--- a/vllm_omni/diffusion/output_formatter.py
+++ b/vllm_omni/diffusion/output_formatter.py
@@ -211,6 +211,7 @@ def _format_single_prompt_output(
                 stage_durations=diffusion_output.stage_durations,
                 peak_memory_mb=diffusion_output.peak_memory_mb,
                 finished=finished,
+                perf_stats=diffusion_output.perf_stats,
             ),
         ]
 
@@ -237,6 +238,7 @@ def _format_single_prompt_output(
                 stage_durations=diffusion_output.stage_durations,
                 peak_memory_mb=diffusion_output.peak_memory_mb,
                 finished=finished,
+                perf_stats=diffusion_output.perf_stats,
             ),
         ]
 
@@ -256,6 +258,7 @@ def _format_single_prompt_output(
             stage_durations=diffusion_output.stage_durations,
             peak_memory_mb=diffusion_output.peak_memory_mb,
             finished=finished,
+            perf_stats=diffusion_output.perf_stats,
         ),
     ]
 
@@ -275,7 +278,8 @@ def _format_multi_prompt_outputs(
     output_idx = 0
     request_id = request.request_id
 
-    for prompt in request.prompts:
+    for prompt_idx, prompt in enumerate(request.prompts):
+        perf_stats = diffusion_output.perf_stats if prompt_idx == 0 else None
         num_outputs = request.sampling_params.num_outputs_per_prompt
         start_idx = output_idx
         end_idx = start_idx + num_outputs
@@ -311,6 +315,7 @@ def _format_multi_prompt_outputs(
                     stage_durations=diffusion_output.stage_durations,
                     peak_memory_mb=diffusion_output.peak_memory_mb,
                     finished=finished,
+                    perf_stats=perf_stats,
                 ),
             )
             continue
@@ -351,6 +356,7 @@ def _format_multi_prompt_outputs(
                 stage_durations=diffusion_output.stage_durations,
                 peak_memory_mb=diffusion_output.peak_memory_mb,
                 finished=finished,
+                perf_stats=perf_stats,
             ),
         )
 

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -31,6 +31,7 @@ from vllm_omni.diffusion.cache.selector import get_cache_backend
 from vllm_omni.diffusion.compile import regionally_compile
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.forward_context import set_forward_context
+from vllm_omni.diffusion.metrics.perf import estimate_dit_perf_stats
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.interface import supports_step_execution
 from vllm_omni.diffusion.offloader import get_offload_backend
@@ -283,6 +284,31 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             pool_overhead_gb / peak_reserved_gb * 100 if peak_reserved_gb > 0 else 0.0,
         )
 
+    def _enable_dit_mfu_metrics(self) -> bool:
+        observability_config = getattr(self.vllm_config, "observability_config", None)
+        return bool(getattr(observability_config, "enable_mfu_metrics", False))
+
+    def _attach_dit_perf_stats(self, req: OmniDiffusionRequest, output: DiffusionOutput) -> None:
+        if not self._enable_dit_mfu_metrics():
+            return
+        if getattr(output, "error", None) or getattr(output, "perf_stats", None) is not None:
+            return
+
+        get_dit_forward_stats = getattr(self.pipeline, "get_dit_forward_stats", None)
+        if get_dit_forward_stats is None:
+            return
+
+        try:
+            dit_forward_stats = get_dit_forward_stats(req, output)
+        except Exception:
+            logger.warning("Failed to collect DiT MFU stats from diffusion pipeline", exc_info=True)
+            return
+
+        if dit_forward_stats is None:
+            return
+
+        output.perf_stats = estimate_dit_perf_stats(dit_forward_stats)
+
     def execute_model(self, req: OmniDiffusionRequest, kv_prefetch_jobs: dict | None = None) -> DiffusionOutput:
         """
         Execute a forward pass for the given requests.
@@ -376,12 +402,26 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
             if is_primary:
                 current_omni_platform.reset_peak_memory_stats()
 
-            with set_forward_context(vllm_config=self.vllm_config, omni_diffusion_config=self.od_config):
-                with record_function("pipeline_forward"):
-                    output = self.pipeline.forward(req)
+            collect_dit_mfu_stats = self._enable_dit_mfu_metrics()
+            missing = object()
+            previous_collect_flag = getattr(self.pipeline, "collect_dit_mfu_stats", missing)
+            # Lightweight runner-pipeline protocol: when enabled, the pipeline
+            # may cache runtime shape stats for get_dit_forward_stats().
+            setattr(self.pipeline, "collect_dit_mfu_stats", collect_dit_mfu_stats)
+            try:
+                with set_forward_context(vllm_config=self.vllm_config, omni_diffusion_config=self.od_config):
+                    with record_function("pipeline_forward"):
+                        output = self.pipeline.forward(req)
+            finally:
+                if previous_collect_flag is missing:
+                    delattr(self.pipeline, "collect_dit_mfu_stats")
+                else:
+                    setattr(self.pipeline, "collect_dit_mfu_stats", previous_collect_flag)
 
             if is_primary:
                 self._record_peak_memory(output)
+
+            self._attach_dit_perf_stats(req, output)
 
             # Log prompt-embed cache activity (hits/misses accumulate across requests).
             if is_primary and self.prompt_embed_cache is not None:

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -751,8 +751,23 @@ class Orchestrator:
     ) -> None:
         if self._stat_logger is None or output.perf_stats is None:
             return
-        engine_idx = self._stage_replica_to_engine_idx[(stage_id, replica_id)]
-        self._stat_logger.record_perf_stats(output.perf_stats, engine_idx=engine_idx)
+        engine_idx = self._stage_replica_to_engine_idx.get((stage_id, replica_id))
+        if engine_idx is None:
+            logger.warning(
+                "Skipping diffusion perf stats for stage %d replica %d: engine index is missing",
+                stage_id,
+                replica_id,
+            )
+            return
+        try:
+            self._stat_logger.record_perf_stats(output.perf_stats, engine_idx=engine_idx)
+        except Exception:
+            logger.warning(
+                "Failed to record diffusion perf stats for stage %d replica %d",
+                stage_id,
+                replica_id,
+                exc_info=True,
+            )
 
     async def _handle_processed_outputs(self, stage_id: int, replica_id: int, outputs: list[Any]) -> None:
         """Route processed stage outputs produced by one stage poll."""

--- a/vllm_omni/engine/orchestrator.py
+++ b/vllm_omni/engine/orchestrator.py
@@ -652,6 +652,7 @@ class Orchestrator:
                         if output is None:
                             continue
 
+                        self._record_diffusion_perf_stats(stage_id, replica_id, output)
                         pool.record_output_timestamps([output])
                         await self._handle_processed_outputs(stage_id, replica_id, [output])
                         idle = False
@@ -741,6 +742,17 @@ class Orchestrator:
                 await asyncio.sleep(0.001)
             else:
                 await asyncio.sleep(0)
+
+    def _record_diffusion_perf_stats(
+        self,
+        stage_id: int,
+        replica_id: int,
+        output: OmniRequestOutput,
+    ) -> None:
+        if self._stat_logger is None or output.perf_stats is None:
+            return
+        engine_idx = self._stage_replica_to_engine_idx[(stage_id, replica_id)]
+        self._stat_logger.record_perf_stats(output.perf_stats, engine_idx=engine_idx)
 
     async def _handle_processed_outputs(self, stage_id: int, replica_id: int, outputs: list[Any]) -> None:
         """Route processed stage outputs produced by one stage poll."""

--- a/vllm_omni/metrics/stat_logger.py
+++ b/vllm_omni/metrics/stat_logger.py
@@ -24,7 +24,7 @@ from prometheus_client import Counter, Gauge, Histogram
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorProm
 from vllm.v1.metrics.loggers import PrometheusStatLogger
-from vllm.v1.metrics.perf import PerfMetricsProm
+from vllm.v1.metrics.perf import PerfMetricsProm, PerfStats
 from vllm.v1.spec_decode.metrics import SpecDecodingProm
 
 # Process-wide translation table written by OmniPrometheusStatLogger at init.
@@ -241,3 +241,10 @@ class OmniPrometheusStatLogger(PrometheusStatLogger):
             stage, replica = self._stage_replica_map[idx]
             rewritten[idx] = [model_name, stage, replica]
         self._omni_per_engine_labelvalues = rewritten
+
+    def record_perf_stats(self, perf_stats: PerfStats, engine_idx: int = 0) -> None:
+        """Record diffusion-side PerfStats through the upstream MFU collector."""
+        observability_config = getattr(self.vllm_config, "observability_config", None)
+        if not getattr(observability_config, "enable_mfu_metrics", False):
+            return
+        self.perf_metrics_prom.observe(perf_stats, engine_idx)

--- a/vllm_omni/outputs.py
+++ b/vllm_omni/outputs.py
@@ -4,6 +4,7 @@ from typing import Any
 import torch
 from PIL import Image
 from vllm.outputs import RequestOutput
+from vllm.v1.metrics.perf import PerfStats
 from vllm.v1.outputs import ModelRunnerOutput
 
 from vllm_omni.inputs.data import OmniPromptType
@@ -102,6 +103,9 @@ class OmniRequestOutput:
     # memory usage info
     peak_memory_mb: float = 0.0
 
+    # Optional upstream vLLM MFU stats produced by diffusion stages.
+    perf_stats: PerfStats | None = None
+
     # error handling
     error: str | None = None
     error_status_code: int | None = None
@@ -176,6 +180,7 @@ class OmniRequestOutput:
         stage_durations: dict[str, float] | None = None,
         peak_memory_mb: float = 0.0,
         finished: bool = True,
+        perf_stats: PerfStats | None = None,
     ) -> "OmniRequestOutput":
         """Create output from diffusion model.
 
@@ -212,6 +217,7 @@ class OmniRequestOutput:
             _custom_output=custom_output or {},
             stage_durations=stage_durations or {},
             peak_memory_mb=peak_memory_mb,
+            perf_stats=perf_stats,
             finished=finished,
         )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Fixes #4077.

This PR adds a diffusion-side MFU perf stats bridge for DiT workloads and reuses the existing vLLM/vLLM-Omni MFU metric path instead of introducing a new Prometheus metric family.

Main changes:

- Add a diffusion DiT FLOPs estimator under `vllm_omni.diffusion.metrics`.
- Collect coarse Flux DiT forward stats from runtime tensor/config shapes when MFU metrics are enabled.
- Convert estimated DiT FLOPs into upstream-compatible `PerfStats`.
- Propagate `perf_stats` through:
  - `DiffusionOutput`
  - `OmniRequestOutput`
  - diffusion engine output handling
  - orchestrator stat logging
  - existing Prometheus MFU export path
- Keep MFU collection gated behind `enable_mfu_metrics`.
- Make metrics collection fail-closed so metric estimation does not fail generation.
- Add unit coverage for estimator logic, IPC propagation, runner attachment, orchestrator routing, and Prometheus export labels.

## Test Plan

**vLLM Version:**

Local vLLM source checkout commit:

`4f423bd5bcf38cb2fc09db5dc9e0bc8a6bfb1638`

**vLLM-Omni Commit:**

`d6e51e73a1177fe1e863481003aecce45b3b0eb3`

## Test Result

Passed locally:

```bash
uv run --no-sync python -m py_compile \
  vllm_omni/diffusion/metrics/perf.py \
  vllm_omni/diffusion/data.py \
  vllm_omni/outputs.py \
  vllm_omni/diffusion/diffusion_engine.py \
  vllm_omni/diffusion/models/flux/pipeline_flux.py \
  vllm_omni/diffusion/worker/diffusion_model_runner.py \
  vllm_omni/engine/orchestrator.py \
  vllm_omni/metrics/stat_logger.py \
  tests/diffusion/test_dit_mfu_metrics.py \
  tests/diffusion/test_diffusion_ipc.py \
  tests/diffusion/test_diffusion_model_runner.py \
  tests/diffusion/test_diffusion_engine.py \
  tests/engine/test_orchestrator.py \
  tests/metrics/test_stat_logger.py