### PR TITLE
[Perf] Optimize video postprocess with pinned DtoH fast path

### DIFF
--- a/vllm_omni/diffusion/models/ltx2/ltx2_components.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_components.py
@@ -270,10 +270,16 @@ def get_ltx2_post_process_func(od_config: Any):
     """Build the common LTX engine-output adapter."""
     output_sample_rate = _detect_vocoder_output_sample_rate(od_config.model)
 
-    def post_process_func(output: tuple[torch.Tensor, torch.Tensor] | torch.Tensor):
+    def post_process_func(
+        output: tuple[torch.Tensor, torch.Tensor] | torch.Tensor,
+        sampling_params: Any | None = None,
+    ):
         if not (isinstance(output, tuple) and len(output) == 2):
             return output
         video, audio = output
+        output_type = getattr(sampling_params, "output_type", None) if sampling_params is not None else None
+        if output_type in (None, "np") and sampling_params is not None and isinstance(video, torch.Tensor):
+            video = video.detach().cpu().numpy()
         if isinstance(audio, torch.Tensor):
             audio = audio.detach().cpu()
         result: dict[str, Any] = {"video": video, "audio": audio}

--- a/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_runtime.py
@@ -22,6 +22,7 @@ from vllm_omni.diffusion.distributed.parallel_state import (
 )
 from vllm_omni.diffusion.models.interface import SupportsComponentDiscovery
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
+from vllm_omni.diffusion.postprocess import prepare_video_for_transport
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch, split_diffusion_output_by_request
 from vllm_omni.platforms import current_omni_platform
@@ -494,7 +495,10 @@ class LTXRuntime(
             )
 
         if video.numel() > 0:
-            video = self.video_processor.postprocess_video(video, output_type=output_type)
+            if output_type == "np":
+                video = prepare_video_for_transport(video, self.video_processor)
+            else:
+                video = self.video_processor.postprocess_video(video, output_type=output_type)
         generated_mel = self.audio_vae.decode(audio_latents.to(self.audio_vae.dtype), return_dict=False)[0]
         audio = self.vocoder(generated_mel)
         return self._make_output((video, audio))

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -13,6 +13,7 @@ from typing import Any, ClassVar, cast
 import PIL.Image
 import torch
 from diffusers.utils.torch_utils import randn_tensor
+from diffusers.video_processor import VideoProcessor
 from torch import nn
 from transformers import AutoTokenizer, UMT5EncoderModel
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
@@ -33,7 +34,7 @@ from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_z
 from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
 from vllm_omni.diffusion.models.wan2_2.scheduling_wan_euler import WanEulerScheduler
 from vllm_omni.diffusion.models.wan2_2.wan2_2_transformer import WanTransformer3DModel
-from vllm_omni.diffusion.postprocess import interpolate_video_tensor
+from vllm_omni.diffusion.postprocess import interpolate_video_tensor, prepare_video_for_transport
 from vllm_omni.diffusion.profiler.diffusion_pipeline_profiler import DiffusionPipelineProfilerMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 from vllm_omni.diffusion.worker.request_batch import DiffusionRequestBatch
