### PR TITLE
[Bugfix][HunyuanImage3] Add infer-align image sizing

### DIFF
--- a/docs/serving/image_edit_api.md
+++ b/docs/serving/image_edit_api.md
@@ -104,6 +104,7 @@ Content-Type: multipart/form-data
 | `num_inference_steps` | integer | model defaults | Number of diffusion steps |
 | `guidance_scale` | float | model defaults | Classifier-free guidance scale (typically 0.0-20.0) |
 | `true_cfg_scale` | float | model defaults | True CFG scale (model-specific parameter, may be ignored if not supported) |
+| `infer_align_image_size` | boolean | model default | HunyuanImage3-only img2img alignment flag. When true, condition images are resized instead of center-cropped and eligible outputs are resized back to the input-image ratio at the model base-size area. |
 | `seed` | integer | null | Random seed for reproducibility |
 | `reference_image` | string or array | null | Reference image for inpainting |
 | `mask_image` | string or array | null | Mask for inpainting (white areas will be inpainted) |

--- a/docs/serving/image_generation_api.md
+++ b/docs/serving/image_generation_api.md
@@ -149,6 +149,7 @@ Content-Type: application/json
 | `num_inference_steps` | integer | model defaults | Number of diffusion steps |
 | `guidance_scale` | float | model defaults | Classifier-free guidance scale (typically 0.0-20.0) |
 | `true_cfg_scale` | float | model defaults | True CFG scale (model-specific parameter, may be ignored if not supported) |
+| `infer_align_image_size` | boolean | model default | HunyuanImage3-only image-conditioning alignment flag. Plain text-to-image requests have no condition image to align, so this does not change T2I output sizing. |
 | `seed` | integer | null | Random seed for reproducibility |
 
 ### Response Format

--- a/examples/offline_inference/hunyuan_image3/end2end.py
+++ b/examples/offline_inference/hunyuan_image3/end2end.py
@@ -63,6 +63,12 @@ def parse_args():
     parser.add_argument("--seed", type=int, default=42, help="Random seed.")
     parser.add_argument("--height", type=int, default=None, help="Output image height.")
     parser.add_argument("--width", type=int, default=None, help="Output image width.")
