### PR TITLE
[Bugfix][HunyuanImage3] Pin AR ratio token to requested size

### DIFF
--- a/examples/offline_inference/hunyuan_image3/end2end.py
+++ b/examples/offline_inference/hunyuan_image3/end2end.py
@@ -14,7 +14,7 @@ from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import (
     resolve_sys_type,
 )
 from vllm_omni.entrypoints.omni import Omni
-from vllm_omni.inputs.data import OmniPromptType
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniPromptType
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _DEFAULT_DEPLOY_CONFIG = str(_REPO_ROOT / "vllm_omni" / "deploy" / "hunyuan_image_3_moe.yaml")
@@ -127,6 +127,40 @@ def parse_additional_config(raw_value: str | None) -> dict | None:
     return additional_config
 
 
+def _configure_sampling_params(
+    params_list: list,
+    *,
+    modality: str,
+    steps: int,
+    guidance_scale: float,
+    seed: int | None,
+    height: int | None,
+    width: int | None,
+    ar_stop_token_ids: list[int],
+) -> None:
+    user_specified_image_size = modality in ("text2img", "img2img") and height is not None and width is not None
+
+    for sp in params_list:
+        if isinstance(sp, OmniDiffusionSamplingParams):
+            sp.num_inference_steps = steps
+            sp.guidance_scale = guidance_scale
+            sp.guidance_scale_provided = True
+            if seed is not None:
+                sp.seed = seed
+            if modality == "text2img" or (modality == "img2img" and user_specified_image_size):
+                sp.height = height
+                sp.width = width
+        elif hasattr(sp, "stop_token_ids"):
+            sp.stop_token_ids = ar_stop_token_ids
+            if user_specified_image_size:
+                extra_args = getattr(sp, "extra_args", None)
+                if extra_args is None:
+                    extra_args = {}
+                    sp.extra_args = extra_args
+                extra_args["target_h"] = int(height)
+                extra_args["target_w"] = int(width)
+
+
 def main():
     args = parse_args()
     os.makedirs(args.output, exist_ok=True)
@@ -224,8 +258,6 @@ def main():
 
     params_list = list(omni.default_sampling_params_list)
 
-    from vllm_omni.inputs.data import OmniDiffusionSamplingParams
-
     if (args.height is None) != (args.width is None):
         raise ValueError("--height and --width must both be specified or both omitted.")
     user_specified_size = args.height is not None and args.width is not None
@@ -241,18 +273,16 @@ def main():
     print(
         f"[AR Config] task={task}, bot_task={bot_task}, image_size={ar_image_size}, stop_token_ids={ar_stop_token_ids}"
     )
-    for sp in params_list:
-        if isinstance(sp, OmniDiffusionSamplingParams):
-            sp.num_inference_steps = args.steps
-            sp.guidance_scale = args.guidance_scale
-            sp.guidance_scale_provided = True
-            if args.seed is not None:
-                sp.seed = args.seed
-            if args.modality == "text2img":
-                sp.height = args.height
-                sp.width = args.width
-        elif hasattr(sp, "stop_token_ids"):
-            sp.stop_token_ids = ar_stop_token_ids
+    _configure_sampling_params(
+        params_list,
+        modality=args.modality,
+        steps=args.steps,
+        guidance_scale=args.guidance_scale,
+        seed=args.seed,
+        height=args.height,
+        width=args.width,
+        ar_stop_token_ids=ar_stop_token_ids,
+    )
 
     print(f"\n{'=' * 60}")
     print("HunyuanImage-3.0 Generation Configuration:")

--- a/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_sampler.py
+++ b/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_sampler.py
@@ -22,6 +22,13 @@ RATIO_OTHER_START = 220
 RATIO_OTHER_END = 223
 
 
+class _FakeResolutionGroup:
+    def get_base_size_and_ratio_index(self, width: int, height: int):
+        if (width, height) == (1280, 768):
+            return 1024, 4
+        return 1024, 0
+
+
 class FakeSamplerModel:
     """Minimal stub that replicates the sampler-relevant attributes of
     HunyuanImage3ForConditionalGeneration without loading real weights."""
