### PR TITLE
[Bugfix] Wire log_stats to AsyncOmni and add missing token metrics for non-text requests

### DIFF
--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -530,6 +530,15 @@ class OmniBase(PDDisaggregationMixin):
                     finished_reason=fr,
                 )
 
+                # Token counters — aggregate across all stages for this request.
+                _prompt_tok = 0
+                _gen_tok = 0
+                for evt in metrics.stage_events.get(rid_key, []):
+                    if evt.stage_id == 0:
+                        _prompt_tok += int(evt.num_tokens_in)
+                    _gen_tok += int(evt.num_tokens_out)
+                self.prom_metrics.observe_tokens(_prompt_tok, _gen_tok)
+
                 # Modality observe inside the same finalize guard so it fires
                 # once per request and inherits the try/except isolation.
                 observe_modality_at_finalize(
@@ -578,9 +587,8 @@ class OmniBase(PDDisaggregationMixin):
             if current_stage_metrics is not None:
                 response_metrics["stage_id"] = current_stage_metrics["stage_id"]
                 response_metrics["final_output_type"] = current_stage_metrics["final_output_type"]
-                if current_stage_metrics["final_output_type"] == "text":
-                    response_metrics["num_tokens_in"] = current_stage_metrics["num_tokens_in"]
-                    response_metrics["num_tokens_out"] = current_stage_metrics["num_tokens_out"]
+                response_metrics["num_tokens_in"] = current_stage_metrics["num_tokens_in"]
+                response_metrics["num_tokens_out"] = current_stage_metrics["num_tokens_out"]
         return OmniRequestOutput(
             request_id=req_id or "",
             stage_id=stage_id,

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -296,8 +296,34 @@ class OmniBase(PDDisaggregationMixin):
         try:
             if req_state is None or req_state.metrics is None:
                 return
-            if str(request_id) not in req_state.metrics.e2e_done:
-                self.prom_metrics.request_failed()
+            rid_key = str(request_id)
+            if rid_key not in req_state.metrics.e2e_done:
+                # Fallback finalize for paths where the in-flight guard
+                # in _process_single_result did not fire (e.g. async_chunk
+                # TTS where engine_outputs.finished propagation differs).
+                # stage_events are already populated by on_stage_metrics,
+                # so we can still emit e2e + token counters.
+                _has_stage_events = bool(req_state.metrics.stage_events.get(rid_key))
+                if _has_stage_events:
+                    _final_sid = req_state.metrics.final_stage_id_for_e2e
+                    if isinstance(_final_sid, dict):
+                        _final_sid = _final_sid.get("*", max(_final_sid.values()))
+                    req_state.metrics.on_finalize_request(
+                        _final_sid,
+                        request_id,
+                        req_state.metrics.wall_start_ts,
+                    )
+                    e2e_seconds = time.time() - req_state.metrics.wall_start_ts
+                    self.prom_metrics.request_succeeded(e2e_seconds, finished_reason="stop")
+                    _prompt_tok = 0
+                    _gen_tok = 0
+                    for evt in req_state.metrics.stage_events.get(rid_key, []):
+                        if evt.stage_id == 0:
+                            _prompt_tok += int(evt.num_tokens_in)
+                        _gen_tok += int(evt.num_tokens_out)
+                    self.prom_metrics.observe_tokens(_prompt_tok, _gen_tok)
+                else:
+                    self.prom_metrics.request_failed()
             if self.log_stats:
                 # Emit per-request orchestrator timing (including e2e_total_ms)
                 # before dropping request state.

--- a/vllm_omni/entrypoints/omni_base.py
+++ b/vllm_omni/entrypoints/omni_base.py
@@ -296,34 +296,8 @@ class OmniBase(PDDisaggregationMixin):
         try:
             if req_state is None or req_state.metrics is None:
                 return
-            rid_key = str(request_id)
-            if rid_key not in req_state.metrics.e2e_done:
-                # Fallback finalize for paths where the in-flight guard
-                # in _process_single_result did not fire (e.g. async_chunk
-                # TTS where engine_outputs.finished propagation differs).
-                # stage_events are already populated by on_stage_metrics,
-                # so we can still emit e2e + token counters.
-                _has_stage_events = bool(req_state.metrics.stage_events.get(rid_key))
-                if _has_stage_events:
-                    _final_sid = req_state.metrics.final_stage_id_for_e2e
-                    if isinstance(_final_sid, dict):
-                        _final_sid = _final_sid.get("*", max(_final_sid.values()))
-                    req_state.metrics.on_finalize_request(
-                        _final_sid,
-                        request_id,
-                        req_state.metrics.wall_start_ts,
-                    )
-                    e2e_seconds = time.time() - req_state.metrics.wall_start_ts
-                    self.prom_metrics.request_succeeded(e2e_seconds, finished_reason="stop")
-                    _prompt_tok = 0
-                    _gen_tok = 0
-                    for evt in req_state.metrics.stage_events.get(rid_key, []):
-                        if evt.stage_id == 0:
-                            _prompt_tok += int(evt.num_tokens_in)
-                        _gen_tok += int(evt.num_tokens_out)
-                    self.prom_metrics.observe_tokens(_prompt_tok, _gen_tok)
-                else:
-                    self.prom_metrics.request_failed()
+            if str(request_id) not in req_state.metrics.e2e_done:
+                self.prom_metrics.request_failed()
             if self.log_stats:
                 # Emit per-request orchestrator timing (including e2e_total_ms)
                 # before dropping request state.

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -646,6 +646,7 @@ async def build_async_omni_from_stage_config(
     try:
         kwargs = args.get_explicit_kwargs_dict()
         model = kwargs.pop("model", None) or args.model
+        kwargs.setdefault("log_stats", not args.disable_log_stats)
         async_omni = AsyncOmni(model=model, **kwargs)
 
         # # Don't keep the dummy data in memory

--- a/vllm_omni/metrics/definitions.py
+++ b/vllm_omni/metrics/definitions.py
@@ -114,6 +114,10 @@ E2E_REQUEST_LATENCY_S = METRIC_PREFIX + "e2e_request_latency_s"
 # ``_total`` at exposition time.
 REQUESTS_SUCCESS = METRIC_PREFIX + "requests_success"
 
+# Token counters — aggregated across all pipeline stages per request.
+PROMPT_TOKENS = METRIC_PREFIX + "prompt_tokens"
+GENERATION_TOKENS = METRIC_PREFIX + "generation_tokens"
+
 
 # ============================================================================
 # Audio family (per-stage + per-replica audio path metrics)

--- a/vllm_omni/metrics/prometheus.py
+++ b/vllm_omni/metrics/prometheus.py
@@ -27,6 +27,16 @@ _e2e_latency_family = Histogram(
     labelnames=_labelnames,
     buckets=defs.SECONDS_BUCKETS,
 )
+_prompt_tokens_family = Counter(
+    defs.PROMPT_TOKENS,
+    "Total prompt (input) tokens processed across all pipeline stages.",
+    labelnames=_labelnames,
+)
+_generation_tokens_family = Counter(
+    defs.GENERATION_TOKENS,
+    "Total generation (output) tokens produced across all pipeline stages.",
+    labelnames=_labelnames,
+)
 
 
 class OmniPrometheusMetrics:
@@ -43,6 +53,8 @@ class OmniPrometheusMetrics:
         self._running = _running_family.labels(model_name=model_name)
         self._waiting = _waiting_family.labels(model_name=model_name)
         self._e2e_latency = _e2e_latency_family.labels(model_name=model_name)
+        self._prompt_tokens = _prompt_tokens_family.labels(model_name=model_name)
+        self._generation_tokens = _generation_tokens_family.labels(model_name=model_name)
 
     def set_running(self, n: int) -> None:
         if not self._log_stats:
@@ -53,6 +65,14 @@ class OmniPrometheusMetrics:
         if not self._log_stats:
             return
         self._waiting.set(n)
+
+    def observe_tokens(self, prompt_tokens: int, generation_tokens: int) -> None:
+        if not self._log_stats:
+            return
+        if prompt_tokens > 0:
+            self._prompt_tokens.inc(prompt_tokens)
+        if generation_tokens > 0:
+            self._generation_tokens.inc(generation_tokens)
 
     def request_succeeded(
         self,


### PR DESCRIPTION
## Purpose

Fix #4444 — Token metrics (`num_tokens_in` / `num_tokens_out`) for TTS/audio
requests via `/v1/audio/speech` remain 0 in the Prometheus `/metrics` endpoint.

Investigation revealed **two layers** of issues:

### Layer 1: Missing token Prometheus counters

- No Prometheus Counter families existed for token metrics — added
  `vllm:omni_prompt_tokens_total` and `vllm:omni_generation_tokens_total`.
- `response_metrics` was gated by `final_output_type == "text"`, silently
  dropping token info for audio/image/video requests. Removed the gate.

**Token aggregation semantics:** `prompt_tokens` counts `num_tokens_in` from stage 0 only (the entry stage); `generation_tokens` sums `num_tokens_out` across all stages. This avoids double-counting in multi-stage pipelines.

### Layer 2: All omni-level metrics silently disabled (root cause)

`api_server.py` never passed `log_stats` to `AsyncOmni`, so `OmniBase.__init__`
defaulted it to `False`. Every method in `OmniPrometheusMetrics` starts with
`if not self._log_stats: return` — this silently suppressed **all** omni-level
Prometheus metrics, not just tokens: e2e latency, request success counts, and
the new token counters were all gated off.

Fixed by wiring `not args.disable_log_stats` through to `AsyncOmni`, matching
the upstream vLLM convention (enabled by default, opt-out via
`--disable-log-stats`).

**Files changed:**
- `vllm_omni/metrics/definitions.py` — new metric name constants
- `vllm_omni/metrics/prometheus.py` — new Counter families + `observe_tokens()`
- `vllm_omni/entrypoints/omni_base.py` — call `observe_tokens()` at finalize;
  remove `text`-only gate on response_metrics
- `vllm_omni/entrypoints/openai/api_server.py` — wire `log_stats` to `AsyncOmni`

## Test Plan

- [x] Deploy with Qwen3-TTS, send requests to `/v1/audio/speech`
- [x] `curl /metrics | grep omni_prompt_tokens` → verify counter increments
- [x] `curl /metrics | grep omni_generation_tokens` → verify counter increments
- [x] Verify e2e latency and success counters also report correctly
- [ ] Verify text (chat/completion) requests still report tokens normally
- [x] Verify no regression in audio-specific metrics (duration, RTF, frames)

**vLLM Version:** v0.23.0

**vLLM-Omni Commit:** 188845cc

## Test Result

Verified on RTX 5090 with Qwen3-TTS-12Hz-1.7B-CustomVoice (async_chunk mode):

| Config | prompt_tokens | generation_tokens | e2e/success |
|--------|--------------|-------------------|-------------|
| Before fix (log_stats=False default) | 0.0 | 0.0 | 0 |
| After fix (log_stats wired through) | 17.0 | 21.0 | 1 / 1 |
