### PR TITLE
[Bugfix] Support append/extend/count actions in TrackingArgumentParser

### DIFF
--- a/tests/utils/test_tracking_parser.py
+++ b/tests/utils/test_tracking_parser.py
@@ -16,7 +16,12 @@ from vllm_omni.config.stage_config import (
     StageDeployConfig,
     StagePipelineConfig,
 )
-from vllm_omni.utils.tracking_parser import TrackingArgumentParser, TrackingNamespace
+from vllm_omni.utils.tracking_parser import (
+    UNSET,
+    TrackingArgumentParser,
+    TrackingNamespace,
+    build_shadow_kwargs,
+)
 
 ### Fake pipeline/deploy config for integration tests
 
@@ -327,9 +332,10 @@ def test_omitted_nargs():
 
 
 ### Tests for in-place mutating actions (append / extend / count).
-# These actions make argparse mutate the shadow default in place, so the
-# shadow default cannot be the bare ``object()`` sentinel (it would raise
-# AttributeError/TypeError). See _UnsetList / _UnsetCount in tracking_parser.
+# These actions mutate their default in place, which would crash on the bare
+# ``UNSET`` sentinel. The shadow parser remaps them to a non-mutating store-style
+# action (see build_shadow_kwargs in tracking_parser), so the real namespace
+# still accumulates while explicit-arg tracking keeps working.
 def test_append_action_omitted():
     """Omitted append args parse without error and aren't marked explicit."""
     p = TrackingArgumentParser()
@@ -419,6 +425,36 @@ def test_group_append_action_explicit():
     assert ns.explicit_keys == {"tag"}
     assert isinstance(ns, TrackingNamespace)
     assert ns.tag == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    ("action", "expected"),
+    [
+        ("append", "store"),
+        ("extend", "store"),
+        ("append_const", "store_const"),
+        ("count", "store_const"),
+    ],
+)
+def test_build_shadow_kwargs_remaps_mutating_actions(action, expected):
+    """Mutating actions are remapped to a store-style action with an UNSET default."""
+    shadow = build_shadow_kwargs({"action": action, "const": "c"})
+    assert shadow["action"] == expected
+    assert shadow["default"] is UNSET
+
+
+def test_build_shadow_kwargs_count_gets_marker_const():
+    """count carries no const, so the remapped store_const gets a non-UNSET marker."""
+    shadow = build_shadow_kwargs({"action": "count"})
+    assert shadow["action"] == "store_const"
+    assert shadow["const"] is not UNSET
+
+
+def test_build_shadow_kwargs_leaves_other_actions_untouched():
+    """Non-mutating actions keep their action and only get the UNSET default."""
+    shadow = build_shadow_kwargs({"action": "store_true"})
+    assert shadow["action"] == "store_true"
+    assert shadow["default"] is UNSET
 
 
 def test_parse_known_args_tracking():

--- a/tests/utils/test_tracking_parser.py
+++ b/tests/utils/test_tracking_parser.py
@@ -326,6 +326,101 @@ def test_omitted_nargs():
     assert ns.items is None
 
 
