### PR TITLE
[TTS][New Model] support sesame/csm-1b

### DIFF
--- a/.buildkite/test-merge.yml
+++ b/.buildkite/test-merge.yml
@@ -315,6 +315,23 @@ steps:
                       path: /mnt/hf-cache
                       type: DirectoryOrCreate
 
+      - label: "TTS · CSM-1B Test"
+        source_file_dependencies:
+          - tests/e2e/offline_inference/test_csm.py
+          - vllm_omni/model_executor/models/csm/
+          - vllm_omni/model_executor/stage_input_processors/csm.py
+          - vllm_omni/entrypoints/openai/tts_adapters/csm.py
+          - vllm_omni/deploy/csm.yaml
+        timeout_in_minutes: 20
+        commands:
+          - |
+            timeout 20m bash -c "
+              export VLLM_LOGGING_LEVEL=DEBUG
+              pytest -s -v tests/e2e/offline_inference/test_csm.py -m 'advanced_model and cuda' --run-level 'advanced_model'
+            "
+        agents:
+          queue: "mithril-h100-pool"
+
       - label: "TTS · GLM-TTS Test"
         source_file_dependencies:
           - tests/e2e/online_serving/test_glm_tts.py

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -51,6 +51,7 @@ th {
 | `StableDiffusionXLPipeline` | Stable-Diffusion-XL | `stabilityai/stable-diffusion-xl-base-1.0` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `StableDiffusion3Pipeline` | Stable-Diffusion-3 | `stabilityai/stable-diffusion-3.5-medium` | ✅︎ | ✅︎ | | ✅︎ |
 | `CosyVoice3Model` | CosyVoice3 | `FunAudioLLM/Fun-CosyVoice3-0.5B-2512` | ✅︎ | ✅︎ | | ✅︎ |
+| `CsmForConditionalGeneration` | CSM-1B | `sesame/csm-1b` | ✅︎ | | | |
 | `OmniVoiceModel` | OmniVoice | `k2-fsa/OmniVoice` | ✅︎ | | | |
 | `VoxCPM2TalkerForConditionalGeneration` | VoxCPM2 | `openbmb/VoxCPM2` | ✅︎ | | | |
 | `MammothModa2ForConditionalGeneration` | MammothModa2-Preview | `bytedance-research/MammothModa2-Preview` | ✅︎ | ✅︎ | | |

--- a/examples/offline_inference/text_to_speech/README.md
+++ b/examples/offline_inference/text_to_speech/README.md
@@ -95,6 +95,26 @@ Streaming is enabled by default via `async_chunk: true` in `vllm_omni/deploy/cos
 
 ---
 
+## CSM-1B
+
+2-stage TTS pipeline (Llama-3.2-1B backbone + Kyutai Mimi vocoder) at 24 kHz. Plain text to speech with single-speaker conditioning; no reference-audio voice cloning on this path.
+
+### Quick start
+```bash
+python examples/offline_inference/text_to_speech/csm/end2end.py \
+    --text "The quick brown fox jumps over the lazy dog." \
+    --speaker 0 \
+    --output-dir ./output
+```
+
+### Notes
+- `sesame/csm-1b` is gated; accept its license on Hugging Face first.
+- Single default speaker; `--speaker` is a non-negative integer id.
+- `--max-new-tokens` caps frames (1 frame == 80 ms); the model also stops on its own end-of-speech frame.
+- Eager, no CUDA graph in this first pass.
+
+---
+
 ## GLM-TTS
 
 2-stage TTS pipeline (AR + DiT flow-matching) at 24 kHz. Every request requires reference audio and its transcript for zero-shot voice cloning.

--- a/examples/offline_inference/text_to_speech/README.md
+++ b/examples/offline_inference/text_to_speech/README.md
@@ -15,6 +15,7 @@ list of supported architectures across all modalities, see
 | Model | HuggingFace repo | Stages | Voice cloning | Streaming | Special modes | Sample rate |
 |---|---|---|---|---|---|---|
 | CosyVoice3 | `FunAudioLLM/Fun-CosyVoice3-0.5B-2512` | 2 (talker + code2wav) | ✓ | ✓ | — | 24 kHz |
+| CSM-1B | `sesame/csm-1b` | 2 (backbone + Mimi) | — | — | — | 24 kHz |
 | Fish Speech S2 Pro | `fishaudio/s2-pro` | dual-AR | ✓ | ✓ | — | 44.1 kHz |
 | GLM-TTS | `zai-org/GLM-TTS` | 2 (AR + DiT) | ✓ (required) | ✓ | — | 24 kHz |
 | Ming-omni-tts | `inclusionAI/Ming-omni-tts-0.5B` | 2 (AR + audio VAE) | ✓ | ✓ | style / IP / dialect / TTA / podcast | 44.1 kHz |

--- a/examples/offline_inference/text_to_speech/csm/end2end.py
+++ b/examples/offline_inference/text_to_speech/csm/end2end.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CSM-1B (Sesame) End-to-End Offline Inference Example.
+
+CSM-1B is a two-stage TTS model:
+  - Stage 0 (AR): a Llama-3.2-1B backbone samples codebook-0 per 80 ms frame and
+    runs a 31-step depth decoder inline to complete the 32-code Mimi frame.
+  - Stage 1: the Mimi vocoder decodes the frames to 24 kHz audio.
+
+Plain text to speech with speaker-id conditioning (no reference-audio voice
+cloning on this path); the OpenAI-style ``voice`` field maps to a CSM speaker id.
+
+Usage:
+    python examples/offline_inference/text_to_speech/csm/end2end.py \
+        --model sesame/csm-1b \
+        --text "The quick brown fox jumps over the lazy dog." \
+        --speaker 0 \
+        --output-dir ./output
+"""
+
+import logging
+import os
+import time
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+import torch
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+from vllm_omni import Omni
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DEPLOY_CONFIG = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "..", "vllm_omni", "deploy", "csm.yaml"
+)
+SAMPLE_RATE = 24000
+# CSM's inline-depth AR loop has no reliable natural EOS; bound length with the
+# same cap the served path uses (64 frames == 5.12 s at 80 ms/frame).
+DEFAULT_MAX_FRAMES = 64
+
+
+def _concat_audio(audio_val: Any) -> np.ndarray:
+    """Concatenate audio tensors from the multimodal output."""
+    if isinstance(audio_val, list):
+        tensors = [torch.as_tensor(t).float().reshape(-1) for t in audio_val if t is not None]
+        if not tensors:
+            return np.zeros((0,), dtype=np.float32)
+        return torch.cat(tensors, dim=-1).cpu().numpy().astype(np.float32, copy=False)
+    if isinstance(audio_val, torch.Tensor):
+        return audio_val.float().cpu().numpy().reshape(-1)
+    return np.asarray(audio_val, dtype=np.float32).reshape(-1)
+
+
+def _extract_sample_rate(audio_mm: dict) -> int:
+    sr_raw = audio_mm.get("sr", SAMPLE_RATE)
+    if isinstance(sr_raw, list):
+        sr_raw = sr_raw[-1] if sr_raw else SAMPLE_RATE
+    if hasattr(sr_raw, "item"):
+        return int(sr_raw.item())
+    return int(sr_raw)
+
+
+def _build_csm_input(model: str, text: str, speaker: str, max_frames: int) -> dict:
+    """Build the Stage-0 backbone prompt: ``<|begin_of_text|>[<spk>]<text><|end_of_text|>``.
+
+    The backbone reads the ids back out of ``additional_information`` via ``_pick``
+    (batch-of-1 convention), so every field is list-wrapped. Greedy (temperature 0,
+    top_k 0) matches the served path and the bit-parity tests.
+    """
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model, trust_remote_code=True)
+    tagged = f"<|begin_of_text|>[{speaker}]{text}<|end_of_text|>"
+    prompt_token_ids = list(tokenizer(tagged, add_special_tokens=False)["input_ids"])
+    return {
+        "prompt_token_ids": prompt_token_ids,
+        "additional_information": {
+            "prompt_token_ids": [prompt_token_ids],
+            "temperature": [0.0],
+            "top_k": [0],
+            "max_new_frames": [max_frames],
+        },
+    }
+
+
+def main(args):
+    """Run offline CSM-1B inference."""
+    os.makedirs(args.output_dir, exist_ok=True)
+    deploy_config_path = args.deploy_config or DEFAULT_DEPLOY_CONFIG
+    max_frames = args.max_new_tokens or DEFAULT_MAX_FRAMES
+
+    inputs = [_build_csm_input(args.model, args.text, str(args.speaker), max_frames)]
+
+    omni = Omni(
+        model=args.model,
+        stage_configs_path=deploy_config_path,
+        log_stats=args.log_stats,
+        stage_init_timeout=args.stage_init_timeout,
+    )
+
+    t_start = time.perf_counter()
+    outputs = omni.generate(inputs)
+    elapsed = (time.perf_counter() - t_start) * 1000
+
+    assert outputs, "No outputs returned"
+    audio_mm = outputs[0].multimodal_output
+    assert "audio" in audio_mm, "No audio output found"
+
+    audio = _concat_audio(audio_mm["audio"])
+    sr = _extract_sample_rate(audio_mm)
+    out_path = os.path.join(args.output_dir, "output.wav")
+    sf.write(out_path, audio, samplerate=sr, format="WAV")
+
+    logger.info("Saved %s (%.2fs @ %dHz)", out_path, len(audio) / sr, sr)
+    logger.info("Total inference: %.1f ms", elapsed)
+
+
+def parse_args():
+    parser = FlexibleArgumentParser(description="CSM-1B Text-to-Speech Example")
+    parser.add_argument("--model", type=str, default="sesame/csm-1b", help="Model path or HF id")
+    parser.add_argument("--text", type=str, default="The quick brown fox jumps over the lazy dog.")
+    parser.add_argument("--speaker", type=str, default="0", help="CSM speaker id (non-negative integer)")
+    parser.add_argument("--output-dir", type=str, default="./output")
+    parser.add_argument("--max-new-tokens", type=int, default=None, help="Max frames to generate (1 frame == 80 ms)")
+    parser.add_argument("--deploy-config", type=str, default=None)
+    parser.add_argument("--log-stats", action="store_true")
+    parser.add_argument("--stage-init-timeout", type=int, default=600)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    main(parse_args())

--- a/examples/online_serving/text_to_speech/README.md
+++ b/examples/online_serving/text_to_speech/README.md
@@ -14,6 +14,7 @@ For the full list of supported architectures across all modalities, see
 
 | Model | HuggingFace repo | Voice cloning | Streaming | Voice presets / upload | Gradio demo |
 |---|---|---|---|---|---|
+| CSM-1B | `sesame/csm-1b` | — | — (async-chunk follow-up) | — | — |
 | Fish Speech S2 Pro | `fishaudio/s2-pro` | ✓ (`ref_audio`+`ref_text`) | ✓ (PCM stream) | — | ✓ |
 | GLM-TTS | `zai-org/GLM-TTS` | ✓ (`ref_audio`+`ref_text`, required) | ✓ (PCM stream) | — | ✓ |
 | Ming-omni-tts | `inclusionAI/Ming-omni-tts-0.5B` | ✓ (`ref_audio` / `speaker_embedding`) | ✓ (PCM stream) | IP labels + structured `instructions` | — |
@@ -93,6 +94,34 @@ curl -X POST http://localhost:8091/v1/audio/speech \
 Adjust the player's sample rate to match the model (44.1 kHz for Fish Speech, 48 kHz for VoxCPM2, 24 kHz for the others).
 
 For full request-shape documentation (all parameters, response formats, error codes), see the [Speech API reference](../../../docs/serving/speech_api.md).
+
+---
+
+## CSM-1B
+
+Plain text to speech (Llama-3.2-1B backbone + Kyutai Mimi vocoder) at 24 kHz, single default speaker. The OpenAI `voice` field maps to a CSM speaker id (a non-negative integer string, default `"0"`); no reference-audio voice cloning on this path.
+
+### Launch
+```bash
+vllm-omni serve sesame/csm-1b --deploy-config vllm_omni/deploy/csm.yaml --omni --trust-remote-code --port 8091
+# or:
+./csm/run_server.sh
+```
+
+### CLI client
+```bash
+cd examples/online_serving/text_to_speech/csm
+# Non-streaming WAV
+python speech_client.py --text "Hello from CSM." --output out.wav
+# Cap the length (frames; 1 frame == 80 ms)
+python speech_client.py --text "A longer line." --max-new-tokens 128
+```
+The client supports `--api-base`, `--model`, `--text`, `--voice`, `--response-format`, `--max-new-tokens`, `--seed`, `--stream`, and `--output`.
+
+### Notes
+- `sesame/csm-1b` is gated; accept its license on Hugging Face first.
+- `voice` is a CSM speaker id (non-negative integer string), default `"0"`.
+- `stream=true` currently returns the full clip after generation (no early time-to-first-audio); incremental async-chunk streaming is a follow-up.
 
 ---
 

--- a/examples/online_serving/text_to_speech/csm/run_server.sh
+++ b/examples/online_serving/text_to_speech/csm/run_server.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Launch a vLLM-Omni server for CSM-1B (Sesame) text-to-speech.
+#
+# CSM-1B is a 2-stage TTS model: Stage 0 is a Llama-style backbone AR that
+# samples codebook-0 per 80 ms frame and runs a 31-step depth decoder inline to
+# produce the full 32-code frame; Stage 1 is the Mimi vocoder (code2wav). The
+# stage topology + per-stage GPU memory split is defined in the deploy config.
+#
+# Usage:
+#   ./run_server.sh
+#   PORT=8091 ./run_server.sh
+#   HF_HUB_OFFLINE=1 ./run_server.sh        # use only the local checkpoint cache
+
+set -e
+
+MODEL="${MODEL:-sesame/csm-1b}"
+PORT="${PORT:-8091}"
+
+echo "Starting CSM-1B server with model: $MODEL"
+
+vllm-omni serve "$MODEL" \
+    --deploy-config vllm_omni/deploy/csm.yaml \
+    --host 0.0.0.0 \
+    --port "$PORT" \
+    --trust-remote-code \
+    --omni

--- a/examples/online_serving/text_to_speech/csm/speech_client.py
+++ b/examples/online_serving/text_to_speech/csm/speech_client.py
@@ -1,0 +1,110 @@
+"""Client for CSM-1B (Sesame) text-to-speech via the /v1/audio/speech endpoint.
+
+CSM-1B is a plain text -> speech model with speaker-id conditioning. The OpenAI
+``voice`` field maps to a CSM speaker id (a non-negative integer string, default
+"0"); there are no named voice presets and no reference-audio voice cloning on
+this path.
+
+Examples:
+    # Non-streaming WAV
+    python speech_client.py --text "Hello from CSM." --output out.wav
+
+    # Streaming PCM (24 kHz, mono, s16le); prints time-to-first-audio-byte
+    python speech_client.py --text "Hello from CSM." --stream --output out.pcm
+
+    # Cap the generation length (frames; 1 frame == 80 ms)
+    python speech_client.py --text "A longer line." --max-new-tokens 64
+"""
+
+import argparse
+import time
+
+import httpx
+
+DEFAULT_API_BASE = "http://localhost:8091"
+DEFAULT_API_KEY = "EMPTY"
+DEFAULT_MODEL = "sesame/csm-1b"
+
+# CSM / Mimi output audio is 24 kHz mono s16le PCM.
+SAMPLE_RATE = 24000
+
+
+def run_tts(args) -> None:
+    """Generate speech via the /v1/audio/speech API."""
+    payload: dict = {
+        "model": args.model,
+        "input": args.text,
+        "voice": args.voice,
+        "response_format": args.response_format,
+    }
+    if args.max_new_tokens is not None:
+        payload["max_new_tokens"] = args.max_new_tokens
+    if args.seed is not None:
+        payload["seed"] = args.seed
+
+    api_url = f"{args.api_base}/v1/audio/speech"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {args.api_key}",
+    }
+
+    print(f"Model: {args.model}")
+    print(f"Text: {args.text!r}  speaker={args.voice}")
+
+    if args.stream:
+        payload["stream"] = True
+        payload["response_format"] = "pcm"
+        output_path = args.output or "output.pcm"
+        total = 0
+        t0 = time.perf_counter()
+        ttfa_ms = None
+        with httpx.Client(timeout=300.0) as client:
+            with client.stream("POST", api_url, json=payload, headers=headers) as resp:
+                if resp.status_code != 200:
+                    print(f"Error {resp.status_code}: {resp.read().decode(errors='replace')}")
+                    return
+                with open(output_path, "wb") as f:
+                    for chunk in resp.iter_bytes():
+                        if not chunk:
+                            continue
+                        if ttfa_ms is None:
+                            ttfa_ms = (time.perf_counter() - t0) * 1000.0
+                        total += len(chunk)
+                        f.write(chunk)
+        dur_s = total / (SAMPLE_RATE * 2)  # 2 bytes/sample, mono
+        print(f"Streamed {total} PCM bytes (~{dur_s:.2f}s audio) -> {output_path}")
+        if ttfa_ms is not None:
+            print(f"Time-to-first-audio-byte (streamed TTFA): {ttfa_ms:.1f} ms")
+        print(f"Play with: ffplay -f s16le -ar {SAMPLE_RATE} -ch_layout mono {output_path}")
+        return
+
+    output_path = args.output or "output.wav"
+    t0 = time.perf_counter()
+    with httpx.Client(timeout=300.0) as client:
+        resp = client.post(api_url, json=payload, headers=headers)
+    if resp.status_code != 200:
+        print(f"Error {resp.status_code}: {resp.text}")
+        return
+    with open(output_path, "wb") as f:
+        f.write(resp.content)
+    print(f"Wrote {len(resp.content)} bytes -> {output_path} in {(time.perf_counter() - t0):.2f}s")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CSM-1B TTS client")
+    parser.add_argument("--api-base", default=DEFAULT_API_BASE)
+    parser.add_argument("--api-key", default=DEFAULT_API_KEY)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--text", default="Hello, this is CSM speaking from vLLM Omni.")
+    parser.add_argument("--voice", default="0", help="CSM speaker id (non-negative integer string)")
+    parser.add_argument("--response-format", default="wav", choices=["wav", "pcm"])
+    parser.add_argument("--stream", action="store_true", help="Stream PCM and report TTFA")
+    parser.add_argument("--max-new-tokens", type=int, default=None, help="Frame cap (1 frame == 80 ms)")
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--output", default=None)
+    args = parser.parse_args()
+    run_tts(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/offline_inference/test_csm.py
+++ b/tests/e2e/offline_inference/test_csm.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""E2E offline inference test for CSM-1B (Sesame).
+
+CSM-1B is a plain text to speech model (speaker-id conditioning, no reference
+audio on this path). Two-stage pipeline: backbone AR + inline 31-step depth
+decoder, then the Mimi vocoder (code2wav) at 24 kHz.
+"""
+
+import os
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+os.environ["VLLM_TEST_CLEAN_GPU_MEMORY"] = "0"
+
+import numpy as np
+import pytest
+import torch
+
+from tests.helpers.mark import hardware_test
+from tests.helpers.stage_config import get_deploy_config_path, modify_stage_config
+
+MODEL = os.environ.get("CSM_MODEL_PATH", "sesame/csm-1b")
+DEPLOY_CONFIG = get_deploy_config_path("csm.yaml")
+_DEFAULT_MAX_FRAMES = 64
+
+
+def _concat_audio(audio_val) -> np.ndarray:
+    if isinstance(audio_val, list):
+        tensors = [torch.as_tensor(t).float().reshape(-1) for t in audio_val if t is not None]
+        if not tensors:
+            return np.zeros((0,), dtype=np.float32)
+        return torch.cat(tensors, dim=-1).cpu().numpy().astype(np.float32, copy=False)
+    if isinstance(audio_val, torch.Tensor):
+        return audio_val.float().cpu().numpy().reshape(-1)
+    return np.asarray(audio_val, dtype=np.float32).reshape(-1)
+
+
+def _extract_sample_rate(audio_mm: dict) -> int:
+    sr_raw = audio_mm.get("sr", 24000)
+    if isinstance(sr_raw, list):
+        sr_raw = sr_raw[-1] if sr_raw else 24000
+    if hasattr(sr_raw, "item"):
+        return int(sr_raw.item())
+    return int(sr_raw)
+
+
+def _build_csm_input(text: str, speaker: str = "0", max_frames: int = _DEFAULT_MAX_FRAMES) -> dict:
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL, trust_remote_code=True)
+    tagged = f"<|begin_of_text|>[{speaker}]{text}<|end_of_text|>"
+    ids = list(tokenizer(tagged, add_special_tokens=False)["input_ids"])
+    return {
+        "prompt_token_ids": ids,
+        "additional_information": {
+            "prompt_token_ids": [ids],
+            "temperature": [0.0],
+            "top_k": [0],
+            "max_new_frames": [max_frames],
+        },
+    }
+
+
+def _get_deploy_config() -> str:
+    """CSM deploy with both stages eager (matches the example + first-pass deploy)."""
+    return modify_stage_config(
+        DEPLOY_CONFIG,
+        updates={"stages": {0: {"enforce_eager": True}, 1: {"enforce_eager": True}}},
+    )
+
+
+@pytest.mark.advanced_model
+@pytest.mark.omni
+@hardware_test(res={"cuda": "H100"}, num_cards=1)
+def test_offline_text_to_speech() -> None:
+    """Plain text to speech offline.
+
+    Deploy: csm.yaml, both stages eager.
+    Input modal: text (speaker-id conditioning).
+    Output modal: 24 kHz audio, bounded by the per-request frame cap.
+    """
+    from tests.helpers.runtime import OmniRunner
+
+    with OmniRunner(
+        MODEL,
+        stage_configs_path=_get_deploy_config(),
+        stage_init_timeout=600,
+    ) as omni_runner:
+        outputs = omni_runner.omni.generate(
+            [_build_csm_input("The quick brown fox jumps over the lazy dog.")],
+            omni_runner.get_default_sampling_params_list(),
+        )
+
+    assert outputs, "No outputs returned"
+    audio_mm = outputs[0].multimodal_output
+    assert "audio" in audio_mm, "No audio output found"
+    audio = _concat_audio(audio_mm["audio"])
+    sr = _extract_sample_rate(audio_mm)
+    assert sr == 24000, f"Unexpected sample rate {sr}"
+    assert audio.size > 0, "Empty audio"
+    assert np.isfinite(audio).all(), "Non-finite audio samples"
+    # 64-frame cap at 80 ms/frame is up to ~5.12 s; expect a plausible clip.
+    assert audio.size / sr > 0.3, f"Implausibly short audio: {audio.size / sr:.2f}s"

--- a/tests/model_executor/models/csm/test_csm_backbone.py
+++ b/tests/model_executor/models/csm/test_csm_backbone.py
@@ -185,7 +185,19 @@ def test_forward_returns_omni_output_with_codes_latent(monkeypatch):
 # --------------------------------------------------------------------------
 
 
-def test_preprocess_decode_adds_cached_sigma_to_base_embed():
+def test_preprocess_decode_uses_cached_sigma_alone():
+    """REGRESSION GUARD (served-path fidelity): the decode-step backbone input is
+    the FULL previous-frame Sigma-embed ALONE, not ``base_cb0_embed + cached``.
+
+    HF ``CsmBackboneModelEmbeddings.forward`` builds a position's input as
+    ``embed_audio_tokens(codes + audio_tokens_offsets).sum(dim=2)`` over all 32
+    codebooks, and during AR generation that position's codes ARE the previously
+    generated frame. The cached Sigma is exactly that sum (cb0 is already its
+    k=0 term). Adding a separate cb0 base embed on top double-counts codebook 0
+    every decode step, compounds through the KV cache, and derails the rollout
+    (audio degrades after the first word, runs past EOS, over-loud). So the
+    composed decode embedding MUST equal the cached Sigma (5.0), NOT
+    base(2.0)+cached(5.0)=7.0."""
     m = _make_backbone()
     m.config = SimpleNamespace(vocab_size=2051)
     m._compose_frame_embed = lambda fc: torch.full((1, _HIDDEN), 2.0)
@@ -197,8 +209,8 @@ def test_preprocess_decode_adds_cached_sigma_to_base_embed():
         _omni_is_prefill=False,
     )
     assert torch.equal(ids, torch.tensor([7]))
-    # base (2.0) + cached Sigma (5.0) == 7.0 elementwise.
-    torch.testing.assert_close(embeds, torch.full((1, _HIDDEN), 7.0))
+    # Cached Sigma (5.0) ALONE. If this is 7.0 again, cb0 is being double-counted.
+    torch.testing.assert_close(embeds, torch.full((1, _HIDDEN), 5.0))
     assert upd == {}
 
 

--- a/tests/model_executor/models/csm/test_csm_backbone.py
+++ b/tests/model_executor/models/csm/test_csm_backbone.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU correctness tests for the CSM-1B Stage-0 backbone control logic.
+
+These lock the three places the 2-stage redesign is subtle, all reachable on
+CPU by building the model via ``object.__new__`` + stubbing the vLLM-native
+backbone / depth wrapper:
+
+  * ``compute_logits`` EOS row-mapping (the "unknown #2" fix): EOS is forced
+    POSITIONALLY on ``_eos_flags_by_row`` rows, never by dict insertion order.
+  * ``forward`` EOS / GATE-B frame-cap emit policy: a natural all-zero EOS frame
+    is DROPPED (empty latent) while a cap-forced stop KEEPS its real audio frame;
+    both latch the row so the scheduler stops.
+  * I5 per-request state: ``preprocess`` decode re-injects the cached Sigma-embed,
+    and ``on_requests_finished`` frees every per-request dict.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm_omni.model_executor.models.csm.csm_backbone import (
+    _CODEBOOK_EOS_ID,
+    CsmBackboneForConditionalGeneration,
+)
+from vllm_omni.model_executor.models.output_templates import OmniOutput
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_VOCAB = 8
+_HIDDEN = 8
+
+
+class _FakeLogitsProcessor:
+    """Deterministic per-row logits so EOS overrides are checkable. Row i gets a
+    strictly-increasing ramp offset by i, so its natural argmax is the last id
+    (never id 0), making a forced-EOS (argmax -> 0) unambiguous."""
+
+    def __call__(self, head, hidden):
+        n = int(hidden.shape[0])
+        return torch.arange(n * _VOCAB, dtype=torch.float32).reshape(n, _VOCAB)
+
+
+def _make_backbone() -> CsmBackboneForConditionalGeneration:
+    m = object.__new__(CsmBackboneForConditionalGeneration)
+    nn.Module.__init__(m)
+    m.num_codebooks = 32
+    m.hidden_size = _HIDDEN
+    m._backbone_dtype = torch.float32
+    m._dtype = torch.float32
+    m._eos_flags_by_row = []
+    m._eos_by_req = {}
+    m._cached_sigma_by_req = {}
+    m._sampling_by_req = {}
+    m._max_frames_by_req = {}
+    m._frames_emitted_by_req = {}
+    m.backbone = SimpleNamespace(logits_processor=_FakeLogitsProcessor(), cb0_head=object())
+    return m
+
+
+# --------------------------------------------------------------------------
+# compute_logits: positional EOS row mapping
+# --------------------------------------------------------------------------
+
+
+def test_compute_logits_forces_eos_on_flagged_rows_only():
+    m = _make_backbone()
+    m._eos_flags_by_row = [False, True, False]
+    logits = m.compute_logits(torch.randn(3, _HIDDEN))
+
+    assert logits.shape == (3, _VOCAB)
+    # Flagged row 1 -> all -inf except the EOS id, set to a huge positive.
+    assert int(logits[1].argmax()) == _CODEBOOK_EOS_ID
+    assert logits[1, _CODEBOOK_EOS_ID].item() == pytest.approx(1.0e6)
+    others = torch.cat([logits[1, :_CODEBOOK_EOS_ID], logits[1, _CODEBOOK_EOS_ID + 1 :]])
+    assert torch.isneginf(others).all()
+    # Unflagged rows are untouched (finite ramp, argmax != EOS id).
+    assert torch.isfinite(logits[0]).all() and int(logits[0].argmax()) != _CODEBOOK_EOS_ID
+    assert torch.isfinite(logits[2]).all() and int(logits[2].argmax()) != _CODEBOOK_EOS_ID
+
+
+def test_compute_logits_none_hidden_returns_none():
+    assert _make_backbone().compute_logits(None) is None
+
+
+def test_compute_logits_unsqueezes_1d_hidden():
+    out = _make_backbone().compute_logits(torch.randn(_HIDDEN))
+    assert out.shape == (1, _VOCAB)
+
+
+def test_compute_logits_accepts_omni_output():
+    m = _make_backbone()
+    m._eos_flags_by_row = [False, False]
+    oo = OmniOutput(text_hidden_states=torch.randn(2, _HIDDEN), multimodal_outputs=None)
+    assert m.compute_logits(oo).shape == (2, _VOCAB)
+
+
+def test_compute_logits_tolerates_flags_shorter_than_batch():
+    # Stale/short flag list must not crash or touch unflagged rows.
+    m = _make_backbone()
+    m._eos_flags_by_row = [True]  # only row 0
+    logits = m.compute_logits(torch.randn(3, _HIDDEN))
+    assert int(logits[0].argmax()) == _CODEBOOK_EOS_ID
+    assert torch.isfinite(logits[1]).all()
+    assert torch.isfinite(logits[2]).all()
+
+
+# --------------------------------------------------------------------------
+# forward: EOS / GATE-B frame-cap emit policy
+# --------------------------------------------------------------------------
+
+
+def _drive_forward(monkeypatch, frame, *, cap, emitted=0):
+    m = _make_backbone()
+    m._sampling_by_req = {"r0": (0.0, 0)}  # greedy -> deterministic cb0
+    m._max_frames_by_req = {"r0": cap}
+    m._frames_emitted_by_req = {"r0": emitted}
+    m.backbone.forward = lambda **kw: torch.randn(1, _HIDDEN)
+    m.depth = SimpleNamespace(run=lambda **kw: frame)
+    m._compose_frame_embed = lambda fc: torch.zeros(1, _HIDDEN)
+    monkeypatch.setattr(
+        "vllm.forward_context.get_forward_context",
+        lambda: SimpleNamespace(attn_metadata=None),
+    )
+    out = m.forward(
+        input_ids=torch.tensor([5], dtype=torch.long),
+        positions=torch.tensor([0]),
+        inputs_embeds=torch.zeros(1, _HIDDEN),
+        runtime_additional_information=[{"request_id": "r0"}],
+    )
+    return m, out
+
+
+def test_forward_natural_eos_drops_frame_and_flags_row(monkeypatch):
+    frame = torch.zeros(1, 32, dtype=torch.long)  # cb0..cb30 == 0 -> natural EOS
+    m, out = _drive_forward(monkeypatch, frame, cap=100)
+    codes = out.multimodal_outputs["codes"]["audio"]
+    assert codes[0].shape == (0, 32)  # all-zero EOS frame is dropped
+    assert m._eos_flags_by_row == [True]
+    assert m._eos_by_req["r0"] is True
+
+
+def test_forward_eos_ignores_codebook31(monkeypatch):
+    # EOS is cb0..cb30 all-zero; a nonzero cb31 must NOT defeat the EOS check.
+    frame = torch.zeros(1, 32, dtype=torch.long)
+    frame[0, 31] = 9
+    m, out = _drive_forward(monkeypatch, frame, cap=100)
+    assert m._eos_flags_by_row == [True]
+    assert out.multimodal_outputs["codes"]["audio"][0].shape == (0, 32)
+
+
+def test_forward_cap_forced_keeps_real_frame_and_flags_row(monkeypatch):
+    frame = torch.ones(1, 32, dtype=torch.long)  # real audio, no natural EOS
+    m, out = _drive_forward(monkeypatch, frame, cap=1, emitted=0)
+    codes = out.multimodal_outputs["codes"]["audio"]
+    assert codes[0].shape == (1, 32)  # cap-forced stop KEEPS the final frame
+    assert torch.equal(codes[0], frame)
+    assert m._eos_flags_by_row == [True]  # but still stops the scheduler
+    assert m._frames_emitted_by_req["r0"] == 1
+
+
+def test_forward_normal_frame_is_kept_and_not_flagged(monkeypatch):
+    frame = torch.ones(1, 32, dtype=torch.long)
+    m, out = _drive_forward(monkeypatch, frame, cap=100, emitted=0)
+    codes = out.multimodal_outputs["codes"]["audio"]
+    assert codes[0].shape == (1, 32)
+    assert m._eos_flags_by_row == [False]
+    assert m._eos_by_req["r0"] is False
+    # Sigma cached for the next step's feedback (I5), frame counter advanced.
+    assert "r0" in m._cached_sigma_by_req
+    assert m._frames_emitted_by_req["r0"] == 1
+
+
+def test_forward_returns_omni_output_with_codes_latent(monkeypatch):
+    m, out = _drive_forward(monkeypatch, torch.ones(1, 32, dtype=torch.long), cap=100)
+    assert isinstance(out, OmniOutput)
+    assert "codes" in out.multimodal_outputs
+    assert "audio" in out.multimodal_outputs["codes"]
+
+
+# --------------------------------------------------------------------------
+# I5 per-request state: preprocess Sigma re-inject + cleanup
+# --------------------------------------------------------------------------
+
+
+def test_preprocess_decode_adds_cached_sigma_to_base_embed():
+    m = _make_backbone()
+    m.config = SimpleNamespace(vocab_size=2051)
+    m._compose_frame_embed = lambda fc: torch.full((1, _HIDDEN), 2.0)
+    m._cached_sigma_by_req = {"r0": torch.full((1, _HIDDEN), 5.0)}
+    ids, embeds, upd = m.preprocess(
+        input_ids=torch.tensor([7], dtype=torch.long),
+        input_embeds=None,
+        request_id="r0",
+        _omni_is_prefill=False,
+    )
+    assert torch.equal(ids, torch.tensor([7]))
+    # base (2.0) + cached Sigma (5.0) == 7.0 elementwise.
+    torch.testing.assert_close(embeds, torch.full((1, _HIDDEN), 7.0))
+    assert upd == {}
+
+
+def test_preprocess_decode_without_cache_uses_base_embed_only():
+    m = _make_backbone()
+    m.config = SimpleNamespace(vocab_size=2051)
+    m._compose_frame_embed = lambda fc: torch.full((1, _HIDDEN), 2.0)
+    m._cached_sigma_by_req = {}
+    _, embeds, _ = m.preprocess(
+        input_ids=torch.tensor([7], dtype=torch.long),
+        input_embeds=None,
+        request_id="r0",
+        _omni_is_prefill=False,
+    )
+    torch.testing.assert_close(embeds, torch.full((1, _HIDDEN), 2.0))
+
+
+def test_preprocess_prefill_returns_text_prompt_span():
+    m = _make_backbone()
+    m.config = SimpleNamespace(vocab_size=2051)
+    prompt = torch.arange(3 * _HIDDEN, dtype=torch.float32).reshape(3, _HIDDEN)
+    m._embed_text_prompt = lambda info, device: prompt
+    ids, embeds, upd = m.preprocess(
+        input_ids=torch.tensor([1, 2, 3], dtype=torch.long),
+        input_embeds=None,
+        request_id="rp",
+        _omni_is_prefill=True,
+        _omni_num_computed_tokens=0,
+        _omni_prompt_len=3,
+    )
+    assert embeds.shape == (3, _HIDDEN)
+    torch.testing.assert_close(embeds, prompt)
+    assert upd == {}
+
+
+def test_on_requests_finished_frees_all_per_request_state():
+    m = _make_backbone()
+    m._cached_sigma_by_req = {"r": torch.zeros(1)}
+    m._eos_by_req = {"r": True}
+    m._sampling_by_req = {"r": (0.9, 50)}
+    m._max_frames_by_req = {"r": 64}
+    m._frames_emitted_by_req = {"r": 5}
+    m.on_requests_finished(["r"])
+    assert m._cached_sigma_by_req == {}
+    assert m._eos_by_req == {}
+    assert m._sampling_by_req == {}
+    assert m._max_frames_by_req == {}
+    assert m._frames_emitted_by_req == {}

--- a/tests/model_executor/models/csm/test_csm_config.py
+++ b/tests/model_executor/models/csm/test_csm_config.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU correctness tests for CSM-1B config hoisting + backbone LlamaConfig synthesis.
+
+Covers the two fragile spots:
+  * ``CsmConfig`` hoists the nested ``backbone_config`` fields to the top level
+    (so vLLM reads them) while keeping depth / codec params nested.
+  * ``build_backbone_llama_config`` recovers ``rope_theta`` across the
+    transformers >= 5.12 RoPE migration (where ``rope_theta`` is folded INTO
+    ``rope_scaling`` and no longer a top-level attribute) and clamps
+    ``original_max_position_embeddings`` strictly below ``max_position_embeddings``
+    so transformers' rope-parameter validation passes.
+"""
+
+import pytest
+from transformers import LlamaConfig
+
+from vllm_omni.model_executor.models.csm.configuration_csm import (
+    CsmConfig,
+    build_backbone_llama_config,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def test_default_config_hoists_backbone_facts():
+    cfg = CsmConfig()
+    assert cfg.model_type == "csm"
+    assert cfg.hidden_size == 2048
+    assert cfg.num_hidden_layers == 16
+    assert cfg.num_attention_heads == 32
+    assert cfg.num_key_value_heads == 8
+    assert cfg.head_dim == 64
+    assert cfg.intermediate_size == 8192
+    # cb0 logits surface == per-codebook vocab (2051: 2048 codes + 3 reserved).
+    assert cfg.vocab_size == 2051
+    assert cfg.num_codebooks == 32
+    assert cfg.reserved_codebook_ids == (2048, 2049, 2050)
+    # vLLM requires this to be absent / None.
+    assert cfg.speculative_config is None
+    # get_text_config returns self so vLLM reads the hoisted backbone fields.
+    assert cfg.get_text_config() is cfg
+
+
+def test_default_config_keeps_depth_and_codec_facts_nested():
+    cfg = CsmConfig()
+    assert cfg.depth_hidden_size == 1024
+    assert cfg.depth_num_hidden_layers == 4
+    assert cfg.depth_head_dim == 128
+    assert cfg.depth_num_positions == 33
+    assert cfg.codec_sample_rate == 24000
+    assert cfg.codec_samples_per_frame == 1920
+
+
+def test_backbone_llama_config_is_a_real_llama_config():
+    llama = build_backbone_llama_config(CsmConfig())
+    assert isinstance(llama, LlamaConfig)
+    assert llama.hidden_size == 2048
+    assert llama.num_hidden_layers == 16
+    assert llama.num_attention_heads == 32
+    assert llama.num_key_value_heads == 8
+    assert llama.head_dim == 64
+    assert llama.vocab_size == 2051
+    assert llama.tie_word_embeddings is True
+
+
+def test_rope_theta_falls_back_to_csm_default_when_absent():
+    # Default config carries no rope_theta inside rope_scaling -> recover from the
+    # top-level attribute / CSM-1B default (500000.0) and fold it back in. Under
+    # transformers >= 5.12 LlamaConfig has NO top-level ``rope_theta`` attribute,
+    # so vLLM's get_rope reads it from rope_scaling/rope_parameters -- that is
+    # exactly where build_backbone_llama_config must leave it.
+    llama = build_backbone_llama_config(CsmConfig())
+    assert llama.rope_scaling["rope_theta"] == 500000.0
+    assert llama.rope_parameters["rope_theta"] == 500000.0
+    assert not hasattr(llama, "rope_theta")  # confirms the migration shape
+
+
+def test_rope_theta_recovered_from_nested_rope_scaling():
+    # transformers >= 5.12 shape: rope_theta lives INSIDE rope_scaling, no
+    # top-level attribute. build_backbone_llama_config must read it from there
+    # and keep it there (not drop it back onto a dead top-level attribute).
+    cfg = CsmConfig(
+        backbone_config={
+            "rope_scaling": {
+                "rope_type": "llama3",
+                "factor": 32.0,
+                "low_freq_factor": 1.0,
+                "high_freq_factor": 4.0,
+                "original_max_position_embeddings": 8192,
+                "rope_theta": 123456.0,
+            }
+        }
+    )
+    llama = build_backbone_llama_config(cfg)
+    assert llama.rope_scaling["rope_theta"] == 123456.0
+    assert llama.rope_parameters["rope_theta"] == 123456.0
+
+
+def test_original_max_position_clamped_below_max_position():
+    # rope-parameter validation requires original_max_position_embeddings <
+    # max_position_embeddings (2048). The default 8192 must be clamped to 2047.
+    llama = build_backbone_llama_config(CsmConfig())
+    assert llama.rope_scaling["original_max_position_embeddings"] == llama.max_position_embeddings - 1
+    assert llama.rope_scaling["original_max_position_embeddings"] < llama.max_position_embeddings
+
+
+def test_explicit_backbone_overrides_are_honored():
+    cfg = CsmConfig(backbone_config={"hidden_size": 1536, "num_hidden_layers": 12, "vocab_size": 4096})
+    assert cfg.hidden_size == 1536
+    assert cfg.num_hidden_layers == 12
+    assert cfg.vocab_size == 4096
+    llama = build_backbone_llama_config(cfg)
+    assert llama.hidden_size == 1536
+    assert llama.num_hidden_layers == 12
+    assert llama.vocab_size == 4096

--- a/tests/model_executor/models/csm/test_csm_depth.py
+++ b/tests/model_executor/models/csm/test_csm_depth.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU correctness tests for the CSM-1B depth decoder (Stage-0 inner AR loop).
+
+Two surfaces, both CPU-only:
+  * ``sample_logits`` numerics -- the b3 fix (fp32 + nan_to_num before any
+    softmax/argmax) and the greedy / top-k contract.
+  * ``CsmDepthDecoder.run`` loop wiring -- the 31-step seeding contract (step 0
+    gets the padded ``(B, 2)`` ids + ``backbone_last_hidden_state``; steps 1..30
+    get ``(B, 1)`` and no hidden), cb0 passthrough, output shape/dtype, and
+    determinism. Bit-parity against the real HF module (with checkpoint weights)
+    lives in ``test_csm_gpu_parity.py``; here we lock the loop logic with a
+    deterministic fake so it runs without weights or a GPU.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.models.csm.csm_depth import CsmDepthDecoder, sample_logits
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+# --------------------------------------------------------------------------
+# sample_logits
+# --------------------------------------------------------------------------
+
+
+def test_sample_logits_greedy_is_argmax():
+    logits = torch.tensor([[0.1, 5.0, 0.2], [9.0, 0.0, 1.0]])
+    out = sample_logits(logits, temperature=0.0, top_k=0)
+    assert out.tolist() == [1, 0]
+    assert out.dtype == torch.long
+    assert out.shape == (2,)
+
+
+def test_sample_logits_none_or_negative_temperature_is_greedy():
+    logits = torch.tensor([[0.1, 0.2, 9.0]])
+    assert sample_logits(logits, temperature=None, top_k=0).tolist() == [2]
+    assert sample_logits(logits, temperature=-1.0, top_k=0).tolist() == [2]
+
+
+def test_sample_logits_sanitizes_nonfinite_without_assert():
+    # The bf16 backbone can emit +/-inf or NaN; nan_to_num must clamp them so
+    # multinomial never hits its device-side "probability tensor" assert.
+    logits = torch.tensor([[float("nan"), float("inf"), float("-inf"), 0.0]])
+    out = sample_logits(logits, temperature=0.9, top_k=0)
+    # posinf -> 1e4 dominates the softmax; others underflow to ~0.
+    assert out.tolist() == [1]
+    assert torch.isfinite(out.float()).all()
+
+
+def test_sample_logits_topk1_collapses_to_the_top_token():
+    logits = torch.tensor([[1.0, 2.0, 3.0, 0.5]])
+    # top_k=1 masks all but the max to -inf, so the sample is deterministic.
+    assert sample_logits(logits, temperature=1.0, top_k=1).tolist() == [2]
+
+
+def test_sample_logits_topk_ge_vocab_is_a_noop_mask():
+    # top_k >= vocab must not mask anything (the `top_k < shape[-1]` guard).
+    logits = torch.tensor([[10.0, 0.0, 0.0, 0.0]])
+    assert sample_logits(logits, temperature=1.0, top_k=999).tolist() == [0]
+
+
+# --------------------------------------------------------------------------
+# CsmDepthDecoder.run -- 31-step loop wiring
+# --------------------------------------------------------------------------
+
+
+class _FakeDepthOut:
+    def __init__(self, logits, past):
+        self.logits = logits
+        self.past_key_values = past
+
+
+class _FakeDepthModule:
+    """Deterministic stand-in for ``CsmDepthDecoderForCausalLM``.
+
+    Records each call so the seeding contract is assertable, and emits logits
+    whose argmax is a fixed function of the step index, so greedy decode is
+    reproducible. ``config`` is consumed only by the (patched) ``DynamicCache``.
+    """
+
+    def __init__(self, vocab: int = 2051):
+        self.vocab = vocab
+        self.calls: list[dict] = []
+        self.config = SimpleNamespace()
+
+    def __call__(self, *, input_ids, past_key_values, use_cache, logits_to_keep, backbone_last_hidden_state=None):
+        self.calls.append(
+            {
+                "input_shape": tuple(input_ids.shape),
+                "has_hidden": backbone_last_hidden_state is not None,
+                "use_cache": use_cache,
+                "logits_to_keep": logits_to_keep,
+            }
+        )
+        bsz = int(input_ids.shape[0])
+        step = len(self.calls) - 1  # 0-based depth step
+        logits = torch.full((bsz, 1, self.vocab), -10.0)
+        logits[:, -1, (step + 1) % self.vocab] = 100.0  # argmax -> step+1
+        return _FakeDepthOut(logits, past_key_values)
+
+
+@pytest.fixture
+def _patch_cache(monkeypatch):
+    # Isolate the loop from transformers' real DynamicCache construction.
+    monkeypatch.setattr("transformers.cache_utils.DynamicCache", lambda config=None: object())
+
+
+def _make_depth(fake: _FakeDepthModule, num_codebooks: int = 32) -> CsmDepthDecoder:
+    depth = CsmDepthDecoder(num_codebooks=num_codebooks, hidden_size=2048, aux_dtype=torch.float32)
+    depth.set_module(fake)
+    return depth
+
+
+def test_run_returns_32_long_codes_with_cb0_passthrough(_patch_cache):
+    fake = _FakeDepthModule()
+    depth = _make_depth(fake)
+    cb0 = torch.tensor([7], dtype=torch.long)
+    codes = depth.run(
+        cb0=cb0,
+        backbone_last_hidden_state=torch.randn(1, 2048),
+        temperature=0.0,  # greedy -> deterministic
+        top_k=0,
+    )
+    assert codes.shape == (1, 32)
+    assert codes.dtype == torch.long
+    # cb0 is the backbone's token, copied verbatim into slot 0.
+    assert int(codes[0, 0]) == 7
+    # Greedy argmax of the fake = step+1, so cb1..cb31 == 1..31.
+    assert codes[0, 1:].tolist() == list(range(1, 32))
+
+
+def test_run_seeds_step0_with_padded_ids_and_hidden_state(_patch_cache):
+    fake = _FakeDepthModule()
+    depth = _make_depth(fake)
+    depth.run(
+        cb0=torch.tensor([3], dtype=torch.long),
+        backbone_last_hidden_state=torch.randn(1, 2048),
+        temperature=0.0,
+        top_k=0,
+    )
+    # 31 inner steps for 32 codebooks.
+    assert len(fake.calls) == 31
+    # Step 0: input padded to (B, 2) AND the backbone hidden state is supplied.
+    assert fake.calls[0]["input_shape"] == (1, 2)
+    assert fake.calls[0]["has_hidden"] is True
+    # Steps 1..30: single-token (B, 1) input, NO hidden state re-supplied.
+    for c in fake.calls[1:]:
+        assert c["input_shape"] == (1, 1)
+        assert c["has_hidden"] is False
+        assert c["logits_to_keep"] == 1
+        assert c["use_cache"] is True
+
+
+def test_run_handles_batch_dim(_patch_cache):
+    fake = _FakeDepthModule()
+    depth = _make_depth(fake)
+    cb0 = torch.tensor([5, 9], dtype=torch.long)
+    codes = depth.run(
+        cb0=cb0,
+        backbone_last_hidden_state=torch.randn(2, 2048),
+        temperature=0.0,
+        top_k=0,
+    )
+    assert codes.shape == (2, 32)
+    assert codes[:, 0].tolist() == [5, 9]
+    assert fake.calls[0]["input_shape"] == (2, 2)
+
+
+def test_run_is_deterministic_under_greedy(_patch_cache):
+    cb0 = torch.tensor([11], dtype=torch.long)
+    hs = torch.randn(1, 2048)
+    a = _make_depth(_FakeDepthModule()).run(cb0=cb0, backbone_last_hidden_state=hs, temperature=0.0, top_k=0)
+    b = _make_depth(_FakeDepthModule()).run(cb0=cb0, backbone_last_hidden_state=hs, temperature=0.0, top_k=0)
+    assert torch.equal(a, b)

--- a/tests/model_executor/models/csm/test_csm_gpu_parity.py
+++ b/tests/model_executor/models/csm/test_csm_gpu_parity.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CUDA bit-parity tests for CSM-1B against the HuggingFace reference weights.
+
+These need a GPU and the gated ``sesame/csm-1b`` checkpoint; they skip cleanly
+without either (so CI on a GPU-less / un-gated host is green). On a host that
+has both they MUST run -- they are the real correctness guarantee behind the
+2-stage port:
+
+  * Depth decoder: our incremental, KV-cached 31-step loop
+    (``CsmDepthDecoder.run``) must be BIT-EXACT under greedy against an
+    independent cacheless full-recompute reference driving the SAME real HF
+    ``CsmDepthDecoderForCausalLM`` module. This proves the cache reset, the
+    position-0 ``backbone_last_hidden_state`` seeding, and the per-step
+    codebook-head indexing are all correct (the "incremental == full recompute"
+    equivalence).
+  * Mimi vocoder: ``CsmMimiVocoder._mimi_decode`` must be bit-exact against the
+    raw ``MimiModel.decode`` for in-range codes (the "Mimi diff 0.0" guarantee),
+    and the reserved-id clamp must route 2048/2049/2050 to the clamped decode
+    (never feeding the codec an out-of-range id) while still producing finite
+    audio.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+_MODEL = "sesame/csm-1b"
+
+cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+pytestmark = [pytest.mark.core_model, cuda]
+
+
+def _model_is_cached() -> bool:
+    try:
+        from huggingface_hub import try_to_load_from_cache
+
+        return try_to_load_from_cache(_MODEL, "config.json") is not None
+    except Exception:
+        return False
+
+
+requires_weights = pytest.mark.skipif(not _model_is_cached(), reason=f"{_MODEL} not in local HF cache (gated)")
+
+
+@pytest.fixture(scope="module")
+def hf_csm():
+    pytest.importorskip("transformers")
+    from transformers.models.csm.modeling_csm import CsmForConditionalGeneration
+
+    model = CsmForConditionalGeneration.from_pretrained(_MODEL, torch_dtype=torch.float32)
+    model = model.to("cuda").eval()
+    for p in model.parameters():
+        p.requires_grad_(False)
+    return model
+
+
+# --------------------------------------------------------------------------
+# Depth decoder: incremental KV loop == cacheless full recompute (greedy)
+# --------------------------------------------------------------------------
+
+
+@torch.inference_mode()
+def _reference_depth_full_recompute(depth, cb0, backbone_hidden, num_codebooks):
+    """Independent reference: greedily decode cb1..cb31 by re-feeding the WHOLE
+    growing sequence each step with NO KV cache. Shares no code with
+    ``CsmDepthDecoder.run`` -- HF seeds the backbone hidden at position 0 only
+    when ``past_seen == 0`` (verified in CsmDepthDecoderModel.forward), which is
+    always the case here, so this is exactly equivalent to a correct incremental
+    decode."""
+    codes = [cb0]  # list of (B,) Long
+    for _k in range(1, num_codebooks):
+        prefix = torch.stack(codes, dim=1)  # (B, k)
+        ids = torch.nn.functional.pad(prefix, (1, 0), value=0)  # pos-0 placeholder
+        out = depth(
+            input_ids=ids,
+            backbone_last_hidden_state=backbone_hidden,
+            use_cache=False,
+            logits_to_keep=1,
+        )
+        logits = out.logits[:, -1, :].float()
+        codes.append(torch.argmax(logits, dim=-1))
+    return torch.stack(codes, dim=1)  # (B, num_codebooks)
+
+
+@torch.inference_mode()
+def _real_backbone_hidden(model, text="The quick brown fox."):
+    """A real backbone last-hidden-state vector, so depth logits are confident
+    (no argmax ties that would make a greedy comparison flaky)."""
+    tok = getattr(model.config, "text_vocab_size", 128256)
+    # Deterministic short token sequence inside the text vocab.
+    ids = torch.tensor([[1, 2, 3, 4, 5]], device="cuda") % tok
+    embeds = model.embed_text_tokens(ids)
+    bb = model.backbone_model(inputs_embeds=embeds)
+    h = bb.last_hidden_state[:, -1, :]  # (1, hidden)
+    return h.to(torch.float32)
+
+
+@requires_weights
+def test_depth_incremental_matches_full_recompute_bitexact(hf_csm):
+    from vllm_omni.model_executor.models.csm.csm_depth import CsmDepthDecoder
+
+    num_codebooks = int(hf_csm.config.num_codebooks)
+    hidden_size = int(hf_csm.config.hidden_size)
+    h_t = _real_backbone_hidden(hf_csm)
+
+    wrapper = CsmDepthDecoder(num_codebooks=num_codebooks, hidden_size=hidden_size, aux_dtype=torch.float32)
+    wrapper.set_module(hf_csm.depth_decoder)
+
+    for cb0_val in (0, 100, 1000, 2047):
+        cb0 = torch.tensor([cb0_val], device="cuda", dtype=torch.long)
+        ours = wrapper.run(cb0=cb0, backbone_last_hidden_state=h_t, temperature=0.0, top_k=0)
+        ref = _reference_depth_full_recompute(hf_csm.depth_decoder, cb0, h_t, num_codebooks)
+        assert ours.shape == (1, num_codebooks)
+        assert int(ours[0, 0]) == cb0_val  # cb0 passthrough
+        assert torch.equal(ours, ref), f"depth mismatch at cb0={cb0_val}: {ours} vs {ref}"
+
+
+@requires_weights
+def test_depth_run_is_deterministic_greedy(hf_csm):
+    from vllm_omni.model_executor.models.csm.csm_depth import CsmDepthDecoder
+
+    h_t = _real_backbone_hidden(hf_csm)
+    wrapper = CsmDepthDecoder(
+        num_codebooks=int(hf_csm.config.num_codebooks),
+        hidden_size=int(hf_csm.config.hidden_size),
+        aux_dtype=torch.float32,
+    )
+    wrapper.set_module(hf_csm.depth_decoder)
+    cb0 = torch.tensor([100], device="cuda", dtype=torch.long)
+    a = wrapper.run(cb0=cb0, backbone_last_hidden_state=h_t, temperature=0.0, top_k=0)
+    b = wrapper.run(cb0=cb0, backbone_last_hidden_state=h_t, temperature=0.0, top_k=0)
+    assert torch.equal(a, b)
+
+
+# --------------------------------------------------------------------------
+# Mimi vocoder: wrapper decode == raw MimiModel.decode + reserved-id clamp
+# --------------------------------------------------------------------------
+
+
+def _make_vocoder(codec, num_codebooks, sample_rate):
+    from vllm_omni.model_executor.models.csm.csm_mimi import CsmMimiVocoder
+
+    v = object.__new__(CsmMimiVocoder)
+    nn.Module.__init__(v)
+    v.num_codebooks = num_codebooks
+    v.sample_rate = sample_rate
+    v._device = torch.device("cuda")
+    v.config = SimpleNamespace(codec_samples_per_frame=1920)
+    v._stream_state_by_req = {}
+    v._mimi_codec = codec
+    return v
+
+
+@torch.inference_mode()
+def _raw_mimi_decode(codec, codes_qf):
+    out = codec.decode(codes_qf.unsqueeze(0))
+    av = out.audio_values
+    return av.reshape(av.shape[0], -1)[0].to(torch.float32)
+
+
+@requires_weights
+def test_mimi_decode_bitexact_vs_raw_for_in_range_codes(hf_csm):
+    codec = hf_csm.codec_model
+    num_codebooks = int(hf_csm.config.num_codebooks)
+    sr = int(getattr(hf_csm.config, "codec_sample_rate", 24000) or 24000)
+    v = _make_vocoder(codec, num_codebooks, sr)
+
+    g = torch.Generator(device="cuda").manual_seed(0)
+    for _ in range(8):  # the "diff 0.0 across 8 frames" guarantee
+        frames = int(torch.randint(1, 6, (1,), generator=g, device="cuda").item())
+        codes = torch.randint(0, 2048, (num_codebooks, frames), generator=g, device="cuda", dtype=torch.long)
+        ours = v._mimi_decode(codes)
+        ref = _raw_mimi_decode(codec, codes)
+        assert torch.equal(ours, ref)
+
+
+@requires_weights
+def test_mimi_decode_clamps_reserved_ids_to_codec_range(hf_csm):
+    codec = hf_csm.codec_model
+    num_codebooks = int(hf_csm.config.num_codebooks)
+    sr = int(getattr(hf_csm.config, "codec_sample_rate", 24000) or 24000)
+    v = _make_vocoder(codec, num_codebooks, sr)
+
+    codes = torch.randint(0, 2048, (num_codebooks, 3), device="cuda", dtype=torch.long)
+    codes[0, 0] = 2048
+    codes[1, 1] = 2049
+    codes[2, 2] = 2050
+    clamped = codes.clamp(min=0, max=2047)
+
+    ours = v._mimi_decode(codes)
+    ref = _raw_mimi_decode(codec, clamped)
+    # Reserved ids must be clamped before reaching the codec -> identical to the
+    # clamped decode, and the caller's tensor is not mutated.
+    assert torch.equal(ours, ref)
+    assert torch.isfinite(ours).all()
+    assert int(codes[0, 0]) == 2048  # original tensor untouched (clamp on a copy)

--- a/tests/model_executor/models/csm/test_csm_mimi.py
+++ b/tests/model_executor/models/csm/test_csm_mimi.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU correctness tests for the CSM-1B Stage-1 Mimi vocoder (code2wav).
+
+Locks the framework-glue invariants that do not need real codec weights:
+  * Reserved-id clamp ([0, 2047] on a COPY) -- ids 2048/2049/2050 must never
+    reach Mimi, and the caller's tensor must not be mutated.
+  * Codebook-major reshape ``[32*F] -> (1, 32, F)`` into ``decode``.
+  * I1 delta streaming -- the leading ``left_context_size`` frames are trimmed
+    so each chunk emits only its new audio.
+  * Per-request split + "all return paths emit model_outputs" -- empty and
+    malformed-length requests still produce a length-matched output list.
+  * I5 -- per-request streaming state is freed on finish.
+
+Bit-parity of ``_mimi_decode`` against the real ``transformers.MimiModel`` lives
+in ``test_csm_gpu_parity.py``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm_omni.model_executor.models.csm.csm_mimi import _MIMI_CODEBOOK_SIZE, CsmMimiVocoder
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+_SAMPLES_PER_FRAME = 4  # tiny stand-in for the real 1920 so trims are checkable
+
+
+class _FakeCodec(nn.Module):
+    """Records every ``decode`` call and returns ``arange`` audio so trimming is
+    bit-checkable. Emits ``F * _SAMPLES_PER_FRAME`` samples per request row."""
+
+    def __init__(self):
+        super().__init__()
+        self.received: list[torch.Tensor] = []
+
+    def decode(self, audio_codes: torch.Tensor):
+        self.received.append(audio_codes.clone())
+        b = int(audio_codes.shape[0])
+        f = int(audio_codes.shape[-1])
+        samples = f * _SAMPLES_PER_FRAME
+        wav = torch.arange(samples, dtype=torch.float32).view(1, 1, -1).expand(b, 1, samples).clone()
+        return SimpleNamespace(audio_values=wav)
+
+
+def _make_vocoder() -> CsmMimiVocoder:
+    v = object.__new__(CsmMimiVocoder)
+    nn.Module.__init__(v)
+    v.num_codebooks = 32
+    v.sample_rate = 24000
+    v._device = torch.device("cpu")
+    v.config = SimpleNamespace(codec_samples_per_frame=_SAMPLES_PER_FRAME)
+    v._stream_state_by_req = {}
+    v._mimi_codec = _FakeCodec()
+    return v
+
+
+def test_mimi_decode_clamps_reserved_ids_on_a_copy():
+    v = _make_vocoder()
+    # A single frame whose codes include all three reserved ids.
+    frame = torch.full((32, 1), 2050, dtype=torch.long)
+    frame[0, 0] = 2049
+    frame[1, 0] = 2048
+    original = frame.clone()
+
+    v._mimi_decode(frame)
+
+    received = v._mimi_codec.received[-1]
+    assert received.shape == (1, 32, 1)
+    # Nothing >= 2048 reached the codec.
+    assert int(received.max()) <= _MIMI_CODEBOOK_SIZE - 1
+    # The caller's tensor was NOT mutated (clamp ran on a copy).
+    assert torch.equal(frame, original)
+
+
+def test_forward_reshapes_codebook_major_into_codec():
+    v = _make_vocoder()
+    # F = 2 frames, codebook-major flat [32*2]; values stay in range.
+    ids = torch.arange(64, dtype=torch.long)
+    v.forward(input_ids=ids, runtime_additional_information=[{"meta": {"left_context_size": 0}}])
+
+    received = v._mimi_codec.received[-1]
+    assert received.shape == (1, 32, 2)
+    # [Q*F] codebook-major reshapes to [Q, F] row-major.
+    assert torch.equal(received[0], ids.reshape(32, 2))
+
+
+def test_forward_delta_trims_left_context():
+    v = _make_vocoder()
+    # 3 frames -> fake emits arange(12); 2 context frames -> trim 2*4 = 8 samples.
+    ids = torch.arange(96, dtype=torch.long)  # 32 * 3
+    out = v.forward(input_ids=ids, runtime_additional_information=[{"meta": {"left_context_size": 2}}])
+    audio = out.multimodal_outputs["model_outputs"][0]
+    torch.testing.assert_close(audio, torch.arange(8, 12, dtype=torch.float32))
+
+
+def test_forward_no_context_emits_full_chunk():
+    v = _make_vocoder()
+    ids = torch.arange(96, dtype=torch.long)
+    out = v.forward(input_ids=ids, runtime_additional_information=[{"meta": {"left_context_size": 0}}])
+    audio = out.multimodal_outputs["model_outputs"][0]
+    torch.testing.assert_close(audio, torch.arange(12, dtype=torch.float32))
+
+
+def test_forward_empty_input_emits_one_empty_output():
+    v = _make_vocoder()
+    out = v.forward(input_ids=torch.empty((0,), dtype=torch.long))
+    audios = out.multimodal_outputs["model_outputs"]
+    assert len(audios) == 1
+    assert audios[0].numel() == 0
+    assert "sr" in out.multimodal_outputs
+
+
+def test_forward_skips_malformed_length_but_keeps_output_slot():
+    v = _make_vocoder()
+    # 33 ids is not divisible by 32 -> skip, but the output list still has 1 slot.
+    out = v.forward(
+        input_ids=torch.arange(33, dtype=torch.long),
+        runtime_additional_information=[{"meta": {"left_context_size": 0}}],
+    )
+    audios = out.multimodal_outputs["model_outputs"]
+    assert len(audios) == 1
+    assert audios[0].numel() == 0
+    assert v._mimi_codec.received == []  # codec never called for a bad length
+
+
+def test_forward_per_request_split_emits_one_output_each():
+    v = _make_vocoder()
+    ids = torch.arange(64, dtype=torch.long)  # two 32-code frames, one per request
+    out = v.forward(
+        input_ids=ids,
+        seq_token_counts=[32, 32],
+        runtime_additional_information=[
+            {"meta": {"left_context_size": 0}},
+            {"meta": {"left_context_size": 0}},
+        ],
+    )
+    audios = out.multimodal_outputs["model_outputs"]
+    assert len(audios) == 2
+    assert all(a.numel() == _SAMPLES_PER_FRAME for a in audios)  # 1 frame each
+
+
+def test_forward_mixed_valid_and_malformed_keeps_indices_aligned():
+    v = _make_vocoder()
+    # req0: 32 valid ids (1 frame); req1: 5 ids (malformed) -> empty, not dropped.
+    ids = torch.arange(37, dtype=torch.long)
+    out = v.forward(
+        input_ids=ids,
+        seq_token_counts=[32, 5],
+        runtime_additional_information=[{"meta": {}}, {"meta": {}}],
+    )
+    audios = out.multimodal_outputs["model_outputs"]
+    assert len(audios) == 2
+    assert audios[0].numel() == _SAMPLES_PER_FRAME
+    assert audios[1].numel() == 0
+
+
+def test_on_requests_finished_frees_stream_state():
+    v = _make_vocoder()
+    v._stream_state_by_req = {"a": object(), "b": object()}
+    v.on_requests_finished(["a"])
+    assert "a" not in v._stream_state_by_req
+    assert "b" in v._stream_state_by_req
+
+
+def test_make_omni_output_passthrough_and_rejects_bad_type():
+    v = _make_vocoder()
+    out = v.forward(input_ids=torch.empty((0,), dtype=torch.long))
+    assert v.make_omni_output(out) is out
+    with pytest.raises(TypeError):
+        v.make_omni_output(torch.zeros(3))
+
+
+def test_compute_logits_is_none_for_non_ar_stage():
+    v = _make_vocoder()
+    assert v.compute_logits(torch.zeros(2, 4)) is None

--- a/tests/model_executor/stage_input_processors/test_csm.py
+++ b/tests/model_executor/stage_input_processors/test_csm.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU correctness tests for the CSM-1B Stage-0 -> Stage-1 input processor.
+
+Locks the CSM-specific valid-frame mask and the codebook-major handoff:
+  * ``backbone2mimi`` (sync): drops the all-zero EOS frame and any frame holding
+    a reserved code (>= 2048), then flattens the survivors CODEBOOK-MAJOR.
+  * ``_extract_last_frame``: all-zero frame -> None (nothing to decode), 1D / 2D
+    handling, invalid shape -> ValueError.
+  * ``backbone2mimi_async_chunk``: invalid chunk config -> ValueError; a finished
+    short request flushes its windowed frames codebook-major; an empty finished
+    request emits an empty finished payload.
+"""
+
+from collections import defaultdict
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.model_executor.stage_input_processors import csm as proc
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+class _FakeBackboneOutput:
+    def __init__(self, audio_codes, finished=True):
+        self.finished = finished
+        self.outputs = [SimpleNamespace(multimodal_output={"codes": {"audio": audio_codes}})]
+
+
+# --------------------------------------------------------------------------
+# backbone2mimi (sync collect)
+# --------------------------------------------------------------------------
+
+
+def test_backbone2mimi_drops_eos_and_reserved_frames_then_flattens_codebook_major():
+    frames = torch.zeros(3, 32, dtype=torch.long)
+    frames[0, :] = 1  # valid frame (all ones)
+    # frame 1 stays all-zero -> EOS -> dropped
+    frames[2, :] = 1
+    frames[2, 5] = 2048  # reserved code -> whole frame dropped (max >= 2048)
+
+    out = proc.backbone2mimi([_FakeBackboneOutput(frames)])
+    assert len(out) == 1
+    # Only frame 0 survives; codebook-major flat of a single all-ones frame = 32 ones.
+    assert out[0]["prompt_token_ids"] == [1] * 32
+
+
+def test_backbone2mimi_codebook_major_order():
+    # Two valid frames; verify the flatten is codebook-major (all of cb0, then cb1...).
+    frames = torch.zeros(2, 4, dtype=torch.long)
+    frames[0] = torch.tensor([10, 11, 12, 13])
+    frames[1] = torch.tensor([20, 21, 22, 23])
+    out = proc.backbone2mimi([_FakeBackboneOutput(frames)])
+    # transpose(0,1) -> [[10,20],[11,21],[12,22],[13,23]] -> flat row-major.
+    assert out[0]["prompt_token_ids"] == [10, 20, 11, 21, 12, 22, 13, 23]
+
+
+def test_backbone2mimi_skips_unfinished_request():
+    frames = torch.ones(2, 32, dtype=torch.long)
+    out = proc.backbone2mimi([_FakeBackboneOutput(frames, finished=False)])
+    assert out == []
+
+
+def test_backbone2mimi_empty_audio_emits_empty_prompt():
+    out = proc.backbone2mimi([_FakeBackboneOutput(torch.empty((0,), dtype=torch.long))])
+    assert len(out) == 1
+    assert out[0]["prompt_token_ids"] == []
+
+
+def test_backbone2mimi_reshapes_1d_audio_to_frames():
+    flat = torch.ones(64, dtype=torch.long)  # 2 frames of 32, flattened frame-major
+    out = proc.backbone2mimi([_FakeBackboneOutput(flat)])
+    assert len(out) == 1
+    assert len(out[0]["prompt_token_ids"]) == 64
+
+
+# --------------------------------------------------------------------------
+# _extract_last_frame
+# --------------------------------------------------------------------------
+
+
+def test_extract_last_frame_returns_last_nonzero_2d_frame():
+    codes = torch.zeros(3, 32, dtype=torch.long)
+    codes[-1, :] = 7
+    frame = proc._extract_last_frame({"codes": {"audio": codes}})
+    assert frame is not None
+    assert frame.tolist() == [7] * 32
+
+
+def test_extract_last_frame_none_for_all_zero_eos_frame():
+    codes = torch.zeros(2, 32, dtype=torch.long)
+    assert proc._extract_last_frame({"codes": {"audio": codes}}) is None
+
+
+def test_extract_last_frame_passthrough_1d():
+    codes = torch.arange(32, dtype=torch.long)
+    frame = proc._extract_last_frame({"codes": {"audio": codes}})
+    assert frame.tolist() == list(range(32))
+
+
+def test_extract_last_frame_none_for_missing_audio():
+    assert proc._extract_last_frame({"codes": {}}) is None
+    assert proc._extract_last_frame({"codes": {"audio": torch.empty((0,), dtype=torch.long)}}) is None
+
+
+def test_extract_last_frame_raises_on_invalid_shape():
+    bad = torch.zeros(2, 3, 4, dtype=torch.long)
+    with pytest.raises(ValueError, match="Invalid audio_codes shape"):
+        proc._extract_last_frame({"codes": {"audio": bad}})
+
+
+# --------------------------------------------------------------------------
+# backbone2mimi_async_chunk
+# --------------------------------------------------------------------------
+
+
+def _tm(config):
+    return SimpleNamespace(
+        code_prompt_token_ids=defaultdict(list),
+        connector=SimpleNamespace(config=config),
+    )
+
+
+def test_async_chunk_rejects_invalid_chunk_config():
+    tm = _tm({"extra": {"codec_chunk_frames": 0}})
+    req = SimpleNamespace(external_req_id="r", is_finished=lambda: False)
+    with pytest.raises(ValueError, match="codec_chunk_frames"):
+        proc.backbone2mimi_async_chunk(
+            tm, {"codes": {"audio": torch.ones(1, 32, dtype=torch.long)}}, req, is_finished=False
+        )
+
+
+def test_async_chunk_finished_with_no_frames_emits_empty_finished_payload():
+    tm = _tm({})
+    req = SimpleNamespace(external_req_id="r", is_finished=lambda: True)
+    out = proc.backbone2mimi_async_chunk(tm, None, req, is_finished=True)
+    assert out is not None
+    assert out.codes.audio.numel() == 0
+    assert bool(out.meta.finished) is True
+
+
+def test_async_chunk_flushes_codebook_major_window_on_finish():
+    tm = _tm({"extra": {"codec_chunk_frames": 25, "codec_left_context_frames": 0}})
+    req = SimpleNamespace(external_req_id="r", is_finished=lambda: False)
+
+    # Frame 0 arrives unfinished -> buffered, nothing flushed yet.
+    out0 = proc.backbone2mimi_async_chunk(tm, {"codes": {"audio": torch.tensor([[1, 2, 3]])}}, req, is_finished=False)
+    assert out0 is None
+
+    # Frame 1 arrives on the finishing step -> flush the 2-frame window.
+    out1 = proc.backbone2mimi_async_chunk(tm, {"codes": {"audio": torch.tensor([[4, 5, 6]])}}, req, is_finished=True)
+    assert out1 is not None
+    # codebook-major: all of cb0 (1,4), then cb1 (2,5), then cb2 (3,6).
+    assert out1.codes.audio.tolist() == [1, 4, 2, 5, 3, 6]
+    assert int(out1.meta.left_context_size) == 0
+    assert bool(out1.meta.finished) is True

--- a/vllm_omni/config/pipeline_registry.py
+++ b/vllm_omni/config/pipeline_registry.py
@@ -32,6 +32,10 @@ from __future__ import annotations
 # --- Multi-stage omni pipelines (LLM-centric; audio / video I/O) ---
 _OMNI_PIPELINES: dict[str, tuple[str, str]] = {
     # model_type -> (module_path, variable_name)
+    "csm": (
+        "vllm_omni.model_executor.models.csm.pipeline",
+        "CSM_PIPELINE",
+    ),
     "qwen2_5_omni": (
         "vllm_omni.model_executor.models.qwen2_5_omni.pipeline",
         "QWEN2_5_OMNI_PIPELINE",

--- a/vllm_omni/deploy/csm.yaml
+++ b/vllm_omni/deploy/csm.yaml
@@ -1,0 +1,74 @@
+# CSM-1B (Sesame) deploy: 2-stage dual-AR TTS (~1.6B incl. Mimi codec).
+# Stage 0 = backbone AR + inline 31-step depth decoder (LLM_AR);
+# Stage 1 = Mimi vocoder / code2wav (LLM_GENERATION).
+#
+# Fields omitted from a stage fall back to StageDeployConfig defaults (see
+# vllm_omni/config/stage_config.py). Non-default choices in this file:
+#   * async_chunk: false — first GPU pass validates the non-streaming sync path
+#     (backbone2mimi). Flip to true (+ the connector block) once N7 single-stream
+#     passes, to enable backbone2mimi_async_chunk streaming.
+#   * trust_remote_code: true — the Mimi codec + depth decoder are built via
+#     transformers AutoConfig/AutoModel from the checkpoint config.
+#   * enforce_eager: true — Stage 0 runs the 31-step depth decoder (DynamicCache)
+#     inline as dense torch with a per-frame host EOS read; the de-risked eager
+#     path (A3 §6 option b). Stage 1 Mimi decode is also eager for the first pass.
+#   * skip_mm_profiling: true — CSM takes a text prompt only (no multimodal input).
+#   * Stage 1 max_num_batched_tokens: 65536 — codec prefill length (32 * F)
+#     exceeds the 32k default for long utterances.
+async_chunk: false
+trust_remote_code: true
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      shm_threshold_bytes: 65536
+      codec_streaming: true
+      connector_get_sleep_s: 0.01
+      connector_get_max_wait_first_chunk: 3000
+      connector_get_max_wait: 300
+      # Mimi decode chunk window + left context (frames). Tuned with the codec's
+      # sliding attention window once streaming (async_chunk: true) is enabled.
+      codec_chunk_frames: 25
+      codec_left_context_frames: 72
+      initial_codec_chunk_frames: 1
+
+stages:
+  - stage_id: 0
+    max_num_seqs: 4
+    # Real serving split on a 12 GB RTX 3060: Stage 0 (backbone ~1B in bf16 +
+    # KV) takes the larger share, Stage 1 (Mimi vocoder) the smaller. Both
+    # fractions are of TOTAL device memory and the stages co-reside on device 0,
+    # so 0.55 + 0.35 = 0.90 leaves headroom for the HF aux modules (fp32 depth
+    # decoder + frame/text embeds loaded in Stage 0) and the Mimi codec weights.
+    # The committed 0.3/0.3 was a de-risking placeholder that under-provisions
+    # the backbone KV cache for real utterances.
+    gpu_memory_utilization: 0.55
+    enforce_eager: true
+    enable_prefix_caching: false
+    max_num_batched_tokens: 2048
+    max_model_len: 2048
+    devices: "0"
+    skip_mm_profiling: true
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 1.0
+      top_k: 50
+      max_tokens: 2048
+      seed: 42
+
+  - stage_id: 1
+    max_num_seqs: 1
+    gpu_memory_utilization: 0.35
+    enforce_eager: true
+    trust_remote_code: true
+    enable_prefix_caching: false
+    max_num_batched_tokens: 65536
+    max_model_len: 65536
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      seed: 42

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -85,6 +85,7 @@ _HIGGS_AUDIO_V2_TTS_MODEL_STAGES = {"higgs_audio_v2"}
 _HIGGS_V3_TTS_MODEL_STAGES = {"higgs_audio_v3"}
 _GLM_TTS_MODEL_STAGES = {"glm_tts"}
 _STEP_AUDIO2_TTS_MODEL_STAGES = {"step_audio2_thinker"}
+_CSM_TTS_MODEL_STAGES = {"csm"}
 _TTS_MODEL_STAGES: set[str] = (
     _VOXTRAL_TTS_MODEL_STAGES
     | _QWEN3_TTS_MODEL_STAGES
@@ -100,6 +101,7 @@ _TTS_MODEL_STAGES: set[str] = (
     | _MOSS_TTS_FULL_MODEL_STAGES
     | _GLM_TTS_MODEL_STAGES
     | _STEP_AUDIO2_TTS_MODEL_STAGES
+    | _CSM_TTS_MODEL_STAGES
 )
 _SAMPLING_MAX_TOKENS_TTS_MODEL_TYPES = {
     "fish_tts",
@@ -693,6 +695,8 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             return "glm_tts"
         if model_stage in _STEP_AUDIO2_TTS_MODEL_STAGES:
             return "step_audio2"
+        if model_stage in _CSM_TTS_MODEL_STAGES:
+            return "csm"
         return None
 
     def _get_custom_voice_dir(self) -> str | None:

--- a/vllm_omni/entrypoints/openai/tts_adapters/__init__.py
+++ b/vllm_omni/entrypoints/openai/tts_adapters/__init__.py
@@ -53,6 +53,7 @@ def resolve_adapter(model_type: str | None) -> type[TTSModelAdapter] | None:
 from vllm_omni.entrypoints.openai.tts_adapters import (  # noqa: E402,F401
     cosyvoice3,
     covo_audio,
+    csm,
     fish_speech,
     glm_tts,
     higgs_audio_v2,

--- a/vllm_omni/entrypoints/openai/tts_adapters/csm.py
+++ b/vllm_omni/entrypoints/openai/tts_adapters/csm.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CSM-1B (Sesame) serving adapter (#4330 TTS adapter framework).
+
+CSM-1B is a plain text -> speech model with speaker-id conditioning, served on
+the AR engine_client path. The OpenAI ``voice`` field maps to a CSM speaker id
+(a non-negative integer string, default ``"0"``); there is no reference-audio
+voice cloning on this path. The adapter owns request validation and Stage-0
+backbone prompt construction for the two-stage CSM pipeline (backbone AR +
+inline 31-step depth -> Mimi code2wav; see ``model_executor/models/csm``).
+
+Drop-in for vllm_omni/entrypoints/openai/tts_adapters/csm.py and add ``csm`` to
+the import list in that package's __init__.py.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from vllm.inputs import tokens_input
+from vllm.logger import init_logger
+
+from vllm_omni.entrypoints.openai.tts_adapters import register_tts_adapter
+from vllm_omni.entrypoints.openai.tts_adapters.base import (
+    ARTTSAdapter,
+    PreparedRequest,
+    conditioning_cache_salt,
+)
+
+if TYPE_CHECKING:
+    from vllm_omni.entrypoints.openai.protocol.audio import OpenAICreateSpeechRequest
+
+logger = init_logger(__name__)
+
+# Request bounds (mirror serving_speech._TTS_MAX_NEW_TOKENS_{MIN,MAX}).
+_TTS_MAX_NEW_TOKENS_MIN = 1
+_TTS_MAX_NEW_TOKENS_MAX = 4096
+# CSM-1B's inline-depth AR loop has no reliable natural EOS (greedy hits a
+# non-terminating saturating attractor; do_sample EOS is bi-modal). Bound served
+# audio with the cap the offline 2-stage harness validated its WAVs at
+# (64 frames == 5.12 s at 80 ms/frame). The backbone forces the frame EOS at the
+# cap (csm_backbone _DEFAULT_MAX_FRAMES / GATE-B).
+_DEFAULT_CSM_MAX_FRAMES = 64
+
+
+@register_tts_adapter
+class CsmTTSAdapter(ARTTSAdapter):
+    """Adapter for Sesame CSM-1B (AR ``engine_client`` backend)."""
+
+    stage_keys = frozenset({"csm"})
+    name = "csm"
+
+    def __init__(self, ctx) -> None:
+        super().__init__(ctx)
+        self._tokenizer = None
+
+    def _get_tokenizer(self):
+        """Lazily load + cache the CSM Llama text tokenizer.
+
+        CSM-1B ships a standard Llama tokenizer plus ``<|begin_of_text|>`` /
+        ``<|end_of_text|>``. We tokenize the speaker-tagged text here so the
+        prompt carries the exact ``prompt_token_ids`` the Stage-0 backbone embeds
+        in ``_embed_text_prompt``.
+        """
+        if self._tokenizer is None:
+            from transformers import AutoTokenizer
+
+            model_name = self.ctx.engine_client.model_config.model
+            self._tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+        return self._tokenizer
+
+    def validate(self, request: "OpenAICreateSpeechRequest") -> str | None:
+        if not request.input or not request.input.strip():
+            return "Input text cannot be empty"
+        if request.voice is not None and not str(request.voice).strip().isdigit():
+            return "CSM 'voice' must be a non-negative integer speaker id (e.g. '0')"
+        if request.max_new_tokens is not None:
+            if request.max_new_tokens < _TTS_MAX_NEW_TOKENS_MIN:
+                return f"max_new_tokens must be at least {_TTS_MAX_NEW_TOKENS_MIN}"
+            if request.max_new_tokens > _TTS_MAX_NEW_TOKENS_MAX:
+                return f"max_new_tokens cannot exceed {_TTS_MAX_NEW_TOKENS_MAX}"
+        return None
+
+    async def build(
+        self,
+        request: "OpenAICreateSpeechRequest",
+        sampling_params_list: list,
+        has_inline_ref_audio: bool,
+    ) -> PreparedRequest:
+        """Build the Stage-0 backbone prompt for a CSM text -> speech request.
+
+        CSM's text conditioning is ``<|begin_of_text|>[<spk>]<text><|end_of_text|>``.
+        The backbone reads the ids back out of ``additional_information`` via
+        ``_pick`` (csm_backbone), which unwraps the batch-of-1 convention by
+        returning ``val[0]`` for list values, so every field is LIST-WRAPPED (a
+        bare list would make ``_pick`` return only the first id, embedding one BOS
+        token and zero-padding the rest: the 1-2-frame truncated-audio bug). Stage
+        0 runs greedy (temperature 0, top_k 0) for deterministic validated output,
+        and an explicit ``max_new_frames`` cap bounds the non-terminating AR loop.
+        """
+        tokenizer = self._get_tokenizer()
+        speaker = str(request.voice).strip() if request.voice is not None else "0"
+        text = f"<|begin_of_text|>[{speaker}]{request.input}<|end_of_text|>"
+        prompt_token_ids = list(tokenizer(text, add_special_tokens=False)["input_ids"])
+
+        max_frames = request.max_new_tokens if request.max_new_tokens is not None else _DEFAULT_CSM_MAX_FRAMES
+        additional_information: dict[str, Any] = {
+            "prompt_token_ids": [prompt_token_ids],
+            "temperature": [0.0],
+            "top_k": [0],
+            "max_new_frames": [max_frames],
+        }
+
+        prompt = tokens_input(prompt_token_ids=prompt_token_ids)
+        prompt["additional_information"] = additional_information
+        prompt["cache_salt"] = conditioning_cache_salt(request, additional_information)
+        return PreparedRequest(prompt=prompt, tts_params={}, model_type="csm")

--- a/vllm_omni/model_executor/models/csm/__init__.py
+++ b/vllm_omni/model_executor/models/csm/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""vLLM-Omni integration for Sesame's CSM-1B (2-stage dual-AR TTS).
+
+Stage 0 = backbone AR + inline 31-step depth decoder (LLM_AR);
+Stage 1 = Mimi vocoder / code2wav (LLM_GENERATION).
+"""
+
+from vllm_omni.model_executor.models.csm.configuration_csm import CsmConfig
+
+__all__ = ["CsmConfig"]

--- a/vllm_omni/model_executor/models/csm/configuration_csm.py
+++ b/vllm_omni/model_executor/models/csm/configuration_csm.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Configuration for CSM-1B in the vLLM-Omni 2-stage pipeline.
+
+CSM-1B (``sesame/csm-1b``) is a dual-autoregressive speech model: a
+Llama-style **backbone** that predicts codebook-0 (cb0) for each 80 ms audio
+frame, plus a small **depth decoder** that autoregressively predicts the
+remaining RVQ codebook tokens for that frame. The audio is reconstructed from
+the 32-codebook frame stream by the Mimi codec (24 kHz / 12.5 Hz).
+
+All fields below are public model facts taken from HF ``transformers``'
+``CsmConfig`` and the Mimi model card. This config exposes the backbone
+parameters at the top level so vLLM's machinery can read them, and provides a
+:func:`build_backbone_llama_config` helper that synthesises a plain
+``transformers.LlamaConfig`` describing *only* the backbone, so the backbone
+can be rebuilt on vLLM-native ``LlamaDecoderLayer`` + ``PagedAttention``
+(rather than wrapping the HF model).
+"""
+
+from __future__ import annotations
+
+from transformers import LlamaConfig
+from transformers.configuration_utils import PretrainedConfig
+
+# --- Public CSM-1B backbone facts (transformers.CsmConfig) ---
+_BACKBONE_HIDDEN_SIZE = 2048
+_BACKBONE_NUM_LAYERS = 16
+_BACKBONE_NUM_ATTENTION_HEADS = 32
+_BACKBONE_NUM_KV_HEADS = 8
+_BACKBONE_HEAD_DIM = 64
+_BACKBONE_INTERMEDIATE_SIZE = 8192
+_BACKBONE_MAX_POSITION_EMBEDDINGS = 2048
+_BACKBONE_ROPE_THETA = 500000.0
+# llama3 RoPE scaling (same family as Llama-3.x): scaled by `factor`.
+# ``original_max_position_embeddings`` is clamped strictly below the backbone
+# context in :func:`build_backbone_llama_config` to satisfy transformers'
+# rope-parameter validation (it must be < max_position_embeddings).
+_BACKBONE_ROPE_SCALING = {
+    "rope_type": "llama3",
+    "factor": 32.0,
+    "low_freq_factor": 1.0,
+    "high_freq_factor": 4.0,
+    "original_max_position_embeddings": 8192,
+}
+
+# --- Public CSM-1B depth-decoder facts (transformers.CsmConfig) ---
+_DEPTH_HIDDEN_SIZE = 1024
+_DEPTH_NUM_LAYERS = 4
+_DEPTH_HEAD_DIM = 128
+# Depth decoder runs a 31-step inner AR loop per frame (cb1..cb31 after the
+# backbone has produced cb0), i.e. 33 positions of dense static KV that reset
+# every frame. See A2 design §2.2.
+_DEPTH_NUM_POSITIONS = 33
+
+# --- Public Mimi codec facts (Mimi model card) ---
+_NUM_CODEBOOKS = 32
+_CODEBOOK_VOCAB_SIZE = 2051  # per-codebook vocab; 2048/2049/2050 are reserved
+_RESERVED_CODEBOOK_IDS = (2048, 2049, 2050)
+_MIMI_SAMPLE_RATE = 24000
+_MIMI_FRAME_RATE_HZ = 12.5
+_MIMI_SAMPLES_PER_FRAME = 1920  # 80 ms @ 24 kHz
+
+
+class CsmConfig(PretrainedConfig):
+    """Config for CSM-1B (``sesame/csm-1b``) in vLLM-Omni.
+
+    Exposes the backbone parameters at the top level (so vLLM reads them
+    directly), keeps the depth-decoder + Mimi codec parameters as nested
+    attributes, and registers under ``model_type = "csm"``. The flat HF
+    ``CsmConfig`` nests ``backbone_config`` / ``depth_decoder_config`` /
+    ``codec_config``; this class hoists the backbone fields and stores the rest
+    for the depth loop (C2) and the Mimi stage (C3).
+    """
+
+    model_type = "csm"
+
+    def __init__(self, **kwargs):
+        backbone_cfg = kwargs.pop("backbone_config", None) or {}
+        if hasattr(backbone_cfg, "to_dict"):
+            backbone_cfg = backbone_cfg.to_dict()
+        depth_cfg = kwargs.pop("depth_decoder_config", None) or {}
+        if hasattr(depth_cfg, "to_dict"):
+            depth_cfg = depth_cfg.to_dict()
+        codec_cfg = kwargs.pop("codec_config", None) or {}
+        if hasattr(codec_cfg, "to_dict"):
+            codec_cfg = codec_cfg.to_dict()
+
+        super().__init__(**kwargs)
+
+        # --- Backbone parameters (hoisted to top level for vLLM) ---
+        self.hidden_size = backbone_cfg.get("hidden_size", _BACKBONE_HIDDEN_SIZE)
+        self.num_hidden_layers = backbone_cfg.get("num_hidden_layers", _BACKBONE_NUM_LAYERS)
+        self.num_attention_heads = backbone_cfg.get("num_attention_heads", _BACKBONE_NUM_ATTENTION_HEADS)
+        self.num_key_value_heads = backbone_cfg.get("num_key_value_heads", _BACKBONE_NUM_KV_HEADS)
+        self.head_dim = backbone_cfg.get("head_dim", _BACKBONE_HEAD_DIM)
+        self.intermediate_size = backbone_cfg.get("intermediate_size", _BACKBONE_INTERMEDIATE_SIZE)
+        self.max_position_embeddings = backbone_cfg.get("max_position_embeddings", _BACKBONE_MAX_POSITION_EMBEDDINGS)
+        self.rope_theta = backbone_cfg.get("rope_theta", _BACKBONE_ROPE_THETA)
+        self.rope_scaling = backbone_cfg.get("rope_scaling", dict(_BACKBONE_ROPE_SCALING))
+        # tie_word_embeddings avoids a dead ~525 MB text head (A2 §2.1).
+        self.tie_word_embeddings = kwargs.get("tie_word_embeddings", True)
+
+        # --- Codebook / frame-embedding parameters ---
+        self.num_codebooks = getattr(self, "num_codebooks", _NUM_CODEBOOKS)
+        self.codebook_vocab_size = getattr(self, "codebook_vocab_size", _CODEBOOK_VOCAB_SIZE)
+        # Backbone vocab is the cb0 logits surface (one codebook of audio tokens).
+        self.vocab_size = backbone_cfg.get("vocab_size", self.codebook_vocab_size)
+        self.reserved_codebook_ids = _RESERVED_CODEBOOK_IDS
+
+        # --- Depth decoder (nested; consumed by C2 depth loop) ---
+        self.depth_hidden_size = depth_cfg.get("hidden_size", _DEPTH_HIDDEN_SIZE)
+        self.depth_num_hidden_layers = depth_cfg.get("num_hidden_layers", _DEPTH_NUM_LAYERS)
+        self.depth_head_dim = depth_cfg.get("head_dim", _DEPTH_HEAD_DIM)
+        self.depth_num_positions = depth_cfg.get("num_positions", _DEPTH_NUM_POSITIONS)
+        self.depth_decoder_config = depth_cfg
+
+        # --- Mimi codec (nested; consumed by C3 Stage-1 decoder) ---
+        self.codec_config = codec_cfg
+        self.codec_sample_rate = codec_cfg.get("sample_rate", _MIMI_SAMPLE_RATE)
+        self.codec_frame_rate_hz = codec_cfg.get("frame_rate", _MIMI_FRAME_RATE_HZ)
+        self.codec_samples_per_frame = codec_cfg.get("samples_per_frame", _MIMI_SAMPLES_PER_FRAME)
+        self.codec_pretrained_name_or_path = getattr(self, "codec_pretrained_name_or_path", "kyutai/mimi")
+
+        # vLLM requires speculative_config to be absent or None.
+        self.speculative_config = None
+
+    def get_text_config(self, **kwargs):
+        """Return self so vLLM reads our hoisted top-level backbone config."""
+        return self
+
+
+def build_backbone_llama_config(config: CsmConfig) -> LlamaConfig:
+    """Synthesise a plain ``LlamaConfig`` describing only the CSM backbone.
+
+    vLLM's native ``LlamaModel`` / ``LlamaDecoderLayer`` consume a standard
+    ``LlamaConfig``. CSM's HF config nests its backbone fields; this builds the
+    flat ``LlamaConfig`` so the backbone can be rebuilt on vLLM-native layers +
+    PagedAttention (A2 §2.1) rather than wrapping the HF model.
+
+    ``vocab_size`` is the cb0 audio-token surface; the depth decoder (C2) and
+    Mimi stage (C3) handle the remaining 31 codebooks and waveform synthesis.
+
+    Config-source note: ``config`` here is the **native** ``transformers``
+    ``CsmConfig`` (transformers >= 5.12 ships first-class CSM support), which is
+    authoritative for the backbone RoPE/attention facts and which carries the
+    typed nested ``depth_decoder_config`` / ``codec_config`` the C2/C3 aux
+    modules need (see ``CsmForGeneration._build_aux_modules``). We deliberately
+    do NOT register the vllm-omni ``CsmConfig`` over ``model_type="csm"`` (that
+    would (a) override ``AutoConfig.from_pretrained`` and break the aux-module
+    build, and (b) substitute hand-transcribed RoPE-scaling constants for the
+    checkpoint's real values). Instead we read ``rope_theta`` defensively: the
+    native config (and transformers >= 5.12 ``LlamaConfig``) folds ``rope_theta``
+    into ``rope_scaling`` / ``rope_parameters`` and exposes no top-level
+    ``rope_theta`` attribute, so we recover it from there.
+    """
+    rope_scaling = dict(config.rope_scaling) if config.rope_scaling else None
+    if rope_scaling and "original_max_position_embeddings" in rope_scaling:
+        # transformers' rope-parameter validation requires
+        # original_max_position_embeddings < max_position_embeddings.
+        rope_scaling["original_max_position_embeddings"] = min(
+            rope_scaling["original_max_position_embeddings"],
+            config.max_position_embeddings - 1,
+        )
+
+    # transformers >= 5.12 unified the RoPE config: ``rope_theta`` is nested
+    # inside ``rope_scaling`` (key ``"rope_theta"``) and is NOT exposed as a
+    # top-level attribute on either the native ``CsmConfig`` or the resulting
+    # ``LlamaConfig``. Read it from ``rope_scaling`` first, then any top-level
+    # attribute (older configs / the vllm-omni hoisted config), then the public
+    # CSM-1B default. Keep it inside ``rope_scaling`` too so vLLM's
+    # ``get_rope`` (which reads ``rope_parameters[...]["rope_theta"]``) finds it.
+    rope_theta = None
+    if rope_scaling is not None:
+        rope_theta = rope_scaling.get("rope_theta")
+    if rope_theta is None:
+        rope_theta = getattr(config, "rope_theta", None)
+    if rope_theta is None:
+        rope_theta = _BACKBONE_ROPE_THETA
+    if rope_scaling is not None:
+        rope_scaling.setdefault("rope_theta", rope_theta)
+
+    return LlamaConfig(
+        hidden_size=config.hidden_size,
+        num_hidden_layers=config.num_hidden_layers,
+        num_attention_heads=config.num_attention_heads,
+        num_key_value_heads=config.num_key_value_heads,
+        head_dim=config.head_dim,
+        intermediate_size=config.intermediate_size,
+        max_position_embeddings=config.max_position_embeddings,
+        vocab_size=config.vocab_size,
+        rope_theta=rope_theta,
+        rope_scaling=rope_scaling,
+        tie_word_embeddings=config.tie_word_embeddings,
+        hidden_act="silu",
+        attention_bias=False,
+        rms_norm_eps=1e-5,
+    )

--- a/vllm_omni/model_executor/models/csm/csm_backbone.py
+++ b/vllm_omni/model_executor/models/csm/csm_backbone.py
@@ -1,0 +1,837 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CSM-1B Stage-0 backbone AR model (with the 31-step depth decoder INSIDE).
+
+This is Stage 0 of the 2-stage CSM pipeline (A3 design §2). It runs the CSM
+backbone as a vLLM-native ``LlamaModel`` under PagedAttention, samples codebook-0
+(cb0) per 80 ms frame, runs the 31-step depth decoder inline to produce cb1..cb31,
+composes the next-frame Sigma-embedding, caches it per request, and surfaces the
+finished 32-code frame forward to Stage 1 (Mimi vocoder) as a latent payload.
+
+WHY 2-stage / why this shape is illegal-address-proof (A3 design §1, §3)
+------------------------------------------------------------------------
+The single-stage model (csm.py ``inference_stream``, d92e35f7) drove the backbone
+with a PRIVATE python loop that advanced its own ``positions`` thousands of times
+per request, OUTSIDE the vLLM scheduler. vLLM derives every KV slot purely from
+``positions`` + the per-request ``block_table``; positions the scheduler never
+allocated scatter ``reshape_and_cache`` writes into other requests' KV blocks ->
+silent heap corruption -> the deferred ``cudaErrorIllegalAddress`` on the next
+request's first kernel. That is NOT one clamp away from working.
+
+The fix (this file) is structural and mirrors MiMo-Audio (``mimo_audio_llm.py``,
+the feedback twin) + Qwen3-TTS (``qwen3_tts_talker.py``, the engine-contract
+twin):
+
+  1. Exactly ONE real, in-vocab token per frame stays in the sequence (cb0). vLLM
+     schedules it as a normal 1-token decode; the scheduler owns ``positions`` /
+     ``block_table`` / ``slot_mapping``. The model only overwrites the token's
+     EMBEDDING value -- never a position. (Qwen3 invariant verbatim:
+     ``qwen3_tts_talker.py:687-689``.)
+  2. The composed Sigma-embedding is delivered through the supported decode-time
+     ``preprocess`` hook (``has_preprocess=True``); the runner writes the returned
+     embedding back at the request's exact span
+     (``gpu_model_runner.py:1536-1563``). Positions stay runner-owned.
+  3. ``forward()`` runs the backbone EXACTLY once per step -> h_t; cb0 via the
+     ``LogitsProcessor`` (NOT a direct ``ParallelLMHead.forward`` -- that was the
+     b3c bug); then the 31-step depth loop INLINE (de-risked eager option (b),
+     A3 §6). The scheduler advances one frame per step.
+  4. Feedback via per-request cache + re-inject: ``forward()`` computes the
+     Sigma-embed and stashes it in ``self._cached_sigma_by_req[req_id]``; the next
+     ``preprocess`` call adds it onto the in-vocab token's base embedding. Because
+     the next step is also a real scheduled token, its KV slot is always
+     allocated -> no IMA. (MiMo cache+reinject:
+     ``mimo_audio_llm.py:939-969`` / ``:1112-1131``.)
+
+Every KV write therefore lands at a scheduler-allocated slot. The model's only
+GPU influence is the VALUE of ``inputs_embeds`` and of the sampled next token --
+never the position arithmetic. This is the mechanism MiMo-Audio ships today.
+
+Weight loading (A3 §5, B2 fix): the ``sesame/csm-1b`` checkpoint is split by
+prefix. ``backbone_model.* / lm_head / *embed*`` and ``depth_decoder.*`` are
+loaded HERE (Stage 0). ``codec_model.*`` is drained here and (re)loaded by Stage 1
+(``csm_mimi``) from the same checkpoint. Every returned name is a REAL registered
+parameter name so vLLM's load-completeness validator passes.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+from vllm.model_executor.models.llama import LlamaModel
+from vllm.model_executor.models.utils import maybe_prefix
+
+from vllm_omni.model_executor.models.csm.configuration_csm import (
+    CsmConfig,
+    build_backbone_llama_config,
+)
+from vllm_omni.model_executor.models.csm.csm_depth import (
+    CsmDepthDecoder,
+    sample_logits,
+)
+from vllm_omni.model_executor.models.output_templates import OmniOutput
+
+logger = init_logger(__name__)
+
+__all__ = ["CsmBackboneForConditionalGeneration"]
+
+# Default sampling parameters (public CSM-1B / Mimi facts).
+_DEFAULT_TEMPERATURE = 0.9
+_DEFAULT_TOP_K = 50
+
+# Public CSM/Mimi frame constants.
+_NUM_CODEBOOKS = 32
+_CODEBOOK_EOS_ID = 0  # codebook_eos_token_id; a frame with cb0..cb30==0 is EOS.
+
+# Hard frame-cap fallback (GATE-B follow-up). One scheduler decode step == one
+# 80 ms frame, so the AR loop length is bounded by SamplingParams.max_tokens.
+# But CSM-1B at do_sample has a non-terminating greedy/repetition attractor that
+# can keep emitting non-EOS frames indefinitely; if the scheduler stop on
+# max_tokens ever races the in-flight async streaming step, a request can run
+# PAST its cap (observed: 113 frames at cap 64). This model-owned counter is the
+# fail-closed guard: forward() counts emitted frames per request and
+# compute_logits forces the frame EOS (token id 0) the step the count reaches the
+# cap, so the request ALWAYS stops at the cap even with no natural EOS frame.
+# 2048 mirrors the deploy default_sampling_params max_tokens for Stage 0.
+_DEFAULT_MAX_FRAMES = 2048
+
+
+def _pick(info: dict, key: str, default):
+    """Extract scalar from additional_information dict (list or plain value)."""
+    val = info.get(key, default)
+    if isinstance(val, (list, tuple)) and len(val) > 0:
+        return val[0]
+    return val if val is not None else default
+
+
+def _req_key(info: dict[str, Any]) -> str:
+    """Resolve the per-request key (I5).
+
+    The runner sets ``request_id`` for the generic preprocess path
+    (``gpu_model_runner.py:1521``) and passes the same scheduler ids to
+    ``on_requests_finished`` (``gpu_ar_model_runner.py:379-380``). ``_omni_req_id``
+    is a legacy fallback that is never set in this runner; we still honor it (I5
+    canonical name) plus ``global_request_id`` so the key used at re-inject time
+    matches the key freed at finish time.
+    """
+    return str(
+        info.get("request_id") or info.get("global_request_id") or info.get("_omni_req_id") or info.get("req_id") or "0"
+    )
+
+
+class CsmBackbone(nn.Module):
+    """The CSM-1B backbone, rebuilt on vLLM-native Llama layers (REUSE: csm.py:116).
+
+    Wraps :class:`vllm.model_executor.models.llama.LlamaModel` (PagedAttention,
+    fused QKV, RoPE) driven by a synthetic ``LlamaConfig`` from ``CsmConfig``. The
+    cb0 logits head is ``cb0_head`` (the untied ``lm_head`` in the checkpoint).
+    """
+
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        csm_config: CsmConfig = vllm_config.model_config.hf_config
+        self.csm_config = csm_config
+
+        backbone_llama_config = build_backbone_llama_config(csm_config)
+        # Swap the synthetic LlamaConfig in so vLLM's native LlamaModel sees a
+        # standard Llama config (parent caches the CsmConfig first).
+        vllm_config.model_config.hf_config = backbone_llama_config
+        vllm_config.model_config.hf_text_config = backbone_llama_config
+
+        self.model = LlamaModel(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "model"),
+        )
+        self.cb0_head = ParallelLMHead(
+            csm_config.vocab_size,
+            csm_config.hidden_size,
+            prefix=maybe_prefix(prefix, "cb0_head"),
+        )
+        self.logits_processor = LogitsProcessor(csm_config.vocab_size)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """One backbone forward (the Sigma-embed is composed by the caller)."""
+        return self.model(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+        )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Delegate the backbone decoder layers + norm to vLLM's LlamaModel."""
+        return self.model.load_weights(weights)
+
+
+class CsmBackboneForConditionalGeneration(nn.Module):
+    """CSM-1B Stage-0 backbone AR model + inline 31-step depth decoder.
+
+    Contract surface (A3 §4.3):
+      * ``has_preprocess`` / ``has_postprocess`` -> the runner delivers the
+        composed inputs_embeds via ``preprocess`` and captures h_t via
+        ``postprocess``.
+      * ``have_multimodal_outputs`` -> ``forward`` returns an ``OmniOutput`` whose
+        ``multimodal_outputs`` carries the per-step 32-code frame as a latent
+        payload (``codes.audio``), surfaced forward to Stage 1.
+      * cb0 via ``logits_processor`` (NOT direct LMHead -- the b3c bug).
+      * Real frame EOS: cb0..cb30 all-zero (A3 §5; the *real* stop authority,
+        replacing the single-stage fake ``compute_logits`` EOS grid).
+
+    NOTE: this model deliberately does NOT declare ``talker_mtp_output_key`` /
+    ``mtp_hidden_size``. That keeps ``has_talker_mtp`` False on the runner so the
+    runner takes the plain ``preprocess`` path and the depth loop runs INSIDE this
+    model's ``forward()`` (the de-risked eager option (b), A3 §6) rather than via
+    the runner's single-shot MTP residual fast-path (which assumes a fixed-length
+    graph-safe predictor -- CSM's depth is a genuine 31-step sequential AR).
+    """
+
+    requires_raw_input_tokens = True
+    have_multimodal_outputs = True
+    has_preprocess = True
+    has_postprocess = True
+    enable_update_additional_information = True
+    inject_omni_request_id_into_runtime_info = True
+
+    packed_modules_mapping = CsmBackbone.packed_modules_mapping
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.vllm_config = vllm_config
+        self.config: CsmConfig = vllm_config.model_config.hf_config
+        self.model_path: str = vllm_config.model_config.model
+
+        self.num_codebooks = int(getattr(self.config, "num_codebooks", _NUM_CODEBOOKS))
+        self.hidden_size = int(getattr(self.config, "hidden_size", 2048))
+
+        # Backbone (vLLM-native layers). Constructing it mutates
+        # vllm_config.model_config.hf_config into the synthetic LlamaConfig, so we
+        # cache the CsmConfig above first.
+        self.backbone = CsmBackbone(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "backbone"),
+        )
+
+        # Aux modules (built in load_weights, after distributed init).
+        self._depth_decoder: nn.Module | None = None  # CsmDepthDecoderForCausalLM
+        self._frame_embed: nn.Module | None = None  # CsmBackboneModelEmbeddings
+        self._text_embed: nn.Module | None = None  # nn.Embedding (text prompt)
+        self._hf_config: Any = None
+        self._device: torch.device | None = None
+        self._dtype: torch.dtype = torch.float32  # aux (depth/embeds) compute dtype
+        self._backbone_dtype: torch.dtype = torch.bfloat16  # vLLM Llama dtype
+        self._lock = threading.Lock()
+
+        # Single-call depth wrapper (N2); its HF module is wired in load_weights.
+        self.depth = CsmDepthDecoder(
+            num_codebooks=self.num_codebooks,
+            hidden_size=self.hidden_size,
+            aux_dtype=self._dtype,
+        )
+
+        # I5: per-request feedback cache. Keyed by _req_key(info); holds the
+        # previous frame's Sigma-embed (1, hidden) to add onto the next step's
+        # in-vocab token embedding inside preprocess(). Freed in
+        # on_requests_finished.
+        self._cached_sigma_by_req: dict[str, torch.Tensor] = {}
+        # Per-request EOS latch so compute_logits can stop the scheduler on the
+        # real frame-level EOS (cb0..cb30 all-zero) computed in forward().
+        # Kept for debugging only; NOT used for row mapping (dict order is
+        # first-seen insertion order, which is NOT the per-step sampler row
+        # order once a request finishes or requests arrive out of order).
+        self._eos_by_req: dict[str, bool] = {}
+        # Authoritative EOS->logits-row mapping (unknown #2 fix). forward() fills
+        # this in EXACT batch-row order (the same order the runner gathers
+        # runtime_additional_information and the same order hidden_states are
+        # gathered into compute_logits' sample rows -- input_batch.req_ids).
+        # compute_logits consumes it positionally so EOS lands on the correct
+        # request's row even under concurrency / staggered finishes.
+        self._eos_flags_by_row: list[bool] = []
+        # Per-request sampling params resolved at first preprocess.
+        self._sampling_by_req: dict[str, tuple[float, int]] = {}
+        # GATE-B hard frame cap. _max_frames_by_req[req] is the resolved cap
+        # (from the request's SamplingParams.max_tokens, falling back to
+        # _DEFAULT_MAX_FRAMES); _frames_emitted_by_req[req] counts non-prefill
+        # frames surfaced from forward(). When the count reaches the cap,
+        # compute_logits forces the frame EOS for that request's row so the AR
+        # loop stops at the cap regardless of the natural all-zero EOS firing.
+        self._max_frames_by_req: dict[str, int] = {}
+        self._frames_emitted_by_req: dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # Weight loading (A3 §5; split: codec_model.* -> Stage 1)
+    # ------------------------------------------------------------------
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Split the CSM checkpoint by prefix; route Stage-0 parts, drain codec.
+
+        REUSE: csm.py:278 prefix routing, minus the Mimi codec (Stage 1 loads it).
+        Every returned name is a REAL registered parameter name (the
+        ``backbone.`` / leading-underscore aux prefixes) to satisfy vLLM's
+        load-completeness validator (B2).
+        """
+        with self._lock:
+            if self._depth_decoder is not None:
+                return set()
+            try:
+                self._device = next(self.parameters()).device
+            except StopIteration:
+                self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            self._dtype = self.config.torch_dtype or torch.float32
+            try:
+                self._backbone_dtype = next(self.backbone.parameters()).dtype
+            except StopIteration:
+                self._backbone_dtype = self.vllm_config.model_config.dtype or self._dtype
+            self._build_aux_modules()
+
+        backbone_layer_weights: list[tuple[str, torch.Tensor]] = []
+        depth_weights: list[tuple[str, torch.Tensor]] = []
+        loaded: set[str] = set()
+
+        frame_embed_state: dict[str, torch.Tensor] = {}
+        text_embed_state: dict[str, torch.Tensor] = {}
+        cb0_head_state: dict[str, torch.Tensor] = {}
+
+        for name, w in weights:
+            if name.startswith("backbone_model.embed_tokens."):
+                sub = name[len("backbone_model.embed_tokens.") :]
+                frame_embed_state[sub] = w
+                loaded.add(name)
+            elif name.startswith("backbone_model."):
+                backbone_layer_weights.append((name[len("backbone_model.") :], w))
+            elif name == "lm_head.weight":
+                cb0_head_state["weight"] = w
+                loaded.add(name)
+            elif name == "embed_text_tokens.weight":
+                text_embed_state["weight"] = w
+                loaded.add(name)
+            elif name.startswith("depth_decoder."):
+                depth_weights.append((name[len("depth_decoder.") :], w))
+            elif name.startswith("codec_model."):
+                # Stage 1 (csm_mimi) loads the Mimi codec from the same
+                # checkpoint; drain it here so this stage's loader does not
+                # report it as unrouted, and credit it as "loaded" for this
+                # iterator (Stage 0 owns no codec parameters).
+                loaded.add(name)
+            else:
+                logger.warning("CSM Stage-0 load_weights: unrouted weight %s", name)
+
+        self.backbone.load_weights(iter(backbone_layer_weights))
+        loaded |= {n for n, _ in self.backbone.named_parameters(prefix="backbone")}
+
+        if "weight" in cb0_head_state:
+            self._load_into(self.backbone.cb0_head, {"weight": cb0_head_state["weight"]})
+
+        if self._frame_embed is not None and frame_embed_state:
+            _, fe_unexpected = self._frame_embed.load_state_dict(frame_embed_state, strict=False)
+            if fe_unexpected:
+                logger.warning("CSM frame_embed unexpected keys: %s", fe_unexpected[:8])
+            loaded |= {n for n, _ in self._frame_embed.named_parameters(prefix="_frame_embed")}
+        if self._text_embed is not None and text_embed_state:
+            self._text_embed.load_state_dict(text_embed_state, strict=False)
+            loaded |= {n for n, _ in self._text_embed.named_parameters(prefix="_text_embed")}
+
+        if self._depth_decoder is not None:
+            _, dd_unexpected = self._depth_decoder.load_state_dict(dict(depth_weights), strict=False)
+            if list(dd_unexpected):
+                logger.warning("CSM depth_decoder unexpected keys: %s", list(dd_unexpected)[:8])
+            loaded |= {n for n, _ in self._depth_decoder.named_parameters(prefix="_depth_decoder")}
+            # The same HF depth module is also wired into the ``depth`` wrapper
+            # (``self.depth.set_module(self._depth_decoder)``), which auto-
+            # registers it under ``depth._module.*`` (nn.Module submodule
+            # registration). Credit that aliased name span too, else vLLM's
+            # load-completeness validator (default_loader.track_weights_loading)
+            # flags ``depth._module.*`` as uninitialized at boot (B2).
+            loaded |= {n for n, _ in self.depth.named_parameters(prefix="depth")}
+
+        self._maybe_tie_depth_embed()
+        return loaded
+
+    def _build_aux_modules(self) -> None:
+        """Construct the depth decoder + frame-embed + text embed (REUSE: csm.py:416).
+
+        Mimi codec is NOT built here (Stage 1 owns it). Built from the
+        authoritative HF ``CsmConfig`` loaded from the model path.
+        """
+        from transformers import AutoConfig
+        from transformers.models.csm.modeling_csm import (
+            CsmBackboneModelEmbeddings,
+            CsmDepthDecoderForCausalLM,
+        )
+
+        hf_cfg = AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
+        self._hf_config = hf_cfg
+        depth_cfg = hf_cfg.depth_decoder_config
+
+        self._frame_embed = CsmBackboneModelEmbeddings(hf_cfg)
+        self._text_embed = nn.Embedding(int(hf_cfg.text_vocab_size), int(hf_cfg.hidden_size))
+        self._depth_decoder = CsmDepthDecoderForCausalLM(depth_cfg)
+
+        for m in (self._frame_embed, self._text_embed, self._depth_decoder):
+            m.to(device=self._device, dtype=self._dtype)
+            m.eval()
+            for p in m.parameters():
+                p.requires_grad_(False)
+
+        # Wire the HF depth module into the single-call wrapper.
+        self.depth._aux_dtype = self._dtype
+        self.depth.set_module(self._depth_decoder)
+
+    def _maybe_tie_depth_embed(self) -> None:
+        """Tie depth audio embed to backbone audio embed (REUSE: csm.py:458)."""
+        if self._frame_embed is None or self._depth_decoder is None:
+            return
+        if not getattr(self.config, "tie_codebooks_embeddings", True):
+            return
+        try:
+            src = self._frame_embed.embed_audio_tokens.weight
+            self._depth_decoder.model.embed_tokens.weight = src
+        except AttributeError:
+            logger.warning("CSM: could not tie depth embed to backbone audio embed")
+
+    @staticmethod
+    def _load_into(module: nn.Module, state: dict[str, torch.Tensor]) -> None:
+        """REUSE: csm.py:476."""
+        params = dict(module.named_parameters())
+        from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+        for name, w in state.items():
+            if name not in params:
+                logger.warning("CSM: %s not in %s", name, type(module).__name__)
+                continue
+            param = params[name]
+            loader = getattr(param, "weight_loader", default_weight_loader)
+            loader(param, w)
+
+    # ------------------------------------------------------------------
+    # Dummy run support
+    # ------------------------------------------------------------------
+
+    def get_dummy_runtime_additional_information(self, num_reqs: int) -> list[dict]:
+        return [{"text": "hello", "_is_dummy": True} for _ in range(num_reqs)]
+
+    def embed_input_ids(self, input_ids: torch.Tensor, *_: Any, **__: Any) -> torch.Tensor:
+        """Stable dummy embedding for the runner's pre-embed path.
+
+        The real per-step embedding is composed in ``preprocess`` (cb0 base embed
+        + cached prev-frame Sigma). The runner pre-embeds the token here only to
+        seed the CUDA-graph-stable inputs_embeds buffer; ``preprocess`` overwrites
+        the request's span.
+        """
+        return torch.zeros(
+            (input_ids.shape[0], self.hidden_size),
+            device=input_ids.device,
+            dtype=self._backbone_dtype,
+        )
+
+    # ------------------------------------------------------------------
+    # Embedding primitives
+    # ------------------------------------------------------------------
+
+    def _embed_text_prompt(self, info: dict[str, Any], device: torch.device) -> torch.Tensor:
+        """Embed the text prompt token ids -> (T, hidden). REUSE: csm.py:525."""
+        token_ids = _pick(info, "prompt_token_ids", None)
+        if token_ids is None:
+            token_ids = info.get("prompt_token_ids")
+        if token_ids is None:
+            bos = int(getattr(self.config, "bos_token_id", 128000) or 128000)
+            token_ids = [bos]
+        ids = torch.as_tensor(token_ids, dtype=torch.long, device=device).view(-1)
+        return self._text_embed(ids).to(self._backbone_dtype)
+
+    def _compose_frame_embed(self, frame_codes: torch.Tensor) -> torch.Tensor:
+        """Sigma over the 32 codebooks -> one backbone input embedding.
+
+        REUSE: csm.py:544 ``_compose_frame_embed``. ``frame_codes`` is ``(B, 32)``
+        Long; ``CsmBackboneModelEmbeddings`` expects ``(B, T, num_codebooks)`` and
+        sums over the codebook dim. Returns ``(B, hidden)`` (we squeeze the
+        length-1 frame axis) cast to the BACKBONE dtype (the b3b dtype fix: the
+        fp32 frame-embed must match the bf16 QKV matmul or it raises
+        "mat1 and mat2 must have the same dtype").
+        """
+        emb = self._frame_embed(frame_codes.unsqueeze(1))  # (B, 1, hidden)
+        return emb.squeeze(1).to(self._backbone_dtype)  # (B, hidden)
+
+    # ------------------------------------------------------------------
+    # preprocess: re-inject the cached Sigma-embed (the feedback, A3 §3)
+    # ------------------------------------------------------------------
+
+    def preprocess(
+        self,
+        input_ids: torch.Tensor,
+        input_embeds: torch.Tensor | None,
+        **info_dict: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Deliver the composed inputs_embeds for this request's span.
+
+        Mirrors Qwen3-TTS ``preprocess`` (``qwen3_tts_talker.py:571``) for the
+        contract shape ``(input_ids_out, embeds_out, update_dict)``, and MiMo's
+        cache-add semantics (``mimo_audio_llm.py:964`` ``+= prev_new_audio_emb``).
+
+        PREFILL (span_len >= 1, first scheduled tokens): embed the text prompt;
+        positions/slots are scheduler-owned. The in-vocab token ids are kept (they
+        stay in vocab; the model reads only the embedding).
+
+        DECODE (span_len == 1): the embedding is the base embedding of the in-vocab
+        token PLUS the cached previous-frame Sigma-embed for this request. This is
+        the ONLY place the feedback is re-injected; the next step is again a real
+        scheduled token, so its KV slot is always allocated -> no IMA.
+        """
+        device = input_ids.device
+        req_key = _req_key(info_dict)
+        span_len = int(input_ids.shape[0])
+        if span_len <= 0:
+            base = input_embeds if input_embeds is not None else self.embed_input_ids(input_ids)
+            return input_ids, base, {}
+
+        # Resolve + cache per-request sampling once.
+        if req_key not in self._sampling_by_req:
+            temperature = float(_pick(info_dict, "temperature", _DEFAULT_TEMPERATURE))
+            top_k = int(_pick(info_dict, "top_k", _DEFAULT_TOP_K))
+            self._sampling_by_req[req_key] = (temperature, top_k)
+
+        # Resolve + cache the hard frame cap once (GATE-B). Prefer an explicit
+        # per-request cap forwarded via additional_information ("max_new_frames"
+        # or its "max_tokens" alias, set by the serving param-builder), else the
+        # deploy-level default. This is the fail-closed backstop to the
+        # scheduler's own SamplingParams.max_tokens stop.
+        if req_key not in self._max_frames_by_req:
+            cap = _pick(info_dict, "max_new_frames", None)
+            if cap is None:
+                cap = _pick(info_dict, "max_tokens", None)
+            try:
+                cap_int = int(cap) if cap is not None else _DEFAULT_MAX_FRAMES
+            except (TypeError, ValueError):
+                cap_int = _DEFAULT_MAX_FRAMES
+            if cap_int <= 0:
+                cap_int = _DEFAULT_MAX_FRAMES
+            self._max_frames_by_req[req_key] = cap_int
+            self._frames_emitted_by_req[req_key] = 0
+
+        is_prefill_raw = info_dict.get("_omni_is_prefill")
+        if isinstance(is_prefill_raw, bool):
+            is_prefill = is_prefill_raw
+        else:
+            try:
+                is_prefill = int(info_dict["_omni_num_computed_tokens"]) < int(info_dict["_omni_prompt_len"])
+            except Exception:
+                is_prefill = span_len > 1
+
+        # Keep token ids in-vocab for vLLM bookkeeping (Qwen3 invariant
+        # qwen3_tts_talker.py:687-689). cb0 ids are already in [0, vocab); clamp
+        # defensively so a stray id can never index out of the embedding table.
+        input_ids_out = input_ids.clone()
+        input_ids_out.clamp_(min=0, max=int(self.config.vocab_size) - 1)
+
+        if is_prefill:
+            prompt_embeds = self._embed_text_prompt(info_dict, device)  # (T, hidden)
+            offset = int(info_dict.get("_omni_num_computed_tokens", 0) or 0)
+            offset = max(0, offset)
+            s = max(0, min(offset, int(prompt_embeds.shape[0])))
+            e = max(0, min(offset + span_len, int(prompt_embeds.shape[0])))
+            take = prompt_embeds[s:e]
+            if int(take.shape[0]) < span_len:
+                pad_n = span_len - int(take.shape[0])
+                pad = torch.zeros((pad_n, self.hidden_size), device=device, dtype=self._backbone_dtype)
+                take = torch.cat([take, pad], dim=0)
+            return input_ids_out, take, {}
+
+        # Decode: span_len == 1. base = embed(cb0_token); add cached Sigma.
+        # The in-vocab token's base embedding is taken from the same per-codebook
+        # cb0 row of the frame-embed table (codebook 0), so the composed embedding
+        # equals embed_cb0(token) + Sigma(prev frame). When no cache yet (first
+        # decode after prefill), fall back to the runner-provided base embed.
+        cb0_token = input_ids_out.reshape(-1)[:1].to(torch.long)  # (1,)
+        # Build a (1, 32) frame with only cb0 set so the Sigma table contributes
+        # exactly the cb0 codebook-0 embedding for this token.
+        cb0_frame = torch.zeros((1, self.num_codebooks), dtype=torch.long, device=device)
+        cb0_frame[0, 0] = cb0_token[0]
+        base = self._compose_frame_embed(cb0_frame)  # (1, hidden)
+
+        cached = self._cached_sigma_by_req.get(req_key)
+        if cached is not None:
+            base = base + cached.to(device=device, dtype=self._backbone_dtype)
+        return input_ids_out, base, {}
+
+    def preprocess_decode_batch(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        req_infos: list[dict[str, Any]],
+    ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Batched decode-only preprocess (B>1 continuous batching, A3 N8).
+
+        Loops ``preprocess`` over the batch and stacks. CSM does NOT use the
+        runner's talker_mtp fast-path, so we return only ``(ids, embeds, [])``
+        (no mtp_inputs); the runner's plain ``preprocess`` flush path consumes
+        this. Kept here so ``has_talker_mtp`` stays False while still offering a
+        batched entry point symmetric with ``preprocess``.
+        """
+        ids_flat = input_ids.reshape(-1)
+        if int(ids_flat.numel()) != len(req_infos):
+            raise ValueError(f"preprocess_decode_batch expected {len(req_infos)} ids, got {int(ids_flat.numel())}")
+        out_ids: list[torch.Tensor] = []
+        out_embeds: list[torch.Tensor] = []
+        for i, info in enumerate(req_infos):
+            rid, remb, _ = self.preprocess(input_ids=ids_flat[i : i + 1], input_embeds=None, **info)
+            out_ids.append(rid.reshape(-1)[:1])
+            out_embeds.append(remb.reshape(1, -1))
+        return torch.cat(out_ids, dim=0), torch.cat(out_embeds, dim=0), {}
+
+    def postprocess(self, hidden_states: torch.Tensor, **_: Any) -> dict[str, Any]:
+        """No-op postprocess (h_t is consumed inline in forward).
+
+        Declared (``has_postprocess=True``) only to keep the runner's
+        per-request additional_information refresh path active
+        (``gpu_model_runner.py:1208``). CSM forms its own next-step embedding
+        inside ``forward()`` + ``preprocess``, so there is nothing to stash here.
+        """
+        return {}
+
+    # ------------------------------------------------------------------
+    # Core forward: one backbone step + inline depth + Sigma cache
+    # ------------------------------------------------------------------
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        intermediate_tensors: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        runtime_additional_information: list[dict[str, Any]] | None = None,
+        model_intermediate_buffer: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> OmniOutput:
+        """Run the backbone once, sample cb0, run inline depth, cache Sigma.
+
+        Streaming contract (I1): DELTA -- ``codes.audio`` carries ONLY the new
+        32-code frame(s) produced this step (forward-flowing latent to Stage 1);
+        nothing is re-decoded. Hot-loop discipline (I3): no ``.item()`` / ``.cpu()``
+        inside the depth loop (handled in ``CsmDepthDecoder.run``); the single EOS
+        host-read is per-frame, outside the 31-step loop.
+        """
+        infos = runtime_additional_information or model_intermediate_buffer or [{}]
+
+        # vLLM owns positions/slots; we only read h_t and overwrite embedding
+        # VALUES. The runner already wrote the composed embedding (from
+        # preprocess) into inputs_embeds[s:e].
+        hidden = self.backbone.forward(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+        )
+        # hidden: (sum_tokens, hidden). Resolve per-request last-row spans from
+        # the forward context query_start_loc (mirrors mimo_audio_llm.py:1038).
+        from vllm.forward_context import get_forward_context
+
+        ctx = get_forward_context()
+        if ctx is not None and ctx.attn_metadata is not None:
+            qsl = next(iter(ctx.attn_metadata.values())).query_start_loc
+        else:
+            qsl = torch.tensor([0, hidden.shape[0]], device=hidden.device)
+
+        num_reqs = max(0, int(qsl.numel()) - 1)
+        device = hidden.device
+        codes_out: list[torch.Tensor | None] = [None] * num_reqs
+        # Per-row EOS flags for THIS step, in batch-row order (unknown #2). Index
+        # i corresponds to sampler logits row i in compute_logits (both derive
+        # from input_batch.req_ids order). Default False (incl. dummy rows).
+        eos_flags_by_row: list[bool] = [False] * num_reqs
+
+        for i in range(num_reqs):
+            info = infos[i] if i < len(infos) else {}
+            if info.get("_is_dummy"):
+                continue
+            req_key = _req_key(info)
+            temperature, top_k = self._sampling_by_req.get(req_key, (_DEFAULT_TEMPERATURE, _DEFAULT_TOP_K))
+
+            start = int(qsl[i].item())
+            end = int(qsl[i + 1].item())
+            if end <= start:
+                continue
+            last_hidden = hidden[end - 1 : end].to(self._backbone_dtype)  # (1, hidden)
+
+            # cb0 via the LogitsProcessor (NOT a direct ParallelLMHead.forward --
+            # the b3c bug). Applies the head matmul + TP gather + vocab trim.
+            cb0_logits = self.backbone.logits_processor(self.backbone.cb0_head, last_hidden)
+            cb0 = sample_logits(cb0_logits, temperature, top_k)  # (1,)
+
+            # 31-step inline depth -> (1, 32) Long.
+            frame_codes = self.depth.run(
+                cb0=cb0,
+                backbone_last_hidden_state=last_hidden,
+                temperature=temperature,
+                top_k=top_k,
+            )
+
+            # Real frame EOS (A3 §5): cb0..cb30 all-zero. One host-read per frame
+            # (outside the depth loop, I3-compliant). Latch so compute_logits stops
+            # the scheduler this step.
+            natural_eos = bool((frame_codes[0, : self.num_codebooks - 1] == _CODEBOOK_EOS_ID).all().item())
+
+            # GATE-B hard frame cap: count the frame we are about to surface and
+            # force a stop once the per-request cap is reached, even if the
+            # natural all-zero EOS never fires (the non-terminating greedy/
+            # repetition attractor). This is the fail-closed backstop to the
+            # scheduler's SamplingParams.max_tokens stop; it guarantees the AR
+            # loop ends at the cap and protects the server from unbounded
+            # requests. Distinct from natural_eos because a cap-forced frame is a
+            # REAL audio frame (keep it), whereas a natural EOS frame is all-zero
+            # (drop it).
+            emitted = self._frames_emitted_by_req.get(req_key, 0) + 1
+            self._frames_emitted_by_req[req_key] = emitted
+            cap = self._max_frames_by_req.get(req_key, _DEFAULT_MAX_FRAMES)
+            cap_forced = emitted >= cap and not natural_eos
+            if cap_forced:
+                logger.warning(
+                    "CSM req %s hit frame cap %d without a natural EOS frame; "
+                    "forcing stop (greedy non-terminating attractor guard).",
+                    req_key,
+                    cap,
+                )
+
+            # is_eos drives the scheduler stop for BOTH natural EOS and the
+            # cap-forced stop; the emit branch below keeps the cap-forced frame's
+            # audio but drops the all-zero natural-EOS frame.
+            is_eos = natural_eos or cap_forced
+            self._eos_by_req[req_key] = is_eos
+            eos_flags_by_row[i] = is_eos  # authoritative row mapping (unknown #2)
+
+            # Cache the next-frame Sigma-embed for this request (I5). On the
+            # terminal EOS frame we still cache (harmless; freed at finish).
+            sigma = self._compose_frame_embed(frame_codes)  # (1, hidden)
+            self._cached_sigma_by_req[req_key] = sigma.detach()
+
+            # Surface the finished 32-code frame forward to Stage 1 as latent.
+            # Layout [F=1, 32] (frame-major; the stage processor flattens
+            # codebook-major). On the NATURAL all-zero EOS emit an empty frame so
+            # Stage 1 trims it; on a CAP-FORCED stop the frame is real audio --
+            # keep it so the capped request still produces its final frame of
+            # speech (the cap bounds length, it does not truncate the last frame).
+            if natural_eos:
+                codes_out[i] = torch.zeros((0, self.num_codebooks), dtype=torch.long, device=device)
+            else:
+                codes_out[i] = frame_codes.to(torch.long)  # (1, 32)
+
+            # Default-off validation hook: dump per-request served frames to a
+            # JSONL so an offline driver can assert frame-for-frame vs HF greedy
+            # (GATE-B). Zero effect unless ``VLLM_CSM_DUMP_FRAMES`` is set.
+            _dump = __import__("os").environ.get("VLLM_CSM_DUMP_FRAMES")
+            if _dump:
+                try:
+                    import json as _json
+
+                    _rec = {
+                        "req": req_key,
+                        "eos": bool(is_eos),
+                        "frame": frame_codes[0].detach().cpu().tolist(),
+                    }
+                    # Drift probe (unknown #1): when VLLM_CSM_DUMP_HIDDEN is set,
+                    # also dump the backbone last-hidden-state row used to drive
+                    # cb0 + the inline depth loop, so an offline driver can diff
+                    # it against an HF-eager run on the same prefix (kernel-drift
+                    # signature: small ~1e-3 delta growing with t). Zero cost by
+                    # default; fp32 list for exact compare.
+                    if __import__("os").environ.get("VLLM_CSM_DUMP_HIDDEN"):
+                        _rec["hidden"] = last_hidden[0].detach().float().cpu().tolist()
+                    with open(_dump, "a") as _fh:
+                        _fh.write(_json.dumps(_rec) + "\n")
+                except Exception:
+                    pass
+
+        # Publish the per-row EOS mapping for compute_logits (called immediately
+        # after forward in the same step, same batch-row order). Unknown #2 fix.
+        self._eos_flags_by_row = eos_flags_by_row
+
+        # text_hidden_states feeds compute_logits' sample-row gather; pass through.
+        return OmniOutput(
+            text_hidden_states=hidden,
+            multimodal_outputs={"codes": {"audio": codes_out}},
+        )
+
+    def make_omni_output(self, model_outputs: torch.Tensor | OmniOutput, **kwargs: Any) -> OmniOutput:
+        """Passthrough when forward already returned an OmniOutput.
+
+        ``forward`` returns ``OmniOutput`` directly, so ``extract_multimodal_outputs``
+        (``gpu_model_runner.py:686``) consumes it and the runner does NOT call this
+        (``_model_forward`` only calls ``make_omni_output`` when the output is not an
+        ``OmniOutput``). Provided for symmetry with qwen3_tts
+        (``qwen3_tts_talker.py:505-507``) / robustness.
+        """
+        if isinstance(model_outputs, OmniOutput):
+            return model_outputs
+        return OmniOutput(text_hidden_states=model_outputs, multimodal_outputs={})
+
+    # ------------------------------------------------------------------
+    # AR scheduler interface: cb0 logits + real frame EOS stop
+    # ------------------------------------------------------------------
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor | OmniOutput,
+        sampling_metadata: Any = None,
+    ) -> torch.Tensor | None:
+        """Emit cb0 logits so the external sampler advances one real in-vocab
+        token per frame, with a real frame-EOS override.
+
+        The cb0 token id the sampler picks becomes ``input_ids`` for the next
+        step's ``preprocess`` (the scheduler-visible in-vocab token; A3 §3 inv.1).
+        On the real frame EOS (cb0..cb30 all-zero, latched in ``forward``) we force
+        the configured stop id so the scheduler finishes the request. NOT the fake
+        ``(num_rows, 2051)`` EOS grid the single-stage model used (csm.py:847,
+        discarded -- it was a second, conflicting stop authority, A3 §1).
+        """
+        if isinstance(hidden_states, OmniOutput):
+            hidden_states = hidden_states.text_hidden_states
+        if hidden_states is None:
+            return None
+        if hidden_states.ndim == 1:
+            hidden_states = hidden_states.unsqueeze(0)
+        logits = self.backbone.logits_processor(self.backbone.cb0_head, hidden_states.to(self._backbone_dtype))
+        if logits is None:
+            return None
+
+        # Force EOS (token id 0) on rows whose frame was the real all-zero EOS.
+        # The AR runner gathers one sample row per request in batch-row order
+        # (hidden_states[logits_indices], same order as input_batch.req_ids);
+        # forward() filled _eos_flags_by_row in that SAME order this step, so we
+        # map positionally (unknown #2 fix). Using dict.values() here was wrong:
+        # dict order is first-seen insertion order, which desyncs from the
+        # current sampler-row order once any request finishes or requests arrive
+        # out of order -> EOS could fire on the wrong request's row.
+        eos_flags = self._eos_flags_by_row
+        num_rows = int(logits.shape[0])
+        for row in range(num_rows):
+            if row < len(eos_flags) and eos_flags[row]:
+                logits[row, :] = float("-inf")
+                logits[row, _CODEBOOK_EOS_ID] = 1.0e6
+        return logits
+
+    def on_requests_finished(self, finished_req_ids: set[str] | list[str]) -> None:
+        """Free per-request state on finish (I5). REUSE shape: csm.py:829."""
+        for req_id in finished_req_ids:
+            key = str(req_id)
+            self._cached_sigma_by_req.pop(key, None)
+            self._eos_by_req.pop(key, None)
+            self._sampling_by_req.pop(key, None)
+            self._max_frames_by_req.pop(key, None)
+            self._frames_emitted_by_req.pop(key, None)

--- a/vllm_omni/model_executor/models/csm/csm_backbone.py
+++ b/vllm_omni/model_executor/models/csm/csm_backbone.py
@@ -553,21 +553,31 @@ class CsmBackboneForConditionalGeneration(nn.Module):
                 take = torch.cat([take, pad], dim=0)
             return input_ids_out, take, {}
 
-        # Decode: span_len == 1. base = embed(cb0_token); add cached Sigma.
-        # The in-vocab token's base embedding is taken from the same per-codebook
-        # cb0 row of the frame-embed table (codebook 0), so the composed embedding
-        # equals embed_cb0(token) + Sigma(prev frame). When no cache yet (first
-        # decode after prefill), fall back to the runner-provided base embed.
+        # Decode: span_len == 1. The backbone input for this position is the FULL
+        # 32-codebook Sigma-embedding of the PREVIOUS frame, and nothing else. HF
+        # CsmBackboneModelEmbeddings.forward sums embed_audio over ALL 32 codebooks
+        # (modeling_csm.py: `embed_audio_tokens(input_ids + audio_tokens_offsets)`
+        # then `.sum(dim=2)`), and during AR generation a position's codes ARE the
+        # previously generated frame. That full-frame Sigma is composed from the
+        # real sampled 32-code frame and cached after the prior step's sampling, so
+        # we re-inject it as-is.
+        #
+        # Do NOT add a separate cb0 base embed on top: cb0 is already the k=0 term
+        # of the cached Sigma (frame_codes[...,0]). Adding embed_audio(cb0) again
+        # double-counts codebook 0 every decode step, which compounds through the
+        # KV cache and drifts the rollout (audio derails after frame 0, runs past
+        # EOS, over-loud). This was the served-path fidelity bug.
+        cached = self._cached_sigma_by_req.get(req_key)
+        if cached is not None:
+            return input_ids_out, cached.to(device=device, dtype=self._backbone_dtype), {}
+
+        # No cache yet. This should not happen at a real decode step (the prefill
+        # forward caches frame 0's Sigma before the first decode), but keep a safe
+        # fallback: the cb0-only embed of the scheduler-delivered token.
         cb0_token = input_ids_out.reshape(-1)[:1].to(torch.long)  # (1,)
-        # Build a (1, 32) frame with only cb0 set so the Sigma table contributes
-        # exactly the cb0 codebook-0 embedding for this token.
         cb0_frame = torch.zeros((1, self.num_codebooks), dtype=torch.long, device=device)
         cb0_frame[0, 0] = cb0_token[0]
         base = self._compose_frame_embed(cb0_frame)  # (1, hidden)
-
-        cached = self._cached_sigma_by_req.get(req_key)
-        if cached is not None:
-            base = base + cached.to(device=device, dtype=self._backbone_dtype)
         return input_ids_out, base, {}
 
     def preprocess_decode_batch(

--- a/vllm_omni/model_executor/models/csm/csm_depth.py
+++ b/vllm_omni/model_executor/models/csm/csm_depth.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CSM-1B depth decoder: the 31-step inner AR loop (Stage-0 side computation).
+
+This wraps the HF ``CsmDepthDecoderForCausalLM`` 31-step autoregressive loop as
+a single ``run(...)`` call so the Stage-0 backbone model can invoke it once per
+frame inside its own ``forward()`` (mirroring MiMo-Audio's ``base_local_forward``
+inner multi-step decode, ``mimo_audio_llm.py:807-859``). The body is the proven
+``_run_depth_loop`` from the single-stage CSM worktree (csm.py:647 @ d92e35f7),
+which already passed bit-exact-vs-HF on the clean req-0 run.
+
+Why this lives in Stage 0 (A3 design §2): the backbone's input at frame t+1 is
+the sum of the embeddings of all 32 codebooks of frame t (cb0 from the backbone,
+cb1..cb31 from this depth decoder). Keeping the depth loop inside Stage 0 makes
+the entire per-frame coupling a side-computation of Stage 0's own AR step, so the
+inter-stage boundary stays clean (only finished 32-code frames cross to Stage 1).
+
+The depth decoder runs as custom dense torch (its own ``DynamicCache``, reset
+every frame, 33 positions) OUTSIDE vLLM PagedAttention. It never advances a
+backbone KV position, so it cannot corrupt the paged KV heap (A3 design §1).
+
+Hot-loop discipline (I3): one ``(B, 32)`` device staging tensor filled in place;
+no per-step ``.item()`` / ``.cpu()`` host syncs. ``_sample_logits`` casts to fp32
++ ``nan_to_num`` before every sample (the b3 numerics fix).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+def sample_logits(logits: torch.Tensor, temperature: float, top_k: int) -> torch.Tensor:
+    """Sample one token id per row from logits (REUSE: csm.py:89 ``_sample_logits``).
+
+    Logits are cast to fp32 + ``nan_to_num`` before any softmax/argmax (the b3
+    numerics fix: the bf16 backbone can emit +/-inf or NaN that would trip
+    ``torch.multinomial``'s device-side assert). ``temperature<=0`` is greedy.
+    Op shapes are kept fixed (top-k via masked fill) so a future CUDA-graph
+    capture sees a stable reduction order. Returns a ``(B,)`` LongTensor.
+    """
+    logits = logits.float()
+    logits = torch.nan_to_num(logits, nan=0.0, posinf=1e4, neginf=-1e4)
+    if temperature is None or temperature <= 0.0:
+        return torch.argmax(logits, dim=-1)
+
+    logits = logits / temperature
+    if top_k and top_k > 0 and top_k < logits.shape[-1]:
+        kth = torch.topk(logits, top_k, dim=-1).values[..., -1, None]
+        logits = torch.where(logits < kth, torch.full_like(logits, float("-inf")), logits)
+    probs = torch.softmax(logits, dim=-1)
+    return torch.multinomial(probs, num_samples=1).squeeze(-1)
+
+
+class CsmDepthDecoder(nn.Module):
+    """Single-call wrapper around the CSM depth decoder's 31-step AR loop.
+
+    Holds the HF ``CsmDepthDecoderForCausalLM`` module (built + tied + weight-
+    loaded by ``CsmBackboneForConditionalGeneration.load_weights``). ``run()`` is
+    the de-risked eager path (A3 design §6 "risk call", option (b)): the 31 steps
+    run in plain torch inside one Stage-0 ``forward()``; it is NOT captured as a
+    single CUDA-graph primitive (the deploy yaml sets ``enforce_eager`` for the
+    first GPU pass).
+    """
+
+    def __init__(self, *, num_codebooks: int, hidden_size: int, aux_dtype: torch.dtype) -> None:
+        super().__init__()
+        # The HF depth module is assigned by the parent after construction so the
+        # parent owns the load_weights / tie path (B2 weight-name contract). Kept
+        # as a plain attribute (NOT a submodule) so the parent's registered-name
+        # bookkeeping stays under ``_depth_decoder`` exactly as the reuse loader
+        # credits it.
+        self._module = None  # CsmDepthDecoderForCausalLM
+        self.num_codebooks = int(num_codebooks)
+        self.hidden_size = int(hidden_size)
+        self._aux_dtype = aux_dtype
+
+    def set_module(self, module: nn.Module) -> None:
+        self._module = module
+
+    @torch.inference_mode()
+    def run(
+        self,
+        *,
+        cb0: torch.Tensor,
+        backbone_last_hidden_state: torch.Tensor,
+        temperature: float,
+        top_k: int,
+    ) -> torch.Tensor:
+        """31-step inner depth-decoder AR loop -> a 32-code frame.
+
+        REUSE VERBATIM: csm.py:647 ``_run_depth_loop`` (d92e35f7). The depth
+        decoder (4 layers / d1024 / head_dim128) runs with its own
+        ``DynamicCache`` reset every frame (33 positions: backbone hidden at
+        position 0, then cb0..cb31 at positions 1..32).
+
+        Args are kept ``(B, *)`` (per-lane B=1 is the correctness anchor) so a
+        future across-lane depth-batch can be flipped on by stacking lanes into
+        the batch dim without changing the loop body.
+
+        Returns ``(B, 32)`` Long: cb0 from the backbone plus cb1..cb31.
+        """
+        from transformers.cache_utils import DynamicCache
+
+        depth = self._module
+        device = cb0.device
+        bsz = cb0.shape[0]
+        n_steps = self.num_codebooks - 1  # 31
+
+        # Packed staging (I3): one (B, 32) tensor filled on device; NO per-step
+        # host sync inside the loop.
+        codes = torch.empty((bsz, self.num_codebooks), dtype=torch.long, device=device)
+        codes[:, 0] = cb0
+
+        past = DynamicCache(config=depth.config)
+        cur_input = cb0.view(bsz, 1)  # (B, 1) = cb0
+        backbone_hs = backbone_last_hidden_state.view(bsz, self.hidden_size).to(self._aux_dtype)
+
+        for step in range(n_steps):
+            depth_ids = cur_input
+            if step == 0:
+                # Seed position 0 from the backbone hidden state. Sequence is
+                # [hidden(pos0), cb0]; the placeholder at position 0 is
+                # overwritten internally by ``backbone_last_hidden_state``.
+                depth_ids = torch.nn.functional.pad(cur_input, (1, 0), value=0)  # (B, 2)
+                out = depth(
+                    input_ids=depth_ids,
+                    backbone_last_hidden_state=backbone_hs,
+                    past_key_values=past,
+                    use_cache=True,
+                    logits_to_keep=1,
+                )
+            else:
+                out = depth(
+                    input_ids=depth_ids,
+                    past_key_values=past,
+                    use_cache=True,
+                    logits_to_keep=1,
+                )
+            past = out.past_key_values
+            step_logits = out.logits[:, -1, :]  # (B, vocab)
+            next_code = sample_logits(step_logits, temperature, top_k)  # (B,)
+            codes[:, step + 1] = next_code
+            cur_input = next_code.view(bsz, 1)
+
+        return codes

--- a/vllm_omni/model_executor/models/csm/csm_mimi.py
+++ b/vllm_omni/model_executor/models/csm/csm_mimi.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CSM-1B Stage-1 Mimi vocoder (code2wav). Frames of 32 codes -> PCM audio.
+
+Stage 1 of the 2-stage CSM pipeline (A3 design §4.5). It is a pure, stateless-
+per-frame decoder of the completed 32-code frames produced by Stage 0: the
+backbone<->depth feedback is fully resolved in Stage 0, so nothing crosses back.
+
+Body: REUSE ``_mimi_decode`` (csm.py:729 @ d92e35f7) -- float32 decode (autocast
+corrupts codec audio, SKILL Phase-2 dtype rule), reserved-id clamp [0, 2047] on a
+COPY before decode (ids 2048/2049/2050 must NEVER reach Mimi; its real codebook
+size is 2048).
+
+Invariants honored:
+  * I1 (delta streaming): ``forward`` decodes ONLY this chunk's frames and emits
+    the delta waveform; left context is trimmed off the front so chunk boundaries
+    are seamless without re-emitting. Documented in ``forward``'s docstring.
+  * I5 (per-request state): Mimi's streaming conv-state is the known
+    "first-request-clean, later-requests-flicker" leak point (#233/#234). We use a
+    per-request streaming context keyed by req id; a shared buffer would cross-talk
+    under concurrency. Freed in ``on_requests_finished``.
+  * "All return paths emit model_outputs" (SKILL): every branch returns an
+    ``OmniOutput`` with a ``model_outputs`` list of matching length.
+
+Shape contract from Stage 0 / the stage input processor (A3 §4.4): ``input_ids``
+is a flat CODEBOOK-MAJOR ``[32 * F]`` int tensor per request; reshape to
+``[32, F]`` -> Mimi ``decode`` wants ``[B, num_quantizers, codes_length]``.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.logger import init_logger
+
+from vllm_omni.model_executor.models.csm.configuration_csm import CsmConfig
+from vllm_omni.model_executor.models.output_templates import OmniOutput
+
+logger = init_logger(__name__)
+
+__all__ = ["CsmMimiVocoder"]
+
+_NUM_CODEBOOKS = 32
+_MIMI_CODEBOOK_SIZE = 2048  # reserved ids 2048/2049/2050 must not reach Mimi
+
+
+class CsmMimiVocoder(nn.Module):
+    """Stage-1 Mimi codec decoder for CSM (GenerationModelRunner)."""
+
+    input_modalities = "audio"
+
+    have_multimodal_outputs = True
+    has_preprocess = False
+    has_postprocess = False
+    enable_update_additional_information = True
+    requires_raw_input_tokens = True
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.vllm_config = vllm_config
+        self.config: CsmConfig = vllm_config.model_config.hf_config
+        self.model_path: str = vllm_config.model_config.model
+
+        self.num_codebooks = int(getattr(self.config, "num_codebooks", _NUM_CODEBOOKS))
+        self.sample_rate = int(getattr(self.config, "codec_sample_rate", 24000))
+
+        self._mimi_codec: nn.Module | None = None  # MimiModel
+        self._device: torch.device | None = None
+        self._lock = threading.Lock()
+
+        # I5: per-request Mimi streaming conv-state, keyed by req id.
+        self._stream_state_by_req: dict[str, Any] = {}
+
+    def embed_input_ids(self, input_ids: torch.Tensor, **_: Any) -> torch.Tensor:
+        # Vocoder ignores token embeddings; stable dummy for the runner.
+        if input_ids.numel() == 0:
+            return torch.empty((0, 1), device=input_ids.device, dtype=torch.float32)
+        return torch.zeros((input_ids.shape[0], 1), device=input_ids.device, dtype=torch.float32)
+
+    def compute_logits(self, hidden_states: torch.Tensor | OmniOutput, sampling_metadata: Any = None) -> None:
+        # Vocoder is non-AR (qwen3_tts_code2wav.py:89).
+        return None
+
+    # ------------------------------------------------------------------
+    # Weight loading: codec_model.* from the same checkpoint
+    # ------------------------------------------------------------------
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load the Mimi codec from the ``codec_model.*`` checkpoint prefix.
+
+        REUSE shape: csm.py:404-410 codec load. Built lazily (after distributed
+        init). Every returned name is a real registered parameter name under
+        ``_mimi_codec`` (B2 validator contract).
+        """
+        with self._lock:
+            if self._mimi_codec is None:
+                try:
+                    self._device = next(self.parameters()).device
+                except StopIteration:
+                    self._device = self.vllm_config.device_config.device
+                self._build_codec()
+
+        codec_weights: list[tuple[str, torch.Tensor]] = []
+        loaded: set[str] = set()
+        for name, w in weights:
+            if name.startswith("codec_model."):
+                codec_weights.append((name[len("codec_model.") :], w))
+            # All non-codec prefixes belong to Stage 0; drain + ignore here.
+
+        if self._mimi_codec is not None and codec_weights:
+            _, mc_unexpected = self._mimi_codec.load_state_dict(dict(codec_weights), strict=False)
+            if list(mc_unexpected):
+                logger.warning("CSM Stage-1 codec unexpected keys: %s", list(mc_unexpected)[:8])
+            loaded |= {n for n, _ in self._mimi_codec.named_parameters(prefix="_mimi_codec")}
+        return loaded
+
+    def _build_codec(self) -> None:
+        from transformers import AutoConfig, AutoModel
+
+        hf_cfg = AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
+        codec_cfg = hf_cfg.codec_config
+        self._mimi_codec = AutoModel.from_config(codec_cfg)
+        # Codec MUST run in float32 (autocast corrupts audio; SKILL Phase-2).
+        self._mimi_codec.to(device=self._device, dtype=torch.float32)
+        self._mimi_codec.eval()
+        for p in self._mimi_codec.parameters():
+            p.requires_grad_(False)
+
+    # ------------------------------------------------------------------
+    # Decode
+    # ------------------------------------------------------------------
+
+    def _mimi_decode(self, frame_codes_qf: torch.Tensor) -> torch.Tensor:
+        """Mimi decode: ``[Q=32, F]`` codes -> ``(samples,)`` fp32.
+
+        REUSE: csm.py:729 ``_mimi_decode``. Reserved guard: clamp to [0, 2047] on a
+        COPY (the reserved ids are valid frame-embed inputs upstream but must not
+        reach the codec). ``decode`` wants ``[B, num_quantizers, codes_length]``.
+        """
+        codes = frame_codes_qf.clamp(min=0, max=_MIMI_CODEBOOK_SIZE - 1)
+        audio_codes = codes.unsqueeze(0)  # (1, Q, F)
+        with torch.no_grad():
+            out = self._mimi_codec.decode(audio_codes)
+        audio_values = out.audio_values  # (B, channels, samples) or (B, samples)
+        wav = audio_values.reshape(audio_values.shape[0], -1)[0]
+        return wav.to(torch.float32)
+
+    def _split_request_ids(self, ids: torch.Tensor, seq_token_counts: list[int] | None = None) -> list[torch.Tensor]:
+        """Split concatenated input_ids into per-request segments (qwen3 pattern)."""
+        if seq_token_counts is not None and len(seq_token_counts) > 1:
+            boundaries = [0]
+            for count in seq_token_counts:
+                boundaries.append(boundaries[-1] + count)
+            n = ids.numel()
+            return [ids[boundaries[i] : min(boundaries[i + 1], n)] for i in range(len(seq_token_counts))]
+        if is_forward_context_available():
+            slices = getattr(get_forward_context(), "ubatch_slices", None)
+            if slices is not None and len(slices) > 1 and not any(hasattr(s, "token_slice") for s in slices):
+                boundaries = [0]
+                for s in slices:
+                    boundaries.append(boundaries[-1] + s)
+                return [ids[boundaries[i] : boundaries[i + 1]] for i in range(len(boundaries) - 1)]
+        return [ids]
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        intermediate_tensors: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        runtime_additional_information: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> OmniOutput:
+        """Decode flat codebook-major ``[32*F]`` codes per request into audio.
+
+        Streaming contract (I1): DELTA. Each call decodes only this chunk's frames
+        and trims the leading ``left_context_size`` frames (decoder context only),
+        so the emitted waveform is the new audio for this chunk -- never a re-decode
+        of the full sequence. All return paths emit a ``model_outputs`` list whose
+        length matches the request count.
+        """
+        sr_tensor = torch.tensor(self.sample_rate, dtype=torch.int32)
+        empty = torch.zeros((0,), dtype=torch.float32)
+
+        if input_ids is None or input_ids.numel() == 0:
+            return OmniOutput(
+                text_hidden_states=None,
+                multimodal_outputs={"model_outputs": [empty], "sr": [sr_tensor]},
+            )
+
+        ids = input_ids.reshape(-1).to(dtype=torch.long)
+        per_req = self._split_request_ids(ids, kwargs.get("seq_token_counts"))
+        num_req = len(per_req)
+
+        left_context_size = [0] * num_req
+        if runtime_additional_information is not None:
+            for i, info in enumerate(runtime_additional_information):
+                if i >= num_req:
+                    break
+                meta = info.get("meta", {}) if isinstance(info, dict) else {}
+                if "left_context_size" in meta:
+                    left_context_size[i] = int(meta["left_context_size"] or 0)
+
+        q = self.num_codebooks
+        device = self._device or input_ids.device
+        audios: list[torch.Tensor] = [empty] * num_req
+        srs: list[torch.Tensor] = [sr_tensor] * num_req
+
+        for i, req_ids in enumerate(per_req):
+            n = int(req_ids.numel())
+            if n == 0 or n % q != 0:
+                if n > 0:
+                    logger.warning(
+                        "CSM Stage-1 input_ids length %d not divisible by num_codebooks %d; skipping.",
+                        n,
+                        q,
+                    )
+                continue
+            frames = n // q
+            # [Q*F] codebook-major -> [Q, F]
+            codes_qf = req_ids.reshape(q, frames).to(device)
+            wav = self._mimi_decode(codes_qf)  # (samples,) fp32
+
+            # I1 delta: trim the leading left-context frames (decoder context).
+            ctx = left_context_size[i]
+            samples_per_frame = int(getattr(self.config, "codec_samples_per_frame", 1920))
+            start = max(0, ctx * samples_per_frame)
+            if start < wav.shape[0]:
+                wav = wav[start:]
+            else:
+                wav = empty
+            audios[i] = wav.reshape(-1)
+
+        return OmniOutput(
+            text_hidden_states=None,
+            multimodal_outputs={"model_outputs": audios, "sr": srs},
+        )
+
+    def make_omni_output(self, model_outputs: torch.Tensor | OmniOutput | tuple, **kwargs: Any) -> OmniOutput:
+        """Passthrough (forward returns OmniOutput). REUSE shape: qwen3_tts_code2wav.py:425."""
+        if isinstance(model_outputs, OmniOutput):
+            return model_outputs
+        if isinstance(model_outputs, tuple) and len(model_outputs) == len(OmniOutput._fields):
+            return OmniOutput(*model_outputs)
+        raise TypeError(f"CsmMimiVocoder expected OmniOutput, got {type(model_outputs)}")
+
+    def on_requests_finished(self, finished_req_ids: set[str] | list[str]) -> None:
+        """Free per-request Mimi streaming state on finish (I5, #233/#234)."""
+        for req_id in finished_req_ids:
+            self._stream_state_by_req.pop(str(req_id), None)

--- a/vllm_omni/model_executor/models/csm/pipeline.py
+++ b/vllm_omni/model_executor/models/csm/pipeline.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CSM-1B 2-stage pipeline topology (frozen).
+
+Stage 0 (LLM_AR): the Llama-style backbone runs under vLLM PagedAttention; cb0 is
+sampled per 80 ms frame; the 31-step depth decoder runs INLINE inside Stage 0's
+``forward()`` to produce cb1..cb31; the finished 32-code frame is emitted forward
+as a latent payload (``codes.audio``). The backbone<->depth feedback (the next
+frame's Sigma-embedding) is resolved entirely inside Stage 0 via a per-request
+cache + the ``preprocess`` re-inject hook -- it NEVER crosses the stage boundary.
+
+Stage 1 (LLM_GENERATION): the Mimi vocoder decodes the 32-code frames into PCM
+audio (code2wav), stateless per frame.
+
+This replaces the single-stage scaffold (CsmForGeneration / ``inference_stream``)
+whose private per-frame ``positions`` loop corrupted the paged KV heap and caused
+the deferred illegal-memory-access (A3 design §1). The 2-stage shape mirrors the
+two shipping precedents: qwen3_tts (talker + code2wav) and mimo_audio (the
+multi-codebook RVQ feedback twin).
+"""
+
+from vllm_omni.config.stage_config import (
+    PipelineConfig,
+    StageExecutionType,
+    StagePipelineConfig,
+)
+
+_PROC = "vllm_omni.model_executor.stage_input_processors.csm"
+
+CSM_PIPELINE = PipelineConfig(
+    model_type="csm",
+    # Pipeline-level default arch = Stage-0 backbone; Stage 1 overrides per-stage.
+    model_arch="CsmBackboneForConditionalGeneration",
+    stages=(
+        StagePipelineConfig(
+            # STAGE 0 -- backbone AR + inline 31-step depth + Sigma feedback.
+            stage_id=0,
+            model_stage="csm",
+            execution_type=StageExecutionType.LLM_AR,
+            input_sources=(),
+            owns_tokenizer=True,
+            engine_output_type="latent",  # emits 32-code frames forward, not audio
+            # Producing stage declares the async-chunk next-stage processor
+            # (mirrors qwen3_tts pipeline.py:28).
+            async_chunk_process_next_stage_input_func=f"{_PROC}.backbone2mimi_async_chunk",
+            sampling_constraints={
+                "detokenize": False,
+                # Real frame-level EOS is "cb0..cb30 all-zero" forced in
+                # compute_logits (token id 0); this scheduler stop matches it.
+                "stop_token_ids": [0],
+            },
+        ),
+        StagePipelineConfig(
+            # STAGE 1 -- Mimi vocoder (code2wav).
+            stage_id=1,
+            model_stage="mimi",
+            execution_type=StageExecutionType.LLM_GENERATION,
+            input_sources=(0,),
+            final_output=True,
+            final_output_type="audio",
+            engine_output_type="audio",
+            model_arch="CsmMimiVocoder",  # per-stage arch override
+            # Consuming stage declares the sync (non-async) input processor
+            # (mirrors qwen3_tts pipeline.py:43).
+            sync_process_input_func=f"{_PROC}.backbone2mimi",
+            sampling_constraints={"detokenize": True},
+        ),
+    ),
+)

--- a/vllm_omni/model_executor/models/registry.py
+++ b/vllm_omni/model_executor/models/registry.py
@@ -343,6 +343,24 @@ _OMNI_MODELS = {
         "minicpmo_4_5_omni_tts",
         "MiniCPMO45OmniTTSForConditionalGeneration",
     ),
+    # CSM-1B (Sesame): 2-stage dual-AR TTS (Stage 0 backbone AR + inline depth).
+    "CsmBackboneForConditionalGeneration": (
+        "csm",
+        "csm_backbone",
+        "CsmBackboneForConditionalGeneration",
+    ),
+    # Stage 1: Mimi vocoder / code2wav.
+    "CsmMimiVocoder": (
+        "csm",
+        "csm_mimi",
+        "CsmMimiVocoder",
+    ),
+    # Alias: HF config.json ships this arch name; route it to the Stage-0 backbone.
+    "CsmForConditionalGeneration": (
+        "csm",
+        "csm_backbone",
+        "CsmBackboneForConditionalGeneration",
+    ),
 }
 
 

--- a/vllm_omni/model_executor/stage_input_processors/csm.py
+++ b/vllm_omni/model_executor/stage_input_processors/csm.py
@@ -1,0 +1,178 @@
+"""Stage input processor for CSM-1B: backbone (Stage 0) -> Mimi (Stage 1).
+
+Bridges the forward-flowing latent (32-code frames) Stage 0 emits in
+``codes.audio`` to the flat CODEBOOK-MAJOR ``[32 * F]`` ``input_ids`` Stage 1's
+Mimi vocoder consumes (A3 design §4.4). Two modes, picked by
+``deploy.async_chunk`` (``stage_config._select_processor_funcs``):
+
+  * ``backbone2mimi`` (sync / non-async): collect all of a request's frames once
+    it finishes, trim invalid/EOS frames, flatten codebook-major.
+  * ``backbone2mimi_async_chunk``: window frames into chunks (+ left context) as
+    Stage 0 streams, for low-latency streaming audio.
+
+Modeled on ``stage_input_processors/qwen3_tts.py`` (talker2code2wav*), with
+CSM specifics: 32 codebooks; CSM-tuned valid mask (frames with any nonzero code
+and all codes < 2048 -- excludes the all-zero EOS frame and reserved codec ids);
+no ref_code / voice-cloning plumbing.
+"""
+
+from typing import Any
+
+import torch
+from vllm.logger import init_logger
+
+from vllm_omni.data_entry_keys import (
+    CodesStruct,
+    MetaStruct,
+    OmniPayload,
+    OmniPayloadStruct,
+)
+
+logger = init_logger(__name__)
+
+_NUM_CODEBOOKS = 32
+_CODEBOOK_SIZE = 2048  # codes >= 2048 are reserved ids, never valid frames
+
+
+def backbone2mimi(
+    source_outputs: list[Any],
+    prompt: Any = None,
+    _requires_multimodal_data: bool = False,
+) -> list[Any]:
+    """Non-async: collect all Stage-0 frames, then decode in Stage 1 at once."""
+    from vllm_omni.inputs.data import OmniTokensPrompt
+
+    backbone_outputs = source_outputs
+    mimi_inputs: list[OmniTokensPrompt] = []
+    for _i, backbone_output in enumerate(backbone_outputs):
+        if not backbone_output.finished:
+            # Non-async decode runs once, after Stage 0 has accumulated the frames.
+            continue
+        output = backbone_output.outputs[0]
+        mm = output.multimodal_output
+        mm_codes = mm.get("codes", {})
+
+        # audio_codes: [num_frames, 32] (frame-major), accumulated across steps.
+        audio_codes = mm_codes.get("audio")
+        if not isinstance(audio_codes, torch.Tensor) or audio_codes.numel() == 0:
+            mimi_inputs.append(OmniTokensPrompt(prompt_token_ids=[], multi_modal_data=None))
+            continue
+        audio_codes = audio_codes.to(torch.long)
+        if audio_codes.ndim == 1:
+            audio_codes = audio_codes.reshape(-1, _NUM_CODEBOOKS)
+
+        # CSM valid mask: drop zero-padded / all-zero EOS frames and frames with
+        # out-of-range (reserved) codes that must not reach Mimi.
+        valid_mask = audio_codes.any(dim=1) & (audio_codes.max(dim=1).values < _CODEBOOK_SIZE)
+        audio_codes = audio_codes[valid_mask]
+
+        # Mimi expects codebook-major flat [32 * num_frames].
+        codec_codes = audio_codes.transpose(0, 1).cpu().reshape(-1).tolist()
+        mimi_inputs.append(
+            OmniTokensPrompt(
+                prompt_token_ids=codec_codes,
+                multi_modal_data=None,
+                mm_processor_kwargs=None,
+                additional_information=None,
+            )
+        )
+    return mimi_inputs
+
+
+def _extract_last_frame(pooling_output: OmniPayload) -> torch.Tensor | None:
+    audio_codes = pooling_output.get("codes", {}).get("audio")
+    if not isinstance(audio_codes, torch.Tensor) or audio_codes.numel() == 0:
+        return None
+    if audio_codes.ndim == 2:
+        frame = audio_codes[-1]
+        if frame.numel() == 0 or not bool(frame.any().item()):
+            return None  # all-zero EOS frame -> nothing to decode
+        return frame.to(torch.long).reshape(-1)
+    if audio_codes.ndim == 1:
+        return audio_codes.to(torch.long).reshape(-1)
+    raise ValueError(f"Invalid audio_codes shape for CSM async_chunk: {tuple(audio_codes.shape)}")
+
+
+def backbone2mimi_async_chunk(
+    transfer_manager: Any,
+    pooling_output: OmniPayload | None,
+    request: Any,
+    is_finished: bool = False,
+) -> OmniPayloadStruct | None:
+    """Window Stage-0 frames into Mimi decode chunks (+ left context).
+
+    Mirrors ``qwen3_tts.talker2code2wav_async_chunk`` minus ref_code; CSM has 32
+    codebooks and an all-zero-frame EOS (filtered by ``_extract_last_frame``).
+    """
+    request_id = request.external_req_id
+    finished = bool(is_finished or request.is_finished())
+
+    if isinstance(pooling_output, dict):
+        frame = _extract_last_frame(pooling_output)
+        if frame is not None:
+            transfer_manager.code_prompt_token_ids[request_id].append(frame.cpu().tolist())
+    elif not finished:
+        return None
+
+    connector = getattr(transfer_manager, "connector", None)
+    raw_cfg = getattr(connector, "config", {}) or {}
+    cfg = raw_cfg.get("extra", raw_cfg) if isinstance(raw_cfg, dict) else {}
+    chunk_size = int(cfg.get("codec_chunk_frames", 25))
+    left_context_size_config = int(cfg.get("codec_left_context_frames", 25))
+    initial_chunk_size = int(cfg.get("initial_codec_chunk_frames") or 0)
+
+    if chunk_size <= 0 or left_context_size_config < 0 or initial_chunk_size < 0:
+        raise ValueError(
+            f"Invalid CSM codec chunk config: codec_chunk_frames={chunk_size}, "
+            f"codec_left_context_frames={left_context_size_config}, "
+            f"initial_codec_chunk_frames={initial_chunk_size}"
+        )
+    if initial_chunk_size > chunk_size:
+        logger.warning(
+            "initial_codec_chunk_frames=%d > codec_chunk_frames=%d, clamping.",
+            initial_chunk_size,
+            chunk_size,
+        )
+        initial_chunk_size = chunk_size
+
+    length = len(transfer_manager.code_prompt_token_ids[request_id])
+    if length <= 0:
+        if finished:
+            return OmniPayloadStruct(
+                codes=CodesStruct(audio=torch.empty(0, dtype=torch.long)),
+                meta=MetaStruct(finished=torch.tensor(True, dtype=torch.bool)),
+            )
+        return None
+
+    use_first_chunk = 0 < initial_chunk_size < chunk_size
+    if use_first_chunk and length <= initial_chunk_size:
+        if not finished and length < initial_chunk_size:
+            return None
+        context_length = length if finished and length < initial_chunk_size else initial_chunk_size
+    else:
+        initial_coverage = initial_chunk_size if use_first_chunk else 0
+        adjusted = length - initial_coverage
+        if not finished and adjusted % chunk_size != 0:
+            return None
+        chunk_length = adjusted % chunk_size
+        context_length = chunk_length if chunk_length != 0 else chunk_size
+
+    end_index = min(length, left_context_size_config + context_length)
+    left_context_size = max(0, end_index - context_length)
+    window_frames = transfer_manager.code_prompt_token_ids[request_id][-end_index:]
+
+    num_quantizers = len(window_frames[0])
+    num_frames = len(window_frames)
+    # Codebook-major flat [Q * num_frames].
+    codec_codes = torch.tensor(
+        [window_frames[f][qi] for qi in range(num_quantizers) for f in range(num_frames)],
+        dtype=torch.long,
+    )
+
+    return OmniPayloadStruct(
+        codes=CodesStruct(audio=codec_codes),
+        meta=MetaStruct(
+            left_context_size=left_context_size,
+            finished=torch.tensor(finished, dtype=torch.bool),
+        ),
+    )


### PR DESCRIPTION
Adds Sesame CSM-1B (`sesame/csm-1b`, Apache-2.0): a Llama-3.2-1B backbone that emits one frame per autoregressive step, a 31-step depth decoder over 32 Kyutai Mimi RVQ codebooks, and the Mimi vocoder. Two-stage Omni pipeline following the Higgs / Qwen3-TTS layout: Stage 0 is the backbone AR with the 31-step depth decoder run inline; Stage 1 is the Mimi vocoder (code2wav). The one new component is a Kyutai Mimi codec stage, the first Mimi vocoder in the zoo and reusable by other Mimi-based models.

Closes #4488.

### Modes
- [x] plain text
- [ ] voice clone (single default speaker; OpenAI `voice` maps to a CSM speaker id, e.g. `"0"`)

### Design
Two-stage pipeline (`CSM_PIPELINE`). Stage 0 (LLM_AR) composes the backbone on vLLM-native `LlamaModel` under PagedAttention and samples codebook 0 per 80 ms frame; the 31-step depth decoder runs inline (its own dense cache, reset per frame, outside PagedAttention) so it never advances a backbone KV slot. The next frame's backbone input is the full 32-codebook embedding of the previous frame (matching HF `CsmBackboneModelEmbeddings`), cached per request. Frame EOS is cb0..cb30 all-zero, forced positionally; a per-request frame cap is the fail-closed backstop. Stage 1 (LLM_GENERATION) decodes the codebook-major frames with Mimi in float32 (reserved ids 2048/2049/2050 clamped before the codec). Serving uses the #4330 TTS adapter framework.

### Validation (RTX 3060, 12 GB)
- Lint: `ruff check` and `ruff format` clean.
- Unit: 58 passed, including a decode-feedback contract regression test. The depth incremental KV loop is bit-exact under greedy vs a cacheless full-recompute reference on the real HF depth module; Mimi decode is bit-exact vs `MimiModel.decode`.
- Served intelligibility (Whisper-small ASR over a fixed 8-prompt set): clean prompts transcribe verbatim and match an HF `generate()` greedy reference (4 of 8 at WER 0.000). The residual is model-level early-EOS prompts that the HF reference reproduces too, not a serving defect.
- Batching + isolation: continuous batching (`max_num_seqs: 4`); concurrent c=4 and c=8 requests overlap (no serialization), all non-silent, each transcribes to its own prompt (no crosstalk, no per-request state leak).

### Run
```bash
vllm-omni serve sesame/csm-1b --deploy-config vllm_omni/deploy/csm.yaml --omni --trust-remote-code
```

### Follow-ups (intentionally out of this first PR)
- Incremental async-chunk streaming: the delta path is implemented but gated (`async_chunk: false`), so `stream=true` currently returns the full clip after generation. This matches the upstream sgl-omni CSM config (`enable_async_decode: false`); flipping it on after chunk-boundary validation is the immediate follow-up.
- CUDA-graph capture and fused depth-loop / whole-frame batching (throughput, on top of the continuous batching above).
- Online-serving e2e test + Gradio demo (offline e2e landed; the TTS online e2e gap is tracked in #4226).

### Notes for reviewers
- `sesame/csm-1b` is gated; accept its license on Hugging Face first.
- Eager, no CUDA graph; example config splits 0.55 / 0.35 GPU memory across the two stages (sized for a 12 GB card).
