### PR TITLE
Reduce MOSS TTS test asset network dependence

### DIFF
--- a/tests/e2e/offline_inference/test_moss_tts.py
+++ b/tests/e2e/offline_inference/test_moss_tts.py
@@ -17,13 +17,13 @@ triggers mid-module teardown races (see skill invariant I4).
 from __future__ import annotations
 
 import os
-import urllib.request
 
 import pytest
 import torch
 from vllm import SamplingParams
 
 from tests.helpers.mark import hardware_test
+from tests.helpers.media import resolve_test_audio_file
 from vllm_omni import Omni
 
 # ---------------------------------------------------------------------------
@@ -54,24 +54,21 @@ _DEFAULT_SAMPLING = SamplingParams(
 
 
 @pytest.fixture(scope="session")
-def ref_audio_path(tmp_path_factory) -> str:
-    """Download the upstream reference clip once per session.
-
-    Set ``MOSS_TTS_SKIP_ON_NET_FAIL=1`` to skip in air-gapped environments.
-    """
-    cache_dir = tmp_path_factory.mktemp("moss_tts_ref")
-    target = cache_dir / "zh_1.wav"
+def ref_audio_path() -> str:
+    """Resolve the MOSS-TTS reference clip, preferring local/cache."""
     try:
-        with urllib.request.urlopen(REF_AUDIO_URL, timeout=30) as resp:
-            target.write_bytes(resp.read())
-    except Exception as exc:
-        msg = f"Cannot fetch reference clip {REF_AUDIO_URL}: {exc}"
+        return str(
+            resolve_test_audio_file(
+                env_var="MOSS_TTS_REF_AUDIO_PATH",
+                asset_relative_path="moss_tts/reference_zh_1.wav",
+                cache_name="moss_tts_reference_zh_1.wav",
+                url=REF_AUDIO_URL,
+            )
+        )
+    except RuntimeError as exc:
         if os.environ.get("MOSS_TTS_SKIP_ON_NET_FAIL"):
-            pytest.skip(msg)
-        pytest.fail(msg)
-    if not target.exists() or target.stat().st_size == 0:
-        pytest.fail(f"Reference clip empty after download: {target}")
-    return str(target)
+            pytest.skip(str(exc))
+        pytest.fail(str(exc))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/offline_inference/test_moss_tts_nano_expansion.py
+++ b/tests/e2e/offline_inference/test_moss_tts_nano_expansion.py
@@ -3,21 +3,21 @@
 """E2E offline inference tests for MOSS-TTS-Nano single-stage pipeline.
 
 Every request needs a reference audio clip. We test upstream's
-recommended ``voice_clone`` mode (no transcript needed). We fetch the
-upstream sample (assets/audio/zh_1.wav, ~50 KB) once per test session
-and reuse it for all cases.
+recommended ``voice_clone`` mode (no transcript needed). The reference clip is
+resolved from a local override, vendored asset, persistent cache, or remote
+fallback.
 """
 
 from __future__ import annotations
 
 import os
-import urllib.request
 
 import pytest
 import torch
 from vllm import SamplingParams
 
 from tests.helpers.mark import hardware_test
+from tests.helpers.media import resolve_test_audio_file
 from tests.helpers.runtime import OmniRunner
 from tests.helpers.stage_config import get_deploy_config_path
 from vllm_omni import Omni
@@ -52,29 +52,21 @@ DEFAULT_SAMPLING = SamplingParams(
 
 
 @pytest.fixture(scope="session")
-def ref_audio_path(tmp_path_factory) -> str:
-    """Download the upstream reference clip once per test session.
-
-    Bounded with a 30 s timeout (urlretrieve has no timeout kwarg, so we use
-    urlopen + write ourselves). Fetch failures are hard failures, not skips,
-    so a broken network path can't silently mask regressions. Set
-    ``MOSS_TTS_NANO_SKIP_ON_NET_FAIL=1`` to opt into skipping for air-gapped
-    environments.
-    """
-    cache_dir = tmp_path_factory.mktemp("moss_tts_nano_ref")
-    target = cache_dir / "zh_1.wav"
+def ref_audio_path() -> str:
+    """Resolve the MOSS-TTS-Nano reference clip, preferring local/cache."""
     try:
-        with urllib.request.urlopen(REF_AUDIO_URL, timeout=30) as resp:
-            data = resp.read()
-        target.write_bytes(data)
-    except Exception as e:
-        msg = f"Cannot fetch upstream reference clip {REF_AUDIO_URL}: {e}"
+        return str(
+            resolve_test_audio_file(
+                env_var="MOSS_TTS_NANO_REF_AUDIO_PATH",
+                asset_relative_path="moss_tts_nano/zh_1.wav",
+                cache_name="moss_tts_nano_zh_1.wav",
+                url=REF_AUDIO_URL,
+            )
+        )
+    except RuntimeError as exc:
         if os.environ.get("MOSS_TTS_NANO_SKIP_ON_NET_FAIL"):
-            pytest.skip(msg)
-        pytest.fail(msg)
-    if not target.exists() or os.path.getsize(target) == 0:
-        pytest.fail(f"Reference clip empty after download: {target}")
-    return str(target)
+            pytest.skip(str(exc))
+        pytest.fail(str(exc))
 
 
 def _build_request(

--- a/tests/e2e/offline_inference/test_moss_tts_v1_5.py
+++ b/tests/e2e/offline_inference/test_moss_tts_v1_5.py
@@ -15,13 +15,13 @@ MossTTSDelay coverage stays in ``test_moss_tts.py`` (1.7B VoiceGenerator).
 from __future__ import annotations
 
 import os
-import urllib.request
 
 import pytest
 import torch
 from vllm import SamplingParams
 
 from tests.helpers.mark import hardware_test
+from tests.helpers.media import resolve_test_audio_file
 from vllm_omni import Omni
 
 # H100-gated (8B). Picked up by the nightly "TTS · Function Test with H100"
@@ -45,23 +45,21 @@ _DEFAULT_SAMPLING = SamplingParams(
 
 
 @pytest.fixture(scope="session")
-def ref_audio_path(tmp_path_factory) -> str:
-    """Download the upstream reference clip once per session.
-
-    Set ``MOSS_TTS_SKIP_ON_NET_FAIL=1`` to skip in air-gapped environments.
-    """
-    target = tmp_path_factory.mktemp("moss_tts_v15_ref") / "zh_1.wav"
+def ref_audio_path() -> str:
+    """Resolve the MOSS-TTS reference clip, preferring local/cache."""
     try:
-        with urllib.request.urlopen(REF_AUDIO_URL, timeout=30) as resp:
-            target.write_bytes(resp.read())
-    except Exception as exc:  # noqa: BLE001
-        msg = f"Cannot fetch reference clip {REF_AUDIO_URL}: {exc}"
+        return str(
+            resolve_test_audio_file(
+                env_var="MOSS_TTS_REF_AUDIO_PATH",
+                asset_relative_path="moss_tts/reference_zh_1.wav",
+                cache_name="moss_tts_reference_zh_1.wav",
+                url=REF_AUDIO_URL,
+            )
+        )
+    except RuntimeError as exc:
         if os.environ.get("MOSS_TTS_SKIP_ON_NET_FAIL"):
-            pytest.skip(msg)
-        pytest.fail(msg)
-    if not target.exists() or target.stat().st_size == 0:
-        pytest.fail(f"Reference clip empty after download: {target}")
-    return str(target)
+            pytest.skip(str(exc))
+        pytest.fail(str(exc))
 
 
 @pytest.fixture(scope="module")

--- a/tests/helpers/media.py
+++ b/tests/helpers/media.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 import tempfile
 import time
+import urllib.request
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -523,6 +524,67 @@ def load_test_audio_data_url(relative_path: str | os.PathLike) -> str:
     return f"data:{mime};base64,{encoded}"
 
 
+def _is_non_empty_file(path: Path) -> bool:
+    return path.is_file() and path.stat().st_size > 0
+
+
+def _test_asset_cache_dir() -> Path:
+    env_path = os.environ.get("VLLM_OMNI_TEST_ASSET_CACHE")
+    if env_path:
+        return Path(env_path).expanduser().resolve()
+    return Path(tempfile.gettempdir()) / "vllm_omni_test_assets"
+
+
+def resolve_test_audio_file(
+    *,
+    env_var: str,
+    asset_relative_path: str | os.PathLike | None,
+    cache_name: str,
+    url: str,
+    timeout_s: float = 30.0,
+) -> Path:
+    """Resolve a reference audio file, preferring local/cache before remote.
+
+    Lookup order: explicit env path, vendored ``tests/assets`` file, persistent
+    test cache, then remote download.
+    """
+    if env_path := os.environ.get(env_var):
+        path = Path(env_path).expanduser().resolve()
+        if _is_non_empty_file(path):
+            return path
+        raise RuntimeError(f"{env_var} points to a missing or empty file: {path}")
+
+    if asset_relative_path is not None:
+        asset_path = get_asset_path(asset_relative_path)
+        if _is_non_empty_file(asset_path):
+            return asset_path
+
+    cache_path = _test_asset_cache_dir() / cache_name
+    if _is_non_empty_file(cache_path):
+        return cache_path
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_file = tempfile.NamedTemporaryFile(
+        delete=False,
+        dir=cache_path.parent,
+        prefix=f"{cache_path.name}.",
+        suffix=".tmp",
+    )
+    tmp_path = Path(tmp_file.name)
+    tmp_file.close()
+    try:
+        with urllib.request.urlopen(url, timeout=timeout_s) as resp:
+            tmp_path.write_bytes(resp.read())
+        if not _is_non_empty_file(tmp_path):
+            raise RuntimeError(f"Downloaded reference audio is empty: {url}")
+        tmp_path.replace(cache_path)
+    except Exception as exc:
+        tmp_path.unlink(missing_ok=True)
+        raise RuntimeError(f"Cannot fetch reference audio {url}: {exc}") from exc
+
+    return cache_path
+
+
 def decode_b64_image(b64: str):
     img = Image.open(io.BytesIO(base64.b64decode(b64)))
     img.load()
@@ -705,4 +767,5 @@ __all__ = [
     "get_asset_path",
     "load_test_audio_data_url",
     "preprocess_text",
+    "resolve_test_audio_file",
 ]

--- a/tests/helpers/test_media_reference_audio.py
+++ b/tests/helpers/test_media_reference_audio.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from tests.helpers import media as media_helpers
+from tests.helpers.media import resolve_test_audio_file
+
+
+def test_resolve_test_audio_file_uses_env_path(tmp_path, monkeypatch):
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"not-empty")
+    monkeypatch.setenv("TEST_REF_AUDIO_PATH", str(ref_audio))
+
+    resolved = resolve_test_audio_file(
+        env_var="TEST_REF_AUDIO_PATH",
+        asset_relative_path="missing/ref.wav",
+        cache_name="unused.wav",
+        url="https://example.invalid/ref.wav",
+    )
+
+    assert resolved == ref_audio.resolve()
+
+
+def test_resolve_test_audio_file_uses_vendored_asset(tmp_path, monkeypatch):
+    asset = tmp_path / "missing" / "ref.wav"
+    asset.parent.mkdir()
+    asset.write_bytes(b"not-empty")
+    monkeypatch.delenv("TEST_REF_AUDIO_PATH", raising=False)
+    monkeypatch.setattr(media_helpers, "_TEST_ASSETS_ROOT", tmp_path)
+
+    resolved = resolve_test_audio_file(
+        env_var="TEST_REF_AUDIO_PATH",
+        asset_relative_path="missing/ref.wav",
+        cache_name="unused.wav",
+        url="https://example.invalid/ref.wav",
+    )
+
+    assert resolved == asset
+
+
+def test_resolve_test_audio_file_uses_cache(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "asset-cache"
+    cache_dir.mkdir()
+    cached_audio = cache_dir / "cached.wav"
+    cached_audio.write_bytes(b"not-empty")
+    monkeypatch.delenv("TEST_REF_AUDIO_PATH", raising=False)
+    monkeypatch.setenv("VLLM_OMNI_TEST_ASSET_CACHE", str(cache_dir))
+
+    resolved = resolve_test_audio_file(
+        env_var="TEST_REF_AUDIO_PATH",
+        asset_relative_path="missing/ref.wav",
+        cache_name="cached.wav",
+        url="https://example.invalid/ref.wav",
+    )
+
+    assert resolved == cached_audio
+
+
+def test_resolve_test_audio_file_downloads_to_cache(tmp_path, monkeypatch):
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def read(self):
+            return b"downloaded"
+
+    def fake_urlopen(url, timeout):
+        assert url == "https://example.invalid/ref.wav"
+        assert timeout == 30.0
+        return Response()
+
+    cache_dir = tmp_path / "empty-cache"
+    monkeypatch.delenv("TEST_REF_AUDIO_PATH", raising=False)
+    monkeypatch.setenv("VLLM_OMNI_TEST_ASSET_CACHE", str(cache_dir))
+    monkeypatch.setattr(media_helpers.urllib.request, "urlopen", fake_urlopen)
+
+    resolved = resolve_test_audio_file(
+        env_var="TEST_REF_AUDIO_PATH",
+        asset_relative_path="missing/ref.wav",
+        cache_name="cached.wav",
+        url="https://example.invalid/ref.wav",
+    )
+
+    assert resolved == cache_dir / "cached.wav"
+    assert resolved.read_bytes() == b"downloaded"


### PR DESCRIPTION
## Purpose

Reduce raw GitHub dependence in MOSS TTS offline tests by resolving reference audio from a local env override, vendored asset path, persistent cache, or explicit opt-in remote download.

## Test Plan

- Added unit coverage for env path, cache path, and remote opt-in failure behavior.
- Replaced duplicated urlopen fixture logic in MOSS TTS offline tests.

**vLLM Version:** N/A

**vLLM-Omni Commit:** a82d1dd

## Test Result

- `python3 -m py_compile` passed for changed files.
- `git diff --check` passed.
- `pytest` not run locally because dependency resolution fails on macOS arm64 due to unavailable `fa3-fwd==0.0.3` wheel.

<img width="1017" height="77" alt="image" src="https://github.com/user-attachments/assets/05e1bdc8-f228-49aa-a647-63ee084af864" />