+    parser.add_argument(
+        "--infer-align-image-size",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="For img2img, align condition-image preprocessing and output sizing to the input image ratio.",
+    )
     parser.add_argument("--vae-use-tiling", action="store_true", help="Enable VAE tiling.")
     parser.add_argument(
         "--bot-task",
@@ -221,6 +227,8 @@ def main():
             prompt_dict["multi_modal_data"] = {"image": mm_image_payload}
             prompt_dict["height"] = input_images[0].height
             prompt_dict["width"] = input_images[0].width
+            if args.infer_align_image_size is not None:
+                prompt_dict["mm_processor_kwargs"] = {"infer_align_image_size": args.infer_align_image_size}
         elif args.modality == "img2text":
             prompt_dict["modalities"] = ["text"]
             prompt_dict["multi_modal_data"] = {"image": mm_image_payload}
@@ -259,6 +267,8 @@ def main():
             if args.modality == "text2img":
                 sp.height = args.height
                 sp.width = args.width
+            if args.modality == "img2img" and args.infer_align_image_size is not None:
+                sp.extra_args["infer_align_image_size"] = args.infer_align_image_size
         elif hasattr(sp, "stop_token_ids"):
             sp.stop_token_ids = ar_stop_token_ids
             # When --stream is set, request DELTA output from the AR stage
@@ -288,6 +298,8 @@ def main():
         print(f"  Output size: {args.width}x{args.height}")
     if args.image_path:
         print(f"  Input image: {args.image_path}")
+    if args.modality == "img2img" and args.infer_align_image_size is not None:
+        print(f"  Infer-align image size: {args.infer_align_image_size}")
     if additional_config is not None:
         print(f"  Additional config: {additional_config}")
     print(f"  Prompts: {prompts}")

--- a/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_infer_align_size.py
+++ b/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_infer_align_size.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 from PIL import Image
 
+from vllm_omni.diffusion.models.hunyuan_image3 import pipeline_hunyuan_image3 as hunyuan_pipeline
 from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import (
     HunyuanImage3ImageProcessor,
     ImageInfo,
@@ -17,6 +18,8 @@ from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import
 from vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 import (
     _flag_value_enabled,
 )
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
 from vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3 import (
     HunyuanImage3Processor,
 )
@@ -35,6 +38,8 @@ def _gradient_image(width: int = 8, height: int = 4) -> Image.Image:
 def test_flag_parser_handles_string_false():
     assert _flag_value_enabled("false") is False
     assert _flag_value_enabled("true") is True
+    assert _flag_value_enabled("0") is False
+    assert _flag_value_enabled("yes") is True
     assert _flag_value_enabled(False) is False
     assert _flag_value_enabled(True) is True
 
@@ -90,6 +95,77 @@ def test_ar_process_image_uses_requested_crop_mode_and_preserves_original_size(
     assert torch.equal(result["vae_pixel_values"], expected_tensor)
     assert result["ori_image_width"].tolist() == [src.width]
     assert result["ori_image_height"].tolist() == [src.height]
+
+
+def test_resize_and_crop_rejects_unknown_crop_type():
+    src = _gradient_image()
+
+    with pytest.raises(ValueError, match="Unsupported crop_type"):
+        HunyuanImage3Processor._resize_and_crop(None, src, (4, 4), crop_type="unknown")
+
+
+class _FixedDiffusionResolutionGroup:
+    base_size = 1024
+
+    def __getitem__(self, idx: int):
+        assert idx == 0
+        return SimpleNamespace(width=4, height=4, ratio=1.0)
+
+    def get_base_size_and_ratio_index(self, width: int, height: int):
+        return self.base_size, 0
+
+
+class _FakeVisionProcessor:
+    patch_size = 1
+
+    def __call__(self, image: Image.Image, return_tensors: str = "pt"):
+        assert return_tensors == "pt"
+        return _fake_vit_processor(image)
+
+
+class _FakeDiffusionImageProcessor:
+    def __init__(self, _hf_config):
+        self.reso_group = _FixedDiffusionResolutionGroup()
+        self.vae_processor = _fake_vae_processor
+        self.vision_encoder_processor = _FakeVisionProcessor()
+
+
+@pytest.mark.parametrize(
+    ("infer_align_image_size", "expected_image"),
+    [
+        (False, lambda src: HunyuanImage3Processor._resize_and_crop(None, src, (4, 4), crop_type="center")),
+        (True, lambda src: HunyuanImage3Processor._resize_and_crop(None, src, (4, 4), crop_type="resize")),
+    ],
+)
+def test_dit_preprocess_uses_requested_crop_mode_and_records_original_size(
+    monkeypatch: pytest.MonkeyPatch,
+    infer_align_image_size: bool,
+    expected_image,
+):
+    monkeypatch.setattr(
+        hunyuan_pipeline,
+        "get_config",
+        lambda *args, **kwargs: SimpleNamespace(vae_downsample_factor=(1, 1), patch_size=1),
+    )
+    monkeypatch.setattr(hunyuan_pipeline, "HunyuanImage3ImageProcessor", _FakeDiffusionImageProcessor)
+
+    src = _gradient_image()
+    request = OmniDiffusionRequest(
+        prompts=[{"prompt": "edit", "multi_modal_data": {"image": src}}],
+        sampling_params=OmniDiffusionSamplingParams(extra_args={"infer_align_image_size": infer_align_image_size}),
+        request_id="req-1",
+    )
+
+    processed = hunyuan_pipeline.get_hunyuan_image_3_pre_process_func(SimpleNamespace(model="fake"))(request)
+    payload = processed.prompts[0]["additional_information"]["batch_cond_image_info"][0]
+    vae_payload = payload["vae_image_info"]
+
+    expected_tensor = _fake_vae_processor(expected_image(src))
+    assert torch.equal(vae_payload["image_tensor"], expected_tensor)
+    assert vae_payload["ori_image_width"] == src.width
+    assert vae_payload["ori_image_height"] == src.height
+    assert processed.sampling_params.width == src.width
+    assert processed.sampling_params.height == src.height
 
 
 class _FakeResolutionGroup:
@@ -150,6 +226,27 @@ def test_postprocess_single_matching_bucket_resizes_to_input_ratio_area():
     cond = _joint_cond(ratio_index=0, ori_width=1200, ori_height=800)
 
     processed = _fake_processor().postprocess_outputs([output], [[cond]], infer_align_image_size=True)
+
+    assert processed[0].size == (1254, 836)
+
+
+def test_postprocess_keeps_output_when_disabled_or_bucket_mismatched():
+    output = Image.new("RGB", (1024, 1024), color="white")
+    cond = _joint_cond(ratio_index=2, ori_width=1200, ori_height=800)
+
+    disabled = _fake_processor().postprocess_outputs([output], [[cond]], infer_align_image_size=False)
+    mismatched = _fake_processor().postprocess_outputs([output], [[cond]], infer_align_image_size=True)
+
+    assert disabled[0] is output
+    assert mismatched[0] is output
+
+
+def test_postprocess_multi_image_uses_first_matching_bucket_only():
+    output = Image.new("RGB", (1024, 1024), color="white")
+    mismatch = _joint_cond(ratio_index=2, ori_width=2048, ori_height=1024)
+    match = _joint_cond(ratio_index=0, ori_width=1200, ori_height=800)
+
+    processed = _fake_processor().postprocess_outputs([output], [[mismatch, match]], infer_align_image_size=True)
 
     assert processed[0].size == (1254, 836)
 

--- a/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_infer_align_size.py
+++ b/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_infer_align_size.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for HunyuanImage3 infer_align_image_size handling."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import (
+    HunyuanImage3ImageProcessor,
+    ImageInfo,
+    JointImageInfo,
+)
+from vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 import (
+    _flag_value_enabled,
+)
+from vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3 import (
+    HunyuanImage3Processor,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _gradient_image(width: int = 8, height: int = 4) -> Image.Image:
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    arr[:, :, 0] = np.arange(width, dtype=np.uint8) * 25
+    arr[:, :, 1] = np.arange(height, dtype=np.uint8)[:, None] * 60
+    arr[:, :, 2] = 17
+    return Image.fromarray(arr, mode="RGB")
+
+
+def test_flag_parser_handles_string_false():
+    assert _flag_value_enabled("false") is False
+    assert _flag_value_enabled("true") is True
+    assert _flag_value_enabled(False) is False
+    assert _flag_value_enabled(True) is True
+
+
+class _FixedTargetResolutionGroup:
+    def get_target_size(self, width: int, height: int):
+        return 4, 4
+
+    def get_base_size_and_ratio_index(self, width: int, height: int):
+        return 1024, 0
+
+
+def _fake_vae_processor(image: Image.Image):
+    arr = np.asarray(image, dtype=np.float32)
+    tensor = torch.from_numpy(arr).permute(2, 0, 1)
+    return tensor.unsqueeze(0)
+
+
+def _fake_vit_processor(_image: Image.Image):
+    return {
+        "pixel_values": torch.zeros((1, 1, 3), dtype=torch.float32),
+        "pixel_attention_mask": torch.ones((1, 1), dtype=torch.bool),
+        "spatial_shapes": torch.tensor([[1, 1]], dtype=torch.long),
+    }
+
+
+@pytest.mark.parametrize(
+    ("infer_align_image_size", "expected_image"),
+    [
+        (False, lambda src: HunyuanImage3Processor._resize_and_crop(None, src, (4, 4), crop_type="center")),
+        (True, lambda src: HunyuanImage3Processor._resize_and_crop(None, src, (4, 4), crop_type="resize")),
+    ],
+)
+def test_ar_process_image_uses_requested_crop_mode_and_preserves_original_size(
+    infer_align_image_size: bool,
+    expected_image,
+):
+    src = _gradient_image()
+    processor = object.__new__(HunyuanImage3Processor)
+    processor.infer_align_image_size = infer_align_image_size
+    processor.hf_config = SimpleNamespace(
+        vit={"num_channels": 3},
+        vae_downsample_factor=(1, 1),
+        patch_size=1,
+    )
+    processor.reso_group = _FixedTargetResolutionGroup()
+    processor.vae_processor = _fake_vae_processor
+    processor.vision_encoder_processor = _fake_vit_processor
+
+    result = processor.process_image(src)
+
+    expected_tensor = _fake_vae_processor(expected_image(src)).squeeze(0).reshape(-1)
+    assert torch.equal(result["vae_pixel_values"], expected_tensor)
+    assert result["ori_image_width"].tolist() == [src.width]
+    assert result["ori_image_height"].tolist() == [src.height]
+
+
+class _FakeResolutionGroup:
+    base_size = 1024
+
+    def __init__(self) -> None:
+        self._ratios = {
+            0: 1.0,
+            1: 0.75,
+            2: 2.0,
+        }
+
+    def __getitem__(self, idx: int):
+        return SimpleNamespace(ratio=self._ratios[idx])
+
+    def get_base_size_and_ratio_index(self, width: int, height: int):
+        ratio = height / width
+        if abs(ratio - 0.75) < 0.01:
+            return self.base_size, 1
+        if abs(ratio - 2.0) < 0.01:
+            return self.base_size, 2
+        return self.base_size, 0
+
+
+def _fake_processor():
+    processor = object.__new__(HunyuanImage3ImageProcessor)
+    processor.reso_group = _FakeResolutionGroup()
+    return processor
+
+
+def _joint_cond(*, ratio_index: int, ori_width: int, ori_height: int) -> JointImageInfo:
+    vae = ImageInfo(
+        image_type="vae",
+        image_width=1024,
+        image_height=1024,
+        token_width=64,
+        token_height=64,
+        base_size=1024,
+        ratio_index=ratio_index,
+        ori_image_width=ori_width,
+        ori_image_height=ori_height,
+    )
+    vit = ImageInfo(
+        image_type="siglip2",
+        image_width=1024,
+        image_height=1024,
+        token_width=64,
+        token_height=64,
+        image_token_length=4096,
+        ori_image_width=ori_width,
+        ori_image_height=ori_height,
+    )
+    return JointImageInfo(vae_image_info=vae, vision_image_info=vit)
+
+
+def test_postprocess_single_matching_bucket_resizes_to_input_ratio_area():
+    output = Image.new("RGB", (1024, 1024), color="white")
+    cond = _joint_cond(ratio_index=0, ori_width=1200, ori_height=800)
+
+    processed = _fake_processor().postprocess_outputs([output], [[cond]], infer_align_image_size=True)
+
+    assert processed[0].size == (1254, 836)
+
+
+def test_postprocess_returns_outputs_when_batch_has_no_cond_info():
+    outputs = [Image.new("RGB", (1024, 1024), color="white")]
+
+    assert _fake_processor().postprocess_outputs(outputs, None, infer_align_image_size=True) is outputs

--- a/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_it2i_ar_format.py
+++ b/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_it2i_ar_format.py
@@ -16,7 +16,7 @@ and what the model was actually trained on, this test asserts:
 1. ``build_prompt_tokens`` token-id sequence equals the HF reference produced
    by ``tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=True)``
    for the same `(system, user_prompt, image)` triple.
-2. The image-tensor produced by the diffusion-side ``_resize_and_crop_center``
+2. The image-tensor produced by the diffusion-side ``_resize_and_crop``
    is byte-identical to the AR-side ``HunyuanImage3Processor._resize_and_crop``
    output (i.e. AR and DiT preprocess the IT2I condition image identically).
 
@@ -128,7 +128,7 @@ def _import_official_snapshot_modules():
     reason=f"{_HUNYUAN_MODEL_ID} not in HF cache",
 )
 def test_dit_condition_image_preprocessing_byte_matches_official_hf():
-    """The diffusion pipeline's ``_resize_and_crop_center`` (used to feed
+    """The diffusion pipeline's ``_resize_and_crop(..., crop_type="center")`` (used to feed
     the VAE encoder for IT2I conditioning) must produce byte-identical
     pixels to the **official** HuggingFace
     ``image_processor.resize_and_crop`` (loaded straight out of the
@@ -146,9 +146,7 @@ def test_dit_condition_image_preprocessing_byte_matches_official_hf():
     import numpy as np
     from PIL import Image
 
-    from vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 import (
-        _resize_and_crop_center,
-    )
+    from vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 import _resize_and_crop
 
     _tok_mod, official_module = _import_official_snapshot_modules()
     if official_module is None or not hasattr(official_module, "resize_and_crop"):
@@ -169,7 +167,7 @@ def test_dit_condition_image_preprocessing_byte_matches_official_hf():
                 resample=Image.Resampling.LANCZOS,
                 crop_type="center",
             )
