### PR TITLE
[Feat] support TP  and Quantization for  Ovis-Image

### DIFF
--- a/tests/diffusion/models/ovis_image/test_ovis_image_tp.py
+++ b/tests/diffusion/models/ovis_image/test_ovis_image_tp.py
@@ -1,0 +1,507 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Tests for Ovis-Image tensor parallelism.
+
+This module tests:
+1. Weight loading with TP sharding for special layers
+2. Packed module mapping for QKV projections
+3. Forward pass shape consistency
+
+The weight loading logic for Ovis-Image requires manual sharding for:
+1. proj_out in single_transformer_blocks: splits [attn, mlp] features separately
+2. SwiGLU layers: re-interleaves [hidden, gate] pairs after sharding
+"""
+
+import pytest
+import torch
+from pytest_mock import MockerFixture
+
+from tests.helpers.mark import hardware_test
+from vllm_omni.diffusion.data import OmniDiffusionConfig, TransformerConfig
+from vllm_omni.diffusion.models.ovis_image.ovis_image_transformer import (
+    OvisImagePosEmbed,
+    OvisImageTransformer2DModel,
+)
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(scope="function")
+def setup_tp_group(mocker: MockerFixture):
+    """Set up TP group for each test function (default TP=2)."""
+    mocker.patch(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size",
+        return_value=2,
+    )
+    mocker.patch(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_rank",
+        return_value=0,
+    )
+    mock_get_tp_group = mocker.patch("vllm.distributed.parallel_state.get_tp_group")
+    mock_tp_group = mocker.MagicMock()
+    mock_tp_group.world_size = 2
+    mock_get_tp_group.return_value = mock_tp_group
+    yield
+
+
+@pytest.fixture(scope="function")
+def setup_tp1(mocker: MockerFixture):
+    """Set up TP=1 environment."""
+    mocker.patch(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size",
+        return_value=1,
+    )
+    mocker.patch(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_rank",
+        return_value=0,
+    )
+    mocker.patch(
+        "vllm_omni.diffusion.models.ovis_image.ovis_image_transformer.get_tensor_model_parallel_world_size",
+        return_value=1,
+    )
+    mocker.patch(
+        "vllm_omni.diffusion.models.ovis_image.ovis_image_transformer.get_tensor_model_parallel_rank",
+        return_value=0,
+    )
+
+
+@pytest.fixture(scope="function")
+def setup_tp2(mocker: MockerFixture):
+    """Set up TP=2 environment for ovis_image_transformer."""
+    mocker.patch(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size",
+        return_value=2,
+    )
+    mocker.patch(
+        "vllm.model_executor.layers.linear.get_tensor_model_parallel_rank",
+        return_value=0,
+    )
+    mocker.patch(
+        "vllm_omni.diffusion.models.ovis_image.ovis_image_transformer.get_tensor_model_parallel_world_size",
+        return_value=2,
+    )
+    mocker.patch(
+        "vllm_omni.diffusion.models.ovis_image.ovis_image_transformer.get_tensor_model_parallel_rank",
+        return_value=0,
+    )
+
+
+# ============================================================================
+# Test Classes
+# ============================================================================
+
+
+class TestOvisImageProjOutWeightSharding:
+    """Test proj_out weight sharding for single_transformer_blocks.
+
+    proj_out input is torch.cat([attn_output, mlp_hidden_states], dim=-1) where:
+    - attn_output: [batch, seq, inner_dim / tp_size] (TP-sharded)
+    - mlp_hidden_states: [batch, seq, mlp_hidden_dim / tp_size] (TP-sharded)
+
+    The weight must be split into attn and mlp portions, each sharded separately.
+    """
+
+    pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+    def test_proj_out_weight_split_correctness(self, setup_tp2):
+        """Verify proj_out weight is correctly split for TP=2."""
+        inner_dim = 512
+        mlp_ratio = 4.0
+        mlp_hidden_dim = int(inner_dim * mlp_ratio)
+
+        # Full weight shape: [inner_dim, inner_dim + mlp_hidden_dim]
+        full_weight = torch.randn(inner_dim, inner_dim + mlp_hidden_dim)
+
+        # Simulate the load_weights logic for rank 0
+        tp_size = 2
+        tp_rank = 0
+
+        w_attn, w_mlp = full_weight.split([inner_dim, mlp_hidden_dim], dim=1)
+        w_attn_local = w_attn.chunk(tp_size, dim=1)[tp_rank]
+        w_mlp_local = w_mlp.chunk(tp_size, dim=1)[tp_rank]
+        local_weight_rank0 = torch.cat([w_attn_local, w_mlp_local], dim=1)
+
+        # Verify shapes
+        assert w_attn_local.shape == (inner_dim, inner_dim // tp_size)
+        assert w_mlp_local.shape == (inner_dim, mlp_hidden_dim // tp_size)
+        assert local_weight_rank0.shape == (
+            inner_dim,
+            (inner_dim + mlp_hidden_dim) // tp_size,
+        )
+
+    def test_proj_out_weight_different_ranks(self, setup_tp2):
+        """Verify different TP ranks get different weight shards."""
+        inner_dim = 512
+        mlp_hidden_dim = inner_dim * 4
+        full_weight = torch.randn(inner_dim, inner_dim + mlp_hidden_dim)
+
+        tp_size = 2
+
+        # Rank 0
+        w_attn, w_mlp = full_weight.split([inner_dim, mlp_hidden_dim], dim=1)
+        local_rank0 = torch.cat([w_attn.chunk(tp_size, dim=1)[0], w_mlp.chunk(tp_size, dim=1)[0]], dim=1)
+
+        # Rank 1
+        local_rank1 = torch.cat([w_attn.chunk(tp_size, dim=1)[1], w_mlp.chunk(tp_size, dim=1)[1]], dim=1)
+
+        # Ranks should have different weights
+        assert not torch.allclose(local_rank0, local_rank1)
+
+    def test_proj_out_weight_reconstruction(self, setup_tp2):
+        """Verify full weight can be reconstructed from TP shards."""
+        inner_dim = 512
+        mlp_hidden_dim = inner_dim * 4
+        full_weight = torch.randn(inner_dim, inner_dim + mlp_hidden_dim)
+
+        tp_size = 2
+        w_attn, w_mlp = full_weight.split([inner_dim, mlp_hidden_dim], dim=1)
+
+        # Get all shards
+        attn_shards = w_attn.chunk(tp_size, dim=1)
+        mlp_shards = w_mlp.chunk(tp_size, dim=1)
+
+        # Reconstruct
+        reconstructed = torch.cat(
+            [
+                torch.cat([attn_shards[0], attn_shards[1]], dim=1),
+                torch.cat([mlp_shards[0], mlp_shards[1]], dim=1),
+            ],
+            dim=1,
+        )
+
+        assert torch.allclose(reconstructed, full_weight)
+
+
+class TestOvisImageSwiGLUWeightSharding:
+    """Test SwiGLU weight interleaving for tensor parallelism.
+
+    SwiGLU weight layout is [hidden, gate] interleaved. For TP, we shard each
+    portion separately then re-interleave so each rank gets matching hidden/gate pairs.
+    """
+
+    pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+    def test_swiglu_weight_split_correctness(self, setup_tp2):
+        """Verify SwiGLU weight is correctly interleaved for TP=2."""
+        hidden_dim = 512
+        inner_dim = 2048
+
+        # Full weight shape: [inner_dim * 2, hidden_dim] for ColumnParallelLinear
+        full_weight = torch.randn(inner_dim * 2, hidden_dim)
+
+        tp_size = 2
+        tp_rank = 0
+
+        w_hidden, w_gate = full_weight.chunk(2, dim=0)
+        w_h_local = w_hidden.chunk(tp_size, dim=0)[tp_rank]
+        w_g_local = w_gate.chunk(tp_size, dim=0)[tp_rank]
+        local_weight = torch.cat([w_h_local, w_g_local], dim=0)
+
+        # Verify shapes
+        assert w_h_local.shape == (inner_dim // tp_size, hidden_dim)
+        assert w_g_local.shape == (inner_dim // tp_size, hidden_dim)
+        assert local_weight.shape == (inner_dim, hidden_dim)
+
+    def test_swiglu_bias_split_correctness(self, setup_tp2):
+        """Verify SwiGLU bias is correctly interleaved for TP=2."""
+        inner_dim = 2048
+        full_bias = torch.randn(inner_dim * 2)
+
+        tp_size = 2
+        tp_rank = 0
+
+        b_hidden, b_gate = full_bias.chunk(2, dim=0)
+        b_h_local = b_hidden.chunk(tp_size, dim=0)[tp_rank]
+        b_g_local = b_gate.chunk(tp_size, dim=0)[tp_rank]
+        local_bias = torch.cat([b_h_local, b_g_local], dim=0)
+
+        assert local_bias.shape == (inner_dim,)
+
+    def test_swiglu_weight_reconstruction(self, setup_tp2):
+        """Verify full SwiGLU weight can be reconstructed from TP shards."""
+        hidden_dim = 512
+        inner_dim = 2048
+        full_weight = torch.randn(inner_dim * 2, hidden_dim)
+
+        tp_size = 2
+        w_hidden, w_gate = full_weight.chunk(2, dim=0)
+
+        # Get all shards and reconstruct
+        h_shards = w_hidden.chunk(tp_size, dim=0)
+        g_shards = w_gate.chunk(tp_size, dim=0)
+
+        reconstructed = torch.cat(
+            [
+                torch.cat([h_shards[0], h_shards[1]], dim=0),
+                torch.cat([g_shards[0], g_shards[1]], dim=0),
+            ],
+            dim=0,
+        )
+
+        assert torch.allclose(reconstructed, full_weight)
+
+
+class TestOvisImageWeightLoadingIntegration:
+    """Integration tests for Ovis-Image weight loading with TP."""
+
+    @pytest.mark.core_model
+    @hardware_test(res={"cuda": "L4"}, num_cards=1)
+    def test_weight_loading_tp2(self, mocker: MockerFixture, setup_tp2):
+        """Verify weights load correctly with TP=2."""
+        # Mock distributed functions
+        mocker.patch(
+            "vllm.distributed.get_tensor_model_parallel_world_size",
+            return_value=2,
+        )
+        mocker.patch(
+            "vllm.distributed.get_tensor_model_parallel_rank",
+            return_value=0,
+        )
+
+        inner_dim = 8 * 64  # num_heads * head_dim
+        mlp_hidden_dim = inner_dim * 4
+
+        # Create minimal config
+        od_config = OmniDiffusionConfig(
+            model="test",
+            model_class_name="OvisImagePipeline",
+            tf_model_config=TransformerConfig(
+                num_layers=1,
+                num_single_layers=1,
+            ),
+        )
+
+        model = OvisImageTransformer2DModel(
+            od_config=od_config,
+            num_layers=1,
+            num_single_layers=1,
+            attention_head_dim=64,
+            num_attention_heads=8,
+            quant_config=None,
+        )
+
+        # Create mock weights
+        mock_weights = [
+            # Embeddings
+            ("time_proj.weight", torch.randn(256, inner_dim)),
+            ("timestep_embedder.linear_1.weight", torch.randn(inner_dim, 256)),
+            ("timestep_embedder.linear_2.weight", torch.randn(inner_dim * 4, inner_dim)),
+            ("context_embedder.weight", torch.randn(inner_dim, 2048)),
+            ("x_embedder.weight", torch.randn(inner_dim, 64)),
+            ("proj_out.weight", torch.randn(64, inner_dim)),
+            # Transformer block
+            ("transformer_blocks.0.norm1.linear.weight", torch.randn(inner_dim * 6, inner_dim)),
+            ("transformer_blocks.0.attn.to_qkv.weight", torch.randn(inner_dim * 3, inner_dim)),
+            ("transformer_blocks.0.attn.add_kv_proj.weight", torch.randn(inner_dim * 3, inner_dim)),
+            ("transformer_blocks.0.attn.to_out.0.weight", torch.randn(inner_dim, inner_dim)),
+            ("transformer_blocks.0.ff.net.0.proj.weight", torch.randn(mlp_hidden_dim * 2, inner_dim)),
+            ("transformer_blocks.0.ff.net.2.weight", torch.randn(inner_dim, mlp_hidden_dim)),
+            # Single block
+            ("single_transformer_blocks.0.proj_mlp.weight", torch.randn(mlp_hidden_dim * 2, inner_dim)),
+            ("single_transformer_blocks.0.attn.to_qkv.weight", torch.randn(inner_dim * 3, inner_dim)),
+            ("single_transformer_blocks.0.proj_out.weight", torch.randn(inner_dim, inner_dim + mlp_hidden_dim)),
+        ]
+
+        loaded_params = model.load_weights(mock_weights)
+
+        assert len(loaded_params) > 0, "Parameters should be loaded"
+
+        # Verify proj_out weight shape after TP sharding
+        proj_out_weight = model.single_transformer_blocks[0].proj_out.weight
+        expected_shape = (inner_dim, (inner_dim + mlp_hidden_dim) // 2)
+        assert proj_out_weight.shape == expected_shape, (
+            f"Expected proj_out shape {expected_shape}, got {proj_out_weight.shape}"
+        )
+
+        # Verify proj_mlp weight shape
+        proj_mlp_weight = model.single_transformer_blocks[0].proj_mlp.weight
+        expected_mlp_shape = (mlp_hidden_dim, inner_dim)
+        assert proj_mlp_weight.shape == expected_mlp_shape
+
+    @pytest.mark.core_model
+    @hardware_test(res={"cuda": "L4"}, num_cards=1)
+    def test_packed_module_mapping(self, mocker: MockerFixture, setup_tp_group):
+        """Verify QKV packing matches expected configuration."""
+        mocker.patch(
+            "vllm_omni.diffusion.models.ovis_image.ovis_image_transformer.get_tensor_model_parallel_world_size",
+            return_value=2,
+        )
+        mocker.patch(
+            "vllm_omni.diffusion.models.ovis_image.ovis_image_transformer.get_tensor_model_parallel_rank",
+            return_value=0,
+        )
+
+        od_config = OmniDiffusionConfig(
+            model="test",
+            model_class_name="OvisImagePipeline",
+            tf_model_config=TransformerConfig(num_layers=1, num_single_layers=0),
+        )
+
+        model = OvisImageTransformer2DModel(
+            od_config=od_config,
+            num_layers=1,
+            num_single_layers=0,
+            attention_head_dim=64,
+            num_attention_heads=8,
+            quant_config=None,
+        )
+
+        model.load_weights([])
+
+        # Verify stacked_params_mapping
+        assert model.stacked_params_mapping is not None
+        expected_mappings = [
+            (".to_qkv", ".to_q", "q"),
+            (".to_qkv", ".to_k", "k"),
+            (".to_qkv", ".to_v", "v"),
+            (".add_kv_proj", ".add_q_proj", "q"),
+            (".add_kv_proj", ".add_k_proj", "k"),
+            (".add_kv_proj", ".add_v_proj", "v"),
+        ]
+        assert model.stacked_params_mapping == expected_mappings
+
+    @pytest.mark.core_model
+    @hardware_test(res={"cuda": "L4"}, num_cards=1)
+    def test_unexpected_parameter_warning(self, mocker: MockerFixture, setup_tp2):
+        """Test that unexpected parameters trigger a warning."""
+        mocker.patch(
+            "vllm.distributed.get_tensor_model_parallel_world_size",
+            return_value=2,
+        )
+        mocker.patch(
+            "vllm.distributed.get_tensor_model_parallel_rank",
+            return_value=0,
+        )
+
+        od_config = OmniDiffusionConfig(
+            model="test",
+            model_class_name="OvisImagePipeline",
+            tf_model_config=TransformerConfig(num_layers=1, num_single_layers=0),
+        )
+
+        model = OvisImageTransformer2DModel(
+            od_config=od_config,
+            num_layers=1,
+            num_single_layers=0,
+            attention_head_dim=64,
+            num_attention_heads=8,
+            quant_config=None,
+        )
+
+        # Load weights with invalid names
+        invalid_weights = [("invalid.weight", torch.randn(10, 10))]
+        loaded_params = model.load_weights(invalid_weights)
+
+        assert len(loaded_params) == 0, "Should not load invalid weights"
+
+
+class TestOvisImageRopePositionEmbedding:
+    """Test Ovis-Image RoPE position embedding functionality."""
+
+    pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+    def test_rope_position_embedding(self):
+        """Verify RoPE produces correct embeddings for 3D coordinates."""
+        # Ovis-Image default: axes_dims_rope = (16, 56, 56)
+        axes_dims = (16, 56, 56)
+        rope_theta = 10000
+        pos_embed = OvisImagePosEmbed(theta=rope_theta, axes_dim=axes_dims)
+
+        seq_len = 10
+        ids = torch.randint(0, 100, (seq_len, 3))
+
+        freqs_cos, freqs_sin = pos_embed(ids)
+
+        # Expected dimension: sum(axes_dims) // 2
+        expected_dim = sum(axes_dims) // 2  # 128/2 = 64
+        assert freqs_cos.shape == (seq_len, expected_dim)
+        assert freqs_sin.shape == (seq_len, expected_dim)
+
+        # Verify value range
+        assert torch.all(freqs_cos >= -1) and torch.all(freqs_cos <= 1)
+        assert torch.all(freqs_sin >= -1) and torch.all(freqs_sin <= 1)
+
+        # Verify trigonometric relationship
+        cos_sq_sin_sq = freqs_cos**2 + freqs_sin**2
+        assert torch.allclose(cos_sq_sin_sq, torch.ones_like(cos_sq_sin_sq), atol=1e-6)
+
+    def test_rope_different_positions(self):
+        """Verify different positions produce different embeddings."""
+        axes_dims = (16, 56, 56)
+        pos_embed = OvisImagePosEmbed(theta=10000, axes_dim=axes_dims)
+
+        ids1 = torch.randint(0, 100, (10, 3))
+        ids2 = torch.randint(0, 100, (10, 3))
+
+        freqs_cos1, _ = pos_embed(ids1)
+        freqs_cos2, _ = pos_embed(ids2)
+
+        assert not torch.allclose(freqs_cos1, freqs_cos2)
+
+    def test_rope_same_positions(self):
+        """Verify same positions produce same embeddings."""
+        axes_dims = (16, 56, 56)
+        pos_embed = OvisImagePosEmbed(theta=10000, axes_dim=axes_dims)
+
+        ids = torch.randint(0, 100, (10, 3))
+
+        freqs_cos1, freqs_sin1 = pos_embed(ids)
+        freqs_cos2, freqs_sin2 = pos_embed(ids.clone())
+
+        assert torch.allclose(freqs_cos1, freqs_cos2)
+        assert torch.allclose(freqs_sin1, freqs_sin2)
+
+
+class TestOvisImageForwardShape:
+    """Test Ovis-Image forward pass shape consistency."""
+
+    @pytest.mark.core_model
+    @hardware_test(res={"cuda": "L4"}, num_cards=1)
+    def test_forward_shape_consistency(self, mocker: MockerFixture, setup_tp1):
+        """Verify forward pass produces correct shapes."""
+        mocker.patch(
+            "vllm.distributed.get_tensor_model_parallel_world_size",
+            return_value=1,
+        )
+        mocker.patch(
+            "vllm.distributed.get_tensor_model_parallel_rank",
+            return_value=0,
+        )
+
+        od_config = OmniDiffusionConfig(
+            model="test",
+            model_class_name="OvisImagePipeline",
+            tf_model_config=TransformerConfig(num_layers=1, num_single_layers=1),
+        )
+
+        model = OvisImageTransformer2DModel(
+            od_config=od_config,
+            num_layers=1,
+            num_single_layers=1,
+            attention_head_dim=64,
+            num_attention_heads=8,
+            quant_config=None,
+        )
+
+        inner_dim = 8 * 64
+
+        # Create dummy inputs
+        batch_size = 1
+        seq_len = 16
+        encoder_seq_len = 8
+
+        hidden_states = torch.randn(batch_size, seq_len, inner_dim)
+        encoder_hidden_states = torch.randn(batch_size, encoder_seq_len, 2048)
+        temb = torch.randn(batch_size, inner_dim)
+
+        output = model(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            temb=temb,
+        )
+
+        assert output.sample.shape == hidden_states.shape

--- a/vllm_omni/diffusion/models/ovis_image/ovis_image_transformer.py
+++ b/vllm_omni/diffusion/models/ovis_image/ovis_image_transformer.py
@@ -16,23 +16,30 @@
 # limitations under the License.
 
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 import torch
 import torch.nn as nn
-from diffusers.models.attention import FeedForward
-from diffusers.models.embeddings import TimestepEmbedding, Timesteps, get_1d_rotary_pos_embed, CombinedTimestepLabelEmbeddings
+from diffusers.models.embeddings import (
+    CombinedTimestepLabelEmbeddings,
+    TimestepEmbedding,
+    Timesteps,
+    get_1d_rotary_pos_embed,
+)
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 from diffusers.models.normalization import AdaLayerNormContinuous, AdaLayerNormZeroSingle
 from diffusers.utils import is_torch_npu_available
+from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import QKVParallelLinear, ReplicatedLinear, RowParallelLinear, ColumnParallelLinear, MergedColumnParallelLinear
-from vllm.model_executor.model_loader.weight_utils import default_weight_loader
-from vllm.distributed import (
-    get_tensor_model_parallel_world_size,
-    get_tensor_model_parallel_rank
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
 )
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
@@ -49,7 +56,7 @@ class AdaLayerNormZero(nn.Module):
         num_embeddings (`int`): The size of the embeddings dictionary.
     """
 
