### PR TITLE
[Bugfix] Forward seeded generator to AudioX VAE adapter

### DIFF
--- a/tests/e2e/offline_inference/test_audiox_model_expansion.py
+++ b/tests/e2e/offline_inference/test_audiox_model_expansion.py
@@ -102,11 +102,8 @@ def test_audiox_determinism(omni_runner: OmniRunner) -> None:
     audio_a = _generate()
     audio_b = _generate()
 
-    assert audio_a.shape == audio_b.shape, (
-        f"shape mismatch between runs: {audio_a.shape} vs {audio_b.shape}"
-    )
+    assert audio_a.shape == audio_b.shape, f"shape mismatch between runs: {audio_a.shape} vs {audio_b.shape}"
     abs_diff = np.abs(audio_a - audio_b)
     assert np.allclose(audio_a, audio_b, atol=1e-3), (
-        "same-seed AudioX runs diverged: "
-        f"max abs diff {abs_diff.max():.6f}, mean abs diff {abs_diff.mean():.6f}"
+        f"same-seed AudioX runs diverged: max abs diff {abs_diff.max():.6f}, mean abs diff {abs_diff.mean():.6f}"
     )

--- a/tests/e2e/offline_inference/test_audiox_model_expansion.py
+++ b/tests/e2e/offline_inference/test_audiox_model_expansion.py
@@ -69,3 +69,44 @@ def test_audiox_model(omni_runner: OmniRunner) -> None:
     assert audio.shape[2] > 0
     expected_samples = int(seconds_total * sample_rate)
     assert abs(audio.shape[2] - expected_samples) <= 2 * 1024
+
+
+@hardware_test(res={"cuda": "L4", "xpu": "B60"})
+def test_audiox_determinism(omni_runner: OmniRunner) -> None:
+    # Same seed must produce identical audio. Guards against the global-RNG leak
+    # where ``audio_vae_adapter`` drew noise from the unseeded global RNG instead
+    # of the user's seeded generator (non-deterministic same-seed runs).
+    prompt = {"prompt": "A dog barking in a quiet park."}
+
+    def _generate():
+        outputs = omni_runner.omni.generate(
+            prompts=prompt,
+            sampling_params_list=OmniDiffusionSamplingParams(
+                num_inference_steps=4,
+                guidance_scale=6.0,
+                # A generator is stateful/consumed, so each run needs a fresh one
+                # seeded identically for a valid same-seed comparison.
+                generator=torch.Generator(current_omni_platform.device_type).manual_seed(42),
+                num_outputs_per_prompt=1,
+                extra_args={
+                    "audiox_task": "t2a",
+                    "seconds_start": 0.0,
+                    "seconds_total": 2.0,
+                },
+            ),
+        )
+        audio = outputs[0].request_output.multimodal_output.get("audio")
+        assert isinstance(audio, np.ndarray)
+        return audio
+
+    audio_a = _generate()
+    audio_b = _generate()
+
+    assert audio_a.shape == audio_b.shape, (
+        f"shape mismatch between runs: {audio_a.shape} vs {audio_b.shape}"
+    )
+    abs_diff = np.abs(audio_a - audio_b)
+    assert np.allclose(audio_a, audio_b, atol=1e-3), (
+        "same-seed AudioX runs diverged: "
+        f"max abs diff {abs_diff.max():.6f}, mean abs diff {abs_diff.mean():.6f}"
+    )

--- a/tests/e2e/offline_inference/test_audiox_model_expansion.py
+++ b/tests/e2e/offline_inference/test_audiox_model_expansion.py
@@ -95,7 +95,7 @@ def test_audiox_determinism(omni_runner: OmniRunner) -> None:
                 },
             ),
         )
-        audio = outputs[0].request_output.multimodal_output.get("audio")
+        audio = outputs[0].multimodal_output.get("audio")
         assert isinstance(audio, np.ndarray)
         return audio
 

--- a/vllm_omni/diffusion/models/audiox/pipeline_audiox.py
+++ b/vllm_omni/diffusion/models/audiox/pipeline_audiox.py
@@ -186,8 +186,10 @@ class AudioVaePromptAdapter(nn.Module):
         self.proj_features_128 = nn.Linear(latent_seq_len, 128)
         self.proj_out = nn.Linear(in_ch, cond_dim) if in_ch != cond_dim else nn.Identity()
 
