### PR TITLE
[Refactor] Use get_mem_allocator_instance() instead of CuMemAllocator

### DIFF
--- a/tests/diffusion/test_diffusion_worker.py
+++ b/tests/diffusion/test_diffusion_worker.py
@@ -23,15 +23,6 @@ from vllm_omni.diffusion.worker.diffusion_worker import (
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.gpu]
 
 
-def patch_cumem_allocator(mocker: MockerFixture):
-    mock_allocator_class = mocker.Mock()
-    mocker.patch(
-        "vllm_omni.diffusion.worker.diffusion_worker._get_cumem_allocator_class",
-        return_value=mock_allocator_class,
-    )
-    return mock_allocator_class
-
-
 @pytest.fixture
 def mock_od_config(mocker: MockerFixture):
     """Create a mock OmniDiffusionConfig."""
@@ -127,15 +118,14 @@ class TestDiffusionWorkerSleep:
         """
         Unified interception of Allocators, and provision of default security values.
         """
-        self.mock_allocator_class = patch_cumem_allocator(mocker)
+        mock_get_allocator = mocker.patch("vllm.device_allocator.get_mem_allocator_instance")
         self.mock_allocator = mocker.Mock()
-        self.mock_allocator_class.get_instance.return_value = self.mock_allocator
+        mock_get_allocator.return_value = self.mock_allocator
         self.mock_allocator.get_current_usage.return_value = 4 * 1024**3
         self.mock_allocator.sleep = mocker.Mock()
 
     def test_sleep_level_1(self, mocker: MockerFixture, mock_gpu_worker):
         """Test sleep mode level 1 (offload weights only)."""
-        mock_allocator_class = patch_cumem_allocator(mocker)
         mock_platform = mocker.patch("vllm_omni.diffusion.worker.diffusion_worker.current_omni_platform")
         mock_platform.get_free_memory.side_effect = [10 * 1024**3, 12 * 1024**3]
         mock_platform.get_device_total_memory.return_value = 80 * 1024**3
@@ -150,24 +140,19 @@ class TestDiffusionWorkerSleep:
             1 * 1024**3,
         ]
 
-        # Setup allocator mock
-        mock_allocator = mocker.Mock()
-        mock_allocator_class.get_instance = mocker.Mock(return_value=mock_allocator)
-        mock_allocator.sleep = mocker.Mock()
-        mock_allocator.get_current_usage.return_value = initial_usage
+        self.mock_allocator.get_current_usage.return_value = initial_usage
 
         # Call sleep with level 1
         result = mock_gpu_worker.sleep(level=1)
 
         # Verify sleep was called with correct tags
-        mock_allocator.sleep.assert_called_once_with(offload_tags=("weights",))
+        self.mock_allocator.sleep.assert_called_once_with(offload_tags=("weights",))
         assert bool(result) is True
         # Verify buffers were NOT saved (level 1 doesn't save buffers)
         assert len(mock_gpu_worker._sleep_saved_buffers) == 0
 
     def test_sleep_level_2(self, mocker: MockerFixture, mock_gpu_worker):
         """Test sleep mode level 2 (offload all, save buffers)."""
-        mock_allocator_class = patch_cumem_allocator(mocker)
         mock_platform = mocker.patch("vllm_omni.diffusion.worker.diffusion_worker.current_omni_platform")
         mock_platform.get_free_memory.side_effect = [5 * 1024**3, 10 * 1024**3]
         mock_platform.get_device_total_memory.return_value = 80 * 1024**3
@@ -180,11 +165,7 @@ class TestDiffusionWorkerSleep:
             1 * 1024**3,  # After sleep (freed 4GB)
         ]
 
-        # Setup allocator mock
-        mock_allocator = mocker.Mock()
-        mock_allocator_class.get_instance = mocker.Mock(return_value=mock_allocator)
-        mock_allocator.sleep = mocker.Mock()
-        mock_allocator.get_current_usage.return_value = initial_usage
+        self.mock_allocator.get_current_usage.return_value = initial_usage
 
         # Mock pipeline buffers
         mock_buffer1 = torch.randn(10, 10)
@@ -200,7 +181,7 @@ class TestDiffusionWorkerSleep:
         result = mock_gpu_worker.sleep(level=2)
 
         # Verify sleep was called with empty tags (offload all)
-        mock_allocator.sleep.assert_called_once_with(offload_tags=tuple())
+        self.mock_allocator.sleep.assert_called_once_with(offload_tags=tuple())
         assert bool(result) is True
 
         # Verify buffers were saved