-    def __init__(self, embedding_dim: int, num_embeddings: Optional[int] = None, norm_type="layer_norm", bias=True):
+    def __init__(self, embedding_dim: int, num_embeddings: int | None = None, norm_type="layer_norm", bias=True):
         super().__init__()
         if num_embeddings is not None:
             self.emb = CombinedTimestepLabelEmbeddings(num_embeddings, embedding_dim)
@@ -57,11 +64,7 @@ class AdaLayerNormZero(nn.Module):
             self.emb = None
 
         self.silu = nn.SiLU()
-        self.linear = ReplicatedLinear(
-            embedding_dim, 
-            6 * embedding_dim, 
-            bias=bias
-        )
+        self.linear = ReplicatedLinear(embedding_dim, 6 * embedding_dim, bias=bias)
         if norm_type == "layer_norm":
             self.norm = nn.LayerNorm(embedding_dim, elementwise_affine=False, eps=1e-6)
         else:
@@ -70,21 +73,21 @@ class AdaLayerNormZero(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        timestep: Optional[torch.Tensor] = None,
-        class_labels: Optional[torch.LongTensor] = None,
-        hidden_dtype: Optional[torch.dtype] = None,
-        emb: Optional[torch.Tensor] = None,
+        timestep: torch.Tensor | None = None,
+        class_labels: torch.LongTensor | None = None,
+        hidden_dtype: torch.dtype | None = None,
+        emb: torch.Tensor | None = None,
     ):
         if self.emb is not None:
             emb = self.emb(timestep, class_labels, hidden_dtype=hidden_dtype)
