### PR TITLE
[BugFix] Fix HunyuanImage3 size match issue

### DIFF
--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -216,14 +216,19 @@ def get_hunyuan_image_3_pre_process_func(od_config: OmniDiffusionConfig):
         pil_image = _to_pil_image(raw_image).convert("RGB")
         orig_width, orig_height = pil_image.size
 
-        target_width, target_height = image_processor.reso_group.get_target_size(orig_width, orig_height)
-        target_width = int(target_width)
-        target_height = int(target_height)
-        vae_input = _resize_and_crop_center(pil_image, target_width, target_height)
-        vae_tensor = image_processor.vae_processor(vae_input)
+        # Use index-based primary resolution lookup for conditioning images
+        # (matching official HunyuanImage-3.0 behavior). This avoids the
+        # area-based sub-resolution matching via get_target_size().match(),
+        # which would shrink small inputs (e.g. 512x512 → 512x512) and
+        # diverge from the output generation size determined by AR ratio_idx.
         base_size, ratio_idx = image_processor.reso_group.get_base_size_and_ratio_index(orig_width, orig_height)
         base_size = int(base_size)
         ratio_idx = int(ratio_idx)
+        reso = image_processor.reso_group[ratio_idx]
+        target_width = int(reso.width)
+        target_height = int(reso.height)
+        vae_input = _resize_and_crop_center(pil_image, target_width, target_height)
+        vae_tensor = image_processor.vae_processor(vae_input)
 
         vae_info = ImageInfo(
             image_type="vae",


### PR DESCRIPTION
Fix issue in matching HunyuanImage3 generation image size by input image

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Fix resolution match isse
## Test Plan
test cmd:
`pytest -s -v tests/e2e/accuracy/test_hunyuan_image3.py`

**vLLM Version:**
vllm 0.23.0
**vLLM-Omni Commit:**
this pr: a8b9386e4adaaaca3e4072ba9bc0f6464d15be03
## Test Result
<img width="490" height="224" alt="image" src="https://github.com/user-attachments/assets/b01912d7-3c18-4262-ae69-9b6c766f093b" />

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