@@ -210,7 +191,6 @@ class TestDiffusionWorkerSleep:
 
     def test_sleep_memory_freed_validation(self, mocker: MockerFixture, mock_gpu_worker):
         """Test that sleep validates memory was actually freed."""
-        mock_allocator_class = patch_cumem_allocator(mocker)
         mock_platform = mocker.patch("vllm_omni.diffusion.worker.diffusion_worker.current_omni_platform")
         mock_platform.get_free_memory.return_value = 10 * 1024**3
         mock_platform.get_device_total_memory.return_value = 80 * 1024**3
@@ -223,10 +203,7 @@ class TestDiffusionWorkerSleep:
             3 * 1024**3,  # After sleep: 3GB used (negative freed)
         ]
 
-        mock_allocator = mocker.Mock()
-        mock_allocator_class.get_instance = mocker.Mock(return_value=mock_allocator)
-        mock_allocator.sleep = mocker.Mock()
-        mock_allocator.get_current_usage.return_value = initial_usage
+        self.mock_allocator.get_current_usage.return_value = initial_usage
 
         # This should raise an assertion error
         result = mock_gpu_worker.sleep(level=1)
@@ -234,8 +211,6 @@ class TestDiffusionWorkerSleep:
 
     def test_sleep_falls_back_to_device_memory_when_nvml_unavailable(self, mocker: MockerFixture, mock_gpu_worker):
         """Test sleep uses device-scoped fallback when NVML is unavailable."""
-
-        mock_allocator_class = patch_cumem_allocator(mocker)
         mock_platform = mocker.patch("vllm_omni.diffusion.worker.diffusion_worker.current_omni_platform")
         mock_get_process_memory = mocker.patch("vllm_omni.diffusion.worker.diffusion_worker.get_process_gpu_memory")
         mock_get_process_memory.side_effect = [None, None]
@@ -245,30 +220,26 @@ class TestDiffusionWorkerSleep:
         ]
         mock_platform.get_device_total_memory.return_value = 8 * 1024**3
 
-        mock_allocator = mocker.Mock()
-        mock_allocator_class.get_instance = mocker.Mock(return_value=mock_allocator)
-        mock_allocator.sleep = mocker.Mock()
-        mock_allocator.get_current_usage.return_value = 2 * 1024**3
+        self.mock_allocator.get_current_usage.return_value = 2 * 1024**3
 
         result = mock_gpu_worker.sleep(level=1)
 
-        mock_allocator.sleep.assert_called_once_with(offload_tags=("weights",))
+        self.mock_allocator.sleep.assert_called_once_with(offload_tags=("weights",))
         assert bool(result) is True
 
 
 class TestDiffusionWorkerWakeUp:
     """Test DiffusionWorker.wake_up method."""
 
+    @pytest.fixture(autouse=True)
+    def setup_allocator(self, mocker: MockerFixture):
+        mock_get_allocator = mocker.patch("vllm.device_allocator.get_mem_allocator_instance")
+        self.mock_allocator = mocker.Mock()
+        mock_get_allocator.return_value = self.mock_allocator
+        self.mock_allocator.get_current_usage.return_value = 10 * 1024**3
+
     def test_wake_up_without_buffers(self, mocker: MockerFixture, mock_gpu_worker):
         """Test wake_up without saved buffers (level 1 sleep)."""
-        mock_allocator_class = patch_cumem_allocator(mocker)
-
-        # Setup allocator mock
-        mock_allocator = mocker.Mock()
-        mock_allocator_class.get_instance = mocker.Mock(return_value=mock_allocator)
-        mock_allocator.wake_up = mocker.Mock()
-        mock_allocator.get_current_usage.return_value = 10 * 1024**3
-
         # Ensure no saved buffers
         mock_gpu_worker._sleep_saved_buffers = {}
 
@@ -276,18 +247,11 @@ class TestDiffusionWorkerWakeUp:
         result = mock_gpu_worker.wake_up(tags=["weights"])
 
         # Verify allocator.wake_up was called
-        mock_allocator.wake_up.assert_called_once_with(["weights"])
+        self.mock_allocator.wake_up.assert_called_once_with(["weights"])
         assert bool(result) is True
 
     def test_wake_up_with_buffers(self, mocker: MockerFixture, mock_gpu_worker):
         """Test wake_up with saved buffers (level 2 sleep)."""
-        mock_allocator_class = patch_cumem_allocator(mocker)
-
-        # Setup allocator mock
-        mock_allocator = mocker.Mock()
-        mock_allocator_class.get_instance = mocker.Mock(return_value=mock_allocator)
-        mock_allocator.wake_up = mocker.Mock()
-        mock_allocator.get_current_usage.return_value = 10 * 1024**3
 
         # Create saved buffers
         saved_buffer1 = torch.randn(10, 10)