-        
+
         emb, _ = self.linear(self.silu(emb))
-        
+
         chunks = emb.chunk(6, dim=1)
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = chunks
 
         x = self.norm(x) * (1 + scale_msa.unsqueeze(1)) + shift_msa.unsqueeze(1)
-        
+
         return x, gate_msa, shift_mlp, scale_mlp, gate_mlp
 
 
@@ -127,7 +130,7 @@ class FeedForward(nn.Module):
         self.net.append(act_fn)
         self.net.append(nn.Dropout(dropout))
         self.net.append(RowParallelLinear(inner_dim, dim_out, bias=bias))
-        
+
         if final_dropout:
             self.net.append(nn.Dropout(dropout))
 
@@ -198,10 +201,7 @@ class OvisImageAttention(nn.Module):
             )
 
             self.to_add_out = RowParallelLinear(
-                input_size=self.inner_dim,
-                output_size=query_dim, 
-                bias=out_bias,
-                input_is_parallel=True 
+                input_size=self.inner_dim, output_size=query_dim, bias=out_bias, input_is_parallel=True
             )
 
         self.rope = RotaryEmbedding(is_neox_style=False)
@@ -220,13 +220,11 @@ class OvisImageAttention(nn.Module):
         **kwargs,
     ) -> torch.Tensor:
         qkv, _ = self.to_qkv(hidden_states)
-        
+
         local_num_heads = self.to_qkv.num_heads
         head_dim = self.head_dim
-        
-        # vLLM QKV format is contiguous [Q, K, V]
         query, key, value = qkv.chunk(3, dim=-1)
-        
+
         query = query.unflatten(-1, (local_num_heads, head_dim))
         key = key.unflatten(-1, (local_num_heads, head_dim))
         value = value.unflatten(-1, (local_num_heads, head_dim))
@@ -236,13 +234,12 @@ class OvisImageAttention(nn.Module):
 
         if self.added_kv_proj_dim is not None:
             encoder_qkv, _ = self.add_kv_proj(encoder_hidden_states)
-            
             encoder_query, encoder_key, encoder_value = encoder_qkv.chunk(3, dim=-1)
-            
+
             encoder_query = encoder_query.unflatten(-1, (local_num_heads, head_dim))
             encoder_key = encoder_key.unflatten(-1, (local_num_heads, head_dim))
             encoder_value = encoder_value.unflatten(-1, (local_num_heads, head_dim))
-            
+
             encoder_query = self.norm_added_q(encoder_query)
             encoder_key = self.norm_added_k(encoder_key)
 
@@ -251,14 +248,18 @@ class OvisImageAttention(nn.Module):
             value = torch.cat([encoder_value, value], dim=1)
 
         if image_rotary_emb is not None:
-            cos, sin = image_rotary_emb
+            cos, sin = image_rotary_emb  # [S, D/2]
             cos = cos.to(query.dtype)
             sin = sin.to(query.dtype)
             query = self.rope(query, cos, sin)
             key = self.rope(key, cos, sin)
 
-        hidden_states = self.attn(query, key, value)
-        hidden_states = hidden_states.flatten(2, 3) 
+        hidden_states = self.attn(
+            query,
+            key,
+            value,
+        )
+        hidden_states = hidden_states.flatten(2, 3)
 
         if encoder_hidden_states is not None:
             enc_len = encoder_hidden_states.shape[1]
@@ -266,10 +267,8 @@ class OvisImageAttention(nn.Module):
                 hidden_states[:, :enc_len],
                 hidden_states[:, enc_len:],
             )
-            
             hidden_states, _ = self.to_out[0](hidden_states)
             hidden_states = self.to_out[1](hidden_states)
-            
             encoder_hidden_states, _ = self.to_add_out(encoder_hidden_states)
 
             return hidden_states, encoder_hidden_states
@@ -305,9 +304,8 @@ class OvisImageSingleTransformerBlock(nn.Module):
         image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
         joint_attention_kwargs: dict[str, Any] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        
         text_seq_len = encoder_hidden_states.shape[1]
-        
+
         combined_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
         residual = combined_states
 
@@ -330,14 +328,11 @@ class OvisImageSingleTransformerBlock(nn.Module):
         proj_output = gate.unsqueeze(1) * proj_output
 
         hidden_states = residual + proj_output
-        
+
         if hidden_states.dtype == torch.float16:
             hidden_states = hidden_states.clip(-65504, 65504)
 
-        encoder_hidden_states, hidden_states = (
-            hidden_states[:, :text_seq_len],
-            hidden_states[:, text_seq_len:],
-        )
+        encoder_hidden_states, hidden_states = hidden_states[:, :text_seq_len], hidden_states[:, text_seq_len:]
         return encoder_hidden_states, hidden_states
 
 
@@ -380,13 +375,13 @@ class OvisImageTransformerBlock(nn.Module):
         image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
         joint_attention_kwargs: dict[str, Any] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-
         norm_hidden_states, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.norm1(hidden_states, emb=temb)
         norm_encoder_hidden_states, c_gate_msa, c_shift_mlp, c_scale_mlp, c_gate_mlp = self.norm1_context(
             encoder_hidden_states, emb=temb
         )
         joint_attention_kwargs = joint_attention_kwargs or {}
 
