### PR TITLE
Update VoxCPM and Qwen3TTS perf baseline.

### DIFF
--- a/tests/dfx/perf/tests/test_tts.json
+++ b/tests/dfx/perf/tests/test_tts.json
@@ -27,10 +27,10 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            122.4504
+            139.9434
           ],
           "median_audio_rtf": [
-            0.1472
+            0.1683
           ]
         }
       },
@@ -55,17 +55,17 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            199.1197,
+            227.5653,
             647.1272,
             4777.2714
           ],
           "median_audio_rtf": [
-            0.2899,
+            0.3313,
             0.3642,
             1.2282
           ],
           "audio_throughput": [
-            20.5634,
+            23.501,
             40.634,
             43.0758
           ]
@@ -129,10 +129,10 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            43.5669
+            49.7908
           ],
           "median_audio_rtf": [
-            0.1247
+            0.1425
           ]
         }
       },
@@ -162,17 +162,17 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            65.9174,
+            75.3341,
             713.7727,
-            5941.7179
+            5000
           ],
           "median_audio_rtf": [
-            0.1626,
+            0.1859,
             0.3148,
-            1.1662
+            1.1
           ],
           "audio_throughput": [
-            31.9068,
+            36.465,
             49.6268,
             48.3091
           ]
@@ -228,13 +228,13 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            49.6105
+            56.6977
           ],
           "median_audio_rtf": [
-            0.1361
+            0.1555
           ],
           "audio_throughput": [
-            10.0881
+            11.5292
           ]
         }
       },
@@ -259,10 +259,10 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            45.5391
+            52.0447
           ],
           "median_audio_rtf": [
-            0.1271
+            0.1452
           ]
         }
       },
@@ -291,17 +291,17 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            66.1471,
+            75.5967,
             587.5877,
             4960.3726
           ],
           "median_audio_rtf": [
-            0.1637,
+            0.1871,
             0.3143,
             1.1703
           ],
           "audio_throughput": [
-            35.1923,
+            40.2198,
             48.9046,
             48.0505
           ]
@@ -328,13 +328,13 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            49.3466
+            56.3961
           ],
           "median_audio_rtf": [
-            0.1349
+            0.1542
           ],
           "audio_throughput": [
-            9
+            9.6672
           ]
         }
       }

--- a/tests/dfx/perf/tests/test_tts.json
+++ b/tests/dfx/perf/tests/test_tts.json
@@ -164,12 +164,12 @@
           "median_audio_ttfp_ms": [
             75.3341,
             713.7727,
-            5000
+            5941.7179
           ],
           "median_audio_rtf": [
             0.1859,
             0.3148,
-            1.1
+            1.1662
           ],
           "audio_throughput": [
             36.465,

--- a/tests/dfx/perf/tests/test_voxcpm2.json
+++ b/tests/dfx/perf/tests/test_voxcpm2.json
@@ -23,10 +23,10 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            113.9351
+            130.2115
           ],
           "median_audio_rtf": [
-            0.0427
+            0.0488
           ]
         }
       },
@@ -47,13 +47,13 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            415.9187
+            475.3357
           ],
           "median_audio_rtf": [
-            0.1462
+            0.1671
           ],
           "audio_throughput": [
-            20.0128
+            22.8717
           ]
         }
       },
@@ -100,10 +100,10 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            66.2748
+            75.7427
           ],
           "median_audio_rtf": [
-            0.0366
+            0.0419
           ]
         }
       },
@@ -127,13 +127,13 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            307.6373
+            351.5855
           ],
           "median_audio_rtf": [
-            0.1056
+            0.1207
           ],
           "audio_throughput": [
-            64.5428
+            73.7632
           ]
         }
       },
@@ -157,13 +157,13 @@
         "percentile-metrics": "ttft,e2el,audio_rtf,audio_ttfp,audio_duration",
         "baseline": {
           "median_audio_ttfp_ms": [
-            70.0958
+            80.1095
           ],
           "median_audio_rtf": [
-            0.0424
+            0.0485
           ],
           "audio_throughput": [
-            16.075
+            18.3715
           ]
         }
       },


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
#4289  Introduce updated baselines for model VoxCPM2 and Qwen 3 TTS. 
However, the new baselines are wrongly calculated (only got 7 days of data, but divided by 8)
This PR intends to fix the baseline calculation errors