+### Tests for in-place mutating actions (append / extend / count).
+# These actions make argparse mutate the shadow default in place, so the
+# shadow default cannot be the bare ``object()`` sentinel (it would raise
+# AttributeError/TypeError). See _UnsetList / _UnsetCount in tracking_parser.
+def test_append_action_omitted():
+    """Omitted append args parse without error and aren't marked explicit."""
+    p = TrackingArgumentParser()
+    p.add_argument("--tag", action="append")
+    ns = p.parse_args([])
+    assert ns.explicit_keys == set()
+    assert isinstance(ns, TrackingNamespace)
+    assert ns.tag is None
+
+
+def test_append_action_explicit():
+    """Repeated append args are collected and marked explicit."""
+    p = TrackingArgumentParser()
+    p.add_argument("--tag", action="append")
+    ns = p.parse_args(["--tag", "a", "--tag", "b"])
+    assert ns.explicit_keys == {"tag"}
+    assert isinstance(ns, TrackingNamespace)
+    assert ns.tag == ["a", "b"]
+
+
+def test_append_const_action_omitted():
+    """Omitted append_const args aren't marked explicit."""
+    p = TrackingArgumentParser()
+    p.add_argument("--dbg", action="append_const", const="x", dest="flags")
+    ns = p.parse_args([])
+    assert ns.explicit_keys == set()
+    assert isinstance(ns, TrackingNamespace)
+    assert ns.flags is None
+
+
+def test_append_const_action_explicit():
+    """Repeated append_const args accumulate the const and are explicit."""
+    p = TrackingArgumentParser()
+    p.add_argument("--dbg", action="append_const", const="x", dest="flags")
+    ns = p.parse_args(["--dbg", "--dbg"])
+    assert ns.explicit_keys == {"flags"}
+    assert isinstance(ns, TrackingNamespace)
+    assert ns.flags == ["x", "x"]
+
+
+def test_extend_action_omitted():
+    """Omitted extend args parse without error and aren't marked explicit."""
+    p = TrackingArgumentParser()
+    p.add_argument("--items", action="extend", nargs="+")
+    ns = p.parse_args([])
+    assert ns.explicit_keys == set()
+    assert isinstance(ns, TrackingNamespace)
+    assert ns.items is None
+
+
+def test_extend_action_explicit():
+    """Repeated extend args are flattened into one list and marked explicit."""
+    p = TrackingArgumentParser()
+    p.add_argument("--items", action="extend", nargs="+")
+    ns = p.parse_args(["--items", "a", "b", "--items", "c"])
+    assert ns.explicit_keys == {"items"}
+    assert isinstance(ns, TrackingNamespace)
+    assert ns.items == ["a", "b", "c"]
+
+
+def test_count_action_omitted():
+    """Omitted count args keep their default and aren't marked explicit."""
+    p = TrackingArgumentParser()
+    p.add_argument("-v", "--verbose", action="count", default=0)
+    ns = p.parse_args([])
+    assert ns.explicit_keys == set()
+    assert isinstance(ns, TrackingNamespace)
+    assert ns.verbose == 0
+
+
+def test_count_action_explicit():
+    """Repeated count flags increment and are marked explicit."""
+    p = TrackingArgumentParser()
+    p.add_argument("-v", "--verbose", action="count", default=0)
+    ns = p.parse_args(["-vv"])
+    assert ns.explicit_keys == {"verbose"}
+    assert isinstance(ns, TrackingNamespace)
+    assert ns.verbose == 2
+
+
+def test_group_append_action_explicit():
+    """append args added via a group go through the same shadow-default path."""
+    p = TrackingArgumentParser()
+    g = p.add_argument_group("TestGroup")
+    g.add_argument("--tag", action="append")
+    ns = p.parse_args(["--tag", "a", "--tag", "b"])
+    assert ns.explicit_keys == {"tag"}
+    assert isinstance(ns, TrackingNamespace)
+    assert ns.tag == ["a", "b"]
+
+
 def test_parse_known_args_tracking():
     """Ensure parse_known_args is also trackable"""
     p = TrackingArgumentParser()

--- a/vllm_omni/utils/tracking_parser.py
+++ b/vllm_omni/utils/tracking_parser.py
@@ -9,51 +9,27 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 UNSET = object()
 
 
-class _UnsetList(list):
-    """Sentinel default for ``append``/``append_const``/``extend`` shadow args.
+def build_shadow_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Build kwargs for the shadow argument with an ``UNSET`` default.
 
-    argparse's append/extend actions do ``_copy_items(default).append(...)``,
-    which raises ``AttributeError: 'object' object has no attribute 'append'``
-    when the default is the bare ``object()`` sentinel (UNSET). An empty list
-    subclass keeps those actions working while staying distinguishable from a
-    real value: an untouched shadow default remains an empty ``_UnsetList``;
-    once the arg is passed it becomes a non-empty list.
+    Actions that mutate their default in place (append/extend/append_const/
+    count) would crash on the bare ``UNSET`` sentinel, so they are remapped to
+    an equivalent store-style action; the shadow value only needs to flip away
+    from ``UNSET`` when the arg is passed explicitly.
     """
-
-
-class _UnsetCount(int):
-    """Sentinel default (0) for the ``count`` shadow action.
-
-    ``count`` computes ``(default or 0) + 1``; the bare ``object()`` sentinel
-    would raise ``TypeError``. A zero-valued ``int`` subclass increments
-    normally, while an untouched default stays an ``_UnsetCount`` equal to 0.
-    """
-
-
-def _shadow_default(kwargs: dict[str, Any]) -> Any:
-    """Pick a shadow default that survives in-place argparse actions.
-
-    Most actions tolerate the ``UNSET`` sentinel, but the ones that mutate the
-    existing namespace value in place (append/extend/count) need a default that
-    supports that mutation. See ``_UnsetList`` / ``_UnsetCount`` for why.
-    """
+    shadow_kwargs = {**kwargs, "default": UNSET}
     action = kwargs.get("action")