+        # Attention.
         attention_outputs = self.attn(
             hidden_states=norm_hidden_states,
             encoder_hidden_states=norm_encoder_hidden_states,
@@ -399,6 +394,7 @@ class OvisImageTransformerBlock(nn.Module):
         elif len(attention_outputs) == 3:
             attn_output, context_attn_output, ip_attn_output = attention_outputs
 
+        # Process attention outputs for the `hidden_states`.
         attn_output = gate_msa.unsqueeze(1) * attn_output
         hidden_states = hidden_states + attn_output
 
@@ -412,6 +408,7 @@ class OvisImageTransformerBlock(nn.Module):
         if len(attention_outputs) == 3:
             hidden_states = hidden_states + ip_attn_output
 
+        # Process attention outputs for the `encoder_hidden_states`.
         context_attn_output = c_gate_msa.unsqueeze(1) * context_attn_output
         encoder_hidden_states = encoder_hidden_states + context_attn_output
 
@@ -505,7 +502,6 @@ class OvisImageTransformer2DModel(nn.Module):
         self.in_channels = in_channels
         self.out_channels = out_channels or in_channels
         self.inner_dim = num_attention_heads * attention_head_dim
-        
         self.pos_embed = OvisImagePosEmbed(theta=10000, axes_dim=axes_dims_rope)
 
         self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0)
@@ -537,7 +533,9 @@ class OvisImageTransformer2DModel(nn.Module):
             ]
         )
         self.norm_out = AdaLayerNormContinuous(self.inner_dim, self.inner_dim, elementwise_affine=False, eps=1e-6)
-        self.proj_out = RowParallelLinear(self.inner_dim, patch_size * patch_size * self.out_channels, bias=True, input_is_parallel=False)
+        self.proj_out = RowParallelLinear(
+            self.inner_dim, patch_size * patch_size * self.out_channels, bias=True, input_is_parallel=False
+        )
 
     def forward(
         self,
@@ -570,6 +568,7 @@ class OvisImageTransformer2DModel(nn.Module):
             If `return_dict` is True, an [`~models.transformer_2d.Transformer2DModelOutput`] is returned, otherwise a
             `tuple` where the first element is the sample tensor.
         """
+
         hidden_states, _ = self.x_embedder(hidden_states)
         timestep = timestep.to(device=hidden_states.device, dtype=hidden_states.dtype) * 1000
 
@@ -578,7 +577,6 @@ class OvisImageTransformer2DModel(nn.Module):
 
         encoder_hidden_states = self.context_embedder_norm(encoder_hidden_states)
         encoder_hidden_states, _ = self.context_embedder(encoder_hidden_states)
-        
         if txt_ids.ndim == 3:
             logger.warning(
                 "Passing `txt_ids` 3d torch.Tensor is deprecated."
@@ -644,7 +642,6 @@ class OvisImageTransformer2DModel(nn.Module):
         tp_rank = get_tensor_model_parallel_rank()
 
         for name, loaded_weight in weights:
-            
             # 1. Single Block proj_out (RowParallelLinear) weight restructuring
             if "single_transformer_blocks" in name and "proj_out.weight" in name:
                 if tp_size > 1:
@@ -652,7 +649,7 @@ class OvisImageTransformer2DModel(nn.Module):
                     w_attn_local = w_attn.chunk(tp_size, dim=1)[tp_rank]
                     w_mlp_local = w_mlp.chunk(tp_size, dim=1)[tp_rank]
                     local_weight = torch.cat([w_attn_local, w_mlp_local], dim=1)
-                    
+
                     if name in params_dict:
                         params_dict[name].data.copy_(local_weight)
                         loaded_params.add(name)
@@ -665,19 +662,19 @@ class OvisImageTransformer2DModel(nn.Module):
                     w_h_local = w_hidden.chunk(tp_size, dim=0)[tp_rank]
                     w_g_local = w_gate.chunk(tp_size, dim=0)[tp_rank]
                     local_weight = torch.cat([w_h_local, w_g_local], dim=0)
-                    
+
                     if name in params_dict:
                         params_dict[name].data.copy_(local_weight)
                         loaded_params.add(name)
                     continue
-                    
+
             if ("net.0.proj.bias" in name) or ("proj_mlp.bias" in name):
                 if tp_size > 1:
                     b_hidden, b_gate = loaded_weight.chunk(2, dim=0)
                     b_h_local = b_hidden.chunk(tp_size, dim=0)[tp_rank]
                     b_g_local = b_gate.chunk(tp_size, dim=0)[tp_rank]
                     local_bias = torch.cat([b_h_local, b_g_local], dim=0)
-                    
+
                     if name in params_dict:
                         params_dict[name].data.copy_(local_bias)
                         loaded_params.add(name)
@@ -700,10 +697,9 @@ class OvisImageTransformer2DModel(nn.Module):
             # 4. Standard parameter loading
             if name not in params_dict:
                 continue
-            
+
             param = params_dict[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
             loaded_params.add(name)
-
         return loaded_params

--- a/vllm_omni/diffusion/models/ovis_image/ovis_image_transformer.py
+++ b/vllm_omni/diffusion/models/ovis_image/ovis_image_transformer.py
@@ -98,6 +98,7 @@ class SwiGLU(nn.Module):
         self.activation = nn.SiLU()
 
     def forward(self, hidden_states):
+        # Weight layout: [hidden_local, gate_local] interleaved within each TP shard
         hidden_states, _ = self.proj(hidden_states)
         hidden_states, gate = hidden_states.chunk(2, dim=-1)
         out = hidden_states * self.activation(gate)
@@ -260,7 +261,7 @@ class OvisImageAttention(nn.Module):
             value,
         )
         hidden_states = hidden_states.flatten(2, 3)
-
+        hidden_states = hidden_states.to(query.dtype)
         if encoder_hidden_states is not None:
             enc_len = encoder_hidden_states.shape[1]
             encoder_hidden_states, hidden_states = (
@@ -508,8 +509,8 @@ class OvisImageTransformer2DModel(nn.Module):
         self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=self.inner_dim)
 
         self.context_embedder_norm = RMSNorm(joint_attention_dim, eps=1e-6)
-        self.context_embedder = ColumnParallelLinear(joint_attention_dim, self.inner_dim, bias=True, gather_output=True)
-        self.x_embedder = ColumnParallelLinear(in_channels, self.inner_dim, bias=True, gather_output=True)
+        self.context_embedder = nn.Linear(joint_attention_dim, self.inner_dim)
+        self.x_embedder = nn.Linear(in_channels, self.inner_dim)
 
         self.transformer_blocks = nn.ModuleList(
             [
@@ -533,9 +534,7 @@ class OvisImageTransformer2DModel(nn.Module):
             ]
         )
         self.norm_out = AdaLayerNormContinuous(self.inner_dim, self.inner_dim, elementwise_affine=False, eps=1e-6)
-        self.proj_out = RowParallelLinear(
-            self.inner_dim, patch_size * patch_size * self.out_channels, bias=True, input_is_parallel=False
-        )
+        self.proj_out = nn.Linear(self.inner_dim, patch_size * patch_size * self.out_channels, bias=True)
 
     def forward(
         self,
@@ -569,14 +568,14 @@ class OvisImageTransformer2DModel(nn.Module):
             `tuple` where the first element is the sample tensor.
         """
 
-        hidden_states, _ = self.x_embedder(hidden_states)
+        hidden_states = self.x_embedder(hidden_states)
         timestep = timestep.to(device=hidden_states.device, dtype=hidden_states.dtype) * 1000
 
         timesteps_proj = self.time_proj(timestep)
         temb = self.timestep_embedder(timesteps_proj.to(device=hidden_states.device, dtype=hidden_states.dtype))
 
         encoder_hidden_states = self.context_embedder_norm(encoder_hidden_states)
-        encoder_hidden_states, _ = self.context_embedder(encoder_hidden_states)
+        encoder_hidden_states = self.context_embedder(encoder_hidden_states)
         if txt_ids.ndim == 3:
             logger.warning(
                 "Passing `txt_ids` 3d torch.Tensor is deprecated."
@@ -614,7 +613,7 @@ class OvisImageTransformer2DModel(nn.Module):
             )
 
         hidden_states = self.norm_out(hidden_states, temb)
-        output, _ = self.proj_out(hidden_states)
+        output = self.proj_out(hidden_states)
 
         if not return_dict:
             return (output,)
@@ -636,6 +635,12 @@ class OvisImageTransformer2DModel(nn.Module):
         self.stacked_params_mapping = stacked_params_mapping
 
         params_dict = dict(self.named_parameters())
+
+        # we need to load the buffers for beta and eps (XIELU)
+        for name, buffer in self.named_buffers():
+            if name.endswith(".beta") or name.endswith(".eps"):
+                params_dict[name] = buffer
+
         loaded_params: set[str] = set()
 
         tp_size = get_tensor_model_parallel_world_size()
@@ -696,6 +701,7 @@ class OvisImageTransformer2DModel(nn.Module):
 
             # 4. Standard parameter loading
             if name not in params_dict:
+                logger.warning("Unexpected parameter in checkpoint: %s", name)
                 continue
 
             param = params_dict[name]

--- a/vllm_omni/diffusion/models/ovis_image/ovis_image_transformer.py
+++ b/vllm_omni/diffusion/models/ovis_image/ovis_image_transformer.py
@@ -16,25 +16,129 @@
 # limitations under the License.
 
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Optional
 
 import torch
 import torch.nn as nn
 from diffusers.models.attention import FeedForward
-from diffusers.models.embeddings import TimestepEmbedding, Timesteps, get_1d_rotary_pos_embed
+from diffusers.models.embeddings import TimestepEmbedding, Timesteps, get_1d_rotary_pos_embed, CombinedTimestepLabelEmbeddings
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
-from diffusers.models.normalization import AdaLayerNormContinuous, AdaLayerNormZero, AdaLayerNormZeroSingle
+from diffusers.models.normalization import AdaLayerNormContinuous, AdaLayerNormZeroSingle
 from diffusers.utils import is_torch_npu_available
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import QKVParallelLinear, ReplicatedLinear
+from vllm.model_executor.layers.linear import QKVParallelLinear, ReplicatedLinear, RowParallelLinear, ColumnParallelLinear, MergedColumnParallelLinear
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
-
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    get_tensor_model_parallel_rank
+)
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
 
 logger = init_logger(__name__)