-            dit_out = _resize_and_crop_center(src, tw, th)
+            dit_out = _resize_and_crop(src, tw, th, crop_type="center")
             assert ref_out.size == dit_out.size == (tw, th), (
                 f"size mismatch for src={(src_w, src_h)} target={(tw, th)}: "
                 f"hf_official={ref_out.size} dit={dit_out.size}"

--- a/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py
+++ b/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py
@@ -5,18 +5,23 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from PIL import Image
 
 import vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 as hy3_module
 from vllm_omni.diffusion.data import AttentionConfig, AttentionSpec
 from vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 import (
     _STEP_AR_KV,
+    _STEP_BATCH_COND_IMAGE_INFO,
     _STEP_CFG_FACTOR,
     _STEP_GENERATOR,
     _STEP_GUIDANCE_SCALE,
+    _STEP_INFER_ALIGN_IMAGE_SIZE,
     _STEP_INPUT_IDS,
     _STEP_MODEL_KWARGS,
     _STEP_PROMPT_KV,
     HunyuanImage3Pipeline,
+    ImageInfo,
+    JointImageInfo,
 )
 from vllm_omni.diffusion.worker.input_batch import InputBatch
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
@@ -74,6 +79,32 @@ def _sampling_params(**extra_args):
         guidance_rescale=0.0,
         generator=None,
     )
+
+
+def _joint_cond_info() -> JointImageInfo:
+    vae = ImageInfo(
+        image_type="vae",
+        image_width=1024,
+        image_height=1024,
+        token_width=64,
+        token_height=64,
+        image_token_length=4096,
+        base_size=1024,
+        ratio_index=0,
+        ori_image_width=1200,
+        ori_image_height=800,
+    )
+    vit = ImageInfo(
+        image_type="siglip2",
+        image_width=1024,
+        image_height=1024,
+        token_width=64,
+        token_height=64,
+        image_token_length=4096,
+        ori_image_width=1200,
+        ori_image_height=800,
+    )
+    return JointImageInfo(vae_image_info=vae, vision_image_info=vit)
 
 
 def test_hunyuan_step_group_key_ignores_step_index_for_later_steps():
