### PR TITLE
[Perf]Enable regional compile for Cosmos3 HSDP blocks

### DIFF
--- a/tests/diffusion/test_compile.py
+++ b/tests/diffusion/test_compile.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch.nn as nn
+
+from vllm_omni.diffusion.compile import regionally_compile
+
+
+class _WrappedBlock(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.compile_called = False
+
+    def compile(self, *args, **kwargs):
+        self.compile_called = True
+        return self
+
+
+class _ModelWithWrappedRepeatedBlocks(nn.Module):
+    _repeated_blocks = ["OriginalBlock"]
+    _layerwise_offload_blocks_attrs = ["transformer_blocks"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.transformer_blocks = nn.ModuleList([_WrappedBlock(), _WrappedBlock()])
+        self.other_blocks = nn.ModuleList([_WrappedBlock()])
+
+
+def test_regionally_compile_matches_wrapped_blocks_by_declared_container_attr():
+    model = _ModelWithWrappedRepeatedBlocks()
+
+    regionally_compile(model)
+
+    assert all(block.compile_called for block in model.transformer_blocks)
+    assert not model.other_blocks[0].compile_called

--- a/vllm_omni/diffusion/compile.py
+++ b/vllm_omni/diffusion/compile.py
@@ -8,6 +8,25 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
+def _matches_repeated_block(name: str, module: nn.Module, repeated_blocks: list[str]) -> bool:
+    class_name = module.__class__.__name__
+    if class_name in repeated_blocks:
+        return True
+
+    for attr in ("_fsdp_wrapped_module", "module", "_orig_mod"):
+        wrapped = getattr(module, attr, None)
+        if wrapped is not None and wrapped.__class__.__name__ in repeated_blocks:
+            return True
+
+    parts = name.split(".")
+    return (
+        "Cosmos3GenDecoderLayer" in repeated_blocks
+        and len(parts) >= 2
+        and parts[-2] == "gen_layers"
+        and parts[-1].isdigit()
+    )
+
+
 def regionally_compile(model: nn.Module, *compile_args: Any, **compile_kwargs: Any) -> nn.Module:
     """
     Apply regional compilation to a PyTorch model.
@@ -29,13 +48,21 @@ def regionally_compile(model: nn.Module, *compile_args: Any, **compile_kwargs: A
 
     # Check if we have modules with the specified class names
     has_compiled_region = False
-    for submod in model.modules():
-        if submod.__class__.__name__ in repeated_blocks:
+    compiled_region_count = 0
+    for name, submod in model.named_modules():
+        if _matches_repeated_block(name, submod, repeated_blocks):
             # Compile this submodule
             submod.compile(*compile_args, **compile_kwargs)
             has_compiled_region = True
+            compiled_region_count += 1
 
     if not has_compiled_region:
         logger.warning(f"Regional compilation skipped because {repeated_blocks} classes are not found in the model.")
+    else:
+        logger.info(
+            "Regional compilation applied to %d module(s) for repeated blocks %s.",
+            compiled_region_count,
+            repeated_blocks,
+        )
 
     return model

--- a/vllm_omni/diffusion/compile.py
+++ b/vllm_omni/diffusion/compile.py
@@ -8,7 +8,12 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
-def _matches_repeated_block(name: str, module: nn.Module, repeated_blocks: list[str]) -> bool:
+def _matches_repeated_block(
+    name: str,
+    module: nn.Module,
+    repeated_blocks: list[str],
+    repeated_block_attrs: list[str],
+) -> bool:
     class_name = module.__class__.__name__
     if class_name in repeated_blocks:
         return True
@@ -19,12 +24,7 @@ def _matches_repeated_block(name: str, module: nn.Module, repeated_blocks: list[
             return True
 
     parts = name.split(".")
-    return (
-        "Cosmos3GenDecoderLayer" in repeated_blocks
-        and len(parts) >= 2
-        and parts[-2] == "gen_layers"
-        and parts[-1].isdigit()
-    )
+    return len(parts) >= 2 and parts[-2] in repeated_block_attrs and parts[-1].isdigit()
 
 
 def regionally_compile(model: nn.Module, *compile_args: Any, **compile_kwargs: Any) -> nn.Module:
@@ -46,11 +46,13 @@ def regionally_compile(model: nn.Module, *compile_args: Any, **compile_kwargs: A
         logger.warning("Regional compilation skipped because the model does not define `_repeated_blocks`.")
         return model
 
+    repeated_block_attrs = getattr(model, "_layerwise_offload_blocks_attrs", [])
+
     # Check if we have modules with the specified class names
     has_compiled_region = False
     compiled_region_count = 0
     for name, submod in model.named_modules():
-        if _matches_repeated_block(name, submod, repeated_blocks):
+        if _matches_repeated_block(name, submod, repeated_blocks, repeated_block_attrs):
             # Compile this submodule
             submod.compile(*compile_args, **compile_kwargs)
             has_compiled_region = True


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

#4340 

  Enable regional torch.compile to match Cosmos3 denoising blocks under HSDP.

  Cosmos3 declares Cosmos3GenDecoderLayer as its repeated block, but after HSDP wrapping, the module class name no longer matches the original block class name. As a result, regional compilation was skipped even though the model runner attempted to compile the transformer.

  This change keeps the existing class-name matching path, adds common wrapper unwrapping checks, and falls back to Cosmos3's stable gen_layers.<idx> module path for HSDP-wrapped denoising blocks.

## Test Plan
Cosmos3 I2V 35-step smoke benchmark, 4 GPUs, cfg2 + usp2 + vaepp4 + hsdp

  Setup:

  - Model: nvidia/Cosmos3-Nano
  - Task: I2V
  - Resolution: 1280x720
  - Frames: 189
  - Steps: 35
  - Guidance scale: 6.0
  - Seed: 1234
  - Parallel config: cfg_parallel_size=2, usp=2, vae_patch_parallel_size=4, hsdp_shard_size=4

| Build | wall time |
| -- | -- |
| Before compiled | 275.438s |
| After compiled | 268.396s |

The change improves wall time by ~2.6% in this smoke run.

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

before:

https://github.com/user-attachments/assets/c4ab5b76-f709-46d2-8263-e38c90c173f0

fixed:

https://github.com/user-attachments/assets/8e79fd0d-8394-4caa-8fe6-276ab39a907d

To satisfy the requirement that each size of video should be under 10Mb, the output was idited in 5s.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
