### PR TITLE
[Feat] Add Cosmos3-Nano Pipeline Parallel support

### DIFF
--- a/vllm_omni/diffusion/distributed/pipeline_parallel.py
+++ b/vllm_omni/diffusion/distributed/pipeline_parallel.py
@@ -17,6 +17,21 @@ from vllm_omni.diffusion.distributed.parallel_state import (
 )
 
 
+def _wrap(pred: torch.Tensor | tuple[torch.Tensor, ...]) -> tuple[torch.Tensor, ...]:
+    """Normalize prediction to tuple form."""
+    return pred if isinstance(pred, tuple) else (pred,)
+
+
+def _unwrap(pred: tuple[torch.Tensor, ...]) -> torch.Tensor | tuple[torch.Tensor, ...]:
+    """Unwrap single-element tuple to plain tensor; keep multi-element as tuple."""
+    return pred[0] if len(pred) == 1 else pred
+
+
+def _slice_pred(pred: tuple[torch.Tensor, ...], output_slice: int) -> tuple[torch.Tensor, ...]:
+    """Slice each element along dim 1."""
+    return tuple(p[:, :output_slice] for p in pred)
+
+
 class AsyncLatents:
     """Transparent async wrapper returned by scheduler_step on rank 0.
 
@@ -237,23 +252,26 @@ class PipelineParallelMixin:
         if cfg_parallel_ready:
             # All-gather the single-branch prediction across the CFG group and combine
             # on all CFG ranks so every last PP rank has an identical noise_pred.
-            local_pred = noise_preds[0]
+            local_pred = _wrap(noise_preds[0])
             if output_slice is not None:
-                local_pred = local_pred[:, :output_slice]
-            gathered = get_cfg_group().all_gather(local_pred, separate_tensors=True)
-            return self.combine_cfg_noise(gathered[0], gathered[1], true_cfg_scale, cfg_normalize)
+                local_pred = _slice_pred(local_pred, output_slice)
+            gathered = [get_cfg_group().all_gather(p, separate_tensors=True) for p in local_pred]
+            positive_noise_pred = tuple(g[0] for g in gathered)
+            negative_noise_pred = tuple(g[1] for g in gathered)
+            return self.combine_cfg_noise(positive_noise_pred, negative_noise_pred, true_cfg_scale, cfg_normalize)
 
         # Sequential CFG or no-CFG path.
         if do_true_cfg:
-            pos, neg = noise_preds[0], noise_preds[1]
+            pos = _wrap(noise_preds[0])
+            neg = _wrap(noise_preds[1])
             if output_slice is not None:
-                pos = pos[:, :output_slice]
-                neg = neg[:, :output_slice]
+                pos = _slice_pred(pos, output_slice)
+                neg = _slice_pred(neg, output_slice)
             return self.combine_cfg_noise(pos, neg, true_cfg_scale, cfg_normalize)
-        pred = noise_preds[0]
+        pred = _wrap(noise_preds[0])
         if output_slice is not None:
-            pred = pred[:, :output_slice]
-        return pred
+            pred = _slice_pred(pred, output_slice)
+        return _unwrap(pred)
 
     def scheduler_step_maybe_with_cfg(
         self,

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -2222,6 +2222,20 @@ class Cosmos3OmniDiffusersPipeline(
                         sound_latents = unpacked[idx]
                 else:
                     latents = next_latents
+
+                if condition_latents is not None and velocity_mask is not None:
+                    latents = velocity_mask * latents + (1.0 - velocity_mask) * condition_latents
+                elif image_latent is not None:
+                    latents[:, :, 0:1, :, :] = image_latent
+                if (
+                    action_latents is not None
+                    and action_condition_latents is not None
+                    and action_velocity_mask is not None
+                ):
+                    action_latents = (
+                        action_velocity_mask * action_latents + (1.0 - action_velocity_mask) * action_condition_latents
+                    )
+
                 # action/sound latents unchanged on non-last ranks
                 outputs = [latents]
                 if action_latents is not None:
@@ -2260,15 +2274,6 @@ class Cosmos3OmniDiffusersPipeline(
                     idx += 1
                 if sound_latents is not None:
                     sound_latents = unpacked[idx]
-
-            # Condition re-injection：only rank 0 have latents updated
-            if not is_pipeline_first_stage():
-                outputs = [latents]
-                if action_latents is not None:
-                    outputs.append(action_latents)
-                if sound_latents is not None:
-                    outputs.append(sound_latents)
-                return outputs[0] if len(outputs) == 1 else tuple(outputs)
 
             if condition_latents is not None and velocity_mask is not None:
                 latents = velocity_mask * latents + (1.0 - velocity_mask) * condition_latents

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -2209,9 +2209,9 @@ class Cosmos3OmniDiffusersPipeline(
                 next_latents = self.scheduler_step_maybe_with_cfg(
                     None, t, latents, do_true_cfg=False, per_request_scheduler=step_scheduler
                 )
-                if _has_multimodal:
-                    if isinstance(next_latents, AsyncLatents):
-                        next_latents = next_latents._resolve()
+                if isinstance(next_latents, AsyncLatents):
+                    next_latents = next_latents._resolve()
+                if _has_multimodal and is_pipeline_first_stage():
                     unpacked = _unpack_joint(next_latents, _joint_shapes, _joint_numels)
                     latents = unpacked[0]
                     idx = 1

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -33,7 +33,7 @@ from diffusers.video_processor import VideoProcessor
 from torch import nn
 from transformers import AutoTokenizer
 from vllm.logger import init_logger
-from vllm.model_executor.models.utils import AutoWeightsLoader
+from vllm.model_executor.models.utils import AutoWeightsLoader, is_pp_missing_parameter
 
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import DistributedAutoencoderKLWan
@@ -41,6 +41,7 @@ from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.parallel_state import (
     get_classifier_free_guidance_world_size,
 )
+from vllm_omni.diffusion.distributed.pipeline_parallel import PipelineParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.interface import (
@@ -596,7 +597,12 @@ def get_cosmos3_ir_op_priority_func(od_config: OmniDiffusionConfig):
 # Pipeline
 # ---------------------------------------------------------------------------
 class Cosmos3OmniDiffusersPipeline(
-    nn.Module, CFGParallelMixin, SupportImageInput, ProgressBarMixin, DiffusionPipelineProfilerMixin
+    nn.Module,
+    PipelineParallelMixin,
+    CFGParallelMixin,
+    SupportImageInput,
+    ProgressBarMixin,
+    DiffusionPipelineProfilerMixin,
 ):
     """Cosmos3 text/image/video-to-video / text-to-image pipeline.
 
