### PR TITLE
[Bugfix] Temp workaround: tolerate path-less routes in metrics middle ware (FastAPI >=0.137)

### DIFF
--- a/vllm_omni/patch.py
+++ b/vllm_omni/patch.py
@@ -269,3 +269,78 @@ def _patch_fp8_use_quack_fused_bias():
 
 
 _patch_fp8_use_quack_fused_bias()
+
+
+# =============================================================================
+# Patch prometheus-fastapi-instrumentator route walk to tolerate path-less
+# routes (FastAPI >= 0.137)
+# =============================================================================
+# WHY: FastAPI >= 0.137 stores lazy `_IncludedRouter` objects in `app.routes`;
+# these are `BaseRoute` subclasses with no `.path` attribute. The instrumentator
+# (prometheus-fastapi-instrumentator <= 8.0.0) reads `route.path` unconditionally
+# in `_get_route_name`, so every request raises `AttributeError` in the metrics
+# middleware and the server returns 500 (e.g. `/health` never goes ready and the
+# engine looks hung at startup). Omni reuses upstream vLLM's `build_app`, which
+# wires this instrumentator via `register_instrumentator_api_routers`, so omni
+# servers are hit by this whenever fastapi >= 0.137 and the installed vLLM lacks
+# the upstream fix.
+#
+# WHAT: Replace `prometheus_fastapi_instrumentator.routing._get_route_name` with
+# a version that skips path-less routes. This only affects the per-request metric
+# handler label, not request routing. Idempotent and a no-op on older FastAPI.
+#
+# FORWARD COMPAT:
+#   * vLLM upgrade — once the installed vLLM carries the upstream fix, vLLM's own
+#     patch (in `metrics.py`, applied at `build_app()` time) runs *after* this one
+#     and re-replaces the same function with an equivalent implementation. Both are
+#     idempotent and logically identical, so this patch simply becomes redundant,
+#     never conflicting.
+#   * instrumentator upgrade — guarded to versions <= 8.0.0 (those that read
+#     `route.path` unconditionally). A newer release is trusted to handle path-less
+#     routes itself, so we skip patching and defer to it.
+#
+# REMOVAL: Remove this patch once the installed vLLM carries the upstream fix, or
+# the pinned instrumentator is > 8.0.0 with the issue resolved.
+# Track: https://github.com/vllm-project/vllm/pull/45629
+def _patch_instrumentator_route_walk():
+    try:
+        from importlib.metadata import version as _pkg_version
+
+        from packaging.version import Version
+        from prometheus_fastapi_instrumentator import routing as _pfi_routing
+        from starlette.routing import Match, Mount
+        from starlette.types import Scope
+    except ImportError:
+        return
+
+    # Only versions <= 8.0.0 read `route.path` unconditionally. Newer releases
+    # are expected to handle path-less routes themselves, so defer to them rather
+    # than overwriting a corrected implementation with ours (its `_get_route_name`
+    # signature may also have changed). Patch defensively if the version is
+    # unknown.
+    try:
+        if Version(_pkg_version("prometheus-fastapi-instrumentator")) > Version("8.0.0"):
+            return
+    except Exception:  # noqa: BLE001
+        pass
+
+    def _get_route_name(scope: Scope, routes, route_name=None):
+        for route in routes:
+            if getattr(route, "path", None) is None:
+                continue
+            match, child_scope = route.matches(scope)
+            if match == Match.FULL:
+                route_name = route.path
+                child_scope = {**scope, **child_scope}
+                if isinstance(route, Mount) and route.routes:
+                    child = _get_route_name(child_scope, route.routes, route_name)
+                    route_name = None if child is None else route_name + child
+                return route_name
+            elif match == Match.PARTIAL and route_name is None:
+                route_name = route.path
+        return None
+
+    _pfi_routing._get_route_name = _get_route_name
+
+
+_patch_instrumentator_route_walk()


### PR DESCRIPTION
## Purpose

This is a temporary vllm-omni-side patch pending the upstream vLLM fix (vllm-project/vllm#45629). It could be removed once the installed vLLM carries that fix, or the pinned instrumentator is > 8.0.0 with the issue resolved.

FastAPI >= 0.137 stores lazy `_IncludedRouter` objects in `app.routes`; these are `BaseRoute` subclasses with no `.path` attribute. The metrics instrumentator (prometheus-fastapi-instrumentator <= 8.0.0) reads `route.path` unconditionally in `_get_route_name`, so every request raises `AttributeError` in the metrics middleware and the server returns 500 -- e.g. `/health` never goes ready and the engine looks hung at startup.

vllm-omni reuses upstream vLLM's `build_app`, which wires this instrumentator via `register_instrumentator_api_routers`, so omni servers are hit by this whenever fastapi >= 0.137 and the installed vLLM lacks the upstream fix.

Patch `prometheus_fastapi_instrumentator.routing._get_route_name` in `vllm_omni/patch.py` to skip path-less routes. This only affects the per-request metric handler label, not request routing.

Forward-compatible by design:
- vLLM upgrade: once the installed vLLM carries the upstream fix, its own patch runs after ours and re-replaces the same function with an equivalent, idempotent implementation -- this fix becomes redundant, not conflicting.
- instrumentator upgrade: guarded to versions <= 8.0.0; newer releases are trusted to handle path-less routes themselves, so we defer to them.

## Test Plan

**vLLM Version:** 0.23.0

**vLLM-Omni Commit:** c9d5545b520787f3c7f1b22c1000b1b2a5feeb8d

## Test Result

1. **Bug reproduced (before patch):**
   `_get_route_name` over an app with an `_IncludedRouter` route raised `'_IncludedRouter' object has no attribute 'path'`.

2. **Fixed (after `import vllm_omni`):**
   `_get_route_name.__module__ == "vllm_omni.patch"`; the same walk returns without error.

3. **Forward-compat guard works:**
   With the instrumentator version faked to `9.0.0`, the patch returns early and leaves `_get_route_name` untouched (defers to the upstream fix).

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
