### PR TITLE
[Doc] validate Cosmos3-Super online FP8

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -36,7 +36,7 @@ th {
 | `ZImagePipeline` | Z-Image | `Tongyi-MAI/Z-Image-Turbo` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `WanPipeline` | Wan2.1-T2V, Wan2.2-T2V, Wan2.2-TI2V | `Wan-AI/Wan2.1-T2V-1.3B-Diffusers`, `Wan-AI/Wan2.1-T2V-14B-Diffusers`, `Wan-AI/Wan2.2-T2V-A14B-Diffusers`, `Wan-AI/Wan2.2-TI2V-5B-Diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `WanImageToVideoPipeline` | Wan2.2-I2V | `Wan-AI/Wan2.2-I2V-A14B-Diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
-| `Cosmos3OmniDiffusersPipeline` | Cosmos3 T2I, T2V, I2V, V2V, T2V with sound, action policy | `nvidia/Cosmos3-Nano` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
+| `Cosmos3OmniDiffusersPipeline` | Cosmos3 T2I, T2V, I2V, V2V, T2V with sound, action policy | `nvidia/Cosmos3-Nano`, `nvidia/Cosmos3-Super` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `WanSpeechToVideoPipeline` | Wan2.2-S2V | `Wan-AI/Wan2.2-S2V-14B` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `Wan22VACEPipeline` | Wan2.1-VACE | `Wan-AI/Wan2.1-VACE-1.3B-diffusers`, `Wan-AI/Wan2.1-VACE-14B-diffusers` | ✅︎ | ✅︎ | ✅︎ | ✅︎ |
 | `LTX2Pipeline` | LTX-2-T2V | `Lightricks/LTX-2` | ✅︎ | ✅︎ | | |

--- a/docs/user_guide/quantization/fp8.md
+++ b/docs/user_guide/quantization/fp8.md
@@ -85,7 +85,7 @@ warmup_quack_fp8([(14040, 2048, 6144), (14040, 2048, 2048)])
 | FLUX.2-klein | `black-forest-labs/FLUX.2-klein-4B` | Yes | Yes | All layers | None | |
 | HunyuanImage-3.0 | `tencent/HunyuanImage-3.0`, `tencent/HunyuanImage-3.0-Instruct` | Yes | Yes | All layers; use the Hunyuan stage config for multi-stage runs | None | |
 | HunyuanVideo-1.5 | `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v`, `720p_t2v`, `480p_i2v` | Yes | Yes | All layers | None | |
-| Cosmos3 | `nvidia/Cosmos3-Nano` | Yes | Not validated | All layers | None | |
+| Cosmos3 | `nvidia/Cosmos3-Nano`, `nvidia/Cosmos3-Super` | Yes | Not validated | All layers | None | |
 
 ### Multi-Stage Omni/TTS Model (Qwen3-Omni, Qwen3-TTS)
 

--- a/recipes/cosmos3/Cosmos3-Super.md
+++ b/recipes/cosmos3/Cosmos3-Super.md
@@ -57,7 +57,10 @@ vllm serve nvidia/Cosmos3-Super \
 
 Guardrails are on by default (gated `nvidia/Cosmos-1.0-Guardrail` — `pip install
 cosmos-guardrail`, accept the license, set `HF_TOKEN`); add `--no-guardrails` to
-disable. `--enable-layerwise-offload` reduces VRAM on smaller GPUs.
+disable. `--enable-layerwise-offload` reduces VRAM on smaller GPUs;
+`--quantization fp8` (online, no calibration) cuts peak VRAM for 720p video
+generation from ~83 GB to ~55 GB per GPU (2-GPU) with BF16-level quality (T2V
+composition can shift at the same seed).
 
 #### Verification
 


### PR DESCRIPTION
# Cosmos3-Super FP8 Validation

**Part of #4340.**

**Cosmos3-Super online FP8 (`--quantization fp8`) validation, referencing [Cosmos3-Nano FP8 (#4393)](https://github.com/vllm-project/vllm-omni/pull/4393).**

Environment:
- GPU: 8× NVIDIA H20 96GB
- torch: 2.11.0+cu130
- vLLM: 0.23.0
- vLLM-Omni: 0.23.0rc1
- Commit: `cead6152`

---

## Server commands

Server commands follow the [Cosmos3-Super recipe](https://github.com/vllm-project/vllm-omni/blob/cead6152/recipes/cosmos3/Cosmos3-Super.md),
with `--quantization fp8` added for the FP8 variant.

### 2-GPU minimum (HSDP shard 2, CFG-parallel 2)

```bash
# BF16 baseline
vllm serve nvidia/Cosmos3-Super \
  --omni \
  --host 0.0.0.0 --port 8000 \
  --cfg-parallel-size 2 \
  --use-hsdp --hsdp-shard-size 2 \
  --no-guardrails \
  --init-timeout 1800

# FP8
vllm serve nvidia/Cosmos3-Super \
  --omni \
  --host 0.0.0.0 --port 8000 \
  --cfg-parallel-size 2 \
  --use-hsdp --hsdp-shard-size 2 \
  --quantization fp8 \
  --no-guardrails \
  --init-timeout 1800
```

### 8-GPU recommended (HSDP shard 8, CFG-parallel 2, Ulysses SP 4)

```bash
# BF16 baseline
vllm serve nvidia/Cosmos3-Super \
  --omni \
  --host 0.0.0.0 --port 8000 \
  --cfg-parallel-size 2 \
  --ulysses-degree 4 \
  --use-hsdp --hsdp-shard-size 8 \
  --no-guardrails \
  --init-timeout 1800

# FP8
vllm serve nvidia/Cosmos3-Super \
  --omni \
  --host 0.0.0.0 --port 8000 \
  --cfg-parallel-size 2 \
  --ulysses-degree 4 \
  --use-hsdp --hsdp-shard-size 8 \
  --quantization fp8 \
  --no-guardrails \
  --init-timeout 1800
```

Run each request below once against each server, saving outputs with `_bf16` / `_fp8` suffixes.

### T2I (1024x1024, 50 steps, guidance 7.0)

```bash
curl -sS -X POST http://localhost:8000/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{
    "model": "nvidia/Cosmos3-Super",
    "prompt": "A photorealistic red sports car on a city street at golden hour, cinematic lighting.",
    "negative_prompt": "blurry, distorted, low quality",
    "size": "1024x1024", "n": 1, "response_format": "b64_json",
    "num_inference_steps": 50, "guidance_scale": 7.0, "seed": 42
  }' | python3 -c "import sys,json,base64; open('cosmos3_super_t2i_TAG.png','wb').write(base64.b64decode(json.load(sys.stdin)['data'][0]['b64_json']))"
```

### T2V (1280x720, 189 frames, 35 steps, guidance 6.0 — official params)

```bash
curl -sS -X POST http://localhost:8000/v1/videos/sync \
  -H "Accept: video/mp4" \
  -F "model=nvidia/Cosmos3-Super" \
  -F "prompt=A robot arm is cleaning a plate in the kitchen" \
  -F "negative_prompt=blurry, distorted, low quality, jittery, deformed" \
  -F "size=1280x720" -F "num_frames=189" -F "fps=24" \
  -F "num_inference_steps=35" -F "guidance_scale=6.0" \
  -F "max_sequence_length=4096" -F "flow_shift=10.0" \
  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false}' \
  -F "seed=123" \
  -o cosmos3_super_t2v_TAG.mp4
```

### I2V (1280x720, 189 frames, 35 steps, model-card asset as reference)

```bash
curl -sS -X POST http://localhost:8000/v1/videos/sync \
  -H "Accept: video/mp4" \
  -F "model=nvidia/Cosmos3-Super" \
  -F "prompt=The scene comes to life with smooth, natural motion." \
  -F "negative_prompt=blurry, distorted, low quality" \
  -F "size=1280x720" -F "num_frames=189" -F "fps=24" \
  -F "num_inference_steps=35" -F "guidance_scale=6.0" \
  -F "max_sequence_length=4096" -F "flow_shift=10.0" \
  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false}' \
  -F "seed=1111" \
  -F "input_reference=@Cosmos3-Super/assets/example_i2v_input.jpg;type=image/jpeg" \
  -o cosmos3_super_i2v_TAG.mp4
```

---

## Test Results

### Memory (per GPU)

**2-GPU (HSDP-2, CFG-2)**

| | BF16 | FP8 | saving |
|---:|---:|---:|---:|
| Idle after load | 67.8 GB | 40.1 GB | 27.7 GB (−40.9%) |
| Peak during 720p/189f T2V | 83.0 GB | 55.4 GB | 27.6 GB (−33.3%) |

**8-GPU (HSDP-8, CFG-2, SP-4)**

| | BF16 | FP8 | saving |
|---:|---:|---:|---:|
| Idle after load | 25.5 GB | 24.4 GB | 1.1 GB (−4.3%) |
| Peak during 720p/189f T2V | 42.6 GB | 40.0 GB | 2.6 GB (−6.1%) |

### Latency (client-side E2E, with one warmup before timed run)

**2-GPU (HSDP-2, CFG-2)**

| Scenario | BF16 | FP8 | speedup |
|---:|---:|---:|---:|
| T2I 1024x1024, 50 steps | 31.3 s | 19.4 s | 1.61× |
| T2V 1280x720, 189f, 35 steps | 1735.3 s | 1408.2 s | 1.23× |
| I2V 1280x720, 189f, 35 steps | 1745.3 s | 1418.0 s | 1.23× |

**8-GPU (HSDP-8, CFG-2, SP-4)**

| Scenario | BF16 | FP8 | speedup |
|---:|---:|---:|---:|
| T2I 1024x1024, 50 steps | 13.8 s | 9.3 s | 1.48× |
| T2V 1280x720, 189f, 35 steps | 471.3 s | 393.7 s | 1.20× |
| I2V 1280x720, 189f, 35 steps | 481.9 s | 404.0 s | 1.19× |

### Quality vs BF16 (identical seed)

LPIPS (VGG, frame-wise), MaxAbsDiff (per-pixel [0,255] 8-bit RGB).

```bash
python quality_compare.py cosmos3_super_t2i_bf16.png cosmos3_super_t2i_fp8.png
python quality_compare.py cosmos3_super_t2v_bf16.mp4 cosmos3_super_t2v_fp8.mp4
python quality_compare.py cosmos3_super_i2v_bf16.mp4 cosmos3_super_i2v_fp8.mp4
```

**2-GPU (HSDP-2, CFG-2)**

| Scenario | LPIPS mean | LPIPS p95 | MaxAbsDiff (mean/max) |
|---|---|---|---|
| T2I | 0.1361 | — | 8.9 / 252 |
| I2V | 0.2545 | 0.2962 | 6.5 / 240 |
| T2V | 0.5932 | 0.5998 | 35.1 / 254 |

**8-GPU (HSDP-8, CFG-2, SP-4)**

| Scenario | LPIPS mean | LPIPS p95 | MaxAbsDiff (mean/max) |
|---|---|---|---|
| T2I | 0.1402 | — | 9.2 / 251 |
| I2V | 0.2597 | 0.2936 | 6.8 / 239 |
| T2V | 0.5856 | 0.5925 | 34.0 / 248 |

### Visual comparison

**2-GPU (HSDP-2, CFG-2)**

T2I (1024x1024, seed 42):

| BF16 | FP8 |
|------|-----|
| <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/faa8f827-10bd-4b87-8558-64d51a3b720a" /> | <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/ecf7c6f6-fc14-4f43-a0e7-2d95c9f05216" /> |

T2V (720p/189f, seed 123):

BF16: 

https://github.com/user-attachments/assets/0f6a7ac2-fd95-4099-a1e1-edb42ad95b08

FP8: 

https://github.com/user-attachments/assets/422582a2-f97c-4739-bc38-111c7e9028fb

I2V (720p/189f, seed 1111):

BF16: (uploaded zip file because the mp4 size is slightly larger than GitHub's limit for mp4 files)
[cosmos3_i2v_bf16_2gpu.mp4.zip](https://github.com/user-attachments/files/29172311/cosmos3_i2v_bf16_2gpu.mp4.zip)

FP8: 
[cosmos3_i2v_fp8_2gpu.mp4.zip](https://github.com/user-attachments/files/29172328/cosmos3_i2v_fp8_2gpu.mp4.zip)


**8-GPU (HSDP-8, CFG-2, SP-4)**

T2I (1024x1024, seed 42):

| BF16 | FP8 |
|------|-----|
| <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/b4d68673-60c4-4b0a-a0d5-ad3e5ab55119" /> | <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/88c77b7e-626f-4479-a531-b528509915e7" />|

T2V (720p/189f, seed 123):

BF16: 

https://github.com/user-attachments/assets/3e49d8b0-84b8-4401-a03f-9da431d16e38

FP8: 

https://github.com/user-attachments/assets/cf184597-4c30-45a7-a460-476cb757a8d1

I2V (720p/189f, seed 1111):

BF16: 
[cosmos3_i2v_bf16_8gpu.mp4.zip](https://github.com/user-attachments/files/29172381/cosmos3_i2v_bf16_8gpu.mp4.zip)

FP8: 
[cosmos3_i2v_fp8_8gpu.mp4.zip](https://github.com/user-attachments/files/29172388/cosmos3_i2v_fp8_8gpu.mp4.zip)