### PR TITLE
[DiT] Pipeline Parallelism for HunyuanImage-3.0 DiT-only (+ grouped step path)

### DIFF
--- a/tests/diffusion/distributed/test_hunyuan_image3_pipeline_parallel.py
+++ b/tests/diffusion/distributed/test_hunyuan_image3_pipeline_parallel.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the HunyuanImage3 DiT-only Pipeline-Parallelism wiring.
+
+The generic ``PipelineParallelMixin`` plumbing (async send/recv, the diffuse /
+predict_noise / scheduler_step wrappers) is covered by
+``test_pipeline_parallel.py``. This file covers the *HunyuanImage3-specific*
+logic added on top of it, which that generic test does not exercise:
+
+* the two ``HunyuanImage3Model.forward`` PP guards (PP+SP unsupported; non-first
+  stage requires ``intermediate_tensors``),
+* ``HunyuanImage3Pipeline._owned_layers`` and the per-layer KV-state helpers,
+  which key state by *global* layer index so it stays consistent when pipeline
+  parallelism leaves only a layer subset on each rank,
+* the ``_pad_tensor_rows`` step-batch row merge.
+
+The per-layer numeric forward across stages needs the real ~158 GB checkpoint
+and is covered by the end-to-end / pixel-accuracy suites, not here.
+"""
+
+import os
+import socket
+import types
+
+import pytest
+import torch
+from vllm.model_executor.models.utils import PPMissingLayer, make_layers
+
+import vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer as hi3_transformer
+from vllm_omni.diffusion.distributed.parallel_state import (
+    destroy_distributed_env,
+    initialize_model_parallel,
+)
+from vllm_omni.diffusion.models.hunyuan_image3.hunyuan_image3_transformer import (
+    HunyuanImage3Model,
+)
+from vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 import (
+    _STEP_AR_KV,
+    _STEP_PROMPT_KV,
+    HunyuanImage3Pipeline,
+)
+from vllm_omni.platforms import current_omni_platform
+
+
+def _find_free_port() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return str(s.getsockname()[1])
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeKVManager:
+    """Stand-in for ``layer.self_attn.image_attn`` holding only the KV state
+    the pipeline's PP helpers read and write."""
+
+    def __init__(self):
+        self._injected_ar_kv = None
+        self.image_kv_cache_map = None
+        self.image_kv_cache_lens = None
+
+
+class _FakeAttn:
+    def __init__(self):
+        self.image_attn = _FakeKVManager()
+
+
+class _FakeDecoderLayer(torch.nn.Module):
+    """Minimal decoder layer exposing ``self_attn.image_attn`` so that
+    ``_owned_layers`` treats it as a real (non-placeholder) layer.
+
+    An ``nn.Module`` so it can be partitioned by ``make_layers`` (which returns
+    an ``nn.ModuleList``); ``PPMissingLayer`` stands in for layers owned by
+    other stages and is skipped because it has no ``self_attn``.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.self_attn = _FakeAttn()
+
+
+class _KVHarness:
+    """Borrows the real HunyuanImage3Pipeline PP helper methods onto a light
+    object whose only state is ``self.model.layers``.
+
+    Subclassing the real pipeline would drag in ``nn.Module``/PreTrainedModel
+    initialisation; the helpers only touch ``self.model.layers`` (via
+    ``_owned_layers``) and ``self._pad_tensor_rows``, so binding the unbound
+    methods here exercises the real code without that machinery.
+    """
+
+    _owned_layers = HunyuanImage3Pipeline._owned_layers
+    _snapshot_injected_ar_kv = HunyuanImage3Pipeline._snapshot_injected_ar_kv
+    _restore_injected_ar_kv = HunyuanImage3Pipeline._restore_injected_ar_kv
+    _accumulate_prompt_kv_cache = HunyuanImage3Pipeline._accumulate_prompt_kv_cache
+    _finalize_prompt_kv_cache = HunyuanImage3Pipeline._finalize_prompt_kv_cache
+    _capture_prompt_kv_cache = HunyuanImage3Pipeline._capture_prompt_kv_cache
+    _restore_prompt_kv_cache = HunyuanImage3Pipeline._restore_prompt_kv_cache
+    _prompt_kv_prefix_lens = HunyuanImage3Pipeline._prompt_kv_prefix_lens
+    # staticmethods: re-wrap so `self._pad_tensor_rows(rows)` does not bind self.
+    _pad_tensor_rows = staticmethod(HunyuanImage3Pipeline._pad_tensor_rows)
+
+    def __init__(self, layers):
+        self.model = types.SimpleNamespace(layers=layers)
+
+
+def _make_state(step_index: int):
+    """Minimal DiffusionRequestState stand-in: the KV helpers only read
+    ``.step_index``, ``.request_id`` and the ``.extra`` dict."""
+    return types.SimpleNamespace(step_index=step_index, request_id="req-0", extra={})
+
+
+# ===========================================================================
+# 1. HunyuanImage3Model.forward PP guards
+# ===========================================================================
+
+
+@pytest.mark.cpu
+class TestForwardPPGuards:
+    @staticmethod
+    def _stub_model():
+        config = types.SimpleNamespace(
+            output_attentions=False,
+            output_hidden_states=False,
+            use_cache=False,
+            use_return_dict=True,
+        )
+        return types.SimpleNamespace(config=config)
+
+    def test_pp_with_sp_raises_not_implemented(self, monkeypatch):
+        monkeypatch.setattr(hi3_transformer, "get_pipeline_parallel_world_size", lambda: 2)
+        monkeypatch.setattr(hi3_transformer, "get_sequence_parallel_world_size", lambda: 2)
+
+        with pytest.raises(NotImplementedError, match="pipeline parallelism with sequence parallelism"):
+            HunyuanImage3Model.forward(self._stub_model())
+
+    def test_non_first_stage_requires_intermediate_tensors(self, monkeypatch):
+        monkeypatch.setattr(hi3_transformer, "get_pipeline_parallel_world_size", lambda: 2)
+        monkeypatch.setattr(hi3_transformer, "get_sequence_parallel_world_size", lambda: 1)
+        monkeypatch.setattr(hi3_transformer, "is_pipeline_first_stage", lambda: False)
+
+        with pytest.raises(RuntimeError, match="intermediate_tensors must be provided"):
+            HunyuanImage3Model.forward(self._stub_model(), intermediate_tensors=None)
+
+
+# ===========================================================================
+# 2. _owned_layers: skip placeholders, key by global layer index
+# ===========================================================================
+
+
+@pytest.mark.cpu
+class TestOwnedLayers:
+    def test_skips_placeholders_and_yields_global_indices(self):
+        # Global layers 0..3; this "rank" owns 1 and 2, others are placeholders.
+        layers = [PPMissingLayer(), _FakeDecoderLayer(), _FakeDecoderLayer(), PPMissingLayer()]
+        harness = _KVHarness(layers)
+
+        owned = list(harness._owned_layers())
+        assert owned == [layers[1], layers[2]]
+
+        indexed = list(harness._owned_layers(with_index=True))
+        assert [idx for idx, _ in indexed] == [1, 2], "indices must be global, not 0-based within the owned subset"
+        assert [layer for _, layer in indexed] == [layers[1], layers[2]]
+
+
+# ===========================================================================
+# 3. AR-KV snapshot/restore — global-index keying round trip (CPU)
+# ===========================================================================
+
+
+@pytest.mark.cpu
+class TestArKvRoundTrip:
+    def test_snapshot_is_global_indexed_and_clears_source(self):
+        layers = [PPMissingLayer(), _FakeDecoderLayer(), _FakeDecoderLayer(), PPMissingLayer()]
+        # Distinct per-layer KV so a local-vs-global indexing bug is observable.
+        for gidx in (1, 2):
+            k = torch.full((1, 3), float(gidx))
+            v = torch.full((1, 3), float(gidx) + 0.5)
+            layers[gidx].self_attn.image_attn._injected_ar_kv = [(k, v)]
+        harness = _KVHarness(layers)
+
+        snapshot = harness._snapshot_injected_ar_kv()
+
+        assert snapshot is not None
+        assert len(snapshot) == 4
+        assert snapshot[0] is None and snapshot[3] is None, "placeholder stages contribute None"
+        assert snapshot[1] is not None and snapshot[2] is not None
+        torch.testing.assert_close(snapshot[1][0][0], torch.full((1, 3), 1.0))
+        torch.testing.assert_close(snapshot[2][0][0], torch.full((1, 3), 2.0))
+        # snapshotting detaches the manager's copy
+        for gidx in (1, 2):
+            assert layers[gidx].self_attn.image_attn._injected_ar_kv is None
+
+    def test_snapshot_returns_none_when_nothing_injected(self):
+        layers = [PPMissingLayer(), _FakeDecoderLayer(), PPMissingLayer()]
+        harness = _KVHarness(layers)
+        assert harness._snapshot_injected_ar_kv() is None
+
+    def test_restore_reads_state_by_global_index(self):
+        layers = [PPMissingLayer(), _FakeDecoderLayer(), _FakeDecoderLayer(), PPMissingLayer()]
+        for gidx in (1, 2):
+            k = torch.full((1, 3), float(gidx))
+            v = torch.full((1, 3), float(gidx) + 0.5)
+            layers[gidx].self_attn.image_attn._injected_ar_kv = [(k, v)]
+        harness = _KVHarness(layers)
+
+        state = _make_state(step_index=1)
+        state.extra[_STEP_AR_KV] = harness._snapshot_injected_ar_kv()
+
+        harness._restore_injected_ar_kv([state], row_state_indexes=[0], row_branches=[0])
+
+        # Each owned layer gets back exactly its own (global-indexed) KV.
+        torch.testing.assert_close(layers[1].self_attn.image_attn._injected_ar_kv[0][0], torch.full((1, 3), 1.0))
+        torch.testing.assert_close(layers[2].self_attn.image_attn._injected_ar_kv[0][0], torch.full((1, 3), 2.0))
+
+
+# ===========================================================================
+# 4. _pad_tensor_rows: step-batch row merge
+# ===========================================================================
+
+
+@pytest.mark.cpu
+class TestPadTensorRows:
+    def test_equal_shapes_concatenate(self):
+        rows = [torch.ones(1, 2, 3), torch.full((1, 2, 3), 2.0)]
+        out = HunyuanImage3Pipeline._pad_tensor_rows(rows)
+        assert out.shape == (2, 2, 3)
+        torch.testing.assert_close(out[0], torch.ones(2, 3))
+        torch.testing.assert_close(out[1], torch.full((2, 3), 2.0))
+
+    def test_ragged_rows_are_zero_padded_to_max(self):
+        rows = [torch.ones(1, 2, 4), torch.ones(1, 5, 4)]  # differ on dim 1
+        out = HunyuanImage3Pipeline._pad_tensor_rows(rows)
+        assert out.shape == (2, 5, 4)
+        # original content preserved
+        torch.testing.assert_close(out[0, :2], torch.ones(2, 4))
+        torch.testing.assert_close(out[1, :5], torch.ones(5, 4))
+        # padding region is zero
+        torch.testing.assert_close(out[0, 2:], torch.zeros(3, 4))
+
+    def test_empty_rows_raise(self):
+        with pytest.raises(ValueError, match="empty"):
+            HunyuanImage3Pipeline._pad_tensor_rows([])
+
+
+# ===========================================================================
+# 5. GPU / distributed: global-index keying under a real make_layers partition
+# ===========================================================================
+
+
+def _partition_kv_worker(local_rank, world_size, master_port, pp_size, num_layers, result_queue):
+    """On each PP rank, build the layer list via the real ``make_layers``
+    partition and check that both KV families key state by global layer index."""
+    os.environ.update(
+        {
+            "RANK": str(local_rank),
+            "LOCAL_RANK": str(local_rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": master_port,
+        }
+    )
+    device = torch.device(f"{current_omni_platform.device_type}:{local_rank}")
+    current_omni_platform.set_device(device)
+    from vllm_omni.diffusion.distributed.parallel_state import init_distributed_environment
+
+    init_distributed_environment()
+    initialize_model_parallel(pipeline_parallel_size=pp_size)
+
+    start_layer, end_layer, layers = make_layers(
+        num_layers,
+        lambda prefix: _FakeDecoderLayer(),
+        prefix="layers",
+    )
+    harness = _KVHarness(layers)
+
+    owned = [idx for idx, _ in harness._owned_layers(with_index=True)]
+
+    # AR-KV: snapshot must place non-None entries exactly at this rank's owned
+    # global indices.
+    for gidx, layer in harness._owned_layers(with_index=True):
+        k = torch.full((1, 2), float(gidx), device=device)
+        layer.self_attn.image_attn._injected_ar_kv = [(k, k.clone())]
+    ar_snapshot = harness._snapshot_injected_ar_kv()
+    ar_nonnull = [i for i, s in enumerate(ar_snapshot) if s is not None]
+
+    # Prompt-KV: capture must key the per-state cache dict by global index too.
+    for _, layer in harness._owned_layers(with_index=True):
+        mgr = layer.self_attn.image_attn
+        mgr.image_kv_cache_map = (torch.ones(1, 2, device=device), torch.ones(1, 2, device=device))
+        mgr.image_kv_cache_lens = torch.tensor([2], device=device)
+    state = _make_state(step_index=1)
+    harness._capture_prompt_kv_cache([state], row_state_indexes=[0], row_branches=[0])
+    prompt_keys = sorted(state.extra[_STEP_PROMPT_KV].keys())
+
+    result_queue.put(
+        {
+            "rank": local_rank,
+            "start": start_layer,
+            "end": end_layer,
+            "owned": owned,
+            "ar_nonnull": ar_nonnull,
+            "prompt_keys": prompt_keys,
+            "ar_len": len(ar_snapshot),
+        }
+    )
+
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+    destroy_distributed_env()
+
+
+@pytest.mark.gpu
+@pytest.mark.parallel
+@pytest.mark.parametrize(
+    "pp_size, num_layers",
+    [
+        pytest.param(
+            2,
+            4,
+            marks=pytest.mark.skipif(current_omni_platform.get_device_count() < 2, reason="Need at least 2 GPUs"),
+            id="pp2-4layers",
+        ),
+        pytest.param(
+            3,
+            6,
+            marks=pytest.mark.skipif(current_omni_platform.get_device_count() < 3, reason="Need at least 3 GPUs"),
+            id="pp3-6layers",
+        ),
+    ],
+)
+def test_kv_helpers_key_by_global_index_under_real_partition(pp_size, num_layers):
+    """Under a real ``make_layers`` PP partition, every rank's owned layers are
+    its contiguous global slice ``[start, end)``, and both the AR-KV snapshot and
+    the prompt-KV capture key their per-layer state by that global index — so
+    the partition is reconstructed identically across stages."""
+    mp_context = torch.multiprocessing.get_context("spawn")
+    manager = mp_context.Manager()
+    q = manager.Queue()
+
+    port = _find_free_port()
+    torch.multiprocessing.spawn(
+        _partition_kv_worker,
+        args=(pp_size, port, pp_size, num_layers, q),
+        nprocs=pp_size,
+    )
+
+    results = [q.get() for _ in range(pp_size)]
+    seen_indices: list[int] = []
+    for r in results:
+        expected = list(range(r["start"], r["end"]))
+        assert r["owned"] == expected, f"rank {r['rank']} owned {r['owned']} != global slice {expected}"
+        assert r["ar_nonnull"] == expected, f"rank {r['rank']} AR-KV snapshot not keyed by global index"
+        assert r["prompt_keys"] == expected, f"rank {r['rank']} prompt-KV cache not keyed by global index"
+        assert r["ar_len"] == num_layers, "AR-KV snapshot must span all global layers"
+        seen_indices.extend(r["owned"])
+
+    # The ranks together cover every global layer exactly once.
+    assert sorted(seen_indices) == list(range(num_layers))

--- a/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py
+++ b/tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py
@@ -25,6 +25,27 @@ from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
 
+@pytest.fixture(autouse=True)
+def _single_rank_pp_group(monkeypatch):
+    """Stub a single-rank pipeline-parallel group.
+
+    The grouped denoise / scheduler paths call ``get_pp_group()`` (and
+    ``get_pipeline_parallel_world_size()``) since the DiT pipeline-parallel
+    wiring landed. These are CPU logic tests for grouping/merge/scheduler
+    behavior at pipeline-parallel size 1, not distributed-comm tests, so stub a
+    single-rank group (first == last rank) rather than standing up a real
+    process group.
+    """
+
+    class _SingleRankPPGroup:
+        is_first_rank = True
+        is_last_rank = True
+        world_size = 1
+
+    monkeypatch.setattr(hy3_module, "get_pp_group", lambda: _SingleRankPPGroup())
+    monkeypatch.setattr(hy3_module, "get_pipeline_parallel_world_size", lambda: 1)
+
+
 def _pipeline():
     pipeline = object.__new__(HunyuanImage3Pipeline)
     pipeline._tkwrapper = SimpleNamespace(pad_token_id=0)
@@ -235,8 +256,8 @@ def test_later_step_merge_shifts_spans_without_polluting_request_state():
             "full_attn_spans": [[(4, 7)]],
         }
     )
-    states[0].extra[_STEP_PROMPT_KV] = [{"lens": torch.tensor([2])}]
-    states[1].extra[_STEP_PROMPT_KV] = [{"lens": torch.tensor([4])}]
+    states[0].extra[_STEP_PROMPT_KV] = {0: {"lens": torch.tensor([2])}}
+    states[1].extra[_STEP_PROMPT_KV] = {0: {"lens": torch.tensor([4])}}
 
     row_state_indexes = [0, 1]
     row_branches = [0, 0]
@@ -270,7 +291,7 @@ def test_later_step_merge_allows_request_local_step_counts_and_guidance_values()
                 "num_inference_steps": 20 + idx,
             }
         )
-        state.extra[_STEP_PROMPT_KV] = [{"lens": torch.tensor([2])}]
+        state.extra[_STEP_PROMPT_KV] = {0: {"lens": torch.tensor([2])}}
 
     _, merged = pipeline._merge_step_model_inputs(
         states,
@@ -325,13 +346,13 @@ def test_denoise_step_uses_input_batch_group_order_and_splits_back(monkeypatch):
                 "full_attn_spans": [[(prefix_len, prefix_len + 2)], [(prefix_len, prefix_len + 2)]],
             }
         )
-        state.extra[_STEP_PROMPT_KV] = [
-            {
+        state.extra[_STEP_PROMPT_KV] = {
+            0: {
                 "key": torch.zeros(2, prefix_len, 1, 1),
                 "value": torch.zeros(2, prefix_len, 1, 1),
                 "lens": torch.tensor([prefix_len, prefix_len]),
             }
-        ]
+        }
 
     captured = {}
 
@@ -369,3 +390,385 @@ def test_denoise_step_uses_input_batch_group_order_and_splits_back(monkeypatch):
     assert states[1].extra[_STEP_MODEL_KWARGS]["attention_mask"].shape == (2, 1, 2, 6)
     assert states[0].extra[_STEP_MODEL_KWARGS]["full_attn_spans"] == [[(2, 4)], [(2, 4)]]
     assert states[1].extra[_STEP_MODEL_KWARGS]["full_attn_spans"] == [[(4, 6)], [(4, 6)]]
+
+
+def test_step_microbatch_plan_cfg_policy_splits_branches():
+    pipeline = _pipeline()
+    states = [_state("a", 1), _state("b", 1), _state("c", 1)]
+
+    plan = pipeline._step_microbatch_plan(states, cfg_factor=2, axes=frozenset({"cfg"}))
+    assert len(plan) == 2
+    cond, uncond = plan
+    assert cond.row_state_indexes == [0, 1, 2]
+    assert cond.row_branches == [0, 0, 0]
+    assert cond.global_rows == [0, 1, 2]
+    assert uncond.row_state_indexes == [0, 1, 2]
+    assert uncond.row_branches == [1, 1, 1]
+    assert uncond.global_rows == [3, 4, 5]
+
+    # Without a second branch there is nothing to split.
+    plan1 = pipeline._step_microbatch_plan(states, cfg_factor=1, axes=frozenset({"cfg"}))
+    assert len(plan1) == 1
+    assert plan1[0].row_branches == [0, 0, 0]
+    assert plan1[0].global_rows == [0, 1, 2]
+
+
+def test_denoise_step_cfg_policy_matches_cat_output(monkeypatch):
+    # The cfg policy runs two single-branch microbatches; the combined output and
+    # the next-step request state must match the single-forward cat path.
+    pipeline = _pipeline()
+    pipeline.od_config.parallel_config.microbatch_axes = ["cfg"]
+    monkeypatch.setattr(HunyuanImage3Pipeline, "device", property(lambda self: torch.device("cpu")))
+    states = [_state("req-0", 1), _state("req-1", 3)]
+    for idx, state in enumerate(states):
+        prefix_len = 2 + idx * 2
+        state.latents = torch.full((1, 1), float(idx))
+        state.extra[_STEP_CFG_FACTOR] = 2
+        state.extra[_STEP_GUIDANCE_SCALE] = 1.0
+        state.extra[_STEP_INPUT_IDS] = None
+        state.extra[_STEP_MODEL_KWARGS].update(
+            {
+                "attention_mask": torch.ones(2, 1, 2, prefix_len + 2, dtype=torch.bool),
+                "full_attn_spans": [[(prefix_len, prefix_len + 2)], [(prefix_len, prefix_len + 2)]],
+            }
+        )
+        state.extra[_STEP_PROMPT_KV] = {
+            0: {
+                "key": torch.zeros(2, prefix_len, 1, 1),
+                "value": torch.zeros(2, prefix_len, 1, 1),
+                "lens": torch.tensor([prefix_len, prefix_len]),
+            }
+        }
+
+    restore_calls = []
+
+    def fake_restore_prompt_kv_cache(states_arg, row_state_indexes, row_branches):
+        del states_arg
+        restore_calls.append((list(row_state_indexes), list(row_branches)))
+
+    pipeline._restore_prompt_kv_cache = fake_restore_prompt_kv_cache
+    pipeline.prepare_inputs_for_generation = lambda input_ids, images, timestep, **mk: {"model_kwargs": mk}
+    # Per-microbatch forward: branch 0 (cond) -> rows [10, 20]; branch 1 (uncond) -> rows [1, 2].
+    forward_returns = [torch.tensor([[10.0], [20.0]]), torch.tensor([[1.0], [2.0]])]
+    forward_call_index = {"i": 0}
+
+    def fake_forward(**kwargs):
+        out = forward_returns[forward_call_index["i"]]
+        forward_call_index["i"] += 1
+        return {"diffusion_prediction": out}
+
+    pipeline.forward_call = fake_forward
+    pipeline._update_model_kwargs_for_generation = lambda model_output, model_kwargs: model_kwargs
+    pipeline._pipeline = SimpleNamespace(cfg_operator=lambda cond, uncond, scale, step: cond + uncond)
+
+    out = pipeline.denoise_step(InputBatch.make_batch(states))
+
+    # Two single-branch microbatches, cond then uncond.
+    assert restore_calls == [([0, 1], [0, 0]), ([0, 1], [1, 1])]
+    assert forward_call_index["i"] == 2
+    # Reassembled + combined output equals the cat path's [[11], [22]].
+    torch.testing.assert_close(out, torch.tensor([[11.0], [22.0]]))
+    # Next-step split runs over the full batch -> same per-state shapes as the cat path.
+    assert states[0].extra[_STEP_MODEL_KWARGS]["attention_mask"].shape == (2, 1, 2, 4)
+    assert states[1].extra[_STEP_MODEL_KWARGS]["attention_mask"].shape == (2, 1, 2, 6)
+
+
+def test_prompt_kv_accumulation_matches_single_capture():
+    # Capturing both branches in one microbatch must equal capturing each branch
+    # in its own microbatch (the cfg policy), including joint re-padding when the
+    # branches have different prompt lengths.
+    pipeline = _pipeline()
+
+    def _fake_layers(kv_map, lens):
+        image_attn = SimpleNamespace(image_kv_cache_map=kv_map, image_kv_cache_lens=lens)
+        return [SimpleNamespace(self_attn=SimpleNamespace(image_attn=image_attn))]
+
+    key = torch.arange(2 * 3, dtype=torch.float32).reshape(2, 3, 1, 1)
+    key[0, 2:] = 0.0  # cond prompt length 2 (model zero-pads beyond each row's len)
+    value = key + 100.0
+    lens = torch.tensor([2, 3])  # cond len 2, uncond len 3
+
+    # Single full microbatch (both branches at once).
+    state_full = _state("s", 1)
+    pipeline.model = SimpleNamespace(layers=_fake_layers((key.clone(), value.clone()), lens.clone()))
+    pipeline._capture_prompt_kv_cache([state_full], row_state_indexes=[0, 0], row_branches=[0, 1])
+    full_cache = state_full.extra[_STEP_PROMPT_KV]
+
+    # Two microbatches: cond, then uncond (each overwrites the per-layer singleton).
+    state_cfg = _state("s", 1)
+    accumulator: dict = {}
+    pipeline.model = SimpleNamespace(layers=_fake_layers((key[0:1].clone(), value[0:1].clone()), lens[0:1].clone()))
+    pipeline._accumulate_prompt_kv_cache([state_cfg], [0], [0], accumulator)
+    pipeline.model = SimpleNamespace(layers=_fake_layers((key[1:2].clone(), value[1:2].clone()), lens[1:2].clone()))
+    pipeline._accumulate_prompt_kv_cache([state_cfg], [0], [1], accumulator)
+    pipeline._finalize_prompt_kv_cache([state_cfg], accumulator)
+    cfg_cache = state_cfg.extra[_STEP_PROMPT_KV]
+
+    assert full_cache.keys() == cfg_cache.keys()
+    for layer_idx in full_cache:
+        torch.testing.assert_close(full_cache[layer_idx]["key"], cfg_cache[layer_idx]["key"])
+        torch.testing.assert_close(full_cache[layer_idx]["value"], cfg_cache[layer_idx]["value"])
+        torch.testing.assert_close(full_cache[layer_idx]["lens"], cfg_cache[layer_idx]["lens"])
+
+
+def test_step_microbatch_plan_requests_axis_chunks_states():
+    pipeline = _pipeline()
+    states = [_state(str(i), 1) for i in range(4)]
+
+    # Default chunk size 1: one microbatch per request, carrying both branches.
+    plan = pipeline._step_microbatch_plan(states, cfg_factor=2, axes=frozenset({"requests"}))
+    assert len(plan) == 4
+    assert plan[0].row_state_indexes == [0, 0]
+    assert plan[0].row_branches == [0, 1]
+    assert plan[0].global_rows == [0, 4]  # N=4 -> cond pos 0, uncond pos 4
+    assert plan[1].global_rows == [1, 5]
+
+    # Chunk size 2: two microbatches, each two requests x both branches.
+    pipeline.od_config.parallel_config.microbatch_requests = 2
+    plan2 = pipeline._step_microbatch_plan(states, cfg_factor=2, axes=frozenset({"requests"}))
+    assert len(plan2) == 2
+    assert plan2[0].row_state_indexes == [0, 1, 0, 1]
+    assert plan2[0].row_branches == [0, 0, 1, 1]
+    assert plan2[0].global_rows == [0, 1, 4, 5]
+    assert plan2[1].row_state_indexes == [2, 3, 2, 3]
+    assert plan2[1].global_rows == [2, 3, 6, 7]
+
+    # No CFG: the requests split still chunks requests (single branch) -> fills the bubble.
+    plan3 = pipeline._step_microbatch_plan(states, cfg_factor=1, axes=frozenset({"requests"}))
+    assert len(plan3) == 2
+    assert plan3[0].row_state_indexes == [0, 1]
+    assert plan3[0].row_branches == [0, 0]
+    assert plan3[0].global_rows == [0, 1]
+
+
+def test_denoise_step_requests_axis_matches_cat_output(monkeypatch):
+    # The requests axis runs one microbatch per request (both branches); the
+    # combined output and next-step state must match the single-forward cat path.
+    pipeline = _pipeline()
+    pipeline.od_config.parallel_config.microbatch_axes = ["requests"]  # default chunk size 1
+    monkeypatch.setattr(HunyuanImage3Pipeline, "device", property(lambda self: torch.device("cpu")))
+    states = [_state("req-0", 1), _state("req-1", 3)]
+    for idx, state in enumerate(states):
+        prefix_len = 2 + idx * 2
+        state.latents = torch.full((1, 1), float(idx))
+        state.extra[_STEP_CFG_FACTOR] = 2
+        state.extra[_STEP_GUIDANCE_SCALE] = 1.0
+        state.extra[_STEP_INPUT_IDS] = None
+        state.extra[_STEP_MODEL_KWARGS].update(
+            {
+                "attention_mask": torch.ones(2, 1, 2, prefix_len + 2, dtype=torch.bool),
+                "full_attn_spans": [[(prefix_len, prefix_len + 2)], [(prefix_len, prefix_len + 2)]],
+            }
+        )
+        state.extra[_STEP_PROMPT_KV] = {
+            0: {
+                "key": torch.zeros(2, prefix_len, 1, 1),
+                "value": torch.zeros(2, prefix_len, 1, 1),
+                "lens": torch.tensor([prefix_len, prefix_len]),
+            }
+        }
+
+    restore_calls = []
+
+    def fake_restore_prompt_kv_cache(states_arg, row_state_indexes, row_branches):
+        del states_arg
+        restore_calls.append((list(row_state_indexes), list(row_branches)))
+
+    pipeline._restore_prompt_kv_cache = fake_restore_prompt_kv_cache
+    pipeline.prepare_inputs_for_generation = lambda input_ids, images, timestep, **mk: {"model_kwargs": mk}
+    # Per-microbatch forward (one request, both branches): req-0 -> [cond 10, uncond 1];
+    # req-1 -> [cond 20, uncond 2].
+    forward_returns = [torch.tensor([[10.0], [1.0]]), torch.tensor([[20.0], [2.0]])]
+    forward_call_index = {"i": 0}
+
+    def fake_forward(**kwargs):
+        out = forward_returns[forward_call_index["i"]]
+        forward_call_index["i"] += 1
+        return {"diffusion_prediction": out}
+
+    pipeline.forward_call = fake_forward
+    pipeline._update_model_kwargs_for_generation = lambda model_output, model_kwargs: model_kwargs
+    pipeline._pipeline = SimpleNamespace(cfg_operator=lambda cond, uncond, scale, step: cond + uncond)
+
+    out = pipeline.denoise_step(InputBatch.make_batch(states))
+
+    # One microbatch per request, each carrying both branches.
+    assert restore_calls == [([0, 0], [0, 1]), ([1, 1], [0, 1])]
+    assert forward_call_index["i"] == 2
+    # Reassembled + combined output equals the cat path's [[11], [22]].
+    torch.testing.assert_close(out, torch.tensor([[11.0], [22.0]]))
+    assert states[0].extra[_STEP_MODEL_KWARGS]["attention_mask"].shape == (2, 1, 2, 4)
+    assert states[1].extra[_STEP_MODEL_KWARGS]["attention_mask"].shape == (2, 1, 2, 6)
+
+
+def test_step_microbatch_plan_cfg_requests_2d_split():
+    pipeline = _pipeline()
+    states = [_state(str(i), 1) for i in range(3)]
+
+    # c=1, cfg=2: one microbatch per (request, branch) -> 3*2 = 6, deepest split.
+    plan = pipeline._step_microbatch_plan(states, cfg_factor=2, axes=frozenset({"cfg", "requests"}))
+    assert len(plan) == 6
+    # branch 0 chunks first, then branch 1 (N=3 -> uncond positions offset by 3)
+    assert [mb.row_state_indexes for mb in plan] == [[0], [1], [2], [0], [1], [2]]
+    assert [mb.row_branches for mb in plan] == [[0], [0], [0], [1], [1], [1]]
+    assert [mb.global_rows for mb in plan] == [[0], [1], [2], [3], [4], [5]]
+
+    # c=2, cfg=2: ceil(3/2)*2 = 4 microbatches.
+    pipeline.od_config.parallel_config.microbatch_requests = 2
+    plan2 = pipeline._step_microbatch_plan(states, cfg_factor=2, axes=frozenset({"cfg", "requests"}))
+    assert len(plan2) == 4
+    assert plan2[0].row_state_indexes == [0, 1]
+    assert plan2[0].row_branches == [0, 0]
+    assert plan2[0].global_rows == [0, 1]
+    assert plan2[2].row_state_indexes == [0, 1]  # branch 1 chunk 0
+    assert plan2[2].row_branches == [1, 1]
+    assert plan2[2].global_rows == [3, 4]
+
+    # CFG off -> reduces to the requests-only split.
+    plan3 = pipeline._step_microbatch_plan(states, cfg_factor=1, axes=frozenset({"cfg", "requests"}))
+    requests3 = pipeline._step_microbatch_plan(states, cfg_factor=1, axes=frozenset({"requests"}))
+    assert [mb.row_state_indexes for mb in plan3] == [mb.row_state_indexes for mb in requests3]
+    assert [mb.global_rows for mb in plan3] == [mb.global_rows for mb in requests3]
+
+
+def test_denoise_step_cfg_requests_matches_cat_output(monkeypatch):
+    # 2-D split (one microbatch per request per branch) must match the cat path.
+    pipeline = _pipeline()
+    pipeline.od_config.parallel_config.microbatch_axes = ["cfg", "requests"]  # default chunk size 1
+    monkeypatch.setattr(HunyuanImage3Pipeline, "device", property(lambda self: torch.device("cpu")))
+    states = [_state("req-0", 1), _state("req-1", 3)]
+    for idx, state in enumerate(states):
+        prefix_len = 2 + idx * 2
+        state.latents = torch.full((1, 1), float(idx))
+        state.extra[_STEP_CFG_FACTOR] = 2
+        state.extra[_STEP_GUIDANCE_SCALE] = 1.0
+        state.extra[_STEP_INPUT_IDS] = None
+        state.extra[_STEP_MODEL_KWARGS].update(
+            {
+                "attention_mask": torch.ones(2, 1, 2, prefix_len + 2, dtype=torch.bool),
+                "full_attn_spans": [[(prefix_len, prefix_len + 2)], [(prefix_len, prefix_len + 2)]],
+            }
+        )
+        state.extra[_STEP_PROMPT_KV] = {
+            0: {
+                "key": torch.zeros(2, prefix_len, 1, 1),
+                "value": torch.zeros(2, prefix_len, 1, 1),
+                "lens": torch.tensor([prefix_len, prefix_len]),
+            }
+        }
+
+    restore_calls = []
+
+    def fake_restore_prompt_kv_cache(states_arg, row_state_indexes, row_branches):
+        del states_arg
+        restore_calls.append((list(row_state_indexes), list(row_branches)))
+
+    pipeline._restore_prompt_kv_cache = fake_restore_prompt_kv_cache
+    pipeline.prepare_inputs_for_generation = lambda input_ids, images, timestep, **mk: {"model_kwargs": mk}
+    # 4 microbatches: (req0,cond)=10, (req1,cond)=20, (req0,uncond)=1, (req1,uncond)=2.
+    forward_returns = [torch.tensor([[10.0]]), torch.tensor([[20.0]]), torch.tensor([[1.0]]), torch.tensor([[2.0]])]
+    forward_call_index = {"i": 0}
+
+    def fake_forward(**kwargs):
+        out = forward_returns[forward_call_index["i"]]
+        forward_call_index["i"] += 1
+        return {"diffusion_prediction": out}
+
+    pipeline.forward_call = fake_forward
+    pipeline._update_model_kwargs_for_generation = lambda model_output, model_kwargs: model_kwargs
+    pipeline._pipeline = SimpleNamespace(cfg_operator=lambda cond, uncond, scale, step: cond + uncond)
+
+    out = pipeline.denoise_step(InputBatch.make_batch(states))
+
+    assert restore_calls == [([0], [0]), ([1], [0]), ([0], [1]), ([1], [1])]
+    assert forward_call_index["i"] == 4
+    torch.testing.assert_close(out, torch.tensor([[11.0], [22.0]]))
+    assert states[0].extra[_STEP_MODEL_KWARGS]["attention_mask"].shape == (2, 1, 2, 4)
+    assert states[1].extra[_STEP_MODEL_KWARGS]["attention_mask"].shape == (2, 1, 2, 6)
+
+
+def test_microbatch_axes_config_driven():
+    pipeline = _pipeline()
+    pc = pipeline.od_config.parallel_config
+
+    # No axes set -> empty split, default chunk size.
+    assert pipeline._selected_microbatch_axes(2) == frozenset()
+    assert pipeline._requests_microbatch_size() == 1
+
+    # The config list drives the active axes (and the request chunk size).
+    pc.microbatch_axes = ["requests"]
+    pc.microbatch_requests = 4
+    assert pipeline._selected_microbatch_axes(2) == frozenset({"requests"})
+    assert pipeline._requests_microbatch_size() == 4
+
+    # cfg drops out without a second branch.
+    pc.microbatch_axes = ["cfg"]
+    assert pipeline._selected_microbatch_axes(1) == frozenset()
+    assert pipeline._selected_microbatch_axes(2) == frozenset({"cfg"})
+
+    # Two-axis list, order-insensitive.
+    pc.microbatch_axes = ["cfg", "requests"]
+    assert pipeline._selected_microbatch_axes(2) == frozenset({"cfg", "requests"})
+    pc.microbatch_axes = ["requests", "cfg"]
+    assert pipeline._selected_microbatch_axes(2) == frozenset({"cfg", "requests"})
+    # With no second branch it collapses to the requests axis only.
+    assert pipeline._selected_microbatch_axes(1) == frozenset({"requests"})
+
+    # Empty list is the no-op.
+    pc.microbatch_axes = []
+    assert pipeline._selected_microbatch_axes(2) == frozenset()
+
+
+def test_microbatch_axes_config_validation():
+    """DiffusionParallelConfig accepts valid axis lists and rejects malformed ones."""
+    from pydantic import ValidationError
+
+    from vllm_omni.diffusion.data import DiffusionParallelConfig
+
+    # Valid: empty, single, and 2-axis (order-insensitive).
+    for policies in ([], ["cfg"], ["requests"], ["cfg", "requests"], ["requests", "cfg"]):
+        DiffusionParallelConfig(microbatch_axes=policies)
+
+    # Unknown axis rejected (only "cfg" / "requests" are valid).
+    for bad in (["foo"], ["bar"], ["cfg", "baz"]):
+        with pytest.raises(ValidationError):
+            DiffusionParallelConfig(microbatch_axes=bad)
+
+    # Duplicate axis rejected.
+    with pytest.raises(ValidationError):
+        DiffusionParallelConfig(microbatch_axes=["cfg", "cfg"])
+
+    # Bare scalar (not a list) rejected.
+    with pytest.raises(ValidationError):
+        DiffusionParallelConfig(microbatch_axes="cfg")
+
+    # microbatch_requests < 1 rejected.
+    with pytest.raises(ValidationError):
+        DiffusionParallelConfig(microbatch_requests=0)
+
+
+def test_validate_microbatch_axes_supported_axes():
+    """The runner load-time check rejects axes the pipeline does not implement."""
+    from vllm_omni.diffusion.worker.diffusion_model_runner import validate_microbatch_axes
+
+    def _cfg(policies, supported=frozenset({"cfg", "requests"})):
+        pipe = SimpleNamespace(supported_microbatch_axes=supported)
+        od = SimpleNamespace(
+            model_class_name="TestPipeline",
+            parallel_config=SimpleNamespace(microbatch_axes=list(policies)),
+        )
+        return pipe, od
+
+    # Supported subsets pass.
+    for policies in ([], ["cfg"], ["requests"], ["cfg", "requests"]):
+        validate_microbatch_axes(*_cfg(policies))
+
+    # A pipeline supporting only "cfg" rejects "requests".
+    with pytest.raises(ValueError):
+        validate_microbatch_axes(*_cfg(["requests"], supported=frozenset({"cfg"})))
+
+    # A pipeline declaring no axes rejects any non-empty policy.
+    pipe = SimpleNamespace()  # no supported_microbatch_axes attr
+    od = SimpleNamespace(model_class_name="NoAxes", parallel_config=SimpleNamespace(microbatch_axes=["cfg"]))
+    with pytest.raises(ValueError):
+        validate_microbatch_axes(pipe, od)

--- a/tests/diffusion/test_diffusion_model_runner.py
+++ b/tests/diffusion/test_diffusion_model_runner.py
@@ -10,7 +10,10 @@ import torch
 import vllm_omni.diffusion.worker.diffusion_model_runner as model_runner_module
 from tests.helpers.mark import hardware_test
 from vllm_omni.diffusion.data import DiffusionOutput
-from vllm_omni.diffusion.worker.diffusion_model_runner import DiffusionModelRunner
+from vllm_omni.diffusion.worker.diffusion_model_runner import (
+    DiffusionModelRunner,
+    validate_pp_step_execution,
+)
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch, split_diffusion_output_by_request
 
 pytestmark = [pytest.mark.diffusion]
@@ -699,3 +702,53 @@ def test_vllm_set_forward_context_implementation(monkeypatch):
             ),
         ),
     ], ERROR_MESSAGE
+
+
+class _PPGuardPipeline:
+    """Minimal pipeline carrying only the grouped-only PP contract flag."""
+
+    def __init__(self, requires_step_execution_for_pp):
+        self.requires_step_execution_for_pp = requires_step_execution_for_pp
+
+
+def _od_config(step_execution):
+    return SimpleNamespace(step_execution=step_execution, model_class_name="HunyuanImage3Pipeline")
+
+
+def test_validate_pp_step_execution_raises_for_grouped_only_pp_without_step_execution():
+    pipeline = _PPGuardPipeline(requires_step_execution_for_pp=True)
+    with pytest.raises(ValueError, match="step_execution=True"):
+        validate_pp_step_execution(pipeline, _od_config(step_execution=False), pp_world_size=2)
+
+
+def test_validate_pp_step_execution_allows_step_execution():
+    pipeline = _PPGuardPipeline(requires_step_execution_for_pp=True)
+    # step_execution=True satisfies the contract -> no raise.
+    validate_pp_step_execution(pipeline, _od_config(step_execution=True), pp_world_size=2)
+
+
+def test_validate_pp_step_execution_allows_single_pp_stage():
+    pipeline = _PPGuardPipeline(requires_step_execution_for_pp=True)
+    # pp_world_size == 1 -> guard is irrelevant -> no raise.
+    validate_pp_step_execution(pipeline, _od_config(step_execution=False), pp_world_size=1)
+
+
+def test_validate_pp_step_execution_ignores_pipelines_without_flag():
+    # A pipeline that wires PP into its monolithic path (flag False/absent) is unaffected.
+    validate_pp_step_execution(
+        _PPGuardPipeline(requires_step_execution_for_pp=False),
+        _od_config(step_execution=False),
+        pp_world_size=4,
+    )
+    validate_pp_step_execution(SimpleNamespace(), _od_config(step_execution=False), pp_world_size=4)
+
+
+def test_hunyuan_image3_pipeline_declares_grouped_only_pp_contract():
+    # HunyuanImage3 opts into the grouped-only PP contract via a duck-typed flag.
+    # (Pipelines that don't set it default to False through getattr in the guard,
+    # covered by test_validate_pp_step_execution_ignores_pipelines_without_flag.)
+    from vllm_omni.diffusion.models.hunyuan_image3.pipeline_hunyuan_image3 import (
+        HunyuanImage3Pipeline,
+    )
+
+    assert HunyuanImage3Pipeline.requires_step_execution_for_pp is True

--- a/vllm_omni/diffusion/data.py
+++ b/vllm_omni/diffusion/data.py
@@ -7,7 +7,7 @@ import random
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, fields
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 import diffusers
 import torch
@@ -138,6 +138,10 @@ def parse_kv_cache_skip_selector(
     return values
 
 
+# Valid microbatch axes (validated at runtime in __post_init__).
+MicrobatchAxis = Literal["cfg", "requests"]
+
+
 @config
 @dataclass
 class DiffusionParallelConfig:
@@ -180,6 +184,23 @@ class DiffusionParallelConfig:
 
     cfg_parallel_size: int = 1
     """Number of Classifier Free Guidance (CFG) parallel groups."""
+
+    microbatch_axes: list[MicrobatchAxis] = field(default_factory=list)
+    """Pipeline-parallel microbatching axes to enable.
+
+    Treated as a set (order-insensitive, no duplicates); empty (the default) disables
+    microbatching. Each pipeline declares which axes it implements via
+    ``supported_microbatch_axes`` and rejects the rest at load time -- see there for the
+    axes a given pipeline honors. Example axes: ``"cfg"`` (split the CFG branches),
+    ``"requests"`` (split request chunks of ``microbatch_requests``).
+    """
+
+    microbatch_requests: int = 1
+    """Requests per microbatch -- applies only when the "requests" axis is enabled.
+
+    Trades batch efficiency (larger -> fewer, fatter forwards) against pipeline fill
+    (smaller -> more microbatches; 1 = max pipelining). Ignored otherwise.
+    """
 
     vae_patch_parallel_size: int = 1
     """Number of ranks used for VAE patch/tile parallelism (decode/encode)."""
@@ -229,6 +250,17 @@ class DiffusionParallelConfig:
         assert self.cfg_parallel_size in [1, 2, 3], (
             f"CFG parallel size must be 1, 2, or 3, but got {self.cfg_parallel_size}"
         )
+        assert isinstance(self.microbatch_axes, list), (
+            "microbatch_axes must be a list of axes (e.g. [] or ['cfg', 'requests']), "
+            f"but got {type(self.microbatch_axes).__name__} {self.microbatch_axes!r}"
+        )
+        _valid_axes = get_args(MicrobatchAxis)
+        for _axis in self.microbatch_axes:
+            assert _axis in _valid_axes, f"microbatch_axes entries must each be one of {_valid_axes}, but got {_axis!r}"
+        assert len(set(self.microbatch_axes)) == len(self.microbatch_axes), (
+            f"microbatch_axes must not contain duplicate axes, but got {self.microbatch_axes!r}"
+        )
+        assert self.microbatch_requests >= 1, f"microbatch_requests must be >= 1, but got {self.microbatch_requests}"
         assert self.vae_patch_parallel_size > 0, "VAE patch parallel size must be > 0"
         assert self.vae_parallel_mode in {"tile", "spatial_shard_height", "spatial_shard_width"}, (
             "vae_parallel_mode must be one of {'tile', 'spatial_shard_height', 'spatial_shard_width'}, "

--- a/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/hunyuan_image3_transformer.py
@@ -52,8 +52,10 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.model_executor.models.utils import (
     PPMissingLayer,
     is_pp_missing_parameter,
+    make_empty_intermediate_tensors_factory,
     make_layers,
 )
+from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
 
 from vllm_omni.diffusion.attention.backends.abstract import (
@@ -65,9 +67,12 @@ from vllm_omni.diffusion.distributed.parallel_state import (
     get_cfg_group,
     get_classifier_free_guidance_rank,
     get_classifier_free_guidance_world_size,
+    get_pipeline_parallel_world_size,
     get_pp_group,
     get_sequence_parallel_rank,
     get_sequence_parallel_world_size,
+    is_pipeline_first_stage,
+    is_pipeline_last_stage,
 )
 from vllm_omni.diffusion.distributed.sp_plan import (
     SequenceParallelInput,
@@ -2081,6 +2086,11 @@ class HunyuanImage3Model(nn.Module):
         self.unifiled_cat = UnifiledCat()
         self.post_processor = HunyuanImagePostprocessor()
 
+        # Handoff between PP stages: factory for the receiving stage's empty hidden-state tensors.
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states"], config.hidden_size
+        )
+
     def _split_qkv_weight(self, qkv: torch.Tensor):
         num_attention_heads = self.config.num_attention_heads
         num_kv_heads = getattr(self.config, "num_key_value_heads", self.config.num_attention_heads)
@@ -2353,6 +2363,8 @@ class HunyuanImage3Model(nn.Module):
                     name = "norm.weight"
                 if name == "wte.weight":
                     name = "embed_tokens.weight"
+                if is_pp_missing_parameter(name, self) or name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
@@ -2385,7 +2397,8 @@ class HunyuanImage3Model(nn.Module):
         uncond_cfg_prefill: bool = False,
         ar_kv_reuse_len: int = 0,
         full_attn_spans: list[list[tuple[int, int]]] | None = None,
-    ) -> tuple | BaseModelOutputWithPast:
+        intermediate_tensors: IntermediateTensors | None = None,
+    ) -> tuple | BaseModelOutputWithPast | IntermediateTensors:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -2394,17 +2407,28 @@ class HunyuanImage3Model(nn.Module):
 
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        if inputs_embeds is None:
-            inputs_embeds = self.embed_tokens(input_ids)
+        sp_world_size = get_sequence_parallel_world_size()
+        pp_world_size = get_pipeline_parallel_world_size()
+        if pp_world_size > 1 and sp_world_size > 1:
+            raise NotImplementedError(
+                "Combining pipeline parallelism with sequence parallelism is not supported for HunyuanImage3."
+            )
 
-        # embed positions
-        hidden_states = inputs_embeds
+        if is_pipeline_first_stage():
+            # Build the token embeddings from the prepared inputs.
+            if inputs_embeds is None:
+                inputs_embeds = self.embed_tokens(input_ids)
+            hidden_states = inputs_embeds
+        else:
+            # Resume from the previous stage's hidden states.
+            if intermediate_tensors is None:
+                raise RuntimeError("intermediate_tensors must be provided for non-first PP stages")
+            hidden_states = intermediate_tensors["hidden_states"]
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None
         next_decoder_cache = None
-        sp_world_size = get_sequence_parallel_world_size()
         prompt_size = 0
         shard_image_size = 0
         shard_padding_size = 0
@@ -2468,7 +2492,7 @@ class HunyuanImage3Model(nn.Module):
                 k_pad = attention_mask.new_zeros(B, H, Q + pad, pad)
                 attention_mask = torch.cat((attention_mask, k_pad), dim=3)
 
-        for layer_idx, decoder_layer in enumerate(self.layers):
+        for decoder_layer in self.layers[self.start_layer : self.end_layer]:
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
@@ -2504,6 +2528,12 @@ class HunyuanImage3Model(nn.Module):
         # add hidden states from the last decoder layer
         if output_hidden_states:
             all_hidden_states += (hidden_states,)
+
+        if not is_pipeline_last_stage():
+            # Hand the token sequence to the caller for the next stage; the final norm /
+            # diffusion head run only on the last stage.
+            return IntermediateTensors({"hidden_states": hidden_states})
+
         if sp_world_size > 1:
             text_output, image_output = self._split_result(hidden_states, prompt_size)
             hidden_states = self.post_processor(image_output)

--- a/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
+++ b/vllm_omni/diffusion/models/hunyuan_image3/pipeline_hunyuan_image3.py
@@ -4,6 +4,7 @@
 import copy
 import logging
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
@@ -18,9 +19,15 @@ from transformers.generation.utils import ALL_CACHE_NAMES, GenerationMixin
 from transformers.utils.generic import ModelOutput
 from vllm.config.vllm import get_current_vllm_config
 from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
+from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.config import get_config
+from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.parallel_state import (
+    get_pipeline_parallel_world_size,
+    get_pp_group,
+)
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.forward_context import set_forward_context_denoise_step_idx
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
@@ -53,6 +60,7 @@ from .hunyuan_image3_transformer import (
 from .system_prompt import get_system_prompt
 
 if TYPE_CHECKING:
+    from vllm_omni.diffusion.distributed.group_coordinator import PipelineGroupCoordinator
     from vllm_omni.diffusion.worker.input_batch import InputBatch
     from vllm_omni.diffusion.worker.utils import DiffusionRequestState
 
@@ -70,6 +78,22 @@ _STEP_OUTPUT_SIZE = "hunyuan_output_size"
 _STEP_COT_TEXT_LIST = "hunyuan_cot_text_list"
 _STEP_AR_KV = "hunyuan_ar_kv"
 _STEP_PROMPT_KV = "hunyuan_prompt_kv"
+
+
+@dataclass
+class _StepMicrobatch:
+    """One pipeline microbatch of rows within a grouped denoise step.
+
+    ``row_state_indexes`` / ``row_branches`` index the step's ``states`` and CFG
+    branch (like :meth:`_step_row_order`) for this microbatch's rows; ``global_rows``
+    maps each local row to its position in the canonical full-step order, so outputs
+    reassemble into the canonical branch-major order (rows grouped by CFG branch)
+    before the CFG combine.
+    """
+
+    row_state_indexes: list[int]
+    row_branches: list[int]
+    global_rows: list[int]
 
 
 def default(val, d):
@@ -342,6 +366,8 @@ class HunyuanImage3Pipeline(
 ):
     supports_step_execution: ClassVar[bool] = True
     supports_request_batch = False
+    requires_step_execution_for_pp: ClassVar[bool] = True
+    supported_microbatch_axes: ClassVar[frozenset[str]] = frozenset({"cfg", "requests"})
     support_image_input = True
     _dit_modules: ClassVar[list[str]] = ["model"]
     _encoder_modules: ClassVar[list[str]] = ["vision_model"]
@@ -594,10 +620,27 @@ class HunyuanImage3Pipeline(
             allow_cond_image=False,
         )
 
+    def _owned_layers(self, with_index: bool = False):
+        """Iterate decoder layers present on this pipeline-parallel rank.
+
+        ``self.model.layers`` holds ``PPMissingLayer`` placeholders for layers
+        owned by other stages; those carry no attention/KV state and are
+        skipped. The yielded index is the global layer index, stable across
+        ranks, so per-layer state keyed by it stays consistent.
+        """
+        for layer_idx, layer in enumerate(self.model.layers):
+            if not hasattr(layer, "self_attn"):
+                continue
+            yield (layer_idx, layer) if with_index else layer
+
     def _snapshot_injected_ar_kv(self) -> list[list[tuple[torch.Tensor, torch.Tensor]] | None] | None:
+        # Indexed by global layer index; placeholder stages contribute None.
         snapshot: list[list[tuple[torch.Tensor, torch.Tensor]] | None] = []
         found = False
         for layer in self.model.layers:
+            if not hasattr(layer, "self_attn"):
+                snapshot.append(None)
+                continue
             mgr = layer.self_attn.image_attn
             injected = mgr._injected_ar_kv
             if injected is None:
@@ -618,11 +661,11 @@ class HunyuanImage3Pipeline(
         if any(snapshot is None for snapshot in snapshots):
             if any(snapshot is not None for snapshot in snapshots):
                 raise ValueError("Cannot mix Hunyuan AR-KV reuse and non-reuse requests in one step batch yet.")
-            for layer in self.model.layers:
+            for layer in self._owned_layers():
                 layer.self_attn.image_attn._injected_ar_kv = None
             return
 
-        for layer_idx, layer in enumerate(self.model.layers):
+        for layer_idx, layer in self._owned_layers(with_index=True):
             injected_rows = []
             for state_idx, branch in zip(row_state_indexes, row_branches):
                 layer_snapshot = snapshots[state_idx][layer_idx]
@@ -769,7 +812,9 @@ class HunyuanImage3Pipeline(
                     f"Missing Hunyuan prompt KV cache for request {states[state_idx].request_id} "
                     "during later denoise step."
                 )
-            prefix_lens.append(int(prompt_kv[0]["lens"][branch].item()))
+            # The prefix length is layer-independent; use any layer this rank owns.
+            any_layer_kv = next(iter(prompt_kv.values()))
+            prefix_lens.append(int(any_layer_kv["lens"][branch].item()))
         return prefix_lens
 
     def _merge_step_model_inputs(
@@ -833,13 +878,13 @@ class HunyuanImage3Pipeline(
         row_branches: list[int],
     ) -> None:
         if states[0].step_index == 0:
-            for layer in self.model.layers:
+            for layer in self._owned_layers():
                 mgr = layer.self_attn.image_attn
                 mgr.image_kv_cache_map = None
                 mgr.image_kv_cache_lens = None
             return
 
-        for layer_idx, layer in enumerate(self.model.layers):
+        for layer_idx, layer in self._owned_layers(with_index=True):
             rows_k, rows_v, lens = [], [], []
             for state_idx, branch in zip(row_state_indexes, row_branches):
                 cache = states[state_idx].extra[_STEP_PROMPT_KV][layer_idx]
@@ -853,34 +898,73 @@ class HunyuanImage3Pipeline(
             )
             mgr.image_kv_cache_lens = torch.cat(lens, dim=0).to(device=mgr.image_kv_cache_map[0].device)
 
+    def _accumulate_prompt_kv_cache(
+        self,
+        states: list["DiffusionRequestState"],
+        row_state_indexes: list[int],
+        row_branches: list[int],
+        accumulator: dict[int, dict[int, dict[int, dict[str, torch.Tensor]]]],
+    ) -> None:
+        """Stash this microbatch's first-step prompt KV into ``accumulator``.
+
+        Captures the per-layer ``image_kv_cache_map`` rows produced by the
+        forward *immediately*, before the next microbatch overwrites the
+        per-layer singleton. Indexed ``accumulator[state][layer][branch]`` so
+        microbatches that each carry only a subset of branches (e.g. the ``cfg``
+        axis) combine correctly. Each row is trimmed to its own prompt length;
+        :meth:`_finalize_prompt_kv_cache` stacks branches and re-pads.
+        """
+        for layer_idx, layer in self._owned_layers(with_index=True):
+            mgr = layer.self_attn.image_attn
+            if mgr.image_kv_cache_map is None or mgr.image_kv_cache_lens is None:
+                raise ValueError("Hunyuan first step did not produce prompt KV cache.")
+            key, value = mgr.image_kv_cache_map
+            lens = mgr.image_kv_cache_lens
+            for row_idx, (state_idx, branch) in enumerate(zip(row_state_indexes, row_branches)):
+                prompt_len = int(lens[row_idx].item())
+                accumulator.setdefault(state_idx, {}).setdefault(layer_idx, {})[branch] = {
+                    "key": key[row_idx : row_idx + 1, :prompt_len].detach().clone(),
+                    "value": value[row_idx : row_idx + 1, :prompt_len].detach().clone(),
+                    "len": lens[row_idx : row_idx + 1].detach().clone(),
+                }
+
+    def _finalize_prompt_kv_cache(
+        self,
+        states: list["DiffusionRequestState"],
+        accumulator: dict[int, dict[int, dict[int, dict[str, torch.Tensor]]]],
+    ) -> None:
+        """Assemble accumulated per-branch prompt KV into per-state caches.
+
+        For each state/layer, stacks the captured rows in branch order and pads
+        them to a common length, producing the same branch-row layout
+        :meth:`_restore_prompt_kv_cache` expects (``[branch:branch+1]`` rows,
+        keyed by global layer index).
+        """
+        for state_idx, layers in accumulator.items():
+            cache: dict[int, dict[str, torch.Tensor]] = {}
+            for layer_idx, branches in layers.items():
+                ordered = [branches[branch] for branch in sorted(branches)]
+                cache[layer_idx] = {
+                    "key": self._pad_tensor_rows([entry["key"] for entry in ordered]),
+                    "value": self._pad_tensor_rows([entry["value"] for entry in ordered]),
+                    "lens": torch.cat([entry["len"] for entry in ordered], dim=0),
+                }
+            states[state_idx].extra[_STEP_PROMPT_KV] = cache
+
     def _capture_prompt_kv_cache(
         self,
         states: list["DiffusionRequestState"],
         row_state_indexes: list[int],
         row_branches: list[int],
     ) -> None:
-        by_state: dict[int, list[dict[str, torch.Tensor]]] = {i: [] for i in range(len(states))}
-        for layer in self.model.layers:
-            mgr = layer.self_attn.image_attn
-            if mgr.image_kv_cache_map is None or mgr.image_kv_cache_lens is None:
-                raise ValueError("Hunyuan first step did not produce prompt KV cache.")
-            key, value = mgr.image_kv_cache_map
-            lens = mgr.image_kv_cache_lens
-            for state_idx in by_state:
-                branch_rows = [
-                    row_idx for row_idx, (idx, _) in enumerate(zip(row_state_indexes, row_branches)) if idx == state_idx
-                ]
-                state_lens = lens[branch_rows]
-                max_len = int(state_lens.max().item())
-                by_state[state_idx].append(
-                    {
-                        "key": key[branch_rows, :max_len].detach().clone(),
-                        "value": value[branch_rows, :max_len].detach().clone(),
-                        "lens": state_lens.detach().clone(),
-                    }
-                )
-        for state_idx, cache in by_state.items():
-            states[state_idx].extra[_STEP_PROMPT_KV] = cache
+        """Capture first-step prompt KV for a single (full) microbatch.
+
+        Convenience wrapper over :meth:`_accumulate_prompt_kv_cache` +
+        :meth:`_finalize_prompt_kv_cache` for the one-forward-per-step path.
+        """
+        accumulator: dict[int, dict[int, dict[int, dict[str, torch.Tensor]]]] = {}
+        self._accumulate_prompt_kv_cache(states, row_state_indexes, row_branches, accumulator)
+        self._finalize_prompt_kv_cache(states, accumulator)
 
     @staticmethod
     def get_pos_emb(custom_pos_emb, position_ids):
@@ -1597,7 +1681,8 @@ class HunyuanImage3Pipeline(
                 generator=generator,
                 model_kwargs=kwargs,
             )
-            samples = results[0]
+            # Only the first PP stage decodes the image; later stages return samples=None.
+            samples = results.samples
             return samples
 
         else:
@@ -1641,7 +1726,8 @@ class HunyuanImage3Pipeline(
         uncond_cfg_prefill: bool = False,
         ar_kv_reuse_len: int = 0,
         full_attn_spans: list[list[tuple[int, int]]] | None = None,
-    ) -> tuple | CausalMMOutputWithPast:
+        intermediate_tensors: IntermediateTensors | None = None,
+    ) -> tuple | CausalMMOutputWithPast | IntermediateTensors:
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         # Sanity Check of Inputs
         self._check_inputs(
@@ -1679,48 +1765,67 @@ class HunyuanImage3Pipeline(
         )
         custom_pos_emb = self.get_pos_emb(custom_pos_emb, position_ids)
 
-        if input_ids is not None:
-            inputs_embeds = self.model.embed_tokens(input_ids)
+        # Pipeline parallelism: embedding and placeholder-token instantiation run on the
+        # first stage only (embed_tokens is PPMissingLayer elsewhere). Later stages resume
+        # from intermediate_tensors and recover the shape and token_h/token_w metadata.
+        if get_pp_group().is_first_rank:
+            if input_ids is not None:
+                inputs_embeds = self.model.embed_tokens(input_ids)
+                bsz, seq_len, n_embd = inputs_embeds.shape
+            else:
+                inputs_embeds = None
+                bsz = images.shape[0] if isinstance(images, torch.Tensor) else len(images)
+                seq_len = 0
+                n_embd = self.config.hidden_size
+
+            # Instantiate placeholder tokens: <timestep>, <img> for the gen image
+            if mode == "gen_text":
+                # For gen_text, make sure gen_timestep_scatter_index is None
+                gen_timestep_scatter_index = None
+                token_h, token_w = None, None
+            elif uncond_cfg_prefill:
+                token_h, token_w = None, None
+            else:
+                if first_step:
+                    assert inputs_embeds is not None
+                    inputs_embeds, token_h, token_w = self.instantiate_vae_image_tokens(
+                        inputs_embeds, images, timestep, image_mask
+                    )
+                    inputs_embeds = self.instantiate_timestep_tokens(
+                        inputs_embeds, timestep, gen_timestep_scatter_index
+                    )
+                else:
+                    t_emb = self.time_embed(timestep)
+                    image_emb, token_h, token_w = self.patch_embed(images, t_emb)
+                    timestep_emb = self.timestep_emb(timestep).reshape(bsz, -1, n_embd)
+                    inputs_embeds = torch.cat([timestep_emb, image_emb], dim=1)
+
+            # Instantiate placeholder tokens: <timestep>, <img> for cond images
+            # Should only run once with kv-cache enabled.
+            if cond_vae_images is not None:
+                inputs_embeds, _, _ = self.instantiate_vae_image_tokens(
+                    inputs_embeds, cond_vae_images, cond_timestep, cond_vae_image_mask
+                )
+                inputs_embeds = self.instantiate_timestep_tokens(
+                    inputs_embeds, cond_timestep, cond_timestep_scatter_index
+                )
+            if cond_vit_images is not None:
+                inputs_embeds = self.instantiate_vit_image_tokens(
+                    inputs_embeds, cond_vit_images, cond_vit_image_mask, vit_kwargs
+                )
+            assert inputs_embeds is not None
             bsz, seq_len, n_embd = inputs_embeds.shape
         else:
+            assert intermediate_tensors is not None, "non-first PP stage requires intermediate_tensors"
+            input_ids = None
             inputs_embeds = None
-            bsz = images.shape[0] if isinstance(images, torch.Tensor) else len(images)
-            seq_len = 0
-            n_embd = self.config.hidden_size
-
-        # Instantiate placeholder tokens: <timestep>, <img> for the gen image
-        if mode == "gen_text":
-            # For gen_text, make sure gen_timestep_scatter_index is None
-            gen_timestep_scatter_index = None
-            token_h, token_w = None, None
-        elif uncond_cfg_prefill:
-            token_h, token_w = None, None
-        else:
-            if first_step:
-                assert inputs_embeds is not None
-                inputs_embeds, token_h, token_w = self.instantiate_vae_image_tokens(
-                    inputs_embeds, images, timestep, image_mask
-                )
-                inputs_embeds = self.instantiate_timestep_tokens(inputs_embeds, timestep, gen_timestep_scatter_index)
-            else:
-                t_emb = self.time_embed(timestep)
-                image_emb, token_h, token_w = self.patch_embed(images, t_emb)
-                timestep_emb = self.timestep_emb(timestep).reshape(bsz, -1, n_embd)
-                inputs_embeds = torch.cat([timestep_emb, image_emb], dim=1)
-
-        # Instantiate placeholder tokens: <timestep>, <img> for cond images
-        # Should only run once with kv-cache enabled.
-        if cond_vae_images is not None:
-            inputs_embeds, _, _ = self.instantiate_vae_image_tokens(
-                inputs_embeds, cond_vae_images, cond_timestep, cond_vae_image_mask
-            )
-            inputs_embeds = self.instantiate_timestep_tokens(inputs_embeds, cond_timestep, cond_timestep_scatter_index)
-        if cond_vit_images is not None:
-            inputs_embeds = self.instantiate_vit_image_tokens(
-                inputs_embeds, cond_vit_images, cond_vit_image_mask, vit_kwargs
-            )
-        assert inputs_embeds is not None
-        bsz, seq_len, n_embd = inputs_embeds.shape
+            _hs = intermediate_tensors["hidden_states"]
+            bsz, seq_len, n_embd = _hs.shape
+            try:
+                token_h = int(intermediate_tensors["token_h"].item())
+                token_w = int(intermediate_tensors["token_w"].item())
+            except (KeyError, TypeError, IndexError):
+                token_h, token_w = None, None
 
         # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
         from vllm.forward_context import set_forward_context
@@ -1746,7 +1851,19 @@ class HunyuanImage3Pipeline(
                 uncond_cfg_prefill=uncond_cfg_prefill,
                 ar_kv_reuse_len=ar_kv_reuse_len,
                 full_attn_spans=full_attn_spans,
+                intermediate_tensors=intermediate_tensors,
             )
+
+        # Non-last PP stage: the transformer returns the token sequence to forward
+        # to the next stage. The diffusion head / lm_head only run on the last stage.
+        if isinstance(outputs, IntermediateTensors):
+            # Pass token_h/token_w to the last stage's diffusion head as 0-d int tensors.
+            if token_h is not None and "token_h" not in outputs.tensors:
+                _dev = outputs.tensors["hidden_states"].device
+                outputs.tensors["token_h"] = torch.tensor(int(token_h), device=_dev)
+                outputs.tensors["token_w"] = torch.tensor(int(token_w), device=_dev)
+            return outputs
+
         hidden_states = outputs[0]
 
         if mode == "gen_text":
@@ -1759,7 +1876,9 @@ class HunyuanImage3Pipeline(
             diffusion_prediction = None
         else:
             logits = None
-            hidden_states = hidden_states.to(inputs_embeds.device)
+            # inputs_embeds is None on non-first PP stages; fall back to hidden_states.
+            _target_device = inputs_embeds.device if inputs_embeds is not None else hidden_states.device
+            hidden_states = hidden_states.to(_target_device)
             assert hidden_states.numel() == bsz * seq_len * n_embd, (
                 f"Shape mismatch: {hidden_states.shape} cannot reshape to ({bsz}, {seq_len}, {n_embd})"
             )
@@ -2005,6 +2124,89 @@ class HunyuanImage3Pipeline(
         row_branches = [branch for branch in range(cfg_factor) for _ in states]
         return row_state_indexes, row_branches
 
+    def _selected_microbatch_axes(self, cfg_factor: int) -> frozenset[str]:
+        """Resolve the active microbatch axes for this grouped step.
+
+        Reads ``parallel_config.microbatch_axes`` (a set of axes drawn from
+        ``cfg`` / ``requests``) and drops the ``cfg`` axis when there is only one
+        CFG branch (``cfg_factor <= 1``, nothing to split). The result drives
+        :meth:`_step_microbatch_plan`.
+        """
+        axes = set(getattr(self.od_config.parallel_config, "microbatch_axes", ()) or ())
+        if cfg_factor <= 1:
+            # Nothing to split with only one CFG branch.
+            axes.discard("cfg")
+        return frozenset(axes)
+
+    def _requests_microbatch_size(self) -> int:
+        """Requests per microbatch for the ``requests`` axis.
+
+        Driven by ``parallel_config.microbatch_requests``. Trades batch
+        efficiency (larger = fewer, fatter forwards) against pipeline fill
+        (smaller = more microbatches); 1 = max pipelining.
+        """
+        return max(1, int(getattr(self.od_config.parallel_config, "microbatch_requests", 1)))
+
+    def _step_microbatch_plan(
+        self,
+        states: list["DiffusionRequestState"],
+        cfg_factor: int,
+        axes: frozenset[str] = frozenset(),
+    ) -> list[_StepMicrobatch]:
+        """Partition a grouped denoise step into pipeline-parallel microbatches.
+
+        Each microbatch's ``global_rows`` index the canonical full-step row order
+        (:meth:`_step_row_order`) so outputs reassemble into the canonical branch-major
+        order before the CFG combine. ``axes`` (a subset of ``cfg`` / ``requests``)
+        selects the split:
+
+        - ``frozenset()``: one microbatch over every row.
+        - ``{"cfg"}``: one microbatch per CFG branch (all requests of that branch), so a
+          later PP stage runs one branch while an earlier stage runs the next.
+        - ``{"requests"}``: one microbatch per chunk of ``c`` requests
+          (:meth:`_requests_microbatch_size`), each carrying all CFG branches; fills
+          the bubble by request count, so it works with CFG off too.
+        - ``{"cfg", "requests"}``: 2-D split, one microbatch per (request-chunk, CFG
+          branch) (``ceil(num_states/c) * cfg_factor`` total); the deepest fill. Reduces
+          to the requests-only split with CFG off.
+        """
+        # Every split is "chunk the requests, then handle the CFG branches":
+        #   - request-chunk width: ``microbatch_requests`` when the ``requests`` axis is
+        #     on, else all requests in a single chunk.
+        #   - branches: one microbatch per CFG branch when the ``cfg`` axis is on (the
+        #     deepest fill; per-state KV assembles across them via _accumulate/_finalize),
+        #     else all branches bundled into each microbatch.
+        # Emission is branch-major so outputs reassemble into the canonical branch order;
+        # the step is lockstep (one batched combine after all microbatches drain), so
+        # microbatch order does not affect the result.
+        num_states = len(states)
+        chunk = self._requests_microbatch_size() if "requests" in axes else num_states
+        plan: list[_StepMicrobatch] = []
+        if "cfg" in axes:
+            for branch in range(cfg_factor):
+                for start in range(0, num_states, chunk):
+                    rows = list(range(start, min(start + chunk, num_states)))
+                    plan.append(
+                        _StepMicrobatch(
+                            row_state_indexes=rows,
+                            row_branches=[branch] * len(rows),
+                            global_rows=[branch * num_states + state_idx for state_idx in rows],
+                        )
+                    )
+        else:
+            for start in range(0, num_states, chunk):
+                rows = list(range(start, min(start + chunk, num_states)))
+                plan.append(
+                    _StepMicrobatch(
+                        row_state_indexes=rows * cfg_factor,
+                        row_branches=[branch for branch in range(cfg_factor) for _ in rows],
+                        global_rows=[
+                            branch * num_states + state_idx for branch in range(cfg_factor) for state_idx in rows
+                        ],
+                    )
+                )
+        return plan
+
     @staticmethod
     def _validate_step_group_states(states: list["DiffusionRequestState"]) -> tuple[bool, int]:
         if not states:
@@ -2064,12 +2266,13 @@ class HunyuanImage3Pipeline(
                     if cache is None:
                         next_kwargs[key] = value[state_rows]
                     else:
+                        any_layer_kv = next(iter(cache.values()))
                         compact_masks = []
                         for row_idx in state_rows:
                             branch = row_branches[row_idx]
                             row_mask = value[row_idx : row_idx + 1]
                             query_len = int(row_mask.shape[-2])
-                            prefix_len = int(cache[0]["lens"][branch].item())
+                            prefix_len = int(any_layer_kv["lens"][branch].item())
                             max_prefix_len = int(row_mask.shape[-1]) - query_len
                             prefix_mask = row_mask[:, :, :, :prefix_len]
                             current_mask = row_mask[:, :, :, max_prefix_len : max_prefix_len + query_len]
@@ -2094,17 +2297,47 @@ class HunyuanImage3Pipeline(
             state.extra[_STEP_MODEL_KWARGS] = next_kwargs
             state.extra[_STEP_INPUT_IDS] = None
 
-    def _denoise_step_group(self, states: list["DiffusionRequestState"]) -> torch.Tensor:
-        first_step, cfg_factor = self._validate_step_group_states(states)
-        row_state_indexes, row_branches = self._step_row_order(states, cfg_factor)
-        latents = torch.cat([state.latents for state in states], dim=0)
-        latent_model_input = torch.cat([latents] * cfg_factor, dim=0)
+    @property
+    def _pp_send_work(self) -> list[torch.distributed.Work]:
+        if not hasattr(self, "_pp_send_work_list"):
+            self._pp_send_work_list: list[torch.distributed.Work] = []
+        return self._pp_send_work_list
+
+    def _sync_pp_send(self) -> None:
+        """Wait on pending non-blocking pipeline-parallel sends from prior steps.
+
+        The forward-chain ``isend`` of one denoise step must complete before the
+        next step reuses the activation buffer or posts new receives.
+        """
+        for handle in self._pp_send_work:
+            handle.wait()
+        self._pp_send_work_list = []
+
+    def _run_step_microbatch(
+        self,
+        states: list["DiffusionRequestState"],
+        microbatch: _StepMicrobatch,
+        first_step: bool,
+        pp_group: "PipelineGroupCoordinator",
+        prompt_kv_accumulator: dict[int, dict[int, dict[int, dict[str, torch.Tensor]]]] | None,
+    ) -> torch.Tensor | None:
+        """Run the forward chain for one pipeline microbatch of a denoise step.
+
+        Builds the merged inputs for the microbatch's rows, restores their
+        per-row KV state, runs the model forward (handing activations downstream
+        under pipeline parallelism), and on the first step stashes the produced
+        prompt KV into ``prompt_kv_accumulator`` before the next microbatch
+        overwrites the per-layer singleton. Returns the microbatch's float32
+        noise prediction (rows in microbatch order) on the last stage, or
+        ``None`` on earlier stages. The next-step kwargs evolution is done once
+        over the full batch by :meth:`_denoise_step_group`, not here.
+        """
+        row_state_indexes = microbatch.row_state_indexes
+        row_branches = microbatch.row_branches
+        device = states[row_state_indexes[0]].latents.device
+        latent_model_input = torch.cat([states[state_idx].latents for state_idx in row_state_indexes], dim=0)
         timestep = torch.cat(
-            [
-                state.current_timestep.reshape(1).to(device=latents.device)
-                for _ in range(cfg_factor)
-                for state in states
-            ],
+            [states[state_idx].current_timestep.reshape(1).to(device=device) for state_idx in row_state_indexes],
             dim=0,
         )
 
@@ -2126,19 +2359,95 @@ class HunyuanImage3Pipeline(
             **model_kwargs,
         )
 
+        intermediate_tensors = None
+        if not pp_group.is_first_rank:
+            intermediate_tensors = AsyncIntermediateTensors(*pp_group.irecv_tensor_dict())
+
         step_indexes = {state.step_index for state in states}
         context_step_index = next(iter(step_indexes)) if len(step_indexes) == 1 else None
         set_forward_context_denoise_step_idx(context_step_index)
         try:
             with torch.autocast(device_type=self.device.type, dtype=torch.bfloat16, enabled=True):
-                model_output = self.forward_call(**model_inputs, first_step=first_step)
-                pred = model_output["diffusion_prediction"]
+                model_output = self.forward_call(
+                    **model_inputs,
+                    first_step=first_step,
+                    intermediate_tensors=intermediate_tensors,
+                )
         finally:
             set_forward_context_denoise_step_idx(None)
-        pred = pred.to(dtype=torch.float32)
+
+        if isinstance(model_output, IntermediateTensors):
+            # Non-last pipeline stage: hand activations to the next stage. The
+            # diffusion head runs only on the last stage, so there is no noise
+            # prediction here.
+            self._pp_send_work.extend(pp_group.isend_tensor_dict(model_output.tensors))
+            pred = None
+        else:
+            pred = model_output["diffusion_prediction"].to(dtype=torch.float32)
 
         if first_step:
-            self._capture_prompt_kv_cache(states, row_state_indexes, row_branches)
+            self._accumulate_prompt_kv_cache(states, row_state_indexes, row_branches, prompt_kv_accumulator)
+        return pred
+
+    def _denoise_step_group(self, states: list["DiffusionRequestState"]) -> torch.Tensor | None:
+        """Run one grouped denoise step.
+
+        The step is partitioned into pipeline microbatches (see
+        :meth:`_step_microbatch_plan`) and each is run through the forward chain
+        in turn; their per-row noise predictions are reassembled into the
+        canonical branch-major order before the CFG combine.
+        Returns the float32 noise prediction on the last pipeline-parallel stage
+        (or when pipeline parallelism is disabled), and ``None`` on earlier
+        stages, which only forward intermediate activations downstream.
+        """
+        first_step, cfg_factor = self._validate_step_group_states(states)
+        axes = self._selected_microbatch_axes(cfg_factor)
+        plan = self._step_microbatch_plan(states, cfg_factor, axes)
+        full_row_state_indexes, full_row_branches = self._step_row_order(states, cfg_factor)
+        pp_group = get_pp_group()
+
+        # Merge the full-batch kwargs up front (before any microbatch overwrites
+        # per-state state) for the next-step evolution below.
+        _, full_model_kwargs = self._merge_step_model_inputs(
+            states, full_row_state_indexes, full_row_branches, first_step
+        )
+
+        # First-step prompt KV is accumulated across microbatches (each may carry
+        # only a subset of branches) and assembled once after the loop.
+        prompt_kv_accumulator: dict[int, dict[int, dict[int, dict[str, torch.Tensor]]]] | None = (
+            {} if first_step else None
+        )
+        microbatch_preds = [
+            self._run_step_microbatch(states, microbatch, first_step, pp_group, prompt_kv_accumulator)
+            for microbatch in plan
+        ]
+        if first_step:
+            self._finalize_prompt_kv_cache(states, prompt_kv_accumulator)
+
+        # Evolve per-request kwargs for the next step on every rank so stage
+        # shapes stay consistent. The gen-image update ignores the model-output
+        # KV cache, so it is output-independent: run it once over the full batch
+        # (independent of the microbatch partition) with a cache-less surrogate,
+        # which also keeps it deterministic across ranks.
+        updated_kwargs = self._update_model_kwargs_for_generation(ModelOutput(), full_model_kwargs)
+        self._split_merged_kwargs_to_states(states, updated_kwargs, full_row_state_indexes, full_row_branches)
+
+        if all(pred is None for pred in microbatch_preds):
+            # Non-last pipeline stage: activations were forwarded downstream.
+            return None
+
+        if len(plan) == 1:
+            # Single microbatch: rows are already in canonical order, so skip the
+            # per-row reassembly copy.
+            pred = microbatch_preds[0]
+        else:
+            total_rows = len(full_row_state_indexes)
+            canonical_rows: list[torch.Tensor | None] = [None] * total_rows
+            for microbatch, mb_pred in zip(plan, microbatch_preds):
+                for local_row, global_row in enumerate(microbatch.global_rows):
+                    canonical_rows[global_row] = mb_pred[local_row : local_row + 1]
+            pred = torch.cat(canonical_rows, dim=0)
+
         if cfg_factor > 1:
             pred_cond, pred_uncond = pred.chunk(2)
             pred = torch.cat(
@@ -2153,9 +2462,6 @@ class HunyuanImage3Pipeline(
                 ],
                 dim=0,
             )
-
-        updated_kwargs = self._update_model_kwargs_for_generation(model_output, model_kwargs)
-        self._split_merged_kwargs_to_states(states, updated_kwargs, row_state_indexes, row_branches)
         return pred
 
     def denoise_step(
@@ -2166,15 +2472,24 @@ class HunyuanImage3Pipeline(
         del kwargs
         if getattr(self, "interrupt", False):
             return None
+        # Drain the previous step's pipeline-parallel sends before posting new
+        # receives / reusing activation buffers.
+        self._sync_pp_send()
         states = list(input_batch.states)
         if not states:
             raise ValueError("HunyuanImage3 denoise_step received an empty batch.")
         self._ensure_grouped_attention_backend_supported(len(states))
+        is_last_stage = get_pp_group().is_last_rank
         outputs: dict[str, torch.Tensor] = {}
+        # Every rank runs the forward chain for every group; only the last stage
+        # yields a noise prediction to feed the scheduler.
         for group in self._split_step_groups(states):
             pred = self._denoise_step_group(group)
-            for state, state_pred in zip(group, pred):
-                outputs[state.request_id] = state_pred.unsqueeze(0)
+            if is_last_stage:
+                for state, state_pred in zip(group, pred):
+                    outputs[state.request_id] = state_pred.unsqueeze(0)
+        if not is_last_stage:
+            return None
         return torch.cat([outputs[state.request_id] for state in states], dim=0)
 
     def step_scheduler(
@@ -2186,16 +2501,32 @@ class HunyuanImage3Pipeline(
         del kwargs
         if getattr(self, "interrupt", False):
             return
-        generator = state.extra.get(_STEP_GENERATOR)
-        step_kwargs = self.pipeline.prepare_extra_func_kwargs(state.scheduler.step, {"generator": generator})
-        latent_dtype = state.latents.dtype
-        state.latents = state.scheduler.step(
-            noise_pred,
-            state.current_timestep,
-            state.latents,
-            **step_kwargs,
-            return_dict=False,
-        )[0].to(dtype=latent_dtype)
+
+        pp_group = get_pp_group()
+        pp_enabled = get_pipeline_parallel_world_size() > 1
+
+        # With pipeline parallelism only the last stage holds the noise
+        # prediction, so only it advances the scheduler. The updated latents are
+        # handed back to the first stage, which starts the next forward and runs
+        # the final decode. Intermediate stages keep stale latents (ignored by
+        # their forward) and only advance the step counter.
+        if not pp_enabled or pp_group.is_last_rank:
+            generator = state.extra.get(_STEP_GENERATOR)
+            step_kwargs = self.pipeline.prepare_extra_func_kwargs(state.scheduler.step, {"generator": generator})
+            latent_dtype = state.latents.dtype
+            state.latents = state.scheduler.step(
+                noise_pred,
+                state.current_timestep,
+                state.latents,
+                **step_kwargs,
+                return_dict=False,
+            )[0].to(dtype=latent_dtype)
+            if pp_enabled and not pp_group.is_first_rank:
+                pp_group.send_tensor_dict({"latents": state.latents.contiguous()}, dst=0)
+        elif pp_group.is_first_rank:
+            received = pp_group.recv_tensor_dict(src=pp_group.world_size - 1)
+            state.latents = received["latents"].to(dtype=state.latents.dtype)
+
         state.step_index += 1
 
     def post_decode(
@@ -2204,6 +2535,16 @@ class HunyuanImage3Pipeline(
         **kwargs: Any,
     ) -> DiffusionOutput:
         output_type = kwargs.get("output_type", "pil")
+        # Under pipeline parallelism the up-to-date latents are handed back to the
+        # first stage each step; only it decodes the final image. Other stages
+        # hold stale latents and produce no output (the worker replies from the
+        # first stage).
+        if get_pipeline_parallel_world_size() > 1 and not get_pp_group().is_first_rank:
+            return DiffusionOutput(
+                output=None,
+                custom_output={},
+                stage_durations=getattr(self, "stage_durations", None),
+            )
         generator = state.extra.get(_STEP_GENERATOR)
         latents = state.latents
         if output_type == "latent":
@@ -2301,7 +2642,8 @@ class HunyuanImage3Pipeline(
         model_inputs.update(ar_kv_kwargs)
 
         outputs = self._generate(**model_inputs, **kwargs)
-        image = outputs[0]
+        # Non-first PP stages produce no image (None); the worker replies from rank 0 only.
+        image = outputs[0] if outputs is not None else None
         custom_output = {}
         if any(t is not None for t in cot_text_list):
             custom_output["ar_generated_text"] = cot_text_list[0] if len(cot_text_list) == 1 else cot_text_list

--- a/vllm_omni/diffusion/worker/diffusion_model_runner.py
+++ b/vllm_omni/diffusion/worker/diffusion_model_runner.py
@@ -92,6 +92,51 @@ def _normalize_pipeline_outputs(
     return outputs
 
 
+def validate_pp_step_execution(pipeline: object, od_config: object, pp_world_size: int) -> None:
+    """Enforce the grouped-only PP contract.
+
+    A pipeline that wires PP only into its grouped step-execution path sets
+    ``requires_step_execution_for_pp=True``; for it, ``pipeline_parallel_size>1``
+    requires ``step_execution=True`` (else the monolithic path runs stages with no
+    intermediate-tensor passing). Raises ``ValueError`` on violation.
+    """
+    if (
+        pp_world_size > 1
+        and not getattr(od_config, "step_execution", False)
+        and getattr(pipeline, "requires_step_execution_for_pp", False)
+    ):
+        model_name = getattr(od_config, "model_class_name", type(pipeline).__name__)
+        raise ValueError(
+            "pipeline_parallel_size>1 requires step_execution=True for "
+            f"{model_name}: its pipeline parallelism is implemented only in the "
+            "grouped step-execution path. Set step_execution=True "
+            "(or pipeline_parallel_size=1)."
+        )
+
+
+def validate_microbatch_axes(pipeline: object, od_config: object) -> None:
+    """Enforce the per-pipeline supported microbatch axes.
+
+    A pipeline declares the microbatch axes it implements via
+    ``supported_microbatch_axes`` (a frozenset). Any enabled ``microbatch_axes``
+    axis outside that set is rejected at load time -- a pipeline that has not opted
+    in rejects any non-empty ``microbatch_axes`` rather than silently
+    misbehaving. Raises ``ValueError`` on violation.
+    """
+    parallel_config = getattr(od_config, "parallel_config", None)
+    policies = set(getattr(parallel_config, "microbatch_axes", []) or [])
+    if not policies:
+        return
+    supported = set(getattr(pipeline, "supported_microbatch_axes", frozenset()))
+    unknown = policies - supported
+    if unknown:
+        model_name = getattr(od_config, "model_class_name", type(pipeline).__name__)
+        raise ValueError(
+            f"{model_name} does not support microbatch axes {sorted(unknown)}; "
+            f"supported: {sorted(supported)}. Adjust microbatch_axes."
+        )
+
+
 class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
     """
     Model runner that handles model loading and execution for diffusion models.
