### PR TITLE
[Bugfix][HunyuanImage3] Accept shared img2img bridge input

### DIFF
--- a/tests/model_executor/stage_input_processors/test_hunyuan_image3_bridge.py
+++ b/tests/model_executor/stage_input_processors/test_hunyuan_image3_bridge.py
@@ -90,3 +90,14 @@ def test_ar2diffusion_forwards_custom_system_prompt_body():
 
     assert result[0]["use_system_prompt"] == "custom"
     assert result[0]["system_prompt"] == marker
+
+
+def test_ar2diffusion_forwards_img2img_multimodal_data_as_image():
+    img = object()
+
+    result = ar2diffusion(
+        [_source_output([100], text="thought")],
+        prompt=[{"prompt": "edit", "multi_modal_data": {"img2img": img}}],
+    )
+
+    assert result[0]["multi_modal_data"] == {"image": img}

--- a/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
+++ b/vllm_omni/model_executor/stage_input_processors/hunyuan_image3.py
@@ -203,6 +203,8 @@ def ar2diffusion(
             prompt_images = mm_data.get("image")
             if prompt_images is None:
                 prompt_images = mm_data.get("images")
+            if prompt_images is None:
+                prompt_images = mm_data.get("img2img")
             if prompt_images is not None:
                 diffusion_input["multi_modal_data"] = {"image": prompt_images}
 


### PR DESCRIPTION
## Purpose

Fix HunyuanImage3 image-conditioned serving requests that arrive with `multi_modal_data["img2img"]`.

The shared online image-edit and image-conditioned chat paths can use `img2img` for a single reference image. The HunyuanImage3 AR-to-DiT bridge already accepted `image` and `images`, but not `img2img`, so that reference image could be lost before DiT conditioning.

This PR maps `multi_modal_data["img2img"]` into the existing DiT-facing `image` field. It keeps the fix narrow: no new API shape, no DiT schema change, and no behavior change for the existing `image` / `images` inputs.

## Test Plan

Targeted bridge regression test:

```bash
python -m pytest \
  tests/model_executor/stage_input_processors/test_hunyuan_image3_bridge.py::test_ar2diffusion_forwards_img2img_multimodal_data_as_image \
  -q
```

This verifies that `ar2diffusion()` forwards `multi_modal_data["img2img"]` into the DiT-facing `multi_modal_data["image"]` field.

## Test Result

Remote validation on PR head `eca75a1dca9b40088b8b29825e1406781099f7b3` with `vllm==0.23.0`:

```text
1 passed, 21 warnings in 10.83s
```

Existing HunyuanImage3 img2img accuracy coverage remains the end-to-end runtime guard for offline and online image-conditioned generation.