-    if action in ("append", "append_const", "extend"):
-        return _UnsetList()
-    if action == "count":
-        return _UnsetCount()
-    return UNSET
 
+    if action in ("append", "extend"):
+        shadow_kwargs["action"] = "store"
 
-def _is_shadow_unset(value: Any) -> bool:
-    """Whether a shadow namespace value was left at its default (not passed)."""
-    if value is UNSET:
-        return True
-    if isinstance(value, _UnsetList):
-        return len(value) == 0
-    if isinstance(value, _UnsetCount):
-        return value == 0
-    return False
+    elif action in ("append_const", "count"):
+        shadow_kwargs["action"] = "store_const"
+
+        if action == "count":
+            shadow_kwargs["const"] = True
+
+    return shadow_kwargs
 
 
 class TrackingNamespace(argparse.Namespace):
@@ -105,7 +81,7 @@ class TrackingGroup:
     def add_argument(self, *args: Any, **kwargs: Any) -> argparse.Action:
         """Add an argument to the real group and to the shadow group."""
         action = self._real.add_argument(*args, **kwargs)
-        default_kwargs = {**kwargs, "default": _shadow_default(kwargs)}
+        default_kwargs = build_shadow_kwargs(kwargs)
         self._shadow.add_argument(*args, **default_kwargs)
         return action
 
@@ -162,7 +138,7 @@ class TrackingArgumentParser(FlexibleArgumentParser):
     def add_argument(self, *args: Any, **kwargs: Any) -> argparse.Action:
         """Add an arg to the parser & the shadow, where the latter has UNSET for the default."""
         action = super().add_argument(*args, **kwargs)
-        shadow_kwargs = {**kwargs, "default": _shadow_default(kwargs)}
+        shadow_kwargs = build_shadow_kwargs(kwargs)
         self._shadow.add_argument(*args, **shadow_kwargs)
         return action
 
@@ -183,7 +159,7 @@ class TrackingArgumentParser(FlexibleArgumentParser):
 
     def build_tracking_namespace(self, real_ns: argparse.Namespace, shadow_ns: argparse.Namespace) -> TrackingNamespace:
         """Build a tracking namespace for the real / shadow namespaces."""
