### PR TITLE
[Doc] JoyVL recipe: describe model as retrained Qwen3-VL, not vanilla

### DIFF
--- a/recipes/JD/JoyAI-VL-Interaction.md
+++ b/recipes/JD/JoyAI-VL-Interaction.md
@@ -5,7 +5,7 @@
 ## Summary
 
 - Vendor: JD (Joy Future Academy)
-- Model: [`jdopensource/JoyAI-VL-Interaction-Preview`](https://huggingface.co/jdopensource/JoyAI-VL-Interaction-Preview) (8B, vanilla Qwen3-VL weights)
+- Model: [`jdopensource/JoyAI-VL-Interaction-Preview`](https://huggingface.co/jdopensource/JoyAI-VL-Interaction-Preview) (8B, Qwen3-VL architecture with weights retrained for streaming interaction)
 - Task: Per-tick proactive interaction over a live video stream — the model decides
   on its own each second to speak, stay silent, or delegate a hard question
 - Mode: Online serving — an OpenAI-compatible interaction orchestrator in front of
@@ -33,7 +33,7 @@ framework internals and how to add another full-duplex model, see
 From repository root:
 
 ```bash
-# 1. Serve the model (plain `vllm serve`, NOT --omni; it is vanilla Qwen3-VL).
+# 1. Serve the model (plain `vllm serve`, NOT --omni; it uses the Qwen3-VL architecture).
 #    The image limit must cover the short-term frame window (chunk_frames, default 100 = T_s);
 #    prefix caching keeps the accumulating window cheap. Lower both for smaller GPUs.
 vllm serve jdopensource/JoyAI-VL-Interaction-Preview \
@@ -176,8 +176,9 @@ the audio-track caveat.
 
 ## Notes
 
-- `--omni` is **not** used: the model is standard Qwen3-VL, so stock `vllm serve`
-  runs the forward pass; this recipe only adds the interaction/serving layer.
+- `--omni` is **not** used: the model keeps the Qwen3-VL architecture (only the
+  weights are retrained), so stock `vllm serve` runs the forward pass; this recipe
+  only adds the interaction/serving layer.
 - On a host without `nvcc` / `ninja`, `vllm serve` of the 8B can crash engine-core in the
   FlashInfer sampler JIT (`FileNotFoundError: 'ninja'`) during `profile_run`. Set
   `VLLM_USE_FLASHINFER_SAMPLER=0` (or install `ninja`) to work around it.


### PR DESCRIPTION
## Purpose

Follow-up to #4575. The `JoyAI-VL-Interaction-Preview` checkpoint **keeps the Qwen3-VL architecture but its weights are retrained** for streaming interaction. The recipe previously described it as "vanilla Qwen3-VL weights" / "standard Qwen3-VL", which mis-states the model on the marketing axis. This reword aligns with the JD authors' positioning (see jd-opensource/JoyAI-VL-Interaction).

## Changes

`recipes/JD/JoyAI-VL-Interaction.md` only:
- Summary line: `(8B, Qwen3-VL architecture with weights retrained for streaming interaction)`
- Serve-step comment + Notes bullet: "uses the Qwen3-VL architecture" / "keeps the Qwen3-VL architecture (only the weights are retrained)"

The operational guidance is unchanged: it is still served by a plain `vllm serve` (no `--omni`) because the **architecture** is Qwen3-VL.

## Test

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)