### PR TITLE
[Bugfix] Qwen3-TTS: handle preempt/resume multi-token decode span in talker preprocess

### DIFF
--- a/tests/model_executor/models/qwen3_tts/test_qwen3_tts_talker_preprocess.py
+++ b/tests/model_executor/models/qwen3_tts/test_qwen3_tts_talker_preprocess.py
@@ -682,3 +682,55 @@ def test_ref_audio_artifact_only_cache_miss_fails_fast():
                 REF_AUDIO_CACHE_KEY: ["missing-ref"],
             },
         )
+
+
+def test_decode_multi_token_span_replays_kv_on_preempt_resume():
+    # When a running talker request is preempted and resumed, vLLM replays the
+    # already-generated codec tokens as a single decode-side span (is_prefill
+    # False, span_len > 1). The pre-fix decode path assumed span_len == 1 and
+    # reshape(1, 1) crashed Stage-0's EngineCore on it. The resume branch must
+    # instead embed every replayed token (one row each), return the span ids
+    # unchanged, and leave the decode state untouched — the preserved
+    # talker_text_offset / trailing_text live in model_intermediate_buffer and
+    # must not be advanced or popped while only rebuilding KV.
+    model = _make_minimal_talker(tts_pad_embed=torch.full((1, 4), -1.0, dtype=torch.bfloat16))
+    # preprocess reads ``self._embedding_dtype``; the __new__ construction in
+    # _make_minimal_talker skips __init__, so set it explicitly.
+    model._embedding_dtype = torch.bfloat16
+
+    def fake_embed_input_ids(ids):
+        flat = ids.reshape(-1).to(torch.float32)
+        return flat.reshape(-1, 1, 1).expand(flat.shape[0], 1, 4)
+
+    model.embed_input_ids = fake_embed_input_ids
+
+    input_ids = torch.tensor([11, 22, 33], dtype=torch.long)
+    out_ids, out_embeds, update = model.preprocess(
+        input_ids=input_ids,
+        input_embeds=None,
+        text=["hello"],
+        task_type=["CustomVoice"],
+        # Decode-side state that the normal span_len == 1 path would consume;
+        # the resume replay must ignore it (no offset advance, no tail rewrite).
+        hidden_states={
+            "trailing_text": torch.arange(12, dtype=torch.float32).reshape(3, 4),
+            "last": torch.ones(4, dtype=torch.float32),
+        },
+        meta={"talker_text_offset": 1, "codec_streaming": True},
+        _omni_is_prefill=False,
+        _omni_num_computed_tokens=5,
+        _omni_prompt_len=2,
+    )
+
+    # Span ids returned unchanged (token ids stay in-vocab for vLLM bookkeeping).
+    assert torch.equal(out_ids, input_ids)
+    # One embedding row per replayed token — not a single decode step.
+    assert out_embeds.shape == (3, 4)
+    expected = input_ids.to(torch.float32).reshape(3, 1).expand(3, 4).to(torch.bfloat16)
+    assert torch.equal(out_embeds.cpu(), expected)
+    # No decode-state mutation: no mtp fast-path inputs, no trailing_text rewrite,
+    # and the text offset is not advanced. codec_streaming is carried through from
+    # the per-request meta (not re-derived from task_type, which would be False here).
+    assert "mtp_inputs" not in update
+    assert "hidden_states" not in update
+    assert update["meta"] == {"codec_streaming": True}

--- a/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
+++ b/vllm_omni/model_executor/models/qwen3_tts/qwen3_tts_talker.py
@@ -719,6 +719,21 @@ class Qwen3TTSTalkerForConditionalGeneration(nn.Module):
         # ``tts_pad_embed`` was materialized above from :attr:`_tts_pad_embed`
         # (request-independent buffer) — no per-request fetch needed.
 