@@ -40,6 +47,9 @@ class FakeSamplerModel:
         self._ratio_other_slices = [(RATIO_OTHER_START, RATIO_OTHER_END + 1)]
         self._all_ratio_ids = set(range(RATIO_START, RATIO_END + 1))
         self._all_ratio_ids.update(range(RATIO_OTHER_START, RATIO_OTHER_END + 1))
+        self._cur_sampling_extra_args = None
+        self._reso_group = _FakeResolutionGroup()
+        self._ratio_idx_to_token_id = [RATIO_START + i for i in range(RATIO_END - RATIO_START + 1)]
 
         self._stage_transitions: dict[int, list[int]] = {}
         if not is_comprehension:
@@ -58,6 +68,7 @@ class FakeSamplerModel:
 
     _get_forced_token = _Real._get_forced_token
     _apply_ratio_restriction = _Real._apply_ratio_restriction
+    _resolve_forced_ratio_token = _Real._resolve_forced_ratio_token
 
 
 class TestGetForcedToken:
@@ -171,6 +182,20 @@ class TestRatioRestriction:
 
         assert logits[0, RATIO_OTHER_START].item() == 0
         assert logits[0, RATIO_START].item() == min_score
+
+    def test_target_size_forces_matching_ratio_token(self):
+        model = FakeSamplerModel(is_comprehension=False)
+        model._cur_sampling_extra_args = [{"target_h": "768", "target_w": "1280"}]
+        vocab_size = 300
+        logits = torch.zeros(1, vocab_size)
+        logits[0, RATIO_START + 1] = 15.0
+        logits[0, RATIO_START + 4] = 1.0
+        min_score = torch.finfo(logits.dtype).min
+
+        model._apply_ratio_restriction(logits, 0, min_score)
+
+        assert logits[0, RATIO_START + 4].item() == 0
+        assert logits[0, RATIO_START + 1].item() == min_score
 
 
 class TestForceEosAfterRatio:

--- a/tests/diffusion/models/hunyuan_image3/test_prompt_utils.py
+++ b/tests/diffusion/models/hunyuan_image3/test_prompt_utils.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import ast
+import importlib.util
 import os
 import pathlib
 
 import pytest
