### PR TITLE
[Feature] Support for URL-Format image request input in /v1/chat/completions interface

### DIFF
--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3031,7 +3031,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                     allowed_local_media_path="",
                     allowed_media_domains=None,
                 )
-            
+
             # Decode reference images if provided
             pil_images: list[Image.Image] = []
             for img_str in reference_images:

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -10,7 +10,6 @@ from io import BytesIO
 from typing import Any, Final, cast
 
 import jinja2
-import requests
 import torch
 from fastapi import Request
 from openai.types.chat.chat_completion_audio import ChatCompletionAudio as OpenAIChatCompletionAudio
@@ -3021,21 +3020,31 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 {k: v for k, v in extra_body.items() if v is not None},
             )
 
+            model_config = getattr(self.engine_client, "model_config", None)
+            if model_config is not None:
+                connector = MediaConnector(
+                    allowed_local_media_path=getattr(model_config, "allowed_local_media_path", "") or "",
+                    allowed_media_domains=getattr(model_config, "allowed_media_domains", None),
+                )
+            else:
+                connector = MediaConnector(
+                    allowed_local_media_path="",
+                    allowed_media_domains=None,
+                )
+            
             # Decode reference images if provided
             pil_images: list[Image.Image] = []
             for img_str in reference_images:
                 try:
                     if img_str.startswith(("http://", "https://")):
-                        logger.info(f"img_str is {img_str}")
-                        resp = requests.get(img_str, timeout=10)
-                        resp.raise_for_status()
-                        img_bytes = resp.content
-                        pil_images.append(Image.open(BytesIO(img_bytes)))
+                        result = await connector.fetch_image_async(img_str)
+                        pil_images.append(result.media)
                     else:
                         img_bytes = base64.b64decode(img_str)
                         pil_images.append(Image.open(BytesIO(img_bytes)))
                 except Exception as e:
                     logger.warning("Failed to decode reference image: %s", e)
+
 
             # Build generation kwargs
             gen_prompt: OmniTextPrompt = {

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3045,7 +3045,6 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                 except Exception as e:
                     logger.warning("Failed to decode reference image: %s", e)
 
-
             # Build generation kwargs
             gen_prompt: OmniTextPrompt = {
                 "prompt": prompt,

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -1,6 +1,5 @@
 import asyncio
 import base64
-import requests
 import json
 import time
 import uuid
@@ -11,6 +10,7 @@ from io import BytesIO
 from typing import Any, Final, cast
 
 import jinja2
+import requests
 import torch
 from fastapi import Request
 from openai.types.chat.chat_completion_audio import ChatCompletionAudio as OpenAIChatCompletionAudio

--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import requests
 import json
 import time
 import uuid
@@ -3022,10 +3023,17 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
 
             # Decode reference images if provided
             pil_images: list[Image.Image] = []
-            for img_b64 in reference_images:
+            for img_str in reference_images:
                 try:
-                    img_bytes = base64.b64decode(img_b64)
-                    pil_images.append(Image.open(BytesIO(img_bytes)))
+                    if img_str.startswith(("http://", "https://")):
+                        logger.info(f"img_str is {img_str}")
+                        resp = requests.get(img_str, timeout=10)
+                        resp.raise_for_status()
+                        img_bytes = resp.content
+                        pil_images.append(Image.open(BytesIO(img_bytes)))
+                    else:
+                        img_bytes = base64.b64decode(img_str)
+                        pil_images.append(Image.open(BytesIO(img_bytes)))
                 except Exception as e:
                     logger.warning("Failed to decode reference image: %s", e)
 
@@ -3373,6 +3381,8 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                                     images.append(b64_data)
                                 except ValueError:
                                     logger.warning("Invalid data URL format")
+                            elif url.startswith(("http://", "https://")):
+                                images.append(url)
                         elif item.get("type") == "video_url":
                             url = item.get("video_url", {}).get("url", "")
                             if isinstance(url, str) and url:


### PR DESCRIPTION
Support for URL-Format image request input in /v1/chat/completions interface

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Support for URL-Format image request input in /v1/chat/completions interface.
For example:
{
  "type": "image_url",
  "image_url": {
       "url": "http://127.0.0.1:8090/images/001.png"
   }
}
To support parsing image input in HTTP or HTTPS Url format within the /v1/chat/completions API .

## Test Plan
Submit an image in URL format and verify if it can be parsed normally.

## Test Result
Test passed. And the Image URL parsed successfully.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
