### PR TITLE
[WIP] Modified the ep_size computation in Omni to align with vLLM's implementation.

### DIFF
--- a/vllm_omni/diffusion/distributed/parallel_state.py
+++ b/vllm_omni/diffusion/distributed/parallel_state.py
@@ -189,8 +189,8 @@ class RankGenerator:
         self.dp = dp
         self.fs = fs
         self.rank_offset = rank_offset
-        self.world_size = tp * sp * pp * cfg * dp
-        self.ep = tp * sp * cfg * dp  # EP level exclude PP
+        self.world_size = tp * sp * pp * (cfg + dp)
+        self.ep = tp * sp * (cfg + dp)  # EP level exclude PP
 
         self.name_to_size = {
             "tp": self.tp,


### PR DESCRIPTION
## Summary

Fix the computation of `world_size` and `ep` size in `RankGenerator`. CFG and DP are **additive** parallel dimensions (a rank participates in either CFG or DP, not both simultaneously), so they should be summed (`cfg + dp`) rather than multiplied (`cfg * dp`).
