### PR TITLE
[Feature] Allow vllm-omni to (partially) run on CPU only machines

### DIFF
--- a/tests/worker/test_cpu_ar_model_runner.py
+++ b/tests/worker/test_cpu_ar_model_runner.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_omni.worker.cpu_ar_model_runner import CPUARModelRunner
+
+pytestmark = [pytest.mark.core_model, pytest.mark.cpu]
+
+
+def _make_runner() -> CPUARModelRunner:
+    runner = object.__new__(CPUARModelRunner)
+    model_config = SimpleNamespace(
+        engine_output_type="audio",
+        async_chunk=True,
+        enable_return_routed_experts=False,
+    )
+    runner.vllm_config = SimpleNamespace(model_config=model_config)
+    runner.model_config = model_config
+    runner.omni_prefix_cache = None
+    runner.speculative_config = None
+    runner.use_async_scheduling = True
+    runner.model = SimpleNamespace(has_postprocess=False, use_async_omni_output=True)
+    return runner
+
+
+def test_cpu_ar_model_runner_never_uses_async_omni_output():
+    runner = _make_runner()
+
+    # Same flags that make GPUARModelRunner._should_use_async_omni_output
+    # return True; CPUARModelRunner must still refuse, since building
+    # OmniAsyncGPUModelRunnerOutput unconditionally touches torch.cuda APIs
+    # that don't exist without a CUDA device.
+    assert not CPUARModelRunner._should_use_async_omni_output(runner)

--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -308,6 +308,14 @@ class UnspecifiedOmniPlatform(OmniPlatform, CpuPlatform):
         return torch.device("cpu")
 
     @classmethod
+    def get_omni_ar_worker_cls(cls) -> str:
+        return "vllm_omni.worker.cpu_ar_worker.CPUARWorker"
+
+    @classmethod
+    def get_omni_generation_worker_cls(cls) -> str:
+        return "vllm_omni.worker.cpu_generation_worker.CPUGenerationWorker"
+
+    @classmethod
     def get_default_stage_config_path(cls) -> str:
         return "vllm_omni/deploy"
 

--- a/vllm_omni/platforms/interface.py
+++ b/vllm_omni/platforms/interface.py
@@ -11,6 +11,7 @@ from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import BatchDescriptor
 from vllm.logger import init_logger
 from vllm.platforms import Platform
+from vllm.platforms.cpu import CpuPlatform
 from vllm.platforms.interface import PlatformEnum
 
 logger = init_logger(__name__)
@@ -298,15 +299,30 @@ class OmniPlatform(Platform):
         )
 
 
-class UnspecifiedOmniPlatform(OmniPlatform):
+class UnspecifiedOmniPlatform(OmniPlatform, CpuPlatform):
     _omni_enum = OmniPlatformEnum.UNSPECIFIED
     _enum = PlatformEnum.UNSPECIFIED
-    device_type = "cpu"
 
     @classmethod
     def get_torch_device(cls, local_rank: int | None = None) -> torch.device:
         return torch.device("cpu")
 
     @classmethod
+    def get_default_stage_config_path(cls) -> str:
+        return "vllm_omni/deploy"
+
+    @classmethod
+    def synchronize(cls) -> None:
+        pass
+
+    @classmethod
+    def empty_cache(cls) -> None:
+        pass
+
+    @classmethod
+    def supports_torch_inductor(cls) -> bool:
+        return True
+
+    @classmethod
     def get_device_count(cls) -> int:
-        return 0
+        return 1

--- a/vllm_omni/worker/cpu_ar_model_runner.py
+++ b/vllm_omni/worker/cpu_ar_model_runner.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm_omni.worker.cpu_model_runner import OmniCPUModelRunner
+from vllm_omni.worker.gpu_ar_model_runner import GPUARModelRunner
+
+
+# GPUARModelRunner provides omni AR hooks (sample_tokens, hidden-state
+# extraction, connector init); OmniCPUModelRunner supplies the CPU-safe
+# overrides from vLLM's CPUModelRunner via MRO.
+class CPUARModelRunner(OmniCPUModelRunner, GPUARModelRunner):
+    pass

--- a/vllm_omni/worker/cpu_ar_worker.py
+++ b/vllm_omni/worker/cpu_ar_worker.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.v1.worker.cpu_worker import CPUWorker
+
+from vllm_omni.worker.cpu_ar_model_runner import CPUARModelRunner
+from vllm_omni.worker.mixins import OmniWorkerMixin
+
+
+class CPUARWorker(OmniWorkerMixin, CPUWorker):
+    def init_device(self):
+        super().init_device()
+        self.model_runner: CPUARModelRunner = CPUARModelRunner(self.vllm_config, self.device)

--- a/vllm_omni/worker/cpu_generation_model_runner.py
+++ b/vllm_omni/worker/cpu_generation_model_runner.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm_omni.worker.cpu_model_runner import OmniCPUModelRunner
+from vllm_omni.worker.gpu_generation_model_runner import GPUGenerationModelRunner
+
+
+# GPUGenerationModelRunner provides omni generation hooks;
+# OmniCPUModelRunner supplies the CPU-safe overrides from vLLM's
+# CPUModelRunner via MRO.
+class CPUGenerationModelRunner(OmniCPUModelRunner, GPUGenerationModelRunner):
+    pass