-    def forward(self, audio: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        z = self.pretransform.encode(audio, return_dict=True).latent_dist.sample()
+    def forward(
+        self, audio: torch.Tensor, generator: torch.Generator | None = None
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        z = self.pretransform.encode(audio, return_dict=True).latent_dist.sample(generator=generator)
         latents = z / float(self.pretransform.audiox_scaling_factor)
         latents = rearrange(self.proj_features_128(latents), "b c s -> b s c")
         latents = self.proj_out(latents)
@@ -783,11 +785,13 @@ class AudioXPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMix
         hidden = torch.where(is_zero.view(batch_size, 1, 1), empty, hidden)
         return [hidden, torch.ones(batch_size, 1, device=device)]
 
-    def _encode_conditioning_tensors(self, batch_metadata: list[dict[str, Any]]) -> dict[str, Any]:
+    def _encode_conditioning_tensors(
+        self, batch_metadata: list[dict[str, Any]], generator: torch.Generator | None = None
+    ) -> dict[str, Any]:
         device = self.device
         audio = torch.cat([item["audio_prompt"] for item in batch_metadata], dim=0).to(device)
         return {
-            "audio_prompt": list(self.audio_vae_adapter(audio)),
+            "audio_prompt": list(self.audio_vae_adapter(audio, generator=generator)),
             "text_prompt": self._encode_text([item["text_prompt"] for item in batch_metadata], device),
             "video_prompt": self._encode_video([item["video_prompt"] for item in batch_metadata], device),
         }
@@ -901,10 +905,12 @@ class AudioXPipeline(nn.Module, SupportAudioOutput, DiffusionPipelineProfilerMix
                 task_norm=task_norm,
             )
 
-        conditioning_tensors = self._encode_conditioning_tensors(conditioning_batch)
+        conditioning_tensors = self._encode_conditioning_tensors(conditioning_batch, generator=generator)
         negative_conditioning_tensors: dict[str, Any] | None = None
         if negative_conditioning_batch is not None:
-            negative_conditioning_tensors = self._encode_conditioning_tensors(negative_conditioning_batch)
+            negative_conditioning_tensors = self._encode_conditioning_tensors(
+                negative_conditioning_batch, generator=generator
+            )
 
         audio = self.diffuse(
             steps=num_inference_steps,


### PR DESCRIPTION
Found this issue while working on https://github.com/vllm-project/vllm-omni/issues/4540

Fixes #4595


## Repro
The newly added test fails on main branch:
```
pytest tests/e2e/offline_inference/test_audiox_model_expansion.py::test_audiox_det
erminism -v
```

Alternatively, generate two audio files with same output and verify the differences:
```
python examples/offline_inference/audiox/end2end.py --tasks tv2a --video https://zeyuet.github.io/AudioX/static/samples/V2M/1XeBotOFqHA.mp4
```

## Root cause

The seed generator isn't forwarded properly to sampler:
`AudioVaePromptAdapter.forward` called `latent_dist.sample()` with no generator, drawing noise from PyTorch's unseeded global RNG on every request.

## Fix

* Forward the user's seeded `generator` through `_encode_conditioning_tensors` →
`audio_vae_adapter` → `latent_dist.sample(generator=...)`. 
* Adds `test_audiox_determinism` regression test (fails on pre-fix code, passes after). This test generates two audio files with the same seed and test if they are the same.

`test_audiox_determinism` regression test result:
```
=========================================== warnings summary ===========================================
../.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /root/dev/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

vllm_omni/version.py:55
  /root/dev/vllm-omni/vllm_omni/version.py:55: RuntimeWarning: vLLM and vLLM-Omni appear to have mismatched major/minor versions:
   --> vLLM-Omni version 0.1.dev2626+g10906e3a6
   --> vLLM version 0.26.0
  This will likely cause compatibility issues.
    warn_if_misaligned_vllm_version()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--- Running Summary
=================================== 1 passed, 15 warnings in 34.98s ====================================
```