@@ -144,6 +175,67 @@ def test_prepare_encode_preserves_normal_hunyuan_bot_task_semantics(
 
     assert captured["bot_task"] == expected_model_bot_task
     assert captured["system_prompt_bot_task"] == expected_system_bot_task
+
+
+def test_prepare_encode_persists_infer_align_postprocess_metadata(monkeypatch):
+    pipeline = _pipeline()
+    monkeypatch.setattr(HunyuanImage3Pipeline, "device", property(lambda self: torch.device("cpu")))
+    monkeypatch.setattr(hy3_module, "retrieve_timesteps", lambda *args, **kwargs: (torch.tensor([1.0, 0.0]), 2))
+
+    cond_info = _joint_cond_info()
+
+    class FakeScheduler:
+        def set_begin_index(self, index):
+            self.begin_index = index
+
+    def fake_prepare_model_inputs(**kwargs):
+        return {
+            "input_ids": torch.tensor([[1, 2]], dtype=torch.long),
+            "batch_gen_image_info": [
+                ImageInfo(
+                    image_type="vae",
+                    image_width=1024,
+                    image_height=1024,
+                    token_width=64,
+                    token_height=64,
+                    image_token_length=4096,
+                    add_timestep_token=False,
+                    add_guidance_token=False,
+                )
+            ],
+            "generator": None,
+        }
+
+    pipeline.scheduler = FakeScheduler()
+    pipeline.config = SimpleNamespace(vae={"latent_channels": 4})
+    pipeline.generation_config = SimpleNamespace()
+    pipeline.prepare_model_inputs = fake_prepare_model_inputs
+    pipeline._prepare_attention_mask_for_generation = lambda *args, **kwargs: torch.ones(1, 1, 2, 4, dtype=torch.bool)
+    pipeline._snapshot_injected_ar_kv = lambda: None
+    pipeline._pipeline = SimpleNamespace(
+        _guidance_scale=0.0,
+        _guidance_rescale=0.0,
+        prepare_latents=lambda **kwargs: torch.zeros(1, 4, 8, 8, dtype=torch.bfloat16),
+        _maybe_handle_ar_kv_reuse=lambda input_ids, model_kwargs, **kwargs: (input_ids, 0),
+    )
+    state = DiffusionRequestState(
+        request_id="req-infer-align-step",
+        sampling=_sampling_params(infer_align_image_size="true"),
+        prompts=[
+            {
+                "prompt": "edit",
+                "additional_information": {
+                    "batch_cond_image_info": [cond_info],
+                },
+            }
+        ],
+    )
+
+    pipeline.prepare_encode(state)
+
+    assert state.extra[_STEP_INFER_ALIGN_IMAGE_SIZE] is True
+    assert state.extra[_STEP_BATCH_COND_IMAGE_INFO] == [[cond_info]]
+    assert state.extra[_STEP_MODEL_KWARGS]["num_image_tokens"] == 4096
 
 
 def test_forward_uses_same_hunyuan_bot_task_semantics(monkeypatch):
@@ -218,6 +310,48 @@ def test_step_scheduler_preserves_latent_dtype_for_mixed_progress_batches():
 
     assert state.latents.dtype == torch.bfloat16
     assert state.step_index == 1
+
+
+def test_post_decode_applies_infer_align_postprocess(monkeypatch):
+    pipeline = _pipeline()
+    monkeypatch.setattr(HunyuanImage3Pipeline, "device", property(lambda self: torch.device("cpu")))
+    decoded_image = Image.new("RGB", (1024, 1024), color="white")
+    resized_image = Image.new("RGB", (1254, 836), color="white")
+    cond_info = _joint_cond_info()
+    captured = {}
+
+    class FakeVAE:
+        config = SimpleNamespace(scaling_factor=None, shift_factor=None)
+
+        def decode(self, latents, return_dict=False, generator=None):
+            del return_dict, generator
+            return (torch.zeros(latents.shape[0], 3, 4, 4),)
+
+    def fake_postprocess_outputs(outputs, *, batch_cond_image_info, infer_align_image_size):
+        captured["outputs"] = outputs
+        captured["batch_cond_image_info"] = batch_cond_image_info
+        captured["infer_align_image_size"] = infer_align_image_size
+        return [resized_image]
+
+    pipeline.vae = FakeVAE()
+    pipeline._pipeline = SimpleNamespace(
+        image_processor=SimpleNamespace(
+            postprocess=lambda image, output_type, do_denormalize: [decoded_image],
+        )
+    )
+    pipeline.image_processor = SimpleNamespace(postprocess_outputs=fake_postprocess_outputs)
+    state = _state("req-post-decode", 0)
+    state.latents = torch.zeros(1, 4, 8, 8)
+    state.extra[_STEP_GENERATOR] = None
+    state.extra[_STEP_INFER_ALIGN_IMAGE_SIZE] = True
+    state.extra[_STEP_BATCH_COND_IMAGE_INFO] = [[cond_info]]
+
+    result = pipeline.post_decode(state)
+
+    assert result.output is resized_image
+    assert captured["outputs"] == [decoded_image]
+    assert captured["batch_cond_image_info"] == [[cond_info]]
+    assert captured["infer_align_image_size"] is True
 
 
 def test_later_step_merge_shifts_spans_without_polluting_request_state():

--- a/tests/e2e/accuracy/test_hunyuan_image3.py
+++ b/tests/e2e/accuracy/test_hunyuan_image3.py
@@ -118,7 +118,7 @@ THRESHOLDS = {
     "cot_semantic_sim": 0.9,  # Full CoT semantic similarity
     # Image comparison
     "clip_score": 90,  # CLIP image semantic similarity
-    "ssim": 0.26,  # Structural similarity
+    "ssim": 0.60,  # Structural similarity
     "psnr": 12.5,  # Peak signal-to-noise ratio (dB)
 }
 
@@ -435,9 +435,9 @@ def test_image_to_image_alignment_online(accuracy_artifact_root: Path, accuracy_
     table = [
         ["COT similarity to reference", f"{cot_results['cot_semantic_sim']:.4f}", 0.9644],
         ["COT prefix match", f"{cot_results['text_prefix_match_count']:.4f}", 29],
-        ["Image-Image similarity", f"{image_clip_score:.4f}", 94.5538],
-        ["SSIM", f"{ssim_value:.4f}", 0.242],
-        ["PSNR (dB)", f"{psnr_value:.2f}", 14.1],
+        ["Image-Image similarity", f"{image_clip_score:.4f}", 96.2812],
+        ["SSIM", f"{ssim_value:.4f}", 0.6158],
+        ["PSNR (dB)", f"{psnr_value:.2f}", 14.88],
     ]
     print("[ONLINE] " + tabulate(table, headers=["Metric", "Value", "L20x Reference"], tablefmt="grid"))
 
@@ -544,9 +544,9 @@ def test_image_to_image_alignment(accuracy_artifact_root: Path, accuracy_assets_
     table = [
         ["COT similarity to reference", f"{cot_results['cot_semantic_sim']:.4f}", 0.9644],
         ["COT prefix match", f"{cot_results['text_prefix_match_count']:.4f}", 29],
-        ["Image-Image similarity", f"{image_clip_score:.4f}", 94.5538],
-        ["SSIM", f"{ssim_value:.4f}", 0.242],
-        ["PSNR (dB)", f"{psnr_value:.2f}", 14.1],
+        ["Image-Image similarity", f"{image_clip_score:.4f}", 96.2812],
+        ["SSIM", f"{ssim_value:.4f}", 0.6158],
+        ["PSNR (dB)", f"{psnr_value:.2f}", 14.88],
     ]
 
     print(tabulate(table, headers=["Metric", "Value", "L20x Reference"], tablefmt="grid"))

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -1227,6 +1227,10 @@ def test_parameter_validation():
     assert req.size is None  # Engine will use model defaults
     assert req.num_inference_steps is None  # Engine will use model defaults
     assert req.true_cfg_scale is None  # Engine will use model defaults
+    assert req.infer_align_image_size is None
+
+    req = ImageGenerationRequest(prompt="test", infer_align_image_size=False)
+    assert req.infer_align_image_size is False
 
     # Invalid num_inference_steps (out of range)
     with pytest.raises(ValueError):
@@ -1248,6 +1252,19 @@ def test_parameter_validation():
 
     with pytest.raises(ValueError):
         ImageGenerationRequest(prompt="test", layers=11)
+
+
+def test_hunyuan_edit_extra_args_preserve_infer_align_false():
+    from vllm_omni.entrypoints.openai.api_server import _build_hunyuan_edit_extra_args
+
+    extra_args = _build_hunyuan_edit_extra_args(
+        bot_task=None,
+        sys_type=None,
+        system_prompt=None,
+        infer_align_image_size=False,
+    )
+
+    assert extra_args["infer_align_image_size"] is False
 
 
 # Pass-Through Tests

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -1095,6 +1095,27 @@ def test_flow_shift_absent_when_not_requested(test_client):
     assert "flow_shift" not in (captured.extra_args or {})
 
 
+@pytest.mark.parametrize("value", [True, False])
+def test_image_generation_forwards_infer_align_image_size_to_extra_args(test_client, value: bool):
+    response = test_client.post(
+        "/v1/images/generations",
+        json={"prompt": "a tree", "size": "1024x1024", "infer_align_image_size": value},
+    )
+    assert response.status_code == 200
+    captured = test_client.app.state.engine_client.captured_sampling_params_list[0]
+    assert captured.extra_args["infer_align_image_size"] is value
+
+
+def test_image_generation_omits_infer_align_image_size_by_default(test_client):
+    response = test_client.post(
+        "/v1/images/generations",
+        json={"prompt": "a tree", "size": "1024x1024"},
+    )
+    assert response.status_code == 200
+    captured = test_client.app.state.engine_client.captured_sampling_params_list[0]
+    assert "infer_align_image_size" not in (captured.extra_args or {})
+
+
 def test_invalid_size(test_client):
     """Test with invalid size parameter - rejected by Pydantic"""
     response = test_client.post(
@@ -1764,6 +1785,43 @@ def test_image_edit_parameter_default(async_omni_test_client):
         },
     )
     assert response.status_code == 400
+
+
+@pytest.mark.parametrize("value", ["true", "false"])
+def test_image_edit_forwards_infer_align_image_size_to_multistage_extra_args(
+    async_omni_test_client,
+    value: str,
+):
+    img_bytes = make_test_image_bytes((16, 16))
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes)],
+        data={"prompt": "hello world.", "size": "auto", "infer_align_image_size": value},
+    )
+    assert response.status_code == 200
+    engine = async_omni_test_client.app.state.engine_client
+    captured_sampling_params = engine.captured_sampling_params_list[-1]
+    captured_prompt = engine.captured_prompt
+
+    expected = value == "true"
+    assert captured_sampling_params.extra_args["infer_align_image_size"] is expected
+    assert captured_prompt["mm_processor_kwargs"]["infer_align_image_size"] is expected
+
+
+def test_image_edit_omits_infer_align_image_size_by_default(async_omni_test_client):
+    img_bytes = make_test_image_bytes((16, 16))
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes)],
+        data={"prompt": "hello world.", "size": "auto"},
+    )
+    assert response.status_code == 200
+    engine = async_omni_test_client.app.state.engine_client
+    captured_sampling_params = engine.captured_sampling_params_list[-1]
+    captured_prompt = engine.captured_prompt
+
+    assert "infer_align_image_size" not in (captured_sampling_params.extra_args or {})
+    assert "infer_align_image_size" not in (captured_prompt.get("mm_processor_kwargs") or {})
 
 
 def test_image_edit_parameter_default_single_stage(test_client):

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -3,6 +3,7 @@
 
 import inspect
 import logging