--- a/vllm_omni/worker/cpu_generation_worker.py
+++ b/vllm_omni/worker/cpu_generation_worker.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.v1.worker.cpu_worker import CPUWorker
+
+from vllm_omni.worker.cpu_generation_model_runner import CPUGenerationModelRunner
+from vllm_omni.worker.mixins import OmniWorkerMixin
+
+
+class CPUGenerationWorker(OmniWorkerMixin, CPUWorker):
+    def init_device(self):
+        super().init_device()
+        self.model_runner: CPUGenerationModelRunner = CPUGenerationModelRunner(self.vllm_config, self.device)

--- a/vllm_omni/worker/cpu_model_runner.py
+++ b/vllm_omni/worker/cpu_model_runner.py
@@ -16,3 +16,10 @@ class OmniCPUModelRunner(CPUModelRunner, OmniGPUModelRunner):
         if self.compilation_config.mode == CompilationMode.NONE:
             return
         super().warming_up_model()
+
+    def _should_use_async_omni_output(self) -> bool:
+        # Omni async output overlaps a GPU->CPU copy with the next step's
+        # GPU kernels via a dedicated CUDA stream/event. There is no such
+        # overlap opportunity on CPU, and building it would unconditionally
+        # touch torch.cuda APIs that don't work without a CUDA device.
+        return False

--- a/vllm_omni/worker/cpu_model_runner.py
+++ b/vllm_omni/worker/cpu_model_runner.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from vllm.config import CompilationMode
 from vllm.v1.worker.cpu_model_runner import CPUModelRunner
 
 from vllm_omni.worker.gpu_model_runner import OmniGPUModelRunner
@@ -10,3 +11,8 @@ class OmniCPUModelRunner(CPUModelRunner, OmniGPUModelRunner):
     def load_model(self, *args, **kwargs) -> None:
         CPUModelRunner.load_model(self, *args, **kwargs)
         self._omni_post_load_model()
+
+    def warming_up_model(self) -> None:
+        if self.compilation_config.mode == CompilationMode.NONE:
+            return
+        super().warming_up_model()

--- a/vllm_omni/worker/cpu_model_runner.py
+++ b/vllm_omni/worker/cpu_model_runner.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.v1.worker.cpu_model_runner import CPUModelRunner
+
+from vllm_omni.worker.gpu_model_runner import OmniGPUModelRunner
+
+
+class OmniCPUModelRunner(CPUModelRunner, OmniGPUModelRunner):
+    def load_model(self, *args, **kwargs) -> None:
+        CPUModelRunner.load_model(self, *args, **kwargs)
+        self._omni_post_load_model()

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -217,7 +217,7 @@ class OmniGPUModelRunner(GPUModelRunner):
         hidden_size = int(
             getattr(self.model, "mtp_hidden_size", 0) or getattr(self.model_config.hf_text_config, "hidden_size")
         )
-        max_batch_size = max(self.max_num_reqs, self.compilation_config.max_cudagraph_capture_size)
+        max_batch_size = max(self.max_num_reqs, self.compilation_config.max_cudagraph_capture_size or 0)
         self.talker_mtp_input_ids = self._make_buffer(max_batch_size, dtype=torch.int32)
         self.talker_mtp_inputs_embeds = self._make_buffer(max_batch_size, hidden_size, dtype=self.dtype, numpy=False)
         self.last_talker_hidden = self._make_buffer(max_batch_size, hidden_size, dtype=self.dtype, numpy=False)

--- a/vllm_omni/worker/gpu_model_runner.py
+++ b/vllm_omni/worker/gpu_model_runner.py
@@ -178,6 +178,9 @@ class OmniGPUModelRunner(GPUModelRunner):
     @instrument(span_name="Loading (GPU)")
     def load_model(self, *args, **kwargs) -> None:
         super().load_model(*args, **kwargs)
+        self._omni_post_load_model()
+
+    def _omni_post_load_model(self) -> None:
         model = getattr(self, "model", None)
         override_fn = None
         if bool(getattr(model, "supports_sampled_token_ids_cpu_override", False)):


### PR DESCRIPTION
## Purpose

Allow smaller models (like TTS ones) to run on CPU only machines, for testing or development purpose.

## Test Plan

**vLLM Version:** 0.25.0

**vLLM-Omni Commit:** 7794f603d9f274764772fd98eb44b52ce619ec1c

On a CPU only machine:

Setup vllm-omni following https://docs.vllm.ai/projects/vllm-omni/en/latest/getting_started/quickstart/#installation, but replace the vllm installation command with the one from https://docs.vllm.ai/en/latest/getting_started/installation/cpu/#pre-built-wheels (to install the cpu wheels instead of the default CUDA ones).

```bash
vllm serve Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice \
  --omni --enforce-eager \
  --kv-cache-memory-bytes 1073741824 --max-model-len 2048 --stage-init-timeout 3600
```

```bash
python examples/online_serving/text_to_speech/qwen3_tts/openai_speech_client.py \
  --model Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice --speaker aiden \
  --text "Hello from TTS model running on CPU" --api-base http://localhost:8000
```

## Test Result

Generates intelligible speech. 
