### PR TITLE
[CI/Build] Skip L2/L3 CI for pytest skip-mark changes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,11 +1,12 @@
-# Document 1: Buildkite loads only this block on first parse. The next step resolves docs-only skip-ci
-# from git diff, then uploads document 2. When docs-only skip applies, image-build still runs for the nightly
-# exception in upload_pipeline.py (nightly-test label or main NIGHTLY=1); otherwise upload-nightly
-# can be skipped together with test-ready/test-merge. Weekly uploads also depend on image-build.
+# Document 1: Buildkite loads only this block on first parse. The next step resolves docs-only,
+# pytest skip-mark-only, or combined skip-ci from git diff, then uploads document 2. When skip-ci
+# applies, image-build still runs for the nightly exception in upload_pipeline.py (nightly-test
+# label or main NIGHTLY=1); otherwise upload-nightly can be skipped together with test-ready/test-merge.
+# Weekly uploads also depend on image-build.
 
 # Document 2: appended after `---`; same file, read by upload_pipeline.py (not evaluated as a second pipeline by Buildkite). Child uploads include test-ready.yml, test-merge.yml, test-nightly.yml, and test-weekly.yml.
 steps:
-  - label: ":github: Resolve skip-ci & upload pipeline"
+  - label: ":github: Resolve skip-ci (docs / skip marks) & upload pipeline"
     key: upload-ci-pipeline
     commands:
       - "python3 .buildkite/scripts/upload_pipeline.py --upload .buildkite/pipeline.yml"

