### PR TITLE
[Model] Add Irodori-TTS v3 support

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -66,6 +66,7 @@ th {
 | `Qwen3TTSForConditionalGeneration` | Qwen3-TTS-12Hz-1.7B-Base | `Qwen/Qwen3-TTS-12Hz-0.6B-Base` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `MingTTSForConditionalGeneration` | Ming-omni-tts dense 0.5B | `inclusionAI/Ming-omni-tts-0.5B` | ✅︎ | | | |
 | `GLMTTSForConditionalGeneration` | GLM-TTS | `zai-org/GLM-TTS` | ✅︎ | | | |
+| `IrodoriTTSPipeline` | Irodori-TTS v3 | `Aratako/Irodori-TTS-500M-v3` | ✅︎ | | | |
 | `MossTTSNanoForCausalLM` | MOSS-TTS-Nano | `OpenMOSS-Team/MOSS-TTS-Nano` | ✅︎ | | | |
 | `MossTTSDelayModel` | MOSS-TTS, MOSS-TTSD, MOSS-SoundEffect, MOSS-VoiceGenerator | `OpenMOSS-Team/MOSS-VoiceGenerator` | ✅︎ | | | |
 | `MossTTSRealtime` | MOSS-TTS-Realtime | `OpenMOSS-Team/MOSS-TTS-Realtime` | ✅︎ | | | |

--- a/docs/user_guide/examples/offline_inference/text_to_speech.md
+++ b/docs/user_guide/examples/offline_inference/text_to_speech.md
@@ -20,6 +20,7 @@ list of supported architectures across all modalities, see
 | CosyVoice3 | `FunAudioLLM/Fun-CosyVoice3-0.5B-2512` | 2 (talker + code2wav) | ✓ | ✓ (`async_chunk: true` default) | — | 22.05 kHz |
 | Fish Speech S2 Pro | `fishaudio/s2-pro` | dual-AR | ✓ | ✓ (`--streaming`) | — | 44.1 kHz |
 | GLM-TTS | `zai-org/GLM-TTS` | 2 (AR + DiT) | ✓ (required) | ✓ | — | 24 kHz |
+| Irodori-TTS v3 | `Aratako/Irodori-TTS-500M-v3` | single (pure DiT) | ✓ | — | — | 48 kHz |
 | OmniVoice | `k2-fsa/OmniVoice` | 2 (gen + dec) | ✓ | — | voice design (`--instruct`), language (`--lang`) | 24 kHz |
 | Qwen3-TTS | `Qwen/Qwen3-TTS-12Hz-1.7B-{CustomVoice,VoiceDesign,Base}` | 2 (talker + code2wav) | ✓ (Base) | ✓ | 3 task variants (`--query-type`) | 24 kHz |
 | Voxtral TTS | `mistralai/Voxtral-4B-TTS-2603` | varies | ✓ | ✓ | voice presets (`--voice`) | 24 kHz |
@@ -186,6 +187,39 @@ Text → [Stage 0: AR] → Speech Tokens → [Stage 1: DiT + HiFT] → Audio (24
 - First run may be slow due to lazy loading of WhisperVQ tokenizer and CampPlus ONNX speaker embedder.
 - Default sampling: temperature=1.0, top_k=25, top_p=0.8 (RAS method).
 - The `--model` path should point to the repository root (not `llm/` subdirectory).
+
+---
+
+## Irodori-TTS v3
+
+Single-stage Flow Matching DiT text-to-speech model at 48 kHz. Supports high-fidelity voice cloning.
+
+> "Irodori-TTS-500M-v3 is a Japanese Text-to-Speech model based on a Rectified Flow Diffusion Transformer (RF-DiT) architecture." — [Aratako/Irodori-TTS-500M-v3](https://huggingface.co/Aratako/Irodori-TTS-500M-v3)
+
+### Prerequisites
+
+```bash
+uv pip install -e ".[irodori-tts]"
+```
+
+### Offline Stage Configuration
+The offline pipeline is configured using the stage config at `vllm_omni/model_executor/stage_configs/irodori_tts.yaml` (default):
+```yaml
+stage_args:
+  - stage_id: 0
+    stage_type: diffusion
+    runtime:
+      devices: "0"
+      max_batch_size: 1
+    engine_args:
+      model_stage: dit
+      model_class_name: IrodoriTTSPipeline
+```
+
+### Notes
+- Output: 48 kHz mono WAV.
+- Voice cloning works with automatic duration prediction, producing standard mono waveform audio outputs.
+- High-fidelity decoding is handled via `Aratako/Semantic-DACVAE-Japanese-32dim`.
 
 ---
 

--- a/docs/user_guide/examples/online_serving/text_to_speech.md
+++ b/docs/user_guide/examples/online_serving/text_to_speech.md
@@ -21,6 +21,7 @@ For the full list of supported architectures across all modalities, see
 | Fish Speech S2 Pro | `fishaudio/s2-pro` | ✓ (`ref_audio`+`ref_text`) | ✓ (PCM stream) | — | ✓ |
 | higgs-audio v2 | `bosonai/higgs-audio-v2-generation-3B-base` | ✓ (`ref_audio`+`ref_text`) | ✓ (codec_streaming) | — | — |
 | GLM-TTS | `zai-org/GLM-TTS` | ✓ (`ref_audio`+`ref_text`, required) | ✓ (PCM stream) | — | ✓ |
+| Irodori-TTS v3 | `Aratako/Irodori-TTS-500M-v3` | ✓ (`ref_wav`) | — | — | — |
 | OmniVoice | `k2-fsa/OmniVoice` | (offline only) | — | — | — |
 | Qwen3-TTS | `Qwen/Qwen3-TTS-12Hz-1.7B-{CustomVoice,VoiceDesign,Base}` | ✓ (Base) | ✓ (PCM + WebSocket) | ✓ (presets + `/v1/audio/voices` upload) | ✓ (standard + FastRTC) |
 | VoxCPM2 | `openbmb/VoxCPM2` | ✓ | ✓ (AudioWorklet via gradio) | — | ✓ |
@@ -269,6 +270,45 @@ bash examples/online_serving/text_to_speech/glm_tts/run_gradio_demo.sh
 - Output: 24 kHz mono WAV via HiFT vocoder.
 - `ref_audio` + `ref_text` are **required** together on every request. Reference audio should be 3-10 seconds.
 - Voice cloning feature extraction (WhisperVQ, CampPlus, mel) runs on the model side — no external dependency on the serving layer.
+
+---
+
+## Irodori-TTS v3
+
+Flow Matching TTS over continuous DACVAE latents at 48 kHz. Supports zero-shot voice cloning.
+
+> "Irodori-TTS-500M-v3 is a Japanese Text-to-Speech model based on a Rectified Flow Diffusion Transformer (RF-DiT) architecture." — [Aratako/Irodori-TTS-500M-v3](https://huggingface.co/Aratako/Irodori-TTS-500M-v3)
+
+### Prerequisites
+
+```bash
+uv pip install -e ".[irodori-tts]"
+```
+
+### Launch
+```bash
+vllm serve Aratako/Irodori-TTS-500M-v3 --omni --port 8091
+```
+
+### Sending requests
+```bash
+# Voice cloning via OpenAI-compatible endpoint
+curl -X POST http://localhost:8091/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{
+        "input": "こんにちは、これは私のクローンされた声です。",
+        "voice": "default",
+        "response_format": "wav",
+        "extra_args": {
+            "ref_wav": "/path/to/reference.wav"
+        }
+    }' --output cloned.wav
+```
+
+### Notes
+- Output: 48 kHz mono WAV.
+- Uses `Aratako/Semantic-DACVAE-Japanese-32dim` for high-fidelity audio decoding.
+- Automatically estimates speech frame length using an integrated duration predictor.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ classifiers = [
 # without requiring extras like [cuda]. See requirements/ directory for platform-specific dependencies.
 
 [project.optional-dependencies]
-
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
@@ -89,6 +88,11 @@ local = [
 # who only need other models; opt in with `pip install vllm-omni[minicpmo]`.
 minicpmo = [
     "stepaudio2-minicpmo",
+]
+
+# Optional runtime dependencies for the Irodori TTS pipeline.
+irodori-tts = [
+    "dacvae @ git+https://github.com/facebookresearch/dacvae"
 ]
 
 # Optional Blackwell-only fused-bias FP8 GEMM; package is `quack-kernels` (imported

--- a/tests/diffusion/models/irodori_tts/test_irodori_tts.py
+++ b/tests/diffusion/models/irodori_tts/test_irodori_tts.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import torch
+
+from tests.helpers.media import get_asset_path
+from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.models.irodori_tts.irodori_tts_transformer import IrodoriTTSTransformer, ModelConfig
+from vllm_omni.diffusion.models.irodori_tts.pipeline_irodori_tts import IrodoriTTSPipeline
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+
+
+def test_irodori_transformer_forward():
+    # Initialize a lightweight configuration for fast unit testing
+    cfg = ModelConfig(
+        model_dim=128,  # small model dim
+        num_layers=2,  # lightweight layers
+        num_heads=4,  # divisible heads
+        text_dim=64,
+        text_layers=2,
+        text_heads=2,
+        speaker_dim=64,
+        speaker_layers=2,
+        speaker_heads=2,
+        use_speaker_condition=True,
+        use_duration_predictor=True,
+        duration_aux_dim=14,
+        duration_hidden_dim=64,
+        duration_layers=2,
+    )
+
+    model = IrodoriTTSTransformer(cfg=cfg).eval()
+
+    # Define shape parameters
+    batch_size = 2
+    latent_seq_len = 32
+    text_seq_len = 16
+    ref_seq_len = 24
+
+    # Generate mock inputs
+    x_t = torch.randn(batch_size, latent_seq_len, cfg.patched_latent_dim)
+    t = torch.tensor([0.25, 0.75], dtype=torch.float32)
+    text_input_ids = torch.randint(0, cfg.text_vocab_size, (batch_size, text_seq_len))
+    text_mask = torch.ones(batch_size, text_seq_len, dtype=torch.bool)
+
+    ref_latent = torch.randn(batch_size, ref_seq_len, cfg.patched_latent_dim)
+    ref_mask = torch.ones(batch_size, ref_seq_len, dtype=torch.bool)
+
+    duration_features = torch.randn(batch_size, cfg.duration_aux_dim)
+    duration_has_speaker = torch.ones(batch_size, dtype=torch.bool)
+    duration_has_caption = torch.zeros(batch_size, dtype=torch.bool)
+
+    # Test 1: Standard RF Forward
+    with torch.no_grad():
+        v_pred = model(
+            x_t=x_t,
+            t=t,
+            text_input_ids=text_input_ids,
+            text_mask=text_mask,
+            ref_latent=ref_latent,
+            ref_mask=ref_mask,
+        )
+    assert v_pred.shape == x_t.shape, f"Expected shape {x_t.shape}, got {v_pred.shape}"
+
+    # Test 2: Forward with Duration Predictor
+    with torch.no_grad():
+        v_pred_dur, duration_pred = model(
+            x_t=x_t,
+            t=t,
+            text_input_ids=text_input_ids,
+            text_mask=text_mask,
+            ref_latent=ref_latent,
+            ref_mask=ref_mask,
+            duration_features=duration_features,
+            duration_has_speaker=duration_has_speaker,
+            duration_has_caption=duration_has_caption,
+        )
+    assert v_pred_dur.shape == x_t.shape, f"Expected shape {x_t.shape}, got {v_pred_dur.shape}"
+    assert duration_pred.shape == (batch_size,), f"Expected shape {(batch_size,)}, got {duration_pred.shape}"
+
+    # Test 3: Duration-only Prediction
+    with torch.no_grad():
+        duration_pred_only = model(
+            x_t=None,
+            t=None,
+            text_input_ids=text_input_ids,
+            text_mask=text_mask,
+            ref_latent=ref_latent,
+            ref_mask=ref_mask,
+            duration_features=duration_features,
+            duration_has_speaker=duration_has_speaker,
+            duration_has_caption=duration_has_caption,
+            duration_only=True,
+        )
+    assert duration_pred_only.shape == (batch_size,), f"Expected shape {(batch_size,)}, got {duration_pred_only.shape}"
+
+
+class MockTFModelConfig:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.quant_config = None
+
+
+def test_irodori_pipeline_forward():
+    # Initialize a lightweight configuration for fast integration testing
+    tf_model_config = MockTFModelConfig(
+        latent_dim=32,  # matches DACVAE 32-dim latent space
+        model_dim=128,
+        num_layers=2,
+        num_heads=4,
+        text_dim=64,
+        text_layers=2,
+        text_heads=2,
+        speaker_dim=64,
+        speaker_layers=2,
+        speaker_heads=2,
+        use_speaker_condition=True,
+        use_duration_predictor=True,
+        duration_aux_dim=14,
+        duration_hidden_dim=64,
+        duration_layers=2,
+    )
+
+    od_config = OmniDiffusionConfig(
+        model="Aratako/Irodori-TTS-500M-v3",
+        tf_model_config=tf_model_config,
+        dtype=torch.float32,  # use float32 for stable CPU testing if executed on CPU
+    )
+
+    print("Instantiating IrodoriTTSPipeline...")
+    pipeline = IrodoriTTSPipeline(od_config=od_config).eval()
+
+    # Define simple Japanese text prompt for testing
+    prompt = "こんにちは、私はGeorgeです。"
+
+    sampling_params = OmniDiffusionSamplingParams(
+        num_inference_steps=2,  # 2 steps for super-fast test execution
+        seed=42,
+        extra_args={
+            "ref_wav": str(get_asset_path("qwen3_tts/clone_2.wav")),
+            "duration_scale": 1.0,
+            "cfg_scale_text": 1.5,
+            "cfg_scale_speaker": 2.0,
+        },
+    )
+
+    req = OmniDiffusionRequest(
+        request_id="test-pipeline-req",
+        prompts=[prompt],
+        sampling_params=sampling_params,
+    )
+
+    print("Executing pipeline.forward()...")
+    with torch.no_grad():
+        output = pipeline(req)
+
+    print(f"Pipeline output waveform shape: {tuple(output.output.shape)}")
+
+    # Assert mono waveform output has 3 dimensions (B, 1, samples)
+    assert output.output.ndim == 3, f"Expected 3D waveform tensor, got shape {output.output.shape}"
+    assert output.output.shape[0] == 1, f"Expected batch size 1, got {output.output.shape[0]}"
+    assert output.output.shape[1] == 1, f"Expected mono audio channel dimension 1, got {output.output.shape[1]}"
+    assert output.output.shape[2] > 0, "Expected generated samples count > 0"
+
+    # Test post-processing function
+    from vllm_omni.diffusion.models.irodori_tts.pipeline_irodori_tts import get_irodori_tts_post_process_func
+
+    print("Testing post-processing function...")
+    post_process_func = get_irodori_tts_post_process_func(od_config)
+    audio_np = post_process_func(output.output)
+    print(f"Post-processed numpy audio shape: {audio_np.shape}")
+    assert audio_np.ndim == 3
+    assert audio_np.shape[0] == 1
+    assert audio_np.shape[1] == 1
+
+    print("Pipeline end-to-end forward pass and post-processing validated successfully!")

--- a/tests/e2e/offline_inference/test_irodori_tts_e2e.py
+++ b/tests/e2e/offline_inference/test_irodori_tts_e2e.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import numpy as np
+
+from tests.helpers.media import get_asset_path
+from vllm_omni import Omni
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.outputs import OmniRequestOutput
+
+
+def generate_irodori_tts(omni: Omni) -> np.ndarray:
+    # 2 steps for extremely fast test execution in CI/pytest
+    outputs = omni.generate(
+        prompts={
+            "prompt": "こんにちは、私はGeorgeです。前方路口左转。",
+        },
+        sampling_params_list=OmniDiffusionSamplingParams(
+            num_inference_steps=2,
+            seed=42,
+            extra_args={
+                "ref_wav": str(get_asset_path("qwen3_tts/clone_2.wav")),
+                "duration_scale": 1.0,
+                "cfg_scale_text": 1.5,
+                "cfg_scale_speaker": 2.0,
+            },
+        ),
+    )
+
+    assert outputs is not None
+    first_output = outputs[0]
+    assert first_output.final_output_type == "audio"
+
+    req_out = first_output.request_output
+    assert isinstance(req_out, OmniRequestOutput)
+    assert req_out.final_output_type == "audio"
+    assert req_out.multimodal_output is not None
+
+    audio = req_out.multimodal_output.get("audio")
+    assert isinstance(audio, np.ndarray)
+    return audio
+
+
+def test_irodori_tts_e2e():
+    print("Initializing Omni engine with IrodoriTTSPipeline...")
+    omni = Omni(
+        model="Aratako/Irodori-TTS-500M-v3",
+        model_class_name="IrodoriTTSPipeline",
+    )
+    try:
+        print("Starting e2e audio generation...")
+        audio = generate_irodori_tts(omni)
+        print(f"E2E generated audio shape: {audio.shape}")
+
+        # Audio output should be 3D numpy array (B, 1, samples)
+        assert audio.ndim == 3
+        assert audio.shape[0] == 1
+        assert audio.shape[1] == 1
+        assert audio.shape[2] > 0
+        print("End-to-end Irodori TTS integration test completed successfully!")
+    finally:
+        omni.close()

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -996,6 +996,10 @@ class OmniDiffusionConfig:
                         self.set_tf_model_config(TransformerConfig())
                         self.update_multimodal_support()
                         return
+                    if self.model_class_name == "IrodoriTTSPipeline":
+                        self.set_tf_model_config(TransformerConfig())
+                        self.update_multimodal_support()
+                        return
                     raise ValueError(f"Could not find config.json or model_index.json for model {self.model}")
 
                 self.set_tf_model_config(TransformerConfig.from_dict(cfg))

--- a/vllm_omni/diffusion/models/irodori_tts/__init__.py
+++ b/vllm_omni/diffusion/models/irodori_tts/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from .irodori_tts_transformer import IrodoriTTSTransformer
+from .pipeline_irodori_tts import IrodoriTTSPipeline, get_irodori_tts_post_process_func
+
+__all__ = [
+    "IrodoriTTSPipeline",
+    "IrodoriTTSTransformer",
+    "get_irodori_tts_post_process_func",
+]

--- a/vllm_omni/diffusion/models/irodori_tts/codec.py
+++ b/vllm_omni/diffusion/models/irodori_tts/codec.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+import torchaudio
+from huggingface_hub import hf_hub_download
+
+_CODEC_DEFAULT = object()
+
+
+def patchify_latent(latent: torch.Tensor, patch_size: int) -> torch.Tensor:
+    """
+    Convert latent from (B, T, D) -> (B, T//patch, D*patch).
+    Extra tail tokens are dropped.
+    """
+    if patch_size <= 1:
+        return latent
+    bsz, seq_len, dim = latent.shape
+    usable = (seq_len // patch_size) * patch_size
+    latent = latent[:, :usable]
+    latent = latent.reshape(bsz, usable // patch_size, dim * patch_size)
+    return latent
+
+
+def unpatchify_latent(patched: torch.Tensor, patch_size: int, latent_dim: int) -> torch.Tensor:
+    """
+    Convert latent from (B, T_p, D*patch) -> (B, T_p*patch, D).
+    """
+    if patch_size <= 1:
+        return patched
+    return patched.reshape(patched.shape[0], patched.shape[1] * patch_size, latent_dim)
+
+
+@dataclass
+class DACVAECodec:
+    model: torch.nn.Module
+    sample_rate: int
+    latent_dim: int
+    device: torch.device
+    dtype: torch.dtype
+    deterministic_encode: bool
+    deterministic_decode: bool
+    normalize_db: float | None
+
+    @classmethod
+    def load(
+        cls,
+        repo_id: str = "Aratako/Semantic-DACVAE-Japanese-32dim",
+        device: str = "cuda",
+        dtype: torch.dtype | None = None,
+        deterministic_encode: bool = True,
+        deterministic_decode: bool = True,
+        normalize_db: float | None = -16.0,
+    ) -> DACVAECodec:
+        try:
+            from dacvae import DACVAE
+        except ImportError as e:
+            raise ImportError(
+                "The 'dacvae' package is required for Irodori TTS, but it is not installed. "
+                "Please install it via 'pip install vllm-omni[irodori-tts]' or "
+                "'pip install git+https://github.com/facebookresearch/dacvae'."
+            ) from e
+
+        location = str(repo_id).strip()
+        if location.startswith("hf://"):
+            location = location[len("hf://") :]
+        if not Path(location).exists() and "/" in location and not location.endswith(".pth"):
+            try:
+                location = hf_hub_download(repo_id=location, filename="weights.pth")
+                print(f"[codec] dacvae: hf://{repo_id} -> {location}", flush=True)
+            except Exception:
+                # Let DACVAE.load surface a clearer error if this is not a valid path/repo.
+                pass
+
+        model = DACVAE.load(location).eval().to(device)
+        if dtype is not None:
+            model = model.to(dtype=dtype)
+
+        decoder = getattr(model, "decoder", None)
+        if decoder is not None and hasattr(decoder, "alpha"):
+            decoder.alpha = 0.0
+            if hasattr(decoder, "wm_model"):
+                # Irodori checkpoints were trained without the DACVAE watermark branch.
+                # Keep decode output mono while skipping that encode/decode path.
+                def _watermark_passthrough(
+                    x: torch.Tensor,
+                    message: torch.Tensor | None = None,
+                    _decoder=decoder,
+                ) -> torch.Tensor:
+                    del message
+                    return _decoder.wm_model.encoder_block.forward_no_conv(x)
+
+                decoder.watermark = _watermark_passthrough
+
+        if deterministic_decode:
+            cls._configure_deterministic_decode(model=model, device=device)
+
+        model_dtype = next(model.parameters()).dtype
+        # Infer latent dimension by encoding a tiny random signal.
+        dummy = torch.zeros(1, 1, 2048, device=device, dtype=model_dtype)
+        with torch.inference_mode():
+            z = model.encode(dummy)  # (B, D, T)
+        return cls(
+            model=model,
+            sample_rate=int(model.sample_rate),
+            latent_dim=int(z.shape[1]),
+            device=torch.device(device),
+            dtype=model_dtype,
+            deterministic_encode=bool(deterministic_encode),
+            deterministic_decode=bool(deterministic_decode),
+            normalize_db=None if normalize_db is None else float(normalize_db),
+        )
+
+    @staticmethod
+    def _configure_deterministic_decode(model: torch.nn.Module, device: str | torch.device) -> None:
+        decoder = getattr(model, "decoder", None)
+        wm_model = getattr(decoder, "wm_model", None)
+        msg_processor = getattr(wm_model, "msg_processor", None)
+        if msg_processor is None:
+            return
+        nbits = int(msg_processor.nbits)
+        message_device = torch.device(device)
+
+        def _fixed_message(batch_size: int) -> torch.Tensor:
+            return torch.zeros((batch_size, nbits), dtype=torch.float32, device=message_device)
+
+        wm_model.random_message = _fixed_message
+
+    @staticmethod
+    def _normalize_loudness(wav: torch.Tensor, sample_rate: int, target_db: float | None) -> torch.Tensor:
+        if target_db is None:
+            return wav
+        wav_device = wav.device
+        wav = wav.to(dtype=torch.float32)
+        if wav.ndim == 2:
+            if wav.shape[0] == 1:
+                wav = wav[0]
+            elif wav.shape[1] == 1:
+                wav = wav[:, 0]
+            else:
+                wav = wav.mean(dim=0)
+        if wav.ndim != 1:
+            raise ValueError(
+                "normalize_loudness expects a mono waveform with shape (T,) "
+                f"or singleton-channel (1, T)/(T, 1), got {tuple(wav.shape)}"
+            )
+
+        try:
+            from audiotools import AudioSignal
+        except Exception as exc:
+            raise RuntimeError(
+                "audiotools is required when normalize_db is set. Install audiotools or disable normalize_db."
+            ) from exc
+
+        signal = AudioSignal(wav.unsqueeze(0).unsqueeze(0), int(sample_rate))
+        signal.normalize(float(target_db))
+        signal.ensure_max_of_audio()
+        normalized = signal.audio_data
+        if not isinstance(normalized, torch.Tensor):
+            normalized = torch.as_tensor(normalized)
+        normalized = normalized.to(dtype=torch.float32, device=wav_device)
+        normalized = normalized.squeeze()
+        if normalized.ndim != 1:
+            raise RuntimeError(
+                f"audiotools normalization returned an unexpected waveform shape {tuple(normalized.shape)}"
+            )
+        return normalized
+
+    @torch.inference_mode()
+    def encode_waveform(
+        self,
+        waveform: torch.Tensor,
+        sample_rate: int,
+        *,
+        normalize_db: float | None | object = _CODEC_DEFAULT,
+        ensure_max: bool | None = None,
+    ) -> torch.Tensor:
+        """
+        Input:
+          waveform: (B, C, T) or (C, T)
+          normalize_db: Optional target loudness (LUFS-like dB) applied before encode
+          ensure_max: If True and normalize_db is None, scale down only when abs peak exceeds 1.0
+        Output:
+          latent: (B, T_latent, D_latent)
+        """
+        if waveform.ndim == 2:
+            waveform = waveform.unsqueeze(0)
+        if waveform.ndim != 3:
+            raise ValueError(f"Expected waveform ndim=3, got shape={tuple(waveform.shape)}")
+
+        if waveform.shape[1] != 1:
+            waveform = waveform.mean(dim=1, keepdim=True)
+        if sample_rate != self.sample_rate:
+            waveform = torchaudio.functional.resample(waveform, sample_rate, self.sample_rate)
+
+        if normalize_db is _CODEC_DEFAULT:
+            effective_normalize_db = self.normalize_db
+        elif normalize_db is None:
+            effective_normalize_db = None
+        else:
+            effective_normalize_db = float(normalize_db)
+        # audiotools normalization already applies ensure_max_of_audio(), so codec-side
+        # peak scaling is only needed when normalization is disabled.
+        effective_ensure_max = effective_normalize_db is None and bool(ensure_max) if ensure_max is not None else False
+
+        waveform = waveform.to(dtype=torch.float32)
+        if effective_normalize_db is not None or effective_ensure_max:
+            # Keep behavior deterministic per utterance by normalizing each waveform independently.
+            processed: list[torch.Tensor] = []
+            for wav in waveform.squeeze(1):
+                if effective_normalize_db is not None:
+                    wav = self._normalize_loudness(wav, sample_rate=self.sample_rate, target_db=effective_normalize_db)
+                wav = wav.squeeze()
+                if wav.ndim != 1:
+                    raise RuntimeError(
+                        f"Expected mono per-item waveform after preprocessing, got shape={tuple(wav.shape)}"
+                    )
+                if effective_ensure_max:
+                    peak = wav.abs().max()
+                    if torch.isfinite(peak) and peak > 1.0:
+                        wav = wav * (1.0 / float(peak))
+                processed.append(wav)
+            waveform = torch.stack(processed, dim=0).unsqueeze(1)
+
+        waveform = waveform.to(self.device, dtype=self.dtype)
+        if self.deterministic_encode:
+            required_paths_present = (
+                hasattr(self.model, "encoder")
+                and hasattr(self.model, "_pad")
+                and hasattr(self.model, "quantizer")
+                and hasattr(self.model.quantizer, "in_proj")
+            )
+            if not required_paths_present:
+                raise RuntimeError("deterministic_encode=True requires encoder/_pad/quantizer.in_proj on DACVAE model.")
+            z = self.model.encoder(self.model._pad(waveform))
+            mean, _scale = self.model.quantizer.in_proj(z).chunk(2, dim=1)
+            encoded = mean
+        else:
+            encoded = self.model.encode(waveform)  # (B, D, T)
+        return encoded.transpose(1, 2).contiguous()  # (B, T, D)
+
+    @torch.inference_mode()
+    def decode_latent(self, latent: torch.Tensor) -> torch.Tensor:
+        """
+        Input:
+          latent: (B, T, D)
+        Output:
+          audio: (B, 1, samples)
+        """
+        if latent.ndim != 3:
+            raise ValueError(f"Expected latent ndim=3, got shape={tuple(latent.shape)}")
+        z = latent.transpose(1, 2).contiguous().to(self.device, dtype=self.dtype)  # (B, D, T)
+        return self.model.decode(z)
+
+    def encode_file(self, path: str | Path) -> torch.Tensor:
+        try:
+            wav, sr = torchaudio.load(str(path))
+        except RuntimeError:
+            import soundfile as sf
+
+            data, sr = sf.read(str(path), dtype="float32")
+            wav = torch.from_numpy(data)
+            if wav.ndim == 1:
+                wav = wav.unsqueeze(0)
+            else:
+                wav = wav.T
+        wav = wav.unsqueeze(0)  # (1, C, T)
+        return self.encode_waveform(wav, sr).cpu()

--- a/vllm_omni/diffusion/models/irodori_tts/duration.py
+++ b/vllm_omni/diffusion/models/irodori_tts/duration.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Iterable, Sequence
+
+import torch
+
+ALLOWED_ANNOTATION_EMOJIS: tuple[str, ...] = (
+    "⏩",
+    "⏱️",
+    "⏸️",
+    "🌬️",
+    "🍭",
+    "🎛️",
+    "🎭",
+    "🎵",
+    "🐢",
+    "🐱",
+    "👂",
+    "👃",
+    "👅",
+    "👌",
+    "👏",
+    "💋",
+    "💥",
+    "💦",
+    "💪",
+    "📄",
+    "📞",
+    "📢",
+    "📣",
+    "😆",
+    "😊",
+    "😌",
+    "😎",
+    "😏",
+    "😒",
+    "😖",
+    "😟",
+    "😠",
+    "😪",
+    "😭",
+    "😮",
+    "😮‍💨",
+    "😰",
+    "😱",
+    "😲",
+    "😴",
+    "🙄",
+    "🙏",
+    "🤐",
+    "🤔",
+    "🤢",
+    "🤧",
+    "🤭",
+    "🥤",
+    "🥱",
+    "🥴",
+    "🥵",
+    "🥹",
+    "🥺",
+    "🫣",
+    "🫶",
+    "📖",
+)
+
+_ALLOWED_ANNOTATION_EMOJI_PATTERN = re.compile(
+    "|".join(sorted((re.escape(x) for x in ALLOWED_ANNOTATION_EMOJIS), key=len, reverse=True))
+)
+
+
+def _log1p_cap(count: int, cap: int) -> float:
+    return math.log1p(float(min(max(int(count), 0), int(cap)))) / math.log1p(float(cap))
+
+
+def _log1p_cap_float(value: float, cap: float) -> float:
+    value = min(max(float(value), 0.0), float(cap))
+    return math.log1p(value) / math.log1p(float(cap))
+
+
+def _is_kana(ch: str) -> bool:
+    code = ord(ch)
+    return (0x3040 <= code <= 0x309F) or (0x30A0 <= code <= 0x30FF)
+
+
+def _is_kanji(ch: str) -> bool:
+    code = ord(ch)
+    return (
+        (0x3400 <= code <= 0x4DBF)
+        or (0x4E00 <= code <= 0x9FFF)
+        or (0xF900 <= code <= 0xFAFF)
+        or (0x20000 <= code <= 0x2FA1F)
+    )
+
+
+def _is_alnum(ch: str) -> bool:
+    return ch.isascii() and ch.isalnum()
+
+
+def count_annotation_emojis(text: str) -> int:
+    return len(_ALLOWED_ANNOTATION_EMOJI_PATTERN.findall(text))
+
+
+def build_duration_features(
+    texts: Sequence[str] | Iterable[str],
+    *,
+    token_counts: Sequence[int] | torch.Tensor,
+    max_text_len: int,
+    has_speaker: Sequence[bool] | torch.Tensor,
+) -> torch.Tensor:
+    text_list = [str(x) for x in texts]
+    if isinstance(token_counts, torch.Tensor):
+        token_count_list = [int(x) for x in token_counts.detach().cpu().tolist()]
+    else:
+        token_count_list = [int(x) for x in token_counts]
+    if isinstance(has_speaker, torch.Tensor):
+        has_speaker_list = [bool(x) for x in has_speaker.detach().cpu().tolist()]
+    else:
+        has_speaker_list = [bool(x) for x in has_speaker]
+
+    if len(text_list) != len(token_count_list) or len(text_list) != len(has_speaker_list):
+        raise ValueError(
+            "Duration feature inputs must have matching lengths: "
+            f"texts={len(text_list)} token_counts={len(token_count_list)} "
+            f"has_speaker={len(has_speaker_list)}"
+        )
+    if max_text_len <= 0:
+        raise ValueError(f"max_text_len must be > 0, got {max_text_len}")
+
+    rows: list[list[float]] = []
+    for text, token_count, speaker_available in zip(text_list, token_count_list, has_speaker_list, strict=True):
+        char_count = max(len(text), 1)
+        kana_count = sum(1 for ch in text if _is_kana(ch))
+        kanji_count = sum(1 for ch in text if _is_kanji(ch))
+        alnum_count = sum(1 for ch in text if _is_alnum(ch))
+        emoji_count = count_annotation_emojis(text)
+
+        period_count = text.count("。") + text.count(".")
+        comma_count = text.count("、") + text.count(",")
+        long_vowel_count = text.count("ー")
+        ellipsis_count = text.count("…")
+        exclamation_count = text.count("！") + text.count("!")
+        question_count = text.count("？") + text.count("?")
+
+        rows.append(
+            [
+                min(max(float(token_count), 0.0), float(max_text_len)) / float(max_text_len),
+                _log1p_cap_float(float(char_count), 512.0),
+                float(token_count) / float(char_count),
+                _log1p_cap(period_count, 8),
+                _log1p_cap(comma_count, 16),
+                _log1p_cap(long_vowel_count, 8),
+                _log1p_cap(ellipsis_count, 8),
+                _log1p_cap(exclamation_count, 8),
+                _log1p_cap(question_count, 8),
+                _log1p_cap(emoji_count, 8),
+                float(kana_count) / float(char_count),
+                float(kanji_count) / float(char_count),
+                float(alnum_count) / float(char_count),
+                1.0 if speaker_available else 0.0,
+            ]
+        )
+
+    return torch.tensor(rows, dtype=torch.float32)
+
+
+def set_duration_has_speaker_feature(
+    features: torch.Tensor,
+    has_speaker: torch.Tensor,
+) -> torch.Tensor:
+    if features.ndim != 2:
+        raise ValueError(f"Expected duration features shape (B, D), got {tuple(features.shape)}")
+    if features.shape[1] <= 0:
+        raise ValueError(f"duration features must have at least one column, got {features.shape[1]}")
+    out = features.clone()
+    out[:, -1] = has_speaker.to(device=features.device, dtype=features.dtype)
+    return out

--- a/vllm_omni/diffusion/models/irodori_tts/irodori_tts_transformer.py
+++ b/vllm_omni/diffusion/models/irodori_tts/irodori_tts_transformer.py
@@ -1,0 +1,1888 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.layer import Attention
+
+if TYPE_CHECKING:
+    from vllm_omni.diffusion.data import OmniDiffusionConfig
+
+# Standalone Constants
+DURATION_SPEAKER_FUSIONS = {
+    "concat",
+    "adarn",
+    "adarn_zero",
+    "speaker_cross_attn",
+    "text_cross_attn",
+}
+DURATION_CAPTION_FUSIONS = {"adarn_zero"}
+DURATION_CAPTION_POOLINGS = {"masked_mean"}
+DURATION_ARCHITECTURES = {
+    "pooled",
+    "token_sum_adarn_zero_no_aux",
+    "token_sum_dual_adarn_zero_no_aux",
+}
+
+SPEAKER_INVERSION_UNCOND_MODES = {"mask", "noise"}
+SPEAKER_EMBEDDING_KEY = "speaker_embedding"
+
+
+# ----------------------------------------------------------------------------
+# 1. Configuration Dataclass (ModelConfig)
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class ModelConfig:
+    latent_dim: int = 128
+    latent_patch_size: int = 1
+    model_dim: int = 2048
+    num_layers: int = 24
+    num_heads: int = 16
+    mlp_ratio: float = 2.875
+    text_mlp_ratio: float | None = 2.6
+    speaker_mlp_ratio: float | None = 2.6
+    dropout: float = 0.0
+    text_vocab_size: int = 102400
+    text_tokenizer_repo: str = "sbintuitions/sarashina2.2-0.5b"
+    text_add_bos: bool = True
+    text_dim: int = 1280
+    text_layers: int = 14
+    text_heads: int = 10
+    use_caption_condition: bool = False
+    use_speaker_condition: bool | None = None
+    caption_vocab_size: int | None = None
+    caption_tokenizer_repo: str | None = None
+    caption_add_bos: bool | None = None
+    caption_dim: int | None = None
+    caption_layers: int | None = None
+    caption_heads: int | None = None
+    caption_mlp_ratio: float | None = None
+    speaker_dim: int = 1280
+    speaker_layers: int = 14
+    speaker_heads: int = 10
+    speaker_patch_size: int = 1
+    timestep_embed_dim: int = 512
+    adaln_rank: int = 256
+    norm_eps: float = 1e-5
+    use_duration_predictor: bool = False
+    duration_aux_dim: int = 14
+    duration_hidden_dim: int = 1024
+    duration_layers: int = 3
+    duration_dropout: float = 0.1
+    duration_attention_heads: int = 8
+    duration_architecture: str = "token_sum_adarn_zero_no_aux"
+    duration_token_init_frames: float = 9.0
+    duration_speaker_fusion: str = "adarn_zero"
+    duration_caption_fusion: str = "adarn_zero"
+    duration_caption_pooling: str = "masked_mean"
+
+    @property
+    def patched_latent_dim(self) -> int:
+        return self.latent_dim * self.latent_patch_size
+
+    @property
+    def speaker_patched_latent_dim(self) -> int:
+        return self.patched_latent_dim * self.speaker_patch_size
+
+    @property
+    def use_speaker_condition_resolved(self) -> bool:
+        if self.use_speaker_condition is None:
+            return not bool(self.use_caption_condition)
+        return bool(self.use_speaker_condition)
+
+    @property
+    def text_mlp_ratio_resolved(self) -> float:
+        if self.text_mlp_ratio is None:
+            return self.mlp_ratio
+        return float(self.text_mlp_ratio)
+
+    @property
+    def caption_vocab_size_resolved(self) -> int:
+        if self.caption_vocab_size is None:
+            return int(self.text_vocab_size)
+        return int(self.caption_vocab_size)
+
+    @property
+    def caption_tokenizer_repo_resolved(self) -> str:
+        if self.caption_tokenizer_repo is None:
+            return self.text_tokenizer_repo
+        return str(self.caption_tokenizer_repo)
+
+    @property
+    def caption_add_bos_resolved(self) -> bool:
+        if self.caption_add_bos is None:
+            return bool(self.text_add_bos)
+        return bool(self.caption_add_bos)
+
+    @property
+    def caption_dim_resolved(self) -> int:
+        if self.caption_dim is None:
+            return int(self.text_dim)
+        return int(self.caption_dim)
+
+    @property
+    def caption_layers_resolved(self) -> int:
+        if self.caption_layers is None:
+            return int(self.text_layers)
+        return int(self.caption_layers)
+
+    @property
+    def caption_heads_resolved(self) -> int:
+        if self.caption_heads is None:
+            return int(self.text_heads)
+        return int(self.caption_heads)
+
+    @property
+    def caption_mlp_ratio_resolved(self) -> float:
+        if self.caption_mlp_ratio is None:
+            return self.text_mlp_ratio_resolved
+        return float(self.caption_mlp_ratio)
+
+    @property
+    def speaker_mlp_ratio_resolved(self) -> float:
+        if self.speaker_mlp_ratio is None:
+            return self.mlp_ratio
+        return float(self.speaker_mlp_ratio)
+
+
+# ----------------------------------------------------------------------------
+# 2. Math & Attention Helper Functions
+# ----------------------------------------------------------------------------
+
+
+def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0) -> torch.Tensor:
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    t = torch.arange(end, dtype=torch.float32)
+    freqs = torch.outer(t, freqs)
+    return torch.complex(torch.cos(freqs), torch.sin(freqs))
+
+
+def apply_rotary_emb(x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    # x: (B, S, H, Dh), Dh must be even.
+    x_ = torch.view_as_complex(x.float().reshape(*x.shape[:3], -1, 2))
+    x_ = x_ * freqs_cis[None, :, None, :]
+    x_ = torch.view_as_real(x_).reshape_as(x)
+    return x_.type_as(x)
+
+
+def get_timestep_embedding(timestep: torch.Tensor, dim: int) -> torch.Tensor:
+    assert dim % 2 == 0
+    half = dim // 2
+    freqs = 1000.0 * torch.exp(
+        -torch.log(torch.tensor(10000.0, device=timestep.device, dtype=torch.float32))
+        * torch.arange(half, device=timestep.device, dtype=torch.float32)
+        / half
+    )
+    args = timestep[:, None].float() * freqs[None, :]
+    return torch.cat([torch.cos(args), torch.sin(args)], dim=-1).to(timestep.dtype)
+
+
+def patch_sequence_with_mask(
+    seq: torch.Tensor,
+    mask: torch.Tensor,
+    patch_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if patch_size <= 1:
+        return seq, mask
+    if seq.ndim != 3 or mask.ndim != 2:
+        raise ValueError(f"Expected seq=(B,S,D), mask=(B,S), got seq={tuple(seq.shape)} mask={tuple(mask.shape)}")
+    if seq.shape[0] != mask.shape[0] or seq.shape[1] != mask.shape[1]:
+        raise ValueError(
+            f"Sequence/mask shape mismatch: seq={tuple(seq.shape)}, mask={tuple(mask.shape)}. Expected matching (B,S)."
+        )
+    bsz, seq_len, dim = seq.shape
+    usable = (seq_len // patch_size) * patch_size
+    if usable <= 0:
+        raise ValueError(f"Reference sequence too short for speaker_patch_size={patch_size}: seq_len={seq_len}")
+    seq = seq[:, :usable].reshape(bsz, usable // patch_size, dim * patch_size)
+    mask = mask[:, :usable].reshape(bsz, usable // patch_size, patch_size).all(dim=-1)
+    return seq, mask
+
+
+# ----------------------------------------------------------------------------
+# 3. Foundational Layer Components
+# ----------------------------------------------------------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int | tuple[int, ...], eps: float = 1e-6):
+        super().__init__()
+        if isinstance(dim, int):
+            dim = (dim,)
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_dtype = x.dtype
+        x = x.float()
+        x = x * torch.rsqrt((x * x).mean(dim=-1, keepdim=True) + self.eps)
+        return (x * self.weight).to(x_dtype)
+
+
+class LowRankAdaLN(nn.Module):
+    def __init__(self, model_dim: int, rank: int, eps: float):
+        super().__init__()
+        rank = max(1, min(int(rank), int(model_dim)))
+        self.eps = eps
+        self.shift_down = nn.Linear(model_dim, rank, bias=False)
+        self.scale_down = nn.Linear(model_dim, rank, bias=False)
+        self.gate_down = nn.Linear(model_dim, rank, bias=False)
+        self.shift_up = nn.Linear(rank, model_dim, bias=True)
+        self.scale_up = nn.Linear(rank, model_dim, bias=True)
+        self.gate_up = nn.Linear(rank, model_dim, bias=True)
+
+        # Zero-init projections
+        nn.init.zeros_(self.shift_up.weight)
+        nn.init.zeros_(self.scale_up.weight)
+        nn.init.zeros_(self.gate_up.weight)
+        if self.shift_up.bias is not None:
+            nn.init.zeros_(self.shift_up.bias)
+        if self.scale_up.bias is not None:
+            nn.init.zeros_(self.scale_up.bias)
+        if self.gate_up.bias is not None:
+            nn.init.zeros_(self.gate_up.bias)
+
+    def forward(self, x: torch.Tensor, cond_embed: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        shift, scale, gate = cond_embed.chunk(3, dim=-1)
+        shift = self.shift_up(self.shift_down(F.silu(shift))) + shift
+        scale = self.scale_up(self.scale_down(F.silu(scale))) + scale
+        gate = self.gate_up(self.gate_down(F.silu(gate))) + gate
+
+        x_dtype = x.dtype
+        x = x.float()
+        x = x * torch.rsqrt((x * x).mean(dim=-1, keepdim=True) + self.eps)
+        x = x * (1.0 + scale) + shift
+        gate = torch.tanh(gate)
+        return x.to(x_dtype), gate
+
+
+# ----------------------------------------------------------------------------
+# 4. Attention Layers
+# ----------------------------------------------------------------------------
+
+
+class SelfAttention(nn.Module):
+    def __init__(self, dim: int, heads: int, norm_eps: float):
+        super().__init__()
+        if dim % heads != 0:
+            raise ValueError(f"dim={dim} must be divisible by heads={heads}")
+        if (dim // heads) % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.dim = dim
+        self.heads = heads
+        self.head_dim = dim // heads
+
+        self.wq = nn.Linear(dim, dim, bias=False)
+        self.wk = nn.Linear(dim, dim, bias=False)
+        self.wv = nn.Linear(dim, dim, bias=False)
+        self.wo = nn.Linear(dim, dim, bias=False)
+        self.gate = nn.Linear(dim, dim, bias=False)
+
+        self.q_norm = RMSNorm((self.heads, self.head_dim), eps=norm_eps)
+        self.k_norm = RMSNorm((self.heads, self.head_dim), eps=norm_eps)
+
+        # vLLM Optimized Attention backend
+        self.attn = Attention(
+            num_heads=heads,
+            head_size=self.head_dim,
+            softmax_scale=1.0 / (self.head_dim**0.5),
+            causal=False,
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        key_mask: torch.Tensor | None,
+        freqs_cis: torch.Tensor,
+    ) -> torch.Tensor:
+        bsz, seq_len, _ = x.shape
+        q = self.wq(x).reshape(bsz, seq_len, self.heads, self.head_dim)
+        k = self.wk(x).reshape(bsz, seq_len, self.heads, self.head_dim)
+        v = self.wv(x).reshape(bsz, seq_len, self.heads, self.head_dim)
+        gate = self.gate(x)
+
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+        q = apply_rotary_emb(q, freqs_cis[:seq_len])
+        k = apply_rotary_emb(k, freqs_cis[:seq_len])
+
+        # Prepare attention metadata with padding mask
+        attn_metadata = None
+        if key_mask is not None:
+            attn_metadata = AttentionMetadata(attn_mask=key_mask)
+
+        # Route execution to vLLM's optimized Attention backend
+        y = self.attn(q, k, v, attn_metadata=attn_metadata)
+        y = y.reshape(bsz, seq_len, self.dim)
+        y = y * torch.sigmoid(gate)
+        return self.wo(y)
+
+
+class JointAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        heads: int,
+        text_ctx_dim: int,
+        speaker_ctx_dim: int | None,
+        caption_ctx_dim: int | None,
+        norm_eps: float,
+    ):
+        super().__init__()
+        if dim % heads != 0:
+            raise ValueError(f"dim={dim} must be divisible by heads={heads}")
+        if (dim // heads) % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.dim = dim
+        self.heads = heads
+        self.head_dim = dim // heads
+
+        self.wq = nn.Linear(dim, dim, bias=False)
+        self.wk = nn.Linear(dim, dim, bias=False)
+        self.wv = nn.Linear(dim, dim, bias=False)
+        self.wk_text = nn.Linear(text_ctx_dim, dim, bias=False)
+        self.wv_text = nn.Linear(text_ctx_dim, dim, bias=False)
+
+        self.has_speaker_condition = speaker_ctx_dim is not None
+        if self.has_speaker_condition:
+            self.wk_speaker = nn.Linear(int(speaker_ctx_dim), dim, bias=False)
+            self.wv_speaker = nn.Linear(int(speaker_ctx_dim), dim, bias=False)
+
+        self.has_caption_condition = caption_ctx_dim is not None
+        if self.has_caption_condition:
+            self.wk_caption = nn.Linear(int(caption_ctx_dim), dim, bias=False)
+            self.wv_caption = nn.Linear(int(caption_ctx_dim), dim, bias=False)
+
+        self.gate = nn.Linear(dim, dim, bias=False)
+        self.wo = nn.Linear(dim, dim, bias=False)
+
+        self.q_norm = RMSNorm((self.heads, self.head_dim), eps=norm_eps)
+        self.k_norm = RMSNorm((self.heads, self.head_dim), eps=norm_eps)
+
+        # vLLM Optimized Attention backend
+        self.attn = Attention(
+            num_heads=heads,
+            head_size=self.head_dim,
+            softmax_scale=1.0 / (self.head_dim**0.5),
+            causal=False,
+        )
+
+    def _apply_rotary_half(self, x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+        # Note: chunks along dim=-2 (Heads H), NOT dim=-1 (Channels D).
+        # This means applying RoPE on only the first half of heads.
+        x_rot, x_passthrough = x.chunk(2, dim=-2)
+        x_rot = apply_rotary_emb(x_rot, freqs_cis)
+        return torch.cat([x_rot, x_passthrough], dim=-2)
+
+    def project_context_kv(
+        self,
+        text_context: torch.Tensor,
+        speaker_context: torch.Tensor | None,
+        caption_context: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, ...]:
+        bsz = text_context.shape[0]
+        k_text = self.wk_text(text_context).reshape(bsz, text_context.shape[1], self.heads, self.head_dim)
+        v_text = self.wv_text(text_context).reshape(bsz, text_context.shape[1], self.heads, self.head_dim)
+        k_text = self.k_norm(k_text)
+        projected: list[torch.Tensor] = [k_text, v_text]
+
+        if self.has_speaker_condition:
+            if speaker_context is None:
+                raise ValueError("speaker_context is required when speaker conditioning is enabled.")
+            if speaker_context.shape[0] != bsz:
+                raise ValueError(
+                    "Batch mismatch for speaker context projection: "
+                    f"text={tuple(text_context.shape)} speaker={tuple(speaker_context.shape)}"
+                )
+            k_speaker = self.wk_speaker(speaker_context).reshape(
+                bsz, speaker_context.shape[1], self.heads, self.head_dim
+            )
+            v_speaker = self.wv_speaker(speaker_context).reshape(
+                bsz, speaker_context.shape[1], self.heads, self.head_dim
+            )
+            k_speaker = self.k_norm(k_speaker)
+            projected.extend([k_speaker, v_speaker])
+
+        if self.has_caption_condition:
+            if caption_context is None:
+                raise ValueError("caption_context is required when caption conditioning is enabled.")
+            if caption_context.shape[0] != bsz:
+                raise ValueError(
+                    "Batch mismatch for caption context projection: "
+                    f"text={tuple(text_context.shape)} caption={tuple(caption_context.shape)}"
+                )
+            k_caption = self.wk_caption(caption_context).reshape(
+                bsz, caption_context.shape[1], self.heads, self.head_dim
+            )
+            v_caption = self.wv_caption(caption_context).reshape(
+                bsz, caption_context.shape[1], self.heads, self.head_dim
+            )
+            k_caption = self.k_norm(k_caption)
+            projected.extend([k_caption, v_caption])
+
+        return tuple(projected)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        text_context: torch.Tensor,
+        text_mask: torch.Tensor | None,
+        speaker_context: torch.Tensor | None,
+        speaker_mask: torch.Tensor | None,
+        caption_context: torch.Tensor | None,
+        caption_mask: torch.Tensor | None,
+        freqs_cis: torch.Tensor,
+        self_mask: torch.Tensor | None = None,
+        context_kv: tuple[torch.Tensor, ...] | None = None,
+    ) -> torch.Tensor:
+        bsz, seq_len, _ = x.shape
+        q = self.wq(x).reshape(bsz, seq_len, self.heads, self.head_dim)
+        k_self = self.wk(x).reshape(bsz, seq_len, self.heads, self.head_dim)
+        v_self = self.wv(x).reshape(bsz, seq_len, self.heads, self.head_dim)
+
+        if context_kv is None:
+            projected = self.project_context_kv(
+                text_context=text_context,
+                speaker_context=speaker_context,
+                caption_context=caption_context,
+            )
+        else:
+            projected = context_kv
+
+        if projected is None:
+            raise RuntimeError("JointAttention projected context unexpectedly missing.")
+
+        offset = 0
+        k_text, v_text = projected[offset], projected[offset + 1]
+        offset += 2
+
+        k_speaker = None
+        v_speaker = None
+        if self.has_speaker_condition:
+            k_speaker, v_speaker = projected[offset], projected[offset + 1]
+            offset += 2
+
+        k_caption = None
+        v_caption = None
+        if self.has_caption_condition:
+            k_caption, v_caption = projected[offset], projected[offset + 1]
+
+        q = self.q_norm(q)
+        k_self = self.k_norm(k_self)
+
+        # Apply RoPE to first half of Heads H
+        q = self._apply_rotary_half(q, freqs_cis[:seq_len])
+        k_self = self._apply_rotary_half(k_self, freqs_cis[:seq_len])
+
+        if self_mask is None:
+            self_mask = torch.ones((bsz, seq_len), dtype=torch.bool, device=x.device)
+        if text_mask is None:
+            text_mask = torch.ones(
+                (bsz, text_context.shape[1]),
+                dtype=torch.bool,
+                device=x.device,
+            )
+
+        context_k = [k_self, k_text]
+        context_v = [v_self, v_text]
+        context_masks = [self_mask, text_mask]
+
+        if self.has_speaker_condition:
+            if speaker_context is None or k_speaker is None or v_speaker is None:
+                raise ValueError("speaker_context is required when speaker conditioning is enabled.")
+            if speaker_mask is None:
+                speaker_mask = torch.ones(
+                    (bsz, speaker_context.shape[1]),
+                    dtype=torch.bool,
+                    device=x.device,
+                )
+            context_k.append(k_speaker)
+            context_v.append(v_speaker)
+            context_masks.append(speaker_mask)
+
+        if self.has_caption_condition:
+            if caption_context is None:
+                raise ValueError("caption_context is required when caption conditioning is enabled.")
+            if caption_mask is None:
+                caption_mask = torch.ones(
+                    (bsz, caption_context.shape[1]),
+                    dtype=torch.bool,
+                    device=x.device,
+                )
+            if k_caption is None or v_caption is None:
+                raise RuntimeError("Caption projections are missing despite enabled caption conditioning.")
+            context_k.append(k_caption)
+            context_v.append(v_caption)
+            context_masks.append(caption_mask)
+
+        # Concatenate keys, values, and masks to construct the joint conditioning sequence
+        k = torch.cat(context_k, dim=1)
+        v = torch.cat(context_v, dim=1)
+        joint_mask = torch.cat(context_masks, dim=1)
+
+        # Prepare vLLM AttentionMetadata with the combined 2D mask
+        attn_metadata = AttentionMetadata(attn_mask=joint_mask)
+
+        # Route execution to vLLM's optimized Attention backend (supports mismatched Q and K/V len)
+        y = self.attn(q, k, v, attn_metadata=attn_metadata)
+        y = y.reshape(bsz, seq_len, self.dim)
+        y = y * torch.sigmoid(self.gate(x))
+        return self.wo(y)
+
+
+# ----------------------------------------------------------------------------
+# 5. Intermediate Helper blocks
+# ----------------------------------------------------------------------------
+
+
+class SwiGLU(nn.Module):
+    def __init__(self, dim: int, hidden_dim: int):
+        super().__init__()
+        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+        self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+def _safe_attention_mask(
+    x: torch.Tensor,
+    mask: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if mask.ndim != 2 or mask.shape[0] != x.shape[0] or mask.shape[1] != x.shape[1]:
+        raise ValueError(f"mask must have shape (B, S) matching x, got x={tuple(x.shape)} mask={tuple(mask.shape)}")
+    mask = mask.to(device=x.device, dtype=torch.bool)
+    has_any = mask.any(dim=1)
+    if bool(has_any.all()):
+        return x, mask
+    if x.shape[1] <= 0:
+        raise ValueError("Cannot attention-pool an empty sequence.")
+    x = x.clone()
+    mask = mask.clone()
+    x[~has_any] = 0
+    mask[~has_any, 0] = True
+    return x, mask
+
+
+class AttentionPooling(nn.Module):
+    def __init__(self, dim: int, heads: int, norm_eps: float):
+        super().__init__()
+        if dim % heads != 0:
+            raise ValueError(f"dim={dim} must be divisible by heads={heads}")
+        self.dim = int(dim)
+        self.heads = int(heads)
+        self.head_dim = int(dim) // int(heads)
+        self.query = nn.Parameter(torch.empty(1, 1, int(dim)))
+        nn.init.normal_(self.query, mean=0.0, std=0.02)
+        self.q_norm = RMSNorm(dim, eps=norm_eps)
+        self.k_norm = RMSNorm(dim, eps=norm_eps)
+        self.wq = nn.Linear(dim, dim, bias=False)
+        self.wk = nn.Linear(dim, dim, bias=False)
+        self.wv = nn.Linear(dim, dim, bias=False)
+        self.wo = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        if x.ndim != 3 or x.shape[-1] != self.dim:
+            raise ValueError(f"x must have shape (B, S, {self.dim}), got {tuple(x.shape)}")
+        x, mask = _safe_attention_mask(x, mask)
+        bsz, seq_len, _ = x.shape
+        q = self.query.to(dtype=x.dtype).expand(bsz, -1, -1)
+        q = self.wq(self.q_norm(q)).reshape(bsz, 1, self.heads, self.head_dim)
+        k = self.wk(self.k_norm(x)).reshape(bsz, seq_len, self.heads, self.head_dim)
+        v = self.wv(x).reshape(bsz, seq_len, self.heads, self.head_dim)
+        y = F.scaled_dot_product_attention(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            attn_mask=mask[:, None, None, :],
+            is_causal=False,
+        )
+        y = y.transpose(1, 2).reshape(bsz, 1, self.dim)
+        return self.wo(y).squeeze(1)
+
+
+class CrossAttentionPooling(nn.Module):
+    def __init__(
+        self,
+        *,
+        query_dim: int,
+        context_dim: int,
+        output_dim: int,
+        heads: int,
+        norm_eps: float,
+    ):
+        super().__init__()
+        if output_dim % heads != 0:
+            raise ValueError(f"output_dim={output_dim} must be divisible by heads={heads}")
+        self.query_dim = int(query_dim)
+        self.context_dim = int(context_dim)
+        self.output_dim = int(output_dim)
+        self.heads = int(heads)
+        self.head_dim = int(output_dim) // int(heads)
+        self.q_norm = RMSNorm(query_dim, eps=norm_eps)
+        self.k_norm = RMSNorm(context_dim, eps=norm_eps)
+        self.wq = nn.Linear(query_dim, output_dim, bias=False)
+        self.wk = nn.Linear(context_dim, output_dim, bias=False)
+        self.wv = nn.Linear(context_dim, output_dim, bias=False)
+        self.wo = nn.Linear(output_dim, output_dim, bias=False)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        context: torch.Tensor,
+        context_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        if query.ndim != 2 or query.shape[-1] != self.query_dim:
+            raise ValueError(f"query must have shape (B, {self.query_dim}), got {tuple(query.shape)}")
+        if context.ndim != 3 or context.shape[-1] != self.context_dim:
+            raise ValueError(f"context must have shape (B, S, {self.context_dim}), got {tuple(context.shape)}")
+        context, context_mask = _safe_attention_mask(context, context_mask)
+        bsz, seq_len, _ = context.shape
+        q = query[:, None, :]
+        q = self.wq(self.q_norm(q)).reshape(bsz, 1, self.heads, self.head_dim)
+        k = self.wk(self.k_norm(context)).reshape(bsz, seq_len, self.heads, self.head_dim)
+        v = self.wv(context).reshape(bsz, seq_len, self.heads, self.head_dim)
+        y = F.scaled_dot_product_attention(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            attn_mask=context_mask[:, None, None, :],
+            is_causal=False,
+        )
+        y = y.transpose(1, 2).reshape(bsz, 1, self.output_dim)
+        return self.wo(y).squeeze(1)
+
+
+class DurationSwiGLUBlock(nn.Module):
+    def __init__(
+        self,
+        *,
+        dim: int,
+        hidden_dim: int,
+        dropout: float,
+        norm_eps: float,
+        cond_dim: int | None = None,
+        caption_cond_dim: int | None = None,
+    ):
+        super().__init__()
+        self.norm = RMSNorm(dim, eps=norm_eps)
+        self.mlp = SwiGLU(dim, hidden_dim)
+        self.dropout = nn.Dropout(dropout)
+        self.cond_dim = cond_dim
+        self.modulation = None
+        if cond_dim is not None:
+            self.modulation = nn.Linear(cond_dim, dim * 3, bias=True)
+            nn.init.zeros_(self.modulation.weight)
+            nn.init.zeros_(self.modulation.bias)
+        self.caption_cond_dim = caption_cond_dim
+        self.caption_modulation = None
+        if caption_cond_dim is not None:
+            self.caption_modulation = nn.Linear(caption_cond_dim, dim * 3, bias=True)
+            nn.init.zeros_(self.caption_modulation.weight)
+            nn.init.zeros_(self.caption_modulation.bias)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cond: torch.Tensor | None = None,
+        caption_cond: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        h = self.norm(x)
+        if self.modulation is not None or self.caption_modulation is not None:
+            shift = scale = gate = None
+            if self.modulation is not None:
+                if cond is None:
+                    raise ValueError("cond is required for AdaRN-Zero duration blocks.")
+                shift, scale, gate = self.modulation(F.silu(cond)).chunk(3, dim=-1)
+            if self.caption_modulation is not None:
+                if caption_cond is None:
+                    raise ValueError("caption_cond is required for caption AdaRN-Zero duration blocks.")
+                caption_shift, caption_scale, caption_gate = self.caption_modulation(F.silu(caption_cond)).chunk(
+                    3, dim=-1
+                )
+                if shift is None:
+                    shift, scale, gate = caption_shift, caption_scale, caption_gate
+                else:
+                    shift = shift + caption_shift
+                    scale = scale + caption_scale
+                    gate = gate + caption_gate
+            if shift is None or scale is None or gate is None:
+                raise RuntimeError("Duration block modulation state is incomplete.")
+            if h.ndim == 3 and shift.ndim == 2:
+                shift = shift.unsqueeze(1)
+                scale = scale.unsqueeze(1)
+                gate = gate.unsqueeze(1)
+            h = h * (1.0 + scale) + shift
+            return x + self.dropout(torch.tanh(gate) * self.mlp(h))
+        return x + self.dropout(self.mlp(h))
+
+
+class TextBlock(nn.Module):
+    def __init__(self, dim: int, heads: int, mlp_ratio: float, norm_eps: float, dropout: float):
+        super().__init__()
+        self.attention_norm = RMSNorm(dim, eps=norm_eps)
+        self.attention = SelfAttention(dim, heads, norm_eps=norm_eps)
+        self.mlp_norm = RMSNorm(dim, eps=norm_eps)
+        self.mlp = SwiGLU(dim, int(dim * mlp_ratio))
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+        x = x + self.dropout(self.attention(self.attention_norm(x), key_mask=mask, freqs_cis=freqs_cis))
+        x = x + self.dropout(self.mlp(self.mlp_norm(x)))
+        return x
+
+
+# ----------------------------------------------------------------------------
+# 6. Encoders & Predictors
+# ----------------------------------------------------------------------------
+
+
+class TextEncoder(nn.Module):
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        dim: int,
+        layers: int,
+        heads: int,
+        mlp_ratio: float,
+        norm_eps: float,
+        dropout: float,
+    ):
+        super().__init__()
+        self.text_embedding = nn.Embedding(vocab_size, dim)
+        self.blocks = nn.ModuleList(
+            TextBlock(
+                dim=dim,
+                heads=heads,
+                mlp_ratio=mlp_ratio,
+                norm_eps=norm_eps,
+                dropout=dropout,
+            )
+            for _ in range(layers)
+        )
+        self.head_dim = dim // heads
+        self.register_buffer("_freqs_cis_cache", torch.empty(0, 0, dtype=torch.complex64), persistent=False)
+
+    def _rope_freqs(self, seq_len: int, device: torch.device) -> torch.Tensor:
+        cache = self._freqs_cis_cache
+        if cache.device != device or cache.shape[0] < seq_len:
+            cache = precompute_freqs_cis(self.head_dim, seq_len).to(device)
+            self._freqs_cis_cache = cache
+        return cache[:seq_len]
+
+    def forward(self, input_ids: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        x = self.text_embedding(input_ids)
+        mask_f = mask.unsqueeze(-1).to(dtype=x.dtype)
+        x = x * mask_f
+        freqs = self._rope_freqs(input_ids.shape[1], x.device)
+        for block in self.blocks:
+            x = block(x, mask=mask, freqs_cis=freqs)
+            x = x * mask_f
+        return x * mask_f
+
+
+class ReferenceLatentEncoder(nn.Module):
+    def __init__(self, cfg: ModelConfig):
+        super().__init__()
+        self.in_proj = nn.Linear(cfg.speaker_patched_latent_dim, cfg.speaker_dim, bias=True)
+        speaker_mlp_ratio = cfg.speaker_mlp_ratio_resolved
+        self.blocks = nn.ModuleList(
+            TextBlock(
+                dim=cfg.speaker_dim,
+                heads=cfg.speaker_heads,
+                mlp_ratio=speaker_mlp_ratio,
+                norm_eps=cfg.norm_eps,
+                dropout=cfg.dropout,
+            )
+            for _ in range(cfg.speaker_layers)
+        )
+        self.head_dim = cfg.speaker_dim // cfg.speaker_heads
+        self.register_buffer("_freqs_cis_cache", torch.empty(0, 0, dtype=torch.complex64), persistent=False)
+
+    def _rope_freqs(self, seq_len: int, device: torch.device) -> torch.Tensor:
+        cache = self._freqs_cis_cache
+        if cache.device != device or cache.shape[0] < seq_len:
+            cache = precompute_freqs_cis(self.head_dim, seq_len).to(device)
+            self._freqs_cis_cache = cache
+        return cache[:seq_len]
+
+    def forward(self, latent: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        x = self.in_proj(latent)
+        x = x / 6.0
+        mask_f = mask.unsqueeze(-1).to(dtype=x.dtype)
+        x = x * mask_f
+        freqs = self._rope_freqs(x.shape[1], x.device)
+        for block in self.blocks:
+            x = block(x, mask=mask, freqs_cis=freqs)
+            x = x * mask_f
+        return x * mask_f
+
+
+class DurationPredictor(nn.Module):
+    def __init__(
+        self,
+        *,
+        text_dim: int,
+        aux_dim: int,
+        hidden_dim: int,
+        layers: int,
+        dropout: float,
+        speaker_dim: int | None = None,
+        speaker_fusion: str = "concat",
+        caption_dim: int | None = None,
+        caption_fusion: str = "adarn_zero",
+        caption_pooling: str = "masked_mean",
+        attention_heads: int = 8,
+        norm_eps: float = 1e-5,
+        architecture: str = "pooled",
+        token_init_frames: float = 6.3,
+    ):
+        super().__init__()
+        self.text_dim = int(text_dim)
+        self.aux_dim = int(aux_dim)
+        self.hidden_dim = int(hidden_dim)
+        self.speaker_dim = None if speaker_dim is None else int(speaker_dim)
+        self.speaker_fusion = speaker_fusion
+        self.caption_dim = None if caption_dim is None else int(caption_dim)
+        self.caption_fusion = caption_fusion
+        self.caption_pooling = caption_pooling
+        self.duration_architecture = architecture
+        self.text_pool = None
+        self.null_speaker = nn.Parameter(torch.zeros(int(speaker_dim))) if speaker_dim is not None else None
+        self.null_caption = nn.Parameter(torch.zeros(int(caption_dim))) if caption_dim is not None else None
+        self.text_adarn_norm = None
+        self.text_adarn = None
+        self.speaker_cross_attn = None
+        self.text_cross_attn = None
+        self.token_input_proj = None
+        self.token_blocks = None
+        self.token_out_norm = None
+        self.token_out_proj = None
+
+        if architecture in {
+            "token_sum_adarn_zero_no_aux",
+            "token_sum_dual_adarn_zero_no_aux",
+        }:
+            self.token_input_proj = nn.Linear(int(text_dim), int(hidden_dim))
+            self.token_blocks = nn.ModuleList(
+                DurationSwiGLUBlock(
+                    dim=int(hidden_dim),
+                    hidden_dim=int(hidden_dim),
+                    dropout=float(dropout),
+                    norm_eps=float(norm_eps),
+                    cond_dim=int(speaker_dim),
+                    caption_cond_dim=(int(caption_dim) if architecture == "token_sum_dual_adarn_zero_no_aux" else None),
+                )
+                for _ in range(int(layers))
+            )
+            self.token_out_norm = RMSNorm(int(hidden_dim), eps=float(norm_eps))
+            self.token_out_proj = nn.Linear(int(hidden_dim), 1)
+            nn.init.zeros_(self.token_out_proj.weight)
+            nn.init.constant_(
+                self.token_out_proj.bias,
+                float(math.log(math.expm1(float(token_init_frames)))),
+            )
+            return
+
+        self.text_pool = AttentionPooling(
+            dim=int(text_dim),
+            heads=int(attention_heads),
+            norm_eps=float(norm_eps),
+        )
+
+        if speaker_dim is not None:
+            if speaker_fusion == "concat":
+                input_dim = int(text_dim) + int(speaker_dim) + int(aux_dim)
+            elif speaker_fusion == "adarn":
+                input_dim = int(text_dim) + int(aux_dim)
+                self.text_adarn_norm = RMSNorm(int(text_dim), eps=float(norm_eps))
+                self.text_adarn = nn.Linear(int(speaker_dim), int(text_dim) * 2)
+                nn.init.zeros_(self.text_adarn.weight)
+                nn.init.zeros_(self.text_adarn.bias)
+            elif speaker_fusion == "adarn_zero":
+                input_dim = int(text_dim) + int(aux_dim)
+            elif speaker_fusion == "speaker_cross_attn":
+                input_dim = int(text_dim) * 2 + int(aux_dim)
+                self.speaker_cross_attn = CrossAttentionPooling(
+                    query_dim=int(text_dim),
+                    context_dim=int(speaker_dim),
+                    output_dim=int(text_dim),
+                    heads=int(attention_heads),
+                    norm_eps=float(norm_eps),
+                )
+            elif speaker_fusion == "text_cross_attn":
+                input_dim = int(text_dim) + int(speaker_dim) + int(aux_dim)
+                self.text_cross_attn = CrossAttentionPooling(
+                    query_dim=int(speaker_dim),
+                    context_dim=int(text_dim),
+                    output_dim=int(text_dim),
+                    heads=int(attention_heads),
+                    norm_eps=float(norm_eps),
+                )
+        else:
+            input_dim = int(text_dim) + int(aux_dim)
+
+        self.input_proj = nn.Linear(int(input_dim), int(hidden_dim))
+        block_cond_dim = int(speaker_dim) if speaker_fusion == "adarn_zero" else None
+        self.blocks = nn.ModuleList(
+            DurationSwiGLUBlock(
+                dim=int(hidden_dim),
+                hidden_dim=int(hidden_dim),
+                dropout=float(dropout),
+                norm_eps=float(norm_eps),
+                cond_dim=block_cond_dim,
+            )
+            for _ in range(int(layers))
+        )
+        self.out_norm = RMSNorm(int(hidden_dim), eps=float(norm_eps))
+        self.out_proj = nn.Linear(int(hidden_dim), 1)
+
+    def _speaker_vec(
+        self,
+        *,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        speaker_state: torch.Tensor | None,
+        has_speaker: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.null_speaker is None or self.speaker_dim is None:
+            raise RuntimeError("Duration speaker modules are missing.")
+        null_vec = self.null_speaker.to(device=device, dtype=dtype)[None, :].expand(batch_size, -1)
+        if speaker_state is None:
+            return null_vec
+        if speaker_state.ndim != 3 or speaker_state.shape[0] != batch_size:
+            raise ValueError(f"speaker_state must have shape (B, S, D), got {tuple(speaker_state.shape)}")
+        if speaker_state.shape[-1] != self.speaker_dim:
+            raise ValueError(f"speaker_state last dim must be {self.speaker_dim}, got {speaker_state.shape[-1]}")
+        speaker_vec = speaker_state[:, 0].to(device=device, dtype=dtype)
+        return torch.where(has_speaker[:, None], speaker_vec, null_vec)
+
+    def _caption_vec(
+        self,
+        *,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        caption_state: torch.Tensor | None,
+        caption_mask: torch.Tensor | None,
+        has_caption: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.null_caption is None or self.caption_dim is None:
+            raise RuntimeError("Duration caption modules are missing.")
+        null_vec = self.null_caption.to(device=device, dtype=dtype)[None, :].expand(batch_size, -1)
+        if caption_state is None:
+            return null_vec
+        if caption_state.ndim != 3 or caption_state.shape[0] != batch_size:
+            raise ValueError(f"caption_state must have shape (B, S, D), got {tuple(caption_state.shape)}")
+        if caption_state.shape[-1] != self.caption_dim:
+            raise ValueError(f"caption_state last dim must be {self.caption_dim}, got {caption_state.shape[-1]}")
+        caption_state = caption_state.to(device=device, dtype=dtype)
+        if caption_mask is None:
+            caption_mask = torch.ones((batch_size, caption_state.shape[1]), dtype=torch.bool, device=device)
+        elif caption_mask.ndim != 2 or caption_mask.shape[:2] != caption_state.shape[:2]:
+            raise ValueError(
+                "caption_mask must have shape matching caption_state (B, S), "
+                f"got caption_state={tuple(caption_state.shape)} mask={tuple(caption_mask.shape)}"
+            )
+        caption_mask = caption_mask.to(device=device, dtype=torch.bool) & has_caption[:, None]
+        caption_mask_f = caption_mask.unsqueeze(-1).to(dtype=caption_state.dtype)
+        denom = caption_mask_f.sum(dim=1).clamp_min(1.0)
+        caption_vec = (caption_state * caption_mask_f).sum(dim=1) / denom
+        return torch.where(caption_mask.any(dim=1, keepdim=True), caption_vec, null_vec)
+
+    def _speaker_sequence(
+        self,
+        *,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+        speaker_state: torch.Tensor | None,
+        speaker_mask: torch.Tensor | None,
+        has_speaker: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.null_speaker is None or self.speaker_dim is None:
+            raise RuntimeError("Duration speaker modules are missing.")
+        null_token = self.null_speaker.to(device=device, dtype=dtype)[None, None, :].expand(batch_size, 1, -1)
+        if speaker_state is None:
+            return null_token, torch.ones((batch_size, 1), dtype=torch.bool, device=device)
+        if speaker_state.ndim != 3 or speaker_state.shape[0] != batch_size:
+            raise ValueError(f"speaker_state must have shape (B, S, D), got {tuple(speaker_state.shape)}")
+        if speaker_state.shape[-1] != self.speaker_dim:
+            raise ValueError(f"speaker_state last dim must be {self.speaker_dim}, got {speaker_state.shape[-1]}")
+        speaker_state = speaker_state.to(device=device, dtype=dtype)
+        if speaker_mask is None:
+            speaker_mask = torch.ones((batch_size, speaker_state.shape[1]), dtype=torch.bool, device=device)
+        elif speaker_mask.ndim != 2 or speaker_mask.shape[:2] != speaker_state.shape[:2]:
+            raise ValueError(
+                "speaker_mask must have shape matching speaker_state (B, S), "
+                f"got speaker_state={tuple(speaker_state.shape)} mask={tuple(speaker_mask.shape)}"
+            )
+        speaker_mask = speaker_mask.to(device=device, dtype=torch.bool)
+        real_mask = speaker_mask & has_speaker[:, None]
+        fallback_mask = ~real_mask.any(dim=1, keepdim=True)
+        context = torch.cat([speaker_state, null_token], dim=1)
+        context_mask = torch.cat([real_mask, fallback_mask], dim=1)
+        return context, context_mask
+
+    def forward(
+        self,
+        text_state: torch.Tensor,
+        *,
+        text_mask: torch.Tensor,
+        aux_features: torch.Tensor,
+        speaker_state: torch.Tensor | None = None,
+        speaker_mask: torch.Tensor | None = None,
+        has_speaker: torch.Tensor | None = None,
+        caption_state: torch.Tensor | None = None,
+        caption_mask: torch.Tensor | None = None,
+        has_caption: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if text_state.ndim != 3 or text_state.shape[-1] != self.text_dim:
+            raise ValueError(f"text_state must have shape (B, S, {self.text_dim}), got {tuple(text_state.shape)}")
+        if aux_features.ndim != 2 or aux_features.shape[1] != self.aux_dim:
+            raise ValueError(f"aux_features must have shape (B, {self.aux_dim}), got {tuple(aux_features.shape)}")
+        if aux_features.shape[0] != text_state.shape[0]:
+            raise ValueError(
+                "Batch mismatch for duration predictor: "
+                f"text_state={tuple(text_state.shape)} aux_features={tuple(aux_features.shape)}"
+            )
+        text_state, text_mask = _safe_attention_mask(text_state, text_mask)
+        aux_features = aux_features.to(device=text_state.device, dtype=text_state.dtype)
+
+        if self.duration_architecture in {
+            "token_sum_adarn_zero_no_aux",
+            "token_sum_dual_adarn_zero_no_aux",
+        }:
+            if self.speaker_dim is None:
+                raise RuntimeError("Token-sum duration architecture requires speaker modules.")
+            if has_speaker is None:
+                raise ValueError("has_speaker is required for speaker-conditioned duration prediction.")
+            has_speaker = has_speaker.to(device=text_state.device, dtype=torch.bool)
+            if has_speaker.ndim != 1 or has_speaker.shape[0] != text_state.shape[0]:
+                raise ValueError(f"has_speaker must have shape (B,), got {tuple(has_speaker.shape)}")
+            speaker_vec = self._speaker_vec(
+                batch_size=text_state.shape[0],
+                device=text_state.device,
+                dtype=text_state.dtype,
+                speaker_state=speaker_state,
+                has_speaker=has_speaker,
+            )
+            caption_vec = None
+            if self.duration_architecture == "token_sum_dual_adarn_zero_no_aux":
+                if self.caption_dim is None:
+                    raise RuntimeError("Dual token-sum duration architecture requires caption modules.")
+                if has_caption is None:
+                    raise ValueError("has_caption is required for caption-conditioned duration prediction.")
+                has_caption = has_caption.to(device=text_state.device, dtype=torch.bool)
+                if has_caption.ndim != 1 or has_caption.shape[0] != text_state.shape[0]:
+                    raise ValueError(f"has_caption must have shape (B,), got {tuple(has_caption.shape)}")
+                caption_vec = self._caption_vec(
+                    batch_size=text_state.shape[0],
+                    device=text_state.device,
+                    dtype=text_state.dtype,
+                    caption_state=caption_state,
+                    caption_mask=caption_mask,
+                    has_caption=has_caption,
+                )
+            if (
+                self.token_input_proj is None
+                or self.token_blocks is None
+                or self.token_out_norm is None
+                or self.token_out_proj is None
+            ):
+                raise RuntimeError("Token-sum duration modules are missing.")
+            h = self.token_input_proj(text_state)
+            for block in self.token_blocks:
+                h = block(h, cond=speaker_vec, caption_cond=caption_vec)
+            token_logits = self.token_out_proj(self.token_out_norm(h)).squeeze(-1)
+            token_frames = F.softplus(token_logits.float())
+            total_frames = (token_frames * text_mask.to(dtype=token_frames.dtype)).sum(dim=1)
+            return torch.log1p(total_frames.clamp_min(0.0))
+
+        if self.text_pool is None:
+            raise RuntimeError("Pooled duration modules are missing.")
+        text_vec = self.text_pool(text_state, text_mask)
+        if self.speaker_dim is None:
+            x = torch.cat([text_vec, aux_features], dim=-1)
+            h = self.input_proj(x)
+            for block in self.blocks:
+                h = block(h)
+            return self.out_proj(self.out_norm(h)).squeeze(-1)
+
+        if has_speaker is None:
+            raise ValueError("has_speaker is required for speaker-conditioned duration prediction.")
+        has_speaker = has_speaker.to(device=text_vec.device, dtype=torch.bool)
+        if has_speaker.ndim != 1 or has_speaker.shape[0] != text_vec.shape[0]:
+            raise ValueError(f"has_speaker must have shape (B,), got {tuple(has_speaker.shape)}")
+        speaker_vec = self._speaker_vec(
+            batch_size=text_vec.shape[0],
+            device=text_vec.device,
+            dtype=text_vec.dtype,
+            speaker_state=speaker_state,
+            has_speaker=has_speaker,
+        )
+
+        if self.speaker_fusion == "concat":
+            x = torch.cat([text_vec, speaker_vec, aux_features], dim=-1)
+            cond = None
+        elif self.speaker_fusion == "adarn":
+            if self.text_adarn_norm is None or self.text_adarn is None:
+                raise RuntimeError("AdaRN duration speaker modules are missing.")
+            scale, shift = self.text_adarn(speaker_vec).chunk(2, dim=-1)
+            text_vec = (self.text_adarn_norm(text_vec) * (1.0 + scale)) + shift
+            x = torch.cat([text_vec, aux_features], dim=-1)
+            cond = None
+        elif self.speaker_fusion == "adarn_zero":
+            x = torch.cat([text_vec, aux_features], dim=-1)
+            cond = speaker_vec
+        elif self.speaker_fusion == "speaker_cross_attn":
+            if self.speaker_cross_attn is None:
+                raise RuntimeError("speaker_cross_attn duration module is missing.")
+            speaker_context, speaker_context_mask = self._speaker_sequence(
+                batch_size=text_vec.shape[0],
+                device=text_vec.device,
+                dtype=text_vec.dtype,
+                speaker_state=speaker_state,
+                speaker_mask=speaker_mask,
+                has_speaker=has_speaker,
+            )
+            context_vec = self.speaker_cross_attn(
+                query=text_vec,
+                context=speaker_context,
+                context_mask=speaker_context_mask,
+            )
+            x = torch.cat([text_vec, context_vec, aux_features], dim=-1)
+            cond = None
+        elif self.speaker_fusion == "text_cross_attn":
+            if self.text_cross_attn is None:
+                raise RuntimeError("text_cross_attn duration module is missing.")
+            context_vec = self.text_cross_attn(
+                query=speaker_vec,
+                context=text_state,
+                context_mask=text_mask,
+            )
+            x = torch.cat([context_vec, speaker_vec, aux_features], dim=-1)
+            cond = None
+        else:
+            raise RuntimeError(f"Unsupported duration speaker fusion: {self.speaker_fusion!r}")
+
+        h = self.input_proj(x)
+        for block in self.blocks:
+            h = block(h, cond=cond)
+        return self.out_proj(self.out_norm(h)).squeeze(-1)
+
+
+# ----------------------------------------------------------------------------
+# 7. Speaker Inversion Embedding (For runtime zero-shot style adaptation)
+# ----------------------------------------------------------------------------
+
+
+def normalize_speaker_embedding_tensor(
+    tensor: torch.Tensor,
+    *,
+    speaker_dim: int,
+    field_name: str = SPEAKER_EMBEDDING_KEY,
+) -> torch.Tensor:
+    if tensor.ndim == 3 and tensor.shape[0] == 1:
+        tensor = tensor[0]
+    if tensor.ndim != 2:
+        raise ValueError(f"{field_name} must have shape (tokens, dim), got {tuple(tensor.shape)}")
+    if int(tensor.shape[0]) <= 0:
+        raise ValueError(f"{field_name} must contain at least one token.")
+    if int(tensor.shape[1]) != int(speaker_dim):
+        raise ValueError(f"{field_name} dim mismatch: expected {int(speaker_dim)}, got {int(tensor.shape[1])}")
+    return tensor.detach().float().contiguous()
+
+
+class SpeakerInversionEmbedding(nn.Module):
+    def __init__(
+        self,
+        *,
+        num_tokens: int,
+        speaker_dim: int,
+        init_std: float,
+        init_embedding: torch.Tensor | None = None,
+    ) -> None:
+        super().__init__()
+        num_tokens = int(num_tokens)
+        speaker_dim = int(speaker_dim)
+        init_std = float(init_std)
+        if num_tokens <= 0:
+            raise ValueError(f"speaker inversion tokens must be > 0, got {num_tokens}")
+        if speaker_dim <= 0:
+            raise ValueError(f"speaker_dim must be > 0, got {speaker_dim}")
+        if init_std < 0:
+            raise ValueError(f"speaker inversion init_std must be >= 0, got {init_std}")
+
+        if init_embedding is None:
+            embedding = torch.randn(num_tokens, speaker_dim, dtype=torch.float32) * init_std
+        else:
+            embedding = normalize_speaker_embedding_tensor(
+                init_embedding,
+                speaker_dim=speaker_dim,
+                field_name=SPEAKER_EMBEDDING_KEY,
+            )
+            if int(embedding.shape[0]) != num_tokens:
+                raise ValueError(
+                    "speaker inversion init embedding token mismatch: "
+                    f"expected {num_tokens}, got {int(embedding.shape[0])}"
+                )
+        self.embedding = nn.Parameter(embedding)
+
+    @property
+    def num_tokens(self) -> int:
+        return int(self.embedding.shape[0])
+
+    @property
+    def speaker_dim(self) -> int:
+        return int(self.embedding.shape[1])
+
+    def forward(
+        self,
+        *,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        state = self.embedding.to(device=device, dtype=dtype)[None, :, :].expand(
+            int(batch_size),
+            -1,
+            -1,
+        )
+        mask = torch.ones((int(batch_size), self.num_tokens), dtype=torch.bool, device=device)
+        return state, mask
+
+
+# ----------------------------------------------------------------------------
+# 8. Main Diffusion Block Wrapper
+# ----------------------------------------------------------------------------
+
+
+class DiffusionBlock(nn.Module):
+    def __init__(self, cfg: ModelConfig):
+        super().__init__()
+        self.attention = JointAttention(
+            cfg.model_dim,
+            cfg.num_heads,
+            cfg.text_dim,
+            cfg.speaker_dim if cfg.use_speaker_condition_resolved else None,
+            cfg.caption_dim_resolved if cfg.use_caption_condition else None,
+            norm_eps=cfg.norm_eps,
+        )
+        self.mlp = SwiGLU(cfg.model_dim, int(cfg.model_dim * cfg.mlp_ratio))
+        adaln_rank = max(1, min(int(cfg.adaln_rank), int(cfg.model_dim)))
+        self.attention_adaln = LowRankAdaLN(
+            model_dim=cfg.model_dim,
+            rank=adaln_rank,
+            eps=cfg.norm_eps,
+        )
+        self.mlp_adaln = LowRankAdaLN(
+            model_dim=cfg.model_dim,
+            rank=adaln_rank,
+            eps=cfg.norm_eps,
+        )
+        self.dropout = nn.Dropout(cfg.dropout)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cond_embed: torch.Tensor,
+        text_state: torch.Tensor,
+        text_mask: torch.Tensor,
+        speaker_state: torch.Tensor | None,
+        speaker_mask: torch.Tensor | None,
+        caption_state: torch.Tensor | None,
+        caption_mask: torch.Tensor | None,
+        freqs_cis: torch.Tensor,
+        self_mask: torch.Tensor | None = None,
+        context_kv: tuple[torch.Tensor, ...] | None = None,
+    ) -> torch.Tensor:
+        h, attention_gate = self.attention_adaln(x, cond_embed)
+        x = x + self.dropout(
+            attention_gate
+            * self.attention(
+                x=h,
+                text_context=text_state,
+                text_mask=text_mask,
+                speaker_context=speaker_state,
+                speaker_mask=speaker_mask,
+                caption_context=caption_state,
+                caption_mask=caption_mask,
+                freqs_cis=freqs_cis,
+                self_mask=self_mask,
+                context_kv=context_kv,
+            )
+        )
+
+        h, mlp_gate = self.mlp_adaln(x, cond_embed)
+        x = x + self.dropout(mlp_gate * self.mlp(h))
+        return x
+
+
+# ----------------------------------------------------------------------------
+# 9. Main Denoising Transformer
+# ----------------------------------------------------------------------------
+
+
+class IrodoriTTSTransformer(nn.Module):
+    """
+    Main integrated Denoising Transformer for Irodori TTS v3 inside vLLM Omni.
+    """
+
+    def __init__(
+        self,
+        od_config: OmniDiffusionConfig | None = None,
+        cfg: ModelConfig | None = None,
+        **kwargs,
+    ):
+        super().__init__()
+
+        # Resolve config from od_config or fallback
+        if cfg is None:
+            if od_config is not None:
+                # We can extract the underlying model config from od_config
+                from dataclasses import fields
+
+                tf_config = getattr(od_config, "tf_model_config", {})
+                if hasattr(tf_config, "__dict__"):
+                    cfg_kwargs = {k: v for k, v in tf_config.__dict__.items() if k != "quant_config"}
+                elif isinstance(tf_config, dict):
+                    cfg_kwargs = tf_config
+                else:
+                    cfg_kwargs = {}
+
+                # Filter out unrecognized kwargs to avoid strict dataclass __init__ failures
+                valid_fields = {f.name for f in fields(ModelConfig)}
+                filtered_kwargs = {k: v for k, v in cfg_kwargs.items() if k in valid_fields}
+                cfg = ModelConfig(**filtered_kwargs)
+            else:
+                cfg = ModelConfig(**kwargs)
+
+        self.cfg = cfg
+        self.od_config = od_config
+
+        self.text_encoder = TextEncoder(
+            vocab_size=cfg.text_vocab_size,
+            dim=cfg.text_dim,
+            layers=cfg.text_layers,
+            heads=cfg.text_heads,
+            mlp_ratio=cfg.text_mlp_ratio_resolved,
+            norm_eps=cfg.norm_eps,
+            dropout=cfg.dropout,
+        )
+        self.caption_encoder = None
+        self.caption_norm = None
+        if cfg.use_caption_condition:
+            self.caption_encoder = TextEncoder(
+                vocab_size=cfg.caption_vocab_size_resolved,
+                dim=cfg.caption_dim_resolved,
+                layers=cfg.caption_layers_resolved,
+                heads=cfg.caption_heads_resolved,
+                mlp_ratio=cfg.caption_mlp_ratio_resolved,
+                norm_eps=cfg.norm_eps,
+                dropout=cfg.dropout,
+            )
+            self.caption_norm = RMSNorm(cfg.caption_dim_resolved, eps=cfg.norm_eps)
+
+        self.speaker_encoder = None
+        if cfg.use_speaker_condition_resolved:
+            self.speaker_encoder = ReferenceLatentEncoder(cfg)
+
+        self.text_norm = RMSNorm(cfg.text_dim, eps=cfg.norm_eps)
+        self.speaker_norm = None
+        if cfg.use_speaker_condition_resolved:
+            self.speaker_norm = RMSNorm(cfg.speaker_dim, eps=cfg.norm_eps)
+
+        self.duration_predictor = None
+        if cfg.use_duration_predictor:
+            duration_speaker_dim = None
+            if cfg.use_speaker_condition_resolved:
+                duration_speaker_dim = int(cfg.speaker_dim)
+            duration_caption_dim = None
+            if cfg.use_caption_condition:
+                duration_caption_dim = int(cfg.caption_dim_resolved)
+            self.duration_predictor = DurationPredictor(
+                text_dim=cfg.text_dim,
+                aux_dim=cfg.duration_aux_dim,
+                hidden_dim=cfg.duration_hidden_dim,
+                layers=cfg.duration_layers,
+                dropout=cfg.duration_dropout,
+                speaker_dim=duration_speaker_dim,
+                speaker_fusion=cfg.duration_speaker_fusion,
+                caption_dim=duration_caption_dim,
+                caption_fusion=cfg.duration_caption_fusion,
+                caption_pooling=cfg.duration_caption_pooling,
+                attention_heads=cfg.duration_attention_heads,
+                norm_eps=cfg.norm_eps,
+                architecture=cfg.duration_architecture,
+                token_init_frames=cfg.duration_token_init_frames,
+            )
+
+        self.cond_module = nn.Sequential(
+            nn.Linear(cfg.timestep_embed_dim, cfg.model_dim, bias=False),
+            nn.SiLU(),
+            nn.Linear(cfg.model_dim, cfg.model_dim, bias=False),
+            nn.SiLU(),
+            nn.Linear(cfg.model_dim, cfg.model_dim * 3, bias=False),
+        )
+
+        self.in_proj = nn.Linear(cfg.patched_latent_dim, cfg.model_dim)
+        self.blocks = nn.ModuleList(DiffusionBlock(cfg) for _ in range(cfg.num_layers))
+
+        # Removed gradient checkpointing helper variable & setter since we run purely inference.
+        self.out_norm = RMSNorm(cfg.model_dim, eps=cfg.norm_eps)
+        self.out_proj = nn.Linear(cfg.model_dim, cfg.patched_latent_dim)
+        nn.init.zeros_(self.out_proj.weight)
+        if self.out_proj.bias is not None:
+            nn.init.zeros_(self.out_proj.bias)
+
+        self.head_dim = cfg.model_dim // cfg.num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("model head_dim must be even for RoPE")
+        self.register_buffer("_freqs_cis_cache", torch.empty(0, 0, dtype=torch.complex64), persistent=False)
+
+    def _rope_freqs(self, seq_len: int, device: torch.device) -> torch.Tensor:
+        cache = self._freqs_cis_cache
+        if cache.device != device or cache.shape[0] < seq_len:
+            cache = precompute_freqs_cis(self.head_dim, seq_len).to(device)
+            self._freqs_cis_cache = cache
+        return cache[:seq_len]
+
+    @staticmethod
+    def _prepend_masked_mean_token(
+        state: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        mask_f = mask.unsqueeze(-1).to(dtype=state.dtype)
+        denom = mask_f.sum(dim=1, keepdim=True).clamp_min(1.0)
+        mean_token = (state * mask_f).sum(dim=1, keepdim=True) / denom
+        has_any = mask.any(dim=1, keepdim=True)
+        state = torch.cat([mean_token, state], dim=1)
+        mask = torch.cat([has_any, mask], dim=1)
+        return state, mask
+
+    @staticmethod
+    def _expand_speaker_condition_batch(
+        state: torch.Tensor,
+        mask: torch.Tensor | None,
+        *,
+        batch_size: int,
+        speaker_dim: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if state.ndim == 2:
+            state = state.unsqueeze(0)
+        if state.ndim != 3:
+            raise ValueError(f"speaker_state must have shape (B,S,D) or (S,D), got {tuple(state.shape)}")
+        if int(state.shape[-1]) != int(speaker_dim):
+            raise ValueError(f"speaker_state last dim must be {int(speaker_dim)}, got {int(state.shape[-1])}")
+        if state.shape[0] == 1 and batch_size != 1:
+            state = state.expand(batch_size, -1, -1)
+        elif int(state.shape[0]) != int(batch_size):
+            raise ValueError(f"speaker_state batch mismatch: expected {int(batch_size)}, got {int(state.shape[0])}")
+
+        if mask is None:
+            mask = torch.ones(state.shape[:2], dtype=torch.bool, device=state.device)
+        else:
+            if mask.ndim == 1:
+                mask = mask.unsqueeze(0)
+            if mask.ndim != 2:
+                raise ValueError(f"speaker_mask must have shape (B,S) or (S,), got {tuple(mask.shape)}")
+            if mask.shape[0] == 1 and batch_size != 1:
+                mask = mask.expand(batch_size, -1)
+            elif int(mask.shape[0]) != int(batch_size):
+                raise ValueError(f"speaker_mask batch mismatch: expected {int(batch_size)}, got {int(mask.shape[0])}")
+            if int(mask.shape[1]) != int(state.shape[1]):
+                raise ValueError(f"speaker_mask token mismatch: state={tuple(state.shape)} mask={tuple(mask.shape)}")
+            mask = mask.to(device=state.device, dtype=torch.bool)
+        return state, mask
+
+    def _apply_speaker_condition_dropout(
+        self,
+        *,
+        speaker_state: torch.Tensor,
+        speaker_mask: torch.Tensor,
+        dropout_mask: torch.Tensor | None,
+        uncond_state: torch.Tensor | None,
+        uncond_mask: torch.Tensor | None,
+        uncond_mode: str,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if dropout_mask is None:
+            return speaker_state, speaker_mask
+        dropout_mask = dropout_mask.to(device=speaker_state.device, dtype=torch.bool)
+        if dropout_mask.ndim != 1 or dropout_mask.shape[0] != speaker_state.shape[0]:
+            raise ValueError(
+                "speaker_condition_dropout must have shape (B,), "
+                f"got {tuple(dropout_mask.shape)} for speaker_state={tuple(speaker_state.shape)}"
+            )
+        mode = str(uncond_mode).strip().lower()
+        if mode not in SPEAKER_INVERSION_UNCOND_MODES:
+            raise ValueError(
+                f"speaker_uncond_mode must be one of {sorted(SPEAKER_INVERSION_UNCOND_MODES)}, got {uncond_mode!r}"
+            )
+
+        if mode == "noise":
+            if uncond_state is None:
+                scale = speaker_state.detach().std().clamp_min(1e-6)
+                uncond_state = torch.randn_like(speaker_state) * scale
+            if uncond_mask is None:
+                uncond_mask = torch.ones_like(speaker_mask)
+            uncond_state, uncond_mask = self._expand_speaker_condition_batch(
+                uncond_state,
+                uncond_mask,
+                batch_size=speaker_state.shape[0],
+                speaker_dim=self.cfg.speaker_dim,
+            )
+            uncond_state = uncond_state.to(device=speaker_state.device, dtype=speaker_state.dtype)
+            uncond_mask = uncond_mask.to(device=speaker_state.device, dtype=torch.bool)
+            speaker_state = torch.where(dropout_mask[:, None, None], uncond_state, speaker_state)
+            speaker_mask = torch.where(dropout_mask[:, None], uncond_mask, speaker_mask)
+            return speaker_state, speaker_mask
+
+        speaker_mask = speaker_mask.clone()
+        speaker_mask[dropout_mask] = False
+        return speaker_state, speaker_mask
+
+    def encode_conditions(
+        self,
+        text_input_ids: torch.Tensor,
+        text_mask: torch.Tensor,
+        ref_latent: torch.Tensor | None,
+        ref_mask: torch.Tensor | None,
+        caption_input_ids: torch.Tensor | None = None,
+        caption_mask: torch.Tensor | None = None,
+        speaker_state_override: torch.Tensor | None = None,
+        speaker_mask_override: torch.Tensor | None = None,
+        speaker_uncond_mode: str = "mask",
+        text_condition_dropout: torch.Tensor | None = None,
+        speaker_condition_dropout: torch.Tensor | None = None,
+        caption_condition_dropout: torch.Tensor | None = None,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        if text_condition_dropout is not None:
+            text_mask = text_mask.clone()
+            text_mask[text_condition_dropout] = False
+        if self.cfg.use_speaker_condition_resolved:
+            speaker_inversion = getattr(self, "speaker_inversion", None)
+            has_direct_speaker = speaker_state_override is not None or isinstance(
+                speaker_inversion, SpeakerInversionEmbedding
+            )
+            if not has_direct_speaker and (self.speaker_encoder is None or self.speaker_norm is None):
+                raise RuntimeError("Speaker conditioning is enabled but speaker modules are missing.")
+            if not has_direct_speaker and (ref_latent is None or ref_mask is None):
+                raise ValueError("ref_latent and ref_mask are required when speaker conditioning is enabled.")
+        elif speaker_state_override is not None:
+            raise ValueError("speaker_state_override was provided but speaker conditioning is disabled.")
+
+        if self.cfg.use_caption_condition:
+            if self.caption_encoder is None or self.caption_norm is None:
+                raise RuntimeError("Caption conditioning is enabled but caption modules are missing.")
+            if caption_input_ids is None or caption_mask is None:
+                raise ValueError(
+                    "caption_input_ids and caption_mask are required when caption conditioning is enabled."
+                )
+            if caption_condition_dropout is not None:
+                caption_mask = caption_mask.clone()
+                caption_mask[caption_condition_dropout] = False
+
+        text_state = self.text_encoder(text_input_ids, text_mask)
+        text_state = self.text_norm(text_state)
+        ref_state = None
+        if self.cfg.use_speaker_condition_resolved:
+            if speaker_state_override is not None:
+                ref_state, ref_mask = self._expand_speaker_condition_batch(
+                    speaker_state_override,
+                    speaker_mask_override,
+                    batch_size=text_input_ids.shape[0],
+                    speaker_dim=self.cfg.speaker_dim,
+                )
+                ref_state = ref_state.to(device=text_state.device, dtype=text_state.dtype)
+                ref_mask = ref_mask.to(device=text_state.device, dtype=torch.bool)
+            else:
+                speaker_inversion = getattr(self, "speaker_inversion", None)
+                if isinstance(speaker_inversion, SpeakerInversionEmbedding):
+                    ref_state, ref_mask = speaker_inversion(
+                        batch_size=text_input_ids.shape[0],
+                        device=text_state.device,
+                        dtype=text_state.dtype,
+                    )
+                else:
+                    ref_latent, ref_mask = patch_sequence_with_mask(
+                        seq=ref_latent,
+                        mask=ref_mask,
+                        patch_size=self.cfg.speaker_patch_size,
+                    )
+                    ref_state = self.speaker_encoder(ref_latent, ref_mask)
+                    ref_state = self.speaker_norm(ref_state)
+                    ref_state, ref_mask = self._prepend_masked_mean_token(ref_state, ref_mask)
+            ref_state, ref_mask = self._apply_speaker_condition_dropout(
+                speaker_state=ref_state,
+                speaker_mask=ref_mask,
+                dropout_mask=speaker_condition_dropout,
+                uncond_state=None,
+                uncond_mask=None,
+                uncond_mode=speaker_uncond_mode,
+            )
+        caption_state = None
+        if self.cfg.use_caption_condition:
+            caption_state = self.caption_encoder(caption_input_ids, caption_mask)
+            caption_state = self.caption_norm(caption_state)
+        return text_state, text_mask, ref_state, ref_mask, caption_state, caption_mask
+
+    def forward_with_encoded_conditions(
+        self,
+        x_t: torch.Tensor,
+        t: torch.Tensor,
+        text_state: torch.Tensor,
+        text_mask: torch.Tensor,
+        speaker_state: torch.Tensor | None,
+        speaker_mask: torch.Tensor | None,
+        caption_state: torch.Tensor | None = None,
+        caption_mask: torch.Tensor | None = None,
+        latent_mask: torch.Tensor | None = None,
+        context_kv_cache: list[tuple[torch.Tensor, ...]] | None = None,
+    ) -> torch.Tensor:
+        t_embed = get_timestep_embedding(t, self.cfg.timestep_embed_dim).to(dtype=x_t.dtype)
+        cond_embed = self.cond_module(t_embed)
+        cond_embed = cond_embed[:, None, :]
+
+        x = self.in_proj(x_t)
+        freqs = self._rope_freqs(x.shape[1], x.device)
+
+        # Disabled gradient checkpointing completely since we are running offline inference in serving
+        for i, block in enumerate(self.blocks):
+            context_kv = context_kv_cache[i] if context_kv_cache is not None else None
+            x = block(
+                x=x,
+                cond_embed=cond_embed,
+                text_state=text_state,
+                text_mask=text_mask,
+                speaker_state=speaker_state,
+                speaker_mask=speaker_mask,
+                caption_state=caption_state,
+                caption_mask=caption_mask,
+                freqs_cis=freqs,
+                self_mask=latent_mask,
+                context_kv=context_kv,
+            )
+
+        x = self.out_norm(x)
+        x = self.out_proj(x)
+        return x.to(dtype=x_t.dtype)
+
+    def forward(
+        self,
+        x_t: torch.Tensor | None,
+        t: torch.Tensor | None,
+        text_input_ids: torch.Tensor,
+        text_mask: torch.Tensor,
+        ref_latent: torch.Tensor | None,
+        ref_mask: torch.Tensor | None,
+        caption_input_ids: torch.Tensor | None = None,
+        caption_mask: torch.Tensor | None = None,
+        latent_mask: torch.Tensor | None = None,
+        text_condition_dropout: torch.Tensor | None = None,
+        speaker_condition_dropout: torch.Tensor | None = None,
+        caption_condition_dropout: torch.Tensor | None = None,
+        duration_features: torch.Tensor | None = None,
+        duration_has_speaker: torch.Tensor | None = None,
+        duration_has_caption: torch.Tensor | None = None,
+        duration_only: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if duration_features is not None:
+            (
+                text_state,
+                text_mask_full,
+                speaker_state,
+                speaker_mask_full,
+                caption_state,
+                caption_mask_full,
+            ) = self.encode_conditions(
+                text_input_ids=text_input_ids,
+                text_mask=text_mask,
+                ref_latent=ref_latent,
+                ref_mask=ref_mask,
+                caption_input_ids=caption_input_ids,
+                caption_mask=caption_mask,
+            )
+            if duration_only:
+                return self.predict_duration_log_frames(
+                    text_state=text_state,
+                    text_mask=text_mask_full,
+                    speaker_state=speaker_state,
+                    speaker_mask=speaker_mask_full,
+                    caption_state=caption_state,
+                    caption_mask=caption_mask_full,
+                    duration_features=duration_features,
+                    has_speaker=duration_has_speaker,
+                    has_caption=duration_has_caption,
+                )
+
+            if x_t is None or t is None:
+                raise ValueError("x_t and t are required unless duration_only=True.")
+
+            text_mask_dit = text_mask_full
+            speaker_state_dit = speaker_state
+            speaker_mask_dit = speaker_mask_full
+            caption_mask_dit = caption_mask_full
+            if text_condition_dropout is not None:
+                text_mask_dit = text_mask_dit.clone()
+                text_mask_dit[text_condition_dropout] = False
+            if speaker_condition_dropout is not None and speaker_state_dit is not None and speaker_mask_dit is not None:
+                speaker_state_dit, speaker_mask_dit = self._apply_speaker_condition_dropout(
+                    speaker_state=speaker_state_dit,
+                    speaker_mask=speaker_mask_dit,
+                    dropout_mask=speaker_condition_dropout,
+                    uncond_state=None,
+                    uncond_mask=None,
+                    uncond_mode="mask",
+                )
+            if caption_condition_dropout is not None and caption_mask_dit is not None:
+                caption_mask_dit = caption_mask_dit.clone()
+                caption_mask_dit[caption_condition_dropout] = False
+
+            v_pred = self.forward_with_encoded_conditions(
+                x_t=x_t,
+                t=t,
+                text_state=text_state,
+                text_mask=text_mask_dit,
+                speaker_state=speaker_state_dit,
+                speaker_mask=speaker_mask_dit,
+                caption_state=caption_state,
+                caption_mask=caption_mask_dit,
+                latent_mask=latent_mask,
+            )
+            duration_pred = self.predict_duration_log_frames(
+                text_state=text_state,
+                text_mask=text_mask_full,
+                speaker_state=speaker_state,
+                speaker_mask=speaker_mask_full,
+                caption_state=caption_state,
+                caption_mask=caption_mask_full,
+                duration_features=duration_features,
+                has_speaker=duration_has_speaker,
+                has_caption=duration_has_caption,
+            )
+            return v_pred, duration_pred
+
+        if duration_only:
+            raise ValueError("duration_features is required when duration_only=True.")
+        if x_t is None or t is None:
+            raise ValueError("x_t and t are required for RF forward.")
+
+        (
+            text_state,
+            text_mask,
+            speaker_state,
+            speaker_mask,
+            caption_state,
+            caption_mask,
+        ) = self.encode_conditions(
+            text_input_ids=text_input_ids,
+            text_mask=text_mask,
+            ref_latent=ref_latent,
+            ref_mask=ref_mask,
+            caption_input_ids=caption_input_ids,
+            caption_mask=caption_mask,
+            text_condition_dropout=text_condition_dropout,
+            speaker_condition_dropout=speaker_condition_dropout,
+            caption_condition_dropout=caption_condition_dropout,
+        )
+        return self.forward_with_encoded_conditions(
+            x_t=x_t,
+            t=t,
+            text_state=text_state,
+            text_mask=text_mask,
+            speaker_state=speaker_state,
+            speaker_mask=speaker_mask,
+            caption_state=caption_state,
+            caption_mask=caption_mask,
+            latent_mask=latent_mask,
+        )
+
+    def build_context_kv_cache(
+        self,
+        text_state: torch.Tensor,
+        speaker_state: torch.Tensor | None,
+        caption_state: torch.Tensor | None = None,
+    ) -> list[tuple[torch.Tensor, ...]]:
+        return [
+            block.attention.project_context_kv(
+                text_context=text_state,
+                speaker_context=speaker_state,
+                caption_context=caption_state,
+            )
+            for block in self.blocks
+        ]
+
+    @staticmethod
+    def masked_mean(state: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        mask_f = mask.unsqueeze(-1).to(dtype=state.dtype)
+        denom = mask_f.sum(dim=1).clamp_min(1.0)
+        return (state * mask_f).sum(dim=1) / denom
+
+    def predict_duration_log_frames(
+        self,
+        *,
+        text_state: torch.Tensor,
+        text_mask: torch.Tensor,
+        speaker_state: torch.Tensor | None,
+        speaker_mask: torch.Tensor | None,
+        duration_features: torch.Tensor,
+        has_speaker: torch.Tensor | None,
+        caption_state: torch.Tensor | None = None,
+        caption_mask: torch.Tensor | None = None,
+        has_caption: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if self.duration_predictor is None:
+            raise RuntimeError("Duration predictor is disabled for this model.")
+        if duration_features.ndim != 2:
+            raise ValueError(f"duration_features must have shape (B, D), got {tuple(duration_features.shape)}")
+        if duration_features.shape[1] != self.cfg.duration_aux_dim:
+            raise ValueError(
+                "duration_features dim mismatch: "
+                f"expected {self.cfg.duration_aux_dim}, got {duration_features.shape[1]}"
+            )
+
+        pred = self.duration_predictor(
+            text_state.detach(),
+            text_mask=text_mask,
+            aux_features=duration_features,
+            speaker_state=None if speaker_state is None else speaker_state.detach(),
+            speaker_mask=speaker_mask,
+            has_speaker=has_speaker,
+            caption_state=None if caption_state is None else caption_state.detach(),
+            caption_mask=caption_mask,
+            has_caption=has_caption,
+        )
+        return pred.float()
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.parameters()).device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(self.parameters()).dtype
+
+    def as_dict(self) -> dict:
+        return asdict(self.cfg)

--- a/vllm_omni/diffusion/models/irodori_tts/pipeline_irodori_tts.py
+++ b/vllm_omni/diffusion/models/irodori_tts/pipeline_irodori_tts.py
@@ -1,0 +1,457 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Iterable
+from typing import ClassVar
+
+import torch
+import torch.nn as nn
+
+from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.models.interface import SupportAudioOutput
+from vllm_omni.diffusion.request import OmniDiffusionRequest
+
+from .codec import DACVAECodec, patchify_latent, unpatchify_latent
+from .duration import build_duration_features
+from .irodori_tts_transformer import IrodoriTTSTransformer
+from .rf import sample_euler_rf_cfg
+
+logger = logging.getLogger(__name__)
+
+
+# ----------------------------------------------------------------------------
+# 1. Pretrained Text Tokenizer Wrapper
+# ----------------------------------------------------------------------------
+
+
+class PretrainedTextTokenizer:
+    """
+    Hugging Face tokenizer wrapper for Irodori TTS conditioning.
+    Provides standardized right-padding and special BOS token prepending.
+    """
+
+    def __init__(self, tokenizer, add_bos: bool = True) -> None:
+        self.tokenizer = tokenizer
+        self.add_bos = bool(add_bos)
+        self.tokenizer.padding_side = "right"
+
+        if self.tokenizer.pad_token_id is None:
+            if self.tokenizer.eos_token_id is not None and self.tokenizer.eos_token is not None:
+                self.tokenizer.pad_token = self.tokenizer.eos_token
+            else:
+                raise ValueError("Tokenizer has no pad_token_id (and no eos_token fallback).")
+
+        if self.add_bos and self.tokenizer.bos_token_id is None:
+            raise ValueError("Tokenizer has no bos_token_id but add_bos=True.")
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        repo_id: str,
+        add_bos: bool = True,
+        local_files_only: bool = False,
+    ) -> PretrainedTextTokenizer:
+        try:
+            from transformers import AutoTokenizer
+        except ImportError as exc:
+            raise RuntimeError(
+                "transformers is required for pretrained text tokenization. "
+                "Install with `pip install transformers sentencepiece`."
+            ) from exc
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            repo_id,
+            use_fast=True,
+            trust_remote_code=False,
+            local_files_only=local_files_only,
+        )
+        return cls(tokenizer=tokenizer, add_bos=add_bos)
+
+    @property
+    def vocab_size(self) -> int:
+        return int(len(self.tokenizer))
+
+    @property
+    def bos_token_id(self) -> int | None:
+        return self.tokenizer.bos_token_id
+
+    @property
+    def pad_token_id(self) -> int:
+        pad_id = self.tokenizer.pad_token_id
+        if pad_id is None:
+            raise RuntimeError("pad_token_id is unexpectedly None.")
+        return int(pad_id)
+
+    def encode(self, text: str, add_bos: bool | None = None) -> torch.Tensor:
+        token_ids = self.tokenizer.encode(text, add_special_tokens=False)
+        use_bos = self.add_bos if add_bos is None else bool(add_bos)
+        if use_bos:
+            bos_id = self.bos_token_id
+            if bos_id is None:
+                raise ValueError("Tokenizer has no bos_token_id but BOS prepend was requested.")
+            token_ids.insert(0, int(bos_id))
+        return torch.tensor(token_ids, dtype=torch.long)
+
+    def batch_encode(
+        self,
+        texts: Iterable[str],
+        max_length: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        encoded = [self.encode(t) for t in texts]
+        if max_length is None:
+            max_length = max(max(x.numel(), 1) for x in encoded)
+        if max_length <= 0:
+            raise ValueError(f"max_length must be > 0, got {max_length}")
+
+        batch = torch.full(
+            (len(encoded), max_length),
+            fill_value=self.pad_token_id,
+            dtype=torch.long,
+        )
+        mask = torch.zeros((len(encoded), max_length), dtype=torch.bool)
+        for i, seq in enumerate(encoded):
+            n = min(max_length, seq.numel())
+            if n > 0:
+                batch[i, :n] = seq[:n]
+                mask[i, :n] = True
+        return batch, mask
+
+
+# ----------------------------------------------------------------------------
+# 2. Main Integrated Pipeline
+# ----------------------------------------------------------------------------
+
+
+class IrodoriTTSPipeline(nn.Module, SupportAudioOutput):
+    """
+    Unified Pipeline Orchestrator for serving Irodori TTS v3 inside vLLM Omni.
+    """
+
+    support_audio_output: ClassVar[bool] = True
+    audio_sample_rate: ClassVar[int] = 48000
+
+    # Metadata for offloading, HSDP, and CPU sharding controllers
+    _dit_modules = ["transformer"]
+    _encoder_modules = []
+    _vae_modules = ["vae"]
+
+    def __init__(self, od_config: OmniDiffusionConfig):
+        super().__init__()
+        self.od_config = od_config
+        self.device = get_local_device()
+        self.dtype = getattr(od_config, "dtype", torch.float16)
+
+        # 1. Directly resolve local model.safetensors file and parse embedded config metadata
+        import json
+        import os
+        from dataclasses import fields
+
+        from safetensors import safe_open
+
+        from .irodori_tts_transformer import ModelConfig
+
+        cfg_dict = {}
+        try:
+            model_path = self.od_config.model
+            if not os.path.isdir(model_path):
+                # Resolve local HF hub cache directory for the repo ID
+                repo_id_escaped = model_path.replace("/", "--")
+                cache_dir = os.path.expanduser(f"~/.cache/huggingface/hub/models--{repo_id_escaped}/snapshots")
+                if os.path.exists(cache_dir):
+                    snapshots = sorted(os.listdir(cache_dir))
+                    if snapshots:
+                        model_path = os.path.join(cache_dir, snapshots[-1])
+
+            if os.path.isdir(model_path):
+                safetensors_file = os.path.join(model_path, "model.safetensors")
+                if os.path.exists(safetensors_file):
+                    with safe_open(safetensors_file, framework="pt", device="cpu") as f:
+                        metadata = f.metadata()
+                        if metadata is not None and "config_json" in metadata:
+                            cfg_dict = json.loads(metadata["config_json"])
+        except Exception as e:
+            logger.warning("Could not parse config_json metadata from local safetensors file: %s", e)
+
+        # 2. Filter parsed options to strictly match ModelConfig dataclass fields
+        valid_fields = {f.name for f in fields(ModelConfig)}
+        filtered_kwargs = {k: v for k, v in cfg_dict.items() if k in valid_fields}
+        cfg = ModelConfig(**filtered_kwargs)
+
+        # A. Core Denoising Transformer
+        self.transformer = IrodoriTTSTransformer(cfg=cfg, od_config=od_config)
+
+        # B. Autotokenizer Wrapper
+        self.tokenizer = PretrainedTextTokenizer.from_pretrained(
+            self.transformer.cfg.text_tokenizer_repo,
+            add_bos=self.transformer.cfg.text_add_bos,
+            local_files_only=getattr(od_config, "local_files_only", False),
+        )
+
+        # C. DACVAE Codec / VAE Loader (default Aratako Japanese 32dim)
+        self.vae = DACVAECodec.load(
+            repo_id="Aratako/Semantic-DACVAE-Japanese-32dim",
+            device=str(self.device),
+            dtype=self.dtype,
+        )
+
+        # D. Move all layers and weights to the local device & dtype
+        self.to(device=self.device, dtype=self.dtype)
+
+        # E. Define weights source for diffusers loader tracking
+        from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
+
+        self.weights_sources = [
+            DiffusersPipelineLoader.ComponentSource(
+                model_or_path=self.od_config.model,
+                subfolder=None,
+                revision=getattr(self.od_config, "revision", None),
+                prefix="",
+                fall_back_to_pt=False,
+                allow_patterns_overrides=[
+                    "model.safetensors",
+                ],
+            ),
+        ]
+
+    def forward(self, req: OmniDiffusionRequest) -> DiffusionOutput:
+        """
+        Execute request-level text-to-latent voice cloning.
+
+        Args:
+            req: OmniDiffusionRequest containing generations params
+        Returns:
+            DiffusionOutput holding unpatched raw VAE-ready latent tensor
+        """
+        # 1. Parse text prompts from the unified request
+        prompt = [
+            p if isinstance(p, str) else (p.get("prompt") or p.get("input") or p.get("text") or "") for p in req.prompts
+        ]
+        batch_size = len(prompt)
+        device = self.device
+        dtype = self.dtype
+
+        # 2. Extract scheduling and guidance hyperparameters
+        num_inference_steps = req.sampling_params.num_inference_steps
+        if num_inference_steps is None:
+            num_inference_steps = 40  # default linear steps matching baseline
+
+        seed = req.sampling_params.seed if req.sampling_params.seed is not None else 0
+
+        # Optional extras passed via extra_args
+        extra_args = getattr(req.sampling_params, "extra_args", {}) or {}
+        ref_wav_path = extra_args.get("ref_wav")
+        duration_scale = float(extra_args.get("duration_scale", 1.0))
+        min_seconds = float(extra_args.get("min_seconds", 0.0))
+        max_seconds = float(extra_args.get("max_seconds", 300.0))
+
+        cfg_scale_text = float(extra_args.get("cfg_scale_text", 3.0))
+        cfg_scale_speaker = float(extra_args.get("cfg_scale_speaker", 5.0))
+        cfg_scale_caption = float(extra_args.get("cfg_scale_caption", 3.0))
+        cfg_guidance_mode = str(extra_args.get("cfg_guidance_mode", "independent")).strip().lower()
+        speaker_uncond_mode = str(extra_args.get("speaker_uncond_mode", "mask")).strip().lower()
+
+        # 3. Tokenize prompts
+        text_ids, text_mask = self.tokenizer.batch_encode(prompt)
+        text_ids = text_ids.to(device=device)
+        text_mask = text_mask.to(device=device)
+
+        # 4. Process reference audio voice cloning conditioning
+        ref_latent = None
+        ref_mask = None
+        has_speaker = torch.zeros(batch_size, dtype=torch.bool, device=device)
+
+        # Check for inline resolved ref_audio tuple (waveform, sr) in prompts
+        inline_ref_audio = None
+        for p in req.prompts:
+            if isinstance(p, dict) and p.get("ref_audio") is not None:
+                inline_ref_audio = p["ref_audio"]
+                break
+
+        if inline_ref_audio is not None:
+            import numpy as np
+
+            ref_data, ref_sr = inline_ref_audio
+            if isinstance(ref_data, np.ndarray):
+                ref_waveform = torch.from_numpy(ref_data).float().to(device=device)
+            else:
+                ref_waveform = ref_data.float().to(device=device)
+
+            if ref_waveform.ndim == 1:
+                ref_waveform = ref_waveform.unsqueeze(0)  # (1, T)
+            elif ref_waveform.ndim == 2 and ref_waveform.shape[0] > ref_waveform.shape[1]:
+                ref_waveform = ref_waveform.transpose(0, 1)  # (C, T)
+
+            # Preprocess reference audio via VAE encoder (output is unpatched)
+            ref_latent_raw = self.vae.encode_waveform(ref_waveform, ref_sr)
+
+            # Patchify latents to speaker dimension format expected by transformer reference encoder
+            ref_latent = patchify_latent(ref_latent_raw, self.transformer.cfg.speaker_patch_size)
+            ref_latent = ref_latent.to(dtype=dtype, device=device)
+
+            if ref_latent.shape[0] == 1 and batch_size > 1:
+                ref_latent = ref_latent.expand(batch_size, -1, -1)
+
+            ref_mask = torch.ones(ref_latent.shape[:2], dtype=torch.bool, device=device)
+            has_speaker = torch.ones(batch_size, dtype=torch.bool, device=device)
+        elif ref_wav_path is not None:
+            import soundfile as sf
+
+            data, ref_sr = sf.read(ref_wav_path)
+            ref_waveform = torch.from_numpy(data).float().to(device=device)
+            if ref_waveform.ndim == 1:
+                ref_waveform = ref_waveform.unsqueeze(0)  # (1, T)
+            else:
+                ref_waveform = ref_waveform.transpose(0, 1)  # (C, T)
+
+            # Preprocess reference audio via VAE encoder (output is unpatched)
+            ref_latent_raw = self.vae.encode_waveform(ref_waveform, ref_sr)
+
+            # Patchify latents to speaker dimension format expected by transformer reference encoder
+            ref_latent = patchify_latent(ref_latent_raw, self.transformer.cfg.speaker_patch_size)
+            ref_latent = ref_latent.to(dtype=dtype, device=device)
+
+            if ref_latent.shape[0] == 1 and batch_size > 1:
+                ref_latent = ref_latent.expand(batch_size, -1, -1)
+
+            ref_mask = torch.ones(ref_latent.shape[:2], dtype=torch.bool, device=device)
+            has_speaker = torch.ones(batch_size, dtype=torch.bool, device=device)
+        elif req.is_dummy_run():
+            # Generate dummy reference speaker conditioning for the warmup pass
+            ref_latent = torch.zeros(
+                (batch_size, 4, self.transformer.cfg.patched_latent_dim),
+                dtype=dtype,
+                device=device,
+            )
+            ref_mask = torch.ones((batch_size, 4), dtype=torch.bool, device=device)
+            has_speaker = torch.ones(batch_size, dtype=torch.bool, device=device)
+
+        # 5. Predict speech frames length (Durations Predictor)
+        hop_length = int(self.vae.model.hop_length)
+        if self.transformer.duration_predictor is not None:
+            token_counts = text_mask.sum(dim=1)
+            duration_features = build_duration_features(
+                prompt,
+                token_counts=token_counts,
+                max_text_len=text_ids.shape[1],
+                has_speaker=has_speaker,
+            ).to(device=device, dtype=dtype)
+
+            # Retrieve conditions
+            duration_text_state, duration_text_mask, duration_speaker_state, _duration_speaker_mask, _, _ = (
+                self.transformer.encode_conditions(
+                    text_input_ids=text_ids,
+                    text_mask=text_mask,
+                    ref_latent=ref_latent,
+                    ref_mask=ref_mask,
+                )
+            )
+
+            pred_log_frames = self.transformer.predict_duration_log_frames(
+                text_state=duration_text_state,
+                text_mask=duration_text_mask,
+                speaker_state=duration_speaker_state,
+                speaker_mask=_duration_speaker_mask,
+                duration_features=duration_features,
+                has_speaker=has_speaker,
+            )
+
+            pred_frames = torch.expm1(pred_log_frames).float().mean().item()
+            scaled_frames = pred_frames * duration_scale
+
+            min_frames = max(1, math.ceil(min_seconds * self.vae.sample_rate / hop_length))
+            max_frames = max(1, math.floor(max_seconds * self.vae.sample_rate / hop_length))
+            latent_steps = int(round(scaled_frames))
+            latent_steps = max(min_frames, min(max_frames, latent_steps))
+        else:
+            fallback_seconds = 30.0
+            target_samples = int(fallback_seconds * self.vae.sample_rate)
+            latent_steps = math.ceil(target_samples / hop_length)
+
+        patched_steps = math.ceil(latent_steps / self.transformer.cfg.latent_patch_size)
+
+        # 6. Run ODE Euler Flow CFG Denoising Scheduler Loop
+        z_patched = sample_euler_rf_cfg(
+            model=self.transformer,
+            text_input_ids=text_ids,
+            text_mask=text_mask,
+            ref_latent=ref_latent,
+            ref_mask=ref_mask,
+            sequence_length=patched_steps,
+            speaker_uncond_mode=speaker_uncond_mode,
+            num_steps=num_inference_steps,
+            cfg_scale_text=cfg_scale_text,
+            cfg_scale_speaker=cfg_scale_speaker,
+            cfg_scale_caption=cfg_scale_caption,
+            cfg_guidance_mode=cfg_guidance_mode,
+            seed=seed,
+            use_context_kv_cache=True,
+        )
+
+        # 7. Unpatchify final latents back to sequence space
+        z_unpatched = unpatchify_latent(
+            z_patched,
+            self.transformer.cfg.latent_patch_size,
+            self.transformer.cfg.latent_dim,
+        )
+
+        # 8. Decode unpatched final latents to audio waveform using VAE
+        # Output waveform is shape (B, 1, samples)
+        audio = self.vae.decode_latent(z_unpatched)
+
+        return DiffusionOutput(output=audio)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Directly map and load checkpoint weights into the pipeline parameters and buffers."""
+        loaded: set[str] = set()
+        params = dict(self.named_parameters())
+        buffers = dict(self.named_buffers())
+
+        for name, tensor in weights:
+            # Map name to its prefix "transformer." in the pipeline
+            new_name = f"transformer.{name}"
+
+            if new_name in params:
+                param = params[new_name]
+                param.data.copy_(tensor)
+                loaded.add(new_name)
+            elif new_name in buffers:
+                buffers[new_name].data.copy_(tensor)
+                loaded.add(new_name)
+
+        logger.info(
+            "IrodoriTTSPipeline load_weights: successfully loaded %d weights from root checkpoint",
+            len(loaded),
+        )
+        return loaded
+
+
+# ----------------------------------------------------------------------------
+# 3. Post-Processing builder function for Registry
+# ----------------------------------------------------------------------------
+
+
+def get_irodori_tts_post_process_func(od_config: OmniDiffusionConfig):
+    """
+    Create post-processing function for Irodori TTS output.
+    Converts raw waveform tensors to numpy arrays for serving response serialization.
+    """
+
+    def post_process_func(
+        audio: torch.Tensor,
+        output_type: str = "np",
+    ):
+        if output_type == "latent":
+            return audio
+        if output_type == "pt":
+            return audio
+
+        # Convert torch tensor to standard numpy array
+        audio_np = audio.cpu().float().numpy()
+        return audio_np
+
+    return post_process_func

--- a/vllm_omni/diffusion/models/irodori_tts/rf.py
+++ b/vllm_omni/diffusion/models/irodori_tts/rf.py
@@ -1,0 +1,569 @@
+from __future__ import annotations
+
+import math
+
+import torch
+
+from .irodori_tts_transformer import IrodoriTTSTransformer
+
+SPEAKER_INVERSION_UNCOND_MODES = {"mask", "noise"}
+
+
+def _make_rng(seed: int, device: torch.device) -> tuple[torch.Generator, torch.device]:
+    # MPS generators are not available on some PyTorch builds; use CPU generator as fallback.
+    try:
+        return torch.Generator(device=device).manual_seed(seed), device
+    except RuntimeError:
+        return torch.Generator(device="cpu").manual_seed(seed), torch.device("cpu")
+
+
+def sample_logit_normal_t(
+    batch_size: int,
+    device: torch.device,
+    mean: float = 0.0,
+    std: float = 1.0,
+    t_min: float = 1e-3,
+    t_max: float = 0.999,
+) -> torch.Tensor:
+    z = torch.randn(batch_size, device=device) * std + mean
+    t = torch.sigmoid(z)
+    return t.clamp(min=t_min, max=t_max)
+
+
+def sample_stratified_logit_normal_t(
+    batch_size: int,
+    device: torch.device,
+    mean: float = 0.0,
+    std: float = 1.0,
+    t_min: float = 1e-3,
+    t_max: float = 0.999,
+) -> torch.Tensor:
+    """
+    Stratified sampling for logit-normal timesteps.
+
+    u ~ stratified U(0, 1), z = mean + std * Phi^{-1}(u), t = sigmoid(z)
+    """
+    if batch_size <= 0:
+        return torch.empty((0,), device=device)
+    u = (torch.arange(batch_size, device=device, dtype=torch.float32) + torch.rand(batch_size, device=device)) / float(
+        batch_size
+    )
+    u = u.clamp(1e-6, 1.0 - 1e-6)
+    # Phi^{-1}(u) = sqrt(2) * erfinv(2u - 1)
+    z = torch.erfinv(2.0 * u - 1.0) * (2.0**0.5)
+    z = z * std + mean
+    t = torch.sigmoid(z)
+    # Randomize assignment order so dataset ordering does not correlate with t bins.
+    t = t[torch.randperm(batch_size, device=device)]
+    return t.clamp(min=t_min, max=t_max)
+
+
+def rf_interpolate(x0: torch.Tensor, noise: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+    # Straight line interpolation: x_t = (1-t) x0 + t z.
+    return (1.0 - t[:, None, None]) * x0 + t[:, None, None] * noise
+
+
+def rf_velocity_target(x0: torch.Tensor, noise: torch.Tensor) -> torch.Tensor:
+    # For x_t = (1-t) x0 + t z, velocity is d/dt x_t = z - x0.
+    return noise - x0
+
+
+def rf_predict_x0(x_t: torch.Tensor, v_pred: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+    # x_t = x0 + t * v  =>  x0 = x_t - t * v
+    return x_t - t[:, None, None] * v_pred
+
+
+def temporal_score_rescale(
+    v_pred: torch.Tensor,
+    x_t: torch.Tensor,
+    t: float | torch.Tensor,
+    rescale_k: float,
+    rescale_sigma: float,
+) -> torch.Tensor:
+    """
+    Temporal score rescaling from https://arxiv.org/pdf/2510.01184.
+    """
+    t_value = float(t.item()) if isinstance(t, torch.Tensor) else float(t)
+    if t_value >= 1.0:
+        return v_pred
+    one_minus_t = 1.0 - t_value
+    snr = (one_minus_t * one_minus_t) / (t_value * t_value)
+    sigma_sq = float(rescale_sigma) * float(rescale_sigma)
+    ratio = (snr * sigma_sq + 1.0) / (snr * sigma_sq / float(rescale_k) + 1.0)
+    return (ratio * (one_minus_t * v_pred + x_t) - x_t) / one_minus_t
+
+
+def scale_speaker_kv_cache(
+    context_kv_cache: list[tuple[torch.Tensor, ...]],
+    scale: float,
+    max_layers: int | None = None,
+) -> None:
+    """
+    In-place scaling of speaker K/V tensors in precomputed context cache.
+    """
+    if max_layers is None:
+        n_layers = len(context_kv_cache)
+    else:
+        n_layers = max(0, min(int(max_layers), len(context_kv_cache)))
+    for i in range(n_layers):
+        layer_kv = context_kv_cache[i]
+        if len(layer_kv) < 4:
+            raise ValueError(f"Expected at least 4 tensors in context KV cache entry, got {len(layer_kv)}")
+        k_speaker = layer_kv[2]
+        v_speaker = layer_kv[3]
+        k_speaker.mul_(scale)
+        v_speaker.mul_(scale)
+
+
+@torch.inference_mode()
+def sample_euler_rf_cfg(
+    model: IrodoriTTSTransformer,
+    text_input_ids: torch.Tensor,
+    text_mask: torch.Tensor,
+    ref_latent: torch.Tensor | None,
+    ref_mask: torch.Tensor | None,
+    sequence_length: int,
+    caption_input_ids: torch.Tensor | None = None,
+    caption_mask: torch.Tensor | None = None,
+    speaker_state_override: torch.Tensor | None = None,
+    speaker_mask_override: torch.Tensor | None = None,
+    speaker_uncond_mode: str = "mask",
+    num_steps: int = 40,
+    cfg_scale_text: float = 3.0,
+    cfg_scale_caption: float = 3.0,
+    cfg_scale_speaker: float = 5.0,
+    cfg_guidance_mode: str = "independent",
+    cfg_min_t: float = 0.5,
+    cfg_max_t: float = 1.0,
+    seed: int = 0,
+    cfg_scale: float | None = None,
+    truncation_factor: float | None = None,
+    rescale_k: float | None = None,
+    rescale_sigma: float | None = None,
+    use_context_kv_cache: bool = True,
+    speaker_kv_scale: float | None = None,
+    speaker_kv_max_layers: int | None = None,
+    speaker_kv_min_t: float | None = None,
+    t_schedule_mode: str = "linear",
+    sway_coeff: float = -1.0,
+) -> torch.Tensor:
+    """
+    Euler sampling over RF ODE with text/reference/caption conditioning CFG.
+
+    Returns:
+      latent sequence in patched space, shape (B, sequence_length, patched_latent_dim)
+    """
+    device = model.device
+    dtype = model.dtype
+    batch_size = text_input_ids.shape[0]
+    latent_dim = model.cfg.patched_latent_dim
+
+    rng, rng_device = _make_rng(seed=seed, device=device)
+    x_t = torch.randn((batch_size, sequence_length, latent_dim), device=rng_device, dtype=dtype, generator=rng)
+    if rng_device != device:
+        x_t = x_t.to(device=device)
+    if truncation_factor is not None:
+        x_t = x_t * float(truncation_factor)
+
+    if cfg_scale is not None:
+        # Backward compatibility for old single-scale caller.
+        cfg_scale_text = float(cfg_scale)
+        cfg_scale_caption = float(cfg_scale)
+        cfg_scale_speaker = float(cfg_scale)
+    if not model.cfg.use_speaker_condition_resolved:
+        cfg_scale_speaker = 0.0
+        speaker_kv_scale = None
+    speaker_uncond_mode = str(speaker_uncond_mode).strip().lower()
+    if speaker_uncond_mode not in SPEAKER_INVERSION_UNCOND_MODES:
+        raise ValueError(
+            f"speaker_uncond_mode must be one of {sorted(SPEAKER_INVERSION_UNCOND_MODES)}, got {speaker_uncond_mode!r}"
+        )
+
+    cfg_guidance_mode = str(cfg_guidance_mode).strip().lower()
+    if cfg_guidance_mode not in {"independent", "joint", "alternating"}:
+        raise ValueError(
+            f"Unsupported cfg_guidance_mode={cfg_guidance_mode!r}. Expected one of: independent, joint, alternating."
+        )
+
+    init_scale = 0.999
+    t_schedule_mode_norm = str(t_schedule_mode).strip().lower()
+    sway_coeff_value = float(sway_coeff)
+    if not math.isfinite(sway_coeff_value):
+        raise ValueError(f"sway_coeff must be finite, got {sway_coeff!r}.")
+    if t_schedule_mode_norm == "linear":
+        u = torch.linspace(0.0, 1.0, num_steps + 1, device="cpu")
+    elif t_schedule_mode_norm == "sway":
+        # F5-TTS-style Sway Sampling. Negative sway_coeff densifies the noise
+        # side of the schedule (early steps); positive densifies the data side.
+        u = torch.linspace(0.0, 1.0, num_steps + 1, device="cpu")
+        u = u + sway_coeff_value * (torch.cos(0.5 * math.pi * u) + u - 1.0)
+        u = u.clamp(0.0, 1.0)
+    else:
+        raise ValueError(f"Unsupported t_schedule_mode={t_schedule_mode!r}. Expected 'linear' or 'sway'.")
+    t_schedule = (1.0 - u) * init_scale
+    if not bool(torch.all(t_schedule[:-1] > t_schedule[1:]).item()):
+        raise ValueError("t_schedule must be strictly decreasing; adjust num_steps or sway_coeff.")
+    use_independent_cfg = cfg_guidance_mode == "independent"
+    use_joint_cfg = cfg_guidance_mode == "joint"
+    use_alternating_cfg = cfg_guidance_mode == "alternating"
+
+    (
+        text_state_cond,
+        text_mask_cond,
+        speaker_state_cond,
+        speaker_mask_cond,
+        caption_state_cond,
+        caption_mask_cond,
+    ) = model.encode_conditions(
+        text_input_ids=text_input_ids,
+        text_mask=text_mask,
+        ref_latent=ref_latent,
+        ref_mask=ref_mask,
+        caption_input_ids=caption_input_ids,
+        caption_mask=caption_mask,
+        speaker_state_override=speaker_state_override,
+        speaker_mask_override=speaker_mask_override,
+        speaker_uncond_mode=speaker_uncond_mode,
+    )
+    text_state_uncond = torch.zeros_like(text_state_cond)
+    text_mask_uncond = torch.zeros_like(text_mask_cond)
+    speaker_state_uncond = None
+    speaker_mask_uncond = None
+    if model.cfg.use_speaker_condition_resolved:
+        if speaker_state_cond is None or speaker_mask_cond is None:
+            raise RuntimeError("Speaker conditioning is enabled but encoded speaker state is missing.")
+        if speaker_uncond_mode == "noise":
+            speaker_noise = torch.randn(
+                speaker_state_cond.shape,
+                device=rng_device,
+                dtype=speaker_state_cond.dtype,
+                generator=rng,
+            )
+            if rng_device != device:
+                speaker_noise = speaker_noise.to(device=device)
+            speaker_state_uncond = speaker_noise * speaker_state_cond.std().clamp_min(1e-6)
+            speaker_mask_uncond = torch.ones_like(speaker_mask_cond)
+        else:
+            speaker_state_uncond = torch.zeros_like(speaker_state_cond)
+            speaker_mask_uncond = torch.zeros_like(speaker_mask_cond)
+    caption_state_uncond = None
+    caption_mask_uncond = None
+    if model.cfg.use_caption_condition:
+        if caption_state_cond is None or caption_mask_cond is None:
+            raise RuntimeError("Caption conditioning is enabled but encoded caption state is missing.")
+        caption_state_uncond = torch.zeros_like(caption_state_cond)
+        caption_mask_uncond = torch.zeros_like(caption_mask_cond)
+
+    has_text_cfg = cfg_scale_text > 0
+    has_caption_cfg = (
+        model.cfg.use_caption_condition
+        and cfg_scale_caption > 0
+        and caption_mask_cond is not None
+        and bool(caption_mask_cond.any().item())
+    )
+    has_speaker_cfg = cfg_scale_speaker > 0
+
+    def _bundle(
+        *,
+        text_state: torch.Tensor,
+        text_mask_val: torch.Tensor,
+        speaker_state: torch.Tensor | None,
+        speaker_mask_val: torch.Tensor | None,
+        caption_state: torch.Tensor | None,
+        caption_mask_val: torch.Tensor | None,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        return (
+            text_state,
+            text_mask_val,
+            speaker_state,
+            speaker_mask_val,
+            caption_state,
+            caption_mask_val,
+        )
+
+    cond_bundle = _bundle(
+        text_state=text_state_cond,
+        text_mask_val=text_mask_cond,
+        speaker_state=speaker_state_cond,
+        speaker_mask_val=speaker_mask_cond,
+        caption_state=caption_state_cond,
+        caption_mask_val=caption_mask_cond,
+    )
+    enabled_cfg_names: list[str] = []
+    cfg_scales: dict[str, float] = {}
+    if has_text_cfg:
+        enabled_cfg_names.append("text")
+        cfg_scales["text"] = float(cfg_scale_text)
+    if has_speaker_cfg:
+        enabled_cfg_names.append("speaker")
+        cfg_scales["speaker"] = float(cfg_scale_speaker)
+    if has_caption_cfg:
+        enabled_cfg_names.append("caption")
+        cfg_scales["caption"] = float(cfg_scale_caption)
+
+    independent_bundles = [cond_bundle]
+    independent_names = ["cond"]
+    if use_independent_cfg:
+        for name in enabled_cfg_names:
+            independent_names.append(name)
+            independent_bundles.append(
+                _bundle(
+                    text_state=text_state_uncond if name == "text" else text_state_cond,
+                    text_mask_val=text_mask_uncond if name == "text" else text_mask_cond,
+                    speaker_state=(speaker_state_uncond if name == "speaker" else speaker_state_cond),
+                    speaker_mask_val=(speaker_mask_uncond if name == "speaker" else speaker_mask_cond),
+                    caption_state=(caption_state_uncond if name == "caption" else caption_state_cond),
+                    caption_mask_val=(caption_mask_uncond if name == "caption" else caption_mask_cond),
+                )
+            )
+    cfg_batch_mult = len(independent_bundles)
+
+    def _cat_optional_tensors(values: list[torch.Tensor | None]) -> torch.Tensor | None:
+        present = [value for value in values if value is not None]
+        if not present:
+            return None
+        if len(present) != len(values):
+            raise ValueError("Cannot concatenate optional condition tensors with mixed presence.")
+        return torch.cat(present, dim=0)
+
+    independent_text_state = torch.cat([bundle[0] for bundle in independent_bundles], dim=0)
+    independent_text_mask = torch.cat([bundle[1] for bundle in independent_bundles], dim=0)
+    independent_speaker_state = _cat_optional_tensors([bundle[2] for bundle in independent_bundles])
+    independent_speaker_mask = _cat_optional_tensors([bundle[3] for bundle in independent_bundles])
+    independent_caption_state = _cat_optional_tensors([bundle[4] for bundle in independent_bundles])
+    independent_caption_mask = _cat_optional_tensors([bundle[5] for bundle in independent_bundles])
+
+    joint_uncond_bundle = _bundle(
+        text_state=text_state_uncond,
+        text_mask_val=text_mask_uncond,
+        speaker_state=speaker_state_uncond,
+        speaker_mask_val=speaker_mask_uncond,
+        caption_state=caption_state_uncond,
+        caption_mask_val=caption_mask_uncond,
+    )
+
+    alternating_bundles: dict[
+        str,
+        tuple[
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor | None,
+            torch.Tensor | None,
+            torch.Tensor | None,
+            torch.Tensor | None,
+        ],
+    ] = {
+        "text": _bundle(
+            text_state=text_state_uncond,
+            text_mask_val=text_mask_uncond,
+            speaker_state=speaker_state_cond,
+            speaker_mask_val=speaker_mask_cond,
+            caption_state=caption_state_cond,
+            caption_mask_val=caption_mask_cond,
+        ),
+        "caption": _bundle(
+            text_state=text_state_cond,
+            text_mask_val=text_mask_cond,
+            speaker_state=speaker_state_cond,
+            speaker_mask_val=speaker_mask_cond,
+            caption_state=caption_state_uncond,
+            caption_mask_val=caption_mask_uncond,
+        ),
+    }
+    if has_speaker_cfg:
+        alternating_bundles["speaker"] = _bundle(
+            text_state=text_state_cond,
+            text_mask_val=text_mask_cond,
+            speaker_state=speaker_state_uncond,
+            speaker_mask_val=speaker_mask_uncond,
+            caption_state=caption_state_cond,
+            caption_mask_val=caption_mask_cond,
+        )
+
+    # Force-speaker scaling operates on projected speaker K/V, so it requires context KV caches.
+    effective_use_context_kv_cache = bool(use_context_kv_cache or (speaker_kv_scale is not None))
+
+    context_kv_cond = None
+    context_kv_cfg = None
+    context_kv_joint_uncond = None
+    context_kv_alternating: dict[str, list[tuple[torch.Tensor, ...]]] = {}
+    if effective_use_context_kv_cache:
+        context_kv_cond = model.build_context_kv_cache(
+            text_state=text_state_cond,
+            speaker_state=speaker_state_cond,
+            caption_state=caption_state_cond,
+        )
+        if use_independent_cfg and cfg_batch_mult > 1:
+            context_kv_cfg = model.build_context_kv_cache(
+                text_state=independent_text_state,
+                speaker_state=independent_speaker_state,
+                caption_state=independent_caption_state,
+            )
+        elif use_joint_cfg:
+            if enabled_cfg_names:
+                context_kv_joint_uncond = model.build_context_kv_cache(
+                    text_state=joint_uncond_bundle[0],
+                    speaker_state=joint_uncond_bundle[2],
+                    caption_state=joint_uncond_bundle[4],
+                )
+        elif use_alternating_cfg:
+            for name in enabled_cfg_names:
+                bundle = alternating_bundles[name]
+                context_kv_alternating[name] = model.build_context_kv_cache(
+                    text_state=bundle[0],
+                    speaker_state=bundle[2],
+                    caption_state=bundle[4],
+                )
+    if speaker_kv_scale is not None:
+        scale_speaker_kv_cache(
+            context_kv_cache=context_kv_cond,
+            scale=float(speaker_kv_scale),
+            max_layers=speaker_kv_max_layers,
+        )
+        if context_kv_cfg is not None:
+            scale_speaker_kv_cache(
+                context_kv_cache=context_kv_cfg,
+                scale=float(speaker_kv_scale),
+                max_layers=speaker_kv_max_layers,
+            )
+        for cache in context_kv_alternating.values():
+            scale_speaker_kv_cache(
+                context_kv_cache=cache,
+                scale=float(speaker_kv_scale),
+                max_layers=speaker_kv_max_layers,
+            )
+    speaker_kv_active = speaker_kv_scale is not None
+
+    for i in range(num_steps):
+        t = t_schedule[i].item()
+        t_next = t_schedule[i + 1].item()
+        tt = torch.full((batch_size,), t, device=device, dtype=dtype)
+
+        use_cfg = bool(enabled_cfg_names) and (cfg_min_t <= t <= cfg_max_t)
+        if use_cfg:
+            if use_independent_cfg:
+                x_t_cfg = torch.cat([x_t] * cfg_batch_mult, dim=0).to(dtype)
+                tt_cfg = tt.repeat(cfg_batch_mult)
+                v_out = model.forward_with_encoded_conditions(
+                    x_t=x_t_cfg,
+                    t=tt_cfg,
+                    text_state=independent_text_state,
+                    text_mask=independent_text_mask,
+                    speaker_state=independent_speaker_state,
+                    speaker_mask=independent_speaker_mask,
+                    caption_state=independent_caption_state,
+                    caption_mask=independent_caption_mask,
+                    context_kv_cache=context_kv_cfg,
+                )
+                chunks = v_out.chunk(cfg_batch_mult, dim=0)
+                v = chunks[0]
+                for name, chunk in zip(independent_names[1:], chunks[1:], strict=True):
+                    v = v + cfg_scales[name] * (chunks[0] - chunk)
+            else:
+                v_cond = model.forward_with_encoded_conditions(
+                    x_t=x_t.to(dtype),
+                    t=tt,
+                    text_state=text_state_cond,
+                    text_mask=text_mask_cond,
+                    speaker_state=speaker_state_cond,
+                    speaker_mask=speaker_mask_cond,
+                    caption_state=caption_state_cond,
+                    caption_mask=caption_mask_cond,
+                    context_kv_cache=context_kv_cond,
+                )
+                if use_joint_cfg:
+                    if len(enabled_cfg_names) > 1:
+                        joint_scales = [cfg_scales[name] for name in enabled_cfg_names]
+                        if max(joint_scales) - min(joint_scales) > 1e-6:
+                            raise ValueError(
+                                "cfg_guidance_mode='joint' expects equal enabled guidance scales; "
+                                "set matching text/speaker/caption scales or use --cfg-scale."
+                            )
+                    joint_scale = cfg_scales[enabled_cfg_names[0]]
+                    v_uncond_joint = model.forward_with_encoded_conditions(
+                        x_t=x_t.to(dtype),
+                        t=tt,
+                        text_state=joint_uncond_bundle[0],
+                        text_mask=joint_uncond_bundle[1],
+                        speaker_state=joint_uncond_bundle[2],
+                        speaker_mask=joint_uncond_bundle[3],
+                        caption_state=joint_uncond_bundle[4],
+                        caption_mask=joint_uncond_bundle[5],
+                        context_kv_cache=context_kv_joint_uncond,
+                    )
+                    v = v_cond + joint_scale * (v_cond - v_uncond_joint)
+                elif use_alternating_cfg:
+                    alt_name = enabled_cfg_names[i % len(enabled_cfg_names)]
+                    alt_bundle = alternating_bundles[alt_name]
+                    v_uncond_alt = model.forward_with_encoded_conditions(
+                        x_t=x_t.to(dtype),
+                        t=tt,
+                        text_state=alt_bundle[0],
+                        text_mask=alt_bundle[1],
+                        speaker_state=alt_bundle[2],
+                        speaker_mask=alt_bundle[3],
+                        caption_state=alt_bundle[4],
+                        caption_mask=alt_bundle[5],
+                        context_kv_cache=context_kv_alternating.get(alt_name),
+                    )
+                    v = v_cond + cfg_scales[alt_name] * (v_cond - v_uncond_alt)
+                else:
+                    raise RuntimeError(f"Unexpected cfg_guidance_mode: {cfg_guidance_mode}")
+        else:
+            v = model.forward_with_encoded_conditions(
+                x_t=x_t.to(dtype),
+                t=tt,
+                text_state=text_state_cond,
+                text_mask=text_mask_cond,
+                speaker_state=speaker_state_cond,
+                speaker_mask=speaker_mask_cond,
+                caption_state=caption_state_cond,
+                caption_mask=caption_mask_cond,
+                context_kv_cache=context_kv_cond,
+            )
+
+        if rescale_k is not None and rescale_sigma is not None:
+            v = temporal_score_rescale(
+                v_pred=v,
+                x_t=x_t,
+                t=t,
+                rescale_k=float(rescale_k),
+                rescale_sigma=float(rescale_sigma),
+            )
+
+        if (
+            speaker_kv_active
+            and speaker_kv_min_t is not None
+            and (t_next < speaker_kv_min_t)
+            and (t >= speaker_kv_min_t)
+        ):
+            inv_scale = 1.0 / float(speaker_kv_scale)
+            scale_speaker_kv_cache(
+                context_kv_cache=context_kv_cond,
+                scale=inv_scale,
+                max_layers=speaker_kv_max_layers,
+            )
+            if context_kv_cfg is not None:
+                scale_speaker_kv_cache(
+                    context_kv_cache=context_kv_cfg,
+                    scale=inv_scale,
+                    max_layers=speaker_kv_max_layers,
+                )
+            for cache in context_kv_alternating.values():
+                scale_speaker_kv_cache(
+                    context_kv_cache=cache,
+                    scale=inv_scale,
+                    max_layers=speaker_kv_max_layers,
+                )
+            speaker_kv_active = False
+
+        x_t = x_t + v * (t_next - t)
+
+    return x_t

--- a/vllm_omni/diffusion/registry.py
+++ b/vllm_omni/diffusion/registry.py
@@ -291,6 +291,11 @@ _DIFFUSION_MODELS = {
         "pipeline_sdxl",
         "StableDiffusionXLPipeline",
     ),
+    "IrodoriTTSPipeline": (
+        "irodori_tts",
+        "pipeline_irodori_tts",
+        "IrodoriTTSPipeline",
+    ),
 }
 
 
@@ -516,6 +521,7 @@ _DIFFUSION_POST_PROCESS_FUNCS = {
     "Cosmos3OmniDiffusersPipeline": "get_cosmos3_post_process_func",
     "HiDreamImagePipeline": "get_hidream_image_post_process_func",
     "StableDiffusionXLPipeline": "get_sdxl_image_post_process_func",
+    "IrodoriTTSPipeline": "get_irodori_tts_post_process_func",
 }
 
 _DIFFUSION_ACTION_POST_PROCESS_FUNCS = {

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -3722,7 +3722,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                 raise ValueError("TTS model did not produce audio output.")
 
             audio_tensor = audio_output[audio_key]
-            sr_raw = audio_output.get("sr", 24000)
+            sr_raw = audio_output.get("sr", audio_output.get("audio_sample_rate", 24000))
             sr_val = sr_raw[-1] if isinstance(sr_raw, list) and sr_raw else sr_raw
             sample_rate = sr_val.item() if hasattr(sr_val, "item") else int(sr_val)
 

--- a/vllm_omni/model_executor/stage_configs/irodori_tts.yaml
+++ b/vllm_omni/model_executor/stage_configs/irodori_tts.yaml
@@ -1,0 +1,30 @@
+# Stage config for running Irodori TTS v3 DiT.
+# Single GPU (GPU 1 is targeted at runtime using CUDA_VISIBLE_DEVICES=1).
+
+stage_args:
+  - stage_id: 0
+    stage_type: diffusion
+    runtime:
+      devices: "0"
+      max_batch_size: 1
+    engine_args:
+      model_stage: dit
+      model_class_name: IrodoriTTSPipeline
+      max_num_seqs: 1
+      enforce_eager: true
+      trust_remote_code: true
+      distributed_executor_backend: "mp"
+      parallel_config:
+        tensor_parallel_size: 1
+
+    final_output: true
+    final_output_type: audio
+    is_comprehension: false
+    default_sampling_params:
+      seed: 42
+
+runtime:
+  enabled: true
+  defaults:
+    window_size: -1
+    max_inflight: 1


### PR DESCRIPTION
This patch integrates Aratako's Irodori-TTS-500M-v3 Japanese Text-to-Speech model.
- Adds IrodoriTTSPipeline and IrodoriTTSTransformer with Rectified Flow Diffusion Transformer (RF-DiT) architecture.
- Integrates DACVAE codec decoding and duration predictor.
- Updates documentation and registers model pipeline.
- Adds comprehensive unit and E2E integration tests.

<!-- markdownlint-disable -->

## Purpose

This PR integrates support for **Aratako's Irodori-TTS-500M-v3**, a Japanese Text-to-Speech model based on a Rectified Flow Diffusion Transformer (RF-DiT) architecture.
* [Model on HuggingFace](https://huggingface.co/Aratako/Irodori-TTS-500M-v3)
* [Model author's Github repo](https://github.com/Aratako/Irodori-TTS)

### Key Additions:
1. **Model & Core Architecture:**
   - Implemented `IrodoriTTSTransformer` in `vllm_omni/diffusion/models/irodori_tts/irodori_tts_transformer.py`.
   - Developed `IrodoriTTSPipeline` in `vllm_omni/diffusion/models/irodori_tts/pipeline_irodori_tts.py` orchestrating:
     - Standardized Hugging Face tokenizer wrapper (`PretrainedTextTokenizer`) with specialized right-padding and special BOS token prepending.
     - An integrated duration predictor for accurate speech-frame length estimation.
     - Rectified Flow (RF) Euler-based sampling.
     - Audio decoding using the `Aratako/Semantic-DACVAE-Japanese-32dim` codec.
2. **Configuration & Registries:**
   - Added staging configs in `vllm_omni/model_executor/stage_configs/irodori_tts.yaml`.
   - Registered the model and the post-processing watermarking fallback logic in `vllm_omni/diffusion/registry.py`.
   - Handled sample-rate fallback dynamically in `vllm_omni/entrypoints/openai/serving_speech.py` to support 48 kHz.
3. **Tests & Docs:**
   - Created comprehensive unit tests in `tests/diffusion/models/irodori_tts/test_irodori_tts.py`.
   - Created end-to-end integration tests in `tests/e2e/offline_inference/test_irodori_tts_e2e.py`.
   - Updated the supported models table (`docs/models/supported_models.md`) and added offline/online user guide examples.

---

## Test Plan

**vLLM Version:** `0.23.0`

**vLLM-Omni Commit:** `267fe422`

### Run Commands:
```bash
# 1. Run unit tests
.venv/bin/pytest tests/diffusion/models/irodori_tts/test_irodori_tts.py

# 2. Run E2E integration tests
.venv/bin/pytest tests/e2e/offline_inference/test_irodori_tts_e2e.py

# 3. Run formatters and linter checks
pre-commit run --files \
    docs/models/supported_models.md \
    docs/user_guide/examples/offline_inference/text_to_speech.md \
    docs/user_guide/examples/online_serving/text_to_speech.md \
    pyproject.toml \
    tests/diffusion/models/irodori_tts/test_irodori_tts.py \
    tests/e2e/offline_inference/test_irodori_tts_e2e.py \
    vllm_omni/diffusion/data.py \
    vllm_omni/diffusion/models/irodori_tts/__init__.py \
    vllm_omni/diffusion/models/irodori_tts/codec.py \
    vllm_omni/diffusion/models/irodori_tts/duration.py \
    vllm_omni/diffusion/models/irodori_tts/irodori_tts_transformer.py \
    vllm_omni/diffusion/models/irodori_tts/pipeline_irodori_tts.py \
    vllm_omni/diffusion/models/irodori_tts/rf.py \
    vllm_omni/diffusion/registry.py \
    vllm_omni/entrypoints/openai/serving_speech.py \
    vllm_omni/model_executor/stage_configs/irodori_tts.yaml
```

---

## Test Result

All unit and E2E integration tests, as well as lint and pre-commit checks, have **passed 100% successfully**:

### 1. Unit Tests (`test_irodori_tts.py`):
```text
tests/diffusion/models/irodori_tts/test_irodori_tts.py ..                                                                                            [100%]
============================================================== 2 passed, 22 warnings in 7.37s ==============================================================
```

### 2. End-to-End Integration Tests (`test_irodori_tts_e2e.py`):
```text
tests/e2e/offline_inference/test_irodori_tts_e2e.py .                                                                                                [100%]
============================================================= 1 passed, 20 warnings in 19.21s ==============================================================
```

### 3. Pre-commit hooks check:
```text
check yaml...............................................................Passed
debug statements (python)................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
typos....................................................................Passed
Suggestion...............................................................Passed
Prevent new pickle/cloudpickle imports...................................Passed
```

---

## Performance & Evidence

### 1. vLLM-Omni Generation Script (Online Serve)
**Server Launch Command:**
```bash
vllm serve Aratako/Irodori-TTS-500M-v3 \
  --omni \
  --model-class-name IrodoriTTSPipeline \
  --port 8091
```

**Client API Request:**
```bash
curl -X POST http://localhost:8091/v1/audio/speech \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer NONE" \
  -o ./irodori_tts_output.wav \
  -d '{
    "model": "Aratako/Irodori-TTS-500M-v3",
    "input": "誠に申し訳ございませんが、本日の会議は悪天候のため延期とさせていただきます。",
    "voice": "ja-male-test",
    "response_format": "wav"
  }'
```

### 2. Generated Sample Output (Audio)
[irodori_tts_output.wav](https://github.com/user-attachments/files/29128398/irodori_tts_output.wav)

### 3. vLLM-Omni E2E Latency
- **Hardware:** 1x NVIDIA RTX PRO 6000 Blackwell
- **Prompt:** `"誠に申し訳ございませんが、本日の会議は悪天候のため延期とさせていただきます。"`
- **Steps:** 50 (default)
- **Audio Duration:** `7.280` seconds
- **E2E Total Latency:** `1,025.307` ms (1.03s)
- **Real-Time Factor (RTF):** `0.141`
- **Time to First Audio (TTFA):** `1,024.719` ms

### 4. Peak VRAM Usage
- **vLLM Diffusion Worker Memory:** `3,080` MiB
- **API Server Process Memory:** `552` MiB
- **Total Peak VRAM:** `3,632` MiB (**~3.63 GB**)

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
