### PR TITLE
[Refactor] Remove fallback attribute scan from module discovery

### DIFF
--- a/docs/user_guide/diffusion/cpu_offload_diffusion.md
+++ b/docs/user_guide/diffusion/cpu_offload_diffusion.md
@@ -38,9 +38,9 @@ vllm serve Wan-AI/Wan2.2-T2V-A14B-Diffusers --omni --enable-cpu-offload
 
 ### To Support a Model
 
-Implement the `SupportsComponentDiscovery` protocol to declare which
-submodules serve as pipeline components (used by offloading, HSDP
-sharding, and other framework features):
+All diffusion pipelines **should** implement the `SupportsComponentDiscovery`
+protocol.  It declares which submodules serve as pipeline components and
+is used by CPU offloading and HSDP device placement:
 
 ```python
 from typing import ClassVar
@@ -310,19 +310,10 @@ request while AllGather synchronizes only weight shards (request-independent).
 
 **Module Discovery**
 
-The offloader discovers pipeline components in two ways:
-
-1. **Protocol-based** (preferred): If the pipeline implements
-    `SupportsComponentDiscovery`, its `_dit_modules`, `_encoder_modules`,
-    `_vae_modules`, and `_resident_modules` class variables are used
-    directly.  All attribute names support dotted paths (e.g.
-    `"pipe.transformer"`, `"bagel.time_embedder"`) for nested submodules.
-
-2. **Fallback attribute scan**: Otherwise, the offloader scans for
-    well-known attribute names:
-    - **DiT modules**: `transformer`, `transformer_2`, `dit`, `sr_dit`, `language_model`, `transformer_blocks`, `model`
-    - **Encoders**: `text_encoder`, `text_encoder_2`, `text_encoder_3`, `image_encoder`
-    - **VAE**: `vae`, `audio_vae`
+The offloader discovers pipeline components via the `SupportsComponentDiscovery` protocol.
+Pipelines declare their `_dit_modules`, `_encoder_modules`, `_vae_modules`, and `_resident_modules` class variables explicitly.
+All attribute names support dotted paths (e.g. `"pipe.transformer"`, `"bagel.time_embedder"`) for nested submodules.
+Pipelines that do not implement the protocol will log a warning and skip offloading.
 
 **Hook System**
 

--- a/tests/diffusion/offloader/test_module_collector.py
+++ b/tests/diffusion/offloader/test_module_collector.py
@@ -35,28 +35,6 @@ class FallbackPipeline(nn.Module):
         self.vae = nn.Linear(10, 10)
 
 
-class NonModuleAttrPipeline(nn.Module):
-    """Pipeline where an attribute is not an nn.Module (fallback path)."""
-
-    def __init__(self):
-        super().__init__()
-        self.transformer = nn.Linear(10, 10)
-        self.text_encoder = "not_a_module"
-        self.vae = nn.Linear(10, 10)
-
-
-class DuplicateAttrPipeline(nn.Module):
-    """Pipeline where two encoder attrs point to the same module."""
-
-    def __init__(self):
-        super().__init__()
-        self.transformer = nn.Linear(10, 10)
-        encoder = nn.Linear(10, 10)
-        self.text_encoder = encoder
-        self.text_encoder_2 = encoder
-        self.vae = nn.Linear(10, 10)
-
-
 class ProtocolPipeline(nn.Module, SupportsComponentDiscovery):
     """Pipeline with non-standard names, using the protocol."""
 
@@ -188,32 +166,18 @@ class NestedDiTPipeline(nn.Module, SupportsComponentDiscovery):
 # ---------------------------------------------------------------------------
 
 
-class TestFallbackDiscovery:
-    """Test the fallback attribute scan (no SupportsComponentDiscovery)."""
+class TestNoProtocolDiscovery:
+    """Test that pipelines without SupportsComponentDiscovery return empty."""
 
-    def test_discovers_standard_attrs(self):
+    def test_returns_empty_without_protocol(self):
         pipeline = FallbackPipeline()
         result = ModuleDiscovery.discover(pipeline)
 
         assert not isinstance(pipeline, SupportsComponentDiscovery)
-        assert result.dit_names == ["transformer"]
-        assert result.dits[0] is pipeline.transformer
-        assert result.encoder_names == ["text_encoder", "text_encoder_2"]
-        assert result.vaes[0] is pipeline.vae
+        assert result.dits == []
+        assert result.encoders == []
+        assert result.vaes == []
         assert result.resident_modules == []
-
-    def test_deduplicates_encoders(self):
-        pipeline = DuplicateAttrPipeline()
-        result = ModuleDiscovery.discover(pipeline)
-
-        assert len(result.encoders) == 1
-        assert result.encoder_names == ["text_encoder"]
-
-    def test_skips_non_module_attr(self):
-        pipeline = NonModuleAttrPipeline()
-        result = ModuleDiscovery.discover(pipeline)
-
-        assert len(result.encoders) == 0
 
 
 class TestProtocolDiscovery:

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -658,8 +658,7 @@ class DiffusersPipelineLoader:
         self._process_weights_after_loading(model, target_device)
 
         # Discover pipeline components (DiT, encoders, VAEs) via
-        # ModuleDiscovery, which consults SupportsComponentDiscovery
-        # when available and falls back to well-known attribute names.
+        # ModuleDiscovery, which requires SupportsComponentDiscovery.
         # This supports nested pipelines (e.g. LTX2DistilledPipeline
         # where the transformer lives at "pipe.transformer").
         discovered_modules = ModuleDiscovery.discover(model)

--- a/vllm_omni/diffusion/model_loader/diffusers_loader.py
+++ b/vllm_omni/diffusion/model_loader/diffusers_loader.py
@@ -35,6 +35,7 @@ from vllm_omni.diffusion.model_loader.checkpoint_adapters import (
     get_checkpoint_adapter,
 )
 from vllm_omni.diffusion.models.diffusers_adapter.pipeline_diffusers_adapter import DiffusersAdapterPipeline
+from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.offloader.module_collector import ModuleDiscovery
 from vllm_omni.diffusion.registry import initialize_model
 
@@ -695,6 +696,11 @@ class DiffusersPipelineLoader:
 
         # HSDP only shards transformer modules. All other runtime modules must
         # be placed on the execution device explicitly after sharding.
+        if not isinstance(model, SupportsComponentDiscovery):
+            raise TypeError(
+                f"{type(model).__name__} does not implement "
+                "SupportsComponentDiscovery, required for HSDP device placement."
+            )
         modules_to_move: list[nn.Module] = []
         if discovered_modules.vaes is not None:
             modules_to_move.extend(discovered_modules.vaes)

--- a/vllm_omni/diffusion/models/audiox/pipeline_audiox.py
+++ b/vllm_omni/diffusion/models/audiox/pipeline_audiox.py
@@ -382,6 +382,7 @@ class AudioXPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMix
         "clip_proj",
         "clip_proj_sync",
         "clip_temp_transformer",
+        "clip_video_params",
     ]
 
     _PROFILER_TARGETS: ClassVar[list[str]] = ["diffuse"]
@@ -437,10 +438,17 @@ class AudioXPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMix
         self._clip_out_features = 128
         self.clip_proj = nn.Linear(_in_features, self._clip_out_features)
         self.clip_proj_sync = nn.Linear(240, self._clip_out_features)
-        self.clip_sync_weight = nn.Parameter(torch.tensor(0.0))
         self.clip_temp_transformer = SA_Transformer(_DIM, depth=4, heads=16, dim_head=64, mlp_dim=_DIM * 4)
-        self.clip_temp_pos_embedding = nn.Parameter(torch.randn(1, _VIDEO_FPS * _DURATION_SEC, _DIM))
-        self.clip_empty_visual_feat = nn.Parameter(torch.zeros(1, self._clip_out_features, _DIM), requires_grad=False)
+        self.clip_video_params = nn.ParameterDict(
+            {
+                "sync_weight": nn.Parameter(torch.tensor(0.0)),
+                "temp_pos_embedding": nn.Parameter(torch.randn(1, _VIDEO_FPS * _DURATION_SEC, _DIM)),
+                "empty_visual_feat": nn.Parameter(
+                    torch.zeros(1, self._clip_out_features, _DIM),
+                    requires_grad=False,
+                ),
+            }
+        )
         _CLIP_MEAN = (0.48145466, 0.4578275, 0.40821073)
         _CLIP_STD = (0.26862954, 0.26130258, 0.27577711)
         self._clip_normalize = transforms.Compose([transforms.Normalize(mean=list(_CLIP_MEAN), std=list(_CLIP_STD))])
@@ -507,10 +515,17 @@ class AudioXPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMix
             assert out == n_slots * total_heads * head_dim
             return tensor.view(total_heads, head_dim, n_slots).permute(2, 0, 1).reshape(out).contiguous()
 
+        _clip_param_remap = {
+            "clip_sync_weight": "clip_video_params.sync_weight",
+            "clip_temp_pos_embedding": "clip_video_params.temp_pos_embedding",
+            "clip_empty_visual_feat": "clip_video_params.empty_visual_feat",
+        }
+
         def _remap(items):
             for name, tensor in items:
                 if name.startswith(_legacy_prefix):
                     name = "audio_vae_adapter." + name[len(_legacy_prefix) :]
+                name = _clip_param_remap.get(name, name)
                 if qkv_mid in name and (name.endswith(".weight") or name.endswith(".bias")):
                     tensor = _restack_interleaved(tensor, 3)
                 elif to_kv_mid in name and (name.endswith(".weight") or name.endswith(".bias")):
@@ -742,11 +757,12 @@ class AudioXPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMix
                     h_1, h_2 = h, h_1
                 sampled = x
 
-        vae = self.pretransform.to(device=sampled.device, dtype=torch.float32).eval()
-        return vae.decode(sampled.to(torch.float32) * float(vae.audiox_scaling_factor), return_dict=True).sample
+        return self.pretransform.decode(
+            sampled.to(torch.float32) * float(self.pretransform.audiox_scaling_factor),
+            return_dict=True,
+        ).sample
 
     def _encode_text(self, texts: list[str], device: torch.device) -> list[torch.Tensor]:
-        self.text_encoder.to(device)
         encoded = self.tokenizer(
             texts,
             truncation=True,
@@ -765,8 +781,6 @@ class AudioXPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMix
         return [embeddings, attention_mask]
 
     def _encode_video(self, video_list: list[dict], device: torch.device) -> list[torch.Tensor]:
-        self.clip_encoder.to(device).eval()
-
         video_tensors = [item["video_tensors"] for item in video_list]
         video_sync_frames = torch.cat([item["video_sync_frames"] for item in video_list], dim=0).to(device)
 
@@ -781,7 +795,7 @@ class AudioXPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMix
             outputs = self.clip_encoder(pixel_values=pixel_values)
         hidden = outputs.last_hidden_state
         hidden = rearrange(hidden, "(b t) p d -> (b p) t d", b=batch_size, t=time_length)
-        hidden = hidden + self.clip_temp_pos_embedding
+        hidden = hidden + self.clip_video_params["temp_pos_embedding"]
         hidden = self.clip_temp_transformer(hidden)
         hidden = rearrange(hidden, "(b p) t d -> b (t p) d", b=batch_size)
         hidden = self.clip_proj(hidden.view(-1, self._clip_in_features))
@@ -789,9 +803,9 @@ class AudioXPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMix
 
         sync = self.clip_proj_sync(video_sync_frames.view(-1, 240))
         sync = sync.view(batch_size, self._clip_out_features, -1)
-        hidden = hidden + self.clip_sync_weight * sync
+        hidden = hidden + self.clip_video_params["sync_weight"] * sync
 
-        empty = self.clip_empty_visual_feat.expand(batch_size, -1, -1)
+        empty = self.clip_video_params["empty_visual_feat"].expand(batch_size, -1, -1)
         hidden = torch.where(is_zero.view(batch_size, 1, 1), empty, hidden)
         return [hidden, torch.ones(batch_size, 1, device=device)]
 

--- a/vllm_omni/diffusion/models/audiox/pipeline_audiox.py
+++ b/vllm_omni/diffusion/models/audiox/pipeline_audiox.py
@@ -25,7 +25,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.audiox.audiox_transformer import MMDiffusionTransformer
-from vllm_omni.diffusion.models.interface import SupportAudioOutput
+from vllm_omni.diffusion.models.interface import SupportAudioOutput, SupportsComponentDiscovery
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
 from vllm_omni.transformers_utils.processors import audiox as _audiox_transforms
@@ -367,11 +367,23 @@ class _BrownianTreeNoiseSampler:
         return -self._tree(t0, t1) / (t1 - t0).sqrt()
 
 
-class AudioXPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMixin):
+class AudioXPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery):
     supports_request_batch = False
     support_audio_output: ClassVar[bool] = True
     audio_sample_rate: ClassVar[int] = 44100
     audio_channels: ClassVar[int] = 2
+
+    _dit_modules: ClassVar[list[str]] = ["model"]
+    _encoder_modules: ClassVar[list[str]] = ["text_encoder", "clip_encoder"]
+    _vae_modules: ClassVar[list[str]] = ["pretransform"]
+    _resident_modules: ClassVar[list[str]] = [
+        "audio_vae_adapter",
+        "maf_block",
+        "clip_proj",
+        "clip_proj_sync",
+        "clip_temp_transformer",
+    ]
+
     _PROFILER_TARGETS: ClassVar[list[str]] = ["diffuse"]
     _CLIP_SYNC_DURATION_SEC: ClassVar[float] = 10.0
     _VIDEO_SYNC_FRAME_COUNT: ClassVar[int] = 240

--- a/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
@@ -17,6 +17,7 @@ import re as re_module
 from collections import OrderedDict
 from collections.abc import Iterable
 from contextlib import contextmanager
+from typing import ClassVar
 
 import numpy as np
 import torch
@@ -53,6 +54,7 @@ from vllm_omni.diffusion.models.dreamzero.utils import (
     DEFAULT_SEED,
     DEFAULT_SIGMA_SHIFT,
 )
+from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.schedulers.scheduling_flow_unipc_multistep import FlowUniPCMultistepScheduler
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
@@ -108,7 +110,7 @@ class VideoActionScheduler:
 # ---------------------------------------------------------------------------
 
 
-class DreamZeroPipeline(nn.Module, CFGParallelMixin):
+class DreamZeroPipeline(nn.Module, CFGParallelMixin, SupportsComponentDiscovery):
     """DreamZero world model pipeline.
 
     Multi-output: predict_noise() returns (video_pred, action_pred).
@@ -117,6 +119,10 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
     KV is managed by the AR-Diffusion engine through the explicit capability
     methods below. The runner binds one session state only for ``forward()``.
     """
+
+    _dit_modules: ClassVar[list[str]] = ["transformer"]
+    _encoder_modules: ClassVar[list[str]] = ["text_encoder", "image_encoder"]
+    _vae_modules: ClassVar[list[str]] = ["vae"]
 
     _POSITIVE_BRANCH = "positive"
     _NEGATIVE_BRANCH = "negative"

--- a/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
+++ b/vllm_omni/diffusion/models/ernie_image/pipeline_ernie_image.py
@@ -5,6 +5,7 @@
 import json
 import os
 from collections.abc import Callable, Iterable
+from typing import ClassVar
 
 import torch
 import torch.nn as nn
@@ -22,7 +23,7 @@ from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.ernie_image.ernie_image_transformer import ErnieImageTransformer2DModel
-from vllm_omni.diffusion.models.interface import SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportImageInput, SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
@@ -67,9 +68,18 @@ def get_ernie_image_post_process_func(od_config: OmniDiffusionConfig):
 
 
 class ErnieImagePipeline(
-    nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin
+    nn.Module,
+    CFGParallelMixin,
+    SupportImageInput,
+    ProgressBarMixin,
+    DiffusionPipelineProfilerMixin,
+    SupportsComponentDiscovery,
 ):
     support_image_input = False
+
+    _dit_modules: ClassVar[list[str]] = ["transformer"]
+    _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
+    _vae_modules: ClassVar[list[str]] = ["vae"]
 
     def __init__(
         self,

--- a/vllm_omni/diffusion/models/hidream_image/pipeline_hidream_image.py
+++ b/vllm_omni/diffusion/models/hidream_image/pipeline_hidream_image.py
@@ -6,7 +6,7 @@ import json
 import math
 import os
 from collections.abc import Callable, Iterable
-from typing import Any
+from typing import Any, ClassVar
 
 import numpy as np
 import torch
@@ -33,6 +33,7 @@ from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.model_loader.hub_prefetch import from_pretrained_with_prefetch, prefetch_subfolders
 from vllm_omni.diffusion.models.hidream_image import HiDreamImageTransformer2DModel
+from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.utils.tf_utils import get_transformer_config_kwargs
@@ -144,7 +145,22 @@ def retrieve_timesteps(
     return timesteps, num_inference_steps
 
 
-class HiDreamImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMixin, ProgressBarMixin):
+class HiDreamImagePipeline(
+    nn.Module,
+    CFGParallelMixin,
+    DiffusionPipelineProfilerMixin,
+    ProgressBarMixin,
+    SupportsComponentDiscovery,
+):
+    _dit_modules: ClassVar[list[str]] = ["transformer"]
+    _encoder_modules: ClassVar[list[str]] = [
+        "text_encoder",
+        "text_encoder_2",
+        "text_encoder_3",
+        "text_encoder_4",
+    ]
+    _vae_modules: ClassVar[list[str]] = ["vae"]
+
     def __init__(
         self,
         *,

--- a/vllm_omni/diffusion/models/magi_human/pipeline_magi_human.py
+++ b/vllm_omni/diffusion/models/magi_human/pipeline_magi_human.py
@@ -1683,8 +1683,8 @@ def _resolve_subdir(
 # ===========================================================================
 class MagiHumanPipeline(nn.Module, ProgressBarMixin, SupportsComponentDiscovery, DiffusionPipelineProfilerMixin):
     _dit_modules: ClassVar[list[str]] = ["dit", "sr_dit"]
-    _encoder_modules: ClassVar[list[str]] = ["text_encoder"]
-    _vae_modules: ClassVar[list[str]] = ["vae", "audio_vae"]
+    _encoder_modules: ClassVar[list[str]] = ["text_encoder.model"]
+    _vae_modules: ClassVar[list[str]] = ["vae", "audio_vae.vae_model"]
 
     def __init__(self, od_config: OmniDiffusionConfig, **kwargs):
         super().__init__()

--- a/vllm_omni/diffusion/models/ming_flash_omni/pipeline_ming_imagegen.py
+++ b/vllm_omni/diffusion/models/ming_flash_omni/pipeline_ming_imagegen.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import torch
 import torch.nn as nn
@@ -69,6 +69,7 @@ class MingImagePipeline(ZImagePipeline):
     """
 
     supports_request_batch = False
+    _encoder_modules: ClassVar[list[str]] = ["condition_encoder"]
 
     def __init__(
         self,

--- a/vllm_omni/diffusion/models/sdxl/pipeline_sdxl.py
+++ b/vllm_omni/diffusion/models/sdxl/pipeline_sdxl.py
@@ -4,6 +4,7 @@
 import logging
 import os
 from collections.abc import Iterable
+from typing import ClassVar
 
 import torch
 from diffusers.image_processor import VaeImageProcessor
@@ -43,10 +44,10 @@ def get_sdxl_image_post_process_func(od_config: OmniDiffusionConfig):
 class StableDiffusionXLPipeline(
     nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMixin, SupportsComponentDiscovery
 ):
-    _dit_modules: list[str] = ["unet"]
-    _encoder_modules: list[str] = ["text_encoder", "text_encoder_2"]
-    _vae_modules: list[str] = ["vae"]
-    _resident_modules: list[str] = []
+    _dit_modules: ClassVar[list[str]] = ["unet"]
+    _encoder_modules: ClassVar[list[str]] = ["text_encoder", "text_encoder_2"]
+    _vae_modules: ClassVar[list[str]] = ["vae"]
+    _resident_modules: ClassVar[list[str]] = []
 
     def __init__(
         self,

--- a/vllm_omni/diffusion/models/sdxl/pipeline_sdxl.py
+++ b/vllm_omni/diffusion/models/sdxl/pipeline_sdxl.py
@@ -147,8 +147,7 @@ class StableDiffusionXLPipeline(
         )
         text_input_ids = text_inputs.input_ids
 
-        text_encoder_device = next(text_encoder.parameters()).device
-        outputs = text_encoder(text_input_ids.to(text_encoder_device), output_hidden_states=True)
+        outputs = text_encoder(text_input_ids.to(self.device), output_hidden_states=True)
         prompt_embeds = outputs.hidden_states[-2].to(dtype=self.od_config.dtype, device=self.device)
 
         _, seq_len, _ = prompt_embeds.shape

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_s2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_s2v.py
@@ -31,7 +31,7 @@ from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.forward_context import DenoiseProgressMixin
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
-from vllm_omni.diffusion.models.interface import SupportAudioInput, SupportImageInput
+from vllm_omni.diffusion.models.interface import SupportAudioInput, SupportImageInput, SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
 from vllm_omni.diffusion.models.wan2_2.pipeline_wan2_2 import (
@@ -470,6 +470,7 @@ class Wan22S2VPipeline(
     DenoiseProgressMixin,
     ProgressBarMixin,
     DiffusionPipelineProfilerMixin,
+    SupportsComponentDiscovery,
 ):
     """
     Wan2.2 Speech-to-Video Pipeline.
@@ -484,6 +485,10 @@ class Wan22S2VPipeline(
       - Reference image encoded as separate ``ref_latents`` tokens (not
         channel-concatenated like I2V).
     """
+
+    _dit_modules: ClassVar[list[str]] = ["transformer"]
+    _encoder_modules: ClassVar[list[str]] = ["text_encoder", "audio_model"]
+    _vae_modules: ClassVar[list[str]] = ["vae"]
 
     # Default config values from Wan2.2/wan/configs/wan_s2v_14B.py
     _DEFAULT_MOTION_FRAMES = 73

--- a/vllm_omni/diffusion/offloader/module_collector.py
+++ b/vllm_omni/diffusion/offloader/module_collector.py
@@ -56,38 +56,7 @@ class PipelineModules:
 
 
 class ModuleDiscovery:
-    """Discovers pipeline components.
-
-    If the pipeline implements :class:`SupportsComponentDiscovery`,
-    its ``_dit_modules``, ``_encoder_modules``, and ``_vae_modules``
-    class variables are used directly.  Otherwise, falls back to
-    scanning well-known attribute names.
-    """
-
-    # Fallback attribute names for pipelines that do not implement
-    # SupportsComponentDiscovery.
-    _FALLBACK_DIT_ATTRS = [
-        "transformer",
-        "transformer_2",
-        "dit",
-        "sr_dit",
-        "language_model",
-        "transformer_blocks",
-        "model",
-    ]
-    _FALLBACK_ENCODER_ATTRS = [
-        "text_encoder",
-        "text_encoder_2",
-        "text_encoder_3",
-        "image_encoder",
-        "vision_encoder",
-        "mllm",
-    ]
-    _FALLBACK_VAE_ATTRS = [
-        "vae",
-        "audio_vae",
-        "sound_tokenizer",
-    ]
+    """Discovers pipeline components via :class:`SupportsComponentDiscovery`."""
 
     @staticmethod
     def _collect_modules(
@@ -139,22 +108,39 @@ class ModuleDiscovery:
         Returns:
             PipelineModules with lists of discovered modules and names
         """
-        declared = isinstance(pipeline, SupportsComponentDiscovery)
-        if declared:
-            dit_attrs = pipeline._dit_modules
-            enc_attrs = pipeline._encoder_modules
-            vae_attrs = pipeline._vae_modules
-            res_attrs = pipeline._resident_modules
-        else:
-            dit_attrs = ModuleDiscovery._FALLBACK_DIT_ATTRS
-            enc_attrs = ModuleDiscovery._FALLBACK_ENCODER_ATTRS
-            vae_attrs = ModuleDiscovery._FALLBACK_VAE_ATTRS
-            res_attrs = []
+        if not isinstance(pipeline, SupportsComponentDiscovery):
+            logger.warning(
+                "%s does not implement SupportsComponentDiscovery.",
+                type(pipeline).__name__,
+            )
+            return PipelineModules(
+                dits=[],
+                dit_names=[],
+                encoders=[],
+                encoder_names=[],
+                vaes=[],
+            )
 
-        dit_modules, dit_names = ModuleDiscovery._collect_modules(pipeline, dit_attrs, warn_missing=declared)
-        encoders, encoder_names = ModuleDiscovery._collect_modules(pipeline, enc_attrs, warn_missing=declared)
-        vaes, _ = ModuleDiscovery._collect_modules(pipeline, vae_attrs, warn_missing=declared)
-        residents, resident_names = ModuleDiscovery._collect_modules(pipeline, res_attrs, warn_missing=declared)
+        dit_modules, dit_names = ModuleDiscovery._collect_modules(
+            pipeline,
+            pipeline._dit_modules,
+            warn_missing=True,
+        )
+        encoders, encoder_names = ModuleDiscovery._collect_modules(
+            pipeline,
+            pipeline._encoder_modules,
+            warn_missing=True,
+        )
+        vaes, _ = ModuleDiscovery._collect_modules(
+            pipeline,
+            pipeline._vae_modules,
+            warn_missing=True,
+        )
+        residents, resident_names = ModuleDiscovery._collect_modules(
+            pipeline,
+            pipeline._resident_modules,
+            warn_missing=True,
+        )
 
         return PipelineModules(
             dits=dit_modules,


### PR DESCRIPTION
## Purpose

Follow-up to #3076 — audits and completes the SupportsComponentDiscovery migration across all diffusion pipelines.

Bugfixes (existing pipelines):
- MagiHumanPipeline: text_encoder and audio_vae are plain Python wrappers around inner nn.Modules. Use dotted paths (text_encoder.model, audio_vae.vae_model) so the collector reaches the actual modules instead of warning and skipping.
- MingImagePipeline: Inherits _encoder_modules = ["text_encoder"] from ZImagePipeline but sets self.text_encoder = None and uses self.condition_encoder instead. Override with ["condition_encoder"].
- LTX2Pipeline family: connectors and vocoder missing from ClassVars. Match LTX23Pipeline which already has them correct (connectors in _encoder_modules, vocoder in _resident_modules).
- StableDiffusionXLPipeline: Bare list[str] annotations → ClassVar[list[str]] for consistency.

New pipeline migrations (6):
- AudioXPipeline, DreamZeroPipeline, ErnieImagePipeline, HiDreamImagePipeline, HiDreamI1ImagePipeline, Wan22S2VPipeline

Fallback removal:
- Remove the heuristic attribute-name scan from ModuleDiscovery. All pipelines that support CPU offloading now declare their components explicitly. Pipelines without the protocol get a warning and empty results.
- Add a hard check in the HSDP device-placement path — error early instead of silently skipping placement and crashing downstream with a device mismatch.
- Update docs to reflect that SupportsComponentDiscovery is the only discovery mechanism.

Skipped (with reason):
- Cosmos3OmniDiffusersPipeline — explicitly rejects enable_cpu_offload (no separate text encoder).
- DiffusersAdapterPipeline, InternVLAA1Pipeline, OmniVoicePipeline, LTX2LatentUpsamplePipeline — not DiT-based diffusion pipelines.

## Test Plan

**vLLM Version:** 0.23.0

**vLLM-Omni Commit:** 3d1ec86d8b1d35d054a496dde5a88f5d20bd48b9

Unit tests
```
pytest tests/diffusion/offloader/ -v
pytest tests/diffusion/models/ltx2/test_ltx2_3_pipeline.py -v
```

Manual tests

- [x] AudioXPipeline
- [x] Wan22S2VPipeline
- [ ] HiDreamI1ImagePipeline: not used by any model?
- [x] HiDreamImagePipeline
- [x] ErnieImagePipeline
- [ ] DreamZeroPipeline: non-trivial to test
- [x] LTX2
- [x] SDXL
- [ ] MingImagePipeline: too big to test
- [ ] MagiHuman: too big to test

For each: verify the server starts, logs Model-level offloading enabled: <dit> ↔ <encoder>, and responds to a generation request without device-mismatch errors.

## Test Result

All small models are tested.
