### PR TITLE
[Perf] Optimize Cosmos3 video postprocessing

### DIFF
--- a/tests/comfyui/test_comfyui_integration.py
+++ b/tests/comfyui/test_comfyui_integration.py
@@ -6,7 +6,6 @@ It ensures that
 2. The sampling parameters are correctly passed from the node to AsyncOmni through the API layer.
 """
 
-import json
 import multiprocessing
 import time
 import traceback
@@ -15,8 +14,6 @@ from enum import StrEnum, auto
 from types import SimpleNamespace
 from typing import Any, NamedTuple
 
-import aiohttp
-import comfyui_vllm_omni.nodes as comfy_nodes
 import pytest
 import requests
 import torch
@@ -28,8 +25,6 @@ from comfyui_vllm_omni.nodes import (
     VLLMOmniUnderstanding,
     VLLMOmniVoiceClone,
 )
-from comfyui_vllm_omni.utils.api_client import url_bytes
-from comfyui_vllm_omni.utils.format import bytes_to_video, image_tensor_to_png_bytes
 from comfyui_vllm_omni.utils.types import AutoregressionSamplingParams, DiffusionSamplingParams, WanModelSpecificParams
 from PIL import Image
 from pytest_mock import MockerFixture
@@ -219,55 +214,6 @@ def _build_diffusion_video_output() -> OmniRequestOutput:
         images=[video_frames],
         final_output_type="video",
     )
-
-
-async def _generate_video_via_sync_endpoint(
-    self,
-    *,
-    model: str,
-    prompt: str,
-    width: int,
-    height: int,
-    num_frames: int,
-    fps: int,
-    negative_prompt: str | None = None,
-    image: torch.Tensor | None = None,
-    sampling_params: dict | None = None,
-    model_params: dict | None = None,
-    lora: dict | None = None,
-    **extra_body,
-) -> VideoInput:
-    form = aiohttp.FormData()
-    form.add_field("model", model)
-    form.add_field("prompt", prompt)
-    form.add_field("width", str(width))
-    form.add_field("height", str(height))
-    form.add_field("num_frames", str(num_frames))
-    form.add_field("fps", str(fps))
-    if negative_prompt:
-        form.add_field("negative_prompt", negative_prompt)
-    if sampling_params is not None:
-        for k, v in sampling_params.items():
-            form.add_field(k, str(v))
-    if model_params is not None:
-        for k, v in model_params.items():
-            form.add_field(k, str(v))
-    if lora is not None:
-        form.add_field("lora", json.dumps(lora, ensure_ascii=False))
-    if extra_body:
-        form.add_field("extra_body", json.dumps(extra_body, ensure_ascii=False))
-    if image is not None:
-        image_filename = "image.png"
-        form.add_field(
-            "input_reference",
-            image_tensor_to_png_bytes(image, image_filename),
-            filename=image_filename,
-            content_type="image/png",
-        )
-
-    async with aiohttp.ClientSession(timeout=self.timeout) as session:
-        video_bytes = await url_bytes(session, f"{self.base_url}/videos/sync", "post", data=form)
-    return bytes_to_video(video_bytes)
 
 
 def _build_diffusion_image_output_for_chat_endpoint() -> OmniRequestOutput:
@@ -812,17 +758,7 @@ async def test_tts_nodes(api_server: str, node_cls, call_kwargs: dict, sampling_
     ],
     indirect=["sampling_case"],
 )
-async def test_video_generation_node(
-    api_server: str,
-    model: str,
-    image_input: bool,
-    sampling_case: SamplingCase,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    # Keep this ComfyUI node test focused on request wiring. The async
-    # create/status video API has its own coverage and can leave this CPU shard
-    # waiting on long-polling if the mocked background job stalls.
-    monkeypatch.setattr(comfy_nodes.VLLMOmniClient, "generate_video", _generate_video_via_sync_endpoint)
+async def test_video_generation_node(api_server: str, model: str, image_input: bool, sampling_case: SamplingCase):
     node = VLLMOmniGenerateVideo()
 
     kwargs = {

--- a/tests/comfyui/test_comfyui_integration.py
+++ b/tests/comfyui/test_comfyui_integration.py
@@ -442,7 +442,7 @@ def mock_async_omni(
 
 
 @pytest.fixture
-def api_server(unused_tcp_port_factory, tmp_path, server_case: ServerCase, mock_async_omni):
+def api_server(unused_tcp_port_factory, server_case: ServerCase, mock_async_omni):
     """Set up a API server in background process from command line with parametrized model name and mocked AsyncOmni."""
     parser = TrackingArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
@@ -451,16 +451,9 @@ def api_server(unused_tcp_port_factory, tmp_path, server_case: ServerCase, mock_
 
     port = unused_tcp_port_factory()
     args = parser.parse_args(["serve", server_case.served_model, "--omni", "--port", str(port)])
-    storage_path = str(tmp_path / "video_storage")
 
     def run_server():
         try:
-            # Keep the background API server independent from a shared /tmp/storage
-            # directory, which may be owned by another CI job or container user.
-            from vllm_omni.entrypoints.openai import api_server as api_server_module
-            from vllm_omni.entrypoints.openai.storage import LocalStorageManager
-
-            api_server_module.STORAGE_MANAGER = LocalStorageManager(storage_path=storage_path)
             cmd.cmd(args)
         except Exception:
             traceback.print_exc()

--- a/tests/comfyui/test_comfyui_integration.py
+++ b/tests/comfyui/test_comfyui_integration.py
@@ -6,7 +6,6 @@ It ensures that
 2. The sampling parameters are correctly passed from the node to AsyncOmni through the API layer.
 """
 
-import asyncio
 import multiprocessing
 import time
 import traceback
@@ -34,7 +33,7 @@ from vllm.outputs import CompletionOutput, RequestOutput
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni as RealAsyncOmni
 from vllm_omni.entrypoints.cli.serve import OmniServeCommand