@@ -903,7 +909,11 @@ class Cosmos3OmniDiffusersPipeline(
             for name, tensor in weights:
                 total += 1
                 remapped = self._remap_ckpt_key(name)
-                if remapped is not None and (remapped in allowed or remapped in tp_aware):
+                if remapped is None:
+                    continue
+                if is_pp_missing_parameter(remapped, self.transformer):
+                    continue
+                if remapped in allowed or remapped in tp_aware:
                     kept += 1
                     yield remapped, tensor
             if _is_rank_zero():

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -40,8 +40,13 @@ from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import Dist
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.parallel_state import (
     get_classifier_free_guidance_world_size,
+    is_pipeline_first_stage,
+    is_pipeline_last_stage,
 )
-from vllm_omni.diffusion.distributed.pipeline_parallel import PipelineParallelMixin
+from vllm_omni.diffusion.distributed.pipeline_parallel import (
+    AsyncLatents,
+    PipelineParallelMixin,
+)
 from vllm_omni.diffusion.distributed.utils import get_local_device
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.interface import (
@@ -929,7 +934,13 @@ class Cosmos3OmniDiffusersPipeline(
         self.transformer.eval()
         if getattr(self.transformer, "sound_gen", False):
             sound_markers = ("audio_proj_in.", "audio_proj_out.", "audio_modality_embed")
-            missing = [marker.rstrip(".") for marker in sound_markers if not any(marker in name for name in loaded)]
+            # missing = [marker.rstrip(".") for marker in sound_markers if not any(marker in name for name in loaded)]
+            missing = [
+                marker.rstrip(".")
+                for marker in sound_markers
+                if not is_pp_missing_parameter(marker, self.transformer)
+                and not any(marker.rstrip(".") in name for name in loaded)
+            ]
             if missing:
                 raise ValueError(
                     "Cosmos3 transformer config enables sound generation, but "
@@ -938,7 +949,13 @@ class Cosmos3OmniDiffusersPipeline(
                 )
         if getattr(self.transformer, "action_gen", False):
             action_markers = ("action_proj_in.", "action_proj_out.", "action_modality_embed")
-            missing = [marker.rstrip(".") for marker in action_markers if not any(marker in name for name in loaded)]
+            # missing = [marker.rstrip(".") for marker in action_markers if not any(marker in name for name in loaded)]
+            missing = [
+                marker.rstrip(".")
+                for marker in action_markers
+                if not is_pp_missing_parameter(marker, self.transformer)
+                and not any(marker.rstrip(".") in name for name in loaded)
+            ]
             if missing:
                 raise ValueError(
                     "Cosmos3 transformer config enables action generation, but "
@@ -2110,8 +2127,8 @@ class Cosmos3OmniDiffusersPipeline(
         """
         do_cfg = guidance_scale > 1.0
         cfg_parallel = self._cfg_parallel_active() and do_cfg
-        step_scheduler = scheduler if scheduler is not None else self.scheduler
         self.transformer.reset_cache()
+        self.transformer.reset_pp_step()
 
         def _cfg_active_at(t: torch.Tensor) -> bool:
             if guidance_interval is None:
@@ -2173,13 +2190,43 @@ class Cosmos3OmniDiffusersPipeline(
             sound_pred = noise_pred[idx] if has_sound else None
             return video_pred, action_pred, sound_pred
 
+        _has_multimodal = action_latents is not None or sound_latents is not None
+        if _has_multimodal:
+            _, _joint_shapes, _joint_numels = _pack_joint(latents, action_latents, sound_latents)
+        else:
+            _joint_shapes, _joint_numels = None, None
+
         def _step(
-            noise_pred: torch.Tensor | tuple[torch.Tensor, ...],
+            noise_pred: torch.Tensor | tuple[torch.Tensor, ...] | None,
             t: torch.Tensor,
             latents: torch.Tensor,
             action_latents: torch.Tensor | None,
             sound_latents: torch.Tensor | None,
         ) -> torch.Tensor | tuple[torch.Tensor, ...]:
+            if noise_pred is None:
+                # Non-last PP rank: still need to participate in scheduler PP handshake
+                next_latents = self.scheduler_step_maybe_with_cfg(None, t, latents, do_true_cfg=False)
+                if _has_multimodal:
+                    if isinstance(next_latents, AsyncLatents):
+                        next_latents = next_latents._resolve()
+                    unpacked = _unpack_joint(next_latents, _joint_shapes, _joint_numels)
+                    latents = unpacked[0]
+                    idx = 1
+                    if action_latents is not None:
+                        action_latents = unpacked[idx]
+                        idx += 1
+                    if sound_latents is not None:
+                        sound_latents = unpacked[idx]
+                else:
+                    latents = next_latents
+                # action/sound latents unchanged on non-last ranks
+                outputs = [latents]
+                if action_latents is not None:
+                    outputs.append(action_latents)
+                if sound_latents is not None:
+                    outputs.append(sound_latents)
+                return outputs[0] if len(outputs) == 1 else tuple(outputs)
+
             video_pred, action_pred, sound_pred = _split_noise_pred(noise_pred)
             if velocity_mask is not None:
                 if image_latent is not None and condition_latents is None:
@@ -2191,11 +2238,13 @@ class Cosmos3OmniDiffusersPipeline(
                 if raw_action_dim is not None and 0 < raw_action_dim < action_pred.shape[-1]:
                     action_pred[..., raw_action_dim:] = 0
             if action_latents is None and sound_latents is None:
-                latents = step_scheduler.step(video_pred, t, latents, return_dict=False)[0]
+                latents = self.scheduler_step_maybe_with_cfg(video_pred, t, latents, do_true_cfg=False)
             else:
                 packed_noise, shapes, numels = _pack_joint(video_pred, action_pred, sound_pred)
                 packed_latents, _, _ = _pack_joint(latents, action_latents, sound_latents)
-                packed_next = step_scheduler.step(packed_noise, t, packed_latents, return_dict=False)[0]
+                packed_next = self.scheduler_step_maybe_with_cfg(packed_noise, t, packed_latents, do_true_cfg=False)
+                if isinstance(packed_next, AsyncLatents):
+                    packed_next = packed_next._resolve()
                 unpacked = _unpack_joint(packed_next, shapes, numels)
                 latents = unpacked[0]
                 idx = 1
@@ -2204,6 +2253,16 @@ class Cosmos3OmniDiffusersPipeline(
                     idx += 1
                 if sound_latents is not None:
                     sound_latents = unpacked[idx]
+
+            # Condition re-injection：only rank 0 have latents updated
+            if not is_pipeline_first_stage():
+                outputs = [latents]
+                if action_latents is not None:
+                    outputs.append(action_latents)
+                if sound_latents is not None:
+                    outputs.append(sound_latents)
+                return outputs[0] if len(outputs) == 1 else tuple(outputs)
+
             if condition_latents is not None and velocity_mask is not None:
                 latents = velocity_mask * latents + (1.0 - velocity_mask) * condition_latents
             elif image_latent is not None:
@@ -2222,7 +2281,9 @@ class Cosmos3OmniDiffusersPipeline(
         def _assign_step_out(step_out: torch.Tensor | tuple[torch.Tensor, ...]) -> None:
             nonlocal latents, action_latents, sound_latents
             if action_latents is None and sound_latents is None:
-                assert isinstance(step_out, torch.Tensor)
+                # assert isinstance(step_out, torch.Tensor)
+                # latents could be AsyncLatents, which implements __torch_function__
+                # so it will be triggered automatically in self.transformer.forward
                 latents = step_out
                 return
             if not isinstance(step_out, tuple):
@@ -2279,36 +2340,56 @@ class Cosmos3OmniDiffusersPipeline(
                 cfg_active = _cfg_active_at(t)
 
                 self.transformer.cached_kv, self.transformer.cached_freqs_gen = cond_cache
-                noise_cond = self.transformer(
-                    hidden_states=latents,
-                    timestep=timestep,
-                    text_ids=cond_ids,
-                    text_mask=cond_mask,
-                    action_latents=action_latents,
-                    sound_latents=sound_latents,
-                    **shared_kwargs,
+                noise_cond = self.predict_noise_maybe_with_cfg(
+                    do_true_cfg=False,
+                    true_cfg_scale=1.0,
+                    positive_kwargs=dict(
+                        hidden_states=latents,
+                        timestep=timestep,
+                        text_ids=cond_ids,
+                        text_mask=cond_mask,
+                        action_latents=action_latents,
+                        sound_latents=sound_latents,
+                        **shared_kwargs,
+                    ),
+                    negative_kwargs=None,
+                    cfg_normalize=False,
                 )
                 if cond_cache[0] is None:
                     cond_cache = (self.transformer.cached_kv, self.transformer.cached_freqs_gen)
 
                 if cfg_active or keep_uncond_for_cache:
                     self.transformer.cached_kv, self.transformer.cached_freqs_gen = uncond_cache
-                    noise_uncond = self.transformer(
-                        hidden_states=latents,
-                        timestep=timestep,
-                        text_ids=uncond_ids,
-                        text_mask=uncond_mask,
-                        action_latents=action_latents,
-                        sound_latents=sound_latents,
-                        **shared_kwargs,
+                    if uncond_cache[0] is None and not is_pipeline_last_stage():
+                        # refresh cache transfer for sequential CFG
+                        self.transformer.reset_pp_step()
+                    noise_uncond = self.predict_noise_maybe_with_cfg(
+                        do_true_cfg=False,
+                        true_cfg_scale=1.0,
+                        positive_kwargs=dict(
+                            hidden_states=latents,
+                            timestep=timestep,
+                            text_ids=uncond_ids,
+                            text_mask=uncond_mask,
+                            action_latents=action_latents,
+                            sound_latents=sound_latents,
+                            **shared_kwargs,
+                        ),
+                        negative_kwargs=None,
+                        cfg_normalize=False,
                     )
                     if uncond_cache[0] is None:
                         uncond_cache = (self.transformer.cached_kv, self.transformer.cached_freqs_gen)
+
                     # Outside the interval, scale=1.0 makes the combined result
                     # equal to noise_cond; the uncond pass is computed only to
                     # preserve cache-dit's cond/uncond parity.
                     step_scale = guidance_scale if cfg_active else 1.0
-                    noise_pred = self.combine_cfg_noise(noise_cond, noise_uncond, step_scale, cfg_normalize=False)
+                    if is_pipeline_last_stage():
+                        # Last stage: noise_cond or noise_uncond is expected
+                        noise_pred = self.combine_cfg_noise(noise_cond, noise_uncond, step_scale, cfg_normalize=False)
+                    else:
+                        noise_pred = None
                 else:
                     noise_pred = noise_cond
 
@@ -2317,18 +2398,26 @@ class Cosmos3OmniDiffusersPipeline(
         else:
             for t in self.progress_bar(timesteps):
                 timestep = t.unsqueeze(0)
-                noise_pred = self.transformer(
-                    hidden_states=latents,
-                    timestep=timestep,
-                    text_ids=cond_ids,
-                    text_mask=cond_mask,
-                    action_latents=action_latents,
-                    sound_latents=sound_latents,
-                    **shared_kwargs,
+                noise_pred = self.predict_noise_maybe_with_cfg(
+                    do_true_cfg=False,
+                    true_cfg_scale=1.0,
+                    positive_kwargs=dict(
+                        hidden_states=latents,
+                        timestep=timestep,
+                        text_ids=cond_ids,
+                        text_mask=cond_mask,
+                        action_latents=action_latents,
+                        sound_latents=sound_latents,
+                        **shared_kwargs,
+                    ),
+                    negative_kwargs=None,
+                    cfg_normalize=False,
                 )
                 _assign_step_out(_step(noise_pred, t, latents, action_latents, sound_latents))
 
         outputs = [latents]
+        if isinstance(outputs[0], AsyncLatents):
+            outputs[0] = outputs[0]._resolve()
         if action_latents is not None:
             outputs.append(action_latents)
         if sound_latents is not None:

--- a/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/pipeline_cosmos3.py
@@ -2127,6 +2127,7 @@ class Cosmos3OmniDiffusersPipeline(
         """
         do_cfg = guidance_scale > 1.0
         cfg_parallel = self._cfg_parallel_active() and do_cfg
+        step_scheduler = scheduler if scheduler is not None else self.scheduler
         self.transformer.reset_cache()
         self.transformer.reset_pp_step()
 
@@ -2205,7 +2206,9 @@ class Cosmos3OmniDiffusersPipeline(
         ) -> torch.Tensor | tuple[torch.Tensor, ...]:
             if noise_pred is None:
                 # Non-last PP rank: still need to participate in scheduler PP handshake
-                next_latents = self.scheduler_step_maybe_with_cfg(None, t, latents, do_true_cfg=False)
+                next_latents = self.scheduler_step_maybe_with_cfg(
+                    None, t, latents, do_true_cfg=False, per_request_scheduler=step_scheduler
+                )
                 if _has_multimodal:
                     if isinstance(next_latents, AsyncLatents):
                         next_latents = next_latents._resolve()
@@ -2238,11 +2241,15 @@ class Cosmos3OmniDiffusersPipeline(
                 if raw_action_dim is not None and 0 < raw_action_dim < action_pred.shape[-1]:
                     action_pred[..., raw_action_dim:] = 0
             if action_latents is None and sound_latents is None:
-                latents = self.scheduler_step_maybe_with_cfg(video_pred, t, latents, do_true_cfg=False)
+                latents = self.scheduler_step_maybe_with_cfg(
+                    video_pred, t, latents, do_true_cfg=False, per_request_scheduler=step_scheduler
+                )
             else:
                 packed_noise, shapes, numels = _pack_joint(video_pred, action_pred, sound_pred)
                 packed_latents, _, _ = _pack_joint(latents, action_latents, sound_latents)
-                packed_next = self.scheduler_step_maybe_with_cfg(packed_noise, t, packed_latents, do_true_cfg=False)
+                packed_next = self.scheduler_step_maybe_with_cfg(
+                    packed_noise, t, packed_latents, do_true_cfg=False, per_request_scheduler=step_scheduler
+                )
                 if isinstance(packed_next, AsyncLatents):
                     packed_next = packed_next._resolve()
                 unpacked = _unpack_joint(packed_next, shapes, numels)

--- a/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
@@ -28,11 +28,21 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
 )
+from vllm.model_executor.models.utils import (
+    PPMissingLayer,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+)
+from vllm.sequence import IntermediateTensors
 
 from vllm_omni.diffusion.attention.backends.abstract import AttentionMetadata
 from vllm_omni.diffusion.attention.layer import Attention as FrameworkAttention
 from vllm_omni.diffusion.cache.cache_dit_backend import CacheDiTAdapterConfig
 from vllm_omni.diffusion.data import OmniDiffusionConfig
+from vllm_omni.diffusion.distributed.parallel_state import (
+    is_pipeline_first_stage,
+    is_pipeline_last_stage,
+)
 from vllm_omni.diffusion.distributed.sp_plan import SequenceParallelInput, SequenceParallelOutput
 from vllm_omni.diffusion.forward_context import get_forward_context, is_forward_context_available
 from vllm_omni.diffusion.layers.norm import RMSNorm as _VllmRMSNorm
@@ -1083,69 +1093,92 @@ class Cosmos3VFMTransformer(nn.Module):
 
         dtype = od_config.dtype
         quant_config = getattr(od_config, "quantization_config", None) if od_config else None
+        is_pp_first_rank = is_pipeline_first_stage()
+        is_pp_last_rank = is_pipeline_last_stage()
 
-        self.language_model = Cosmos3LanguageModel(
-            hidden_size=self.hidden_size,
-            intermediate_size=self.intermediate_size,
-            num_hidden_layers=self.num_hidden_layers,
-            num_attention_heads=self.num_attention_heads,
-            num_key_value_heads=self.num_key_value_heads,
-            head_dim=self.head_dim,
-            vocab_size=self.vocab_size,
-            rms_norm_eps=self.rms_norm_eps,
-            rope_theta=self.rope_theta,
-            mrope_section=self.mrope_section,
-            quant_config=quant_config,
-            prefix="language_model",
-        )
-
-        # Video projection layers are small; not worth quantizing.
-        self.proj_in = nn.Linear(self.patch_latent_dim, self.hidden_size)
-        self.proj_out = nn.Linear(self.hidden_size, self.patch_latent_dim)
-        self.time_embedder = TimestepEmbedder(self.hidden_size, target_dtype=dtype)
-        if self.action_gen:
-            self.action_proj_in = DomainAwareLinear(
-                self.action_dim,
-                self.hidden_size,
-                self.num_embodiment_domains,
-                dtype=dtype,
+        if is_pp_first_rank:
+            self.language_model = Cosmos3LanguageModel(
+                hidden_size=self.hidden_size,
+                intermediate_size=self.intermediate_size,
+                num_hidden_layers=self.num_hidden_layers,
+                num_attention_heads=self.num_attention_heads,
+                num_key_value_heads=self.num_key_value_heads,
+                head_dim=self.head_dim,
+                vocab_size=self.vocab_size,
+                rms_norm_eps=self.rms_norm_eps,
+                rope_theta=self.rope_theta,
+                mrope_section=self.mrope_section,
+                quant_config=quant_config,
+                prefix="language_model",
             )
-            self.action_proj_out = DomainAwareLinear(
-                self.hidden_size,
-                self.action_dim,
-                self.num_embodiment_domains,
-                dtype=dtype,
+
+            # Video projection layers are small; not worth quantizing.
+            self.proj_in = nn.Linear(self.patch_latent_dim, self.hidden_size)
+            self.time_embedder = TimestepEmbedder(self.hidden_size, target_dtype=dtype)
+        else:
+            self.language_model = PPMissingLayer()
+            self.proj_in = PPMissingLayer()
+            self.time_embedder = PPMissingLayer()
+        if is_pp_last_rank:
+            self.proj_out = nn.Linear(self.hidden_size, self.patch_latent_dim)
+        else:
+            self.proj_out = PPMissingLayer()
+
+        if self.action_gen:
+            self.action_proj_in = (
+                DomainAwareLinear(
+                    self.action_dim,
+                    self.hidden_size,
+                    self.num_embodiment_domains,
+                    dtype=dtype,
+                )
+                if is_pp_first_rank
+                else PPMissingLayer()
+            )
+            self.action_proj_out = (
+                DomainAwareLinear(
+                    self.hidden_size,
+                    self.action_dim,
+                    self.num_embodiment_domains,
+                    dtype=dtype,
+                )
+                if is_pp_last_rank
+                else PPMissingLayer()
             )
             self.action_modality_embed = nn.Parameter(torch.zeros(self.hidden_size, dtype=dtype))
         if self.sound_gen:
-            self.audio_proj_in = nn.Linear(self.sound_dim, self.hidden_size)
-            self.audio_proj_out = nn.Linear(self.hidden_size, self.sound_dim)
+            self.audio_proj_in = nn.Linear(self.sound_dim, self.hidden_size) if is_pp_first_rank else PPMissingLayer()
+            self.audio_proj_out = nn.Linear(self.hidden_size, self.sound_dim) if is_pp_last_rank else PPMissingLayer()
             self.audio_modality_embed = nn.Parameter(torch.zeros(self.hidden_size))
 
-        self.gen_layers = nn.ModuleList(
-            [
-                Cosmos3GenDecoderLayer(
-                    layer_idx=i,
-                    hidden_size=self.hidden_size,
-                    intermediate_size=self.intermediate_size,
-                    num_attention_heads=self.num_attention_heads,
-                    num_key_value_heads=self.num_key_value_heads,
-                    head_dim=self.head_dim,
-                    rms_norm_eps=self.rms_norm_eps,
-                    quant_config=quant_config,
-                    prefix=f"gen_layers.{i}",
-                )
-                for i in range(self.num_hidden_layers)
-            ]
+        self.start_layer, self.end_layer, self.gen_layers = make_layers(
+            self.num_hidden_layers,
+            lambda prefix: Cosmos3GenDecoderLayer(
+                layer_idx=prefix.split(".")[-1],
+                hidden_size=self.hidden_size,
+                intermediate_size=self.intermediate_size,
+                num_attention_heads=self.num_attention_heads,
+                num_key_value_heads=self.num_key_value_heads,
+                head_dim=self.head_dim,
+                rms_norm_eps=self.rms_norm_eps,
+                quant_config=quant_config,
+                prefix=prefix,
+            ),
+            prefix="gen_layers",
         )
 
-        self.norm_moe_gen = RMSNorm(self.hidden_size, eps=self.rms_norm_eps)
-        self.gen_sp_prepare = Cosmos3GenSPPrepare()
+        self.norm_moe_gen = RMSNorm(self.hidden_size, eps=self.rms_norm_eps) if is_pp_last_rank else PPMissingLayer()
+        self.gen_sp_prepare = Cosmos3GenSPPrepare() if is_pp_first_rank else PPMissingLayer()
         self.gen_sp_gather = nn.Identity()
 
         # Cached state (populated on first forward, reused across denoising steps)
         self.cached_kv: list[tuple[torch.Tensor, torch.Tensor]] | None = None
         self.cached_freqs_gen: tuple[torch.Tensor, torch.Tensor] | None = None
+
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_gen"],
+            self.hidden_size,
+        )
 
     @property
     def device(self) -> torch.device:
@@ -1331,6 +1364,42 @@ class Cosmos3VFMTransformer(nn.Module):
         self.cached_kv = None
         self.cached_freqs_gen = None
 
+    def _maybe_load_und_cache_from_intermediate_tensors(
+        self,
+        intermediate_tensors: IntermediateTensors,
+    ) -> None:
+        """Load UND K/V and GEN RoPE freqs forwarded from an upstream PP stage."""
+        if "freqs_cos" not in intermediate_tensors.tensors:
+            return
+        cos = intermediate_tensors["freqs_cos"]
+        sin = intermediate_tensors["freqs_sin"]
+        self.cached_freqs_gen = (cos, sin)
+        cached_kv: list[tuple[torch.Tensor, torch.Tensor]] = []
+        for i in range(self.num_hidden_layers):
+            k_key = f"cached_k_{i}"
+            v_key = f"cached_v_{i}"
+            if k_key not in intermediate_tensors.tensors:
+                break
+            cached_kv.append((intermediate_tensors[k_key], intermediate_tensors[v_key]))
+        if len(cached_kv) != self.num_hidden_layers:
+            raise RuntimeError(
+                "Cosmos3 PP intermediate tensors are missing UND cache entries "
+                f"(expected {self.num_hidden_layers}, got {len(cached_kv)})."
+            )
+        self.cached_kv = cached_kv
+
+    def _build_pp_intermediate_tensors(self, hidden_gen: torch.Tensor) -> IntermediateTensors:
+        """Pack GEN hidden states and UND cache for the next PP stage."""
+        tensors: dict[str, torch.Tensor] = {"hidden_gen": hidden_gen}
+        if self.cached_kv is not None and self.cached_freqs_gen is not None:
+            cos, sin = self.cached_freqs_gen
+            tensors["freqs_cos"] = cos
+            tensors["freqs_sin"] = sin
+            for i, (k, v) in enumerate(self.cached_kv):
+                tensors[f"cached_k_{i}"] = k
+                tensors[f"cached_v_{i}"] = v
+        return IntermediateTensors(tensors)
+
     @staticmethod
     def _validate_gen_sequence_parallel(
         *,
@@ -1388,11 +1457,12 @@ class Cosmos3VFMTransformer(nn.Module):
         action_start_frame_offset: int = 1,
         action_fps: float | None = None,
         sound_latents: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
         noisy_frame_mask: torch.Tensor | None = None,
         control_latents: list[torch.Tensor] | tuple[torch.Tensor, ...] | torch.Tensor | None = None,
         transfer_share_vision_temporal_positions: bool = True,
         **kwargs,
-    ) -> torch.Tensor | tuple[torch.Tensor, ...]:
+    ) -> torch.Tensor | tuple[torch.Tensor, ...] | IntermediateTensors:
         """
         Args:
             hidden_states: [B, C, t, h, w] noisy latents
@@ -1456,112 +1526,122 @@ class Cosmos3VFMTransformer(nn.Module):
         # Query Ulysses state at runtime
         ulysses_size, _, _ = _get_ulysses_state()
 
-        # Patchify latents and project to hidden space
-        hidden_video = self.proj_in(self.patchify(hidden_states, t, h, w))
-        s_video = hidden_video.shape[1]
-        s_control = 0
-        hidden_controls: list[torch.Tensor] = []
-        for idx, control in enumerate(control_latent_list):
-            if control.shape != hidden_states.shape:
-                raise ValueError(
-                    "Cosmos3 transfer control latent shape must match target latent shape: "
-                    f"control[{idx}]={tuple(control.shape)}, target={tuple(hidden_states.shape)}."
-                )
-            hidden_control = self.proj_in(
-                self.patchify(control.to(device=hidden_states.device, dtype=hidden_states.dtype), t, h, w)
-            )
-            hidden_controls.append(hidden_control)
-            s_control += hidden_control.shape[1]
-        s_action = 0
-        hidden_action = None
-        s_sound = 0
-        hidden_sound = None
-        if action_latents is not None:
-            if action_latents.shape[0] != hidden_states.shape[0]:
-                raise ValueError(
-                    "Cosmos3 action and video batch sizes must match: "
-                    f"video={hidden_states.shape[0]}, action={action_latents.shape[0]}."
-                )
-            if action_domain_ids is None:
-                action_domain_ids = torch.zeros(action_latents.shape[0], dtype=torch.long, device=action_latents.device)
-            hidden_action = self.action_proj_in(self.pack_action(action_latents), action_domain_ids)
-            hidden_action = hidden_action + self.action_modality_embed.to(hidden_action.dtype)
-            s_action = hidden_action.shape[1]
-        if sound_latents is not None:
-            if sound_latents.shape[0] != hidden_states.shape[0]:
-                raise ValueError(
-                    "Cosmos3 sound and video batch sizes must match: "
-                    f"video={hidden_states.shape[0]}, sound={sound_latents.shape[0]}."
-                )
-            hidden_sound = self.audio_proj_in(self.pack_sound(sound_latents))
-            hidden_sound = hidden_sound + self.audio_modality_embed.to(hidden_sound.dtype)
-            s_sound = hidden_sound.shape[1]
-
-        # Timestep embedding (fp32 for precision).
-        # For I2V: only add to noisy tokens, not conditioned ones.
-        # Conditioned frames are clean context and should not receive
-        # the diffusion timestep signal.
-        with torch.autocast(current_omni_platform.device_type, enabled=False):
-            time_embed = self.time_embedder((timestep * self.timestep_scale).float())
-        time_embed = time_embed.to(hidden_states.dtype)
-
-        if noisy_frame_mask is not None:
-            # Build per-token mask from per-frame mask.
-            # noisy_frame_mask: [B, 1, t, 1, 1] → token mask: [B, t*hp*wp, 1]
-            token_noisy_mask = (
-                noisy_frame_mask[:, 0, :, 0, 0]  # [B, t]
-                .unsqueeze(-1)  # [B, t, 1]
-                .expand(-1, -1, hp * wp)  # [B, t, hp*wp]
-                .reshape(hidden_video.shape[0], -1, 1)  # [B, t*hp*wp, 1]
-            )
-            hidden_video = hidden_video + time_embed.unsqueeze(1) * token_noisy_mask
-        else:
-            hidden_video = hidden_video + time_embed.unsqueeze(1)
-
-        if hidden_action is not None:
-            if action_noisy_mask is None:
-                hidden_action = hidden_action + time_embed.unsqueeze(1)
-            else:
-                if action_noisy_mask.shape != (hidden_action.shape[0], hidden_action.shape[1], 1):
+        if is_pipeline_first_stage():
+            # Patchify latents and project to hidden space
+            hidden_video = self.proj_in(self.patchify(hidden_states, t, h, w))
+            s_video = hidden_video.shape[1]
+            s_control = 0
+            hidden_controls: list[torch.Tensor] = []
+            for idx, control in enumerate(control_latent_list):
+                if control.shape != hidden_states.shape:
                     raise ValueError(
-                        "Cosmos3 action_noisy_mask must have shape [B, T_action, 1], "
-                        f"got {tuple(action_noisy_mask.shape)}."
+                        "Cosmos3 transfer control latent shape must match target latent shape: "
+                        f"control[{idx}]={tuple(control.shape)}, target={tuple(hidden_states.shape)}."
                     )
-                action_noisy_mask = action_noisy_mask.to(dtype=hidden_action.dtype, device=hidden_action.device)
-                hidden_action = hidden_action + time_embed.unsqueeze(1) * action_noisy_mask
+                hidden_control = self.proj_in(
+                    self.patchify(control.to(device=hidden_states.device, dtype=hidden_states.dtype), t, h, w)
+                )
+                hidden_controls.append(hidden_control)
+                s_control += hidden_control.shape[1]
+            s_action = 0
+            hidden_action = None
+            s_sound = 0
+            hidden_sound = None
+            if action_latents is not None:
+                if action_latents.shape[0] != hidden_states.shape[0]:
+                    raise ValueError(
+                        "Cosmos3 action and video batch sizes must match: "
+                        f"video={hidden_states.shape[0]}, action={action_latents.shape[0]}."
+                    )
+                if action_domain_ids is None:
+                    action_domain_ids = torch.zeros(action_latents.shape[0], dtype=torch.long, device=action_latents.device)
+                hidden_action = self.action_proj_in(self.pack_action(action_latents), action_domain_ids)
+                hidden_action = hidden_action + self.action_modality_embed.to(hidden_action.dtype)
+                s_action = hidden_action.shape[1]
+            if sound_latents is not None:
+                if sound_latents.shape[0] != hidden_states.shape[0]:
+                    raise ValueError(
+                        "Cosmos3 sound and video batch sizes must match: "
+                        f"video={hidden_states.shape[0]}, sound={sound_latents.shape[0]}."
+                    )
+                hidden_sound = self.audio_proj_in(self.pack_sound(sound_latents))
+                hidden_sound = hidden_sound + self.audio_modality_embed.to(hidden_sound.dtype)
+                s_sound = hidden_sound.shape[1]
 
-        if hidden_sound is not None:
-            hidden_sound = hidden_sound + time_embed.unsqueeze(1)
-        hidden_parts = [*hidden_controls, hidden_video]
-        if hidden_action is not None:
-            hidden_parts.append(hidden_action)
-        if hidden_sound is not None:
-            hidden_parts.append(hidden_sound)
-        hidden_gen = torch.cat(hidden_parts, dim=1)
+            # Timestep embedding (fp32 for precision).
+            # For I2V: only add to noisy tokens, not conditioned ones.
+            # Conditioned frames are clean context and should not receive
+            # the diffusion timestep signal.
+            with torch.autocast(current_omni_platform.device_type, enabled=False):
+                time_embed = self.time_embedder((timestep * self.timestep_scale).float())
+            time_embed = time_embed.to(hidden_states.dtype)
 
-        # Run UND pathway once and cache K/V (replicated across all ranks)
-        if self.cached_kv is None:
-            freqs_und, freqs_gen = self._compute_rope_freqs(
-                text_mask,
-                t,
-                hp,
-                wp,
-                fps,
-                hidden_states.device,
-                hidden_states.dtype,
-                t_action=s_action,
-                action_start_frame_offset=action_start_frame_offset,
-                action_fps=action_fps,
-                t_sound=s_sound,
-                num_vision_items=len(control_latent_list) + 1,
-                share_vision_temporal_positions=transfer_share_vision_temporal_positions,
-            )
-            cached_kv_full = self.language_model(text_ids, freqs_und)
-            self.cached_freqs_gen = freqs_gen
+            if noisy_frame_mask is not None:
+                # Build per-token mask from per-frame mask.
+                # noisy_frame_mask: [B, 1, t, 1, 1] → token mask: [B, t*hp*wp, 1]
+                token_noisy_mask = (
+                    noisy_frame_mask[:, 0, :, 0, 0]  # [B, t]
+                    .unsqueeze(-1)  # [B, t, 1]
+                    .expand(-1, -1, hp * wp)  # [B, t, hp*wp]
+                    .reshape(hidden_video.shape[0], -1, 1)  # [B, t*hp*wp, 1]
+                )
+                hidden_video = hidden_video + time_embed.unsqueeze(1) * token_noisy_mask
+            else:
+                hidden_video = hidden_video + time_embed.unsqueeze(1)
 
-            # Trim to real text length (remove padding).  K/V stay replicated;
-            # the framework Attention layer head-slices them via joint_key/value.
-            self.cached_kv = [(k[:, :max_real_len], v[:, :max_real_len]) for k, v in cached_kv_full]
+            if hidden_action is not None:
+                if action_noisy_mask is None:
+                    hidden_action = hidden_action + time_embed.unsqueeze(1)
+                else:
+                    if action_noisy_mask.shape != (hidden_action.shape[0], hidden_action.shape[1], 1):
+                        raise ValueError(
+                            "Cosmos3 action_noisy_mask must have shape [B, T_action, 1], "
+                            f"got {tuple(action_noisy_mask.shape)}."
+                        )
+                    action_noisy_mask = action_noisy_mask.to(dtype=hidden_action.dtype, device=hidden_action.device)
+                    hidden_action = hidden_action + time_embed.unsqueeze(1) * action_noisy_mask
+
+            if hidden_sound is not None:
+                hidden_sound = hidden_sound + time_embed.unsqueeze(1)
+            hidden_parts = [*hidden_controls, hidden_video]
+            if hidden_action is not None:
+                hidden_parts.append(hidden_action)
+            if hidden_sound is not None:
+                hidden_parts.append(hidden_sound)
+            hidden_gen = torch.cat(hidden_parts, dim=1)
+
+            # Run UND pathway once and cache K/V (replicated across all ranks)
+            if self.cached_kv is None:
+                freqs_und, freqs_gen = self._compute_rope_freqs(
+                    text_mask,
+                    t,
+                    hp,
+                    wp,
+                    fps,
+                    hidden_states.device,
+                    hidden_states.dtype,
+                    t_action=s_action,
+                    action_start_frame_offset=action_start_frame_offset,
+                    action_fps=action_fps,
+                    t_sound=s_sound,
+                    num_vision_items=len(control_latent_list) + 1,
+                    share_vision_temporal_positions=transfer_share_vision_temporal_positions,
+                )
+                cached_kv_full = self.language_model(text_ids, freqs_und)
+                self.cached_freqs_gen = freqs_gen
+
+                # Trim to real text length (remove padding).  K/V stay replicated;
+                # the framework Attention layer head-slices them via joint_key/value.
+                self.cached_kv = [(k[:, :max_real_len], v[:, :max_real_len]) for k, v in cached_kv_full]
+        else:
+            if intermediate_tensors is None:
+                raise RuntimeError("Cosmos3 GEN PP non-first stages require intermediate_tensors from the prior stage.")
+            hidden_gen = intermediate_tensors["hidden_gen"]
+            self._maybe_load_und_cache_from_intermediate_tensors(intermediate_tensors)
+            s_video = t * hp * wp
+            s_control = t * hp * wp * len(control_latent_list)
+            s_action = int(action_latents.shape[1]) if action_latents is not None else 0
+            s_sound = int(sound_latents.shape[2]) if sound_latents is not None else 0
 
         # Run GEN layers.  UND K/V (replicated) is passed to each layer;
         # the Cosmos3CrossAttention forwards them as joint_key/value so the
@@ -1580,25 +1660,25 @@ class Cosmos3VFMTransformer(nn.Module):
             ulysses_size=ulysses_size,
         )
         freqs_cos, freqs_sin = self.cached_freqs_gen
-        hidden_gen, freqs_cos, freqs_sin = self.gen_sp_prepare(hidden_gen, freqs_cos, freqs_sin)
+        if is_pipeline_first_stage():
+            hidden_gen, freqs_cos, freqs_sin = self.gen_sp_prepare(hidden_gen, freqs_cos, freqs_sin)
         freqs_gen = (freqs_cos, freqs_sin)
 
         if len(self.gen_layers) == len(self.cached_kv):
-            for layer, (k_und, v_und) in zip(self.gen_layers, self.cached_kv, strict=True):
-                hidden_gen = layer(
+            for i in range(self.start_layer, self.end_layer):
+                hidden_gen = self.gen_layers[i](
                     hidden_gen,
-                    k_und=k_und,
-                    v_und=v_und,
+                    k_und=self.cached_kv[i][0],
+                    v_und=self.cached_kv[i][1],
                     freqs_cos=freqs_cos,
                     freqs_sin=freqs_sin,
                 )
-                # Cache-dit's block wrapper may return a tuple; unwrap it.
                 if isinstance(hidden_gen, tuple):
                     hidden_gen = hidden_gen[0]
         else:
             # Cache-dit patches gen_layers to a grouped wrapper.
-            for layer in self.gen_layers:
-                hidden_gen = layer(
+            for i in range(self.start_layer, self.end_layer):
+                hidden_gen = self.gen_layers[i](
                     hidden_gen,
                     cached_kv=self.cached_kv,
                     freqs_gen=freqs_gen,
@@ -1607,6 +1687,9 @@ class Cosmos3VFMTransformer(nn.Module):
                     hidden_gen = hidden_gen[0]
 
         hidden_gen = self.gen_sp_gather(hidden_gen)
+
+        if not is_pipeline_last_stage():
+            return self._build_pp_intermediate_tensors(hidden_gen)
 
         # Final norm and project back to latent space
         hidden_gen = self.norm_moe_gen(hidden_gen)
@@ -1643,4 +1726,5 @@ class Cosmos3VFMTransformer(nn.Module):
 
     def post_load_weights(self) -> None:
         """Post-load processing: ensure correct dtypes."""
-        self.time_embedder.to(torch.float32)
+        if is_pipeline_first_stage():
+            self.time_embedder.to(torch.float32)

--- a/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
@@ -1569,7 +1569,9 @@ class Cosmos3VFMTransformer(nn.Module):
                         f"video={hidden_states.shape[0]}, action={action_latents.shape[0]}."
                     )
                 if action_domain_ids is None:
-                    action_domain_ids = torch.zeros(action_latents.shape[0], dtype=torch.long, device=action_latents.device)
+                    action_domain_ids = torch.zeros(
+                        action_latents.shape[0], dtype=torch.long, device=action_latents.device
+                    )
                 hidden_action = self.action_proj_in(self.pack_action(action_latents), action_domain_ids)
                 hidden_action = hidden_action + self.action_modality_embed.to(hidden_action.dtype)
                 s_action = hidden_action.shape[1]

--- a/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
+++ b/vllm_omni/diffusion/models/cosmos3/transformer_cosmos3.py
@@ -1199,7 +1199,13 @@ class Cosmos3VFMTransformer(nn.Module):
         p = self.latent_patch_size
         C = self.latent_channel_size
         hp, wp, H_padded, W_padded = self._pad_to_patch_size(h, w)
-
+        # expected = B * C * t * H_padded * W_padded
+        # if latents.numel() != expected:
+        #     raise ValueError(
+        #         f"Cosmos3 patchify received {latents.numel()} elements but expected "
+        #         f"{expected} for video_shape=({t},{h},{w}). The latents are likely still "
+        #         f"packed with action/sound modalities — unpack before calling forward."
+        #     )
         if H_padded != h or W_padded != w:
             latents = F.pad(latents, (0, W_padded - w, 0, H_padded - h))
 
@@ -1364,6 +1370,10 @@ class Cosmos3VFMTransformer(nn.Module):
         self.cached_kv = None
         self.cached_freqs_gen = None
 
+    def reset_pp_step(self) -> None:
+        # PP-aware flag to track if cache is shared across denoising steps
+        self._is_first_denoise_step = True
+
     def _maybe_load_und_cache_from_intermediate_tensors(
         self,
         intermediate_tensors: IntermediateTensors,
@@ -1391,13 +1401,18 @@ class Cosmos3VFMTransformer(nn.Module):
     def _build_pp_intermediate_tensors(self, hidden_gen: torch.Tensor) -> IntermediateTensors:
         """Pack GEN hidden states and UND cache for the next PP stage."""
         tensors: dict[str, torch.Tensor] = {"hidden_gen": hidden_gen}
-        if self.cached_kv is not None and self.cached_freqs_gen is not None:
+
+        # send cache to next stage when first denoising step
+        include_cache = (not is_pipeline_last_stage()) and self._is_first_denoise_step
+        if self.cached_kv is not None and include_cache:
             cos, sin = self.cached_freqs_gen
             tensors["freqs_cos"] = cos
             tensors["freqs_sin"] = sin
             for i, (k, v) in enumerate(self.cached_kv):
                 tensors[f"cached_k_{i}"] = k
                 tensors[f"cached_v_{i}"] = v
+
+        self._is_first_denoise_step = False
         return IntermediateTensors(tensors)
 
     @staticmethod
@@ -1726,5 +1741,4 @@ class Cosmos3VFMTransformer(nn.Module):
 
     def post_load_weights(self) -> None:
         """Post-load processing: ensure correct dtypes."""
-        if is_pipeline_first_stage():
-            self.time_embedder.to(torch.float32)
+        self.time_embedder.to(torch.float32)

--- a/vllm_omni/diffusion/models/internvla_a1/adapter_qwen3_vl.py
+++ b/vllm_omni/diffusion/models/internvla_a1/adapter_qwen3_vl.py
@@ -15,10 +15,10 @@ from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLVisionModel,
     Unpack,
     apply_rotary_pos_emb,
-    check_model_inputs,
+    capture_outputs,
     create_causal_mask,
-    deprecate_kwarg,
     eager_attention_forward,
+    merge_with_config_defaults,
 )
 from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLForConditionalGeneration as HFQwen3VLForConditionalGeneration,
@@ -38,6 +38,7 @@ from transformers.models.qwen3_vl.modeling_qwen3_vl import (
 from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLTextRMSNorm as HFQwen3VLTextRMSNorm,
 )
+from transformers.utils.deprecation import deprecate_kwarg
 
 
 class Qwen3VLTextRMSNorm(HFQwen3VLTextRMSNorm):
@@ -134,7 +135,8 @@ class Qwen3VLTextModel(HFQwen3VLTextModel):
 
         self.post_init()
 
-    @check_model_inputs
+    @merge_with_config_defaults
+    @capture_outputs
     def forward(
         self,
         input_ids: torch.LongTensor = None,


### PR DESCRIPTION
[Feat] Add Cosmos3-Nano Pipeline Parallel support

## Purpose
Part of #4340 

Cosmos3-Nano pipeline-parallel support.

Environment:

GPU: 2× NVIDIA RTX 5880 48GB + 2x NVIDIA RTX 4080 16GB
torch: 2.11.0+cu130
vLLM: 0.23.0

## Changes

1. PipelineParallelMixin: Support multi-modal outputs
    - All CFG paths now operate element-wise, naturally extending to (video, action, sound) without special-casing
2. Cosmos3-Nano pipeline parallel support
    - Pass hidden_gen and UND K/V cache (first step only) between stages via IntermediateTensors
    - Non-last stages skip CFG combination and condition re-injection; participate in scheduler via a dedicated noise_pred is None branch

## Test Plan
Baseline and PP size=2 tests on 2x`NVIDIA RTX 5880`, PP size=2 + CFGP size=2 tests on 2x`NVIDIA RTX 5880` + 2x`NVIDIA RTX 4080`, using the offcial parameters provided in `recipes/cosmos3/Cosmos3-Nano.md`, assets used in tests are downloaded from official repo: https://huggingface.co/nvidia/Cosmos3-Nano

Baseline server:
```bash
vllm serve nvidia/Cosmos3-Nano --omni --host 0.0.0.0 --port 8000 --no-guardrails --init-timeout 1800
```

PP server:
```bash
vllm serve nvidia/Cosmos3-Nano --omni --host 0.0.0.0 --port 8000 --no-guardrails --init-timeout 1800 --pipeline-parallel-size=2
```

PP+CFGP server:
```bash
vllm serve nvidia/Cosmos3-Nano --omni --host 0.0.0.0 --port 8000 --no-guardrails --init-timeout 1800 --pipeline-parallel-size=2 --cfg-parallel-size=2
```

T2I:
```bash
curl -sS -X POST http://localhost:8000/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{
    "model": "nvidia/Cosmos3-Nano",
    "prompt": "A photorealistic red sports car on a city street at golden hour, cinematic lighting.",
    "negative_prompt": "blurry, distorted, low quality",
    "size": "1024x1024", "n": 1, "response_format": "b64_json",
    "num_inference_steps": 50, "guidance_scale": 7.0, "seed": 42
  }' | python3 -c "import sys,json,base64; open('cosmos3_t2i.png','wb').write(base64.b64decode(json.load(sys.stdin)['data'][0]['b64_json']))"
```

T2V:
```bash
curl -sS -X POST http://localhost:8000/v1/videos \
  -H "Accept: video/mp4" \
  -F "model=nvidia/Cosmos3-Nano" \
  -F "prompt=A robot arm is cleaning a plate in the kitchen" \
  -F "negative_prompt=blurry, distorted, low quality, jittery, deformed" \
  -F "size=1280x720" -F "num_frames=189" -F "fps=24" \
  -F "num_inference_steps=35" -F "guidance_scale=6.0" \
  -F "max_sequence_length=4096" -F "flow_shift=10.0" \
  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false}' \
  -F "seed=123" \
  -o cosmos3_t2v.mp4
```

I2V:
```bash
curl -sS -X POST http://localhost:8000/v1/videos \
  -H "Accept: video/mp4" \
  -F "model=nvidia/Cosmos3-Nano" \
  -F "prompt=The scene comes to life with smooth, natural motion." \
  -F "negative_prompt=blurry, distorted, low quality" \
  -F "size=1280x720" -F "num_frames=189" -F "fps=24" \
  -F "num_inference_steps=35" -F "guidance_scale=6.0" \
  -F "max_sequence_length=4096" -F "flow_shift=10.0" \
  -F 'extra_params={"use_resolution_template":false,"use_duration_template":false}' \
  -F "seed=1111" \
  -F "input_reference=@Cosmos3-Nano/assets/example_i2v_input.jpg;type=image/jpeg" \
  -o cosmos3_i2v.mp4
```

## Test Result

| **Task** | **Baseline (sec)** | **PP2 (sec)** | **PP2+CFGP2 (s)** | **PP2 Speedup** | **PP2+CFGP2 Speedup** |
|----------|-----------------|-------------|-------------------|--------------|-------------------|
| T2I | 64.80 | 47.96 | 47.82 | 1.35× | 1.35× |
| T2V | 928.89 | 713.88 | 564.89 | 1.30× | 1.64× |
| I2V | 927.29 | 710.70 | 565.12 | 1.30× | 1.64× |

**BEFORE SUBMITTING:** read [CONTRIBUTING.md](https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md) and run the [precheck-pr skill](https://github.com/vllm-project/vllm-omni/blob/main/.claude/skills/precheck-pr/SKILL.md) with the code agent for a self-check against project conventions.
(anything written below this line will be removed by GitHub Actions)
D K/V cache (first step only) between stages via IntermediateTensors
    - Non-last stages skip CFG combination and condition re-injection; participate in scheduler via a dedicated noise_pred is None branch

Images (left: baseline, middle: PP size=2, right: PP size=2 + CFG size=2)
| **baseline** | **PP size=2** | **PP size=2 + CFG size=2** |
|:---:|:---:|:---:|
| <img width="1024" height="1024" alt="cosmos3_t2i" src="https://github.com/user-attachments/assets/97b2194f-ef8b-40e1-a9a8-49a89fb5fd8c" /> | <img width="1024" height="1024" alt="cosmos3_t2i_pp2" src="https://github.com/user-attachments/assets/a53524fc-1f0b-4c6c-90ec-c5d3c4b30128" /> | <img width="1024" height="1024" alt="cosmos3_t2i_pp2cfg" src="https://github.com/user-attachments/assets/ba22cb53-a194-4fa4-b977-2663c4212a46" /> |