### PR TITLE
 [Docs] Fix hallucinated stage CLI flags in documentation and comments 

### DIFF
--- a/docs/user_guide/examples/online_serving/glm_image.md
+++ b/docs/user_guide/examples/online_serving/glm_image.md
@@ -19,7 +19,7 @@ both stages on a single GPU, override per stage:
 
 ```bash
 vllm serve zai-org/GLM-Image --omni --port 8091 \
-    --stage-0-devices 0 --stage-1-devices 0
+    --stage-overrides '{"0": {"devices": "0"}, "1": {"devices": "0"}}'
 ```
 
 ## API Calls

--- a/vllm_omni/deploy/mimo_audio.yaml
+++ b/vllm_omni/deploy/mimo_audio.yaml
@@ -4,8 +4,8 @@
 # Default mode is async-chunk streaming on a single GPU (both stages on
 # device 0) through SharedMemoryConnector. For the legacy 2-GPU sync
 # pipeline (stage 1 on a second card), pass ``--no-async-chunk
-# --stage-1-devices 1 --stage-1-max-model-len 18192
-# --stage-1-max-num-batched-tokens 18192`` to the serve CLI.
+# --stage-overrides '{"1": {"devices": "1", "max_model_len": 18192, "max_num_batched_tokens": 18192}}'``
+# to the serve CLI.
 async_chunk: true
 dtype: bfloat16
 

--- a/vllm_omni/model_executor/stage_configs/mimo_audio.yaml
+++ b/vllm_omni/model_executor/stage_configs/mimo_audio.yaml
@@ -4,8 +4,8 @@
 # Default mode is async-chunk streaming on a single GPU (both stages on
 # device 0) through SharedMemoryConnector. For the legacy 2-GPU sync
 # pipeline (stage 1 on a second card), pass ``--no-async-chunk
-# --stage-1-devices 1 --stage-1-max-model-len 18192
-# --stage-1-max-num-batched-tokens 18192`` to the serve CLI.
+# --stage-overrides '{"1": {"devices": "1", "max_model_len": 18192, "max_num_batched_tokens": 18192}}'``
+# to the serve CLI.
 async_chunk: true
 dtype: bfloat16
 


### PR DESCRIPTION
Fixes #4508 

### Description

This PR fixes incorrect stage-specific CLI examples in the documentation and YAML comments that reference non-existent `--stage-X-*` flags.

Using these flags causes `vllm serve` to fail with `unrecognized arguments` errors because `vllm-omni` does not expose stage configuration fields as individual CLI arguments.

**Changes**
- Replace invalid `--stage-X-*` examples with the supported `--stage-overrides` JSON syntax.
- Update documentation and inline YAML comments to reflect the correct configuration mechanism.

Example:

```bash
# Before
--stage-0-devices 0 --stage-1-devices 0

# After
--stage-overrides '{"0": {"devices": "0"}, "1": {"devices": "0"}}'
```