+        # Preemption->resume (or prefix-cache reconstruction) replays already-
+        # generated codec tokens as a multi-token span with is_prefill False; the
+        # stock reshape(1, 1) below crashes the EngineCore on it. Decode state is
+        # preserved across preemption in model_intermediate_buffer (cleared only on
+        # request finish), so rebuild only the main-transformer KV: embed every
+        # replayed codec token, mutate no decode state, emit no mtp_inputs (the
+        # talker_mtp fast-path is span_len==1 gated and never pops it for this span).
+        if span_len > 1:
+            inputs_embeds_out = (
+                self.embed_input_ids(input_ids.reshape(-1, 1).to(torch.long))
+                .to(device=input_ids.device, dtype=dtype)
+                .reshape(span_len, -1)
+            )
+            return input_ids, inputs_embeds_out, {"meta": {"codec_streaming": codec_streaming}}
+
         tail = hs.get("trailing_text")
         text_offset = max(0, int(meta.get("talker_text_offset", 0) or 0))
         trailing_text_update = None


### PR DESCRIPTION
Addresses #4471 (part 1: the Stage-0 `reshape(1, 1)` crash on preempt/resume).
This does **not** close #4471 — part 2 (a runner-side block-gather assert) is
engine-side and remains; see the caveat below.

## What

`qwen3_tts_talker.py::preprocess` has a prefill branch (handles `span_len > 1`)
and a decode branch that assumes `span_len == 1`:

```python
last_id_hidden = self.embed_input_ids(input_ids.reshape(1, 1).to(torch.long)).to(...)
```

The caller picks the branch from `is_prefill = num_computed_tokens < prompt_len`
(`gpu_model_runner.py::_preprocess`). When a running talker request is **preempted
and resumed**, vLLM recomputes `prompt + generated` as a chunked prefill; once that
crosses `prompt_len` into the generated region, `num_computed_tokens >= prompt_len`
so `is_prefill` is `False`, **but the scheduled span is a whole chunk of generated
codec tokens** (`span_len > 1`, up to `max_num_batched_tokens`). The decode branch
then `reshape(1, 1)`s a multi-element tensor and crashes the EngineCore. The
engine's `dump_input` confirms it: a `resumed_req_ids` request with
`num_scheduled_tokens=510` and `num_computed_tokens (2400) >> prompt_len (~213)`.

This handles `span_len > 1` in the decode branch as a **KV-rebuild replay**: embed
every replayed codec token (mirroring `preprocess_decode_batch`'s batched embed),
return them as the per-step `inputs_embeds`, and **mutate no decode state**. The
decode state (`talker_text_offset` / `trailing_text` / `hidden_states.last`)
survives preemption in `model_intermediate_buffer` (cleared only on request
finish), so the replay must only rebuild the main-transformer KV, not re-advance
text. It also emits no `mtp_inputs` — the runner's `talker_mtp` fast-path is
`span_len == 1`-gated and never pops it for this span, and the caller already
writes back a `span_len > 1` `inputs_embeds` slice and skips the mtp branch, so no
caller change is needed. Taking only the last token (`input_ids.reshape(-1)[-1:]`)
would be wrong: it leaves the other `span_len - 1` positions' KV unbuilt.

## Test plan

Multi-voice inline-clone sweep, concurrency 16, 128 voices × 10 sentences, on a
4090 (and 5090), with the KV pool squeezed so Stage-0 must preempt
(`--stage-overrides '{"0":{"gpu_memory_utilization":0.18}}'`, ~3.6x max concurrency):

- **Before:** Stage-0 dies on the first resumed request,
  `RuntimeError: shape '[1, 1]' is invalid for input of size 510`, then
  `EngineDeadError` for everything in flight.
- **After:** `0` reshape crashes; the replay path fires on the resumed span with
  valid indices (logged `ids[min=302 max=2005] vocab=3072`).

## Caveat — not a complete fix for #4471

This removes the `reshape` crash, but it is **necessary, not sufficient**, to make
talker preempt/resume work. With this patch applied, the resumed forward then hits
a CUDA device-side assert in the attention KV-block gather
(`vectorized_gather_kernel index out of bounds`, surfaced in
`gpu_model_runner.get_output`) — a second, independent break in the runner's
resume/block-mapping for the talker, which this model-level patch cannot address.
Until that is fixed too, the practical mitigation is to size Stage-0's KV pool so
preemption never happens (`GPU KV cache size >= max_num_seqs * max_model_len`;
startup "Maximum concurrency ... >= max_num_seqs"). Full two-bug analysis in #4471.
