### PR TITLE
[BugFix] add StrEnum compatibility shim for Python 3.10

### DIFF
--- a/vllm_omni/engine/output_modality.py
+++ b/vllm_omni/engine/output_modality.py
@@ -8,8 +8,17 @@ for type-safe multimodal output routing and tensor merging.
 from __future__ import annotations
 
 import re
-from enum import Enum, Flag, StrEnum, auto
+import sys
+from enum import Enum, Flag, auto
 from typing import Literal, TypeAlias
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+
+    class StrEnum(str, Enum):
+        """Python 3.10 compatibility shim for enum.StrEnum (3.11+)."""
+
 
 FinalOutputModalityType: TypeAlias = Literal["text", "image", "audio", "video"]
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose
`pyproject.toml` declares support for Python `>=3.10`, but `vllm_omni/engine/output_modality.py` imports `StrEnum` directly from `enum`, which is only available in the standard library from **Python 3.11+**. On Python 3.10 this raises:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'StrEnum' from 'enum'
```

This PR adds a small version-gated shim so `OutputModalityNames(StrEnum)` works on both 3.10 and 3.11+.

### Change
- **File:** `vllm_omni/engine/output_modality.py`
- **Behavior:**
  - Python ≥ 3.11: use stdlib `enum.StrEnum` (unchanged behavior)
  - Python 3.10: define a local `class StrEnum(str, Enum)` shim

```diff
-from enum import Enum, Flag, StrEnum, auto
+import sys
+from enum import Enum, Flag, auto
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    class StrEnum(str, Enum):
+        """Python 3.10 compatibility shim for enum.StrEnum (3.11+)."""
```
### Scope

- Single-file fix; no API or runtime behavior change on supported Python versions.
- Out of scope (same latent issue, can follow up): `tests/comfyui/test_comfyui_integration.py` also imports `StrEnum` directly.

### Test plan

- [x] Confirm upstream import fails on Python 3.10 without the shim
- [x] Confirm fixed module imports on Python 3.10, 3.11, and 3.12
- [x] Run `tests/engine/test_output_modality.py` on Python 3.10 and 3.12
- [x] Run related `OutputModalityNames` consumer test on Python 3.10

**vLLM Version:**

**vLLM-Omni Commit:**

### Test result
#### 1. Module import smoke tests (with fix)

| Python | Result | Notes |
|--------|--------|-------|
| 3.10.12 | PASS | shim path; `OutputModalityNames.TEXT == 'text'` |
| 3.11.0rc1 | PASS | stdlib `enum.StrEnum` |
| 3.12.13 | PASS | stdlib `enum.StrEnum` (`StrEnum.__module__ == 'enum'`) |

#### 2. Pytest

| Command | Python | Result |
|---------|--------|--------|
| `pytest tests/engine/test_output_modality.py -q` | 3.10.12 | **3 passed** in 0.12s |
| `pytest tests/engine/test_output_modality.py -q` | 3.12.13 | **3 passed** in 0.26s |

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
