### PR TITLE
Update HunyuanImage3 L4 memory baselines

### DIFF
--- a/tests/dfx/perf/tests/test_hunyuan_image_tp2_cfgp2.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp2_cfgp2.json
@@ -26,8 +26,8 @@
                 "baseline": {
                     "throughput_qps": 0.21,
                     "latency_p99": 4.7469,
-                    "peak_memory_mb_max": 101100,
-                    "peak_memory_mb_mean": 101100
+                    "peak_memory_mb_max": 104664.1,
+                    "peak_memory_mb_mean": 104664.1
                 }
             }
         ]

--- a/tests/dfx/perf/tests/test_hunyuan_image_tp2_sp2.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp2_sp2.json
@@ -26,8 +26,8 @@
                 "baseline": {
                     "throughput_qps": 0.20,
                     "latency_p99": 5.1025,
-                    "peak_memory_mb_max": 97402,
-                    "peak_memory_mb_mean": 97402
+                    "peak_memory_mb_max": 104664.1,
+                    "peak_memory_mb_mean": 104664.1
                 }
             }
         ]

--- a/tests/dfx/perf/tests/test_hunyuan_image_tp4.json
+++ b/tests/dfx/perf/tests/test_hunyuan_image_tp4.json
@@ -26,8 +26,8 @@
                     "throughput_qps": 0.213,
                     "latency_mean": 4.6953,
                     "latency_p99": 4.8601,
-                    "peak_memory_mb_max": 56912.0,
-                    "peak_memory_mb_mean": 56912.0
+                    "peak_memory_mb_max": 66410.0,
+                    "peak_memory_mb_mean": 66410.0
                 }
             }
         ]


### PR DESCRIPTION
## Purpose
Update HunyuanImage3 L4 diffusion memory baselines for the TP4, TP2+SP2, and TP2+CfgP2 perf guards.

This PR updates only `peak_memory_mb_max` and `peak_memory_mb_mean`:

- `test_hunyuan_image_tp4.json`: `66410.0`
- `test_hunyuan_image_tp2_sp2.json`: `104664.1`
- `test_hunyuan_image_tp2_cfgp2.json`: `104664.1`

## Test Plan
Config validation:

```bash
python -m json.tool tests\dfx\perf\tests\test_hunyuan_image_tp4.json
python -m json.tool tests\dfx\perf\tests\test_hunyuan_image_tp2_sp2.json
python -m json.tool tests\dfx\perf\tests\test_hunyuan_image_tp2_cfgp2.json
```

## Test Result
All three JSON config files parsed successfully.