### PR TITLE
[CI][Rebase]: run full e2e suite in rebase Ready/Merge pipelines in the rebase pipeline[skip-ci]

### DIFF
--- a/.buildkite/rebase-pipeline.yaml
+++ b/.buildkite/rebase-pipeline.yaml
@@ -14,7 +14,7 @@ steps:
     depends_on: image-build
     key: upload-ready-pipeline
     commands:
-      - python3 .buildkite/scripts/upload_pipeline.py --upload .buildkite/test-ready.yml
+      - buildkite-agent pipeline upload .buildkite/test-ready.yml
     agents:
       queue: "cpu_queue_premerge"
 
@@ -23,7 +23,7 @@ steps:
     depends_on: image-build
     key: upload-merge-pipeline
     commands:
-      - python3 .buildkite/scripts/upload_pipeline.py --upload .buildkite/test-merge.yml
+      - buildkite-agent pipeline upload .buildkite/test-merge.yml
     agents:
       queue: "cpu_queue_premerge"
 


### PR DESCRIPTION
## Problem

The rebase gate uploads the **Ready (L2)** and **Merge (L3)** test pipelines via `upload_pipeline.py`, which drops any step whose `source_file_dependencies` don't intersect the changed files (`_filter_steps` in `.buildkite/scripts/upload_pipeline.py`).

For a **main-branch** gate build, `resolve_changed_files()` uses `diff_range = commit^..commit` — i.e. only the files touched by the single HEAD commit. As a result almost every e2e step is filtered out, and the gate is **not comparable** to the `dev/vllm-align` nightly, which takes the `else` path (returns `None` → "safe defaults") and runs the **full** suite.

Concretely, on a recent comparison the `main` gate ran 64 jobs (Ready kept only `TTS · Higgs-Audio-V3`; Merge kept only `Step-Audio2` + `Higgs-Audio V2`), while the `dev/vllm-align` nightly ran 93 jobs with the complete e2e set.

## Change

Upload the Ready/Merge pipelines directly with `buildkite-agent pipeline upload` — exactly as the **Nightly (L4)** step already does — bypassing the `source_file_dependencies` filtering so the rebase CI always runs the complete e2e suite.

## Scope / safety

- Limited to `.buildkite/rebase-pipeline.yaml`, which **only drives the rebase CI**; other pipelines are unaffected.
- The leftover `source_file_dependencies` keys in `test-ready.yml` / `test-merge.yml` are harmless — they're a custom convention read only by `upload_pipeline.py`, and Buildkite ignores unrecognized step keys (this is why the Nightly step already uploads directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)