### PR TITLE
[Draft] Add DreamZero Ulysses SP support

### DIFF
--- a/examples/offline_inference/dreamzero/bench_dreamzero.py
+++ b/examples/offline_inference/dreamzero/bench_dreamzero.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Local perf harness for PR #4580 parallelism matrix (NOT for commit).
+# Times each autoregressive chunk of DreamZero generation for a given deploy config.
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+import uuid
+from pathlib import Path
+
+os.environ.setdefault("DIFFUSION_ATTENTION_BACKEND", "TORCH_SDPA")
+
+# Reuse the canonical example's observation builder + Omni wiring.
+from export_prediction_video import WORKER_EXTENSION, _build_observations  # noqa: E402
+
+from vllm_omni import Omni  # noqa: E402
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams  # noqa: E402
+
+
+def _stats(secs: list[float]) -> dict:
+    xs = sorted(secs)
+    n = len(xs)
+    return {
+        "count": n,
+        "mean_ms": round(1000 * statistics.fmean(xs), 1),
+        "median_ms": round(1000 * statistics.median(xs), 1),
+        "p90_ms": round(1000 * xs[min(n - 1, int(0.9 * n))], 1),
+        "min_ms": round(1000 * xs[0], 1),
+        "max_ms": round(1000 * xs[-1], 1),
+    }
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="GEAR-Dreams/DreamZero-DROID")
+    ap.add_argument("--deploy-config", type=Path, required=True)
+    ap.add_argument("--video-dir", type=Path, default=repo_root / "outputs" / "dreamzero" / "assets")
+    ap.add_argument("--num-chunks", type=int, default=12)
+    ap.add_argument("--warmup", type=int, default=2, help="leading chunks excluded from steady-state (idx0=prefill)")
+    ap.add_argument("--label", default=None)
+    ap.add_argument(
+        "--prompt",
+        default="Move the pan forward and use the brush in the middle of the plates to brush the inside of the pan",
+    )
+    ap.add_argument("--out-json", type=Path, default=None)
+    args = ap.parse_args()
+
+    label = args.label or args.deploy_config.stem
+    session_id = f"bench-{uuid.uuid4().hex[:8]}"
+    _, observations = _build_observations(
+        args.video_dir,
+        args.prompt,
+        session_id,
+        num_chunks=args.num_chunks,
+        repeat_chunk_observations=True,
+    )
+
+    build_t0 = time.perf_counter()
+    omni = Omni(
+        model=args.model,
+        deploy_config=str(args.deploy_config),
+        enforce_eager=True,
+        worker_extension_cls=WORKER_EXTENSION,
+    )
+    init_s = time.perf_counter() - build_t0
+
+    per_chunk: list[float] = []
+    for index, obs in enumerate(observations):
+        sp = OmniDiffusionSamplingParams(
+            extra_args={"reset": index == 0, "session_id": obs["session_id"], "robot_obs": obs}
+        )
+        t0 = time.perf_counter()
+        result = omni.generate(obs["prompt"], sampling_params_list=[sp])
+        dt = time.perf_counter() - t0
+        if not result:
+            raise RuntimeError(f"no output for chunk {index}")
+        per_chunk.append(dt)
+        print(f"[{label}] chunk {index:2d}  {dt * 1000:8.1f} ms", flush=True)
+
+    steady = per_chunk[args.warmup:] or per_chunk[-1:]
+    summary = {
+        "label": label,
+        "deploy_config": str(args.deploy_config),
+        "num_chunks": args.num_chunks,
+        "warmup": args.warmup,
+        "init_s": round(init_s, 1),
+        "chunk0_prefill_ms": round(1000 * per_chunk[0], 1),
+        "total_gen_s": round(sum(per_chunk), 2),
+        "steady_state": _stats(steady),
+        "steady_chunks_per_s": round(len(steady) / sum(steady), 4) if sum(steady) else None,
+        "all_chunk_ms": [round(1000 * x, 1) for x in per_chunk],
+    }
+    print("BENCH_SUMMARY " + json.dumps(summary), flush=True)
+    if args.out_json:
+        args.out_json.parent.mkdir(parents=True, exist_ok=True)
+        args.out_json.write_text(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_inference/dreamzero/export_prediction_video.py
+++ b/examples/offline_inference/dreamzero/export_prediction_video.py
@@ -5,8 +5,12 @@
 from __future__ import annotations
 
 import argparse
+import os
 import uuid
 from pathlib import Path
+
+# Match DreamZero serving defaults and avoid cuDNN backend auto-selection in offline export.
+os.environ.setdefault("DIFFUSION_ATTENTION_BACKEND", "TORCH_SDPA")
 
 import cv2
 import numpy as np

--- a/handoff.md
+++ b/handoff.md
@@ -283,3 +283,48 @@ At the time this file was written, the local workspace also had unrelated untrac
 - `vLLM-Omni Feature Design Doc Concise.md`
 
 Do not accidentally add these to the PR unless the user explicitly asks for them.
+
+## Performance Benchmarks (Parallelism Matrix)
+
+Measured on this branch to compare TP / Ulysses-SP / CFG-parallel for DreamZero.
+
+### Setup
+- Model: `GEAR-Dreams/DreamZero-DROID` (14B, Wan2.1-I2V based), resolution 180×320, 4-frame AR chunks.
+- Hardware: NVIDIA A100-SXM4-80GB. Software: vLLM 0.22.0 (+cu129) / torch 2.11+cu129, driver 555.
+- Mode: **eager** (`enforce_eager=True`, forced by the offline export path), **step_cache disabled**,
+  batch 1, `DIFFUSION_ATTENTION_BACKEND=TORCH_SDPA`.
+- Workload: 1 prefill + 12 AR chunks; metric = steady-state mean per-chunk latency over chunks[2:].
+- Configs: `vllm_omni/deploy/dreamzero_{sp2,sp4,sp2_cfg2}.yaml` (SP/SP+CFG; the TP and TP×SP/TP×CFG
+  runs used ad-hoc configs not shipped here); harness `examples/offline_inference/dreamzero/bench_dreamzero.py`.
+
+### Results
+
+| config   | GPUs | parallelism    | load (s) | steady mean (ms) | p90 (ms) | chunks/s | vs TP2 |
+|----------|------|----------------|----------|------------------|----------|----------|--------|
+| tp2      | 2    | TP2            | 73       | 8269             | 8777     | 0.121    | 1.00x  |
+| sp2      | 2    | SP2 (ulysses2) | 75       | 8217             | 8648     | 0.122    | 1.01x  |
+| tp4      | 4    | TP4            | 92       | 6347             | 6600     | 0.158    | 1.30x  |
+| sp4      | 4    | SP4 (ulysses4) | 144      | 5527             | 5724     | 0.181    | 1.50x  |
+| tp2_sp2  | 4    | TP2 x SP2      | 111      | 6122             | 6342     | 0.163    | 1.35x  |
+| tp2_cfg2 | 4    | TP2 x CFG2     | 102      | 4998             | 5191     | 0.200    | 1.66x  |
+| sp2_cfg2 | 4    | SP2 x CFG2     | 152      | 4981             | 5149     | 0.201    | 1.66x  |
+
+### Takeaways
+- **2-GPU: SP2 ≈ TP2** (8.22 vs 8.27 s/chunk) — Ulysses SP is a no-regression alternative to TP.
+- **4-GPU single axis: SP4 (1.50x) > TP4 (1.30x)** — SP scales more efficiently (2→4 efficiency: SP 74%, TP 65%).
+- **CFG-parallel is the most efficient axis** — TP2xCFG2 and SP2xCFG2 both 1.66x (fastest); SP composes with CFG as well as TP.
+- TP2xSP2 (1.35x) sits between TP4 and SP4 → pure SP4 beats the TP/SP hybrid here.
+- **Load time**: TP shards weights (TP4 92 s) vs SP/CFG replicate the full 14B per rank (SP2xCFG2 152 s).
+
+### Notes on absolute latency
+These are **conservative** numbers: eager + step_cache-off were chosen so the matrix isolates the
+parallelism axis; they are not production speed.
+- A100 raw bf16 GEMM measured 238–265 TFLOPS (~80% of peak); SM utilization during generation was
+  bursty but low on average (mean ~18%) — eager-mode launch overhead starves the GPU, it is not compute-bound.
+- Enabling **step_cache alone** (TP2 + `cache_backend: step_cache`) cut per-chunk latency
+  **8269 → 3004 ms (2.75x)**. Production (step_cache + CUDA-graph where supported) is expected ~2.5–3x
+  faster than the table above, with the same relative ordering between strategies.
+
+### Environment caveat
+GPU index 3 on the benchmark node is hardware-faulty (CUDA OOM on any allocation despite reporting free);
+4-GPU runs were measured on physical GPUs 0,1,2,4. The committed configs use the standard `devices: "0,1,2,3"`.

--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,285 @@
+# DreamZero Ulysses SP PR Handoff
+
+Date: 2026-06-20
+
+PR: https://github.com/vllm-project/vllm-omni/pull/4580
+
+Base branch: `vllm-project/vllm-omni:main`
+
+PR head branch: `TKONIY:draft/dreamzero-sp-ulysses`
+
+Local branch used for the rebase: `draft/dreamzero-sp-ulysses-rebased`
+
+Core implementation commit before this handoff doc: `4e3fce99 feat: add DreamZero Ulysses SP support`
+
+## Goal
+
+This PR adds Ulysses sequence parallel support for DreamZero while keeping the implementation small and compatible with the current `main` DreamZero code. The important constraint is that DreamZero already has a session-based KV cache, fused self-attention QKV projection, cross-attention cache, stepcache, and Cache-DiT related changes on `main`; this PR should layer SP support on top of those instead of reintroducing older DreamZero code.
+
+## High-Level Design
+
+DreamZero SP is implemented as video-token-only Ulysses sequence parallelism.
+
+- Video tokens are sharded by sequence dimension through `sp_prepare`.
+- Action and state tokens stay replicated and are appended after the local video shard.
+- Self-attention participates in sequence parallelism.
+- Cross-attention does not participate in SP and continues to run with replicated sequence inputs.
+- KV cache is sharded by attention head under Ulysses, not by sequence.
+- Ring SP with KV cache is intentionally not supported yet because its KV layout semantics are different.
+
+## Key Files
+
+### `vllm_omni/diffusion/models/dreamzero/causal_wan_model.py`
+
+Main DreamZero model changes.
+
+- Adds `_with_precise_bf16_matmul_reduction` around `_forward_blocks`.
+  - This temporarily disables `torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction` for bf16 block execution.
+  - Reason: SP sharding changes GEMM shapes, and reduced precision bf16 reduction caused measurable numeric drift versus the single-rank baseline in tiny DreamZero precision tests.
+- Adds `_dreamzero_sp_gather`.
+  - Calls `sp_gather(..., validate=False)` and falls back to identity when no SP context is active.
+- Keeps `WanT2VCrossAttention` and `WanI2VCrossAttention` with `skip_sequence_parallel=True`.
+  - Do not flip these unless you also redesign cross-attn context/crossattn_cache sharding.
+- Sets `CausalWanSelfAttention.attn` to `skip_sequence_parallel=False`.
+  - This is the layer that should run through the active Ulysses strategy.
+- Keeps main's fused `QKVParallelLinear` self-attention path.
+  - Do not restore old separate `q`, `k`, `v` projections.
+- Routes self-attention KV handling through `Attention.forward_with_kv_cache(...)`.
+  - Action/state tokens are passed as `AttentionMetadata(joint_*, joint_strategy="rear")`.
+  - Joint action/state KV is used for the live attention call but is not persisted into the video KV cache.
+- Adds `DreamZeroSPPrepare` and `CausalWanModel._sp_plan`.
+  - `sp_prepare` arg 0: `x_video`, split dim 1.
+  - `sp_prepare` arg 1: `e_video`, split dim 1.
+  - `sp_prepare` arg 2: `freqs`, split dim 0.
+  - All use `expected_dims=3`, `split_output=True`, `auto_pad=False`.
+- Adds `CausalWanModel.kv_cache_num_heads(ulysses_degree=...)`.
+  - Returns local KV heads under Ulysses.
+  - Raises if strict Ulysses degree does not divide local TP heads.
+- In `_forward_blocks`:
+  - Compute `e0 = self.time_projection(e)` before SP sharding.
+  - Split only video `x/e0/freqs` through `self.sp_prepare`.
+  - Append replicated action/state tokens after sharding.
+  - Use local `seq_len` for block execution.
+  - Gather only video tokens before `self.head`.
+  - Use full unsharded `e[:, :video_seq_len]` for the output head.
+
+### `vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py`
+
+Pipeline KV allocation changes.
+
+- Adds `_get_runtime_ulysses_degree()`.
+  - First tries `get_ulysses_parallel_world_size()`.
+  - Falls back to the current diffusion config if parallel state is not initialized.
+- `_prefill_kv_cache` now allocates DreamZero session KV cache with:
+  - `num_heads = self.transformer.kv_cache_num_heads(ulysses_degree=ulysses_degree)`
+  - This is required because under Ulysses the per-rank cache stores only local head shards.
+
+### `vllm_omni/diffusion/attention/layer.py`
+
+Generic attention changes used by DreamZero and covered by tests.
+
+- Adds `append_attention_kv_cache(...)`.
+  - Appends fresh K/V along sequence dimension and trims by `max_cache_len`.
+  - Validates `[2, B, S, H, D]` layout.
+- Adds `Attention.forward_with_kv_cache(...)`.
+  - Runs the active parallel strategy first.
+  - Removes live joint K/V before persisting the cache.
+  - Appends only video K/V into the persistent KV cache.
+  - Re-adds live joint K/V for the attention compute.
+  - Runs local attention and then `strategy.post_attention(...)`.
+- Explicitly rejects ring SP KV cache:
+  - Raises `NotImplementedError("Ring sequence parallel KV cache layout is not implemented...")`.
+  - This is intentional. Ring output may still work for non-cache attention paths, but DreamZero cached self-attn should not silently run with an invalid layout.
+
+### `vllm_omni/diffusion/attention/parallel/ulysses.py`
+
+Ulysses changes.
+
+- Adds a packed Q/K/V all-to-all fast path for strict Ulysses when Q/K/V share shape, dtype, and device.
+- Supports odd/non-divisible head counts in the UAA helper by padding heads before all-to-all and trimming after post attention.
+- Carries joint-token metadata through the Ulysses context so `forward_with_kv_cache` can separate persistent video KV from live action/state KV.
+
+### `vllm_omni/diffusion/attention/backends/sdpa.py`
+
+SDPA test/debug controls.
+
+- `DIFFUSION_SDPA_FORCE_FP32=1` casts Q/K/V to fp32 for SDPA and casts output back to the original dtype.
+- `DIFFUSION_SDPA_FORCE_MATH=1` forces the math SDPA kernel.
+- These are primarily for controlled precision/debug experiments, not a default performance path.
+
+### Deploy Configs
+
+Added:
+
+- `vllm_omni/deploy/dreamzero_sp2.yaml`
+- `vllm_omni/deploy/dreamzero_sp4.yaml`
+- `vllm_omni/deploy/dreamzero_sp2_cfg2.yaml`
+
+These are convenience configs for SP-only and SP+CFG experiments.
+
+### Offline Export Example
+
+`examples/offline_inference/dreamzero/export_prediction_video.py` now defaults `DIFFUSION_ATTENTION_BACKEND` to `TORCH_SDPA`, matching the DreamZero serving default and avoiding backend auto-selection surprises in offline export.
+
+## Tests Added Or Updated
+
+### Unit and contract tests
+
+- `tests/diffusion/attention/test_sdpa_backend.py`
+  - Covers SDPA fp32/math environment controls.
+- `tests/diffusion/attention/test_ulysses_qkv_packing.py`
+  - Covers packed Q/K/V all-to-all behavior.
+- `tests/diffusion/models/dreamzero/test_causal_wan_sp_contract.py`
+  - Covers DreamZero `_sp_plan`, `sp_prepare`, cross-attn/self-attn `skip_sequence_parallel`, fused QKV cached attention, joint metadata, KV append semantics, ring rejection, and local-head cache sizing.
+- `tests/dreamzero/test_pipeline_state.py`
+  - Adds regression coverage that `_prefill_kv_cache` allocates local Ulysses head count.
+- Existing DreamZero tests:
+  - `tests/dreamzero/test_qkv_fusion.py`
+  - `tests/dreamzero/test_fused_qk_rms_norm.py`
+
+### GPU precision tests
+
+`tests/diffusion/models/dreamzero/test_causal_wan_sp_kv_cache.py`
+
+Important tests:
+
+- `test_dreamzero_cached_attention_ulysses_keeps_kv_cache_head_sharded`
+- `test_dreamzero_cached_attention_ulysses_keeps_joint_tokens_out_of_kv_cache`
+- `test_tiny_causal_wan_model_ulysses_matches_single_rank_with_actions`
+- `test_tiny_causal_wan_model_ulysses_matches_single_rank_after_prefill`
+- `test_tiny_causal_wan_model_ulysses_matches_single_rank_after_prefill_with_qk_norm`
+- `test_tiny_causal_wan_model_ulysses_matches_single_rank_with_realistic_action_horizon`
+- `test_tiny_causal_wan_i2v_ulysses_matches_single_rank_with_clip_and_y`
+
+The tiny model tests compare SP outputs/caches against a single-rank baseline and are the most important correctness guard for future changes.
+
+## Verification Already Run
+
+After rebasing to `origin/main`, these commands passed locally:
+
+```bash
+pytest -q \
+  tests/diffusion/attention/test_sdpa_backend.py \
+  tests/diffusion/attention/test_ulysses_qkv_packing.py \
+  tests/diffusion/models/dreamzero/test_causal_wan_sp_contract.py \
+  tests/dreamzero/test_pipeline_state.py \
+  tests/dreamzero/test_qkv_fusion.py \
+  tests/dreamzero/test_fused_qk_rms_norm.py
+```
+
+Result: `29 passed`.
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 pytest -q \
+  tests/diffusion/models/dreamzero/test_causal_wan_sp_kv_cache.py \
+  -k 'tiny_causal_wan_model_ulysses_matches_single_rank_with_actions or tiny_causal_wan_model_ulysses_matches_single_rank_after_prefill or tiny_causal_wan_model_ulysses_matches_single_rank_after_prefill_with_qk_norm'
+```
+
+Result: `4 passed, 8 deselected`.
+
+Environment note from those runs:
+
+- 6 NVIDIA RTX PRO 6000 Blackwell-class GPUs were visible.
+- There was a repository warning about vLLM and vLLM-Omni minor version mismatch:
+  - vLLM-Omni: `0.21.0rc2.dev235+g32ca6e515.d20260601`
+  - vLLM: `0.22.0`
+  - The tested commands still passed.
+
+## Known Risks And Non-Goals
+
+### Ring SP
+
+Ring SP is not implemented for DreamZero KV-cache attention in this PR. The code intentionally raises in `Attention.forward_with_kv_cache` when `self.use_ring` is true. Do not remove that guard unless you implement and test the correct ring KV cache layout.
+
+Reason: Ulysses stores the persistent cache sharded by local heads after all-to-all. Ring uses different sequence/communication semantics, and silently sharing the Ulysses cache layout for ring would be wrong.
+
+### Cross-Attention SP
+
+Cross-attention stays `skip_sequence_parallel=True`.
+
+Reason: DreamZero context/crossattn_cache is short and session-invariant. Sharding cross-attn would require rethinking cached text/image K/V layout and its interaction with replicated action/state tokens. The current PR only shards self-attn video sequence tokens.
+
+### Action/State Tokens
+
+Action/state tokens are intentionally not stored in the session KV cache. They are live joint tokens for the current step only. The persistent KV cache is video-only.
+
+If a future change stores action/state KV persistently, it must update:
+
+- `Attention.forward_with_kv_cache`
+- DreamZero cache shape allocation
+- tiny SP precision tests
+- joint-token cache exclusion tests
+
+### bf16 Precision
+
+The `_with_precise_bf16_matmul_reduction` wrapper exists because SP changes GEMM partitioning, and bf16 reduced precision reduction caused SP-vs-single-rank drift in controlled tests. If you remove it for performance, first reproduce precision with the tiny GPU tests and the real DreamZero video comparison workflow.
+
+### PR Shape
+
+The PR was rebased to latest `origin/main` on 2026-06-20. DreamZero is already upstream on `main`, so the PR should stay focused on SP support and should not replay old DreamZero integration commits.
+
+## Recommended Commands For The Next Agent
+
+Start with:
+
+```bash
+git fetch origin main
+git fetch tkoniy draft/dreamzero-sp-ulysses
+git checkout -B draft/dreamzero-sp-ulysses tkoniy/draft/dreamzero-sp-ulysses
+```
+
+Then inspect:
+
+```bash
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD -- vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+git diff origin/main...HEAD -- vllm_omni/diffusion/attention/layer.py
+```
+
+Run fast tests:
+
+```bash
+pytest -q \
+  tests/diffusion/attention/test_sdpa_backend.py \
+  tests/diffusion/attention/test_ulysses_qkv_packing.py \
+  tests/diffusion/models/dreamzero/test_causal_wan_sp_contract.py \
+  tests/dreamzero/test_pipeline_state.py \
+  tests/dreamzero/test_qkv_fusion.py \
+  tests/dreamzero/test_fused_qk_rms_norm.py
+```
+
+Run GPU precision checks when GPUs are available:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 pytest -q \
+  tests/diffusion/models/dreamzero/test_causal_wan_sp_kv_cache.py \
+  -k 'dreamzero_cached_attention_ulysses or tiny_causal_wan_model_ulysses'
+```
+
+For a shorter GPU check:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 pytest -q \
+  tests/diffusion/models/dreamzero/test_causal_wan_sp_kv_cache.py \
+  -k 'tiny_causal_wan_model_ulysses_matches_single_rank_with_actions or tiny_causal_wan_model_ulysses_matches_single_rank_after_prefill or tiny_causal_wan_model_ulysses_matches_single_rank_after_prefill_with_qk_norm'
+```
+
+## What To Watch When Modifying The PR
+
+1. Do not change DreamZero self-attn back to separate `q/k/v`; `main` uses fused `QKVParallelLinear`.
+2. Do not make cross-attn SP-active unless you also implement crossattn_cache sharding and precision tests.
+3. Do not persist joint action/state tokens into KV cache unless tests are rewritten for the new semantics.
+4. Do not enable ring KV cache without a new layout design and tests.
+5. If changing `_sp_plan` or `sp_prepare`, rerun both CPU contract tests and GPU tiny precision tests.
+6. If changing SDPA fp32/math controls, keep them opt-in environment controls.
+7. If changing bf16 precision handling, verify with GPU SP-vs-single-rank comparisons before claiming success.
+
+## Local Workspace Notes
+
+At the time this file was written, the local workspace also had unrelated untracked files that were intentionally left untouched:
+
+- `docs/design/dreamzero_optimization_rfc.md`
+- `docs/superpowers/`
+- `vLLM-Omni Feature Design Doc Concise.md`
+
+Do not accidentally add these to the PR unless the user explicitly asks for them.

--- a/tests/diffusion/attention/test_sdpa_backend.py
+++ b/tests/diffusion/attention/test_sdpa_backend.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.attention.backends.sdpa import SDPAImpl
+
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.cpu]
+
+
+def test_sdpa_impl_force_math_env_uses_math_only_kernel(monkeypatch) -> None:
+    calls = []
+
+    @contextmanager
+    def fake_sdp_kernel(**kwargs):
+        calls.append(kwargs)
+        yield
+
+    def fake_attention(query, key, value, **kwargs):
+        del key, value, kwargs
+        return query
+
+    monkeypatch.setenv("DIFFUSION_SDPA_FORCE_MATH", "1")
+    monkeypatch.setattr(torch.backends.cuda, "sdp_kernel", fake_sdp_kernel)
+    monkeypatch.setattr(torch.nn.functional, "scaled_dot_product_attention", fake_attention)
+
+    impl = SDPAImpl(num_heads=2, head_size=4, softmax_scale=0.5, num_kv_heads=2)
+    query = torch.zeros(1, 2, 3, 4)
+    key = torch.zeros(1, 2, 3, 4)
+    value = torch.zeros(1, 2, 3, 4)
+
+    output = impl.forward_cuda(query, key, value)
+
+    assert output.shape == query.shape
+    assert calls == [
+        {
+            "enable_flash": False,
+            "enable_math": True,
+            "enable_mem_efficient": False,
+            "enable_cudnn": False,
+        }
+    ]
+
+
+def test_sdpa_impl_force_fp32_env_upcasts_kernel_inputs_and_restores_output_dtype(monkeypatch) -> None:
+    seen = {}
+
+    def fake_attention(query, key, value, **kwargs):
+        del kwargs
+        seen["query_dtype"] = query.dtype
+        seen["key_dtype"] = key.dtype
+        seen["value_dtype"] = value.dtype
+        return query
+
+    monkeypatch.setenv("DIFFUSION_SDPA_FORCE_FP32", "1")
+    monkeypatch.setattr(torch.nn.functional, "scaled_dot_product_attention", fake_attention)
+
+    impl = SDPAImpl(num_heads=2, head_size=4, softmax_scale=0.5, num_kv_heads=2)
+    query = torch.zeros(1, 2, 3, 4, dtype=torch.bfloat16)
+    key = torch.zeros(1, 2, 3, 4, dtype=torch.bfloat16)
+    value = torch.zeros(1, 2, 3, 4, dtype=torch.bfloat16)
+
+    output = impl.forward_cuda(query, key, value)
+
+    assert seen == {
+        "query_dtype": torch.float32,
+        "key_dtype": torch.float32,
+        "value_dtype": torch.float32,
+    }
+    assert output.dtype == torch.bfloat16

--- a/tests/diffusion/attention/test_ulysses_qkv_packing.py
+++ b/tests/diffusion/attention/test_ulysses_qkv_packing.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm_omni.diffusion.attention.parallel import ulysses
+
+
+def _fake_sp_group(world_size: int = 2):
+    return SimpleNamespace(
+        ulysses_group=object(),
+        ulysses_world_size=world_size,
+        ulysses_rank=0,
+        ring_world_size=1,
+        ring_group=object(),
+    )
+
+
+def test_strict_pre_attention_packs_matching_qkv_into_one_5d_all_to_all(monkeypatch) -> None:
+    monkeypatch.setattr(ulysses, "get_ulysses_mode", lambda default="strict": "strict")
+
+    calls_4d = []
+    calls_5d = []
+
+    def fake_4d_apply(pg, x, scatter_idx, gather_idx, use_sync):
+        calls_4d.append((tuple(x.shape), scatter_idx, gather_idx, use_sync))
+        bsz, shard_seq_len, head_cnt, head_size = x.shape
+        return torch.empty(bsz, shard_seq_len * 2, head_cnt // 2, head_size, dtype=x.dtype)
+
+    def fake_5d_apply(pg, x, scatter_idx, gather_idx, use_sync):
+        calls_5d.append((tuple(x.shape), scatter_idx, gather_idx, use_sync))
+        bsz, shard_seq_len, qkv_cnt, head_cnt, head_size = x.shape
+        assert qkv_cnt == 3
+        out = torch.empty(bsz, shard_seq_len * 2, qkv_cnt, head_cnt // 2, head_size, dtype=x.dtype)
+        out[:, :, 0].fill_(1.0)
+        out[:, :, 1].fill_(2.0)
+        out[:, :, 2].fill_(3.0)
+        return out
+
+    monkeypatch.setattr(ulysses.SeqAllToAll4D, "apply", staticmethod(fake_4d_apply))
+    monkeypatch.setattr(ulysses, "SeqAllToAll5D", SimpleNamespace(apply=fake_5d_apply), raising=False)
+
+    attn = ulysses.UlyssesParallelAttention(_fake_sp_group(), scatter_idx=2, gather_idx=1, use_sync=False)
+    query = torch.randn(1, 4, 8, 16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+
+    query_out, key_out, value_out, _, ctx = attn.pre_attention(query, key, value, attn_metadata=None)
+
+    assert calls_5d == [((1, 4, 3, 8, 16), 3, 1, False)]
+    assert calls_4d == []
+    assert tuple(query_out.shape) == (1, 8, 4, 16)
+    assert tuple(key_out.shape) == (1, 8, 4, 16)
+    assert tuple(value_out.shape) == (1, 8, 4, 16)
+    assert torch.all(query_out == 1.0)
+    assert torch.all(key_out == 2.0)
+    assert torch.all(value_out == 3.0)
+    assert not ctx.use_uaa
+
+
+def test_strict_pre_attention_falls_back_to_4d_all_to_all_for_mismatched_qkv(monkeypatch) -> None:
+    monkeypatch.setattr(ulysses, "get_ulysses_mode", lambda default="strict": "strict")
+
+    calls_4d = []
+    calls_5d = []
+
+    def fake_4d_apply(pg, x, scatter_idx, gather_idx, use_sync):
+        calls_4d.append((tuple(x.shape), scatter_idx, gather_idx, use_sync))
+        bsz, shard_seq_len, head_cnt, head_size = x.shape
+        return torch.empty(bsz, shard_seq_len * 2, head_cnt // 2, head_size, dtype=x.dtype)
+
+    def fake_5d_apply(pg, x, scatter_idx, gather_idx, use_sync):
+        calls_5d.append((tuple(x.shape), scatter_idx, gather_idx, use_sync))
+        raise AssertionError("5D all-to-all should not run for mismatched Q/K/V shapes")
+
+    monkeypatch.setattr(ulysses.SeqAllToAll4D, "apply", staticmethod(fake_4d_apply))
+    monkeypatch.setattr(ulysses, "SeqAllToAll5D", SimpleNamespace(apply=fake_5d_apply), raising=False)
+
+    attn = ulysses.UlyssesParallelAttention(_fake_sp_group(), scatter_idx=2, gather_idx=1, use_sync=False)
+    query = torch.randn(1, 4, 8, 16)
+    key = torch.randn(1, 4, 4, 16)
+    value = torch.randn_like(query)
+
+    query_out, key_out, value_out, _, _ = attn.pre_attention(query, key, value, attn_metadata=None)
+
+    assert calls_5d == []
+    assert calls_4d == [
+        ((1, 4, 8, 16), 2, 1, False),
+        ((1, 4, 4, 16), 2, 1, False),
+        ((1, 4, 8, 16), 2, 1, False),
+    ]
+    assert tuple(query_out.shape) == (1, 8, 4, 16)
+    assert tuple(key_out.shape) == (1, 8, 2, 16)
+    assert tuple(value_out.shape) == (1, 8, 4, 16)

--- a/tests/diffusion/models/dreamzero/test_causal_wan_sp_contract.py
+++ b/tests/diffusion/models/dreamzero/test_causal_wan_sp_contract.py
@@ -1,0 +1,632 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn as nn
+from types import SimpleNamespace
+
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.layer import Attention, append_attention_kv_cache
+from vllm_omni.diffusion.distributed.sp_plan import (
+    SequenceParallelInput,
+    SequenceParallelOutput,
+    validate_sp_plan,
+)
+from vllm_omni.diffusion.models.dreamzero.causal_wan_model import (
+    CausalWanModel,
+    CausalWanSelfAttention,
+    WanI2VCrossAttention,
+    WanT2VCrossAttention,
+)
+
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu, pytest.mark.diffusion]
+
+
+def test_causal_wan_model_declares_sp_plan_for_video_only():
+    plan = getattr(CausalWanModel, "_sp_plan", None)
+
+    assert plan is not None
+    validate_sp_plan(plan)
+    assert "sp_prepare" in plan
+    assert "head.head" not in plan
+
+    prepare = plan["sp_prepare"]
+    assert isinstance(prepare[0], SequenceParallelInput)
+    assert prepare[0].split_dim == 1
+    assert prepare[0].expected_dims == 3
+    assert prepare[0].split_output is True
+
+    assert isinstance(prepare[1], SequenceParallelInput)
+    assert prepare[1].split_dim == 1
+    assert prepare[1].expected_dims == 3
+    assert prepare[1].split_output is True
+
+    assert isinstance(prepare[2], SequenceParallelInput)
+    assert prepare[2].split_dim == 0
+    assert prepare[2].expected_dims == 3
+    assert prepare[2].split_output is True
+
+def test_causal_wan_projects_time_embedding_before_sp_prepare():
+    class RecordingSPPrepare(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.seen_e_shape = None
+
+        def forward(self, x_video, e_video, freqs):
+            self.seen_e_shape = tuple(e_video.shape)
+            return x_video[:, :2], e_video[:, :2], freqs[:2]
+
+    class IdentityHead(nn.Module):
+        def forward(self, x, e):
+            return x
+
+    model = CausalWanModel.__new__(CausalWanModel)
+    nn.Module.__init__(model)
+    model.freq_dim = 8
+    model.dim = 4
+    model.time_embedding = nn.Sequential(nn.Linear(model.freq_dim, model.dim), nn.SiLU(), nn.Linear(model.dim, model.dim))
+    model.time_projection = nn.Sequential(nn.SiLU(), nn.Linear(model.dim, model.dim * 6))
+    model.sp_prepare = RecordingSPPrepare()
+    model.text_embedding = nn.Identity()
+    model.blocks = nn.ModuleList()
+    model.head = IdentityHead()
+
+    x = torch.randn(1, model.dim, 1, 4, 1)
+    timestep = torch.zeros(1, 1)
+    context = torch.randn(1, 1, model.dim)
+    freqs = torch.ones(4, 1, 2, dtype=torch.complex64)
+
+    CausalWanModel._forward_blocks(
+        model,
+        x=x,
+        seq_len=4,
+        freqs=freqs,
+        timestep=timestep,
+        context=context,
+        clip_feature=None,
+        embodiment_id=None,
+        action=None,
+        timestep_action=None,
+        state=None,
+        kv_cache=[],
+        crossattn_cache=None,
+        current_start_frame=0,
+    )
+
+    assert model.sp_prepare.seen_e_shape == (1, 4, model.dim * 6)
+
+
+def test_causal_wan_gathers_video_tokens_before_head(monkeypatch):
+    import vllm_omni.diffusion.models.dreamzero.causal_wan_model as causal_wan_model
+
+    class LocalSPPrepare(nn.Module):
+        def forward(self, x_video, e_video, freqs):
+            return x_video[:, :2], e_video[:, :2], freqs[:2]
+
+    class RecordingHead(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.seen_x_shape = None
+            self.seen_e_shape = None
+
+        def forward(self, x, e):
+            self.seen_x_shape = tuple(x.shape)
+            self.seen_e_shape = tuple(e.shape)
+            return x
+
+    def fake_sp_gather(tensor, dim, validate=True):
+        del validate
+        assert dim == 1
+        return torch.cat([tensor, tensor + 100], dim=dim)
+
+    monkeypatch.setattr(causal_wan_model, "sp_gather", fake_sp_gather, raising=False)
+
+    model = CausalWanModel.__new__(CausalWanModel)
+    nn.Module.__init__(model)
+    model.freq_dim = 8
+    model.dim = 4
+    model.time_embedding = nn.Sequential(nn.Linear(model.freq_dim, model.dim), nn.SiLU(), nn.Linear(model.dim, model.dim))
+    model.time_projection = nn.Sequential(nn.SiLU(), nn.Linear(model.dim, model.dim * 6))
+    model.sp_prepare = LocalSPPrepare()
+    model.text_embedding = nn.Identity()
+    model.blocks = nn.ModuleList()
+    model.head = RecordingHead()
+
+    x = torch.randn(1, model.dim, 1, 4, 1)
+    timestep = torch.zeros(1, 1)
+    context = torch.randn(1, 1, model.dim)
+    freqs = torch.ones(4, 1, 2, dtype=torch.complex64)
+
+    CausalWanModel._forward_blocks(
+        model,
+        x=x,
+        seq_len=4,
+        freqs=freqs,
+        timestep=timestep,
+        context=context,
+        clip_feature=None,
+        embodiment_id=None,
+        action=None,
+        timestep_action=None,
+        state=None,
+        kv_cache=[],
+        crossattn_cache=None,
+        current_start_frame=0,
+    )
+
+    assert model.head.seen_x_shape == (1, 4, model.dim)
+    assert model.head.seen_e_shape == (1, 4, 1, model.dim)
+
+
+def test_causal_wan_disables_bf16_reduced_precision_reduction_during_blocks():
+    if not hasattr(torch.backends.cuda.matmul, "allow_bf16_reduced_precision_reduction"):
+        pytest.skip("bf16 reduced precision reduction flag is not available")
+
+    class FlagRecordingTimeEmbedding(nn.Module):
+        def __init__(self, dim: int) -> None:
+            super().__init__()
+            self.dim = dim
+            self.seen_flag = None
+
+        def forward(self, x):
+            self.seen_flag = torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
+            return torch.zeros(x.shape[0], self.dim, dtype=x.dtype, device=x.device)
+
+    class RecordingSPPrepare(nn.Module):
+        def forward(self, x_video, e_video, freqs):
+            return x_video[:, :2], e_video[:, :2], freqs[:2]
+
+    class IdentityHead(nn.Module):
+        def forward(self, x, e):
+            return x
+
+    old_flag = torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
+    torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = True
+    try:
+        model = CausalWanModel.__new__(CausalWanModel)
+        nn.Module.__init__(model)
+        model.freq_dim = 8
+        model.dim = 4
+        model.time_embedding = FlagRecordingTimeEmbedding(model.dim)
+        model.time_projection = nn.Sequential(nn.SiLU(), nn.Linear(model.dim, model.dim * 6)).to(torch.bfloat16)
+        model.sp_prepare = RecordingSPPrepare()
+        model.text_embedding = nn.Identity()
+        model.blocks = nn.ModuleList()
+        model.head = IdentityHead()
+
+        x = torch.randn(1, model.dim, 1, 4, 1, dtype=torch.bfloat16)
+        timestep = torch.zeros(1, 1)
+        context = torch.randn(1, 1, model.dim, dtype=torch.bfloat16)
+        freqs = torch.ones(4, 1, 2, dtype=torch.complex64)
+
+        CausalWanModel._forward_blocks(
+            model,
+            x=x,
+            seq_len=4,
+            freqs=freqs,
+            timestep=timestep,
+            context=context,
+            clip_feature=None,
+            embodiment_id=None,
+            action=None,
+            timestep_action=None,
+            state=None,
+            kv_cache=[],
+            crossattn_cache=None,
+            current_start_frame=0,
+        )
+
+        assert model.time_embedding.seen_flag is False
+        assert torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction is True
+    finally:
+        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = old_flag
+
+
+class _FakeParallelLinear(nn.Module):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+
+
+class _FakeQKVParallelLinear(nn.Module):
+    total_num_kv_heads = 4
+    total_num_heads = 4
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+
+
+class _RepeatQKVProjection(nn.Module):
+    def forward(self, x):
+        return torch.cat([x, x, x], dim=-1), None
+
+
+class _RecordingCachedAttention(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen = {}
+
+    def forward(self, query, key, value, attn_metadata=None):
+        raise AssertionError("regular Attention.forward should not receive cached DreamZero KV")
+
+    def forward_with_kv_cache(
+        self,
+        query,
+        key,
+        value,
+        kv_cache,
+        *,
+        max_cache_len,
+        attn_metadata=None,
+    ):
+        self.seen["query_shape"] = tuple(query.shape)
+        self.seen["key_shape"] = tuple(key.shape)
+        self.seen["value_shape"] = tuple(value.shape)
+        self.seen["kv_cache"] = kv_cache
+        self.seen["max_cache_len"] = max_cache_len
+        self.seen["attn_metadata"] = attn_metadata
+        if attn_metadata is not None and attn_metadata.joint_query is not None:
+            if attn_metadata.joint_strategy == "rear":
+                out = torch.cat([query, attn_metadata.joint_query], dim=1)
+            else:
+                out = torch.cat([attn_metadata.joint_query, query], dim=1)
+            return torch.zeros_like(out), torch.stack([key, value], dim=0)
+        return torch.zeros_like(query), torch.stack([key, value], dim=0)
+
+
+def test_self_attention_enables_sequence_parallel_but_cross_attention_does_not(monkeypatch):
+    import vllm_omni.diffusion.models.dreamzero.causal_wan_model as causal_wan_model
+
+    monkeypatch.setattr(causal_wan_model, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(causal_wan_model, "ColumnParallelLinear", _FakeParallelLinear)
+    monkeypatch.setattr(causal_wan_model, "RowParallelLinear", _FakeParallelLinear)
+    monkeypatch.setattr(causal_wan_model, "QKVParallelLinear", _FakeQKVParallelLinear)
+
+    self_attn = CausalWanSelfAttention(dim=32, num_heads=4, frame_seqlen=4, qk_norm=False)
+    assert self_attn.attn.skip_sequence_parallel is False
+
+    t2v_cross = WanT2VCrossAttention(dim=32, num_heads=4, qk_norm=False)
+    i2v_cross = WanI2VCrossAttention(dim=32, num_heads=4, qk_norm=False)
+    assert t2v_cross.attn.skip_sequence_parallel is True
+    assert i2v_cross.attn.skip_sequence_parallel is True
+
+
+def test_self_attention_uses_generic_cached_attention_for_video_tokens():
+    self_attn = CausalWanSelfAttention.__new__(CausalWanSelfAttention)
+    nn.Module.__init__(self_attn)
+    self_attn.tp_num_heads = 2
+    self_attn.head_dim = 4
+    self_attn.max_attention_size = 8
+    self_attn.num_frame_per_block = 1
+    self_attn.num_action_per_block = 2
+    self_attn.num_state_per_block = 1
+    self_attn.qkv = _RepeatQKVProjection()
+    self_attn.o = nn.Identity()
+    self_attn.norm_q = nn.Identity()
+    self_attn.norm_k = nn.Identity()
+    self_attn.attn = _RecordingCachedAttention()
+
+    x = torch.arange(1 * 2 * 8, dtype=torch.float32).reshape(1, 2, 8)
+    kv_cache = torch.zeros(2, 1, 1, 2, 4)
+    freqs = torch.ones(2, 1, 2, dtype=torch.complex128)
+    freqs_action = torch.ones(4, 2, dtype=torch.complex128)
+    freqs_state = torch.ones(4, 2, dtype=torch.complex128)
+
+    out, updated_cache = CausalWanSelfAttention.forward(
+        self_attn,
+        x=x,
+        freqs=freqs,
+        freqs_action=freqs_action,
+        freqs_state=freqs_state,
+        action_register_length=None,
+        kv_cache=kv_cache,
+        current_start_frame=0,
+    )
+
+    assert self_attn.attn.seen["query_shape"] == (1, 2, 2, 4)
+    assert self_attn.attn.seen["key_shape"] == (1, 2, 2, 4)
+    assert self_attn.attn.seen["value_shape"] == (1, 2, 2, 4)
+    assert self_attn.attn.seen["kv_cache"] is kv_cache
+    assert self_attn.attn.seen["max_cache_len"] == 8
+    assert self_attn.attn.seen["attn_metadata"] is None
+    assert out.shape == x.shape
+    assert updated_cache.shape == (2, 1, 2, 2, 4)
+
+
+def test_self_attention_passes_action_state_tokens_as_joint_metadata():
+    self_attn = CausalWanSelfAttention.__new__(CausalWanSelfAttention)
+    nn.Module.__init__(self_attn)
+    self_attn.tp_num_heads = 2
+    self_attn.head_dim = 4
+    self_attn.max_attention_size = 8
+    self_attn.num_frame_per_block = 1
+    self_attn.num_action_per_block = 2
+    self_attn.num_state_per_block = 1
+    self_attn.qkv = _RepeatQKVProjection()
+    self_attn.o = nn.Identity()
+    self_attn.norm_q = nn.Identity()
+    self_attn.norm_k = nn.Identity()
+    self_attn.attn = _RecordingCachedAttention()
+
+    x = torch.arange(1 * 5 * 8, dtype=torch.float32).reshape(1, 5, 8)
+    kv_cache = torch.zeros(2, 1, 1, 2, 4)
+    freqs = torch.ones(2, 1, 2, dtype=torch.complex128)
+    freqs_action = torch.ones(4, 2, dtype=torch.complex128)
+    freqs_state = torch.ones(4, 2, dtype=torch.complex128)
+
+    out, updated_cache = CausalWanSelfAttention.forward(
+        self_attn,
+        x=x,
+        freqs=freqs,
+        freqs_action=freqs_action,
+        freqs_state=freqs_state,
+        action_register_length=3,
+        kv_cache=kv_cache,
+        current_start_frame=0,
+    )
+
+    metadata = self_attn.attn.seen["attn_metadata"]
+    assert metadata is not None
+    assert metadata.joint_strategy == "rear"
+    assert metadata.joint_query.shape == (1, 3, 2, 4)
+    assert metadata.joint_key.shape == (1, 3, 2, 4)
+    assert metadata.joint_value.shape == (1, 3, 2, 4)
+    assert self_attn.attn.seen["query_shape"] == (1, 2, 2, 4)
+    assert self_attn.attn.seen["key_shape"] == (1, 2, 2, 4)
+    assert self_attn.attn.seen["value_shape"] == (1, 2, 2, 4)
+    assert self_attn.attn.seen["kv_cache"] is kv_cache
+    assert out.shape == x.shape
+    assert updated_cache.shape == (2, 1, 2, 2, 4)
+
+
+def test_append_attention_kv_cache_appends_fresh_tokens():
+    batch = 1
+    old_len = 3
+    fresh_len = 5
+    heads = 2
+    head_dim = 4
+
+    old_k = torch.arange(batch * old_len * heads * head_dim, dtype=torch.float32).reshape(
+        batch, old_len, heads, head_dim
+    )
+    old_v = old_k + 1000
+    cache = torch.stack([old_k, old_v], dim=0)
+
+    fresh_k = torch.full((batch, fresh_len, heads, head_dim), 7.0)
+    fresh_v = torch.full((batch, fresh_len, heads, head_dim), 11.0)
+
+    updated = append_attention_kv_cache(
+        kv_cache=cache,
+        fresh_key=fresh_k,
+        fresh_value=fresh_v,
+        max_cache_len=32,
+    )
+
+    assert updated.shape == (2, batch, old_len + fresh_len, heads, head_dim)
+    torch.testing.assert_close(updated[0, :, :old_len], old_k)
+    torch.testing.assert_close(updated[1, :, :old_len], old_v)
+    torch.testing.assert_close(updated[0, :, old_len:], fresh_k)
+    torch.testing.assert_close(updated[1, :, old_len:], fresh_v)
+
+
+def test_append_attention_kv_cache_trims_sequence_window_not_heads():
+    cache = torch.zeros(2, 1, 6, 3, 4)
+    fresh_k = torch.ones(1, 5, 3, 4)
+    fresh_v = torch.ones(1, 5, 3, 4) * 2
+
+    updated = append_attention_kv_cache(
+        kv_cache=cache,
+        fresh_key=fresh_k,
+        fresh_value=fresh_v,
+        max_cache_len=8,
+    )
+
+    assert updated.shape == (2, 1, 8, 3, 4)
+    torch.testing.assert_close(updated[0, :, -5:], fresh_k)
+    torch.testing.assert_close(updated[1, :, -5:], fresh_v)
+
+
+def test_attention_forward_with_kv_cache_appends_after_parallel_prepare(monkeypatch):
+    attn = Attention(
+        num_heads=2,
+        head_size=4,
+        causal=False,
+        softmax_scale=0.5,
+        skip_sequence_parallel=False,
+    )
+    seen_key_lengths = []
+
+    def record_local_attention(query, key, value, attn_metadata):
+        seen_key_lengths.append(key.shape[1])
+        del key, value, attn_metadata
+        return query + len(seen_key_lengths)
+
+    monkeypatch.setattr(attn, "_run_local_attention", record_local_attention)
+
+    query_1 = torch.zeros(1, 2, 2, 4)
+    key_1 = torch.ones(1, 2, 2, 4)
+    value_1 = torch.ones(1, 2, 2, 4) * 10
+
+    out_1, cache_1 = attn.forward_with_kv_cache(
+        query_1,
+        key_1,
+        value_1,
+        kv_cache=None,
+        max_cache_len=8,
+    )
+
+    assert seen_key_lengths == [2]
+    torch.testing.assert_close(out_1, torch.ones_like(query_1))
+    torch.testing.assert_close(cache_1[0], key_1)
+    torch.testing.assert_close(cache_1[1], value_1)
+
+    query_2 = torch.zeros(1, 3, 2, 4)
+    key_2 = torch.ones(1, 3, 2, 4) * 2
+    value_2 = torch.ones(1, 3, 2, 4) * 20
+
+    out_2, cache_2 = attn.forward_with_kv_cache(
+        query_2,
+        key_2,
+        value_2,
+        kv_cache=cache_1,
+        max_cache_len=8,
+    )
+
+    assert seen_key_lengths == [2, 5]
+    torch.testing.assert_close(out_2, torch.ones_like(query_2) * 2)
+    torch.testing.assert_close(cache_2[0, :, :2], key_1)
+    torch.testing.assert_close(cache_2[1, :, :2], value_1)
+    torch.testing.assert_close(cache_2[0, :, 2:], key_2)
+    torch.testing.assert_close(cache_2[1, :, 2:], value_2)
+
+
+def test_attention_forward_with_kv_cache_does_not_persist_joint_tokens(monkeypatch):
+    attn = Attention(
+        num_heads=2,
+        head_size=4,
+        causal=False,
+        softmax_scale=0.5,
+        skip_sequence_parallel=False,
+    )
+    seen = {}
+
+    def record_local_attention(query, key, value, attn_metadata):
+        del attn_metadata
+        seen["query_shape"] = tuple(query.shape)
+        seen["key_shape"] = tuple(key.shape)
+        seen["value_shape"] = tuple(value.shape)
+        return query
+
+    monkeypatch.setattr(attn, "_run_local_attention", record_local_attention)
+
+    query = torch.zeros(1, 2, 2, 4)
+    key = torch.ones(1, 2, 2, 4)
+    value = torch.ones(1, 2, 2, 4) * 10
+    kv_cache = torch.zeros(2, 1, 1, 2, 4)
+    joint_query = torch.ones(1, 3, 2, 4) * 2
+    joint_key = torch.ones(1, 3, 2, 4) * 3
+    joint_value = torch.ones(1, 3, 2, 4) * 30
+
+    out, updated_cache = attn.forward_with_kv_cache(
+        query,
+        key,
+        value,
+        kv_cache=kv_cache,
+        max_cache_len=8,
+        attn_metadata=AttentionMetadata(
+            joint_query=joint_query,
+            joint_key=joint_key,
+            joint_value=joint_value,
+            joint_strategy="rear",
+        ),
+    )
+
+    assert seen["query_shape"] == (1, 5, 2, 4)
+    assert seen["key_shape"] == (1, 6, 2, 4)
+    assert seen["value_shape"] == (1, 6, 2, 4)
+    assert out.shape == (1, 5, 2, 4)
+    assert updated_cache.shape == (2, 1, 3, 2, 4)
+    torch.testing.assert_close(updated_cache[0, :, :1], kv_cache[0])
+    torch.testing.assert_close(updated_cache[1, :, :1], kv_cache[1])
+    torch.testing.assert_close(updated_cache[0, :, 1:], key)
+    torch.testing.assert_close(updated_cache[1, :, 1:], value)
+
+
+def test_attention_forward_with_kv_cache_rejects_ring_parallel_cache(monkeypatch):
+    attn = Attention(
+        num_heads=2,
+        head_size=4,
+        causal=False,
+        softmax_scale=0.5,
+        skip_sequence_parallel=False,
+    )
+    attn.use_ring = True
+
+    query = torch.zeros(1, 2, 2, 4)
+    key = torch.ones(1, 2, 2, 4)
+    value = torch.ones(1, 2, 2, 4)
+
+    with pytest.raises(NotImplementedError, match="Ring sequence parallel KV cache"):
+        attn.forward_with_kv_cache(
+            query,
+            key,
+            value,
+            kv_cache=None,
+            max_cache_len=8,
+        )
+
+
+def test_causal_wan_model_reports_kv_cache_heads_for_ulysses_degree():
+    model = CausalWanModel.__new__(CausalWanModel)
+    model.blocks = [SimpleNamespace(self_attn=SimpleNamespace(tp_num_heads=4))]
+
+    assert model.kv_cache_num_heads(ulysses_degree=1) == 4
+    assert model.kv_cache_num_heads(ulysses_degree=2) == 2
+
+
+def test_causal_wan_model_rejects_non_divisible_strict_kv_heads():
+    model = CausalWanModel.__new__(CausalWanModel)
+    model.blocks = [SimpleNamespace(self_attn=SimpleNamespace(tp_num_heads=3))]
+
+    with pytest.raises(ValueError, match="must be divisible"):
+        model.kv_cache_num_heads(ulysses_degree=2)
+
+
+def test_sp_prepare_is_called_before_action_tokens_are_reconcatenated(monkeypatch):
+    model = CausalWanModel(
+        model_type="t2v",
+        patch_size=(1, 1, 1),
+        frame_seqlen=4,
+        text_len=8,
+        in_dim=2,
+        dim=32,
+        ffn_dim=64,
+        freq_dim=8,
+        text_dim=16,
+        out_dim=2,
+        num_heads=4,
+        num_layers=0,
+        hidden_size=16,
+        action_dim=3,
+        max_state_dim=5,
+        num_action_per_block=2,
+        num_state_per_block=1,
+    )
+
+    seen = {}
+
+    def record_prepare(x_video, e_video, freqs):
+        seen["x_video_shape"] = tuple(x_video.shape)
+        seen["e_video_shape"] = tuple(e_video.shape)
+        seen["freqs_shape"] = tuple(freqs.shape)
+        return x_video, e_video, freqs
+
+    monkeypatch.setattr(model.sp_prepare, "forward", record_prepare)
+
+    x = torch.randn(1, 2, 1, 2, 2)
+    timestep = torch.zeros(1, 1)
+    context = torch.randn(1, 8, 16)
+    action = torch.randn(1, 2, 3)
+    timestep_action = torch.zeros(1, 2)
+    state = torch.randn(1, 1, 5)
+
+    model._forward_blocks(
+        x=model.patch_embedding(x),
+        seq_len=4,
+        freqs=torch.randn(4, 1, 4, dtype=torch.complex128),
+        timestep=timestep,
+        context=context,
+        clip_feature=None,
+        embodiment_id=None,
+        action=action,
+        timestep_action=timestep_action,
+        state=state,
+        kv_cache=[],
+        crossattn_cache=None,
+        current_start_frame=0,
+    )
+
+    assert seen["x_video_shape"][1] == 4
+    assert seen["e_video_shape"][1] == 4
+    assert seen["freqs_shape"][0] == 4

--- a/tests/diffusion/models/dreamzero/test_causal_wan_sp_kv_cache.py
+++ b/tests/diffusion/models/dreamzero/test_causal_wan_sp_kv_cache.py
@@ -1,0 +1,890 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import os
+import socket
+import tempfile
+
+import numpy as np
+import pytest
+import torch
+
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
+from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.config import set_current_diffusion_config
+from vllm_omni.diffusion.data import DiffusionParallelConfig, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.parallel_state import (
+    destroy_distributed_env,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm_omni.diffusion.distributed.sp_plan import SequenceParallelConfig
+from vllm_omni.diffusion.forward_context import get_forward_context, set_forward_context
+from vllm_omni.diffusion.hooks.sequence_parallel import apply_sequence_parallel
+from vllm_omni.diffusion.models.dreamzero.causal_wan_model import CausalWanModel
+from vllm_omni.platforms import current_omni_platform
+
+
+pytestmark = [pytest.mark.diffusion, pytest.mark.parallel]
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _set_dist_env(*, rank: int, world_size: int, master_port: int) -> None:
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["DIFFUSION_ATTENTION_BACKEND"] = "TORCH_SDPA"
+
+
+def _run_cached_attention_case(
+    local_rank: int,
+    world_size: int,
+    master_port: int,
+    input_file: str,
+    output_file: str,
+    num_heads: int,
+    head_size: int,
+    ulysses_degree: int,
+    use_joint: bool = False,
+) -> None:
+    device = torch.device(f"{current_omni_platform.device_type}:{local_rank}")
+    current_omni_platform.set_device(device)
+
+    _set_dist_env(rank=local_rank, world_size=world_size, master_port=master_port)
+    init_distributed_environment(world_size=world_size, rank=local_rank)
+    initialize_model_parallel(
+        data_parallel_size=1,
+        cfg_parallel_size=1,
+        sequence_parallel_size=world_size,
+        ulysses_degree=ulysses_degree,
+        ring_degree=1,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+    )
+
+    parallel_config = DiffusionParallelConfig(
+        pipeline_parallel_size=1,
+        data_parallel_size=1,
+        tensor_parallel_size=1,
+        sequence_parallel_size=world_size,
+        ulysses_degree=ulysses_degree,
+        ring_degree=1,
+        cfg_parallel_size=1,
+        ulysses_mode="strict",
+    )
+    od_config = OmniDiffusionConfig(model="test", dtype=torch.float32, parallel_config=parallel_config)
+
+    try:
+        with set_forward_context(omni_diffusion_config=od_config), set_current_diffusion_config(od_config):
+            attn = Attention(
+                num_heads=num_heads,
+                head_size=head_size,
+                causal=False,
+                softmax_scale=1.0 / (head_size**0.5),
+            ).to(device=device, dtype=torch.float32)
+
+            with np.load(input_file, allow_pickle=False) as payload:
+                q1_full = torch.from_numpy(payload["q1"]).to(device=device)
+                k1_full = torch.from_numpy(payload["k1"]).to(device=device)
+                v1_full = torch.from_numpy(payload["v1"]).to(device=device)
+                q2_full = torch.from_numpy(payload["q2"]).to(device=device)
+                k2_full = torch.from_numpy(payload["k2"]).to(device=device)
+                v2_full = torch.from_numpy(payload["v2"]).to(device=device)
+                if use_joint:
+                    jq1 = torch.from_numpy(payload["jq1"]).to(device=device)
+                    jk1 = torch.from_numpy(payload["jk1"]).to(device=device)
+                    jv1 = torch.from_numpy(payload["jv1"]).to(device=device)
+                    jq2 = torch.from_numpy(payload["jq2"]).to(device=device)
+                    jk2 = torch.from_numpy(payload["jk2"]).to(device=device)
+                    jv2 = torch.from_numpy(payload["jv2"]).to(device=device)
+                else:
+                    jq1 = jk1 = jv1 = jq2 = jk2 = jv2 = None
+
+            if world_size == 1:
+                q1, k1, v1 = q1_full, k1_full, v1_full
+                q2, k2, v2 = q2_full, k2_full, v2_full
+            else:
+                q1 = torch.tensor_split(q1_full, world_size, dim=1)[local_rank].contiguous()
+                k1 = torch.tensor_split(k1_full, world_size, dim=1)[local_rank].contiguous()
+                v1 = torch.tensor_split(v1_full, world_size, dim=1)[local_rank].contiguous()
+                q2 = torch.tensor_split(q2_full, world_size, dim=1)[local_rank].contiguous()
+                k2 = torch.tensor_split(k2_full, world_size, dim=1)[local_rank].contiguous()
+                v2 = torch.tensor_split(v2_full, world_size, dim=1)[local_rank].contiguous()
+                get_forward_context()._sp_shard_depth = 1
+
+            cache = None
+            metadata_1 = (
+                AttentionMetadata(joint_query=jq1, joint_key=jk1, joint_value=jv1, joint_strategy="rear")
+                if use_joint
+                else None
+            )
+            metadata_2 = (
+                AttentionMetadata(joint_query=jq2, joint_key=jk2, joint_value=jv2, joint_strategy="rear")
+                if use_joint
+                else None
+            )
+            with torch.backends.cuda.sdp_kernel(enable_flash=False, enable_mem_efficient=False, enable_math=True):
+                _, cache = attn.forward_with_kv_cache(
+                    q1,
+                    k1,
+                    v1,
+                    cache,
+                    max_cache_len=16,
+                    attn_metadata=metadata_1,
+                )
+                out_local, cache = attn.forward_with_kv_cache(
+                    q2,
+                    k2,
+                    v2,
+                    cache,
+                    max_cache_len=16,
+                    attn_metadata=metadata_2,
+                )
+
+            local_cache_shape = torch.tensor(cache.shape, device=device, dtype=torch.int64)
+            gathered_cache_shapes = [torch.empty_like(local_cache_shape) for _ in range(world_size)]
+            torch.distributed.all_gather(gathered_cache_shapes, local_cache_shape)
+
+            if world_size == 1:
+                out_full = out_local
+                cache_full = cache
+                cache_shapes = torch.stack(gathered_cache_shapes).cpu().numpy()
+            else:
+                if use_joint:
+                    joint_len = jq2.shape[1]
+                    video_out_local = out_local[:, : q2.shape[1]]
+                    joint_out_local = out_local[:, q2.shape[1] :]
+                    if joint_out_local.shape[1] != joint_len:
+                        raise AssertionError(
+                            f"Expected joint output length {joint_len}, got {joint_out_local.shape[1]}."
+                        )
+                    gathered_out = [torch.empty_like(video_out_local) for _ in range(world_size)]
+                    torch.distributed.all_gather(gathered_out, video_out_local)
+                else:
+                    joint_out_local = None
+                    gathered_out = [torch.empty_like(out_local) for _ in range(world_size)]
+                    torch.distributed.all_gather(gathered_out, out_local)
+
+                gathered_cache = [torch.empty_like(cache) for _ in range(world_size)]
+                torch.distributed.all_gather(gathered_cache, cache)
+
+                if local_rank == 0:
+                    out_full = torch.cat(gathered_out, dim=1)
+                    if use_joint:
+                        out_full = torch.cat([out_full, joint_out_local], dim=1)
+                    cache_full = torch.cat(gathered_cache, dim=3)
+                    cache_shapes = torch.stack(gathered_cache_shapes).cpu().numpy()
+                else:
+                    out_full = None
+                    cache_full = None
+                    cache_shapes = None
+
+            if local_rank == 0:
+                np.savez(
+                    output_file,
+                    out=out_full.detach().cpu().numpy(),
+                    cache=cache_full.detach().cpu().numpy(),
+                    cache_shapes=cache_shapes,
+                )
+    finally:
+        destroy_distributed_env()
+
+
+def _run_tiny_causal_wan_case(
+    local_rank: int,
+    world_size: int,
+    master_port: int,
+    input_file: str,
+    output_file: str,
+    ulysses_degree: int,
+    use_prefill: bool = False,
+    use_qk_norm: bool = False,
+    dtype_name: str = "float32",
+    num_layers: int = 1,
+    num_frame_per_block: int = 1,
+    num_heads: int = 4,
+    action_horizon: int = 2,
+    model_type: str = "t2v",
+    frame_seqlen: int = 4,
+) -> None:
+    device = torch.device(f"{current_omni_platform.device_type}:{local_rank}")
+    current_omni_platform.set_device(device)
+
+    _set_dist_env(rank=local_rank, world_size=world_size, master_port=master_port)
+    init_distributed_environment(world_size=world_size, rank=local_rank)
+    initialize_model_parallel(
+        data_parallel_size=1,
+        cfg_parallel_size=1,
+        sequence_parallel_size=world_size,
+        ulysses_degree=ulysses_degree,
+        ring_degree=1,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+    )
+
+    parallel_config = DiffusionParallelConfig(
+        pipeline_parallel_size=1,
+        data_parallel_size=1,
+        tensor_parallel_size=1,
+        sequence_parallel_size=world_size,
+        ulysses_degree=ulysses_degree,
+        ring_degree=1,
+        cfg_parallel_size=1,
+        ulysses_mode="strict",
+    )
+    dtype = torch.bfloat16 if dtype_name == "bfloat16" else torch.float32
+    od_config = OmniDiffusionConfig(model="test", dtype=dtype, parallel_config=parallel_config)
+
+    try:
+        from vllm.config import DeviceConfig, VllmConfig
+
+        vllm_config = VllmConfig(device_config=DeviceConfig(device=current_omni_platform.device_type))
+        with set_forward_context(vllm_config=vllm_config, omni_diffusion_config=od_config), set_current_diffusion_config(
+            od_config
+        ):
+            torch.manual_seed(1234)
+            current_omni_platform.manual_seed(1234)
+            in_dim = 4 if model_type == "i2v" else 2
+            model = CausalWanModel(
+                model_type=model_type,
+                patch_size=(1, 1, 1),
+                frame_seqlen=frame_seqlen,
+                text_len=8,
+                in_dim=in_dim,
+                dim=32 if num_heads == 4 else 80,
+                ffn_dim=64 if num_heads == 4 else 160,
+                freq_dim=8,
+                text_dim=16,
+                out_dim=2,
+                num_heads=num_heads,
+                num_layers=num_layers,
+                hidden_size=16,
+                action_dim=3,
+                max_state_dim=5,
+                qk_norm=use_qk_norm,
+                cross_attn_norm=use_qk_norm,
+                num_frame_per_block=num_frame_per_block,
+                num_action_per_block=action_horizon,
+                num_state_per_block=1,
+            ).to(device=device, dtype=dtype)
+            model.eval()
+
+            if world_size > 1:
+                apply_sequence_parallel(
+                    model,
+                    SequenceParallelConfig(ulysses_degree=ulysses_degree, ring_degree=1),
+                    model._sp_plan,
+                )
+                get_forward_context().sp_plan_hooks_applied = True
+
+            with np.load(input_file, allow_pickle=False) as payload:
+                x = torch.from_numpy(payload["x"]).to(device=device, dtype=dtype)
+                timestep = torch.from_numpy(payload["timestep"]).to(device=device)
+                context = torch.from_numpy(payload["context"]).to(device=device, dtype=dtype)
+                action = torch.from_numpy(payload["action"]).to(device=device, dtype=dtype)
+                timestep_action = torch.from_numpy(payload["timestep_action"]).to(device=device)
+                state = torch.from_numpy(payload["state"]).to(device=device, dtype=dtype)
+                y = torch.from_numpy(payload["y"]).to(device=device, dtype=dtype) if "y" in payload.files else None
+                clip_feature = (
+                    torch.from_numpy(payload["clip_feature"]).to(device=device, dtype=dtype)
+                    if "clip_feature" in payload.files
+                    else None
+                )
+
+            seq_len = int(x.shape[2] * x.shape[3] * x.shape[4])
+            batch_size = x.shape[0]
+            head_dim = model.dim // model.num_heads
+            num_cache_heads = model.kv_cache_num_heads(ulysses_degree=ulysses_degree)
+            kv_cache = [
+                torch.empty(
+                    2,
+                    batch_size,
+                    0,
+                    num_cache_heads,
+                    head_dim,
+                    dtype=dtype,
+                    device=device,
+                )
+                for _ in range(model.num_layers)
+            ]
+
+            with torch.no_grad(), torch.backends.cuda.sdp_kernel(
+                enable_flash=False,
+                enable_mem_efficient=False,
+                enable_math=True,
+            ):
+                if use_prefill:
+                    _, _, kv_cache = model(
+                        x=x,
+                        timestep=timestep,
+                        context=context,
+                        seq_len=seq_len,
+                        kv_cache=kv_cache,
+                        crossattn_cache=[],
+                        current_start_frame=0,
+                        y=y,
+                        clip_feature=clip_feature,
+                    )
+
+                video_out, action_out, updated_cache = model(
+                    x=x,
+                    timestep=timestep,
+                    context=context,
+                    seq_len=seq_len,
+                    kv_cache=kv_cache,
+                    crossattn_cache=[],
+                    current_start_frame=1 if use_prefill else 0,
+                    y=y,
+                    clip_feature=clip_feature,
+                    action=action,
+                    timestep_action=timestep_action,
+                    state=state,
+                )
+
+            cache = updated_cache[0]
+            if world_size > 1:
+                gathered_cache = [torch.empty_like(cache) for _ in range(world_size)]
+                torch.distributed.all_gather(gathered_cache, cache)
+                if local_rank == 0:
+                    cache_out = torch.cat(gathered_cache, dim=3)
+                else:
+                    cache_out = None
+            else:
+                cache_out = cache
+
+            if local_rank == 0:
+                np.savez(
+                    output_file,
+                    video=video_out.detach().float().cpu().numpy(),
+                    action=action_out.detach().float().cpu().numpy(),
+                    cache=cache_out.detach().float().cpu().numpy(),
+                )
+    finally:
+        destroy_distributed_env()
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_dreamzero_cached_attention_ulysses_keeps_kv_cache_head_sharded(world_size: int) -> None:
+    if current_omni_platform.get_device_count() < world_size:
+        pytest.skip(f"Test requires {world_size} GPUs")
+
+    batch_size = 1
+    seq_len_1 = 4
+    seq_len_2 = 4
+    num_heads = 4
+    head_size = 8
+
+    base_port = _find_free_port()
+    sp_port = _find_free_port()
+    while sp_port == base_port:
+        sp_port = _find_free_port()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_in:
+        input_file = f_in.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_base:
+        baseline_file = f_base.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_sp:
+        sp_file = f_sp.name
+
+    try:
+        torch.manual_seed(0)
+        q1 = torch.randn(batch_size, seq_len_1, num_heads, head_size, dtype=torch.float32)
+        k1 = torch.randn(batch_size, seq_len_1, num_heads, head_size, dtype=torch.float32)
+        v1 = torch.randn(batch_size, seq_len_1, num_heads, head_size, dtype=torch.float32)
+        q2 = torch.randn(batch_size, seq_len_2, num_heads, head_size, dtype=torch.float32)
+        k2 = torch.randn(batch_size, seq_len_2, num_heads, head_size, dtype=torch.float32)
+        v2 = torch.randn(batch_size, seq_len_2, num_heads, head_size, dtype=torch.float32)
+        np.savez(
+            input_file,
+            q1=q1.numpy(),
+            k1=k1.numpy(),
+            v1=v1.numpy(),
+            q2=q2.numpy(),
+            k2=k2.numpy(),
+            v2=v2.numpy(),
+        )
+
+        torch.multiprocessing.spawn(
+            _run_cached_attention_case,
+            args=(1, base_port, input_file, baseline_file, num_heads, head_size, 1),
+            nprocs=1,
+        )
+        torch.multiprocessing.spawn(
+            _run_cached_attention_case,
+            args=(world_size, sp_port, input_file, sp_file, num_heads, head_size, world_size),
+            nprocs=world_size,
+        )
+
+        with np.load(baseline_file, allow_pickle=False) as baseline_payload:
+            baseline_out = torch.from_numpy(baseline_payload["out"])
+            baseline_cache = torch.from_numpy(baseline_payload["cache"])
+        with np.load(sp_file, allow_pickle=False) as sp_payload:
+            sp_out = torch.from_numpy(sp_payload["out"])
+            sp_cache = torch.from_numpy(sp_payload["cache"])
+            sp_cache_shapes = sp_payload["cache_shapes"]
+
+        expected_cache_shape = (2, batch_size, seq_len_1 + seq_len_2, num_heads // world_size, head_size)
+        for rank in range(world_size):
+            assert tuple(sp_cache_shapes[rank]) == expected_cache_shape
+        assert sp_out.shape == baseline_out.shape
+        assert sp_cache.shape == baseline_cache.shape
+        torch.testing.assert_close(sp_out, baseline_out, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_cache, baseline_cache, atol=1e-5, rtol=1e-5)
+    finally:
+        for path in (input_file, baseline_file, sp_file):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_dreamzero_cached_attention_ulysses_keeps_joint_tokens_out_of_kv_cache(world_size: int) -> None:
+    if current_omni_platform.get_device_count() < world_size:
+        pytest.skip(f"Test requires {world_size} GPUs")
+
+    batch_size = 1
+    seq_len_1 = 4
+    seq_len_2 = 4
+    joint_len = 3
+    num_heads = 4
+    head_size = 8
+
+    base_port = _find_free_port()
+    sp_port = _find_free_port()
+    while sp_port == base_port:
+        sp_port = _find_free_port()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_in:
+        input_file = f_in.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_base:
+        baseline_file = f_base.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_sp:
+        sp_file = f_sp.name
+
+    try:
+        torch.manual_seed(1)
+        q1 = torch.randn(batch_size, seq_len_1, num_heads, head_size, dtype=torch.float32)
+        k1 = torch.randn(batch_size, seq_len_1, num_heads, head_size, dtype=torch.float32)
+        v1 = torch.randn(batch_size, seq_len_1, num_heads, head_size, dtype=torch.float32)
+        q2 = torch.randn(batch_size, seq_len_2, num_heads, head_size, dtype=torch.float32)
+        k2 = torch.randn(batch_size, seq_len_2, num_heads, head_size, dtype=torch.float32)
+        v2 = torch.randn(batch_size, seq_len_2, num_heads, head_size, dtype=torch.float32)
+        jq1 = torch.randn(batch_size, joint_len, num_heads, head_size, dtype=torch.float32)
+        jk1 = torch.randn(batch_size, joint_len, num_heads, head_size, dtype=torch.float32)
+        jv1 = torch.randn(batch_size, joint_len, num_heads, head_size, dtype=torch.float32)
+        jq2 = torch.randn(batch_size, joint_len, num_heads, head_size, dtype=torch.float32)
+        jk2 = torch.randn(batch_size, joint_len, num_heads, head_size, dtype=torch.float32)
+        jv2 = torch.randn(batch_size, joint_len, num_heads, head_size, dtype=torch.float32)
+        np.savez(
+            input_file,
+            q1=q1.numpy(),
+            k1=k1.numpy(),
+            v1=v1.numpy(),
+            q2=q2.numpy(),
+            k2=k2.numpy(),
+            v2=v2.numpy(),
+            jq1=jq1.numpy(),
+            jk1=jk1.numpy(),
+            jv1=jv1.numpy(),
+            jq2=jq2.numpy(),
+            jk2=jk2.numpy(),
+            jv2=jv2.numpy(),
+        )
+
+        torch.multiprocessing.spawn(
+            _run_cached_attention_case,
+            args=(1, base_port, input_file, baseline_file, num_heads, head_size, 1, True),
+            nprocs=1,
+        )
+        torch.multiprocessing.spawn(
+            _run_cached_attention_case,
+            args=(world_size, sp_port, input_file, sp_file, num_heads, head_size, world_size, True),
+            nprocs=world_size,
+        )
+
+        with np.load(baseline_file, allow_pickle=False) as baseline_payload:
+            baseline_out = torch.from_numpy(baseline_payload["out"])
+            baseline_cache = torch.from_numpy(baseline_payload["cache"])
+        with np.load(sp_file, allow_pickle=False) as sp_payload:
+            sp_out = torch.from_numpy(sp_payload["out"])
+            sp_cache = torch.from_numpy(sp_payload["cache"])
+            sp_cache_shapes = sp_payload["cache_shapes"]
+
+        expected_cache_shape = (2, batch_size, seq_len_1 + seq_len_2, num_heads // world_size, head_size)
+        for rank in range(world_size):
+            assert tuple(sp_cache_shapes[rank]) == expected_cache_shape
+        assert sp_out.shape == baseline_out.shape
+        assert sp_cache.shape == baseline_cache.shape
+        torch.testing.assert_close(sp_out, baseline_out, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_cache, baseline_cache, atol=1e-5, rtol=1e-5)
+    finally:
+        for path in (input_file, baseline_file, sp_file):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+def test_tiny_causal_wan_model_ulysses_matches_single_rank_with_actions() -> None:
+    world_size = 2
+    if current_omni_platform.get_device_count() < world_size:
+        pytest.skip(f"Test requires {world_size} GPUs")
+
+    base_port = _find_free_port()
+    sp_port = _find_free_port()
+    while sp_port == base_port:
+        sp_port = _find_free_port()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_in:
+        input_file = f_in.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_base:
+        baseline_file = f_base.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_sp:
+        sp_file = f_sp.name
+
+    try:
+        torch.manual_seed(5)
+        x = torch.randn(1, 2, 2, 2, 2, dtype=torch.float32)
+        timestep = torch.zeros(1, 2, dtype=torch.float32)
+        context = torch.randn(1, 8, 16, dtype=torch.float32)
+        action = torch.randn(1, 2, 3, dtype=torch.float32)
+        timestep_action = torch.zeros(1, 2, dtype=torch.float32)
+        state = torch.randn(1, 1, 5, dtype=torch.float32)
+        np.savez(
+            input_file,
+            x=x.numpy(),
+            timestep=timestep.numpy(),
+            context=context.numpy(),
+            action=action.numpy(),
+            timestep_action=timestep_action.numpy(),
+            state=state.numpy(),
+        )
+
+        torch.multiprocessing.spawn(
+            _run_tiny_causal_wan_case,
+            args=(1, base_port, input_file, baseline_file, 1),
+            nprocs=1,
+        )
+        torch.multiprocessing.spawn(
+            _run_tiny_causal_wan_case,
+            args=(world_size, sp_port, input_file, sp_file, world_size),
+            nprocs=world_size,
+        )
+
+        with np.load(baseline_file, allow_pickle=False) as baseline_payload:
+            baseline_video = torch.from_numpy(baseline_payload["video"])
+            baseline_action = torch.from_numpy(baseline_payload["action"])
+            baseline_cache = torch.from_numpy(baseline_payload["cache"])
+        with np.load(sp_file, allow_pickle=False) as sp_payload:
+            sp_video = torch.from_numpy(sp_payload["video"])
+            sp_action = torch.from_numpy(sp_payload["action"])
+            sp_cache = torch.from_numpy(sp_payload["cache"])
+
+        assert sp_video.shape == baseline_video.shape
+        assert sp_action.shape == baseline_action.shape
+        assert sp_cache.shape == baseline_cache.shape
+        torch.testing.assert_close(sp_video, baseline_video, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_action, baseline_action, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_cache, baseline_cache, atol=1e-5, rtol=1e-5)
+    finally:
+        for path in (input_file, baseline_file, sp_file):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+def test_tiny_causal_wan_model_ulysses_matches_single_rank_after_prefill() -> None:
+    world_size = 2
+    if current_omni_platform.get_device_count() < world_size:
+        pytest.skip(f"Test requires {world_size} GPUs")
+
+    base_port = _find_free_port()
+    sp_port = _find_free_port()
+    while sp_port == base_port:
+        sp_port = _find_free_port()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_in:
+        input_file = f_in.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_base:
+        baseline_file = f_base.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_sp:
+        sp_file = f_sp.name
+
+    try:
+        torch.manual_seed(6)
+        x = torch.randn(1, 2, 2, 2, 2, dtype=torch.float32)
+        timestep = torch.zeros(1, 2, dtype=torch.float32)
+        context = torch.randn(1, 8, 16, dtype=torch.float32)
+        action = torch.randn(1, 2, 3, dtype=torch.float32)
+        timestep_action = torch.zeros(1, 2, dtype=torch.float32)
+        state = torch.randn(1, 1, 5, dtype=torch.float32)
+        np.savez(
+            input_file,
+            x=x.numpy(),
+            timestep=timestep.numpy(),
+            context=context.numpy(),
+            action=action.numpy(),
+            timestep_action=timestep_action.numpy(),
+            state=state.numpy(),
+        )
+
+        torch.multiprocessing.spawn(
+            _run_tiny_causal_wan_case,
+            args=(1, base_port, input_file, baseline_file, 1, True),
+            nprocs=1,
+        )
+        torch.multiprocessing.spawn(
+            _run_tiny_causal_wan_case,
+            args=(world_size, sp_port, input_file, sp_file, world_size, True),
+            nprocs=world_size,
+        )
+
+        with np.load(baseline_file, allow_pickle=False) as baseline_payload:
+            baseline_video = torch.from_numpy(baseline_payload["video"])
+            baseline_action = torch.from_numpy(baseline_payload["action"])
+            baseline_cache = torch.from_numpy(baseline_payload["cache"])
+        with np.load(sp_file, allow_pickle=False) as sp_payload:
+            sp_video = torch.from_numpy(sp_payload["video"])
+            sp_action = torch.from_numpy(sp_payload["action"])
+            sp_cache = torch.from_numpy(sp_payload["cache"])
+
+        assert sp_video.shape == baseline_video.shape
+        assert sp_action.shape == baseline_action.shape
+        assert sp_cache.shape == baseline_cache.shape
+        torch.testing.assert_close(sp_video, baseline_video, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_action, baseline_action, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_cache, baseline_cache, atol=1e-5, rtol=1e-5)
+    finally:
+        for path in (input_file, baseline_file, sp_file):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_tiny_causal_wan_model_ulysses_matches_single_rank_after_prefill_with_qk_norm(world_size: int) -> None:
+    if current_omni_platform.get_device_count() < world_size:
+        pytest.skip(f"Test requires {world_size} GPUs")
+
+    base_port = _find_free_port()
+    sp_port = _find_free_port()
+    while sp_port == base_port:
+        sp_port = _find_free_port()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_in:
+        input_file = f_in.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_base:
+        baseline_file = f_base.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_sp:
+        sp_file = f_sp.name
+
+    try:
+        torch.manual_seed(7)
+        x = torch.randn(1, 2, 2, 2, 2, dtype=torch.float32)
+        timestep = torch.zeros(1, 2, dtype=torch.float32)
+        context = torch.randn(1, 8, 16, dtype=torch.float32)
+        action = torch.randn(1, 2, 3, dtype=torch.float32)
+        timestep_action = torch.zeros(1, 2, dtype=torch.float32)
+        state = torch.randn(1, 1, 5, dtype=torch.float32)
+        np.savez(
+            input_file,
+            x=x.numpy(),
+            timestep=timestep.numpy(),
+            context=context.numpy(),
+            action=action.numpy(),
+            timestep_action=timestep_action.numpy(),
+            state=state.numpy(),
+        )
+
+        torch.multiprocessing.spawn(
+            _run_tiny_causal_wan_case,
+            args=(1, base_port, input_file, baseline_file, 1, True, True, "bfloat16", 8, 2),
+            nprocs=1,
+        )
+        torch.multiprocessing.spawn(
+            _run_tiny_causal_wan_case,
+            args=(world_size, sp_port, input_file, sp_file, world_size, True, True, "bfloat16", 8, 2),
+            nprocs=world_size,
+        )
+
+        with np.load(baseline_file, allow_pickle=False) as baseline_payload:
+            baseline_video = torch.from_numpy(baseline_payload["video"])
+            baseline_action = torch.from_numpy(baseline_payload["action"])
+            baseline_cache = torch.from_numpy(baseline_payload["cache"])
+        with np.load(sp_file, allow_pickle=False) as sp_payload:
+            sp_video = torch.from_numpy(sp_payload["video"])
+            sp_action = torch.from_numpy(sp_payload["action"])
+            sp_cache = torch.from_numpy(sp_payload["cache"])
+
+        assert sp_video.shape == baseline_video.shape
+        assert sp_action.shape == baseline_action.shape
+        assert sp_cache.shape == baseline_cache.shape
+        torch.testing.assert_close(sp_video, baseline_video, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_action, baseline_action, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_cache, baseline_cache, atol=1e-5, rtol=1e-5)
+    finally:
+        for path in (input_file, baseline_file, sp_file):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_tiny_causal_wan_model_ulysses_matches_single_rank_with_realistic_action_horizon(
+    world_size: int,
+) -> None:
+    if current_omni_platform.get_device_count() < world_size:
+        pytest.skip(f"Test requires {world_size} GPUs")
+
+    base_port = _find_free_port()
+    sp_port = _find_free_port()
+    while sp_port == base_port:
+        sp_port = _find_free_port()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_in:
+        input_file = f_in.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_base:
+        baseline_file = f_base.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_sp:
+        sp_file = f_sp.name
+
+    try:
+        torch.manual_seed(8)
+        x = torch.randn(1, 2, 2, 2, 2, dtype=torch.float32)
+        timestep = torch.zeros(1, 2, dtype=torch.float32)
+        context = torch.randn(1, 8, 16, dtype=torch.float32)
+        action = torch.randn(1, 24, 3, dtype=torch.float32)
+        timestep_action = torch.zeros(1, 24, dtype=torch.float32)
+        state = torch.randn(1, 1, 5, dtype=torch.float32)
+        np.savez(
+            input_file,
+            x=x.numpy(),
+            timestep=timestep.numpy(),
+            context=context.numpy(),
+            action=action.numpy(),
+            timestep_action=timestep_action.numpy(),
+            state=state.numpy(),
+        )
+
+        common_args = (True, True, "bfloat16", 4, 2, 40, 24)
+        torch.multiprocessing.spawn(
+            _run_tiny_causal_wan_case,
+            args=(1, base_port, input_file, baseline_file, 1, *common_args),
+            nprocs=1,
+        )
+        torch.multiprocessing.spawn(
+            _run_tiny_causal_wan_case,
+            args=(world_size, sp_port, input_file, sp_file, world_size, *common_args),
+            nprocs=world_size,
+        )
+
+        with np.load(baseline_file, allow_pickle=False) as baseline_payload:
+            baseline_video = torch.from_numpy(baseline_payload["video"])
+            baseline_action = torch.from_numpy(baseline_payload["action"])
+            baseline_cache = torch.from_numpy(baseline_payload["cache"])
+        with np.load(sp_file, allow_pickle=False) as sp_payload:
+            sp_video = torch.from_numpy(sp_payload["video"])
+            sp_action = torch.from_numpy(sp_payload["action"])
+            sp_cache = torch.from_numpy(sp_payload["cache"])
+
+        assert sp_video.shape == baseline_video.shape
+        assert sp_action.shape == baseline_action.shape
+        assert sp_cache.shape == baseline_cache.shape
+        torch.testing.assert_close(sp_video, baseline_video, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_action, baseline_action, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_cache, baseline_cache, atol=1e-5, rtol=1e-5)
+    finally:
+        for path in (input_file, baseline_file, sp_file):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_tiny_causal_wan_i2v_ulysses_matches_single_rank_with_clip_and_y(
+    world_size: int,
+) -> None:
+    if current_omni_platform.get_device_count() < world_size:
+        pytest.skip(f"Test requires {world_size} GPUs")
+
+    base_port = _find_free_port()
+    sp_port = _find_free_port()
+    while sp_port == base_port:
+        sp_port = _find_free_port()
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_in:
+        input_file = f_in.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_base:
+        baseline_file = f_base.name
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".npz") as f_sp:
+        sp_file = f_sp.name
+
+    try:
+        torch.manual_seed(9)
+        x = torch.randn(1, 2, 2, 2, 2, dtype=torch.float32)
+        y = torch.randn(1, 2, 2, 2, 2, dtype=torch.float32)
+        timestep = torch.zeros(1, 2, dtype=torch.float32)
+        context = torch.randn(1, 8, 16, dtype=torch.float32)
+        clip_feature = torch.randn(1, 257, 1280, dtype=torch.float32)
+        action = torch.randn(1, 24, 3, dtype=torch.float32)
+        timestep_action = torch.zeros(1, 24, dtype=torch.float32)
+        state = torch.randn(1, 1, 5, dtype=torch.float32)
+        np.savez(
+            input_file,
+            x=x.numpy(),
+            y=y.numpy(),
+            timestep=timestep.numpy(),
+            context=context.numpy(),
+            clip_feature=clip_feature.numpy(),
+            action=action.numpy(),
+            timestep_action=timestep_action.numpy(),
+            state=state.numpy(),
+        )
+
+        common_args = (True, True, "bfloat16", 4, 2, 40, 24, "i2v")
+        torch.multiprocessing.spawn(
+            _run_tiny_causal_wan_case,
+            args=(1, base_port, input_file, baseline_file, 1, *common_args),
+            nprocs=1,
+        )
+        torch.multiprocessing.spawn(
+            _run_tiny_causal_wan_case,
+            args=(world_size, sp_port, input_file, sp_file, world_size, *common_args),
+            nprocs=world_size,
+        )
+
+        with np.load(baseline_file, allow_pickle=False) as baseline_payload:
+            baseline_video = torch.from_numpy(baseline_payload["video"])
+            baseline_action = torch.from_numpy(baseline_payload["action"])
+            baseline_cache = torch.from_numpy(baseline_payload["cache"])
+        with np.load(sp_file, allow_pickle=False) as sp_payload:
+            sp_video = torch.from_numpy(sp_payload["video"])
+            sp_action = torch.from_numpy(sp_payload["action"])
+            sp_cache = torch.from_numpy(sp_payload["cache"])
+
+        assert sp_video.shape == baseline_video.shape
+        assert sp_action.shape == baseline_action.shape
+        assert sp_cache.shape == baseline_cache.shape
+        torch.testing.assert_close(sp_video, baseline_video, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_action, baseline_action, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(sp_cache, baseline_cache, atol=1e-5, rtol=1e-5)
+    finally:
+        for path in (input_file, baseline_file, sp_file):
+            try:
+                os.remove(path)
+            except OSError:
+                pass

--- a/tests/dreamzero/test_pipeline_state.py
+++ b/tests/dreamzero/test_pipeline_state.py
@@ -2,10 +2,12 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections import OrderedDict
+from types import SimpleNamespace
 
 import pytest
 import torch
 
+from vllm_omni.diffusion.models.dreamzero import pipeline_dreamzero
 from vllm_omni.diffusion.models.dreamzero.pipeline_dreamzero import DreamZeroPipeline
 from vllm_omni.diffusion.models.dreamzero.state_dreamzero import DreamZeroState
 
@@ -57,3 +59,38 @@ def test_dreamzero_state_cache_access_requires_initialization() -> None:
 
     with pytest.raises(RuntimeError, match="create_kv_caches first"):
         state.update_kv_cache(0, torch.empty(0))
+
+
+def test_prefill_kv_cache_allocates_runtime_ulysses_local_heads(monkeypatch) -> None:
+    pipeline = _empty_pipeline()
+    state = DreamZeroState()
+    state.clip_feas = None
+    state.ys = None
+    pipeline.cfg_scale = 1.0
+    pipeline.transformer = SimpleNamespace(
+        dim=5120,
+        num_heads=40,
+        num_layers=1,
+        kv_cache_num_heads=lambda ulysses_degree=1: 40 // ulysses_degree,
+    )
+    seen: dict[str, tuple[int, ...]] = {}
+
+    def record_predict_noise_maybe_with_cfg(**kwargs):
+        kv_cache = kwargs["positive_kwargs"]["kv_cache"][0]
+        seen["kv_cache_shape"] = tuple(kv_cache.shape)
+
+    monkeypatch.setattr(pipeline, "predict_noise_maybe_with_cfg", record_predict_noise_maybe_with_cfg)
+    monkeypatch.setattr(pipeline_dreamzero, "get_current_diffusion_config_or_none", lambda: None)
+    monkeypatch.setattr(pipeline_dreamzero, "get_ulysses_parallel_world_size", lambda: 2, raising=False)
+
+    pipeline._prefill_kv_cache(
+        image_latents=torch.zeros(1, 1, 16, 2, 2),
+        prompt_embeds=torch.zeros(1, 1, 8),
+        negative_prompt_embeds=None,
+        frame_seqlen=1,
+        seq_len=1,
+        do_true_cfg=False,
+        state=state,
+    )
+
+    assert seen["kv_cache_shape"] == (2, 1, 0, 20, 128)

--- a/vllm_omni/deploy/dreamzero_sp2.yaml
+++ b/vllm_omni/deploy/dreamzero_sp2.yaml
@@ -1,0 +1,28 @@
+# DreamZero-DROID deploy: TP=1, Ulysses SP=2, CFG parallel disabled.
+
+pipeline: dreamzero
+async_chunk: false
+distributed_executor_backend: mp
+dtype: bfloat16
+
+stages:
+  - stage_id: 0
+    devices: "0,1"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    parallel_config:
+      tensor_parallel_size: 1
+      sequence_parallel_size: 2
+      ulysses_degree: 2
+      ring_degree: 1
+      cfg_parallel_size: 1
+    model_config:
+      default_robot_embodiment: roboarena
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position

--- a/vllm_omni/deploy/dreamzero_sp2_cfg2.yaml
+++ b/vllm_omni/deploy/dreamzero_sp2_cfg2.yaml
@@ -1,0 +1,28 @@
+# DreamZero-DROID deploy: TP=1, Ulysses SP=2, CFG parallel size=2.
+
+pipeline: dreamzero
+async_chunk: false
+distributed_executor_backend: mp
+dtype: bfloat16
+
+stages:
+  - stage_id: 0
+    devices: "0,1,2,3"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    parallel_config:
+      tensor_parallel_size: 1
+      sequence_parallel_size: 2
+      ulysses_degree: 2
+      ring_degree: 1
+      cfg_parallel_size: 2
+    model_config:
+      default_robot_embodiment: roboarena
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position

--- a/vllm_omni/deploy/dreamzero_sp4.yaml
+++ b/vllm_omni/deploy/dreamzero_sp4.yaml
@@ -1,0 +1,28 @@
+# DreamZero-DROID deploy: TP=1, Ulysses SP=4, CFG parallel disabled.
+
+pipeline: dreamzero
+async_chunk: false
+distributed_executor_backend: mp
+dtype: bfloat16
+
+stages:
+  - stage_id: 0
+    devices: "0,1,2,3"
+    max_num_seqs: 1
+    enforce_eager: true
+    model_class_name: DreamZeroPipeline
+    parallel_config:
+      tensor_parallel_size: 1
+      sequence_parallel_size: 4
+      ulysses_degree: 4
+      ring_degree: 1
+      cfg_parallel_size: 1
+    model_config:
+      default_robot_embodiment: roboarena
+      policy_server_config:
+        image_resolution: [180, 320]
+        n_external_cameras: 2
+        needs_wrist_camera: true
+        needs_stereo_camera: false
+        needs_session_id: true
+        action_space: joint_position

--- a/vllm_omni/diffusion/attention/backends/sdpa.py
+++ b/vllm_omni/diffusion/attention/backends/sdpa.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from typing import Literal
 
 import torch
@@ -13,6 +14,7 @@ from vllm_omni.diffusion.attention.backends.abstract import (
 )
 
 logger = init_logger(__name__)
+TRUE_VALUES = {"1", "true", "yes", "on"}
 
 
 SDPAMaskMode = Literal["broadcast_k", "full_qk"]
@@ -103,18 +105,44 @@ class SDPAImpl(AttentionImpl):
         if attn_metadata:
             attention_mask = _maybe_reshape_attn_mask(query, key, attn_metadata.attn_mask, mask_mode=mask_mode)
 
+        orig_dtype = query.dtype
         query, key, value = (x.permute(0, 2, 1, 3) for x in (query, key, value))
-        output = torch.nn.functional.scaled_dot_product_attention(
-            query,
-            key,
-            value,
-            attn_mask=attention_mask,
-            dropout_p=0.0,
-            is_causal=self.causal,
-            scale=self.softmax_scale,
-            enable_gqa=self.requires_gqa,
-        )
+        force_fp32 = os.environ.get("DIFFUSION_SDPA_FORCE_FP32", "").lower() in TRUE_VALUES
+        if force_fp32:
+            query, key, value = (x.float() for x in (query, key, value))
+            if attention_mask is not None and attention_mask.dtype != torch.bool:
+                attention_mask = attention_mask.float()
+        if os.environ.get("DIFFUSION_SDPA_FORCE_MATH", "").lower() in TRUE_VALUES:
+            with torch.backends.cuda.sdp_kernel(
+                enable_flash=False,
+                enable_math=True,
+                enable_mem_efficient=False,
+                enable_cudnn=False,
+            ):
+                output = torch.nn.functional.scaled_dot_product_attention(
+                    query,
+                    key,
+                    value,
+                    attn_mask=attention_mask,
+                    dropout_p=0.0,
+                    is_causal=self.causal,
+                    scale=self.softmax_scale,
+                    enable_gqa=self.requires_gqa,
+                )
+        else:
+            output = torch.nn.functional.scaled_dot_product_attention(
+                query,
+                key,
+                value,
+                attn_mask=attention_mask,
+                dropout_p=0.0,
+                is_causal=self.causal,
+                scale=self.softmax_scale,
+                enable_gqa=self.requires_gqa,
+            )
         out = output.permute(0, 2, 1, 3)
+        if force_fp32 and out.dtype != orig_dtype:
+            out = out.to(orig_dtype)
         return out
 
     def forward_cuda(

--- a/vllm_omni/diffusion/attention/layer.py
+++ b/vllm_omni/diffusion/attention/layer.py
@@ -37,6 +37,37 @@ def _try_extract_layer_index(prefix: str) -> int | None:
         return None
 
 
+def append_attention_kv_cache(
+    *,
+    kv_cache: torch.Tensor,
+    fresh_key: torch.Tensor,
+    fresh_value: torch.Tensor,
+    max_cache_len: int,
+) -> torch.Tensor:
+    if kv_cache.ndim != 5:
+        raise ValueError(f"kv_cache must be [2, B, S, H, D], got {tuple(kv_cache.shape)}.")
+    if fresh_key.shape != fresh_value.shape:
+        raise ValueError(
+            "fresh_key and fresh_value must have the same shape, "
+            f"got {tuple(fresh_key.shape)} and {tuple(fresh_value.shape)}."
+        )
+    if kv_cache.shape[0] != 2:
+        raise ValueError(f"kv_cache first dim must be 2 for K/V, got {kv_cache.shape[0]}.")
+    if kv_cache.shape[1] != fresh_key.shape[0]:
+        raise ValueError("batch size mismatch between kv_cache and fresh KV.")
+    if kv_cache.shape[3:] != fresh_key.shape[2:]:
+        raise ValueError(
+            "kv_cache and fresh KV must share [H, D], "
+            f"got cache {tuple(kv_cache.shape[3:])} and fresh {tuple(fresh_key.shape[2:])}."
+        )
+
+    new_k = torch.cat([kv_cache[0], fresh_key], dim=1)
+    new_v = torch.cat([kv_cache[1], fresh_value], dim=1)
+    new_k = new_k[:, -max_cache_len:]
+    new_v = new_v[:, -max_cache_len:]
+    return torch.stack([new_k, new_v], dim=0)
+
+
 class Attention(nn.Module):
     def __init__(
         self,
@@ -252,6 +283,103 @@ class Attention(nn.Module):
         out = strategy.post_attention(out, ctx)
 
         return out
+
+    def forward_with_kv_cache(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor | None,
+        *,
+        max_cache_len: int,
+        attn_metadata: AttentionMetadata | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        strategy = self._get_active_parallel_strategy()
+        if self.use_ring:
+            raise NotImplementedError(
+                "Ring sequence parallel KV cache layout is not implemented. "
+                "Use Ulysses-only cached attention with ring_degree=1."
+            )
+
+        query, key, value, attn_metadata, ctx = strategy.pre_attention(query, key, value, attn_metadata)
+        attn_metadata = self._with_kv_cache_dtype(attn_metadata)
+
+        live_joint_key = None
+        live_joint_value = None
+        joint_len = int(getattr(ctx, "joint_len", 0) or 0)
+        joint_strategy = getattr(ctx, "joint_strategy", None)
+        if joint_strategy is None and attn_metadata is not None:
+            joint_strategy = attn_metadata.joint_strategy
+        joint_strategy = joint_strategy or "front"
+
+        if joint_len > 0:
+            if joint_strategy == "front":
+                live_joint_key = key[:, :joint_len]
+                live_joint_value = value[:, :joint_len]
+                key = key[:, joint_len:]
+                value = value[:, joint_len:]
+            elif joint_strategy == "rear":
+                live_joint_key = key[:, -joint_len:]
+                live_joint_value = value[:, -joint_len:]
+                key = key[:, :-joint_len]
+                value = value[:, :-joint_len]
+            else:
+                raise ValueError(f"joint_strategy: {joint_strategy} not supported.")
+        elif attn_metadata is not None:
+            joint_query = attn_metadata.joint_query
+            live_joint_key = attn_metadata.joint_key
+            live_joint_value = attn_metadata.joint_value
+            if (joint_query is None) != (live_joint_key is None) or (joint_query is None) != (live_joint_value is None):
+                raise ValueError("joint_query, joint_key, and joint_value should be None or not None simultaneously.")
+            if joint_query is not None:
+                if joint_strategy == "front":
+                    query = torch.cat([joint_query, query], dim=1)
+                elif joint_strategy == "rear":
+                    query = torch.cat([query, joint_query], dim=1)
+                else:
+                    raise ValueError(f"joint_strategy: {joint_strategy} not supported.")
+                attn_metadata = replace(
+                    attn_metadata,
+                    joint_query=None,
+                    joint_key=None,
+                    joint_value=None,
+                )
+
+        if kv_cache is None:
+            kv_cache = torch.empty(
+                2,
+                key.shape[0],
+                0,
+                key.shape[2],
+                key.shape[3],
+                dtype=key.dtype,
+                device=key.device,
+            )
+        updated_cache = append_attention_kv_cache(
+            kv_cache=kv_cache,
+            fresh_key=key,
+            fresh_value=value,
+            max_cache_len=max_cache_len,
+        )
+        attn_key = updated_cache[0]
+        attn_value = updated_cache[1]
+        if live_joint_key is not None and live_joint_value is not None:
+            if joint_strategy == "front":
+                attn_key = torch.cat([live_joint_key, attn_key], dim=1)
+                attn_value = torch.cat([live_joint_value, attn_value], dim=1)
+            elif joint_strategy == "rear":
+                attn_key = torch.cat([attn_key, live_joint_key], dim=1)
+                attn_value = torch.cat([attn_value, live_joint_value], dim=1)
+            else:
+                raise ValueError(f"joint_strategy: {joint_strategy} not supported.")
+
+        if self.use_ring and strategy is not self._no_parallel_strategy:
+            out = self._run_ring_attention(query, attn_key, attn_value, attn_metadata)
+        else:
+            out = self._run_local_attention(query, attn_key, attn_value, attn_metadata)
+
+        out = strategy.post_attention(out, ctx)
+        return out, updated_cache
 
     def _run_local_attention(self, query, key, value, attn_metadata):
         if query.dtype == torch.float32:

--- a/vllm_omni/diffusion/attention/parallel/ulysses.py
+++ b/vllm_omni/diffusion/attention/parallel/ulysses.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.parallel.base import ParallelAttentionContext
-from vllm_omni.diffusion.distributed.comm import SeqAllToAll4D
+from vllm_omni.diffusion.distributed.comm import SeqAllToAll4D, SeqAllToAll5D
 from vllm_omni.diffusion.distributed.group_coordinator import SequenceParallelGroupCoordinator
 from vllm_omni.diffusion.forward_context import get_ulysses_mode
 
@@ -144,6 +144,36 @@ def _ulysses_all_to_all_any_o(
     if out.shape[2] != orig_head_cnt:
         out = out[:, :, :orig_head_cnt, :].contiguous()
     return out
+
+
+def _strict_qkv_all_to_all(
+    pg: dist.ProcessGroup,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    scatter_idx: int,
+    gather_idx: int,
+    use_sync: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if (
+        scatter_idx == 2
+        and gather_idx == 1
+        and query.shape == key.shape == value.shape
+        and query.dtype == key.dtype == value.dtype
+        and query.device == key.device == value.device
+    ):
+        # Pack Q/K/V so strict Ulysses self-attn launches one all-to-all instead of three.
+        qkv = torch.stack((query, key, value), dim=2)
+        qkv = SeqAllToAll5D.apply(pg, qkv, 3, 1, use_sync)
+        qkv = qkv.movedim(2, 0).contiguous()
+        query, key, value = qkv.unbind(dim=0)
+        return query, key, value
+
+    query = SeqAllToAll4D.apply(pg, query, scatter_idx, gather_idx, use_sync)
+    key = SeqAllToAll4D.apply(pg, key, scatter_idx, gather_idx, use_sync)
+    value = SeqAllToAll4D.apply(pg, value, scatter_idx, gather_idx, use_sync)
+    return query, key, value
 
 
 @dataclass(frozen=True, slots=True)
@@ -329,9 +359,15 @@ class UlyssesParallelAttention:
                     )
 
             # (bs, seq_len/P, head_cnt, head_size) -> (bs, seq_len, head_cnt/P, head_size)
-            query = SeqAllToAll4D.apply(self._ulysses_pg, query, self._scatter_idx, self._gather_idx, self._use_sync)
-            key = SeqAllToAll4D.apply(self._ulysses_pg, key, self._scatter_idx, self._gather_idx, self._use_sync)
-            value = SeqAllToAll4D.apply(self._ulysses_pg, value, self._scatter_idx, self._gather_idx, self._use_sync)
+            query, key, value = _strict_qkv_all_to_all(
+                self._ulysses_pg,
+                query,
+                key,
+                value,
+                scatter_idx=self._scatter_idx,
+                gather_idx=self._gather_idx,
+                use_sync=self._use_sync,
+            )
             seq_lens = []
             local_seq_len = 0
             orig_head_cnt = 0

--- a/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
+++ b/vllm_omni/diffusion/models/dreamzero/causal_wan_model.py
@@ -14,7 +14,7 @@ Key differences from WanTransformer3DModel:
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import Any, Callable
 
 import torch
 import torch.nn as nn
@@ -31,7 +31,10 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.utils import set_weight_attrs
 
+from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention
+from vllm_omni.diffusion.distributed.sp_sharding import sp_gather
+from vllm_omni.diffusion.distributed.sp_plan import SequenceParallelInput
 from vllm_omni.diffusion.models.dreamzero.action_encoder import (
     CategorySpecificMLP,
     MultiEmbodimentActionEncoder,
@@ -52,6 +55,38 @@ def sinusoidal_embedding_1d(dim: int, position: torch.Tensor) -> torch.Tensor:
     )
     x = torch.cat([torch.cos(sinusoid), torch.sin(sinusoid)], dim=1)
     return x
+
+
+def _with_precise_bf16_matmul_reduction(func: Callable) -> Callable:
+    """Keep SP-sharded bf16 GEMMs numerically aligned with full-sequence GEMMs."""
+
+    def wrapped(self, *args, **kwargs):
+        x = kwargs.get("x")
+        if x is None and args:
+            x = args[0]
+        should_disable = (
+            torch.is_tensor(x)
+            and x.dtype == torch.bfloat16
+            and hasattr(torch.backends.cuda.matmul, "allow_bf16_reduced_precision_reduction")
+        )
+        if not should_disable:
+            return func(self, *args, **kwargs)
+
+        old_flag = torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction
+        torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
+        try:
+            return func(self, *args, **kwargs)
+        finally:
+            torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = old_flag
+
+    return wrapped
+
+
+def _dreamzero_sp_gather(tensor: torch.Tensor, dim: int) -> torch.Tensor:
+    try:
+        return sp_gather(tensor, dim=dim, validate=False)
+    except AssertionError:
+        return tensor
 
 
 def rope_params(max_seq_len: int, dim: int) -> torch.Tensor:
@@ -500,7 +535,7 @@ class CausalWanSelfAttention(nn.Module):
             self.head_dim,
             causal=False,
             softmax_scale=self.head_dim**-0.5,
-            skip_sequence_parallel=True,
+            skip_sequence_parallel=False,
         )
 
     def forward(
@@ -567,24 +602,23 @@ class CausalWanSelfAttention(nn.Module):
             action_v = v[:, -action_register_length:]
             v = v[:, :-action_register_length]
 
-        updated_k = kv_cache[0]
-        updated_v = kv_cache[1]
-        new_k = torch.cat([updated_k, roped_key], dim=1)
-        new_v = torch.cat([updated_v, v], dim=1)
-        new_k = new_k[:, -self.max_attention_size :]
-        new_v = new_v[:, -self.max_attention_size :]
-
+        attn_metadata = None
         if action_register_length is not None:
-            q_cat = torch.cat([roped_query, roped_action_query], dim=1)
-            k_cat = torch.cat([new_k, roped_action_key], dim=1)
-            v_cat = torch.cat([new_v, action_v], dim=1)
-        else:
-            q_cat = roped_query
-            k_cat = new_k
-            v_cat = new_v
+            attn_metadata = AttentionMetadata(
+                joint_query=roped_action_query,
+                joint_key=roped_action_key,
+                joint_value=action_v,
+                joint_strategy="rear",
+            )
 
-        x = self.attn(q_cat, k_cat, v_cat)
-        updated_kv_cache = torch.stack([new_k, new_v], dim=0)
+        x, updated_kv_cache = self.attn.forward_with_kv_cache(
+            roped_query,
+            roped_key,
+            v,
+            kv_cache,
+            max_cache_len=self.max_attention_size,
+            attn_metadata=attn_metadata,
+        )
 
         x = x.flatten(2)
         x = self.o(x)
@@ -700,6 +734,18 @@ class CausalHead(nn.Module):
         return x
 
 
+class DreamZeroSPPrepare(nn.Module):
+    """Module boundary for _sp_plan to shard video tensors together."""
+
+    def forward(
+        self,
+        x_video: torch.Tensor,
+        e_video: torch.Tensor,
+        freqs: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return x_video, e_video, freqs
+
+
 # ── Main Model ──────────────────────────────────────────────────────
 
 
@@ -710,6 +756,13 @@ class CausalWanModel(nn.Module):
     """
 
     _layerwise_offload_blocks_attrs = ["blocks"]
+    _sp_plan = {
+        "sp_prepare": {
+            0: SequenceParallelInput(split_dim=1, expected_dims=3, split_output=True, auto_pad=False),
+            1: SequenceParallelInput(split_dim=1, expected_dims=3, split_output=True, auto_pad=False),
+            2: SequenceParallelInput(split_dim=0, expected_dims=3, split_output=True, auto_pad=False),
+        },
+    }
 
     def __init__(
         self,
@@ -799,6 +852,7 @@ class CausalWanModel(nn.Module):
             nn.SiLU(),
             nn.Linear(dim, dim * 6),
         )
+        self.sp_prepare = DreamZeroSPPrepare()
 
         cross_attn_type = "t2v_cross_attn" if model_type == "t2v" else "i2v_cross_attn"
         self.blocks = nn.ModuleList(
@@ -841,6 +895,17 @@ class CausalWanModel(nn.Module):
             self.img_emb = MLPProj(1280, dim)
 
         self.init_weights()
+
+    def kv_cache_num_heads(self, ulysses_degree: int = 1) -> int:
+        heads = self.blocks[0].self_attn.tp_num_heads
+        if ulysses_degree <= 1:
+            return heads
+        if heads % ulysses_degree != 0:
+            raise ValueError(
+                f"DreamZero self-attn KV heads ({heads}) must be divisible by "
+                f"ulysses_degree ({ulysses_degree}) in strict mode."
+            )
+        return heads // ulysses_degree
 
     def init_weights(self) -> None:
         """Initialize parameters."""
@@ -913,6 +978,7 @@ class CausalWanModel(nn.Module):
         x = x.reshape(B, c, *[i * j for i, j in zip(grid_size, self.patch_size)])
         return x
 
+    @_with_precise_bf16_matmul_reduction
     def _forward_blocks(
         self,
         x: torch.Tensor,
@@ -932,6 +998,7 @@ class CausalWanModel(nn.Module):
         x = x.flatten(start_dim=2).transpose(1, 2)
         B = x.shape[0]
         F_t = timestep.shape[1]
+        video_seq_len = seq_len
 
         if action is not None:
             # Current DreamZero checkpoints have one local action/state adapter.
@@ -959,6 +1026,22 @@ class CausalWanModel(nn.Module):
         e = self.time_embedding(sinusoidal_embedding_1d(self.freq_dim, timestep.flatten()).type_as(x))
         e = e.unflatten(dim=0, sizes=(B, -1))
         e0 = self.time_projection(e)
+
+        x_video = x[:, :seq_len]
+        x_action = x[:, seq_len:] if action_register_length is not None else None
+        e_video = e0[:, :seq_len]
+        e_action = e0[:, seq_len:] if action_register_length is not None else None
+
+        x_video, e_video, freqs = self.sp_prepare(x_video, e_video, freqs)
+        local_video_seq_len = x_video.shape[1]
+        if x_action is not None:
+            x = torch.cat([x_video, x_action], dim=1)
+            e0 = torch.cat([e_video, e_action], dim=1)
+        else:
+            x = x_video
+            e0 = e_video
+        seq_len = local_video_seq_len
+
         e0 = e0.unflatten(dim=2, sizes=(6, self.dim))
 
         context = self.text_embedding(context)
@@ -988,8 +1071,8 @@ class CausalWanModel(nn.Module):
         else:
             action_noise_pred = None
 
-        x_video = x[:, :seq_len]
-        e_video = e[:, :seq_len]
+        x_video = _dreamzero_sp_gather(x[:, :seq_len], dim=1)
+        e_video = e[:, :video_seq_len]
         x_video = self.head(x_video, e_video.unsqueeze(2))
 
         return x_video, action_noise_pred, updated_kv_caches

--- a/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
+++ b/vllm_omni/diffusion/models/dreamzero/pipeline_dreamzero.py
@@ -27,12 +27,16 @@ from vllm_omni.diffusion.cache.stepcache import (
     get_stepcache_state,
     is_stepcache_active,
 )
+from vllm_omni.diffusion.config import get_current_diffusion_config_or_none
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import (
     DistributedAutoencoderKLWan,
 )
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
-from vllm_omni.diffusion.distributed.parallel_state import get_classifier_free_guidance_world_size
+from vllm_omni.diffusion.distributed.parallel_state import (
+    get_classifier_free_guidance_world_size,
+    get_ulysses_parallel_world_size,
+)
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.dreamzero.causal_wan_model import CausalWanModel
@@ -57,6 +61,16 @@ from vllm_omni.platforms import current_omni_platform
 
 logger = logging.getLogger(__name__)
 MAX_DREAMZERO_SESSIONS = 64
+
+
+def _get_runtime_ulysses_degree() -> int:
+    try:
+        return max(1, int(get_ulysses_parallel_world_size()))
+    except (AssertionError, RuntimeError):
+        config = get_current_diffusion_config_or_none()
+        if config is None:
+            return 1
+        return max(1, int(getattr(config.parallel_config, "ulysses_degree", 1) or 1))
 
 
 class VideoActionScheduler:
@@ -641,7 +655,8 @@ class DreamZeroPipeline(nn.Module, CFGParallelMixin):
         batch_size = image_latents.shape[0]
         device = image_latents.device
         dtype = image_latents.dtype
-        num_heads = getattr(self.transformer.blocks[0].self_attn, "tp_num_heads", self.transformer.num_heads)
+        ulysses_degree = _get_runtime_ulysses_degree()
+        num_heads = self.transformer.kv_cache_num_heads(ulysses_degree=ulysses_degree)
         head_dim = self.transformer.dim // self.transformer.num_heads
 
         if state.current_start_frame == 0:


### PR DESCRIPTION
## Summary
- Add DreamZero Ulysses sequence-parallel support with video-token SP prepare/gather, head-sharded session KV cache, and Ulysses-only cached attention wiring.
- Add deploy configs for SP2, SP4, and SP2+CFG2 benchmarking.
- Add precision/perf tooling: math/fp32 SDPA gates, QKV-packed strict Ulysses all-to-all, and DreamZero SP/KV contract tests.

## Notes
- Draft PR: this branch is stacked on the current DreamZero integration work and is intended for review of the SP implementation path.
- Ring + KV cache remains intentionally unsupported because the cache layout is Ulysses head-sharded.

## Test Plan
- `pytest -q tests/diffusion/attention/test_sdpa_backend.py tests/diffusion/attention/test_ulysses_qkv_packing.py tests/diffusion/models/dreamzero/test_causal_wan_sp_contract.py tests/dreamzero/test_pipeline_state.py tests/dreamzero/test_benchmark_prediction_video_cli.py`
- `pytest -q tests/diffusion/models/dreamzero/test_causal_wan_sp_kv_cache.py -k 'tiny_causal_wan_model_ulysses_matches_single_rank_with_actions or tiny_causal_wan_model_ulysses_matches_single_rank_after_prefill or tiny_causal_wan_model_ulysses_matches_single_rank_after_prefill_with_qk_norm'`
- DreamZero exact gate: no-SP vs SP2 with `DIFFUSION_SDPA_FORCE_MATH=1 DIFFUSION_SDPA_FORCE_FP32=1`, reference action `atol=0` passed.

## Performance Snapshot
- DreamZero fast SDPA, GPU0 no-SP: steady `7419.2 ms`.
- DreamZero fast SDPA, GPU0/1 SP2: steady `6100.2 ms`, `1.22x` steady speedup.
- Wan 14B same hardware, 720x1280 f33 s2: SP2 diffuse `1.46x`, total `1.35x`.
- QKV packed all-to-all reduced DreamZero SP2 `nccl:all_to_all` calls from `5440` to `2720` in the profiled chunk.