+
+
+class AdaLayerNormZero(nn.Module):
+    r"""
+    Norm layer adaptive layer norm zero (adaLN-Zero).
+
+    Parameters:
+        embedding_dim (`int`): The size of each embedding vector.
+        num_embeddings (`int`): The size of the embeddings dictionary.
+    """
+
+    def __init__(self, embedding_dim: int, num_embeddings: Optional[int] = None, norm_type="layer_norm", bias=True):
+        super().__init__()
+        if num_embeddings is not None:
+            self.emb = CombinedTimestepLabelEmbeddings(num_embeddings, embedding_dim)
+        else:
+            self.emb = None
+
+        self.silu = nn.SiLU()
+        self.linear = ReplicatedLinear(
+            embedding_dim, 
+            6 * embedding_dim, 
+            bias=bias
+        )
+        if norm_type == "layer_norm":
+            self.norm = nn.LayerNorm(embedding_dim, elementwise_affine=False, eps=1e-6)
+        else:
+            raise ValueError(f"Unsupported `norm_type` ({norm_type})")
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        timestep: Optional[torch.Tensor] = None,
+        class_labels: Optional[torch.LongTensor] = None,
+        hidden_dtype: Optional[torch.dtype] = None,
+        emb: Optional[torch.Tensor] = None,
+    ):
+        if self.emb is not None:
+            emb = self.emb(timestep, class_labels, hidden_dtype=hidden_dtype)
+        
+        emb, _ = self.linear(self.silu(emb))
+        
+        chunks = emb.chunk(6, dim=1)
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = chunks
+
+        x = self.norm(x) * (1 + scale_msa.unsqueeze(1)) + shift_msa.unsqueeze(1)
+        
+        return x, gate_msa, shift_mlp, scale_mlp, gate_mlp
+
+
+class SwiGLU(nn.Module):
+    def __init__(self, dim_in: int, inner_dim: int, bias: bool = True):
+        super().__init__()
+        self.proj = ColumnParallelLinear(dim_in, inner_dim * 2, bias=bias, gather_output=False)
+        self.activation = nn.SiLU()
+
+    def forward(self, hidden_states):
+        hidden_states, _ = self.proj(hidden_states)
+        hidden_states, gate = hidden_states.chunk(2, dim=-1)
+        out = hidden_states * self.activation(gate)
+        return out
+
+
+class FeedForward(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        dim_out: int | None = None,
+        mult: int = 4,
+        dropout: float = 0.0,
+        activation_fn: str = "swiglu",
+        final_dropout: bool = False,
+        inner_dim=None,
+        bias: bool = True,
+    ):
+        super().__init__()
+        if inner_dim is None:
+            inner_dim = int(dim * mult)
+        dim_out = dim_out if dim_out is not None else dim
+
+        if activation_fn == "swiglu":
+            act_fn = SwiGLU(dim, inner_dim, bias=bias)
+        else:
+            raise ValueError(f"Unsupported activation function type: {activation_fn}")
+
+        self.net = nn.ModuleList([])
+        self.net.append(act_fn)
+        self.net.append(nn.Dropout(dropout))
+        self.net.append(RowParallelLinear(inner_dim, dim_out, bias=bias))
+        
+        if final_dropout:
+            self.net.append(nn.Dropout(dropout))
+
+    def forward(self, hidden_states: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        for layer in self.net:
+            output = layer(hidden_states)
+            if isinstance(output, tuple):
+                hidden_states = output[0]
+            else:
+                hidden_states = output
+        return hidden_states
 
 
 class OvisImageAttention(nn.Module):
@@ -63,7 +167,7 @@ class OvisImageAttention(nn.Module):
         self.out_dim = out_dim if out_dim is not None else query_dim
         self.context_pre_only = context_pre_only
         self.pre_only = pre_only
-        self.heads = out_dim // dim_head if out_dim is not None else heads
+        self.heads = heads
         self.added_kv_proj_dim = added_kv_proj_dim
         self.added_proj_bias = added_proj_bias
 
@@ -74,13 +178,12 @@ class OvisImageAttention(nn.Module):
             hidden_size=query_dim,
             head_size=self.head_dim,
             total_num_heads=self.heads,
-            disable_tp=True,
             bias=bias,
         )
 
         if not self.pre_only:
             self.to_out = nn.ModuleList([])
-            self.to_out.append(torch.nn.Linear(self.inner_dim, self.out_dim, bias=out_bias))
+            self.to_out.append(RowParallelLinear(self.inner_dim, self.out_dim, bias=out_bias, input_is_parallel=True))
             self.to_out.append(nn.Dropout(dropout))
 
         if self.added_kv_proj_dim is not None:
@@ -91,15 +194,19 @@ class OvisImageAttention(nn.Module):
                 hidden_size=self.added_kv_proj_dim,
                 head_size=self.head_dim,
                 total_num_heads=self.heads,
-                disable_tp=True,
                 bias=added_proj_bias,
             )
 
-            self.to_add_out = ReplicatedLinear(self.inner_dim, query_dim, bias=out_bias)
+            self.to_add_out = RowParallelLinear(
+                input_size=self.inner_dim,
+                output_size=query_dim, 
+                bias=out_bias,
+                input_is_parallel=True 
+            )
 
         self.rope = RotaryEmbedding(is_neox_style=False)
         self.attn = Attention(
-            num_heads=heads,
+            num_heads=self.to_qkv.num_heads,
             head_size=self.head_dim,
             softmax_scale=1.0 / (self.head_dim**0.5),
             causal=False,
@@ -113,24 +220,29 @@ class OvisImageAttention(nn.Module):
         **kwargs,
     ) -> torch.Tensor:
         qkv, _ = self.to_qkv(hidden_states)
-
+        
+        local_num_heads = self.to_qkv.num_heads
+        head_dim = self.head_dim
+        
+        # vLLM QKV format is contiguous [Q, K, V]
         query, key, value = qkv.chunk(3, dim=-1)
-
-        query = query.unflatten(-1, (self.heads, -1))
-        key = key.unflatten(-1, (self.heads, -1))
-        value = value.unflatten(-1, (self.heads, -1))
+        
+        query = query.unflatten(-1, (local_num_heads, head_dim))
+        key = key.unflatten(-1, (local_num_heads, head_dim))
+        value = value.unflatten(-1, (local_num_heads, head_dim))
 
         query = self.norm_q(query)
         key = self.norm_k(key)
 
         if self.added_kv_proj_dim is not None:
             encoder_qkv, _ = self.add_kv_proj(encoder_hidden_states)
+            
             encoder_query, encoder_key, encoder_value = encoder_qkv.chunk(3, dim=-1)
-
-            encoder_query = encoder_query.unflatten(-1, (self.heads, -1))
-            encoder_key = encoder_key.unflatten(-1, (self.heads, -1))
-            encoder_value = encoder_value.unflatten(-1, (self.heads, -1))
-
+            
+            encoder_query = encoder_query.unflatten(-1, (local_num_heads, head_dim))
+            encoder_key = encoder_key.unflatten(-1, (local_num_heads, head_dim))
+            encoder_value = encoder_value.unflatten(-1, (local_num_heads, head_dim))
+            
             encoder_query = self.norm_added_q(encoder_query)
             encoder_key = self.norm_added_k(encoder_key)
 
@@ -139,26 +251,25 @@ class OvisImageAttention(nn.Module):
             value = torch.cat([encoder_value, value], dim=1)
 
         if image_rotary_emb is not None:
-            cos, sin = image_rotary_emb  # [S, D/2]
+            cos, sin = image_rotary_emb
             cos = cos.to(query.dtype)
             sin = sin.to(query.dtype)
             query = self.rope(query, cos, sin)
             key = self.rope(key, cos, sin)
 
-        hidden_states = self.attn(
-            query,
-            key,
-            value,
-        )
-        hidden_states = hidden_states.flatten(2, 3)
-        hidden_states = hidden_states.to(query.dtype)
+        hidden_states = self.attn(query, key, value)
+        hidden_states = hidden_states.flatten(2, 3) 
 
         if encoder_hidden_states is not None:
-            encoder_hidden_states, hidden_states = hidden_states.split_with_sizes(
-                [encoder_hidden_states.shape[1], hidden_states.shape[1] - encoder_hidden_states.shape[1]], dim=1
+            enc_len = encoder_hidden_states.shape[1]
+            encoder_hidden_states, hidden_states = (
+                hidden_states[:, :enc_len],
+                hidden_states[:, enc_len:],
             )
-            hidden_states = self.to_out[0](hidden_states)
+            
+            hidden_states, _ = self.to_out[0](hidden_states)
             hidden_states = self.to_out[1](hidden_states)
+            
             encoder_hidden_states, _ = self.to_add_out(encoder_hidden_states)
 
             return hidden_states, encoder_hidden_states
@@ -172,9 +283,9 @@ class OvisImageSingleTransformerBlock(nn.Module):
         self.mlp_hidden_dim = int(dim * mlp_ratio)
 
         self.norm = AdaLayerNormZeroSingle(dim)
-        self.proj_mlp = nn.Linear(dim, self.mlp_hidden_dim * 2)
+        self.proj_mlp = ColumnParallelLinear(dim, self.mlp_hidden_dim * 2, bias=True, gather_output=False)
         self.act_mlp = nn.SiLU()
-        self.proj_out = nn.Linear(dim + self.mlp_hidden_dim, dim)
+        self.proj_out = RowParallelLinear(dim + self.mlp_hidden_dim, dim, bias=True, input_is_parallel=True)
 
         self.attn = OvisImageAttention(
             query_dim=dim,
@@ -194,15 +305,18 @@ class OvisImageSingleTransformerBlock(nn.Module):
         image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
         joint_attention_kwargs: dict[str, Any] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        
         text_seq_len = encoder_hidden_states.shape[1]
-        hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
+        
+        combined_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
+        residual = combined_states
 
-        residual = hidden_states
-        norm_hidden_states, gate = self.norm(hidden_states, emb=temb)
-        mlp_hidden_states, mlp_hidden_gate = torch.split(
-            self.proj_mlp(norm_hidden_states), [self.mlp_hidden_dim, self.mlp_hidden_dim], dim=-1
-        )
-        mlp_hidden_states = self.act_mlp(mlp_hidden_gate) * mlp_hidden_states
+        norm_hidden_states, gate = self.norm(combined_states, emb=temb)
+
+        proj_mlp_output, _ = self.proj_mlp(norm_hidden_states)
+        mlp_hidden, mlp_gate = proj_mlp_output.chunk(2, dim=-1)
+        mlp_hidden_states = self.act_mlp(mlp_gate) * mlp_hidden
+
         joint_attention_kwargs = joint_attention_kwargs or {}
         attn_output = self.attn(
             hidden_states=norm_hidden_states,
@@ -210,14 +324,20 @@ class OvisImageSingleTransformerBlock(nn.Module):
             **joint_attention_kwargs,
         )
 
-        hidden_states = torch.cat([attn_output, mlp_hidden_states], dim=2)
-        gate = gate.unsqueeze(1)
-        hidden_states = gate * self.proj_out(hidden_states)
-        hidden_states = residual + hidden_states
+        combined_features = torch.cat([attn_output, mlp_hidden_states], dim=-1)
+        proj_output, _ = self.proj_out(combined_features)
+
+        proj_output = gate.unsqueeze(1) * proj_output
+
+        hidden_states = residual + proj_output
+        
         if hidden_states.dtype == torch.float16:
             hidden_states = hidden_states.clip(-65504, 65504)
 
-        encoder_hidden_states, hidden_states = hidden_states[:, :text_seq_len], hidden_states[:, text_seq_len:]
+        encoder_hidden_states, hidden_states = (
+            hidden_states[:, :text_seq_len],
+            hidden_states[:, text_seq_len:],
+        )
         return encoder_hidden_states, hidden_states
 
 
@@ -260,13 +380,13 @@ class OvisImageTransformerBlock(nn.Module):
         image_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
         joint_attention_kwargs: dict[str, Any] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+
         norm_hidden_states, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.norm1(hidden_states, emb=temb)
         norm_encoder_hidden_states, c_gate_msa, c_shift_mlp, c_scale_mlp, c_gate_mlp = self.norm1_context(
             encoder_hidden_states, emb=temb
         )
         joint_attention_kwargs = joint_attention_kwargs or {}
 
-        # Attention.
         attention_outputs = self.attn(
             hidden_states=norm_hidden_states,
             encoder_hidden_states=norm_encoder_hidden_states,
@@ -279,7 +399,6 @@ class OvisImageTransformerBlock(nn.Module):
         elif len(attention_outputs) == 3:
             attn_output, context_attn_output, ip_attn_output = attention_outputs
 
-        # Process attention outputs for the `hidden_states`.
         attn_output = gate_msa.unsqueeze(1) * attn_output
         hidden_states = hidden_states + attn_output
 
@@ -293,7 +412,6 @@ class OvisImageTransformerBlock(nn.Module):
         if len(attention_outputs) == 3:
             hidden_states = hidden_states + ip_attn_output
 
-        # Process attention outputs for the `encoder_hidden_states`.
         context_attn_output = c_gate_msa.unsqueeze(1) * context_attn_output
         encoder_hidden_states = encoder_hidden_states + context_attn_output
 
@@ -387,14 +505,15 @@ class OvisImageTransformer2DModel(nn.Module):
         self.in_channels = in_channels
         self.out_channels = out_channels or in_channels
         self.inner_dim = num_attention_heads * attention_head_dim
+        
         self.pos_embed = OvisImagePosEmbed(theta=10000, axes_dim=axes_dims_rope)
 
         self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0)
         self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=self.inner_dim)
 
         self.context_embedder_norm = RMSNorm(joint_attention_dim, eps=1e-6)
-        self.context_embedder = nn.Linear(joint_attention_dim, self.inner_dim)
-        self.x_embedder = nn.Linear(in_channels, self.inner_dim)
+        self.context_embedder = ColumnParallelLinear(joint_attention_dim, self.inner_dim, bias=True, gather_output=True)
+        self.x_embedder = ColumnParallelLinear(in_channels, self.inner_dim, bias=True, gather_output=True)
 
         self.transformer_blocks = nn.ModuleList(
             [
@@ -418,7 +537,7 @@ class OvisImageTransformer2DModel(nn.Module):
             ]
         )
         self.norm_out = AdaLayerNormContinuous(self.inner_dim, self.inner_dim, elementwise_affine=False, eps=1e-6)
-        self.proj_out = nn.Linear(self.inner_dim, patch_size * patch_size * self.out_channels, bias=True)
+        self.proj_out = RowParallelLinear(self.inner_dim, patch_size * patch_size * self.out_channels, bias=True, input_is_parallel=False)
 
     def forward(
         self,
@@ -451,15 +570,15 @@ class OvisImageTransformer2DModel(nn.Module):
             If `return_dict` is True, an [`~models.transformer_2d.Transformer2DModelOutput`] is returned, otherwise a
             `tuple` where the first element is the sample tensor.
         """
-
-        hidden_states = self.x_embedder(hidden_states)
+        hidden_states, _ = self.x_embedder(hidden_states)
         timestep = timestep.to(device=hidden_states.device, dtype=hidden_states.dtype) * 1000
 
         timesteps_proj = self.time_proj(timestep)
         temb = self.timestep_embedder(timesteps_proj.to(device=hidden_states.device, dtype=hidden_states.dtype))
 
         encoder_hidden_states = self.context_embedder_norm(encoder_hidden_states)
-        encoder_hidden_states = self.context_embedder(encoder_hidden_states)
+        encoder_hidden_states, _ = self.context_embedder(encoder_hidden_states)
+        
         if txt_ids.ndim == 3:
             logger.warning(
                 "Passing `txt_ids` 3d torch.Tensor is deprecated."
@@ -497,7 +616,7 @@ class OvisImageTransformer2DModel(nn.Module):
             )
 
         hidden_states = self.norm_out(hidden_states, temb)
-        output = self.proj_out(hidden_states)
+        output, _ = self.proj_out(hidden_states)
 
         if not return_dict:
             return (output,)
@@ -519,25 +638,72 @@ class OvisImageTransformer2DModel(nn.Module):
         self.stacked_params_mapping = stacked_params_mapping
 
         params_dict = dict(self.named_parameters())
-
-        # we need to load the buffers for beta and eps (XIELU)
-        for name, buffer in self.named_buffers():
-            if name.endswith(".beta") or name.endswith(".eps"):
-                params_dict[name] = buffer
-
         loaded_params: set[str] = set()
+
+        tp_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
+
         for name, loaded_weight in weights:
-            for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in name:
+            
+            # 1. Single Block proj_out (RowParallelLinear) weight restructuring
+            if "single_transformer_blocks" in name and "proj_out.weight" in name:
+                if tp_size > 1:
+                    w_attn, w_mlp = loaded_weight.split([self.inner_dim, self.inner_dim * 4], dim=1)
+                    w_attn_local = w_attn.chunk(tp_size, dim=1)[tp_rank]
+                    w_mlp_local = w_mlp.chunk(tp_size, dim=1)[tp_rank]
+                    local_weight = torch.cat([w_attn_local, w_mlp_local], dim=1)
+                    
+                    if name in params_dict:
+                        params_dict[name].data.copy_(local_weight)
+                        loaded_params.add(name)
                     continue
-                name = name.replace(weight_name, param_name)
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
-                break
-            else:
-                param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight)
+
+            # 2. All SwiGLU linear layers weight/bias restructuring
+            if ("net.0.proj.weight" in name) or ("proj_mlp.weight" in name):
+                if tp_size > 1:
+                    w_hidden, w_gate = loaded_weight.chunk(2, dim=0)
+                    w_h_local = w_hidden.chunk(tp_size, dim=0)[tp_rank]
+                    w_g_local = w_gate.chunk(tp_size, dim=0)[tp_rank]
+                    local_weight = torch.cat([w_h_local, w_g_local], dim=0)
+                    
+                    if name in params_dict:
+                        params_dict[name].data.copy_(local_weight)
+                        loaded_params.add(name)
+                    continue
+                    
+            if ("net.0.proj.bias" in name) or ("proj_mlp.bias" in name):
+                if tp_size > 1:
+                    b_hidden, b_gate = loaded_weight.chunk(2, dim=0)
+                    b_h_local = b_hidden.chunk(tp_size, dim=0)[tp_rank]
+                    b_g_local = b_gate.chunk(tp_size, dim=0)[tp_rank]
+                    local_bias = torch.cat([b_h_local, b_g_local], dim=0)
+                    
+                    if name in params_dict:
+                        params_dict[name].data.copy_(local_bias)
+                        loaded_params.add(name)
+                    continue
+
+            # 3. Stacked QKV weight loading
+            found_stacked = False
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name in name:
+                    target_param_name = name.replace(weight_name, param_name)
+                    if target_param_name in params_dict:
+                        param = params_dict[target_param_name]
+                        param.weight_loader(param, loaded_weight, shard_id)
+                        loaded_params.add(target_param_name)
+                        found_stacked = True
+                        break
+            if found_stacked:
+                continue
+
+            # 4. Standard parameter loading
+            if name not in params_dict:
+                continue
+            
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
             loaded_params.add(name)
+
         return loaded_params

--- a/vllm_omni/diffusion/models/ovis_image/ovis_image_transformer.py
+++ b/vllm_omni/diffusion/models/ovis_image/ovis_image_transformer.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from collections.abc import Iterable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.nn as nn
@@ -40,11 +40,31 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
 from vllm_omni.diffusion.attention.layer import Attention
 from vllm_omni.diffusion.data import OmniDiffusionConfig
 from vllm_omni.diffusion.layers.rope import RotaryEmbedding
 
 logger = init_logger(__name__)
+
+
+def _safe_quant_config(quant_config: "QuantizationConfig | None") -> "QuantizationConfig | None":
+    """Return quant_config only if it is safe to propagate here, else None.
+
+    Dual-stream transformer_blocks, norm modulation layers, and norm_out are
+    kept at full precision for FP8 (see #2728). Offline quantization (e.g.
+    INC/AutoRound W4A16) needs the config propagated so packed weights load
+    correctly.
+    """
+    if quant_config is None:
+        return None
+    from vllm.model_executor.layers.quantization.inc import INCConfig
+
+    if isinstance(quant_config, INCConfig):
+        return quant_config
+    return None
 
 
 class AdaLayerNormZero(nn.Module):
@@ -56,7 +76,15 @@ class AdaLayerNormZero(nn.Module):
         num_embeddings (`int`): The size of the embeddings dictionary.
     """
 
-    def __init__(self, embedding_dim: int, num_embeddings: int | None = None, norm_type="layer_norm", bias=True):
+    def __init__(
+        self,
+        embedding_dim: int,
+        num_embeddings: int | None = None,
+        norm_type="layer_norm",
+        bias=True,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
+    ):
         super().__init__()
         if num_embeddings is not None:
             self.emb = CombinedTimestepLabelEmbeddings(num_embeddings, embedding_dim)
@@ -64,7 +92,9 @@ class AdaLayerNormZero(nn.Module):
             self.emb = None
 
         self.silu = nn.SiLU()
-        self.linear = ReplicatedLinear(embedding_dim, 6 * embedding_dim, bias=bias)
+        self.linear = ReplicatedLinear(
+            embedding_dim, 6 * embedding_dim, bias=bias, quant_config=quant_config, prefix=f"{prefix}.linear"
+        )
         if norm_type == "layer_norm":
             self.norm = nn.LayerNorm(embedding_dim, elementwise_affine=False, eps=1e-6)
         else:
@@ -92,9 +122,18 @@ class AdaLayerNormZero(nn.Module):
 
 
 class SwiGLU(nn.Module):
-    def __init__(self, dim_in: int, inner_dim: int, bias: bool = True):
+    def __init__(
+        self,
+        dim_in: int,
+        inner_dim: int,
+        bias: bool = True,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
+    ):
         super().__init__()
-        self.proj = ColumnParallelLinear(dim_in, inner_dim * 2, bias=bias, gather_output=False)
+        self.proj = ColumnParallelLinear(
+            dim_in, inner_dim * 2, bias=bias, gather_output=False, quant_config=quant_config, prefix=f"{prefix}.proj"
+        )
         self.activation = nn.SiLU()
 
     def forward(self, hidden_states):
@@ -116,6 +155,8 @@ class FeedForward(nn.Module):
         final_dropout: bool = False,
         inner_dim=None,
         bias: bool = True,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ):
         super().__init__()
         if inner_dim is None:
@@ -123,25 +164,38 @@ class FeedForward(nn.Module):
         dim_out = dim_out if dim_out is not None else dim
 
         if activation_fn == "swiglu":
-            act_fn = SwiGLU(dim, inner_dim, bias=bias)
+            act_fn = SwiGLU(dim, inner_dim, bias=bias, quant_config=quant_config, prefix=f"{prefix}.net.0")
         else:
             raise ValueError(f"Unsupported activation function type: {activation_fn}")
 
         self.net = nn.ModuleList([])
         self.net.append(act_fn)
         self.net.append(nn.Dropout(dropout))
-        self.net.append(RowParallelLinear(inner_dim, dim_out, bias=bias))
+        self.net.append(
+            RowParallelLinear(
+                inner_dim,
+                dim_out,
+                bias=bias,
+                input_is_parallel=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.net.2",
+            )
+        )
 
         if final_dropout:
             self.net.append(nn.Dropout(dropout))
 
     def forward(self, hidden_states: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         for layer in self.net:
-            output = layer(hidden_states)
-            if isinstance(output, tuple):
-                hidden_states = output[0]
+            if isinstance(layer, RowParallelLinear):
+                # Contiguous for FP8 quantization in RowParallelLinear
+                hidden_states, _ = layer(hidden_states.contiguous())
             else:
-                hidden_states = output
+                output = layer(hidden_states)
+                if isinstance(output, tuple):
+                    hidden_states = output[0]
+                else:
+                    hidden_states = output
         return hidden_states
 
 
@@ -160,6 +214,8 @@ class OvisImageAttention(nn.Module):
         out_dim: int = None,
         context_pre_only: bool | None = None,
         pre_only: bool = False,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ):
         super().__init__()
 
@@ -183,11 +239,22 @@ class OvisImageAttention(nn.Module):
             head_size=self.head_dim,
             total_num_heads=self.heads,
             bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_qkv",
         )
 
         if not self.pre_only:
             self.to_out = nn.ModuleList([])