-from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniSamplingParams
+from vllm_omni.inputs.data import OmniSamplingParams
 from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.utils.tracking_parser import TrackingArgumentParser
 
@@ -409,90 +408,41 @@ def mock_async_omni(
         _mock_preprocess_chat,
     )
 
-    class _MockAsyncOmni:
-        def __init__(self):
-            self.generate = _build_mock_outputs(server_case.outputs, sampling_case, server_case)
-            self.stage_list = server_case.stage_list
-            self.stage_configs = server_case.stage_configs
-            self.output_modalities = _build_output_modalities(server_case.stage_configs)
-            self.default_sampling_params_list = [
-                SamplingParams() if _stage_type(stage) != "diffusion" else OmniDiffusionSamplingParams()
-                for stage in server_case.stage_configs
-            ]
-            self.errored = False
-            self.dead_error = RuntimeError("Mock engine error")
-            self.vllm_config = SimpleNamespace(shutdown_timeout=0, kv_transfer_config=None)
-            self.model_config = SimpleNamespace(
-                model=server_case.served_model,
-                max_model_len=4096,
-                io_processor_plugin=None,
-                allowed_local_media_path=None,
-                allowed_media_domains=None,
-                hf_config=SimpleNamespace(
-                    model_type="mock",
-                    codec_frame_rate_hz=24000,
-                    talker_config=SimpleNamespace(speaker_id={"Vivian": 0}),
-                ),
-            )
-            self.renderer = SimpleNamespace()
-            self.io_processor = SimpleNamespace()
-            self.input_processor = SimpleNamespace()
+    mock_instance = mocker.AsyncMock(spec=RealAsyncOmni)
+    mock_instance.generate = _build_mock_outputs(server_case.outputs, sampling_case, server_case)
 
-        async def get_vllm_config(self):
-            return None
-
-        async def get_supported_tasks(self):
-            return ["generate"]
-
-        async def get_tokenizer(self):
-            return None
-
-        async def check_health(self):
-            return None
-
-        def shutdown(self, timeout: float | None = None) -> None:
-            return None
-
-    if sampling_case.kind in {SamplingKind.VIDEO_NONE, SamplingKind.VIDEO_DIFFUSION_SINGLE}:
-        # Video jobs run through FastAPI background tasks. Use a plain fake here
-        # so the async create/status path does not depend on AsyncMock internals.
-        mock_instance = _MockAsyncOmni()
-    else:
-        mock_instance = mocker.AsyncMock(spec=RealAsyncOmni)
-        mock_instance.generate = _build_mock_outputs(server_case.outputs, sampling_case, server_case)
-
-        mock_instance.stage_list = server_case.stage_list
-        mock_instance.stage_configs = server_case.stage_configs
-        mock_instance.output_modalities = _build_output_modalities(server_case.stage_configs)
-        mock_instance.default_sampling_params_list = [
-            SamplingParams() if _stage_type(stage) != "diffusion" else mocker.MagicMock()
-            for stage in server_case.stage_configs
-        ]
-        mock_instance.errored = False
-        mock_instance.dead_error = RuntimeError("Mock engine error")
-        mock_instance.model_config = mocker.MagicMock(
-            max_model_len=4096,
-            io_processor_plugin=None,
-            allowed_local_media_path=None,
-            allowed_media_domains=None,
-        )
-        # Mimic Qwen3-TTS talker speaker config so CustomVoice validation passes.
-        mock_instance.model_config.hf_config = mocker.MagicMock()
-        mock_instance.model_config.hf_config.talker_config = mocker.MagicMock()
-        mock_instance.model_config.hf_config.talker_config.speaker_id = {"Vivian": 0}
-        mock_instance.io_processor = mocker.MagicMock()
-        mock_instance.input_processor = mocker.MagicMock()
-        mock_instance.shutdown = mocker.MagicMock()
-        mock_instance.get_vllm_config = mocker.AsyncMock(return_value=None)
-        mock_instance.get_supported_tasks = mocker.AsyncMock(return_value=["generate"])
-        mock_instance.get_tokenizer = mocker.AsyncMock(return_value=None)
+    mock_instance.stage_list = server_case.stage_list
+    mock_instance.stage_configs = server_case.stage_configs
+    mock_instance.output_modalities = _build_output_modalities(server_case.stage_configs)
+    mock_instance.default_sampling_params_list = [
+        SamplingParams() if _stage_type(stage) != "diffusion" else mocker.MagicMock()
+        for stage in server_case.stage_configs
+    ]
+    mock_instance.errored = False
+    mock_instance.dead_error = RuntimeError("Mock engine error")
+    mock_instance.model_config = mocker.MagicMock(
+        max_model_len=4096,
+        io_processor_plugin=None,
+        allowed_local_media_path=None,
+        allowed_media_domains=None,
+    )
+    # Mimic Qwen3-TTS talker speaker config so CustomVoice validation passes.
+    mock_instance.model_config.hf_config = mocker.MagicMock()
+    mock_instance.model_config.hf_config.talker_config = mocker.MagicMock()
+    mock_instance.model_config.hf_config.talker_config.speaker_id = {"Vivian": 0}
+    mock_instance.io_processor = mocker.MagicMock()
+    mock_instance.input_processor = mocker.MagicMock()
+    mock_instance.shutdown = mocker.MagicMock()
+    mock_instance.get_vllm_config = mocker.AsyncMock(return_value=None)
+    mock_instance.get_supported_tasks = mocker.AsyncMock(return_value=["generate"])
+    mock_instance.get_tokenizer = mocker.AsyncMock(return_value=None)
 
     mock_async_omni_cls.return_value = mock_instance
     yield mock_async_omni_cls
 
 
 @pytest.fixture
-def api_server(unused_tcp_port_factory, tmp_path, server_case: ServerCase, mock_async_omni):
+def api_server(unused_tcp_port_factory, server_case: ServerCase, mock_async_omni):
     """Set up a API server in background process from command line with parametrized model name and mocked AsyncOmni."""
     parser = TrackingArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
