### PR TITLE
[Bugfix][HunyuanImage3] Share image processing helpers

### DIFF
--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -5,7 +5,6 @@ import inspect
 import logging
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from functools import lru_cache
 from typing import Any, cast
 
 import numpy as np
@@ -76,6 +75,18 @@ from vllm_omni.diffusion.forward_context import set_forward_context_denoise_step
 from vllm_omni.diffusion.layers.norm import RMSNorm
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
 from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_fused_moe import HunyuanFusedMoE
+from vllm_omni.diffusion.models.hunyuan_image3.image_processing import (
+    HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS as HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS,
+)
+from vllm_omni.diffusion.models.hunyuan_image3.image_processing import (
+    Resolution as Resolution,
+)
+from vllm_omni.diffusion.models.hunyuan_image3.image_processing import (
+    ResolutionGroup as ResolutionGroup,
+)
+from vllm_omni.diffusion.models.hunyuan_image3.image_processing import (
+    get_cached_resolution_group,
+)
 from vllm_omni.model_executor.layers.timestep_embedding import timestep_embedding
 
 logger = logging.getLogger(__name__)
@@ -442,199 +453,6 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
 
 def default(value, default_value):
     return value if value is not None else default_value
-
-
-class Resolution:
-    def __init__(self, size, *args):
-        if isinstance(size, str):
-            if "x" in size:
-                size = size.split("x")
-                size = (int(size[0]), int(size[1]))
-            else:
-                size = int(size)
-        if len(args) > 0:
-            size = (size, args[0])
-        if isinstance(size, int):
-            size = (size, size)
-
-        self.h = self.height = size[0]
-        self.w = self.width = size[1]
-        self.r = self.ratio = self.height / self.width
-
-        self.extra_res = set()
-
-    def match(self, width, height) -> tuple[int, int]:
-        if not self.extra_res:
-            return self.w, self.h
-        else:
-            ret_w, ret_h = self.w, self.h
-            target_area = width * height
-            min_area_diff = abs((self.w * self.h) - target_area)
-            for res in self.extra_res:
-                area_diff = abs((res[0] * res[1]) - target_area)
-                if area_diff < min_area_diff:
-                    min_area_diff = area_diff
-                    ret_w, ret_h = res[0], res[1]
-            return (ret_w, ret_h)
-
-    def __getitem__(self, idx):
-        if idx == 0:
-            return self.h
-        elif idx == 1:
-            return self.w
-        else:
-            raise IndexError(f"Index {idx} out of range")
-
-    def __str__(self):
-        return f"{self.h}x{self.w}"
-
-    def __repr__(self) -> str:
-        if not self.extra_res:
-            return "{" + f"{self.h}x{self.w}" + "}"
-        else:
-            ret_str = "{" + f"[{self.h}x{self.w}]"
-            for er in self.extra_res:
-                ret_str = ret_str + f"[{er[0]}x{er[1]}]"
-            ret_str = ret_str + "}"
-            return ret_str
-
-    def append(self, res: "Resolution"):
-        self.extra_res.add((res.w, res.h))
-
-
-# Baked-in extras matching the official model's
-# `HunyuanImage3ImageProcessor.vae_reso_group` (image_processor.py:147-152).
-# These four aspect buckets sit at ratio_token indices 33-36 in the trained
-# model and the AR was trained to address them, so any deviation breaks the
-# ratio-token vocab → output-shape lookup.
-HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS: tuple[str, ...] = (
-    "1024x768",
-    "1280x720",
-    "768x1024",
-    "720x1280",
-    "512x512",
-    "640x640",
-    "768x768",
-    "896x896",
-)
-
-
-class ResolutionGroup:
-    def __init__(self, base_size=None, step=None, align=1, extra_resolutions=None):
-        self.align = align
-        self.base_size = base_size
-        assert base_size % align == 0, f"base_size {base_size} is not divisible by align {align}"
-        if base_size is not None and not isinstance(base_size, int):
-            raise ValueError(f"base_size must be None or int, but got {type(base_size)}")
-        if step is None:
-            step = base_size // 16
-        if step is not None and step > base_size // 2:
-            raise ValueError(f"step must be smaller than base_size // 2, but got {step} > {base_size // 2}")
-
-        self.step = step
-        self.data = self._calc_by_step()
-
-        if extra_resolutions is not None:
-            for er in extra_resolutions:
-                for r in self.data:
-                    if r.ratio == er.ratio:
-                        r.append(er)
-                        break
-                else:
-                    self.data.append(er)
-
-        self.ratio = np.array([x.ratio for x in self.data])
-        self.attr = ["" for _ in range(len(self.data))]
-        self.prefix_space = 0
-        logger.debug(f"ResolutionGroup: {self}")
-
-    def __len__(self):
-        return len(self.data)
-
-    def __getitem__(self, idx):
-        return self.data[idx]
-
-    def __repr__(self):
-        prefix = self.prefix_space * " "
-        prefix_close = (self.prefix_space - 4) * " "
-        res_str = f"ResolutionGroup(base_size={self.base_size}, step={self.step}, data="
-        attr_maxlen = max([len(x) for x in self.attr] + [5])
-        res_str += (
-            f"\n{prefix}ID: height width   ratio {' ' * max(0, attr_maxlen - 4)}count  h/16 w/16    tokens\n{prefix}"
-        )
-
-        rows = []
-        for i, x in enumerate(self.data):
-            main_row = (
-                f"{i:2d}: ({x.h:4d}, {x.w:4d})  {self.ratio[i]:.4f}  {self.attr[i]:>{attr_maxlen}s}  "
-                f"({x.h // 16:3d}, {x.w // 16:3d})  {x.h // 16 * x.w // 16:6d}"
-            )
-            rows.append(main_row)
-            extra_val = getattr(x, "extra_res", None)
-            if extra_val:
-                for sub_h, sub_w in sorted(list(extra_val)):
-                    sub_ratio = sub_h / sub_w
-                    sub_h16, sub_w16 = sub_h // 16, sub_w // 16
-                    sub_tokens = sub_h16 * sub_w16
-                    sub_row = (
-                        f"    ({sub_h:4d}, {sub_w:4d})  {sub_ratio:.4f}  {' ' * attr_maxlen}  "
-                        f"({sub_h16:3d}, {sub_w16:3d})  {sub_tokens:6d}"
-                    )
-                    rows.append(sub_row)
-
-        res_str += ("\n" + prefix).join(rows)
-        res_str += f"\n{prefix_close})"
-        return res_str
-
-    def _calc_by_step(self):
-        assert self.align <= self.step, f"align {self.align} must be smaller than step {self.step}"
-
-        min_height = self.base_size // 2
-        min_width = self.base_size // 2
-        max_height = self.base_size * 2
-        max_width = self.base_size * 2
-
-        resolutions = [Resolution(self.base_size, self.base_size)]
-
-        cur_height, cur_width = self.base_size, self.base_size
-        while True:
-            if cur_height >= max_height and cur_width <= min_width:
-                break
-
-            cur_height = min(cur_height + self.step, max_height)
-            cur_width = max(cur_width - self.step, min_width)
-            resolutions.append(Resolution(cur_height // self.align * self.align, cur_width // self.align * self.align))
-
-        cur_height, cur_width = self.base_size, self.base_size
-        while True:
-            if cur_height <= min_height and cur_width >= max_width:
-                break
-
-            cur_height = max(cur_height - self.step, min_height)
-            cur_width = min(cur_width + self.step, max_width)
-            resolutions.append(Resolution(cur_height // self.align * self.align, cur_width // self.align * self.align))
-
-        resolutions = sorted(resolutions, key=lambda x: x.ratio)
-
-        return resolutions
-
-    def get_target_size(self, width, height):
-        ratio = height / width
-        idx = np.argmin(np.abs(self.ratio - ratio))
-        w, h = self.data[idx].match(width, height)
-        return w, h
-
-    def get_base_size_and_ratio_index(self, width, height):
-        ratio = height / width
-        idx = np.argmin(np.abs(self.ratio - ratio))
-        return self.base_size, idx
-
-
-@lru_cache(maxsize=4)
-def get_cached_resolution_group(base_size: int) -> ResolutionGroup:
-    extra_res_tuple = tuple(Resolution(s) for s in HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS)
-    extra_resolutions = list(extra_res_tuple) if extra_res_tuple else None
-    return ResolutionGroup(base_size=base_size, extra_resolutions=extra_resolutions)
 
 
 class ImageInfo:

--- a/vllm_omni/diffusion/models/hunyuan_image3/image_processing.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/image_processing.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import logging
+from functools import lru_cache
+
+import numpy as np
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+class Resolution:
+    def __init__(self, size, *args):
+        if isinstance(size, str):
+            if "x" in size:
+                size = size.split("x")
+                size = (int(size[0]), int(size[1]))
+            else:
+                size = int(size)
+        if len(args) > 0:
+            size = (size, args[0])
+        if isinstance(size, int):
+            size = (size, size)
+
+        self.h = self.height = size[0]
+        self.w = self.width = size[1]
+        self.r = self.ratio = self.height / self.width
+
+        self.extra_res = set()
+
+    def match(self, width, height) -> tuple[int, int]:
+        if not self.extra_res:
+            return self.w, self.h
+
+        ret_w, ret_h = self.w, self.h
+        target_area = width * height
+        min_area_diff = abs((self.w * self.h) - target_area)
+        for res_w, res_h in self.extra_res:
+            area_diff = abs((res_w * res_h) - target_area)
+            if area_diff < min_area_diff:
+                min_area_diff = area_diff
+                ret_w, ret_h = res_w, res_h
+        return ret_w, ret_h
+
+    def __getitem__(self, idx):
+        if idx == 0:
+            return self.h
+        elif idx == 1:
+            return self.w
+        else:
+            raise IndexError(f"Index {idx} out of range")
+
+    def __str__(self):
+        return f"{self.h}x{self.w}"
+
+    def __repr__(self) -> str:
+        if not self.extra_res:
+            return "{" + f"{self.h}x{self.w}" + "}"
+
+        ret_str = "{" + f"[{self.h}x{self.w}]"
+        for res_w, res_h in self.extra_res:
+            ret_str = ret_str + f"[{res_w}x{res_h}]"
+        ret_str = ret_str + "}"
+        return ret_str
+
+    def append(self, res: "Resolution"):
+        self.extra_res.add((res.w, res.h))
+
+
+# Baked-in extras matching the official model's
+# `HunyuanImage3ImageProcessor.vae_reso_group` (image_processor.py:147-152).
+# These aspect buckets are trained model vocabulary targets, so AR and DiT
+# consumers must share the same table.
+HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS: tuple[str, ...] = (
+    "1024x768",
+    "1280x720",
+    "768x1024",
+    "720x1280",
+    "512x512",
+    "640x640",
+    "768x768",
+    "896x896",
+)
+
+
+class ResolutionGroup:
+    def __init__(self, base_size=None, step=None, align=1, extra_resolutions=None):
+        self.align = align
+        self.base_size = base_size
+        assert base_size % align == 0, f"base_size {base_size} is not divisible by align {align}"
+        if base_size is not None and not isinstance(base_size, int):
+            raise ValueError(f"base_size must be None or int, but got {type(base_size)}")
+        if step is None:
+            step = base_size // 16
+        if step is not None and step > base_size // 2:
+            raise ValueError(f"step must be smaller than base_size // 2, but got {step} > {base_size // 2}")
+
+        self.step = step
+        self.data = self._calc_by_step()
+
+        if extra_resolutions is not None:
+            for er in extra_resolutions:
+                for r in self.data:
+                    if r.ratio == er.ratio:
+                        r.append(er)
+                        break
+                else:
+                    self.data.append(er)
+
+        self.ratio = np.array([x.ratio for x in self.data])
+        self.attr = ["" for _ in range(len(self.data))]
+        self.prefix_space = 0
+        logger.debug("ResolutionGroup: %s", self)
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+    def __repr__(self):
+        prefix = self.prefix_space * " "
+        prefix_close = (self.prefix_space - 4) * " "
+        res_str = f"ResolutionGroup(base_size={self.base_size}, step={self.step}, data="
+        attr_maxlen = max([len(x) for x in self.attr] + [5])
+        res_str += (
+            f"\n{prefix}ID: height width   ratio {' ' * max(0, attr_maxlen - 4)}count  h/16 w/16    tokens\n{prefix}"
+        )
+
+        rows = []
+        for i, x in enumerate(self.data):
+            main_row = (
+                f"{i:2d}: ({x.h:4d}, {x.w:4d})  {self.ratio[i]:.4f}  {self.attr[i]:>{attr_maxlen}s}  "
+                f"({x.h // 16:3d}, {x.w // 16:3d})  {x.h // 16 * x.w // 16:6d}"
+            )
+            rows.append(main_row)
+            extra_val = getattr(x, "extra_res", None)
+            if extra_val:
+                for sub_h, sub_w in sorted(list(extra_val)):
+                    sub_ratio = sub_h / sub_w
+                    sub_h16, sub_w16 = sub_h // 16, sub_w // 16
+                    sub_tokens = sub_h16 * sub_w16
+                    sub_row = (
+                        f"    ({sub_h:4d}, {sub_w:4d})  {sub_ratio:.4f}  {' ' * attr_maxlen}  "
+                        f"({sub_h16:3d}, {sub_w16:3d})  {sub_tokens:6d}"
+                    )
+                    rows.append(sub_row)
+
+        res_str += ("\n" + prefix).join(rows)
+        res_str += f"\n{prefix_close})"
+        return res_str
+
+    def _calc_by_step(self):
+        assert self.align <= self.step, f"align {self.align} must be smaller than step {self.step}"
+
+        min_height = self.base_size // 2
+        min_width = self.base_size // 2
+        max_height = self.base_size * 2
+        max_width = self.base_size * 2
+
+        resolutions = [Resolution(self.base_size, self.base_size)]
+
+        cur_height, cur_width = self.base_size, self.base_size
+        while True:
+            if cur_height >= max_height and cur_width <= min_width:
+                break
+
+            cur_height = min(cur_height + self.step, max_height)
+            cur_width = max(cur_width - self.step, min_width)
+            resolutions.append(Resolution(cur_height // self.align * self.align, cur_width // self.align * self.align))
+
+        cur_height, cur_width = self.base_size, self.base_size
+        while True:
+            if cur_height <= min_height and cur_width >= max_width:
+                break
+
+            cur_height = max(cur_height - self.step, min_height)
+            cur_width = min(cur_width + self.step, max_width)
+            resolutions.append(Resolution(cur_height // self.align * self.align, cur_width // self.align * self.align))
+
+        resolutions = sorted(resolutions, key=lambda x: x.ratio)
+
+        return resolutions
+
+    def get_target_size(self, width, height):
+        ratio = height / width
+        idx = np.argmin(np.abs(self.ratio - ratio))
+        w, h = self.data[idx].match(width, height)
+        return w, h
+
+    def get_base_size_and_ratio_index(self, width, height):
+        ratio = height / width
+        idx = np.argmin(np.abs(self.ratio - ratio))
+        return self.base_size, idx
+
+
+@lru_cache(maxsize=4)
+def get_cached_resolution_group(base_size: int) -> ResolutionGroup:
+    extra_res_tuple = tuple(Resolution(s) for s in HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS)
+    extra_resolutions = list(extra_res_tuple) if extra_res_tuple else None
+    return ResolutionGroup(base_size=base_size, extra_resolutions=extra_resolutions)
+
+
+def resize_and_crop(
+    image: Image.Image,
+    target_size: tuple[int, int],
+    crop_type: str = "center",
+) -> Image.Image:
+    tw, th = target_size
+    if crop_type == "resize":
+        return image.resize((tw, th), resample=Image.Resampling.LANCZOS)
+
+    w, h = image.size
+    tr = th / tw
+    r = h / w
+    if r < tr:
+        resize_height = th
+        resize_width = int(round(th / h * w))
+    else:
+        resize_width = tw
+        resize_height = int(round(tw / w * h))
+    image = image.resize((resize_width, resize_height), resample=Image.Resampling.LANCZOS)
+    crop_top = int(round((resize_height - th) / 2.0))
+    crop_left = int(round((resize_width - tw) / 2.0))
+    return image.crop((crop_left, crop_top, crop_left + tw, crop_top + th))

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -49,6 +49,7 @@ from .hunyuan_image3_transformer import (
     real_batched_index_select,
     retrieve_timesteps,
 )
+from .image_processing import resize_and_crop
 from .system_prompt import get_system_prompt
 
 if TYPE_CHECKING:
@@ -127,20 +128,7 @@ def _resize_and_crop_center(image: PILImage.Image, target_width: int, target_hei
     # Mirrors HunyuanImage3Processor._resize_and_crop in
     # vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3 so the AR
     # and DiT stages preprocess condition images identically.
-    tw, th = target_width, target_height
-    w, h = image.size
-    tr = th / tw
-    r = h / w
-    if r < tr:
-        resize_height = th
-        resize_width = int(round(th / h * w))
-    else:
-        resize_width = tw
-        resize_height = int(round(tw / w * h))
-    resized = image.resize((resize_width, resize_height), PILImage.Resampling.LANCZOS)
-    crop_top = int(round((resize_height - th) / 2.0))
-    crop_left = int(round((resize_width - tw) / 2.0))
-    return resized.crop((crop_left, crop_top, crop_left + tw, crop_top + th))
+    return resize_and_crop(image, (target_width, target_height), crop_type="center")
 
 
 def _to_python_scalar(value: Any) -> Any:

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -6,7 +6,6 @@ import typing
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, Literal, TypeAlias
 
-import numpy as np
 import regex as re
 import torch
 from einops import rearrange
@@ -92,6 +91,12 @@ from vllm.v1.outputs import SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
+from vllm_omni.diffusion.models.hunyuan_image3.image_processing import (
+    HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS,
+    Resolution,
+    ResolutionGroup,
+    resize_and_crop,
+)
 from vllm_omni.model_executor.models.hunyuan_image3.autoencoder_kl_3d import AutoencoderKLConv3D
 from vllm_omni.model_executor.models.hunyuan_image3.siglip2 import LightProjector, Siglip2VisionTransformer
 
@@ -708,131 +713,12 @@ class HunyuanImage3PixelInputs(TensorSchema):
 class HunyuanImage3Processor:
     """Image processor for Hunyuan Image 3.0 model."""
 
-    class Resolution:
-        def __init__(self, size, *args):
-            if isinstance(size, str):
-                if "x" in size:
-                    size = size.split("x")
-                    size = (int(size[0]), int(size[1]))
-                else:
-                    size = int(size)
-            if len(args) > 0:
-                size = (size, args[0])
-            if isinstance(size, int):
-                size = (size, size)
-
-            self.h = self.height = size[0]
-            self.w = self.width = size[1]
-            self.r = self.ratio = self.height / self.width
-
-        def __getitem__(self, idx):
-            if idx == 0:
-                return self.h
-            elif idx == 1:
-                return self.w
-            else:
-                raise IndexError(f"Index {idx} out of range")
-
-        def __str__(self):
-            return f"{self.h}x{self.w}"
-
-    class ResolutionGroup:
-        """Group of resolutions for image processing."""
-
-        def __init__(self, base_size=None, step=None, align=1, extra_resolutions=None):
-            self.align = align
-            self.base_size = base_size
-            assert base_size % align == 0, f"base_size {base_size} is not divisible by align {align}"
-            if base_size is not None and not isinstance(base_size, int):
-                raise ValueError(f"base_size must be None or int, but got {type(base_size)}")
-            if step is None:
-                step = base_size // 16
-            if step is not None and step > base_size // 2:
-                raise ValueError(f"step must be smaller than base_size // 2, but got {step} > {base_size // 2}")
-
-            self.step = step
-            self.data = self._calc_by_step()
-
-            if extra_resolutions is not None:
-                for er in extra_resolutions:
-                    if not any(r.ratio == er.ratio for r in self.data):
-                        self.data.append(er)
-
-            self.ratio = np.array([x.ratio for x in self.data])
-            self.attr = ["" for _ in range(len(self.data))]
-            self.prefix_space = 0
-
-        def __len__(self):
-            return len(self.data)
-
-        def __getitem__(self, idx):
-            return self.data[idx]
-
-        def _calc_by_step(self):
-            assert self.align <= self.step, f"align {self.align} must be smaller than step {self.step}"
-
-            min_height = self.base_size // 2
-            min_width = self.base_size // 2
-            max_height = self.base_size * 2
-            max_width = self.base_size * 2
-
-            resolutions = [HunyuanImage3Processor.Resolution(self.base_size, self.base_size)]
-
-            cur_height, cur_width = self.base_size, self.base_size
-            while True:
-                if cur_height >= max_height and cur_width <= min_width:
-                    break
-
-                cur_height = min(cur_height + self.step, max_height)
-                cur_width = max(cur_width - self.step, min_width)
-                resolutions.append(
-                    HunyuanImage3Processor.Resolution(
-                        cur_height // self.align * self.align, cur_width // self.align * self.align
-                    )
-                )
-
-            cur_height, cur_width = self.base_size, self.base_size
-            while True:
-                if cur_height <= min_height and cur_width >= max_width:
-                    break
-
-                cur_height = max(cur_height - self.step, min_height)
-                cur_width = min(cur_width + self.step, max_width)
-                resolutions.append(
-                    HunyuanImage3Processor.Resolution(
-                        cur_height // self.align * self.align, cur_width // self.align * self.align
-                    )
-                )
-
-            resolutions = sorted(resolutions, key=lambda x: x.ratio)
-
-            return resolutions
-
-        def get_target_size(self, width, height):
-            ratio = height / width
-            idx = np.argmin(np.abs(self.ratio - ratio))
-            reso = self.data[idx]
-            return reso.w, reso.h
-
-        def get_base_size_and_ratio_index(self, width, height):
-            ratio = height / width
-            idx = np.argmin(np.abs(self.ratio - ratio))
-            return self.base_size, idx
-
     def __init__(self, tokenizer, hf_config, **kwargs: object):
         self.tokenizer = tokenizer
         self.hf_config = hf_config
-        # `HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS` mirrors the official
-        # `vae_reso_group` extras (image_processor.py:147-152). Build with
-        # this processor's inner Resolution class so `data` stays
-        # type-homogeneous.
-        from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import (
-            HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS,
-        )
-
-        self.reso_group = self.ResolutionGroup(
+        self.reso_group = ResolutionGroup(
             base_size=hf_config.image_base_size,
-            extra_resolutions=[HunyuanImage3Processor.Resolution(s) for s in HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS],
+            extra_resolutions=[Resolution(s) for s in HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS],
         )
         self.vision_encoder_processor = Siglip2ImageProcessorFast.from_dict(hf_config.vit_processor)
         self.vae_processor = transforms.Compose(
@@ -961,27 +847,7 @@ class HunyuanImage3Processor:
         target_size: tuple[int, int],
         crop_type: str = "resize",
     ) -> Image.Image:
-        # Default mode mirrors the official `infer_align_image_size=True`
-        # path (image_processor.py:355 → crop_type="resize") used by the
-        # IT2I demo: stretch the cond image to the bucket dims so its
-        # `<img_ratio_*>` tag and ViT/VAE features stay aligned with the
-        # bucket, instead of dropping content via center crop.
-        tw, th = target_size
-        if crop_type == "resize":
-            return image.resize((tw, th), resample=Image.Resampling.LANCZOS)
-        w, h = image.size
-        tr = th / tw
-        r = h / w
-        if r < tr:
-            resize_height = th
-            resize_width = int(round(th / h * w))
-        else:
-            resize_width = tw
-            resize_height = int(round(tw / w * h))
-        image = image.resize((resize_width, resize_height), resample=Image.Resampling.LANCZOS)
-        crop_top = int(round((resize_height - th) / 2.0))
-        crop_left = int(round((resize_width - tw) / 2.0))
-        return image.crop((crop_left, crop_top, crop_left + tw, crop_top + th))
+        return resize_and_crop(image, target_size, crop_type=crop_type)
 
 
 class HunyuanImage3ProcessingInfo(BaseProcessingInfo):

--- a/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
+++ b/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
@@ -19,7 +19,7 @@ from typing import Any
 from vllm.inputs import TextPrompt
 from vllm.logger import init_logger
 
-from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import (
+from vllm_omni.diffusion.models.hunyuan_image3.image_processing import (
     Resolution,
     ResolutionGroup,
     get_cached_resolution_group,


### PR DESCRIPTION
## Purpose

Fix the HunyuanImage3 sizing path by centralizing the shared resolution bucket and resize/crop logic.

Current `main` still keeps HunyuanImage3 resolution and resize/crop logic split across AR, DiT, and bridge-side code. The remaining HunyuanImage3 bugfixes all need the same sizing rules:

- explicit user `height` / `width` must map to the same ratio bucket used by AR and DiT
- `infer_align_image_size` must choose the same crop/resize behavior across preprocessing and postprocess
- AR-to-DiT bridge inputs must preserve condition-image sizing metadata

This PR extracts the duplicated resolution bucket table and resize/crop helper into `vllm_omni/diffusion/models/hunyuan_image3/image_processing.py`, then updates the existing AR, DiT, and bridge call sites to import the shared implementation.

## Benefit

This is the enabling bugfix slice for the HunyuanImage3 sizing issues still present on `main`: the resolution table and resize/crop behavior stop being copied in several places. That keeps the follow-up fixes for forced AR ratio tokens, official infer-align sizing, RGB preprocessing parity, and img2img bridge forwarding from each carrying their own slightly different sizing logic.

The intended user-visible behavior of this PR is unchanged; the benefit is making the sizing bugfixes reviewable and preventing drift between AR, DiT, and bridge paths.

## Test Plan

Covered by the HunyuanImage3 repository tests that exercise the call sites now importing the shared helper:

- `tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_infer_align_size.py`
- `tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_it2i_ar_format.py`
- `tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_sampler.py`
- `tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_routing.py`
- `tests/entrypoints/openai_api/test_image_server.py`
- `tests/entrypoints/openai_api/test_serving_chat_multistage_generation.py`
- `tests/e2e/accuracy/test_hunyuan_image3.py::test_image_to_image_alignment_online`

## Test Result

Validation evidence for this split:

- CI/status checks passed on validation head `76b5c32bc00cafa2cc17e8a6d9d5e65b20ff13b1`: `buildkite/vllm-omni`, `buildkite/vllm-omni-amd-ci`, `buildkite/vllm-omni-intel-ci`, and ReadTheDocs.
- Online accuracy: `tests/e2e/accuracy/test_hunyuan_image3.py::test_image_to_image_alignment_online` passed on physical GPUs `4,5,6,7` in `799.27s`.