### PR TITLE
[CI] Add Cosmos3-Nano L2/L3 e2e tests

### DIFF
--- a/.buildkite/test-merge.yml
+++ b/.buildkite/test-merge.yml
@@ -766,6 +766,51 @@ steps:
                       path: /mnt/hf-cache
                       type: DirectoryOrCreate
 
+      - label: "Diffusion · Cosmos3-Nano Test"
+        source_file_dependencies:
+          - tests/e2e/offline_inference/test_cosmos3_nano.py
+          - tests/e2e/online_serving/test_cosmos3_nano.py
+          - vllm_omni/diffusion/models/cosmos3/
+        commands:
+          - |
+            timeout 40m bash -c "
+              export VLLM_IMAGE_FETCH_TIMEOUT=60
+              pytest -s -v tests/e2e/offline_inference/test_cosmos3_nano.py tests/e2e/online_serving/test_cosmos3_nano.py -m 'advanced_model and cuda and diffusion' --run-level 'advanced_model'
+            "
+        agents:
+          queue: "mithril-h100-pool"
+        plugins:
+          - kubernetes:
+              podSpec:
+                containers:
+                  - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
+                    resources:
+                      limits:
+                        nvidia.com/gpu: 1
+                    volumeMounts:
+                      - name: devshm
+                        mountPath: /dev/shm
+                      - name: hf-cache
+                        mountPath: /root/.cache/huggingface
+                    env:
+                      - name: HF_HOME
+                        value: /root/.cache/huggingface
+                      - name: HF_TOKEN
+                        valueFrom:
+                          secretKeyRef:
+                            name: hf-token-secret
+                            key: token
+                nodeSelector:
+                  node.kubernetes.io/instance-type: gpu-h100-sxm
+                volumes:
+                  - name: devshm
+                    emptyDir:
+                      medium: Memory
+                  - name: hf-cache
+                    hostPath:
+                      path: /mnt/hf-cache
+                      type: DirectoryOrCreate
+
       - label: "Diffusion · Wan22 Test"
         source_file_dependencies:
           - tests/e2e/offline_inference/test_wan22_t2v.py

--- a/.buildkite/test-ready.yml
+++ b/.buildkite/test-ready.yml
@@ -540,6 +540,50 @@ steps:
                       path: /mnt/hf-cache
                       type: DirectoryOrCreate
 
+      - label: "Diffusion · Cosmos3-Nano Test"
+        source_file_dependencies:
+          - tests/e2e/online_serving/test_cosmos3_nano.py
+          - vllm_omni/diffusion/models/cosmos3/
+        commands:
+          - |
+            timeout 40m bash -c "
+              export VLLM_IMAGE_FETCH_TIMEOUT=60
+              pytest -s -v tests/e2e/online_serving/test_cosmos3_nano.py -m 'core_model' --run-level 'core_model'
+            "
+        agents:
+          queue: "mithril-h100-pool"
+        plugins:
+          - kubernetes:
+              podSpec:
+                containers:
+                  - image: 936637512419.dkr.ecr.us-west-2.amazonaws.com/vllm-ci-pull-through-cache/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
+                    resources:
+                      limits:
+                        nvidia.com/gpu: 1
+                    volumeMounts:
+                      - name: devshm
+                        mountPath: /dev/shm
+                      - name: hf-cache
+                        mountPath: /root/.cache/huggingface
+                    env:
+                      - name: HF_HOME
+                        value: /root/.cache/huggingface
+                      - name: HF_TOKEN
+                        valueFrom:
+                          secretKeyRef:
+                            name: hf-token-secret
+                            key: token
+                nodeSelector:
+                  node.kubernetes.io/instance-type: gpu-h100-sxm
+                volumes:
+                  - name: devshm
+                    emptyDir:
+                      medium: Memory
+                  - name: hf-cache
+                    hostPath:
+                      path: /mnt/hf-cache
+                      type: DirectoryOrCreate
+
       - label: "Diffusion · Wan22 Test"
         source_file_dependencies:
           - tests/e2e/online_serving/test_wan22_t2v.py

--- a/tests/e2e/offline_inference/test_cosmos3_nano.py
+++ b/tests/e2e/offline_inference/test_cosmos3_nano.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from tests.helpers.mark import hardware_test
+from tests.helpers.runtime import OmniRunnerHandler
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+MODEL = "nvidia/Cosmos3-Nano"
+PROMPT = "A small warehouse robot moves a blue box across a clean floor."
+NEGATIVE_PROMPT = "blurry, distorted, low quality"
+
+# (model, stage_config_path, extra_omni_kwargs). Offline has no --no-guardrails CLI flag, so
+# set its engine-side equivalent: serve.py maps --no-guardrails to model_config["guardrails"]=False.
+OMNI_RUNNER_PARAM = (MODEL, None, {"model_config": {"guardrails": False}})
+
+
+@pytest.mark.advanced_model
+@pytest.mark.diffusion
+@hardware_test(res={"cuda": "H100"}, num_cards={"cuda": 1})
+@pytest.mark.parametrize("omni_runner", [OMNI_RUNNER_PARAM], indirect=True)
+def test_text_to_video_001(omni_runner_handler: OmniRunnerHandler) -> None:
+    """Default Cosmos3-Nano T2V offline smoke: in-process generation returns video bytes."""
+    sampling = OmniDiffusionSamplingParams(
+        height=256,
+        width=256,
+        num_frames=5,
+        fps=1,
+        num_inference_steps=2,
+        guidance_scale=1.0,
+        seed=42,
+    )
+    request_config = {
+        "model": MODEL,
+        "prompt": PROMPT,
+        "negative_prompt": NEGATIVE_PROMPT,
+        "sampling_params": sampling,
+    }
+    omni_runner_handler.send_diffusion_request(request_config)

