### PR TITLE
Fix npu model runner too many values to unpack ($[1][0][4])

### DIFF
--- a/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_ar_model_runner.py
@@ -1087,13 +1087,16 @@ class NPUARModelRunner(OmniNPUModelRunner):
                     payload.update(mm_payload)
                 pooler_output.append(flatten_payload(payload))
 
+        multimodal_outputs_for_wire = (
+            pooler_output if engine_output_type != "text" and needs_pooler_payload else None
+        )
         model_runner_output = OmniModelRunnerOutput(
             req_ids=req_ids_output_copy,
             req_id_to_index=req_id_to_index_output_copy,
             sampled_token_ids=valid_sampled_token_ids,
             logprobs=logprobs_lists,
             prompt_logprobs_dict=prompt_logprobs_dict,
-            pooler_output=(pooler_output if engine_output_type != "text" and needs_pooler_payload else None),
+            multimodal_outputs=multimodal_outputs_for_wire,
             kv_connector_output=kv_connector_output,
             ec_connector_output=ec_connector_output if self.supports_mm_inputs else None,
             cudagraph_stats=cudagraph_stats,

--- a/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
+++ b/vllm_omni/platforms/npu/worker/npu_generation_model_runner.py
@@ -482,7 +482,7 @@ class NPUGenerationModelRunner(OmniNPUModelRunner):
             sampled_token_ids=[],
             logprobs=None,
             prompt_logprobs_dict={},
-            pooler_output=pooler_output,
+            multimodal_outputs=pooler_output,
             kv_connector_output=kv_connector_output,
             ec_connector_output=ec_connector_output if self.supports_mm_inputs else None,
             cudagraph_stats=cudagraph_stats,


### PR DESCRIPTION
# Test Plan

Reproduce the bug, apply the fix, verify Qwen3-TTS Base voice-clone request completes end-to-end on NPU and returns a valid WAV.

```bash
# Bring up Qwen3-TTS Base on NPU
vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-Base \
    --deploy-config vllm_omni/deploy/qwen3_tts.yaml \
    --omni --port 8091 --trust-remote-code

# Smoke: voice clone with a remote reference audio
curl -X POST http://localhost:8091/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{
    "input": "Hello, this is a cloned voice.",
    "task_type": "Base",
    "voice": "clone",
    "ref_audio": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-TTS-Repo/clone_2.wav",
    "ref_text": "Okay. Yeah. I resent you. I love you. I respect you. But you know what? You blew it! And thanks to you.",
    "response_format": "wav"
  }' --output base_remote.wav
```

Without the fix, the orchestrator dies on the first response with:

```
msgspec.ValidationError: too many values to unpack (expected 3) - at `$[1][0][4]`
```

# Test Result

Generated `base_remote.wav` successfully — a valid RIFF/WAVE audio file.

```bash
$ file base_remote.wav
base_remote.wav: RIFF (little-endian) data, WAVE audio, ...
$ head -c 12 base_remote.wav | xxd
00000000: 5249 4646 .... 5741 5645  RIFF....WAVE
```

No `too many values to unpack ($[1][0][4])` error, no `EngineDeadError`.