+import math
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import lru_cache
@@ -653,12 +654,16 @@ class ImageInfo:
         image_token_length: int = None,
         base_size: int = None,
         ratio_index: int = None,
+        ori_image_width: int = None,
+        ori_image_height: int = None,
         **kwargs,
     ):
         self.image_type = image_type
         self.image_tensor = image_tensor
+        self.ori_image_width = ori_image_width
         self.image_width = image_width
         self.w = image_width
+        self.ori_image_height = ori_image_height
         self.image_height = image_height
         self.h = image_height
         self.token_width = token_width
@@ -697,6 +702,7 @@ class ImageInfo:
     def __repr__(self):
         return (
             f"ImageInfo(image_type={self.image_type}, image_tensor={self.image_tensor}, "
+            f"ori_image_width={self.ori_image_width}, ori_image_height={self.ori_image_height}, "
             f"image_width={self.image_width}, image_height={self.image_height}, "
             f"token_width={self.token_width}, token_height={self.token_height}, "
             f"image_token_length={self.image_token_length}, "
@@ -721,6 +727,8 @@ class ImageInfo:
                 # for bc
                 image_height=self.image_height,
                 image_width=self.image_width,
+                ori_image_height=self.ori_image_height,
+                ori_image_width=self.ori_image_width,
             )
         else:
             raise ValueError(f"Unknown image type '{self.image_type}'")
@@ -1517,6 +1525,42 @@ class HunyuanImage3ImageProcessor:
             ratio_index=ratio_idx,
         )
         return image_info
+
+    def postprocess_outputs(
+        self,
+        outputs: list[Image.Image],
+        batch_cond_image_info: list[list[JointImageInfo]] | None,
+        infer_align_image_size: bool = False,
+    ) -> list[Image.Image]:
+        if not infer_align_image_size or not batch_cond_image_info:
+            return outputs
+
+        target_area = self.reso_group.base_size**2
+        for batch_index, (output_image, cond_images) in enumerate(zip(outputs, batch_cond_image_info)):
+            if not cond_images:
+                continue
+
+            output_ratio_index = self.reso_group.get_base_size_and_ratio_index(
+                width=output_image.width,
+                height=output_image.height,
+            )[1]
+
+            for cond_image in cond_images:
+                vae_info = cond_image.vae_image_info
+                ori_width = vae_info.ori_image_width
+                ori_height = vae_info.ori_image_height
+                if output_ratio_index != vae_info.ratio_index or ori_width is None or ori_height is None:
+                    continue
+
+                ratio_diff = abs(ori_height / ori_width - self.reso_group[output_ratio_index].ratio)
+                if ratio_diff >= 0.01:
+                    scale = math.sqrt(target_area / (ori_width * ori_height))
+                    new_w = round(ori_width * scale)
+                    new_h = round(ori_height * scale)
+                    outputs[batch_index] = output_image.resize((new_w, new_h), resample=Image.Resampling.LANCZOS)
+                break
+
+        return outputs
 
 
 class HunYuanMLP(nn.Module):

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -70,6 +70,8 @@ _STEP_OUTPUT_SIZE = "hunyuan_output_size"
 _STEP_COT_TEXT_LIST = "hunyuan_cot_text_list"
 _STEP_AR_KV = "hunyuan_ar_kv"
 _STEP_PROMPT_KV = "hunyuan_prompt_kv"
+_STEP_INFER_ALIGN_IMAGE_SIZE = "hunyuan_infer_align_image_size"
+_STEP_BATCH_COND_IMAGE_INFO = "hunyuan_batch_cond_image_info"
 
 
 def default(val, d):
@@ -622,7 +624,7 @@ class HunyuanImage3Pipeline(
             [state.prompt] if state.prompt is not None else [],
             getattr(sampling, "extra_args", {}) or {},
             request_id=state.request_id,
-            allow_cond_image=False,
+            allow_cond_image=True,
         )
 
     def _snapshot_injected_ar_kv(self) -> list[list[tuple[torch.Tensor, torch.Tensor]] | None] | None:
@@ -1883,6 +1885,9 @@ class HunyuanImage3Pipeline(
             batch_cond_image_info,
             tokenizer_bot_task,
         ) = self._extract_step_prompt_inputs(state)