--- a/tests/e2e/online_serving/test_cosmos3_nano.py
+++ b/tests/e2e/online_serving/test_cosmos3_nano.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+E2E online serving smoke for nvidia/Cosmos3-Nano: text-to-image (/v1/images/generations)
+and text-to-video (/v1/videos).
+
+Runs the real model at small parameters (256x256, 2 steps) with guardrails disabled
+(--no-guardrails) so CI needs no gated repo or cosmos-guardrail package.
+"""
+
+import os
+
+import pytest
+
+from tests.helpers.mark import hardware_marks
+from tests.helpers.runtime import OmniServer, OmniServerParams, OpenAIClientHandler
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+MODEL = "nvidia/Cosmos3-Nano"
+PROMPT = "A small warehouse robot moves a blue box across a clean floor."
+NEGATIVE_PROMPT = "blurry, distorted, low quality"
+WIDTH = HEIGHT = 256
+NUM_INFERENCE_STEPS = 2
+SEED = 42
+
+COSMOS3_SERVER_ARGS = [
+    "--num-gpus",
+    "1",
+    "--no-guardrails",
+]
+
+SINGLE_CARD_FEATURE_MARKS = hardware_marks(res={"cuda": "H100"})
+
+
+def _get_diffusion_feature_cases(model: str):
+    """Return a single default ``OmniServerParams`` row for Cosmos3-Nano."""
+    return [
+        pytest.param(
+            OmniServerParams(
+                model=model,
+                server_args=COSMOS3_SERVER_ARGS,
+                init_timeout=1200,
+                stage_init_timeout=900,
+            ),
+            id="default",
+            marks=SINGLE_CARD_FEATURE_MARKS,
+        ),
+    ]
+
+
+@pytest.mark.core_model
+@pytest.mark.advanced_model
+@pytest.mark.diffusion
+@pytest.mark.parametrize("omni_server", _get_diffusion_feature_cases(MODEL), indirect=True)
+def test_text_to_image_001(omni_server: OmniServer, openai_client: OpenAIClientHandler) -> None:
+    """Default Cosmos3-Nano T2I smoke: ``/v1/images/generations`` returns one 256x256 image."""
+    body = {
+        "model": omni_server.model,
+        "prompt": PROMPT,
+        "negative_prompt": NEGATIVE_PROMPT,
+        "size": f"{WIDTH}x{HEIGHT}",
+        "n": 1,
+        "response_format": "b64_json",
+        "num_inference_steps": NUM_INFERENCE_STEPS,
+        "guidance_scale": 1.0,
+        "seed": SEED,
+    }
+    [resp] = openai_client.send_images_generations_http_request({"json": body, "timeout": 1800})
+    assert resp.success, f"image generation failed: {resp.status_code} {resp.error_message}"
+    assert resp.json_body is not None
+    assert len(resp.json_body["data"]) == 1
+    assert resp.json_body["data"][0]["b64_json"]
+
+
+@pytest.mark.core_model
+@pytest.mark.advanced_model
+@pytest.mark.diffusion
+@pytest.mark.parametrize("omni_server", _get_diffusion_feature_cases(MODEL), indirect=True)
+def test_text_to_video_001(omni_server: OmniServer, openai_client: OpenAIClientHandler) -> None:
+    """Default Cosmos3-Nano T2V smoke: async ``/v1/videos`` job completes and returns video bytes."""
+    request_config = {
+        "model": omni_server.model,
+        "form_data": {
+            "prompt": PROMPT,
+            "negative_prompt": NEGATIVE_PROMPT,
+            "height": HEIGHT,
+            "width": WIDTH,
+            "num_frames": 5,
+            "fps": 1,
+            "num_inference_steps": NUM_INFERENCE_STEPS,
+            "guidance_scale": 1.0,
+            "seed": SEED,
+        },
+    }
+    openai_client.send_video_diffusion_request(request_config)


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Cosmos3 currently has no L2/L3 CI coverage (only an L1 CPU test and an L4 accuracy
  test), as flagged in #4340. This adds basic L2/L3 e2e tests for
  `nvidia/Cosmos3-Nano`

Modified files:
  - `tests/e2e/online_serving/test_cosmos3_nano.py` (new) — online T2I + T2V; `core_model` + `advanced_model` → runs at L2 and L3.
  - `tests/e2e/offline_inference/test_cosmos3_nano.py` (new) — offline T2V smoke via `OmniRunner`; `advanced_model` → runs at L3.
  - `.buildkite/test-ready.yml` — register the L2 job (online only).
  - `.buildkite/test-merge.yml` — register the L3 job (offline + online).

## Test Plan

**vLLM Version: 0.22.1**

**vLLM-Omni Commit: 3b21602b**

```bash
  # L2 (PR-ready label)
  pytest -s -v tests/e2e/online_serving/test_cosmos3_nano.py \
    -m 'core_model' --run-level core_model

  # L3 (merge-test)   
  pytest -s -v tests/e2e/offline_inference/test_cosmos3_nano.py \
                tests/e2e/online_serving/test_cosmos3_nano.py \
    -m 'advanced_model and cuda and diffusion' --run-level advanced_model
  ```

## Test Result

L2 (core_model) — 1x H100:
  ```
================================================= 2 passed, 18 warnings in 50.99s =================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
  ```

L3 (advanced_model, offline + online) — 1x H100:
  ```
============================================ 3 passed, 22 warnings in 81.21s (0:01:21) ============================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
  ```

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
