### PR TITLE
[Bugfix] Fix the issue where the v1/chat/completions endpoint returns an error when receiving requests containing both images and text

### DIFF
--- a/vllm_omni/entrypoints/openai/serving_chat.py
+++ b/vllm_omni/entrypoints/openai/serving_chat.py
@@ -3162,7 +3162,7 @@ class OmniOpenAIServingChat(OpenAIServingChat, AudioMixin):
                         prompt_tokens=len(prompt.split()),
                         completion_tokens=len(text_body.split()),
                         total_tokens=len(prompt.split()) + len(text_body.split()),
-                    ),
+                    ).model_dump(mode="json"),
                     metrics=self._get_diffusion_extra_output_params(result.custom_output),
                 )
                 logger.info(


### PR DESCRIPTION
Fix the issue where the v1/chat/completions endpoint returns an error after successful image generation when receiving requests containing both images and text

<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
Model: Qwen-Image-Edit-2507

When the model receives requests(v1/chat/completions) containing Base64 images and text as inputs, the model service successfully generates images but returns an error, with the error details as follows:
Diffusion chat completion failed: 1 validation error for ChatCompletionResponse
usage , Input should be a vaild dictionary or instance of UsageInfo

This changes fixs the bug causing this error.
## Test Plan
Invoke v1/chat/completions endpoint with Base64 image + text payload to check successful request execution.

**vLLM Version:**
0.18.0

## Test Result
Passed.
**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
