### PR TITLE
[Docs] Add MaineCoon adaptation mini spec

### DIFF
--- a/docs/contributing/model/README.md
+++ b/docs/contributing/model/README.md
@@ -8,7 +8,8 @@ This section provides comprehensive guidance on how to add a new model to vLLM-O
 
 - **[Adding a Diffusion Model](adding_diffusion_model.md)**: Complete step-by-step guide using Qwen/Qwen-Image-Edit as an example.
 
-
+- **[MaineCoon Adaptation Mini Spec](mainecoon_adaptation.md)**: Intake notes for MaineCoon. It records the current public artifact gap and
+  the gates required before listing it as supported.
 
 ## Quick Start
 

--- a/docs/contributing/model/mainecoon_adaptation.md
+++ b/docs/contributing/model/mainecoon_adaptation.md
@@ -1,0 +1,112 @@
+# MaineCoon Adaptation Mini Spec
+
+This note records the current vLLM-Omni intake for
+[`catnip-ai-tech/MaineCoon`](https://huggingface.co/catnip-ai-tech/MaineCoon).
+It is intentionally not a supported-model entry until a runnable checkpoint and
+loader contract are public.
+
+## Current Upstream State
+
+- Hugging Face model id: `catnip-ai-tech/MaineCoon`
+- Hugging Face revision checked: `a4b688a77382bf71ee64132a7b5e4abb82e56771`
+- Published files checked: `.gitattributes`, `README.md`,
+  `MaineCoon_Technical_Report.pdf`
+- Public GitHub repository checked:
+  [`catnip-ai-tech/MaineCoon`](https://github.com/catnip-ai-tech/MaineCoon)
+- Public GitHub scope: project README, report, demos, and links; no model
+  source code or inference loader is published.
+
+The published Hugging Face repository has no `config.json`, `model_index.json`,
+tokenizer files, model subfolders, or weight shards. vLLM-Omni therefore cannot
+auto-detect it as either a Transformers-style model or a Diffusers-style
+pipeline.
+
+## Mini Spec
+
+- Goal: add MaineCoon as a real-time, streaming text/audio-to-audio-video
+  generation model only after a runnable artifact is available.
+- Checkpoint layout:
+  - Runnable model id: none public as of the revision above.
+  - Raw/upstream model id: `catnip-ai-tech/MaineCoon` is a report/model-card
+    repository, not a runnable checkpoint.
+  - Required files/subfolders before implementation:
+    - root `config.json` with `model_type` and `architectures`, or a
+      `model_index.json` with a loadable pipeline class;
+    - transformer block configs and weight shards for the causal audio-visual
+      generator;
+    - tokenizer/processor assets for text, audio, and video conditioning;
+    - audio/video latent tokenizer or VAE configs and weights;
+    - any streaming cache manager, sliding-window decode, and audio
+      reconstruction code needed to match official inference.
+- Public entrypoints:
+  - Offline text/audio-to-audio-video: pending runnable checkpoint and official
+    input contract.
+  - Online streaming generation: pending official streaming protocol and
+    chunk/cadence contract.
+  - Diffusers adapter: not applicable to the current public repo because
+    `DiffusionPipeline.from_pretrained()` has no `model_index.json` or pipeline
+    files to load.
+  - Supported models table: do not list until the runnable artifact is
+    validated.
+- Request fields:
+  - Ingress: likely prompt text plus optional audio/video context, but the
+    public report does not define a stable API schema.
+  - Default semantics: unknown for chunk size, FPS, resolution, seed,
+    prompt-planning, cache budget, audio codec, and conditioning windows.
+  - Owner: model-specific pipeline should own streaming/chunk/cache semantics;
+    OpenAI-compatible serving should only pass user-visible fields through.
+  - Consumers: causal audio-visual generator, KV-cache manager, sliding-window
+    VAE/audio decode path, and streaming response writer.
+  - Failure policy: fail fast until all required official artifacts are
+    available; do not silently route to LTX-2.3 or the generic Diffusers
+    adapter.
+- Path parity:
+  - Normal path: a native multi-stage or single-stage streaming pipeline must
+    share the same request parser between offline and serving paths.
+  - Variant paths: non-streaming smoke, streaming online, and long-horizon
+    cache-managed generation need explicit parity tests.
+  - Shared helper or split: parsing should be shared; cache commitment,
+    eviction, and byte-stream emission are MaineCoon-specific.
+- Validation tiers:
+  - Unit: checkpoint layout detection, request normalization, chunk/cache shape
+    contracts, post-processing/muxing contracts.
+  - Public smoke: one official prompt at an official runnable checkpoint, with
+    generated video+audio artifact and server log.
+  - Formal perf: only after latest-head smoke passes; include resolution,
+    duration, FPS, chunk size, hardware, command, result artifact, and whether
+    cache manager is enabled.
+- PR evidence:
+  - Latest-head: pending runnable checkpoint.
+  - Historical: technical report only; not valid as runtime evidence.
+  - Pending: official source/weights, public input schema, and at least one
+    smoke artifact.
+- Non-goals:
+  - Do not claim support from the current model-card-only HF repository.
+  - Do not alias MaineCoon to LTX-2.3. The report says MaineCoon initializes
+    from LTX-2.3, but its causal audio-visual generator, KV-cache reuse, and
+    agentic streaming inference are different runtime contracts.
+  - Do not publish latency, VRAM, or FPS numbers in vLLM-Omni docs until they
+    come from a latest-head vLLM-Omni run.
+
+## Implementation Plan Once Artifacts Are Published
+
+1. Verify checkpoint layout locally or through the Hugging Face API:
+   `config.json` / `model_index.json`, component subfolders, tokenizer and
+   processor assets, and all weight shards.
+2. Classify the runtime:
+   - If official artifacts are Diffusers-compatible, first try the existing
+     Diffusers backend adapter and only add a native pipeline when vLLM-Omni
+     features such as streaming, cache management, or parallelism require it.
+   - If artifacts are a custom autoregressive audio-visual model, add a native
+     omni pipeline under `vllm_omni/model_executor/models/mainecoon/` with a
+     `PipelineConfig`, deploy YAML, model registry entries, and stage input
+     processors.
+3. Keep the first public PR narrow:
+   load/config detection, offline smoke, and one serving path. Long-horizon
+   agentic planning, formal performance, and advanced cache controls should be
+   follow-up PRs unless official smoke requires them.
+4. Add tests only at behavior owners:
+   registry/config tests for model detection, parser tests for request fields,
+   and model-specific tests for cache/chunk contracts.
+5. Update `docs/models/supported_models.md` only after the runnable model id has
+   a passing latest-head smoke.

--- a/tests/entrypoints/test_utils.py
+++ b/tests/entrypoints/test_utils.py
@@ -313,6 +313,24 @@ class TestResolveModelConfigPath:
         assert result is not None
         assert "glm_image.yaml" in result
 
+    def test_mainecoon_report_repo_requires_runnable_artifacts(self, mocker: MockerFixture):
+        """Current public MaineCoon repo fails with an actionable artifact error."""
+        mocker.patch(
+            "vllm_omni.entrypoints.utils.get_config",
+            side_effect=ValueError("missing config"),
+        )
+        mocker.patch(
+            "vllm_omni.entrypoints.utils.file_or_path_exists",
+            return_value=False,
+        )
+        mocker.patch(
+            "vllm_omni.entrypoints.utils._try_resolve_omni_model_type",
+            return_value=None,
+        )
+
+        with pytest.raises(ValueError, match="MaineCoon report repository"):
+            resolve_model_config_path("catnip-ai-tech/MaineCoon")
+
 
 class TestLoadAndResolveStageConfigs:
     def test_load_and_resolve_with_kwargs(self):

--- a/tests/test_config_factory.py
+++ b/tests/test_config_factory.py
@@ -541,6 +541,21 @@ class TestPipelineDiscovery:
         )
         assert p.hf_architectures == ("SomeCollidingArch",)
 
+    def test_mainecoon_report_repo_requires_runnable_artifacts(self, mocker):
+        """Current public MaineCoon repo is a report/demo repo, not loadable artifacts."""
+
+        mocker.patch(
+            "vllm.transformers_utils.config.get_config",
+            side_effect=ValueError("missing config"),
+        )
+        mocker.patch(
+            "vllm.transformers_utils.config.get_hf_file_to_dict",
+            return_value=None,
+        )
+
+        with pytest.raises(ValueError, match="MaineCoon report repository"):
+            StageConfigFactory._auto_detect_model_type("catnip-ai-tech/MaineCoon")
+
 
 class TestStagePipelineConfig:
     def test_frozen(self):

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -1323,6 +1323,14 @@ class StageConfigFactory:
         except Exception as e:
             logger.debug(f"Failed to detect model type for diffusers-style models: {e}")
 
+        from vllm_omni.diffusion.utils.hf_utils import (
+            _looks_like_public_mainecoon_report_repo,
+            _raise_public_mainecoon_artifact_error,
+        )
+
+        if _looks_like_public_mainecoon_report_repo(model):
+            _raise_public_mainecoon_artifact_error(model)
+
         # Final fallback: some models (e.g. CosyVoice3) ship an empty
         # config.json and rely on naming conventions. Match the model path
         # basename against registered pipeline keys — longest match wins

--- a/vllm_omni/diffusion/utils/hf_utils.py
+++ b/vllm_omni/diffusion/utils/hf_utils.py
@@ -8,6 +8,29 @@ from vllm.transformers_utils.config import get_hf_file_to_dict
 logger = init_logger(__name__)
 
 
+_MAINECOON_REPORT_REPO = "catnip-ai-tech/mainecoon"
+
+
+def _normalize_hf_repo_id(model_name: str) -> str:
+    return model_name.strip().replace("\\", "/").rstrip("/").lower()
+
+
+def _looks_like_public_mainecoon_report_repo(model_name: str) -> bool:
+    """Match the current public MaineCoon report-only repository."""
+    return _normalize_hf_repo_id(model_name) == _MAINECOON_REPORT_REPO
+
+
+def _raise_public_mainecoon_artifact_error(model_name: str) -> None:
+    raise ValueError(
+        f"{model_name!r} matches the public MaineCoon report repository, "
+        "which does not publish runnable vLLM-Omni artifacts yet. "
+        "The current repository is missing config.json, model_index.json, "
+        "tokenizer files, model weights, and an inference pipeline. "
+        "Use a runnable MaineCoon checkpoint/source release with a supported "
+        "model_type or model_index.json before loading it with vLLM-Omni."
+    )
+
+
 def load_diffusers_config(model_name) -> dict:
     from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 

--- a/vllm_omni/entrypoints/utils.py
+++ b/vllm_omni/entrypoints/utils.py
@@ -13,7 +13,11 @@ from vllm.transformers_utils.repo_utils import file_or_path_exists
 
 from vllm_omni.config.stage_config import StageConfigFactory
 from vllm_omni.config.yaml_util import create_config, load_yaml_config, merge_configs
-from vllm_omni.diffusion.utils.hf_utils import _looks_like_dreamzero
+from vllm_omni.diffusion.utils.hf_utils import (
+    _looks_like_dreamzero,
+    _looks_like_public_mainecoon_report_repo,
+    _raise_public_mainecoon_artifact_error,
+)
 from vllm_omni.entrypoints.stage_utils import _to_dict
 from vllm_omni.inputs.data import OmniSamplingParams
 from vllm_omni.platforms import current_omni_platform
@@ -281,6 +285,8 @@ def resolve_model_config_path(model: str) -> str:
             # YAML filenames before giving up.
             model_type = _try_resolve_omni_model_type(model)
             if model_type is None:
+                if _looks_like_public_mainecoon_report_repo(model):
+                    _raise_public_mainecoon_artifact_error(model)
                 raise ValueError(
                     f"Could not determine model_type for model: {model}. "
                     f"Model is not in standard transformers format and does not have model_index.json. "


### PR DESCRIPTION
## Purpose

Add a MaineCoon intake mini spec and an explicit load-time guard for the current public report-only repository.

The public Hugging Face repo only publishes the README and technical report today; it does not include runnable config.json, model_index.json, tokenizer files, weights, or inference source. This PR deliberately does not register MaineCoon as supported. The config resolver now fails fast for `catnip-ai-tech/MaineCoon` with an actionable artifact message after normal config/model_index detection fails.

## Test Plan

No completed semantic test run yet; this PR stays draft until the targeted unit tests can run in a supported vLLM-Omni test environment.

## Test Result

Pending before ready for review.