@@ -228,6 +273,13 @@ class DiffusionModelRunner(OmniConnectorModelRunnerMixin):
                 "streaming_output=True requires step execution support; "
                 f"{self.od_config.model_class_name} does not support that contract."
             )
+
+        # Some pipelines implement PP only in the grouped step-execution path; fail
+        # fast for a PP>1 deploy that leaves step_execution off.
+        pp_size = getattr(getattr(self.od_config, "parallel_config", None), "pipeline_parallel_size", 1)
+        validate_pp_step_execution(self.pipeline, self.od_config, pp_size)
+        # Reject any enabled microbatch axis the pipeline does not implement.
+        validate_microbatch_axes(self.pipeline, self.od_config)
 
         # Apply CPU offloading
         self.offload_backend = get_offload_backend(self.od_config, device=self.device)


### PR DESCRIPTION
Brings inter-layer Pipeline Parallelism (PP) to the single-stage HunyuanImage-3.0 DiT pipeline, taking advantage of the grouped step-batching path (PR #4041): PP is wired into the grouped `step_execution` denoise hooks, so grouped step batching and pipeline parallelism run together on the DiT. To keep the pipeline busy, a grouped step is split into pipeline microbatches, primarily by partitioning the in-flight requests, so a later stage runs one request-chunk while an earlier stage runs the next; this fills the pipeline bubble even with CFG off and scales with concurrency. When CFG is on, CFG branches are pipelined (reusing the idea from PR #2322) as well for a 2-D split over request-chunks × CFG branches that adds further overlap.

RFC: #4617.

## Implementation

The PR routes vLLM-Omni's generic PP machinery through the HunyuanImage-3.0 DiT and its grouped step-execution path, then adds pipeline microbatching on top.

- **DiT PP plumbing.** `HunyuanImage3Model` splits its transformer blocks across PP stages via   `make_layers`/`PPMissingLayer`, threads `intermediate_tensors` between stages (first stage embeds, later stages resume, non-last stages return `IntermediateTensors`), and skips PP-missing params on weight load. Per-layer KV state (AR-KV and prompt-KV) is keyed by **global layer index**, so it stays correct when a stage owns only a subset of layers. PP is hand-wired directly into the grouped step path (below); the monolithic `diffuse()`/`predict_noise()` path is left PP-unaware (out of scope, deferred).
- **PP in the grouped step path.** The `step_execution` hooks that run outside `diffuse()`/`predict_noise()` (`_denoise_step_group`, `denoise_step`, `step_scheduler`, `post_decode`) become PP-aware. Stages exchange activations directly through the PP-group primitives (`get_pp_group()`, first/last-rank checks, `IntermediateTensors`): non-blocking `isend`/`irecv` of the tensor dict, with each step draining the previous step's pending sends before posting new ones. Only the last stage assembles the noise prediction, advances the scheduler, and hands latents back to the first stage (which holds the latest latents and decodes); every stage advances the step counter so termination stays in sync.
- **Pipeline microbatching.** A grouped denoise step is partitioned into pipeline microbatches by `_step_microbatch_plan`, so a later PP stage can run one microbatch while an earlier stage runs the next. Each microbatch runs the full merge → forward → send/recv → KV-capture chain; the last stage reassembles per-microbatch predictions into the canonical branch-major order before the CFG combine. Every split is output-equivalent to the single batched forward.

### Configuration / API

Enabling PP is configuration-only: set `pipeline_parallel_size>1` with `step_execution=true`, then set `microbatch_axes` to a non-empty axis list to fill the pipeline bubble.

<details>
<summary>Example deploy config: PP4×TP1 + grouped step batching</summary>

```yaml
pipeline: hunyuan_image3_dit
async_chunk: false

stages:
  - stage_id: 0
    max_num_seqs: 8
    step_execution: true
    gpu_memory_utilization: 0.9
    enforce_eager: true
    devices: "0,1,2,3"
    vae_use_slicing: false
    vae_use_tiling: false
    parallel_config:
      pipeline_parallel_size: 4
      data_parallel_size: 1
      tensor_parallel_size: 1
      enable_expert_parallel: true
      sequence_parallel_size: 1
      ulysses_degree: 1
      ring_degree: 1
      cfg_parallel_size: 1
      vae_patch_parallel_size: 1
      use_hsdp: false
      hsdp_shard_size: -1
      hsdp_replicate_size: 1
      microbatch_axes: [cfg, requests]
      microbatch_requests: 1
    default_sampling_params:
      seed: 42
```
</details>

For **PP2×TP2**, use the same config with `pipeline_parallel_size: 2` and `tensor_parallel_size: 2`.

The PR adds four public knobs — two `DiffusionParallelConfig` fields and two per-pipeline contract flags. The two config fields carry over to the deploy YAML under the same names, as `parallel_config.microbatch_axes` / `.microbatch_requests`:

| Surface | Name | Default | Purpose |
|---------|------|---------|---------|
| `DiffusionParallelConfig` | `microbatch_axes` | `[]` | Axes to split a grouped step along; `[]` = one forward per step (unchanged). |
| `DiffusionParallelConfig` | `microbatch_requests` | `1` | Requests per microbatch; used only when the `requests` axis is enabled. |
| Pipeline class-var | `requires_step_execution_for_pp` | `False` | Opt-in: `pipeline_parallel_size>1` requires `step_execution=True`, else load fails. |
| Pipeline class-var | `supported_microbatch_axes` | `frozenset()` | Supported axes; axes outside this set are rejected at load. |

HunyuanImage-3.0 sets `requires_step_execution_for_pp = True` and `supported_microbatch_axes = frozenset({"cfg", "requests"})`; the class-var defaults above are what every other pipeline inherits (PP-step-execution not required, no microbatch axes).

`microbatch_axes` (order-insensitive, no duplicates) splits a grouped step per listed axis:

- `["cfg"]`: split the CFG branches.
- `["requests"]`: split in-flight requests into chunks of `microbatch_requests`.
- `["cfg", "requests"]`: 2D split, one microbatch per (request-chunk, CFG branch); reduces to `["requests"]` when CFG is off.

`microbatch_requests` sets the chunk width for the `requests` axis: smaller means more, thinner microbatches (`1` = maximum pipelining); larger means fewer, fatter forwards.

Both config fields are read through `getattr` defaults, so existing YAMLs and test doubles stay at `[]`/`1`.

### Required / incompatible options

- **`step_execution=True` required when `pipeline_parallel_size>1`**: PP is wired only into the grouped step-execution path, so an otherwise-configured deploy fails fast at load (`validate_pp_step_execution` → `ValueError`); an unsupported `microbatch_axes` fails the same way (`validate_microbatch_axes`). Both gates are duck-typed opt-ins (`requires_step_execution_for_pp`, `supported_microbatch_axes`), leaving other pipelines untouched.
- **Incompatible with sequence parallelism (Ulysses / Ring)**: the grouped step path already rejects SP (a `ValueError` inherited from PR #4041), and PP+SP is not wired regardless (the inter-stage `intermediate_tensors` handoff would need to carry SP's sharded sequence layout). `HunyuanImage3Model.forward` raises `NotImplementedError` when both world sizes exceed 1.
- **Inherits the grouped step-batching constraints (PR #4041)**: the grouped path requires the `TORCH_SDPA` attention backend (the merged block-diagonal mask is not expressible in FlashAttention), is text-to-image only, is incompatible with the diffusion cache backends, and only pipelines across requests once more than one is in flight.
- **Not request-level batched (inherited)**: the HunyuanImage-3.0 pipeline already declares `supports_request_batch = False`, independent of this PR — PP runs on the step-execution path instead.

## Tests

**Modified.**

- `tests/diffusion/models/hunyuan_image3/test_hunyuan_image3_step_execution.py`:
  - upstream grouped-step tests updated to autouse single-rank PP-group stubs and dict-form KV fixtures. Required due to the new PP wiring (adding `get_pp_group()` to the grouped denoise/scheduler paths, and migrating the prompt-KV snapshot from a position-indexed list to a global-index dict).
  - new correctness tests: the `["cfg"]`/`["requests"]`/`["cfg", "requests"]` axis combinations each reproduce the single batched forward's denoise output and next-step request state bit-for-bit (including prompt-KV accumulation across microbatches), plus config-driven axis selection (list -> internal plan) and axis validation.
- `tests/diffusion/test_diffusion_model_runner.py`: adds the `validate_pp_step_execution` raise/allow matrix and the HunyuanImage3 opt-in.

**New.**

- `tests/diffusion/distributed/test_hunyuan_image3_pipeline_parallel.py`: HunyuanImage3-specific
  PP wiring not exercised by the generic PP test suite (`test_pipeline_parallel.py`):
  - `forward` guards (PP+SP → `NotImplementedError`; a non-first stage without `intermediate_tensors` → `RuntimeError`)
  - `_owned_layers` and the AR-KV / prompt-KV helpers keying state by global layer index
  - `_pad_tensor_rows` step-batch row merge (equal-shape concat and ragged zero-padding)
  - CPU tests use stubs; one `pp2`/`pp3` GPU/distributed test builds the layer list through the real `make_layers` partition.

Per-stage forward numerics stay covered by the existing upstream e2e / pixel-accuracy suites (`tests/e2e/accuracy/test_hunyuan_image3.py`, `tests/e2e/accuracy/test_hunyuan_image3_pixel_accuracy.py`).

## Validation

- **Correctness** — the pytest suites added and modified above (grouped-step, PP-wiring, and microbatch-axis), all green.
- **Benchmarks** — reported in the RFC (#4617).