@@ -314,7 +278,7 @@ class TestDiffusionWorkerWakeUp:
         result = mock_gpu_worker.wake_up(tags=None)
 
         # Verify allocator.wake_up was called
-        mock_allocator.wake_up.assert_called_once_with(None)
+        self.mock_allocator.wake_up.assert_called_once_with(None)
 
         # Verify buffers were restored
         mock_buffer1.data.copy_.assert_called_once()
@@ -326,14 +290,6 @@ class TestDiffusionWorkerWakeUp:
 
     def test_wake_up_partial_buffer_restore(self, mocker: MockerFixture, mock_gpu_worker):
         """Test wake_up only restores buffers that were saved."""
-        mock_allocator_class = patch_cumem_allocator(mocker)
-
-        # Setup allocator mock
-        mock_allocator = mocker.Mock()
-        mock_allocator_class.get_instance = mocker.Mock(return_value=mock_allocator)
-        mock_allocator.wake_up = mocker.Mock()
-        mock_allocator.get_current_usage.return_value = 10 * 1024**3
-
         # Only save buffer1, not buffer2
         saved_buffer1 = torch.randn(10, 10)
         mock_gpu_worker._sleep_saved_buffers = {

--- a/tests/e2e/offline_inference/custom_pipeline/test_async_omni_collective_rpc.py
+++ b/tests/e2e/offline_inference/custom_pipeline/test_async_omni_collective_rpc.py
@@ -159,18 +159,18 @@ async def test_generate_after_list_loras_inline_mode():
 @hardware_test(res={"cuda": "L4"}, num_cards=1)
 @pytest.mark.asyncio
 async def test_sleep_memory_reclaimed_custom_pipeline():
-    """sleep(level=1) must physically reclaim CuMemAllocator-tracked memory for
+    """sleep(level=1) must physically reclaim allocator-tracked memory for
     custom_pipeline.
 
     Regression test for: custom pipelines constructed under ``with target_device:``
     (CUDA default-device context) caused safetensors >=0.20.0 to use a
     direct-to-GPU fast path (cudaMalloc via the driver API) that bypasses
-    CuMemAllocator, leaving weights invisible to sleep() and pinned in GPU
+    the memory allocator, leaving weights invisible to sleep() and pinned in GPU
     memory after the call.
 
     The fix moves custom_pipeline init outside the CUDA context so all weights
     go through the caching allocator and are therefore fully reclaimed by
-    sleep(level=1).  A non-zero ``CuMemAllocator.get_current_usage()`` after
+    sleep(level=1).  A non-zero ``get_current_usage()`` after
     sleep is the direct signal that the bypass is still occurring.
     """
     with ExitStack() as after:
@@ -191,15 +191,15 @@ async def test_sleep_memory_reclaimed_custom_pipeline():
         free_before, total = torch.cuda.mem_get_info()
         used_before_gib = (total - free_before) / 1024**3
 
-        # Measure CuMemAllocator-tracked usage before sleep.  In inline mode
+        # Measure allocator-tracked usage before sleep.  In inline mode
         # the worker runs in a thread pool inside this process, so the allocator
         # singleton is shared and can be read directly.
         allocator = None
         tracked_before = 0
         try:
-            from vllm.device_allocator.cumem import CuMemAllocator
+            from vllm.device_allocator import get_mem_allocator_instance
 
-            allocator = CuMemAllocator.get_instance()
+            allocator = get_mem_allocator_instance()
             tracked_before = allocator.get_current_usage()
         except Exception:
             pass
@@ -215,16 +215,16 @@ async def test_sleep_memory_reclaimed_custom_pipeline():
         drop_gib = used_before_gib - used_after_gib
 
         # --- Primary assertion: allocator reports zero tracked memory. ---
-        # If this fails it means weights were allocated outside the CuMem pool
+        # If this fails it means weights were allocated outside the memory pool
         # (safetensors direct-to-GPU bypass) — the exact regression this test
         # is designed to catch.
         if allocator is not None:
             tracked_after = allocator.get_current_usage()
             assert tracked_after == 0, (
-                f"CuMemAllocator still tracks {tracked_after / 1024**3:.3f} GiB "
+                f"Memory allocator still tracks {tracked_after / 1024**3:.3f} GiB "
                 f"after sleep(level=1) on custom_pipeline path "
                 f"(was {tracked_before / 1024**3:.3f} GiB before sleep). "
-                "Weights were allocated outside the CuMem pool via the "
+                "Weights were allocated outside the memory pool via the "
                 "safetensors direct-to-GPU fast path — loader-context fix "
                 "may not be applied."
             )
@@ -240,7 +240,7 @@ async def test_sleep_memory_reclaimed_custom_pipeline():
         assert freed_gib > 0 or drop_gib > 0, (
             f"Expected GPU memory to be reclaimed after sleep(level=1) on "
             f"custom_pipeline + enable_sleep_mode=True. "
-            f"CuMemAllocator tracked before={tracked_before / 1024**3:.3f} GiB, "
+            f"Allocator tracked before={tracked_before / 1024**3:.3f} GiB, "
             f"ACK freed={freed_gib:.3f} GiB, global VRAM drop={drop_gib:.3f} GiB."
         )
 

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -567,14 +567,14 @@ class DiffusersPipelineLoader:
             # internally. If we construct them under `with target_device:` (CUDA),
             # safetensors takes a direct-to-GPU fast path that calls `cudaMalloc`
             # via the driver API and BYPASSES PyTorch's caching allocator.
-            # That makes those bytes invisible to CuMemAllocator, so `sleep()`
+            # That makes those bytes invisible to the memory allocator, so `sleep()`
             # cannot offload/unmap them and GPU memory stays pinned.
             #
             # Fix: build the custom pipeline on CPU first (no default device
             # context), then explicitly move it to the target device. The
             # subsequent `.to(target_device)` issues `torch.empty(..., device=cuda)`
             # + `copy_`, which goes through the caching allocator and is fully
-            # tracked by CuMemAllocator.
+            # tracked by the memory allocator.
             model_cls = _resolve_custom_pipeline_cls(custom_pipeline_name)
             with set_current_diffusion_config(self.od_config):
                 model = model_cls(od_config=self.od_config)

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -165,12 +165,6 @@ def _create_diffusion_worker_vllm_config(device: torch.device, od_config: OmniDi
         return vllm_config
 
 
-def _get_cumem_allocator_class() -> type:
-    from vllm.device_allocator.cumem import CuMemAllocator
-
-    return CuMemAllocator
-
-
 def _resolve_ir_op_priority(od_config: OmniDiffusionConfig, vllm_config: VllmConfig) -> Any:
     ir_op_priority = current_omni_platform.get_default_ir_op_priority(vllm_config)
     ir_op_priority_func = get_diffusion_ir_op_priority_func(od_config)
@@ -526,8 +520,9 @@ class DiffusionWorker:
         Args:
             level: Sleep level. Level 1 offloads weights, level 2 also saves buffers.
         """
-        CuMemAllocator = _get_cumem_allocator_class()
-        allocator = CuMemAllocator.get_instance()
+        from vllm.device_allocator import get_mem_allocator_instance
+
+        allocator = get_mem_allocator_instance()
 
         usage_before = allocator.get_current_usage()
 
@@ -578,8 +573,9 @@ class DiffusionWorker:
             tags: List of memory pool tags to re-activate (e.g., ["weights"]
                   to match Level 1 sleep). If None, all pools are re-activated.
         """
-        CuMemAllocator = _get_cumem_allocator_class()
-        allocator = CuMemAllocator.get_instance()
+        from vllm.device_allocator import get_mem_allocator_instance
+
+        allocator = get_mem_allocator_instance()
         allocator.wake_up(tags)
         current_omni_platform.synchronize()
         if len(self._sleep_saved_buffers) and self.model_runner is not None:
@@ -700,11 +696,12 @@ class DiffusionWorker:
         if is_sleep_enabled:
             current_omni_platform.synchronize()
             gc.collect()
-            CuMemAllocator = _get_cumem_allocator_class()
-            allocator = CuMemAllocator.get_instance()
+            from vllm.device_allocator import get_mem_allocator_instance
+
+            allocator = get_mem_allocator_instance()
             if tag == "weights":
                 assert allocator.get_current_usage() == 0, "Sleep mode can only be used for one instance per process."
-            logger.info(f"[Worker {self.rank}] Activating Diffusion CuMem pool for tag: {tag}")
+            logger.info(f"[Worker {self.rank}] Activating diffusion memory pool for tag: {tag}")
             return allocator.use_memory_pool(tag=tag)
         return nullcontext()
 
@@ -1071,7 +1068,7 @@ class WorkerWrapperBase:
         # Create the actual worker instance
         # When custom_pipeline_args is provided, skip initial model loading
         # since re_init_pipeline will handle it. This avoids allocating memory
-        # through CuMemAllocator twice, which causes assertion failures in
+        # through the memory allocator twice, which causes assertion failures in
         # sleep mode.
         self.worker = worker_class(
             local_rank=gpu_id,

--- a/vllm_omni/engine/async_omni_engine.py
+++ b/vllm_omni/engine/async_omni_engine.py
@@ -1560,9 +1560,9 @@ class AsyncOmniEngine:
             except Exception:
                 logger.exception("[AsyncOmniEngine] Failed to shutdown StageRuntime")
 
-        # ── Release CuMem allocator memory pool ──────────────────────────────
-        # When enable_sleep_mode is in use, the CuMem (CUDA Virtual Memory
-        # Management) allocator holds model weights in a singleton memory pool
+        # ── Release memory allocator pool ────────────────────────────────────
+        # When enable_sleep_mode is in use, the memory allocator holds model
+        # weights in a singleton memory pool
         # that lives in the parent process.  Killing the engine-core subprocess
         # does NOT release this pool — the weights stay resident on the GPU
         # and can cause CUDA OOM for subsequent engine instances (especially
@@ -1575,12 +1575,11 @@ class AsyncOmniEngine:
         # and lets the destructor/free path handle asleep entries correctly
         # (returns a null handle so the C extension skips unmap/release).
         try:
-            from vllm.device_allocator.cumem import CuMemAllocator, cumem_available
+            from vllm.device_allocator import get_mem_allocator_instance
 
-            if cumem_available:
-                allocator = CuMemAllocator.get_instance()
-                allocator.release_pools()
-                logger.debug("[AsyncOmniEngine] Released CuMem memory pool during shutdown")
+            allocator = get_mem_allocator_instance()
+            allocator.release_pools()
+            logger.debug("[AsyncOmniEngine] Released memory pool during shutdown")
         except Exception:
             pass
 

--- a/vllm_omni/worker/base.py
+++ b/vllm_omni/worker/base.py
@@ -179,10 +179,10 @@ class OmniGPUWorkerBase(GPUWorker):
         if is_sleep_enabled:
             current_omni_platform.synchronize()
             gc.collect()
-            from vllm.device_allocator.cumem import CuMemAllocator
+            from vllm.device_allocator import get_mem_allocator_instance
 
-            allocator = CuMemAllocator.get_instance()
-            logger.info(f"[LLM Worker {self.rank}] Sleep Mode ENABLED. Activating CuMem pool for tag: {tag}")
+            allocator = get_mem_allocator_instance()
+            logger.info(f"[LLM Worker {self.rank}] Sleep Mode ENABLED. Activating memory pool for tag: {tag}")
             return allocator.use_memory_pool(tag=tag)
         else:
             logger.warning(f"[LLM Worker {self.rank}] Sleep Mode DISABLED.")
@@ -194,11 +194,11 @@ class OmniGPUWorkerBase(GPUWorker):
         Args:
             level: 1 (Offload weights to CPU), level: 2 (Total Discard).
         """
-        from vllm.device_allocator.cumem import CuMemAllocator
+        from vllm.device_allocator import get_mem_allocator_instance
 
         mem_before = current_omni_platform.get_current_memory_usage(self.device)
         offload_tags = ("weights",) if level == 1 else tuple()
-        allocator = CuMemAllocator.get_instance()
+        allocator = get_mem_allocator_instance()
         allocator.sleep(offload_tags=offload_tags)
         current_omni_platform.empty_cache()
         current_omni_platform.synchronize()
@@ -214,9 +214,9 @@ class OmniGPUWorkerBase(GPUWorker):
 
     def wake_up(self, tags: list[str] | None = None) -> bool:
         "Physical video memory reloading logic"
-        from vllm.device_allocator.cumem import CuMemAllocator
+        from vllm.device_allocator import get_mem_allocator_instance
 
-        allocator = CuMemAllocator.get_instance()
+        allocator = get_mem_allocator_instance()
         allocator.wake_up(tags)
         current_omni_platform.synchronize()
         logger.info(f"[LLM Worker {self.rank}] Wake-up complete.")


### PR DESCRIPTION
## Purpose

Replace all direct `CuMemAllocator.get_instance()` calls with the platform-agnostic `get_mem_allocator_instance()` factory from `vllm.device_allocator`, which dispatches to the correct allocator for CUDA, XPU, or future platforms.

## Test Plan

```
pytest tests/diffusion/test_diffusion_worker.py
pytest tests/e2e/offline_inference/custom_pipeline/test_async_omni_collective_rpc.py
```

**vLLM Version:** 0.23.0

**vLLM-Omni Commit:** ded0cfd7c935eb330bd5c3c9c1887a0f0f6b5b73

## Test Result

PASS
