### PR TITLE
[Bugfix][HiggsAudioV3] Fix talker CUDA graph capture crash from boolean-mask indexing

### DIFF
--- a/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
+++ b/vllm_omni/model_executor/models/higgs_audio_v3/higgs_audio_v3_talker.py
@@ -711,6 +711,15 @@ class HiggsAudioV3TalkerForConditionalGeneration(nn.Module):
             starts = q[:-1]
             spans = q[1:] - q[:-1]
             req_rows = torch.arange(int(q.numel()) - 1, dtype=torch.long, device=device)
+            if bool(getattr(self, "_use_external_decode_cudagraph", False)):
+                # Boolean-mask indexing (``req_rows[decode_mask]``) yields a
+                # data-dependent output shape, which forces a host sync and is
+                # illegal during CUDA graph capture. Under the external decode
+                # CUDA graph the batch is a uniform single-token decode (every
+                # span == 1), so ``decode_mask`` is all-True and the filtered
+                # result is identical to the unfiltered tensors. Return them
+                # directly to keep the captured shape static.
+                return req_rows, starts
             decode_mask = (spans == 1) & (starts >= 0) & (starts < int(num_tokens))
             return req_rows[decode_mask], starts[decode_mask]
 


### PR DESCRIPTION
## Purpose

Fixes #4562.

`HiggsAudioV3Talker._decode_request_token_positions` filters its output with
boolean-mask indexing (`req_rows[decode_mask]`), which produces a data-dependent
output shape. That forces a host synchronization and is illegal during CUDA graph
capture, so the `higgs_multimodal_qwen3_low_latency` profile (Stage-0
`enforce_eager: false`, `cudagraph_mode: FULL_DECODE_ONLY`) crashes at capture
time:

```
torch.AcceleratorError: CUDA error: operation not permitted when stream is capturing
```

## Fix

Under the external decode CUDA graph the decode batch is always a uniform
single-token decode (every `span == 1`), so `decode_mask` is all-True and the
filtered result equals the unfiltered tensors. Return them directly when
`_use_external_decode_cudagraph` is set, keeping the captured shape static. The
eager path is unchanged.

## Test

With this patch the Stage-0 CUDA graph profile captures successfully and
generates correct audio (verified on Tesla V100 / sm70 with the `FLASH_ATTN_V100`
backend; the output transcribes back to the input prompt). Without it, capture
aborts with the error above.
