### PR TITLE
Add usage info to SSE speech streaming done event

### DIFF
--- a/tests/entrypoints/openai_api/test_serving_speech.py
+++ b/tests/entrypoints/openai_api/test_serving_speech.py
@@ -1906,6 +1906,24 @@ class TestStreamingResponse:
                 final_output_type="audio",
                 request_output=MockRequestOutput(audio_tensor=chunk),
                 finished=finished,
+                metrics={
+                    "stage_metrics": {
+                        "0": {
+                            "stage_id": 0,
+                            "final_output_type": "text",
+                            "num_tokens_in": 7,
+                            "num_tokens_out": 3,
+                        },
+                        "1": {
+                            "stage_id": 1,
+                            "final_output_type": "audio",
+                            "num_tokens_in": 0,
+                            "num_tokens_out": 11,
+                        },
+                    }
+                }
+                if finished
+                else {},
             )
 
         async def mock_generate_streaming(*args, **kwargs):
@@ -1976,6 +1994,19 @@ class TestStreamingResponse:
         assert payload["type"] == "speech.audio.delta"
         assert payload["response_format"] == "pcm"
         assert base64.b64decode(payload["audio"])
+        done_line = next(
+            line
+            for event in body.split("\n\n")
+            if "event: speech.audio.done" in event
+            for line in event.splitlines()
+            if line.startswith("data: ")
+        )
+        done_payload = json.loads(done_line.removeprefix("data: "))
+        assert done_payload["usage"] == {
+            "prompt_tokens": 7,
+            "completion_tokens": 14,
+            "total_tokens": 21,
+        }
 
     def test_stream_true_prefers_raw_audio_over_sse(self, streaming_app):
         """stream=True keeps the existing raw audio stream behavior even with stream_format=sse."""

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -2588,6 +2588,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         raw_request: Request | None = None,
         request_start_s: float | None = None,
         include_sample_rate: bool = False,
+        output_tracker: list[Any] | None = None,
     ):
         """Generate audio chunks for streaming response.
 
@@ -2614,6 +2615,8 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
 
         try:
             async for res in generator:
+                if output_tracker is not None:
+                    output_tracker[:] = [res]
                 audio_output, audio_key = self._extract_audio_output(res)
                 if audio_key is None:
                     continue
@@ -2727,6 +2730,45 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
             if not artifact_ready:
                 self._discard_ref_audio_artifact_warmup(request_id)
 
+    @staticmethod
+    def _coerce_non_negative_int(value: Any) -> int:
+        try:
+            count = int(value)
+        except (TypeError, ValueError):
+            return 0
+        return max(count, 0)
+
+    @staticmethod
+    def _is_stage_zero(stage_key: Any, stage_metric: Mapping[str, Any]) -> bool:
+        stage_id = stage_metric.get("stage_id", stage_key)
+        try:
+            return int(stage_id) == 0
+        except (TypeError, ValueError):
+            return False
+
+    def _create_speech_usage_from_metrics(self, res: Any | None) -> dict[str, int]:
+        metrics = getattr(res, "metrics", None) or {}
+        if not isinstance(metrics, Mapping):
+            request_output = getattr(res, "request_output", None)
+            metrics = getattr(request_output, "metrics", None) or {}
+
+        stage_metrics = metrics.get("stage_metrics") if isinstance(metrics, Mapping) else None
+        prompt_tokens = 0
+        completion_tokens = 0
+        if isinstance(stage_metrics, Mapping):
+            for stage_key, stage_metric in stage_metrics.items():
+                if not isinstance(stage_metric, Mapping):
+                    continue
+                if self._is_stage_zero(stage_key, stage_metric):
+                    prompt_tokens += self._coerce_non_negative_int(stage_metric.get("num_tokens_in"))
+                completion_tokens += self._coerce_non_negative_int(stage_metric.get("num_tokens_out"))
+
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+
     async def _generate_audio_sse_events(
         self,
         generator,
@@ -2743,12 +2785,14 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
         See https://platform.openai.com/docs/api-reference/audio-streaming.
         """
         try:
+            output_tracker: list[Any] = []
             async for chunk in self._generate_audio_chunks(
                 generator,
                 request_id,
                 response_format,
                 raw_request=raw_request,
                 request_start_s=request_start_s,
+                output_tracker=output_tracker,
             ):
                 payload = {
                     "type": "speech.audio.delta",
@@ -2757,7 +2801,13 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                 }
                 data = json.dumps(payload, separators=(",", ":"))
                 yield f"event: speech.audio.delta\ndata: {data}\n\n"
-            done = json.dumps({"type": "speech.audio.done"}, separators=(",", ":"))
+            usage = self._create_speech_usage_from_metrics(
+                output_tracker[0] if output_tracker else None
+            )
+            done = json.dumps(
+                {"type": "speech.audio.done", "usage": usage},
+                separators=(",", ":"),
+            )
             yield f"event: speech.audio.done\ndata: {done}\n\n"
         except asyncio.CancelledError:
             raise

--- a/vllm_omni/entrypoints/openai/serving_speech.py
+++ b/vllm_omni/entrypoints/openai/serving_speech.py
@@ -2801,9 +2801,7 @@ class OmniOpenAIServingSpeech(OpenAIServing, AudioMixin):
                 }
                 data = json.dumps(payload, separators=(",", ":"))
                 yield f"event: speech.audio.delta\ndata: {data}\n\n"
-            usage = self._create_speech_usage_from_metrics(
-                output_tracker[0] if output_tracker else None
-            )
+            usage = self._create_speech_usage_from_metrics(output_tracker[0] if output_tracker else None)
             done = json.dumps(
                 {"type": "speech.audio.done", "usage": usage},
                 separators=(",", ":"),


### PR DESCRIPTION
## Summary

Add `usage` information to the final SSE event for `/v1/audio/speech` streaming responses.

For SSE speech streaming, the final `speech.audio.done` event now includes OpenAI-style usage fields:

    {
      "type": "speech.audio.done",
      "usage": {
        "prompt_tokens": 0,
        "completion_tokens": 0,
        "total_tokens": 0
      }
    }

## Motivation

Before this change, SSE speech streaming returned audio delta events and a final done event, but the done event did not include token usage information.

For OpenAI-compatible clients, usage information is useful for accounting and observability. Adding it to the final SSE event makes `/v1/audio/speech` SSE streaming easier to consume consistently with other OpenAI-style streaming APIs.

## Behavior

- SSE audio chunks are unchanged.
- The final `speech.audio.done` event includes a `usage` object.
- `prompt_tokens` is derived from stage-0 `num_tokens_in`.
- `completion_tokens` is derived from `num_tokens_out` across all stages.
- `total_tokens` is `prompt_tokens + completion_tokens`.
- If metrics are unavailable, token counts fall back to `0`.

## Notes

The current `prompt_tokens` value follows the engine stage metrics semantics. For some speech model/task paths, this may represent the internal stage-0 prefill token count rather than a pure user input text token count.

## Tests

Added/updated tests for SSE speech streaming to verify that the final `speech.audio.done` event includes the expected `usage` payload.