--- a/.buildkite/scripts/upload_pipeline.py
+++ b/.buildkite/scripts/upload_pipeline.py
@@ -3,7 +3,8 @@
 """Render and optionally upload Buildkite pipeline YAML with diff-aware logic.
 
 Bootstrap mode (pipeline.yml with __IMAGE_BUILD_IF__ placeholders):
-  - Detect docs-only PR/main changes and substitute skip-ci ``if`` expressions.
+  - Detect docs-only, pytest skip-mark-only, or combined docs+skip-mark PR/main changes and
+    substitute skip-ci ``if`` expressions.
 
 Test pipeline mode (e.g. test-merge.yml):
   - Drop steps or groups whose ``source_file_dependencies`` do not match changed files.
@@ -25,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -57,8 +59,8 @@ def _git(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def resolve_changed_files() -> list[str] | None:
-    """Return changed file paths, or None when diff cannot be resolved."""
+def resolve_diff_range() -> str | None:
+    """Return a git diff range for PR or main builds, or None when unavailable."""
     is_pr = os.environ.get("BUILDKITE_PULL_REQUEST", "false") != "false" and os.environ.get(
         "BUILDKITE_PULL_REQUEST", ""
     )
@@ -76,14 +78,22 @@ def resolve_changed_files() -> list[str] | None:
             else:
                 _log(f"cannot resolve PR base {base_branch}; using safe defaults")
                 return None
-        diff_range = f"{base_ref}...{commit}"
-    elif os.environ.get("BUILDKITE_BRANCH", "") == "main":
+        return f"{base_ref}...{commit}"
+
+    if os.environ.get("BUILDKITE_BRANCH", "") == "main":
         if _git("rev-parse", "--verify", f"{commit}^").returncode != 0:
             _log("main commit has no parent; using safe defaults")
             return None
-        diff_range = f"{commit}^..{commit}"
-    else:
-        _log("not PR/main build; using safe defaults")
+        return f"{commit}^..{commit}"
+
+    _log("not PR/main build; using safe defaults")
+    return None
+
+
+def resolve_changed_files() -> list[str] | None:
+    """Return changed file paths, or None when diff cannot be resolved."""
+    diff_range = resolve_diff_range()
+    if diff_range is None:
         return None
 
     result = _git("diff", "--name-only", diff_range)
@@ -96,30 +106,215 @@ def resolve_changed_files() -> list[str] | None:
     return files
 
 
+# Temporarily ignored when evaluating skip-ci (e.g. while debugging pipeline changes in a PR).
+_SKIP_CI_IGNORED_PATH_PREFIXES = (".buildkite/",)
+
+
+def _is_ignored_for_skip_ci_detection(file_path: str) -> bool:
+    for prefix in _SKIP_CI_IGNORED_PATH_PREFIXES:
+        if file_path == prefix.rstrip("/") or file_path.startswith(prefix):
+            return True
+    return False
+
+
+def _filter_skip_ci_changed_files(changed_files: list[str]) -> list[str]:
+    kept: list[str] = []
+    for file_path in changed_files:
+        if not file_path:
+            continue
+        if _is_ignored_for_skip_ci_detection(file_path):
+            _log(f"skip-ci: ignoring {file_path}")
+            continue
+        kept.append(file_path)
+    return kept
+
+
+def _is_doc_file(file_path: str) -> bool:
+    if not file_path:
+        return False
+    if file_path.startswith("docs/"):
+        return True
+    if file_path.endswith(".md"):
+        return True
+    return file_path == "mkdocs.yml"
+
+
 def is_docs_only_change(changed_files: list[str]) -> bool:
     has_any = False
     for file_path in changed_files:
         if not file_path:
             continue
         has_any = True
-        if file_path.startswith("docs/"):
+        if not _is_doc_file(file_path):
+            return False
+    return has_any
+
+
+def _is_test_python_file(file_path: str) -> bool:
+    path = Path(file_path)
+    return path.suffix == ".py" and bool(path.parts) and path.parts[0] == "tests"
+
+
+_SKIP_MARK_RE = re.compile(r"pytest\.mark\.skip(?:if)?\b|pytest\.skip\s*\(")
+_PYTESTMARK_SKIP_RE = re.compile(r"pytest\.mark\.skip\b")
+
+
+def _paren_balance(line: str) -> int:
+    return line.count("(") - line.count(")")
+
+
+def _is_skip_mark_related_content(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return True
+    if stripped.startswith("#"):
+        return True
+    return _SKIP_MARK_RE.search(stripped) is not None
+
+
+def diff_only_contains_skip_mark_changes(diff_text: str) -> bool:
+    """True when every added/removed line in a unified diff is skip-mark related."""
+    pending_depth = 0
+    saw_change = False
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("@@"):
+            pending_depth = 0
             continue
-        if file_path.endswith(".md"):
+        if not (raw_line.startswith("+") or raw_line.startswith("-")):
             continue
-        if file_path == "mkdocs.yml":
+        if raw_line.startswith("+++") or raw_line.startswith("---"):
             continue
+
+        saw_change = True
+        content = raw_line[1:]
+
+        if pending_depth > 0:
+            pending_depth += _paren_balance(content)
+            if pending_depth < 0:
+                pending_depth = 0
+            continue
+
+        if _is_skip_mark_related_content(content):
+            pending_depth = max(0, _paren_balance(content))
+            continue
+
+        return False
+
+    return saw_change
+
+
+def _git_file_diff(file_path: str, diff_range: str) -> str | None:
+    result = _git("diff", diff_range, "--", file_path)
+    if result.returncode != 0:
+        _log(f"skip-mark-only: git diff failed for {file_path}")
+        return None
+    return result.stdout
+
+
+def _is_new_file_diff(diff_text: str) -> bool:
+    return "new file mode" in diff_text or "--- /dev/null" in diff_text
+
+
+def _file_has_module_level_pytest_skip(content: str) -> bool:
+    """True when ``pytestmark`` applies unconditional ``pytest.mark.skip`` to the module."""
+    match = re.search(r"^pytestmark\s*=\s*\[(.*?)^\s*\]", content, re.MULTILINE | re.DOTALL)
+    if match is not None:
+        return _PYTESTMARK_SKIP_RE.search(match.group(1)) is not None
+    match = re.search(r"^pytestmark\s*=\s*pytest\.mark\.skip\b", content, re.MULTILINE)
+    return match is not None
+
+
+def _file_content_at_commit(file_path: str, commit: str) -> str | None:
+    result = _git("show", f"{commit}:{file_path}")
+    if result.returncode != 0:
+        _log(f"skip-mark-only: cannot read {file_path} at {commit}")
+        return None
+    return result.stdout
+
+
+def _qualifies_as_skip_mark_test_change(file_path: str, diff_range: str) -> bool:
+    diff_text = _git_file_diff(file_path, diff_range)
+    if diff_text is None:
+        return False
+    if not diff_text.strip():
+        _log(f"skip-mark-only: empty diff for {file_path}")
+        return False
+
+    if diff_only_contains_skip_mark_changes(diff_text):
+        return True
+
+    if not _is_new_file_diff(diff_text):
+        _log(f"skip-mark-only: non-skip changes in {file_path}")
+        return False
+
+    commit = os.environ.get("BUILDKITE_COMMIT", "")
+    if not commit:
+        return False
+    content = _file_content_at_commit(file_path, commit)
+    if content is None:
+        return False
+    if _file_has_module_level_pytest_skip(content):
+        _log(f"skip-mark-only: new test file with module-level pytest.mark.skip: {file_path}")
+        return True
+
+    _log(f"skip-mark-only: new test file without module-level pytest.mark.skip: {file_path}")
+    return False
+
+
+def is_skip_mark_only_change(changed_files: list[str], *, diff_range: str) -> bool:
+    """True when every changed file is a tests/ module with only skip-mark edits."""
+    has_any = False
+    for file_path in changed_files:
+        if not file_path:
+            continue
+        has_any = True
+        if not _is_test_python_file(file_path):
+            return False
+        if not _qualifies_as_skip_mark_test_change(file_path, diff_range):
+            return False
+    return has_any
+
+
+def is_docs_or_skip_mark_only_change(changed_files: list[str], *, diff_range: str) -> bool:
+    """True when each changed file is a doc path or a qualifying skip-mark test change."""
+    has_any = False
+    for file_path in changed_files:
+        if not file_path:
+            continue
+        has_any = True
+        if _is_doc_file(file_path):
+            continue
+        if _is_test_python_file(file_path) and _qualifies_as_skip_mark_test_change(file_path, diff_range):
+            continue
+        _log(f"docs/skip-mark-only: rejecting {file_path}")
         return False
     return has_any
 
 
-def resolve_skip_ci(changed_files: list[str] | None) -> bool:
+def resolve_skip_ci(changed_files: list[str] | None, *, diff_range: str | None = None) -> bool:
     if changed_files is None:
         _log("skip-ci=0 (could not resolve changed files)")
         return False
-    if is_docs_only_change(changed_files):
+
+    effective_files = _filter_skip_ci_changed_files(changed_files)
+    if not effective_files:
+        _log("skip-ci=0 (no effective changes after ignoring configured paths)")
+        return False
+
+    if diff_range is not None and is_docs_or_skip_mark_only_change(effective_files, diff_range=diff_range):
+        if is_docs_only_change(effective_files):
+            _log("docs-only change detected; skip-ci=1")
+        elif is_skip_mark_only_change(effective_files, diff_range=diff_range):
+            _log("pytest skip-mark-only change detected; skip-ci=1")
+        else:
+            _log("docs + pytest skip-mark-only change detected; skip-ci=1")
+        return True
+
+    if diff_range is None and is_docs_only_change(effective_files):
         _log("docs-only change detected; skip-ci=1")
         return True
-    _log("non-doc changes detected; skip-ci=0")
+
+    _log("non-doc/non-skip-mark changes detected; skip-ci=0")
     return False
 
 
@@ -252,10 +447,14 @@ def resolve_pipeline_path(arg: str) -> Path:
 
 def render_pipeline(path: Path) -> str:
     text = path.read_text(encoding="utf-8")
+    diff_range = resolve_diff_range()
     changed_files = resolve_changed_files()
 
     if BOOTSTRAP_MARKER in text:
-        rendered = render_bootstrap_pipeline(text, skip_ci=resolve_skip_ci(changed_files))
+        rendered = render_bootstrap_pipeline(
+            text,
+            skip_ci=resolve_skip_ci(changed_files, diff_range=diff_range),
+        )
         return rendered
 
     doc = yaml.safe_load(text)

--- a/.buildkite/scripts/upload_pipeline.py
+++ b/.buildkite/scripts/upload_pipeline.py
@@ -106,29 +106,6 @@ def resolve_changed_files() -> list[str] | None:
     return files
 
 
-# Temporarily ignored when evaluating skip-ci (e.g. while debugging pipeline changes in a PR).
-_SKIP_CI_IGNORED_PATH_PREFIXES = (".buildkite/",)
-
-
-def _is_ignored_for_skip_ci_detection(file_path: str) -> bool:
-    for prefix in _SKIP_CI_IGNORED_PATH_PREFIXES:
-        if file_path == prefix.rstrip("/") or file_path.startswith(prefix):
-            return True
-    return False
-
-
-def _filter_skip_ci_changed_files(changed_files: list[str]) -> list[str]:
-    kept: list[str] = []
-    for file_path in changed_files:
-        if not file_path:
-            continue
-        if _is_ignored_for_skip_ci_detection(file_path):
-            _log(f"skip-ci: ignoring {file_path}")
-            continue
-        kept.append(file_path)
-    return kept
-
-
 def _is_doc_file(file_path: str) -> bool:
     if not file_path:
         return False
@@ -316,21 +293,16 @@ def resolve_skip_ci(changed_files: list[str] | None, *, diff_range: str | None =
         _log("skip-ci=0 (could not resolve changed files)")
         return False
 
-    effective_files = _filter_skip_ci_changed_files(changed_files)
-    if not effective_files:
-        _log("skip-ci=0 (no effective changes after ignoring configured paths)")
-        return False
-
-    if diff_range is not None and is_docs_or_skip_mark_only_change(effective_files, diff_range=diff_range):
-        if is_docs_only_change(effective_files):
+    if diff_range is not None and is_docs_or_skip_mark_only_change(changed_files, diff_range=diff_range):
+        if is_docs_only_change(changed_files):
             _log("docs-only change detected; skip-ci=1")
-        elif is_skip_mark_only_change(effective_files, diff_range=diff_range):
+        elif is_skip_mark_only_change(changed_files, diff_range=diff_range):
             _log("pytest skip-mark-only change detected; skip-ci=1")
         else:
             _log("docs + pytest skip-mark-only change detected; skip-ci=1")
         return True
 
-    if diff_range is None and is_docs_only_change(effective_files):
+    if diff_range is None and is_docs_only_change(changed_files):
         _log("docs-only change detected; skip-ci=1")
         return True
 

--- a/.buildkite/scripts/upload_pipeline.py
+++ b/.buildkite/scripts/upload_pipeline.py
@@ -157,6 +157,7 @@ def _is_test_python_file(file_path: str) -> bool:
 
 _SKIP_MARK_RE = re.compile(r"pytest\.mark\.skip(?:if)?\b|pytest\.skip\s*\(")
 _PYTESTMARK_SKIP_RE = re.compile(r"pytest\.mark\.skip\b")
+_PYTEST_MARK_ONLY_RE = re.compile(r"pytest\.mark\.\w+")
 
 
 def _paren_balance(line: str) -> int:
@@ -172,10 +173,25 @@ def _is_skip_mark_related_content(line: str) -> bool:
     return _SKIP_MARK_RE.search(stripped) is not None
 
 
+def _is_pytestmark_adjacent_content(line: str) -> bool:
+    """Allow pytestmark list refactors that only add skip/skipif alongside existing marks."""
+    stripped = line.strip().rstrip(",")
+    if not stripped:
+        return True
+    if stripped in {"[", "]"}:
+        return True
+    if stripped.startswith("#"):
+        return True
+    if stripped.startswith("pytestmark"):
+        return True
+    return _PYTEST_MARK_ONLY_RE.search(stripped) is not None
+
+
 def diff_only_contains_skip_mark_changes(diff_text: str) -> bool:
-    """True when every added/removed line in a unified diff is skip-mark related."""
+    """True when diff only edits skip marks or reformats pytestmark to add them."""
     pending_depth = 0
     saw_change = False
+    has_skip_mark_edit = False
     for raw_line in diff_text.splitlines():
         if raw_line.startswith("@@"):
             pending_depth = 0
@@ -195,12 +211,16 @@ def diff_only_contains_skip_mark_changes(diff_text: str) -> bool:
             continue
 
         if _is_skip_mark_related_content(content):
+            has_skip_mark_edit = True
             pending_depth = max(0, _paren_balance(content))
+            continue
+
+        if _is_pytestmark_adjacent_content(content):
             continue
 
         return False
 
-    return saw_change
+    return saw_change and has_skip_mark_edit
 
 
 def _git_file_diff(file_path: str, diff_range: str) -> str | None:

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -129,6 +129,27 @@ The precheck covers five PR types: Bug Fix, Performance, New Model, Diffusion Mo
 ### Local Test
 Please run the L1 and L2 test cases locally first and attach the results before contacting us to add the "ready" label. Please refer to the [test instructions](./ci/test_guide.md) for running the test cases.
 
+### Automatic skip-ci (docs and pytest skip marks)
+
+On pull requests and `main` pushes, the bootstrap step in [`.buildkite/pipeline.yml`](https://github.com/vllm-project/vllm-omni/blob/main/.buildkite/pipeline.yml) runs [`.buildkite/scripts/upload_pipeline.py`](https://github.com/vllm-project/vllm-omni/blob/main/.buildkite/scripts/upload_pipeline.py) against the git diff. When every changed file qualifies, **L2 (`ready`) and L3 (`merge-test`) pipelines are not uploaded**, so the default GPU CI jobs are skipped.
+
+| Change per file | Examples |
+| --- | --- |
+| Documentation | `docs/**`, any `*.md`, `mkdocs.yml` |
+| Pytest skip marks only (under `tests/`) | Add/remove/edit `@pytest.mark.skip`, `@pytest.mark.skipif`, or `pytest.skip(...)`; reformat `pytestmark` only to add a skip/skipif alongside existing `pytest.mark.*` entries |
+| New skipped test module | New `tests/**/*.py` whose `pytestmark` includes unconditional `pytest.mark.skip` |
+
+These PR shapes all trigger skip-ci:
+
+- Documentation only
+- Qualifying skip-mark edits in `tests/**/*.py` only
+- **A mix of documentation and qualifying skip-mark test edits**
+
+Skip-ci does **not** apply when the diff also touches product code (for example `vllm_omni/`), or when test files change assertions, imports, fixtures, or other non-skip logic. If the diff cannot be resolved (non-PR branches outside `main`), CI runs as usual.
+
+!!! note
+    Skipping L2/L3 does **not** disable the Docker image build step. Nightly (L4) upload can still run when the PR has a `nightly-test` label or on scheduled `main` builds with `NIGHTLY=1`. See [CI levels](./ci/CI_5levels.md) for how bootstrap skip-ci relates to diff-gated E2E jobs.
+
 ### Code Quality
 
 The PR needs to meet the following code quality standards:

--- a/tests/attention/test_fish_kvcache_attn.py
+++ b/tests/attention/test_fish_kvcache_attn.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-# debug for push
 
 import pytest
 import torch

--- a/tests/attention/test_fish_kvcache_attn.py
+++ b/tests/attention/test_fish_kvcache_attn.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# debug for push
 
 import pytest
 import torch

--- a/tests/attention/test_fish_kvcache_attn.py
+++ b/tests/attention/test_fish_kvcache_attn.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-# debug for push cancel
 
 import pytest
 import torch

--- a/tests/attention/test_fish_kvcache_attn.py
+++ b/tests/attention/test_fish_kvcache_attn.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# debug for push cancel
 
 import pytest
 import torch

--- a/tests/attention/test_fish_kvcache_attn.py
+++ b/tests/attention/test_fish_kvcache_attn.py
@@ -6,11 +6,7 @@ import torch
 
 from vllm_omni.attention import fish_kvcache_attn, fish_kvcache_backend
 
-pytestmark = [
-    pytest.mark.core_model,
-    pytest.mark.cpu,
-    pytest.mark.skipif(not torch.cuda.is_available(), reason="debug for test"),
-]
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
 
 class _FakeImpl:

--- a/tests/attention/test_fish_kvcache_attn.py
+++ b/tests/attention/test_fish_kvcache_attn.py
@@ -6,7 +6,11 @@ import torch
 
 from vllm_omni.attention import fish_kvcache_attn, fish_kvcache_backend
 
-pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+pytestmark = [
+    pytest.mark.core_model,
+    pytest.mark.cpu,
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="debug for test"),
+]
 
 
 class _FakeImpl:


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

- Extend bootstrap skip-ci in `.buildkite/scripts/upload_pipeline.py` (same entry point as docs-only detection) so L2/L3 pipelines are not uploaded when a PR/main push only contains low-risk documentation or pytest skip-mark changes.
- Supported change shapes:
  - Documentation only (`docs/**`, `*.md`, `mkdocs.yml`)
  - `tests/**/*.py` with diff lines limited to `@pytest.mark.skip` / `@pytest.mark.skipif` / `pytest.skip()`
  - **New** test modules whose `pytestmark` includes unconditional `pytest.mark.skip`
  - A mix of documentation and qualifying skip-mark test edits
- Update `.buildkite/pipeline.yml` bootstrap step label/comments to reflect the expanded skip-ci behavior.

## Test Plan
- Temporarily ignore `.buildkite/` paths when evaluating skip-ci so pipeline work can be validated in the same PR without disabling skip-ci.
Manual: open a PR that only adds `pytestmark = [pytest.mark.skip(...)]` to a new `tests/` file (plus optional `.buildkite/` edits) and confirm bootstrap logs `skip-ci=1`.

## Test Result
- Buildkite bootstrap: Pending on this PR
**when I only add pytest.mark.skipif:**
<img width="626" height="226" alt="8d4464fe-1a08-4b0e-a223-7f954970edc7" src="https://github.com/user-attachments/assets/ea02f841-87f4-4398-a4f3-12f09ba61ba9" />

**when I add pytest.mark.skipif and doc:**
<img width="620" height="206" alt="dd75ee5f-742f-4163-9185-35612af0769f" src="https://github.com/user-attachments/assets/a86d696f-74bb-4432-9306-889dc43ac676" />

**when I only add doc:**
<img width="682" height="206" alt="77e80b41-fbd1-41ec-86d7-fb3f1c0d88da" src="https://github.com/user-attachments/assets/1baa60df-6996-4197-b123-953580a2b4fb" />

**when I add doc and change other code:**
<img width="1352" height="262" alt="f5c1323a-ffc9-41ce-aa23-11894ac614f8" src="https://github.com/user-attachments/assets/5c5d1642-ddc5-4ed5-948a-ac3c6c4e5145" />




**vLLM Version:** N/A (CI scripting only)

**vLLM-Omni Commit:** `19c6eeaa`

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
