### PR TITLE
[NFC] Update misleading seed-tts-eval optional dependency guidance

### DIFF
--- a/tests/e2e/accuracy/qwen3_omni/run_qwen_omni_acc_benchmark.py
+++ b/tests/e2e/accuracy/qwen3_omni/run_qwen_omni_acc_benchmark.py
@@ -33,7 +33,7 @@ Prerequisites
 
 * **Seed-TTS** optional extras for WER/SIM/UTMOS::
 
-    pip install 'vllm-omni[seed-tts-eval]'
+    pip install 'vllm-omni[dev]'
 
 Examples
 --------

--- a/vllm_omni/benchmarks/data_modules/seed_tts_eval.py
+++ b/vllm_omni/benchmarks/data_modules/seed_tts_eval.py
@@ -33,7 +33,7 @@ https://github.com/zhaochenyang20/seed-tts-eval):
 
 Enable with ``SEED_TTS_WER_EVAL=1`` or ``--seed-tts-wer-eval``. Install optional deps::
 
-    pip install 'vllm-omni[seed-tts-eval]'
+    pip install 'vllm-omni[dev]'
 
 Env: ``SEED_TTS_EVAL_DEVICE`` (e.g. ``cuda:0``, ``cpu``); ``SEED_TTS_HF_WHISPER_MODEL``
 defaults to ``openai/whisper-large-v3`` (override for debugging only).
@@ -446,7 +446,7 @@ def _missing_deps_message(lang: str) -> str | None:
         import jiwer  # noqa: F401
         from zhon.hanzi import punctuation  # noqa: F401
     except ImportError as e:
-        return f"Seed-TTS WER eval needs jiwer and zhon ({e!s}). Install: pip install 'vllm-omni[seed-tts-eval]'"
+        return f"Seed-TTS WER eval needs jiwer and zhon ({e!s}). Install: pip install 'vllm-omni[dev]'"
     try:
         import scipy.signal  # noqa: F401
         import soundfile  # noqa: F401
@@ -457,13 +457,13 @@ def _missing_deps_message(lang: str) -> str | None:
             import torch  # noqa: F401
             from transformers import WhisperForConditionalGeneration  # noqa: F401
         except ImportError as e:
-            return f"English WER needs torch and transformers ({e!s}). Install: pip install 'vllm-omni[seed-tts-eval]'"
+            return f"English WER needs torch and transformers ({e!s}). Install: pip install 'vllm-omni[dev]'"
     else:
         try:
             import zhconv  # noqa: F401
             from funasr import AutoModel  # noqa: F401
         except ImportError as e:
-            return f"Chinese WER needs funasr and zhconv ({e!s}). Install: pip install 'vllm-omni[seed-tts-eval]'"
+            return f"Chinese WER needs funasr and zhconv ({e!s}). Install: pip install 'vllm-omni[dev]'"
     return None
 
 

--- a/vllm_omni/entrypoints/cli/benchmark/serve.py
+++ b/vllm_omni/entrypoints/cli/benchmark/serve.py
@@ -119,7 +119,7 @@ def add_seed_tts_cli_args(parser: argparse.ArgumentParser) -> None:
         help="Keep synthesized audio as 24 kHz mono PCM for WER (works with "
         "--backend openai-audio-speech or openai-chat-omni). Scoring follows "
         "zhaochenyang20/seed-tts-eval (Whisper-large-v3 / Paraformer-zh + jiwer). "
-        "Sets SEED_TTS_WER_EVAL=1. Install: pip install 'vllm-omni[seed-tts-eval]'. "
+        "Sets SEED_TTS_WER_EVAL=1. Install: pip install 'vllm-omni[dev]'. "
         "Optional: SEED_TTS_EVAL_DEVICE, SEED_TTS_HF_WHISPER_MODEL.",
     )
     g.add_argument(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE.

## Purpose

This PR fixed an outdated / misleading log of instruction about dependency installation vllm-omni[seed-tts-eval]:

When I run `vllm bench serve` with arg `--seed-tts-wer-eval` I got the following error and guidance:

```text
ERROR 06-22 10:04:40 [seed_tts_eval.py:489] Seed-TTS WER eval needs jiwer and zhon (No module named 'jiwer'). Install: pip install 'vllm-omni[seed-tts-eval]'
===== Seed-TTS eval (seed-tts-eval protocol) =====
Seed-TTS WER eval needs jiwer and zhon (No module named 'jiwer'). Install: pip install 'vllm-omni[seed-tts-eval]'
```

However, there's no `seed-tts-eval` in optional-dependencies. Thought this guidance log is misleading and we could reminding installing `vllm-omni[dev]` instead.

cc @amy-why-3459 

## Test Plan

Installed `uv pip install vllm-omni[dev]`, and then run vllm bench serve with `--seed-tts-wer-eval`

**vLLM Version:**

**vLLM-Omni Commit:**

## Test Result

`--seed-tts-wer-eval` worked fine with dev dependencies

```text
WARNING 06-22 11:27:00 [seed_tts_eval.py:359] Loading Seed-TTS eval Whisper HF model 'openai/whisper-large-v3' on cuda:0 (one-time, seed-tts-eval protocol)...

...

===== Seed-TTS eval (seed-tts-eval protocol) =====
Evaluated (WER, lower is better):        20        
Mean WER:                                0.0195    
Median WER:                              0.0000    
Request failed:                          0         
No PCM captured:                         0         
ASR / WER failed:                        0         
==================================================
```

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