-            self.to_out.append(RowParallelLinear(self.inner_dim, self.out_dim, bias=out_bias, input_is_parallel=True))
+            self.to_out.append(
+                RowParallelLinear(
+                    self.inner_dim,
+                    self.out_dim,
+                    bias=out_bias,
+                    input_is_parallel=True,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.to_out.0",
+                )
+            )
             self.to_out.append(nn.Dropout(dropout))
 
         if self.added_kv_proj_dim is not None:
@@ -199,10 +266,17 @@ class OvisImageAttention(nn.Module):
                 head_size=self.head_dim,
                 total_num_heads=self.heads,
                 bias=added_proj_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.add_kv_proj",
             )
 
             self.to_add_out = RowParallelLinear(
-                input_size=self.inner_dim, output_size=query_dim, bias=out_bias, input_is_parallel=True
+                input_size=self.inner_dim,
+                output_size=query_dim,
+                bias=out_bias,
+                input_is_parallel=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.to_add_out",
             )
 
         self.rope = RotaryEmbedding(is_neox_style=False)
@@ -220,6 +294,8 @@ class OvisImageAttention(nn.Module):
         image_rotary_emb: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor:
+        # Ensure contiguous for FP8 quantized linear layers
+        hidden_states = hidden_states.contiguous()
         qkv, _ = self.to_qkv(hidden_states)
 
         local_num_heads = self.to_qkv.num_heads
@@ -234,6 +310,7 @@ class OvisImageAttention(nn.Module):
         key = self.norm_k(key)
 
         if self.added_kv_proj_dim is not None:
+            encoder_hidden_states = encoder_hidden_states.contiguous()
             encoder_qkv, _ = self.add_kv_proj(encoder_hidden_states)
             encoder_query, encoder_key, encoder_value = encoder_qkv.chunk(3, dim=-1)
 
@@ -268,9 +345,10 @@ class OvisImageAttention(nn.Module):
                 hidden_states[:, :enc_len],
                 hidden_states[:, enc_len:],
             )
-            hidden_states, _ = self.to_out[0](hidden_states)
+            # Contiguous for FP8 quantization in RowParallelLinear
+            hidden_states, _ = self.to_out[0](hidden_states.contiguous())
             hidden_states = self.to_out[1](hidden_states)
-            encoder_hidden_states, _ = self.to_add_out(encoder_hidden_states)
+            encoder_hidden_states, _ = self.to_add_out(encoder_hidden_states.contiguous())
 
             return hidden_states, encoder_hidden_states
         else:
@@ -278,14 +356,36 @@ class OvisImageAttention(nn.Module):
 
 
 class OvisImageSingleTransformerBlock(nn.Module):
-    def __init__(self, dim: int, num_attention_heads: int, attention_head_dim: int, mlp_ratio: float = 4.0):
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        mlp_ratio: float = 4.0,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
+    ):
         super().__init__()
         self.mlp_hidden_dim = int(dim * mlp_ratio)
 
         self.norm = AdaLayerNormZeroSingle(dim)
-        self.proj_mlp = ColumnParallelLinear(dim, self.mlp_hidden_dim * 2, bias=True, gather_output=False)
+        self.proj_mlp = ColumnParallelLinear(
+            dim,
+            self.mlp_hidden_dim * 2,
+            bias=True,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.proj_mlp",
+        )
         self.act_mlp = nn.SiLU()