+from vllm.sampling_params import SamplingParams
 
 from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import (
     _TASK_PRESETS,
@@ -17,6 +19,7 @@ from vllm_omni.diffusion.models.hunyuan_image3.prompt_utils import (
     build_prompt_tokens,
     resolve_stop_token_ids,
 )
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 
 pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
 
@@ -296,6 +299,15 @@ def _repo_root() -> pathlib.Path:
     return pathlib.Path(__file__).resolve().parents[4]
 
 
+def _load_end2end_module():
+    end2end_path = _repo_root() / "examples" / "offline_inference" / "hunyuan_image3" / "end2end.py"
+    spec = importlib.util.spec_from_file_location("hunyuan_image3_offline_end2end_for_test", end2end_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_end2end_routes_through_shared_prompt_utils():
     end2end_path = _repo_root() / "examples" / "offline_inference" / "hunyuan_image3" / "end2end.py"
     tree = ast.parse(end2end_path.read_text(encoding="utf-8"))
@@ -309,6 +321,51 @@ def test_end2end_routes_through_shared_prompt_utils():
             imported_from_prompt_utils.update(alias.name for alias in node.names)
     expected_imports = {"build_prompt_tokens", "resolve_stop_token_ids", "resolve_sys_type"}
     assert expected_imports <= imported_from_prompt_utils
+
+
+def test_end2end_explicit_size_sets_ar_sampling_extra_args():
+    end2end = _load_end2end_module()
+    ar_params = SamplingParams(max_tokens=128, extra_args={"keep": "value"})
+    diffusion_params = OmniDiffusionSamplingParams()
+
+    end2end._configure_sampling_params(
+        [ar_params, diffusion_params],
+        modality="text2img",
+        steps=24,
+        guidance_scale=2.5,
+        seed=42,
+        height=768,
+        width=1280,
+        ar_stop_token_ids=[101, 102],
+    )
+
+    assert ar_params.stop_token_ids == [101, 102]
+    assert ar_params.extra_args == {"keep": "value", "target_h": 768, "target_w": 1280}
+    assert diffusion_params.height == 768
+    assert diffusion_params.width == 1280
+    assert diffusion_params.num_inference_steps == 24
+    assert diffusion_params.guidance_scale == 2.5
+    assert diffusion_params.seed == 42
+
+
+def test_end2end_no_explicit_size_leaves_ar_target_size_unset():
+    end2end = _load_end2end_module()
+    ar_params = SamplingParams(max_tokens=128, extra_args={"keep": "value"})
+    diffusion_params = OmniDiffusionSamplingParams()
+
+    end2end._configure_sampling_params(
+        [ar_params, diffusion_params],
+        modality="text2img",
+        steps=24,
+        guidance_scale=2.5,
+        seed=None,
+        height=None,
+        width=None,
+        ar_stop_token_ids=[101, 102],
+    )
+
+    assert ar_params.stop_token_ids == [101, 102]
+    assert ar_params.extra_args == {"keep": "value"}
 
 
 _HUNYUAN_MODEL_ID = "tencent/HunyuanImage-3.0-Instruct"

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -1593,6 +1593,24 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
             )
             self._blocked_token_ids.update(self._all_ratio_ids)
 
+        self._cur_sampling_extra_args: list[dict] | None = None
+        self._reso_group: HunyuanImage3Processor.ResolutionGroup | None = None
+        self._ratio_idx_to_token_id: list[int] = []
+        if not self._is_comprehension:
+            self.vllm_config.model_config.has_sampling_extra_args = True
+
+            from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import (
+                HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS,
+            )
+
+            self._reso_group = HunyuanImage3Processor.ResolutionGroup(
+                base_size=image_base_size,
+                extra_resolutions=[HunyuanImage3Processor.Resolution(s) for s in HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS],
+            )
+            self._ratio_idx_to_token_id = [
+                tokenizer.convert_tokens_to_ids(f"<img_ratio_{i}>") for i in range(len(self._reso_group))
+            ]
+
         # For generation mode, build stage transition map.
         # Official logic: </think> → [<recaption>],
         #   </recaption> → [<answer>, <boi>, <img_size_*>]
@@ -2036,6 +2054,7 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
         **kwargs: object,
     ) -> torch.Tensor | IntermediateTensors:
         model_input_ids = None if inputs_embeds is not None else input_ids
+        self._cur_sampling_extra_args = kwargs.get("sampling_extra_args")
         model_output = self.model(model_input_ids, positions, intermediate_tensors, inputs_embeds)
         return model_output
 
@@ -2149,7 +2168,15 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
         """Port of official _ConditionalSliceVocabLogitsProcessor.__call__.
 
         After the size token, only allow ratio tokens and pick greedily.
+        When the request carries a user-requested target size, force the
+        matching ratio token so AR and DiT agree on the requested aspect.
         """
+        target_token_id = self._resolve_forced_ratio_token(req_idx)
+        if target_token_id is not None:
+            logits[req_idx].fill_(min_score)
+            logits[req_idx, target_token_id] = 0
+            return
+
         original = logits[req_idx].clone()
         logits[req_idx].fill_(min_score)
         # Allow primary ratio range.
