### PR TITLE
Add field IDs to bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/400-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/400-bug-report.yml
@@ -19,6 +19,7 @@ body:
 
       Consider redacting or replacing sensitive values with placeholders like `<YOUR_TOKEN_HERE>` when sharing configuration or code examples.
 - type: textarea
+  id: current-environment
   attributes:
     label: Your current environment
     description: |
@@ -42,6 +43,7 @@ body:
     required: true
 
 - type: textarea
+  id: code-version
   attributes:
     label: Your code version
     description: |
@@ -66,6 +68,7 @@ body:
     required: true
 
 - type: textarea
+  id: bug-description
   attributes:
     label: 🐛 Describe the bug
     description: |


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

Add explicit `id` attributes to the three required textarea fields in `.github/ISSUE_TEMPLATE/400-bug-report.yml`:

- `current-environment`
- `code-version`
- `bug-description`

GitHub issue forms only support URL query-parameter prefill when fields declare stable `id`s. This enables automation (CI, docs, or internal tooling) to deep-link reporters into a partially filled bug report with environment, version, and description context, improving triage quality without changing the visible form layout.

## Test Plan

No runtime or pytest changes are required (YAML-only).

Manual verification:

1. Open the bug report form with prefill query parameters, e.g.
   `https://github.com/vllm-project/vllm-omni/issues/new?template=400-bug-report.yml&current-environment=test-env&code-version=test-version&bug-description=test-bug`
2. Confirm the three textareas are prefilled with the corresponding values.
3. Optionally validate YAML syntax: `python -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/400-bug-report.yml'))"`

**vLLM Version:** N/A (issue template only)

**vLLM-Omni Commit:** 628b251e6a1fc389b49218c17ff72564f50fe8f9

## Test Result

- Not run locally (YAML-only change; manual prefill check recommended after merge).
- Pending CI.

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