@@ -194,8 +195,6 @@ def create_transformer_from_config(
 def get_wan22_post_process_func(
     od_config: OmniDiffusionConfig,
 ):
-    from diffusers.video_processor import VideoProcessor
-
     video_processor = VideoProcessor(vae_scale_factor=8)
 
     def post_process_func(
@@ -206,16 +205,24 @@ def get_wan22_post_process_func(
         if output_type == "latent":
             return video
         video_metadata = {}
-        if sampling_params is not None and getattr(sampling_params, "enable_frame_interpolation", False):
-            video, multiplier = interpolate_video_tensor(
-                video,
-                exp=sampling_params.frame_interpolation_exp,
-                scale=sampling_params.frame_interpolation_scale,
-                model_path=sampling_params.frame_interpolation_model_path,
-            )
-            video_metadata["video_fps_multiplier"] = multiplier
+        frame_interpolation = sampling_params is not None and getattr(
+            sampling_params, "enable_frame_interpolation", False
+        )
+        requested_output_type = getattr(sampling_params, "output_type", None) if sampling_params is not None else None
+        if sampling_params is not None and requested_output_type in (None, "np") and not frame_interpolation:
+            processed_video = video.detach().cpu().numpy()
+        else:
+            if frame_interpolation:
+                video, multiplier = interpolate_video_tensor(
+                    video,
+                    exp=sampling_params.frame_interpolation_exp,
+                    scale=sampling_params.frame_interpolation_scale,
+                    model_path=sampling_params.frame_interpolation_model_path,
+                )
+                video_metadata["video_fps_multiplier"] = multiplier
+            processed_video = video_processor.postprocess_video(video, output_type=output_type)
         return {
-            "payload": {"video": video_processor.postprocess_video(video, output_type=output_type)},
+            "payload": {"video": processed_video},
             "metadata": {"video": video_metadata} if video_metadata else {},
         }
 
@@ -401,6 +408,7 @@ class Wan22Pipeline(
             local_files_only=local_files_only,
             torch_dtype=dtype,
         ).to(self.device)
+        self.video_processor = VideoProcessor(vae_scale_factor=8)
 
         # Initialize transformers with correct config (weights loaded via load_weights)
         if load_transformer:
@@ -814,6 +822,9 @@ class Wan22Pipeline(
             )
             latents = latents / latents_std + latents_mean
             output = self.vae.decode(latents, return_dict=False)[0]
+
+            if output_type == "np" and not getattr(req.sampling_params, "enable_frame_interpolation", False):
+                output = prepare_video_for_transport(output, self.video_processor)
 
         if DEBUG_PERF:
             current_omni_platform.synchronize()

--- a/vllm_omni/diffusion/postprocess/__init__.py
+++ b/vllm_omni/diffusion/postprocess/__init__.py
@@ -6,5 +6,10 @@ from vllm_omni.diffusion.postprocess.rife_interpolator import (
     FrameInterpolator,
     interpolate_video_tensor,
 )
+from vllm_omni.diffusion.postprocess.video import prepare_video_for_transport
 
-__all__ = ["FrameInterpolator", "interpolate_video_tensor"]
+__all__ = [
+    "FrameInterpolator",
+    "interpolate_video_tensor",
+    "prepare_video_for_transport",
+]

--- a/vllm_omni/diffusion/postprocess/video.py
+++ b/vllm_omni/diffusion/postprocess/video.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import torch
+from diffusers.video_processor import VideoProcessor
+
+
+def prepare_video_for_transport(
+    video: torch.Tensor,
+    video_processor: VideoProcessor,
+) -> torch.Tensor:
+    """Consume a decoded BCTHW video and prepare BTHWC float32 on-device."""
+    if video.ndim != 5:
+        raise ValueError(f"Expected a decoded BCTHW video, got shape {tuple(video.shape)}.")
+
+    if video_processor.config.do_normalize:
+        video.mul_(0.5).add_(0.5).clamp_(0, 1)
+    # Diffusers NumPy/PIL output is BTHWC float32. Materialize that layout on
+    # the producing device; the generic Worker IPC owns the subsequent D2H.
+    return video.permute(0, 2, 3, 4, 1).to(dtype=torch.float32, copy=True)


### PR DESCRIPTION
[Perf] Optimize video finalization before D2H

<!-- markdownlint-disable -->

## Summary

Large decoded videos spend a measurable tail on denormalization, layoutconversion, FP32 materialization, and D2H transfer.

Async pinned D2H and overlap with the next request are already provided by #4981, merged by @BLANKETusers on July 29, 2026 UTC. This PR does not add second stream, staging allocator, or output-transport protocol.

It keeps only the complementary optimization: a small consuming helper performs denormalization, clamping, BCTHW → BTHWC conversion, and FP32 materialization on the producing device before handing the result to the existing Worker IPC path.

The experimental integration is intentionally limited to:

- the shared LTX runtime;
- Wan T2V when frame interpolation is disabled.

Other output types and Wan frame interpolation keep their existing paths. The tradeoff is lower latency at the cost of a temporary output-sized GPU allocation.

## Test Result

Offline `Omni.generate`, eager single-GPU execution, CPU offload disabled, same loaded model/request/seed, one warmup plus five measured runs. Latency includes the final NumPy-ready output boundary.

| Model | Resolution / frames | Before | After | Saving |
| --- | ---: | ---: | ---: | ---: |
| LTX | 1024×576×81 | 4765.88 ms | 4504.16 ms | 261.71 ms (5.49%) |
| LTX | 1536×1024×121 | 21756.65 ms | 20659.37 ms | 1097.29 ms (5.04%) |
| Wan | 1280×720×81 | 16758.47 ms | 16268.51 ms | 489.97 ms (2.92%) |

All sampled outputs were bitwise equal. Pre-commit passed, and the existing LTX and Wan tests passed (`89 passed`).

The remaining review question is the latency versus temporary GPU-memory tradeoff, rather than introducing another asynchronous D2H implementation.