@@ -2163,6 +2190,27 @@ class HunyuanImage3ForConditionalGeneration(nn.Module, SupportsMultiModal, Suppo
         max_id = logits[req_idx].argmax().item()
         logits[req_idx].fill_(min_score)
         logits[req_idx, max_id] = 0
+
+    def _resolve_forced_ratio_token(self, req_idx: int) -> int | None:
+        extra_args_list = self._cur_sampling_extra_args
+        if not extra_args_list or req_idx >= len(extra_args_list):
+            return None
+
+        extra_args = extra_args_list[req_idx] or {}
+        target_h = extra_args.get("target_h")
+        target_w = extra_args.get("target_w")
+        if target_h is None or target_w is None or self._reso_group is None:
+            return None
+
+        target_h = int(target_h)
+        target_w = int(target_w)
+        if target_h <= 0 or target_w <= 0:
+            return None
+
+        _, ratio_idx = self._reso_group.get_base_size_and_ratio_index(target_w, target_h)
+        if ratio_idx >= len(self._ratio_idx_to_token_id):
+            return None
+        return int(self._ratio_idx_to_token_id[ratio_idx])
 
     def make_empty_intermediate_tensors(
         self, batch_size: int, dtype: torch.dtype, device: torch.device


### PR DESCRIPTION
## Purpose

HunyuanImage3 uses an AR stage to emit image control tokens before DiT generation. For explicit-size requests, the serving path already carries the requested `height` / `width` as `target_h` / `target_w`, and downstream DiT sizing expects the AR tokens to agree with that requested bucket.

The missing piece is the AR ratio-token step. After `<img_size_*>`, current `main` still lets `_apply_ratio_restriction()` greedily choose the highest-scoring `<img_ratio_*>` token. That means a request with an explicit size such as `1280x768` can still have AR select a different ratio bucket, so the user-requested size is no longer authoritative.

This PR makes explicit size win at the AR sampler boundary:

- store per-request `sampling_extra_args` during AR forward
- resolve `target_h` / `target_w` through the HunyuanImage3 resolution table
- force the matching `<img_ratio_*>` token by masking all other ratio logits
- keep the existing greedy ratio selection when no explicit target size is present

This does not change condition-image forwarding between stages. It only uses the explicit target-size metadata that is already attached to the AR request, so AR ratio selection, AR stop-token behavior, and DiT sizing stay on the same requested bucket.

## Test Plan

Coverage in this PR:

- forced ratio-token selection when `target_h` / `target_w` is present, including the case where the matching ratio token has a lower logit than the greedy token
- existing greedy ratio fallback when no explicit target size is present
- existing extra ratio-token slice behavior
- serving path sets AR stop-token constraints for complete explicit size requests
- partial explicit size requests are rejected instead of creating inconsistent AR/DiT state
- no-size requests do not get explicit-size stop-token constraints
- multi-stage online image-editing path still forwards the condition images into the downstream DiT stage

## Test Result

Current PR head: `d8530483a05d267334446bfaccb61b622c9a84a5`.

Focused sampler regression:

- `tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_sampler.py::TestRatioRestriction::test_target_size_forces_matching_ratio_token`: `1 passed`

Multi-stage online accuracy check:

- Base: `d897852258d9bcc05101c54dcd0973d111de9723`
- PR head: `d8530483a05d267334446bfaccb61b622c9a84a5`
- Workload: `tests.e2e.accuracy.test_hunyuan_image3._run_online`
- API path: `/v1/images/edits`
- Request: `size=1280x720`, seed `42`, `50` inference steps, guidance scale `2.5`
- Before/after output: https://github.com/vllm-project/vllm-omni/pull/4501#issuecomment-4726580717

| Metric | Base | PR head |
| --- | ---: | ---: |
| Output size | `1280x720` | `1280x720` |
| COT prefix match | `127` | `127` |
| Required COT markers present | yes | yes |
| Image-Image similarity | `97.2845` | `97.2845` |
| SSIM | `0.2722` | `0.2722` |
| PSNR | `14.19 dB` | `14.19 dB` |

The base and PR output PNGs are byte-identical for this multi-stage case (`sha256=29230ca372fdc612bc226defa20c7fd59d05200daa64b6f739b8a4a49f4b700e`; pixel diff is empty), so this PR does not regress condition-image handoff into the downstream DiT stage.