@@ -501,14 +451,9 @@ def api_server(unused_tcp_port_factory, tmp_path, server_case: ServerCase, mock_
 
     port = unused_tcp_port_factory()
     args = parser.parse_args(["serve", server_case.served_model, "--omni", "--port", str(port)])
-    storage_path = str(tmp_path / "video_storage")
 
     def run_server():
         try:
-            from vllm_omni.entrypoints.openai import api_server as api_server_module
-            from vllm_omni.entrypoints.openai.storage import LocalStorageManager
-
-            api_server_module.STORAGE_MANAGER = LocalStorageManager(storage_path=storage_path)
             cmd.cmd(args)
         except Exception:
             traceback.print_exc()
@@ -834,9 +779,7 @@ async def test_video_generation_node(api_server: str, model: str, image_input: b
     if sampling_case.lora:
         kwargs["lora"] = sampling_case.lora
 
-    # Keep the ComfyUI node on the async create/status/content/delete API path,
-    # but fail quickly if the mocked background job stops making progress.
-    result = await asyncio.wait_for(node.generate(**kwargs), timeout=30)
+    result = await node.generate(**kwargs)
 
     assert isinstance(result, tuple)
     assert len(result) == 1

--- a/tests/comfyui/test_comfyui_integration.py
+++ b/tests/comfyui/test_comfyui_integration.py
@@ -6,6 +6,7 @@ It ensures that
 2. The sampling parameters are correctly passed from the node to AsyncOmni through the API layer.
 """
 
+import json
 import multiprocessing
 import time
 import traceback
@@ -14,6 +15,8 @@ from enum import StrEnum, auto
 from types import SimpleNamespace
 from typing import Any, NamedTuple
 
+import aiohttp
+import comfyui_vllm_omni.nodes as comfy_nodes
 import pytest
 import requests
 import torch
@@ -25,6 +28,8 @@ from comfyui_vllm_omni.nodes import (
     VLLMOmniUnderstanding,
     VLLMOmniVoiceClone,
 )
+from comfyui_vllm_omni.utils.api_client import url_bytes
+from comfyui_vllm_omni.utils.format import bytes_to_video, image_tensor_to_png_bytes
 from comfyui_vllm_omni.utils.types import AutoregressionSamplingParams, DiffusionSamplingParams, WanModelSpecificParams
 from PIL import Image
 from pytest_mock import MockerFixture
@@ -214,6 +219,55 @@ def _build_diffusion_video_output() -> OmniRequestOutput:
         images=[video_frames],
         final_output_type="video",
     )
+
+
+async def _generate_video_via_sync_endpoint(
+    self,
+    *,
+    model: str,
+    prompt: str,
+    width: int,
+    height: int,
+    num_frames: int,
+    fps: int,
+    negative_prompt: str | None = None,
+    image: torch.Tensor | None = None,
+    sampling_params: dict | None = None,
+    model_params: dict | None = None,
+    lora: dict | None = None,
+    **extra_body,
+) -> VideoInput:
+    form = aiohttp.FormData()
+    form.add_field("model", model)
+    form.add_field("prompt", prompt)
+    form.add_field("width", str(width))
+    form.add_field("height", str(height))
+    form.add_field("num_frames", str(num_frames))
+    form.add_field("fps", str(fps))
+    if negative_prompt:
+        form.add_field("negative_prompt", negative_prompt)
+    if sampling_params is not None:
+        for k, v in sampling_params.items():
+            form.add_field(k, str(v))
+    if model_params is not None:
+        for k, v in model_params.items():
+            form.add_field(k, str(v))
+    if lora is not None:
+        form.add_field("lora", json.dumps(lora, ensure_ascii=False))
+    if extra_body:
+        form.add_field("extra_body", json.dumps(extra_body, ensure_ascii=False))
+    if image is not None:
+        image_filename = "image.png"
+        form.add_field(
+            "input_reference",
+            image_tensor_to_png_bytes(image, image_filename),
+            filename=image_filename,
+            content_type="image/png",
+        )
+
+    async with aiohttp.ClientSession(timeout=self.timeout) as session:
+        video_bytes = await url_bytes(session, f"{self.base_url}/videos/sync", "post", data=form)
+    return bytes_to_video(video_bytes)
 
 
 def _build_diffusion_image_output_for_chat_endpoint() -> OmniRequestOutput:
@@ -758,7 +812,17 @@ async def test_tts_nodes(api_server: str, node_cls, call_kwargs: dict, sampling_
     ],
     indirect=["sampling_case"],
 )
-async def test_video_generation_node(api_server: str, model: str, image_input: bool, sampling_case: SamplingCase):
+async def test_video_generation_node(
+    api_server: str,
+    model: str,
+    image_input: bool,
+    sampling_case: SamplingCase,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Keep this ComfyUI node test focused on request wiring. The async
+    # create/status video API has its own coverage and can leave this CPU shard
+    # waiting on long-polling if the mocked background job stalls.
+    monkeypatch.setattr(comfy_nodes.VLLMOmniClient, "generate_video", _generate_video_via_sync_endpoint)
     node = VLLMOmniGenerateVideo()
 
     kwargs = {

--- a/tests/comfyui/test_comfyui_integration.py
+++ b/tests/comfyui/test_comfyui_integration.py
@@ -6,6 +6,7 @@ It ensures that
 2. The sampling parameters are correctly passed from the node to AsyncOmni through the API layer.
 """
 
+import asyncio
 import multiprocessing
 import time
 import traceback
@@ -33,7 +34,7 @@ from vllm.outputs import CompletionOutput, RequestOutput
 
 from vllm_omni.entrypoints.async_omni import AsyncOmni as RealAsyncOmni
 from vllm_omni.entrypoints.cli.serve import OmniServeCommand
-from vllm_omni.inputs.data import OmniSamplingParams
+from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniSamplingParams
 from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.utils.tracking_parser import TrackingArgumentParser
 
@@ -408,41 +409,90 @@ def mock_async_omni(
         _mock_preprocess_chat,
     )
 
-    mock_instance = mocker.AsyncMock(spec=RealAsyncOmni)
-    mock_instance.generate = _build_mock_outputs(server_case.outputs, sampling_case, server_case)
+    class _MockAsyncOmni:
+        def __init__(self):
+            self.generate = _build_mock_outputs(server_case.outputs, sampling_case, server_case)
+            self.stage_list = server_case.stage_list
+            self.stage_configs = server_case.stage_configs
+            self.output_modalities = _build_output_modalities(server_case.stage_configs)
+            self.default_sampling_params_list = [
+                SamplingParams() if _stage_type(stage) != "diffusion" else OmniDiffusionSamplingParams()
+                for stage in server_case.stage_configs
+            ]
+            self.errored = False
+            self.dead_error = RuntimeError("Mock engine error")
+            self.vllm_config = SimpleNamespace(shutdown_timeout=0, kv_transfer_config=None)
+            self.model_config = SimpleNamespace(
+                model=server_case.served_model,
+                max_model_len=4096,
+                io_processor_plugin=None,
+                allowed_local_media_path=None,
+                allowed_media_domains=None,
+                hf_config=SimpleNamespace(
+                    model_type="mock",
+                    codec_frame_rate_hz=24000,
+                    talker_config=SimpleNamespace(speaker_id={"Vivian": 0}),
+                ),
+            )
+            self.renderer = SimpleNamespace()
+            self.io_processor = SimpleNamespace()
+            self.input_processor = SimpleNamespace()
 
-    mock_instance.stage_list = server_case.stage_list
-    mock_instance.stage_configs = server_case.stage_configs
-    mock_instance.output_modalities = _build_output_modalities(server_case.stage_configs)
-    mock_instance.default_sampling_params_list = [
-        SamplingParams() if _stage_type(stage) != "diffusion" else mocker.MagicMock()
-        for stage in server_case.stage_configs
-    ]
-    mock_instance.errored = False
-    mock_instance.dead_error = RuntimeError("Mock engine error")
-    mock_instance.model_config = mocker.MagicMock(
-        max_model_len=4096,
-        io_processor_plugin=None,
-        allowed_local_media_path=None,
-        allowed_media_domains=None,
-    )
-    # Mimic Qwen3-TTS talker speaker config so CustomVoice validation passes.
-    mock_instance.model_config.hf_config = mocker.MagicMock()
-    mock_instance.model_config.hf_config.talker_config = mocker.MagicMock()
-    mock_instance.model_config.hf_config.talker_config.speaker_id = {"Vivian": 0}
-    mock_instance.io_processor = mocker.MagicMock()
-    mock_instance.input_processor = mocker.MagicMock()
-    mock_instance.shutdown = mocker.MagicMock()
-    mock_instance.get_vllm_config = mocker.AsyncMock(return_value=None)
-    mock_instance.get_supported_tasks = mocker.AsyncMock(return_value=["generate"])
-    mock_instance.get_tokenizer = mocker.AsyncMock(return_value=None)
+        async def get_vllm_config(self):
+            return None
+
+        async def get_supported_tasks(self):
+            return ["generate"]
+
+        async def get_tokenizer(self):
+            return None
+
+        async def check_health(self):
+            return None
+
+        def shutdown(self, timeout: float | None = None) -> None:
+            return None
+
+    if sampling_case.kind in {SamplingKind.VIDEO_NONE, SamplingKind.VIDEO_DIFFUSION_SINGLE}:
+        # Video jobs run through FastAPI background tasks. Use a plain fake here
+        # so the async create/status path does not depend on AsyncMock internals.
+        mock_instance = _MockAsyncOmni()
+    else:
+        mock_instance = mocker.AsyncMock(spec=RealAsyncOmni)
+        mock_instance.generate = _build_mock_outputs(server_case.outputs, sampling_case, server_case)
+
+        mock_instance.stage_list = server_case.stage_list
+        mock_instance.stage_configs = server_case.stage_configs
+        mock_instance.output_modalities = _build_output_modalities(server_case.stage_configs)
+        mock_instance.default_sampling_params_list = [
+            SamplingParams() if _stage_type(stage) != "diffusion" else mocker.MagicMock()
+            for stage in server_case.stage_configs
+        ]
+        mock_instance.errored = False
+        mock_instance.dead_error = RuntimeError("Mock engine error")
+        mock_instance.model_config = mocker.MagicMock(
+            max_model_len=4096,
+            io_processor_plugin=None,
+            allowed_local_media_path=None,
+            allowed_media_domains=None,
+        )
+        # Mimic Qwen3-TTS talker speaker config so CustomVoice validation passes.
+        mock_instance.model_config.hf_config = mocker.MagicMock()
+        mock_instance.model_config.hf_config.talker_config = mocker.MagicMock()
+        mock_instance.model_config.hf_config.talker_config.speaker_id = {"Vivian": 0}
+        mock_instance.io_processor = mocker.MagicMock()
+        mock_instance.input_processor = mocker.MagicMock()
+        mock_instance.shutdown = mocker.MagicMock()
+        mock_instance.get_vllm_config = mocker.AsyncMock(return_value=None)
+        mock_instance.get_supported_tasks = mocker.AsyncMock(return_value=["generate"])
+        mock_instance.get_tokenizer = mocker.AsyncMock(return_value=None)
 
     mock_async_omni_cls.return_value = mock_instance
     yield mock_async_omni_cls
 
 
 @pytest.fixture
-def api_server(unused_tcp_port_factory, server_case: ServerCase, mock_async_omni):
+def api_server(unused_tcp_port_factory, tmp_path, server_case: ServerCase, mock_async_omni):
     """Set up a API server in background process from command line with parametrized model name and mocked AsyncOmni."""
     parser = TrackingArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
@@ -451,9 +501,14 @@ def api_server(unused_tcp_port_factory, server_case: ServerCase, mock_async_omni
 
     port = unused_tcp_port_factory()
     args = parser.parse_args(["serve", server_case.served_model, "--omni", "--port", str(port)])
+    storage_path = str(tmp_path / "video_storage")
 
     def run_server():
         try:
+            from vllm_omni.entrypoints.openai import api_server as api_server_module
+            from vllm_omni.entrypoints.openai.storage import LocalStorageManager
+
+            api_server_module.STORAGE_MANAGER = LocalStorageManager(storage_path=storage_path)
             cmd.cmd(args)
         except Exception:
             traceback.print_exc()
@@ -779,7 +834,9 @@ async def test_video_generation_node(api_server: str, model: str, image_input: b
     if sampling_case.lora:
         kwargs["lora"] = sampling_case.lora
 
-    result = await node.generate(**kwargs)
+    # Keep the ComfyUI node on the async create/status/content/delete API path,
+    # but fail quickly if the mocked background job stops making progress.
+    result = await asyncio.wait_for(node.generate(**kwargs), timeout=30)
 
     assert isinstance(result, tuple)
     assert len(result) == 1

--- a/tests/comfyui/test_comfyui_integration.py
+++ b/tests/comfyui/test_comfyui_integration.py
@@ -442,7 +442,7 @@ def mock_async_omni(
 
 
 @pytest.fixture
-def api_server(unused_tcp_port_factory, server_case: ServerCase, mock_async_omni):
+def api_server(unused_tcp_port_factory, tmp_path, server_case: ServerCase, mock_async_omni):
     """Set up a API server in background process from command line with parametrized model name and mocked AsyncOmni."""
     parser = TrackingArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
@@ -451,9 +451,16 @@ def api_server(unused_tcp_port_factory, server_case: ServerCase, mock_async_omni
 
     port = unused_tcp_port_factory()
     args = parser.parse_args(["serve", server_case.served_model, "--omni", "--port", str(port)])
+    storage_path = str(tmp_path / "video_storage")
 
     def run_server():
         try:
+            # Keep the background API server independent from a shared /tmp/storage
+            # directory, which may be owned by another CI job or container user.
+            from vllm_omni.entrypoints.openai import api_server as api_server_module
+            from vllm_omni.entrypoints.openai.storage import LocalStorageManager
+
+            api_server_module.STORAGE_MANAGER = LocalStorageManager(storage_path=storage_path)
             cmd.cmd(args)
         except Exception:
             traceback.print_exc()

--- a/tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py
+++ b/tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py
@@ -698,16 +698,19 @@ def test_postprocess_handles_image_video_audio_and_validation() -> None:
 
     assert func(video, output_type="latent") is video
     assert func({"image": video})[0].size == (4, 4)
-    # Video-only postprocess returns the bare processed video (not a dict),
-    # matching the image/latent branches and peer audio-capable pipelines.
-    assert not isinstance(func({"video": video}), dict)
-    assert (
-        func(
-            {"video": video, "audio": torch.ones(1, 2, 16), "audio_sample_rate": 48000},
-            sampling_params=SimpleNamespace(extra_args={"resolved_frame_rate": 12}),
-        )["audio_sample_rate"]
-        == 48000
+    # Video-only postprocess returns a tensor fast path (not a dict),
+    # matching the decode stage and avoiding Diffusers postprocess_video copies.
+    processed_video = func({"video": video.clone()})
+    assert isinstance(processed_video, torch.Tensor)
+    assert processed_video.shape == video.shape
+    torch.testing.assert_close(processed_video, torch.full_like(video, 0.5))
+
+    video_audio = func(
+        {"video": video.clone(), "audio": torch.ones(1, 2, 16), "audio_sample_rate": 48000},
+        sampling_params=SimpleNamespace(extra_args={"resolved_frame_rate": 12}),
     )
+    assert isinstance(video_audio["video"], torch.Tensor)
+    assert video_audio["audio_sample_rate"] == 48000
 
     with pytest.raises(ValueError, match="text-to-image postprocess expects"):
         func({"image": torch.zeros(1, 3, 2, 4, 4)})

--- a/tests/entrypoints/openai_api/test_video_api_utils.py
+++ b/tests/entrypoints/openai_api/test_video_api_utils.py
@@ -149,6 +149,45 @@ def test_finalize_streaming_mp4_bytes_produces_progressive_mp4():
     assert streamed_info[2] == pytest.approx(expected_duration, rel=0.05)
 
 
+def test_encode_video_bytes_uses_direct_tensor_path(monkeypatch):
+    mux_calls = []
+    _install_fake_video_mux(monkeypatch, mux_calls)
+
+    def _unexpected_stack(*args, **kwargs):
+        raise AssertionError("tensor video path should not materialize a frame list with np.stack")
+
+    monkeypatch.setattr(video_api_utils.np, "stack", _unexpected_stack)
+    video = torch.linspace(0, 1, steps=3 * 5 * 2 * 2, dtype=torch.float32).reshape(3, 5, 2, 2)
+    video_bytes = video_api_utils._encode_video_bytes(video, fps=8)
+
+    assert video_bytes == b"fake-video"
+    frames = mux_calls[0]["frames"]
+    assert frames.shape == (5, 2, 2, 3)
+    assert frames.dtype == np.uint8
+    assert frames.flags.c_contiguous
+    assert frames[0, 0, 0, 0] == 0
+    assert frames[-1, -1, -1, -1] == 255
+
+
+def test_encode_video_bytes_direct_tensor_preserves_raw_minus_one_to_one_range(monkeypatch):
+    mux_calls = []
+    _install_fake_video_mux(monkeypatch, mux_calls)
+
+    video = torch.tensor(
+        [
+            [[[-1.0]], [[1.0]]],
+            [[[-1.0]], [[1.0]]],
+            [[[-1.0]], [[1.0]]],
+        ]
+    )
+    video_api_utils._encode_video_bytes(video, fps=8)
+
+    frames = mux_calls[0]["frames"]
+    assert frames.shape == (2, 1, 1, 3)
+    assert frames[0, 0, 0].tolist() == [0, 0, 0]
+    assert frames[1, 0, 0].tolist() == [255, 255, 255]
+
+
 def test_rife_model_inference_runs_on_dummy_tensors():
     model = rife_interpolator.Model().eval()
     img0 = torch.rand(1, 3, 32, 32)

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -524,8 +524,8 @@ def get_cosmos3_post_process_func(od_config: OmniDiffusionConfig):
 
     def _postprocess_video_tensor(video: torch.Tensor) -> torch.Tensor:
         # Keep the decoded video on a fast tensor path through serving and
-        # only normalize in-place before MP4 encoding.
-        return video.mul_(0.5).add_(0.5).clamp_(0, 1)
+        # match Diffusers denormalization semantics before MP4 encoding.
+        return (video * 0.5 + 0.5).clamp(0, 1)
 
     def post_process_func(
         output: torch.Tensor | dict[str, torch.Tensor] | tuple,

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -522,6 +522,11 @@ def get_cosmos3_post_process_func(od_config: OmniDiffusionConfig):
             fps_value = 24.0
         return int(fps_value) if fps_value.is_integer() else fps_value
 
+    def _postprocess_video_tensor(video: torch.Tensor) -> torch.Tensor:
+        # Keep the decoded video on a fast tensor path through serving and
+        # only normalize in-place before MP4 encoding.
+        return video.mul_(0.5).add_(0.5).clamp_(0, 1)
+
     def post_process_func(
         output: torch.Tensor | dict[str, torch.Tensor] | tuple,
         output_type: str = "np",
@@ -569,9 +574,16 @@ def get_cosmos3_post_process_func(od_config: OmniDiffusionConfig):
                 checked = check_video_safety(image.unsqueeze(2))
                 image = checked.squeeze(2)
             return video_processor.postprocess(image, output_type="pil")
-        if is_guardrails_enabled(od_config, sampling_params):
+        guardrails_enabled = is_guardrails_enabled(od_config, sampling_params)
+        if guardrails_enabled:
             video = check_video_safety(video)
-        processed_video = video_processor.postprocess_video(video, output_type=output_type)
+            processed_video = video_processor.postprocess_video(video, output_type=output_type)
+        elif output_type in ("np", "pt"):
+            # Preserve the serving fast path: avoid Diffusers frame/list
+            # materialization and leave final uint8 conversion to the encoder.
+            processed_video = _postprocess_video_tensor(video)
+        else:
+            processed_video = video_processor.postprocess_video(video, output_type=output_type)
         if audio is None:
             return processed_video
         if isinstance(audio, torch.Tensor):

--- a/vllm_omni/entrypoints/openai/video_api_utils.py
+++ b/vllm_omni/entrypoints/openai/video_api_utils.py
@@ -303,19 +303,56 @@ async def decode_input_reference(
     return None
 
 
-def _normalize_video_tensor(video_tensor: torch.Tensor) -> np.ndarray:
-    """Normalize a torch video tensor into a numpy array of frames (F, H, W, C)."""
-    video_tensor = video_tensor.detach().cpu()
+def _prepare_video_tensor_for_encoding(video_tensor: torch.Tensor) -> torch.Tensor:
+    """Return a single video tensor in frame-major channel-last layout."""
+    video_tensor = video_tensor.detach()
     if video_tensor.dim() == 5:
-        raise ValueError("Batched video tensors are not supported for single-video encoding.")
-    elif video_tensor.dim() == 4 and video_tensor.shape[0] in (3, 4):
+        if video_tensor.shape[0] != 1:
+            raise ValueError("Batched video tensors are not supported for single-video encoding.")
+        video_tensor = video_tensor[0]
+    if video_tensor.dim() == 4 and video_tensor.shape[0] in (3, 4) and video_tensor.shape[-1] not in (3, 4):
         # [C, F, H, W] -> [F, H, W, C]
         video_tensor = video_tensor.permute(1, 2, 3, 0)
+    elif video_tensor.dim() == 4 and video_tensor.shape[1] in (3, 4) and video_tensor.shape[-1] not in (3, 4):
+        # [F, C, H, W] -> [F, H, W, C]
+        video_tensor = video_tensor.permute(0, 2, 3, 1)
+    return video_tensor
 
+
+def _video_tensor_to_uint8_frames(video_tensor: torch.Tensor) -> np.ndarray:
+    """Convert a single video tensor directly to contiguous uint8 frames."""
+    # Keep tensor payloads off the generic frame-list path; do one contiguous
+    # CPU transfer after layout normalization and uint8 conversion.
+    video_tensor = _prepare_video_tensor_for_encoding(video_tensor)
+    if video_tensor.dim() != 4:
+        raise ValueError(f"Unsupported video tensor shape: {tuple(video_tensor.shape)}")
+    if video_tensor.shape[-1] == 4:
+        video_tensor = video_tensor[..., :3]
+    if video_tensor.dtype == torch.uint8:
+        frames = video_tensor.contiguous().cpu().numpy()
+        return np.ascontiguousarray(frames)
+    if video_tensor.is_floating_point():
+        video_tensor = video_tensor.float()
+        # Preserve the legacy behavior for raw model tensors in [-1, 1], while
+        # keeping already-postprocessed tensors in [0, 1] on the fast path.
+        if video_tensor.min().item() < 0.0 or video_tensor.max().item() > 1.0:
+            video_tensor = video_tensor.clamp(-1.0, 1.0).mul(0.5).add(0.5)
+        else:
+            video_tensor = video_tensor.clamp(0.0, 1.0)
+        video_tensor = video_tensor.mul(255.0).round().to(torch.uint8)
+    else:
+        video_tensor = video_tensor.to(torch.float32).div(255.0).clamp(0.0, 1.0).mul(255.0).round().to(torch.uint8)
+    frames = video_tensor.contiguous().cpu().numpy()
+    return np.ascontiguousarray(frames)
+
+
+def _normalize_video_tensor(video_tensor: torch.Tensor) -> np.ndarray:
+    """Normalize a torch video tensor into a numpy array of frames (F, H, W, C)."""
+    video_tensor = _prepare_video_tensor_for_encoding(video_tensor).cpu()
     if video_tensor.is_floating_point():
         # Cast to float32 first: bf16 (e.g. SANA-WM's refiner output) has no
         # numpy dtype, so ``.numpy()`` below raises on it.
-        video_tensor = video_tensor.float().clamp(-1, 1) * 0.5 + 0.5
+        video_tensor = video_tensor.float()
     else:
         video_tensor = video_tensor.to(torch.float32) / 255.0
     video_array = video_tensor.numpy()
@@ -425,6 +462,25 @@ def _coerce_audio_to_numpy(audio: Any) -> np.ndarray:
 
 def _coerce_video_to_uint8_frames(video: Any) -> np.ndarray:
     """Convert a video payload into contiguous uint8 frames shaped (F, H, W, 3)."""
+    if isinstance(video, torch.Tensor):
+        return _video_tensor_to_uint8_frames(video)
+
+    if isinstance(video, np.ndarray) and video.ndim in (4, 5):
+        video_array = _normalize_video_array(video)
+        if isinstance(video_array, list):
+            if len(video_array) != 1:
+                raise ValueError("Batched video arrays must be split before encoding.")
+            video_array = video_array[0]
+        if video_array.ndim == 3:
+            video_array = video_array[None, ...]
+        if video_array.shape[-1] == 4:
+            video_array = video_array[..., :3]
+        if video_array.dtype == np.uint8:
+            frames_u8 = video_array
+        else:
+            frames_u8 = np.round(np.clip(video_array, 0.0, 1.0) * 255.0).astype(np.uint8)
+        return np.ascontiguousarray(frames_u8)
+
     frames = _coerce_video_to_frames(video)
     if not frames:
         raise ValueError("No frames found to encode.")

--- a/vllm_omni/entrypoints/openai/video_api_utils.py
+++ b/vllm_omni/entrypoints/openai/video_api_utils.py
@@ -322,27 +322,46 @@ def _prepare_video_tensor_for_encoding(video_tensor: torch.Tensor) -> torch.Tens
 def _video_tensor_to_uint8_frames(video_tensor: torch.Tensor) -> np.ndarray:
     """Convert a single video tensor directly to contiguous uint8 frames."""
     # Keep tensor payloads off the generic frame-list path; do one contiguous
-    # CPU transfer after layout normalization and uint8 conversion.
+    # frame-major conversion without materializing a Python list of frames.
     video_tensor = _prepare_video_tensor_for_encoding(video_tensor)
     if video_tensor.dim() != 4:
         raise ValueError(f"Unsupported video tensor shape: {tuple(video_tensor.shape)}")
     if video_tensor.shape[-1] == 4:
         video_tensor = video_tensor[..., :3]
-    if video_tensor.dtype == torch.uint8:
-        frames = video_tensor.contiguous().cpu().numpy()
-        return np.ascontiguousarray(frames)
-    if video_tensor.is_floating_point():
+
+    if video_tensor.dtype == torch.bfloat16:
         video_tensor = video_tensor.float()
+
+    video_array = video_tensor.cpu().numpy()
+    return _video_array_to_uint8_frames(video_array)
+
+
+def _video_array_to_uint8_frames(
+    video_array: np.ndarray,
+) -> np.ndarray:
+    """Convert one channel-last video array to contiguous uint8 frames."""
+    if video_array.ndim == 3:
+        video_array = video_array[None, ...]
+    if video_array.ndim != 4:
+        raise ValueError(f"Unsupported video array shape: {video_array.shape}")
+    if video_array.shape[-1] == 4:
+        video_array = video_array[..., :3]
+
+    if video_array.dtype == np.uint8:
+        frames = video_array
+    elif np.issubdtype(video_array.dtype, np.floating):
         # Preserve the legacy behavior for raw model tensors in [-1, 1], while
         # keeping already-postprocessed tensors in [0, 1] on the fast path.
-        if video_tensor.min().item() < 0.0 or video_tensor.max().item() > 1.0:
-            video_tensor = video_tensor.clamp(-1.0, 1.0).mul(0.5).add(0.5)
+        if video_array.min() < 0.0 or video_array.max() > 1.0:
+            video_array = np.clip(video_array, -1.0, 1.0) * 0.5 + 0.5
         else:
-            video_tensor = video_tensor.clamp(0.0, 1.0)
-        video_tensor = video_tensor.mul(255.0).round().to(torch.uint8)
+            video_array = np.clip(video_array, 0.0, 1.0)
+        frames = np.round(video_array * 255.0).astype(np.uint8)
+    elif np.issubdtype(video_array.dtype, np.integer):
+        frames = np.round(np.clip(video_array, 0, 255)).astype(np.uint8)
     else:
-        video_tensor = video_tensor.to(torch.float32).div(255.0).clamp(0.0, 1.0).mul(255.0).round().to(torch.uint8)
-    frames = video_tensor.contiguous().cpu().numpy()
+        frames = np.round(np.clip(video_array.astype(np.float32), 0.0, 1.0) * 255.0).astype(np.uint8)
+
     return np.ascontiguousarray(frames)
 
 
@@ -471,15 +490,7 @@ def _coerce_video_to_uint8_frames(video: Any) -> np.ndarray:
             if len(video_array) != 1:
                 raise ValueError("Batched video arrays must be split before encoding.")
             video_array = video_array[0]
-        if video_array.ndim == 3:
-            video_array = video_array[None, ...]
-        if video_array.shape[-1] == 4:
-            video_array = video_array[..., :3]
-        if video_array.dtype == np.uint8:
-            frames_u8 = video_array
-        else:
-            frames_u8 = np.round(np.clip(video_array, 0.0, 1.0) * 255.0).astype(np.uint8)
-        return np.ascontiguousarray(frames_u8)
+        return _video_array_to_uint8_frames(video_array)
 
     frames = _coerce_video_to_frames(video)
     if not frames:


### PR DESCRIPTION
## Summary

Optimize Cosmos3 video postprocessing by keeping decoded video tensors on the tensor fast path and converting directly to contiguous uint8 frames for MP4 encoding.


## Approach

The optimization keeps Cosmos3 decoded video on a tensor fast path through serving. Instead of materializing frame lists or running the generic Diffusers video postprocess for the normal no-guardrails video path, the pipeline normalizes the decoded tensor in place to `[0, 1]`. The OpenAI video API then converts tensor payloads directly to contiguous uint8 `[F, H, W, C]` frames immediately before MP4 encoding. This removes redundant tensor/NumPy/list layout conversions while preserving the same encoded video bytes.

## Final Benchmark

Common setup: `nvidia/Cosmos3-Nano`, i2v, 1280x720, 189 frames, 35 steps, seed 1111, CFG parallel 2, Ulysses degree 2, VAE patch parallel 4, `--vae-parallel-mode spatial_shard_width`, CUDNN attention, async `POST /v1/videos -> poll status -> GET content` API path.

| Run | Head | API wall | Inference time | stage_0_gen | MP4/output path log | Peak memory | Output SHA | Generated video |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
| upstream baseline | `327e9dca` | 31.7704s | 30.7149s | 28.7163s | 1.9110s | 38850 MB | `b9f05576...` | Binary-identical to this PR video |
| this PR | `7ad33dda` | 30.9786s | 29.9101s | 28.2073s | 1.6310s | 38652 MB | `b9f05576...` | [MP4](https://github.com/david6666666/vllm-omni/releases/download/pr4615-cosmos3-video/cosmos3_pr4615_measured_steps35.mp4) |
| reference stack | `28b095c0` | 30.3376s | 26.5337s | n/a | n/a | 37840 MB | `2b891f3e...` | n/a |

This PR improves the upstream baseline by **0.7918s API wall** on the measured 35-step request. The generated PR video is lossless vs the upstream baseline for this request: both MP4 files have the same size and the same SHA (`b9f0557639a64528551ce6a763c92841b7892037f6ebc12b6069f6c52fd4db56`), and `cmp` reports them as binary-identical.

## vLLM Test Commands

Server:

```bash
cd /path/to/vllm-omni
export CUDA_VISIBLE_DEVICES=4,5,6,7
export PYTHONPATH=$PWD:${PYTHONPATH:-}
export VLLM_WORKER_MULTIPROC_METHOD=spawn
export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
export VLLM_OMNI_SERVER_STORAGE__PATH=/tmp/cosmos3-vllm-storage

/home/zjy/code/david/.venv/bin/python -m vllm_omni.entrypoints.cli.main serve \
  nvidia/Cosmos3-Nano \
  --omni \
  --host 127.0.0.1 \
  --port 8171 \
  --init-timeout 1800 \
  --stage-init-timeout 1800 \
  --model-class-name Cosmos3OmniDiffusersPipeline \
  --no-guardrails \
  --enable-diffusion-pipeline-profiler \
  --diffusion-attention-backend CUDNN_ATTN \
  --cfg-parallel-size 2 \
  --ulysses-degree 2 \
  --vae-patch-parallel-size 4 \
  --vae-parallel-mode spatial_shard_width
```

Request:

```bash
PORT=8171
MODEL=nvidia/Cosmos3-Nano
REF_IMAGE=/home/zjy/.cache/huggingface/hub/models--benjiaiplayground--Cosmos3-Nano_fp8/snapshots/ee4be0843a7817e4f3840e5da91ec4afca55f75d/assets/example_i2v_input.jpg

curl -sS -D create.headers.txt -o create.json \
  -X POST "http://127.0.0.1:${PORT}/v1/videos" \
  -H "Authorization: Bearer EMPTY" \
  -F "model=${MODEL}" \
  -F "prompt=The scene comes to life with smooth, natural motion." \
  -F "negative_prompt=blurry, distorted, low quality" \
  -F "size=1280x720" \
  -F "width=1280" \
  -F "height=720" \
  -F "num_frames=189" \
  -F "fps=24" \
  -F "num_inference_steps=35" \
  -F "guidance_scale=6.0" \
  -F "max_sequence_length=4096" \
  -F "flow_shift=10.0" \
  -F 'extra_params={"max_sequence_length":4096,"use_resolution_template":false,"use_duration_template":false,"guardrails":false,"flow_shift":10.0}' \
  -F "seed=1111" \
  -F "input_reference=@${REF_IMAGE};type=image/jpeg"

ID=$(jq -r '.id' create.json)
for _ in $(seq 1 900); do
  curl -sS -D status.headers.txt -o status.json \
    "http://127.0.0.1:${PORT}/v1/videos/${ID}" \
    -H "Authorization: Bearer EMPTY"
  STATUS=$(jq -r '.status' status.json)
  [ "$STATUS" = "completed" ] && break
  [ "$STATUS" = "failed" ] && cat status.json && exit 1
  sleep 1
done

curl -sS -D content.headers.txt -o measured_steps35.mp4 \
  "http://127.0.0.1:${PORT}/v1/videos/${ID}/content" \
  -H "Authorization: Bearer EMPTY"
sha256sum measured_steps35.mp4
```

## Validation

```bash
python -m py_compile \
  vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py \
  vllm_omni/entrypoints/openai/video_api_utils.py

pytest tests/diffusion/models/cosmos3/test_cosmos3_pipeline.py \
  -k 'postprocess_handles_image_video_audio_and_validation or i2v_encodes_only_conditioning_frame or prepare_latents_for_video_image_sound_and_action' -q

pytest tests/entrypoints/openai_api/test_video_api_utils.py -q

git diff --check refs/remotes/upstream/main...HEAD
```