-        self.proj_out = RowParallelLinear(dim + self.mlp_hidden_dim, dim, bias=True, input_is_parallel=True)
+        self.proj_out = RowParallelLinear(
+            dim + self.mlp_hidden_dim,
+            dim,
+            bias=True,
+            input_is_parallel=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.proj_out",
+        )
 
         self.attn = OvisImageAttention(
             query_dim=dim,
@@ -295,6 +395,8 @@ class OvisImageSingleTransformerBlock(nn.Module):
             bias=True,
             eps=1e-6,
             pre_only=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
         )
 
     def forward(
@@ -324,7 +426,8 @@ class OvisImageSingleTransformerBlock(nn.Module):
         )
 
         combined_features = torch.cat([attn_output, mlp_hidden_states], dim=-1)
-        proj_output, _ = self.proj_out(combined_features)
+        # Contiguous for FP8 quantization in RowParallelLinear
+        proj_output, _ = self.proj_out(combined_features.contiguous())
 
         proj_output = gate.unsqueeze(1) * proj_output
 
@@ -345,11 +448,15 @@ class OvisImageTransformerBlock(nn.Module):
         attention_head_dim: int,
         qk_norm: str = "rms_norm",
         eps: float = 1e-6,
+        quant_config: "QuantizationConfig | None" = None,
+        prefix: str = "",
     ):
         super().__init__()
 
-        self.norm1 = AdaLayerNormZero(dim)
-        self.norm1_context = AdaLayerNormZero(dim)
+        self.norm1 = AdaLayerNormZero(dim, quant_config=_safe_quant_config(quant_config), prefix=f"{prefix}.norm1")
+        self.norm1_context = AdaLayerNormZero(
+            dim, quant_config=_safe_quant_config(quant_config), prefix=f"{prefix}.norm1_context"
+        )
 
         self.attn = OvisImageAttention(
             query_dim=dim,
@@ -360,13 +467,19 @@ class OvisImageTransformerBlock(nn.Module):
             context_pre_only=False,
             bias=True,
             eps=eps,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
         )
 
         self.norm2 = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
-        self.ff = FeedForward(dim=dim, dim_out=dim, activation_fn="swiglu")
+        self.ff = FeedForward(
+            dim=dim, dim_out=dim, activation_fn="swiglu", quant_config=quant_config, prefix=f"{prefix}.ff"
+        )
 
         self.norm2_context = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
-        self.ff_context = FeedForward(dim=dim, dim_out=dim, activation_fn="swiglu")
+        self.ff_context = FeedForward(
+            dim=dim, dim_out=dim, activation_fn="swiglu", quant_config=quant_config, prefix=f"{prefix}.ff_context"
+        )
 
     def forward(
         self,
@@ -483,6 +596,10 @@ class OvisImageTransformer2DModel(nn.Module):
 
     _repeated_blocks = ["OvisImageTransformerBlock", "OvisImageSingleTransformerBlock"]
     _layerwise_offload_blocks_attrs = ["transformer_blocks", "single_transformer_blocks"]
+    packed_modules_mapping = {
+        "to_qkv": ["to_q", "to_k", "to_v"],
+        "add_kv_proj": ["add_q_proj", "add_k_proj", "add_v_proj"],
+    }
 
     def __init__(
         self,
@@ -496,6 +613,7 @@ class OvisImageTransformer2DModel(nn.Module):
         num_attention_heads: int = 24,
         joint_attention_dim: int = 2048,
         axes_dims_rope: tuple[int] = (16, 56, 56),
+        quant_config: "QuantizationConfig | None" = None,
     ):
         super().__init__()
         model_config = od_config.tf_model_config
@@ -518,8 +636,10 @@ class OvisImageTransformer2DModel(nn.Module):
                     dim=self.inner_dim,
                     num_attention_heads=num_attention_heads,
                     attention_head_dim=attention_head_dim,
+                    quant_config=_safe_quant_config(quant_config),
+                    prefix=f"transformer_blocks.{i}",
                 )
-                for _ in range(num_layers)
+                for i in range(num_layers)
             ]
         )
 
@@ -529,8 +649,10 @@ class OvisImageTransformer2DModel(nn.Module):
                     dim=self.inner_dim,
                     num_attention_heads=num_attention_heads,
                     attention_head_dim=attention_head_dim,
+                    quant_config=quant_config,
+                    prefix=f"single_transformer_blocks.{i}",
                 )
-                for _ in range(num_single_layers)
+                for i in range(num_single_layers)
             ]
         )
         self.norm_out = AdaLayerNormContinuous(self.inner_dim, self.inner_dim, elementwise_affine=False, eps=1e-6)

--- a/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
+++ b/vllm_omni/diffusion/models/ovis_image/pipeline_ovis_image.py
@@ -200,7 +200,7 @@ class OvisImagePipeline(nn.Module, CFGParallelMixin, DiffusionPipelineProfilerMi
             model, subfolder="tokenizer", local_files_only=local_files_only
         )
 
-        self.transformer = OvisImageTransformer2DModel(od_config=od_config)
+        self.transformer = OvisImageTransformer2DModel(od_config=od_config, quant_config=od_config.quantization_config)
 
         self.vae_scale_factor = 2 ** (len(self.vae.config.block_out_channels) - 1) if getattr(self, "vae", None) else 8
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
part of  #1217

This PR continues the work from #1372. Since I cannot push to the original branch, I've created this separate PR to include additional enhancements and test coverage.


## Changes

#### 1. Enhanced Testing

  - Added unit tests in tests/diffusion/models/ovis_image/test_ovis_image_tp.py:

#### 2. FP8 Quantization Support
  - Memory reduction: 17.7GB → 14.7GB (~17% reduction)
  - single_transformer_blocks successfully quantized to FP8
  - Note: transformer_blocks are intentionally kept at BF16 via _safe_quant_config forprecision protection (dual-stream blocks are sensitive to FP8)

## Test Result

**vLLM Version:**
0.23.0

**vLLM-Omni Commit:**
cf4b5882c7d087d1b8b2a455e7f4720ae9d73c87

## Test Result
tp

| GPU          | tp-size | time cost       | peak memory | loading memroy         | command                                                         | image                                                        | LPIPS with TP1 Image |
| ------------ | ------- | --------------- | ----------- | ---------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | -------------------- |
| RTX 5090 * 4 | 1       | 29.2081 seconds | 22190.0     | 17.0956 GiB            | python examples/offline_inference/text_to_image/text_to_image.py         --model AIDC-AI/Ovis-Image-7B         --prompt "a cup of coffee on the table"       --negative-prompt "ugly, unclear"       --cfg-scale 4.0         --tensor-parallel-size 1        --output outputs/coffee.png | <img width="1024" height="1024" alt="ovis_5090_tp1" src="https://github.com/user-attachments/assets/3103c69e-5aec-4c3a-95a5-3fc8605801dd" />| /                    |
| RTX 5090 * 4 | 2       | 16.9813 seconds | 16550.0     | 11.6742 GiB/per    GPU | python examples/offline_inference/text_to_image/text_to_image.py         --model AIDC-AI/Ovis-Image-7B         --prompt "a cup of coffee on the table"       --negative-prompt "ugly, unclear"       --cfg-scale 4.0         --tensor-parallel-size 2        --output outputs/coffee.png | <img width="1024" height="1024" alt="ovis_5090_tp2" src="https://github.com/user-attachments/assets/bf7dd538-c766-45f9-8e27-bc7e97d1afff" /> | 0.0044               |
| RTX 5090 * 4 | 4       | 13.2653 seconds | 13720.0     | 8.8809 GiB/per GPU     | python examples/offline_inference/text_to_image/text_to_image.py         --model AIDC-AI/Ovis-Image-7B         --prompt "a cup of coffee on the table"       --negative-prompt "ugly, unclear"       --cfg-scale 4.0         --tensor-parallel-size 4        --output outputs/coffee.png | <img width="1024" height="1024" alt="ovis_5090_tp4" src="https://github.com/user-attachments/assets/d85a90e6-2eee-4168-b683-6fd77f6778e4" /> | 0.0030               |

Quantization 

| GPU          |  Quantization   | time cost       | peak memory | loading memroy | command                                                         | image                                                        |
| ------------ | -------- | --------------- | ----------- | -------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
| RTX PRO 6000 | no       | 15.3458 seconds | 22190.0     | 17.0956 GiB    | python examples/offline_inference/text_to_image/text_to_image.py --model AIDC-AI/Ovis-Image-7B  --prompt "a cup of coffee on the table"    --negative-prompt "ugly, unclear"  --cfg-scale 4.0  --tensor-parallel-size 1 --output outputs/coffee.png | <img width="1024" height="1024" alt="ovis_pro6000_tp1_noquant" src="https://github.com/user-attachments/assets/0ad13598-54aa-4bcc-9071-c251b847eafe" /> |
| RTX PRO 6000 | yes      | 11.8431 seconds | 18554.0     | 13.3007 GiB    | python examples/offline_inference/text_to_image/text_to_image.py   --model AIDC-AI/Ovis-Image-7B   --prompt "a cup of coffee on the table"   --negative-prompt "ugly, unclear"   --cfg-scale 4.0   --tensor-parallel-size 1   --quantization fp8   --output outputs/coffee.png  | <img width="1024" height="1024" alt="ovis_pro6000_tp1_fp8" src="https://github.com/user-attachments/assets/7097f124-54ab-423f-818b-cdd4504a5c7c" /> |


**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