Config | Metric | Baseline before this fix PR | Jun 1-8 average | Updated baseline
-- | -- | -- | -- | --
qwen3_tts_base voice_clone latency c1 n20 | median_audio_ttfp_ms | 122.4504 | 147.3088 | 139.9434
qwen3_tts_base voice_clone latency c1 n20 | median_audio_rtf | 0.1472 | 0.1771 | 0.1683
qwen3_tts_base voice_clone throughput c8 n80 | median_audio_ttfp_ms | 199.1197 | 239.5424 | 227.5653
qwen3_tts_base voice_clone throughput c8 n80 | median_audio_rtf | 0.2899 | 0.3487 | 0.3313
qwen3_tts_base voice_clone throughput c8 n80 | audio_throughput | 20.5634 | 22.3819 | 23.501
qwen3_tts_customvoice default_voice latency c1 n20 | median_audio_ttfp_ms | 43.5669 | 52.4114 | 49.7908
qwen3_tts_customvoice default_voice latency c1 n20 | median_audio_rtf | 0.1247 | 0.1500 | 0.1425
qwen3_tts_customvoice default_voice throughput c8 n80 | median_audio_ttfp_ms | 65.9174 | 79.2991 | 75.3341
qwen3_tts_customvoice default_voice throughput c8 n80 | median_audio_rtf | 0.1626 | 0.1957 | 0.1859
qwen3_tts_customvoice default_voice throughput c8 n80 | audio_throughput | 31.9068 | 34.7285 | 36.465
qwen3_tts_customvoice default_voice stress r2.0 n100 | median_audio_ttfp_ms | 49.6105 | 59.6818 | 56.6977
qwen3_tts_customvoice default_voice stress r2.0 n100 | median_audio_rtf | 0.1361 | 0.1637 | 0.1555
qwen3_tts_customvoice default_voice stress r2.0 n100 | audio_throughput | 10.0881 | 10.9802 | 11.5292
qwen3_tts_customvoice voice_design latency c1 n20 | median_audio_ttfp_ms | 45.5391 | 54.7839 | 52.0447
qwen3_tts_customvoice voice_design latency c1 n20 | median_audio_rtf | 0.1271 | 0.1528 | 0.1452
qwen3_tts_customvoice voice_design throughput c8 n80 | median_audio_ttfp_ms | 66.1471 | 79.5754 | 75.5967
qwen3_tts_customvoice voice_design throughput c8 n80 | median_audio_rtf | 0.1637 | 0.1970 | 0.1871
qwen3_tts_customvoice voice_design throughput c8 n80 | audio_throughput | 35.1923 | 38.3046 | 40.2198
qwen3_tts_customvoice voice_design stress r2.0 n100 | median_audio_ttfp_ms | 49.3466 | 59.3643 | 56.3961
qwen3_tts_customvoice voice_design stress r2.0 n100 | median_audio_rtf | 0.1349 | 0.1623 | 0.1542
qwen3_tts_customvoice voice_design stress r2.0 n100 | audio_throughput | 9 | 9.2069 | 9.6672
voxcpm2 voice_clone latency c1 n20 | median_audio_ttfp_ms | 113.9351 | 137.0647 | 130.2115
voxcpm2 voice_clone latency c1 n20 | median_audio_rtf | 0.0427 | 0.0514 | 0.0488
voxcpm2 voice_clone throughput c8 n80 | median_audio_ttfp_ms | 415.9187 | 500.3533 | 475.3357
voxcpm2 voice_clone throughput c8 n80 | median_audio_rtf | 0.1462 | 0.1759 | 0.1671
voxcpm2 voice_clone throughput c8 n80 | audio_throughput | 20.0128 | 21.7826 | 22.8717
voxcpm2 default_voice latency c1 n20 | median_audio_ttfp_ms | 66.2748 | 79.7291 | 75.7427
voxcpm2 default_voice latency c1 n20 | median_audio_rtf | 0.0366 | 0.0441 | 0.0419
voxcpm2 default_voice throughput c8 n80 | median_audio_ttfp_ms | 307.6373 | 370.0899 | 351.5855
voxcpm2 default_voice throughput c8 n80 | median_audio_rtf | 0.1056 | 0.1271 | 0.1207
voxcpm2 default_voice throughput c8 n80 | audio_throughput | 64.5428 | 70.2506 | 73.7632
voxcpm2 default_voice stress r2.0 n100 | median_audio_ttfp_ms | 70.0958 | 84.3258 | 80.1095
voxcpm2 default_voice stress r2.0 n100 | median_audio_rtf | 0.0424 | 0.0510 | 0.0485
voxcpm2 default_voice stress r2.0 n100 | audio_throughput | 16.075 | 17.4966 | 18.3715


## Test Plan

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result
- Recomputed the Jun 1-8 averages from Buildkite nightly raw data and checked the updated baselines against the 5% rule.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