+        infer_align_image_size = _flag_value_enabled(
+            (getattr(sampling, "extra_args", {}) or {}).get("infer_align_image_size", False)
+        )
         cot_text = (
             [self._normalize_cot_text(text) for text in cot_text_list]
             if any(text is not None for text in cot_text_list)
@@ -1983,6 +1988,8 @@ class HunyuanImage3Pipeline(
             _STEP_OUTPUT_SIZE: (target_height, target_width),
             _STEP_COT_TEXT_LIST: cot_text_list,
             _STEP_AR_KV: self._snapshot_injected_ar_kv(),
+            _STEP_INFER_ALIGN_IMAGE_SIZE: infer_align_image_size,
+            _STEP_BATCH_COND_IMAGE_INFO: batch_cond_image_info,
         }
         return state
 
@@ -2261,6 +2268,12 @@ class HunyuanImage3Pipeline(
             output_type=output_type,
             do_denormalize=[True] * image.shape[0],
         )
+        if output_type == "pil":
+            image = self.image_processor.postprocess_outputs(
+                image,
+                batch_cond_image_info=state.extra.get(_STEP_BATCH_COND_IMAGE_INFO),
+                infer_align_image_size=state.extra.get(_STEP_INFER_ALIGN_IMAGE_SIZE, False),
+            )
 
         cot_text_list = state.extra.get(_STEP_COT_TEXT_LIST) or []
         custom_output = {}

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -162,10 +162,6 @@ def _resize_and_crop(
     return resized.crop((crop_left, crop_top, crop_left + tw, crop_top + th))
 
 
-def _resize_and_crop_center(image: PILImage.Image, target_width: int, target_height: int) -> PILImage.Image:
-    return _resize_and_crop(image, target_width, target_height, crop_type="center")
-
-
 def _to_python_scalar(value: Any) -> Any:
     if isinstance(value, np.generic):
         return value.item()

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -76,6 +76,12 @@ def default(val, d):
     return val if val is not None else d
 
 
+def _flag_value_enabled(value: object) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 def to_device(data, device):
     if device is None:
         return data
@@ -124,11 +130,19 @@ def _to_pil_image(image: Any) -> PILImage.Image:
     raise TypeError(f"Unsupported image input type: {type(image)}")
 
 
-def _resize_and_crop_center(image: PILImage.Image, target_width: int, target_height: int) -> PILImage.Image:
+def _resize_and_crop(
+    image: PILImage.Image,
+    target_width: int,
+    target_height: int,
+    *,
+    crop_type: str,
+) -> PILImage.Image:
     # Mirrors HunyuanImage3Processor._resize_and_crop in
     # vllm_omni.model_executor.models.hunyuan_image3.hunyuan_image3 so the AR
     # and DiT stages preprocess condition images identically.
     tw, th = target_width, target_height
+    if crop_type == "resize":
+        return image.resize((tw, th), resample=PILImage.Resampling.LANCZOS)
     w, h = image.size
     tr = th / tw
     r = h / w
@@ -142,6 +156,10 @@ def _resize_and_crop_center(image: PILImage.Image, target_width: int, target_hei
     crop_top = int(round((resize_height - th) / 2.0))
     crop_left = int(round((resize_width - tw) / 2.0))
     return resized.crop((crop_left, crop_top, crop_left + tw, crop_top + th))
+
+
+def _resize_and_crop_center(image: PILImage.Image, target_width: int, target_height: int) -> PILImage.Image:
+    return _resize_and_crop(image, target_width, target_height, crop_type="center")
 
 
 def _to_python_scalar(value: Any) -> Any:
@@ -174,6 +192,8 @@ def _image_info_to_payload(image_info: ImageInfo) -> dict[str, Any]:
         "image_token_length": _to_python_scalar(image_info.image_token_length),
         "base_size": _to_python_scalar(image_info.base_size),
         "ratio_index": _to_python_scalar(image_info.ratio_index),
+        "ori_image_width": _to_python_scalar(image_info.ori_image_width),
+        "ori_image_height": _to_python_scalar(image_info.ori_image_height),
         "add_timestep_token": image_info.add_timestep_token,
         "add_guidance_token": image_info.add_guidance_token,
         "use_front_boi_token": image_info.use_front_boi_token,
@@ -200,6 +220,8 @@ def _image_info_from_payload(payload: dict[str, Any]) -> ImageInfo:
         image_token_length=payload.get("image_token_length"),
         base_size=payload.get("base_size"),
         ratio_index=payload.get("ratio_index"),
+        ori_image_width=payload.get("ori_image_width"),
+        ori_image_height=payload.get("ori_image_height"),
         add_timestep_token=payload.get("add_timestep_token", True),
         add_guidance_token=payload.get("add_guidance_token", False),
         use_front_boi_token=payload.get("use_front_boi_token", True),
@@ -243,7 +265,7 @@ def get_hunyuan_image_3_pre_process_func(od_config: OmniDiffusionConfig):
     if isinstance(vit_patch_size, tuple | list):
         vit_patch_size = int(vit_patch_size[0])
 
-    def _build_cond_joint_image(raw_image: Any) -> dict[str, Any]:
+    def _build_cond_joint_image(raw_image: Any, *, crop_type: str) -> dict[str, Any]:
         pil_image = _to_pil_image(raw_image).convert("RGB")
         orig_width, orig_height = pil_image.size
 
@@ -258,12 +280,14 @@ def get_hunyuan_image_3_pre_process_func(od_config: OmniDiffusionConfig):
         reso = image_processor.reso_group[ratio_idx]
         target_width = int(reso.width)
         target_height = int(reso.height)
-        vae_input = _resize_and_crop_center(pil_image, target_width, target_height)
+        vae_input = _resize_and_crop(pil_image, target_width, target_height, crop_type=crop_type)
         vae_tensor = image_processor.vae_processor(vae_input)
 
         vae_info = ImageInfo(
             image_type="vae",
             image_tensor=vae_tensor,
+            ori_image_width=orig_width,
+            ori_image_height=orig_height,
             image_width=target_width,
             image_height=target_height,
             token_width=target_width // vae_w_factor,
@@ -282,6 +306,8 @@ def get_hunyuan_image_3_pre_process_func(od_config: OmniDiffusionConfig):
         vit_info = ImageInfo(
             image_type="siglip2",
             image_tensor=vit_tensor,
+            ori_image_width=orig_width,
+            ori_image_height=orig_height,
             image_width=vit_token_w * vit_patch_size,
             image_height=vit_token_h * vit_patch_size,
             token_width=vit_token_w,
@@ -304,6 +330,9 @@ def get_hunyuan_image_3_pre_process_func(od_config: OmniDiffusionConfig):
         prompt = request.prompt
         if isinstance(prompt, str):
             prompt = OmniTextPrompt(prompt=prompt)
+        extra_args = getattr(getattr(request, "sampling_params", None), "extra_args", {}) or {}
+        infer_align_image_size = _flag_value_enabled(extra_args.get("infer_align_image_size", False))
+        crop_type = "resize" if infer_align_image_size else "center"
 
         if "additional_information" not in prompt:
             prompt["additional_information"] = {}
@@ -315,7 +344,7 @@ def get_hunyuan_image_3_pre_process_func(od_config: OmniDiffusionConfig):
         has_images = raw_images is not None and (not isinstance(raw_images, list) or len(raw_images) > 0)
         if has_images:
             image_list = raw_images if isinstance(raw_images, list) else [raw_images]
-            cond_image_infos = [_build_cond_joint_image(image) for image in image_list]
+            cond_image_infos = [_build_cond_joint_image(image, crop_type=crop_type) for image in image_list]
             prompt["additional_information"]["batch_cond_image_info"] = cond_image_infos
 
             bridge_h = prompt.get("height") if isinstance(prompt, dict) else None
@@ -2274,6 +2303,7 @@ class HunyuanImage3Pipeline(
         generator = req.sampling_params.generator or generator
         height = req.sampling_params.height or height
         width = req.sampling_params.width or width
+        infer_align_image_size = _flag_value_enabled(extra_args.get("infer_align_image_size", False))
         num_inference_steps = req.sampling_params.num_inference_steps or num_inference_steps
         if req.sampling_params.guidance_scale_provided:
             guidance_scale = req.sampling_params.guidance_scale
@@ -2301,6 +2331,11 @@ class HunyuanImage3Pipeline(
         model_inputs.update(ar_kv_kwargs)
 
         outputs = self._generate(**model_inputs, **kwargs)
+        outputs = self.image_processor.postprocess_outputs(
+            outputs,
+            batch_cond_image_info=batch_cond_image_info,
+            infer_align_image_size=infer_align_image_size,
+        )
         image = outputs[0]
         custom_output = {}
         if any(t is not None for t in cot_text_list):

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -143,6 +143,8 @@ def _resize_and_crop(
     tw, th = target_width, target_height
     if crop_type == "resize":
         return image.resize((tw, th), resample=PILImage.Resampling.LANCZOS)
+    if crop_type != "center":
+        raise ValueError(f"Unsupported crop_type: {crop_type}")
     w, h = image.size
     tr = th / tw
     r = h / w

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1770,6 +1770,8 @@ async def generate_images(
                 extra_body["flow_shift"] = request.flow_shift
             if request.extra_params is not None:
                 extra_body["extra_params"] = request.extra_params
+            if request.infer_align_image_size is not None:
+                extra_body["infer_align_image_size"] = request.infer_align_image_size
             if request.generator_device is not None:
                 extra_body["generator_device"] = request.generator_device
             if request.lora is not None:
@@ -1814,6 +1816,8 @@ async def generate_images(
             extra_args["bot_task"] = request.bot_task
         if request.flow_shift is not None:
             extra_args["flow_shift"] = request.flow_shift
+        if request.infer_align_image_size is not None:
+            extra_args["infer_align_image_size"] = request.infer_align_image_size
         if extra_args:
             gen_params.extra_args = extra_args
         # Parse per-request LoRA (compatible with chat's extra_body.lora shape).
@@ -1959,6 +1963,7 @@ async def edit_images(
     true_cfg_scale: float | None = Form(None),
     seed: int | None = Form(None),
     generator_device: str | None = Form(None),
+    infer_align_image_size: bool | None = Form(None),
     # vllm-omni extension for per-request LoRA.
     lora: str | None = Form(None),  # Json string
     # vllm-omni extension for layered models (e.g., Qwen-Image-Layered)
@@ -2136,6 +2141,7 @@ async def edit_images(
             bot_task=bot_task,
             sys_type=sys_type,
             system_prompt=system_prompt,
+            infer_align_image_size=infer_align_image_size,
         )
         extra_args.update(edit_extra_args)
         if extra_args:
@@ -2206,6 +2212,8 @@ async def edit_images(
                 extra_body["system_prompt"] = system_prompt
             if return_stage_metrics is not None:
                 extra_body["return_stage_metrics"] = return_stage_metrics
+            if infer_align_image_size is not None:
+                extra_body["infer_align_image_size"] = infer_align_image_size
 
             prompt_text = prompt.get("prompt", "")
             generation_result = await chat_handler.generate_diffusion_images(
@@ -2449,6 +2457,7 @@ def _build_hunyuan_edit_extra_args(
     bot_task: str | None,
     sys_type: str | None,
     system_prompt: str | None,
+    infer_align_image_size: bool | None = None,
 ) -> dict[str, Any]:
     """Map Hunyuan /v1/images/edits form fields to DiT ``extra_args``."""
     extra_args: dict[str, Any] = {}
@@ -2463,6 +2472,8 @@ def _build_hunyuan_edit_extra_args(
         extra_args["system_prompt"] = system_prompt
     if bot_task is not None:
         extra_args["bot_task"] = bot_task
+    if infer_align_image_size is not None:
+        extra_args["infer_align_image_size"] = infer_align_image_size
     return extra_args
 
 

--- a/vllm_omni/entrypoints/openai/protocol/images.py
+++ b/vllm_omni/entrypoints/openai/protocol/images.py
@@ -137,6 +137,13 @@ class ImageGenerationRequest(BaseModel):
         default=None,
         description="Optional model-specific parameters passed directly to the model's extra_args.",
     )
+    infer_align_image_size: bool | None = Field(
+        default=None,
+        description=(
+            "HunyuanImage3 image-conditioning alignment flag. Plain text-to-image requests have no condition image "
+            "to align, so this does not change T2I output sizing."
+        ),
+    )
     seed: int | None = Field(default=None, description="Random seed for reproducibility")
     generator_device: str | None = Field(
         default=None,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -2722,6 +2722,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         bot_task = extra_body.get("bot_task")
         use_system_prompt = extra_body.get("use_system_prompt") or extra_body.get("sys_type")
         custom_system_prompt = extra_body.get("system_prompt")
+        infer_align_image_size = extra_body.get("infer_align_image_size")
 
         engine_prompt_data: dict[str, Any] | None = None
         modalities = ["image"]
@@ -2803,6 +2804,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             mm_processor_kwargs["target_w"] = width
         if seed is not None and engine_prompt_data is not None:
             mm_processor_kwargs["vae_generator_seed"] = int(seed)
+        if infer_align_image_size is not None:
+            mm_processor_kwargs["infer_align_image_size"] = infer_align_image_size
         if mm_processor_kwargs:
             engine_prompt["mm_processor_kwargs"] = mm_processor_kwargs
         if engine_prompt_data is not None:
@@ -2854,6 +2857,12 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 extra_args["target_w"] = int(width)
 
             if stage_type == "diffusion":
+                if infer_align_image_size is not None:
+                    extra_args = getattr(default_stage_params, "extra_args", None)
+                    if extra_args is None:
+                        extra_args = {}
+                        default_stage_params.extra_args = extra_args
+                    extra_args["infer_align_image_size"] = infer_align_image_size
                 self._set_if_supported(
                     default_stage_params,
                     height=height,
@@ -2907,6 +2916,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
         negative_prompt = extra_body.get("negative_prompt")
         num_outputs_per_prompt = extra_body.get("num_outputs_per_prompt", 1)
         lora_body = extra_body.get("lora")
+        infer_align_image_size = extra_body.get("infer_align_image_size")
 
         pil_images: list[Image.Image] = []
         for img_b64 in reference_images:
@@ -2945,11 +2955,17 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             except Exception as e:  # pragma: no cover - safeguard
                 logger.warning("Failed to parse LoRA request: %s", e)
 
+        if infer_align_image_size is not None:
+            gen_params.extra_args["infer_align_image_size"] = infer_align_image_size
+
         gen_prompt: OmniTextPrompt = {
             "prompt": prompt,
             "negative_prompt": negative_prompt,
             "modalities": ["image"],
         }
+        mm_processor_kwargs: dict[str, Any] = {}
+        if infer_align_image_size is not None:
+            mm_processor_kwargs["infer_align_image_size"] = infer_align_image_size
         if pil_images:
             if len(pil_images) == 1:
                 gen_prompt["multi_modal_data"] = {"image": pil_images[0]}
@@ -2967,6 +2983,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         "and send multiple images in the user message content.",
                         status_code=400,
                     )
+        if mm_processor_kwargs:
+            gen_prompt["mm_processor_kwargs"] = mm_processor_kwargs
 
         return engine, gen_prompt, gen_params, pil_images
 
@@ -3326,6 +3344,11 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
             if true_cfg_scale is not None:
                 gen_params.true_cfg_scale = true_cfg_scale
             apply_declared_extra_args(gen_params, self._get_diffusion_extra_body_params(), extra_body)
+            if extra_body.get("infer_align_image_size") is not None:
+                gen_params.extra_args = {
+                    **(gen_params.extra_args or {}),
+                    "infer_align_image_size": extra_body["infer_align_image_size"],
+                }
             if num_frames is not None:
                 gen_params.num_frames = num_frames
             if guidance_scale_2 is not None:

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -97,12 +97,6 @@ from vllm_omni.model_executor.models.hunyuan_image3.siglip2 import LightProjecto
 logger = init_logger(__name__)
 
 
-def _flag_value_enabled(value: object) -> bool:
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return bool(value)
-
-
 @support_torch_compile(
     dynamic_arg_dims={
         "input_ids": 0,
@@ -821,7 +815,10 @@ class HunyuanImage3Processor:
     def __init__(self, tokenizer, hf_config, **kwargs: object):
         self.tokenizer = tokenizer
         self.hf_config = hf_config
-        self.infer_align_image_size = _flag_value_enabled(kwargs.pop("infer_align_image_size", False))
+        infer_align_image_size = kwargs.pop("infer_align_image_size", False)
+        if isinstance(infer_align_image_size, str):
+            infer_align_image_size = infer_align_image_size.strip().lower() in {"1", "true", "yes", "on"}
+        self.infer_align_image_size = bool(infer_align_image_size)
         # `HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS` mirrors the official
         # `vae_reso_group` extras (image_processor.py:147-152). Build with
         # this processor's inner Resolution class so `data` stays

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -97,6 +97,12 @@ from vllm_omni.model_executor.models.hunyuan_image3.siglip2 import LightProjecto
 logger = init_logger(__name__)
 
 
+def _flag_value_enabled(value: object) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 @support_torch_compile(
     dynamic_arg_dims={
         "input_ids": 0,
@@ -815,6 +821,7 @@ class HunyuanImage3Processor:
     def __init__(self, tokenizer, hf_config, **kwargs: object):
         self.tokenizer = tokenizer
         self.hf_config = hf_config
+        self.infer_align_image_size = _flag_value_enabled(kwargs.pop("infer_align_image_size", False))
         # `HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS` mirrors the official
         # `vae_reso_group` extras (image_processor.py:147-152). Build with
         # this processor's inner Resolution class so `data` stays
@@ -907,11 +914,14 @@ class HunyuanImage3Processor:
             # Keep fp32 — the VAE encoder casts to model dtype at its
             # boundary (see `_vae_encode`).
             image_width, image_height = self.reso_group.get_target_size(image.width, image.height)
-            resized_image = self._resize_and_crop(image, (image_width, image_height))
+            crop_type = "resize" if self.infer_align_image_size else "center"
+            resized_image = self._resize_and_crop(image, (image_width, image_height), crop_type=crop_type)
             vae_pixel_values = self.vae_processor(resized_image).squeeze(0)
             token_height = image_height // (self.hf_config.vae_downsample_factor[0] * self.hf_config.patch_size)
             token_width = image_width // (self.hf_config.vae_downsample_factor[1] * self.hf_config.patch_size)
 
+            current_info["ori_image_width"] = torch.tensor(image.width, dtype=torch.long)
+            current_info["ori_image_height"] = torch.tensor(image.height, dtype=torch.long)
             current_info["vae_pixel_values_flat"] = vae_pixel_values.reshape(-1)
             current_info["vae_pixel_size"] = torch.tensor(vae_pixel_values.numel(), dtype=torch.long)
             current_info["vae_token_grid_hw"] = torch.tensor([token_height, token_width])
@@ -935,6 +945,8 @@ class HunyuanImage3Processor:
             "vae_pixel_size",
             "base_size",
             "ratio_index",
+            "ori_image_width",
+            "ori_image_height",
         ]
         for key in same_shape_keys:
             final_image_info[key] = torch.stack([d[key] for d in batch_data], dim=0)
@@ -1078,6 +1090,10 @@ class HunyuanImage3MultiModalProcessor(BaseMultiModalProcessor[HunyuanImage3Proc
             config["ratio_index"] = MultiModalFieldConfig.batched("image")
         if "vae_generator_seed" in hf_inputs:
             config["vae_generator_seed"] = MultiModalFieldConfig.batched("image")
+        if "ori_image_width" in hf_inputs:
+            config["ori_image_width"] = MultiModalFieldConfig.batched("image")
+        if "ori_image_height" in hf_inputs:
+            config["ori_image_height"] = MultiModalFieldConfig.batched("image")
         return config
 
     def _get_prompt_updates(

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -974,6 +974,8 @@ class HunyuanImage3Processor:
         tw, th = target_size
         if crop_type == "resize":
             return image.resize((tw, th), resample=Image.Resampling.LANCZOS)
+        if crop_type != "center":
+            raise ValueError(f"Unsupported crop_type: {crop_type}")
         w, h = image.size
         tr = th / tw
         r = h / w

--- a/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
+++ b/vllm_omni/model_executor/models/hunyuan_image3/hunyuan_image3.py
@@ -815,10 +815,7 @@ class HunyuanImage3Processor:
     def __init__(self, tokenizer, hf_config, **kwargs: object):
         self.tokenizer = tokenizer
         self.hf_config = hf_config
-        infer_align_image_size = kwargs.pop("infer_align_image_size", False)
-        if isinstance(infer_align_image_size, str):
-            infer_align_image_size = infer_align_image_size.strip().lower() in {"1", "true", "yes", "on"}
-        self.infer_align_image_size = bool(infer_align_image_size)
+        self.infer_align_image_size = bool(kwargs.pop("infer_align_image_size", False))
         # `HUNYUAN_IMAGE3_EXTRA_RESOLUTIONS` mirrors the official
         # `vae_reso_group` extras (image_processor.py:147-152). Build with
         # this processor's inner Resolution class so `data` stays


### PR DESCRIPTION
## Purpose

HunyuanImage3 has an official `infer_align_image_size` mode for image-conditioned generation. The important behavior is not just an API flag: when users edit an image, the condition image should be resized into the model bucket without center-cropping away content, and the final image should be restored to the input image's aspect ratio when the generated bucket corresponds to that condition image.

Before this PR, the OpenAI-compatible image APIs and the shared multistage path did not carry that intent end to end. A request could not reliably express the official alignment mode through `/v1/images/generations` or `/v1/images/edits`, the AR and DiT condition-image preprocessing paths did not share the same flag semantics, and the DiT postprocess step did not have the original input image size needed to restore the output ratio. The step-execution path also returned from `post_decode()` directly, so it needed the same postprocess metadata persisted in request state.

This PR wires the flag through the request stack and keeps the model-specific behavior inside the HunyuanImage3 processors/pipeline:

- API/protocol layer accepts `infer_align_image_size` and preserves explicit `false` instead of treating it as absent.
- Multistage serving forwards the flag to both mm processor kwargs and diffusion `extra_args`.
- AR preprocessing uses direct resize instead of center crop when alignment is enabled, while preserving the original input dimensions.
- DiT preprocessing records the original condition-image size in `batch_cond_image_info` so postprocess can make an output-size decision with the right source facts.
- DiT postprocess only resizes eligible outputs: the flag must be enabled, condition metadata must exist, and the generated output bucket must match the condition bucket.
- Step execution persists the parsed flag and condition metadata through `state.extra`, then applies the same output postprocess in `post_decode()`.

Behavior boundaries:

- omitted or false `infer_align_image_size` keeps existing behavior
- bool-like string values such as `"false"` are parsed as false
- plain text-to-image has no condition image to align, so output sizing is unchanged
- unknown internal crop modes now fail fast instead of silently falling back

## Test Plan

Targeted remote pytest on `vllm==0.23.0`:

```bash
python -m pytest \
  tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py \
  tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_infer_align_size.py \
  tests/entrypoints/openai_api/test_image_server.py \
  -q -k "infer_align or hunyuan_edit_extra_args or post_decode or prepare_encode_persists"
```

Coverage added/strengthened in this PR:

- OpenAI image generation/edit request paths forward true, false, and omitted `infer_align_image_size` correctly.
- HunyuanImage3 AR image processor switches crop mode and preserves original input dimensions.
- HunyuanImage3 DiT preprocess consumes the same flag, writes condition-image payloads, and keeps original image dimensions for postprocess.
- Output postprocess covers resize, disabled/no-op, bucket mismatch, no condition info, and multi-condition selection cases.
- Step execution persists postprocess metadata and applies the same resize path in `post_decode()`.
- Crop mode validation rejects unknown internal modes.

## Test Result

Targeted remote pytest on PR head `f69ae3d982d8cb0537932a24d6cea77d8c5557e9`: `19 passed, 84 deselected`.

GitHub checks on the latest PR head are passing: DCO, build 3.11, build 3.12, pre-commit, and ReadTheDocs.