-        explicit_keys = frozenset(k for k, v in vars(shadow_ns).items() if not _is_shadow_unset(v))
+        explicit_keys = frozenset(k for k, v in vars(shadow_ns).items() if v is not UNSET)
         return TrackingNamespace(real_ns, explicit_keys)
 
     def parse_args(

--- a/vllm_omni/utils/tracking_parser.py
+++ b/vllm_omni/utils/tracking_parser.py
@@ -9,6 +9,53 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 UNSET = object()
 
 
+class _UnsetList(list):
+    """Sentinel default for ``append``/``append_const``/``extend`` shadow args.
+
+    argparse's append/extend actions do ``_copy_items(default).append(...)``,
+    which raises ``AttributeError: 'object' object has no attribute 'append'``
+    when the default is the bare ``object()`` sentinel (UNSET). An empty list
+    subclass keeps those actions working while staying distinguishable from a
+    real value: an untouched shadow default remains an empty ``_UnsetList``;
+    once the arg is passed it becomes a non-empty list.
+    """
+
+
+class _UnsetCount(int):
+    """Sentinel default (0) for the ``count`` shadow action.
+
+    ``count`` computes ``(default or 0) + 1``; the bare ``object()`` sentinel
+    would raise ``TypeError``. A zero-valued ``int`` subclass increments
+    normally, while an untouched default stays an ``_UnsetCount`` equal to 0.
+    """
+
+
+def _shadow_default(kwargs: dict[str, Any]) -> Any:
+    """Pick a shadow default that survives in-place argparse actions.
+
+    Most actions tolerate the ``UNSET`` sentinel, but the ones that mutate the
+    existing namespace value in place (append/extend/count) need a default that
+    supports that mutation. See ``_UnsetList`` / ``_UnsetCount`` for why.
+    """
+    action = kwargs.get("action")
+    if action in ("append", "append_const", "extend"):
+        return _UnsetList()
+    if action == "count":
+        return _UnsetCount()
+    return UNSET
+
+
+def _is_shadow_unset(value: Any) -> bool:
+    """Whether a shadow namespace value was left at its default (not passed)."""
+    if value is UNSET:
+        return True
+    if isinstance(value, _UnsetList):
+        return len(value) == 0
+    if isinstance(value, _UnsetCount):
+        return value == 0
+    return False
+
+
 class TrackingNamespace(argparse.Namespace):
     """Proxy that wraps an argparse namespace with explicit keys, which
     can be filtered down to a dict containing only explicitly passed values.
@@ -58,7 +105,7 @@ class TrackingGroup:
     def add_argument(self, *args: Any, **kwargs: Any) -> argparse.Action:
         """Add an argument to the real group and to the shadow group."""
         action = self._real.add_argument(*args, **kwargs)
-        default_kwargs = {**kwargs, "default": UNSET}
+        default_kwargs = {**kwargs, "default": _shadow_default(kwargs)}
         self._shadow.add_argument(*args, **default_kwargs)
         return action
 
@@ -115,7 +162,7 @@ class TrackingArgumentParser(FlexibleArgumentParser):
     def add_argument(self, *args: Any, **kwargs: Any) -> argparse.Action:
         """Add an arg to the parser & the shadow, where the latter has UNSET for the default."""
         action = super().add_argument(*args, **kwargs)
-        shadow_kwargs = {**kwargs, "default": UNSET}
+        shadow_kwargs = {**kwargs, "default": _shadow_default(kwargs)}
         self._shadow.add_argument(*args, **shadow_kwargs)
         return action
 
@@ -136,7 +183,7 @@ class TrackingArgumentParser(FlexibleArgumentParser):
 
     def build_tracking_namespace(self, real_ns: argparse.Namespace, shadow_ns: argparse.Namespace) -> TrackingNamespace:
         """Build a tracking namespace for the real / shadow namespaces."""
-        explicit_keys = frozenset(k for k, v in vars(shadow_ns).items() if v is not UNSET)
+        explicit_keys = frozenset(k for k, v in vars(shadow_ns).items() if not _is_shadow_unset(v))
         return TrackingNamespace(real_ns, explicit_keys)
 
     def parse_args(


### PR DESCRIPTION
## Purpose

`TrackingArgumentParser` builds a shadow parser whose every argument default is
replaced with an `UNSET` sentinel (a bare `object()`) so it can track which args
were explicitly passed. argparse's `append` / `append_const` / `extend` /
`count` actions mutate that default **in place**, so they crash on the sentinel:

```
--tag a      -> AttributeError: 'object' object has no attribute 'append'
--items a b  -> AttributeError: 'object' object has no attribute 'extend'
-vv          -> TypeError: unsupported operand type(s) for +: 'object' and 'int'
```

**Root cause:** the shadow default must support the in-place mutation these
actions perform; a bare `object()` does not.

**Fix:** use action-aware shadow defaults — an empty `_UnsetList` for
append/extend and a zero `_UnsetCount` for count (subclasses that mutate
normally yet stay distinguishable from a real value, since an untouched default
stays empty/zero). `_is_shadow_unset` treats those untouched defaults as
"not passed", so explicit-arg tracking is unchanged for every other action.

Related to #3366 (the RFC that proposed the `UNSET` shadow-parser design) and
#3369 (which implemented it). This PR fixes a bug in that implementation and
does not change the design, so it does not close either; there is also no
existing issue tracking this specific crash.

## Test Plan

**vLLM Version:** N/A (pure stdlib `argparse` behavior, not version-dependent)

**vLLM-Omni Commit:** based on `7e152ca6`

Added tests in `tests/utils/test_tracking_parser.py` covering omitted and
explicit cases for `append`, `append_const`, `extend`, and `count`, plus a
group-level `append`. Each explicit case crashes on `main` and passes on this
branch.

```bash
pytest tests/utils/test_tracking_parser.py
ruff check vllm_omni/utils/tracking_parser.py tests/utils/test_tracking_parser.py
```

## Test Result

```
pytest tests/utils/test_tracking_parser.py  -> all passing
ruff check                                   -> All checks passed!
```
