### PR TITLE
[NPU] Initialize Ascend config for diffusion workers for v0.22.0

### DIFF
--- a/requirements/npu.txt
+++ b/requirements/npu.txt
@@ -1,3 +1,3 @@
 -r common.txt
 onnxruntime-cann>=1.23.2
-torchaudio==2.9.0
+torchaudio==2.10.0

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -239,6 +239,7 @@ class DiffusionWorker:
             "Final IR op priority after setting vLLM-Omni overrides: %s", vllm_config.kernel_config.ir_op_priority
         )
         self.vllm_config = vllm_config
+        current_omni_platform.init_diffusion_worker_vllm_config(vllm_config)
 
         # Initialize distributed environment
         with (

--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -137,6 +137,11 @@ class OmniPlatform(Platform):
         return "vllm_omni.diffusion.worker.diffusion_model_runner.DiffusionModelRunner"
 
     @classmethod
+    def init_diffusion_worker_vllm_config(cls, vllm_config: Any) -> None:
+        """Initialize platform-specific state for diffusion worker VllmConfig."""
+        return None
+
+    @classmethod
     def get_torch_device(cls, local_rank: int | None = None) -> torch.device:
         raise NotImplementedError
 

--- a/vllm_omni/platforms/npu/platform.py
+++ b/vllm_omni/platforms/npu/platform.py
@@ -56,6 +56,12 @@ class NPUOmniPlatform(OmniPlatform, NPUPlatform):
         return "vllm_omni.platforms.npu.worker.npu_generation_worker.NPUGenerationWorker"
 
     @classmethod
+    def init_diffusion_worker_vllm_config(cls, vllm_config: Any) -> None:
+        from vllm_ascend.ascend_config import init_ascend_config
+
+        init_ascend_config(vllm_config)
+
+    @classmethod
     def get_default_stage_config_path(cls) -> str:
         return "vllm_omni/platforms/npu/stage_configs"
 


### PR DESCRIPTION
## Summary

This PR adds a platform hook for diffusion worker `VllmConfig` initialization and implements it for the NPU platform by calling `vllm_ascend.ascend_config.init_ascend_config`.

## Why

Diffusion workers build their own worker-local `VllmConfig` and do not go through the standard vLLM/vLLM-Ascend worker initialization path. Recent vLLM-Ascend versions tightened the global `AscendConfig` singleton reuse rules so it is no longer safe to rely on an Ascend config initialized by another code path or another `VllmConfig` instance.

As a result, NPU diffusion models that construct vLLM-Ascend ops during model loading, such as HunyuanImage3 MoE layers, can fail with:

```text
RuntimeError: Ascend config is not initialized. Please call init_ascend_config first.
```

## What Changed

- Added `OmniPlatform.init_diffusion_worker_vllm_config(...)` as a default no-op platform hook.
- Called that hook after `DiffusionWorker` finishes constructing its worker-local `vllm_config`.
- Overrode the hook in `NPUOmniPlatform` to initialize vLLM-Ascend config with that exact diffusion worker `vllm_config`.

## Why This Shape

The Ascend initialization is NPU-specific, so the common diffusion worker should not import or know about `vllm_ascend`. Routing through `current_omni_platform` keeps the shared worker path generic while letting each backend initialize any platform-specific runtime state it needs.

This also avoids adding a separate NPU diffusion worker class only for a small initialization difference.

## Validation

```bash
python -m py_compile vllm_omni/diffusion/worker/diffusion_worker.py vllm_omni/platforms/interface.py vllm_omni/platforms/npu/platform.py
git diff --check
```